### PR TITLE
Fix PGO and cross-arch CI builds failing on missing `typing_extensions`

### DIFF
--- a/.github/actions/build-pgo-wheel/action.yml
+++ b/.github/actions/build-pgo-wheel/action.yml
@@ -41,6 +41,7 @@ runs:
 
     - name: generate pgo data
       run: |
+        pip install typing_extensions
         pip install pydantic-monty --no-index --no-deps --find-links pgo-wheel --force-reinstall
         python exercise.py
         rustup run ${{ inputs.rust-toolchain }} bash -c 'echo LLVM_PROFDATA=$RUSTUP_HOME/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/$RUST_HOST/bin/llvm-profdata >> "$GITHUB_ENV"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,6 +396,7 @@ jobs:
             ls -lh /dist/
             python3 -m venv venv
             source venv/bin/activate
+            python3 -m pip install typing_extensions
             python3 -m pip install pydantic-monty --no-index --no-deps --find-links /dist --force-reinstall
             python3 -c "import pydantic_monty; print(pydantic_monty.Monty('1 + 2').run())"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,7 +430,8 @@ jobs:
           merge-multiple: true
           path: dist
 
-      - run: pip install pydantic-monty --no-index --find-links dist --force-reinstall
+      - run: pip install typing_extensions
+      - run: pip install pydantic-monty --no-index --no-deps --find-links dist --force-reinstall
       - run: python -c "import pydantic_monty; print(pydantic_monty.Monty('1 + 2').run())"
 
   # Inspect built artifacts


### PR DESCRIPTION
The `--no-deps` flag skips installing runtime dependencies, so `import pydantic_monty` fails with `ModuleNotFoundError`. Install `typing_extensions` explicitly before the `--no-deps` wheel install in both the PGO profiling step and the cross-architecture smoke test.