### PR TITLE
Improve type checking performance

### DIFF
--- a/CODEX_REPORT.md
+++ b/CODEX_REPORT.md
@@ -1,0 +1,33 @@
+# Code Review Report
+
+Follow-up review after the requested fixes.
+
+## Fixed
+
+1. The root-only path restriction is gone.
+   - `type_check()` now accepts nested paths again in [crates/monty-type-checking/src/type_check.rs](/Users/samuel/code/monty/crates/monty-type-checking/src/type_check.rs:59).
+   - Nested-path cleanup is covered by exact tests in [crates/monty-type-checking/tests/main.rs](/Users/samuel/code/monty/crates/monty-type-checking/tests/main.rs:295).
+
+2. Diagnostics are no longer eagerly pre-rendered in every format.
+   - Rendering is lazy again via the retained pooled db in [crates/monty-type-checking/src/type_check.rs](/Users/samuel/code/monty/crates/monty-type-checking/src/type_check.rs:136).
+
+3. The benchmark no longer hides internal failures.
+   - The REPL-sequence benchmark now fails loudly on internal errors and unexpected type-check failures in [crates/monty-type-checking/benches/type_check.rs](/Users/samuel/code/monty/crates/monty-type-checking/benches/type_check.rs:63).
+
+4. The pool-isolation tests now use exact concise diagnostic assertions instead of broad substring checks.
+   - Tightened in [crates/monty-type-checking/tests/main.rs](/Users/samuel/code/monty/crates/monty-type-checking/tests/main.rs:188).
+
+5. The stale `SRC_ROOT` docstring is fixed.
+   - Updated in [crates/monty-type-checking/src/db.rs](/Users/samuel/code/monty/crates/monty-type-checking/src/db.rs:49).
+
+## Remaining Intentional Behavior
+
+1. `pool.rs` still uses panic-based fatal paths for internal pool corruption and drop-time cleanup failures.
+   - Per user instruction, these were intentionally left in place.
+
+## Verification
+
+- Ran `make format-rs`
+- Ran `make lint-rs`
+- Ran `cargo test -p monty_type_checking --tests`
+- Result: all passed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,7 +1803,10 @@ dependencies = [
 name = "monty_type_checking"
 version = "0.0.11"
 dependencies = [
+ "codspeed-criterion-compat",
+ "criterion",
  "monty_typeshed",
+ "pprof",
  "pretty_assertions",
  "ruff_db",
  "ruff_python_ast",

--- a/crates/monty-python/tests/test_type_check.py
+++ b/crates/monty-python/tests/test_type_check.py
@@ -13,9 +13,9 @@ def test_type_check_no_errors():
 def test_type_check_no_cross_call_state_leak():
     """Successive calls must not see stale results from earlier calls.
 
-    Every type_check call writes the same script path ('main.py') into the process-wide
-    warm database. Salsa invalidates the file's memos on each write — this regression
-    test guards that behavior end-to-end.
+    The type checker reuses warm `MemoryDb` instances from a pool, but each call must
+    still scrub its root files before the db is returned. This regression test checks
+    that a pooled db reused for the same script name does not leak the previous result.
     """
     # Valid code first.
     assert pydantic_monty.Monty('x = 1').type_check() is None
@@ -29,23 +29,25 @@ def test_type_check_no_cross_call_state_leak():
 def test_type_check_stubs_not_leaked_to_later_call():
     """Stub declarations from an earlier call must not be visible to a later one.
 
-    The warm-template optimization shares Salsa storage across calls, but each call
-    owns its own in-memory filesystem. A name defined in call 1's stubs must therefore
-    be unresolved in call 2 when that call doesn't pass stubs — regardless of memo
-    state carried over in the shared storage.
+    Warm pooled databases keep their semantic caches, but every call must delete and
+    sync the temporary root files it wrote. A name defined in call 1's stubs must
+    therefore be unresolved in call 2 when that call does not pass stubs.
     """
-    # Call 1: stubs declare `call1_stub_var`; code referencing it type-checks clean.
-    assert (
-        pydantic_monty.Monty(
-            'result = call1_stub_var + 1',
-            type_check_stubs='call1_stub_var = 0',
-        ).type_check()
-        is None
-    )
+    # Call 1: prefix code declares `call1_stub_var`; code referencing it type-checks clean.
+    assert pydantic_monty.Monty('result = call1_stub_var + 1').type_check(prefix_code='call1_stub_var = 0') is None
     # Call 2: same expression, no stubs — `call1_stub_var` must be undefined.
     with pytest.raises(pydantic_monty.MontyTypingError) as exc_info:
         pydantic_monty.Monty('result = call1_stub_var + 1').type_check()
-    assert str(exc_info.value) == snapshot()
+    assert str(exc_info.value) == snapshot("""\
+error[unresolved-reference]: Name `call1_stub_var` used when not defined
+ --> main.py:1:10
+  |
+1 | result = call1_stub_var + 1
+  |          ^^^^^^^^^^^^^^
+  |
+info: rule `unresolved-reference` is enabled by default
+
+""")
 
 
 def test_type_check_with_errors():

--- a/crates/monty-python/tests/test_type_check.py
+++ b/crates/monty-python/tests/test_type_check.py
@@ -10,6 +10,44 @@ def test_type_check_no_errors():
     assert m.type_check() is None
 
 
+def test_type_check_no_cross_call_state_leak():
+    """Successive calls must not see stale results from earlier calls.
+
+    Every type_check call writes the same script path ('main.py') into the process-wide
+    warm database. Salsa invalidates the file's memos on each write — this regression
+    test guards that behavior end-to-end.
+    """
+    # Valid code first.
+    assert pydantic_monty.Monty('x = 1').type_check() is None
+    # Same script path, invalid code — must produce a fresh error, not a cached None.
+    with pytest.raises(pydantic_monty.MontyTypingError):
+        pydantic_monty.Monty('"hello" + 1').type_check()
+    # Back to valid code — must be None again, not a stale error.
+    assert pydantic_monty.Monty('x = 1').type_check() is None
+
+
+def test_type_check_stubs_not_leaked_to_later_call():
+    """Stub declarations from an earlier call must not be visible to a later one.
+
+    The warm-template optimization shares Salsa storage across calls, but each call
+    owns its own in-memory filesystem. A name defined in call 1's stubs must therefore
+    be unresolved in call 2 when that call doesn't pass stubs — regardless of memo
+    state carried over in the shared storage.
+    """
+    # Call 1: stubs declare `call1_stub_var`; code referencing it type-checks clean.
+    assert (
+        pydantic_monty.Monty(
+            'result = call1_stub_var + 1',
+            type_check_stubs='call1_stub_var = 0',
+        ).type_check()
+        is None
+    )
+    # Call 2: same expression, no stubs — `call1_stub_var` must be undefined.
+    with pytest.raises(pydantic_monty.MontyTypingError) as exc_info:
+        pydantic_monty.Monty('result = call1_stub_var + 1').type_check()
+    assert str(exc_info.value) == snapshot()
+
+
 def test_type_check_with_errors():
     """Type checking code with type errors raises MontyTypingError."""
     m = pydantic_monty.Monty('"hello" + 1')

--- a/crates/monty-type-checking/Cargo.toml
+++ b/crates/monty-type-checking/Cargo.toml
@@ -27,6 +27,16 @@ salsa = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+# Use codspeed-criterion-compat for CI benchmarks, real criterion for local flamegraphs
+codspeed-criterion-compat = "4.2.1"
+criterion = "0.5"
+
+[target.'cfg(unix)'.dev-dependencies]
+pprof = { version = "0.15", features = ["flamegraph", "criterion"] }
+
+[[bench]]
+name = "type_check"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/monty-type-checking/benches/type_check.rs
+++ b/crates/monty-type-checking/benches/type_check.rs
@@ -60,7 +60,12 @@ fn bench_repl_sequence(c: &mut Criterion) {
                 let path = format!("step_{i}.py");
                 let stubs_src = SourceFile::new(&stubs, "type_stubs.pyi");
                 let main_src = SourceFile::new(snippet, &path);
-                let out = type_check(&main_src, Some(&stubs_src)).unwrap_or(None);
+                let out = type_check(&main_src, Some(&stubs_src))
+                    .expect("repl-sequence benchmark should not hit internal type-check failures");
+                assert!(
+                    out.is_none(),
+                    "repl-sequence benchmark snippet should type-check cleanly: {snippet}"
+                );
                 black_box(out);
                 stubs.push_str(snippet);
                 stubs.push('\n');

--- a/crates/monty-type-checking/benches/type_check.rs
+++ b/crates/monty-type-checking/benches/type_check.rs
@@ -7,7 +7,7 @@ use monty_type_checking::{SourceFile, type_check};
 #[cfg(all(not(codspeed), unix))]
 use pprof::criterion::{Output, PProfProfiler};
 
-/// Force the warm-template `OnceLock` initialization outside the measurement loop.
+/// Force one warm pooled database to exist before the measurement loop.
 ///
 /// Every benchmark except `type_check__first_call` calls this at setup so the reported
 /// numbers reflect steady-state cost, not the one-shot typeshed prewarm.
@@ -16,8 +16,8 @@ fn prewarm() {
 }
 
 /// Steady-state cost of type-checking a trivial snippet. This is the headline metric —
-/// it isolates per-call overhead (clone the template, write one file, run check_types
-/// against already-memoized stdlib analysis) from the one-time warmup.
+/// it isolates per-call overhead (check out a pooled db, write one file, run
+/// `check_types`, scrub the file, return the db) from the one-time warmup.
 fn bench_warm_trivial(c: &mut Criterion) {
     prewarm();
     c.bench_function("type_check__warm_trivial", |b| {

--- a/crates/monty-type-checking/benches/type_check.rs
+++ b/crates/monty-type-checking/benches/type_check.rs
@@ -1,0 +1,91 @@
+// Use codspeed-criterion-compat when running on CodSpeed (CI), real criterion otherwise (for flamegraphs)
+#[cfg(codspeed)]
+use codspeed_criterion_compat::{Criterion, black_box, criterion_group, criterion_main};
+#[cfg(not(codspeed))]
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use monty_type_checking::{SourceFile, type_check};
+#[cfg(all(not(codspeed), unix))]
+use pprof::criterion::{Output, PProfProfiler};
+
+/// Force the warm-template `OnceLock` initialization outside the measurement loop.
+///
+/// Every benchmark except `type_check__first_call` calls this at setup so the reported
+/// numbers reflect steady-state cost, not the one-shot typeshed prewarm.
+fn prewarm() {
+    let _ = type_check(&SourceFile::new("pass", "warmup.py"), None);
+}
+
+/// Steady-state cost of type-checking a trivial snippet. This is the headline metric —
+/// it isolates per-call overhead (clone the template, write one file, run check_types
+/// against already-memoized stdlib analysis) from the one-time warmup.
+fn bench_warm_trivial(c: &mut Criterion) {
+    prewarm();
+    c.bench_function("type_check__warm_trivial", |b| {
+        b.iter(|| {
+            let out = type_check(&SourceFile::new("x = 1", "main.py"), None).unwrap();
+            black_box(out);
+        });
+    });
+}
+
+/// Steady-state cost of type-checking a snippet that exercises a builtin (`int.__add__`).
+/// Slightly heavier than `warm_trivial` because it actually resolves a type.
+fn bench_warm_builtin(c: &mut Criterion) {
+    prewarm();
+    c.bench_function("type_check__warm_builtin", |b| {
+        b.iter(|| {
+            let out = type_check(&SourceFile::new("x = 1 + 2", "main.py"), None).unwrap();
+            black_box(out);
+        });
+    });
+}
+
+/// Realistic REPL-like pattern: each iteration type-checks a growing accumulated-stubs
+/// context plus a new "current" snippet. Mirrors how the REPL would call `type_check`
+/// per feed_run.
+fn bench_repl_sequence(c: &mut Criterion) {
+    prewarm();
+    c.bench_function("type_check__repl_sequence", |b| {
+        b.iter(|| {
+            let mut stubs = String::new();
+            for (i, snippet) in [
+                "x = 1",
+                "y = x + 2",
+                "def f(a: int) -> int:\n    return a * 2",
+                "z = f(y)",
+            ]
+            .iter()
+            .enumerate()
+            {
+                let path = format!("step_{i}.py");
+                let stubs_src = SourceFile::new(&stubs, "type_stubs.pyi");
+                let main_src = SourceFile::new(snippet, &path);
+                let out = type_check(&main_src, Some(&stubs_src)).unwrap_or(None);
+                black_box(out);
+                stubs.push_str(snippet);
+                stubs.push('\n');
+            }
+        });
+    });
+}
+
+/// Configures the type-checking benchmarks.
+fn criterion_benchmark(c: &mut Criterion) {
+    bench_warm_trivial(c);
+    bench_warm_builtin(c);
+    bench_repl_sequence(c);
+}
+
+// Use pprof flamegraph profiler when running locally on Unix (not on CodSpeed or Windows)
+#[cfg(all(not(codspeed), unix))]
+criterion_group!(
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+);
+
+// Use default config on CodSpeed or Windows (pprof is Unix-only)
+#[cfg(any(codspeed, not(unix)))]
+criterion_group!(benches, criterion_benchmark);
+
+criterion_main!(benches);

--- a/crates/monty-type-checking/benches/type_check.rs
+++ b/crates/monty-type-checking/benches/type_check.rs
@@ -7,17 +7,17 @@ use monty_type_checking::{SourceFile, type_check};
 #[cfg(all(not(codspeed), unix))]
 use pprof::criterion::{Output, PProfProfiler};
 
-/// Force one warm pooled database to exist before the measurement loop.
+/// Force one reusable pooled database to exist before the measurement loop.
 ///
 /// Every benchmark except `type_check__first_call` calls this at setup so the reported
-/// numbers reflect steady-state cost, not the one-shot typeshed prewarm.
+/// numbers reflect steady-state reuse cost, not the first cold call.
 fn prewarm() {
     let _ = type_check(&SourceFile::new("pass", "warmup.py"), None);
 }
 
 /// Steady-state cost of type-checking a trivial snippet. This is the headline metric —
 /// it isolates per-call overhead (check out a pooled db, write one file, run
-/// `check_types`, scrub the file, return the db) from the one-time warmup.
+/// `check_types`, scrub the file, return the db) from the one-time cold start.
 fn bench_warm_trivial(c: &mut Criterion) {
     prewarm();
     c.bench_function("type_check__warm_trivial", |b| {

--- a/crates/monty-type-checking/src/db.rs
+++ b/crates/monty-type-checking/src/db.rs
@@ -48,8 +48,9 @@ impl fmt::Debug for MemoryDb {
 
 /// Virtual source root used for all in-memory type-checking files.
 ///
-/// The reusable database pool only supports root-level user files, so every public
-/// `SourceFile.path` is mapped directly under `/`.
+/// Every public `SourceFile.path` is mapped under `/`, including nested paths such
+/// as `pkg/main.py`. Pool cleanup is responsible for removing any intermediate
+/// directories before a reused db is returned to the next caller.
 pub(crate) const SRC_ROOT: &str = "/";
 
 impl Default for MemoryDb {

--- a/crates/monty-type-checking/src/db.rs
+++ b/crates/monty-type-checking/src/db.rs
@@ -1,33 +1,17 @@
-use std::{
-    fmt,
-    sync::{Arc, Mutex, OnceLock},
-};
+use std::{fmt, sync::Arc};
 
 use ruff_db::{
     Db as SourceDb,
-    files::{File, FileRootKind, Files},
-    system::{DbWithTestSystem, System, SystemPathBuf, TestSystem},
+    files::{File, Files},
+    system::{DbWithTestSystem, System, TestSystem},
     vendored::VendoredFileSystem,
 };
 use ruff_python_ast::PythonVersion;
-use ty_module_resolver::{Db as ModuleResolverDb, SearchPathSettings, SearchPaths};
+use ty_module_resolver::{Db as ModuleResolverDb, SearchPaths};
 use ty_python_semantic::{
-    AnalysisSettings, Db, Program, ProgramSettings, PythonPlatform, PythonVersionSource, PythonVersionWithSource,
-    default_lint_registry,
+    AnalysisSettings, Db, Program, default_lint_registry,
     lint::{LintRegistry, RuleSelection},
 };
-
-/// Virtual source root used for all in-memory type-checking files.
-///
-/// The reusable database pool only supports root-level user files, so every public
-/// `SourceFile.path` is mapped directly under `/`.
-pub(crate) const SRC_ROOT: &str = "/";
-
-/// Maximum number of reusable `MemoryDb` instances kept in the process-wide pool.
-///
-/// The pool is intentionally small because every reused database retains its own
-/// Salsa memo graph and typeshed-derived semantic state.
-const MAX_POOLED_DBS: usize = 8;
 
 /// Very simple in-memory salsa/ty database.
 ///
@@ -63,7 +47,7 @@ impl fmt::Debug for MemoryDb {
 
 impl MemoryDb {
     /// Create a fresh database with its own Salsa storage and Monty's fixed typing config.
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             storage: salsa::Storage::new(None),
             system: TestSystem::default(),
@@ -73,107 +57,6 @@ impl MemoryDb {
             analysis_settings: AnalysisSettings::default().into(),
         }
     }
-}
-
-/// Pool of reusable databases for root-file type checking.
-///
-/// Each checked-out db is owned by exactly one caller until it is either returned
-/// clean or dropped. This keeps Salsa's single-writer invariant intact while still
-/// allowing concurrent type checks to use different databases.
-struct MemoryDbPool {
-    dbs: Mutex<Vec<MemoryDb>>,
-}
-
-impl MemoryDbPool {
-    /// Access the process-wide database pool.
-    fn global() -> &'static Self {
-        static GLOBAL_POOL: OnceLock<MemoryDbPool> = OnceLock::new();
-        GLOBAL_POOL.get_or_init(|| Self {
-            dbs: Mutex::new(Vec::new()),
-        })
-    }
-
-    /// Check out one pooled database, creating a fresh configured db if needed.
-    fn checkout(&'static self) -> Result<PooledMemoryDb, String> {
-        let maybe_db = {
-            let mut dbs = self.dbs.lock().map_err(|e| e.to_string())?;
-            dbs.pop()
-        };
-
-        Ok(PooledMemoryDb {
-            db: Some(maybe_db.unwrap_or_else(build_pooled_db)),
-            pool: self,
-        })
-    }
-
-    /// Return a fully scrubbed database to the pool if there is capacity left.
-    fn release(&self, db: MemoryDb) -> Result<(), String> {
-        let mut dbs = self.dbs.lock().map_err(|e| e.to_string())?;
-        if dbs.len() < MAX_POOLED_DBS {
-            dbs.push(db);
-        }
-        Ok(())
-    }
-}
-
-/// Exclusive lease for one pooled database.
-///
-/// The caller must only return the lease with [`Self::return_clean`] after all user
-/// files have been deleted and synced out of the in-memory filesystem. Dropping the
-/// lease without returning it discards the db, which is the panic-safe fallback.
-pub(crate) struct PooledMemoryDb {
-    db: Option<MemoryDb>,
-    pool: &'static MemoryDbPool,
-}
-
-impl PooledMemoryDb {
-    /// Borrow the checked-out database mutably for one type-check run.
-    pub(crate) fn db(&mut self) -> &mut MemoryDb {
-        self.db
-            .as_mut()
-            .expect("pooled memory db accessed after being returned")
-    }
-
-    /// Return a scrubbed database to the pool.
-    pub(crate) fn return_clean(mut self) -> Result<(), String> {
-        let db = self.db.take().expect("pooled memory db returned more than once");
-        self.pool.release(db)
-    }
-}
-
-/// Check out a database from the global pool.
-pub(crate) fn checkout_db() -> Result<PooledMemoryDb, String> {
-    MemoryDbPool::global().checkout()
-}
-
-/// Build one fresh database ready to enter the pool.
-///
-/// This sets up the source root and `Program` settings, but it intentionally does
-/// not run a synthetic type-check. The first real caller that uses a brand new db
-/// pays the cold-start cost; subsequent pooled reuses benefit from the populated
-/// Salsa caches created by real user work.
-fn build_pooled_db() -> MemoryDb {
-    let db = MemoryDb::new();
-    let src_root = SystemPathBuf::from(SRC_ROOT);
-    db.files().try_add_root(&db, &src_root, FileRootKind::Project);
-
-    let search_paths = SearchPathSettings::new(vec![src_root])
-        .to_search_paths(db.system(), db.vendored())
-        .expect("vendored typeshed search paths always resolve");
-
-    Program::from_settings(
-        &db,
-        ProgramSettings {
-            python_version: PythonVersionWithSource {
-                version: db.python_version(),
-                source: PythonVersionSource::default(),
-            },
-            python_platform: PythonPlatform::default(),
-            search_paths,
-        },
-    );
-
-    db
 }
 
 impl DbWithTestSystem for MemoryDb {

--- a/crates/monty-type-checking/src/db.rs
+++ b/crates/monty-type-checking/src/db.rs
@@ -45,9 +45,9 @@ impl fmt::Debug for MemoryDb {
     }
 }
 
-impl MemoryDb {
+impl Default for MemoryDb {
     /// Create a fresh database with its own Salsa storage and Monty's fixed typing config.
-    pub(crate) fn new() -> Self {
+    fn default() -> Self {
         Self {
             storage: salsa::Storage::new(None),
             system: TestSystem::default(),

--- a/crates/monty-type-checking/src/db.rs
+++ b/crates/monty-type-checking/src/db.rs
@@ -27,7 +27,7 @@ pub(crate) const SRC_ROOT: &str = "/";
 ///
 /// The pool is intentionally small because every reused database retains its own
 /// Salsa memo graph and typeshed-derived semantic state.
-const MAX_POOLED_DBS: usize = 4;
+const MAX_POOLED_DBS: usize = 8;
 
 /// Very simple in-memory salsa/ty database.
 ///

--- a/crates/monty-type-checking/src/db.rs
+++ b/crates/monty-type-checking/src/db.rs
@@ -5,8 +5,8 @@ use std::{
 
 use ruff_db::{
     Db as SourceDb,
-    files::{File, FileRootKind, Files, system_path_to_file},
-    system::{DbWithTestSystem, DbWithWritableSystem as _, System, SystemPathBuf, TestSystem},
+    files::{File, FileRootKind, Files},
+    system::{DbWithTestSystem, System, SystemPathBuf, TestSystem},
     vendored::VendoredFileSystem,
 };
 use ruff_python_ast::PythonVersion;
@@ -15,7 +15,6 @@ use ty_python_semantic::{
     AnalysisSettings, Db, Program, ProgramSettings, PythonPlatform, PythonVersionSource, PythonVersionWithSource,
     default_lint_registry,
     lint::{LintRegistry, RuleSelection},
-    types::check_types,
 };
 
 /// Virtual source root used for all in-memory type-checking files.
@@ -24,15 +23,9 @@ use ty_python_semantic::{
 /// `SourceFile.path` is mapped directly under `/`.
 pub(crate) const SRC_ROOT: &str = "/";
 
-/// Warmup file used to populate stdlib/type-semantic caches in a fresh database.
+/// Maximum number of reusable `MemoryDb` instances kept in the process-wide pool.
 ///
-/// The file is removed before the database is returned to the pool so pooled runs
-/// always start from an empty visible filesystem.
-const WARMUP_PATH: &str = "/__monty_warmup__.py";
-
-/// Maximum number of warm `MemoryDb` instances kept in the process-wide pool.
-///
-/// The pool is intentionally small because every warm database retains its own
+/// The pool is intentionally small because every reused database retains its own
 /// Salsa memo graph and typeshed-derived semantic state.
 const MAX_POOLED_DBS: usize = 4;
 
@@ -82,11 +75,11 @@ impl MemoryDb {
     }
 }
 
-/// Pool of reusable warm databases for root-file type checking.
+/// Pool of reusable databases for root-file type checking.
 ///
 /// Each checked-out db is owned by exactly one caller until it is either returned
 /// clean or dropped. This keeps Salsa's single-writer invariant intact while still
-/// allowing concurrent type checks to use different warm databases.
+/// allowing concurrent type checks to use different databases.
 struct MemoryDbPool {
     dbs: Mutex<Vec<MemoryDb>>,
 }
@@ -100,7 +93,7 @@ impl MemoryDbPool {
         })
     }
 
-    /// Check out one warm database from the pool, creating a fresh warmed db if needed.
+    /// Check out one pooled database, creating a fresh configured db if needed.
     fn checkout(&'static self) -> Result<PooledMemoryDb, String> {
         let maybe_db = {
             let mut dbs = self.dbs.lock().map_err(|e| e.to_string())?;
@@ -108,7 +101,7 @@ impl MemoryDbPool {
         };
 
         Ok(PooledMemoryDb {
-            db: Some(maybe_db.unwrap_or_else(build_warm_db)),
+            db: Some(maybe_db.unwrap_or_else(build_pooled_db)),
             pool: self,
         })
     }
@@ -153,17 +146,18 @@ pub(crate) fn checkout_db() -> Result<PooledMemoryDb, String> {
     MemoryDbPool::global().checkout()
 }
 
-/// Build one warm database ready for pooled reuse.
+/// Build one fresh database ready to enter the pool.
 ///
-/// The warmup initializes the `Program` singleton, resolves typeshed-backed search
-/// paths, runs a trivial check that touches common builtin types, and then removes
-/// the warmup file again so the returned db has no visible user files.
-fn build_warm_db() -> MemoryDb {
-    let mut db = MemoryDb::new();
+/// This sets up the source root and `Program` settings, but it intentionally does
+/// not run a synthetic type-check. The first real caller that uses a brand new db
+/// pays the cold-start cost; subsequent pooled reuses benefit from the populated
+/// Salsa caches created by real user work.
+fn build_pooled_db() -> MemoryDb {
+    let db = MemoryDb::new();
     let src_root = SystemPathBuf::from(SRC_ROOT);
     db.files().try_add_root(&db, &src_root, FileRootKind::Project);
 
-    let search_paths = SearchPathSettings::new(vec![src_root.clone()])
+    let search_paths = SearchPathSettings::new(vec![src_root])
         .to_search_paths(db.system(), db.vendored())
         .expect("vendored typeshed search paths always resolve");
 
@@ -178,26 +172,6 @@ fn build_warm_db() -> MemoryDb {
             search_paths,
         },
     );
-
-    // Prewarm the db with the stdlib stubs every real call tends to touch.
-    let warmup_code = "\
-x: int = 0
-y: str = ''
-z: float = 0.0
-b: bool = False
-xs: list[int] = []
-d: dict[str, int] = {}
-";
-    let warmup = SystemPathBuf::from(WARMUP_PATH);
-    db.write_file(&warmup, warmup_code).expect("warmup write");
-    let warmup_file = system_path_to_file(&db, &warmup).expect("warmup file");
-    let _ = check_types(&db, warmup_file);
-
-    db.memory_file_system()
-        .remove_file(&warmup)
-        .expect("warmup file exists during warmup cleanup");
-    warmup_file.sync(&mut db);
-    File::sync_path(&mut db, &src_root);
 
     db
 }

--- a/crates/monty-type-checking/src/db.rs
+++ b/crates/monty-type-checking/src/db.rs
@@ -1,9 +1,6 @@
 use std::{
     fmt,
-    sync::{
-        Arc, Mutex, OnceLock,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::{Arc, Mutex, OnceLock},
 };
 
 use ruff_db::{
@@ -21,74 +18,35 @@ use ty_python_semantic::{
     types::check_types,
 };
 
-/// Virtual source root — user files are written under this prefix and module resolution
-/// treats it as the project root. Shared between [`build_warm_db`] and [`type_check`].
+/// Virtual source root used for all in-memory type-checking files.
+///
+/// The reusable database pool only supports root-level user files, so every public
+/// `SourceFile.path` is mapped directly under `/`.
 pub(crate) const SRC_ROOT: &str = "/";
 
-/// Path used by the warmup dummy file. Picked to never collide with any user-supplied
-/// script path so its stale interning is never queried again after the db is built.
+/// Warmup file used to populate stdlib/type-semantic caches in a fresh database.
+///
+/// The file is removed before the database is returned to the pool so pooled runs
+/// always start from an empty visible filesystem.
 const WARMUP_PATH: &str = "/__monty_warmup__.py";
 
-/// Prefix used to uniquify per-call internal file paths.
+/// Maximum number of warm `MemoryDb` instances kept in the process-wide pool.
 ///
-/// Each `type_check` call writes to paths like `/__mc42__main.py`, which creates a
-/// distinct salsa `File` ingredient per call so memos from one call never shadow
-/// another's. The prefix is stripped from rendered diagnostics so users see plain
-/// paths like `main.py` — see [`strip_unique_prefix`].
-pub(crate) const CALL_PATH_PREFIX: &str = "__mc";
-
-/// Separator between the call counter and the user's script name (e.g. `__mc42__`).
-pub(crate) const CALL_PATH_SEP: &str = "__";
-
-/// Process-wide counter feeding [`CALL_PATH_PREFIX`]; bumped atomically per call.
-static CALL_COUNTER: AtomicU64 = AtomicU64::new(0);
-
-/// Return the next unique internal-path prefix and its call counter.
-///
-/// The returned `String` (e.g. `"__mc42__"`) is what appears in internal file paths
-/// and must be passed to [`strip_unique_prefix`] when rendering diagnostics.
-pub(crate) fn next_call_prefix() -> String {
-    let counter = CALL_COUNTER.fetch_add(1, Ordering::Relaxed);
-    format!("{CALL_PATH_PREFIX}{counter}{CALL_PATH_SEP}")
-}
-
-/// Remove every `__mc<digits>__` segment from `rendered`.
-///
-/// Used by `TypeCheckingDiagnostics` to hide the internal uniquifying prefix from
-/// the end-user — file paths in error output should read `main.py`, not
-/// `__mc42__main.py`. Implemented as a hand-rolled scanner to avoid pulling in a
-/// regex crate for a trivial pattern.
-pub(crate) fn strip_unique_prefix(rendered: &str) -> String {
-    let mut out = String::with_capacity(rendered.len());
-    let mut cursor = 0;
-    let bytes = rendered.as_bytes();
-    while let Some(start_rel) = rendered[cursor..].find(CALL_PATH_PREFIX) {
-        let start = cursor + start_rel;
-        out.push_str(&rendered[cursor..start]);
-        let after_prefix = start + CALL_PATH_PREFIX.len();
-        let mut digit_end = after_prefix;
-        while digit_end < bytes.len() && bytes[digit_end].is_ascii_digit() {
-            digit_end += 1;
-        }
-        // Only strip when we have at least one digit followed by the separator — otherwise
-        // `__mc` is an ordinary substring (e.g. appearing in user code) and should stay.
-        if digit_end > after_prefix && rendered[digit_end..].starts_with(CALL_PATH_SEP) {
-            cursor = digit_end + CALL_PATH_SEP.len();
-        } else {
-            out.push_str(CALL_PATH_PREFIX);
-            cursor = after_prefix;
-        }
-    }
-    out.push_str(&rendered[cursor..]);
-    out
-}
+/// The pool is intentionally small because every warm database retains its own
+/// Salsa memo graph and typeshed-derived semantic state.
+const MAX_POOLED_DBS: usize = 4;
 
 /// Very simple in-memory salsa/ty database.
 ///
 /// Mostly taken from
 /// https://github.com/astral-sh/ruff/blob/7bacca9b625c2a658470afd99a0bf0aa0b4f1dbb/crates/ty_python_semantic/src/db.rs#L51
+///
+/// ## Lifetime invariant
+///
+/// Each `MemoryDb` owns a unique Salsa storage. It must never be cloned or shared
+/// with another live handle because Salsa setters require exclusive access to the
+/// underlying `Arc<Zalsa>`.
 #[salsa::db]
-#[derive(Clone)]
 pub(crate) struct MemoryDb {
     storage: salsa::Storage<Self>,
     files: Files,
@@ -100,7 +58,7 @@ pub(crate) struct MemoryDb {
 
 impl fmt::Debug for MemoryDb {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TypeCheckingFailure")
+        f.debug_struct("MemoryDb")
             .field("files", &self.files)
             .field("system", &self.system)
             .field("vendored", &self.vendored)
@@ -111,7 +69,8 @@ impl fmt::Debug for MemoryDb {
 }
 
 impl MemoryDb {
-    pub fn new() -> Self {
+    /// Create a fresh database with its own Salsa storage and Monty's fixed typing config.
+    fn new() -> Self {
         Self {
             storage: salsa::Storage::new(None),
             system: TestSystem::default(),
@@ -123,44 +82,88 @@ impl MemoryDb {
     }
 }
 
-/// The single process-wide type-checking database.
+/// Pool of reusable warm databases for root-file type checking.
 ///
-/// ## Why one shared db instead of "clone-per-call"?
-///
-/// Salsa's input setters (what `write_file` ultimately calls) require exclusive access to
-/// the underlying `Arc<Zalsa>` via `Arc::get_mut`. If anything else holds a clone of the
-/// storage, `get_mut` fails and salsa's `cancel_others()` waits indefinitely for the other
-/// handles to drop — a single long-lived "warm template" whose handle never drops would
-/// deadlock the very next write, even from a single-threaded caller. So instead we keep
-/// **one** `MemoryDb` behind a [`Mutex`] and serialize all `type_check` calls through it.
-///
-/// ## How correctness is preserved across calls
-///
-/// Each call writes its user code to a path containing a unique counter (see
-/// [`next_call_prefix`]), which creates a fresh salsa `File` ingredient per call.
-/// That means memos computed for call 1's `File` can never be accidentally returned
-/// for call 2's `File` (different salsa key), so diagnostics produced by an earlier
-/// call continue to render correctly even after later calls have run — they query
-/// their own `File`'s source text, which still lives in the shared in-memory fs.
-///
-/// ## Warmup
-///
-/// First access runs `build_warm_db`, which initializes the salsa `Program` singleton,
-/// resolves vendored typeshed search paths, and runs `check_types` on a trivial snippet
-/// referencing the common builtins (`int`, `str`, etc.). This populates the salsa memo
-/// table so the first *real* call doesn't pay the stdlib parse cost.
-pub(crate) fn global_db() -> &'static Mutex<MemoryDb> {
-    static GLOBAL_DB: OnceLock<Mutex<MemoryDb>> = OnceLock::new();
-    GLOBAL_DB.get_or_init(|| Mutex::new(build_warm_db()))
+/// Each checked-out db is owned by exactly one caller until it is either returned
+/// clean or dropped. This keeps Salsa's single-writer invariant intact while still
+/// allowing concurrent type checks to use different warm databases.
+struct MemoryDbPool {
+    dbs: Mutex<Vec<MemoryDb>>,
 }
 
-/// Build the one-shot warm database. Runs once behind the [`global_db`] `OnceLock`.
+impl MemoryDbPool {
+    /// Access the process-wide database pool.
+    fn global() -> &'static Self {
+        static GLOBAL_POOL: OnceLock<MemoryDbPool> = OnceLock::new();
+        GLOBAL_POOL.get_or_init(|| Self {
+            dbs: Mutex::new(Vec::new()),
+        })
+    }
+
+    /// Check out one warm database from the pool, creating a fresh warmed db if needed.
+    fn checkout(&'static self) -> Result<PooledMemoryDb, String> {
+        let maybe_db = {
+            let mut dbs = self.dbs.lock().map_err(|e| e.to_string())?;
+            dbs.pop()
+        };
+
+        Ok(PooledMemoryDb {
+            db: Some(maybe_db.unwrap_or_else(build_warm_db)),
+            pool: self,
+        })
+    }
+
+    /// Return a fully scrubbed database to the pool if there is capacity left.
+    fn release(&self, db: MemoryDb) -> Result<(), String> {
+        let mut dbs = self.dbs.lock().map_err(|e| e.to_string())?;
+        if dbs.len() < MAX_POOLED_DBS {
+            dbs.push(db);
+        }
+        Ok(())
+    }
+}
+
+/// Exclusive lease for one pooled database.
+///
+/// The caller must only return the lease with [`Self::return_clean`] after all user
+/// files have been deleted and synced out of the in-memory filesystem. Dropping the
+/// lease without returning it discards the db, which is the panic-safe fallback.
+pub(crate) struct PooledMemoryDb {
+    db: Option<MemoryDb>,
+    pool: &'static MemoryDbPool,
+}
+
+impl PooledMemoryDb {
+    /// Borrow the checked-out database mutably for one type-check run.
+    pub(crate) fn db(&mut self) -> &mut MemoryDb {
+        self.db
+            .as_mut()
+            .expect("pooled memory db accessed after being returned")
+    }
+
+    /// Return a scrubbed database to the pool.
+    pub(crate) fn return_clean(mut self) -> Result<(), String> {
+        let db = self.db.take().expect("pooled memory db returned more than once");
+        self.pool.release(db)
+    }
+}
+
+/// Check out a database from the global pool.
+pub(crate) fn checkout_db() -> Result<PooledMemoryDb, String> {
+    MemoryDbPool::global().checkout()
+}
+
+/// Build one warm database ready for pooled reuse.
+///
+/// The warmup initializes the `Program` singleton, resolves typeshed-backed search
+/// paths, runs a trivial check that touches common builtin types, and then removes
+/// the warmup file again so the returned db has no visible user files.
 fn build_warm_db() -> MemoryDb {
     let mut db = MemoryDb::new();
     let src_root = SystemPathBuf::from(SRC_ROOT);
     db.files().try_add_root(&db, &src_root, FileRootKind::Project);
 
-    let search_paths = SearchPathSettings::new(vec![src_root])
+    let search_paths = SearchPathSettings::new(vec![src_root.clone()])
         .to_search_paths(db.system(), db.vendored())
         .expect("vendored typeshed search paths always resolve");
 
@@ -176,12 +179,7 @@ fn build_warm_db() -> MemoryDb {
         },
     );
 
-    // Prewarm: parse and analyze the stdlib stubs every real call transitively touches.
-    // The warmup references the most common builtin types (`int`, `str`, `float`, `list`,
-    // `dict`, `bool`) so typechecking resolves them from typeshed's `builtins.pyi` /
-    // `typing.pyi` / `types.pyi` and caches the resulting semantic graph. These memos
-    // live in the db's salsa storage and are reused by every subsequent `type_check`
-    // call, so the first real call doesn't pay the stdlib parse cost.
+    // Prewarm the db with the stdlib stubs every real call tends to touch.
     let warmup_code = "\
 x: int = 0
 y: str = ''
@@ -194,6 +192,12 @@ d: dict[str, int] = {}
     db.write_file(&warmup, warmup_code).expect("warmup write");
     let warmup_file = system_path_to_file(&db, &warmup).expect("warmup file");
     let _ = check_types(&db, warmup_file);
+
+    db.memory_file_system()
+        .remove_file(&warmup)
+        .expect("warmup file exists during warmup cleanup");
+    warmup_file.sync(&mut db);
+    File::sync_path(&mut db, &src_root);
 
     db
 }

--- a/crates/monty-type-checking/src/db.rs
+++ b/crates/monty-type-checking/src/db.rs
@@ -2,14 +2,15 @@ use std::{fmt, sync::Arc};
 
 use ruff_db::{
     Db as SourceDb,
-    files::{File, Files},
-    system::{DbWithTestSystem, System, TestSystem},
+    files::{File, FileRootKind, Files},
+    system::{DbWithTestSystem, System, SystemPathBuf, TestSystem},
     vendored::VendoredFileSystem,
 };
 use ruff_python_ast::PythonVersion;
-use ty_module_resolver::{Db as ModuleResolverDb, SearchPaths};
+use ty_module_resolver::{Db as ModuleResolverDb, SearchPathSettings, SearchPaths};
 use ty_python_semantic::{
-    AnalysisSettings, Db, Program, default_lint_registry,
+    AnalysisSettings, Db, Program, ProgramSettings, PythonPlatform, PythonVersionSource, PythonVersionWithSource,
+    default_lint_registry,
     lint::{LintRegistry, RuleSelection},
 };
 
@@ -45,17 +46,49 @@ impl fmt::Debug for MemoryDb {
     }
 }
 
+/// Virtual source root used for all in-memory type-checking files.
+///
+/// The reusable database pool only supports root-level user files, so every public
+/// `SourceFile.path` is mapped directly under `/`.
+pub(crate) const SRC_ROOT: &str = "/";
+
 impl Default for MemoryDb {
-    /// Create a fresh database with its own Salsa storage and Monty's fixed typing config.
+    /// Create a fresh database wired up for type checking under `SRC_ROOT`.
+    ///
+    /// Registers `SRC_ROOT` as a Salsa-tracked project root and installs the
+    /// `Program` settings needed by `check_types`. Returning a db without this
+    /// setup would unwrap-panic the first time `check_types` is called, so this
+    /// constructor is the only sanctioned way to build a `MemoryDb`.
     fn default() -> Self {
-        Self {
+        let src_root = SystemPathBuf::from(SRC_ROOT);
+        let db = Self {
             storage: salsa::Storage::new(None),
             system: TestSystem::default(),
             vendored: monty_typeshed::file_system().clone(),
             files: Files::default(),
             rule_selection: Arc::new(RuleSelection::from_registry(default_lint_registry())),
             analysis_settings: AnalysisSettings::default().into(),
-        }
+        };
+
+        db.files().try_add_root(&db, &src_root, FileRootKind::Project);
+
+        let search_paths = SearchPathSettings::new(vec![src_root.to_path_buf()])
+            .to_search_paths(db.system(), db.vendored())
+            .expect("vendored typeshed search paths always resolve");
+
+        Program::from_settings(
+            &db,
+            ProgramSettings {
+                python_version: PythonVersionWithSource {
+                    version: db.python_version(),
+                    source: PythonVersionSource::default(),
+                },
+                python_platform: PythonPlatform::default(),
+                search_paths,
+            },
+        );
+
+        db
     }
 }
 

--- a/crates/monty-type-checking/src/db.rs
+++ b/crates/monty-type-checking/src/db.rs
@@ -1,17 +1,87 @@
-use std::{fmt, sync::Arc};
+use std::{
+    fmt,
+    sync::{
+        Arc, Mutex, OnceLock,
+        atomic::{AtomicU64, Ordering},
+    },
+};
 
 use ruff_db::{
     Db as SourceDb,
-    files::{File, Files},
-    system::{DbWithTestSystem, System, TestSystem},
+    files::{File, FileRootKind, Files, system_path_to_file},
+    system::{DbWithTestSystem, DbWithWritableSystem as _, System, SystemPathBuf, TestSystem},
     vendored::VendoredFileSystem,
 };
 use ruff_python_ast::PythonVersion;
-use ty_module_resolver::{Db as ModuleResolverDb, SearchPaths};
+use ty_module_resolver::{Db as ModuleResolverDb, SearchPathSettings, SearchPaths};
 use ty_python_semantic::{
-    AnalysisSettings, Db, Program, default_lint_registry,
+    AnalysisSettings, Db, Program, ProgramSettings, PythonPlatform, PythonVersionSource, PythonVersionWithSource,
+    default_lint_registry,
     lint::{LintRegistry, RuleSelection},
+    types::check_types,
 };
+
+/// Virtual source root — user files are written under this prefix and module resolution
+/// treats it as the project root. Shared between [`build_warm_db`] and [`type_check`].
+pub(crate) const SRC_ROOT: &str = "/";
+
+/// Path used by the warmup dummy file. Picked to never collide with any user-supplied
+/// script path so its stale interning is never queried again after the db is built.
+const WARMUP_PATH: &str = "/__monty_warmup__.py";
+
+/// Prefix used to uniquify per-call internal file paths.
+///
+/// Each `type_check` call writes to paths like `/__mc42__main.py`, which creates a
+/// distinct salsa `File` ingredient per call so memos from one call never shadow
+/// another's. The prefix is stripped from rendered diagnostics so users see plain
+/// paths like `main.py` — see [`strip_unique_prefix`].
+pub(crate) const CALL_PATH_PREFIX: &str = "__mc";
+
+/// Separator between the call counter and the user's script name (e.g. `__mc42__`).
+pub(crate) const CALL_PATH_SEP: &str = "__";
+
+/// Process-wide counter feeding [`CALL_PATH_PREFIX`]; bumped atomically per call.
+static CALL_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Return the next unique internal-path prefix and its call counter.
+///
+/// The returned `String` (e.g. `"__mc42__"`) is what appears in internal file paths
+/// and must be passed to [`strip_unique_prefix`] when rendering diagnostics.
+pub(crate) fn next_call_prefix() -> String {
+    let counter = CALL_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("{CALL_PATH_PREFIX}{counter}{CALL_PATH_SEP}")
+}
+
+/// Remove every `__mc<digits>__` segment from `rendered`.
+///
+/// Used by `TypeCheckingDiagnostics` to hide the internal uniquifying prefix from
+/// the end-user — file paths in error output should read `main.py`, not
+/// `__mc42__main.py`. Implemented as a hand-rolled scanner to avoid pulling in a
+/// regex crate for a trivial pattern.
+pub(crate) fn strip_unique_prefix(rendered: &str) -> String {
+    let mut out = String::with_capacity(rendered.len());
+    let mut cursor = 0;
+    let bytes = rendered.as_bytes();
+    while let Some(start_rel) = rendered[cursor..].find(CALL_PATH_PREFIX) {
+        let start = cursor + start_rel;
+        out.push_str(&rendered[cursor..start]);
+        let after_prefix = start + CALL_PATH_PREFIX.len();
+        let mut digit_end = after_prefix;
+        while digit_end < bytes.len() && bytes[digit_end].is_ascii_digit() {
+            digit_end += 1;
+        }
+        // Only strip when we have at least one digit followed by the separator — otherwise
+        // `__mc` is an ordinary substring (e.g. appearing in user code) and should stay.
+        if digit_end > after_prefix && rendered[digit_end..].starts_with(CALL_PATH_SEP) {
+            cursor = digit_end + CALL_PATH_SEP.len();
+        } else {
+            out.push_str(CALL_PATH_PREFIX);
+            cursor = after_prefix;
+        }
+    }
+    out.push_str(&rendered[cursor..]);
+    out
+}
 
 /// Very simple in-memory salsa/ty database.
 ///
@@ -51,6 +121,81 @@ impl MemoryDb {
             analysis_settings: AnalysisSettings::default().into(),
         }
     }
+}
+
+/// The single process-wide type-checking database.
+///
+/// ## Why one shared db instead of "clone-per-call"?
+///
+/// Salsa's input setters (what `write_file` ultimately calls) require exclusive access to
+/// the underlying `Arc<Zalsa>` via `Arc::get_mut`. If anything else holds a clone of the
+/// storage, `get_mut` fails and salsa's `cancel_others()` waits indefinitely for the other
+/// handles to drop — a single long-lived "warm template" whose handle never drops would
+/// deadlock the very next write, even from a single-threaded caller. So instead we keep
+/// **one** `MemoryDb` behind a [`Mutex`] and serialize all `type_check` calls through it.
+///
+/// ## How correctness is preserved across calls
+///
+/// Each call writes its user code to a path containing a unique counter (see
+/// [`next_call_prefix`]), which creates a fresh salsa `File` ingredient per call.
+/// That means memos computed for call 1's `File` can never be accidentally returned
+/// for call 2's `File` (different salsa key), so diagnostics produced by an earlier
+/// call continue to render correctly even after later calls have run — they query
+/// their own `File`'s source text, which still lives in the shared in-memory fs.
+///
+/// ## Warmup
+///
+/// First access runs `build_warm_db`, which initializes the salsa `Program` singleton,
+/// resolves vendored typeshed search paths, and runs `check_types` on a trivial snippet
+/// referencing the common builtins (`int`, `str`, etc.). This populates the salsa memo
+/// table so the first *real* call doesn't pay the stdlib parse cost.
+pub(crate) fn global_db() -> &'static Mutex<MemoryDb> {
+    static GLOBAL_DB: OnceLock<Mutex<MemoryDb>> = OnceLock::new();
+    GLOBAL_DB.get_or_init(|| Mutex::new(build_warm_db()))
+}
+
+/// Build the one-shot warm database. Runs once behind the [`global_db`] `OnceLock`.
+fn build_warm_db() -> MemoryDb {
+    let mut db = MemoryDb::new();
+    let src_root = SystemPathBuf::from(SRC_ROOT);
+    db.files().try_add_root(&db, &src_root, FileRootKind::Project);
+
+    let search_paths = SearchPathSettings::new(vec![src_root])
+        .to_search_paths(db.system(), db.vendored())
+        .expect("vendored typeshed search paths always resolve");
+
+    Program::from_settings(
+        &db,
+        ProgramSettings {
+            python_version: PythonVersionWithSource {
+                version: db.python_version(),
+                source: PythonVersionSource::default(),
+            },
+            python_platform: PythonPlatform::default(),
+            search_paths,
+        },
+    );
+
+    // Prewarm: parse and analyze the stdlib stubs every real call transitively touches.
+    // The warmup references the most common builtin types (`int`, `str`, `float`, `list`,
+    // `dict`, `bool`) so typechecking resolves them from typeshed's `builtins.pyi` /
+    // `typing.pyi` / `types.pyi` and caches the resulting semantic graph. These memos
+    // live in the db's salsa storage and are reused by every subsequent `type_check`
+    // call, so the first real call doesn't pay the stdlib parse cost.
+    let warmup_code = "\
+x: int = 0
+y: str = ''
+z: float = 0.0
+b: bool = False
+xs: list[int] = []
+d: dict[str, int] = {}
+";
+    let warmup = SystemPathBuf::from(WARMUP_PATH);
+    db.write_file(&warmup, warmup_code).expect("warmup write");
+    let warmup_file = system_path_to_file(&db, &warmup).expect("warmup file");
+    let _ = check_types(&db, warmup_file);
+
+    db
 }
 
 impl DbWithTestSystem for MemoryDb {

--- a/crates/monty-type-checking/src/lib.rs
+++ b/crates/monty-type-checking/src/lib.rs
@@ -1,4 +1,5 @@
 mod db;
+mod pool;
 mod type_check;
 
 pub use crate::type_check::{SourceFile, TypeCheckingDiagnostics, type_check};

--- a/crates/monty-type-checking/src/pool.rs
+++ b/crates/monty-type-checking/src/pool.rs
@@ -1,24 +1,16 @@
 use std::{
-    fmt::Display,
+    fmt::{self, Display},
     io::ErrorKind,
+    mem,
     sync::{Mutex, OnceLock},
 };
 
 use ruff_db::{
-    Db as SourceDb,
-    files::{File, FileRootKind, system_path_to_file},
+    files::{File, system_path_to_file},
     system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPathBuf},
 };
-use ty_module_resolver::SearchPathSettings;
-use ty_python_semantic::{Program, ProgramSettings, PythonPlatform, PythonVersionSource, PythonVersionWithSource};
 
-use crate::db::MemoryDb;
-
-/// Virtual source root used for all in-memory type-checking files.
-///
-/// The reusable database pool only supports root-level user files, so every public
-/// `SourceFile.path` is mapped directly under `/`.
-pub(crate) const SRC_ROOT: &str = "/";
+use crate::db::{MemoryDb, SRC_ROOT};
 
 /// Maximum number of reusable `MemoryDb` instances kept in the process-wide pool.
 ///
@@ -52,7 +44,7 @@ impl MemoryDbPool {
         };
 
         Ok(PooledMemoryDb {
-            db: maybe_db.unwrap_or_else(build_pooled_db),
+            db: Some(maybe_db.unwrap_or_default()),
             pool: self,
             touched_files: Vec::new(),
         })
@@ -70,13 +62,30 @@ impl MemoryDbPool {
 
 /// Exclusive lease for one pooled database.
 ///
-/// The caller must return the lease with [`Self::finish`], which scrubs the files
-/// written during the run before releasing the db back to the pool. Dropping the
-/// lease without calling `finish` discards the db, which is the panic-safe fallback.
+/// On [`Drop`] the lease scrubs every file that was written during its lifetime
+/// and, if cleanup succeeded, returns the database to the global pool. A db whose
+/// cleanup fails is intentionally discarded — a contaminated db must never re-enter
+/// the pool because it would poison every subsequent type-check.
+///
+/// This RAII pattern lets `TypeCheckingDiagnostics` keep the lease alive across the
+/// entire lifetime of a returned diagnostics object (so lazy rendering still works
+/// against the live db) and the db is released exactly when the diagnostics are no
+/// longer reachable.
 pub(crate) struct PooledMemoryDb {
-    db: MemoryDb,
+    /// `Option` so `Drop` can move the db out into the pool without leaving an
+    /// empty placeholder `MemoryDb` behind. Always `Some` while the lease is
+    /// observable to the rest of the codebase.
+    db: Option<MemoryDb>,
     pool: &'static MemoryDbPool,
     touched_files: Vec<TouchedRootFile>,
+}
+
+impl fmt::Debug for PooledMemoryDb {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PooledMemoryDb")
+            .field("touched_files", &self.touched_files.len())
+            .finish_non_exhaustive()
+    }
 }
 
 impl PooledMemoryDb {
@@ -87,14 +96,13 @@ impl PooledMemoryDb {
 
     /// Write one root file into the db and remember it for mandatory cleanup.
     pub(crate) fn write_root_file(&mut self, path: &SystemPathBuf, source: &str) -> Result<File, String> {
-        self.db().write_file(path, source).map_err(to_string)?;
+        let db = self.db_mut();
+        db.write_file(path, source).map_err(to_string)?;
 
         // The write above succeeded, so interning the path must succeed — otherwise the
         // file would live in the db but be untracked, poisoning the pool on release, hence the panic.
-        let file = match system_path_to_file(self.db(), path) {
-            Ok(file) => file,
-            Err(e) => panic!("interning a just-written root file must succeed, DB in an unsafe state: {e}"),
-        };
+        let file = system_path_to_file(db, path)
+            .unwrap_or_else(|e| panic!("interning a just-written root file must succeed, DB in an unsafe state: {e}"));
 
         self.touched_files.push(TouchedRootFile::new(path.clone(), file));
         Ok(file)
@@ -111,65 +119,37 @@ impl PooledMemoryDb {
             self.touched_files.iter().any(|t| &t.path == path),
             "rewrite_root_file called for untracked path '{path}' — must call write_root_file first",
         );
-        self.db().write_file(path, source).map_err(to_string)
+        self.db_mut().write_file(path, source).map_err(to_string)
     }
 
-    /// Borrow the checked-out database mutably for one type-check run.
-    pub(crate) fn db(&mut self) -> &mut MemoryDb {
-        &mut self.db
+    /// Borrow the checked-out database (e.g. for `check_types` or rendering).
+    pub(crate) fn db(&self) -> &MemoryDb {
+        self.db.as_ref().expect("db is only None inside Drop")
     }
 
-    /// Scrub the run's temporary files, optionally return the db to the pool, and
-    /// then forward the caller's original result.
-    pub(crate) fn finish<T>(self, run_result: Result<T, String>) -> Result<T, String> {
-        let Self {
-            mut db,
-            pool,
-            touched_files,
-        } = self;
-
-        let cleanup_result = cleanup_touched_files(&mut db, &touched_files);
-        if cleanup_result.is_ok() {
-            pool.release(db)?;
-        }
-
-        match (run_result, cleanup_result) {
-            (Ok(result), Ok(())) => Ok(result),
-            (Ok(_), Err(cleanup_err)) => Err(cleanup_err),
-            (Err(run_err), Ok(())) => Err(run_err),
-            (Err(run_err), Err(cleanup_err)) => Err(format!("{run_err}\ncleanup error: {cleanup_err}")),
-        }
+    fn db_mut(&mut self) -> &mut MemoryDb {
+        self.db.as_mut().expect("db is only None inside Drop")
     }
 }
 
-/// Build one fresh database ready to enter the pool.
-///
-/// This sets up the source root and `Program` settings, but it intentionally does
-/// not run a synthetic type-check. The first real caller that uses a brand new db
-/// pays the cold-start cost; subsequent pooled reuses benefit from the populated
-/// Salsa caches created by real user work.
-fn build_pooled_db() -> MemoryDb {
-    let db = MemoryDb::default();
-    let src_root = SystemPathBuf::from(SRC_ROOT);
-    db.files().try_add_root(&db, &src_root, FileRootKind::Project);
+impl Drop for PooledMemoryDb {
+    fn drop(&mut self) {
+        // `Drop` only gives us `&mut self`. Take the db out of the `Option` so we own
+        // it for cleanup and release, leaving `None` behind for the implicit drop of
+        // `self`'s remaining fields.
+        let Some(mut db) = self.db.take() else { return };
+        let touched_files = mem::take(&mut self.touched_files);
 
-    let search_paths = SearchPathSettings::new(vec![src_root])
-        .to_search_paths(db.system(), db.vendored())
-        .expect("vendored typeshed search paths always resolve");
-
-    Program::from_settings(
-        &db,
-        ProgramSettings {
-            python_version: PythonVersionWithSource {
-                version: db.python_version(),
-                source: PythonVersionSource::default(),
-            },
-            python_platform: PythonPlatform::default(),
-            search_paths,
-        },
-    );
-
-    db
+        // Cleanup or release failures leave the global pool in a state we cannot
+        // reason about, so we panic loudly. Drop-time panics will abort if they
+        // happen during unwinding from another panic, which is the desired behavior:
+        // a poisoned pool is worse than aborting the process.
+        cleanup_touched_files(&mut db, &touched_files)
+            .unwrap_or_else(|err| panic!("monty type-check pool: failed to scrub db on drop: {err}"));
+        self.pool
+            .release(db)
+            .unwrap_or_else(|err| panic!("monty type-check pool: failed to release db on drop: {err}"));
+    }
 }
 
 /// File written into a pooled database during one type-check run.
@@ -255,18 +235,18 @@ mod tests {
             system_path_to_file(pooled.db(), &path).is_ok(),
             "file should be visible within the run that wrote it",
         );
-        pooled.finish::<()>(Ok(())).expect("finish first run");
+        drop(pooled);
 
         assert_eq!(pool_len(), 1, "scrubbed db should be released back to the pool");
 
         // Second checkout pops the only entry, so we are guaranteed the same db.
-        let mut pooled = PooledMemoryDb::checkout().expect("re-checkout");
+        let pooled = PooledMemoryDb::checkout().expect("re-checkout");
         assert_eq!(pool_len(), 0, "pool should be empty after re-checkout");
         assert!(
             matches!(system_path_to_file(pooled.db(), &path), Err(FileError::NotFound)),
             "previous run's file must not be visible in the reused db",
         );
-        pooled.finish::<()>(Ok(())).expect("finish second run");
+        drop(pooled);
 
         drain_pool();
     }

--- a/crates/monty-type-checking/src/pool.rs
+++ b/crates/monty-type-checking/src/pool.rs
@@ -1,0 +1,236 @@
+use std::{
+    fmt::Display,
+    io::ErrorKind,
+    sync::{Mutex, OnceLock},
+};
+
+use ruff_db::{
+    Db as SourceDb,
+    files::{File, FileRootKind, system_path_to_file},
+    system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPathBuf},
+};
+use ty_module_resolver::SearchPathSettings;
+use ty_python_semantic::{Program, ProgramSettings, PythonPlatform, PythonVersionSource, PythonVersionWithSource};
+
+use crate::db::MemoryDb;
+
+/// Virtual source root used for all in-memory type-checking files.
+///
+/// The reusable database pool only supports root-level user files, so every public
+/// `SourceFile.path` is mapped directly under `/`.
+pub(crate) const SRC_ROOT: &str = "/";
+
+/// Maximum number of reusable `MemoryDb` instances kept in the process-wide pool.
+///
+/// The pool is intentionally small because every reused database retains its own
+/// Salsa memo graph and typeshed-derived semantic state.
+const MAX_POOLED_DBS: usize = 8;
+
+/// File written into a pooled database during one type-check run.
+///
+/// Cleanup uses both the path and, when available, the interned `File` handle to
+/// make sure Salsa observes the deletion before the db is returned to the pool.
+struct TouchedRootFile {
+    path: SystemPathBuf,
+    file: Option<File>,
+}
+
+impl TouchedRootFile {
+    /// Track a root file path that must be deleted before the db is reused.
+    fn new(path: SystemPathBuf) -> Self {
+        Self { path, file: None }
+    }
+}
+
+/// Pool of reusable databases for root-file type checking.
+///
+/// Each checked-out db is owned by exactly one caller until it is either returned
+/// clean or dropped. This keeps Salsa's single-writer invariant intact while still
+/// allowing concurrent type checks to use different databases.
+struct MemoryDbPool {
+    dbs: Mutex<Vec<MemoryDb>>,
+}
+
+impl MemoryDbPool {
+    /// Access the process-wide database pool.
+    fn global() -> &'static Self {
+        static GLOBAL_POOL: OnceLock<MemoryDbPool> = OnceLock::new();
+        GLOBAL_POOL.get_or_init(|| Self {
+            dbs: Mutex::new(Vec::new()),
+        })
+    }
+
+    /// Check out one pooled database, creating a fresh configured db if needed.
+    fn checkout(&'static self) -> Result<PooledMemoryDb, String> {
+        let maybe_db = {
+            let mut dbs = self.dbs.lock().map_err(|e| e.to_string())?;
+            dbs.pop()
+        };
+
+        Ok(PooledMemoryDb {
+            db: Some(maybe_db.unwrap_or_else(build_pooled_db)),
+            pool: self,
+        })
+    }
+
+    /// Return a fully scrubbed database to the pool if there is capacity left.
+    fn release(&self, db: MemoryDb) -> Result<(), String> {
+        let mut dbs = self.dbs.lock().map_err(|e| e.to_string())?;
+        if dbs.len() < MAX_POOLED_DBS {
+            dbs.push(db);
+        }
+        Ok(())
+    }
+}
+
+/// Exclusive lease for one pooled database.
+///
+/// The caller must only return the lease with [`Self::return_clean`] after all user
+/// files have been deleted and synced out of the in-memory filesystem. Dropping the
+/// lease without returning it discards the db, which is the panic-safe fallback.
+struct PooledMemoryDb {
+    db: Option<MemoryDb>,
+    pool: &'static MemoryDbPool,
+}
+
+impl PooledMemoryDb {
+    /// Borrow the checked-out database mutably for one type-check run.
+    fn db(&mut self) -> &mut MemoryDb {
+        self.db
+            .as_mut()
+            .expect("pooled memory db accessed after being returned")
+    }
+
+    /// Return a scrubbed database to the pool.
+    fn return_clean(mut self) -> Result<(), String> {
+        let db = self.db.take().expect("pooled memory db returned more than once");
+        self.pool.release(db)
+    }
+}
+
+/// Checked-out pooled database together with the files written during one run.
+///
+/// This wrapper lets `type_check.rs` write root files without carrying around its
+/// own cleanup bookkeeping. Calling [`Self::finish`] performs the required scrub.
+pub(crate) struct PooledTypeCheckDb {
+    lease: PooledMemoryDb,
+    touched_files: Vec<TouchedRootFile>,
+}
+
+impl PooledTypeCheckDb {
+    /// Check out a database from the global pool for one type-check run.
+    pub(crate) fn checkout() -> Result<Self, String> {
+        Ok(Self {
+            lease: MemoryDbPool::global().checkout()?,
+            touched_files: Vec::new(),
+        })
+    }
+
+    /// Borrow the checked-out database mutably.
+    pub(crate) fn db(&mut self) -> &mut MemoryDb {
+        self.lease.db()
+    }
+
+    /// Write one root file into the db and remember it for mandatory cleanup.
+    pub(crate) fn write_root_file(&mut self, path: &SystemPathBuf, source: &str) -> Result<File, String> {
+        self.lease.db().write_file(path, source).map_err(to_string)?;
+        self.touched_files.push(TouchedRootFile::new(path.clone()));
+
+        let file = system_path_to_file(self.lease.db(), path).map_err(to_string)?;
+        self.touched_files
+            .last_mut()
+            .expect("newly pushed touched file must exist")
+            .file = Some(file);
+
+        Ok(file)
+    }
+
+    /// Scrub the run's temporary files, optionally return the db to the pool, and
+    /// then forward the caller's original result.
+    pub(crate) fn finish<T>(self, result: Result<T, String>) -> Result<T, String> {
+        let Self {
+            mut lease,
+            touched_files,
+        } = self;
+
+        let cleanup = cleanup_touched_files(lease.db(), &touched_files);
+        if cleanup.is_ok() {
+            lease.return_clean()?;
+        }
+
+        combine_run_result(result, cleanup)
+    }
+}
+
+/// Build one fresh database ready to enter the pool.
+///
+/// This sets up the source root and `Program` settings, but it intentionally does
+/// not run a synthetic type-check. The first real caller that uses a brand new db
+/// pays the cold-start cost; subsequent pooled reuses benefit from the populated
+/// Salsa caches created by real user work.
+fn build_pooled_db() -> MemoryDb {
+    let db = MemoryDb::new();
+    let src_root = SystemPathBuf::from(SRC_ROOT);
+    db.files().try_add_root(&db, &src_root, FileRootKind::Project);
+
+    let search_paths = SearchPathSettings::new(vec![src_root])
+        .to_search_paths(db.system(), db.vendored())
+        .expect("vendored typeshed search paths always resolve");
+
+    Program::from_settings(
+        &db,
+        ProgramSettings {
+            python_version: PythonVersionWithSource {
+                version: db.python_version(),
+                source: PythonVersionSource::default(),
+            },
+            python_platform: PythonPlatform::default(),
+            search_paths,
+        },
+    );
+
+    db
+}
+
+/// Remove all files written during a type-check run and sync the filesystem changes.
+///
+/// Cleanup runs in reverse write order and always syncs `/` once at the end so root
+/// directory listings cannot leak between pooled sessions.
+fn cleanup_touched_files(db: &mut MemoryDb, touched_files: &[TouchedRootFile]) -> Result<(), String> {
+    for touched in touched_files.iter().rev() {
+        match db.memory_file_system().remove_file(&touched.path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(format!(
+                    "Failed to remove pooled type-check file '{}': {err}",
+                    touched.path
+                ));
+            }
+        }
+
+        if let Some(file) = touched.file {
+            file.sync(db);
+        } else {
+            File::sync_path(db, &touched.path);
+        }
+    }
+
+    File::sync_path(db, &SystemPathBuf::from(SRC_ROOT));
+    Ok(())
+}
+
+/// Merge the caller's result with the cleanup result without hiding either error.
+fn combine_run_result<T>(run_result: Result<T, String>, cleanup_result: Result<(), String>) -> Result<T, String> {
+    match (run_result, cleanup_result) {
+        (Ok(result), Ok(())) => Ok(result),
+        (Ok(_), Err(cleanup_err)) => Err(cleanup_err),
+        (Err(run_err), Ok(())) => Err(run_err),
+        (Err(run_err), Err(cleanup_err)) => Err(format!("{run_err}\ncleanup error: {cleanup_err}")),
+    }
+}
+
+/// Convert a displayable error into the string type used throughout pooling logic.
+fn to_string(err: impl Display) -> String {
+    err.to_string()
+}

--- a/crates/monty-type-checking/src/pool.rs
+++ b/crates/monty-type-checking/src/pool.rs
@@ -26,22 +26,6 @@ pub(crate) const SRC_ROOT: &str = "/";
 /// Salsa memo graph and typeshed-derived semantic state.
 const MAX_POOLED_DBS: usize = 8;
 
-/// File written into a pooled database during one type-check run.
-///
-/// Cleanup uses both the path and, when available, the interned `File` handle to
-/// make sure Salsa observes the deletion before the db is returned to the pool.
-struct TouchedRootFile {
-    path: SystemPathBuf,
-    file: Option<File>,
-}
-
-impl TouchedRootFile {
-    /// Track a root file path that must be deleted before the db is reused.
-    fn new(path: SystemPathBuf) -> Self {
-        Self { path, file: None }
-    }
-}
-
 /// Pool of reusable databases for root-file type checking.
 ///
 /// Each checked-out db is owned by exactly one caller until it is either returned
@@ -63,19 +47,20 @@ impl MemoryDbPool {
     /// Check out one pooled database, creating a fresh configured db if needed.
     fn checkout(&'static self) -> Result<PooledMemoryDb, String> {
         let maybe_db = {
-            let mut dbs = self.dbs.lock().map_err(|e| e.to_string())?;
+            let mut dbs = self.dbs.lock().map_err(to_string)?;
             dbs.pop()
         };
 
         Ok(PooledMemoryDb {
-            db: Some(maybe_db.unwrap_or_else(build_pooled_db)),
+            db: maybe_db.unwrap_or_else(build_pooled_db),
             pool: self,
+            touched_files: Vec::new(),
         })
     }
 
     /// Return a fully scrubbed database to the pool if there is capacity left.
     fn release(&self, db: MemoryDb) -> Result<(), String> {
-        let mut dbs = self.dbs.lock().map_err(|e| e.to_string())?;
+        let mut dbs = self.dbs.lock().map_err(to_string)?;
         if dbs.len() < MAX_POOLED_DBS {
             dbs.push(db);
         }
@@ -85,80 +70,61 @@ impl MemoryDbPool {
 
 /// Exclusive lease for one pooled database.
 ///
-/// The caller must only return the lease with [`Self::return_clean`] after all user
-/// files have been deleted and synced out of the in-memory filesystem. Dropping the
-/// lease without returning it discards the db, which is the panic-safe fallback.
-struct PooledMemoryDb {
-    db: Option<MemoryDb>,
+/// The caller must return the lease with [`Self::finish`], which scrubs the files
+/// written during the run before releasing the db back to the pool. Dropping the
+/// lease without calling `finish` discards the db, which is the panic-safe fallback.
+pub(crate) struct PooledMemoryDb {
+    db: MemoryDb,
     pool: &'static MemoryDbPool,
-}
-
-impl PooledMemoryDb {
-    /// Borrow the checked-out database mutably for one type-check run.
-    fn db(&mut self) -> &mut MemoryDb {
-        self.db
-            .as_mut()
-            .expect("pooled memory db accessed after being returned")
-    }
-
-    /// Return a scrubbed database to the pool.
-    fn return_clean(mut self) -> Result<(), String> {
-        let db = self.db.take().expect("pooled memory db returned more than once");
-        self.pool.release(db)
-    }
-}
-
-/// Checked-out pooled database together with the files written during one run.
-///
-/// This wrapper lets `type_check.rs` write root files without carrying around its
-/// own cleanup bookkeeping. Calling [`Self::finish`] performs the required scrub.
-pub(crate) struct PooledTypeCheckDb {
-    lease: PooledMemoryDb,
     touched_files: Vec<TouchedRootFile>,
 }
 
-impl PooledTypeCheckDb {
+impl PooledMemoryDb {
     /// Check out a database from the global pool for one type-check run.
     pub(crate) fn checkout() -> Result<Self, String> {
-        Ok(Self {
-            lease: MemoryDbPool::global().checkout()?,
-            touched_files: Vec::new(),
-        })
-    }
-
-    /// Borrow the checked-out database mutably.
-    pub(crate) fn db(&mut self) -> &mut MemoryDb {
-        self.lease.db()
+        MemoryDbPool::global().checkout()
     }
 
     /// Write one root file into the db and remember it for mandatory cleanup.
     pub(crate) fn write_root_file(&mut self, path: &SystemPathBuf, source: &str) -> Result<File, String> {
-        self.lease.db().write_file(path, source).map_err(to_string)?;
-        self.touched_files.push(TouchedRootFile::new(path.clone()));
+        self.db().write_file(path, source).map_err(to_string)?;
 
-        let file = system_path_to_file(self.lease.db(), path).map_err(to_string)?;
-        self.touched_files
-            .last_mut()
-            .expect("newly pushed touched file must exist")
-            .file = Some(file);
+        // The write above succeeded, so interning the path must succeed — otherwise the
+        // file would live in the db but be untracked, poisoning the pool on release, hence the panic.
+        let file = match system_path_to_file(self.db(), path) {
+            Ok(file) => file,
+            Err(e) => panic!("interning a just-written root file must succeed, DB in an unsafe state: {e}"),
+        };
 
+        self.touched_files.push(TouchedRootFile::new(path.clone(), file));
         Ok(file)
+    }
+
+    /// Borrow the checked-out database mutably for one type-check run.
+    pub(crate) fn db(&mut self) -> &mut MemoryDb {
+        &mut self.db
     }
 
     /// Scrub the run's temporary files, optionally return the db to the pool, and
     /// then forward the caller's original result.
-    pub(crate) fn finish<T>(self, result: Result<T, String>) -> Result<T, String> {
+    pub(crate) fn finish<T>(self, run_result: Result<T, String>) -> Result<T, String> {
         let Self {
-            mut lease,
+            mut db,
+            pool,
             touched_files,
         } = self;
 
-        let cleanup = cleanup_touched_files(lease.db(), &touched_files);
-        if cleanup.is_ok() {
-            lease.return_clean()?;
+        let cleanup_result = cleanup_touched_files(&mut db, &touched_files);
+        if cleanup_result.is_ok() {
+            pool.release(db)?;
         }
 
-        combine_run_result(result, cleanup)
+        match (run_result, cleanup_result) {
+            (Ok(result), Ok(())) => Ok(result),
+            (Ok(_), Err(cleanup_err)) => Err(cleanup_err),
+            (Err(run_err), Ok(())) => Err(run_err),
+            (Err(run_err), Err(cleanup_err)) => Err(format!("{run_err}\ncleanup error: {cleanup_err}")),
+        }
     }
 }
 
@@ -169,7 +135,7 @@ impl PooledTypeCheckDb {
 /// pays the cold-start cost; subsequent pooled reuses benefit from the populated
 /// Salsa caches created by real user work.
 fn build_pooled_db() -> MemoryDb {
-    let db = MemoryDb::new();
+    let db = MemoryDb::default();
     let src_root = SystemPathBuf::from(SRC_ROOT);
     db.files().try_add_root(&db, &src_root, FileRootKind::Project);
 
@@ -192,42 +158,49 @@ fn build_pooled_db() -> MemoryDb {
     db
 }
 
+/// File written into a pooled database during one type-check run.
+///
+/// The path is used to remove the file from the in-memory filesystem, and the
+/// interned `File` handle is then synced so Salsa observes the deletion before
+/// the db is returned to the pool.
+struct TouchedRootFile {
+    path: SystemPathBuf,
+    file: File,
+}
+
+impl TouchedRootFile {
+    /// Track a root file and its interned handle for mandatory cleanup.
+    fn new(path: SystemPathBuf, file: File) -> Self {
+        Self { path, file }
+    }
+
+    fn cleanup(&self, db: &mut MemoryDb) -> Result<(), String> {
+        match db.memory_file_system().remove_file(&self.path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(format!(
+                    "Failed to remove pooled type-check file '{}': {err}",
+                    self.path
+                ));
+            }
+        }
+        self.file.sync(db);
+        Ok(())
+    }
+}
+
 /// Remove all files written during a type-check run and sync the filesystem changes.
 ///
 /// Cleanup runs in reverse write order and always syncs `/` once at the end so root
 /// directory listings cannot leak between pooled sessions.
 fn cleanup_touched_files(db: &mut MemoryDb, touched_files: &[TouchedRootFile]) -> Result<(), String> {
     for touched in touched_files.iter().rev() {
-        match db.memory_file_system().remove_file(&touched.path) {
-            Ok(()) => {}
-            Err(err) if err.kind() == ErrorKind::NotFound => {}
-            Err(err) => {
-                return Err(format!(
-                    "Failed to remove pooled type-check file '{}': {err}",
-                    touched.path
-                ));
-            }
-        }
-
-        if let Some(file) = touched.file {
-            file.sync(db);
-        } else {
-            File::sync_path(db, &touched.path);
-        }
+        touched.cleanup(db)?;
     }
 
     File::sync_path(db, &SystemPathBuf::from(SRC_ROOT));
     Ok(())
-}
-
-/// Merge the caller's result with the cleanup result without hiding either error.
-fn combine_run_result<T>(run_result: Result<T, String>, cleanup_result: Result<(), String>) -> Result<T, String> {
-    match (run_result, cleanup_result) {
-        (Ok(result), Ok(())) => Ok(result),
-        (Ok(_), Err(cleanup_err)) => Err(cleanup_err),
-        (Err(run_err), Ok(())) => Err(run_err),
-        (Err(run_err), Err(cleanup_err)) => Err(format!("{run_err}\ncleanup error: {cleanup_err}")),
-    }
 }
 
 /// Convert a displayable error into the string type used throughout pooling logic.

--- a/crates/monty-type-checking/src/pool.rs
+++ b/crates/monty-type-checking/src/pool.rs
@@ -100,6 +100,20 @@ impl PooledMemoryDb {
         Ok(file)
     }
 
+    /// Overwrite the contents of a root file that was previously written via
+    /// [`Self::write_root_file`].
+    ///
+    /// Panics if `path` is not already tracked — the caller would otherwise be
+    /// leaving an untracked write behind that cleanup would miss, poisoning the
+    /// pool on release.
+    pub(crate) fn rewrite_root_file(&mut self, path: &SystemPathBuf, source: &str) -> Result<(), String> {
+        assert!(
+            self.touched_files.iter().any(|t| &t.path == path),
+            "rewrite_root_file called for untracked path '{path}' — must call write_root_file first",
+        );
+        self.db().write_file(path, source).map_err(to_string)
+    }
+
     /// Borrow the checked-out database mutably for one type-check run.
     pub(crate) fn db(&mut self) -> &mut MemoryDb {
         &mut self.db
@@ -203,8 +217,8 @@ fn cleanup_touched_files(db: &mut MemoryDb, touched_files: &[TouchedRootFile]) -
     Ok(())
 }
 
-/// Convert a displayable error into the string type used throughout pooling logic.
-fn to_string(err: impl Display) -> String {
+/// Convert a displayable error into the string type used throughout type checking.
+pub(crate) fn to_string(err: impl Display) -> String {
     err.to_string()
 }
 

--- a/crates/monty-type-checking/src/pool.rs
+++ b/crates/monty-type-checking/src/pool.rs
@@ -168,6 +168,14 @@ impl TouchedRootFile {
         Self { path, file }
     }
 
+    /// Remove the file from the in-memory filesystem, then walk its ancestor
+    /// chain and remove every directory under `SRC_ROOT` that has become empty.
+    ///
+    /// `remove_directory` requires the directory to be empty, so if two touched
+    /// files live in the same directory the first cleanup hits
+    /// `DirectoryNotEmpty` (silently swallowed) and the second succeeds once its
+    /// file is gone. This gives us correct cleanup without needing to sort paths
+    /// or coordinate across `TouchedRootFile`s.
     fn cleanup(&self, db: &mut MemoryDb) -> Result<(), String> {
         match db.memory_file_system().remove_file(&self.path) {
             Ok(()) => {}
@@ -180,14 +188,46 @@ impl TouchedRootFile {
             }
         }
         self.file.sync(db);
+
+        // Walk parents up to but not including SRC_ROOT, removing each empty directory
+        // and syncing its path so Salsa invalidates any cached directory listing.
+        let src_root = SystemPathBuf::from(SRC_ROOT);
+        let mut ancestor = self.path.parent();
+        while let Some(dir) = ancestor
+            && dir != src_root.as_path()
+        {
+            match db.memory_file_system().remove_directory(dir) {
+                Ok(()) => {}
+                // Another touched file still lives in this directory; it will be
+                // removed by a later `cleanup` call. Every ancestor above this
+                // one is necessarily also non-empty (they contain this directory),
+                // so there is no point walking further up.
+                //
+                // `MemoryFileSystem::remove_directory` reports "directory not
+                // empty" as `io::Error::other(...)` (kind `Other`), so we match on
+                // the message rather than on `ErrorKind::DirectoryNotEmpty`.
+                Err(err) if err.to_string().contains("directory not empty") => break,
+                // `NotFound` at this point would mean the directory never existed
+                // or was already removed, both of which indicate a logic bug
+                // (e.g. the same path tracked twice) — fail loudly.
+                Err(err) => {
+                    return Err(format!("Failed to remove pooled type-check directory '{dir}': {err}"));
+                }
+            }
+            File::sync_path(db, dir);
+            ancestor = dir.parent();
+        }
         Ok(())
     }
 }
 
 /// Remove all files written during a type-check run and sync the filesystem changes.
 ///
-/// Cleanup runs in reverse write order and always syncs `/` once at the end so root
-/// directory listings cannot leak between pooled sessions.
+/// Each `TouchedRootFile::cleanup` removes its own file and walks its ancestor
+/// chain up to `SRC_ROOT`, removing any directory that has become empty. Shared
+/// parent directories collapse naturally once the last file inside them is gone.
+/// We sync `SRC_ROOT` once at the end so the next pooled session cannot observe
+/// the previous root directory listing.
 fn cleanup_touched_files(db: &mut MemoryDb, touched_files: &[TouchedRootFile]) -> Result<(), String> {
     for touched in touched_files.iter().rev() {
         touched.cleanup(db)?;
@@ -206,7 +246,7 @@ pub(crate) fn to_string(err: impl Display) -> String {
 mod tests {
     use std::{ptr, sync::Mutex};
 
-    use ruff_db::files::FileError;
+    use ruff_db::{files::FileError, system::SystemPath};
 
     use super::*;
 
@@ -245,6 +285,93 @@ mod tests {
         assert!(
             matches!(system_path_to_file(pooled.db(), &path), Err(FileError::NotFound)),
             "previous run's file must not be visible in the reused db",
+        );
+        drop(pooled);
+
+        drain_pool();
+    }
+
+    /// Nested file should be removed AND its parent directory collapsed, so a
+    /// reused db cannot tell the previous run's module structure ever existed.
+    #[test]
+    fn nested_file_cleanup_removes_parent_directory() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        drain_pool();
+
+        let path = SystemPathBuf::from("/sub_dir/nested.py");
+
+        let mut pooled = PooledMemoryDb::checkout().expect("checkout");
+        pooled.write_root_file(&path, "x = 1\n").expect("write nested file");
+        assert!(pooled.db().memory_file_system().is_directory("/sub_dir"));
+        assert!(pooled.db().memory_file_system().is_file(&path));
+        drop(pooled);
+
+        // Pop the same db back out and confirm both file and parent dir are gone.
+        let pooled = PooledMemoryDb::checkout().expect("re-checkout");
+        let fs = pooled.db().memory_file_system();
+        assert!(!fs.exists(&path), "nested file must be removed after cleanup");
+        assert!(
+            !fs.is_directory(SystemPath::new("/sub_dir")),
+            "empty parent directory must be removed so it cannot leak into the next run"
+        );
+        drop(pooled);
+
+        drain_pool();
+    }
+
+    /// Deep nesting: the whole ancestor chain between the file and `/` should
+    /// collapse, leaving only `/` behind.
+    #[test]
+    fn deeply_nested_file_cleans_up_full_chain() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        drain_pool();
+
+        let path = SystemPathBuf::from("/a/b/c/deep.py");
+
+        let mut pooled = PooledMemoryDb::checkout().expect("checkout");
+        pooled
+            .write_root_file(&path, "x = 1\n")
+            .expect("write deeply nested file");
+        drop(pooled);
+
+        let pooled = PooledMemoryDb::checkout().expect("re-checkout");
+        let fs = pooled.db().memory_file_system();
+        for dir in ["/a/b/c", "/a/b", "/a"] {
+            assert!(
+                !fs.is_directory(SystemPath::new(dir)),
+                "ancestor directory '{dir}' must be removed after cleanup"
+            );
+        }
+        assert!(fs.is_directory(SystemPath::new("/")), "SRC_ROOT itself must stay");
+        drop(pooled);
+
+        drain_pool();
+    }
+
+    /// Two touched files in the same parent dir: the first cleanup hits
+    /// `DirectoryNotEmpty` (silently tolerated), the second cleanup finally
+    /// removes the now-empty directory.
+    #[test]
+    fn shared_parent_directory_collapses_when_last_file_removed() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        drain_pool();
+
+        let a = SystemPathBuf::from("/shared/a.py");
+        let b = SystemPathBuf::from("/shared/b.py");
+
+        let mut pooled = PooledMemoryDb::checkout().expect("checkout");
+        pooled.write_root_file(&a, "x = 1\n").expect("write a");
+        pooled.write_root_file(&b, "y = 2\n").expect("write b");
+        assert!(pooled.db().memory_file_system().is_directory("/shared"));
+        drop(pooled);
+
+        let pooled = PooledMemoryDb::checkout().expect("re-checkout");
+        let fs = pooled.db().memory_file_system();
+        assert!(!fs.exists(&a));
+        assert!(!fs.exists(&b));
+        assert!(
+            !fs.is_directory(SystemPath::new("/shared")),
+            "shared parent must be removed once both files are gone",
         );
         drop(pooled);
 

--- a/crates/monty-type-checking/src/pool.rs
+++ b/crates/monty-type-checking/src/pool.rs
@@ -207,3 +207,61 @@ fn cleanup_touched_files(db: &mut MemoryDb, touched_files: &[TouchedRootFile]) -
 fn to_string(err: impl Display) -> String {
     err.to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{ptr, sync::Mutex};
+
+    use ruff_db::files::FileError;
+
+    use super::*;
+
+    /// Serializes tests that manipulate the process-wide pool so they observe a
+    /// deterministic pool state rather than racing with each other.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn pool_is_global_singleton() {
+        assert!(
+            ptr::eq(MemoryDbPool::global(), MemoryDbPool::global()),
+            "global pool must resolve to the same instance on every call",
+        );
+    }
+
+    #[test]
+    fn reused_db_does_not_leak_previous_files() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        drain_pool();
+
+        let path = SystemPathBuf::from("/pool_test_reuse.py");
+
+        let mut pooled = PooledMemoryDb::checkout().expect("initial checkout");
+        pooled.write_root_file(&path, "x = 1\n").expect("write root file");
+        assert!(
+            system_path_to_file(pooled.db(), &path).is_ok(),
+            "file should be visible within the run that wrote it",
+        );
+        pooled.finish::<()>(Ok(())).expect("finish first run");
+
+        assert_eq!(pool_len(), 1, "scrubbed db should be released back to the pool");
+
+        // Second checkout pops the only entry, so we are guaranteed the same db.
+        let mut pooled = PooledMemoryDb::checkout().expect("re-checkout");
+        assert_eq!(pool_len(), 0, "pool should be empty after re-checkout");
+        assert!(
+            matches!(system_path_to_file(pooled.db(), &path), Err(FileError::NotFound)),
+            "previous run's file must not be visible in the reused db",
+        );
+        pooled.finish::<()>(Ok(())).expect("finish second run");
+
+        drain_pool();
+    }
+
+    fn pool_len() -> usize {
+        MemoryDbPool::global().dbs.lock().unwrap().len()
+    }
+
+    fn drain_pool() {
+        MemoryDbPool::global().dbs.lock().unwrap().clear();
+    }
+}

--- a/crates/monty-type-checking/src/type_check.rs
+++ b/crates/monty-type-checking/src/type_check.rs
@@ -49,22 +49,19 @@ pub fn type_check(
     python_source: &SourceFile<'_>,
     stubs_file: Option<&SourceFile<'_>>,
 ) -> Result<Option<TypeCheckingDiagnostics>, String> {
-    // Validate paths up front so checkout cost isn't paid for an invalid call,
-    // and so cleanup never has to deal with paths that escape the source root.
-    let main_path = validate_root_file_name(python_source.path, "source")?;
-    let stubs_path = stubs_file
-        .map(|s| validate_root_file_name(s.path, "stub"))
-        .transpose()?;
-
     // Check out a pre-configured db from the global pool. The `Drop` impl on
-    // `PooledMemoryDb` scrubs every file we write below and returns the db to
-    // the pool when the lease is no longer reachable — either at the end of this
-    // function (clean run) or when the returned `TypeCheckingDiagnostics` is dropped.
+    // `PooledMemoryDb` scrubs every file (and now also every parent directory) we
+    // write below and returns the db to the pool when the lease is no longer
+    // reachable — either at the end of this function (clean run) or when the
+    // returned `TypeCheckingDiagnostics` is dropped.
     let mut pooled_db = PooledMemoryDb::checkout()?;
 
+    let src_root = SystemPathBuf::from(SRC_ROOT);
+    let main_path = src_root.join(python_source.path);
     let main_source = python_source.source_code;
 
-    let (main_file, code_offset): (File, u32) = if let Some((stubs_file, stubs_path)) = stubs_file.zip(stubs_path) {
+    let (main_file, code_offset): (File, u32) = if let Some(stubs_file) = stubs_file {
+        let stubs_path = src_root.join(stubs_file.path);
         pooled_db.write_root_file(&stubs_path, stubs_file.source_code)?;
 
         // prepend the stub import to the main source code
@@ -116,30 +113,6 @@ pub fn type_check(
 
         Ok(Some(TypeCheckingDiagnostics::new(diagnostics, pooled_db)))
     }
-}
-
-/// Validate that `path` names a single root-level file suitable for the pooled db.
-///
-/// The pool tracks every written file by exact path and removes them on release;
-/// allowing nested or absolute paths would let stale directory entries leak
-/// between calls and could be used to alias real host paths if the underlying
-/// filesystem ever changed. Reject anything that is not a simple file name.
-fn validate_root_file_name(path: &str, role: &str) -> Result<SystemPathBuf, String> {
-    if path.is_empty() {
-        return Err(format!("Type checking {role} file name cannot be empty"));
-    }
-    if path.contains('\0') {
-        return Err(format!(
-            "Type checking {role} file name must not contain NUL bytes, got '{}'",
-            path.escape_debug()
-        ));
-    }
-    if path == "." || path == ".." || path.contains('/') || path.contains('\\') {
-        return Err(format!(
-            "Type checking only supports root-level {role} file names, got '{path}'"
-        ));
-    }
-    Ok(SystemPathBuf::from(SRC_ROOT).join(path))
 }
 
 /// Adjust the span of an annotation by subtracting the given offset.

--- a/crates/monty-type-checking/src/type_check.rs
+++ b/crates/monty-type-checking/src/type_check.rs
@@ -1,24 +1,17 @@
-use std::{
-    fmt::{self, Display},
-    sync::{Arc, Mutex},
-};
+use std::fmt::{self, Display};
 
 use ruff_db::{
-    Db as SourceDb,
     diagnostic::{
         Annotation, Diagnostic, DiagnosticFormat, DiagnosticId, DisplayDiagnosticConfig, DisplayDiagnostics,
         UnifiedFile,
     },
-    files::{File, FileRootKind, system_path_to_file},
+    files::{File, system_path_to_file},
     system::{DbWithWritableSystem as _, SystemPathBuf},
 };
 use ruff_text_size::{TextRange, TextSize};
-use ty_module_resolver::SearchPathSettings;
-use ty_python_semantic::{
-    Program, ProgramSettings, PythonPlatform, PythonVersionSource, PythonVersionWithSource, types::check_types,
-};
+use ty_python_semantic::types::check_types;
 
-use crate::db::MemoryDb;
+use crate::db::{SRC_ROOT, global_db, next_call_prefix, strip_unique_prefix};
 
 /// Definition of a source file.
 pub struct SourceFile<'a> {
@@ -38,6 +31,12 @@ impl<'a> SourceFile<'a> {
 
 /// Type check some python source code, checking if it's valid to run with monty.
 ///
+/// All `type_check` calls share the process-wide warm database (see [`global_db`])
+/// to amortize typeshed parsing across calls. Calls are serialized on a mutex so
+/// salsa's single-writer invariant holds, and each call writes to a unique internal
+/// path (prefixed with `__mc<N>__`) so its salsa `File` ingredient is independent
+/// of every other call's — diagnostics remain correct across concurrent holders.
+///
 /// # Arguments
 /// * `python_source` - The python source code to type check.
 /// * `stubs_file` - Optional stubs file to use for type checking.
@@ -50,49 +49,30 @@ pub fn type_check(
     python_source: &SourceFile<'_>,
     stubs_file: Option<&SourceFile<'_>>,
 ) -> Result<Option<TypeCheckingDiagnostics>, String> {
-    let mut db = MemoryDb::new();
+    let mut db = global_db().lock().map_err(|e| e.to_string())?;
+    let src_root = SystemPathBuf::from(SRC_ROOT);
+    let call_prefix = next_call_prefix();
 
-    // Files must be written under a directory that's registered as a search path for module
-    // resolution to work. We use "/" as the root directory so paths appear without a prefix.
-    let src_root = SystemPathBuf::from("/");
-
-    // Register the source root for Salsa tracking - required for module resolution
-    db.files().try_add_root(&db, &src_root, FileRootKind::Project);
-
-    let search_paths = SearchPathSettings::new(vec![src_root.clone()])
-        .to_search_paths(db.system(), db.vendored())
-        .map_err(to_string)?;
-
-    // The API is confusing here - we have to load the "program" here like this, otherwise we get unwrap
-    // panics when calling `check_types`
-    Program::from_settings(
-        &db,
-        ProgramSettings {
-            python_version: PythonVersionWithSource {
-                version: db.python_version(),
-                source: PythonVersionSource::default(),
-            },
-            python_platform: PythonPlatform::default(),
-            search_paths,
-        },
-    );
-
-    // Build absolute paths for files under /
-    let main_path = src_root.join(python_source.path);
+    // Per-call unique path — `__mc<N>__<user_path>` — prevents the call's `File`
+    // ingredient from colliding with any other call's and keeps earlier diagnostics
+    // valid after later calls have run.
+    let main_path = unique_path(&src_root, &call_prefix, python_source.path);
     let main_source = python_source.source_code;
 
     let code_offset: u32 = if let Some(stubs_file) = stubs_file {
-        let stubs_path = src_root.join(stubs_file.path);
+        let stubs_path = unique_path(&src_root, &call_prefix, stubs_file.path);
 
         // write the stub file
         db.write_file(&stubs_path, stubs_file.source_code).map_err(to_string)?;
 
-        // prepend the stub import to the main source code
-        let stub_stem = stubs_file
-            .path
+        // prepend the stub import to the main source code. Use the uniquified stub
+        // module name so the import resolves against this call's stub file only.
+        let stub_basename = stubs_file.path.rsplit('/').next().unwrap_or(stubs_file.path);
+        let stub_stem = stub_basename
             .split_once('.')
-            .map_or(stubs_file.path, |(before, _)| before);
-        let mut new_source = format!("from {stub_stem} import *\n");
+            .map_or(stub_basename, |(before, _)| before);
+        let unique_stub_module = format!("{call_prefix}{stub_stem}");
+        let mut new_source = format!("from {unique_stub_module} import *\n");
         let offset = u32::try_from(new_source.len()).map_err(to_string)?;
         new_source.push_str(main_source);
 
@@ -106,14 +86,14 @@ pub fn type_check(
         0
     };
 
-    let main_file = system_path_to_file(&db, &main_path).map_err(to_string)?;
-    let mut diagnostics = check_types(&db, main_file);
+    let main_file = system_path_to_file(&*db, &main_path).map_err(to_string)?;
+    let mut diagnostics = check_types(&*db, main_file);
     diagnostics.retain(filter_diagnostics);
 
     if diagnostics.is_empty() {
         Ok(None)
     } else {
-        // without all this errors would appear on the wrong line because we injected `from type_stubs import *`
+        // without all this errors would appear on the wrong line because we injected `from <stub> import *`
 
         // if we injected the stubs import, we need to write the actual source back to the file in the database
         db.write_file(&main_path, main_source).map_err(to_string)?;
@@ -134,10 +114,21 @@ pub fn type_check(
             }
         }
         // Sort diagnostics by line number
-        diagnostics.sort_by(|a, b| a.rendering_sort_key(&db).cmp(&b.rendering_sort_key(&db)));
+        diagnostics.sort_by(|a, b| a.rendering_sort_key(&*db).cmp(&b.rendering_sort_key(&*db)));
 
-        Ok(Some(TypeCheckingDiagnostics::new(diagnostics, db)))
+        Ok(Some(TypeCheckingDiagnostics::new(diagnostics)))
     }
+}
+
+/// Compose the per-call unique path for a user-supplied script name.
+///
+/// The prefix is applied to the basename so that `src/app.py` becomes
+/// `/__mc42__src/app.py` (not `/src/__mc42__app.py`) — simpler to strip and keeps
+/// rendered output close to the user's original path.
+fn unique_path(src_root: &SystemPathBuf, call_prefix: &str, user_path: &str) -> SystemPathBuf {
+    // Trim leading slashes so joining under src_root stays within the project.
+    let trimmed = user_path.trim_start_matches('/');
+    src_root.join(format!("{call_prefix}{trimmed}"))
 }
 
 fn to_string(err: impl Display) -> String {
@@ -163,12 +154,17 @@ fn adjust_annotation_span(ann: &mut Annotation, main_file: File, offset: TextSiz
 }
 
 /// Represents diagnostic details when type checking fails.
+///
+/// Doesn't hold a database clone: rendering acquires the process-wide [`global_db`]
+/// mutex on demand. This matters for correctness — an `Arc<MemoryDb>` captured here
+/// would pin salsa's `Arc<Zalsa>` refcount above 1 and deadlock the next `write_file`
+/// setter (salsa's `Arc::get_mut` spins until refcount drops to 1). The diagnostic's
+/// `File` ingredients are unique per call, so re-querying the db at display time
+/// still returns the original source text produced during this diagnostic's call.
 #[derive(Clone)]
 pub struct TypeCheckingDiagnostics {
     /// The actual diagnostic message
     diagnostics: Vec<Diagnostic>,
-    /// db used to display diagnostics, wrapped in Mutex for Sync so MontyTypingError is sendable
-    db: Arc<Mutex<MemoryDb>>,
     /// How to format the output
     format: DiagnosticFormat,
     /// Whether to highlight the output with ansi colors
@@ -180,13 +176,7 @@ pub struct TypeCheckingDiagnostics {
 /// raw errors are not useful to end users.
 impl fmt::Debug for TypeCheckingDiagnostics {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let config = self.config();
-        let db = self.db.lock().unwrap();
-        write!(
-            f,
-            "TypeCheckingDiagnostics:\n{}",
-            DisplayDiagnostics::new(&*db, &config, &self.diagnostics)
-        )
+        write!(f, "TypeCheckingDiagnostics:\n{self}")
     }
 }
 
@@ -195,23 +185,26 @@ impl fmt::Debug for TypeCheckingDiagnostics {
 #[expect(dead_code)]
 pub struct DebugTypeCheckingDiagnostics<'a> {
     diagnostics: &'a [Diagnostic],
-    db: Arc<Mutex<MemoryDb>>,
     format: DiagnosticFormat,
     color: bool,
 }
 
 impl fmt::Display for TypeCheckingDiagnostics {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let db = self.db.lock().unwrap();
-        DisplayDiagnostics::new(&*db, &self.config(), &self.diagnostics).fmt(f)
+        let rendered = {
+            let db = global_db().lock().expect("global db mutex poisoned");
+            DisplayDiagnostics::new(&*db, &self.config(), &self.diagnostics).to_string()
+        };
+        // Hide the internal `__mc<N>__` uniquifying prefix from user-visible output so
+        // file paths in error messages read `main.py`, not `__mc42__main.py`.
+        f.write_str(&strip_unique_prefix(&rendered))
     }
 }
 
 impl TypeCheckingDiagnostics {
-    fn new(diagnostics: Vec<Diagnostic>, db: MemoryDb) -> Self {
+    fn new(diagnostics: Vec<Diagnostic>) -> Self {
         Self {
             diagnostics,
-            db: Arc::new(Mutex::new(db)),
             format: DiagnosticFormat::Full,
             color: false,
         }
@@ -228,7 +221,6 @@ impl TypeCheckingDiagnostics {
     pub fn debug_details(&self) -> DebugTypeCheckingDiagnostics<'_> {
         DebugTypeCheckingDiagnostics {
             diagnostics: &self.diagnostics,
-            db: self.db.clone(),
             format: self.format,
             color: self.color,
         }

--- a/crates/monty-type-checking/src/type_check.rs
+++ b/crates/monty-type-checking/src/type_check.rs
@@ -1,4 +1,7 @@
-use std::{fmt, sync::Arc};
+use std::{
+    fmt,
+    sync::{Arc, Mutex},
+};
 
 use ruff_db::{
     diagnostic::{
@@ -12,130 +15,72 @@ use ruff_text_size::{TextRange, TextSize};
 use ty_python_semantic::types::check_types;
 
 use crate::{
-    db::MemoryDb,
-    pool::{PooledMemoryDb, SRC_ROOT, to_string},
+    db::SRC_ROOT,
+    pool::{PooledMemoryDb, to_string},
 };
 
-/// All diagnostic formats supported by `TypeCheckingDiagnostics`.
-const SUPPORTED_FORMATS: [DiagnosticFormat; 9] = [
-    DiagnosticFormat::Full,
-    DiagnosticFormat::Concise,
-    DiagnosticFormat::Azure,
-    DiagnosticFormat::Json,
-    DiagnosticFormat::JsonLines,
-    DiagnosticFormat::Rdjson,
-    DiagnosticFormat::Pylint,
-    DiagnosticFormat::Gitlab,
-    DiagnosticFormat::Github,
-];
-
-/// Definition of a source file used by the Monty type-checking wrapper.
+/// Definition of a source file.
 pub struct SourceFile<'a> {
-    /// Python source code to type check.
+    /// source code
     pub source_code: &'a str,
-    /// User-visible file name used for diagnostics and module resolution.
+    /// file path
     pub path: &'a str,
 }
 
 impl<'a> SourceFile<'a> {
-    /// Create a new source file value.
+    /// Create a new source file.
     #[must_use]
     pub fn new(source_code: &'a str, path: &'a str) -> Self {
         Self { source_code, path }
     }
 }
 
-/// Pre-rendered diagnostic strings detached from the live Salsa database.
-///
-/// Every supported `(format, color)` pair is rendered while the database is still
-/// alive, which lets pooled databases be scrubbed immediately after type checking.
-struct RenderedDiagnostics {
-    plain: [String; SUPPORTED_FORMATS.len()],
-    color: [String; SUPPORTED_FORMATS.len()],
-}
-
-impl RenderedDiagnostics {
-    /// Render all supported format/color combinations against the current db state.
-    fn new(db: &MemoryDb, diagnostics: &[Diagnostic]) -> Self {
-        Self {
-            plain: SUPPORTED_FORMATS.map(|format| render_diagnostics(db, diagnostics, format, false)),
-            color: SUPPORTED_FORMATS.map(|format| render_diagnostics(db, diagnostics, format, true)),
-        }
-    }
-
-    /// Return the pre-rendered output for the requested format and color mode.
-    fn get(&self, format: DiagnosticFormat, color: bool) -> &str {
-        let index = diagnostic_format_index(format);
-        if color { &self.color[index] } else { &self.plain[index] }
-    }
-}
-
-/// Type check some Python source code, checking if it's valid to run with Monty.
-///
-/// Every call checks out one database from the process-wide pool, writes the
-/// root-level source files into that db, renders any diagnostics eagerly, deletes
-/// the temporary files again, and finally returns the scrubbed db to the pool.
+/// Type check some python source code, checking if it's valid to run with monty.
 ///
 /// # Arguments
-/// * `python_source` - The Python source code to type check.
-/// * `stubs_file` - Optional stubs file to import during type checking.
+/// * `python_source` - The python source code to type check.
+/// * `stubs_file` - Optional stubs file to use for type checking.
 ///
 /// # Returns
-/// * `Ok(Some(TypeCheckingDiagnostics))` - The code contains typing errors.
-/// * `Ok(None)` - The code type-checks cleanly.
-/// * `Err(String)` - An unexpected/internal error occurred while type checking.
+/// * `Ok(Some(TypeCheckingFailure))` - If there are typing errors.
+/// * `Ok(None)` - If there are no typing errors.
+/// * `Err(String)` - If there was an unexpected/internal error during type checking.
 pub fn type_check(
     python_source: &SourceFile<'_>,
     stubs_file: Option<&SourceFile<'_>>,
 ) -> Result<Option<TypeCheckingDiagnostics>, String> {
+    // Validate paths up front so checkout cost isn't paid for an invalid call,
+    // and so cleanup never has to deal with paths that escape the source root.
     let main_path = validate_root_file_name(python_source.path, "source")?;
     let stubs_path = stubs_file
-        .map(|stubs_file| validate_root_file_name(stubs_file.path, "stub"))
+        .map(|s| validate_root_file_name(s.path, "stub"))
         .transpose()?;
 
-    if stubs_path.as_ref().is_some_and(|path| path == &main_path) {
-        return Err(format!(
-            "Type checking source and stubs must use different root file names: '{}'",
-            python_source.path
-        ));
-    }
-
+    // Check out a pre-configured db from the global pool. The `Drop` impl on
+    // `PooledMemoryDb` scrubs every root file we write below and returns the db to
+    // the pool when the lease is no longer reachable — either at the end of this
+    // function (clean run) or when the returned `TypeCheckingDiagnostics` is dropped.
     let mut pooled_db = PooledMemoryDb::checkout()?;
-    let result = type_check_with_db(
-        &mut pooled_db,
-        python_source,
-        &main_path,
-        stubs_file.zip(stubs_path.as_ref()),
-    );
-    pooled_db.finish(result)
-}
 
-/// Run one type-check operation against a checked-out pooled database.
-///
-/// The caller provides already-validated root file paths, while the pooled wrapper
-/// owns the temporary-file bookkeeping needed for cleanup.
-fn type_check_with_db(
-    pooled_db: &mut PooledMemoryDb,
-    python_source: &SourceFile<'_>,
-    main_path: &SystemPathBuf,
-    stubs_file: Option<(&SourceFile<'_>, &SystemPathBuf)>,
-) -> Result<Option<TypeCheckingDiagnostics>, String> {
     let main_source = python_source.source_code;
 
-    let (main_file, code_offset) = if let Some((stubs_file, stubs_path)) = stubs_file {
-        pooled_db.write_root_file(stubs_path, stubs_file.source_code)?;
+    let (main_file, code_offset): (File, u32) = if let Some((stubs_file, stubs_path)) = stubs_file.zip(stubs_path) {
+        pooled_db.write_root_file(&stubs_path, stubs_file.source_code)?;
 
-        // Import the stub module into the user's source so ty sees those definitions
-        // while keeping user-visible spans anchored to the original file later.
-        let stub_stem = module_stem(stubs_file.path);
+        // prepend the stub import to the main source code
+        let stub_stem = stubs_file
+            .path
+            .split_once('.')
+            .map_or(stubs_file.path, |(before, _)| before);
         let mut new_source = format!("from {stub_stem} import *\n");
         let offset = u32::try_from(new_source.len()).map_err(to_string)?;
         new_source.push_str(main_source);
 
-        let main_file = pooled_db.write_root_file(main_path, &new_source)?;
+        let main_file = pooled_db.write_root_file(&main_path, &new_source)?;
+        // one line offset for errors vs. the original source code since we injected the stub import
         (main_file, offset)
     } else {
-        let main_file = pooled_db.write_root_file(main_path, main_source)?;
+        let main_file = pooled_db.write_root_file(&main_path, main_source)?;
         (main_file, 0)
     };
 
@@ -146,17 +91,19 @@ fn type_check_with_db(
         return Ok(None);
     }
 
-    // The stub import only exists to seed names into the semantic model. Restore the
-    // original source text before rendering so detached diagnostics show user code.
-    // Route via `rewrite_root_file` so the tracking invariant is checked at runtime
-    // rather than relying on a hand-maintained comment.
+    // without all this errors would appear on the wrong line because we injected `from type_stubs import *`
+
+    // if we injected the stubs import, we need to write the actual source back to the file in the database
+    pooled_db.rewrite_root_file(&main_path, main_source)?;
+    // and then adjust each span in the error message to account for the injected stubs import
     if code_offset > 0 {
-        pooled_db.rewrite_root_file(main_path, main_source)?;
         let offset = TextSize::new(code_offset);
         for diagnostic in &mut diagnostics {
+            // Adjust spans in main diagnostic annotations (only for spans in the main file)
             for ann in diagnostic.annotations_mut() {
                 adjust_annotation_span(ann, main_file, offset);
             }
+            // Adjust spans in sub-diagnostic annotations (e.g., "info: Function defined here")
             for sub in diagnostic.sub_diagnostics_mut() {
                 for ann in sub.annotations_mut() {
                     adjust_annotation_span(ann, main_file, offset);
@@ -164,15 +111,21 @@ fn type_check_with_db(
             }
         }
     }
+    // Sort diagnostics by line number
+    diagnostics.sort_by(|a, b| {
+        a.rendering_sort_key(pooled_db.db())
+            .cmp(&b.rendering_sort_key(pooled_db.db()))
+    });
 
-    let db = pooled_db.db();
-    diagnostics.sort_by(|a, b| a.rendering_sort_key(db).cmp(&b.rendering_sort_key(db)));
-    let rendered = RenderedDiagnostics::new(db, &diagnostics);
-
-    Ok(Some(TypeCheckingDiagnostics::new(rendered)))
+    Ok(Some(TypeCheckingDiagnostics::new(diagnostics, pooled_db)))
 }
 
-/// Validate that `path` names a single root-level file suitable for pooled reuse.
+/// Validate that `path` names a single root-level file suitable for the pooled db.
+///
+/// The pool tracks every written file by exact path and removes them on release;
+/// allowing nested or absolute paths would let stale directory entries leak
+/// between calls and could be used to alias real host paths if the underlying
+/// filesystem ever changed. Reject anything that is not a simple file name.
 fn validate_root_file_name(path: &str, role: &str) -> Result<SystemPathBuf, String> {
     if path.is_empty() {
         return Err(format!("Type checking {role} file name cannot be empty"));
@@ -188,46 +141,17 @@ fn validate_root_file_name(path: &str, role: &str) -> Result<SystemPathBuf, Stri
             "Type checking only supports root-level {role} file names, got '{path}'"
         ));
     }
-
     Ok(SystemPathBuf::from(SRC_ROOT).join(path))
-}
-
-/// Return the importable module stem for a root-level stub file name.
-///
-/// Uses the first `.` as the split so `foo.stubs.pyi` becomes `foo` (matches
-/// Python's package-import semantics for root-level files — there is no
-/// `foo.stubs` module on disk).
-fn module_stem(file_name: &str) -> &str {
-    file_name.split_once('.').map_or(file_name, |(before, _)| before)
-}
-
-/// Render diagnostics with a specific format/color pair while the database is alive.
-fn render_diagnostics(db: &MemoryDb, diagnostics: &[Diagnostic], format: DiagnosticFormat, color: bool) -> String {
-    let config = DisplayDiagnosticConfig::new("monty").format(format).color(color);
-    DisplayDiagnostics::new(db, &config, diagnostics).to_string()
-}
-
-/// Convert a `DiagnosticFormat` to its slot in [`SUPPORTED_FORMATS`].
-fn diagnostic_format_index(format: DiagnosticFormat) -> usize {
-    match format {
-        DiagnosticFormat::Full => 0,
-        DiagnosticFormat::Concise => 1,
-        DiagnosticFormat::Azure => 2,
-        DiagnosticFormat::Json => 3,
-        DiagnosticFormat::JsonLines => 4,
-        DiagnosticFormat::Rdjson => 5,
-        DiagnosticFormat::Pylint => 6,
-        DiagnosticFormat::Gitlab => 7,
-        DiagnosticFormat::Github => 8,
-    }
 }
 
 /// Adjust the span of an annotation by subtracting the given offset.
 ///
-/// This compensates for the injected `from <stub> import *` line so diagnostics still
-/// point at the user's original source.
+/// This is used when we inject a stub import at the beginning of the source code,
+/// and need to adjust all spans to account for the injected code.
+/// Only adjusts spans that belong to the main file being type-checked.
 fn adjust_annotation_span(ann: &mut Annotation, main_file: File, offset: TextSize) {
     let span = ann.get_span();
+    // Only adjust spans for the main file (not stubs or other files)
     if let UnifiedFile::Ty(span_file) = span.file()
         && *span_file == main_file
         && let Some(range) = span.range()
@@ -240,64 +164,94 @@ fn adjust_annotation_span(ann: &mut Annotation, main_file: File, offset: TextSiz
 
 /// Represents diagnostic details when type checking fails.
 ///
-/// The diagnostics are fully detached from the live database. Every supported output
-/// format is rendered eagerly while the db is still checked out, which lets the db be
-/// scrubbed and returned to the pool immediately afterwards.
+/// The pooled database is held inside an `Arc<Mutex<...>>` so that:
+/// 1. Diagnostic rendering can borrow the db lazily on every `Display`/`Debug` call,
+///    avoiding eager pre-rendering of every output format.
+/// 2. The `MontyTypingError` Python exception that wraps this type stays `Send + Sync`.
+/// 3. The `PooledMemoryDb` is released back to the pool exactly when the last clone
+///    of this `Arc` is dropped — RAII via `PooledMemoryDb`'s `Drop` impl.
 #[derive(Clone)]
 pub struct TypeCheckingDiagnostics {
-    rendered: Arc<RenderedDiagnostics>,
+    /// The actual diagnostic message
+    diagnostics: Vec<Diagnostic>,
+    /// Pooled db used to display diagnostics. Wrapped in `Mutex` for `Sync` so
+    /// `MontyTypingError` is sendable; the inner `Drop` impl releases the db when
+    /// the last `Arc` clone is dropped.
+    pooled_db: Arc<Mutex<PooledMemoryDb>>,
+    /// How to format the output
     format: DiagnosticFormat,
+    /// Whether to highlight the output with ansi colors
     color: bool,
 }
 
-/// True debug details for detached type-checking diagnostics.
+/// Debug output for TypeCheckingDiagnostics shows the pretty typing output, and no other values since
+/// this will be displayed when users are printing `Result<..., TypeCheckingDiagnostics>` etc. and the
+/// raw errors are not useful to end users.
+impl fmt::Debug for TypeCheckingDiagnostics {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let config = self.config();
+        let pooled_db = self.pooled_db.lock().unwrap();
+        write!(
+            f,
+            "TypeCheckingDiagnostics:\n{}",
+            DisplayDiagnostics::new(pooled_db.db(), &config, &self.diagnostics)
+        )
+    }
+}
+
+/// To display true debugs details about the TypeCheckingDiagnostics
 #[derive(Debug)]
 #[expect(dead_code)]
 pub struct DebugTypeCheckingDiagnostics<'a> {
-    current_output: &'a str,
+    diagnostics: &'a [Diagnostic],
+    pooled_db: Arc<Mutex<PooledMemoryDb>>,
     format: DiagnosticFormat,
     color: bool,
-}
-
-impl fmt::Debug for TypeCheckingDiagnostics {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "TypeCheckingDiagnostics:\n{self}")
-    }
 }
 
 impl fmt::Display for TypeCheckingDiagnostics {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.rendered.get(self.format, self.color))
+        let pooled_db = self.pooled_db.lock().unwrap();
+        DisplayDiagnostics::new(pooled_db.db(), &self.config(), &self.diagnostics).fmt(f)
     }
 }
 
 impl TypeCheckingDiagnostics {
-    /// Create detached diagnostics with the default full, non-colored output mode.
-    fn new(rendered: RenderedDiagnostics) -> Self {
+    fn new(diagnostics: Vec<Diagnostic>, pooled_db: PooledMemoryDb) -> Self {
         Self {
-            rendered: Arc::new(rendered),
+            diagnostics,
+            pooled_db: Arc::new(Mutex::new(pooled_db)),
             format: DiagnosticFormat::Full,
             color: false,
         }
     }
 
-    /// Return details useful when debugging detached diagnostics behavior.
+    fn config(&self) -> DisplayDiagnosticConfig {
+        DisplayDiagnosticConfig::new("monty")
+            .format(self.format)
+            .color(self.color)
+    }
+
+    /// To display debug details for the TypeCheckingDiagnostics since debug is the pretty output
     #[must_use]
     pub fn debug_details(&self) -> DebugTypeCheckingDiagnostics<'_> {
         DebugTypeCheckingDiagnostics {
-            current_output: self.rendered.get(self.format, self.color),
+            diagnostics: &self.diagnostics,
+            pooled_db: self.pooled_db.clone(),
             format: self.format,
             color: self.color,
         }
     }
 
-    /// Set the output format for later display.
+    /// Set the format of the diagnostics.
     #[must_use]
     pub fn format(self, format: DiagnosticFormat) -> Self {
         Self { format, ..self }
     }
 
-    /// Set the output format from a string accepted by the public bindings.
+    /// Set the format of the diagnostics from a string.
+    /// Valid formats: "full", "concise", "azure", "json", "jsonlines", "rdjson",
+    /// "pylint", "gitlab", "github".
     pub fn format_from_str(self, format: &str) -> Result<Self, String> {
         let format = match format.to_ascii_lowercase().as_str() {
             "full" => DiagnosticFormat::Full,
@@ -307,6 +261,8 @@ impl TypeCheckingDiagnostics {
             "jsonlines" | "json-lines" => DiagnosticFormat::JsonLines,
             "rdjson" => DiagnosticFormat::Rdjson,
             "pylint" => DiagnosticFormat::Pylint,
+            // don't bother with the "junit" feature, please check the binary size and add it if you need this format
+            // "junit" => DiagnosticFormat::Junit,
             "gitlab" => DiagnosticFormat::Gitlab,
             "github" => DiagnosticFormat::Github,
             _ => return Err(format!("Unknown format: {format}")),
@@ -314,14 +270,14 @@ impl TypeCheckingDiagnostics {
         Ok(Self { format, ..self })
     }
 
-    /// Set whether future displays should use the colored pre-rendered output.
+    /// Set whether to highlight the output with ansi colors
     #[must_use]
     pub fn color(self, color: bool) -> Self {
         Self { color, ..self }
     }
 }
 
-/// Filter out diagnostics we intentionally ignore for now.
+/// Filter out diagnostics we want to ignore.
 ///
 /// Should only be necessary until <https://github.com/astral-sh/ty/issues/2599> is fixed.
 fn filter_diagnostics(d: &Diagnostic) -> bool {

--- a/crates/monty-type-checking/src/type_check.rs
+++ b/crates/monty-type-checking/src/type_check.rs
@@ -89,7 +89,7 @@ impl RenderedDiagnostics {
 
 /// Type check some Python source code, checking if it's valid to run with Monty.
 ///
-/// Every call checks out one warm database from the process-wide pool, writes the
+/// Every call checks out one database from the process-wide pool, writes the
 /// root-level source files into that db, renders any diagnostics eagerly, deletes
 /// the temporary files again, and finally returns the scrubbed db to the pool.
 ///

--- a/crates/monty-type-checking/src/type_check.rs
+++ b/crates/monty-type-checking/src/type_check.rs
@@ -1,4 +1,8 @@
-use std::fmt::{self, Display};
+use std::{
+    fmt::{self, Display},
+    io::ErrorKind,
+    sync::Arc,
+};
 
 use ruff_db::{
     diagnostic::{
@@ -6,143 +10,302 @@ use ruff_db::{
         UnifiedFile,
     },
     files::{File, system_path_to_file},
-    system::{DbWithWritableSystem as _, SystemPathBuf},
+    system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPathBuf},
 };
 use ruff_text_size::{TextRange, TextSize};
 use ty_python_semantic::types::check_types;
 
-use crate::db::{SRC_ROOT, global_db, next_call_prefix, strip_unique_prefix};
+use crate::db::{MemoryDb, SRC_ROOT, checkout_db};
 
-/// Definition of a source file.
+/// All diagnostic formats supported by `TypeCheckingDiagnostics`.
+const SUPPORTED_FORMATS: [DiagnosticFormat; 9] = [
+    DiagnosticFormat::Full,
+    DiagnosticFormat::Concise,
+    DiagnosticFormat::Azure,
+    DiagnosticFormat::Json,
+    DiagnosticFormat::JsonLines,
+    DiagnosticFormat::Rdjson,
+    DiagnosticFormat::Pylint,
+    DiagnosticFormat::Gitlab,
+    DiagnosticFormat::Github,
+];
+
+/// Definition of a source file used by the Monty type-checking wrapper.
 pub struct SourceFile<'a> {
-    /// source code
+    /// Python source code to type check.
     pub source_code: &'a str,
-    /// file path
+    /// User-visible file name used for diagnostics and module resolution.
     pub path: &'a str,
 }
 
 impl<'a> SourceFile<'a> {
-    /// Create a new source file.
+    /// Create a new source file value.
     #[must_use]
     pub fn new(source_code: &'a str, path: &'a str) -> Self {
         Self { source_code, path }
     }
 }
 
-/// Type check some python source code, checking if it's valid to run with monty.
+/// File written into a pooled database during one type-check run.
 ///
-/// All `type_check` calls share the process-wide warm database (see [`global_db`])
-/// to amortize typeshed parsing across calls. Calls are serialized on a mutex so
-/// salsa's single-writer invariant holds, and each call writes to a unique internal
-/// path (prefixed with `__mc<N>__`) so its salsa `File` ingredient is independent
-/// of every other call's — diagnostics remain correct across concurrent holders.
+/// Cleanup uses both the path and, when available, the interned `File` handle to
+/// make sure Salsa observes the deletion before the db is returned to the pool.
+struct TouchedRootFile {
+    path: SystemPathBuf,
+    file: Option<File>,
+}
+
+impl TouchedRootFile {
+    /// Track a root file path that must be deleted before the db is reused.
+    fn new(path: SystemPathBuf) -> Self {
+        Self { path, file: None }
+    }
+}
+
+/// Pre-rendered diagnostic strings detached from the live Salsa database.
+///
+/// Every supported `(format, color)` pair is rendered while the database is still
+/// alive, which lets pooled databases be scrubbed immediately after type checking.
+struct RenderedDiagnostics {
+    plain: [String; SUPPORTED_FORMATS.len()],
+    color: [String; SUPPORTED_FORMATS.len()],
+}
+
+impl RenderedDiagnostics {
+    /// Render all supported format/color combinations against the current db state.
+    fn new(db: &MemoryDb, diagnostics: &[Diagnostic]) -> Self {
+        Self {
+            plain: SUPPORTED_FORMATS.map(|format| render_diagnostics(db, diagnostics, format, false)),
+            color: SUPPORTED_FORMATS.map(|format| render_diagnostics(db, diagnostics, format, true)),
+        }
+    }
+
+    /// Return the pre-rendered output for the requested format and color mode.
+    fn get(&self, format: DiagnosticFormat, color: bool) -> &str {
+        let index = diagnostic_format_index(format);
+        if color { &self.color[index] } else { &self.plain[index] }
+    }
+}
+
+/// Type check some Python source code, checking if it's valid to run with Monty.
+///
+/// Every call checks out one warm database from the process-wide pool, writes the
+/// root-level source files into that db, renders any diagnostics eagerly, deletes
+/// the temporary files again, and finally returns the scrubbed db to the pool.
 ///
 /// # Arguments
-/// * `python_source` - The python source code to type check.
-/// * `stubs_file` - Optional stubs file to use for type checking.
+/// * `python_source` - The Python source code to type check.
+/// * `stubs_file` - Optional stubs file to import during type checking.
 ///
 /// # Returns
-/// * `Ok(Some(TypeCheckingFailure))` - If there are typing errors.
-/// * `Ok(None)` - If there are no typing errors.
-/// * `Err(String)` - If there was an unexpected/internal error during type checking.
+/// * `Ok(Some(TypeCheckingDiagnostics))` - The code contains typing errors.
+/// * `Ok(None)` - The code type-checks cleanly.
+/// * `Err(String)` - An unexpected/internal error occurred while type checking.
 pub fn type_check(
     python_source: &SourceFile<'_>,
     stubs_file: Option<&SourceFile<'_>>,
 ) -> Result<Option<TypeCheckingDiagnostics>, String> {
-    let mut db = global_db().lock().map_err(|e| e.to_string())?;
-    let src_root = SystemPathBuf::from(SRC_ROOT);
-    let call_prefix = next_call_prefix();
+    let main_path = validate_root_file_name(python_source.path, "source")?;
+    let stubs_path = stubs_file
+        .map(|stubs_file| validate_root_file_name(stubs_file.path, "stub"))
+        .transpose()?;
 
-    // Per-call unique path — `__mc<N>__<user_path>` — prevents the call's `File`
-    // ingredient from colliding with any other call's and keeps earlier diagnostics
-    // valid after later calls have run.
-    let main_path = unique_path(&src_root, &call_prefix, python_source.path);
+    if stubs_path.as_ref().is_some_and(|path| path == &main_path) {
+        return Err(format!(
+            "Type checking source and stubs must use different root file names: '{}'",
+            python_source.path
+        ));
+    }
+
+    let mut pooled_db = checkout_db()?;
+    let mut touched_files = Vec::new();
+    let result = type_check_with_db(
+        pooled_db.db(),
+        python_source,
+        &main_path,
+        stubs_file.zip(stubs_path.as_ref()),
+        &mut touched_files,
+    );
+    let cleanup = cleanup_touched_files(pooled_db.db(), &touched_files);
+
+    if cleanup.is_ok() {
+        pooled_db.return_clean()?;
+    }
+
+    combine_type_check_results(result, cleanup)
+}
+
+/// Run one type-check operation against a checked-out database.
+///
+/// The caller provides the already-validated root file paths and a mutable list of
+/// touched files so cleanup can run even if this function returns an error.
+fn type_check_with_db(
+    db: &mut MemoryDb,
+    python_source: &SourceFile<'_>,
+    main_path: &SystemPathBuf,
+    stubs_file: Option<(&SourceFile<'_>, &SystemPathBuf)>,
+    touched_files: &mut Vec<TouchedRootFile>,
+) -> Result<Option<TypeCheckingDiagnostics>, String> {
     let main_source = python_source.source_code;
 
-    let code_offset: u32 = if let Some(stubs_file) = stubs_file {
-        let stubs_path = unique_path(&src_root, &call_prefix, stubs_file.path);
+    let (main_file, code_offset) = if let Some((stubs_file, stubs_path)) = stubs_file {
+        write_root_file(db, touched_files, stubs_path, stubs_file.source_code)?;
 
-        // write the stub file
-        db.write_file(&stubs_path, stubs_file.source_code).map_err(to_string)?;
-
-        // prepend the stub import to the main source code. Use the uniquified stub
-        // module name so the import resolves against this call's stub file only.
-        let stub_basename = stubs_file.path.rsplit('/').next().unwrap_or(stubs_file.path);
-        let stub_stem = stub_basename
-            .split_once('.')
-            .map_or(stub_basename, |(before, _)| before);
-        let unique_stub_module = format!("{call_prefix}{stub_stem}");
-        let mut new_source = format!("from {unique_stub_module} import *\n");
+        // Import the stub module into the user's source so ty sees those definitions
+        // while keeping user-visible spans anchored to the original file later.
+        let stub_stem = module_stem(stubs_file.path);
+        let mut new_source = format!("from {stub_stem} import *\n");
         let offset = u32::try_from(new_source.len()).map_err(to_string)?;
         new_source.push_str(main_source);
 
-        // write the main source code
-        db.write_file(&main_path, &new_source).map_err(to_string)?;
-        // one line offset for errors vs. the original source code since we injected the stub import
-        offset
+        let main_file = write_root_file(db, touched_files, main_path, &new_source)?;
+        (main_file, offset)
     } else {
-        // write just the main source code
-        db.write_file(&main_path, main_source).map_err(to_string)?;
-        0
+        let main_file = write_root_file(db, touched_files, main_path, main_source)?;
+        (main_file, 0)
     };
 
-    let main_file = system_path_to_file(&*db, &main_path).map_err(to_string)?;
-    let mut diagnostics = check_types(&*db, main_file);
+    let mut diagnostics = check_types(db, main_file);
     diagnostics.retain(filter_diagnostics);
 
     if diagnostics.is_empty() {
-        Ok(None)
-    } else {
-        // without all this errors would appear on the wrong line because we injected `from <stub> import *`
+        return Ok(None);
+    }
 
-        // if we injected the stubs import, we need to write the actual source back to the file in the database
-        db.write_file(&main_path, main_source).map_err(to_string)?;
-        // and then adjust each span in the error message to account for the injected stubs import
-        if code_offset > 0 {
-            let offset = TextSize::new(code_offset);
-            for diagnostic in &mut diagnostics {
-                // Adjust spans in main diagnostic annotations (only for spans in the main file)
-                for ann in diagnostic.annotations_mut() {
+    // The stub import only exists to seed names into the semantic model. Restore the
+    // original source text before rendering so detached diagnostics show user code.
+    if code_offset > 0 {
+        db.write_file(main_path, main_source).map_err(to_string)?;
+        let offset = TextSize::new(code_offset);
+        for diagnostic in &mut diagnostics {
+            for ann in diagnostic.annotations_mut() {
+                adjust_annotation_span(ann, main_file, offset);
+            }
+            for sub in diagnostic.sub_diagnostics_mut() {
+                for ann in sub.annotations_mut() {
                     adjust_annotation_span(ann, main_file, offset);
-                }
-                // Adjust spans in sub-diagnostic annotations (e.g., "info: Function defined here")
-                for sub in diagnostic.sub_diagnostics_mut() {
-                    for ann in sub.annotations_mut() {
-                        adjust_annotation_span(ann, main_file, offset);
-                    }
                 }
             }
         }
-        // Sort diagnostics by line number
-        diagnostics.sort_by(|a, b| a.rendering_sort_key(&*db).cmp(&b.rendering_sort_key(&*db)));
+    }
 
-        Ok(Some(TypeCheckingDiagnostics::new(diagnostics)))
+    diagnostics.sort_by(|a, b| a.rendering_sort_key(db).cmp(&b.rendering_sort_key(db)));
+    let rendered = RenderedDiagnostics::new(db, &diagnostics);
+
+    Ok(Some(TypeCheckingDiagnostics::new(rendered)))
+}
+
+/// Write one root file into the db and remember it for mandatory cleanup.
+fn write_root_file(
+    db: &mut MemoryDb,
+    touched_files: &mut Vec<TouchedRootFile>,
+    path: &SystemPathBuf,
+    source: &str,
+) -> Result<File, String> {
+    db.write_file(path, source).map_err(to_string)?;
+    touched_files.push(TouchedRootFile::new(path.clone()));
+
+    let file = system_path_to_file(db, path).map_err(to_string)?;
+    touched_files
+        .last_mut()
+        .expect("newly pushed touched file must exist")
+        .file = Some(file);
+
+    Ok(file)
+}
+
+/// Remove all files written during a type-check run and sync the filesystem changes.
+///
+/// Cleanup runs in reverse write order and always syncs `/` once at the end so root
+/// directory listings cannot leak between pooled sessions.
+fn cleanup_touched_files(db: &mut MemoryDb, touched_files: &[TouchedRootFile]) -> Result<(), String> {
+    for touched in touched_files.iter().rev() {
+        match db.memory_file_system().remove_file(&touched.path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(format!(
+                    "Failed to remove pooled type-check file '{}': {err}",
+                    touched.path
+                ));
+            }
+        }
+
+        if let Some(file) = touched.file {
+            file.sync(db);
+        } else {
+            File::sync_path(db, &touched.path);
+        }
+    }
+
+    File::sync_path(db, &SystemPathBuf::from(SRC_ROOT));
+    Ok(())
+}
+
+/// Merge the type-check result with the cleanup result without hiding either failure.
+fn combine_type_check_results(
+    type_check_result: Result<Option<TypeCheckingDiagnostics>, String>,
+    cleanup_result: Result<(), String>,
+) -> Result<Option<TypeCheckingDiagnostics>, String> {
+    match (type_check_result, cleanup_result) {
+        (Ok(result), Ok(())) => Ok(result),
+        (Ok(_), Err(cleanup_err)) => Err(cleanup_err),
+        (Err(type_check_err), Ok(())) => Err(type_check_err),
+        (Err(type_check_err), Err(cleanup_err)) => Err(format!("{type_check_err}\ncleanup error: {cleanup_err}")),
     }
 }
 
-/// Compose the per-call unique path for a user-supplied script name.
-///
-/// The prefix is applied to the basename so that `src/app.py` becomes
-/// `/__mc42__src/app.py` (not `/src/__mc42__app.py`) — simpler to strip and keeps
-/// rendered output close to the user's original path.
-fn unique_path(src_root: &SystemPathBuf, call_prefix: &str, user_path: &str) -> SystemPathBuf {
-    // Trim leading slashes so joining under src_root stays within the project.
-    let trimmed = user_path.trim_start_matches('/');
-    src_root.join(format!("{call_prefix}{trimmed}"))
+/// Validate that `path` names a single root-level file suitable for pooled reuse.
+fn validate_root_file_name(path: &str, role: &str) -> Result<SystemPathBuf, String> {
+    if path.is_empty() {
+        return Err(format!("Type checking {role} file name cannot be empty"));
+    }
+    if path == "." || path == ".." || path.contains('/') || path.contains('\\') {
+        return Err(format!(
+            "Type checking only supports root-level {role} file names, got '{path}'"
+        ));
+    }
+
+    Ok(SystemPathBuf::from(SRC_ROOT).join(path))
 }
 
+/// Return the importable module stem for a root-level stub file name.
+fn module_stem(file_name: &str) -> &str {
+    file_name.rsplit_once('.').map_or(file_name, |(before, _)| before)
+}
+
+/// Render diagnostics with a specific format/color pair while the database is alive.
+fn render_diagnostics(db: &MemoryDb, diagnostics: &[Diagnostic], format: DiagnosticFormat, color: bool) -> String {
+    let config = DisplayDiagnosticConfig::new("monty").format(format).color(color);
+    DisplayDiagnostics::new(db, &config, diagnostics).to_string()
+}
+
+/// Convert a `DiagnosticFormat` to its slot in [`SUPPORTED_FORMATS`].
+fn diagnostic_format_index(format: DiagnosticFormat) -> usize {
+    match format {
+        DiagnosticFormat::Full => 0,
+        DiagnosticFormat::Concise => 1,
+        DiagnosticFormat::Azure => 2,
+        DiagnosticFormat::Json => 3,
+        DiagnosticFormat::JsonLines => 4,
+        DiagnosticFormat::Rdjson => 5,
+        DiagnosticFormat::Pylint => 6,
+        DiagnosticFormat::Gitlab => 7,
+        DiagnosticFormat::Github => 8,
+    }
+}
+
+/// Convert a displayable error into the string type used by `type_check`.
 fn to_string(err: impl Display) -> String {
     err.to_string()
 }
 
 /// Adjust the span of an annotation by subtracting the given offset.
 ///
-/// This is used when we inject a stub import at the beginning of the source code,
-/// and need to adjust all spans to account for the injected code.
-/// Only adjusts spans that belong to the main file being type-checked.
+/// This compensates for the injected `from <stub> import *` line so diagnostics still
+/// point at the user's original source.
 fn adjust_annotation_span(ann: &mut Annotation, main_file: File, offset: TextSize) {
     let span = ann.get_span();
-    // Only adjust spans for the main file (not stubs or other files)
     if let UnifiedFile::Ty(span_file) = span.file()
         && *span_file == main_file
         && let Some(range) = span.range()
@@ -155,86 +318,64 @@ fn adjust_annotation_span(ann: &mut Annotation, main_file: File, offset: TextSiz
 
 /// Represents diagnostic details when type checking fails.
 ///
-/// Doesn't hold a database clone: rendering acquires the process-wide [`global_db`]
-/// mutex on demand. This matters for correctness — an `Arc<MemoryDb>` captured here
-/// would pin salsa's `Arc<Zalsa>` refcount above 1 and deadlock the next `write_file`
-/// setter (salsa's `Arc::get_mut` spins until refcount drops to 1). The diagnostic's
-/// `File` ingredients are unique per call, so re-querying the db at display time
-/// still returns the original source text produced during this diagnostic's call.
+/// The diagnostics are fully detached from the live database. Every supported output
+/// format is rendered eagerly while the db is still checked out, which lets the db be
+/// scrubbed and returned to the pool immediately afterwards.
 #[derive(Clone)]
 pub struct TypeCheckingDiagnostics {
-    /// The actual diagnostic message
-    diagnostics: Vec<Diagnostic>,
-    /// How to format the output
+    rendered: Arc<RenderedDiagnostics>,
     format: DiagnosticFormat,
-    /// Whether to highlight the output with ansi colors
     color: bool,
 }
 
-/// Debug output for TypeCheckingDiagnostics shows the pretty typing output, and no other values since
-/// this will be displayed when users are printing `Result<..., TypeCheckingDiagnostics>` etc. and the
-/// raw errors are not useful to end users.
+/// True debug details for detached type-checking diagnostics.
+#[derive(Debug)]
+#[expect(dead_code)]
+pub struct DebugTypeCheckingDiagnostics<'a> {
+    current_output: &'a str,
+    format: DiagnosticFormat,
+    color: bool,
+}
+
 impl fmt::Debug for TypeCheckingDiagnostics {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "TypeCheckingDiagnostics:\n{self}")
     }
 }
 
-/// To display true debugs details about the TypeCheckingDiagnostics
-#[derive(Debug)]
-#[expect(dead_code)]
-pub struct DebugTypeCheckingDiagnostics<'a> {
-    diagnostics: &'a [Diagnostic],
-    format: DiagnosticFormat,
-    color: bool,
-}
-
 impl fmt::Display for TypeCheckingDiagnostics {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let rendered = {
-            let db = global_db().lock().expect("global db mutex poisoned");
-            DisplayDiagnostics::new(&*db, &self.config(), &self.diagnostics).to_string()
-        };
-        // Hide the internal `__mc<N>__` uniquifying prefix from user-visible output so
-        // file paths in error messages read `main.py`, not `__mc42__main.py`.
-        f.write_str(&strip_unique_prefix(&rendered))
+        f.write_str(self.rendered.get(self.format, self.color))
     }
 }
 
 impl TypeCheckingDiagnostics {
-    fn new(diagnostics: Vec<Diagnostic>) -> Self {
+    /// Create detached diagnostics with the default full, non-colored output mode.
+    fn new(rendered: RenderedDiagnostics) -> Self {
         Self {
-            diagnostics,
+            rendered: Arc::new(rendered),
             format: DiagnosticFormat::Full,
             color: false,
         }
     }
 
-    fn config(&self) -> DisplayDiagnosticConfig {
-        DisplayDiagnosticConfig::new("monty")
-            .format(self.format)
-            .color(self.color)
-    }
-
-    /// To display debug details for the TypeCheckingDiagnostics since debug is the pretty output
+    /// Return details useful when debugging detached diagnostics behavior.
     #[must_use]
     pub fn debug_details(&self) -> DebugTypeCheckingDiagnostics<'_> {
         DebugTypeCheckingDiagnostics {
-            diagnostics: &self.diagnostics,
+            current_output: self.rendered.get(self.format, self.color),
             format: self.format,
             color: self.color,
         }
     }
 
-    /// Set the format of the diagnostics.
+    /// Set the output format for later display.
     #[must_use]
     pub fn format(self, format: DiagnosticFormat) -> Self {
         Self { format, ..self }
     }
 
-    /// Set the format of the diagnostics from a string.
-    /// Valid formats: "full", "concise", "azure", "json", "jsonlines", "rdjson",
-    /// "pylint", "gitlab", "github".
+    /// Set the output format from a string accepted by the public bindings.
     pub fn format_from_str(self, format: &str) -> Result<Self, String> {
         let format = match format.to_ascii_lowercase().as_str() {
             "full" => DiagnosticFormat::Full,
@@ -244,8 +385,6 @@ impl TypeCheckingDiagnostics {
             "jsonlines" | "json-lines" => DiagnosticFormat::JsonLines,
             "rdjson" => DiagnosticFormat::Rdjson,
             "pylint" => DiagnosticFormat::Pylint,
-            // don't bother with the "junit" feature, please check the binary size and add it if you need this format
-            // "junit" => DiagnosticFormat::Junit,
             "gitlab" => DiagnosticFormat::Gitlab,
             "github" => DiagnosticFormat::Github,
             _ => return Err(format!("Unknown format: {format}")),
@@ -253,14 +392,14 @@ impl TypeCheckingDiagnostics {
         Ok(Self { format, ..self })
     }
 
-    /// Set whether to highlight the output with ansi colors
+    /// Set whether future displays should use the colored pre-rendered output.
     #[must_use]
     pub fn color(self, color: bool) -> Self {
         Self { color, ..self }
     }
 }
 
-/// Filter out diagnostics we want to ignore.
+/// Filter out diagnostics we intentionally ignore for now.
 ///
 /// Should only be necessary until <https://github.com/astral-sh/ty/issues/2599> is fixed.
 fn filter_diagnostics(d: &Diagnostic) -> bool {

--- a/crates/monty-type-checking/src/type_check.rs
+++ b/crates/monty-type-checking/src/type_check.rs
@@ -57,7 +57,7 @@ pub fn type_check(
         .transpose()?;
 
     // Check out a pre-configured db from the global pool. The `Drop` impl on
-    // `PooledMemoryDb` scrubs every root file we write below and returns the db to
+    // `PooledMemoryDb` scrubs every file we write below and returns the db to
     // the pool when the lease is no longer reachable — either at the end of this
     // function (clean run) or when the returned `TypeCheckingDiagnostics` is dropped.
     let mut pooled_db = PooledMemoryDb::checkout()?;
@@ -88,36 +88,34 @@ pub fn type_check(
     diagnostics.retain(filter_diagnostics);
 
     if diagnostics.is_empty() {
-        return Ok(None);
-    }
+        Ok(None)
+    } else {
+        // without all this errors would appear on the wrong line because we injected `from type_stubs import *`
 
-    // without all this errors would appear on the wrong line because we injected `from type_stubs import *`
-
-    // if we injected the stubs import, we need to write the actual source back to the file in the database
-    pooled_db.rewrite_root_file(&main_path, main_source)?;
-    // and then adjust each span in the error message to account for the injected stubs import
-    if code_offset > 0 {
-        let offset = TextSize::new(code_offset);
-        for diagnostic in &mut diagnostics {
-            // Adjust spans in main diagnostic annotations (only for spans in the main file)
-            for ann in diagnostic.annotations_mut() {
-                adjust_annotation_span(ann, main_file, offset);
-            }
-            // Adjust spans in sub-diagnostic annotations (e.g., "info: Function defined here")
-            for sub in diagnostic.sub_diagnostics_mut() {
-                for ann in sub.annotations_mut() {
+        // if we injected the stubs import, we need to write the actual source back to the file in the database
+        pooled_db.rewrite_root_file(&main_path, main_source)?;
+        // and then adjust each span in the error message to account for the injected stubs import
+        if code_offset > 0 {
+            let offset = TextSize::new(code_offset);
+            for diagnostic in &mut diagnostics {
+                // Adjust spans in main diagnostic annotations (only for spans in the main file)
+                for ann in diagnostic.annotations_mut() {
                     adjust_annotation_span(ann, main_file, offset);
+                }
+                // Adjust spans in sub-diagnostic annotations (e.g., "info: Function defined here")
+                for sub in diagnostic.sub_diagnostics_mut() {
+                    for ann in sub.annotations_mut() {
+                        adjust_annotation_span(ann, main_file, offset);
+                    }
                 }
             }
         }
-    }
-    // Sort diagnostics by line number
-    diagnostics.sort_by(|a, b| {
-        a.rendering_sort_key(pooled_db.db())
-            .cmp(&b.rendering_sort_key(pooled_db.db()))
-    });
+        // Sort diagnostics by line number
+        let db = pooled_db.db();
+        diagnostics.sort_by(|a, b| a.rendering_sort_key(db).cmp(&b.rendering_sort_key(db)));
 
-    Ok(Some(TypeCheckingDiagnostics::new(diagnostics, pooled_db)))
+        Ok(Some(TypeCheckingDiagnostics::new(diagnostics, pooled_db)))
+    }
 }
 
 /// Validate that `path` names a single root-level file suitable for the pooled db.

--- a/crates/monty-type-checking/src/type_check.rs
+++ b/crates/monty-type-checking/src/type_check.rs
@@ -1,6 +1,5 @@
 use std::{
     fmt::{self, Display},
-    io::ErrorKind,
     sync::Arc,
 };
 
@@ -9,13 +8,16 @@ use ruff_db::{
         Annotation, Diagnostic, DiagnosticFormat, DiagnosticId, DisplayDiagnosticConfig, DisplayDiagnostics,
         UnifiedFile,
     },
-    files::{File, system_path_to_file},
-    system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPathBuf},
+    files::File,
+    system::{DbWithWritableSystem as _, SystemPathBuf},
 };
 use ruff_text_size::{TextRange, TextSize};
 use ty_python_semantic::types::check_types;
 
-use crate::db::{MemoryDb, SRC_ROOT, checkout_db};
+use crate::{
+    db::MemoryDb,
+    pool::{PooledTypeCheckDb, SRC_ROOT},
+};
 
 /// All diagnostic formats supported by `TypeCheckingDiagnostics`.
 const SUPPORTED_FORMATS: [DiagnosticFormat; 9] = [
@@ -43,22 +45,6 @@ impl<'a> SourceFile<'a> {
     #[must_use]
     pub fn new(source_code: &'a str, path: &'a str) -> Self {
         Self { source_code, path }
-    }
-}
-
-/// File written into a pooled database during one type-check run.
-///
-/// Cleanup uses both the path and, when available, the interned `File` handle to
-/// make sure Salsa observes the deletion before the db is returned to the pool.
-struct TouchedRootFile {
-    path: SystemPathBuf,
-    file: Option<File>,
-}
-
-impl TouchedRootFile {
-    /// Track a root file path that must be deleted before the db is reused.
-    fn new(path: SystemPathBuf) -> Self {
-        Self { path, file: None }
     }
 }
 
@@ -117,39 +103,30 @@ pub fn type_check(
         ));
     }
 
-    let mut pooled_db = checkout_db()?;
-    let mut touched_files = Vec::new();
+    let mut pooled_db = PooledTypeCheckDb::checkout()?;
     let result = type_check_with_db(
-        pooled_db.db(),
+        &mut pooled_db,
         python_source,
         &main_path,
         stubs_file.zip(stubs_path.as_ref()),
-        &mut touched_files,
     );
-    let cleanup = cleanup_touched_files(pooled_db.db(), &touched_files);
-
-    if cleanup.is_ok() {
-        pooled_db.return_clean()?;
-    }
-
-    combine_type_check_results(result, cleanup)
+    pooled_db.finish(result)
 }
 
-/// Run one type-check operation against a checked-out database.
+/// Run one type-check operation against a checked-out pooled database.
 ///
-/// The caller provides the already-validated root file paths and a mutable list of
-/// touched files so cleanup can run even if this function returns an error.
+/// The caller provides already-validated root file paths, while the pooled wrapper
+/// owns the temporary-file bookkeeping needed for cleanup.
 fn type_check_with_db(
-    db: &mut MemoryDb,
+    pooled_db: &mut PooledTypeCheckDb,
     python_source: &SourceFile<'_>,
     main_path: &SystemPathBuf,
     stubs_file: Option<(&SourceFile<'_>, &SystemPathBuf)>,
-    touched_files: &mut Vec<TouchedRootFile>,
 ) -> Result<Option<TypeCheckingDiagnostics>, String> {
     let main_source = python_source.source_code;
 
     let (main_file, code_offset) = if let Some((stubs_file, stubs_path)) = stubs_file {
-        write_root_file(db, touched_files, stubs_path, stubs_file.source_code)?;
+        pooled_db.write_root_file(stubs_path, stubs_file.source_code)?;
 
         // Import the stub module into the user's source so ty sees those definitions
         // while keeping user-visible spans anchored to the original file later.
@@ -158,13 +135,14 @@ fn type_check_with_db(
         let offset = u32::try_from(new_source.len()).map_err(to_string)?;
         new_source.push_str(main_source);
 
-        let main_file = write_root_file(db, touched_files, main_path, &new_source)?;
+        let main_file = pooled_db.write_root_file(main_path, &new_source)?;
         (main_file, offset)
     } else {
-        let main_file = write_root_file(db, touched_files, main_path, main_source)?;
+        let main_file = pooled_db.write_root_file(main_path, main_source)?;
         (main_file, 0)
     };
 
+    let db = pooled_db.db();
     let mut diagnostics = check_types(db, main_file);
     diagnostics.retain(filter_diagnostics);
 
@@ -193,66 +171,6 @@ fn type_check_with_db(
     let rendered = RenderedDiagnostics::new(db, &diagnostics);
 
     Ok(Some(TypeCheckingDiagnostics::new(rendered)))
-}
-
-/// Write one root file into the db and remember it for mandatory cleanup.
-fn write_root_file(
-    db: &mut MemoryDb,
-    touched_files: &mut Vec<TouchedRootFile>,
-    path: &SystemPathBuf,
-    source: &str,
-) -> Result<File, String> {
-    db.write_file(path, source).map_err(to_string)?;
-    touched_files.push(TouchedRootFile::new(path.clone()));
-
-    let file = system_path_to_file(db, path).map_err(to_string)?;
-    touched_files
-        .last_mut()
-        .expect("newly pushed touched file must exist")
-        .file = Some(file);
-
-    Ok(file)
-}
-
-/// Remove all files written during a type-check run and sync the filesystem changes.
-///
-/// Cleanup runs in reverse write order and always syncs `/` once at the end so root
-/// directory listings cannot leak between pooled sessions.
-fn cleanup_touched_files(db: &mut MemoryDb, touched_files: &[TouchedRootFile]) -> Result<(), String> {
-    for touched in touched_files.iter().rev() {
-        match db.memory_file_system().remove_file(&touched.path) {
-            Ok(()) => {}
-            Err(err) if err.kind() == ErrorKind::NotFound => {}
-            Err(err) => {
-                return Err(format!(
-                    "Failed to remove pooled type-check file '{}': {err}",
-                    touched.path
-                ));
-            }
-        }
-
-        if let Some(file) = touched.file {
-            file.sync(db);
-        } else {
-            File::sync_path(db, &touched.path);
-        }
-    }
-
-    File::sync_path(db, &SystemPathBuf::from(SRC_ROOT));
-    Ok(())
-}
-
-/// Merge the type-check result with the cleanup result without hiding either failure.
-fn combine_type_check_results(
-    type_check_result: Result<Option<TypeCheckingDiagnostics>, String>,
-    cleanup_result: Result<(), String>,
-) -> Result<Option<TypeCheckingDiagnostics>, String> {
-    match (type_check_result, cleanup_result) {
-        (Ok(result), Ok(())) => Ok(result),
-        (Ok(_), Err(cleanup_err)) => Err(cleanup_err),
-        (Err(type_check_err), Ok(())) => Err(type_check_err),
-        (Err(type_check_err), Err(cleanup_err)) => Err(format!("{type_check_err}\ncleanup error: {cleanup_err}")),
-    }
 }
 
 /// Validate that `path` names a single root-level file suitable for pooled reuse.

--- a/crates/monty-type-checking/src/type_check.rs
+++ b/crates/monty-type-checking/src/type_check.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt::{self, Display},
-    sync::Arc,
-};
+use std::{fmt, sync::Arc};
 
 use ruff_db::{
     diagnostic::{
@@ -9,14 +6,14 @@ use ruff_db::{
         UnifiedFile,
     },
     files::File,
-    system::{DbWithWritableSystem as _, SystemPathBuf},
+    system::SystemPathBuf,
 };
 use ruff_text_size::{TextRange, TextSize};
 use ty_python_semantic::types::check_types;
 
 use crate::{
     db::MemoryDb,
-    pool::{PooledMemoryDb, SRC_ROOT},
+    pool::{PooledMemoryDb, SRC_ROOT, to_string},
 };
 
 /// All diagnostic formats supported by `TypeCheckingDiagnostics`.
@@ -142,8 +139,7 @@ fn type_check_with_db(
         (main_file, 0)
     };
 
-    let db = pooled_db.db();
-    let mut diagnostics = check_types(db, main_file);
+    let mut diagnostics = check_types(pooled_db.db(), main_file);
     diagnostics.retain(filter_diagnostics);
 
     if diagnostics.is_empty() {
@@ -152,8 +148,10 @@ fn type_check_with_db(
 
     // The stub import only exists to seed names into the semantic model. Restore the
     // original source text before rendering so detached diagnostics show user code.
+    // Route via `rewrite_root_file` so the tracking invariant is checked at runtime
+    // rather than relying on a hand-maintained comment.
     if code_offset > 0 {
-        db.write_file(main_path, main_source).map_err(to_string)?;
+        pooled_db.rewrite_root_file(main_path, main_source)?;
         let offset = TextSize::new(code_offset);
         for diagnostic in &mut diagnostics {
             for ann in diagnostic.annotations_mut() {
@@ -167,6 +165,7 @@ fn type_check_with_db(
         }
     }
 
+    let db = pooled_db.db();
     diagnostics.sort_by(|a, b| a.rendering_sort_key(db).cmp(&b.rendering_sort_key(db)));
     let rendered = RenderedDiagnostics::new(db, &diagnostics);
 
@@ -178,6 +177,12 @@ fn validate_root_file_name(path: &str, role: &str) -> Result<SystemPathBuf, Stri
     if path.is_empty() {
         return Err(format!("Type checking {role} file name cannot be empty"));
     }
+    if path.contains('\0') {
+        return Err(format!(
+            "Type checking {role} file name must not contain NUL bytes, got '{}'",
+            path.escape_debug()
+        ));
+    }
     if path == "." || path == ".." || path.contains('/') || path.contains('\\') {
         return Err(format!(
             "Type checking only supports root-level {role} file names, got '{path}'"
@@ -188,8 +193,12 @@ fn validate_root_file_name(path: &str, role: &str) -> Result<SystemPathBuf, Stri
 }
 
 /// Return the importable module stem for a root-level stub file name.
+///
+/// Uses the first `.` as the split so `foo.stubs.pyi` becomes `foo` (matches
+/// Python's package-import semantics for root-level files — there is no
+/// `foo.stubs` module on disk).
 fn module_stem(file_name: &str) -> &str {
-    file_name.rsplit_once('.').map_or(file_name, |(before, _)| before)
+    file_name.split_once('.').map_or(file_name, |(before, _)| before)
 }
 
 /// Render diagnostics with a specific format/color pair while the database is alive.
@@ -211,11 +220,6 @@ fn diagnostic_format_index(format: DiagnosticFormat) -> usize {
         DiagnosticFormat::Gitlab => 7,
         DiagnosticFormat::Github => 8,
     }
-}
-
-/// Convert a displayable error into the string type used by `type_check`.
-fn to_string(err: impl Display) -> String {
-    err.to_string()
 }
 
 /// Adjust the span of an annotation by subtracting the given offset.

--- a/crates/monty-type-checking/src/type_check.rs
+++ b/crates/monty-type-checking/src/type_check.rs
@@ -16,7 +16,7 @@ use ty_python_semantic::types::check_types;
 
 use crate::{
     db::MemoryDb,
-    pool::{PooledTypeCheckDb, SRC_ROOT},
+    pool::{PooledMemoryDb, SRC_ROOT},
 };
 
 /// All diagnostic formats supported by `TypeCheckingDiagnostics`.
@@ -103,7 +103,7 @@ pub fn type_check(
         ));
     }
 
-    let mut pooled_db = PooledTypeCheckDb::checkout()?;
+    let mut pooled_db = PooledMemoryDb::checkout()?;
     let result = type_check_with_db(
         &mut pooled_db,
         python_source,
@@ -118,7 +118,7 @@ pub fn type_check(
 /// The caller provides already-validated root file paths, while the pooled wrapper
 /// owns the temporary-file bookkeeping needed for cleanup.
 fn type_check_with_db(
-    pooled_db: &mut PooledTypeCheckDb,
+    pooled_db: &mut PooledMemoryDb,
     python_source: &SourceFile<'_>,
     main_path: &SystemPathBuf,
     stubs_file: Option<(&SourceFile<'_>, &SystemPathBuf)>,

--- a/crates/monty-type-checking/tests/main.rs
+++ b/crates/monty-type-checking/tests/main.rs
@@ -1,4 +1,4 @@
-use std::{env, fs};
+use std::{env, fs, thread};
 
 use monty_type_checking::{SourceFile, type_check};
 use pretty_assertions::assert_eq;
@@ -260,6 +260,44 @@ fn pooled_db_no_cross_run_stubs_leak() {
         msg.contains("unresolved-import") || msg.contains("unresolved-reference"),
         "second run must report the stub import as unresolved; got:\n{msg}"
     );
+}
+
+/// Security-critical: exercise the pool under concurrent load mixing both
+/// clean and failing type-checks. If the cleanup / release logic ever returned
+/// a contaminated db to the pool, subsequent checks would see stale names
+/// from other threads and fail intermittently.
+#[test]
+fn pooled_db_concurrent_runs_stay_isolated() {
+    thread::scope(|scope| {
+        let handles: Vec<_> = (0..8)
+            .map(|thread_idx| {
+                scope.spawn(move || {
+                    for iter in 0..20 {
+                        // Alternate between a clean run that defines a name and
+                        // a run that would only succeed if the prior run's
+                        // name leaked through the pool.
+                        let code_ok = format!("T_{thread_idx}_{iter}: int = 1\n");
+                        let r1 = type_check(&SourceFile::new(&code_ok, "main.py"), None).unwrap();
+                        assert!(r1.is_none(), "ok run must succeed: {r1:#?}");
+
+                        let leak_probe = format!("x: int = T_{thread_idx}_{iter}\n");
+                        // Reusing the same path: if the pool leaked the prior
+                        // run's defs, `T_*_*` would still resolve. It must not.
+                        let r2 = type_check(&SourceFile::new(&leak_probe, "main.py"), None).unwrap();
+                        let d = r2.expect("leak probe must error — prior run's name must not be visible");
+                        let msg = d.format(DiagnosticFormat::Concise).to_string();
+                        assert!(
+                            msg.contains("unresolved-reference") || msg.contains("possibly-unbound"),
+                            "expected unresolved-reference for T_{thread_idx}_{iter}, got:\n{msg}"
+                        );
+                    }
+                })
+            })
+            .collect();
+        for handle in handles {
+            handle.join().unwrap();
+        }
+    });
 }
 
 /// Security-critical: path validation rejects any path that could write outside

--- a/crates/monty-type-checking/tests/main.rs
+++ b/crates/monty-type-checking/tests/main.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, thread};
+use std::{env, fs};
 
 use monty_type_checking::{SourceFile, type_check};
 use pretty_assertions::assert_eq;
@@ -15,44 +15,6 @@ result = add(1, 2)
 
     let result = type_check(&SourceFile::new(code, "main.py"), None).unwrap();
     assert!(result.is_none());
-}
-
-#[test]
-fn type_checking_pool_reuse_does_not_leak_state() {
-    let ok = type_check(&SourceFile::new("x = 1", "main.py"), None).unwrap();
-    assert!(ok.is_none());
-
-    let err = type_check(&SourceFile::new("'hello' + 1", "main.py"), None).unwrap();
-    assert!(err.is_some());
-
-    let ok_again = type_check(&SourceFile::new("x = 1", "main.py"), None).unwrap();
-    assert!(ok_again.is_none());
-}
-
-#[test]
-fn type_checking_pool_reuse_does_not_leak_stubs() {
-    let with_stubs = type_check(
-        &SourceFile::new("result = call1_stub_var + 1", "main.py"),
-        Some(&SourceFile::new("call1_stub_var = 0", "type_stubs.pyi")),
-    )
-    .unwrap();
-    assert!(with_stubs.is_none());
-
-    let without_stubs = type_check(&SourceFile::new("result = call1_stub_var + 1", "main.py"), None).unwrap();
-    let failure = without_stubs.expect("stub-defined name should not survive db cleanup");
-
-    assert_eq!(
-        failure.to_string(),
-        r"error[unresolved-reference]: Name `call1_stub_var` used when not defined
- --> main.py:1:10
-  |
-1 | result = call1_stub_var + 1
-  |          ^^^^^^^^^^^^^^
-  |
-info: rule `unresolved-reference` is enabled by default
-
-"
-    );
 }
 
 #[test]
@@ -89,46 +51,6 @@ info: rule `invalid-argument-type` is enabled by default
 
 "#
     );
-}
-
-#[test]
-fn type_checking_rejects_nested_paths() {
-    let error = type_check(&SourceFile::new("x = 1", "nested/main.py"), None).unwrap_err();
-    assert_eq!(
-        error,
-        "Type checking only supports root-level source file names, got 'nested/main.py'"
-    );
-}
-
-#[test]
-fn type_checking_concurrent_calls() {
-    thread::scope(|scope| {
-        let handles = (0..8)
-            .map(|_| {
-                scope.spawn(|| {
-                    for _ in 0..10 {
-                        let result = type_check(
-                            &SourceFile::new(
-                                "\
-def add(x: int, y: int) -> int:
-    return x + y
-
-result = add(1, 2)",
-                                "main.py",
-                            ),
-                            None,
-                        )
-                        .unwrap();
-                        assert!(result.is_none());
-                    }
-                })
-            })
-            .collect::<Vec<_>>();
-
-        for handle in handles {
-            handle.join().unwrap();
-        }
-    });
 }
 
 #[test]
@@ -256,6 +178,103 @@ fn type_bad_types() {
     let actual = failure.format(DiagnosticFormat::Concise).to_string();
 
     check_file_content("bad_types_output.txt", &actual);
+}
+
+/// Security-critical: verify the reusable `MemoryDb` pool never exposes files,
+/// modules, or derived query results from a previous `type_check` call to a
+/// later one. If any of these assertions break, code from a prior run could
+/// leak into a later run's semantic analysis.
+#[test]
+fn pooled_db_no_cross_run_module_leak() {
+    // First run: define a module with a secret constant. Looks valid on its own.
+    let first = "SECRET = 'hunter2'\n";
+    let r1 = type_check(&SourceFile::new(first, "leaky.py"), None).unwrap();
+    assert!(r1.is_none(), "first run should succeed: {r1:#?}");
+
+    // Second run: try to import the first run's symbol via its file stem.
+    // Must fail with unresolved-import — the file was deleted when the db was
+    // returned to the pool, and Salsa's module-resolution memo must have been
+    // invalidated.
+    let second = "from leaky import SECRET\nprint(SECRET)\n";
+    let r2 = type_check(&SourceFile::new(second, "main.py"), None)
+        .unwrap()
+        .expect("second run must raise unresolved-import for the stale module");
+    let msg = r2.format(DiagnosticFormat::Concise).to_string();
+    assert!(
+        msg.contains("unresolved-import") || msg.contains("unresolved-reference"),
+        "second run must report the import as unresolved; got:\n{msg}"
+    );
+    // Belt-and-braces: the leaked constant name itself must not show up as a
+    // known symbol (would indicate partial resolution).
+    assert!(
+        !msg.contains("hunter2"),
+        "second run diagnostics must not surface the first run's content; got:\n{msg}"
+    );
+}
+
+/// Security-critical: same path, different content on consecutive runs. The
+/// second run must be evaluated against its own source, not a cached version
+/// of the first run's source.
+#[test]
+fn pooled_db_no_cross_run_same_path_leak() {
+    // First run: defines `GOOD` and type-checks cleanly.
+    let first = "GOOD: int = 1\nresult = GOOD + 1\n";
+    let r1 = type_check(&SourceFile::new(first, "main.py"), None).unwrap();
+    assert!(r1.is_none(), "first run should succeed: {r1:#?}");
+
+    // Second run on the *same* path references a name that doesn't exist in
+    // this run's source. If the pool leaked `GOOD` from the first run, this
+    // would type-check clean — so we assert an error is produced.
+    let second = "x: int = GOOD\n";
+    let r2 = type_check(&SourceFile::new(second, "main.py"), None)
+        .unwrap()
+        .expect("second run must error — `GOOD` was only defined in the first run");
+    let msg = r2.format(DiagnosticFormat::Concise).to_string();
+    assert!(
+        msg.contains("unresolved-reference") || msg.contains("Name `GOOD`") || msg.contains("possibly-unbound"),
+        "second run must report `GOOD` as undefined; got:\n{msg}"
+    );
+}
+
+/// Security-critical: stubs from a previous run must not persist as importable
+/// modules in a later run.
+#[test]
+fn pooled_db_no_cross_run_stubs_leak() {
+    let stubs = "class Widget:\n    x: int\n";
+    let first = "from type_stubs import Widget\nw: Widget\n";
+    let r1 = type_check(
+        &SourceFile::new(first, "main.py"),
+        Some(&SourceFile::new(stubs, "type_stubs.pyi")),
+    )
+    .unwrap();
+    assert!(r1.is_none(), "first run with stubs should succeed: {r1:#?}");
+
+    // Second run: no stubs provided, but still references `Widget`. Must fail
+    // to resolve the name — the stubs file was deleted on cleanup.
+    let second = "from type_stubs import Widget\n";
+    let r2 = type_check(&SourceFile::new(second, "main.py"), None)
+        .unwrap()
+        .expect("second run must error — `type_stubs` was only provided in the first run");
+    let msg = r2.format(DiagnosticFormat::Concise).to_string();
+    assert!(
+        msg.contains("unresolved-import") || msg.contains("unresolved-reference"),
+        "second run must report the stub import as unresolved; got:\n{msg}"
+    );
+}
+
+/// Security-critical: path validation rejects any path that could write outside
+/// the root or alias a different file via path traversal.
+#[test]
+fn pooled_db_rejects_non_root_paths() {
+    let code = "x: int = 1\n";
+    for bad in ["", ".", "..", "a/b.py", "a\\b.py", "sub/mod.py", "../mod.py"] {
+        let err = type_check(&SourceFile::new(code, bad), None)
+            .expect_err(&format!("expected validation error for path {bad:?}"));
+        assert!(
+            err.contains("root-level") || err.contains("empty"),
+            "path {bad:?} should be rejected by validation, got: {err}"
+        );
+    }
 }
 
 #[test]

--- a/crates/monty-type-checking/tests/main.rs
+++ b/crates/monty-type-checking/tests/main.rs
@@ -200,15 +200,9 @@ fn pooled_db_no_cross_run_module_leak() {
         .unwrap()
         .expect("second run must raise unresolved-import for the stale module");
     let msg = r2.format(DiagnosticFormat::Concise).to_string();
-    assert!(
-        msg.contains("unresolved-import") || msg.contains("unresolved-reference"),
-        "second run must report the import as unresolved; got:\n{msg}"
-    );
-    // Belt-and-braces: the leaked constant name itself must not show up as a
-    // known symbol (would indicate partial resolution).
-    assert!(
-        !msg.contains("hunter2"),
-        "second run diagnostics must not surface the first run's content; got:\n{msg}"
+    assert_eq!(
+        msg,
+        "main.py:1:6: error[unresolved-import] Cannot resolve imported module `leaky`\n",
     );
 }
 
@@ -230,9 +224,9 @@ fn pooled_db_no_cross_run_same_path_leak() {
         .unwrap()
         .expect("second run must error — `GOOD` was only defined in the first run");
     let msg = r2.format(DiagnosticFormat::Concise).to_string();
-    assert!(
-        msg.contains("unresolved-reference") || msg.contains("Name `GOOD`") || msg.contains("possibly-unbound"),
-        "second run must report `GOOD` as undefined; got:\n{msg}"
+    assert_eq!(
+        msg,
+        "main.py:1:10: error[unresolved-reference] Name `GOOD` used when not defined\n",
     );
 }
 
@@ -256,9 +250,9 @@ fn pooled_db_no_cross_run_stubs_leak() {
         .unwrap()
         .expect("second run must error — `type_stubs` was only provided in the first run");
     let msg = r2.format(DiagnosticFormat::Concise).to_string();
-    assert!(
-        msg.contains("unresolved-import") || msg.contains("unresolved-reference"),
-        "second run must report the stub import as unresolved; got:\n{msg}"
+    assert_eq!(
+        msg,
+        "main.py:1:6: error[unresolved-import] Cannot resolve imported module `type_stubs`\n",
     );
 }
 
@@ -286,9 +280,11 @@ fn pooled_db_concurrent_runs_stay_isolated() {
                         let r2 = type_check(&SourceFile::new(&leak_probe, "main.py"), None).unwrap();
                         let d = r2.expect("leak probe must error — prior run's name must not be visible");
                         let msg = d.format(DiagnosticFormat::Concise).to_string();
-                        assert!(
-                            msg.contains("unresolved-reference") || msg.contains("possibly-unbound"),
-                            "expected unresolved-reference for T_{thread_idx}_{iter}, got:\n{msg}"
+                        assert_eq!(
+                            msg,
+                            format!(
+                                "main.py:1:10: error[unresolved-reference] Name `T_{thread_idx}_{iter}` used when not defined\n"
+                            ),
                         );
                     }
                 })
@@ -316,9 +312,9 @@ fn pooled_db_nested_paths_are_cleaned_up() {
         .unwrap()
         .expect("nested-path leak probe must error — `LEAKY` must not survive into the next run");
     let msg = r2.format(DiagnosticFormat::Concise).to_string();
-    assert!(
-        msg.contains("unresolved-reference") || msg.contains("Name `LEAKY`") || msg.contains("possibly-unbound"),
-        "nested-path leak probe must report `LEAKY` as undefined; got:\n{msg}"
+    assert_eq!(
+        msg,
+        "sub_dir/leaky.py:1:10: error[unresolved-reference] Name `LEAKY` used when not defined\n",
     );
 
     // Third run from a *different* nested path importing the previous module must
@@ -327,9 +323,9 @@ fn pooled_db_nested_paths_are_cleaned_up() {
         .unwrap()
         .expect("third run must error — sub_dir/leaky.py was deleted on cleanup");
     let msg = r3.format(DiagnosticFormat::Concise).to_string();
-    assert!(
-        msg.contains("unresolved-import") || msg.contains("unresolved-reference"),
-        "third run must report the import as unresolved; got:\n{msg}"
+    assert_eq!(
+        msg,
+        "other.py:1:6: error[unresolved-import] Cannot resolve imported module `sub_dir.leaky`\n",
     );
 }
 

--- a/crates/monty-type-checking/tests/main.rs
+++ b/crates/monty-type-checking/tests/main.rs
@@ -300,30 +300,37 @@ fn pooled_db_concurrent_runs_stay_isolated() {
     });
 }
 
-/// Security-critical: path validation rejects any path that could write outside
-/// the root or alias a different file via path traversal.
+/// Security-critical: nested paths must be accepted and fully scrubbed (including
+/// the intermediate directories) so the next pooled run cannot see the previous
+/// run's module structure.
 #[test]
-fn pooled_db_rejects_non_root_paths() {
-    let code = "x: int = 1\n";
-    for bad in [
-        "",
-        ".",
-        "..",
-        "a/b.py",
-        "a\\b.py",
-        "sub/mod.py",
-        "../mod.py",
-        "/abs/path.py",
-        "/etc/passwd",
-        "has\0nul.py",
-    ] {
-        let err = type_check(&SourceFile::new(code, bad), None)
-            .expect_err(&format!("expected validation error for path {bad:?}"));
-        assert!(
-            err.contains("root-level") || err.contains("empty") || err.contains("NUL"),
-            "path {bad:?} should be rejected by validation, got: {err}"
-        );
-    }
+fn pooled_db_nested_paths_are_cleaned_up() {
+    // First run defines a name in a nested module; type-checks clean.
+    let r1 = type_check(&SourceFile::new("LEAKY: int = 1\n", "sub_dir/leaky.py"), None).unwrap();
+    assert!(r1.is_none(), "first nested-path run should succeed: {r1:#?}");
+
+    // Second run on the same path uses a different name; if the previous run's
+    // file or its containing directory leaked into the pool, `LEAKY` would still
+    // resolve. Must error.
+    let r2 = type_check(&SourceFile::new("x: int = LEAKY\n", "sub_dir/leaky.py"), None)
+        .unwrap()
+        .expect("nested-path leak probe must error — `LEAKY` must not survive into the next run");
+    let msg = r2.format(DiagnosticFormat::Concise).to_string();
+    assert!(
+        msg.contains("unresolved-reference") || msg.contains("Name `LEAKY`") || msg.contains("possibly-unbound"),
+        "nested-path leak probe must report `LEAKY` as undefined; got:\n{msg}"
+    );
+
+    // Third run from a *different* nested path importing the previous module must
+    // also fail — the directory should be empty / unresolvable.
+    let r3 = type_check(&SourceFile::new("from sub_dir.leaky import LEAKY\n", "other.py"), None)
+        .unwrap()
+        .expect("third run must error — sub_dir/leaky.py was deleted on cleanup");
+    let msg = r3.format(DiagnosticFormat::Concise).to_string();
+    assert!(
+        msg.contains("unresolved-import") || msg.contains("unresolved-reference"),
+        "third run must report the import as unresolved; got:\n{msg}"
+    );
 }
 
 #[test]

--- a/crates/monty-type-checking/tests/main.rs
+++ b/crates/monty-type-checking/tests/main.rs
@@ -305,11 +305,22 @@ fn pooled_db_concurrent_runs_stay_isolated() {
 #[test]
 fn pooled_db_rejects_non_root_paths() {
     let code = "x: int = 1\n";
-    for bad in ["", ".", "..", "a/b.py", "a\\b.py", "sub/mod.py", "../mod.py"] {
+    for bad in [
+        "",
+        ".",
+        "..",
+        "a/b.py",
+        "a\\b.py",
+        "sub/mod.py",
+        "../mod.py",
+        "/abs/path.py",
+        "/etc/passwd",
+        "has\0nul.py",
+    ] {
         let err = type_check(&SourceFile::new(code, bad), None)
             .expect_err(&format!("expected validation error for path {bad:?}"));
         assert!(
-            err.contains("root-level") || err.contains("empty"),
+            err.contains("root-level") || err.contains("empty") || err.contains("NUL"),
             "path {bad:?} should be rejected by validation, got: {err}"
         );
     }

--- a/crates/monty-type-checking/tests/main.rs
+++ b/crates/monty-type-checking/tests/main.rs
@@ -1,4 +1,4 @@
-use std::{env, fs};
+use std::{env, fs, thread};
 
 use monty_type_checking::{SourceFile, type_check};
 use pretty_assertions::assert_eq;
@@ -15,6 +15,44 @@ result = add(1, 2)
 
     let result = type_check(&SourceFile::new(code, "main.py"), None).unwrap();
     assert!(result.is_none());
+}
+
+#[test]
+fn type_checking_pool_reuse_does_not_leak_state() {
+    let ok = type_check(&SourceFile::new("x = 1", "main.py"), None).unwrap();
+    assert!(ok.is_none());
+
+    let err = type_check(&SourceFile::new("'hello' + 1", "main.py"), None).unwrap();
+    assert!(err.is_some());
+
+    let ok_again = type_check(&SourceFile::new("x = 1", "main.py"), None).unwrap();
+    assert!(ok_again.is_none());
+}
+
+#[test]
+fn type_checking_pool_reuse_does_not_leak_stubs() {
+    let with_stubs = type_check(
+        &SourceFile::new("result = call1_stub_var + 1", "main.py"),
+        Some(&SourceFile::new("call1_stub_var = 0", "type_stubs.pyi")),
+    )
+    .unwrap();
+    assert!(with_stubs.is_none());
+
+    let without_stubs = type_check(&SourceFile::new("result = call1_stub_var + 1", "main.py"), None).unwrap();
+    let failure = without_stubs.expect("stub-defined name should not survive db cleanup");
+
+    assert_eq!(
+        failure.to_string(),
+        r"error[unresolved-reference]: Name `call1_stub_var` used when not defined
+ --> main.py:1:10
+  |
+1 | result = call1_stub_var + 1
+  |          ^^^^^^^^^^^^^^
+  |
+info: rule `unresolved-reference` is enabled by default
+
+"
+    );
 }
 
 #[test]
@@ -51,6 +89,46 @@ info: rule `invalid-argument-type` is enabled by default
 
 "#
     );
+}
+
+#[test]
+fn type_checking_rejects_nested_paths() {
+    let error = type_check(&SourceFile::new("x = 1", "nested/main.py"), None).unwrap_err();
+    assert_eq!(
+        error,
+        "Type checking only supports root-level source file names, got 'nested/main.py'"
+    );
+}
+
+#[test]
+fn type_checking_concurrent_calls() {
+    thread::scope(|scope| {
+        let handles = (0..8)
+            .map(|_| {
+                scope.spawn(|| {
+                    for _ in 0..10 {
+                        let result = type_check(
+                            &SourceFile::new(
+                                "\
+def add(x: int, y: int) -> int:
+    return x + y
+
+result = add(1, 2)",
+                                "main.py",
+                            ),
+                            None,
+                        )
+                        .unwrap();
+                        assert!(result.is_none());
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+    });
 }
 
 #[test]

--- a/scripts/bench_type_checking.py
+++ b/scripts/bench_type_checking.py
@@ -2,8 +2,9 @@
 Benchmark: time successive calls to `Monty.type_check()` on different snippets.
 
 Runs six distinct snippets in a fixed order so you can see the one-time pooled-db
-warmup cost (call 1) vs. the steady-state cost (calls 2-6) once a scrubbed warm
-database is available for reuse, without re-checking the exact same source text.
+cold-start cost (call 1) vs. the steady-state cost (calls 2-6) once a scrubbed
+pooled database is available for reuse, without re-checking the exact same source
+text.
 
 Usage:
     python scripts/bench_type_checking.py

--- a/scripts/bench_type_checking.py
+++ b/scripts/bench_type_checking.py
@@ -1,0 +1,72 @@
+"""
+Benchmark: time successive calls to `Monty.type_check()` on the same small snippet.
+
+Measures the first, second, third, and fourth call independently so you can see
+the one-time warm-template cost (first call) vs. the steady-state cost (calls 2+)
+of the shared Salsa storage pre-warm.
+
+Usage:
+    python scripts/bench_type_checking.py [--runs N]
+"""
+
+import sys
+import time
+
+import pydantic_monty
+
+CODE = """\
+def foo(x: int, y: str | bytes) -> list[int | str | bytes]:
+    return [x, y]
+
+foo(1, '2')
+"""
+
+
+def format_ms(seconds: float) -> str:
+    """Format seconds as ms or us depending on magnitude."""
+    if seconds >= 1e-3:
+        return f'{seconds * 1000:.2f} ms'
+    return f'{seconds * 1_000_000:.1f} us'
+
+
+def time_one_call() -> float:
+    """Create a fresh Monty and time a single type_check invocation.
+
+    A new Monty per call mirrors typical usage (each snippet gets its own instance)
+    and avoids any per-instance caching hiding the effect we want to measure.
+    """
+    m = pydantic_monty.Monty(CODE)
+    start = time.perf_counter()
+    result = m.type_check()
+    elapsed = time.perf_counter() - start
+    assert result is None, f'unexpected type errors: {result}'
+    return elapsed
+
+
+def main() -> None:
+    runs = 4
+    if '--runs' in sys.argv:
+        runs = int(sys.argv[sys.argv.index('--runs') + 1])
+
+    print('type_check() latency, successive calls on the same snippet')
+    print('(if call 1 looks stuck, rebuild with `make dev-py-release`)')
+    print('-' * 60, flush=True)
+
+    times: list[float] = []
+    for i in range(1, runs + 1):
+        print(f'  call {i}: running...', end='', flush=True)
+        t = time_one_call()
+        times.append(t)
+        speedup = f'  {times[0] / t:.1f}x faster than call 1' if i > 1 and t > 0 else ''
+        print(f'\r  call {i}: {format_ms(t):>10}{speedup}          ', flush=True)
+
+    if len(times) > 1:
+        steady_avg = sum(times[1:]) / len(times[1:])
+        print('-' * 60)
+        print(f'  steady-state avg (calls 2..{runs}): {format_ms(steady_avg)}')
+        if steady_avg > 0:
+            print(f'  first-call overhead vs. steady-state: {times[0] / steady_avg:.1f}x')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/bench_type_checking.py
+++ b/scripts/bench_type_checking.py
@@ -1,25 +1,81 @@
 """
-Benchmark: time successive calls to `Monty.type_check()` on the same small snippet.
+Benchmark: time successive calls to `Monty.type_check()` on different snippets.
 
-Measures the first, second, third, and fourth call independently so you can see
-the one-time pooled-db warmup cost (first call) vs. the steady-state cost (calls 2+)
-once a scrubbed warm database is available for reuse.
+Runs six distinct snippets in a fixed order so you can see the one-time pooled-db
+warmup cost (call 1) vs. the steady-state cost (calls 2-6) once a scrubbed warm
+database is available for reuse, without re-checking the exact same source text.
 
 Usage:
-    python scripts/bench_type_checking.py [--runs N]
+    python scripts/bench_type_checking.py
 """
 
-import sys
 import time
 
 import pydantic_monty
 
-CODE = """\
-def foo(x: int, y: str | bytes) -> list[int | str | bytes]:
-    return [x, y]
+SNIPPETS: list[tuple[str, str]] = [
+    (
+        'union_return',
+        """\
+def pick_value(flag: bool, text: str) -> str | None:
+    if flag:
+        return text
+    return None
 
-foo(1, '2')
-"""
+pick_value(True, 'hello')
+""",
+    ),
+    (
+        'list_comprehension',
+        """\
+def scale(values: list[int]) -> list[int]:
+    return [value * 2 for value in values]
+
+scale([1, 2, 3])
+""",
+    ),
+    (
+        'dict_lookup',
+        """\
+def total(data: dict[str, int]) -> int:
+    return data['left'] + data['right']
+
+total({'left': 1, 'right': 2})
+""",
+    ),
+    (
+        'tuple_unpack',
+        """\
+def make_pair(name: str, count: int) -> tuple[str, int]:
+    return name, count
+
+label, amount = make_pair('item', 3)
+""",
+    ),
+    (
+        'optional_branch',
+        """\
+def normalize(value: int | None) -> int:
+    if value is None:
+        return 0
+    return value
+
+normalize(5)
+""",
+    ),
+    (
+        'nested_function',
+        """\
+def outer(scale: int) -> int:
+    def inner(value: int) -> int:
+        return value * scale
+
+    return inner(4)
+
+outer(3)
+""",
+    ),
+]
 
 
 def format_ms(seconds: float) -> str:
@@ -29,13 +85,13 @@ def format_ms(seconds: float) -> str:
     return f'{seconds * 1_000_000:.1f} us'
 
 
-def time_one_call() -> float:
+def time_one_call(code: str) -> float:
     """Create a fresh Monty and time a single type_check invocation.
 
     A new Monty per call mirrors typical usage (each snippet gets its own instance)
     and avoids any per-instance caching hiding the effect we want to measure.
     """
-    m = pydantic_monty.Monty(CODE)
+    m = pydantic_monty.Monty(code)
     start = time.perf_counter()
     result = m.type_check()
     elapsed = time.perf_counter() - start
@@ -44,22 +100,18 @@ def time_one_call() -> float:
 
 
 def main() -> None:
-    runs = 4
-    if '--runs' in sys.argv:
-        runs = int(sys.argv[sys.argv.index('--runs') + 1])
-
-    print('type_check() latency, successive calls')
-    print('-' * 50, flush=True)
+    print('type_check() latency, six successive calls on distinct snippets')
+    print('-' * 70, flush=True)
 
     times: list[float] = []
-    for i in range(1, runs + 1):
-        print(f'  call {i}: running...', end='', flush=True)
-        t = time_one_call()
+    for i, (name, code) in enumerate(SNIPPETS, start=1):
+        print(f'  call {i} ({name}): running...', end='', flush=True)
+        t = time_one_call(code)
         times.append(t)
         speedup = f'  {times[0] / t:.1f}x faster than call 1' if i > 1 and t > 0 else ''
-        print(f'\r  call {i}: {format_ms(t):>10}{speedup}          ', flush=True)
+        print(f'\r  call {i} {name:>20}: {format_ms(t):>10}{speedup}          ', flush=True)
 
-    print('-' * 50)
+    print('-' * 70)
 
 
 if __name__ == '__main__':

--- a/scripts/bench_type_checking.py
+++ b/scripts/bench_type_checking.py
@@ -48,9 +48,8 @@ def main() -> None:
     if '--runs' in sys.argv:
         runs = int(sys.argv[sys.argv.index('--runs') + 1])
 
-    print('type_check() latency, successive calls on the same snippet')
-    print('(if call 1 looks stuck, rebuild with `make dev-py-release`)')
-    print('-' * 60, flush=True)
+    print('type_check() latency, successive calls')
+    print('-' * 50, flush=True)
 
     times: list[float] = []
     for i in range(1, runs + 1):
@@ -60,12 +59,7 @@ def main() -> None:
         speedup = f'  {times[0] / t:.1f}x faster than call 1' if i > 1 and t > 0 else ''
         print(f'\r  call {i}: {format_ms(t):>10}{speedup}          ', flush=True)
 
-    if len(times) > 1:
-        steady_avg = sum(times[1:]) / len(times[1:])
-        print('-' * 60)
-        print(f'  steady-state avg (calls 2..{runs}): {format_ms(steady_avg)}')
-        if steady_avg > 0:
-            print(f'  first-call overhead vs. steady-state: {times[0] / steady_avg:.1f}x')
+    print('-' * 50)
 
 
 if __name__ == '__main__':

--- a/scripts/bench_type_checking.py
+++ b/scripts/bench_type_checking.py
@@ -2,8 +2,8 @@
 Benchmark: time successive calls to `Monty.type_check()` on the same small snippet.
 
 Measures the first, second, third, and fourth call independently so you can see
-the one-time warm-template cost (first call) vs. the steady-state cost (calls 2+)
-of the shared Salsa storage pre-warm.
+the one-time pooled-db warmup cost (first call) vs. the steady-state cost (calls 2+)
+once a scrubbed warm database is available for reuse.
 
 Usage:
     python scripts/bench_type_checking.py [--runs N]


### PR DESCRIPTION
Reusable pool of `MemoryDb`s to improve performance on repeated typechecking within a process.

Performance gains:

```
type_check() latency, six successive calls on distinct snippets
----------------------------------------------------------------------
  call 1         union_return:   93.09 ms
  call 2   list_comprehension:    5.18 ms  18.0x faster than call 1
  call 3          dict_lookup:    2.06 ms  45.2x faster than call 1
  call 4         tuple_unpack:   886.2 us  105.0x faster than call 1
  call 5      optional_branch:   689.5 us  135.0x faster than call 1
  call 6      nested_function:   968.0 us  96.2x faster than call 1
----------------------------------------------------------------------
```