### PR TITLE
merge `py_call_attr` and `py_call_attr_raw`

### DIFF
--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -268,7 +268,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
     /// Calls an attribute on an object.
     ///
     /// For heap-allocated objects (`Value::Ref`), dispatches to the type's
-    /// attribute call implementation via `heap.call_attr_raw()`, which may return
+    /// attribute call implementation via `Heap::call_attr()`, which may return
     /// `AttrCallResult::OsCall`, `AttrCallResult::ExternalCall`, or
     /// `AttrCallResult::MethodCall` for operations that require host involvement.
     ///
@@ -281,7 +281,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
         match obj {
             Value::Ref(heap_id) => {
                 defer_drop!(obj, this);
-                let result = Heap::call_attr_raw(this, heap_id, &attr, args);
+                let result = Heap::call_attr(this, heap_id, &attr, args);
                 result.map(Into::into)
             }
             Value::InternString(string_id) => {

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -615,45 +615,23 @@ impl PyTrait for HeapData {
 
     fn py_call_attr(
         &mut self,
-        heap: &mut Heap<impl ResourceTracker>,
-        attr: &EitherStr,
-        args: ArgValues,
-        interns: &Interns,
-    ) -> RunResult<Value> {
-        match self {
-            Self::Str(s) => s.py_call_attr(heap, attr, args, interns),
-            Self::Bytes(b) => b.py_call_attr(heap, attr, args, interns),
-            Self::List(l) => l.py_call_attr(heap, attr, args, interns),
-            Self::Tuple(t) => t.py_call_attr(heap, attr, args, interns),
-            Self::Dict(d) => d.py_call_attr(heap, attr, args, interns),
-            Self::Set(s) => s.py_call_attr(heap, attr, args, interns),
-            Self::FrozenSet(fs) => fs.py_call_attr(heap, attr, args, interns),
-            Self::Dataclass(dc) => dc.py_call_attr(heap, attr, args, interns),
-            Self::Path(p) => p.py_call_attr(heap, attr, args, interns),
-            _ => Err(ExcType::attribute_error(self.py_type(heap), attr.as_str(interns))),
-        }
-    }
-
-    fn py_call_attr_raw(
-        &mut self,
         self_id: HeapId,
         vm: &mut VM<'_, '_, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<AttrCallResult> {
         match self {
-            // List intercepts sort for key function support via PrintWriter
-            Self::List(l) => l.py_call_attr_raw(self_id, vm, attr, args),
-            // Dataclass detects public method calls and returns MethodCall
-            Self::Dataclass(dc) => dc.py_call_attr_raw(self_id, vm, attr, args),
-            // Path has special handling for OS calls (exists, read_text, etc.)
-            Self::Path(p) => p.py_call_attr_raw(self_id, vm, attr, args),
-            // Module has special handling for OS calls (os.getenv, etc.)
-            Self::Module(m) => m.py_call_attr_raw(self_id, vm, attr, args),
-            // All other types use the default implementation (wrap py_call_attr)
-            _ => self
-                .py_call_attr(vm.heap, attr, args, vm.interns)
-                .map(AttrCallResult::Value),
+            Self::Str(s) => s.py_call_attr(self_id, vm, attr, args),
+            Self::Bytes(b) => b.py_call_attr(self_id, vm, attr, args),
+            Self::List(l) => l.py_call_attr(self_id, vm, attr, args),
+            Self::Tuple(t) => t.py_call_attr(self_id, vm, attr, args),
+            Self::Dict(d) => d.py_call_attr(self_id, vm, attr, args),
+            Self::Set(s) => s.py_call_attr(self_id, vm, attr, args),
+            Self::FrozenSet(fs) => fs.py_call_attr(self_id, vm, attr, args),
+            Self::Dataclass(dc) => dc.py_call_attr(self_id, vm, attr, args),
+            Self::Path(p) => p.py_call_attr(self_id, vm, attr, args),
+            Self::Module(m) => m.py_call_attr(self_id, vm, attr, args),
+            _ => Err(ExcType::attribute_error(self.py_type(vm.heap), attr.as_str(vm.interns))),
         }
     }
 
@@ -1230,18 +1208,12 @@ impl<T: ResourceTracker> Heap<T> {
     /// Temporarily takes ownership of the payload to avoid borrow conflicts when attribute
     /// implementations also need mutable heap access (e.g. for refcounting).
     ///
-    /// The `print_writer` parameter is threaded through for `list.sort(key=...)` which
-    /// needs it to call builtin key functions.
-    ///
     /// Returns `AttrCallResult` which may be:
     /// - `Value(v)` - Method completed synchronously with value `v`
     /// - `OsCall(func, args)` - Method needs OS operation; VM should yield to host
     /// - `ExternalCall(id, args)` - Method needs external function call
     /// - `MethodCall(name, args)` - Dataclass method call; VM should yield to host
-    pub fn call_attr_raw(
-        // FIXME: this is pretty awkward - the `take_data!` pattern is probably a code
-        // smell. We need the full VM here to enable method implementations to enter
-        // user-defined functions.
+    pub fn call_attr(
         vm: &mut VM<'_, '_, T>,
         id: HeapId,
         attr: &EitherStr,
@@ -1251,11 +1223,11 @@ impl<T: ResourceTracker> Heap<T> {
         let heap = &mut *vm.heap;
         let mut data = take_data!(heap, id, "call_attr");
 
-        let result = data.py_call_attr_raw(id, vm, attr, args);
+        let result = data.py_call_attr(id, vm, attr, args);
 
         // Restore data
         let heap = &mut *vm.heap;
-        restore_data!(heap, id, data, "call_attr_raw");
+        restore_data!(heap, id, data, "call_attr");
         result
     }
 

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -637,45 +637,23 @@ impl PyTrait for HeapDataMut<'_> {
 
     fn py_call_attr(
         &mut self,
-        heap: &mut Heap<impl ResourceTracker>,
-        attr: &EitherStr,
-        args: ArgValues,
-        interns: &Interns,
-    ) -> RunResult<Value> {
-        match self {
-            Self::Str(s) => s.py_call_attr(heap, attr, args, interns),
-            Self::Bytes(b) => b.py_call_attr(heap, attr, args, interns),
-            Self::List(l) => l.py_call_attr(heap, attr, args, interns),
-            Self::Tuple(t) => t.py_call_attr(heap, attr, args, interns),
-            Self::Dict(d) => d.py_call_attr(heap, attr, args, interns),
-            Self::Set(s) => s.py_call_attr(heap, attr, args, interns),
-            Self::FrozenSet(fs) => fs.py_call_attr(heap, attr, args, interns),
-            Self::Dataclass(dc) => dc.py_call_attr(heap, attr, args, interns),
-            Self::Path(p) => p.py_call_attr(heap, attr, args, interns),
-            _ => Err(ExcType::attribute_error(self.py_type(heap), attr.as_str(interns))),
-        }
-    }
-
-    fn py_call_attr_raw(
-        &mut self,
         self_id: HeapId,
         vm: &mut VM<'_, '_, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<AttrCallResult> {
         match self {
-            // List intercepts sort for key function support via PrintWriter
-            Self::List(l) => l.py_call_attr_raw(self_id, vm, attr, args),
-            // Dataclass detects public method calls and returns MethodCall
-            Self::Dataclass(dc) => dc.py_call_attr_raw(self_id, vm, attr, args),
-            // Path has special handling for OS calls (exists, read_text, etc.)
-            Self::Path(p) => p.py_call_attr_raw(self_id, vm, attr, args),
-            // Module has special handling for OS calls (os.getenv, etc.)
-            Self::Module(m) => m.py_call_attr_raw(self_id, vm, attr, args),
-            // All other types use the default implementation (wrap py_call_attr)
-            _ => self
-                .py_call_attr(vm.heap, attr, args, vm.interns)
-                .map(AttrCallResult::Value),
+            Self::Str(s) => s.py_call_attr(self_id, vm, attr, args),
+            Self::Bytes(b) => b.py_call_attr(self_id, vm, attr, args),
+            Self::List(l) => l.py_call_attr(self_id, vm, attr, args),
+            Self::Tuple(t) => t.py_call_attr(self_id, vm, attr, args),
+            Self::Dict(d) => d.py_call_attr(self_id, vm, attr, args),
+            Self::Set(s) => s.py_call_attr(self_id, vm, attr, args),
+            Self::FrozenSet(fs) => fs.py_call_attr(self_id, vm, attr, args),
+            Self::Dataclass(dc) => dc.py_call_attr(self_id, vm, attr, args),
+            Self::Path(p) => p.py_call_attr(self_id, vm, attr, args),
+            Self::Module(m) => m.py_call_attr(self_id, vm, attr, args),
+            _ => Err(ExcType::attribute_error(self.py_type(vm.heap), attr.as_str(vm.interns))),
         }
     }
 

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -70,9 +70,10 @@ use std::fmt::Write;
 use ahash::AHashSet;
 use smallvec::smallvec;
 
-use super::{MontyIter, PyTrait, Type, str::Str};
+use super::{MontyIter, PyTrait, Type, py_trait::AttrCallResult, str::Str};
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult, SimpleException},
     heap::{DropWithHeap, Heap, HeapData, HeapGuard, HeapId},
@@ -312,17 +313,19 @@ impl PyTrait for Bytes {
 
     fn py_call_attr(
         &mut self,
-        heap: &mut Heap<impl ResourceTracker>,
+        _self_id: HeapId,
+        vm: &mut VM<impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
-        interns: &Interns,
-    ) -> RunResult<Value> {
+    ) -> RunResult<AttrCallResult> {
+        let heap = &mut *vm.heap;
+        let interns = vm.interns;
         let Some(method) = attr.static_string() else {
             args.drop_with_heap(heap);
             return Err(ExcType::attribute_error(Type::Bytes, attr.as_str(interns)));
         };
 
-        call_bytes_method_impl(self.as_slice(), method, args, heap, interns)
+        call_bytes_method_impl(self.as_slice(), method, args, heap, interns).map(AttrCallResult::Value)
     }
 }
 

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -263,55 +263,44 @@ impl PyTrait for Dataclass {
         Ok(())
     }
 
-    fn py_call_attr(
-        &mut self,
-        heap: &mut Heap<impl ResourceTracker>,
-        attr: &EitherStr,
-        args: ArgValues,
-        interns: &Interns,
-    ) -> RunResult<Value> {
-        // Public method calls are intercepted by py_call_attr_raw before reaching
-        // this method. This path is reached for:
-        // - Private/dunder attributes that aren't in attrs (AttributeError)
-        // - Attributes that exist in attrs but aren't callable (TypeError)
-        let method_name = attr.as_str(interns);
-        defer_drop!(args, heap);
-
-        // If the attribute exists in attrs, it's a data value (not callable)
-        if let Some(value) = self.attrs.get_by_str(method_name, heap, interns) {
-            let type_name = value.py_type(heap);
-            Err(ExcType::type_error_not_callable_object(type_name))
-        } else {
-            // Attribute doesn't exist — use the class name (e.g., "Point") not "Dataclass"
-            Err(ExcType::attribute_error(self.name(interns), method_name))
-        }
-    }
-
     /// Performs lazy method detection for dataclass instances.
     ///
     /// If the attribute is a public name (no leading underscore) not found in the
     /// dataclass's attrs dict, returns `MethodCall` so the VM yields to the host.
-    /// Otherwise falls through to `py_call_attr`.
-    fn py_call_attr_raw(
+    /// Otherwise handles the call directly:
+    /// - Attributes that exist in attrs but aren't callable produce `TypeError`
+    /// - Private/dunder attributes that aren't in attrs produce `AttributeError`
+    fn py_call_attr(
         &mut self,
         self_id: HeapId,
-        vm: &mut VM<'_, '_, impl ResourceTracker>,
+        vm: &mut VM<impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<AttrCallResult> {
-        let attr_str = attr.as_str(vm.interns);
+        let heap = &mut *vm.heap;
+        let interns = vm.interns;
+        let attr_str = attr.as_str(interns);
         // Only public methods (no underscore prefix = no dunders, no private)
-        if !attr_str.starts_with('_') && self.attrs.get_by_str(attr_str, vm.heap, vm.interns).is_none() {
+        if !attr_str.starts_with('_') && self.attrs.get_by_str(attr_str, heap, interns).is_none() {
             // Clone self and prepend to args for the method call
             // inc_ref works even when data is taken out (refcount metadata is separate)
-            vm.heap.inc_ref(self_id);
+            heap.inc_ref(self_id);
             let self_arg = Value::Ref(self_id);
             let args_with_self = args.prepend(self_arg);
             Ok(AttrCallResult::MethodCall(attr.clone(), args_with_self))
         } else {
-            // Not a method call — delegate to standard attr dispatch
-            self.py_call_attr(vm.heap, attr, args, vm.interns)
-                .map(AttrCallResult::Value)
+            // Not a method call — handle directly
+            let method_name = attr.as_str(interns);
+            defer_drop!(args, heap);
+
+            // If the attribute exists in attrs, it's a data value (not callable)
+            if let Some(value) = self.attrs.get_by_str(method_name, heap, interns) {
+                let type_name = value.py_type(heap);
+                Err(ExcType::type_error_not_callable_object(type_name))
+            } else {
+                // Attribute doesn't exist — use the class name (e.g., "Point") not "Dataclass"
+                Err(ExcType::attribute_error(self.name(interns), method_name))
+            }
         }
     }
 

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -8,9 +8,10 @@ use ahash::AHashSet;
 use hashbrown::{HashTable, hash_table::Entry};
 use smallvec::smallvec;
 
-use super::{List, MontyIter, PyTrait, allocate_tuple};
+use super::{List, MontyIter, PyTrait, allocate_tuple, py_trait::AttrCallResult};
 use crate::{
     args::{ArgValues, KwargsValues},
+    bytecode::VM,
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult},
     heap::{DropWithHeap, Heap, HeapData, HeapGuard, HeapId},
@@ -548,17 +549,19 @@ impl PyTrait for Dict {
 
     fn py_call_attr(
         &mut self,
-        heap: &mut Heap<impl ResourceTracker>,
+        _self_id: HeapId,
+        vm: &mut VM<impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
-        interns: &Interns,
-    ) -> RunResult<Value> {
+    ) -> RunResult<AttrCallResult> {
+        let heap = &mut *vm.heap;
+        let interns = vm.interns;
         let Some(method) = attr.static_string() else {
             args.drop_with_heap(heap);
             return Err(ExcType::attribute_error(Type::Dict, attr.as_str(interns)));
         };
 
-        match method {
+        let value = match method {
             StaticStrings::Get => {
                 // dict.get() accepts 1 or 2 arguments
                 let (key, default) = args.get_one_two_args("get", heap)?;
@@ -636,9 +639,10 @@ impl PyTrait for Dict {
             StaticStrings::Fromkeys => dict_fromkeys(args, heap, interns),
             _ => {
                 args.drop_with_heap(heap);
-                Err(ExcType::attribute_error(Type::Dict, attr.as_str(interns)))
+                return Err(ExcType::attribute_error(Type::Dict, attr.as_str(interns)));
             }
-        }
+        };
+        value.map(AttrCallResult::Value)
     }
 }
 

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -413,28 +413,12 @@ impl PyTrait for List {
         Ok(true)
     }
 
+    /// Intercepts `sort` to call `do_list_sort` (which needs `PrintWriter` for key functions),
+    /// and delegates all other methods to `call_list_method`.
     fn py_call_attr(
         &mut self,
-        heap: &mut Heap<impl ResourceTracker>,
-        attr: &EitherStr,
-        args: ArgValues,
-        interns: &Interns,
-    ) -> RunResult<Value> {
-        let args_guard = HeapGuard::new(args, heap);
-        let Some(method) = attr.static_string() else {
-            return Err(ExcType::attribute_error(Type::List, attr.as_str(interns)));
-        };
-
-        let (args, heap) = args_guard.into_parts();
-        call_list_method(self, method, args, heap, interns)
-    }
-
-    /// Intercepts `sort` to call `do_list_sort` (which needs `PrintWriter` for key functions),
-    /// and delegates all other methods to `py_call_attr`.
-    fn py_call_attr_raw(
-        &mut self,
         _self_id: HeapId,
-        vm: &mut VM<'_, '_, impl ResourceTracker>,
+        vm: &mut VM<impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<AttrCallResult> {
@@ -442,8 +426,15 @@ impl PyTrait for List {
             do_list_sort(self, args, vm)?;
             return Ok(AttrCallResult::Value(Value::None));
         }
-        self.py_call_attr(vm.heap, attr, args, vm.interns)
-            .map(AttrCallResult::Value)
+        let heap = &mut *vm.heap;
+        let interns = vm.interns;
+        let args_guard = HeapGuard::new(args, heap);
+        let Some(method) = attr.static_string() else {
+            return Err(ExcType::attribute_error(Type::List, attr.as_str(interns)));
+        };
+
+        let (args, heap) = args_guard.into_parts();
+        call_list_method(self, method, args, heap, interns).map(AttrCallResult::Value)
     }
 }
 
@@ -490,7 +481,7 @@ fn call_list_method(
             list.items.reverse();
             Ok(Value::None)
         }
-        // Note: list.sort is handled by py_call_attr_raw which intercepts it
+        // Note: list.sort is handled by py_call_attr which intercepts it before reaching here
         _ => {
             args.drop_with_heap(heap);
             Err(ExcType::attribute_error(Type::List, method.into()))

--- a/crates/monty/src/types/module.rs
+++ b/crates/monty/src/types/module.rs
@@ -125,7 +125,7 @@ impl Module {
     ///
     /// Returns `AttrCallResult` because module functions may need OS operations
     /// (e.g., `os.getenv()`) that require host involvement.
-    pub fn py_call_attr_raw(
+    pub fn py_call_attr(
         &self,
         _self_id: HeapId,
         vm: &mut VM<'_, '_, impl ResourceTracker>,

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -491,20 +491,36 @@ impl PyTrait for Path {
         std::mem::size_of::<Self>() + self.path.capacity()
     }
 
+    /// Handles attribute calls on Path objects, including both pure methods (no I/O)
+    /// and OS methods that require host system access.
+    ///
+    /// OS methods (exists, read_text, etc.) are detected via `OsFunction::try_from`
+    /// and returned as `AttrCallResult::OsCall` for the VM to yield to the host.
+    /// Pure methods (is_absolute, joinpath, etc.) are handled directly.
     fn py_call_attr(
         &mut self,
-        heap: &mut Heap<impl ResourceTracker>,
+        _self_id: HeapId,
+        vm: &mut VM<impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
-        interns: &Interns,
-    ) -> RunResult<Value> {
+    ) -> RunResult<AttrCallResult> {
+        let heap = &mut *vm.heap;
+        let interns = vm.interns;
         let Some(method) = attr.static_string() else {
             args.drop_with_heap(heap);
             return Err(ExcType::attribute_error(Type::Path, attr.as_str(interns)));
         };
 
-        match method {
-            // Pure methods (no I/O)
+        // Check if this is an OS method that requires host system access
+        if let Ok(os_fn) = OsFunction::try_from(method) {
+            // Package path as first argument for OS call (as Path, not string)
+            let path_arg = Value::Ref(heap.allocate(HeapData::Path(self.clone()))?);
+            let os_args = prepend_path_arg(path_arg, args);
+            return Ok(AttrCallResult::OsCall(os_fn, os_args));
+        }
+
+        // Pure methods (no I/O)
+        let value = match method {
             StaticStrings::IsAbsolute => {
                 args.check_zero_args("is_absolute", heap)?;
                 Ok(Value::Bool(self.is_absolute()))
@@ -551,35 +567,10 @@ impl PyTrait for Path {
             }
             _ => {
                 args.drop_with_heap(heap);
-                Err(ExcType::attribute_error(Type::Path, attr.as_str(interns)))
+                return Err(ExcType::attribute_error(Type::Path, attr.as_str(interns)));
             }
-        }
-    }
-
-    fn py_call_attr_raw(
-        &mut self,
-        _self_id: HeapId,
-        vm: &mut VM<'_, '_, impl ResourceTracker>,
-        attr: &EitherStr,
-        args: ArgValues,
-    ) -> RunResult<AttrCallResult> {
-        let Some(method) = attr.static_string() else {
-            return self
-                .py_call_attr(vm.heap, attr, args, vm.interns)
-                .map(AttrCallResult::Value);
         };
-
-        // Check if this is an OS method that requires host system access
-        if let Ok(os_fn) = OsFunction::try_from(method) {
-            // Package path as first argument for OS call (as Path, not string)
-            let path_arg = Value::Ref(vm.heap.allocate(HeapData::Path(self.clone()))?);
-            let os_args = prepend_path_arg(path_arg, args);
-            return Ok(AttrCallResult::OsCall(os_fn, os_args));
-        }
-
-        // Fall back to py_call_attr for pure methods
-        self.py_call_attr(vm.heap, attr, args, vm.interns)
-            .map(AttrCallResult::Value)
+        value.map(AttrCallResult::Value)
     }
 
     fn py_getattr(

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -24,7 +24,7 @@ use crate::{
     value::{EitherStr, Value},
 };
 
-/// Result of calling an attribute method via `py_call_attr_raw`.
+/// Result of calling an attribute method via `py_call_attr`.
 ///
 /// This enum enables attribute methods to signal different outcomes to the VM:
 /// - `Value`: The call completed synchronously with a return value
@@ -32,8 +32,8 @@ use crate::{
 /// - `ExternalCall`: The method needs to call an external function
 ///
 /// This unifies the pattern where `call_function` returns `CallResult` to indicate
-/// different outcomes. Types that only support synchronous attribute calls can
-/// use the default `py_call_attr_raw` implementation which wraps `py_call_attr`.
+/// different outcomes. Types that only support synchronous attribute calls should
+/// wrap their return value with `AttrCallResult::Value`.
 ///
 /// # Future Extensibility
 ///
@@ -62,7 +62,7 @@ pub enum AttrCallResult {
     /// Dataclass method call — VM should yield `FrameExit::MethodCall` to host.
     ///
     /// Carries the method name (e.g. `"distance"`) and args with self prepended.
-    /// This is detected by `call_dataclass_attr_raw` when a public attribute name is not
+    /// This is detected by `Dataclass::py_call_attr` when a public attribute name is not
     /// found in the dataclass's attrs dict.
     MethodCall(EitherStr, ArgValues),
     /// The method returned a value that should be implicitly awaited.
@@ -296,30 +296,17 @@ pub trait PyTrait {
         Ok(None)
     }
 
-    /// Calls an attribute method on this value (e.g., `list.append()`).
-    ///
-    /// Returns an error if the attribute doesn't exist or the arguments are invalid.
-    /// Generic over ResourceTracker to work with any heap configuration.
-    fn py_call_attr(
-        &mut self,
-        heap: &mut Heap<impl ResourceTracker>,
-        attr: &EitherStr,
-        _args: ArgValues,
-        interns: &Interns,
-    ) -> RunResult<Value> {
-        Err(ExcType::attribute_error(self.py_type(heap), attr.as_str(interns)))
-    }
-
-    /// Calls an attribute method, returning an `AttrCallResult` that may signal OS, external,
-    /// or method calls.
+    /// Calls an attribute method on this value (e.g., `list.append()`), returning an
+    /// `AttrCallResult` that may signal OS, external, or method calls.
     ///
     /// This method enables types to signal that they need operations the VM cannot perform
     /// directly (OS operations, external function calls, dataclass method calls). The VM
     /// converts the result to the appropriate `FrameExit` variant.
     ///
-    /// The default implementation wraps `py_call_attr` in `AttrCallResult::Value`. Types that
-    /// need to perform OS/external operations, intercept specific methods (e.g. `list.sort`),
-    /// or detect method calls (e.g. dataclass methods) should override this method.
+    /// Types that only support synchronous attribute calls should wrap their return value
+    /// with `AttrCallResult::Value`. Types that need to perform OS/external operations,
+    /// intercept specific methods (e.g. `list.sort`), or detect method calls (e.g. dataclass
+    /// methods) should return the appropriate `AttrCallResult` variant.
     ///
     /// # Arguments
     /// * `self_id` - The heap ID of this value, needed by types that must reference themselves
@@ -332,15 +319,14 @@ pub trait PyTrait {
     /// - `Ok(AttrCallResult::ExternalCall(id, args))` - Method needs external function call
     /// - `Ok(AttrCallResult::MethodCall(attr, args))` - Dataclass method call; VM yields to host
     /// - `Err(e)` - Method call failed with error
-    fn py_call_attr_raw(
+    fn py_call_attr(
         &mut self,
         _self_id: HeapId,
         vm: &mut VM<impl ResourceTracker>,
         attr: &EitherStr,
-        args: ArgValues,
+        _args: ArgValues,
     ) -> RunResult<AttrCallResult> {
-        let value = self.py_call_attr(vm.heap, attr, args, vm.interns)?;
-        Ok(AttrCallResult::Value(value))
+        Err(ExcType::attribute_error(self.py_type(vm.heap), attr.as_str(vm.interns)))
     }
 
     /// Estimates the memory size in bytes of this value.

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -3,9 +3,10 @@ use std::fmt::Write;
 use ahash::AHashSet;
 use hashbrown::HashTable;
 
-use super::{MontyIter, PyTrait};
+use super::{MontyIter, PyTrait, py_trait::AttrCallResult};
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult},
     heap::{DropWithHeap, Heap, HeapData, HeapId},
@@ -635,12 +636,14 @@ impl PyTrait for Set {
 
     fn py_call_attr(
         &mut self,
-        heap: &mut Heap<impl ResourceTracker>,
+        _self_id: HeapId,
+        vm: &mut VM<impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
-        interns: &Interns,
-    ) -> RunResult<Value> {
-        match attr.static_string() {
+    ) -> RunResult<AttrCallResult> {
+        let heap = &mut *vm.heap;
+        let interns = vm.interns;
+        let value = match attr.static_string() {
             Some(StaticStrings::Add) => {
                 let value = args.get_one_arg("set.add", heap)?;
                 self.add(value, heap, interns)?;
@@ -719,9 +722,10 @@ impl PyTrait for Set {
             }
             _ => {
                 args.drop_with_heap(heap);
-                Err(ExcType::attribute_error(Type::Set, attr.as_str(interns)))
+                return Err(ExcType::attribute_error(Type::Set, attr.as_str(interns)));
             }
-        }
+        };
+        value.map(AttrCallResult::Value)
     }
 
     fn py_sub(
@@ -1137,12 +1141,14 @@ impl PyTrait for FrozenSet {
 
     fn py_call_attr(
         &mut self,
-        heap: &mut Heap<impl ResourceTracker>,
+        _self_id: HeapId,
+        vm: &mut VM<impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
-        interns: &Interns,
-    ) -> RunResult<Value> {
-        match attr.static_string() {
+    ) -> RunResult<AttrCallResult> {
+        let heap = &mut *vm.heap;
+        let interns = vm.interns;
+        let value = match attr.static_string() {
             Some(StaticStrings::Copy) => {
                 args.check_zero_args("frozenset.copy", heap)?;
                 let copy = self.copy(heap);
@@ -1206,9 +1212,10 @@ impl PyTrait for FrozenSet {
             }
             _ => {
                 args.drop_with_heap(heap);
-                Err(ExcType::attribute_error(Type::FrozenSet, attr.as_str(interns)))
+                return Err(ExcType::attribute_error(Type::FrozenSet, attr.as_str(interns)));
             }
-        }
+        };
+        value.map(AttrCallResult::Value)
     }
 
     fn py_sub(

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -8,9 +8,10 @@ use std::{borrow::Cow, fmt};
 use ahash::AHashSet;
 use smallvec::smallvec;
 
-use super::{Bytes, MontyIter, PyTrait};
+use super::{Bytes, MontyIter, PyTrait, py_trait::AttrCallResult};
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult},
     heap::{DropWithHeap, Heap, HeapData, HeapGuard, HeapId},
@@ -312,18 +313,20 @@ impl PyTrait for Str {
 
     fn py_call_attr(
         &mut self,
-        heap: &mut Heap<impl ResourceTracker>,
+        _self_id: HeapId,
+        vm: &mut VM<impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
-        interns: &Interns,
-    ) -> RunResult<Value> {
+    ) -> RunResult<AttrCallResult> {
+        let heap = &mut *vm.heap;
+        let interns = vm.interns;
         let args_guard = HeapGuard::new(args, heap);
         let Some(method) = attr.static_string() else {
             return Err(ExcType::attribute_error(Type::Str, attr.as_str(interns)));
         };
 
         let (args, heap) = args_guard.into_parts();
-        call_str_method_impl(&self.0, method, args, heap, interns)
+        call_str_method_impl(&self.0, method, args, heap, interns).map(AttrCallResult::Value)
     }
 }
 

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -29,9 +29,11 @@ pub(crate) type TupleVec = SmallVec<[Value; TUPLE_INLINE_CAPACITY]>;
 use super::{
     MontyIter, PyTrait,
     list::{get_slice_items, repr_sequence_fmt},
+    py_trait::AttrCallResult,
 };
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult},
     heap::{Heap, HeapData, HeapGuard, HeapId},
@@ -251,20 +253,22 @@ impl PyTrait for Tuple {
 
     fn py_call_attr(
         &mut self,
-        heap: &mut Heap<impl ResourceTracker>,
+        _self_id: HeapId,
+        vm: &mut VM<impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
-        interns: &Interns,
-    ) -> RunResult<Value> {
+    ) -> RunResult<AttrCallResult> {
+        let heap = &mut *vm.heap;
+        let interns = vm.interns;
         let args_guard = HeapGuard::new(args, heap);
         match attr.static_string() {
             Some(StaticStrings::Index) => {
                 let (args, heap) = args_guard.into_parts();
-                tuple_index(self, args, heap, interns)
+                tuple_index(self, args, heap, interns).map(AttrCallResult::Value)
             }
             Some(StaticStrings::Count) => {
                 let (args, heap) = args_guard.into_parts();
-                tuple_count(self, args, heap, interns)
+                tuple_count(self, args, heap, interns).map(AttrCallResult::Value)
             }
             _ => Err(ExcType::attribute_error(Type::Tuple, attr.as_str(interns))),
         }


### PR DESCRIPTION
This is a refactoring to make #207 easier.

By merging `py_call_attr_raw` and `py_call_attr`, less work to do on that branch, and overall leads to cleaner code anyway.