### PR TITLE
Fix forward function references at module scope

### DIFF
--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -1,6 +1,7 @@
 use std::collections::hash_map::Entry;
 
 use ahash::{AHashMap, AHashSet};
+use indexmap::IndexSet;
 
 use crate::{
     args::{ArgExprs, CallArg, CallKwarg},
@@ -37,6 +38,22 @@ pub struct PrepareResult {
     pub nodes: Vec<PreparedNode>,
     /// The string interner containing all interned identifiers and filenames.
     pub interner: InternerBuilder,
+}
+
+trait AssignedNameCollector {
+    fn insert_name(&mut self, name: String);
+}
+
+impl AssignedNameCollector for AHashSet<String> {
+    fn insert_name(&mut self, name: String) {
+        self.insert(name);
+    }
+}
+
+impl AssignedNameCollector for IndexSet<String> {
+    fn insert_name(&mut self, name: String) {
+        self.insert(name);
+    }
 }
 
 /// Prepares parsed nodes for compilation by resolving names and building the initial namespace.
@@ -317,7 +334,7 @@ impl<'i> Prepare<'i> {
         // Collect all names that will be assigned at module level.
         // We reuse collect_scope_info_from_node which already handles all node types
         // including walrus expressions, unpack targets, and control flow recursion.
-        let mut assigned_names = AHashSet::new();
+        let mut assigned_names = IndexSet::new();
         let mut global_names = AHashSet::new();
         let mut nonlocal_names = AHashSet::new();
         for node in nodes {
@@ -1973,7 +1990,7 @@ fn collect_scope_info_from_node(
     node: &ParseNode,
     global_names: &mut AHashSet<String>,
     nonlocal_names: &mut AHashSet<String>,
-    assigned_names: &mut AHashSet<String>,
+    assigned_names: &mut impl AssignedNameCollector,
     interner: &InternerBuilder,
 ) {
     match node {
@@ -1988,7 +2005,7 @@ fn collect_scope_info_from_node(
             }
         }
         Node::Assign { target, object } => {
-            assigned_names.insert(interner.get_str(target.name_id).to_string());
+            assigned_names.insert_name(interner.get_str(target.name_id).to_string());
             // Scan value expression for walrus operators
             collect_assigned_names_from_expr(object, assigned_names, interner);
         }
@@ -2001,7 +2018,7 @@ fn collect_scope_info_from_node(
             collect_assigned_names_from_expr(object, assigned_names, interner);
         }
         Node::OpAssign { target, object, .. } => {
-            assigned_names.insert(interner.get_str(target.name_id).to_string());
+            assigned_names.insert_name(interner.get_str(target.name_id).to_string());
             // Scan value expression for walrus operators
             collect_assigned_names_from_expr(object, assigned_names, interner);
         }
@@ -2064,7 +2081,7 @@ fn collect_scope_info_from_node(
         Node::FunctionDef(RawFunctionDef { name, .. }) => {
             // Function definition creates a local binding for the function name
             // But we don't recurse into the function body - that's a separate scope
-            assigned_names.insert(interner.get_str(name.name_id).to_string());
+            assigned_names.insert_name(interner.get_str(name.name_id).to_string());
         }
         Node::Try(Try {
             body,
@@ -2079,7 +2096,7 @@ fn collect_scope_info_from_node(
             for handler in handlers {
                 // Exception variable name is assigned
                 if let Some(ref name) = handler.name {
-                    assigned_names.insert(interner.get_str(name.name_id).to_string());
+                    assigned_names.insert_name(interner.get_str(name.name_id).to_string());
                 }
                 for n in &handler.body {
                     collect_scope_info_from_node(n, global_names, nonlocal_names, assigned_names, interner);
@@ -2094,12 +2111,12 @@ fn collect_scope_info_from_node(
         }
         // Import creates a binding for the module name (or alias)
         Node::Import { binding, .. } => {
-            assigned_names.insert(interner.get_str(binding.name_id).to_string());
+            assigned_names.insert_name(interner.get_str(binding.name_id).to_string());
         }
         // ImportFrom creates bindings for each imported name (or alias)
         Node::ImportFrom { names, .. } => {
             for (_import_name, binding) in names {
-                assigned_names.insert(interner.get_str(binding.name_id).to_string());
+                assigned_names.insert_name(interner.get_str(binding.name_id).to_string());
             }
         }
         // Statements with expressions that may contain walrus operators
@@ -2125,11 +2142,15 @@ fn collect_scope_info_from_node(
 /// Per PEP 572, walrus operator targets are assignments in the enclosing scope.
 /// This function recursively scans expressions to find all `Named` expression targets.
 /// It does NOT recurse into lambda bodies as those have their own scope.
-fn collect_assigned_names_from_expr(expr: &ExprLoc, assigned_names: &mut AHashSet<String>, interner: &InternerBuilder) {
+fn collect_assigned_names_from_expr(
+    expr: &ExprLoc,
+    assigned_names: &mut impl AssignedNameCollector,
+    interner: &InternerBuilder,
+) {
     match &expr.expr {
         Expr::Named { target, value } => {
             // The target of a walrus operator is assigned in this scope
-            assigned_names.insert(interner.get_str(target.name_id).to_string());
+            assigned_names.insert_name(interner.get_str(target.name_id).to_string());
             // Also scan the value expression
             collect_assigned_names_from_expr(value, assigned_names, interner);
         }
@@ -2241,7 +2262,7 @@ fn collect_assigned_names_from_expr(expr: &ExprLoc, assigned_names: &mut AHashSe
 /// Helper to collect assigned names from argument expressions.
 fn collect_assigned_names_from_args(
     args: &ArgExprs,
-    assigned_names: &mut AHashSet<String>,
+    assigned_names: &mut impl AssignedNameCollector,
     interner: &InternerBuilder,
 ) {
     match args {
@@ -3044,15 +3065,44 @@ fn collect_referenced_names_from_fstring_parts(
 /// Collects all names from an unpack target into the given set.
 ///
 /// Recursively traverses nested tuples to find all identifier names.
-fn collect_names_from_unpack_target(target: &UnpackTarget, names: &mut AHashSet<String>, interner: &InternerBuilder) {
+fn collect_names_from_unpack_target(
+    target: &UnpackTarget,
+    names: &mut impl AssignedNameCollector,
+    interner: &InternerBuilder,
+) {
     match target {
         UnpackTarget::Name(ident) | UnpackTarget::Starred(ident) => {
-            names.insert(interner.get_str(ident.name_id).to_string());
+            names.insert_name(interner.get_str(ident.name_id).to_string());
         }
         UnpackTarget::Tuple { targets, .. } => {
             for t in targets {
                 collect_names_from_unpack_target(t, names, interner);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parse::parse;
+
+    #[test]
+    fn prepare_with_existing_names_appends_new_globals_in_first_seen_order() {
+        let mut existing_name_map = AHashMap::new();
+        existing_name_map.insert("existing".to_string(), NamespaceId::new(0));
+
+        let parse_result = parse(
+            "def caller():\n    return callee()\n\nvalue = 1\n\ndef callee():\n    return value\n",
+            "test.py",
+        )
+        .expect("parse succeeds");
+        let prepared = prepare_with_existing_names(parse_result, existing_name_map).expect("prepare succeeds");
+
+        assert_eq!(prepared.name_map["existing"].index(), 0);
+        assert_eq!(prepared.name_map["caller"].index(), 1);
+        assert_eq!(prepared.name_map["value"].index(), 2);
+        assert_eq!(prepared.name_map["callee"].index(), 3);
+        assert_eq!(prepared.namespace_size, 4);
     }
 }

--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -311,101 +311,32 @@ impl<'i> Prepare<'i> {
     /// slot-based approach, we achieve the same effect by pre-allocating slots for all
     /// module-level names before the main prepare pass.
     ///
-    /// Recurses into control flow blocks (if/for/while/try) because Python has no block
-    /// scoping — names defined inside these blocks are still module-level globals.
+    /// Reuses `collect_scope_info_from_node` to avoid duplicating the node traversal logic.
     fn pre_scan_module_names(&mut self, nodes: &[ParseNode]) {
         debug_assert!(self.is_module_scope);
+        // Collect all names that will be assigned at module level.
+        // We reuse collect_scope_info_from_node which already handles all node types
+        // including walrus expressions, unpack targets, and control flow recursion.
+        let mut assigned_names = AHashSet::new();
+        let mut global_names = AHashSet::new();
+        let mut nonlocal_names = AHashSet::new();
         for node in nodes {
-            match node {
-                Node::FunctionDef(RawFunctionDef { name, .. }) => {
-                    self.ensure_name_slot(name.name_id);
-                }
-                Node::Assign { target, .. }
-                | Node::OpAssign { target, .. }
-                | Node::SubscriptOpAssign { target, .. }
-                | Node::SubscriptAssign { target, .. } => {
-                    self.ensure_name_slot(target.name_id);
-                }
-                Node::UnpackAssign { targets, .. } => {
-                    self.pre_scan_unpack_targets(targets);
-                }
-                Node::Import { binding, .. } => {
-                    self.ensure_name_slot(binding.name_id);
-                }
-                Node::ImportFrom { names, .. } => {
-                    for (_, binding) in names {
-                        self.ensure_name_slot(binding.name_id);
-                    }
-                }
-                // Recurse into control flow — Python has no block scoping
-                Node::For {
-                    target, body, or_else, ..
-                } => {
-                    self.pre_scan_unpack_target(target);
-                    self.pre_scan_module_names(body);
-                    self.pre_scan_module_names(or_else);
-                }
-                Node::If { body, or_else, .. } | Node::While { body, or_else, .. } => {
-                    self.pre_scan_module_names(body);
-                    self.pre_scan_module_names(or_else);
-                }
-                Node::Try(try_block) => {
-                    self.pre_scan_module_names(&try_block.body);
-                    for handler in &try_block.handlers {
-                        if let Some(name) = &handler.name {
-                            self.ensure_name_slot(name.name_id);
-                        }
-                        self.pre_scan_module_names(&handler.body);
-                    }
-                    self.pre_scan_module_names(&try_block.or_else);
-                    self.pre_scan_module_names(&try_block.finally);
-                }
-                // Statements that don't define names at module level
-                Node::Pass
-                | Node::Expr(_)
-                | Node::Return(_)
-                | Node::ReturnNone
-                | Node::Raise(_)
-                | Node::Assert { .. }
-                | Node::AttrAssign { .. }
-                | Node::Break { .. }
-                | Node::Continue { .. }
-                | Node::Global { .. }
-                | Node::Nonlocal { .. } => {}
-            }
+            collect_scope_info_from_node(
+                node,
+                &mut global_names,
+                &mut nonlocal_names,
+                &mut assigned_names,
+                self.interner,
+            );
         }
-    }
-
-    /// Pre-scans an unpack target to register all names it binds.
-    fn pre_scan_unpack_target(&mut self, target: &UnpackTarget) {
-        match target {
-            UnpackTarget::Name(ident) | UnpackTarget::Starred(ident) => {
-                self.ensure_name_slot(ident.name_id);
+        // Pre-allocate a namespace slot for each name so the global_name_map
+        // snapshot passed to function bodies is complete.
+        for name in assigned_names {
+            if !self.name_map.contains_key(name.as_str()) {
+                let id = NamespaceId::new(self.namespace_size);
+                self.namespace_size += 1;
+                self.name_map.insert(name, id);
             }
-            UnpackTarget::Tuple { targets, .. } => {
-                self.pre_scan_unpack_targets(targets);
-            }
-        }
-    }
-
-    /// Pre-scans a list of unpack targets to register all names they bind.
-    fn pre_scan_unpack_targets(&mut self, targets: &[UnpackTarget]) {
-        for target in targets {
-            self.pre_scan_unpack_target(target);
-        }
-    }
-
-    /// Ensures a name has a slot allocated in the module namespace.
-    ///
-    /// If the name already exists (e.g., from input variables), this is a no-op.
-    /// Otherwise, a new slot is allocated. The slot index is stable — when `get_id`
-    /// later processes this name, it will find the existing entry.
-    fn ensure_name_slot(&mut self, name_id: StringId) {
-        let name_str = self.interner.get_str(name_id);
-        if let Entry::Vacant(e) = self.name_map.entry(name_str.to_string()) {
-            let id = NamespaceId::new(self.namespace_size);
-            self.namespace_size += 1;
-            e.insert(id);
         }
     }
 

--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -46,6 +46,11 @@ pub struct PrepareResult {
 pub(crate) fn prepare(parse_result: ParseResult, input_names: Vec<String>) -> Result<PrepareResult, ParseError> {
     let ParseResult { nodes, interner } = parse_result;
     let mut p = Prepare::new_module(input_names, &interner);
+    // Pre-scan all module-level names so function bodies can resolve forward references.
+    // In CPython, names inside function bodies are resolved at call time, not definition time,
+    // so `def foo(): return bar()` works even when `bar` is defined after `foo`. We achieve
+    // this by ensuring the global name_map is complete before any function body is prepared.
+    p.pre_scan_module_names(&nodes);
     let mut prepared_nodes = p.prepare_nodes(nodes)?;
 
     // In the root frame, the last expression is implicitly returned
@@ -77,6 +82,7 @@ pub(crate) fn prepare_with_existing_names(
 ) -> Result<PrepareResult, ParseError> {
     let ParseResult { nodes, interner } = parse_result;
     let mut p = Prepare::new_module_with_name_map(existing_name_map, &interner);
+    p.pre_scan_module_names(&nodes);
     let mut prepared_nodes = p.prepare_nodes(nodes)?;
 
     // In the root frame, the last expression is implicitly returned to match REPL behavior.
@@ -294,6 +300,112 @@ impl<'i> Prepare<'i> {
             free_var_map,
             cell_var_map,
             unassigned_ref_names: AHashSet::new(),
+        }
+    }
+
+    /// Pre-scans module-level statements to register all names that will be defined.
+    ///
+    /// This ensures the global `name_map` is complete before any function body is prepared,
+    /// enabling forward references. In CPython, names inside function bodies are resolved at
+    /// call time (via dictionary lookup), so definition order doesn't matter. In Monty's
+    /// slot-based approach, we achieve the same effect by pre-allocating slots for all
+    /// module-level names before the main prepare pass.
+    ///
+    /// Recurses into control flow blocks (if/for/while/try) because Python has no block
+    /// scoping — names defined inside these blocks are still module-level globals.
+    fn pre_scan_module_names(&mut self, nodes: &[ParseNode]) {
+        debug_assert!(self.is_module_scope);
+        for node in nodes {
+            match node {
+                Node::FunctionDef(RawFunctionDef { name, .. }) => {
+                    self.ensure_name_slot(name.name_id);
+                }
+                Node::Assign { target, .. }
+                | Node::OpAssign { target, .. }
+                | Node::SubscriptOpAssign { target, .. }
+                | Node::SubscriptAssign { target, .. } => {
+                    self.ensure_name_slot(target.name_id);
+                }
+                Node::UnpackAssign { targets, .. } => {
+                    self.pre_scan_unpack_targets(targets);
+                }
+                Node::Import { binding, .. } => {
+                    self.ensure_name_slot(binding.name_id);
+                }
+                Node::ImportFrom { names, .. } => {
+                    for (_, binding) in names {
+                        self.ensure_name_slot(binding.name_id);
+                    }
+                }
+                // Recurse into control flow — Python has no block scoping
+                Node::For {
+                    target, body, or_else, ..
+                } => {
+                    self.pre_scan_unpack_target(target);
+                    self.pre_scan_module_names(body);
+                    self.pre_scan_module_names(or_else);
+                }
+                Node::If { body, or_else, .. } | Node::While { body, or_else, .. } => {
+                    self.pre_scan_module_names(body);
+                    self.pre_scan_module_names(or_else);
+                }
+                Node::Try(try_block) => {
+                    self.pre_scan_module_names(&try_block.body);
+                    for handler in &try_block.handlers {
+                        if let Some(name) = &handler.name {
+                            self.ensure_name_slot(name.name_id);
+                        }
+                        self.pre_scan_module_names(&handler.body);
+                    }
+                    self.pre_scan_module_names(&try_block.or_else);
+                    self.pre_scan_module_names(&try_block.finally);
+                }
+                // Statements that don't define names at module level
+                Node::Pass
+                | Node::Expr(_)
+                | Node::Return(_)
+                | Node::ReturnNone
+                | Node::Raise(_)
+                | Node::Assert { .. }
+                | Node::AttrAssign { .. }
+                | Node::Break { .. }
+                | Node::Continue { .. }
+                | Node::Global { .. }
+                | Node::Nonlocal { .. } => {}
+            }
+        }
+    }
+
+    /// Pre-scans an unpack target to register all names it binds.
+    fn pre_scan_unpack_target(&mut self, target: &UnpackTarget) {
+        match target {
+            UnpackTarget::Name(ident) | UnpackTarget::Starred(ident) => {
+                self.ensure_name_slot(ident.name_id);
+            }
+            UnpackTarget::Tuple { targets, .. } => {
+                self.pre_scan_unpack_targets(targets);
+            }
+        }
+    }
+
+    /// Pre-scans a list of unpack targets to register all names they bind.
+    fn pre_scan_unpack_targets(&mut self, targets: &[UnpackTarget]) {
+        for target in targets {
+            self.pre_scan_unpack_target(target);
+        }
+    }
+
+    /// Ensures a name has a slot allocated in the module namespace.
+    ///
+    /// If the name already exists (e.g., from input variables), this is a no-op.
+    /// Otherwise, a new slot is allocated. The slot index is stable — when `get_id`
+    /// later processes this name, it will find the existing entry.
+    fn ensure_name_slot(&mut self, name_id: StringId) {
+        let name_str = self.interner.get_str(name_id);
+        if let Entry::Vacant(e) = self.name_map.entry(name_str.to_string()) {
+            let id = NamespaceId::new(self.namespace_size);
+            self.namespace_size += 1;
+            e.insert(id);
         }
     }
 

--- a/crates/monty/test_cases/function__ops.py
+++ b/crates/monty/test_cases/function__ops.py
@@ -292,3 +292,73 @@ def double(x):
 
 
 assert double(x) == 10, 'global used as argument, param shadows inside'
+
+
+# === Forward function references ===
+# In CPython, names inside function bodies are resolved at call time,
+# so definition order at module level doesn't matter.
+
+def caller():
+    return callee()
+
+
+def callee():
+    return 'hello from callee'
+
+
+assert caller() == 'hello from callee', 'forward function reference'
+
+
+# Chain of forward references
+def chain_a():
+    return chain_b()
+
+
+def chain_b():
+    return chain_c()
+
+
+def chain_c():
+    return 42
+
+
+assert chain_a() == 42, 'chained forward references'
+
+
+# Forward reference to a function that takes arguments
+def uses_helper(val):
+    return helper(val, 10)
+
+
+def helper(a, b):
+    return a + b
+
+
+assert uses_helper(5) == 15, 'forward reference with arguments'
+
+
+# Forward reference with variable defined after function
+def reads_global_var():
+    return later_var
+
+
+later_var = 'defined later'
+assert reads_global_var() == 'defined later', 'forward reference to global variable'
+
+
+# Mutual recursion via forward references
+def is_even(n):
+    if n == 0:
+        return True
+    return is_odd(n - 1)
+
+
+def is_odd(n):
+    if n == 0:
+        return False
+    return is_even(n - 1)
+
+
+assert is_even(4) is True, 'mutual recursion: is_even(4)'
+assert is_odd(3) is True, 'mutual recursion: is_odd(3)'
+assert is_even(3) is False, 'mutual recursion: is_even(3)'


### PR DESCRIPTION
Closes #183

## Summary

- Pre-scan all module-level names before the main prepare pass so function bodies can resolve forward references
- In CPython, names inside function bodies are resolved at call time (via dictionary lookup), so `def foo(): return bar()` works even when `bar` is defined after `foo`
- Monty's prepare phase was snapshotting the global `name_map` when processing each function def, but the snapshot only contained names processed so far — causing forward references to fail with `NameError`

## Approach

Added a `pre_scan_module_names` method that reuses the existing `collect_scope_info_from_node` helper to collect all names that will be assigned at module level, then pre-allocates namespace slots for each. This runs before `prepare_nodes`, ensuring the `global_name_map` snapshot passed to each function body is complete.

By reusing `collect_scope_info_from_node`, the implementation:
- Avoids duplicating the node traversal logic (~25 lines vs ~100 in the initial version)
- Correctly handles walrus expressions, unpack targets, and control flow recursion
- Correctly skips `SubscriptAssign`/`SubscriptOpAssign` (which modify containers, not create new names)
- Stays in sync automatically when new node types are added

## Test plan

- [x] Added 5 test cases to `function__ops.py`: basic forward ref, chained forward refs, forward ref with arguments, forward ref to global variable, mutual recursion
- [x] All 887 existing test cases pass (1 pre-existing failure in `math__module.py` unrelated to this change)
- [x] `ref-count-panic` tests pass with no leaks
- [x] `cargo clippy` clean