### PR TITLE
Forward printCallback in JS runMontyAsync

### DIFF
--- a/crates/monty-js/__test__/async.spec.ts
+++ b/crates/monty-js/__test__/async.spec.ts
@@ -296,3 +296,55 @@ factorial(5)
 
   t.is(result, 120)
 })
+
+// =============================================================================
+// printCallback tests
+// =============================================================================
+
+test('runMontyAsync with printCallback', async (t) => {
+  const m = new Monty('print("hello from async")')
+  const output: string[] = []
+
+  const result = await runMontyAsync(m, {
+    printCallback: (stream, text) => {
+      t.is(stream, 'stdout')
+      output.push(text)
+    },
+  })
+
+  t.is(result, null)
+  t.deepEqual(output, ['hello from async', '\n'])
+})
+
+test('runMontyAsync printCallback with external functions', async (t) => {
+  const m = new Monty('x = get_value()\nprint(f"got {x}")\nx', {
+    externalFunctions: ['get_value'],
+  })
+  const output: string[] = []
+
+  const result = await runMontyAsync(m, {
+    externalFunctions: {
+      get_value: () => 42,
+    },
+    printCallback: (stream, text) => {
+      t.is(stream, 'stdout')
+      output.push(text)
+    },
+  })
+
+  t.is(result, 42)
+  t.deepEqual(output, ['got 42', '\n'])
+})
+
+test('runMontyAsync printCallback with multiple prints', async (t) => {
+  const m = new Monty('print("a")\nprint("b")\nprint("c")')
+  const output: string[] = []
+
+  await runMontyAsync(m, {
+    printCallback: (_stream, text) => {
+      output.push(text)
+    },
+  })
+
+  t.deepEqual(output, ['a', '\n', 'b', '\n', 'c', '\n'])
+})

--- a/crates/monty-js/wrapper.ts
+++ b/crates/monty-js/wrapper.ts
@@ -529,6 +529,8 @@ export interface RunMontyAsyncOptions {
   externalFunctions?: Record<string, (...args: unknown[]) => unknown>
   /** Resource limits. */
   limits?: ResourceLimits
+  /** Callback invoked on each print() call. The first argument is the stream name (always "stdout"), the second is the printed text. */
+  printCallback?: (stream: string, text: string) => void
 }
 
 /**
@@ -561,11 +563,12 @@ export interface RunMontyAsyncOptions {
  * });
  */
 export async function runMontyAsync(montyRunner: Monty, options: RunMontyAsyncOptions = {}): Promise<JsMontyObject> {
-  const { inputs, externalFunctions = {}, limits } = options
+  const { inputs, externalFunctions = {}, limits, printCallback } = options
 
   let progress: MontySnapshot | MontyComplete = montyRunner.start({
     inputs,
     limits,
+    printCallback,
   })
 
   while (progress instanceof MontySnapshot) {


### PR DESCRIPTION
> **This is a PR authored by Claude Code. A human wants to capture stdout from Monty on the JavaScript side and found that `runMontyAsync` doesn't support it, even though the underlying API does.**

## Problem

The Python `run_monty_async` function accepts a `print_callback` parameter and forwards it to `monty_runner.start()`:

```python
# Python — works
async def run_monty_async(
    monty_runner, *, print_callback=None, ...
):
    progress = await run_in_pool(
        partial(monty_runner.start, ..., print_callback=print_callback)
    )
```

The JS `runMontyAsync` function does **not** have a `printCallback` option, even though `StartOptions` already supports it:

```typescript
// JS — printCallback is missing from RunMontyAsyncOptions
export async function runMontyAsync(montyRunner, options = {}) {
  const { inputs, externalFunctions = {}, limits } = options
  let progress = montyRunner.start({ inputs, limits })  // no printCallback
```

This means JS users who want to capture `print()` output while using async external functions have to reimplement the entire `runMontyAsync` loop themselves just to pass `printCallback` through to `start()`.

## Fix

Two small changes to `crates/monty-js/wrapper.ts`:

1. Add `printCallback` to the `RunMontyAsyncOptions` interface
2. Destructure it from `options` and forward it to `montyRunner.start()`

This matches what the Python side already does.

## Tests

Three new tests in `crates/monty-js/__test__/async.spec.ts`:

- `runMontyAsync with printCallback` — basic print capture
- `runMontyAsync printCallback with external functions` — print capture works alongside async external function calls
- `runMontyAsync printCallback with multiple prints` — multiple `print()` calls accumulate correctly

All 289 tests pass locally (including the 3 new ones).

## Context

We're building an Electron app ([nanalogue-gui](https://github.com/sathish-t/nanalogue-gui)) that uses Monty as a sandboxed Python interpreter for an AI chat feature. The LLM generates Python code that runs in Monty with async external functions. We want to capture `print()` output so we can feed it back to the LLM as debugging context. Without this fix, we'd need to duplicate the `runMontyAsync` implementation in our codebase.