### PR TITLE
allow `clone_with_heap` and `drop_with_heap` to take VM

### DIFF
--- a/crates/monty/src/args.rs
+++ b/crates/monty/src/args.rs
@@ -300,7 +300,7 @@ impl ArgValues {
 }
 
 impl DropWithHeap for ArgValues {
-    fn drop_with_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
+    fn drop_with_concrete_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
         match self {
             Self::Empty => {}
             Self::One(v) => v.drop_with_heap(heap),
@@ -384,7 +384,7 @@ impl Iterator for ArgPosIter {
 impl ExactSizeIterator for ArgPosIter {}
 
 impl DropWithHeap for ArgPosIter {
-    fn drop_with_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
+    fn drop_with_concrete_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
         match self {
             Self::Empty => {}
             Self::One(v1) => v1.drop_with_heap(heap),
@@ -464,7 +464,7 @@ impl KwargsValues {
 
 impl DropWithHeap for KwargsValues {
     /// Properly drops all values in the arguments, decrementing reference counts.
-    fn drop_with_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
+    fn drop_with_concrete_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
         match self {
             Self::Empty => {}
             Self::Inline(kvs) => {
@@ -529,7 +529,7 @@ impl Iterator for KwargsValuesIter {
 impl ExactSizeIterator for KwargsValuesIter {}
 
 impl DropWithHeap for KwargsValuesIter {
-    fn drop_with_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
+    fn drop_with_concrete_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
         match self {
             Self::Empty => {}
             Self::Inline(iter) => {

--- a/crates/monty/src/builtins/filter.rs
+++ b/crates/monty/src/builtins/filter.rs
@@ -49,10 +49,10 @@ pub fn builtin_filter(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> Run
             item.py_bool(vm.heap, vm.interns)
         } else {
             // Clone for predicate call - the clone is consumed by evaluate_function
-            let item_for_predicate = item.clone_with_heap(vm.heap);
+            let item_for_predicate = item.clone_with_heap(vm);
             let result = vm.evaluate_function("filter()", function, ArgValues::One(item_for_predicate))?;
             let is_truthy = result.py_bool(vm.heap, vm.interns);
-            result.drop_with_heap(vm.heap);
+            result.drop_with_heap(vm);
             is_truthy
         };
 

--- a/crates/monty/src/builtins/map.rs
+++ b/crates/monty/src/builtins/map.rs
@@ -64,7 +64,7 @@ pub fn builtin_map(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunRes
         [single] => {
             while let Some(arg1) = first_iter.for_next(vm.heap, vm.interns)? {
                 let Some(arg2) = single.for_next(vm.heap, vm.interns)? else {
-                    arg1.drop_with_heap(vm.heap);
+                    arg1.drop_with_heap(vm);
                     break;
                 };
                 let args = ArgValues::Two(arg1, arg2);
@@ -79,7 +79,7 @@ pub fn builtin_map(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunRes
                 if let Some(item) = iter.for_next(vm.heap, vm.interns)? {
                     items.push(item);
                 } else {
-                    items.drop_with_heap(vm.heap);
+                    items.drop_with_heap(vm);
                     break 'outer;
                 }
             }

--- a/crates/monty/src/builtins/sorted.rs
+++ b/crates/monty/src/builtins/sorted.rs
@@ -40,7 +40,7 @@ pub fn builtin_sorted(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> Run
             items
                 .iter()
                 .map(|item| {
-                    let item = item.clone_with_heap(vm.heap);
+                    let item = item.clone_with_heap(vm);
                     vm.evaluate_function("sorted() key argument", f, ArgValues::One(item))
                 })
                 .process_results(|keys_iter| keys.extend(keys_iter))?;

--- a/crates/monty/src/builtins/sum.rs
+++ b/crates/monty/src/builtins/sum.rs
@@ -28,7 +28,7 @@ pub fn builtin_sum(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunRes
         Some(v) => {
             // Reject string start values - Python explicitly forbids this
             if matches!(v.py_type(vm.heap), Type::Str) {
-                v.drop_with_heap(vm.heap);
+                v.drop_with_heap(vm);
                 return Err(SimpleException::new_msg(
                     ExcType::TypeError,
                     "sum() can't sum strings [use ''.join(seq) instead]",
@@ -53,7 +53,7 @@ pub fn builtin_sum(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunRes
         if let Some(new_value) = accumulator.py_add(item, vm.heap, vm.interns)? {
             // Replace the old accumulator with the new value, dropping the old one
             let old = std::mem::replace(accumulator, new_value);
-            old.drop_with_heap(vm.heap);
+            old.drop_with_heap(vm);
         } else {
             // Types don't support addition
             let acc_type = accumulator.py_type(vm.heap);

--- a/crates/monty/src/builtins/zip.rs
+++ b/crates/monty/src/builtins/zip.rs
@@ -37,7 +37,7 @@ pub fn builtin_zip(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunRes
             Err(e) => {
                 // Clean up already-created iterators
                 for iter in iterators {
-                    iter.drop_with_heap(vm.heap);
+                    iter.drop_with_heap(vm);
                 }
                 return Err(e);
             }
@@ -56,7 +56,7 @@ pub fn builtin_zip(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunRes
             } else {
                 // This iterator is exhausted - drop partial tuple items and stop
                 for item in tuple_items {
-                    item.drop_with_heap(vm.heap);
+                    item.drop_with_heap(vm);
                 }
                 break 'outer;
             }
@@ -69,7 +69,7 @@ pub fn builtin_zip(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunRes
 
     // Clean up iterators
     for iter in iterators {
-        iter.drop_with_heap(vm.heap);
+        iter.drop_with_heap(vm);
     }
 
     let heap_id = vm.heap.allocate(HeapData::List(List::new(result)))?;

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -378,7 +378,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
         }
 
         // Mark task as completed and store result in task state
-        let task_result = result.clone_with_heap(self.heap);
+        let task_result = result.clone_with_heap(self);
         self.scheduler_mut().complete_task(task_id, task_result);
 
         // If task belongs to a gather, store result and check if gather is complete
@@ -389,7 +389,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
             {
                 gather.results[idx] = Some(result);
             } else {
-                result.drop_with_heap(self.heap);
+                result.drop_with_heap(self);
             }
 
             // Extract gather metadata - clone task_ids since we need to check completion
@@ -475,7 +475,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
             }
         } else {
             // Drop the result (it's stored in the task state now)
-            result.drop_with_heap(self.heap);
+            result.drop_with_heap(self);
         }
 
         // Gather not complete or no gather - switch to next task
@@ -723,7 +723,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
 
         // Extract coroutine data
         let func_id = coro.func_id;
-        let namespace_values: Vec<Value> = coro.namespace.iter().map(|v| v.clone_with_heap(self.heap)).collect();
+        let namespace_values: Vec<Value> = coro.namespace.iter().map(|v| v.clone_with_heap(self)).collect();
         let frame_cells: Vec<HeapId> = coro.frame_cells.clone();
 
         // Increment refcounts for shared cell references

--- a/crates/monty/src/bytecode/vm/binary.rs
+++ b/crates/monty/src/bytecode/vm/binary.rs
@@ -248,8 +248,8 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
     pub(super) fn binary_matmul(&mut self) -> Result<(), RunError> {
         let rhs = self.pop();
         let lhs = self.pop();
-        lhs.drop_with_heap(self.heap);
-        rhs.drop_with_heap(self.heap);
+        lhs.drop_with_heap(self);
+        rhs.drop_with_heap(self);
         Err(ExcType::not_implemented("matrix multiplication (@) is not supported").into())
     }
 }

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -298,7 +298,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
             _ => {
                 // Non-heap values without method support
                 let type_name = obj.py_type(this.heap);
-                args.drop_with_heap(this.heap);
+                args.drop_with_heap(this);
                 Err(ExcType::attribute_error(type_name, this.interns.get_str(name_id)))
             }
         }
@@ -384,7 +384,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
                 self.call_heap_callable(*heap_id, args)
             }
             _ => {
-                args.drop_with_heap(self.heap);
+                args.drop_with_heap(self);
                 let ty = callable.py_type(self.heap);
                 Err(ExcType::type_error(format!("'{ty}' object is not callable")))
             }
@@ -396,16 +396,15 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
         let (func_id, cells, defaults) = match self.heap.get(heap_id) {
             HeapData::Closure(closure) => {
                 let cloned_cells = closure.cells.clone();
-                let cloned_defaults: Vec<Value> =
-                    closure.defaults.iter().map(|v| v.clone_with_heap(self.heap)).collect();
+                let cloned_defaults: Vec<Value> = closure.defaults.iter().map(|v| v.clone_with_heap(self)).collect();
                 (closure.func_id, cloned_cells, cloned_defaults)
             }
             HeapData::FunctionDefaults(fd) => {
-                let cloned_defaults: Vec<Value> = fd.defaults.iter().map(|v| v.clone_with_heap(self.heap)).collect();
+                let cloned_defaults: Vec<Value> = fd.defaults.iter().map(|v| v.clone_with_heap(self)).collect();
                 (fd.func_id, Vec::new(), cloned_defaults)
             }
             _ => {
-                args.drop_with_heap(self.heap);
+                args.drop_with_heap(self);
                 return Err(ExcType::type_error("object is not callable"));
             }
         };
@@ -484,7 +483,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
         let HeapData::Tuple(tuple) = self.heap.get(*id) else {
             unreachable!("CallFunctionExtended: args_tuple must be a Tuple")
         };
-        tuple.as_slice().iter().map(|v| v.clone_with_heap(self.heap)).collect()
+        tuple.as_slice().iter().map(|v| v.clone_with_heap(self)).collect()
     }
 
     /// Builds `ArgValues` with kwargs for `CallFunctionExtended`.
@@ -557,7 +556,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
         let HeapData::Tuple(tuple) = self.heap.get(*id) else {
             unreachable!("CallAttrExtended: args_tuple must be a Tuple")
         };
-        tuple.as_slice().iter().map(|v| v.clone_with_heap(self.heap)).collect()
+        tuple.as_slice().iter().map(|v| v.clone_with_heap(self)).collect()
     }
 
     /// Builds `ArgValues` with kwargs for `CallAttrExtended`.
@@ -733,7 +732,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
             if let Err(e) = bind_result {
                 self.namespaces.drop_with_heap(namespace_idx, self.heap);
                 for default in defaults {
-                    default.drop_with_heap(self.heap);
+                    default.drop_with_heap(self);
                 }
                 return Err(e);
             }

--- a/crates/monty/src/bytecode/vm/collections.rs
+++ b/crates/monty/src/bytecode/vm/collections.rs
@@ -239,8 +239,8 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
                 _ => false,
             };
             if !is_string {
-                key.drop_with_heap(this.heap);
-                value.drop_with_heap(this.heap);
+                key.drop_with_heap(this);
+                value.drop_with_heap(this);
                 return Err(ExcType::type_error_kwargs_nonstring_key());
             }
 
@@ -268,7 +268,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
 
             // If set returned Some, the key already existed (duplicate kwarg)
             if let Some(old_value) = result? {
-                old_value.drop_with_heap(this.heap);
+                old_value.drop_with_heap(this);
                 return Err(ExcType::type_error_multiple_values(&func_name, &key_str));
             }
         }
@@ -295,7 +295,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
 
         // Get the list reference
         let Value::Ref(list_id) = self.stack[list_pos] else {
-            value.drop_with_heap(self.heap);
+            value.drop_with_heap(self);
             return Err(RunError::internal("ListAppend: expected list ref on stack"));
         };
 
@@ -323,7 +323,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
 
         // Get the set reference
         let Value::Ref(set_id) = self.stack[set_pos] else {
-            value.drop_with_heap(self.heap);
+            value.drop_with_heap(self);
             return Err(RunError::internal("SetAdd: expected set ref on stack"));
         };
 
@@ -353,8 +353,8 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
 
         // Get the dict reference
         let Value::Ref(dict_id) = self.stack[dict_pos] else {
-            key.drop_with_heap(self.heap);
-            value.drop_with_heap(self.heap);
+            key.drop_with_heap(self);
+            value.drop_with_heap(self);
             return Err(RunError::internal("DictSetItem: expected dict ref on stack"));
         };
 
@@ -371,7 +371,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
 
         // Drop old value if key already existed
         if let Some(old) = old_value {
-            old.drop_with_heap(self.heap);
+            old.drop_with_heap(self);
         }
 
         Ok(())

--- a/crates/monty/src/bytecode/vm/exceptions.rs
+++ b/crates/monty/src/bytecode/vm/exceptions.rs
@@ -156,7 +156,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
                 // Unwind stack to target depth (drop excess values)
                 while this.stack.len() > target_stack_depth {
                     let value = this.stack.pop().unwrap();
-                    value.drop_with_heap(this.heap);
+                    value.drop_with_heap(this);
                 }
 
                 // Push exception value onto stack (handler expects it)

--- a/crates/monty/src/bytecode/vm/format.rs
+++ b/crates/monty/src/bytecode/vm/format.rs
@@ -20,7 +20,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
             // Each part should be a string (interned or heap-allocated)
             let part_str = part.py_str(self.heap, self.interns);
             result.push_str(&part_str);
-            part.drop_with_heap(self.heap);
+            part.drop_with_heap(self);
         }
 
         let value = allocate_string(result, self.heap)?;

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -779,10 +779,10 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
                 // ============================================================
                 Opcode::Pop => {
                     let value = self.pop();
-                    value.drop_with_heap(self.heap);
+                    value.drop_with_heap(self);
                 }
                 Opcode::Dup => {
-                    let value = self.peek().clone_with_heap(self.heap);
+                    let value = self.peek().clone_with_heap(self);
                     self.push(value);
                 }
                 Opcode::Rot2 => {
@@ -810,7 +810,7 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
                             Err(e) => catch_sync!(self, cached_frame, RunError::from(e)),
                         }
                     } else {
-                        self.push(value.clone_with_heap(self.heap));
+                        self.push(value.clone_with_heap(self));
                     }
                 }
                 Opcode::LoadNone => self.push(Value::None),
@@ -903,7 +903,7 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
                 Opcode::UnaryNot => {
                     let value = self.pop();
                     let result = !value.py_bool(self.heap, self.interns);
-                    value.drop_with_heap(self.heap);
+                    value.drop_with_heap(self);
                     self.push(Value::Bool(result));
                 }
                 Opcode::UnaryNeg => {
@@ -928,20 +928,20 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
                         Value::Ref(id) => {
                             if let HeapData::LongInt(li) = self.heap.get(id) {
                                 let negated = -LongInt::new(li.inner().clone());
-                                value.drop_with_heap(self.heap);
+                                value.drop_with_heap(self);
                                 match negated.into_value(self.heap) {
                                     Ok(v) => self.push(v),
                                     Err(e) => catch_sync!(self, cached_frame, RunError::from(e)),
                                 }
                             } else {
                                 let value_type = value.py_type(self.heap);
-                                value.drop_with_heap(self.heap);
+                                value.drop_with_heap(self);
                                 catch_sync!(self, cached_frame, ExcType::unary_type_error("-", value_type));
                             }
                         }
                         _ => {
                             let value_type = value.py_type(self.heap);
-                            value.drop_with_heap(self.heap);
+                            value.drop_with_heap(self);
                             catch_sync!(self, cached_frame, ExcType::unary_type_error("-", value_type));
                         }
                     }
@@ -958,13 +958,13 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
                                 self.push(value);
                             } else {
                                 let value_type = value.py_type(self.heap);
-                                value.drop_with_heap(self.heap);
+                                value.drop_with_heap(self);
                                 catch_sync!(self, cached_frame, ExcType::unary_type_error("+", value_type));
                             }
                         }
                         _ => {
                             let value_type = value.py_type(self.heap);
-                            value.drop_with_heap(self.heap);
+                            value.drop_with_heap(self);
                             catch_sync!(self, cached_frame, ExcType::unary_type_error("+", value_type));
                         }
                     }
@@ -979,20 +979,20 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
                             if let HeapData::LongInt(li) = self.heap.get(id) {
                                 // LongInt bitwise NOT: ~x = -(x + 1)
                                 let inverted = -(li.inner() + 1i32);
-                                value.drop_with_heap(self.heap);
+                                value.drop_with_heap(self);
                                 match LongInt::new(inverted).into_value(self.heap) {
                                     Ok(v) => self.push(v),
                                     Err(e) => catch_sync!(self, cached_frame, RunError::from(e)),
                                 }
                             } else {
                                 let value_type = value.py_type(self.heap);
-                                value.drop_with_heap(self.heap);
+                                value.drop_with_heap(self);
                                 catch_sync!(self, cached_frame, ExcType::unary_type_error("~", value_type));
                             }
                         }
                         _ => {
                             let value_type = value.py_type(self.heap);
-                            value.drop_with_heap(self.heap);
+                            value.drop_with_heap(self);
                             catch_sync!(self, cached_frame, ExcType::unary_type_error("~", value_type));
                         }
                     }
@@ -1075,8 +1075,8 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
                     let index = self.pop();
                     let obj = self.pop();
                     let result = obj.py_getitem(&index, self.heap, self.interns);
-                    obj.drop_with_heap(self.heap);
-                    index.drop_with_heap(self.heap);
+                    obj.drop_with_heap(self);
+                    index.drop_with_heap(self);
                     match result {
                         Ok(v) => self.push(v),
                         Err(e) => catch_sync!(self, cached_frame, e),
@@ -1088,7 +1088,7 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
                     let mut obj = self.pop();
                     let value = self.pop();
                     let result = obj.py_setitem(index, value, self.heap, self.interns);
-                    obj.drop_with_heap(self.heap);
+                    obj.drop_with_heap(self);
                     if let Err(e) = result {
                         catch_sync!(self, cached_frame, e);
                     }
@@ -1119,7 +1119,7 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
                     if cond.py_bool(self.heap, self.interns) {
                         jump_relative!(cached_frame.ip, offset);
                     }
-                    cond.drop_with_heap(self.heap);
+                    cond.drop_with_heap(self);
                 }
                 Opcode::JumpIfFalse => {
                     let offset = fetch_i16!(cached_frame);
@@ -1127,7 +1127,7 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
                     if !cond.py_bool(self.heap, self.interns) {
                         jump_relative!(cached_frame.ip, offset);
                     }
-                    cond.drop_with_heap(self.heap);
+                    cond.drop_with_heap(self);
                 }
                 Opcode::JumpIfTrueOrPop => {
                     let offset = fetch_i16!(cached_frame);
@@ -1135,14 +1135,14 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
                         jump_relative!(cached_frame.ip, offset);
                     } else {
                         let value = self.pop();
-                        value.drop_with_heap(self.heap);
+                        value.drop_with_heap(self);
                     }
                 }
                 Opcode::JumpIfFalseOrPop => {
                     let offset = fetch_i16!(cached_frame);
                     if self.peek().py_bool(self.heap, self.interns) {
                         let value = self.pop();
-                        value.drop_with_heap(self.heap);
+                        value.drop_with_heap(self);
                     } else {
                         jump_relative!(cached_frame.ip, offset);
                     }
@@ -1173,13 +1173,13 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
                         Ok(None) => {
                             // Iterator exhausted - pop it and jump to end
                             let iter = self.pop();
-                            iter.drop_with_heap(self.heap);
+                            iter.drop_with_heap(self);
                             jump_relative!(cached_frame.ip, offset);
                         }
                         Err(e) => {
                             // Error during iteration (e.g., dict size changed)
                             let iter = self.pop();
-                            iter.drop_with_heap(self.heap);
+                            iter.drop_with_heap(self);
                             catch_sync!(self, cached_frame, e);
                         }
                     }
@@ -1373,7 +1373,7 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
                     // Pop the current exception from the stack
                     // This restores the previous exception context (if any)
                     if let Some(exc) = self.exception_stack.pop() {
-                        exc.drop_with_heap(self.heap);
+                        exc.drop_with_heap(self);
                     }
                 }
                 Opcode::CheckExcMatch => {
@@ -1381,7 +1381,7 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
                     let exc_type = self.pop();
                     let exception = self.peek();
                     let result = self.check_exc_match(exception, &exc_type);
-                    exc_type.drop_with_heap(self.heap);
+                    exc_type.drop_with_heap(self);
                     let result = result?;
                     self.push(Value::Bool(result));
                 }
@@ -1611,7 +1611,7 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
         // Clean up frame's stack region
         self.stack
             .drain(frame.stack_base..)
-            .for_each(|value| value.drop_with_heap(self.heap));
+            .for_each(|value| value.drop_with_heap(&mut *self.heap));
 
         // Clean up the namespace (but not the global namespace)
         if frame.namespace_idx != GLOBAL_NS_IDX {
@@ -1692,7 +1692,7 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
             return Err(err);
         }
 
-        self.push(value.clone_with_heap(self.heap));
+        self.push(value.clone_with_heap(self));
         Ok(())
     }
 
@@ -1729,7 +1729,7 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
         let namespace = self.namespaces.get_mut(cached_frame.namespace_idx);
         let ns_slot = NamespaceId::new(slot as usize);
         let old_value = std::mem::replace(namespace.get_mut(ns_slot), value);
-        old_value.drop_with_heap(self.heap);
+        old_value.drop_with_heap(self);
     }
 
     /// Deletes a local variable (sets it to Undefined).
@@ -1737,7 +1737,7 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
         let namespace = self.namespaces.get_mut(cached_frame.namespace_idx);
         let ns_slot = NamespaceId::new(slot as usize);
         let old_value = std::mem::replace(namespace.get_mut(ns_slot), Value::Undefined);
-        old_value.drop_with_heap(self.heap);
+        old_value.drop_with_heap(self);
     }
 
     /// Loads a global variable and pushes it onto the stack.
@@ -1746,9 +1746,7 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
     fn load_global(&mut self, slot: u16) -> RunResult<()> {
         let namespace = self.namespaces.get(GLOBAL_NS_IDX);
         // Copy without incrementing refcount first (avoids borrow conflict)
-        let value = namespace
-            .get(NamespaceId::new(slot as usize))
-            .clone_with_heap(self.heap);
+        let value = namespace.get(NamespaceId::new(slot as usize)).clone_with_heap(self);
 
         // Check for undefined value - raise NameError if so
         if matches!(value, Value::Undefined) {
@@ -1767,7 +1765,7 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
         let namespace = self.namespaces.get_mut(GLOBAL_NS_IDX);
         let ns_slot = NamespaceId::new(slot as usize);
         let old_value = std::mem::replace(namespace.get_mut(ns_slot), value);
-        old_value.drop_with_heap(self.heap);
+        old_value.drop_with_heap(self);
     }
 
     /// Loads from a closure cell and pushes onto the stack.
@@ -1808,6 +1806,9 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
 // `heap` is not a public field on VM, so this implementation needs to go here rather than in `heap.rs`
 impl<T: ResourceTracker> ContainsHeap for VM<'_, '_, T> {
     type ResourceTracker = T;
+    fn heap(&self) -> &Heap<T> {
+        self.heap
+    }
     fn heap_mut(&mut self) -> &mut Heap<T> {
         self.heap
     }

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -773,7 +773,7 @@ pub(crate) struct RecursionToken(());
 
 impl DropWithHeap for RecursionToken {
     #[inline]
-    fn drop_with_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
+    fn drop_with_concrete_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
         heap.decr_recursion_depth();
     }
 }
@@ -1748,11 +1748,15 @@ impl<T: ResourceTracker> Drop for Heap<T> {
 /// to participate in the `HeapGuard` pattern.
 pub(crate) trait ContainsHeap {
     type ResourceTracker: ResourceTracker;
+    fn heap(&self) -> &Heap<Self::ResourceTracker>;
     fn heap_mut(&mut self) -> &mut Heap<Self::ResourceTracker>;
 }
 
 impl<T: ResourceTracker> ContainsHeap for Heap<T> {
     type ResourceTracker = T;
+    fn heap(&self) -> &Self {
+        self
+    }
     #[inline]
     fn heap_mut(&mut self) -> &mut Self {
         self
@@ -1773,21 +1777,26 @@ impl<T: ResourceTracker> ContainsHeap for Heap<T> {
 ///
 /// Implemented for `Value`, `Option<V>`, `Vec<Value>`, `ArgValues`, iterators, and other
 /// types that hold heap references.
-pub(crate) trait DropWithHeap {
+pub(crate) trait DropWithHeap: Sized {
     /// Consume `self` and decrement reference counts for any heap-allocated values contained within.
-    fn drop_with_heap<T: ResourceTracker>(self, heap: &mut Heap<T>);
+    fn drop_with_heap<H: ContainsHeap>(self, heap: &mut H) {
+        self.drop_with_concrete_heap(heap.heap_mut());
+    }
+
+    /// Consume `self` and decrement reference counts for any heap-allocated values contained within.
+    fn drop_with_concrete_heap<T: ResourceTracker>(self, heap: &mut Heap<T>);
 }
 
 impl DropWithHeap for Value {
     #[inline]
-    fn drop_with_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
+    fn drop_with_concrete_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
         Self::drop_with_heap(self, heap);
     }
 }
 
 impl<U: DropWithHeap> DropWithHeap for Option<U> {
     #[inline]
-    fn drop_with_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
+    fn drop_with_concrete_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
         if let Some(value) = self {
             value.drop_with_heap(heap);
         }
@@ -1795,7 +1804,7 @@ impl<U: DropWithHeap> DropWithHeap for Option<U> {
 }
 
 impl<U: DropWithHeap> DropWithHeap for Vec<U> {
-    fn drop_with_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
+    fn drop_with_concrete_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
         for value in self {
             value.drop_with_heap(heap);
         }
@@ -1803,7 +1812,7 @@ impl<U: DropWithHeap> DropWithHeap for Vec<U> {
 }
 
 impl<U: DropWithHeap> DropWithHeap for vec::IntoIter<U> {
-    fn drop_with_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
+    fn drop_with_concrete_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
         for value in self {
             value.drop_with_heap(heap);
         }
@@ -1811,7 +1820,7 @@ impl<U: DropWithHeap> DropWithHeap for vec::IntoIter<U> {
 }
 
 impl<const N: usize> DropWithHeap for [Value; N] {
-    fn drop_with_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
+    fn drop_with_concrete_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
         for value in self {
             value.drop_with_heap(heap);
         }
@@ -1819,7 +1828,7 @@ impl<const N: usize> DropWithHeap for [Value; N] {
 }
 
 impl<U: DropWithHeap, V: DropWithHeap> DropWithHeap for (U, V) {
-    fn drop_with_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
+    fn drop_with_concrete_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
         let (left, right) = self;
         left.drop_with_heap(heap);
         right.drop_with_heap(heap);

--- a/crates/monty/src/signature.rs
+++ b/crates/monty/src/signature.rs
@@ -659,7 +659,7 @@ struct NamespaceGuard<'a> {
 }
 
 impl DropWithHeap for NamespaceGuard<'_> {
-    fn drop_with_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
+    fn drop_with_concrete_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
         for value in self.namespace.drain(..) {
             value.drop_with_heap(heap);
         }

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -647,7 +647,7 @@ impl PyTrait for Dict {
 }
 
 impl DropWithHeap for Dict {
-    fn drop_with_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
+    fn drop_with_concrete_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
         for entry in self.entries {
             entry.key.drop_with_heap(heap);
             entry.value.drop_with_heap(heap);

--- a/crates/monty/src/types/iter.rs
+++ b/crates/monty/src/types/iter.rs
@@ -33,7 +33,7 @@
 use crate::{
     args::ArgValues,
     exception_private::{ExcType, RunResult},
-    heap::{DropWithHeap, Heap, HeapData, HeapGuard, HeapId},
+    heap::{ContainsHeap, DropWithHeap, Heap, HeapData, HeapGuard, HeapId},
     heap_data::HeapDataMut,
     intern::{BytesId, Interns, StringId},
     resource::ResourceTracker,
@@ -116,7 +116,7 @@ impl MontyIter {
     }
 
     /// Drops the iterator and its held value properly.
-    pub fn drop_with_heap(self, heap: &mut Heap<impl ResourceTracker>) {
+    pub fn drop_with_heap(self, heap: &mut impl ContainsHeap) {
         self.value.drop_with_heap(heap);
     }
 
@@ -756,7 +756,7 @@ impl IterValue {
 
 impl DropWithHeap for MontyIter {
     #[inline]
-    fn drop_with_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
+    fn drop_with_concrete_heap<T: ResourceTracker>(self, heap: &mut Heap<T>) {
         Self::drop_with_heap(self, heap);
     }
 }

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -706,7 +706,7 @@ fn do_list_sort(list: &mut List, args: ArgValues, vm: &mut VM<impl ResourceTrack
     // Convert reverse to bool (default false)
     let reverse = if let Some(v) = reverse_arg {
         let result = v.py_bool(vm.heap, vm.interns);
-        v.drop_with_heap(vm.heap);
+        v.drop_with_heap(vm);
         result
     } else {
         false
@@ -715,7 +715,7 @@ fn do_list_sort(list: &mut List, args: ArgValues, vm: &mut VM<impl ResourceTrack
     // Handle key function (None means no key function)
     let key_fn = match key_arg {
         Some(v) if matches!(v, Value::None) => {
-            v.drop_with_heap(vm.heap);
+            v.drop_with_heap(vm);
             None
         }
         other => other,
@@ -736,7 +736,7 @@ fn do_list_sort(list: &mut List, args: ArgValues, vm: &mut VM<impl ResourceTrack
         items
             .iter()
             .map(|item| {
-                let item = item.clone_with_heap(vm.heap);
+                let item = item.clone_with_heap(vm);
                 vm.evaluate_function("sorted() key argument", f, ArgValues::One(item))
             })
             .process_results(|keys_iter| keys.extend(keys_iter))?;

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -9,7 +9,7 @@ use crate::{
     bytecode::VM,
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult},
-    heap::{DropWithHeap, Heap, HeapData, HeapId},
+    heap::{ContainsHeap, DropWithHeap, Heap, HeapData, HeapId},
     intern::{Interns, StaticStrings},
     resource::{ResourceError, ResourceTracker},
     types::Type,
@@ -210,7 +210,7 @@ impl SetStorage {
     }
 
     /// Creates a deep clone with proper reference counting.
-    fn clone_with_heap(&self, heap: &Heap<impl ResourceTracker>) -> Self {
+    fn clone_with_heap(&self, heap: &impl ContainsHeap) -> Self {
         Self {
             indices: self.indices.clone(),
             entries: self

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -17,7 +17,7 @@ use crate::{
     asyncio::CallId,
     builtins::Builtins,
     exception_private::{ExcType, RunError, RunResult, SimpleException},
-    heap::{Heap, HeapData, HeapId},
+    heap::{ContainsHeap, Heap, HeapData, HeapId},
     heap_data::HeapDataMut,
     intern::{BytesId, ExtFunctionId, FunctionId, Interns, LongIntId, StaticStrings, StringId},
     modules::ModuleFunctions,
@@ -1853,15 +1853,19 @@ impl Value {
     /// For heap-allocated values (Ref variant), this increments the reference count
     /// and returns a new reference to the same heap value.
     ///
+    /// Takes `ContainsHeap` to allow directly passing the `VM` in many contexts. Where
+    /// borrow checking creates conflicts, it may be preferred to pass `&Heap` directly
+    /// (e.g. as `vm.heap` / `self.heap` etc.).
+    ///
     /// # Important
     /// This method MUST be used instead of the derived `Clone` implementation to ensure
     /// proper reference counting. Using `.clone()` directly will bypass reference counting
     /// and cause memory leaks or double-frees.
     #[must_use]
-    pub fn clone_with_heap(&self, heap: &Heap<impl ResourceTracker>) -> Self {
+    pub fn clone_with_heap(&self, heap: &impl ContainsHeap) -> Self {
         match self {
             Self::Ref(id) => {
-                heap.inc_ref(*id);
+                heap.heap().inc_ref(*id);
                 Self::Ref(*id)
             }
             // Immediate values can be copied without heap interaction
@@ -1876,24 +1880,28 @@ impl Value {
     /// the count reaches zero. For Closure variants, this decrements ref counts on all
     /// captured cells.
     ///
+    /// Takes `ContainsHeap` to allow directly passing the `VM` in many contexts. Where
+    /// borrow checking creates conflicts, it may be preferred to pass `&mut Heap` directly
+    /// (e.g. as `vm.heap` / `self.heap` etc.).
+    ///
     /// # Important
     /// This method MUST be called before overwriting a namespace slot or discarding
     /// a value to prevent memory leaks.
     #[cfg(not(feature = "ref-count-panic"))]
     #[inline]
-    pub fn drop_with_heap(self, heap: &mut Heap<impl ResourceTracker>) {
+    pub fn drop_with_heap(self, heap: &mut impl ContainsHeap) {
         if let Self::Ref(id) = self {
-            heap.dec_ref(id);
+            heap.heap_mut().dec_ref(id);
         }
     }
     /// With `ref-count-panic` enabled, `Ref` variants are replaced with `Dereferenced` and
     /// the original is forgotten to prevent the Drop impl from panicking. Non-Ref variants
     /// are left unchanged since they don't trigger the Drop panic.
     #[cfg(feature = "ref-count-panic")]
-    pub fn drop_with_heap(mut self, heap: &mut Heap<impl ResourceTracker>) {
+    pub fn drop_with_heap(mut self, heap: &mut impl ContainsHeap) {
         let old = std::mem::replace(&mut self, Self::Dereferenced);
         if let Self::Ref(id) = &old {
-            heap.dec_ref(*id);
+            heap.heap_mut().dec_ref(*id);
             std::mem::forget(old);
         }
     }


### PR DESCRIPTION
This is a convenience change to allow syntactical conciseness in some contexts. Will be more useful in #207.