### PR TITLE
Fix grammar and clarity in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ A minimal, secure Python interpreter written in Rust for use by AI.
 
 Monty avoids the cost, latency, complexity and general faff of using full container based sandbox for running LLM generated code.
 
-Instead, it let's you run safely run Python code written by an LLM embedded in your agent, with startup times measured in single digit microseconds not hundreds of milliseconds.
+Instead, it let's you safely run Python code written by an LLM embedded in your agent, with startup times measured in single digit microseconds not hundreds of milliseconds.
 
 What Monty **can** do:
-* Run a reasonable subset of Python code - enough for your agent to express that it wants to do
+* Run a reasonable subset of Python code - enough for your agent to express what it wants to do
 * Completely block access to the host environment: filesystem, env variables and network access are all implemented via external function calls the developer can control
 * Call functions on the host - only functions you give it access to
-* Run typechecking - monty supports full modern python type hints and comes with [ty](https://docs.astral.sh/ty/) including in a single binary to run typechecking
+* Run typechecking - monty supports full modern python type hints and comes with [ty](https://docs.astral.sh/ty/) included in a single binary to run typechecking
 * Be snapshotted to bytes at external function calls, meaning you can store the interpreter state in a file or database, and resume later
 * Startup extremely fast (<1μs to go from code to execution result), and has runtime performance that is similar to CPython (generally between 5x faster and 5x slower)
 * Be called from Rust, Python, or Javascript - because Monty has no dependencies on cpython, you can use it anywhere you can run Rust


### PR DESCRIPTION
Corrected minor grammatical errors and improved clarity in the README.

Project is super cool! Little grammar mistakes show it wasn't all just yolo'd and created with a coding agent 🤣