### PR TITLE
convert all `builtins` to take `VM`

### DIFF
--- a/crates/monty/src/builtins/abs.rs
+++ b/crates/monty/src/builtins/abs.rs
@@ -5,9 +5,10 @@ use num_traits::Signed;
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
-    heap::{Heap, HeapData},
+    heap::HeapData,
     resource::ResourceTracker,
     types::{LongInt, PyTrait},
     value::Value,
@@ -17,9 +18,9 @@ use crate::{
 ///
 /// Returns the absolute value of a number. Works with integers, floats, and LongInts.
 /// For `i64::MIN`, which overflows on negation, promotes to LongInt.
-pub fn builtin_abs(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-    let value = args.get_one_arg("abs", heap)?;
-    defer_drop!(value, heap);
+pub fn builtin_abs(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let value = args.get_one_arg("abs", vm.heap)?;
+    defer_drop!(value, vm);
 
     match value {
         Value::Int(n) => {
@@ -29,25 +30,25 @@ pub fn builtin_abs(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> Ru
             } else {
                 // i64::MIN.abs() overflows, promote to LongInt
                 let bi = BigInt::from(*n).abs();
-                Ok(LongInt::new(bi).into_value(heap)?)
+                Ok(LongInt::new(bi).into_value(vm.heap)?)
             }
         }
         Value::Float(f) => Ok(Value::Float(f.abs())),
         Value::Bool(b) => Ok(Value::Int(i64::from(*b))),
         Value::Ref(id) => {
-            if let HeapData::LongInt(li) = heap.get(*id) {
-                Ok(li.abs().into_value(heap)?)
+            if let HeapData::LongInt(li) = vm.heap.get(*id) {
+                Ok(li.abs().into_value(vm.heap)?)
             } else {
                 Err(SimpleException::new_msg(
                     ExcType::TypeError,
-                    format!("bad operand type for abs(): '{}'", value.py_type(heap)),
+                    format!("bad operand type for abs(): '{}'", value.py_type(vm.heap)),
                 )
                 .into())
             }
         }
         _ => Err(SimpleException::new_msg(
             ExcType::TypeError,
-            format!("bad operand type for abs(): '{}'", value.py_type(heap)),
+            format!("bad operand type for abs(): '{}'", value.py_type(vm.heap)),
         )
         .into()),
     }

--- a/crates/monty/src/builtins/all.rs
+++ b/crates/monty/src/builtins/all.rs
@@ -2,10 +2,9 @@
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop, defer_drop_mut,
     exception_private::RunResult,
-    heap::Heap,
-    intern::Interns,
     resource::ResourceTracker,
     types::{MontyIter, PyTrait},
     value::Value,
@@ -15,14 +14,14 @@ use crate::{
 ///
 /// Returns True if all elements of the iterable are true (or if the iterable is empty).
 /// Short-circuits on the first falsy value.
-pub fn builtin_all(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
-    let iterable = args.get_one_arg("all", heap)?;
-    let iter = MontyIter::new(iterable, heap, interns)?;
-    defer_drop_mut!(iter, heap);
+pub fn builtin_all(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let iterable = args.get_one_arg("all", vm.heap)?;
+    let iter = MontyIter::new(iterable, vm.heap, vm.interns)?;
+    defer_drop_mut!(iter, vm);
 
-    while let Some(item) = iter.for_next(heap, interns)? {
-        defer_drop!(item, heap);
-        let is_truthy = item.py_bool(heap, interns);
+    while let Some(item) = iter.for_next(vm.heap, vm.interns)? {
+        defer_drop!(item, vm);
+        let is_truthy = item.py_bool(vm.heap, vm.interns);
         if !is_truthy {
             return Ok(Value::Bool(false));
         }

--- a/crates/monty/src/builtins/any.rs
+++ b/crates/monty/src/builtins/any.rs
@@ -2,10 +2,9 @@
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop, defer_drop_mut,
     exception_private::RunResult,
-    heap::Heap,
-    intern::Interns,
     resource::ResourceTracker,
     types::{MontyIter, PyTrait},
     value::Value,
@@ -15,14 +14,14 @@ use crate::{
 ///
 /// Returns True if any element of the iterable is true.
 /// Returns False for an empty iterable. Short-circuits on the first truthy value.
-pub fn builtin_any(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
-    let iterable = args.get_one_arg("any", heap)?;
-    let iter = MontyIter::new(iterable, heap, interns)?;
-    defer_drop_mut!(iter, heap);
+pub fn builtin_any(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let iterable = args.get_one_arg("any", vm.heap)?;
+    let iter = MontyIter::new(iterable, vm.heap, vm.interns)?;
+    defer_drop_mut!(iter, vm);
 
-    while let Some(item) = iter.for_next(heap, interns)? {
-        defer_drop!(item, heap);
-        let is_truthy = item.py_bool(heap, interns);
+    while let Some(item) = iter.for_next(vm.heap, vm.interns)? {
+        defer_drop!(item, vm);
+        let is_truthy = item.py_bool(vm.heap, vm.interns);
         if is_truthy {
             return Ok(Value::Bool(true));
         }

--- a/crates/monty/src/builtins/bin.rs
+++ b/crates/monty/src/builtins/bin.rs
@@ -5,9 +5,10 @@ use num_traits::Signed;
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult},
-    heap::{Heap, HeapData},
+    heap::HeapData,
     resource::ResourceTracker,
     types::{PyTrait, Str},
     value::Value,
@@ -17,32 +18,34 @@ use crate::{
 ///
 /// Converts an integer to a binary string prefixed with '0b'.
 /// Supports both i64 and BigInt integers.
-pub fn builtin_bin(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-    let value = args.get_one_arg("bin", heap)?;
-    defer_drop!(value, heap);
+pub fn builtin_bin(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let value = args.get_one_arg("bin", vm.heap)?;
+    defer_drop!(value, vm);
 
     match value {
         Value::Int(n) => {
             let abs_digits = format!("{:b}", n.unsigned_abs());
             let prefix = if *n < 0 { "-0b" } else { "0b" };
-            let heap_id = heap.allocate(HeapData::Str(Str::new(format!("{prefix}{abs_digits}"))))?;
+            let heap_id = vm
+                .heap
+                .allocate(HeapData::Str(Str::new(format!("{prefix}{abs_digits}"))))?;
             Ok(Value::Ref(heap_id))
         }
         Value::Bool(b) => {
             let s = if *b { "0b1" } else { "0b0" };
-            let heap_id = heap.allocate(HeapData::Str(Str::new(s.to_string())))?;
+            let heap_id = vm.heap.allocate(HeapData::Str(Str::new(s.to_string())))?;
             Ok(Value::Ref(heap_id))
         }
         Value::Ref(id) => {
-            if let HeapData::LongInt(li) = heap.get(*id) {
+            if let HeapData::LongInt(li) = vm.heap.get(*id) {
                 let bin_str = format_bigint_bin(li.inner());
-                let heap_id = heap.allocate(HeapData::Str(Str::new(bin_str)))?;
+                let heap_id = vm.heap.allocate(HeapData::Str(Str::new(bin_str)))?;
                 Ok(Value::Ref(heap_id))
             } else {
-                Err(ExcType::type_error_not_integer(value.py_type(heap)))
+                Err(ExcType::type_error_not_integer(value.py_type(vm.heap)))
             }
         }
-        _ => Err(ExcType::type_error_not_integer(value.py_type(heap))),
+        _ => Err(ExcType::type_error_not_integer(value.py_type(vm.heap))),
     }
 }
 

--- a/crates/monty/src/builtins/chr.rs
+++ b/crates/monty/src/builtins/chr.rs
@@ -2,9 +2,9 @@
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
-    heap::Heap,
     resource::ResourceTracker,
     types::{PyTrait, str::allocate_char},
     value::Value,
@@ -14,16 +14,16 @@ use crate::{
 ///
 /// Returns a string representing a character whose Unicode code point is the integer.
 /// The valid range for the argument is from 0 through 1,114,111 (0x10FFFF).
-pub fn builtin_chr(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-    let value = args.get_one_arg("chr", heap)?;
-    defer_drop!(value, heap);
+pub fn builtin_chr(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let value = args.get_one_arg("chr", vm.heap)?;
+    defer_drop!(value, vm);
 
     match value {
         Value::Int(n) => {
             if *n < 0 || *n > 0x0010_FFFF {
                 Err(SimpleException::new_msg(ExcType::ValueError, "chr() arg not in range(0x110000)").into())
             } else if let Some(c) = char::from_u32(u32::try_from(*n).expect("chr() range check failed")) {
-                Ok(allocate_char(c, heap)?)
+                Ok(allocate_char(c, vm.heap)?)
             } else {
                 // This shouldn't happen for valid Unicode range, but handle it
                 Err(SimpleException::new_msg(ExcType::ValueError, "chr() arg not in range(0x110000)").into())
@@ -32,10 +32,10 @@ pub fn builtin_chr(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> Ru
         Value::Bool(b) => {
             // bool is subclass of int
             let c = if *b { '\x01' } else { '\x00' };
-            Ok(allocate_char(c, heap)?)
+            Ok(allocate_char(c, vm.heap)?)
         }
         _ => {
-            let type_name = value.py_type(heap);
+            let type_name = value.py_type(vm.heap);
             Err(SimpleException::new_msg(
                 ExcType::TypeError,
                 format!("an integer is required (got type {type_name})"),

--- a/crates/monty/src/builtins/divmod.rs
+++ b/crates/monty/src/builtins/divmod.rs
@@ -6,9 +6,10 @@ use smallvec::smallvec;
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
-    heap::{Heap, HeapData},
+    heap::HeapData,
     resource::{ResourceTracker, check_div_size},
     types::{LongInt, PyTrait, allocate_tuple},
     value::{Value, floor_divmod},
@@ -18,12 +19,13 @@ use crate::{
 ///
 /// Returns a tuple (quotient, remainder) from integer division.
 /// Equivalent to (a // b, a % b).
-pub fn builtin_divmod(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-    let (a, b) = args.get_two_args("divmod", heap)?;
+pub fn builtin_divmod(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let (a, b) = args.get_two_args("divmod", vm.heap)?;
     let a = super::round::normalize_bool_to_int(a);
     let b = super::round::normalize_bool_to_int(b);
-    defer_drop!(a, heap);
-    defer_drop!(b, heap);
+    defer_drop!(a, vm);
+    defer_drop!(b, vm);
+    let heap = &mut *vm.heap;
 
     match (a, b) {
         (Value::Int(x), Value::Int(y)) => {

--- a/crates/monty/src/builtins/enumerate.rs
+++ b/crates/monty/src/builtins/enumerate.rs
@@ -4,10 +4,10 @@ use smallvec::smallvec;
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult, SimpleException},
-    heap::{Heap, HeapData},
-    intern::Interns,
+    heap::HeapData,
     resource::ResourceTracker,
     types::{List, MontyIter, PyTrait, allocate_tuple},
     value::Value,
@@ -17,22 +17,18 @@ use crate::{
 ///
 /// Returns a list of (index, value) tuples.
 /// Note: In Python this returns an iterator, but we return a list for simplicity.
-pub fn builtin_enumerate(
-    heap: &mut Heap<impl ResourceTracker>,
-    args: ArgValues,
-    interns: &Interns,
-) -> RunResult<Value> {
-    let (iterable, start) = args.get_one_two_args("enumerate", heap)?;
-    let iter = MontyIter::new(iterable, heap, interns)?;
-    defer_drop_mut!(iter, heap);
-    defer_drop!(start, heap);
+pub fn builtin_enumerate(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let (iterable, start) = args.get_one_two_args("enumerate", vm.heap)?;
+    let iter = MontyIter::new(iterable, vm.heap, vm.interns)?;
+    defer_drop_mut!(iter, vm);
+    defer_drop!(start, vm);
 
     // Get start index (default 0)
     let mut index: i64 = match start {
         Some(Value::Int(n)) => *n,
         Some(Value::Bool(b)) => i64::from(*b),
         Some(v) => {
-            let type_name = v.py_type(heap);
+            let type_name = v.py_type(vm.heap);
             return Err(SimpleException::new_msg(
                 ExcType::TypeError,
                 format!("'{type_name}' object cannot be interpreted as an integer"),
@@ -44,13 +40,13 @@ pub fn builtin_enumerate(
 
     let mut result: Vec<Value> = Vec::new();
 
-    while let Some(item) = iter.for_next(heap, interns)? {
+    while let Some(item) = iter.for_next(vm.heap, vm.interns)? {
         // Create tuple (index, item)
-        let tuple_val = allocate_tuple(smallvec![Value::Int(index), item], heap)?;
+        let tuple_val = allocate_tuple(smallvec![Value::Int(index), item], vm.heap)?;
         result.push(tuple_val);
         index += 1;
     }
 
-    let heap_id = heap.allocate(HeapData::List(List::new(result)))?;
+    let heap_id = vm.heap.allocate(HeapData::List(List::new(result)))?;
     Ok(Value::Ref(heap_id))
 }

--- a/crates/monty/src/builtins/getattr.rs
+++ b/crates/monty/src/builtins/getattr.rs
@@ -3,10 +3,9 @@
 use crate::{
     ExcType,
     args::ArgValues,
+    bytecode::VM,
     defer_drop,
     exception_private::{RunResult, SimpleException},
-    heap::Heap,
-    intern::Interns,
     resource::ResourceTracker,
     types::{AttrCallResult, PyTrait},
     value::Value,
@@ -28,9 +27,10 @@ use crate::{
 /// getattr(obj, 'y', None)       # Get obj.y or None if not found
 /// getattr(module, 'function')   # Get module.function
 /// ```
-pub fn builtin_getattr(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
-    let positional = args.into_pos_only("getattr", heap)?;
-    defer_drop!(positional, heap);
+pub fn builtin_getattr(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let positional = args.into_pos_only("getattr", vm.heap)?;
+    defer_drop!(positional, vm);
+    let heap = &mut *vm.heap;
 
     let (object, name, default) = match positional.as_slice() {
         too_few @ ([] | [_]) => return Err(ExcType::type_error_at_least("getattr", 2, too_few.len())),
@@ -46,7 +46,7 @@ pub fn builtin_getattr(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, i
         );
     };
 
-    match object.py_getattr(&attr, heap, interns) {
+    match object.py_getattr(&attr, heap, vm.interns) {
         Ok(AttrCallResult::Value(value)) => Ok(value),
         Ok(_) => {
             // getattr() only retrieves attribute values — OS calls, external calls,

--- a/crates/monty/src/builtins/hash.rs
+++ b/crates/monty/src/builtins/hash.rs
@@ -2,10 +2,9 @@
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult},
-    heap::Heap,
-    intern::Interns,
     resource::ResourceTracker,
     types::PyTrait,
     value::Value,
@@ -15,15 +14,15 @@ use crate::{
 ///
 /// Returns the hash value of an object (if it has one).
 /// Raises TypeError for unhashable types like lists and dicts.
-pub fn builtin_hash(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
-    let value = args.get_one_arg("hash", heap)?;
-    defer_drop!(value, heap);
-    match value.py_hash(heap, interns)? {
+pub fn builtin_hash(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let value = args.get_one_arg("hash", vm.heap)?;
+    defer_drop!(value, vm);
+    match value.py_hash(vm.heap, vm.interns)? {
         Some(hash) => {
             // Python's hash() returns a signed integer; reinterpret bits for large values
             let hash_i64 = i64::from_ne_bytes(hash.to_ne_bytes());
             Ok(Value::Int(hash_i64))
         }
-        None => Err(ExcType::type_error_unhashable(value.py_type(heap))),
+        None => Err(ExcType::type_error_unhashable(value.py_type(vm.heap))),
     }
 }

--- a/crates/monty/src/builtins/hex.rs
+++ b/crates/monty/src/builtins/hex.rs
@@ -5,9 +5,10 @@ use num_traits::Signed;
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult},
-    heap::{Heap, HeapData},
+    heap::HeapData,
     resource::ResourceTracker,
     types::{PyTrait, Str},
     value::Value,
@@ -17,9 +18,10 @@ use crate::{
 ///
 /// Converts an integer to a lowercase hexadecimal string prefixed with '0x'.
 /// Supports both i64 and BigInt integers.
-pub fn builtin_hex(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-    let value = args.get_one_arg("hex", heap)?;
-    defer_drop!(value, heap);
+pub fn builtin_hex(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let value = args.get_one_arg("hex", vm.heap)?;
+    defer_drop!(value, vm);
+    let heap = &mut *vm.heap;
 
     match value {
         Value::Int(n) => {

--- a/crates/monty/src/builtins/id.rs
+++ b/crates/monty/src/builtins/id.rs
@@ -1,15 +1,15 @@
 //! Implementation of the id() builtin function.
 
 use crate::{
-    args::ArgValues, defer_drop, exception_private::RunResult, heap::Heap, resource::ResourceTracker, value::Value,
+    args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, resource::ResourceTracker, value::Value,
 };
 
 /// Implementation of the id() builtin function.
 ///
 /// Returns the identity of an object (unique integer for the object's lifetime).
-pub fn builtin_id(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-    let value = args.get_one_arg("id", heap)?;
-    defer_drop!(value, heap);
+pub fn builtin_id(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let value = args.get_one_arg("id", vm.heap)?;
+    defer_drop!(value, vm);
 
     let id = value.id();
 

--- a/crates/monty/src/builtins/isinstance.rs
+++ b/crates/monty/src/builtins/isinstance.rs
@@ -3,6 +3,7 @@
 use super::Builtins;
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult},
     heap::{Heap, HeapData},
@@ -14,10 +15,11 @@ use crate::{
 /// Implementation of the isinstance() builtin function.
 ///
 /// Checks if an object is an instance of a class or a tuple of classes.
-pub fn builtin_isinstance(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-    let (obj, classinfo) = args.get_two_args("isinstance", heap)?;
-    defer_drop!(obj, heap);
-    defer_drop!(classinfo, heap);
+pub fn builtin_isinstance(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let (obj, classinfo) = args.get_two_args("isinstance", vm.heap)?;
+    defer_drop!(obj, vm);
+    defer_drop!(classinfo, vm);
+    let heap = &mut *vm.heap;
 
     let obj_type = obj.py_type(heap);
 

--- a/crates/monty/src/builtins/len.rs
+++ b/crates/monty/src/builtins/len.rs
@@ -2,10 +2,9 @@
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
-    heap::Heap,
-    intern::Interns,
     resource::ResourceTracker,
     types::PyTrait,
     value::Value,
@@ -14,13 +13,13 @@ use crate::{
 /// Implementation of the len() builtin function.
 ///
 /// Returns the length of an object (number of items in a container).
-pub fn builtin_len(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
-    let value = args.get_one_arg("len", heap)?;
-    defer_drop!(value, heap);
-    if let Some(len) = value.py_len(heap, interns) {
+pub fn builtin_len(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let value = args.get_one_arg("len", vm.heap)?;
+    defer_drop!(value, vm);
+    if let Some(len) = value.py_len(vm.heap, vm.interns) {
         Ok(Value::Int(i64::try_from(len).expect("len exceeds i64::MAX")))
     } else {
-        let type_name = value.py_type(heap);
+        let type_name = value.py_type(vm.heap);
         Err(SimpleException::new_msg(ExcType::TypeError, format!("object of type '{type_name}' has no len()")).into())
     }
 }

--- a/crates/monty/src/builtins/min_max.rs
+++ b/crates/monty/src/builtins/min_max.rs
@@ -4,6 +4,7 @@ use std::cmp::Ordering;
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop_mut,
     exception_private::{ExcType, RunError, RunResult, SimpleException},
     heap::{Heap, HeapGuard},
@@ -19,8 +20,8 @@ use crate::{
 /// Supports two forms:
 /// - `min(iterable)` - returns smallest item from iterable
 /// - `min(arg1, arg2, ...)` - returns smallest of the arguments
-pub fn builtin_min(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
-    builtin_min_max(heap, args, interns, true)
+pub fn builtin_min(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    builtin_min_max(vm.heap, args, vm.interns, true)
 }
 
 /// Implementation of the max() builtin function.
@@ -29,8 +30,8 @@ pub fn builtin_min(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, inter
 /// Supports two forms:
 /// - `max(iterable)` - returns largest item from iterable
 /// - `max(arg1, arg2, ...)` - returns largest of the arguments
-pub fn builtin_max(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
-    builtin_min_max(heap, args, interns, false)
+pub fn builtin_max(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    builtin_min_max(vm.heap, args, vm.interns, false)
 }
 
 /// Shared implementation for min() and max().

--- a/crates/monty/src/builtins/mod.rs
+++ b/crates/monty/src/builtins/mod.rs
@@ -61,17 +61,11 @@ pub(crate) enum Builtins {
 
 impl Builtins {
     /// Calls this builtin with the given arguments.
-    ///
-    /// # Arguments
-    /// * `heap` - The heap for allocating objects
-    /// * `args` - The arguments to pass to the callable
-    /// * `interns` - String storage for looking up interned names in error messages
-    /// * `print` - The print for print output
     pub fn call(self, vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         match self {
             Self::Function(b) => b.call(vm, args),
-            Self::ExcType(exc) => exc.call(vm.heap, args, vm.interns),
-            Self::Type(t) => t.call(vm.heap, args, vm.interns),
+            Self::ExcType(exc) => exc.call(vm, args),
+            Self::Type(t) => t.call(vm, args),
         }
     }
 
@@ -212,41 +206,41 @@ pub enum BuiltinsFunctions {
 }
 
 impl BuiltinsFunctions {
-    /// Executes the builtin with the provided positional arguments.
+    /// Executes the builtin with the provided arguments.
     ///
-    /// The `interns` parameter provides access to interned string content for py_str and py_repr.
-    /// The `print` parameter is used for print output.
+    /// All builtins receive the full VM context, which provides access to the heap,
+    /// interned strings, and print output.
     pub(crate) fn call(self, vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         match self {
-            Self::Abs => abs::builtin_abs(vm.heap, args),
-            Self::All => all::builtin_all(vm.heap, args, vm.interns),
-            Self::Any => any::builtin_any(vm.heap, args, vm.interns),
-            Self::Bin => bin::builtin_bin(vm.heap, args),
-            Self::Chr => chr::builtin_chr(vm.heap, args),
-            Self::Divmod => divmod::builtin_divmod(vm.heap, args),
-            Self::Enumerate => enumerate::builtin_enumerate(vm.heap, args, vm.interns),
+            Self::Abs => abs::builtin_abs(vm, args),
+            Self::All => all::builtin_all(vm, args),
+            Self::Any => any::builtin_any(vm, args),
+            Self::Bin => bin::builtin_bin(vm, args),
+            Self::Chr => chr::builtin_chr(vm, args),
+            Self::Divmod => divmod::builtin_divmod(vm, args),
+            Self::Enumerate => enumerate::builtin_enumerate(vm, args),
             Self::Filter => filter::builtin_filter(vm, args),
-            Self::Getattr => getattr::builtin_getattr(vm.heap, args, vm.interns),
-            Self::Hash => hash::builtin_hash(vm.heap, args, vm.interns),
-            Self::Hex => hex::builtin_hex(vm.heap, args),
-            Self::Id => id::builtin_id(vm.heap, args),
-            Self::Isinstance => isinstance::builtin_isinstance(vm.heap, args),
-            Self::Len => len::builtin_len(vm.heap, args, vm.interns),
+            Self::Getattr => getattr::builtin_getattr(vm, args),
+            Self::Hash => hash::builtin_hash(vm, args),
+            Self::Hex => hex::builtin_hex(vm, args),
+            Self::Id => id::builtin_id(vm, args),
+            Self::Isinstance => isinstance::builtin_isinstance(vm, args),
+            Self::Len => len::builtin_len(vm, args),
             Self::Map => map::builtin_map(vm, args),
-            Self::Max => min_max::builtin_max(vm.heap, args, vm.interns),
-            Self::Min => min_max::builtin_min(vm.heap, args, vm.interns),
-            Self::Next => next::builtin_next(vm.heap, args, vm.interns),
-            Self::Oct => oct::builtin_oct(vm.heap, args),
-            Self::Ord => ord::builtin_ord(vm.heap, args, vm.interns),
-            Self::Pow => pow::builtin_pow(vm.heap, args),
-            Self::Print => print::builtin_print(vm.heap, args, vm.interns, vm.print_writer),
-            Self::Repr => repr::builtin_repr(vm.heap, args, vm.interns),
-            Self::Reversed => reversed::builtin_reversed(vm.heap, args, vm.interns),
-            Self::Round => round::builtin_round(vm.heap, args),
+            Self::Max => min_max::builtin_max(vm, args),
+            Self::Min => min_max::builtin_min(vm, args),
+            Self::Next => next::builtin_next(vm, args),
+            Self::Oct => oct::builtin_oct(vm, args),
+            Self::Ord => ord::builtin_ord(vm, args),
+            Self::Pow => pow::builtin_pow(vm, args),
+            Self::Print => print::builtin_print(vm, args),
+            Self::Repr => repr::builtin_repr(vm, args),
+            Self::Reversed => reversed::builtin_reversed(vm, args),
+            Self::Round => round::builtin_round(vm, args),
             Self::Sorted => sorted::builtin_sorted(vm, args),
-            Self::Sum => sum::builtin_sum(vm.heap, args, vm.interns),
-            Self::Type => type_::builtin_type(vm.heap, args),
-            Self::Zip => zip::builtin_zip(vm.heap, args, vm.interns),
+            Self::Sum => sum::builtin_sum(vm, args),
+            Self::Type => type_::builtin_type(vm, args),
+            Self::Zip => zip::builtin_zip(vm, args),
         }
     }
 }

--- a/crates/monty/src/builtins/next.rs
+++ b/crates/monty/src/builtins/next.rs
@@ -1,7 +1,7 @@
 //! Implementation of the next() builtin function.
 
 use crate::{
-    args::ArgValues, defer_drop, exception_private::RunResult, heap::Heap, intern::Interns, resource::ResourceTracker,
+    args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, resource::ResourceTracker,
     types::iter::iterator_next, value::Value,
 };
 
@@ -14,8 +14,8 @@ use crate::{
 ///   `StopIteration` when the iterator is exhausted.
 /// - `next(iterator, default)` - Returns the next item from the iterator, or
 ///   `default` if the iterator is exhausted.
-pub fn builtin_next(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
-    let (iterator, default) = args.get_one_two_args("next", heap)?;
-    defer_drop!(iterator, heap);
-    iterator_next(iterator, default, heap, interns)
+pub fn builtin_next(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let (iterator, default) = args.get_one_two_args("next", vm.heap)?;
+    defer_drop!(iterator, vm);
+    iterator_next(iterator, default, vm.heap, vm.interns)
 }

--- a/crates/monty/src/builtins/oct.rs
+++ b/crates/monty/src/builtins/oct.rs
@@ -5,9 +5,10 @@ use num_traits::Signed;
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult},
-    heap::{Heap, HeapData},
+    heap::HeapData,
     resource::ResourceTracker,
     types::{PyTrait, Str},
     value::Value,
@@ -17,32 +18,34 @@ use crate::{
 ///
 /// Converts an integer to an octal string prefixed with '0o'.
 /// Supports both i64 and BigInt integers.
-pub fn builtin_oct(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-    let value = args.get_one_arg("oct", heap)?;
-    defer_drop!(value, heap);
+pub fn builtin_oct(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let value = args.get_one_arg("oct", vm.heap)?;
+    defer_drop!(value, vm);
 
     match value {
         Value::Int(n) => {
             let abs_digits = format!("{:o}", n.unsigned_abs());
             let prefix = if *n < 0 { "-0o" } else { "0o" };
-            let heap_id = heap.allocate(HeapData::Str(Str::new(format!("{prefix}{abs_digits}"))))?;
+            let heap_id = vm
+                .heap
+                .allocate(HeapData::Str(Str::new(format!("{prefix}{abs_digits}"))))?;
             Ok(Value::Ref(heap_id))
         }
         Value::Bool(b) => {
             let s = if *b { "0o1" } else { "0o0" };
-            let heap_id = heap.allocate(HeapData::Str(Str::new(s.to_string())))?;
+            let heap_id = vm.heap.allocate(HeapData::Str(Str::new(s.to_string())))?;
             Ok(Value::Ref(heap_id))
         }
         Value::Ref(id) => {
-            if let HeapData::LongInt(li) = heap.get(*id) {
+            if let HeapData::LongInt(li) = vm.heap.get(*id) {
                 let oct_str = format_bigint_oct(li.inner());
-                let heap_id = heap.allocate(HeapData::Str(Str::new(oct_str)))?;
+                let heap_id = vm.heap.allocate(HeapData::Str(Str::new(oct_str)))?;
                 Ok(Value::Ref(heap_id))
             } else {
-                Err(ExcType::type_error_not_integer(value.py_type(heap)))
+                Err(ExcType::type_error_not_integer(value.py_type(vm.heap)))
             }
         }
-        _ => Err(ExcType::type_error_not_integer(value.py_type(heap))),
+        _ => Err(ExcType::type_error_not_integer(value.py_type(vm.heap))),
     }
 }
 

--- a/crates/monty/src/builtins/ord.rs
+++ b/crates/monty/src/builtins/ord.rs
@@ -2,10 +2,10 @@
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
-    heap::{Heap, HeapData},
-    intern::Interns,
+    heap::HeapData,
     resource::ResourceTracker,
     types::PyTrait,
     value::Value,
@@ -14,13 +14,13 @@ use crate::{
 /// Implementation of the ord() builtin function.
 ///
 /// Returns the Unicode code point of a one-character string.
-pub fn builtin_ord(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
-    let value = args.get_one_arg("ord", heap)?;
-    defer_drop!(value, heap);
+pub fn builtin_ord(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let value = args.get_one_arg("ord", vm.heap)?;
+    defer_drop!(value, vm);
 
     match value {
         Value::InternString(string_id) => {
-            let s = interns.get_str(*string_id);
+            let s = vm.interns.get_str(*string_id);
             let mut chars = s.chars();
             if let (Some(c), None) = (chars.next(), chars.next()) {
                 Ok(Value::Int(c as i64))
@@ -34,7 +34,7 @@ pub fn builtin_ord(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, inter
             }
         }
         Value::Ref(id) => {
-            if let HeapData::Str(s) = heap.get(*id) {
+            if let HeapData::Str(s) = vm.heap.get(*id) {
                 let mut chars = s.as_str().chars();
                 if let (Some(c), None) = (chars.next(), chars.next()) {
                     Ok(Value::Int(c as i64))
@@ -47,7 +47,7 @@ pub fn builtin_ord(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, inter
                     .into())
                 }
             } else {
-                let type_name = value.py_type(heap);
+                let type_name = value.py_type(vm.heap);
                 Err(SimpleException::new_msg(
                     ExcType::TypeError,
                     format!("ord() expected string of length 1, but {type_name} found"),
@@ -56,7 +56,7 @@ pub fn builtin_ord(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, inter
             }
         }
         _ => {
-            let type_name = value.py_type(heap);
+            let type_name = value.py_type(vm.heap);
             Err(SimpleException::new_msg(
                 ExcType::TypeError,
                 format!("ord() expected string of length 1, but {type_name} found"),

--- a/crates/monty/src/builtins/pow.rs
+++ b/crates/monty/src/builtins/pow.rs
@@ -5,6 +5,7 @@ use num_traits::{Signed, ToPrimitive, Zero};
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
     heap::{Heap, HeapData},
@@ -17,16 +18,16 @@ use crate::{
 ///
 /// Returns base to the power exp. With three arguments, returns (base ** exp) % mod.
 /// Handles negative exponents by returning a float.
-pub fn builtin_pow(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_pow(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     // pow() accepts 2 or 3 arguments
-    let positional = args.into_pos_only("pow", heap)?;
-    defer_drop!(positional, heap);
+    let positional = args.into_pos_only("pow", vm.heap)?;
+    defer_drop!(positional, vm);
 
     match positional.as_slice() {
         [base, exp] => {
             let base = normalize_bool(base);
             let exp = normalize_bool(exp);
-            two_arg_pow(base, exp, heap)
+            two_arg_pow(base, exp, vm.heap)
         }
         [base, exp, m] => {
             let base = normalize_bool(base);

--- a/crates/monty/src/builtins/print.rs
+++ b/crates/monty/src/builtins/print.rs
@@ -2,11 +2,11 @@
 
 use crate::{
     args::{ArgValues, KwargsValues},
+    bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunError, RunResult, SimpleException},
     heap::{Heap, HeapData},
     intern::Interns,
-    io::PrintWriter,
     resource::ResourceTracker,
     types::PyTrait,
     value::Value,
@@ -20,18 +20,13 @@ use crate::{
 /// - `flush`: whether to flush the stream (accepted but ignored)
 ///
 /// The `file` kwarg is not supported.
-pub fn builtin_print(
-    heap: &mut Heap<impl ResourceTracker>,
-    args: ArgValues,
-    interns: &Interns,
-    print: &mut PrintWriter<'_>,
-) -> RunResult<Value> {
+pub fn builtin_print(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     // Split into positional args and kwargs
     let (positional, kwargs) = args.into_parts();
-    defer_drop!(positional, heap);
+    defer_drop!(positional, vm);
 
     // Extract kwargs first
-    let (sep, end) = extract_print_kwargs(kwargs, heap, interns)?;
+    let (sep, end) = extract_print_kwargs(kwargs, vm.heap, vm.interns)?;
 
     // Print positional args with separator, dropping each value after use
     let mut first = true;
@@ -39,18 +34,18 @@ pub fn builtin_print(
         if first {
             first = false;
         } else if let Some(sep) = &sep {
-            print.stdout_write(sep.as_str().into())?;
+            vm.print_writer.stdout_write(sep.as_str().into())?;
         } else {
-            print.stdout_push(' ')?;
+            vm.print_writer.stdout_push(' ')?;
         }
-        print.stdout_write(value.py_str(heap, interns))?;
+        vm.print_writer.stdout_write(value.py_str(vm.heap, vm.interns))?;
     }
 
     // Append end string
     if let Some(end) = end {
-        print.stdout_write(end.into())?;
+        vm.print_writer.stdout_write(end.into())?;
     } else {
-        print.stdout_push('\n')?;
+        vm.print_writer.stdout_push('\n')?;
     }
 
     Ok(Value::None)

--- a/crates/monty/src/builtins/repr.rs
+++ b/crates/monty/src/builtins/repr.rs
@@ -1,22 +1,18 @@
 //! Implementation of the repr() builtin function.
 
 use crate::{
-    args::ArgValues,
-    defer_drop,
-    exception_private::RunResult,
-    heap::{Heap, HeapData},
-    intern::Interns,
-    resource::ResourceTracker,
-    types::PyTrait,
-    value::Value,
+    args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, heap::HeapData, resource::ResourceTracker,
+    types::PyTrait, value::Value,
 };
 
 /// Implementation of the repr() builtin function.
 ///
 /// Returns a string containing a printable representation of an object.
-pub fn builtin_repr(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
-    let value = args.get_one_arg("repr", heap)?;
-    defer_drop!(value, heap);
-    let heap_id = heap.allocate(HeapData::Str(value.py_repr(heap, interns).into_owned().into()))?;
+pub fn builtin_repr(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let value = args.get_one_arg("repr", vm.heap)?;
+    defer_drop!(value, vm);
+    let heap_id = vm
+        .heap
+        .allocate(HeapData::Str(value.py_repr(vm.heap, vm.interns).into_owned().into()))?;
     Ok(Value::Ref(heap_id))
 }

--- a/crates/monty/src/builtins/reversed.rs
+++ b/crates/monty/src/builtins/reversed.rs
@@ -2,9 +2,9 @@
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     exception_private::RunResult,
-    heap::{Heap, HeapData},
-    intern::Interns,
+    heap::HeapData,
     resource::ResourceTracker,
     types::{List, MontyIter},
     value::Value,
@@ -14,15 +14,15 @@ use crate::{
 ///
 /// Returns a list with elements in reverse order.
 /// Note: In Python this returns an iterator, but we return a list for simplicity.
-pub fn builtin_reversed(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
-    let value = args.get_one_arg("reversed", heap)?;
+pub fn builtin_reversed(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let value = args.get_one_arg("reversed", vm.heap)?;
 
     // Collect all items
-    let mut items: Vec<_> = MontyIter::new(value, heap, interns)?.collect(heap, interns)?;
+    let mut items: Vec<_> = MontyIter::new(value, vm.heap, vm.interns)?.collect(vm.heap, vm.interns)?;
 
     // Reverse in place
     items.reverse();
 
-    let heap_id = heap.allocate(HeapData::List(List::new(items)))?;
+    let heap_id = vm.heap.allocate(HeapData::List(List::new(items)))?;
     Ok(Value::Ref(heap_id))
 }

--- a/crates/monty/src/builtins/round.rs
+++ b/crates/monty/src/builtins/round.rs
@@ -2,9 +2,9 @@
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
-    heap::Heap,
     resource::ResourceTracker,
     types::PyTrait,
     value::Value,
@@ -22,11 +22,11 @@ pub fn normalize_bool_to_int(value: Value) -> Value {
 /// Rounds a number to a given precision in decimal digits.
 /// If ndigits is omitted or None, returns the nearest integer.
 /// Uses banker's rounding (round half to even).
-pub fn builtin_round(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-    let (number, ndigits) = args.get_one_two_args("round", heap)?;
+pub fn builtin_round(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let (number, ndigits) = args.get_one_two_args("round", vm.heap)?;
     let number = normalize_bool_to_int(number);
-    defer_drop!(number, heap);
-    defer_drop!(ndigits, heap);
+    defer_drop!(number, vm);
+    defer_drop!(ndigits, vm);
 
     // Determine the number of digits (None means round to integer)
     // Extract digits value before potentially consuming ndigits for error handling
@@ -35,7 +35,7 @@ pub fn builtin_round(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> 
         Some(Value::Int(n)) => Some(*n),
         Some(Value::Bool(b)) => Some(i64::from(*b)),
         Some(v) => {
-            let type_name = v.py_type(heap);
+            let type_name = v.py_type(vm.heap);
             return Err(SimpleException::new_msg(
                 ExcType::TypeError,
                 format!("'{type_name}' object cannot be interpreted as an integer"),
@@ -84,7 +84,7 @@ pub fn builtin_round(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> 
             }
         }
         _ => {
-            let type_name = number.py_type(heap);
+            let type_name = number.py_type(vm.heap);
             Err(SimpleException::new_msg(
                 ExcType::TypeError,
                 format!("type {type_name} doesn't define __round__ method"),

--- a/crates/monty/src/builtins/sum.rs
+++ b/crates/monty/src/builtins/sum.rs
@@ -2,10 +2,10 @@
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult, SimpleException},
-    heap::{Heap, HeapGuard},
-    intern::Interns,
+    heap::HeapGuard,
     resource::ResourceTracker,
     types::{MontyIter, PyTrait, Type},
     value::Value,
@@ -16,19 +16,19 @@ use crate::{
 /// Sums the items of an iterable from left to right with an optional start value.
 /// The default start value is 0. String start values are explicitly rejected
 /// (use `''.join(seq)` instead for string concatenation).
-pub fn builtin_sum(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
-    let (iterable, start) = args.get_one_two_args("sum", heap)?;
-    defer_drop_mut!(start, heap);
+pub fn builtin_sum(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let (iterable, start) = args.get_one_two_args("sum", vm.heap)?;
+    defer_drop_mut!(start, vm);
 
-    let iter = MontyIter::new(iterable, heap, interns)?;
-    defer_drop_mut!(iter, heap);
+    let iter = MontyIter::new(iterable, vm.heap, vm.interns)?;
+    defer_drop_mut!(iter, vm);
 
     // Get the start value, defaulting to 0
     let accumulator = match start.take() {
         Some(v) => {
             // Reject string start values - Python explicitly forbids this
-            if matches!(v.py_type(heap), Type::Str) {
-                v.drop_with_heap(heap);
+            if matches!(v.py_type(vm.heap), Type::Str) {
+                v.drop_with_heap(vm.heap);
                 return Err(SimpleException::new_msg(
                     ExcType::TypeError,
                     "sum() can't sum strings [use ''.join(seq) instead]",
@@ -42,22 +42,22 @@ pub fn builtin_sum(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, inter
 
     // HeapGuard for accumulator: on success we extract it via into_inner(),
     // on any error path it's dropped automatically
-    let mut acc_guard = HeapGuard::new(accumulator, heap);
-    let (accumulator, heap) = acc_guard.as_parts_mut();
+    let mut acc_guard = HeapGuard::new(accumulator, vm);
+    let (accumulator, vm) = acc_guard.as_parts_mut();
 
     // Sum all items
-    while let Some(item) = iter.for_next(heap, interns)? {
-        defer_drop!(item, heap);
+    while let Some(item) = iter.for_next(vm.heap, vm.interns)? {
+        defer_drop!(item, vm);
 
         // Try to add the item to accumulator
-        if let Some(new_value) = accumulator.py_add(item, heap, interns)? {
+        if let Some(new_value) = accumulator.py_add(item, vm.heap, vm.interns)? {
             // Replace the old accumulator with the new value, dropping the old one
             let old = std::mem::replace(accumulator, new_value);
-            old.drop_with_heap(heap);
+            old.drop_with_heap(vm.heap);
         } else {
             // Types don't support addition
-            let acc_type = accumulator.py_type(heap);
-            let item_type = item.py_type(heap);
+            let acc_type = accumulator.py_type(vm.heap);
+            let item_type = item.py_type(vm.heap);
             return Err(ExcType::binary_type_error("+", acc_type, item_type));
         }
     }

--- a/crates/monty/src/builtins/type_.rs
+++ b/crates/monty/src/builtins/type_.rs
@@ -2,15 +2,15 @@
 
 use super::Builtins;
 use crate::{
-    args::ArgValues, defer_drop, exception_private::RunResult, heap::Heap, resource::ResourceTracker, types::PyTrait,
+    args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, resource::ResourceTracker, types::PyTrait,
     value::Value,
 };
 
 /// Implementation of the type() builtin function.
 ///
 /// Returns the type of an object.
-pub fn builtin_type(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-    let value = args.get_one_arg("type", heap)?;
-    defer_drop!(value, heap);
-    Ok(Value::Builtin(Builtins::Type(value.py_type(heap))))
+pub fn builtin_type(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let value = args.get_one_arg("type", vm.heap)?;
+    defer_drop!(value, vm);
+    Ok(Value::Builtin(Builtins::Type(value.py_type(vm.heap))))
 }

--- a/crates/monty/src/builtins/zip.rs
+++ b/crates/monty/src/builtins/zip.rs
@@ -2,10 +2,10 @@
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop_mut,
     exception_private::RunResult,
-    heap::{Heap, HeapData},
-    intern::Interns,
+    heap::HeapData,
     resource::ResourceTracker,
     types::{List, MontyIter, allocate_tuple, tuple::TupleVec},
     value::Value,
@@ -16,28 +16,28 @@ use crate::{
 /// Returns a list of tuples, where the i-th tuple contains the i-th element
 /// from each of the argument iterables. Stops when the shortest iterable is exhausted.
 /// Note: In Python this returns an iterator, but we return a list for simplicity.
-pub fn builtin_zip(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
+pub fn builtin_zip(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (positional, kwargs) = args.into_parts();
-    defer_drop_mut!(positional, heap);
+    defer_drop_mut!(positional, vm);
 
     // TODO: support kwargs (strict)
-    kwargs.not_supported_yet("zip", heap)?;
+    kwargs.not_supported_yet("zip", vm.heap)?;
 
     if positional.len() == 0 {
         // zip() with no arguments returns empty list
-        let heap_id = heap.allocate(HeapData::List(List::new(Vec::new())))?;
+        let heap_id = vm.heap.allocate(HeapData::List(List::new(Vec::new())))?;
         return Ok(Value::Ref(heap_id));
     }
 
     // Create iterators for each iterable
     let mut iterators: Vec<MontyIter> = Vec::with_capacity(positional.len());
     for iterable in positional {
-        match MontyIter::new(iterable, heap, interns) {
+        match MontyIter::new(iterable, vm.heap, vm.interns) {
             Ok(iter) => iterators.push(iter),
             Err(e) => {
                 // Clean up already-created iterators
                 for iter in iterators {
-                    iter.drop_with_heap(heap);
+                    iter.drop_with_heap(vm.heap);
                 }
                 return Err(e);
             }
@@ -51,27 +51,27 @@ pub fn builtin_zip(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, inter
         let mut tuple_items = TupleVec::with_capacity(iterators.len());
 
         for iter in &mut iterators {
-            if let Some(item) = iter.for_next(heap, interns)? {
+            if let Some(item) = iter.for_next(vm.heap, vm.interns)? {
                 tuple_items.push(item);
             } else {
                 // This iterator is exhausted - drop partial tuple items and stop
                 for item in tuple_items {
-                    item.drop_with_heap(heap);
+                    item.drop_with_heap(vm.heap);
                 }
                 break 'outer;
             }
         }
 
         // Create tuple from collected items
-        let tuple_val = allocate_tuple(tuple_items, heap)?;
+        let tuple_val = allocate_tuple(tuple_items, vm.heap)?;
         result.push(tuple_val);
     }
 
     // Clean up iterators
     for iter in iterators {
-        iter.drop_with_heap(heap);
+        iter.drop_with_heap(vm.heap);
     }
 
-    let heap_id = heap.allocate(HeapData::List(List::new(result)))?;
+    let heap_id = vm.heap.allocate(HeapData::List(List::new(result)))?;
     Ok(Value::Ref(heap_id))
 }

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -14,14 +14,11 @@ use crate::{
     exception_private::{ExcType, RunError},
     heap::{DropWithHeap, Heap, HeapData, HeapGuard, HeapId},
     heap_data::CellValue,
-    intern::{ExtFunctionId, FunctionId, Interns, StaticStrings, StringId},
+    intern::{ExtFunctionId, FunctionId, StringId},
     os::OsFunction,
     resource::ResourceTracker,
     types::{
-        AttrCallResult, Dict, PyTrait, Type,
-        bytes::{bytes_fromhex, call_bytes_method},
-        dict::dict_fromkeys,
-        str::call_str_method,
+        AttrCallResult, Dict, PyTrait, Type, bytes::call_bytes_method, str::call_str_method, r#type::call_type_method,
     },
     value::{EitherStr, Value},
 };
@@ -110,7 +107,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
         // Convert u8 to Type via callable_from_u8
         if let Some(t) = Type::callable_from_u8(type_id) {
             let args = self.pop_n_args(arg_count);
-            t.call(self.heap, args, self.interns)
+            t.call(self, args)
         } else {
             Err(RunError::internal("CallBuiltinType: invalid type_id"))
         }
@@ -296,7 +293,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
             }
             Value::Builtin(Builtins::Type(t)) => {
                 // Handle classmethods on type objects like dict.fromkeys()
-                call_type_method(t, name_id, args, this.heap, this.interns).map(CallResult::Push)
+                call_type_method(t, name_id, args, this).map(CallResult::Push)
             }
             _ => {
                 // Non-heap values without method support
@@ -793,25 +790,4 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
 
         Ok(CallResult::FramePushed)
     }
-}
-
-/// Dispatches a classmethod call on a type object.
-///
-/// Handles classmethods like `dict.fromkeys()` and `bytes.fromhex()` that are
-/// called on the type itself rather than on an instance.
-fn call_type_method(
-    t: Type,
-    method_id: StringId,
-    args: ArgValues,
-    heap: &mut Heap<impl ResourceTracker>,
-    interns: &Interns,
-) -> Result<Value, RunError> {
-    match (t, method_id) {
-        (Type::Dict, m) if m == StaticStrings::Fromkeys => return dict_fromkeys(args, heap, interns),
-        (Type::Bytes, m) if m == StaticStrings::Fromhex => return bytes_fromhex(args, heap, interns),
-        _ => {}
-    }
-    // Other types or unknown methods - report actual type name, not 'type'
-    args.drop_with_heap(heap);
-    Err(ExcType::attribute_error(t, interns.get_str(method_id)))
 }

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -9,6 +9,7 @@ use strum::{Display, EnumString, IntoStaticStr};
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop,
     exception_public::{MontyException, StackFrame},
     fstring::FormatError,
@@ -157,21 +158,17 @@ impl ExcType {
     ///
     /// The `interns` parameter provides access to interned string content.
     /// Returns a heap-allocated exception value.
-    pub(crate) fn call(
-        self,
-        heap: &mut Heap<impl ResourceTracker>,
-        args: ArgValues,
-        interns: &Interns,
-    ) -> RunResult<Value> {
-        defer_drop!(args, heap);
+    pub(crate) fn call(self, vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+        defer_drop!(args, vm);
         let exc = match args {
             ArgValues::Empty => Ok(SimpleException::new_none(self)),
             ArgValues::One(value) => match value {
-                Value::InternString(string_id) => {
-                    Ok(SimpleException::new_msg(self, interns.get_str(*string_id).to_owned()))
-                }
+                Value::InternString(string_id) => Ok(SimpleException::new_msg(
+                    self,
+                    vm.interns.get_str(*string_id).to_owned(),
+                )),
                 Value::Ref(heap_id) => {
-                    if let HeapData::Str(s) = heap.get(*heap_id) {
+                    if let HeapData::Str(s) = vm.heap.get(*heap_id) {
                         Ok(SimpleException::new_msg(self, s.as_str().to_owned()))
                     } else {
                         Err(RunError::internal(
@@ -187,7 +184,7 @@ impl ExcType {
                 "exceptions can only be called with zero or one string argument",
             )),
         }?;
-        let heap_id = heap.allocate(HeapData::Exception(exc))?;
+        let heap_id = vm.heap.allocate(HeapData::Exception(exc))?;
         Ok(Value::Ref(heap_id))
     }
 

--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -4,13 +4,15 @@ use num_bigint::BigInt;
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunError, RunResult, SimpleException},
-    heap::{Heap, HeapData},
-    intern::Interns,
+    heap::{DropWithHeap, Heap, HeapData},
+    intern::{StaticStrings, StringId},
     resource::ResourceTracker,
     types::{
-        Bytes, Dict, FrozenSet, List, LongInt, MontyIter, Path, PyTrait, Range, Set, Slice, Str, Tuple, str::StringRepr,
+        Bytes, Dict, FrozenSet, List, LongInt, MontyIter, Path, PyTrait, Range, Set, Slice, Str, Tuple,
+        bytes::bytes_fromhex, dict::dict_fromkeys, str::StringRepr,
     },
     value::Value,
 };
@@ -194,12 +196,9 @@ impl Type {
     ///
     /// Dispatches to the appropriate type's init method for container types,
     /// or handles primitive type conversions inline.
-    pub(crate) fn call(
-        self,
-        heap: &mut Heap<impl ResourceTracker>,
-        args: ArgValues,
-        interns: &Interns,
-    ) -> RunResult<Value> {
+    pub(crate) fn call(self, vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+        let heap = &mut *vm.heap;
+        let interns = vm.interns;
         match self {
             // Container types - delegate to init methods
             Self::List => List::init(heap, args, interns),
@@ -369,4 +368,26 @@ fn value_error_invalid_literal_for_int(value: &str) -> RunError {
         format!("invalid literal for int() with base 10: {}", StringRepr(value)),
     )
     .into()
+}
+
+/// Dispatches a classmethod call on a type object.
+///
+/// Handles classmethods like `dict.fromkeys()` and `bytes.fromhex()` that are
+/// called on the type itself rather than on an instance.
+pub(crate) fn call_type_method(
+    t: Type,
+    method_id: StringId,
+    args: ArgValues,
+    vm: &mut VM<'_, '_, impl ResourceTracker>,
+) -> Result<Value, RunError> {
+    let heap = &mut *vm.heap;
+    let interns = vm.interns;
+    match (t, method_id) {
+        (Type::Dict, m) if m == StaticStrings::Fromkeys => return dict_fromkeys(args, heap, interns),
+        (Type::Bytes, m) if m == StaticStrings::Fromhex => return bytes_fromhex(args, heap, interns),
+        _ => {}
+    }
+    // Other types or unknown methods - report actual type name, not 'type'
+    args.drop_with_heap(heap);
+    Err(ExcType::attribute_error(t, interns.get_str(method_id)))
 }


### PR DESCRIPTION
This changes all methods in `builtins` to take `vm` rather than separate `heap` and `interns`. This is a consistency change, mostly churn, which will help with #207.