### PR TITLE
fix: include wrapper.js and wrapper.d.ts in npm package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,6 +505,8 @@ jobs:
             crates/monty-js/browser.js
             crates/monty-js/index.js
             crates/monty-js/index.d.ts
+            crates/monty-js/wrapper.js
+            crates/monty-js/wrapper.d.ts
             crates/monty-js/monty.wasi.cjs
             crates/monty-js/monty.wasi-browser.js
             crates/monty-js/wasi-worker.mjs


### PR DESCRIPTION
Fixes #108.

I've tested locally if the package is build locally (so without the CI step that uploads artifacts) it actually works, so I guess it's mainly the issue.