### PR TITLE
drop pyo3 `extension-module` feature

### DIFF
--- a/crates/monty-python/Cargo.toml
+++ b/crates/monty-python/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 [dependencies]
 monty = { path = "../monty" }
 monty_type_checking = { path = "../monty-type-checking" }
-pyo3 = { version = "0.27.2", features = ["extension-module", "indexmap", "generate-import-lib"] }
+pyo3 = { version = "0.27.2", features = ["indexmap", "generate-import-lib"] }
 indexmap = "2.9"
 serde = { version = "1.0", features = ["derive"] }
 postcard = { version = "1.1", features = ["alloc"] }
@@ -29,7 +29,7 @@ pyo3-build-config = { version = "0.27.2", features = ["resolve-config"] }
 
 [features]
 # make extensions visible to cargo vendor
-extension-module = ["pyo3/extension-module", "pyo3/generate-import-lib"]
+extension-module = ["pyo3/generate-import-lib"]
 
 [lints]
 workspace = true

--- a/crates/monty-python/pyproject.toml
+++ b/crates/monty-python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.0,<2.0"]
+requires = ["maturin>=1.9.4,<2.0"]
 build-backend = "maturin"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ members = ["crates/monty-python"]
 [dependency-groups]
 dev = [
     "basedpyright>=1.34.0",
-    "maturin>=1.0,<2.0",
+    "maturin>=1.9.4,<2.0",
     "mypy>=1.19.1",
     "ruff>=0.14.7",
 ]


### PR DESCRIPTION
This allows `cargo run` to "just work" without linker issues. The `extension-module` feature causes linker conflicts, and newer PyO3 versions instead allow the linker subtlety to be deferred to the packaging tool (in this case `maturin >= 1.9.4`).