### PR TITLE
handle i64::MIN division overflow in //, %, and divmod()

### DIFF
--- a/crates/monty/src/resource.rs
+++ b/crates/monty/src/resource.rs
@@ -59,6 +59,14 @@ pub fn check_lshift_size(
     check_estimated_size(estimate_bits_to_bytes(value_bits.saturating_add(shift_amount)), tracker)
 }
 
+/// Pre-checks that an integer division overflow promotion won't exceed resource limits.
+///
+/// Division results are bounded by the dividend size, but we still check for consistency
+/// with other BigInt promotion paths.
+pub fn check_div_size(dividend_bits: u64, tracker: &impl ResourceTracker) -> Result<(), ResourceError> {
+    check_estimated_size(estimate_bits_to_bytes(dividend_bits), tracker)
+}
+
 /// Checks an estimated result size against the resource tracker.
 ///
 /// Only calls the tracker when the estimate exceeds `LARGE_RESULT_THRESHOLD`

--- a/crates/monty/test_cases/int__overflow_division.py
+++ b/crates/monty/test_cases/int__overflow_division.py
@@ -1,0 +1,84 @@
+# === i64::MIN // -1 overflow ===
+INT_MIN = -(2**63)
+INT_MAX = 2**63 - 1
+
+assert INT_MIN // -1 == 9223372036854775808, 'INT_MIN // -1'
+assert INT_MIN % -1 == 0, 'INT_MIN % -1'
+
+q, r = divmod(INT_MIN, -1)
+assert q == 9223372036854775808, 'divmod(INT_MIN, -1) quot'
+assert r == 0, 'divmod(INT_MIN, -1) rem'
+
+# === augmented assignment ===
+x = INT_MIN
+x //= -1
+assert x == 9223372036854775808, 'INT_MIN //= -1'
+
+x = INT_MIN
+x %= -1
+assert x == 0, 'INT_MIN %= -1'
+
+# === i64 boundary values ===
+assert INT_MIN // 1 == INT_MIN, 'INT_MIN // 1'
+assert INT_MIN // -2 == 4611686018427387904, 'INT_MIN // -2'
+assert INT_MIN % 1 == 0, 'INT_MIN % 1'
+assert INT_MIN % -2 == 0, 'INT_MIN % -2'
+assert INT_MIN % 3 == 1, 'INT_MIN % 3'
+
+assert INT_MAX // -1 == -INT_MAX, 'INT_MAX // -1'
+assert INT_MAX % -1 == 0, 'INT_MAX % -1'
+assert INT_MAX // 2 == 4611686018427387903, 'INT_MAX // 2'
+assert INT_MAX % 2 == 1, 'INT_MAX % 2'
+
+# === boundary divisors ===
+assert INT_MIN // INT_MIN == 1, 'INT_MIN // INT_MIN'
+assert INT_MIN // INT_MAX == -2, 'INT_MIN // INT_MAX'
+assert INT_MAX // INT_MIN == -1, 'INT_MAX // INT_MIN'
+assert INT_MIN % INT_MIN == 0, 'INT_MIN % INT_MIN'
+assert INT_MAX % INT_MAX == 0, 'INT_MAX % INT_MAX'
+
+# === sign combinations ===
+assert -7 // 2 == -4, '-7 // 2'
+assert 7 // -2 == -4, '7 // -2'
+assert -7 % 2 == 1, '-7 % 2'
+assert 7 % -2 == -1, '7 % -2'
+
+q, r = divmod(-7, 2)
+assert q == -4, 'divmod(-7, 2) quot'
+assert r == 1, 'divmod(-7, 2) rem'
+
+q, r = divmod(7, -2)
+assert q == -4, 'divmod(7, -2) quot'
+assert r == -1, 'divmod(7, -2) rem'
+
+# === divmod at boundaries ===
+q, r = divmod(INT_MIN, 2)
+assert q == -4611686018427387904, 'divmod(INT_MIN, 2) quot'
+assert r == 0, 'divmod(INT_MIN, 2) rem'
+
+q, r = divmod(INT_MAX, -1)
+assert q == -INT_MAX, 'divmod(INT_MAX, -1) quot'
+assert r == 0, 'divmod(INT_MAX, -1) rem'
+
+q, r = divmod(INT_MIN, INT_MAX)
+assert q == -2, 'divmod(INT_MIN, INT_MAX) quot'
+assert r == INT_MAX - 1, 'divmod(INT_MIN, INT_MAX) rem'
+
+# === divmod invariant: q * b + r == a ===
+q, r = divmod(INT_MIN, -1)
+assert q * -1 + r == INT_MIN, 'divmod(INT_MIN, -1) invariant'
+
+q, r = divmod(INT_MIN, 3)
+assert q * 3 + r == INT_MIN, 'divmod(INT_MIN, 3) invariant'
+assert q == -3074457345618258603, 'divmod(INT_MIN, 3) quot'
+assert r == 1, 'divmod(INT_MIN, 3) rem'
+
+# === CompareModEq patterns ===
+x = INT_MIN
+assert x % -1 == 0, 'INT_MIN % -1 == 0'
+assert x % 2 == 0, 'INT_MIN % 2 == 0'
+assert x % 3 == 1, 'INT_MIN % 3 == 1'
+
+x = INT_MAX
+assert x % -1 == 0, 'INT_MAX % -1 == 0'
+assert x % 2 == 1, 'INT_MAX % 2 == 1'


### PR DESCRIPTION
`-(2**63) // -1` panics with `attempt to divide with overflow` because `i64::MIN / -1` doesn't fit in `i64`. Same overflow in `%`, `divmod()`, `//=`, `%=`, and `CompareModEq`.

Uses `checked_div`/`checked_rem` and promotes to `LongInt` on overflow, matching the existing `checked_add`/`checked_sub`/`checked_mul` pattern.

Shared `floor_divmod` returns `Option<(i64, i64)>` for both `builtin_divmod` and `py_floordiv`. Added `check_div_size` pre-check on the BigInt promotion path.

Four code paths fixed:
- `py_floordiv` — `//` and `//=`
- `py_mod` — `%` and `%=`
- `py_mod_eq` — `CompareModEq` optimization
- `builtin_divmod` — `divmod()`