### PR TITLE
fix: correct bugs in expense_analysis example

### DIFF
--- a/examples/expense_analysis/data.py
+++ b/examples/expense_analysis/data.py
@@ -106,7 +106,7 @@ async def get_expenses(user_id: int, quarter: str, category: str) -> dict[str, A
         Dictionary with expense items.
     """
     items = expenses.get(user_id, [])
-    return {'user_id': user_id, 'quarter': quarter, 'category': category, 'items': items}
+    return {'user_id': user_id, 'quarter': quarter, 'category': category, 'expenses': items}
 
 
 async def get_custom_budget(user_id: int) -> dict[str, Any] | None:
@@ -118,4 +118,7 @@ async def get_custom_budget(user_id: int) -> dict[str, Any] | None:
     Returns:
         Custom budget info or None if no custom budget.
     """
-    custom_budgets.get(user_id)
+    budget_info = custom_budgets.get(user_id)
+    if budget_info:
+        return {'user_id': user_id, 'budget': budget_info['amount'], 'reason': budget_info['reason']}
+    return None


### PR DESCRIPTION
## Summary
Fix two bugs in `examples/expense_analysis/data.py` that prevented the example from running correctly.

## Bug Fixes

### 1. `get_expenses()` - Wrong dictionary key
- **Before:** `return {..., 'items': items}`
- **After:** `return {..., 'expenses': items}`
- **Reason:** `main.py` line 56 calls `expenses_data.get("expenses", [])`, so the key must be `"expenses"` not `"items"`

### 2. `get_custom_budget()` - Missing return statement
- **Before:** `custom_budgets.get(user_id)` (result was discarded)
- **After:** Added proper logic to return budget info or `None`

## Testing
Ran `python examples/expense_analysis/main.py` and confirmed it now produces correct output:
{'total_team_members_analyzed': 5, 'count_exceeded_budget': 1, 'over_budget_details': [{'name': 'Carol Jones', 'total_spent': 6740.0, 'budget': 5000, 'amount_over': 1740.0}]}
