### PR TITLE
support sorted kwargs

### DIFF
--- a/crates/monty/src/builtins/map.rs
+++ b/crates/monty/src/builtins/map.rs
@@ -76,7 +76,7 @@ pub fn builtin_map(
         [] => {
             while let Some(item) = first_iter.for_next(heap, interns)? {
                 let args = ArgValues::One(item);
-                out.push(builtin.call(heap, args, interns, print_writer)?);
+                out.push(builtin.call_basic(heap, args, interns, print_writer)?);
             }
         }
         // map(f, iter1, iter2)
@@ -87,7 +87,7 @@ pub fn builtin_map(
                     break;
                 };
                 let args = ArgValues::Two(arg1, arg2);
-                out.push(builtin.call(heap, args, interns, print_writer)?);
+                out.push(builtin.call_basic(heap, args, interns, print_writer)?);
             }
         }
         // map(f, iter1, iter2, *iterables)
@@ -108,7 +108,7 @@ pub fn builtin_map(
                 kwargs: KwargsValues::Empty,
             };
 
-            out.push(builtin.call(heap, args, interns, print_writer)?);
+            out.push(builtin.call_basic(heap, args, interns, print_writer)?);
         },
     }
 

--- a/crates/monty/src/builtins/mod.rs
+++ b/crates/monty/src/builtins/mod.rs
@@ -36,12 +36,13 @@ use strum::{Display, EnumString, FromRepr, IntoStaticStr};
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     exception_private::{ExcType, RunResult},
     heap::Heap,
     intern::Interns,
     io::PrintWriter,
     resource::ResourceTracker,
-    types::Type,
+    types::{CallOutcome, Type},
     value::Value,
 };
 
@@ -60,22 +61,34 @@ pub(crate) enum Builtins {
 }
 
 impl Builtins {
-    /// Calls this builtin with the given arguments.
+    /// Calls this builtin with full VM context, returning a `CallOutcome`.
     ///
-    /// # Arguments
-    /// * `heap` - The heap for allocating objects
-    /// * `args` - The arguments to pass to the callable
-    /// * `interns` - String storage for looking up interned names in error messages
-    /// * `print` - The print for print output
-    pub fn call(
+    /// Builtin functions that need VM access (e.g., `sorted()` with key functions)
+    /// are dispatched through `BuiltinsFunctions::call`. All others delegate to
+    /// `call_basic` which only needs heap/interns/print_writer.
+    ///
+    /// Exception types and type constructors always complete synchronously.
+    pub fn call<T: ResourceTracker>(self, vm: &mut VM<'_, '_, T>, args: ArgValues) -> RunResult<CallOutcome> {
+        match self {
+            Self::Function(b) => b.call(vm, args),
+            Self::ExcType(exc) => exc.call(vm.heap, args, vm.interns).map(CallOutcome::Value),
+            Self::Type(t) => t.call(vm.heap, args, vm.interns).map(CallOutcome::Value),
+        }
+    }
+
+    /// Calls this builtin without VM context.
+    ///
+    /// Used by `map()` and other contexts where builtins are called as function
+    /// arguments without needing VM access.
+    pub fn call_basic(
         self,
         heap: &mut Heap<impl ResourceTracker>,
         args: ArgValues,
         interns: &Interns,
-        print: &mut PrintWriter<'_>,
+        print_writer: &mut PrintWriter<'_>,
     ) -> RunResult<Value> {
         match self {
-            Self::Function(b) => b.call(heap, args, interns, print),
+            Self::Function(b) => b.call_basic(heap, args, interns, print_writer),
             Self::ExcType(exc) => exc.call(heap, args, interns),
             Self::Type(t) => t.call(heap, args, interns),
         }
@@ -218,11 +231,28 @@ pub enum BuiltinsFunctions {
 }
 
 impl BuiltinsFunctions {
-    /// Executes the builtin with the provided positional arguments.
+    /// Executes the builtin with full VM context.
     ///
-    /// The `interns` parameter provides access to interned string content for py_str and py_repr.
-    /// The `print` parameter is used for print output.
-    pub(crate) fn call(
+    /// Builtins that need VM access (e.g., `sorted()` for calling user-defined key
+    /// functions via `call_sync`) are dispatched directly here. All others delegate
+    /// to `call_basic` which only needs heap/interns/print_writer, then wrap the
+    /// result in `CallOutcome::Value`.
+    pub(crate) fn call<T: ResourceTracker>(self, vm: &mut VM<'_, '_, T>, args: ArgValues) -> RunResult<CallOutcome> {
+        match self {
+            // Sorted needs VM access for call_sync (user-defined key functions)
+            Self::Sorted => sorted::builtin_sorted(vm, args),
+            // All other builtins delegate to call_basic
+            _ => self
+                .call_basic(vm.heap, args, vm.interns, vm.print_writer)
+                .map(CallOutcome::Value),
+        }
+    }
+
+    /// Executes the builtin without VM context.
+    ///
+    /// Used by `call_key_function` in `list.sort()` where no VM is available,
+    /// and as the default path for most builtins that don't need VM access.
+    pub(crate) fn call_basic(
         self,
         heap: &mut Heap<impl ResourceTracker>,
         args: ArgValues,
@@ -253,7 +283,10 @@ impl BuiltinsFunctions {
             Self::Repr => repr::builtin_repr(heap, args, interns),
             Self::Reversed => reversed::builtin_reversed(heap, args, interns),
             Self::Round => round::builtin_round(heap, args),
-            Self::Sorted => sorted::builtin_sorted(heap, args, interns),
+            Self::Sorted => {
+                // sorted() with no kwargs — call_basic is used from list.sort's call_key_function
+                sorted::builtin_sorted_basic(heap, args, interns)
+            }
             Self::Sum => sum::builtin_sum(heap, args, interns),
             Self::Type => type_::builtin_type(heap, args),
             Self::Zip => zip::builtin_zip(heap, args, interns),

--- a/crates/monty/src/builtins/sorted.rs
+++ b/crates/monty/src/builtins/sorted.rs
@@ -1,23 +1,91 @@
 //! Implementation of the sorted() builtin function.
+//!
+//! Supports `sorted(iterable, *, key=None, reverse=False)` matching Python's
+//! signature. The `key` argument can be any callable, including user-defined
+//! functions and lambdas — these are called via `VM::call_sync`.
 
 use std::cmp::Ordering;
 
 use crate::{
-    args::ArgValues,
+    args::{ArgValues, KwargsValues},
+    bytecode::VM,
     defer_drop_mut,
-    exception_private::{ExcType, RunResult, SimpleException},
+    exception_private::{ExcType, RunError, RunResult, SimpleException},
     heap::{Heap, HeapData},
     intern::Interns,
     resource::{DepthGuard, ResourceTracker},
-    types::{List, MontyIter, PyTrait},
+    types::{CallOutcome, List, MontyIter, PyTrait},
     value::Value,
 };
 
-/// Implementation of the sorted() builtin function.
+/// Implementation of `sorted()` with full VM context for calling key functions.
 ///
-/// Returns a new sorted list from the items in an iterable.
-/// Note: Currently does not support key or reverse arguments.
-pub fn builtin_sorted(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
+/// Supports the `key` and `reverse` keyword arguments. When a `key` function is
+/// provided, each element is passed through it via `VM::call_sync`, which allows
+/// user-defined functions (lambdas, closures) to be used as key functions.
+pub fn builtin_sorted<T: ResourceTracker>(vm: &mut VM<'_, '_, T>, args: ArgValues) -> RunResult<CallOutcome> {
+    let (positional, kwargs) = args.into_parts();
+    defer_drop_mut!(positional, vm);
+
+    // Parse key and reverse kwargs
+    let (key_arg, reverse_arg) = parse_sorted_kwargs(kwargs, vm.heap, vm.interns)?;
+
+    let positional_len = positional.len();
+    if positional_len != 1 {
+        if let Some(k) = key_arg {
+            k.drop_with_heap(vm.heap);
+        }
+        return Err(SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("sorted expected 1 argument, got {positional_len}"),
+        )
+        .into());
+    }
+
+    // Convert reverse to bool (default false)
+    let reverse = if let Some(v) = reverse_arg {
+        let result = v.py_bool(vm.heap, vm.interns);
+        v.drop_with_heap(vm.heap);
+        result
+    } else {
+        false
+    };
+
+    // Handle key function: None means no key function
+    let key_fn = match key_arg {
+        Some(v) if matches!(v, Value::None) => {
+            v.drop_with_heap(vm.heap);
+            None
+        }
+        other => other,
+    };
+
+    // Collect items from iterable
+    let iterable = positional.next().unwrap();
+    let iter = MontyIter::new(iterable, vm.heap, vm.interns)?;
+    let items = iter.collect(vm.heap, vm.interns)?;
+
+    // Sort and return
+    let sorted = sort_items(items, key_fn.as_ref(), reverse, vm)?;
+    let heap_id = vm.heap.allocate(HeapData::List(List::new(sorted)))?;
+
+    // Clean up key function
+    if let Some(k) = key_fn {
+        k.drop_with_heap(vm.heap);
+    }
+
+    Ok(CallOutcome::Value(Value::Ref(heap_id)))
+}
+
+/// Basic sorted() without VM context (no kwargs support).
+///
+/// Used via `call_basic` when sorted() is called as a key function from
+/// `list.sort()`, where no VM is available.
+pub fn builtin_sorted_basic(
+    heap: &mut Heap<impl ResourceTracker>,
+    args: ArgValues,
+    interns: &Interns,
+) -> RunResult<Value> {
     let (positional, kwargs) = args.into_parts();
     defer_drop_mut!(positional, heap);
 
@@ -34,38 +102,257 @@ pub fn builtin_sorted(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, in
 
     let iterable = positional.next().unwrap();
     let iter = MontyIter::new(iterable, heap, interns)?;
-    let mut items: Vec<_> = iter.collect(heap, interns)?;
+    let items = iter.collect(heap, interns)?;
 
-    // Sort using insertion sort (simple, stable, works with py_cmp)
-    // For small lists this is fine; for large lists we'd want a better algorithm
-    let mut guard = DepthGuard::default();
-    for i in 1..items.len() {
-        let mut j = i;
-        while j > 0 {
-            // Enforce timeout inside the O(n^2) comparison loop
-            heap.check_time()?;
-            match items[j - 1].py_cmp(&items[j], heap, &mut guard, interns)? {
-                Some(Ordering::Greater) => {
-                    items.swap(j - 1, j);
-                    j -= 1;
-                }
-                Some(_) => break,
-                None => {
-                    let left_type = items[j - 1].py_type(heap);
-                    let right_type = items[j].py_type(heap);
-                    for item in items {
-                        item.drop_with_heap(heap);
-                    }
-                    return Err(SimpleException::new_msg(
-                        ExcType::TypeError,
-                        format!("'<' not supported between instances of '{left_type}' and '{right_type}'"),
-                    )
-                    .into());
-                }
+    let sorted = sort_items_basic(items, false, heap, interns)?;
+    let heap_id = heap.allocate(HeapData::List(List::new(sorted)))?;
+    Ok(Value::Ref(heap_id))
+}
+
+/// Parses `key` and `reverse` keyword arguments from kwargs.
+///
+/// Consumes the `KwargsValues`, extracting optional `key` and `reverse` values.
+/// Any unexpected keyword argument produces a TypeError.
+fn parse_sorted_kwargs(
+    kwargs: KwargsValues,
+    heap: &mut Heap<impl ResourceTracker>,
+    interns: &Interns,
+) -> RunResult<(Option<Value>, Option<Value>)> {
+    if kwargs.is_empty() {
+        return Ok((None, None));
+    }
+
+    let mut key_val: Option<Value> = None;
+    let mut reverse_val: Option<Value> = None;
+
+    for (k, value) in kwargs {
+        let keyword_name = k.as_either_str(&*heap);
+        k.drop_with_heap(heap);
+
+        let Some(keyword_name) = keyword_name else {
+            value.drop_with_heap(heap);
+            // Clean up already-parsed values
+            if let Some(v) = key_val {
+                v.drop_with_heap(heap);
             }
+            if let Some(v) = reverse_val {
+                v.drop_with_heap(heap);
+            }
+            return Err(ExcType::type_error("keywords must be strings"));
+        };
+
+        let key_str = keyword_name.as_str(interns);
+        if key_str == "key" {
+            if let Some(old) = key_val.replace(value) {
+                old.drop_with_heap(heap);
+            }
+        } else if key_str == "reverse" {
+            if let Some(old) = reverse_val.replace(value) {
+                old.drop_with_heap(heap);
+            }
+        } else {
+            value.drop_with_heap(heap);
+            if let Some(v) = key_val {
+                v.drop_with_heap(heap);
+            }
+            if let Some(v) = reverse_val {
+                v.drop_with_heap(heap);
+            }
+            return Err(ExcType::type_error(format!(
+                "'{key_str}' is an invalid keyword argument for sorted()"
+            )));
         }
     }
 
-    let heap_id = heap.allocate(HeapData::List(List::new(items)))?;
-    Ok(Value::Ref(heap_id))
+    Ok((key_val, reverse_val))
+}
+
+/// Sorts items using an optional key function and reverse flag.
+///
+/// When a key function is provided, calls it on each element via `VM::call_sync`,
+/// then uses index-based permutation sorting (same pattern as `do_list_sort` in
+/// `list.rs`). This ensures stability and correct reference counting.
+fn sort_items<T: ResourceTracker>(
+    mut items: Vec<Value>,
+    key_fn: Option<&Value>,
+    reverse: bool,
+    vm: &mut VM<'_, '_, T>,
+) -> RunResult<Vec<Value>> {
+    // Step 1: Compute key values if key function provided
+    let key_values: Option<Vec<Value>> = if let Some(key) = key_fn {
+        let mut keys: Vec<Value> = Vec::with_capacity(items.len());
+        for item in &items {
+            let elem = item.clone_with_heap(vm.heap);
+            let key_args = ArgValues::One(elem);
+            match vm.call_sync(key, key_args) {
+                Ok(key_value) => keys.push(key_value),
+                Err(e) => {
+                    // Clean up computed keys and items on error
+                    for k in keys {
+                        k.drop_with_heap(vm.heap);
+                    }
+                    for item in items {
+                        item.drop_with_heap(vm.heap);
+                    }
+                    return Err(e);
+                }
+            }
+        }
+        Some(keys)
+    } else {
+        None
+    };
+
+    // Step 2: Sort indices based on items or key values
+    let len = items.len();
+    let mut indices: Vec<usize> = (0..len).collect();
+    let mut sort_error: Option<RunError> = None;
+    let guard = std::cell::RefCell::new(DepthGuard::default());
+
+    if let Some(ref keys) = key_values {
+        indices.sort_by(|&a, &b| {
+            if sort_error.is_some() {
+                return Ordering::Equal;
+            }
+            if let Err(e) = vm.heap.check_time() {
+                sort_error = Some(e.into());
+                return Ordering::Equal;
+            }
+            match keys[a].py_cmp(&keys[b], vm.heap, &mut guard.borrow_mut(), vm.interns) {
+                Ok(Some(ord)) => {
+                    if reverse {
+                        ord.reverse()
+                    } else {
+                        ord
+                    }
+                }
+                Ok(None) => {
+                    sort_error = Some(ExcType::type_error(format!(
+                        "'<' not supported between instances of '{}' and '{}'",
+                        keys[a].py_type(vm.heap),
+                        keys[b].py_type(vm.heap)
+                    )));
+                    Ordering::Equal
+                }
+                Err(e) => {
+                    sort_error = Some(e.into());
+                    Ordering::Equal
+                }
+            }
+        });
+    } else {
+        indices.sort_by(|&a, &b| {
+            if sort_error.is_some() {
+                return Ordering::Equal;
+            }
+            if let Err(e) = vm.heap.check_time() {
+                sort_error = Some(e.into());
+                return Ordering::Equal;
+            }
+            match items[a].py_cmp(&items[b], vm.heap, &mut guard.borrow_mut(), vm.interns) {
+                Ok(Some(ord)) => {
+                    if reverse {
+                        ord.reverse()
+                    } else {
+                        ord
+                    }
+                }
+                Ok(None) => {
+                    sort_error = Some(ExcType::type_error(format!(
+                        "'<' not supported between instances of '{}' and '{}'",
+                        items[a].py_type(vm.heap),
+                        items[b].py_type(vm.heap)
+                    )));
+                    Ordering::Equal
+                }
+                Err(e) => {
+                    sort_error = Some(e.into());
+                    Ordering::Equal
+                }
+            }
+        });
+    }
+
+    // Clean up key values
+    if let Some(keys) = key_values {
+        for k in keys {
+            k.drop_with_heap(vm.heap);
+        }
+    }
+
+    // Check for sort error
+    if let Some(err) = sort_error {
+        for item in items {
+            item.drop_with_heap(vm.heap);
+        }
+        return Err(err);
+    }
+
+    // Step 3: Rearrange items in sorted order using index permutation
+    let mut sorted_items: Vec<Value> = Vec::with_capacity(len);
+    for &i in &indices {
+        sorted_items.push(std::mem::replace(&mut items[i], Value::Undefined));
+    }
+
+    Ok(sorted_items)
+}
+
+/// Sorts items without a key function (basic path without VM).
+///
+/// Used by `builtin_sorted_basic` for the no-kwargs case.
+fn sort_items_basic(
+    mut items: Vec<Value>,
+    reverse: bool,
+    heap: &mut Heap<impl ResourceTracker>,
+    interns: &Interns,
+) -> RunResult<Vec<Value>> {
+    let len = items.len();
+    let mut indices: Vec<usize> = (0..len).collect();
+    let mut sort_error: Option<RunError> = None;
+    let guard = std::cell::RefCell::new(DepthGuard::default());
+
+    indices.sort_by(|&a, &b| {
+        if sort_error.is_some() {
+            return Ordering::Equal;
+        }
+        if let Err(e) = heap.check_time() {
+            sort_error = Some(e.into());
+            return Ordering::Equal;
+        }
+        match items[a].py_cmp(&items[b], heap, &mut guard.borrow_mut(), interns) {
+            Ok(Some(ord)) => {
+                if reverse {
+                    ord.reverse()
+                } else {
+                    ord
+                }
+            }
+            Ok(None) => {
+                sort_error = Some(ExcType::type_error(format!(
+                    "'<' not supported between instances of '{}' and '{}'",
+                    items[a].py_type(heap),
+                    items[b].py_type(heap)
+                )));
+                Ordering::Equal
+            }
+            Err(e) => {
+                sort_error = Some(e.into());
+                Ordering::Equal
+            }
+        }
+    });
+
+    if let Some(err) = sort_error {
+        for item in items {
+            item.drop_with_heap(heap);
+        }
+        return Err(err);
+    }
+
+    let mut sorted_items: Vec<Value> = Vec::with_capacity(len);
+    for &i in &indices {
+        sorted_items.push(std::mem::replace(&mut items[i], Value::Undefined));
+    }
+
+    Ok(sorted_items)
 }

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -16,7 +16,7 @@ use crate::{
     os::OsFunction,
     resource::ResourceTracker,
     types::{
-        AttrCallResult, Dict, PyTrait, Type,
+        CallOutcome, Dict, PyTrait, Type,
         bytes::{bytes_fromhex, call_bytes_method},
         dict::dict_fromkeys,
         str::call_str_method,
@@ -49,13 +49,13 @@ pub(super) enum CallResult {
     MethodCall(EitherStr, ArgValues),
 }
 
-impl From<AttrCallResult> for CallResult {
-    fn from(result: AttrCallResult) -> Self {
+impl From<CallOutcome> for CallResult {
+    fn from(result: CallOutcome) -> Self {
         match result {
-            AttrCallResult::Value(v) => Self::Push(v),
-            AttrCallResult::OsCall(func, args) => Self::OsCall(func, args),
-            AttrCallResult::ExternalCall(ext_id, args) => Self::External(ext_id, args),
-            AttrCallResult::MethodCall(name, args) => Self::MethodCall(name, args),
+            CallOutcome::Value(v) => Self::Push(v),
+            CallOutcome::OsCall(func, args) => Self::OsCall(func, args),
+            CallOutcome::ExternalCall(ext_id, args) => Self::External(ext_id, args),
+            CallOutcome::MethodCall(name, args) => Self::MethodCall(name, args),
         }
     }
 }
@@ -82,11 +82,19 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
     ///
     /// Calls a builtin function directly without stack manipulation for the callable.
     /// This is an optimization that avoids constant pool lookup and stack manipulation.
-    pub(super) fn exec_call_builtin_function(&mut self, builtin_id: u8, arg_count: usize) -> Result<Value, RunError> {
+    ///
+    /// Returns `CallResult` because some builtins (e.g., `sorted()` with key functions)
+    /// may push frames via `call_sync`, requiring `handle_call_result!` in the dispatch loop.
+    pub(super) fn exec_call_builtin_function(
+        &mut self,
+        builtin_id: u8,
+        arg_count: usize,
+    ) -> Result<CallResult, RunError> {
         // Convert u8 to BuiltinsFunctions via FromRepr
         if let Some(builtin) = BuiltinsFunctions::from_repr(builtin_id) {
             let args = self.pop_n_args(arg_count);
-            builtin.call(self.heap, args, self.interns, self.print_writer)
+            let outcome = builtin.call(self, args)?;
+            Ok(outcome.into())
         } else {
             Err(RunError::internal("CallBuiltinFunction: invalid builtin_id"))
         }
@@ -257,8 +265,8 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
     ///
     /// For heap-allocated objects (`Value::Ref`), dispatches to the type's
     /// attribute call implementation via `heap.call_attr_raw()`, which may return
-    /// `AttrCallResult::OsCall`, `AttrCallResult::ExternalCall`, or
-    /// `AttrCallResult::MethodCall` for operations that require host involvement.
+    /// `CallOutcome::OsCall`, `CallOutcome::ExternalCall`, or
+    /// `CallOutcome::MethodCall` for operations that require host involvement.
     ///
     /// For interned strings (`Value::InternString`), uses the unified `call_str_method`.
     /// For interned bytes (`Value::InternBytes`), uses the unified `call_bytes_method`.
@@ -305,11 +313,11 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
     /// - `Value::ExtFunction`: returns `External` for caller to execute
     /// - `Value::DefFunction`: pushes a new frame, returns `FramePushed`
     /// - `Value::Ref`: checks for closure/function on heap
-    fn call_function(&mut self, callable: Value, args: ArgValues) -> Result<CallResult, RunError> {
+    pub(super) fn call_function(&mut self, callable: Value, args: ArgValues) -> Result<CallResult, RunError> {
         match callable {
             Value::Builtin(builtin) => {
-                let result = builtin.call(self.heap, args, self.interns, self.print_writer)?;
-                Ok(CallResult::Push(result))
+                let result = builtin.call(self, args)?;
+                Ok(result.into())
             }
             Value::ModuleFunction(mf) => {
                 let result = mf.call(self.heap, args)?;

--- a/crates/monty/src/bytecode/vm/exceptions.rs
+++ b/crates/monty/src/bytecode/vm/exceptions.rs
@@ -176,7 +176,18 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
                 return None; // Continue execution at handler
             }
 
-            // No handler in this frame - pop frame and try outer
+            // No handler in this frame - check subcall boundary before unwinding further.
+            // If we're inside a call_sync() and about to unwind past the subcall boundary,
+            // stop here and propagate the error back to call_sync().
+            if let Some(depth) = this.subcall_depth
+                && this.frames.len() <= depth + 1
+            {
+                // Drop exc_value before returning
+                drop(exc_guard);
+                self.pop_frame();
+                return Some(error);
+            }
+
             if this.frames.len() <= 1 {
                 // No more frames - exception is unhandled
                 let is_spawned = this.is_spawned_task();

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     asyncio::{CallId, TaskId},
     bytecode::{code::Code, op::Opcode},
     exception_private::{ExcType, RunError, RunResult, SimpleException},
-    heap::{ContainsHeap, Heap, HeapData, HeapId},
+    heap::{ContainsHeap, DropWithHeap, Heap, HeapData, HeapId},
     intern::{ExtFunctionId, FunctionId, Interns, StringId},
     io::PrintWriter,
     modules::BuiltinModule,
@@ -447,16 +447,23 @@ pub struct VM<'a, 'p, T: ResourceTracker> {
     frames: Vec<CallFrame<'a>>,
 
     /// Heap for reference-counted objects.
-    heap: &'a mut Heap<T>,
+    ///
+    /// `pub(crate)` so builtins receiving `&mut VM` can access the heap directly,
+    /// enabling split borrows that avoid conflicts with `call_sync`.
+    pub(crate) heap: &'a mut Heap<T>,
 
     /// Namespace stack for variable storage.
     namespaces: &'a mut Namespaces,
 
     /// Interned strings/bytes.
-    interns: &'a Interns,
+    ///
+    /// `pub(crate)` so builtins receiving `&mut VM` can read interned strings.
+    pub(crate) interns: &'a Interns,
 
     /// Print output writer, borrowed so callers retain access to collected output.
-    print_writer: &'a mut PrintWriter<'p>,
+    ///
+    /// `pub(crate)` so builtins receiving `&mut VM` can write output.
+    pub(crate) print_writer: &'a mut PrintWriter<'p>,
 
     /// Stack of exceptions being handled for nested except blocks.
     ///
@@ -489,6 +496,16 @@ pub struct VM<'a, 'p, T: ResourceTracker> {
     /// Stored here because the main task's frames have `function_id: None` and
     /// need a reference to the module code when being restored after task switching.
     module_code: Option<&'a Code>,
+
+    /// Frame depth at which a `call_sync` subcall should return.
+    ///
+    /// When set, `ReturnValue` checks if we've returned to this depth and stops
+    /// the run loop instead of continuing. This allows builtins like `sorted()`
+    /// to call user-defined functions (lambdas) synchronously within the VM.
+    ///
+    /// Uses a stack of depths to support nested `call_sync` calls (e.g., a key
+    /// function that itself calls `sorted()`).
+    subcall_depth: Option<usize>,
 }
 
 impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
@@ -511,6 +528,7 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
             next_call_id: 0,
             scheduler: None, // Lazy - no allocation for sync code
             module_code: None,
+            subcall_depth: None,
         }
     }
 
@@ -568,6 +586,7 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
             next_call_id: snapshot.next_call_id,
             scheduler: snapshot.scheduler,
             module_code: Some(module_code),
+            subcall_depth: None,
         }
     }
     /// Consumes the VM and creates a snapshot for pause/resume if needed.
@@ -1160,11 +1179,15 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
                     let builtin_id = fetch_u8!(cached_frame);
                     let arg_count = fetch_u8!(cached_frame) as usize;
 
-                    match self.exec_call_builtin_function(builtin_id, arg_count) {
-                        Ok(result) => self.push(result),
-                        // IP sync deferred to error path (no frame push possible)
-                        Err(err) => catch_sync!(self, cached_frame, err),
-                    }
+                    // Sync IP before call (some builtins like sorted() may call user
+                    // functions via call_sync, which pushes frames)
+                    self.current_frame_mut().ip = cached_frame.ip;
+
+                    handle_call_result!(
+                        self,
+                        cached_frame,
+                        self.exec_call_builtin_function(builtin_id, arg_count)
+                    );
                 }
                 Opcode::CallBuiltinType => {
                     // Fetch operands: type_id (u8) + arg_count (u8)
@@ -1372,6 +1395,13 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
                     }
                     // Pop current frame and push return value
                     self.pop_frame();
+
+                    // Check if we've returned to the subcall boundary — if so,
+                    // stop the run loop and return the value to call_sync().
+                    if self.subcall_depth == Some(self.frames.len()) {
+                        return Ok(FrameExit::Return(value));
+                    }
+
                     self.push(value);
                     // Reload cache from parent frame
                     reload_cache!(self, cached_frame);
@@ -1466,6 +1496,52 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
         }
         // Exception was caught, continue execution
         self.run()
+    }
+
+    /// Calls a callable synchronously within the VM run loop.
+    ///
+    /// This is used by builtins like `sorted()` that need to invoke user-defined
+    /// functions (e.g., lambda key functions) during their execution. The callable
+    /// is called as if it were a normal function call, but the run loop returns
+    /// control to the caller when the subcall completes.
+    ///
+    /// Supports builtins, defined functions (including closures/lambdas), and type
+    /// constructors. External functions are rejected since they would require
+    /// yielding to the host, which is not possible during a synchronous subcall.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The callable is an external function (cannot be called synchronously)
+    /// - The callable raises an exception
+    /// - The callable is not callable
+    pub(crate) fn call_sync(&mut self, callable: &Value, args: ArgValues) -> RunResult<Value> {
+        let callable_clone = callable.clone_with_heap(self.heap);
+        let result = self.call_function(callable_clone, args)?;
+        match result {
+            CallResult::Push(value) => Ok(value),
+            CallResult::FramePushed => {
+                // A new frame was pushed — run the VM until it returns from that frame.
+                // Save and set subcall_depth so ReturnValue knows when to stop.
+                let prev = self.subcall_depth;
+                self.subcall_depth = Some(self.frames.len() - 1);
+                let result = self.run();
+                self.subcall_depth = prev;
+                match result {
+                    Ok(FrameExit::Return(value)) => Ok(value),
+                    Err(e) => Err(e),
+                    _ => Err(RunError::internal("unexpected exit in call_sync")),
+                }
+            }
+            CallResult::External(_, args) | CallResult::OsCall(_, args) => {
+                args.drop_with_heap(self.heap);
+                Err(ExcType::type_error("key function cannot be an external function"))
+            }
+            CallResult::MethodCall(_, args) => {
+                args.drop_with_heap(self.heap);
+                Err(ExcType::type_error("key function cannot be an external function"))
+            }
+        }
     }
 
     // ========================================================================

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -17,7 +17,7 @@ use crate::{
     parse::CodeRange,
     resource::{DepthGuard, ResourceTracker},
     types::{
-        AttrCallResult, PyTrait, Str, Type, allocate_tuple,
+        CallOutcome, PyTrait, Str, Type, allocate_tuple,
         str::{StringRepr, string_repr_fmt},
     },
     value::Value,
@@ -1205,7 +1205,7 @@ impl SimpleException {
         attr_id: StringId,
         heap: &mut Heap<impl ResourceTracker>,
         _interns: &Interns,
-    ) -> RunResult<Option<AttrCallResult>> {
+    ) -> RunResult<Option<CallOutcome>> {
         if attr_id == StaticStrings::Args {
             // Construct tuple with 0 or 1 elements based on whether arg exists
             let elements = if let Some(arg_str) = &self.arg {
@@ -1214,7 +1214,7 @@ impl SimpleException {
             } else {
                 smallvec![]
             };
-            Ok(Some(AttrCallResult::Value(allocate_tuple(elements, heap)?)))
+            Ok(Some(CallOutcome::Value(allocate_tuple(elements, heap)?)))
         } else {
             Ok(None)
         }

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -20,7 +20,7 @@ use crate::{
     io::PrintWriter,
     resource::{DepthGuard, ResourceError, ResourceTracker, check_mult_size, check_repeat_size},
     types::{
-        AttrCallResult, Bytes, Dataclass, Dict, FrozenSet, List, LongInt, Module, MontyIter, NamedTuple, Path, PyTrait,
+        Bytes, CallOutcome, Dataclass, Dict, FrozenSet, List, LongInt, Module, MontyIter, NamedTuple, Path, PyTrait,
         Range, Set, Slice, Str, Tuple, Type, allocate_tuple,
     },
     value::{EitherStr, Value},
@@ -721,7 +721,7 @@ impl PyTrait for HeapData {
         args: ArgValues,
         interns: &Interns,
         print_writer: &mut PrintWriter<'_>,
-    ) -> RunResult<AttrCallResult> {
+    ) -> RunResult<CallOutcome> {
         match self {
             // List intercepts sort for key function support via PrintWriter
             Self::List(l) => l.py_call_attr_raw(self_id, heap, attr, args, interns, print_writer),
@@ -732,7 +732,7 @@ impl PyTrait for HeapData {
             // Module has special handling for OS calls (os.getenv, etc.)
             Self::Module(m) => m.py_call_attr_raw(self_id, heap, attr, args, interns, print_writer),
             // All other types use the default implementation (wrap py_call_attr)
-            _ => self.py_call_attr(heap, attr, args, interns).map(AttrCallResult::Value),
+            _ => self.py_call_attr(heap, attr, args, interns).map(CallOutcome::Value),
         }
     }
 
@@ -771,7 +771,7 @@ impl PyTrait for HeapData {
         attr_id: StringId,
         heap: &mut Heap<impl ResourceTracker>,
         interns: &Interns,
-    ) -> RunResult<Option<AttrCallResult>> {
+    ) -> RunResult<Option<CallOutcome>> {
         match self {
             Self::Dataclass(dc) => dc.py_getattr(attr_id, heap, interns),
             Self::Module(m) => Ok(m.py_getattr(attr_id, heap, interns)),
@@ -1209,7 +1209,7 @@ impl<T: ResourceTracker> Heap<T> {
         hash
     }
 
-    /// Calls an attribute on the heap entry, returning an `AttrCallResult` that may signal
+    /// Calls an attribute on the heap entry, returning an `CallOutcome` that may signal
     /// OS, external, or method calls.
     ///
     /// Temporarily takes ownership of the payload to avoid borrow conflicts when attribute
@@ -1218,7 +1218,7 @@ impl<T: ResourceTracker> Heap<T> {
     /// The `print_writer` parameter is threaded through for `list.sort(key=...)` which
     /// needs it to call builtin key functions.
     ///
-    /// Returns `AttrCallResult` which may be:
+    /// Returns `CallOutcome` which may be:
     /// - `Value(v)` - Method completed synchronously with value `v`
     /// - `OsCall(func, args)` - Method needs OS operation; VM should yield to host
     /// - `ExternalCall(id, args)` - Method needs external function call
@@ -1230,7 +1230,7 @@ impl<T: ResourceTracker> Heap<T> {
         args: ArgValues,
         interns: &Interns,
         print_writer: &mut PrintWriter<'_>,
-    ) -> RunResult<AttrCallResult> {
+    ) -> RunResult<CallOutcome> {
         // Take data out so the borrow of self.entries ends
         let mut data = take_data!(self, id, "call_attr");
 

--- a/crates/monty/src/modules/asyncio.rs
+++ b/crates/monty/src/modules/asyncio.rs
@@ -15,7 +15,7 @@ use crate::{
     intern::{Interns, StaticStrings},
     modules::ModuleFunctions,
     resource::{ResourceError, ResourceTracker},
-    types::{AttrCallResult, Module},
+    types::{CallOutcome, Module},
     value::Value,
 };
 
@@ -53,9 +53,9 @@ pub(super) fn call(
     heap: &mut Heap<impl ResourceTracker>,
     functions: AsyncioFunctions,
     args: ArgValues,
-) -> RunResult<AttrCallResult> {
+) -> RunResult<CallOutcome> {
     match functions {
-        AsyncioFunctions::Gather => gather(heap, args).map(AttrCallResult::Value),
+        AsyncioFunctions::Gather => gather(heap, args).map(CallOutcome::Value),
     }
 }
 

--- a/crates/monty/src/modules/mod.rs
+++ b/crates/monty/src/modules/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     heap::{Heap, HeapId},
     intern::{Interns, StaticStrings, StringId},
     resource::{ResourceError, ResourceTracker},
-    types::AttrCallResult,
+    types::CallOutcome,
 };
 
 pub(crate) mod asyncio;
@@ -88,9 +88,9 @@ impl fmt::Display for ModuleFunctions {
 impl ModuleFunctions {
     /// Calls the module function with the given arguments.
     ///
-    /// Returns `AttrCallResult` to support both immediate values and OS calls that
+    /// Returns `CallOutcome` to support both immediate values and OS calls that
     /// require host involvement (e.g., `os.getenv()` needs the host to provide environment variables).
-    pub fn call(self, heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> RunResult<AttrCallResult> {
+    pub fn call(self, heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> RunResult<CallOutcome> {
         match self {
             Self::Asyncio(functions) => asyncio::call(heap, functions, args),
             Self::Os(functions) => os::call(heap, functions, args),

--- a/crates/monty/src/modules/os.rs
+++ b/crates/monty/src/modules/os.rs
@@ -16,7 +16,7 @@ use crate::{
     modules::ModuleFunctions,
     os::OsFunction,
     resource::{ResourceError, ResourceTracker},
-    types::{AttrCallResult, Module, Property, PyTrait},
+    types::{CallOutcome, Module, Property, PyTrait},
     value::Value,
 };
 
@@ -64,13 +64,13 @@ pub fn create_module(heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -
 
 /// Dispatches a call to an os module function.
 ///
-/// Returns `AttrCallResult::OsCall` for functions that need host involvement,
-/// or `AttrCallResult::Value` for functions that can be computed immediately.
+/// Returns `CallOutcome::OsCall` for functions that need host involvement,
+/// or `CallOutcome::Value` for functions that can be computed immediately.
 pub(super) fn call(
     heap: &mut Heap<impl ResourceTracker>,
     functions: OsFunctions,
     args: ArgValues,
-) -> RunResult<AttrCallResult> {
+) -> RunResult<CallOutcome> {
     match functions {
         OsFunctions::Getenv => getenv(heap, args),
     }
@@ -86,7 +86,7 @@ pub(super) fn call(
 /// * `args` - Function arguments: `key` (required string), `default` (optional, defaults to None)
 ///
 /// # Returns
-/// `AttrCallResult::OsCall` with `OsFunction::Getenv` - the host should look up the
+/// `CallOutcome::OsCall` with `OsFunction::Getenv` - the host should look up the
 /// environment variable and return the value, or the default if not found.
 ///
 /// # Errors
@@ -94,7 +94,7 @@ pub(super) fn call(
 /// - No arguments are provided
 /// - More than 2 arguments are provided
 /// - `key` is not a string
-fn getenv(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> RunResult<AttrCallResult> {
+fn getenv(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> RunResult<CallOutcome> {
     // getenv(key, default=None) - accepts 1 or 2 positional arguments
     let (key, default) = args.get_one_two_args("os.getenv", heap)?;
 
@@ -105,7 +105,7 @@ fn getenv(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> RunResult<A
         let final_default = default.unwrap_or(Value::None);
         let args = ArgValues::Two(key, final_default);
 
-        Ok(AttrCallResult::OsCall(OsFunction::Getenv, args))
+        Ok(CallOutcome::OsCall(OsFunction::Getenv, args))
     } else {
         let type_name = key.py_type(heap);
         key.drop_with_heap(heap);

--- a/crates/monty/src/os.rs
+++ b/crates/monty/src/os.rs
@@ -2,7 +2,7 @@
 //!
 //! This module defines the `OsFunction` enum, which represents operations that
 //! cannot be performed in a sandboxed environment. When a type method needs to
-//! perform one of these operations, it returns an `AttrCallResult::OsCall` variant
+//! perform one of these operations, it returns an `CallOutcome::OsCall` variant
 //! with the function and arguments. The VM then yields control to the host via
 //! `FrameExit::OsCall`, allowing the host to execute the operation and resume.
 //!

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -11,7 +11,7 @@ use crate::{
     intern::{Interns, StringId},
     io::PrintWriter,
     resource::{DepthGuard, ResourceError, ResourceTracker},
-    types::{AttrCallResult, Type},
+    types::{CallOutcome, Type},
     value::{EitherStr, Value},
 };
 
@@ -293,7 +293,7 @@ impl PyTrait for Dataclass {
         args: ArgValues,
         interns: &Interns,
         _print_writer: &mut PrintWriter<'_>,
-    ) -> RunResult<AttrCallResult> {
+    ) -> RunResult<CallOutcome> {
         let attr_str = attr.as_str(interns);
         // Only public methods (no underscore prefix = no dunders, no private)
         if !attr_str.starts_with('_') && self.attrs.get_by_str(attr_str, heap, interns).is_none() {
@@ -302,10 +302,10 @@ impl PyTrait for Dataclass {
             heap.inc_ref(self_id);
             let self_arg = Value::Ref(self_id);
             let args_with_self = args.prepend(self_arg);
-            Ok(AttrCallResult::MethodCall(attr.clone(), args_with_self))
+            Ok(CallOutcome::MethodCall(attr.clone(), args_with_self))
         } else {
             // Not a method call — delegate to standard attr dispatch
-            self.py_call_attr(heap, attr, args, interns).map(AttrCallResult::Value)
+            self.py_call_attr(heap, attr, args, interns).map(CallOutcome::Value)
         }
     }
 
@@ -314,10 +314,10 @@ impl PyTrait for Dataclass {
         attr_id: StringId,
         heap: &mut Heap<impl ResourceTracker>,
         interns: &Interns,
-    ) -> RunResult<Option<AttrCallResult>> {
+    ) -> RunResult<Option<CallOutcome>> {
         let attr_name = interns.get_str(attr_id);
         match self.attrs.get_by_str(attr_name, heap, interns) {
-            Some(value) => Ok(Some(AttrCallResult::Value(value.clone_with_heap(heap)))),
+            Some(value) => Ok(Some(CallOutcome::Value(value.clone_with_heap(heap)))),
             // we use name here, not `self.py_type(heap)` hence returning a Ok(None)
             None => Err(ExcType::attribute_error(self.name(interns), attr_name)),
         }

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, fmt::Write};
 use ahash::AHashSet;
 use smallvec::SmallVec;
 
-use super::{AttrCallResult, MontyIter, PyTrait};
+use super::{CallOutcome, MontyIter, PyTrait};
 use crate::{
     args::ArgValues,
     builtins::Builtins,
@@ -441,12 +441,12 @@ impl PyTrait for List {
         args: ArgValues,
         interns: &Interns,
         print_writer: &mut PrintWriter<'_>,
-    ) -> RunResult<AttrCallResult> {
+    ) -> RunResult<CallOutcome> {
         if attr.static_string() == Some(StaticStrings::Sort) {
             do_list_sort(self, args, heap, interns, print_writer)?;
-            return Ok(AttrCallResult::Value(Value::None));
+            return Ok(CallOutcome::Value(Value::None));
         }
-        self.py_call_attr(heap, attr, args, interns).map(AttrCallResult::Value)
+        self.py_call_attr(heap, attr, args, interns).map(CallOutcome::Value)
     }
 }
 
@@ -913,7 +913,7 @@ fn call_key_function(
     match key_fn {
         Value::Builtin(Builtins::Function(builtin)) => {
             let args = ArgValues::One(elem);
-            builtin.call(heap, args, interns, print_writer)
+            builtin.call_basic(heap, args, interns, print_writer)
         }
         Value::Builtin(Builtins::Type(t)) => {
             // Type constructors (int, str, float, etc.) are callable key functions

--- a/crates/monty/src/types/mod.rs
+++ b/crates/monty/src/types/mod.rs
@@ -33,7 +33,7 @@ pub(crate) use module::Module;
 pub(crate) use namedtuple::NamedTuple;
 pub(crate) use path::Path;
 pub(crate) use property::Property;
-pub(crate) use py_trait::{AttrCallResult, PyTrait};
+pub(crate) use py_trait::{CallOutcome, PyTrait};
 pub(crate) use range::Range;
 pub(crate) use set::{FrozenSet, Set};
 pub(crate) use slice::Slice;

--- a/crates/monty/src/types/module.rs
+++ b/crates/monty/src/types/module.rs
@@ -7,7 +7,7 @@ use crate::{
     intern::{Interns, StringId},
     io::PrintWriter,
     resource::ResourceTracker,
-    types::{AttrCallResult, Dict, PyTrait},
+    types::{CallOutcome, Dict, PyTrait},
     value::{EitherStr, Value},
 };
 
@@ -108,14 +108,14 @@ impl Module {
         attr_id: StringId,
         heap: &mut Heap<impl ResourceTracker>,
         interns: &Interns,
-    ) -> Option<AttrCallResult> {
+    ) -> Option<CallOutcome> {
         let value = self.attrs.get_by_str(interns.get_str(attr_id), heap, interns)?;
 
         // If the value is a Property, invoke its getter to compute the actual value
         if let Value::Property(prop) = *value {
             Some(prop.get())
         } else {
-            Some(AttrCallResult::Value(value.clone_with_heap(heap)))
+            Some(CallOutcome::Value(value.clone_with_heap(heap)))
         }
     }
 
@@ -124,7 +124,7 @@ impl Module {
     /// Modules don't have methods - they have callable attributes. This looks up
     /// the attribute and calls it if it's a `ModuleFunction`.
     ///
-    /// Returns `AttrCallResult` because module functions may need OS operations
+    /// Returns `CallOutcome` because module functions may need OS operations
     /// (e.g., `os.getenv()`) that require host involvement.
     pub fn py_call_attr_raw(
         &self,
@@ -134,7 +134,7 @@ impl Module {
         args: ArgValues,
         interns: &Interns,
         _print_writer: &mut PrintWriter<'_>,
-    ) -> RunResult<AttrCallResult> {
+    ) -> RunResult<CallOutcome> {
         let mut args_guard = HeapGuard::new(args, heap);
 
         let attr_key = match attr {

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -25,7 +25,7 @@ use crate::{
     heap::{Heap, HeapId},
     intern::{Interns, StringId},
     resource::{DepthGuard, ResourceError, ResourceTracker},
-    types::{AttrCallResult, Type},
+    types::{CallOutcome, Type},
     value::{EitherStr, Value},
 };
 
@@ -261,9 +261,9 @@ impl PyTrait for NamedTuple {
         attr_id: StringId,
         heap: &mut Heap<impl ResourceTracker>,
         interns: &Interns,
-    ) -> RunResult<Option<AttrCallResult>> {
+    ) -> RunResult<Option<CallOutcome>> {
         if let Some(value) = self.get_by_name(attr_id, interns) {
-            Ok(Some(AttrCallResult::Value(value.clone_with_heap(heap))))
+            Ok(Some(CallOutcome::Value(value.clone_with_heap(heap))))
         } else {
             // we use name here, not `self.py_type(heap)` hence returning a Ok(None)
             Err(ExcType::attribute_error(self.name(interns), interns.get_str(attr_id)))

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -18,7 +18,7 @@ use crate::{
     io::PrintWriter,
     os::OsFunction,
     resource::{DepthGuard, ResourceError, ResourceTracker},
-    types::{AttrCallResult, PyTrait, Str, Type, allocate_tuple},
+    types::{CallOutcome, PyTrait, Str, Type, allocate_tuple},
     value::{EitherStr, Value},
 };
 
@@ -509,9 +509,9 @@ impl PyTrait for Path {
         args: ArgValues,
         interns: &Interns,
         _print_writer: &mut PrintWriter<'_>,
-    ) -> RunResult<AttrCallResult> {
+    ) -> RunResult<CallOutcome> {
         let Some(method) = attr.static_string() else {
-            return self.py_call_attr(heap, attr, args, interns).map(AttrCallResult::Value);
+            return self.py_call_attr(heap, attr, args, interns).map(CallOutcome::Value);
         };
 
         // Check if this is an OS method that requires host system access
@@ -519,11 +519,11 @@ impl PyTrait for Path {
             // Package path as first argument for OS call (as Path, not string)
             let path_arg = Value::Ref(heap.allocate(HeapData::Path(self.clone()))?);
             let os_args = prepend_path_arg(path_arg, args);
-            return Ok(AttrCallResult::OsCall(os_fn, os_args));
+            return Ok(CallOutcome::OsCall(os_fn, os_args));
         }
 
         // Fall back to py_call_attr for pure methods
-        self.py_call_attr(heap, attr, args, interns).map(AttrCallResult::Value)
+        self.py_call_attr(heap, attr, args, interns).map(CallOutcome::Value)
     }
 
     fn py_getattr(
@@ -531,7 +531,7 @@ impl PyTrait for Path {
         attr_id: StringId,
         heap: &mut Heap<impl ResourceTracker>,
         interns: &Interns,
-    ) -> RunResult<Option<AttrCallResult>> {
+    ) -> RunResult<Option<CallOutcome>> {
         let v = match StaticStrings::from_string_id(attr_id) {
             // Properties returning strings
             Some(StaticStrings::Name) => {
@@ -580,6 +580,6 @@ impl PyTrait for Path {
             // NOTE: For method calls, we'd need to return a bound method. For now, properties only.
             _ => return Err(ExcType::attribute_error(Type::Path, interns.get_str(attr_id))),
         };
-        Ok(Some(AttrCallResult::Value(v)))
+        Ok(Some(CallOutcome::Value(v)))
     }
 }

--- a/crates/monty/src/types/property.rs
+++ b/crates/monty/src/types/property.rs
@@ -4,7 +4,7 @@
 //! When a Property is retrieved via `py_getattr`, its getter is invoked
 //! rather than returning the Property itself.
 
-use crate::{args::ArgValues, os::OsFunction, types::AttrCallResult};
+use crate::{args::ArgValues, os::OsFunction, types::CallOutcome};
 
 /// Property descriptor for computed attributes.
 ///
@@ -23,13 +23,13 @@ pub(crate) enum Property {
 }
 
 impl Property {
-    /// Invokes the property getter, returning the appropriate `AttrCallResult`.
+    /// Invokes the property getter, returning the appropriate `CallOutcome`.
     ///
-    /// For OS properties, returns `AttrCallResult::OsCall` to signal the VM
+    /// For OS properties, returns `CallOutcome::OsCall` to signal the VM
     /// should yield to the host for the value.
-    pub fn get(self) -> AttrCallResult {
+    pub fn get(self) -> CallOutcome {
         match self {
-            Self::Os(os_fn) => AttrCallResult::OsCall(os_fn, ArgValues::Empty),
+            Self::Os(os_fn) => CallOutcome::OsCall(os_fn, ArgValues::Empty),
         }
     }
 }

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -24,25 +24,20 @@ use crate::{
     value::{EitherStr, Value},
 };
 
-/// Result of calling an attribute method via `py_call_attr_raw`.
+/// Result of a call that may require host involvement beyond a simple return value.
 ///
-/// This enum enables attribute methods to signal different outcomes to the VM:
+/// Used by attribute methods (`py_call_attr_raw`), builtin functions, and module
+/// functions to signal different outcomes to the VM:
 /// - `Value`: The call completed synchronously with a return value
 /// - `OsCall`: The method needs an OS operation; VM should yield to host
 /// - `ExternalCall`: The method needs to call an external function
+/// - `MethodCall`: A dataclass method call; VM should yield to host
 ///
-/// This unifies the pattern where `call_function` returns `CallResult` to indicate
-/// different outcomes. Types that only support synchronous attribute calls can
+/// The VM converts these into the appropriate `FrameExit` variant or pushes the
+/// value onto the stack. Types that only support synchronous attribute calls can
 /// use the default `py_call_attr_raw` implementation which wraps `py_call_attr`.
-///
-/// # Future Extensibility
-///
-/// When needed for features like `list.sort(key=func)`, we can add:
-/// ```ignore
-/// CallFunction(Value, ArgValues)  // Call a callable, result becomes attr result
-/// ```
 #[derive(Debug)]
-pub enum AttrCallResult {
+pub enum CallOutcome {
     /// Call completed synchronously with a value to return.
     Value(Value),
 
@@ -321,14 +316,14 @@ pub trait PyTrait {
         Err(ExcType::attribute_error(self.py_type(heap), attr.as_str(interns)))
     }
 
-    /// Calls an attribute method, returning an `AttrCallResult` that may signal OS, external,
+    /// Calls an attribute method, returning an `CallOutcome` that may signal OS, external,
     /// or method calls.
     ///
     /// This method enables types to signal that they need operations the VM cannot perform
     /// directly (OS operations, external function calls, dataclass method calls). The VM
     /// converts the result to the appropriate `FrameExit` variant.
     ///
-    /// The default implementation wraps `py_call_attr` in `AttrCallResult::Value`. Types that
+    /// The default implementation wraps `py_call_attr` in `CallOutcome::Value`. Types that
     /// need to perform OS/external operations, intercept specific methods (e.g. `list.sort`),
     /// or detect method calls (e.g. dataclass methods) should override this method.
     ///
@@ -340,10 +335,10 @@ pub trait PyTrait {
     ///
     /// # Returns
     ///
-    /// - `Ok(AttrCallResult::Value(v))` - Method completed synchronously with value `v`
-    /// - `Ok(AttrCallResult::OsCall(func, args))` - Method needs OS operation; VM yields to host
-    /// - `Ok(AttrCallResult::ExternalCall(id, args))` - Method needs external function call
-    /// - `Ok(AttrCallResult::MethodCall(attr, args))` - Dataclass method call; VM yields to host
+    /// - `Ok(CallOutcome::Value(v))` - Method completed synchronously with value `v`
+    /// - `Ok(CallOutcome::OsCall(func, args))` - Method needs OS operation; VM yields to host
+    /// - `Ok(CallOutcome::ExternalCall(id, args))` - Method needs external function call
+    /// - `Ok(CallOutcome::MethodCall(attr, args))` - Dataclass method call; VM yields to host
     /// - `Err(e)` - Method call failed with error
     fn py_call_attr_raw(
         &mut self,
@@ -353,9 +348,9 @@ pub trait PyTrait {
         args: ArgValues,
         interns: &Interns,
         _print_writer: &mut PrintWriter<'_>,
-    ) -> RunResult<AttrCallResult> {
+    ) -> RunResult<CallOutcome> {
         let value = self.py_call_attr(heap, attr, args, interns)?;
-        Ok(AttrCallResult::Value(value))
+        Ok(CallOutcome::Value(value))
     }
 
     /// Estimates the memory size in bytes of this value.
@@ -425,7 +420,7 @@ pub trait PyTrait {
         _attr_id: StringId,
         _heap: &mut Heap<impl ResourceTracker>,
         _interns: &Interns,
-    ) -> RunResult<Option<AttrCallResult>> {
+    ) -> RunResult<Option<CallOutcome>> {
         Ok(None)
     }
 }

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -14,7 +14,7 @@ use crate::{
     heap::{Heap, HeapData, HeapId},
     intern::{Interns, StaticStrings, StringId},
     resource::{DepthGuard, ResourceError, ResourceTracker},
-    types::{AttrCallResult, PyTrait, Type},
+    types::{CallOutcome, PyTrait, Type},
     value::Value,
 };
 
@@ -231,12 +231,12 @@ impl PyTrait for Slice {
         attr_id: StringId,
         _heap: &mut Heap<impl ResourceTracker>,
         _interns: &Interns,
-    ) -> RunResult<Option<AttrCallResult>> {
+    ) -> RunResult<Option<CallOutcome>> {
         // Slice attributes are computed values (Int or None), return Cow::Owned
         match StaticStrings::from_string_id(attr_id) {
-            Some(StaticStrings::Start) => Ok(Some(AttrCallResult::Value(option_i64_to_value(self.start)))),
-            Some(StaticStrings::Stop) => Ok(Some(AttrCallResult::Value(option_i64_to_value(self.stop)))),
-            Some(StaticStrings::Step) => Ok(Some(AttrCallResult::Value(option_i64_to_value(self.step)))),
+            Some(StaticStrings::Start) => Ok(Some(CallOutcome::Value(option_i64_to_value(self.start)))),
+            Some(StaticStrings::Stop) => Ok(Some(CallOutcome::Value(option_i64_to_value(self.stop)))),
+            Some(StaticStrings::Step) => Ok(Some(CallOutcome::Value(option_i64_to_value(self.step)))),
             _ => Ok(None),
         }
     }

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -25,7 +25,7 @@ use crate::{
         check_repeat_size,
     },
     types::{
-        AttrCallResult, LongInt, Property, PyTrait, Str, Type,
+        CallOutcome, LongInt, Property, PyTrait, Str, Type,
         bytes::{bytes_repr_fmt, get_byte_at_index, get_bytes_slice},
         path,
         str::{allocate_char, get_char_at_index, get_str_slice, string_repr_fmt},
@@ -1724,7 +1724,7 @@ impl Value {
         name_id: StringId,
         heap: &mut Heap<impl ResourceTracker>,
         interns: &Interns,
-    ) -> RunResult<AttrCallResult> {
+    ) -> RunResult<CallOutcome> {
         match self {
             Self::Ref(heap_id) => {
                 // Use with_entry_mut to get access to both data and heap without borrow conflicts.
@@ -1739,7 +1739,7 @@ impl Value {
                 if name_id == StaticStrings::DunderName {
                     let name_str = t.to_string();
                     let str_id = heap.allocate(HeapData::Str(Str::from(name_str)))?;
-                    return Ok(AttrCallResult::Value(Self::Ref(str_id)));
+                    return Ok(CallOutcome::Value(Self::Ref(str_id)));
                 }
             }
             _ => {}

--- a/crates/monty/test_cases/builtin__sorted_kwargs.py
+++ b/crates/monty/test_cases/builtin__sorted_kwargs.py
@@ -1,0 +1,20 @@
+# === reverse=True ===
+assert sorted([3, 1, 2], reverse=True) == [3, 2, 1], 'reverse int list'
+assert sorted([1, 2, 3], reverse=False) == [1, 2, 3], 'reverse=False is default'
+assert sorted([], reverse=True) == [], 'reverse empty'
+assert sorted('cab', reverse=True) == ['c', 'b', 'a'], 'reverse string iterable'
+
+# === key function (lambda) ===
+assert sorted([3, 1, 2], key=lambda x: -x) == [3, 2, 1], 'key negate'
+assert sorted(['banana', 'apple', 'cherry'], key=lambda s: len(s)) == ['apple', 'banana', 'cherry'], 'key len'
+assert sorted([(1, 'b'), (2, 'a'), (1, 'a')], key=lambda t: t[1]) == [(2, 'a'), (1, 'a'), (1, 'b')], 'key element'
+
+# === key function (builtin) ===
+assert sorted([3, -1, 2], key=abs) == [-1, 2, 3], 'key abs'
+
+# === key + reverse ===
+assert sorted([3, 1, 2], key=lambda x: -x, reverse=True) == [1, 2, 3], 'key + reverse'
+
+# === key=None (default) ===
+assert sorted([3, 1, 2], key=None) == [1, 2, 3], 'key None default'
+assert sorted([3, 1, 2], key=None, reverse=True) == [3, 2, 1], 'key None + reverse'


### PR DESCRIPTION
part of #163.

Plant from claude:

---

# Plan: Add `key=` and `reverse=` support to `sorted()`

## Context

`sorted()` currently rejects all keyword arguments (`kwargs.not_supported_yet()`). The goal is to support `sorted([3,1,2], key=lambda x: -x)` and `sorted([3,1,2], reverse=True)`, including user-defined key functions (lambdas).

The key architectural change: extend `BuiltinsFunctions::call` to take a VM context and return `CallOutcome` (renamed from `AttrCallResult`), so builtins can call user-defined functions via `VM::call_sync`. Business logic stays in the builtin files.

## Changes

### 1. Rename `AttrCallResult` → `CallOutcome`

Use `/fastmod` to rename across the codebase. `CallOutcome` is more general since it's used by builtins, modules, heap types, and attribute calls — not just attribute calls.

**Files:** ~15 files across `types/`, `modules/`, `heap.rs`, `value.rs`, `exception_private.rs`, `bytecode/vm/call.rs`

### 2. Extend `BuiltinsFunctions::call` signature

**File:** `crates/monty/src/builtins/mod.rs`

```rust
impl BuiltinsFunctions {
    /// Primary call method with VM context for full function calling capability.
    pub(crate) fn call<T: ResourceTracker>(
        self,
        vm: &mut VM<'_, '_, T>,
        args: ArgValues,
    ) -> RunResult<CallOutcome> {
        match self {
            // Sorted needs VM for call_sync (key functions)
            Self::Sorted => sorted::builtin_sorted(vm, args),
            // All other builtins delegate to call_basic
            _ => self.call_basic(vm.heap, args, vm.interns, vm.print_writer)
                     .map(CallOutcome::Value),
        }
    }

    /// Basic call without VM context.
    /// Used by call_key_function in list.sort where VM isn't available.
    pub(crate) fn call_basic(
        self,
        heap: &mut Heap<impl ResourceTracker>,
        args: ArgValues,
        interns: &Interns,
        print_writer: &mut PrintWriter<'_>,
    ) -> RunResult<Value> {
        // Existing dispatch logic unchanged
        match self { ... }
    }
}
```

This keeps most builtin implementations unchanged. Only builtins needing VM access (sorted, later map) are handled in `call` directly.

Similarly update `Builtins::call` to take `&mut VM` and return `RunResult<CallOutcome>`, delegating `Type::call` through `.map(CallOutcome::Value)`.

### 3. Make VM fields accessible & implement `ContainsHeap`

**File:** `crates/monty/src/bytecode/vm/mod.rs`

Make `heap`, `interns`, `print_writer` fields `pub(crate)` so builtins receiving `&mut VM` can access them directly (enabling split borrows that avoid conflicts with `call_sync`).

Implement `ContainsHeap` for VM so `defer_drop!(value, vm)` works:
```rust
impl<T: ResourceTracker> ContainsHeap for VM<'_, '_, T> {
    type ResourceTracker = T;
    fn heap_mut(&mut self) -> &mut Heap<T> { self.heap }
}
```

### 4. Add `VM::call_sync` for calling functions synchronously

**File:** `crates/monty/src/bytecode/vm/mod.rs`

Add `subcall_depth: Option<usize>` field to VM. Add method:

```rust
pub(crate) fn call_sync(&mut self, callable: &Value, args: ArgValues) -> RunResult<Value> {
    let callable_clone = callable.clone_with_heap(self.heap);
    let result = self.call_function(callable_clone, args)?;
    match result {
        CallResult::Push(value) => Ok(value),
        CallResult::FramePushed => {
            let prev = self.subcall_depth;
            self.subcall_depth = Some(self.frames.len() - 1);
            let result = self.run();
            self.subcall_depth = prev;
            match result {
                Ok(FrameExit::Return(value)) => Ok(value),
                Err(e) => Err(e),
                _ => Err(RunError::internal("unexpected exit in call_sync")),
            }
        }
        _ => Err(ExcType::type_error("key function cannot be an external function")),
    }
}
```

### 5. Modify `ReturnValue` handler for subcall boundary

**File:** `crates/monty/src/bytecode/vm/mod.rs`

After `self.pop_frame()` in the `ReturnValue` opcode handler, check:
```rust
if Some(self.frames.len()) == self.subcall_depth {
    return Ok(FrameExit::Return(value));
}
```

### 6. Modify `handle_exception` for subcall boundary

**File:** `crates/monty/src/bytecode/vm/exceptions.rs`

Before unwinding past the subcall boundary frame, stop and return the error:
```rust
if let Some(depth) = this.subcall_depth {
    if this.frames.len() <= depth + 1 {
        this.pop_frame();
        return Some(error);
    }
}
```

### 7. Update VM call sites

**File:** `crates/monty/src/bytecode/vm/call.rs`

- `call_function`: Change `Value::Builtin(builtin) => builtin.call(self, args)` (pass VM, handle `CallOutcome`)
- `exec_call_builtin_function`: Change to use `builtin.call(self, args)`, return type becomes `Result<CallResult, RunError>`
- Update `CallBuiltinFunction` opcode dispatch in `mod.rs` to use `handle_call_result!` instead of direct push

Remove `CallResult` enum — replace with `CallOutcome` plus `FramePushed` (either merge or keep `CallResult` as a simple conversion from `CallOutcome` plus `FramePushed`). Actually, keep `CallResult` as VM-internal with `FramePushed` variant, and convert from `CallOutcome` via the existing `From` impl (renamed).

### 8. Implement `builtin_sorted` with kwargs

**File:** `crates/monty/src/builtins/sorted.rs`

```rust
pub fn builtin_sorted<T: ResourceTracker>(
    vm: &mut VM<'_, '_, T>,
    args: ArgValues,
) -> RunResult<CallOutcome> {
    let (positional, kwargs) = args.into_parts();
    // Parse kwargs: key and reverse (reuse extract pattern from list.sort)
    // Collect items from iterable
    // If key_fn provided and not None:
    //   for each item: vm.call_sync(&key_fn, One(item.clone_with_heap(vm.heap)))
    // Sort using index-based permutation (same pattern as do_list_sort)
    // with reverse flag
    // Return sorted list as CallOutcome::Value(...)
}
```

Key implementation details:
- Use `defer_drop!` with `vm` (works because VM implements `ContainsHeap`)
- Sequential borrows: `vm.heap` for cloning items, then `vm.call_sync()` for key functions — borrows don't overlap
- Sorting uses index permutation pattern from `do_list_sort` (`crates/monty/src/types/list.rs:800-895`)
- `key=None` treated as no key function (same as Python)
- Handle `DepthGuard` for `py_cmp` calls during sorting

### 9. Update `call_key_function` in list.rs

**File:** `crates/monty/src/types/list.rs`

Change from calling `builtin.call(heap, args, interns, print_writer)` to `builtin.call_basic(heap, args, interns, print_writer)`. This preserves the current behavior (builtin-only key functions for `list.sort`).

### 10. Add tests

**File:** `crates/monty/test_cases/builtin__sorted_kwargs.py` (new, separate file because kwargs path uses different compilation)

```python
# === reverse=True ===
assert sorted([3, 1, 2], reverse=True) == [3, 2, 1], 'reverse int list'
assert sorted([1, 2, 3], reverse=False) == [1, 2, 3], 'reverse=False is default'
assert sorted([], reverse=True) == [], 'reverse empty'
assert sorted('cab', reverse=True) == ['c', 'b', 'a'], 'reverse string iterable'

# === key function (lambda) ===
assert sorted([3, 1, 2], key=lambda x: -x) == [3, 2, 1], 'key negate'
assert sorted(['banana', 'apple', 'cherry'], key=lambda s: len(s)) == ['apple', 'banana', 'cherry'], 'key len'
assert sorted([(1, 'b'), (2, 'a'), (1, 'a')], key=lambda t: t[1]) == [(2, 'a'), (1, 'a'), (1, 'b')], 'key element'

# === key function (builtin) ===
assert sorted([3, -1, 2], key=abs) == [-1, 2, 3], 'key abs'

# === key + reverse ===
assert sorted([3, 1, 2], key=lambda x: -x, reverse=True) == [1, 2, 3], 'key + reverse'

# === key=None (default) ===
assert sorted([3, 1, 2], key=None) == [1, 2, 3], 'key None default'
assert sorted([3, 1, 2], key=None, reverse=True) == [3, 2, 1], 'key None + reverse'
```

## Files summary

| File | Change |
|------|--------|
| ~15 files | Rename `AttrCallResult` → `CallOutcome` |
| `crates/monty/src/builtins/mod.rs` | Split `call` into `call` (VM) + `call_basic` (old) |
| `crates/monty/src/builtins/sorted.rs` | Full rewrite with VM, kwargs, key/reverse support |
| `crates/monty/src/bytecode/vm/mod.rs` | `pub(crate)` fields, `ContainsHeap` impl, `subcall_depth`, `call_sync`, `ReturnValue` check |
| `crates/monty/src/bytecode/vm/exceptions.rs` | Subcall boundary in `handle_exception` |
| `crates/monty/src/bytecode/vm/call.rs` | Update `call_function`, `exec_call_builtin_function` for new signature |
| `crates/monty/src/types/list.rs` | `call_key_function` uses `call_basic` |
| `crates/monty/test_cases/builtin__sorted_kwargs.py` | New test file |

## Verification

```bash
# Run new sorted kwargs tests
cargo test -p monty --test datatest_runner --features ref-count-panic sorted_kwargs

# Run existing sorted tests (regression check)
cargo test -p monty --test datatest_runner --features ref-count-panic builtin__more_iter_funcs

# Run ref-count-panic tests (leak detection)
make test-ref-count-panic

# Format and lint
make format-rs && make lint-rs
```
