### PR TITLE
feat: add class skeleton support

### DIFF
--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -360,6 +360,7 @@ impl<'a> Compiler<'a> {
                 }
             }
             Node::FunctionDef(func_def) => self.compile_function_def(func_def)?,
+            Node::ClassDef { name } => self.compile_class_def(name),
             Node::Try(try_block) => self.compile_try(try_block)?,
             Node::Import { module_name, binding } => self.compile_import(*module_name, binding),
             Node::ImportFrom {
@@ -373,6 +374,17 @@ impl<'a> Compiler<'a> {
             Node::Pass | Node::Global { .. } | Node::Nonlocal { .. } => {}
         }
         Ok(())
+    }
+
+    /// Compiles an empty class skeleton definition.
+    ///
+    /// The current implementation pushes the class name constant, creates a
+    /// skeletal runtime class object, and stores it into the resolved binding.
+    fn compile_class_def(&mut self, name: &Identifier) {
+        let name_const = self.code.add_const(Value::InternString(name.name_id));
+        self.code.emit_u16(Opcode::LoadConst, name_const);
+        self.code.emit(Opcode::MakeClass);
+        self.compile_store(name);
     }
 
     /// Compiles a function definition.

--- a/crates/monty/src/bytecode/op.rs
+++ b/crates/monty/src/bytecode/op.rs
@@ -345,6 +345,10 @@ pub enum Opcode {
     ForIter,
 
     // === Function Definition ===
+    /// Create a skeletal user-defined class from a name on the stack.
+    ///
+    /// Pops the class name string and pushes a heap-allocated class object.
+    MakeClass,
     /// Create function object. Operand: u16 func_id.
     MakeFunction,
     /// Create closure. Operands: u16 func_id, u8 cell_count.
@@ -437,7 +441,7 @@ impl Opcode {
             InplacePow, InplaceRShift, InplaceSub, InplaceXor, Jump, JumpIfFalse, JumpIfFalseOrPop, JumpIfTrue,
             JumpIfTrueOrPop, ListAppend, ListExtend, ListToTuple, LoadAttr, LoadAttrImport, LoadCell, LoadConst,
             LoadFalse, LoadGlobal, LoadGlobalCallable, LoadLocal, LoadLocal0, LoadLocal1, LoadLocal2, LoadLocal3,
-            LoadLocalCallable, LoadLocalCallableW, LoadLocalW, LoadModule, LoadNone, LoadSmallInt, LoadTrue,
+            LoadLocalCallable, LoadLocalCallableW, LoadLocalW, LoadModule, LoadNone, LoadSmallInt, LoadTrue, MakeClass,
             MakeClosure, MakeFunction, Nop, Pop, Raise, RaiseImportError, Reraise, ReturnValue, Rot2, Rot3, SetAdd,
             StoreAttr, StoreCell, StoreGlobal, StoreLocal, StoreLocalW, StoreSubscr, UnaryInvert, UnaryNeg, UnaryNot,
             UnaryPos, UnpackEx, UnpackSequence,
@@ -512,7 +516,8 @@ impl Opcode {
             // Async/await
             Await => 0, // pop awaitable, push result
 
-            // Function definition - push 1 (the function/closure)
+            // Function/class definition
+            MakeClass => 0, // pop name, push class
             MakeFunction | MakeClosure => 1,
 
             // Exception handling

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -33,7 +33,7 @@ use crate::{
     os::OsFunction,
     parse::CodeRange,
     resource::ResourceTracker,
-    types::{LongInt, MontyIter, PyTrait, iter::advance_on_heap},
+    types::{Class, LongInt, MontyIter, PyTrait, iter::advance_on_heap},
     value::{BitwiseOp, EitherStr, Value},
 };
 
@@ -1379,7 +1379,22 @@ impl<'a, 'p, T: ResourceTracker> VM<'a, 'p, T> {
 
                     handle_call_result!(self, cached_frame, self.exec_call_attr_extended(name_id, has_kwargs));
                 }
-                // Function Definition
+                // Function and Class Definition
+                Opcode::MakeClass => {
+                    let name_id = match self.pop() {
+                        Value::InternString(name_id) => name_id,
+                        value => {
+                            let ty = value.py_type(self.heap);
+                            value.drop_with_heap(self.heap);
+                            return Err(RunError::internal(format!(
+                                "MakeClass expected an interned class name, got '{ty}'"
+                            )));
+                        }
+                    };
+
+                    let heap_id = self.heap.allocate(HeapData::Class(Class::new(name_id)))?;
+                    self.push(Value::Ref(heap_id));
+                }
                 Opcode::MakeFunction => {
                     let func_idx = fetch_u16!(cached_frame);
                     let defaults_count = fetch_u8!(cached_frame) as usize;

--- a/crates/monty/src/expressions.rs
+++ b/crates/monty/src/expressions.rs
@@ -476,6 +476,14 @@ pub enum Node<F> {
         or_else: Vec<Self>,
     },
     FunctionDef(F),
+    /// Minimal class definition binding.
+    ///
+    /// The current class skeleton stores only the class name because the parser
+    /// rejects non-empty class bodies and inheritance features for now.
+    ClassDef {
+        /// The class name. In prepared form this includes the resolved namespace slot.
+        name: Identifier,
+    },
     /// Global variable declaration. Only present in parsed form, consumed during prepare.
     ///
     /// Declares that the listed names refer to module-level (global) variables,

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -24,8 +24,8 @@ use crate::{
     intern::Interns,
     resource::{ResourceError, ResourceTracker, check_mult_size, check_repeat_size},
     types::{
-        AttrCallResult, Bytes, Dataclass, Dict, FrozenSet, List, LongInt, Module, MontyIter, NamedTuple, Path, PyTrait,
-        Range, ReMatch, RePattern, Set, Slice, Str, Tuple, Type, allocate_tuple,
+        AttrCallResult, Bytes, Class, Dataclass, Dict, FrozenSet, List, LongInt, Module, MontyIter, NamedTuple, Path,
+        PyTrait, Range, ReMatch, RePattern, Set, Slice, Str, Tuple, Type, allocate_tuple,
     },
     value::{EitherStr, Value},
 };
@@ -101,6 +101,8 @@ pub(crate) enum HeapData {
     /// when values fit, and promote to LongInt on overflow. When LongInt results fit back
     /// in i64, they are demoted back to `Value::Int` for performance.
     LongInt(LongInt),
+    /// A skeletal user-defined class object from `class Foo: pass`.
+    Class(Class),
     /// A Python module (e.g., `sys`, `typing`).
     ///
     /// Modules have a name and a dictionary of attributes. They are created by
@@ -195,6 +197,7 @@ impl HeapData {
             Self::Dataclass(dc) => dc.has_refs(),
             Self::Iter(iter) => iter.has_refs(),
             Self::Module(m) => m.has_refs(),
+            Self::Class(_) => false,
             // Coroutines always have refs (namespace values, frame_cells)
             Self::Coroutine(coro) => {
                 !coro.frame_cells.is_empty() || coro.namespace.iter().any(|v| matches!(v, Value::Ref(_)))
@@ -244,6 +247,7 @@ impl HeapData {
             Self::Dataclass(dc) => HeapDataMut::Dataclass(dc),
             Self::Iter(iter) => HeapDataMut::Iter(iter),
             Self::LongInt(li) => HeapDataMut::LongInt(li),
+            Self::Class(class) => HeapDataMut::Class(class),
             Self::Module(m) => HeapDataMut::Module(m),
             Self::Coroutine(coro) => HeapDataMut::Coroutine(coro),
             Self::GatherFuture(gather) => HeapDataMut::GatherFuture(gather),
@@ -279,6 +283,7 @@ impl PyTrait for HeapData {
             Self::Iter(_) => Type::Iterator,
             // LongInt is still `int` in Python - it's an implementation detail
             Self::LongInt(_) => Type::Int,
+            Self::Class(class) => class.py_type(heap),
             Self::Module(_) => Type::Module,
             Self::Coroutine(_) | Self::GatherFuture(_) => Type::Coroutine,
             Self::Path(p) => p.py_type(heap),
@@ -306,6 +311,7 @@ impl PyTrait for HeapData {
             Self::Dataclass(dc) => dc.py_estimate_size(),
             Self::Iter(_) => std::mem::size_of::<MontyIter>(),
             Self::LongInt(li) => li.estimate_size(),
+            Self::Class(class) => class.py_estimate_size(),
             Self::Module(m) => std::mem::size_of::<Module>() + m.attrs().py_estimate_size(),
             Self::Coroutine(coro) => {
                 std::mem::size_of::<Coroutine>()
@@ -386,8 +392,10 @@ impl PyTrait for HeapData {
             (Self::RePattern(a), Self::RePattern(b)) => a.py_eq(b, heap, interns),
             // ReMatch equality
             (Self::ReMatch(a), Self::ReMatch(b)) => a.py_eq(b, heap, interns),
-            // Cells, Exceptions, Iterators, Modules, and async types compare by identity only (handled at Value level via HeapId comparison)
-            (Self::Cell(_), Self::Cell(_))
+            // Cells, classes, exceptions, iterators, modules, and async types compare
+            // by identity only (handled at Value level via HeapId comparison).
+            (Self::Class(_), Self::Class(_))
+            | (Self::Cell(_), Self::Cell(_))
             | (Self::Exception(_), Self::Exception(_))
             | (Self::Iter(_), Self::Iter(_))
             | (Self::Module(_), Self::Module(_))
@@ -424,6 +432,7 @@ impl PyTrait for HeapData {
             Self::Cell(cell) => cell.0.py_dec_ref_ids(stack),
             Self::Dataclass(dc) => dc.py_dec_ref_ids(stack),
             Self::Iter(iter) => iter.py_dec_ref_ids(stack),
+            Self::Class(class) => class.py_dec_ref_ids(stack),
             Self::Module(m) => m.py_dec_ref_ids(stack),
             Self::Coroutine(coro) => {
                 // Decrement ref count for frame cells
@@ -468,6 +477,7 @@ impl PyTrait for HeapData {
             Self::Dataclass(dc) => dc.py_bool(heap, interns),
             Self::Iter(_) => true, // Iterators are always truthy
             Self::LongInt(li) => !li.is_zero(),
+            Self::Class(_) => true,        // Classes are always truthy
             Self::Module(_) => true,       // Modules are always truthy
             Self::Coroutine(_) => true,    // Coroutines are always truthy
             Self::GatherFuture(_) => true, // GatherFutures are always truthy
@@ -503,6 +513,7 @@ impl PyTrait for HeapData {
             Self::Dataclass(dc) => dc.py_repr_fmt(f, heap, heap_ids, interns),
             Self::Iter(_) => write!(f, "<iterator>"),
             Self::LongInt(li) => write!(f, "{li}"),
+            Self::Class(class) => class.py_repr_fmt(f, heap, heap_ids, interns),
             Self::Module(m) => write!(f, "<module '{}'>", interns.get_str(m.name())),
             Self::Coroutine(coro) => {
                 let func = interns.get_function(coro.func_id);
@@ -642,6 +653,7 @@ impl PyTrait for HeapData {
             Self::FrozenSet(fs) => fs.py_call_attr(self_id, vm, attr, args),
             Self::Dataclass(dc) => dc.py_call_attr(self_id, vm, attr, args),
             Self::Path(p) => p.py_call_attr(self_id, vm, attr, args),
+            Self::Class(class) => class.py_call_attr(self_id, vm, attr, args),
             Self::Module(m) => m.py_call_attr(self_id, vm, attr, args),
             Self::RePattern(p) => p.py_call_attr(self_id, vm, attr, args),
             Self::ReMatch(m) => m.py_call_attr(self_id, vm, attr, args),
@@ -687,6 +699,7 @@ impl PyTrait for HeapData {
     ) -> RunResult<Option<AttrCallResult>> {
         match self {
             Self::Dataclass(dc) => dc.py_getattr(attr, heap, interns),
+            Self::Class(class) => class.py_getattr(attr, heap, interns),
             Self::Module(m) => Ok(m.py_getattr(attr, heap, interns)),
             Self::NamedTuple(nt) => nt.py_getattr(attr, heap, interns),
             Self::Slice(s) => s.py_getattr(attr, heap, interns),
@@ -731,6 +744,7 @@ impl HashState {
             | HeapData::Range(_)
             | HeapData::Slice(_)
             | HeapData::LongInt(_) => Self::Unknown,
+            HeapData::Class(_) => Self::Unknown,
             // Dataclass hashability depends on the mutable flag
             HeapData::Dataclass(dc) => {
                 if dc.is_frozen() {

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -17,8 +17,8 @@ use crate::{
     heap::{Heap, HeapId},
     intern::{FunctionId, Interns},
     types::{
-        AttrCallResult, Bytes, Dataclass, Dict, FrozenSet, List, LongInt, Module, MontyIter, NamedTuple, Path, PyTrait,
-        Range, ReMatch, RePattern, Set, Slice, Str, Tuple, Type,
+        AttrCallResult, Bytes, Class, Dataclass, Dict, FrozenSet, List, LongInt, Module, MontyIter, NamedTuple, Path,
+        PyTrait, Range, ReMatch, RePattern, Set, Slice, Str, Tuple, Type,
     },
     value::{EitherStr, Value},
 };
@@ -75,6 +75,8 @@ pub(crate) enum HeapDataMut<'a> {
     /// when values fit, and promote to LongInt on overflow. When LongInt results fit back
     /// in i64, they are demoted back to `Value::Int` for performance.
     LongInt(&'a mut LongInt),
+    /// A skeletal user-defined class object from `class Foo: pass`.
+    Class(&'a mut Class),
     /// A Python module (e.g., `sys`, `typing`).
     ///
     /// Modules have a name and a dictionary of attributes. They are created by
@@ -241,6 +243,12 @@ impl HeapDataMut<'_> {
                 range.step.hash(&mut hasher);
                 Ok(Some(hasher.finish()))
             }
+            Self::Class(class) => {
+                let mut hasher = DefaultHasher::new();
+                discriminant(self).hash(&mut hasher);
+                class.name().hash(&mut hasher);
+                Ok(Some(hasher.finish()))
+            }
             // Dataclass hashability depends on the mutable flag
             // Recursion depth is checked inside compute_hash
             Self::Dataclass(dc) => dc.compute_hash(heap, interns),
@@ -299,6 +307,7 @@ impl PyTrait for HeapDataMut<'_> {
             Self::Iter(_) => Type::Iterator,
             // LongInt is still `int` in Python - it's an implementation detail
             Self::LongInt(_) => Type::Int,
+            Self::Class(class) => class.py_type(heap),
             Self::Module(_) => Type::Module,
             Self::Coroutine(_) | Self::GatherFuture(_) => Type::Coroutine,
             Self::Path(p) => p.py_type(heap),
@@ -326,6 +335,7 @@ impl PyTrait for HeapDataMut<'_> {
             Self::Dataclass(dc) => dc.py_estimate_size(),
             Self::Iter(_) => std::mem::size_of::<MontyIter>(),
             Self::LongInt(li) => li.estimate_size(),
+            Self::Class(class) => class.py_estimate_size(),
             Self::Module(m) => std::mem::size_of::<Module>() + m.attrs().py_estimate_size(),
             Self::Coroutine(coro) => {
                 std::mem::size_of::<Coroutine>()
@@ -406,8 +416,9 @@ impl PyTrait for HeapDataMut<'_> {
             (Self::ReMatch(a), Self::ReMatch(b)) => a.py_eq(b, heap, interns),
             // RePattern equality by pattern string and flags
             (Self::RePattern(a), Self::RePattern(b)) => a.py_eq(b, heap, interns),
-            // Cells, Exceptions, Iterators, Modules, and async types compare by identity only (handled at Value level via HeapId comparison)
-            (Self::Cell(_), Self::Cell(_))
+            // Cells, classes, exceptions, iterators, modules, and async types compare by identity only (handled at Value level via HeapId comparison)
+            (Self::Class(_), Self::Class(_))
+            | (Self::Cell(_), Self::Cell(_))
             | (Self::Exception(_), Self::Exception(_))
             | (Self::Iter(_), Self::Iter(_))
             | (Self::Module(_), Self::Module(_))
@@ -444,6 +455,7 @@ impl PyTrait for HeapDataMut<'_> {
             Self::Cell(cell) => cell.0.py_dec_ref_ids(stack),
             Self::Dataclass(dc) => dc.py_dec_ref_ids(stack),
             Self::Iter(iter) => iter.py_dec_ref_ids(stack),
+            Self::Class(class) => class.py_dec_ref_ids(stack),
             Self::Module(m) => m.py_dec_ref_ids(stack),
             Self::Coroutine(coro) => {
                 // Decrement ref count for frame cells
@@ -488,6 +500,7 @@ impl PyTrait for HeapDataMut<'_> {
             Self::Dataclass(dc) => dc.py_bool(heap, interns),
             Self::Iter(_) => true, // Iterators are always truthy
             Self::LongInt(li) => !li.is_zero(),
+            Self::Class(_) => true,        // Classes are always truthy
             Self::Module(_) => true,       // Modules are always truthy
             Self::Coroutine(_) => true,    // Coroutines are always truthy
             Self::GatherFuture(_) => true, // GatherFutures are always truthy
@@ -523,6 +536,7 @@ impl PyTrait for HeapDataMut<'_> {
             Self::Dataclass(dc) => dc.py_repr_fmt(f, heap, heap_ids, interns),
             Self::Iter(_) => write!(f, "<iterator>"),
             Self::LongInt(li) => write!(f, "{li}"),
+            Self::Class(class) => class.py_repr_fmt(f, heap, heap_ids, interns),
             Self::Module(m) => write!(f, "<module '{}'>", interns.get_str(m.name())),
             Self::Coroutine(coro) => {
                 let func = interns.get_function(coro.func_id);
@@ -648,6 +662,7 @@ impl PyTrait for HeapDataMut<'_> {
             Self::FrozenSet(fs) => fs.py_call_attr(self_id, vm, attr, args),
             Self::Dataclass(dc) => dc.py_call_attr(self_id, vm, attr, args),
             Self::Path(p) => p.py_call_attr(self_id, vm, attr, args),
+            Self::Class(class) => class.py_call_attr(self_id, vm, attr, args),
             Self::Module(m) => m.py_call_attr(self_id, vm, attr, args),
             Self::ReMatch(m) => m.py_call_attr(self_id, vm, attr, args),
             Self::RePattern(p) => p.py_call_attr(self_id, vm, attr, args),
@@ -694,6 +709,7 @@ impl PyTrait for HeapDataMut<'_> {
     ) -> RunResult<Option<AttrCallResult>> {
         match self {
             Self::Dataclass(dc) => dc.py_getattr(attr, heap, interns),
+            Self::Class(class) => class.py_getattr(attr, heap, interns),
             Self::Module(m) => Ok(m.py_getattr(attr, heap, interns)),
             Self::NamedTuple(nt) => nt.py_getattr(attr, heap, interns),
             Self::Slice(s) => s.py_getattr(attr, heap, interns),

--- a/crates/monty/src/object.rs
+++ b/crates/monty/src/object.rs
@@ -472,6 +472,7 @@ impl MontyObject {
                         Self::Repr("<iterator>".to_owned())
                     }
                     HeapData::LongInt(li) => Self::BigInt(li.inner().clone()),
+                    HeapData::Class(_) => Self::Repr(object.py_repr(heap, interns).into_owned()),
                     HeapData::Module(m) => {
                         // Modules are represented as a repr string
                         Self::Repr(format!("<module '{}'>", interns.get_str(m.name())))

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -275,10 +275,7 @@ impl<'a> Parser<'a> {
                     is_async,
                 }))
             }
-            Stmt::ClassDef(c) => Err(ParseError::not_implemented(
-                "class definitions",
-                self.convert_range(c.range),
-            )),
+            Stmt::ClassDef(class_def) => self.parse_class_def(&class_def),
             Stmt::Return(ast::StmtReturn { value, .. }) => match value {
                 Some(value) => Ok(Node::Return(self.parse_expression(*value)?)),
                 None => Ok(Node::ReturnNone),
@@ -502,6 +499,40 @@ impl<'a> Parser<'a> {
                 self.convert_range(i.range),
             )),
         }
+    }
+
+    /// Parses the currently supported subset of class definitions.
+    ///
+    /// For now, this accepts only skeletal empty classes like `class Foo: pass`.
+    /// Richer class features need a dedicated class namespace model and remain
+    /// intentionally unsupported until that runtime exists.
+    fn parse_class_def(&mut self, class_def: &ast::StmtClassDef) -> Result<ParseNode, ParseError> {
+        let position = self.convert_range(class_def.range);
+
+        if !class_def.decorator_list.is_empty() {
+            return Err(ParseError::not_implemented("class decorators", position));
+        }
+        if class_def.arguments.is_some() {
+            return Err(ParseError::not_implemented("class inheritance", position));
+        }
+        if class_def.type_params.is_some() {
+            return Err(ParseError::not_implemented("generic class parameters", position));
+        }
+        if !Self::class_body_is_empty(&class_def.body) {
+            return Err(ParseError::not_implemented("non-empty class bodies", position));
+        }
+
+        Ok(Node::ClassDef {
+            name: self.identifier(&class_def.name.id, class_def.name.range),
+        })
+    }
+
+    /// Returns whether a class body is empty enough for the current skeleton support.
+    ///
+    /// Only `pass` statements are accepted. This keeps the initial class support
+    /// honest: no class namespace execution is attempted before that machinery exists.
+    fn class_body_is_empty(body: &[Stmt]) -> bool {
+        body.iter().all(|stmt| matches!(stmt, Stmt::Pass(_)))
     }
 
     /// `lhs = rhs` -> `lhs, rhs`

--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -455,6 +455,12 @@ impl<'i> Prepare<'i> {
                     let func_node = self.prepare_function_def(name, &signature, body, is_async)?;
                     new_nodes.push(func_node);
                 }
+                Node::ClassDef { name } => {
+                    self.names_assigned_in_order
+                        .insert(self.interner.get_str(name.name_id).to_string());
+                    let (name, _) = self.get_id(name);
+                    new_nodes.push(Node::ClassDef { name });
+                }
                 Node::Global { names, position } => {
                     // At module level, `global` is a no-op since all variables are already global.
                     // In functions, the global declarations are already collected in the first pass
@@ -1978,9 +1984,10 @@ fn collect_scope_info_from_node(
                 collect_scope_info_from_node(n, global_names, nonlocal_names, assigned_names, interner);
             }
         }
-        Node::FunctionDef(RawFunctionDef { name, .. }) => {
+        Node::FunctionDef(RawFunctionDef { name, .. }) | Node::ClassDef { name } => {
             // Function definition creates a local binding for the function name
-            // But we don't recurse into the function body - that's a separate scope
+            // Class skeletons also create a local binding for the class name.
+            // We don't recurse into nested scopes here.
             assigned_names.insert(interner.get_str(name.name_id).to_string());
         }
         Node::Try(Try {
@@ -2243,6 +2250,9 @@ fn collect_cell_vars_from_node(
                     cell_vars.insert(name.clone());
                 }
             }
+        }
+        Node::ClassDef { .. } => {
+            // Empty class skeletons do not create nested scopes or captures.
         }
         // Recurse into control flow structures
         Node::For { body, or_else, .. } => {
@@ -2573,8 +2583,9 @@ fn collect_referenced_names_from_node(node: &ParseNode, referenced: &mut AHashSe
                 collect_referenced_names_from_node(n, referenced, interner);
             }
         }
-        Node::FunctionDef(_) => {
-            // Don't recurse into nested function bodies - they have their own scope
+        Node::FunctionDef(_) | Node::ClassDef { .. } => {
+            // Don't recurse into nested function bodies. Class skeletons also
+            // don't carry an executable class body yet.
         }
         Node::Try(Try {
             body,

--- a/crates/monty/src/types/class.rs
+++ b/crates/monty/src/types/class.rs
@@ -1,0 +1,93 @@
+//! Minimal user-defined class object support.
+//!
+//! This type implements the first slice of Python `class` support in Monty:
+//! a class statement can bind a real class object that exposes class metadata
+//! like `__name__` and renders with a Python class-style repr.
+//!
+//! It is intentionally narrow. Richer class semantics like executing class
+//! bodies, descriptors, inheritance, and instance creation are future work.
+
+use std::{fmt::Write, mem::size_of};
+
+use ahash::AHashSet;
+
+use super::{AttrCallResult, PyTrait, Type};
+use crate::{
+    exception_private::RunResult,
+    heap::{Heap, HeapId},
+    intern::{Interns, StaticStrings, StringId},
+    resource::ResourceTracker,
+    value::{EitherStr, Value},
+};
+
+/// A minimal user-defined class object created by `class Foo: pass`.
+///
+/// The object currently stores only the class name. It behaves like a Python
+/// class object for repr and `__name__`, but does not yet support general class
+/// bodies, inheritance, or instantiation.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct Class {
+    name: StringId,
+}
+
+impl Class {
+    /// Creates a new skeletal class object with the given interned name.
+    pub fn new(name: StringId) -> Self {
+        Self { name }
+    }
+
+    /// Returns the interned class name.
+    pub fn name(&self) -> StringId {
+        self.name
+    }
+}
+
+impl PyTrait for Class {
+    fn py_type(&self, _heap: &Heap<impl ResourceTracker>) -> Type {
+        Type::Type
+    }
+
+    fn py_len(&self, _heap: &Heap<impl ResourceTracker>, _interns: &Interns) -> Option<usize> {
+        None
+    }
+
+    fn py_eq(
+        &self,
+        _other: &Self,
+        _heap: &mut Heap<impl ResourceTracker>,
+        _interns: &Interns,
+    ) -> Result<bool, crate::ResourceError> {
+        Ok(false)
+    }
+
+    fn py_dec_ref_ids(&mut self, _stack: &mut Vec<HeapId>) {}
+
+    fn py_repr_fmt(
+        &self,
+        f: &mut impl Write,
+        _heap: &Heap<impl ResourceTracker>,
+        _heap_ids: &mut AHashSet<HeapId>,
+        interns: &Interns,
+    ) -> std::fmt::Result {
+        write!(f, "<class '{}'>", interns.get_str(self.name))
+    }
+
+    fn py_estimate_size(&self) -> usize {
+        size_of::<Self>()
+    }
+
+    fn py_getattr(
+        &self,
+        attr: &EitherStr,
+        _heap: &mut Heap<impl ResourceTracker>,
+        _interns: &Interns,
+    ) -> RunResult<Option<AttrCallResult>> {
+        let is_dunder_name = attr
+            .static_string()
+            .map_or_else(|| false, |ss| ss == StaticStrings::DunderName);
+        if is_dunder_name {
+            return Ok(Some(AttrCallResult::Value(Value::InternString(self.name))));
+        }
+        Ok(None)
+    }
+}

--- a/crates/monty/src/types/mod.rs
+++ b/crates/monty/src/types/mod.rs
@@ -6,6 +6,7 @@
 /// The `AbstractValue` trait provides a common interface for all heap-allocated
 /// types, enabling efficient dispatch via `enum_dispatch`.
 pub mod bytes;
+pub mod class;
 pub mod dataclass;
 pub mod dict;
 pub mod iter;
@@ -26,6 +27,7 @@ pub mod tuple;
 pub mod r#type;
 
 pub(crate) use bytes::Bytes;
+pub(crate) use class::Class;
 pub(crate) use dataclass::Dataclass;
 pub(crate) use dict::Dict;
 pub(crate) use iter::MontyIter;

--- a/crates/monty/test_cases/class__skeleton.py
+++ b/crates/monty/test_cases/class__skeleton.py
@@ -1,0 +1,23 @@
+# === Empty class skeletons ===
+class Foo:
+    pass
+
+assert Foo.__name__ == 'Foo', 'class __name__ should expose the declared class name'
+assert repr(Foo) == "<class 'Foo'>", 'class repr should match the datatest harness module context'
+assert str(Foo) == "<class 'Foo'>", 'class str should match repr'
+assert repr(type(Foo)) == "<class 'type'>", 'type(Foo) should produce the type type object'
+assert bool(Foo), 'class objects should be truthy'
+
+# === Distinct class objects ===
+class Bar:
+    pass
+
+assert Foo != Bar, 'different class definitions should not compare equal'
+
+first_foo = Foo
+
+class Foo:
+    pass
+
+assert Foo is not first_foo, 'redefining a class should create a new class object'
+assert Foo != first_foo, 'redefined classes should not compare equal'

--- a/crates/monty/tests/parse_errors.rs
+++ b/crates/monty/tests/parse_errors.rs
@@ -38,8 +38,14 @@ fn yield_expressions_return_not_implemented_error() {
 }
 
 #[test]
-fn classes_return_not_implemented_error() {
+fn empty_classes_compile_successfully() {
     let result = MontyRun::new("class Foo: pass".to_owned(), "test.py", vec![]);
+    assert!(result.is_ok(), "empty class skeletons should compile");
+}
+
+#[test]
+fn non_empty_classes_return_not_implemented_error() {
+    let result = MontyRun::new("class Foo:\n    x = 1".to_owned(), "test.py", vec![]);
     assert_eq!(get_exc_type(result), ExcType::NotImplementedError);
 }
 


### PR DESCRIPTION
## Summary
- add a minimal class skeleton runtime object for empty class definitions
- wire empty `class Foo: pass` definitions through parse, prepare, compile, and VM execution
- add regression coverage for accepted empty classes and rejected non-empty class bodies

## Testing
- make lint-rs
- cargo test -p monty --test parse_errors --features ref-count-panic
- cargo test -p monty --test datatest_runner --features ref-count-panic class__skeleton