### PR TITLE
Remove use of `take_data!` from get/set cell value methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,7 +1623,6 @@ dependencies = [
  "postcard",
  "pprof",
  "pyo3",
- "pyo3-build-config",
  "ruff_python_ast",
  "ruff_python_parser",
  "ruff_text_size",

--- a/crates/monty/Cargo.toml
+++ b/crates/monty/Cargo.toml
@@ -51,9 +51,6 @@ serde_json = "1.0"
 pprof = { version = "0.15", features = ["flamegraph", "criterion"] }
 similar = "2.7.0"
 
-[build-dependencies]
-pyo3-build-config = "0.28"
-
 [[bench]]
 name = "main"
 harness = false

--- a/crates/monty/build.rs
+++ b/crates/monty/build.rs
@@ -1,5 +1,0 @@
-fn main() {
-    // This ensures that the tests and benchmarks link to exact path to libpython, which avoids need
-    // to manually set LD_LIBRARY_PATH when running them.
-    pyo3_build_config::add_libpython_rpath_link_args();
-}


### PR DESCRIPTION
As per #167, I don't like `take_data!`.

This PR is a small simplification which avoids two needless calls to `take_data!` inside the cell methods, where it's not needed anyway.