### PR TITLE
Implement `del` statement for subscript deletion

### DIFF
--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -291,6 +291,18 @@ impl<'a> Compiler<'a> {
                 self.code.emit(Opcode::StoreSubscr);
             }
 
+            Node::SubscriptDelete {
+                target,
+                index,
+                target_position,
+            } => {
+                self.compile_name(target);
+                self.compile_expr(index)?;
+                // Set location to the target (e.g., `lst[10]`) for proper caret in tracebacks
+                self.code.set_location(*target_position, None);
+                self.code.emit(Opcode::DeleteSubscr);
+            }
+
             Node::AttrAssign {
                 object,
                 attr,

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -744,12 +744,13 @@ impl<'a, T: ResourceTracker, P: PrintWriter> VM<'a, T, P> {
                     }
                 }
                 Opcode::DeleteSubscr => {
-                    // TODO: Implement py_delitem on Value
                     let index = self.pop();
-                    let obj = self.pop();
+                    let mut obj = self.pop();
+                    let result = obj.py_delitem(index, self.heap, self.interns);
                     obj.drop_with_heap(self.heap);
-                    index.drop_with_heap(self.heap);
-                    todo!("DeleteSubscr: py_delitem not yet implemented")
+                    if let Err(e) = result {
+                        catch_sync!(self, cached_frame, e);
+                    }
                 }
                 Opcode::LoadAttr => {
                     let name_idx = fetch_u16!(cached_frame);

--- a/crates/monty/src/expressions.rs
+++ b/crates/monty/src/expressions.rs
@@ -472,6 +472,15 @@ pub enum Node<F> {
         /// Source position for error reporting.
         position: CodeRange,
     },
+    /// Subscript deletion (e.g., `del lst[10]` or `del d['key']`).
+    ///
+    /// Deletes an item from a subscriptable object. For lists, this removes the element at the index.
+    /// For dicts, this removes the key-value pair. Returns an error if the index/key doesn't exist.
+    SubscriptDelete {
+        target: Identifier,
+        index: ExprLoc,
+        target_position: CodeRange,
+    },
 }
 
 /// A prepared function definition with resolved names and scope information.

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -610,6 +610,17 @@ impl PyTrait for HeapData {
             _ => Err(ExcType::type_error_not_sub_assignment(self.py_type(heap))),
         }
     }
+
+    fn py_delitem(&mut self, key: Value, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<()> {
+        match self {
+            Self::List(l) => l.py_delitem(key, heap, interns),
+            Self::Dict(d) => d.py_delitem(key, heap, interns),
+            _ => Err(ExcType::type_error(format!(
+                "'{}' object does not support item deletion",
+                self.py_type(heap)
+            ))),
+        }
+    }
 }
 
 /// Hash caching state stored alongside each heap entry.

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -597,6 +597,21 @@ impl PyTrait for Dict {
         Ok(())
     }
 
+    fn py_delitem(&mut self, key: Value, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<()> {
+        if let Some((old_key, old_value)) = self.pop(&key, heap, interns)? {
+            old_key.drop_with_heap(heap);
+            old_value.drop_with_heap(heap);
+            key.drop_with_heap(heap);
+
+            Ok(())
+        } else {
+            let err = ExcType::key_error(&key, heap, interns);
+            key.drop_with_heap(heap);
+
+            Err(err)
+        }
+    }
+
     fn py_call_attr(
         &mut self,
         heap: &mut Heap<impl ResourceTracker>,

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -278,4 +278,20 @@ pub trait PyTrait {
         )
         .into())
     }
+
+    /// Deletes an item from this value, e.g. `del obj[key]`
+    ///
+    /// Returns Ok(()) on success, or an error if the key doesn't exist or deletion isn't supported
+    /// Takes ownership of `key` and drops it on error
+    ///
+    /// The `interns` parameter provides access to interned string content
+    ///
+    /// Default implementation returns TypeError
+    fn py_delitem(&mut self, _key: Value, heap: &mut Heap<impl ResourceTracker>, _interns: &Interns) -> RunResult<()> {
+        Err(SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("'{}' object does not support item deletion", self.py_type(heap)),
+        )
+        .into())
+    }
 }

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -1431,6 +1431,19 @@ impl PyTrait for Value {
             ))),
         }
     }
+
+    fn py_delitem(&mut self, key: Self, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<()> {
+        match self {
+            Self::Ref(id) => {
+                let id = *id;
+                heap.with_entry_mut(id, |heap, data| data.py_delitem(key, heap, interns))
+            }
+            _ => Err(ExcType::type_error(format!(
+                "'{}' object does not support item deletion",
+                self.py_type(heap)
+            ))),
+        }
+    }
 }
 
 impl Value {

--- a/crates/monty/test_cases/del_subscript.py
+++ b/crates/monty/test_cases/del_subscript.py
@@ -1,0 +1,22 @@
+# Test del operation on lists and dicts
+
+x = [1, 2, 3, 4, 5]
+del x[2]
+assert x == [1, 2, 4, 5], f'Expected [1, 2, 4, 5], got {x}'
+
+y = [10, 20, 30, 40]
+del y[-1]
+assert y == [10, 20, 30], f'Expected [10, 20, 30], got {y}'
+
+z = ['a', 'b', 'c']
+del z[0]
+assert z == ['b', 'c'], f"Expected ['b', 'c'], got {z}"
+
+d = {'a': 1, 'b': 2, 'c': 3}
+del d['b']
+assert d == {'a': 1, 'c': 3}, f"Expected {{'a': 1, 'c': 3}}, got {d}"
+assert len(d) == 2, f'Expected length 2, got {len(d)}'
+
+d2 = {1: 'one', 2: 'two', 3: 'three'}
+del d2[2]
+assert d2 == {1: 'one', 3: 'three'}, f"Expected {{1: 'one', 3: 'three'}}, got {d2}"

--- a/crates/monty/test_cases/del_subscript_errors.py
+++ b/crates/monty/test_cases/del_subscript_errors.py
@@ -1,0 +1,36 @@
+# Test error cases for del operation
+
+try:
+    x = [1, 2, 3]
+    del x[10]
+    assert False, 'Should have raised IndexError'
+except IndexError:
+    print('IndexError for out of bounds - OK')
+
+try:
+    y = [1, 2, 3]
+    del y[-10]
+    assert False, 'Should have raised IndexError'
+except IndexError:
+    print('IndexError for negative out of bounds - OK')
+
+try:
+    d = {'a': 1, 'b': 2}
+    del d['c']
+    assert False, 'Should have raised KeyError'
+except KeyError:
+    print('KeyError for missing key - OK')
+
+try:
+    num = 42
+    del num[0]  # pyright: ignore[reportIndexIssue]
+    assert False, 'Should have raised TypeError'
+except TypeError as e:
+    assert 'does not support item deletion' in str(e)
+
+try:
+    lst = [1, 2, 3]
+    del lst['string']
+    assert False, 'Should have raised TypeError'
+except TypeError as e:
+    assert 'indices' in str(e)


### PR DESCRIPTION
This PR adds support for the `del` statement on subscripted objects, which enable deletion of list elements and dict entries through the `del foo['bar']` syntax