### PR TITLE
Fix `TypeError` when comparing heap-allocated strings

### DIFF
--- a/crates/monty/test_cases/builtin__more_iter_funcs.py
+++ b/crates/monty/test_cases/builtin__more_iter_funcs.py
@@ -43,6 +43,16 @@ assert sorted([5]) == [5], 'sorted single element'
 # sorted with strings
 assert sorted(['c', 'a', 'b']) == ['a', 'b', 'c'], 'sorted strings'
 
+# sorted with heap-allocated strings (from split)
+assert sorted('banana,apple,cherry'.split(',')) == ['apple', 'banana', 'cherry'], 'sorted split strings'
+
+# sorted with multi-char string literals (heap-allocated)
+assert sorted(['banana', 'apple', 'cherry']) == ['apple', 'banana', 'cherry'], 'sorted multi-char strings'
+
+# min/max with heap-allocated strings
+assert min('banana,apple,cherry'.split(',')) == 'apple', 'min of split strings'
+assert max('banana,apple,cherry'.split(',')) == 'cherry', 'max of split strings'
+
 # sorted with negative numbers
 assert sorted([-3, 1, -2, 2]) == [-3, -2, 1, 2], 'sorted with negatives'
 

--- a/crates/monty/test_cases/compare__mixed_types.py
+++ b/crates/monty/test_cases/compare__mixed_types.py
@@ -81,6 +81,20 @@ assert 'abd' > 'abc', 'str gt'
 assert 'abc' >= 'abc', 'str ge'
 assert 'a' < 'b', 'single char lt'
 
+# === Heap-allocated string ordering (from split) ===
+parts = 'banana,apple'.split(',')
+assert parts[1] < parts[0], 'heap str lt'
+assert parts[0] > parts[1], 'heap str gt'
+assert parts[0] >= parts[0], 'heap str ge self'
+assert parts[0] <= parts[0], 'heap str le self'
+
+# === Cross-type string ordering (interned vs heap) ===
+heap_str = 'banana,apple'.split(',')[0]
+assert heap_str > 'apple', 'heap str gt interned'
+assert 'cherry' > heap_str, 'interned gt heap str'
+assert heap_str >= 'banana', 'heap str ge interned eq'
+assert 'banana' <= heap_str, 'interned le heap str eq'
+
 # === Containment: not in list ===
 assert 999 not in [1, 2, 3], 'not in list'
 assert 0 not in [1, 2, 3], 'zero not in list'


### PR DESCRIPTION
## Bug

A human user encountered this bug while using Monty via the JavaScript bindings. This PR was authored with Claude Code to diagnose the root cause and implement the fix.

`sorted()`, `min()`, `max()`, and comparison operators (`<`, `>`, `<=`, `>=`) fail with:

```
TypeError: '<' not supported between instances of 'str' and 'str'
```

when operating on strings created at runtime (e.g. from `str.split()`), even though the same operations work fine on string literals.

### Reproduction

```javascript
const { Monty, runMontyAsync } = require("@pydantic/monty");

// Works: sorted on literal strings
const m1 = new Monty('sorted(["banana", "apple", "cherry"])', { externalFunctions: [] });
const r1 = await runMontyAsync(m1, { limits: { maxDurationSecs: 5 } });
// => ["apple", "banana", "cherry"]

// Fails: sorted on strings from split()
const m2 = new Monty('sorted("banana,apple,cherry".split(","))', { externalFunctions: [] });
const r2 = await runMontyAsync(m2, { limits: { maxDurationSecs: 5 } });
// => TypeError: '<' not supported between instances of 'str' and 'str'
```

Equivalent Python reproduction:

```python
sorted(['banana', 'apple', 'cherry'])          # works (InternString literals)
sorted('banana,apple,cherry'.split(','))        # fails (heap-allocated Str)
```

## Root Cause

`Value::py_cmp()` in `value.rs` only handled string ordering for `InternString` vs `InternString` (compile-time string literals). String literals are interned at compile time, but strings created at runtime (from `split()`, concatenation, etc.) are heap-allocated as `Value::Ref(HeapData::Str)`.

The `(Ref, Ref)` match arm in `py_cmp()` only compared `LongInt` values, returning `Ok(None)` for any other heap type — which `sorted()` and `min()`/`max()` interpret as "comparison not supported", triggering the `TypeError`.

Note: `py_eq()` already handled all three string representation combinations correctly — `py_cmp()` was simply missing the same coverage.

## Fix

Extended `Value::py_cmp()` with three new comparison cases:

1. **`Ref(Str)` vs `Ref(Str)`** — two heap-allocated strings (added to the existing `Ref` vs `Ref` arm alongside `LongInt`)
2. **`InternString` vs `Ref(Str)`** — interned literal compared with heap string
3. **`Ref(Str)` vs `InternString`** — heap string compared with interned literal

## Tests

Added tests to existing test files:
- `builtin__more_iter_funcs.py` — `sorted()`, `min()`, `max()` with heap strings from `split()`
- `compare__mixed_types.py` — direct `<`/`>`/`<=`/`>=` between heap-allocated and interned strings

All 760 test cases pass, plus the full `make test-ref-count-panic` suite.

---

🤖 Generated with [Claude Code](https://claude.ai/code)