### PR TITLE
Fix bootstrap workflow: install deps and create npm dirs

### DIFF
--- a/.github/workflows/init-npm-packages.yml
+++ b/.github/workflows/init-npm-packages.yml
@@ -22,6 +22,14 @@ jobs:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
 
+      - name: Install dependencies
+        run: npm install
+        working-directory: crates/monty-js
+
+      - name: Create npm dirs
+        run: npm run create-npm-dirs
+        working-directory: crates/monty-js
+
       - name: Check and create missing platform packages
         working-directory: crates/monty-js
         env:


### PR DESCRIPTION
## Summary
- The `npm/` platform directories are generated by `napi create-npm-dirs` and not checked into git
- Without installing dependencies and running `create-npm-dirs` first, the glob `npm/*/` matches nothing and the workflow fails
- Adds `npm install` and `npm run create-npm-dirs` steps before the package check