### PR TITLE
convert iteration to take `VM`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,9 @@ Beyond safety, `defer_drop!` is often much more concise than inserting `drop_wit
 `defer_drop!` gives you an immutable reference to the value. Use `defer_drop_mut!` when you need a mutable reference (e.g. iterators, values you may swap):
 
 ```rust
-let iter = heap.get_iter(iter_ref);
-defer_drop_mut!(iter, heap);
-while let Some(item) = iter.for_next(heap)? { ... }
+let iter = vm.heap.get_iter(iter_ref);
+defer_drop_mut!(iter, vm);
+while let Some(item) = iter.for_next(vm)? { ... }
 ```
 
 **Limitation:** because the macro rebinds the heap, it cannot be used inside `&mut self` methods where `self` owns the heap — first assign `let this = self;` and pass `this` instead.

--- a/crates/monty/src/builtins/abs.rs
+++ b/crates/monty/src/builtins/abs.rs
@@ -18,7 +18,7 @@ use crate::{
 ///
 /// Returns the absolute value of a number. Works with integers, floats, and LongInts.
 /// For `i64::MIN`, which overflows on negation, promotes to LongInt.
-pub fn builtin_abs(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_abs(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("abs", vm.heap)?;
     defer_drop!(value, vm);
 

--- a/crates/monty/src/builtins/all.rs
+++ b/crates/monty/src/builtins/all.rs
@@ -14,12 +14,12 @@ use crate::{
 ///
 /// Returns True if all elements of the iterable are true (or if the iterable is empty).
 /// Short-circuits on the first falsy value.
-pub fn builtin_all(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_all(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let iterable = args.get_one_arg("all", vm.heap)?;
-    let iter = MontyIter::new(iterable, vm.heap, vm.interns)?;
+    let iter = MontyIter::new(iterable, vm)?;
     defer_drop_mut!(iter, vm);
 
-    while let Some(item) = iter.for_next(vm.heap, vm.interns)? {
+    while let Some(item) = iter.for_next(vm)? {
         defer_drop!(item, vm);
         let is_truthy = item.py_bool(vm.heap, vm.interns);
         if !is_truthy {

--- a/crates/monty/src/builtins/any.rs
+++ b/crates/monty/src/builtins/any.rs
@@ -14,12 +14,12 @@ use crate::{
 ///
 /// Returns True if any element of the iterable is true.
 /// Returns False for an empty iterable. Short-circuits on the first truthy value.
-pub fn builtin_any(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_any(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let iterable = args.get_one_arg("any", vm.heap)?;
-    let iter = MontyIter::new(iterable, vm.heap, vm.interns)?;
+    let iter = MontyIter::new(iterable, vm)?;
     defer_drop_mut!(iter, vm);
 
-    while let Some(item) = iter.for_next(vm.heap, vm.interns)? {
+    while let Some(item) = iter.for_next(vm)? {
         defer_drop!(item, vm);
         let is_truthy = item.py_bool(vm.heap, vm.interns);
         if is_truthy {

--- a/crates/monty/src/builtins/bin.rs
+++ b/crates/monty/src/builtins/bin.rs
@@ -18,7 +18,7 @@ use crate::{
 ///
 /// Converts an integer to a binary string prefixed with '0b'.
 /// Supports both i64 and BigInt integers.
-pub fn builtin_bin(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_bin(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("bin", vm.heap)?;
     defer_drop!(value, vm);
 

--- a/crates/monty/src/builtins/chr.rs
+++ b/crates/monty/src/builtins/chr.rs
@@ -14,7 +14,7 @@ use crate::{
 ///
 /// Returns a string representing a character whose Unicode code point is the integer.
 /// The valid range for the argument is from 0 through 1,114,111 (0x10FFFF).
-pub fn builtin_chr(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_chr(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("chr", vm.heap)?;
     defer_drop!(value, vm);
 

--- a/crates/monty/src/builtins/divmod.rs
+++ b/crates/monty/src/builtins/divmod.rs
@@ -19,7 +19,7 @@ use crate::{
 ///
 /// Returns a tuple (quotient, remainder) from integer division.
 /// Equivalent to (a // b, a % b).
-pub fn builtin_divmod(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_divmod(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (a, b) = args.get_two_args("divmod", vm.heap)?;
     let a = super::round::normalize_bool_to_int(a);
     let b = super::round::normalize_bool_to_int(b);

--- a/crates/monty/src/builtins/enumerate.rs
+++ b/crates/monty/src/builtins/enumerate.rs
@@ -17,9 +17,9 @@ use crate::{
 ///
 /// Returns a list of (index, value) tuples.
 /// Note: In Python this returns an iterator, but we return a list for simplicity.
-pub fn builtin_enumerate(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_enumerate(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (iterable, start) = args.get_one_two_args("enumerate", vm.heap)?;
-    let iter = MontyIter::new(iterable, vm.heap, vm.interns)?;
+    let iter = MontyIter::new(iterable, vm)?;
     defer_drop_mut!(iter, vm);
     defer_drop!(start, vm);
 
@@ -40,7 +40,7 @@ pub fn builtin_enumerate(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> 
 
     let mut result: Vec<Value> = Vec::new();
 
-    while let Some(item) = iter.for_next(vm.heap, vm.interns)? {
+    while let Some(item) = iter.for_next(vm)? {
         // Create tuple (index, item)
         let tuple_val = allocate_tuple(smallvec![Value::Int(index), item], vm.heap)?;
         result.push(tuple_val);

--- a/crates/monty/src/builtins/filter.rs
+++ b/crates/monty/src/builtins/filter.rs
@@ -30,18 +30,18 @@ use crate::{
 /// filter(lambda x: x > 0, [-1, 0, 1, 2])  # [1, 2]
 /// filter(None, [0, 1, False, True, ''])   # [1, True]
 /// ```
-pub fn builtin_filter(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_filter(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (function, iterable) = args.get_two_args("filter", vm.heap)?;
     defer_drop!(function, vm);
 
-    let iter = MontyIter::new(iterable, vm.heap, vm.interns)?;
+    let iter = MontyIter::new(iterable, vm)?;
     defer_drop_mut!(iter, vm);
 
     let out: Vec<Value> = Vec::new();
     let mut out_guard = HeapGuard::new(out, vm);
     let (out, vm) = out_guard.as_parts_mut();
 
-    while let Some(item) = iter.for_next(vm.heap, vm.interns)? {
+    while let Some(item) = iter.for_next(vm)? {
         let mut item_guard = HeapGuard::new(item, vm);
         let (item, vm) = item_guard.as_parts_mut();
         let should_include = if let Value::None = function {

--- a/crates/monty/src/builtins/getattr.rs
+++ b/crates/monty/src/builtins/getattr.rs
@@ -27,7 +27,7 @@ use crate::{
 /// getattr(obj, 'y', None)       # Get obj.y or None if not found
 /// getattr(module, 'function')   # Get module.function
 /// ```
-pub fn builtin_getattr(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_getattr(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let positional = args.into_pos_only("getattr", vm.heap)?;
     defer_drop!(positional, vm);
     let heap = &mut *vm.heap;

--- a/crates/monty/src/builtins/hash.rs
+++ b/crates/monty/src/builtins/hash.rs
@@ -14,7 +14,7 @@ use crate::{
 ///
 /// Returns the hash value of an object (if it has one).
 /// Raises TypeError for unhashable types like lists and dicts.
-pub fn builtin_hash(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_hash(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("hash", vm.heap)?;
     defer_drop!(value, vm);
     match value.py_hash(vm.heap, vm.interns)? {

--- a/crates/monty/src/builtins/hex.rs
+++ b/crates/monty/src/builtins/hex.rs
@@ -18,7 +18,7 @@ use crate::{
 ///
 /// Converts an integer to a lowercase hexadecimal string prefixed with '0x'.
 /// Supports both i64 and BigInt integers.
-pub fn builtin_hex(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_hex(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("hex", vm.heap)?;
     defer_drop!(value, vm);
     let heap = &mut *vm.heap;

--- a/crates/monty/src/builtins/id.rs
+++ b/crates/monty/src/builtins/id.rs
@@ -7,7 +7,7 @@ use crate::{
 /// Implementation of the id() builtin function.
 ///
 /// Returns the identity of an object (unique integer for the object's lifetime).
-pub fn builtin_id(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_id(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("id", vm.heap)?;
     defer_drop!(value, vm);
 

--- a/crates/monty/src/builtins/isinstance.rs
+++ b/crates/monty/src/builtins/isinstance.rs
@@ -15,7 +15,7 @@ use crate::{
 /// Implementation of the isinstance() builtin function.
 ///
 /// Checks if an object is an instance of a class or a tuple of classes.
-pub fn builtin_isinstance(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_isinstance(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (obj, classinfo) = args.get_two_args("isinstance", vm.heap)?;
     defer_drop!(obj, vm);
     defer_drop!(classinfo, vm);

--- a/crates/monty/src/builtins/len.rs
+++ b/crates/monty/src/builtins/len.rs
@@ -13,7 +13,7 @@ use crate::{
 /// Implementation of the len() builtin function.
 ///
 /// Returns the length of an object (number of items in a container).
-pub fn builtin_len(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_len(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("len", vm.heap)?;
     defer_drop!(value, vm);
     if let Some(len) = value.py_len(vm.heap, vm.interns) {

--- a/crates/monty/src/builtins/map.rs
+++ b/crates/monty/src/builtins/map.rs
@@ -25,7 +25,7 @@ use crate::{
 /// map(pow, [2, 3], [3, 2])          # [8, 9]
 /// map(str, [1, 2, 3])               # ['1', '2', '3']
 /// ```
-pub fn builtin_map(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_map(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (positional, kwargs) = args.into_parts();
     defer_drop_mut!(positional, vm);
 
@@ -39,14 +39,14 @@ pub fn builtin_map(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunRes
     defer_drop!(function, vm);
 
     let first_iterable = positional.next().expect("checked length above");
-    let first_iter = MontyIter::new(first_iterable, vm.heap, vm.interns)?;
+    let first_iter = MontyIter::new(first_iterable, vm)?;
     defer_drop_mut!(first_iter, vm);
 
     let extra_iterators: Vec<MontyIter> = Vec::with_capacity(positional.len());
     defer_drop_mut!(extra_iterators, vm);
 
     for iterable in positional {
-        extra_iterators.push(MontyIter::new(iterable, vm.heap, vm.interns)?);
+        extra_iterators.push(MontyIter::new(iterable, vm)?);
     }
 
     let mut out = Vec::with_capacity(first_iter.size_hint(vm.heap));
@@ -55,15 +55,15 @@ pub fn builtin_map(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunRes
     match extra_iterators.as_mut_slice() {
         // map(f, iter)
         [] => {
-            while let Some(item) = first_iter.for_next(vm.heap, vm.interns)? {
+            while let Some(item) = first_iter.for_next(vm)? {
                 let args = ArgValues::One(item);
                 out.push(vm.evaluate_function("map()", function, args)?);
             }
         }
         // map(f, iter1, iter2)
         [single] => {
-            while let Some(arg1) = first_iter.for_next(vm.heap, vm.interns)? {
-                let Some(arg2) = single.for_next(vm.heap, vm.interns)? else {
+            while let Some(arg1) = first_iter.for_next(vm)? {
+                let Some(arg2) = single.for_next(vm)? else {
                     arg1.drop_with_heap(vm);
                     break;
                 };
@@ -76,7 +76,7 @@ pub fn builtin_map(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunRes
             let mut items = Vec::with_capacity(1 + multiple.len());
 
             for iter in std::iter::once(&mut *first_iter).chain(multiple.iter_mut()) {
-                if let Some(item) = iter.for_next(vm.heap, vm.interns)? {
+                if let Some(item) = iter.for_next(vm)? {
                     items.push(item);
                 } else {
                     items.drop_with_heap(vm);

--- a/crates/monty/src/builtins/min_max.rs
+++ b/crates/monty/src/builtins/min_max.rs
@@ -8,7 +8,6 @@ use crate::{
     defer_drop_mut,
     exception_private::{ExcType, RunError, RunResult, SimpleException},
     heap::{Heap, HeapGuard},
-    intern::Interns,
     resource::ResourceTracker,
     types::{MontyIter, PyTrait},
     value::Value,
@@ -20,8 +19,8 @@ use crate::{
 /// Supports two forms:
 /// - `min(iterable)` - returns smallest item from iterable
 /// - `min(arg1, arg2, ...)` - returns smallest of the arguments
-pub fn builtin_min(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-    builtin_min_max(vm.heap, args, vm.interns, true)
+pub fn builtin_min(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    builtin_min_max(vm, args, true)
 }
 
 /// Implementation of the max() builtin function.
@@ -30,25 +29,20 @@ pub fn builtin_min(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunRes
 /// Supports two forms:
 /// - `max(iterable)` - returns largest item from iterable
 /// - `max(arg1, arg2, ...)` - returns largest of the arguments
-pub fn builtin_max(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-    builtin_min_max(vm.heap, args, vm.interns, false)
+pub fn builtin_max(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    builtin_min_max(vm, args, false)
 }
 
 /// Shared implementation for min() and max().
 ///
 /// When `is_min` is true, returns the minimum; otherwise returns the maximum.
-fn builtin_min_max(
-    heap: &mut Heap<impl ResourceTracker>,
-    args: ArgValues,
-    interns: &Interns,
-    is_min: bool,
-) -> RunResult<Value> {
+fn builtin_min_max(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues, is_min: bool) -> RunResult<Value> {
     let func_name = if is_min { "min" } else { "max" };
     let (positional, kwargs) = args.into_parts();
-    defer_drop_mut!(positional, heap);
+    defer_drop_mut!(positional, vm);
 
     // TODO: support kwargs (key, default)
-    kwargs.not_supported_yet(func_name, heap)?;
+    kwargs.not_supported_yet(func_name, vm.heap)?;
 
     let Some(first_arg) = positional.next() else {
         return Err(SimpleException::new_msg(
@@ -61,10 +55,10 @@ fn builtin_min_max(
     // decide what to do based on remaining arguments
     if positional.len() == 0 {
         // Single argument: iterate over it
-        let iter = MontyIter::new(first_arg, heap, interns)?;
-        defer_drop_mut!(iter, heap);
+        let iter = MontyIter::new(first_arg, vm)?;
+        defer_drop_mut!(iter, vm);
 
-        let Some(result) = iter.for_next(heap, interns)? else {
+        let Some(result) = iter.for_next(vm)? else {
             return Err(SimpleException::new_msg(
                 ExcType::ValueError,
                 format!("{func_name}() iterable argument is empty"),
@@ -72,14 +66,14 @@ fn builtin_min_max(
             .into());
         };
 
-        let mut result_guard = HeapGuard::new(result, heap);
-        let (result, heap) = result_guard.as_parts_mut();
+        let mut result_guard = HeapGuard::new(result, vm);
+        let (result, vm) = result_guard.as_parts_mut();
 
-        while let Some(item) = iter.for_next(heap, interns)? {
-            defer_drop_mut!(item, heap);
+        while let Some(item) = iter.for_next(vm)? {
+            defer_drop_mut!(item, vm);
 
-            let Some(ordering) = result.py_cmp(item, heap, interns)? else {
-                return Err(ord_not_supported(result, item, heap));
+            let Some(ordering) = result.py_cmp(item, vm.heap, vm.interns)? else {
+                return Err(ord_not_supported(result, item, vm.heap));
             };
 
             if (is_min && ordering == Ordering::Greater) || (!is_min && ordering == Ordering::Less) {
@@ -90,14 +84,14 @@ fn builtin_min_max(
         Ok(result_guard.into_inner())
     } else {
         // Multiple arguments: compare them directly
-        let mut result_guard = HeapGuard::new(first_arg, heap);
-        let (result, heap) = result_guard.as_parts_mut();
+        let mut result_guard = HeapGuard::new(first_arg, vm);
+        let (result, vm) = result_guard.as_parts_mut();
 
         for item in positional {
-            defer_drop_mut!(item, heap);
+            defer_drop_mut!(item, vm);
 
-            let Some(ordering) = result.py_cmp(item, heap, interns)? else {
-                return Err(ord_not_supported(result, item, heap));
+            let Some(ordering) = result.py_cmp(item, vm.heap, vm.interns)? else {
+                return Err(ord_not_supported(result, item, vm.heap));
             };
 
             if (is_min && ordering == Ordering::Greater) || (!is_min && ordering == Ordering::Less) {

--- a/crates/monty/src/builtins/mod.rs
+++ b/crates/monty/src/builtins/mod.rs
@@ -61,7 +61,7 @@ pub(crate) enum Builtins {
 
 impl Builtins {
     /// Calls this builtin with the given arguments.
-    pub fn call(self, vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub fn call(self, vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         match self {
             Self::Function(b) => b.call(vm, args),
             Self::ExcType(exc) => exc.call(vm, args),
@@ -210,7 +210,7 @@ impl BuiltinsFunctions {
     ///
     /// All builtins receive the full VM context, which provides access to the heap,
     /// interned strings, and print output.
-    pub(crate) fn call(self, vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub(crate) fn call(self, vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         match self {
             Self::Abs => abs::builtin_abs(vm, args),
             Self::All => all::builtin_all(vm, args),

--- a/crates/monty/src/builtins/next.rs
+++ b/crates/monty/src/builtins/next.rs
@@ -14,7 +14,7 @@ use crate::{
 ///   `StopIteration` when the iterator is exhausted.
 /// - `next(iterator, default)` - Returns the next item from the iterator, or
 ///   `default` if the iterator is exhausted.
-pub fn builtin_next(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_next(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (iterator, default) = args.get_one_two_args("next", vm.heap)?;
     defer_drop!(iterator, vm);
     iterator_next(iterator, default, vm.heap, vm.interns)

--- a/crates/monty/src/builtins/oct.rs
+++ b/crates/monty/src/builtins/oct.rs
@@ -18,7 +18,7 @@ use crate::{
 ///
 /// Converts an integer to an octal string prefixed with '0o'.
 /// Supports both i64 and BigInt integers.
-pub fn builtin_oct(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_oct(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("oct", vm.heap)?;
     defer_drop!(value, vm);
 

--- a/crates/monty/src/builtins/ord.rs
+++ b/crates/monty/src/builtins/ord.rs
@@ -14,7 +14,7 @@ use crate::{
 /// Implementation of the ord() builtin function.
 ///
 /// Returns the Unicode code point of a one-character string.
-pub fn builtin_ord(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_ord(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("ord", vm.heap)?;
     defer_drop!(value, vm);
 

--- a/crates/monty/src/builtins/pow.rs
+++ b/crates/monty/src/builtins/pow.rs
@@ -18,7 +18,7 @@ use crate::{
 ///
 /// Returns base to the power exp. With three arguments, returns (base ** exp) % mod.
 /// Handles negative exponents by returning a float.
-pub fn builtin_pow(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_pow(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     // pow() accepts 2 or 3 arguments
     let positional = args.into_pos_only("pow", vm.heap)?;
     defer_drop!(positional, vm);

--- a/crates/monty/src/builtins/print.rs
+++ b/crates/monty/src/builtins/print.rs
@@ -20,7 +20,7 @@ use crate::{
 /// - `flush`: whether to flush the stream (accepted but ignored)
 ///
 /// The `file` kwarg is not supported.
-pub fn builtin_print(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_print(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     // Split into positional args and kwargs
     let (positional, kwargs) = args.into_parts();
     defer_drop!(positional, vm);

--- a/crates/monty/src/builtins/repr.rs
+++ b/crates/monty/src/builtins/repr.rs
@@ -8,7 +8,7 @@ use crate::{
 /// Implementation of the repr() builtin function.
 ///
 /// Returns a string containing a printable representation of an object.
-pub fn builtin_repr(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_repr(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("repr", vm.heap)?;
     defer_drop!(value, vm);
     let heap_id = vm

--- a/crates/monty/src/builtins/reversed.rs
+++ b/crates/monty/src/builtins/reversed.rs
@@ -14,11 +14,11 @@ use crate::{
 ///
 /// Returns a list with elements in reverse order.
 /// Note: In Python this returns an iterator, but we return a list for simplicity.
-pub fn builtin_reversed(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_reversed(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("reversed", vm.heap)?;
 
     // Collect all items
-    let mut items: Vec<_> = MontyIter::new(value, vm.heap, vm.interns)?.collect(vm.heap, vm.interns)?;
+    let mut items: Vec<_> = MontyIter::new(value, vm)?.collect(vm)?;
 
     // Reverse in place
     items.reverse();

--- a/crates/monty/src/builtins/round.rs
+++ b/crates/monty/src/builtins/round.rs
@@ -22,7 +22,7 @@ pub fn normalize_bool_to_int(value: Value) -> Value {
 /// Rounds a number to a given precision in decimal digits.
 /// If ndigits is omitted or None, returns the nearest integer.
 /// Uses banker's rounding (round half to even).
-pub fn builtin_round(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_round(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (number, ndigits) = args.get_one_two_args("round", vm.heap)?;
     let number = normalize_bool_to_int(number);
     defer_drop!(number, vm);

--- a/crates/monty/src/builtins/sorted.rs
+++ b/crates/monty/src/builtins/sorted.rs
@@ -20,11 +20,11 @@ use crate::{
 /// Returns a new sorted list from the items in an iterable.
 /// Supports `key` and `reverse` keyword arguments matching Python's
 /// `sorted(iterable, /, *, key=None, reverse=False)` signature.
-pub fn builtin_sorted(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_sorted(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (iterable, key_fn, reverse) = parse_sorted_args(args, vm.heap, vm.interns)?;
     defer_drop!(key_fn, vm);
 
-    let items: Vec<_> = MontyIter::new(iterable, vm.heap, vm.interns)?.collect(vm.heap, vm.interns)?;
+    let items: Vec<_> = MontyIter::new(iterable, vm)?.collect(vm)?;
     let mut items_guard = HeapGuard::new(items, vm);
     let (items, vm) = items_guard.as_parts_mut();
 

--- a/crates/monty/src/builtins/sum.rs
+++ b/crates/monty/src/builtins/sum.rs
@@ -16,11 +16,11 @@ use crate::{
 /// Sums the items of an iterable from left to right with an optional start value.
 /// The default start value is 0. String start values are explicitly rejected
 /// (use `''.join(seq)` instead for string concatenation).
-pub fn builtin_sum(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_sum(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (iterable, start) = args.get_one_two_args("sum", vm.heap)?;
     defer_drop_mut!(start, vm);
 
-    let iter = MontyIter::new(iterable, vm.heap, vm.interns)?;
+    let iter = MontyIter::new(iterable, vm)?;
     defer_drop_mut!(iter, vm);
 
     // Get the start value, defaulting to 0
@@ -46,7 +46,7 @@ pub fn builtin_sum(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunRes
     let (accumulator, vm) = acc_guard.as_parts_mut();
 
     // Sum all items
-    while let Some(item) = iter.for_next(vm.heap, vm.interns)? {
+    while let Some(item) = iter.for_next(vm)? {
         defer_drop!(item, vm);
 
         // Try to add the item to accumulator

--- a/crates/monty/src/builtins/type_.rs
+++ b/crates/monty/src/builtins/type_.rs
@@ -9,7 +9,7 @@ use crate::{
 /// Implementation of the type() builtin function.
 ///
 /// Returns the type of an object.
-pub fn builtin_type(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_type(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("type", vm.heap)?;
     defer_drop!(value, vm);
     Ok(Value::Builtin(Builtins::Type(value.py_type(vm.heap))))

--- a/crates/monty/src/builtins/zip.rs
+++ b/crates/monty/src/builtins/zip.rs
@@ -16,7 +16,7 @@ use crate::{
 /// Returns a list of tuples, where the i-th tuple contains the i-th element
 /// from each of the argument iterables. Stops when the shortest iterable is exhausted.
 /// Note: In Python this returns an iterator, but we return a list for simplicity.
-pub fn builtin_zip(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_zip(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (positional, kwargs) = args.into_parts();
     defer_drop_mut!(positional, vm);
 
@@ -32,7 +32,7 @@ pub fn builtin_zip(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunRes
     // Create iterators for each iterable
     let mut iterators: Vec<MontyIter> = Vec::with_capacity(positional.len());
     for iterable in positional {
-        match MontyIter::new(iterable, vm.heap, vm.interns) {
+        match MontyIter::new(iterable, vm) {
             Ok(iter) => iterators.push(iter),
             Err(e) => {
                 // Clean up already-created iterators
@@ -51,7 +51,7 @@ pub fn builtin_zip(vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunRes
         let mut tuple_items = TupleVec::with_capacity(iterators.len());
 
         for iter in &mut iterators {
-            if let Some(item) = iter.for_next(vm.heap, vm.interns)? {
+            if let Some(item) = iter.for_next(vm)? {
                 tuple_items.push(item);
             } else {
                 // This iterator is exhausted - drop partial tuple items and stop

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -284,12 +284,12 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
             Value::InternString(string_id) => {
                 // Call string method on interned string literal using the unified dispatcher
                 let s = this.interns.get_str(string_id);
-                call_str_method(s, name_id, args, this.heap, this.interns).map(CallResult::Push)
+                call_str_method(s, name_id, args, this).map(CallResult::Push)
             }
             Value::InternBytes(bytes_id) => {
                 // Call bytes method on interned bytes literal using the unified dispatcher
                 let b = this.interns.get_bytes(bytes_id);
-                call_bytes_method(b, name_id, args, this.heap, this.interns).map(CallResult::Push)
+                call_bytes_method(b, name_id, args, this).map(CallResult::Push)
             }
             Value::Builtin(Builtins::Type(t)) => {
                 // Handle classmethods on type objects like dict.fromkeys()

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -1151,7 +1151,7 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
                 Opcode::GetIter => {
                     let value = self.pop();
                     // Create a MontyIter from the value and store on heap
-                    match MontyIter::new(value, self.heap, self.interns) {
+                    match MontyIter::new(value, self) {
                         Ok(iter) => match self.heap.allocate(HeapData::Iter(iter)) {
                             Ok(heap_id) => self.push(Value::Ref(heap_id)),
                             Err(e) => catch_sync!(self, cached_frame, e.into()),

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -158,7 +158,7 @@ impl ExcType {
     ///
     /// The `interns` parameter provides access to interned string content.
     /// Returns a heap-allocated exception value.
-    pub(crate) fn call(self, vm: &mut VM<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub(crate) fn call(self, vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         defer_drop!(args, vm);
         let exc = match args {
             ArgValues::Empty => Ok(SimpleException::new_none(self)),

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -190,7 +190,9 @@ impl Bytes {
     /// - `bytes(bytes)` returns a copy of the bytes
     ///
     /// Note: Full Python semantics for bytes() are more complex (encoding, errors params).
-    pub fn init(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
+    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+        let heap = &mut *vm.heap;
+        let interns = vm.interns;
         let value = args.get_zero_one_arg("bytes", heap)?;
         defer_drop!(value, heap);
         let new_data = match value {
@@ -314,18 +316,16 @@ impl PyTrait for Bytes {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<impl ResourceTracker>,
+        vm: &mut VM<'_, '_, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<AttrCallResult> {
-        let heap = &mut *vm.heap;
-        let interns = vm.interns;
         let Some(method) = attr.static_string() else {
-            args.drop_with_heap(heap);
-            return Err(ExcType::attribute_error(Type::Bytes, attr.as_str(interns)));
+            args.drop_with_heap(vm.heap);
+            return Err(ExcType::attribute_error(Type::Bytes, attr.as_str(vm.interns)));
         };
 
-        call_bytes_method_impl(self.as_slice(), method, args, heap, interns).map(AttrCallResult::Value)
+        call_bytes_method_impl(self.as_slice(), method, args, vm).map(AttrCallResult::Value)
     }
 }
 
@@ -337,14 +337,13 @@ pub fn call_bytes_method(
     bytes: &[u8],
     method_id: StringId,
     args: ArgValues,
-    heap: &mut Heap<impl ResourceTracker>,
-    interns: &Interns,
+    vm: &mut VM<'_, '_, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let Some(method) = StaticStrings::from_string_id(method_id) else {
-        args.drop_with_heap(heap);
-        return Err(ExcType::attribute_error(Type::Bytes, interns.get_str(method_id)));
+        args.drop_with_heap(vm.heap);
+        return Err(ExcType::attribute_error(Type::Bytes, vm.interns.get_str(method_id)));
     };
-    call_bytes_method_impl(bytes, method, args, heap, interns)
+    call_bytes_method_impl(bytes, method, args, vm)
 }
 
 /// Calls a bytes method on a byte slice.
@@ -356,9 +355,10 @@ fn call_bytes_method_impl(
     bytes: &[u8],
     method: StaticStrings,
     args: ArgValues,
-    heap: &mut Heap<impl ResourceTracker>,
-    interns: &Interns,
+    vm: &mut VM<'_, '_, impl ResourceTracker>,
 ) -> RunResult<Value> {
+    let heap = &mut *vm.heap;
+    let interns = vm.interns;
     match method {
         // Decode method
         StaticStrings::Decode => bytes_decode(bytes, args, heap, interns),
@@ -444,8 +444,8 @@ fn call_bytes_method_impl(
         StaticStrings::Zfill => bytes_zfill(bytes, args, heap),
         // Join method
         StaticStrings::Join => {
-            let iterable = args.get_one_arg("bytes.join", heap)?;
-            bytes_join(bytes, iterable, heap, interns)
+            let iterable = args.get_one_arg("bytes.join", vm.heap)?;
+            bytes_join(bytes, iterable, vm)
         }
         // Hex method
         StaticStrings::Hex => bytes_hex(bytes, args, heap, interns),
@@ -2096,22 +2096,17 @@ fn bytes_zfill(bytes: &[u8], args: ArgValues, heap: &mut Heap<impl ResourceTrack
 /// Implements Python's `bytes.join(iterable)` method.
 ///
 /// Joins elements of the iterable with the separator bytes.
-fn bytes_join(
-    separator: &[u8],
-    iterable: Value,
-    heap: &mut Heap<impl ResourceTracker>,
-    interns: &Interns,
-) -> RunResult<Value> {
-    let Ok(iter) = MontyIter::new(iterable, heap, interns) else {
+fn bytes_join(separator: &[u8], iterable: Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Value> {
+    let Ok(iter) = MontyIter::new(iterable, vm) else {
         return Err(ExcType::type_error_join_not_iterable());
     };
-    defer_drop_mut!(iter, heap);
+    defer_drop_mut!(iter, vm);
 
     let mut result = Vec::new();
     let mut index = 0usize;
 
-    while let Some(item) = iter.for_next(heap, interns)? {
-        defer_drop!(item, heap);
+    while let Some(item) = iter.for_next(vm)? {
+        defer_drop!(item, vm);
 
         if index > 0 {
             result.extend_from_slice(separator);
@@ -2120,20 +2115,20 @@ fn bytes_join(
         // Check item is bytes and extract its content
         match item {
             Value::InternBytes(id) => {
-                result.extend_from_slice(interns.get_bytes(*id));
+                result.extend_from_slice(vm.interns.get_bytes(*id));
             }
             Value::Ref(heap_id) => {
-                if let HeapData::Bytes(b) = heap.get(*heap_id) {
+                if let HeapData::Bytes(b) = vm.heap.get(*heap_id) {
                     result.extend_from_slice(b.as_slice());
                 } else {
-                    let t = item.py_type(heap);
+                    let t = item.py_type(vm.heap);
                     return Err(ExcType::type_error(format!(
                         "sequence item {index}: expected a bytes-like object, {t} found"
                     )));
                 }
             }
             _ => {
-                let t = item.py_type(heap);
+                let t = item.py_type(vm.heap);
                 return Err(ExcType::type_error(format!(
                     "sequence item {index}: expected a bytes-like object, {t} found"
                 )));
@@ -2142,7 +2137,7 @@ fn bytes_join(
         index += 1;
     }
 
-    allocate_bytes(result, heap)
+    allocate_bytes(result, vm.heap)
 }
 
 // =============================================================================

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -273,7 +273,7 @@ impl PyTrait for Dataclass {
     fn py_call_attr(
         &mut self,
         self_id: HeapId,
-        vm: &mut VM<impl ResourceTracker>,
+        vm: &mut VM<'_, '_, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<AttrCallResult> {

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -332,15 +332,15 @@ impl Dict {
     ///
     /// For now, only real `dict` values use mapping-copy semantics; other values
     /// are interpreted as iterables of pairs.
-    pub fn init(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
+    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         let dict = Self::new();
-        let mut dict_guard = HeapGuard::new(dict, heap);
+        let mut dict_guard = HeapGuard::new(dict, vm);
 
         {
-            let (dict, heap) = dict_guard.as_parts_mut();
+            let (dict, vm) = dict_guard.as_parts_mut();
             let (pos_iter, kwargs) = args.into_parts();
-            defer_drop_mut!(pos_iter, heap);
-            let mut kwargs_guard = HeapGuard::new(kwargs, heap);
+            defer_drop_mut!(pos_iter, vm);
+            let mut kwargs_guard = HeapGuard::new(kwargs, vm);
 
             if let Some(other_value) = pos_iter.next() {
                 let other_value_guard = HeapGuard::new(other_value, kwargs_guard.heap());
@@ -348,15 +348,15 @@ impl Dict {
                     return Err(ExcType::type_error_at_most("dict", 1, pos_iter.len() + 1));
                 }
                 let other_value = other_value_guard.into_inner();
-                dict_merge_from_value(dict, other_value, kwargs_guard.heap(), interns)?;
+                dict_merge_from_value(dict, other_value, kwargs_guard.heap())?;
             }
 
             let kwargs = kwargs_guard.into_inner();
-            dict_merge_from_kwargs(dict, kwargs, heap, interns)?;
+            dict_merge_from_kwargs(dict, kwargs, vm.heap, vm.interns)?;
         }
 
         let dict = dict_guard.into_inner();
-        let heap_id = heap.allocate(HeapData::Dict(dict))?;
+        let heap_id = vm.heap.allocate(HeapData::Dict(dict))?;
         Ok(Value::Ref(heap_id))
     }
 
@@ -550,7 +550,7 @@ impl PyTrait for Dict {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<impl ResourceTracker>,
+        vm: &mut VM<'_, '_, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<AttrCallResult> {
@@ -629,14 +629,14 @@ impl PyTrait for Dict {
                 args.check_zero_args("dict.copy", heap)?;
                 dict_copy(self, heap, interns)
             }
-            StaticStrings::Update => dict_update(self, args, heap, interns),
+            StaticStrings::Update => dict_update(self, args, vm),
             StaticStrings::Setdefault => dict_setdefault(self, args, heap, interns),
             StaticStrings::Popitem => {
                 args.check_zero_args("dict.popitem", heap)?;
                 dict_popitem(self, heap)
             }
             // fromkeys is a classmethod but also accessible on instances
-            StaticStrings::Fromkeys => dict_fromkeys(args, heap, interns),
+            StaticStrings::Fromkeys => dict_fromkeys(args, vm),
             _ => {
                 args.drop_with_heap(heap);
                 return Err(ExcType::attribute_error(Type::Dict, attr.as_str(interns)));
@@ -688,15 +688,10 @@ fn dict_copy(dict: &Dict, heap: &mut Heap<impl ResourceTracker>, interns: &Inter
 /// If `other` is a dict, copies its key-value pairs.
 /// If `other` is an iterable, expects pairs of (key, value).
 /// Keyword arguments are also added to the dict.
-fn dict_update(
-    dict: &mut Dict,
-    args: ArgValues,
-    heap: &mut Heap<impl ResourceTracker>,
-    interns: &Interns,
-) -> RunResult<Value> {
+fn dict_update(dict: &mut Dict, args: ArgValues, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Value> {
     let (pos_iter, kwargs) = args.into_parts();
-    defer_drop_mut!(pos_iter, heap);
-    let mut kwargs_guard = HeapGuard::new(kwargs, heap);
+    defer_drop_mut!(pos_iter, vm);
+    let mut kwargs_guard = HeapGuard::new(kwargs, vm);
 
     if let Some(other_value) = pos_iter.next() {
         let other_value_guard = HeapGuard::new(other_value, kwargs_guard.heap());
@@ -704,11 +699,11 @@ fn dict_update(
             return Err(ExcType::type_error_at_most("dict.update", 1, pos_iter.len() + 1));
         }
         let other_value = other_value_guard.into_inner();
-        dict_merge_from_value(dict, other_value, kwargs_guard.heap(), interns)?;
+        dict_merge_from_value(dict, other_value, kwargs_guard.heap())?;
     }
 
     let kwargs = kwargs_guard.into_inner();
-    dict_merge_from_kwargs(dict, kwargs, heap, interns)?;
+    dict_merge_from_kwargs(dict, kwargs, vm.heap, vm.interns)?;
     Ok(Value::None)
 }
 
@@ -719,25 +714,24 @@ fn dict_update(
 fn dict_merge_from_value(
     dict: &mut Dict,
     other_value: Value,
-    heap: &mut Heap<impl ResourceTracker>,
-    interns: &Interns,
+    vm: &mut VM<'_, '_, impl ResourceTracker>,
 ) -> RunResult<()> {
-    let mut other_value_guard = HeapGuard::new(other_value, heap);
+    let mut other_value_guard = HeapGuard::new(other_value, vm);
     {
-        let (other_value, heap) = other_value_guard.as_parts();
+        let (other_value, vm) = other_value_guard.as_parts();
         if let Value::Ref(id) = other_value
-            && let HeapData::Dict(src_dict) = heap.get(*id)
+            && let HeapData::Dict(src_dict) = vm.heap.get(*id)
         {
             // Clone key-value pairs from the source dict.
             let pairs: Vec<(Value, Value)> = src_dict
                 .iter()
-                .map(|(k, v)| (k.clone_with_heap(heap), v.clone_with_heap(heap)))
+                .map(|(k, v)| (k.clone_with_heap(vm.heap), v.clone_with_heap(vm.heap)))
                 .collect();
 
             // Apply pairs into the target dict.
             for (key, value) in pairs {
-                if let Some(old_value) = dict.set(key, value, heap, interns)? {
-                    old_value.drop_with_heap(heap);
+                if let Some(old_value) = dict.set(key, value, vm.heap, vm.interns)? {
+                    old_value.drop_with_heap(vm.heap);
                 }
             }
             return Ok(());
@@ -745,8 +739,8 @@ fn dict_merge_from_value(
     }
 
     // Non-dict values are interpreted as iterable-of-pairs.
-    let (other_value, heap) = other_value_guard.into_parts();
-    dict_merge_from_iterable_pairs(dict, other_value, heap, interns)
+    let other_value = other_value_guard.into_inner();
+    dict_merge_from_iterable_pairs(dict, other_value, vm)
 }
 
 /// Merges key-value pairs from an iterable of 2-item iterables.
@@ -756,32 +750,31 @@ fn dict_merge_from_value(
 fn dict_merge_from_iterable_pairs(
     dict: &mut Dict,
     iterable: Value,
-    heap: &mut Heap<impl ResourceTracker>,
-    interns: &Interns,
+    vm: &mut VM<'_, '_, impl ResourceTracker>,
 ) -> RunResult<()> {
-    let iter = MontyIter::new(iterable, heap, interns)?;
-    defer_drop_mut!(iter, heap);
+    let iter = MontyIter::new(iterable, vm)?;
+    defer_drop_mut!(iter, vm);
 
-    while let Some(item) = iter.for_next(heap, interns)? {
+    while let Some(item) = iter.for_next(vm)? {
         // Each item should be a pair (iterable of 2 elements).
-        let pair_iter = MontyIter::new(item, heap, interns)?;
-        defer_drop_mut!(pair_iter, heap);
+        let pair_iter = MontyIter::new(item, vm)?;
+        defer_drop_mut!(pair_iter, vm);
 
-        let Some(key) = pair_iter.for_next(heap, interns)? else {
+        let Some(key) = pair_iter.for_next(vm)? else {
             return Err(ExcType::type_error(
                 "dictionary update sequence element has length 0; 2 is required",
             ));
         };
-        let mut key_guard = HeapGuard::new(key, heap);
+        let mut key_guard = HeapGuard::new(key, vm);
 
-        let Some(value) = pair_iter.for_next(key_guard.heap(), interns)? else {
+        let Some(value) = pair_iter.for_next(key_guard.heap())? else {
             return Err(ExcType::type_error(
                 "dictionary update sequence element has length 1; 2 is required",
             ));
         };
         let mut value_guard = HeapGuard::new(value, key_guard.heap());
 
-        if let Some(extra) = pair_iter.for_next(value_guard.heap(), interns)? {
+        if let Some(extra) = pair_iter.for_next(value_guard.heap())? {
             extra.drop_with_heap(value_guard.heap());
             return Err(ExcType::type_error(
                 "dictionary update sequence element has length > 2; 2 is required",
@@ -791,8 +784,8 @@ fn dict_merge_from_iterable_pairs(
         let value = value_guard.into_inner();
         let key = key_guard.into_inner();
 
-        if let Some(old_value) = dict.set(key, value, heap, interns)? {
-            old_value.drop_with_heap(heap);
+        if let Some(old_value) = dict.set(key, value, vm.heap, vm.interns)? {
+            old_value.drop_with_heap(vm);
         }
     }
 
@@ -929,28 +922,28 @@ impl<'de> serde::Deserialize<'de> for Dict {
 /// dict.fromkeys(['a', 'b', 'c'])  # {'a': None, 'b': None, 'c': None}
 /// dict.fromkeys(['a', 'b'], 0)    # {'a': 0, 'b': 0}
 /// ```
-pub fn dict_fromkeys(args: ArgValues, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<Value> {
-    let (iterable, default) = args.get_one_two_args("dict.fromkeys", heap)?;
+pub fn dict_fromkeys(args: ArgValues, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Value> {
+    let (iterable, default) = args.get_one_two_args("dict.fromkeys", vm.heap)?;
     let default = default.unwrap_or(Value::None);
-    defer_drop!(default, heap);
+    defer_drop!(default, vm);
 
-    let iter = MontyIter::new(iterable, heap, interns)?;
-    defer_drop_mut!(iter, heap);
+    let iter = MontyIter::new(iterable, vm)?;
+    defer_drop_mut!(iter, vm);
 
     let dict = Dict::new();
-    let mut dict_guard = HeapGuard::new(dict, heap);
+    let mut dict_guard = HeapGuard::new(dict, vm);
 
     {
-        let (dict, heap) = dict_guard.as_parts_mut();
+        let (dict, vm) = dict_guard.as_parts_mut();
 
-        while let Some(key) = iter.for_next(heap, interns)? {
-            if let Some(old_value) = dict.set(key, default.clone_with_heap(heap), heap, interns)? {
-                old_value.drop_with_heap(heap);
+        while let Some(key) = iter.for_next(vm)? {
+            if let Some(old_value) = dict.set(key, default.clone_with_heap(vm), vm.heap, vm.interns)? {
+                old_value.drop_with_heap(vm);
             }
         }
     }
 
     let dict = dict_guard.into_inner();
-    let heap_id = heap.allocate(HeapData::Dict(dict))?;
+    let heap_id = vm.heap.allocate(HeapData::Dict(dict))?;
     Ok(Value::Ref(heap_id))
 }

--- a/crates/monty/src/types/iter.rs
+++ b/crates/monty/src/types/iter.rs
@@ -32,6 +32,7 @@
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     exception_private::{ExcType, RunResult},
     heap::{ContainsHeap, DropWithHeap, Heap, HeapData, HeapGuard, HeapId},
     heap_data::HeapDataMut,
@@ -63,28 +64,28 @@ impl MontyIter {
     /// - `iter(iterable)` - Returns an iterator for the iterable. If the argument is
     ///   already an iterator, returns the same object.
     /// - `iter(callable, sentinel)` - Not yet supported.
-    pub fn init(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
-        let (iterable, sentinel) = args.get_one_two_args("iter", heap)?;
+    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+        let (iterable, sentinel) = args.get_one_two_args("iter", vm.heap)?;
 
         if let Some(s) = sentinel {
             // Two-argument form: iter(callable, sentinel)
             // This is the sentinel iteration protocol, not yet supported
-            iterable.drop_with_heap(heap);
-            s.drop_with_heap(heap);
+            iterable.drop_with_heap(vm);
+            s.drop_with_heap(vm);
             return Err(ExcType::type_error("iter(callable, sentinel) is not yet supported"));
         }
 
         // Check if already an iterator - return self
         if let Value::Ref(id) = &iterable
-            && matches!(heap.get(*id), HeapData::Iter(_))
+            && matches!(vm.heap.get(*id), HeapData::Iter(_))
         {
             // Already an iterator - return it (refcount already correct from caller)
             return Ok(iterable);
         }
 
         // Create new iterator
-        let iter = Self::new(iterable, heap, interns)?;
-        let id = heap.allocate(HeapData::Iter(iter))?;
+        let iter = Self::new(iterable, vm)?;
+        let id = vm.heap.allocate(HeapData::Iter(iter))?;
         Ok(Value::Ref(id))
     }
 
@@ -93,14 +94,14 @@ impl MontyIter {
     /// Returns an error if the value is not iterable.
     /// For strings, copies the string content for byte-offset based iteration.
     /// For ranges, the data is copied so the heap reference is dropped immediately.
-    pub fn new(mut value: Value, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<Self> {
-        if let Some(iter_value) = IterValue::new(&value, heap, interns) {
+    pub fn new(mut value: Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Self> {
+        if let Some(iter_value) = IterValue::new(&value, vm) {
             // For Range, we copy next/step/len into ForIterValue::Range, so we don't need
             // to keep the heap object alive during iteration. Drop it immediately to avoid
             // GC issues (the Range isn't in any namespace slot, so GC wouldn't see it).
             // Same for IterStr which copies the string content.
             if matches!(iter_value, IterValue::Range { .. } | IterValue::IterStr { .. }) {
-                value.drop_with_heap(heap);
+                value.drop_with_heap(vm);
                 value = Value::None;
             }
             Ok(Self {
@@ -109,8 +110,8 @@ impl MontyIter {
                 value,
             })
         } else {
-            let err = ExcType::type_error_not_iterable(value.py_type(heap));
-            value.drop_with_heap(heap);
+            let err = ExcType::type_error_not_iterable(value.py_type(vm.heap));
+            value.drop_with_heap(vm);
             Err(err)
         }
     }
@@ -269,12 +270,12 @@ impl MontyIter {
     /// Returns `Ok(None)` when the iterator is exhausted.
     /// Returns `Err` if allocation fails (for string character iteration) or if
     /// a dict/set changes size during iteration (RuntimeError).
-    pub fn for_next(&mut self, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<Option<Value>> {
+    pub fn for_next(&mut self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Option<Value>> {
         // Check timeout on every iteration step. For NoLimitTracker this is
         // inlined as a no-op. For LimitTracker it ensures that Rust-side loops
         // (sum, sorted, min, max, etc.) cannot bypass the VM's per-instruction
         // timeout check by running entirely within a single bytecode instruction.
-        heap.check_time()?;
+        vm.heap.check_time()?;
         match &mut self.iter_value {
             IterValue::Range { next, step, len } => {
                 if self.index >= *len {
@@ -306,7 +307,7 @@ impl MontyIter {
                         .expect("index < len implies char exists");
                     *byte_offset += c.len_utf8();
                     self.index += 1;
-                    Ok(Some(allocate_char(c, heap)?))
+                    Ok(Some(allocate_char(c, vm.heap)?))
                 }
             }
             IterValue::InternBytes { bytes_id, len } => {
@@ -315,7 +316,7 @@ impl MontyIter {
                 }
                 let i = self.index;
                 self.index += 1;
-                let bytes = interns.get_bytes(*bytes_id);
+                let bytes = vm.interns.get_bytes(*bytes_id);
                 Ok(Some(Value::Int(i64::from(bytes[i]))))
             }
             IterValue::HeapRef {
@@ -331,7 +332,7 @@ impl MontyIter {
                 }
                 let i = self.index;
                 let expected_len = if *checks_mutation { *len } else { None };
-                let item = get_heap_item(heap, *heap_id, i, expected_len)?;
+                let item = get_heap_item(vm.heap, *heap_id, i, expected_len)?;
                 // Check for list exhaustion (list can shrink during iteration)
                 let Some(item) = item else {
                     return Ok(None);
@@ -369,28 +370,24 @@ impl MontyIter {
     /// and similar constructors that need to materialize all items.
     ///
     /// Pre-allocates capacity based on `size_hint()` for better performance.
-    pub fn collect<T: FromIterator<Value>>(
-        self,
-        heap: &mut Heap<impl ResourceTracker>,
-        interns: &Interns,
-    ) -> RunResult<T> {
-        let mut guard = HeapGuard::new(self, heap);
-        let (this, heap) = guard.as_parts_mut();
-        HeapedMontyIter(this, heap, interns).collect()
+    pub fn collect<T: FromIterator<Value>>(self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<T> {
+        let mut guard = HeapGuard::new(self, vm);
+        let (this, vm) = guard.as_parts_mut();
+        HeapedMontyIter(this, vm).collect()
     }
 }
 
-struct HeapedMontyIter<'a, T: ResourceTracker>(&'a mut MontyIter, &'a mut Heap<T>, &'a Interns);
+struct HeapedMontyIter<'this, 'a, 'p, T: ResourceTracker>(&'this mut MontyIter, &'this mut VM<'a, 'p, T>);
 
-impl<T: ResourceTracker> Iterator for HeapedMontyIter<'_, T> {
+impl<T: ResourceTracker> Iterator for HeapedMontyIter<'_, '_, '_, T> {
     type Item = RunResult<Value>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.for_next(self.1, self.2).transpose()
+        self.0.for_next(self.1).transpose()
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.0.size_hint(self.1);
+        let remaining = self.0.size_hint(self.1.heap);
         (remaining, Some(remaining))
     }
 }
@@ -650,11 +647,11 @@ enum IterValue {
 }
 
 impl IterValue {
-    fn new(value: &Value, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> Option<Self> {
+    fn new(value: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> Option<Self> {
         match &value {
-            Value::InternString(string_id) => Some(Self::from_str(interns.get_str(*string_id))),
-            Value::InternBytes(bytes_id) => Some(Self::from_intern_bytes(*bytes_id, interns)),
-            Value::Ref(heap_id) => Self::from_heap_data(*heap_id, heap),
+            Value::InternString(string_id) => Some(Self::from_str(vm.interns.get_str(*string_id))),
+            Value::InternBytes(bytes_id) => Some(Self::from_intern_bytes(*bytes_id, vm.interns)),
+            Value::Ref(heap_id) => Self::from_heap_data(*heap_id, vm.heap),
             _ => None,
         }
     }

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -165,16 +165,16 @@ impl List {
     ///
     /// - `list()` with no args returns an empty list
     /// - `list(iterable)` creates a list from any iterable (list, tuple, range, str, bytes, dict)
-    pub fn init(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
-        let value = args.get_zero_one_arg("list", heap)?;
+    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+        let value = args.get_zero_one_arg("list", vm.heap)?;
         match value {
             None => {
-                let heap_id = heap.allocate(HeapData::List(Self::new(Vec::new())))?;
+                let heap_id = vm.heap.allocate(HeapData::List(Self::new(Vec::new())))?;
                 Ok(Value::Ref(heap_id))
             }
             Some(v) => {
-                let items = MontyIter::new(v, heap, interns)?.collect(heap, interns)?;
-                let heap_id = heap.allocate(HeapData::List(Self::new(items)))?;
+                let items = MontyIter::new(v, vm)?.collect(vm)?;
+                let heap_id = vm.heap.allocate(HeapData::List(Self::new(items)))?;
                 Ok(Value::Ref(heap_id))
             }
         }
@@ -418,7 +418,7 @@ impl PyTrait for List {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<impl ResourceTracker>,
+        vm: &mut VM<'_, '_, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<AttrCallResult> {
@@ -426,15 +426,13 @@ impl PyTrait for List {
             do_list_sort(self, args, vm)?;
             return Ok(AttrCallResult::Value(Value::None));
         }
-        let heap = &mut *vm.heap;
-        let interns = vm.interns;
-        let args_guard = HeapGuard::new(args, heap);
+        let args_guard = HeapGuard::new(args, vm.heap);
         let Some(method) = attr.static_string() else {
-            return Err(ExcType::attribute_error(Type::List, attr.as_str(interns)));
+            return Err(ExcType::attribute_error(Type::List, attr.as_str(vm.interns)));
         };
 
-        let (args, heap) = args_guard.into_parts();
-        call_list_method(self, method, args, heap, interns).map(AttrCallResult::Value)
+        let args = args_guard.into_inner();
+        call_list_method(self, method, args, vm).map(AttrCallResult::Value)
     }
 }
 
@@ -452,9 +450,10 @@ fn call_list_method(
     list: &mut List,
     method: StaticStrings,
     args: ArgValues,
-    heap: &mut Heap<impl ResourceTracker>,
-    interns: &Interns,
+    vm: &mut VM<'_, '_, impl ResourceTracker>,
 ) -> RunResult<Value> {
+    let heap = &mut *vm.heap;
+    let interns = vm.interns;
     match method {
         StaticStrings::Append => {
             let item = args.get_one_arg("list.append", heap)?;
@@ -473,7 +472,7 @@ fn call_list_method(
             args.check_zero_args("list.copy", heap)?;
             Ok(list_copy(list, heap)?)
         }
-        StaticStrings::Extend => list_extend(list, args, heap, interns),
+        StaticStrings::Extend => list_extend(list, args, vm),
         StaticStrings::Index => list_index(list, args, heap, interns),
         StaticStrings::Count => list_count(list, args, heap, interns),
         StaticStrings::Reverse => {
@@ -606,18 +605,13 @@ fn list_copy(list: &List, heap: &mut Heap<impl ResourceTracker>) -> Result<Value
 /// Implements Python's `list.extend(iterable)` method.
 ///
 /// Extends the list by appending all items from the iterable.
-fn list_extend(
-    list: &mut List,
-    args: ArgValues,
-    heap: &mut Heap<impl ResourceTracker>,
-    interns: &Interns,
-) -> RunResult<Value> {
-    let iterable = args.get_one_arg("list.extend", heap)?;
-    let items: SmallVec<[_; 2]> = MontyIter::new(iterable, heap, interns)?.collect(heap, interns)?;
+fn list_extend(list: &mut List, args: ArgValues, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Value> {
+    let iterable = args.get_one_arg("list.extend", vm.heap)?;
+    let items: SmallVec<[_; 2]> = MontyIter::new(iterable, vm)?.collect(vm)?;
 
     // Add each item to the list
     for item in items {
-        list.append(heap, item);
+        list.append(vm.heap, item);
     }
 
     Ok(Value::None)
@@ -699,7 +693,7 @@ fn normalize_list_index(index: i64, len: usize) -> usize {
 }
 
 /// Performs an in-place sort on a list with optional key function and reverse flag.
-fn do_list_sort(list: &mut List, args: ArgValues, vm: &mut VM<impl ResourceTracker>) -> Result<(), RunError> {
+fn do_list_sort(list: &mut List, args: ArgValues, vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<(), RunError> {
     // Parse keyword-only arguments: key and reverse
     let (key_arg, reverse_arg) = args.extract_two_kwargs_only("list.sort", "key", "reverse", vm.heap, vm.interns)?;
 

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -261,7 +261,9 @@ impl Path {
     /// - `Path('a')` returns `Path('a')`
     /// - `Path('a', 'b', 'c')` returns `Path('a/b/c')`
     /// - If an absolute path appears, it replaces everything before it.
-    pub fn init(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
+    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+        let heap = &mut *vm.heap;
+        let interns = vm.interns;
         let pos_args = args.into_pos_only("Path", heap)?;
         defer_drop!(pos_args, heap);
 
@@ -500,7 +502,7 @@ impl PyTrait for Path {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<impl ResourceTracker>,
+        vm: &mut VM<'_, '_, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<AttrCallResult> {

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -322,7 +322,7 @@ pub trait PyTrait {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<impl ResourceTracker>,
+        vm: &mut VM<'_, '_, impl ResourceTracker>,
         attr: &EitherStr,
         _args: ArgValues,
     ) -> RunResult<AttrCallResult> {

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -9,6 +9,7 @@ use ahash::AHashSet;
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult},
     heap::{Heap, HeapData, HeapId},
@@ -116,7 +117,8 @@ impl Range {
     /// - `range(stop)` - range from 0 to stop
     /// - `range(start, stop)` - range from start to stop
     /// - `range(start, stop, step)` - range with custom step
-    pub fn init(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+        let heap = &mut *vm.heap;
         let pos_args = args.into_pos_only("range", heap)?;
         defer_drop!(pos_args, heap);
 

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -9,7 +9,7 @@ use crate::{
     bytecode::VM,
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult},
-    heap::{ContainsHeap, DropWithHeap, Heap, HeapData, HeapId},
+    heap::{ContainsHeap, DropWithHeap, Heap, HeapData, HeapGuard, HeapId},
     intern::{Interns, StaticStrings},
     resource::{ResourceError, ResourceTracker},
     types::Type,
@@ -66,14 +66,14 @@ impl SetStorage {
     }
 
     /// Drops all values in this storage, decrementing their reference counts.
-    fn drop_all_values(self, heap: &mut Heap<impl ResourceTracker>) {
+    fn drop_all_values(self, heap: &mut impl ContainsHeap) {
         for entry in self.entries {
             entry.value.drop_with_heap(heap);
         }
     }
 
     /// Clones entries with proper reference counting.
-    fn clone_entries(&self, heap: &Heap<impl ResourceTracker>) -> Vec<(Value, u64)> {
+    fn clone_entries(&self, heap: &impl ContainsHeap) -> Vec<(Value, u64)> {
         self.entries
             .iter()
             .map(|e| (e.value.clone_with_heap(heap), e.hash))
@@ -106,7 +106,24 @@ impl SetStorage {
     ///
     /// The caller transfers ownership of `value`. If the value is already in
     /// the set, it will be dropped.
-    fn add(&mut self, value: Value, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<bool> {
+    fn add(&mut self, value: Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
+        self.add_heap_interns(value, vm.heap, vm.interns)
+    }
+
+    /// Adds an element to the set, transferring ownership.
+    ///
+    /// Returns `Ok(true)` if the element was added (not already present),
+    /// `Ok(false)` if the element was already in the set.
+    /// Returns `Err` if the element is unhashable.
+    ///
+    /// The caller transfers ownership of `value`. If the value is already in
+    /// the set, it will be dropped.
+    fn add_heap_interns(
+        &mut self,
+        value: Value,
+        heap: &mut Heap<impl ResourceTracker>,
+        interns: &Interns,
+    ) -> RunResult<bool> {
         let hash = match value.py_hash(heap, interns) {
             Ok(Some(h)) => h,
             Ok(None) => {
@@ -225,7 +242,17 @@ impl SetStorage {
     }
 
     /// Checks if the set contains a value.
-    pub fn contains(&self, value: &Value, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<bool> {
+    pub fn contains(&self, value: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
+        self.contains_heap_interns(value, vm.heap, vm.interns)
+    }
+
+    /// Checks if the set contains a value.
+    pub fn contains_heap_interns(
+        &self,
+        value: &Value,
+        heap: &mut Heap<impl ResourceTracker>,
+        interns: &Interns,
+    ) -> RunResult<bool> {
         let hash = value
             .py_hash(heap, interns)?
             .ok_or_else(|| ExcType::type_error_unhashable_set_element(value.py_type(heap)))?;
@@ -278,7 +305,7 @@ impl SetStorage {
         defer_drop!(token, heap);
         // Check that every element in self is in other
         for entry in &self.entries {
-            if !matches!(other.contains(&entry.value, heap, interns), Ok(true)) {
+            if !matches!(other.contains_heap_interns(&entry.value, heap, interns), Ok(true)) {
                 return Ok(false);
             }
         }
@@ -286,9 +313,9 @@ impl SetStorage {
     }
 
     /// Returns true if this set is a subset of other.
-    fn is_subset(&self, other: &Self, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<bool> {
+    fn is_subset(&self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
         for entry in &self.entries {
-            if !other.contains(&entry.value, heap, interns)? {
+            if !other.contains(&entry.value, vm)? {
                 return Ok(false);
             }
         }
@@ -296,12 +323,12 @@ impl SetStorage {
     }
 
     /// Returns true if this set is a superset of other.
-    fn is_superset(&self, other: &Self, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<bool> {
-        other.is_subset(self, heap, interns)
+    fn is_superset(&self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
+        other.is_subset(self, vm)
     }
 
     /// Returns true if this set has no elements in common with other.
-    fn is_disjoint(&self, other: &Self, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<bool> {
+    fn is_disjoint(&self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
         // Iterate over the smaller set for efficiency
         let (smaller, larger) = if self.len() <= other.len() {
             (self, other)
@@ -310,7 +337,7 @@ impl SetStorage {
         };
 
         for entry in &smaller.entries {
-            if larger.contains(&entry.value, heap, interns)? {
+            if larger.contains(&entry.value, vm)? {
                 return Ok(false);
             }
         }
@@ -318,18 +345,20 @@ impl SetStorage {
     }
 
     /// Returns a new set containing elements in either set (union).
-    fn union(&self, other: &Self, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<Self> {
-        let mut result = self.clone_with_heap(heap);
+    fn union(&self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Self> {
+        let mut result_guard = HeapGuard::new(self.clone_with_heap(vm), vm);
+        let (result, vm) = result_guard.as_parts_mut();
         for entry in &other.entries {
-            let value = entry.value.clone_with_heap(heap);
-            result.add(value, heap, interns)?;
+            let value = entry.value.clone_with_heap(vm);
+            result.add(value, vm)?;
         }
-        Ok(result)
+        Ok(result_guard.into_inner())
     }
 
     /// Returns a new set containing elements in both sets (intersection).
-    fn intersection(&self, other: &Self, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<Self> {
-        let mut result = Self::new();
+    fn intersection(&self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Self> {
+        let mut result_guard = HeapGuard::new(Self::new(), vm);
+        let (result, vm) = result_guard.as_parts_mut();
         // Iterate over the smaller set for efficiency
         let (smaller, larger) = if self.len() <= other.len() {
             (self, other)
@@ -338,59 +367,56 @@ impl SetStorage {
         };
 
         for entry in &smaller.entries {
-            if larger.contains(&entry.value, heap, interns)? {
-                let value = entry.value.clone_with_heap(heap);
-                result.add(value, heap, interns)?;
+            if larger.contains(&entry.value, vm)? {
+                let value = entry.value.clone_with_heap(vm);
+                result.add(value, vm)?;
             }
         }
-        Ok(result)
+        Ok(result_guard.into_inner())
     }
 
     /// Returns a new set containing elements in self but not in other (difference).
-    fn difference(&self, other: &Self, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<Self> {
-        let mut result = Self::new();
+    fn difference(&self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Self> {
+        let mut result_guard = HeapGuard::new(Self::new(), vm);
+        let (result, vm) = result_guard.as_parts_mut();
         for entry in &self.entries {
-            if !other.contains(&entry.value, heap, interns)? {
-                let value = entry.value.clone_with_heap(heap);
-                result.add(value, heap, interns)?;
+            if !other.contains(&entry.value, vm)? {
+                let value = entry.value.clone_with_heap(vm);
+                result.add(value, vm)?;
             }
         }
-        Ok(result)
+        Ok(result_guard.into_inner())
     }
 
     /// Returns a new set containing elements in either set but not both (symmetric difference).
-    fn symmetric_difference(
-        &self,
-        other: &Self,
-        heap: &mut Heap<impl ResourceTracker>,
-        interns: &Interns,
-    ) -> RunResult<Self> {
-        let mut result = Self::new();
+    fn symmetric_difference(&self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Self> {
+        let mut result_guard = HeapGuard::new(Self::new(), vm);
+        let (result, vm) = result_guard.as_parts_mut();
 
         // Add elements in self but not in other
         for entry in &self.entries {
-            if !other.contains(&entry.value, heap, interns)? {
-                let value = entry.value.clone_with_heap(heap);
-                result.add(value, heap, interns)?;
+            if !other.contains(&entry.value, vm)? {
+                let value = entry.value.clone_with_heap(vm);
+                result.add(value, vm)?;
             }
         }
 
         // Add elements in other but not in self
         for entry in &other.entries {
-            if !self.contains(&entry.value, heap, interns)? {
-                let value = entry.value.clone_with_heap(heap);
-                result.add(value, heap, interns)?;
+            if !self.contains(&entry.value, vm)? {
+                let value = entry.value.clone_with_heap(vm);
+                result.add(value, vm)?;
             }
         }
 
-        Ok(result)
+        Ok(result_guard.into_inner())
     }
 
     /// Adds all elements from other to this set (in-place union).
-    fn update(&mut self, other: &Self, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<()> {
+    fn update(&mut self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<()> {
         for entry in &other.entries {
-            let value = entry.value.clone_with_heap(heap);
-            self.add(value, heap, interns)?;
+            let value = entry.value.clone_with_heap(vm);
+            self.add(value, vm)?;
         }
         Ok(())
     }
@@ -502,7 +528,7 @@ impl Set {
     ///
     /// Returns `Ok(true)` if added, `Ok(false)` if already present.
     pub fn add(&mut self, value: Value, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<bool> {
-        self.0.add(value, heap, interns)
+        self.0.add_heap_interns(value, heap, interns)
     }
 
     /// Removes an element from the set.
@@ -548,7 +574,7 @@ impl Set {
 
     /// Checks if the set contains a value.
     pub fn contains(&self, value: &Value, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<bool> {
-        self.0.contains(value, heap, interns)
+        self.0.contains_heap_interns(value, heap, interns)
     }
 
     /// Returns the internal storage (for set operations between Set and FrozenSet).
@@ -560,13 +586,13 @@ impl Set {
     ///
     /// - `set()` with no args returns an empty set
     /// - `set(iterable)` creates a set from any iterable (list, tuple, set, dict, range, str, bytes)
-    pub fn init(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
-        let value = args.get_zero_one_arg("set", heap)?;
+    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+        let value = args.get_zero_one_arg("set", vm.heap)?;
         let set = match value {
             None => Self::new(),
-            Some(v) => Self::from_iterable(v, heap, interns)?,
+            Some(v) => Self::from_iterable(v, vm)?,
         };
-        let heap_id = heap.allocate(HeapData::Set(set))?;
+        let heap_id = vm.heap.allocate(HeapData::Set(set))?;
         Ok(Value::Ref(heap_id))
     }
 
@@ -574,11 +600,11 @@ impl Set {
     ///
     /// Unlike list/tuple which can just collect into a Vec, sets need to add
     /// each element individually to handle duplicates and compute hashes.
-    fn from_iterator(iter: MontyIter, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<Self> {
-        defer_drop_mut!(iter, heap);
-        let mut set = Self::with_capacity(iter.size_hint(heap));
-        while let Some(item) = iter.for_next(heap, interns)? {
-            set.add(item, heap, interns)?;
+    fn from_iterator(iter: MontyIter, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Self> {
+        defer_drop_mut!(iter, vm);
+        let mut set = Self::with_capacity(iter.size_hint(vm.heap));
+        while let Some(item) = iter.for_next(vm)? {
+            set.add(item, vm.heap, vm.interns)?;
         }
         Ok(set)
     }
@@ -587,10 +613,28 @@ impl Set {
     ///
     /// This is a convenience method used by helper methods that need to convert
     /// arbitrary iterables to sets. It uses `MontyIter` internally.
-    fn from_iterable(iterable: Value, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<Self> {
-        let iter = MontyIter::new(iterable, heap, interns)?;
-        let set = Self::from_iterator(iter, heap, interns)?;
+    fn from_iterable(iterable: Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Self> {
+        let iter = MontyIter::new(iterable, vm)?;
+        let set = Self::from_iterator(iter, vm)?;
         Ok(set)
+    }
+}
+
+impl DropWithHeap for Set {
+    fn drop_with_heap<H: ContainsHeap>(self, heap: &mut H) {
+        self.0.drop_with_heap(heap);
+    }
+}
+
+impl DropWithHeap for SetStorage {
+    fn drop_with_heap<H: ContainsHeap>(self, heap: &mut H) {
+        self.drop_all_values(heap);
+    }
+}
+
+impl DropWithHeap for FrozenSet {
+    fn drop_with_heap<H: ContainsHeap>(self, heap: &mut H) {
+        self.0.drop_with_heap(heap);
     }
 }
 
@@ -637,7 +681,7 @@ impl PyTrait for Set {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<impl ResourceTracker>,
+        vm: &mut VM<'_, '_, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<AttrCallResult> {
@@ -678,47 +722,47 @@ impl PyTrait for Set {
             }
             Some(StaticStrings::Update) => {
                 let other = args.get_one_arg("set.update", heap)?;
-                self.update_from_value(other, heap, interns)?;
+                self.update_from_value(other, vm)?;
                 Ok(Value::None)
             }
             Some(StaticStrings::Union) => {
                 let other = args.get_one_arg("set.union", heap)?;
-                let result = self.union_from_value(other, heap, interns)?;
-                let heap_id = heap.allocate(HeapData::Set(result))?;
+                let result = self.union_from_value(other, vm)?;
+                let heap_id = vm.heap.allocate(HeapData::Set(result))?;
                 Ok(Value::Ref(heap_id))
             }
             Some(StaticStrings::Intersection) => {
                 let other = args.get_one_arg("set.intersection", heap)?;
-                let result = self.intersection_from_value(other, heap, interns)?;
-                let heap_id = heap.allocate(HeapData::Set(result))?;
+                let result = self.intersection_from_value(other, vm)?;
+                let heap_id = vm.heap.allocate(HeapData::Set(result))?;
                 Ok(Value::Ref(heap_id))
             }
             Some(StaticStrings::Difference) => {
                 let other = args.get_one_arg("set.difference", heap)?;
-                let result = self.difference_from_value(other, heap, interns)?;
-                let heap_id = heap.allocate(HeapData::Set(result))?;
+                let result = self.difference_from_value(other, vm)?;
+                let heap_id = vm.heap.allocate(HeapData::Set(result))?;
                 Ok(Value::Ref(heap_id))
             }
             Some(StaticStrings::SymmetricDifference) => {
                 let other = args.get_one_arg("set.symmetric_difference", heap)?;
-                let result = self.symmetric_difference_from_value(other, heap, interns)?;
-                let heap_id = heap.allocate(HeapData::Set(result))?;
+                let result = self.symmetric_difference_from_value(other, vm)?;
+                let heap_id = vm.heap.allocate(HeapData::Set(result))?;
                 Ok(Value::Ref(heap_id))
             }
             Some(StaticStrings::Issubset) => {
                 let other = args.get_one_arg("set.issubset", heap)?;
-                defer_drop!(other, heap);
-                Ok(Value::Bool(self.issubset_from_value(other, heap, interns)?))
+                defer_drop!(other, vm);
+                Ok(Value::Bool(self.issubset_from_value(other, vm)?))
             }
             Some(StaticStrings::Issuperset) => {
                 let other = args.get_one_arg("set.issuperset", heap)?;
-                defer_drop!(other, heap);
-                Ok(Value::Bool(self.issuperset_from_value(other, heap, interns)?))
+                defer_drop!(other, vm);
+                Ok(Value::Bool(self.issuperset_from_value(other, vm)?))
             }
             Some(StaticStrings::Isdisjoint) => {
                 let other = args.get_one_arg("set.isdisjoint", heap)?;
-                defer_drop!(other, heap);
-                Ok(Value::Bool(self.isdisjoint_from_value(other, heap, interns)?))
+                defer_drop!(other, vm);
+                Ok(Value::Bool(self.isdisjoint_from_value(other, vm)?))
             }
             _ => {
                 args.drop_with_heap(heap);
@@ -744,12 +788,8 @@ impl PyTrait for Set {
 /// Helper methods for set operations with arbitrary iterables.
 impl Set {
     /// Updates this set with elements from an iterable value.
-    fn update_from_value(
-        &mut self,
-        other: Value,
-        heap: &mut Heap<impl ResourceTracker>,
-        interns: &Interns,
-    ) -> RunResult<()> {
+    fn update_from_value(&mut self, other: Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<()> {
+        let heap = &mut *vm.heap;
         // Try to get entries from a Set/FrozenSet directly
         let entries_opt = match &other {
             Value::Ref(id) => match heap.get(*id) {
@@ -763,61 +803,39 @@ impl Set {
         if let Some(entries) = entries_opt {
             other.drop_with_heap(heap);
             for (value, _hash) in entries {
-                self.add(value, heap, interns)?;
+                self.add(value, heap, vm.interns)?;
             }
             return Ok(());
         }
 
         // Fall back to creating a temporary set from the iterable
-        let temp_set = Self::from_iterable(other, heap, interns)?;
-        self.0.update(&temp_set.0, heap, interns)?;
-        temp_set.0.drop_all_values(heap);
+        let temp_set = Self::from_iterable(other, vm)?;
+        defer_drop!(temp_set, vm);
+        self.0.update(&temp_set.0, vm)?;
         Ok(())
     }
 
     /// Returns a new set with elements from both this set and an iterable.
-    fn union_from_value(
-        &self,
-        other: Value,
-        heap: &mut Heap<impl ResourceTracker>,
-        interns: &Interns,
-    ) -> RunResult<Self> {
-        let other_storage = Self::get_storage_from_value(other, heap, interns)?;
-        let result_storage = self.0.union(&other_storage, heap, interns)?;
-        // Clean up other_storage if it was created from a non-set
-        for entry in other_storage.entries {
-            entry.value.drop_with_heap(heap);
-        }
+    fn union_from_value(&self, other: Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Self> {
+        let other_storage = Self::get_storage_from_value(other, vm)?;
+        defer_drop!(other_storage, vm);
+        let result_storage = self.0.union(other_storage, vm)?;
         Ok(Self(result_storage))
     }
 
     /// Returns a new set with elements common to both this set and an iterable.
-    fn intersection_from_value(
-        &self,
-        other: Value,
-        heap: &mut Heap<impl ResourceTracker>,
-        interns: &Interns,
-    ) -> RunResult<Self> {
-        let other_storage = Self::get_storage_from_value(other, heap, interns)?;
-        let result_storage = self.0.intersection(&other_storage, heap, interns)?;
-        for entry in other_storage.entries {
-            entry.value.drop_with_heap(heap);
-        }
+    fn intersection_from_value(&self, other: Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Self> {
+        let other_storage = Self::get_storage_from_value(other, vm)?;
+        defer_drop!(other_storage, vm);
+        let result_storage = self.0.intersection(other_storage, vm)?;
         Ok(Self(result_storage))
     }
 
     /// Returns a new set with elements in this set but not in an iterable.
-    fn difference_from_value(
-        &self,
-        other: Value,
-        heap: &mut Heap<impl ResourceTracker>,
-        interns: &Interns,
-    ) -> RunResult<Self> {
-        let other_storage = Self::get_storage_from_value(other, heap, interns)?;
-        let result_storage = self.0.difference(&other_storage, heap, interns)?;
-        for entry in other_storage.entries {
-            entry.value.drop_with_heap(heap);
-        }
+    fn difference_from_value(&self, other: Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Self> {
+        let other_storage = Self::get_storage_from_value(other, vm)?;
+        defer_drop!(other_storage, vm);
+        let result_storage = self.0.difference(other_storage, vm)?;
         Ok(Self(result_storage))
     }
 
@@ -825,136 +843,105 @@ impl Set {
     fn symmetric_difference_from_value(
         &self,
         other: Value,
-        heap: &mut Heap<impl ResourceTracker>,
-        interns: &Interns,
+        vm: &mut VM<'_, '_, impl ResourceTracker>,
     ) -> RunResult<Self> {
-        let other_storage = Self::get_storage_from_value(other, heap, interns)?;
-        let result_storage = self.0.symmetric_difference(&other_storage, heap, interns)?;
-        for entry in other_storage.entries {
-            entry.value.drop_with_heap(heap);
-        }
+        let other_storage = Self::get_storage_from_value(other, vm)?;
+        defer_drop!(other_storage, vm);
+        let result_storage = self.0.symmetric_difference(other_storage, vm)?;
         Ok(Self(result_storage))
     }
 
     /// Checks if this set is a subset of an iterable.
-    fn issubset_from_value(
-        &self,
-        other: &Value,
-        heap: &mut Heap<impl ResourceTracker>,
-        interns: &Interns,
-    ) -> RunResult<bool> {
+    fn issubset_from_value(&self, other: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
         // Try to get entries from a Set/FrozenSet directly
         let entries_opt = match other {
-            Value::Ref(id) => match heap.get(*id) {
-                HeapData::Set(other_set) => Some(other_set.0.clone_entries(heap)),
-                HeapData::FrozenSet(other_set) => Some(other_set.0.clone_entries(heap)),
+            Value::Ref(id) => match vm.heap.get(*id) {
+                HeapData::Set(other_set) => Some(other_set.0.clone_entries(vm.heap)),
+                HeapData::FrozenSet(other_set) => Some(other_set.0.clone_entries(vm.heap)),
                 _ => None,
             },
             _ => None,
         };
 
         if let Some(entries) = entries_opt {
-            // Build temporary storage and check
             let other_storage = SetStorage::from_entries(entries);
-            let result = self.0.is_subset(&other_storage, heap, interns);
-            other_storage.drop_all_values(heap);
-            return result;
+            defer_drop!(other_storage, vm);
+            return self.0.is_subset(other_storage, vm);
         }
 
         // Handle all other iterables (list, tuple, range, str, bytes, dict, etc.)
-        let temp = Self::from_iterable(other.clone_with_heap(heap), heap, interns)?;
-        let result = self.0.is_subset(&temp.0, heap, interns);
-        temp.0.drop_all_values(heap);
-        result
+        let temp = Self::from_iterable(other.clone_with_heap(vm), vm)?;
+        defer_drop!(temp, vm);
+        self.0.is_subset(&temp.0, vm)
     }
 
     /// Checks if this set is a superset of an iterable.
-    fn issuperset_from_value(
-        &self,
-        other: &Value,
-        heap: &mut Heap<impl ResourceTracker>,
-        interns: &Interns,
-    ) -> RunResult<bool> {
+    fn issuperset_from_value(&self, other: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
         // Try to get entries from a Set/FrozenSet directly
         let entries_opt = match other {
-            Value::Ref(id) => match heap.get(*id) {
-                HeapData::Set(other_set) => Some(other_set.0.clone_entries(heap)),
-                HeapData::FrozenSet(other_set) => Some(other_set.0.clone_entries(heap)),
+            Value::Ref(id) => match vm.heap.get(*id) {
+                HeapData::Set(other_set) => Some(other_set.0.clone_entries(vm.heap)),
+                HeapData::FrozenSet(other_set) => Some(other_set.0.clone_entries(vm.heap)),
                 _ => None,
             },
             _ => None,
         };
 
         if let Some(entries) = entries_opt {
-            // Build temporary storage and check
             let other_storage = SetStorage::from_entries(entries);
-            let result = self.0.is_superset(&other_storage, heap, interns);
-            other_storage.drop_all_values(heap);
-            return result;
+            defer_drop!(other_storage, vm);
+            return self.0.is_superset(other_storage, vm);
         }
 
         // Handle all other iterables (list, tuple, range, str, bytes, dict, etc.)
-        let temp = Self::from_iterable(other.clone_with_heap(heap), heap, interns)?;
-        let result = self.0.is_superset(&temp.0, heap, interns);
-        temp.0.drop_all_values(heap);
-        result
+        let temp = Self::from_iterable(other.clone_with_heap(vm), vm)?;
+        defer_drop!(temp, vm);
+        self.0.is_superset(&temp.0, vm)
     }
 
     /// Checks if this set has no elements in common with an iterable.
-    fn isdisjoint_from_value(
-        &self,
-        other: &Value,
-        heap: &mut Heap<impl ResourceTracker>,
-        interns: &Interns,
-    ) -> RunResult<bool> {
+    fn isdisjoint_from_value(&self, other: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
         // Try to get entries from a Set/FrozenSet directly
         let entries_opt = match other {
-            Value::Ref(id) => match heap.get(*id) {
-                HeapData::Set(other_set) => Some(other_set.0.clone_entries(heap)),
-                HeapData::FrozenSet(other_set) => Some(other_set.0.clone_entries(heap)),
+            Value::Ref(id) => match vm.heap.get(*id) {
+                HeapData::Set(other_set) => Some(other_set.0.clone_entries(vm.heap)),
+                HeapData::FrozenSet(other_set) => Some(other_set.0.clone_entries(vm.heap)),
                 _ => None,
             },
             _ => None,
         };
 
         if let Some(entries) = entries_opt {
-            // Build temporary storage and check
             let other_storage = SetStorage::from_entries(entries);
-            let result = self.0.is_disjoint(&other_storage, heap, interns);
-            other_storage.drop_all_values(heap);
-            return result;
+            defer_drop!(other_storage, vm);
+            return self.0.is_disjoint(other_storage, vm);
         }
 
         // Handle all other iterables (list, tuple, range, str, bytes, dict, etc.)
-        let temp = Self::from_iterable(other.clone_with_heap(heap), heap, interns)?;
-        let result = self.0.is_disjoint(&temp.0, heap, interns);
-        temp.0.drop_all_values(heap);
-        result
+        let temp = Self::from_iterable(other.clone_with_heap(vm), vm)?;
+        defer_drop!(temp, vm);
+        self.0.is_disjoint(&temp.0, vm)
     }
 
     /// Helper to get SetStorage from a Value (either directly or by conversion).
-    fn get_storage_from_value(
-        value: Value,
-        heap: &mut Heap<impl ResourceTracker>,
-        interns: &Interns,
-    ) -> RunResult<SetStorage> {
+    fn get_storage_from_value(value: Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<SetStorage> {
         // Try to get entries from a Set/FrozenSet directly
         let entries_opt = match &value {
-            Value::Ref(id) => match heap.get(*id) {
-                HeapData::Set(set) => Some(set.0.clone_entries(heap)),
-                HeapData::FrozenSet(set) => Some(set.0.clone_entries(heap)),
+            Value::Ref(id) => match vm.heap.get(*id) {
+                HeapData::Set(set) => Some(set.0.clone_entries(vm.heap)),
+                HeapData::FrozenSet(set) => Some(set.0.clone_entries(vm.heap)),
                 _ => None,
             },
             _ => None,
         };
 
         if let Some(entries) = entries_opt {
-            value.drop_with_heap(heap);
+            value.drop_with_heap(vm);
             return Ok(SetStorage::from_entries(entries));
         }
 
         // Convert iterable to set
-        let temp_set = Self::from_iterable(value, heap, interns)?;
+        let temp_set = Self::from_iterable(value, vm)?;
         Ok(temp_set.0)
     }
 }
@@ -1011,7 +998,7 @@ impl FrozenSet {
 
     /// Checks if the frozenset contains a value.
     pub fn contains(&self, value: &Value, heap: &mut Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<bool> {
-        self.0.contains(value, heap, interns)
+        self.0.contains_heap_interns(value, heap, interns)
     }
 
     /// Computes the hash of this frozenset.
@@ -1048,54 +1035,42 @@ impl FrozenSet {
     ///
     /// - `frozenset()` with no args returns an empty frozenset
     /// - `frozenset(iterable)` creates a frozenset from any iterable (list, tuple, set, dict, range, str, bytes)
-    pub fn init(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
-        let value = args.get_zero_one_arg("frozenset", heap)?;
+    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+        let value = args.get_zero_one_arg("frozenset", vm.heap)?;
         let frozenset = match value {
             None => Self::new(),
-            Some(v) => Self::from_set(Set::from_iterable(v, heap, interns)?),
+            Some(v) => Self::from_set(Set::from_iterable(v, vm)?),
         };
-        let heap_id = heap.allocate(HeapData::FrozenSet(frozenset))?;
+        let heap_id = vm.heap.allocate(HeapData::FrozenSet(frozenset))?;
         Ok(Value::Ref(heap_id))
     }
 
     /// Returns a new frozenset with elements from both this and another set.
-    pub(crate) fn union(
-        &self,
-        other: &SetStorage,
-        heap: &mut Heap<impl ResourceTracker>,
-        interns: &Interns,
-    ) -> RunResult<Self> {
-        Ok(Self(self.0.union(other, heap, interns)?))
+    pub(crate) fn union(&self, other: &SetStorage, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Self> {
+        Ok(Self(self.0.union(other, vm)?))
     }
 
     /// Returns a new frozenset with elements common to both sets.
     pub(crate) fn intersection(
         &self,
         other: &SetStorage,
-        heap: &mut Heap<impl ResourceTracker>,
-        interns: &Interns,
+        vm: &mut VM<'_, '_, impl ResourceTracker>,
     ) -> RunResult<Self> {
-        Ok(Self(self.0.intersection(other, heap, interns)?))
+        Ok(Self(self.0.intersection(other, vm)?))
     }
 
     /// Returns a new frozenset with elements in this set but not in other.
-    pub(crate) fn difference(
-        &self,
-        other: &SetStorage,
-        heap: &mut Heap<impl ResourceTracker>,
-        interns: &Interns,
-    ) -> RunResult<Self> {
-        Ok(Self(self.0.difference(other, heap, interns)?))
+    pub(crate) fn difference(&self, other: &SetStorage, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Self> {
+        Ok(Self(self.0.difference(other, vm)?))
     }
 
     /// Returns a new frozenset with elements in either set but not both.
     pub(crate) fn symmetric_difference(
         &self,
         other: &SetStorage,
-        heap: &mut Heap<impl ResourceTracker>,
-        interns: &Interns,
+        vm: &mut VM<'_, '_, impl ResourceTracker>,
     ) -> RunResult<Self> {
-        Ok(Self(self.0.symmetric_difference(other, heap, interns)?))
+        Ok(Self(self.0.symmetric_difference(other, vm)?))
     }
 }
 
@@ -1142,7 +1117,7 @@ impl PyTrait for FrozenSet {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<impl ResourceTracker>,
+        vm: &mut VM<'_, '_, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<AttrCallResult> {
@@ -1157,58 +1132,50 @@ impl PyTrait for FrozenSet {
             }
             Some(StaticStrings::Union) => {
                 let other = args.get_one_arg("frozenset.union", heap)?;
-                let other_storage = Set::get_storage_from_value(other, heap, interns)?;
-                let result = self.union(&other_storage, heap, interns)?;
-                for entry in other_storage.entries {
-                    entry.value.drop_with_heap(heap);
-                }
-                let heap_id = heap.allocate(HeapData::FrozenSet(result))?;
+                let other_storage = Set::get_storage_from_value(other, vm)?;
+                defer_drop!(other_storage, vm);
+                let result = self.union(other_storage, vm)?;
+                let heap_id = vm.heap.allocate(HeapData::FrozenSet(result))?;
                 Ok(Value::Ref(heap_id))
             }
             Some(StaticStrings::Intersection) => {
                 let other = args.get_one_arg("frozenset.intersection", heap)?;
-                let other_storage = Set::get_storage_from_value(other, heap, interns)?;
-                let result = self.intersection(&other_storage, heap, interns)?;
-                for entry in other_storage.entries {
-                    entry.value.drop_with_heap(heap);
-                }
-                let heap_id = heap.allocate(HeapData::FrozenSet(result))?;
+                let other_storage = Set::get_storage_from_value(other, vm)?;
+                defer_drop!(other_storage, vm);
+                let result = self.intersection(other_storage, vm)?;
+                let heap_id = vm.heap.allocate(HeapData::FrozenSet(result))?;
                 Ok(Value::Ref(heap_id))
             }
             Some(StaticStrings::Difference) => {
                 let other = args.get_one_arg("frozenset.difference", heap)?;
-                let other_storage = Set::get_storage_from_value(other, heap, interns)?;
-                let result = self.difference(&other_storage, heap, interns)?;
-                for entry in other_storage.entries {
-                    entry.value.drop_with_heap(heap);
-                }
-                let heap_id = heap.allocate(HeapData::FrozenSet(result))?;
+                let other_storage = Set::get_storage_from_value(other, vm)?;
+                defer_drop!(other_storage, vm);
+                let result = self.difference(other_storage, vm)?;
+                let heap_id = vm.heap.allocate(HeapData::FrozenSet(result))?;
                 Ok(Value::Ref(heap_id))
             }
             Some(StaticStrings::SymmetricDifference) => {
                 let other = args.get_one_arg("frozenset.symmetric_difference", heap)?;
-                let other_storage = Set::get_storage_from_value(other, heap, interns)?;
-                let result = self.symmetric_difference(&other_storage, heap, interns)?;
-                for entry in other_storage.entries {
-                    entry.value.drop_with_heap(heap);
-                }
-                let heap_id = heap.allocate(HeapData::FrozenSet(result))?;
+                let other_storage = Set::get_storage_from_value(other, vm)?;
+                defer_drop!(other_storage, vm);
+                let result = self.symmetric_difference(other_storage, vm)?;
+                let heap_id = vm.heap.allocate(HeapData::FrozenSet(result))?;
                 Ok(Value::Ref(heap_id))
             }
             Some(StaticStrings::Issubset) => {
                 let other = args.get_one_arg("frozenset.issubset", heap)?;
-                defer_drop!(other, heap);
-                Ok(Value::Bool(self.issubset_from_value(other, heap, interns)?))
+                defer_drop!(other, vm);
+                Ok(Value::Bool(self.issubset_from_value(other, vm)?))
             }
             Some(StaticStrings::Issuperset) => {
                 let other = args.get_one_arg("frozenset.issuperset", heap)?;
-                defer_drop!(other, heap);
-                Ok(Value::Bool(self.issuperset_from_value(other, heap, interns)?))
+                defer_drop!(other, vm);
+                Ok(Value::Bool(self.issuperset_from_value(other, vm)?))
             }
             Some(StaticStrings::Isdisjoint) => {
                 let other = args.get_one_arg("frozenset.isdisjoint", heap)?;
-                defer_drop!(other, heap);
-                Ok(Value::Bool(self.isdisjoint_from_value(other, heap, interns)?))
+                defer_drop!(other, vm);
+                Ok(Value::Bool(self.isdisjoint_from_value(other, vm)?))
             }
             _ => {
                 args.drop_with_heap(heap);
@@ -1231,17 +1198,12 @@ impl PyTrait for FrozenSet {
 /// Helper methods for frozenset operations with arbitrary iterables.
 impl FrozenSet {
     /// Checks if this frozenset is a subset of an iterable.
-    fn issubset_from_value(
-        &self,
-        other: &Value,
-        heap: &mut Heap<impl ResourceTracker>,
-        interns: &Interns,
-    ) -> RunResult<bool> {
+    fn issubset_from_value(&self, other: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
         // Try to get entries from a Set/FrozenSet directly
         let entries_opt = match other {
-            Value::Ref(id) => match heap.get(*id) {
-                HeapData::Set(other_set) => Some(other_set.0.clone_entries(heap)),
-                HeapData::FrozenSet(other_set) => Some(other_set.0.clone_entries(heap)),
+            Value::Ref(id) => match vm.heap.get(*id) {
+                HeapData::Set(other_set) => Some(other_set.0.clone_entries(vm.heap)),
+                HeapData::FrozenSet(other_set) => Some(other_set.0.clone_entries(vm.heap)),
                 _ => None,
             },
             _ => None,
@@ -1250,30 +1212,23 @@ impl FrozenSet {
         if let Some(entries) = entries_opt {
             // Build temporary storage and check
             let other_storage = SetStorage::from_entries(entries);
-            let result = self.0.is_subset(&other_storage, heap, interns);
-            other_storage.drop_all_values(heap);
-            return result;
+            defer_drop!(other_storage, vm);
+            return self.0.is_subset(other_storage, vm);
         }
 
         // Handle all other iterables (list, tuple, range, str, bytes, dict, etc.)
-        let temp = Set::from_iterable(other.clone_with_heap(heap), heap, interns)?;
-        let result = self.0.is_subset(&temp.0, heap, interns);
-        temp.0.drop_all_values(heap);
-        result
+        let temp = Set::from_iterable(other.clone_with_heap(vm), vm)?;
+        defer_drop!(temp, vm);
+        self.0.is_subset(&temp.0, vm)
     }
 
     /// Checks if this frozenset is a superset of an iterable.
-    fn issuperset_from_value(
-        &self,
-        other: &Value,
-        heap: &mut Heap<impl ResourceTracker>,
-        interns: &Interns,
-    ) -> RunResult<bool> {
+    fn issuperset_from_value(&self, other: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
         // Try to get entries from a Set/FrozenSet directly
         let entries_opt = match other {
-            Value::Ref(id) => match heap.get(*id) {
-                HeapData::Set(other_set) => Some(other_set.0.clone_entries(heap)),
-                HeapData::FrozenSet(other_set) => Some(other_set.0.clone_entries(heap)),
+            Value::Ref(id) => match vm.heap.get(*id) {
+                HeapData::Set(other_set) => Some(other_set.0.clone_entries(vm.heap)),
+                HeapData::FrozenSet(other_set) => Some(other_set.0.clone_entries(vm.heap)),
                 _ => None,
             },
             _ => None,
@@ -1282,30 +1237,23 @@ impl FrozenSet {
         if let Some(entries) = entries_opt {
             // Build temporary storage and check
             let other_storage = SetStorage::from_entries(entries);
-            let result = self.0.is_superset(&other_storage, heap, interns);
-            other_storage.drop_all_values(heap);
-            return result;
+            defer_drop!(other_storage, vm);
+            return self.0.is_superset(other_storage, vm);
         }
 
         // Handle all other iterables (list, tuple, range, str, bytes, dict, etc.)
-        let temp = Set::from_iterable(other.clone_with_heap(heap), heap, interns)?;
-        let result = self.0.is_superset(&temp.0, heap, interns);
-        temp.0.drop_all_values(heap);
-        result
+        let temp = Set::from_iterable(other.clone_with_heap(vm), vm)?;
+        defer_drop!(temp, vm);
+        self.0.is_superset(&temp.0, vm)
     }
 
     /// Checks if this frozenset has no elements in common with an iterable.
-    fn isdisjoint_from_value(
-        &self,
-        other: &Value,
-        heap: &mut Heap<impl ResourceTracker>,
-        interns: &Interns,
-    ) -> RunResult<bool> {
+    fn isdisjoint_from_value(&self, other: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
         // Try to get entries from a Set/FrozenSet directly
         let entries_opt = match other {
-            Value::Ref(id) => match heap.get(*id) {
-                HeapData::Set(other_set) => Some(other_set.0.clone_entries(heap)),
-                HeapData::FrozenSet(other_set) => Some(other_set.0.clone_entries(heap)),
+            Value::Ref(id) => match vm.heap.get(*id) {
+                HeapData::Set(other_set) => Some(other_set.0.clone_entries(vm.heap)),
+                HeapData::FrozenSet(other_set) => Some(other_set.0.clone_entries(vm.heap)),
                 _ => None,
             },
             _ => None,
@@ -1314,16 +1262,14 @@ impl FrozenSet {
         if let Some(entries) = entries_opt {
             // Build temporary storage and check
             let other_storage = SetStorage::from_entries(entries);
-            let result = self.0.is_disjoint(&other_storage, heap, interns);
-            other_storage.drop_all_values(heap);
-            return result;
+            defer_drop!(other_storage, vm);
+            return self.0.is_disjoint(other_storage, vm);
         }
 
         // Handle all other iterables (list, tuple, range, str, bytes, dict, etc.)
-        let temp = Set::from_iterable(other.clone_with_heap(heap), heap, interns)?;
-        let result = self.0.is_disjoint(&temp.0, heap, interns);
-        temp.0.drop_all_values(heap);
-        result
+        let temp = Set::from_iterable(other.clone_with_heap(vm), vm)?;
+        defer_drop!(temp, vm);
+        self.0.is_disjoint(&temp.0, vm)
     }
 }
 

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -9,6 +9,7 @@ use ahash::AHashSet;
 
 use crate::{
     args::ArgValues,
+    bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult},
     heap::{Heap, HeapData, HeapId},
@@ -51,7 +52,8 @@ impl Slice {
     /// - `slice(start, stop, step)` - slice with all three components
     ///
     /// Each argument can be None to indicate "use default".
-    pub fn init(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+        let heap = &mut *vm.heap;
         let pos_args = args.into_pos_only("slice", heap)?;
         defer_drop!(pos_args, heap);
 

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -50,7 +50,9 @@ impl Str {
     ///
     /// - `str()` with no args returns an empty string
     /// - `str(x)` converts x to its string representation using `py_str`
-    pub fn init(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
+    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+        let heap = &mut *vm.heap;
+        let interns = vm.interns;
         let value = args.get_zero_one_arg("str", heap)?;
         match value {
             None => Ok(Value::InternString(StaticStrings::EmptyString.into())),
@@ -314,19 +316,17 @@ impl PyTrait for Str {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<impl ResourceTracker>,
+        vm: &mut VM<'_, '_, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<AttrCallResult> {
-        let heap = &mut *vm.heap;
-        let interns = vm.interns;
-        let args_guard = HeapGuard::new(args, heap);
+        let args_guard = HeapGuard::new(args, vm.heap);
         let Some(method) = attr.static_string() else {
-            return Err(ExcType::attribute_error(Type::Str, attr.as_str(interns)));
+            return Err(ExcType::attribute_error(Type::Str, attr.as_str(vm.interns)));
         };
 
-        let (args, heap) = args_guard.into_parts();
-        call_str_method_impl(&self.0, method, args, heap, interns).map(AttrCallResult::Value)
+        let args = args_guard.into_inner();
+        call_str_method_impl(&self.0, method, args, vm).map(AttrCallResult::Value)
     }
 }
 
@@ -338,15 +338,14 @@ pub fn call_str_method(
     s: &str,
     method_id: StringId,
     args: ArgValues,
-    heap: &mut Heap<impl ResourceTracker>,
-    interns: &Interns,
+    vm: &mut VM<'_, '_, impl ResourceTracker>,
 ) -> RunResult<Value> {
-    let args_guard = HeapGuard::new(args, heap);
+    let args_guard = HeapGuard::new(args, vm.heap);
     let Some(method) = StaticStrings::from_string_id(method_id) else {
-        return Err(ExcType::attribute_error(Type::Str, interns.get_str(method_id)));
+        return Err(ExcType::attribute_error(Type::Str, vm.interns.get_str(method_id)));
     };
-    let (args, heap) = args_guard.into_parts();
-    call_str_method_impl(s, method, args, heap, interns)
+    let args = args_guard.into_inner();
+    call_str_method_impl(s, method, args, vm)
 }
 
 /// Dispatches a method call on a string value.
@@ -372,9 +371,10 @@ fn call_str_method_impl(
     s: &str,
     method: StaticStrings,
     args: ArgValues,
-    heap: &mut Heap<impl ResourceTracker>,
-    interns: &Interns,
+    vm: &mut VM<'_, '_, impl ResourceTracker>,
 ) -> RunResult<Value> {
+    let heap = &mut *vm.heap;
+    let interns = vm.interns;
     match method {
         // Simple transformations (no arguments)
         StaticStrings::Lower => {
@@ -476,8 +476,8 @@ fn call_str_method_impl(
         }
         // Existing method
         StaticStrings::Join => {
-            let iterable = args.get_one_arg("str.join", heap)?;
-            str_join(s, iterable, heap, interns)
+            let iterable = args.get_one_arg("str.join", vm.heap)?;
+            str_join(s, iterable, vm)
         }
         _ => {
             args.drop_with_heap(heap);
@@ -499,24 +499,19 @@ fn call_str_method_impl(
 ///
 /// # Errors
 /// Returns `TypeError` if the argument is not iterable or if any element is not a string.
-fn str_join(
-    separator: &str,
-    iterable: Value,
-    heap: &mut Heap<impl ResourceTracker>,
-    interns: &Interns,
-) -> RunResult<Value> {
+fn str_join(separator: &str, iterable: Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Value> {
     // Create MontyIter from the iterable, with join-specific error message
-    let Ok(iter) = MontyIter::new(iterable, heap, interns) else {
+    let Ok(iter) = MontyIter::new(iterable, vm) else {
         return Err(ExcType::type_error_join_not_iterable());
     };
-    defer_drop_mut!(iter, heap);
+    defer_drop_mut!(iter, vm);
 
     // Build result string, tracking index for error messages
     let mut result = String::new();
     let mut index = 0usize;
 
-    while let Some(item) = iter.for_next(heap, interns)? {
-        defer_drop!(item, heap);
+    while let Some(item) = iter.for_next(vm)? {
+        defer_drop!(item, vm);
         if index > 0 {
             result.push_str(separator);
         }
@@ -524,18 +519,18 @@ fn str_join(
         // Check item is a string and extract its content
         match item {
             Value::InternString(id) => {
-                result.push_str(interns.get_str(*id));
+                result.push_str(vm.interns.get_str(*id));
             }
             Value::Ref(heap_id) => {
-                if let HeapData::Str(s) = heap.get(*heap_id) {
+                if let HeapData::Str(s) = vm.heap.get(*heap_id) {
                     result.push_str(s.as_str());
                 } else {
-                    let t = item.py_type(heap);
+                    let t = item.py_type(vm.heap);
                     return Err(ExcType::type_error_join_item(index, t));
                 }
             }
             _ => {
-                let t = item.py_type(heap);
+                let t = item.py_type(vm.heap);
                 return Err(ExcType::type_error_join_item(index, t));
             }
         }
@@ -543,7 +538,7 @@ fn str_join(
     }
 
     // Allocate result (uses interned empty string if result is empty)
-    allocate_string(result, heap)
+    allocate_string(result, vm.heap)
 }
 
 /// Writes a Python repr() string for a given string slice to a formatter.

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -101,16 +101,16 @@ impl Tuple {
     ///
     /// - `tuple()` with no args returns an empty tuple (singleton)
     /// - `tuple(iterable)` creates a tuple from any iterable (list, tuple, range, str, bytes, dict)
-    pub fn init(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
-        let value = args.get_zero_one_arg("tuple", heap)?;
+    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+        let value = args.get_zero_one_arg("tuple", vm.heap)?;
         match value {
             None => {
                 // Use empty tuple singleton
-                Ok(heap.get_empty_tuple())
+                Ok(vm.heap.get_empty_tuple())
             }
             Some(v) => {
-                let items = MontyIter::new(v, heap, interns)?.collect(heap, interns)?;
-                Ok(allocate_tuple(items, heap)?)
+                let items = MontyIter::new(v, vm)?.collect(vm)?;
+                Ok(allocate_tuple(items, vm.heap)?)
             }
         }
     }
@@ -254,7 +254,7 @@ impl PyTrait for Tuple {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<impl ResourceTracker>,
+        vm: &mut VM<'_, '_, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<AttrCallResult> {

--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -197,24 +197,24 @@ impl Type {
     /// Dispatches to the appropriate type's init method for container types,
     /// or handles primitive type conversions inline.
     pub(crate) fn call(self, vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-        let heap = &mut *vm.heap;
-        let interns = vm.interns;
         match self {
             // Container types - delegate to init methods
-            Self::List => List::init(heap, args, interns),
-            Self::Tuple => Tuple::init(heap, args, interns),
-            Self::Dict => Dict::init(heap, args, interns),
-            Self::Set => Set::init(heap, args, interns),
-            Self::FrozenSet => FrozenSet::init(heap, args, interns),
-            Self::Str => Str::init(heap, args, interns),
-            Self::Bytes => Bytes::init(heap, args, interns),
-            Self::Range => Range::init(heap, args),
-            Self::Slice => Slice::init(heap, args),
-            Self::Iterator => MontyIter::init(heap, args, interns),
-            Self::Path => Path::init(heap, args, interns),
+            Self::List => List::init(vm, args),
+            Self::Tuple => Tuple::init(vm, args),
+            Self::Dict => Dict::init(vm, args),
+            Self::Set => Set::init(vm, args),
+            Self::FrozenSet => FrozenSet::init(vm, args),
+            Self::Str => Str::init(vm, args),
+            Self::Bytes => Bytes::init(vm, args),
+            Self::Range => Range::init(vm, args),
+            Self::Slice => Slice::init(vm, args),
+            Self::Iterator => MontyIter::init(vm, args),
+            Self::Path => Path::init(vm, args),
 
             // Primitive types - inline implementation
             Self::Int => {
+                let heap = &mut *vm.heap;
+                let interns = vm.interns;
                 let Some(v) = args.get_zero_one_arg("int", heap)? else {
                     return Ok(Value::Int(0));
                 };
@@ -239,6 +239,8 @@ impl Type {
                 }
             }
             Self::Float => {
+                let heap = &mut *vm.heap;
+                let interns = vm.interns;
                 let Some(v) = args.get_zero_one_arg("float", heap)? else {
                     return Ok(Value::Float(0.0));
                 };
@@ -258,6 +260,8 @@ impl Type {
                 }
             }
             Self::Bool => {
+                let heap = &mut *vm.heap;
+                let interns = vm.interns;
                 let Some(v) = args.get_zero_one_arg("bool", heap)? else {
                     return Ok(Value::Bool(false));
                 };
@@ -380,14 +384,14 @@ pub(crate) fn call_type_method(
     args: ArgValues,
     vm: &mut VM<'_, '_, impl ResourceTracker>,
 ) -> Result<Value, RunError> {
-    let heap = &mut *vm.heap;
-    let interns = vm.interns;
     match (t, method_id) {
-        (Type::Dict, m) if m == StaticStrings::Fromkeys => return dict_fromkeys(args, heap, interns),
-        (Type::Bytes, m) if m == StaticStrings::Fromhex => return bytes_fromhex(args, heap, interns),
+        (Type::Dict, m) if m == StaticStrings::Fromkeys => return dict_fromkeys(args, vm),
+        (Type::Bytes, m) if m == StaticStrings::Fromhex => {
+            return bytes_fromhex(args, vm.heap, vm.interns);
+        }
         _ => {}
     }
     // Other types or unknown methods - report actual type name, not 'type'
-    args.drop_with_heap(heap);
-    Err(ExcType::attribute_error(t, interns.get_str(method_id)))
+    args.drop_with_heap(vm.heap);
+    Err(ExcType::attribute_error(t, vm.interns.get_str(method_id)))
 }


### PR DESCRIPTION
This makes `MontyIter::new` and its methods take `VM` instead of `Heap` and `Interns` pair. This will make landing #207 easier, at the same time it made the `Set` code a lot more concise.