### PR TITLE
JSON perf improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 /crates/fuzz/corpus/
 /.worktrees/
 /.zed/
+/scripts/json_files/

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -31,7 +31,7 @@ use crate::{
     heap_data::{Closure, FunctionDefaults},
     intern::{FunctionId, Interns, StringId},
     io::PrintWriter,
-    modules::StandardLib,
+    modules::{StandardLib, json::JsonStringCache},
     os::OsFunction,
     parse::CodeRange,
     resource::ResourceTracker,
@@ -583,6 +583,13 @@ pub struct VM<'h, 'a, T: ResourceTracker> {
     /// back to a `NameError`, so the traceback points to the name reference rather than
     /// the call expression.
     ext_function_load_ip: Option<usize>,
+
+    /// Per-run string cache for `json.loads()`.
+    ///
+    /// Deduplicates heap allocations for repeated strings (especially dict keys)
+    /// across multiple `json.loads()` calls within a single execution. Lazily
+    /// initialized on first use, cleaned up in [`cleanup()`](Self::cleanup).
+    pub(crate) json_string_cache: JsonStringCache,
 }
 
 impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
@@ -605,6 +612,7 @@ impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
             scheduler: Scheduler::new(),
             ext_function_load_ip: None, // Set by LoadGlobalCallable/LoadLocalCallable
             module_code: None,
+            json_string_cache: JsonStringCache::default(),
         }
     }
 
@@ -666,8 +674,10 @@ impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
             scheduler: snapshot.scheduler,
             module_code: Some(module_code),
             ext_function_load_ip: None,
+            json_string_cache: JsonStringCache::default(),
         }
     }
+
     /// Consumes the VM and creates a snapshot for pause/resume.
     ///
     /// **Ownership transfer:** This method takes `self` by value, consuming the VM.
@@ -676,7 +686,11 @@ impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
     ///
     /// This is NOT a clone - it's a transfer. After calling this, the original VM
     /// is gone and only the snapshot (+ serialized heap/namespaces) represents the state.
-    pub fn snapshot(self) -> VMSnapshot {
+    pub fn snapshot(mut self) -> VMSnapshot {
+        // Drop cached JSON strings before consuming the VM — they are not
+        // included in the snapshot and their refcounts must be decremented.
+        self.json_string_cache.drop_all(self.heap);
+
         VMSnapshot {
             // Move values directly — no clone, no refcount increment needed
             // (the VM owned them, now the snapshot owns them)
@@ -709,6 +723,8 @@ impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
         // Clean up scheduler state (task stacks, pending calls, resolved values, frame cells)
         self.scheduler.cleanup(self.heap);
         self.globals.drain(..).drop_with_heap(self.heap);
+        // Release cached JSON string values
+        self.json_string_cache.drop_all(self.heap);
     }
 
     /// Returns the `stack_base` of the current (topmost) call frame.
@@ -1710,9 +1726,14 @@ impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
         let stack_roots = self.stack.iter().filter_map(Value::ref_id);
         let globals_roots = self.globals.iter().filter_map(Value::ref_id);
         let exc_roots = self.exception_stack.iter().filter_map(Value::ref_id);
+        let json_cache_roots = self.json_string_cache.gc_roots();
 
         // Collect all roots into a vec to avoid lifetime issues
-        let roots: Vec<HeapId> = stack_roots.chain(globals_roots).chain(exc_roots).collect();
+        let roots: Vec<HeapId> = stack_roots
+            .chain(globals_roots)
+            .chain(exc_roots)
+            .chain(json_cache_roots)
+            .collect();
 
         self.heap.collect_garbage(roots);
     }

--- a/crates/monty/src/modules/json/dump.rs
+++ b/crates/monty/src/modules/json/dump.rs
@@ -6,7 +6,6 @@
 use std::{
     cmp::Ordering,
     fmt::{Display, Write},
-    mem,
 };
 
 use crate::{
@@ -17,7 +16,7 @@ use crate::{
     heap::{DropWithHeap, HeapData, HeapGuard, HeapId, HeapReadOutput},
     intern::StaticStrings,
     resource::ResourceTracker,
-    sorting::sort_indices,
+    sorting::{apply_permutation, sort_indices},
     types::{PyTrait, long_int::check_bigint_str_digits_limit, str::allocate_string},
     value::Value,
 };
@@ -521,18 +520,7 @@ fn serialize_dict(
     vm: &mut VM<'_, '_, impl ResourceTracker>,
 ) -> RunResult<()> {
     if config.skipkeys() {
-        // Cannot use `retain` here because removed `Value::Ref` entries need
-        // `drop_with_heap` to decrement reference counts properly.
-        let mut i = 0;
-        while i < entries.len() {
-            if is_json_key_allowed(&entries[i].0, vm) {
-                i += 1;
-            } else {
-                let (key, value) = entries.remove(i);
-                key.drop_with_heap(vm);
-                value.drop_with_heap(vm);
-            }
-        }
+        skip_disallowed_dict_keys(entries, vm);
     } else if let Some((key, _)) = entries.iter().find(|(key, _)| !is_json_key_allowed(key, vm)) {
         return Err(ExcType::json_invalid_key_error(key.py_type(vm)));
     }
@@ -575,18 +563,31 @@ fn sort_dict_entries(entries: &mut Vec<(Value, Value)>, vm: &mut VM<'_, '_, impl
     let mut compare_values_guard = HeapGuard::new(compare_values, vm);
     let (compare_values, vm) = compare_values_guard.as_parts_mut();
     sort_indices(&mut indices, compare_values.as_slice(), false, vm)?;
+    apply_permutation(entries.as_mut_slice(), &mut indices);
+    Ok(())
+}
 
-    let mut ordered: Vec<(Value, Value)> = Vec::with_capacity(entries.len());
-    for index in indices {
-        ordered.push((
-            entries[index].0.clone_with_heap(vm),
-            entries[index].1.clone_with_heap(vm),
-        ));
+/// Removes dict entries whose keys are not JSON-serializable, preserving order.
+///
+/// `skipkeys=True` must drop invalid entries without disturbing the relative
+/// order of the retained pairs. A two-pointer compaction avoids the repeated
+/// shifting cost of `Vec::remove(i)` while still cleaning up skipped `Value`
+/// references with `drop_with_heap`.
+fn skip_disallowed_dict_keys(entries: &mut Vec<(Value, Value)>, vm: &mut VM<'_, '_, impl ResourceTracker>) {
+    let mut write = 0;
+    for read in 0..entries.len() {
+        if is_json_key_allowed(&entries[read].0, vm) {
+            if write != read {
+                entries.swap(write, read);
+            }
+            write += 1;
+        }
     }
 
-    let old_entries = mem::replace(entries, ordered);
-    old_entries.drop_with_heap(vm);
-    Ok(())
+    for (key, value) in entries.drain(write..) {
+        key.drop_with_heap(vm);
+        value.drop_with_heap(vm);
+    }
 }
 
 /// Returns whether a value is an allowed JSON object key type.

--- a/crates/monty/src/modules/json/dump.rs
+++ b/crates/monty/src/modules/json/dump.rs
@@ -788,29 +788,104 @@ fn with_entered_container<R>(
 
 /// Writes a Rust string as a JSON string token.
 ///
-/// The writer escapes control characters, quotes, and backslashes in all modes.
-/// When `ensure_ascii` is enabled, non-ASCII code points are emitted as `\uXXXX`
-/// escapes using surrogate pairs for supplementary-plane characters.
+/// Uses a byte-oriented batch strategy inspired by serde_json: a 256-entry
+/// lookup table classifies each byte in O(1), and contiguous runs of safe bytes
+/// are flushed with a single `push_str` rather than character-by-character.
+///
+/// When `ensure_ascii` is enabled, non-ASCII code points (bytes >= 0x80) are
+/// emitted as `\uXXXX` escapes using surrogate pairs for supplementary-plane
+/// characters.
 fn write_json_string(value: &str, out: &mut String, ensure_ascii: bool) {
     out.push('"');
-    for ch in value.chars() {
-        match ch {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\u{08}' => out.push_str("\\b"),
-            '\u{0C}' => out.push_str("\\f"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            ch if ch <= '\u{1F}' => {
-                write!(out, "\\u{:04x}", ch as u32).expect("writing to String cannot fail");
+    let bytes = value.as_bytes();
+    let mut start = 0;
+    let mut i = 0;
+
+    while i < bytes.len() {
+        let byte = bytes[i];
+
+        if ensure_ascii && byte >= 0x7F {
+            // Flush the safe ASCII run accumulated so far.
+            out.push_str(&value[start..i]);
+            if byte == 0x7F {
+                // DEL (0x7F) is a control character that CPython escapes.
+                out.push_str("\\u007f");
+                i += 1;
+            } else {
+                // Decode the full character at this position and emit \uXXXX escapes.
+                let ch = value[i..].chars().next().expect("valid UTF-8");
+                write_json_escape_for_non_ascii(ch, out);
+                i += ch.len_utf8();
             }
-            ch if ensure_ascii && (ch as u32) > 0x7E => write_json_escape_for_non_ascii(ch, out),
-            ch => out.push(ch),
+            start = i;
+            continue;
         }
+
+        let escape = ESCAPE_TABLE[byte as usize];
+        if escape == 0 {
+            // Safe byte — keep scanning.
+            i += 1;
+            continue;
+        }
+
+        // Flush the safe run before this byte.
+        out.push_str(&value[start..i]);
+
+        // Write the escape sequence.
+        match escape {
+            b'b' => out.push_str("\\b"),
+            b't' => out.push_str("\\t"),
+            b'n' => out.push_str("\\n"),
+            b'f' => out.push_str("\\f"),
+            b'r' => out.push_str("\\r"),
+            b'"' => out.push_str("\\\""),
+            b'\\' => out.push_str("\\\\"),
+            b'u' => {
+                write!(out, "\\u{:04x}", u32::from(byte)).expect("writing to String cannot fail");
+            }
+            _ => unreachable!(),
+        }
+
+        i += 1;
+        start = i;
     }
+
+    // Flush the final safe run.
+    out.push_str(&value[start..]);
     out.push('"');
 }
+
+/// Byte lookup table for JSON string escaping.
+///
+/// Each entry is either 0 (byte is safe, no escaping needed) or a shorthand
+/// character that indicates which escape to emit:
+/// - `b'"'`  → `\"`
+/// - `b'\\'` → `\\`
+/// - `b'b'`  → `\b` (backspace, 0x08)
+/// - `b't'`  → `\t` (tab, 0x09)
+/// - `b'n'`  → `\n` (newline, 0x0A)
+/// - `b'f'`  → `\f` (form feed, 0x0C)
+/// - `b'r'`  → `\r` (carriage return, 0x0D)
+/// - `b'u'`  → `\u00XX` (other control characters, 0x00–0x1F)
+#[rustfmt::skip]
+static ESCAPE_TABLE: [u8; 256] = {
+    let mut table = [0u8; 256];
+    // Control characters 0x00–0x1F default to \u00XX escapes.
+    let mut i = 0;
+    while i < 0x20 {
+        table[i] = b'u';
+        i += 1;
+    }
+    // Override the named escapes.
+    table[0x08] = b'b';  // backspace
+    table[0x09] = b't';  // tab
+    table[0x0A] = b'n';  // newline
+    table[0x0C] = b'f';  // form feed
+    table[0x0D] = b'r';  // carriage return
+    table[0x22] = b'"';  // quote
+    table[0x5C] = b'\\'; // backslash
+    table
+};
 
 /// Writes a non-ASCII character using JSON `\uXXXX` escapes.
 ///

--- a/crates/monty/src/modules/json/load.rs
+++ b/crates/monty/src/modules/json/load.rs
@@ -3,16 +3,17 @@
 //! This module owns conversion from JSON bytes into Monty runtime values,
 //! including CPython-compatible `JSONDecodeError` construction.
 
-use std::borrow::Cow;
+use std::{borrow::Cow, mem};
 
 use jiter::{Jiter, JiterError, JiterErrorType, JsonErrorType, NumberAny, NumberInt, Peek};
 
+use super::JsonStringCache;
 use crate::{
     args::ArgValues,
     bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunError, RunResult},
-    heap::{DropWithHeap, HeapData, HeapGuard},
+    heap::{ContainsHeap, DropWithHeap, HeapData, HeapGuard, HeapReader},
     resource::{ResourceError, ResourceTracker},
     types::{
         Dict, List, LongInt, PyTrait,
@@ -120,11 +121,21 @@ fn parse_json_input(value: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) ->
 
 /// Parses raw JSON bytes using `jiter` and converts the result to a Monty value.
 ///
+/// The VM's per-run string cache is temporarily extracted so that it can be
+/// passed alongside the VM through the recursive parse functions without
+/// borrow conflicts. It is always restored before returning.
+///
 /// Syntax errors are wrapped in `json.JSONDecodeError` using the same
 /// line/column/character suffix as CPython.
 fn parse_json_bytes(bytes: &[u8], vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Value> {
     let mut jiter = Jiter::new(bytes).with_allow_inf_nan();
-    let value = parse_json_value(&mut jiter, 0, vm).map_err(|error| match error {
+    // Take the cache out of the VM so we can pass it alongside &mut VM
+    // without conflicting borrows. `mem::take` leaves `Default` in its place.
+    let mut cache = mem::take(&mut vm.json_string_cache);
+    let result = parse_json_value(&mut jiter, 0, &mut cache, vm);
+    // Always restore the cache before returning, regardless of success/failure.
+    vm.json_string_cache = cache;
+    let value = result.map_err(|error| match error {
         JsonLoadError::Parse(error) => json_number_out_of_range_to_run_error(&error, bytes)
             .unwrap_or_else(|| json_error_to_run_error(&error, &jiter, bytes)),
         JsonLoadError::Run(error) => error,
@@ -145,10 +156,11 @@ fn parse_json_bytes(bytes: &[u8], vm: &mut VM<'_, '_, impl ResourceTracker>) -> 
 fn parse_json_value(
     jiter: &mut Jiter<'_>,
     depth: usize,
+    cache: &mut JsonStringCache,
     vm: &mut VM<'_, '_, impl ResourceTracker>,
 ) -> ParseResult<Value> {
     let peek = jiter.peek()?;
-    parse_json_value_from_peek(peek, jiter, depth, vm)
+    parse_json_value_from_peek(peek, jiter, depth, cache, vm)
 }
 
 /// Converts a peeked JSON token into a Monty value.
@@ -159,6 +171,7 @@ fn parse_json_value_from_peek(
     peek: Peek,
     jiter: &mut Jiter<'_>,
     depth: usize,
+    cache: &mut JsonStringCache,
     vm: &mut VM<'_, '_, impl ResourceTracker>,
 ) -> ParseResult<Value> {
     match peek {
@@ -167,14 +180,30 @@ fn parse_json_value_from_peek(
             Ok(Value::None)
         }
         Peek::True | Peek::False => jiter.known_bool(peek).map(Value::Bool).map_err(Into::into),
-        Peek::String => Ok(allocate_string(parse_json_string(jiter)?, vm.heap)?),
-        Peek::Array => parse_json_array(jiter, depth, vm),
-        Peek::Object => parse_json_object(jiter, depth, vm),
+        Peek::String => allocate_cached_string(parse_json_string(jiter)?, cache, vm.heap),
+        Peek::Array => parse_json_array(jiter, depth, cache, vm),
+        Peek::Object => parse_json_object(jiter, depth, cache, vm),
         _ if peek.is_num() => parse_json_number(peek, jiter, vm),
         _ => Err(JsonLoadError::Parse(JiterError {
             error_type: JiterErrorType::JsonError(JsonErrorType::ExpectedSomeValue),
             index: jiter.current_index(),
         })),
+    }
+}
+
+/// Allocates a string using the cache when eligible, falling back to direct
+/// allocation for empty/single-char strings (already interned by
+/// `allocate_string`).
+fn allocate_cached_string(
+    s: String,
+    cache: &mut JsonStringCache,
+    heap: &HeapReader<'_, impl ResourceTracker>,
+) -> ParseResult<Value> {
+    if s.len() < 2 {
+        // Empty and single-char strings are interned by allocate_string.
+        Ok(allocate_string(s, heap.heap())?)
+    } else {
+        Ok(cache.get_or_allocate(s, heap)?)
     }
 }
 
@@ -208,6 +237,7 @@ fn parse_json_number(
 fn parse_json_array(
     jiter: &mut Jiter<'_>,
     depth: usize,
+    cache: &mut JsonStringCache,
     vm: &mut VM<'_, '_, impl ResourceTracker>,
 ) -> ParseResult<Value> {
     check_json_recursion_limit(jiter, depth)?;
@@ -222,7 +252,7 @@ fn parse_json_array(
     {
         let (values, vm) = values_guard.as_parts_mut();
         loop {
-            values.push(parse_json_value_from_peek(next, jiter, depth + 1, vm)?);
+            values.push(parse_json_value_from_peek(next, jiter, depth + 1, cache, vm)?);
             let Some(array_peek) = jiter.array_step()? else {
                 break;
             };
@@ -250,6 +280,7 @@ fn parse_json_string(jiter: &mut Jiter<'_>) -> ParseResult<String> {
 fn parse_json_object(
     jiter: &mut Jiter<'_>,
     depth: usize,
+    cache: &mut JsonStringCache,
     vm: &mut VM<'_, '_, impl ResourceTracker>,
 ) -> ParseResult<Value> {
     check_json_recursion_limit(jiter, depth)?;
@@ -264,8 +295,8 @@ fn parse_json_object(
     {
         let (pairs, vm) = pairs_guard.as_parts_mut();
         loop {
-            let key_value = allocate_string(key, vm.heap)?;
-            let value = parse_json_value(jiter, depth + 1, vm)?;
+            let key_value = allocate_cached_string(key, cache, vm.heap)?;
+            let value = parse_json_value(jiter, depth + 1, cache, vm)?;
             pairs.push((key_value, value));
 
             let Some(next_key) = parse_next_object_key(jiter)? else {

--- a/crates/monty/src/modules/json/load.rs
+++ b/crates/monty/src/modules/json/load.rs
@@ -290,14 +290,15 @@ fn parse_json_object(
         return Ok(Value::Ref(dict_id));
     };
 
-    let pairs = Vec::new();
-    let mut pairs_guard = HeapGuard::new(pairs, vm);
+    let mut dict_guard = HeapGuard::new(Dict::new(), vm);
     {
-        let (pairs, vm) = pairs_guard.as_parts_mut();
+        let (dict, vm) = dict_guard.as_parts_mut();
         loop {
             let key_value = allocate_cached_string(key, cache, vm.heap)?;
             let value = parse_json_value(jiter, depth + 1, cache, vm)?;
-            pairs.push((key_value, value));
+            if let Some(old_value) = dict.set_json_string_key(key_value, value, vm)? {
+                old_value.drop_with_heap(vm);
+            }
 
             let Some(next_key) = parse_next_object_key(jiter)? else {
                 break;
@@ -306,8 +307,7 @@ fn parse_json_object(
         }
     }
 
-    let pairs = pairs_guard.into_inner();
-    let dict = Dict::from_pairs(pairs, vm)?;
+    let dict = dict_guard.into_inner();
     let dict_id = vm.heap.allocate(HeapData::Dict(dict))?;
     Ok(Value::Ref(dict_id))
 }

--- a/crates/monty/src/modules/json/mod.rs
+++ b/crates/monty/src/modules/json/mod.rs
@@ -12,6 +12,9 @@
 
 mod dump;
 mod load;
+mod string_cache;
+
+pub(crate) use string_cache::JsonStringCache;
 
 use super::ModuleFunctions;
 use crate::{

--- a/crates/monty/src/modules/json/string_cache.rs
+++ b/crates/monty/src/modules/json/string_cache.rs
@@ -1,0 +1,187 @@
+//! Per-run string cache for `json.loads()`.
+//!
+//! Repeated JSON parsing within a single execution often encounters the same
+//! strings — especially dict keys like `"id"`, `"name"`, `"type"` — across
+//! multiple `json.loads()` calls. This cache deduplicates heap allocations for
+//! those strings by hashing incoming bytes and returning a `clone_with_heap` of
+//! a previously allocated `Value` on cache hits.
+//!
+//! The design is modelled on jiter's `PyStringCache`: a fixed-capacity
+//! fully-associative cache with linear probing and no eviction (when all probe
+//! slots are occupied, the string is allocated without caching). The cache is
+//! lazily initialized so programs that never call `json.loads()` pay zero cost.
+//!
+//! The cache lives on the [`VM`] and is scoped to a single execution run. It
+//! is cleaned up in [`VM::cleanup()`] and its entries are registered as GC
+//! roots in [`VM::run_gc()`].
+
+use std::iter;
+
+use ahash::RandomState;
+
+use crate::{
+    heap::{ContainsHeap, HeapData, HeapId, HeapReader},
+    resource::{ResourceError, ResourceTracker},
+    types::str::Str,
+    value::Value,
+};
+
+/// Number of slots in the cache.
+///
+/// Must be a power of two so the compiler can convert modulo to a bitwise AND.
+const CAPACITY: usize = 16_384;
+
+/// Minimum string length eligible for caching.
+///
+/// Empty strings and single-ASCII-character strings are already interned by
+/// `allocate_string`, so caching them would be redundant.
+const MIN_LEN: usize = 2;
+
+/// Maximum string length eligible for caching.
+///
+/// Very long strings rarely repeat and would waste cache space.
+const MAX_LEN: usize = 64;
+
+/// Entry in the string cache: `(hash, raw string, allocated Value)`.
+type CacheEntry = Option<(u64, Box<str>, Value)>;
+
+/// Lazily-initialized string cache for `json.loads()`.
+///
+/// Wraps an `Option<CacheInner>` so the backing array is only allocated on the
+/// first eligible string, and programs that never parse JSON pay nothing.
+///
+/// # Lifecycle
+///
+/// - Created as empty (`None`) when the VM starts.
+/// - Backing storage allocated on the first `get_or_allocate` call with an
+///   eligible string (2–64 bytes).
+/// - Persists across multiple `json.loads()` calls within the same run.
+/// - Cleaned up in `VM::cleanup()` via [`drop_all`](Self::drop_all).
+/// - Cached values are reported as GC roots via [`gc_roots`](Self::gc_roots).
+#[derive(Default)]
+pub(crate) struct JsonStringCache {
+    inner: Option<CacheInner>,
+}
+
+/// Backing storage: a fixed-size array of cache entries plus a hash builder.
+struct CacheInner {
+    entries: Box<[CacheEntry; CAPACITY]>,
+    hash_builder: RandomState,
+}
+
+impl JsonStringCache {
+    /// Looks up `s` in the cache. On hit, returns a cloned `Value` (with its
+    /// refcount incremented). On miss, allocates the string on the heap, stores
+    /// a clone in the cache, and returns the original.
+    ///
+    /// Strings shorter than [`MIN_LEN`] or longer than [`MAX_LEN`] bypass the
+    /// cache entirely and are allocated directly.
+    ///
+    /// The backing array is allocated lazily on the first eligible string.
+    pub fn get_or_allocate(
+        &mut self,
+        s: String,
+        heap: &HeapReader<'_, impl ResourceTracker>,
+    ) -> Result<Value, ResourceError> {
+        let len = s.len();
+        if !(MIN_LEN..=MAX_LEN).contains(&len) {
+            let heap_id = heap.heap().allocate(HeapData::Str(Str::new(s)))?;
+            return Ok(Value::Ref(heap_id));
+        }
+
+        let inner = self.inner.get_or_insert_with(CacheInner::new);
+        inner.get_or_allocate(s, heap)
+    }
+
+    /// Drops all cached values, decrementing their refcounts.
+    ///
+    /// Called during `VM::cleanup()` before the heap is torn down.
+    pub fn drop_all(&mut self, heap: &mut impl ContainsHeap) {
+        if let Some(inner) = &mut self.inner {
+            for entry in inner.entries.iter_mut() {
+                if let Some((_, _, value)) = entry.take() {
+                    value.drop_with_heap(heap);
+                }
+            }
+        }
+    }
+
+    /// Yields the `HeapId` of every cached value so the GC treats them as roots.
+    ///
+    /// Without this, a GC cycle could free a heap string that the cache still
+    /// references, leading to a use-after-free on the next cache hit.
+    pub fn gc_roots(&self) -> impl Iterator<Item = HeapId> + '_ {
+        self.inner
+            .iter()
+            .flat_map(|inner| inner.entries.iter())
+            .filter_map(|entry| entry.as_ref().and_then(|(_, _, value)| value.ref_id()))
+    }
+}
+
+impl CacheInner {
+    /// Creates a new cache with zeroed entries.
+    ///
+    /// Uses `iter::repeat_with().collect()` to avoid allocating the large array
+    /// on the stack (see jiter PR #239).
+    fn new() -> Self {
+        Self {
+            entries: iter::repeat_with(|| None)
+                .take(CAPACITY)
+                .collect::<Vec<_>>()
+                .into_boxed_slice()
+                .try_into()
+                .expect("Vec length equals CAPACITY"),
+            hash_builder: RandomState::default(),
+        }
+    }
+
+    /// Looks up `s` in the cache. On hit, returns a cloned `Value`. On miss,
+    /// allocates on the heap and inserts into the cache.
+    fn get_or_allocate(
+        &mut self,
+        s: String,
+        heap: &HeapReader<'_, impl ResourceTracker>,
+    ) -> Result<Value, ResourceError> {
+        let hash = self.hash_builder.hash_one(s.as_str());
+        // Truncation is intentional — we only need the low bits for indexing.
+        #[expect(clippy::cast_possible_truncation)]
+        let primary = hash as usize & (CAPACITY - 1);
+
+        // Linear probe up to 5 contiguous slots, wrapping around the table end.
+        for offset in 0..5 {
+            let index = (primary + offset) & (CAPACITY - 1);
+            let entry = &mut self.entries[index];
+            match entry {
+                Some((entry_hash, cached_str, cached_value)) => {
+                    if *entry_hash == hash && **cached_str == *s {
+                        return Ok(cached_value.clone_with_heap(heap));
+                    }
+                }
+                None => {
+                    // Empty slot — allocate and insert.
+                    return self.insert_at(index, hash, s, heap);
+                }
+            }
+        }
+        // All 5 probe slots occupied — allocate without caching.
+        let heap_id = heap.heap().allocate(HeapData::Str(Str::new(s)))?;
+        Ok(Value::Ref(heap_id))
+    }
+
+    /// Allocates `s` on the heap, stores a clone in `entries[index]`, and
+    /// returns the original `Value`.
+    fn insert_at(
+        &mut self,
+        index: usize,
+        hash: u64,
+        s: String,
+        heap: &HeapReader<'_, impl ResourceTracker>,
+    ) -> Result<Value, ResourceError> {
+        let key = s.clone().into_boxed_str();
+        let heap_id = heap.heap().allocate(HeapData::Str(Str::new(s)))?;
+        let value = Value::Ref(heap_id);
+        let cached = value.clone_with_heap(heap);
+        self.entries[index] = Some((hash, key, cached));
+        Ok(value)
+    }
+}

--- a/crates/monty/src/sorting.rs
+++ b/crates/monty/src/sorting.rs
@@ -73,15 +73,16 @@ pub fn sort_indices(
 
 /// Rearranges `items` in-place according to a permutation of indices.
 ///
-/// After calling this, `items[i]` will hold the value that was originally at
+/// After calling this, `items[i]` will hold the element that was originally at
 /// `items[indices[i]]`. The algorithm chases permutation cycles and swaps
 /// elements into their final positions, using O(1) extra memory beyond the
 /// `indices` slice (which is mutated to track visited positions).
 ///
-/// Each element is moved at most twice (one swap = two moves), so the total
-/// work is O(n) moves. This is at most 2x the moves of building a fresh
-/// `Vec`, but avoids allocating a second buffer.
-pub fn apply_permutation(items: &mut [Value], indices: &mut [usize]) {
+/// The helper is generic so callers can avoid allocating a second buffer when
+/// reordering either raw `Value`s or compound structures that already own their
+/// contents. Each element is moved at most twice (one swap = two moves), so
+/// the total work is O(n) moves while preserving the target permutation.
+pub fn apply_permutation<T>(items: &mut [T], indices: &mut [usize]) {
     for i in 0..items.len() {
         if indices[i] == i {
             continue;

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -127,6 +127,96 @@ impl Dict {
         }
         Ok(dict_guard.into_inner())
     }
+
+    /// Inserts a JSON object entry whose key is guaranteed to be a string.
+    ///
+    /// This specialized path avoids the generic `py_eq`/candidate-cloning lookup
+    /// used by ordinary dict insertion. JSON object keys are always strings, so
+    /// we can compare keys directly by their string contents while preserving the
+    /// same duplicate-key semantics as CPython (`{"a": 1, "a": 2}` keeps the
+    /// last value and retains the first insertion position).
+    pub fn set_json_string_key(
+        &mut self,
+        key: Value,
+        value: Value,
+        vm: &mut VM<'_, '_, impl ResourceTracker>,
+    ) -> RunResult<Option<Value>> {
+        debug_assert!(json_key_string_slice(&key, vm.heap, vm.interns).is_some());
+
+        if matches!(key, Value::Ref(_)) || matches!(value, Value::Ref(_)) {
+            self.contains_refs = true;
+        }
+
+        let hash = key.py_hash(vm)?.expect("json object keys are always hashable strings");
+        let opt_index = self.find_json_string_key_index(hash, &key, vm.heap, vm.interns);
+
+        let entry = DictEntry { key, value, hash };
+        if let Some(index) = opt_index {
+            let old_entry = mem::replace(&mut self.entries[index], entry);
+            old_entry.key.drop_with_heap(vm);
+            Ok(Some(old_entry.value))
+        } else {
+            vm.heap.track_growth(2 * VALUE_SIZE)?;
+            let index = self.entries.len();
+            self.entries.push(entry);
+            self.indices.insert_unique(hash, index, |&i| self.entries[i].hash);
+            Ok(None)
+        }
+    }
+
+    /// Finds the existing entry index for a JSON string key.
+    ///
+    /// The `hash` must match the Python string hash for `key`. Only string keys
+    /// participate; any non-string entry is treated as non-equal.
+    fn find_json_string_key_index(
+        &self,
+        hash: u64,
+        key: &Value,
+        heap: &Heap<impl ResourceTracker>,
+        interns: &Interns,
+    ) -> Option<usize> {
+        let key_str = json_key_string_slice(key, heap, interns).expect("json object keys are always string values");
+        self.indices
+            .find(hash, |&idx| {
+                let entry = &self.entries[idx];
+                entry.hash == hash && json_key_equals_str(&entry.key, key_str, heap, interns)
+            })
+            .copied()
+    }
+}
+
+/// Returns the underlying string slice for a JSON object key value.
+///
+/// JSON object parsing only inserts string keys, but the helper remains
+/// defensive and returns `None` for any non-string value.
+fn json_key_string_slice<'a>(
+    key: &'a Value,
+    heap: &'a Heap<impl ResourceTracker>,
+    interns: &'a Interns,
+) -> Option<&'a str> {
+    match key {
+        Value::InternString(id) => Some(interns.get_str(*id)),
+        Value::Ref(id) => match heap.get(*id) {
+            HeapData::Str(string) => Some(string.as_str()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Returns whether `key` is a string equal to `expected`.
+///
+/// This bypasses Python's full equality machinery because JSON object keys are
+/// always strings, so content comparison is sufficient and much cheaper.
+fn json_key_equals_str(key: &Value, expected: &str, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> bool {
+    match key {
+        Value::InternString(id) => interns.get_str(*id) == expected,
+        Value::Ref(id) => match heap.get(*id) {
+            HeapData::Str(string) => string.as_str() == expected,
+            _ => false,
+        },
+        _ => false,
+    }
 }
 
 impl<'h> HeapRead<'h, Dict> {

--- a/crates/monty/test_cases/json__dumps_formatting.py
+++ b/crates/monty/test_cases/json__dumps_formatting.py
@@ -74,3 +74,8 @@ assert json.dumps('\x01') == '"\\u0001"', 'control char 0x01 is escaped'
 assert json.dumps('\x1f') == '"\\u001f"', 'control char 0x1f is escaped'
 assert json.dumps('\x7f') == '"\\u007f"', 'DEL char 0x7f is escaped with ensure_ascii'
 assert json.dumps('\x7f', ensure_ascii=False) == '"\x7f"', 'DEL char 0x7f is literal with ensure_ascii=False'
+assert json.dumps('😀') == '"\\ud83d\\ude00"', 'non-BMP unicode escapes as surrogate pair with ensure_ascii'
+assert json.dumps('😀', ensure_ascii=False) == '"😀"', 'non-BMP unicode stays literal with ensure_ascii=False'
+assert json.dumps('ascii😀"\\\x01z') == '"ascii\\ud83d\\ude00\\"\\\\\\u0001z"', (
+    'mixed string escapes flush correctly across ascii, unicode, quotes, backslashes, and control chars'
+)

--- a/crates/monty/test_cases/json__dumps_keys.py
+++ b/crates/monty/test_cases/json__dumps_keys.py
@@ -41,5 +41,120 @@ assert result == '{"true": 1, "false": 2, "null": 3, "4": 5, "1.5": 6, "a": 7}',
     'all allowed key types serialize correctly'
 )
 
+# === skipkeys preserves insertion order ===
+d = {}
+d['a'] = 1
+d[(1,)] = 'skip'
+d['b'] = 2
+d[(2,)] = 'skip'
+d['c'] = 3
+assert json.dumps(d, skipkeys=True) == '{"a": 1, "b": 2, "c": 3}', 'skipkeys preserves order of remaining keys'
+
+# === skipkeys drops keys at the start ===
+d2 = {}
+d2[(1,)] = 'skip'
+d2['a'] = 1
+d2['b'] = 2
+assert json.dumps(d2, skipkeys=True) == '{"a": 1, "b": 2}', 'skipkeys drops disallowed keys at the start'
+
+# === skipkeys drops keys at the end ===
+d3 = {}
+d3['a'] = 1
+d3['b'] = 2
+d3[(1,)] = 'skip'
+assert json.dumps(d3, skipkeys=True) == '{"a": 1, "b": 2}', 'skipkeys drops disallowed keys at the end'
+
+# === skipkeys drops consecutive disallowed keys ===
+d4 = {}
+d4['a'] = 1
+d4[(1,)] = 'skip'
+d4[(2,)] = 'skip'
+d4[(3,)] = 'skip'
+d4['b'] = 2
+assert json.dumps(d4, skipkeys=True) == '{"a": 1, "b": 2}', 'skipkeys drops consecutive disallowed keys'
+
+# === skipkeys with single allowed key ===
+assert json.dumps({(1,): 'skip', 'a': 1, (2,): 'skip'}, skipkeys=True) == '{"a": 1}', (
+    'skipkeys with only one allowed key'
+)
+
+# === skipkeys with single disallowed key ===
+assert json.dumps({(1,): 1}, skipkeys=True) == '{}', 'skipkeys with single disallowed key produces empty object'
+
+# === skipkeys with only allowed keys is a no-op ===
+assert json.dumps({'a': 1, 'b': 2}, skipkeys=True) == '{"a": 1, "b": 2}', (
+    'skipkeys with all allowed keys changes nothing'
+)
+
+# === skipkeys in nested dicts ===
+assert json.dumps({'a': {(1,): 'skip', 'b': 2}}, skipkeys=True) == '{"a": {"b": 2}}', (
+    'skipkeys applies recursively to nested dicts'
+)
+assert json.dumps({'a': {(1,): 'skip', (2,): 'skip'}}, skipkeys=True) == '{"a": {}}', (
+    'skipkeys recursively produces empty nested dict'
+)
+
+# === skipkeys with complex values on skipped entries ===
+assert (
+    json.dumps(
+        {
+            (1,): [1, 2, 3],
+            'a': {'nested': True},
+            (2,): {'also': 'skipped'},
+            'b': [4, 5],
+        },
+        skipkeys=True,
+    )
+    == '{"a": {"nested": true}, "b": [4, 5]}'
+), 'skipkeys drops entries with complex values without errors'
+
+# === skipkeys combined with indent ===
+result = json.dumps({'a': 1, (1,): 'skip', 'b': 2}, skipkeys=True, indent=2)
+assert result == '{\n  "a": 1,\n  "b": 2\n}', 'skipkeys works with indent'
+
+# === skipkeys with mixed allowed key types ===
+assert (
+    json.dumps(
+        {
+            'str': 1,
+            42: 2,
+            True: 3,
+            None: 4,
+            3.14: 5,
+            (1,): 'skip',
+        },
+        skipkeys=True,
+    )
+    == '{"str": 1, "42": 2, "true": 3, "null": 4, "3.14": 5}'
+), 'skipkeys drops tuple but keeps str, int, bool, None, float keys'
+
+# === skipkeys with bytes key ===
+assert json.dumps({b'hello': 1, 'a': 2}, skipkeys=True) == '{"a": 2}', 'skipkeys drops bytes keys'
+
+# === skipkeys with empty dict ===
+assert json.dumps({}, skipkeys=True) == '{}', 'skipkeys with empty dict'
+
+# === skipkeys=False TypeError for various disallowed types ===
+try:
+    json.dumps({(1, 2): 3})
+    assert False, 'should raise TypeError for tuple key without skipkeys'
+except TypeError as exc:
+    assert str(exc) == 'keys must be str, int, float, bool or None, not tuple', 'TypeError message for tuple key'
+
+try:
+    json.dumps({b'hello': 1})
+    assert False, 'should raise TypeError for bytes key without skipkeys'
+except TypeError as exc:
+    assert str(exc) == 'keys must be str, int, float, bool or None, not bytes', 'TypeError message for bytes key'
+
+# === skipkeys + sort_keys (only allowed keys) ===
+d5 = {}
+d5['c'] = 3
+d5['a'] = 1
+d5['b'] = 2
+assert json.dumps(d5, skipkeys=True, sort_keys=True) == '{"a": 1, "b": 2, "c": 3}', (
+    'skipkeys + sort_keys: allowed keys are sorted correctly'
+)
+
 # === string key with ensure_ascii ===
 assert json.dumps({'hello': 1}) == '{"hello": 1}', 'simple string key'

--- a/crates/monty/test_cases/json__module.py
+++ b/crates/monty/test_cases/json__module.py
@@ -23,6 +23,7 @@ assert json.loads(b'true') is True, 'loads bytes true'
 assert json.loads(b'false') is False, 'loads bytes false'
 assert json.loads(b'null') is None, 'loads bytes null'
 assert json.loads('"\\u2603"') == '☃', 'loads unicode escape'
+assert json.loads('{"a": 1, "a": 2}') == {'a': 2}, 'loads duplicate object keys with last value winning'
 
 # === loads big integers ===
 big = 1234567890123456789012345678901234567890

--- a/scripts/bench_json.py
+++ b/scripts/bench_json.py
@@ -1,0 +1,274 @@
+"""
+Benchmark: CPython vs Monty JSON parse (loads) and serialize (dumps).
+
+Downloads JSON fixtures from the jiter benchmarks and times
+json.loads / json.dumps in both CPython and Monty.
+
+The loop runs *inside* each runtime so that Monty's startup overhead
+is paid once, not per-iteration.
+
+Usage:
+    python playground/bench_json.py [--duration N]
+"""
+
+import json
+import sys
+import time
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+import pydantic_monty
+
+BASE_URL = 'https://raw.githubusercontent.com/pydantic/jiter/main/crates/jiter/benches'
+
+BENCH_FILES = [
+    'short_numbers.json',
+    'bigints_array.json',
+    'floats_array.json',
+    'string_array.json',
+    'true_array.json',
+    'true_object.json',
+    'sentence.json',
+    'unicode.json',
+    'medium_response.json',
+    'pass1.json',
+    'pass2.json',
+]
+
+target_duration = 2.0  # seconds per benchmark
+
+MONTY_LOADS_CODE = """\
+import json
+
+for _ in range(iterations):
+    json.loads(data)
+"""
+
+MONTY_DUMPS_CODE = """\
+import json
+
+obj = json.loads(data)
+for _ in range(iterations):
+    json.dumps(obj)
+"""
+
+
+@dataclass
+class BenchResult:
+    name: str
+    size_bytes: int
+    cpython_loads_us: float
+    monty_loads_us: float
+    cpython_dumps_us: float
+    monty_dumps_us: float
+
+
+def download_fixtures() -> dict[str, bytes]:
+    """Download all benchmark JSON files and return {name: content}.
+
+    Files are cached in a local `json_files` directory next to this script
+    so they only need to be downloaded once.
+    """
+    cache_dir = Path(__file__).parent / 'json_files'
+    cache_dir.mkdir(exist_ok=True)
+
+    fixtures: dict[str, bytes] = {}
+    for filename in BENCH_FILES:
+        cached = cache_dir / filename
+        if cached.exists():
+            fixtures[filename] = cached.read_bytes()
+        else:
+            url = f'{BASE_URL}/{filename}'
+            try:
+                with urllib.request.urlopen(url) as resp:
+                    content = resp.read()
+                cached.write_bytes(content)
+                fixtures[filename] = content
+            except Exception as e:
+                print(f'  SKIP {filename}: {e}')
+    return fixtures
+
+
+def calibrate_iterations(func: Callable[[int], None], pilot_n: int = 100) -> int:
+    """Run func(pilot_n), then return iterations needed for ~target_duration seconds."""
+    start = time.perf_counter()
+    func(pilot_n)
+    pilot_elapsed = time.perf_counter() - start
+    if pilot_elapsed <= 0:
+        pilot_elapsed = 1e-9
+    per_iter = pilot_elapsed / pilot_n
+    return max(pilot_n, int(target_duration / per_iter))
+
+
+def bench_cpython_loads(data: bytes) -> tuple[float, int]:
+    """Return (average us, iterations) for json.loads."""
+
+    def run(n: int) -> None:
+        for _ in range(n):
+            json.loads(data)
+
+    iterations = calibrate_iterations(run)
+    start = time.perf_counter()
+    run(iterations)
+    elapsed = time.perf_counter() - start
+    return (elapsed / iterations) * 1_000_000, iterations
+
+
+def bench_cpython_dumps(data: bytes) -> tuple[float, int]:
+    """Return (average us, iterations) for json.dumps."""
+    obj = json.loads(data)
+
+    def run(n: int) -> None:
+        for _ in range(n):
+            json.dumps(obj)
+
+    iterations = calibrate_iterations(run)
+    start = time.perf_counter()
+    run(iterations)
+    elapsed = time.perf_counter() - start
+    return (elapsed / iterations) * 1_000_000, iterations
+
+
+def bench_monty_loads(data: bytes) -> tuple[float, int]:
+    """Return (average us, iterations) for Monty json.loads (loop inside Monty)."""
+    m = pydantic_monty.Monty(MONTY_LOADS_CODE, inputs=['data', 'iterations'])
+
+    def run(n: int) -> None:
+        m.run(inputs={'data': data, 'iterations': n})
+
+    iterations = calibrate_iterations(run)
+    start = time.perf_counter()
+    run(iterations)
+    elapsed = time.perf_counter() - start
+    return (elapsed / iterations) * 1_000_000, iterations
+
+
+def bench_monty_dumps(data: bytes) -> tuple[float, int]:
+    """Return (average us, iterations) for Monty json.dumps (loop inside Monty)."""
+    m = pydantic_monty.Monty(MONTY_DUMPS_CODE, inputs=['data', 'iterations'])
+
+    def run(n: int) -> None:
+        m.run(inputs={'data': data, 'iterations': n})
+
+    iterations = calibrate_iterations(run)
+    start = time.perf_counter()
+    run(iterations)
+    elapsed = time.perf_counter() - start
+    return (elapsed / iterations) * 1_000_000, iterations
+
+
+def format_us(us: float) -> str:
+    """Format microseconds nicely."""
+    if us >= 1000:
+        return f'{us / 1000:.2f}ms'
+    return f'{us:.1f}us'
+
+
+def format_ratio(cpython_us: float, monty_us: float) -> str:
+    """Format the speed ratio."""
+    if monty_us < cpython_us:
+        return f'{cpython_us / monty_us:.2f}x faster'
+    return f'{monty_us / cpython_us:.2f}x slower'
+
+
+def run_benchmarks() -> list[BenchResult]:
+    print(f'Downloading {len(BENCH_FILES)} JSON fixtures from jiter benchmarks...')
+    fixtures = download_fixtures()
+    print(f'Downloaded {len(fixtures)} fixtures')
+    print(f'Target duration per benchmark: {target_duration}s\n')
+
+    results: list[BenchResult] = []
+    for name, data in fixtures.items():
+        size = len(data)
+        print(f'--- {name} ({size:,} bytes) ---')
+
+        # loads
+        print('  json.loads:', end=' ', flush=True)
+        cp_loads, cp_n = bench_cpython_loads(data)
+        print(f'CPython={format_us(cp_loads)} ({cp_n:,} iters)', end='  ', flush=True)
+        mt_loads, mt_n = bench_monty_loads(data)
+        print(f'Monty={format_us(mt_loads)} ({mt_n:,} iters)', end='  ')
+        print(f'[{format_ratio(cp_loads, mt_loads)}]')
+
+        # dumps
+        print('  json.dumps:', end=' ', flush=True)
+        cp_dumps, cp_n = bench_cpython_dumps(data)
+        print(f'CPython={format_us(cp_dumps)} ({cp_n:,} iters)', end='  ', flush=True)
+        mt_dumps, mt_n = bench_monty_dumps(data)
+        print(f'Monty={format_us(mt_dumps)} ({mt_n:,} iters)', end='  ')
+        print(f'[{format_ratio(cp_dumps, mt_dumps)}]')
+
+        results.append(
+            BenchResult(
+                name=name,
+                size_bytes=size,
+                cpython_loads_us=cp_loads,
+                monty_loads_us=mt_loads,
+                cpython_dumps_us=cp_dumps,
+                monty_dumps_us=mt_dumps,
+            )
+        )
+        print()
+
+    return results
+
+
+def print_summary(results: list[BenchResult]) -> None:
+    """Print a summary table."""
+    header = f'{"Fixture":<25} {"Size":>8} {"loads CPy":>10} {"loads Mty":>10} {"loads ratio":>14} {"dumps CPy":>10} {"dumps Mty":>10} {"dumps ratio":>14}'
+    print('=' * len(header))
+    print('SUMMARY')
+    print('=' * len(header))
+    print(header)
+    print('-' * len(header))
+
+    for r in results:
+        print(
+            f'{r.name:<25} {r.size_bytes:>7,}B'
+            f' {format_us(r.cpython_loads_us):>10} {format_us(r.monty_loads_us):>10} {format_ratio(r.cpython_loads_us, r.monty_loads_us):>14}'
+            f' {format_us(r.cpython_dumps_us):>10} {format_us(r.monty_dumps_us):>10} {format_ratio(r.cpython_dumps_us, r.monty_dumps_us):>14}'
+        )
+
+    # overall geometric mean of ratios
+    loads_ratios = [r.monty_loads_us / r.cpython_loads_us for r in results]
+    dumps_ratios = [r.monty_dumps_us / r.cpython_dumps_us for r in results]
+
+    geo_mean_loads = _geo_mean(loads_ratios)
+    geo_mean_dumps = _geo_mean(dumps_ratios)
+
+    print('-' * len(header))
+    print(f'Geometric mean ratio (Monty/CPython):  loads={geo_mean_loads:.2f}x  dumps={geo_mean_dumps:.2f}x')
+    if geo_mean_loads < 1:
+        print(f'  -> Monty loads is {1 / geo_mean_loads:.2f}x faster on average')
+    else:
+        print(f'  -> Monty loads is {geo_mean_loads:.2f}x slower on average')
+    if geo_mean_dumps < 1:
+        print(f'  -> Monty dumps is {1 / geo_mean_dumps:.2f}x faster on average')
+    else:
+        print(f'  -> Monty dumps is {geo_mean_dumps:.2f}x slower on average')
+
+
+def _geo_mean(values: list[float]) -> float:
+    product = 1.0
+    for v in values:
+        product *= v
+    return product ** (1.0 / len(values))
+
+
+def main() -> None:
+    global target_duration
+    if '--duration' in sys.argv:
+        idx = sys.argv.index('--duration')
+        target_duration = float(sys.argv[idx + 1])
+
+    print('JSON Benchmark: CPython vs Monty\n')
+
+    results = run_benchmarks()
+    print()
+    print_summary(results)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
After these changes:

```
============================================================================================================
SUMMARY
============================================================================================================
Fixture                       Size  loads CPy  loads Mty    loads ratio  dumps CPy  dumps Mty    dumps ratio
------------------------------------------------------------------------------------------------------------
short_numbers.json          4,801B     36.8us      9.0us   4.08x faster     18.9us     15.4us   1.23x faster
bigints_array.json         17,519B     61.4us     18.1us   3.39x faster     31.5us     25.0us   1.26x faster
floats_array.json          19,356B    142.1us     22.8us   6.23x faster    245.7us     57.5us   4.28x faster
string_array.json             700B      3.3us      3.5us   1.06x slower      3.4us      2.0us   1.70x faster
true_array.json               600B      1.7us      0.9us   1.90x faster      1.9us      1.0us   1.90x faster
true_object.json            1,390B      6.7us      5.5us   1.24x faster      4.7us      2.8us   1.67x faster
sentence.json                 374B      1.0us      0.4us   2.41x faster      0.7us      0.6us   1.10x faster
unicode.json                  381B      1.7us      0.5us   3.67x faster      0.9us      0.6us   1.45x faster
medium_response.json        2,329B      6.6us      7.3us   1.10x slower      6.7us      4.1us   1.63x faster
pass1.json                  1,441B      5.1us      4.3us   1.18x faster      5.4us      3.3us   1.62x faster
pass2.json                     52B      1.0us      0.8us   1.24x faster      1.5us      1.0us   1.59x faster
------------------------------------------------------------------------------------------------------------
Geometric mean ratio (Monty/CPython):  loads=0.50x  dumps=0.61x
  -> Monty loads is 2.02x faster on average
  -> Monty dumps is 1.65x faster on average
```