### PR TITLE
remove some uses of `Heap::with_two`

### DIFF
--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -648,6 +648,10 @@ impl PyTrait for HeapData {
             (Self::List(a), Self::List(b)) => a.py_add(b, heap, interns),
             (Self::Tuple(a), Self::Tuple(b)) => a.py_add(b, heap, interns),
             (Self::Dict(a), Self::Dict(b)) => a.py_add(b, heap, interns),
+            (Self::LongInt(a), Self::LongInt(b)) => {
+                let bi = a.inner() + b.inner();
+                Ok(LongInt::new(bi).into_value(heap).map(Some)?)
+            }
             // Cells and Dataclasses don't support arithmetic operations
             _ => Ok(None),
         }
@@ -666,6 +670,10 @@ impl PyTrait for HeapData {
             (Self::Dict(a), Self::Dict(b)) => a.py_sub(b, heap),
             (Self::Set(a), Self::Set(b)) => a.py_sub(b, heap),
             (Self::FrozenSet(a), Self::FrozenSet(b)) => a.py_sub(b, heap),
+            (Self::LongInt(a), Self::LongInt(b)) => {
+                let bi = a.inner() - b.inner();
+                Ok(LongInt::new(bi).into_value(heap).map(Some)?)
+            }
             // Cells don't support arithmetic operations
             _ => Ok(None),
         }
@@ -1414,15 +1422,11 @@ impl<T: ResourceTracker> Heap<T> {
     ///
     /// Returns `Ok(None)` if the heap entry is neither a LongInt nor a sequence type.
     pub fn mult_ref_by_i64(&mut self, id: HeapId, int_val: i64) -> RunResult<Option<Value>> {
-        let data = take_data!(self, id, "mult_ref_by_i64");
-
-        if let HeapData::LongInt(li) = &data {
+        if let HeapData::LongInt(li) = self.get(id) {
             check_mult_size(li.bits(), i64_bits(int_val), &self.tracker)?;
             let result = LongInt::new(li.inner().clone()) * LongInt::from(int_val);
-            restore_data!(self, id, data, "mult_ref_by_i64");
             Ok(Some(result.into_value(self)?))
         } else {
-            restore_data!(self, id, data, "mult_ref_by_i64");
             let count = i64_to_repeat_count(int_val)?;
             self.mult_sequence(id, count)
         }
@@ -1430,47 +1434,26 @@ impl<T: ResourceTracker> Heap<T> {
 
     /// Multiplies two heap-allocated values.
     ///
-    /// Uses `with_two` to take both entries out once, then matches on the pair:
-    /// - `LongInt * LongInt`: integer multiplication with size pre-check
-    /// - `LongInt * sequence` or `sequence * LongInt`: sequence repetition
-    /// - Anything else: returns `Ok(None)` for unsupported type combinations
+    /// Returns Ok(None) for unsupported type combinations.
     pub fn mult_heap_values(&mut self, id1: HeapId, id2: HeapId) -> RunResult<Option<Value>> {
-        // Extract the information we need from a single lookup of both values
-        enum MultKind {
-            LongInts { a_bits: u64, b_bits: u64 },
-            SeqTimesLong { seq_id: HeapId, count: usize },
-            Unsupported,
-        }
-
-        let kind = self.with_two(id1, id2, |_heap, left, right| match (left, right) {
-            (HeapData::LongInt(a), HeapData::LongInt(b)) => Ok(MultKind::LongInts {
-                a_bits: a.bits(),
-                b_bits: b.bits(),
-            }),
-            (_, HeapData::LongInt(li)) => {
-                longint_to_repeat_count(li).map(|c| MultKind::SeqTimesLong { seq_id: id1, count: c })
+        let (seq_id, count) = match (self.get(id1), self.get(id2)) {
+            (HeapData::LongInt(a), HeapData::LongInt(b)) => {
+                check_mult_size(a.bits(), b.bits(), &self.tracker)?;
+                let result = LongInt::new(a.inner() * b.inner());
+                return Ok(Some(result.into_value(self)?));
             }
             (HeapData::LongInt(li), _) => {
-                longint_to_repeat_count(li).map(|c| MultKind::SeqTimesLong { seq_id: id2, count: c })
+                let count = longint_to_repeat_count(li)?;
+                (id2, count)
             }
-            _ => Ok(MultKind::Unsupported),
-        })?;
+            (_, HeapData::LongInt(li)) => {
+                let count = longint_to_repeat_count(li)?;
+                (id1, count)
+            }
+            _ => return Ok(None),
+        };
 
-        match kind {
-            MultKind::LongInts { a_bits, b_bits } => {
-                check_mult_size(a_bits, b_bits, &self.tracker)?;
-                Ok(self.with_two(id1, id2, |heap, left, right| {
-                    if let (HeapData::LongInt(a), HeapData::LongInt(b)) = (left, right) {
-                        let result = LongInt::new(a.inner() * b.inner());
-                        result.into_value(heap).map(Some)
-                    } else {
-                        Ok(None)
-                    }
-                })?)
-            }
-            MultKind::SeqTimesLong { seq_id, count } => self.mult_sequence(seq_id, count),
-            MultKind::Unsupported => Ok(None),
-        }
+        self.mult_sequence(seq_id, count)
     }
 
     /// Multiplies (repeats) a sequence by an integer count.

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -292,13 +292,11 @@ impl PyTrait for Value {
                 }
             }
             // Ref vs Ref comparison: handles LongInt and Str
-            (Self::Ref(id1), Self::Ref(id2)) => {
-                Ok(heap.with_two(*id1, *id2, |_heap, left, right| match (left, right) {
-                    (HeapData::LongInt(a), HeapData::LongInt(b)) => a.inner().partial_cmp(b.inner()),
-                    (HeapData::Str(a), HeapData::Str(b)) => a.as_str().partial_cmp(b.as_str()),
-                    _ => None,
-                }))
-            }
+            (Self::Ref(id1), Self::Ref(id2)) => match (heap.get(*id1), heap.get(*id2)) {
+                (HeapData::LongInt(a), HeapData::LongInt(b)) => Ok(a.inner().partial_cmp(b.inner())),
+                (HeapData::Str(a), HeapData::Str(b)) => Ok(a.as_str().partial_cmp(b.as_str())),
+                _ => Ok(None),
+            },
             // Interned string comparisons
             (Self::InternString(s1), Self::InternString(s2)) => {
                 Ok(interns.get_str(*s1).partial_cmp(interns.get_str(*s2)))
@@ -445,18 +443,9 @@ impl PyTrait for Value {
                 }
             }
             // Int + LongInt
-            (Self::Int(a), Self::Ref(id)) => {
+            (Self::Int(i), Self::Ref(id)) | (Self::Ref(id), Self::Int(i)) => {
                 if let HeapData::LongInt(li) = heap.get(*id) {
-                    let result = LongInt::from(*a) + LongInt::new(li.inner().clone());
-                    result.into_value(heap).map(Some)
-                } else {
-                    Ok(None)
-                }
-            }
-            // LongInt + Int
-            (Self::Ref(id), Self::Int(b)) => {
-                if let HeapData::LongInt(li) = heap.get(*id) {
-                    let result = LongInt::new(li.inner().clone()) + LongInt::from(*b);
+                    let result = LongInt::new(li.inner() + i);
                     result.into_value(heap).map(Some)
                 } else {
                     Ok(None)
@@ -467,21 +456,7 @@ impl PyTrait for Value {
             (Self::Int(a), Self::Float(b)) => Ok(Some(Self::Float(*a as f64 + b))),
             (Self::Float(a), Self::Int(b)) => Ok(Some(Self::Float(a + *b as f64))),
             (Self::Ref(id1), Self::Ref(id2)) => {
-                // Check if both are LongInts
-                let is_longint1 = matches!(heap.get(*id1), HeapData::LongInt(_));
-                let is_longint2 = matches!(heap.get(*id2), HeapData::LongInt(_));
-                if is_longint1 && is_longint2 {
-                    heap.with_two(*id1, *id2, |heap, left, right| {
-                        if let (HeapData::LongInt(a), HeapData::LongInt(b)) = (left, right) {
-                            let result = LongInt::new(a.inner() + b.inner());
-                            result.into_value(heap).map(Some)
-                        } else {
-                            Ok(None)
-                        }
-                    })
-                } else {
-                    heap.with_two(*id1, *id2, |heap, left, right| left.py_add(right, heap, interns))
-                }
+                heap.with_two(*id1, *id2, |heap, left, right| left.py_add(right, heap, interns))
             }
             (Self::InternString(s1), Self::InternString(s2)) => {
                 let concat = format!("{}{}", interns.get_str(*s1), interns.get_str(*s2));
@@ -574,22 +549,7 @@ impl PyTrait for Value {
                 }
             }
             // LongInt - LongInt
-            (Self::Ref(id1), Self::Ref(id2)) => {
-                let is_longint1 = matches!(heap.get(*id1), HeapData::LongInt(_));
-                let is_longint2 = matches!(heap.get(*id2), HeapData::LongInt(_));
-                if is_longint1 && is_longint2 {
-                    heap.with_two(*id1, *id2, |heap, left, right| {
-                        if let (HeapData::LongInt(a), HeapData::LongInt(b)) = (left, right) {
-                            let result = LongInt::new(a.inner() - b.inner());
-                            result.into_value(heap).map(Some)
-                        } else {
-                            Ok(None)
-                        }
-                    })
-                } else {
-                    Ok(None)
-                }
-            }
+            (Self::Ref(id1), Self::Ref(id2)) => heap.with_two(*id1, *id2, |heap, left, right| left.py_sub(right, heap)),
             // Float - Float
             (Self::Float(a), Self::Float(b)) => Ok(Some(Self::Float(a - b))),
             // Int - Float and Float - Int
@@ -642,26 +602,7 @@ impl PyTrait for Value {
                 Ok(Some(LongInt::new(bi).into_value(heap)?))
             }
             // LongInt % LongInt
-            (Self::Ref(id1), Self::Ref(id2)) => {
-                let is_longint1 = matches!(heap.get(*id1), HeapData::LongInt(_));
-                let is_longint2 = matches!(heap.get(*id2), HeapData::LongInt(_));
-                if is_longint1 && is_longint2 {
-                    // Check for zero division first
-                    if matches!(heap.get(*id2), HeapData::LongInt(li) if li.is_zero()) {
-                        return Err(ExcType::zero_division().into());
-                    }
-                    Ok(heap.with_two(*id1, *id2, |heap, left, right| {
-                        if let (HeapData::LongInt(a), HeapData::LongInt(b)) = (left, right) {
-                            let bi = a.inner().mod_floor(b.inner());
-                            LongInt::new(bi).into_value(heap).map(Some)
-                        } else {
-                            Ok(None)
-                        }
-                    })?)
-                } else {
-                    Ok(None)
-                }
-            }
+            (Self::Ref(id1), Self::Ref(id2)) => heap.with_two(*id1, *id2, |heap, left, right| left.py_mod(right, heap)),
             (Self::Float(v1), Self::Float(v2)) => {
                 if *v2 == 0.0 {
                     Err(ExcType::zero_division().into())
@@ -939,30 +880,19 @@ impl PyTrait for Value {
                     Ok(None)
                 }
             }
-            // LongInt / LongInt or LongInt / Float or Float / LongInt
-            (Self::Ref(id1), Self::Ref(id2)) => {
-                let is_longint1 = matches!(heap.get(*id1), HeapData::LongInt(_));
-                let is_longint2 = matches!(heap.get(*id2), HeapData::LongInt(_));
-                if is_longint1 && is_longint2 {
-                    // Check for zero division first
-                    if matches!(heap.get(*id2), HeapData::LongInt(li) if li.is_zero()) {
-                        return Err(ExcType::zero_division().into());
+            // LongInt / LongInt
+            (Self::Ref(id1), Self::Ref(id2)) => match (heap.get(*id1), heap.get(*id2)) {
+                (HeapData::LongInt(li1), HeapData::LongInt(li2)) => {
+                    if li2.is_zero() {
+                        Err(ExcType::zero_division().into())
+                    } else {
+                        let a_f64 = li1.to_f64().unwrap_or(f64::INFINITY);
+                        let b_f64 = li2.to_f64().unwrap_or(f64::INFINITY);
+                        Ok(Some(Self::Float(a_f64 / b_f64)))
                     }
-                    Ok(
-                        heap.with_two(*id1, *id2, |_heap, left, right| -> RunResult<Option<Self>> {
-                            if let (HeapData::LongInt(a), HeapData::LongInt(b)) = (left, right) {
-                                let a_f64 = a.to_f64().unwrap_or(f64::INFINITY);
-                                let b_f64 = b.to_f64().unwrap_or(f64::INFINITY);
-                                Ok(Some(Self::Float(a_f64 / b_f64)))
-                            } else {
-                                Ok(None)
-                            }
-                        })?,
-                    )
-                } else {
-                    Ok(None)
                 }
-            }
+                _ => Ok(None),
+            },
             // LongInt / Float
             (Self::Ref(id), Self::Float(b)) => {
                 if let HeapData::LongInt(li) = heap.get(*id) {
@@ -1100,26 +1030,17 @@ impl PyTrait for Value {
                 }
             }
             // LongInt // LongInt
-            (Self::Ref(id1), Self::Ref(id2)) => {
-                let is_longint1 = matches!(heap.get(*id1), HeapData::LongInt(_));
-                let is_longint2 = matches!(heap.get(*id2), HeapData::LongInt(_));
-                if is_longint1 && is_longint2 {
-                    // Check for zero division first
-                    if matches!(heap.get(*id2), HeapData::LongInt(li) if li.is_zero()) {
-                        return Err(ExcType::zero_division().into());
+            (Self::Ref(id1), Self::Ref(id2)) => match (heap.get(*id1), heap.get(*id2)) {
+                (HeapData::LongInt(li1), HeapData::LongInt(li2)) => {
+                    if li2.is_zero() {
+                        Err(ExcType::zero_division().into())
+                    } else {
+                        let bi = li1.inner().div_floor(li2.inner());
+                        Ok(Some(LongInt::new(bi).into_value(heap)?))
                     }
-                    Ok(heap.with_two(*id1, *id2, |heap, left, right| {
-                        if let (HeapData::LongInt(a), HeapData::LongInt(b)) = (left, right) {
-                            let bi = a.inner().div_floor(b.inner());
-                            LongInt::new(bi).into_value(heap).map(Some)
-                        } else {
-                            Ok(None)
-                        }
-                    })?)
-                } else {
-                    Ok(None)
                 }
-            }
+                _ => Ok(None),
+            },
             // Float floor division returns float
             (Self::Float(a), Self::Float(b)) => {
                 if *b == 0.0 {


### PR DESCRIPTION
All uses of `Heap::with_two` are antipatterns due to `take_data!` used internally being an antipattern - it doesn't work well with re-entrancy and introduces overhead of moving the data in & out of the heap.

This PR removes some uses of `with_two` that can be trivially removed.