### PR TITLE
replace `vm.cleanup()` with `Drop` implementation

### DIFF
--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -588,7 +588,7 @@ pub struct VM<'h, 'a, T: ResourceTracker> {
     ///
     /// Deduplicates heap allocations for repeated strings (especially dict keys)
     /// across multiple `json.loads()` calls within a single execution. Lazily
-    /// initialized on first use, cleaned up in [`cleanup()`](Self::cleanup).
+    /// initialized on first use, cleaned up when the VM is dropped.
     pub(crate) json_string_cache: JsonStringCache,
 }
 
@@ -694,12 +694,12 @@ impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
         VMSnapshot {
             // Move values directly — no clone, no refcount increment needed
             // (the VM owned them, now the snapshot owns them)
-            stack: self.stack,
-            globals: self.globals,
-            frames: self.frames.into_iter().map(|f| f.serialize()).collect(),
-            exception_stack: self.exception_stack,
+            stack: mem::take(&mut self.stack),
+            globals: mem::take(&mut self.globals),
+            frames: self.frames.iter().map(CallFrame::serialize).collect(),
+            exception_stack: mem::take(&mut self.exception_stack),
             instruction_ip: self.instruction_ip,
-            scheduler: self.scheduler,
+            scheduler: mem::take(&mut self.scheduler),
         }
     }
 
@@ -709,22 +709,6 @@ impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
         self.module_code = Some(code);
         self.push_frame(CallFrame::new_module(code))?;
         self.run()
-    }
-
-    /// Cleans up VM state before the VM is dropped.
-    ///
-    /// This method must be called before the VM goes out of scope to ensure
-    /// proper reference counting cleanup for any exception values and scheduler state.
-    pub fn cleanup(&mut self) {
-        // Drop all exceptions in the exception stack
-        self.exception_stack.drain(..).drop_with_heap(self.heap);
-        // Clean up current task's stack values and frame cell references
-        self.cleanup_current_task();
-        // Clean up scheduler state (task stacks, pending calls, resolved values, frame cells)
-        self.scheduler.cleanup(self.heap);
-        self.globals.drain(..).drop_with_heap(self.heap);
-        // Release cached JSON string values
-        self.json_string_cache.drop_all(self.heap);
     }
 
     /// Returns the `stack_base` of the current (topmost) call frame.
@@ -740,8 +724,9 @@ impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
 
     /// Takes ownership of the globals vector, replacing it with an empty vec.
     ///
-    /// Used by the REPL to reclaim globals after VM execution completes,
-    /// before calling `cleanup()` (which would destroy them in ref-count-panic mode).
+    /// Used by the REPL to reclaim globals after VM execution completes.
+    /// Must be called before the VM is dropped, since `Drop` will clean up
+    /// any remaining globals with `drop_with_heap`.
     pub fn take_globals(&mut self) -> Vec<Value> {
         mem::take(&mut self.globals)
     }
@@ -1970,5 +1955,21 @@ impl<T: ResourceTracker> ContainsHeap for VM<'_, '_, T> {
     }
     fn heap_mut(&mut self) -> &mut Heap<T> {
         self.heap
+    }
+}
+
+/// Ensures proper reference-counting cleanup when the VM goes out of scope.
+///
+/// Drains exception stack, operand stack, globals, scheduler state, and JSON
+/// string cache — all of which may hold heap references that need their
+/// ref-counts decremented. Fields that were already emptied (e.g. by
+/// `take_globals`) are harmlessly drained as empty.
+impl<T: ResourceTracker> Drop for VM<'_, '_, T> {
+    fn drop(&mut self) {
+        self.exception_stack.drain(..).drop_with_heap(self.heap);
+        self.cleanup_current_task();
+        self.scheduler.cleanup(self.heap);
+        self.globals.drain(..).drop_with_heap(self.heap);
+        self.json_string_cache.drop_all(self.heap);
     }
 }

--- a/crates/monty/src/modules/json/string_cache.rs
+++ b/crates/monty/src/modules/json/string_cache.rs
@@ -12,7 +12,7 @@
 //! lazily initialized so programs that never call `json.loads()` pay zero cost.
 //!
 //! The cache lives on the [`VM`] and is scoped to a single execution run. It
-//! is cleaned up in [`VM::cleanup()`] and its entries are registered as GC
+//! is cleaned up when the VM is dropped and its entries are registered as GC
 //! roots in [`VM::run_gc()`].
 
 use std::iter;
@@ -56,7 +56,7 @@ type CacheEntry = Option<(u64, Box<str>, Value)>;
 /// - Backing storage allocated on the first `get_or_allocate` call with an
 ///   eligible string (2–64 bytes).
 /// - Persists across multiple `json.loads()` calls within the same run.
-/// - Cleaned up in `VM::cleanup()` via [`drop_all`](Self::drop_all).
+/// - Cleaned up when the VM is dropped via [`drop_all`](Self::drop_all).
 /// - Cached values are reported as GC roots via [`gc_roots`](Self::gc_roots).
 #[derive(Default)]
 pub(crate) struct JsonStringCache {
@@ -95,7 +95,7 @@ impl JsonStringCache {
 
     /// Drops all cached values, decrementing their refcounts.
     ///
-    /// Called during `VM::cleanup()` before the heap is torn down.
+    /// Called during `VM::drop()` before the heap is torn down.
     pub fn drop_all(&mut self, heap: &mut impl ContainsHeap) {
         if let Some(inner) = &mut self.inner {
             for entry in inner.entries.iter_mut() {

--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -145,7 +145,6 @@ impl<T: ResourceTracker> MontyRepl<T> {
             // Inject inputs with VM alive
             if let Err(error) = inject_inputs_into_vm(&executor, input_values, &mut vm) {
                 this.globals = vm.take_globals();
-                vm.cleanup();
                 return Err(error);
             }
 
@@ -157,7 +156,6 @@ impl<T: ResourceTracker> MontyRepl<T> {
                 Some(vm.snapshot())
             } else {
                 this.globals = vm.take_globals();
-                vm.cleanup();
                 None
             };
             Ok((converted, vm_state))
@@ -205,7 +203,6 @@ impl<T: ResourceTracker> MontyRepl<T> {
 
             if let Err(e) = inject_inputs_into_vm(&executor, input_values, &mut vm) {
                 self.globals = vm.take_globals();
-                vm.cleanup();
                 return Err(e);
             }
 
@@ -213,7 +210,6 @@ impl<T: ResourceTracker> MontyRepl<T> {
 
             // Reclaim globals before cleanup.
             self.globals = vm.take_globals();
-            vm.cleanup();
             Ok(result)
         })?;
 
@@ -565,7 +561,6 @@ impl<T: ResourceTracker> ReplNameLookup<T> {
                         Ok(v) => v,
                         Err(e) => {
                             repl.globals = vm.take_globals();
-                            vm.cleanup();
                             return Err(MontyException::runtime_error(format!(
                                 "invalid name lookup result: {e}"
                             )));
@@ -600,7 +595,6 @@ impl<T: ResourceTracker> ReplNameLookup<T> {
                 Some(vm.snapshot())
             } else {
                 repl.globals = vm.take_globals();
-                vm.cleanup();
                 None
             };
             Ok((converted, vm_state))
@@ -687,7 +681,6 @@ impl<T: ResourceTracker> ReplResolveFutures<T> {
 
             if let Some(call_id) = invalid_call_id {
                 repl.globals = vm.take_globals();
-                vm.cleanup();
                 return Err(MontyException::runtime_error(format!(
                     "unknown call_id {call_id}, expected one of: {pending_call_ids:?}"
                 )));
@@ -698,7 +691,6 @@ impl<T: ResourceTracker> ReplResolveFutures<T> {
                     ExtFunctionResult::Return(obj) => {
                         if let Err(e) = vm.resolve_future(call_id, obj) {
                             repl.globals = vm.take_globals();
-                            vm.cleanup();
                             return Err(MontyException::runtime_error(format!(
                                 "Invalid return type for call {call_id}: {e}"
                             )));
@@ -714,7 +706,6 @@ impl<T: ResourceTracker> ReplResolveFutures<T> {
 
             if let Some(error) = vm.take_failed_task_error() {
                 repl.globals = vm.take_globals();
-                vm.cleanup();
                 return Err(error.into_python_exception(&executor.interns, &executor.code));
             }
 
@@ -724,7 +715,6 @@ impl<T: ResourceTracker> ReplResolveFutures<T> {
                 Ok(loaded) => loaded,
                 Err(e) => {
                     repl.globals = vm.take_globals();
-                    vm.cleanup();
                     return Err(e.into_python_exception(&executor.interns, &executor.code));
                 }
             };
@@ -746,7 +736,6 @@ impl<T: ResourceTracker> ReplResolveFutures<T> {
                 Some(vm.snapshot())
             } else {
                 repl.globals = vm.take_globals();
-                vm.cleanup();
                 None
             };
             Ok((converted, vm_state))
@@ -886,7 +875,6 @@ impl<T: ResourceTracker> ReplSnapshot<T> {
                 Some(vm.snapshot())
             } else {
                 repl.globals = vm.take_globals();
-                vm.cleanup();
                 None
             };
             (converted, vm_state)

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -312,9 +312,7 @@ impl Executor {
         let result = HeapReader::with(&mut heap, |heap| {
             let mut vm = VM::new(globals, heap, &self.interns, print.reborrow());
             self.populate_inputs(inputs, &mut vm)?;
-            let result = self.run_to_completion(&mut vm);
-            vm.cleanup();
-            result
+            self.run_to_completion(&mut vm)
         });
 
         if heap.size() > heap_capacity {
@@ -421,8 +419,6 @@ impl Executor {
             let py_object = frame_exit_to_object(frame_exit_result, &mut vm)
                 .map_err(|e| e.into_python_exception(&self.interns, &self.code))?;
 
-            vm.cleanup();
-
             // Drop globals with proper ref counting
             for value in globals {
                 value.drop_with_heap(vm.heap);
@@ -452,7 +448,7 @@ impl Executor {
     /// Converts `MontyObject` inputs to `Value`s and writes them into the VM's globals.
     ///
     /// This runs with the VM alive so that `to_value` has access to the full VM context.
-    /// On error partway through, the VM's `cleanup()` (via drop) will drain globals and
+    /// On error partway through, the VM's `Drop` impl will drain globals and
     /// properly decrement refcounts for any already-converted values.
     pub(crate) fn populate_inputs(
         &self,

--- a/crates/monty/src/run_progress.rs
+++ b/crates/monty/src/run_progress.rs
@@ -332,10 +332,9 @@ impl<T: ResourceTracker> NameLookup<T> {
             // Resolve the name lookup result with the VM alive
             let vm_result = match result {
                 NameLookupResult::Value(obj) => {
-                    let value = obj.to_value(&mut vm).map_err(|e| {
-                        vm.cleanup();
-                        MontyException::runtime_error(format!("invalid name lookup result: {e}"))
-                    })?;
+                    let value = obj
+                        .to_value(&mut vm)
+                        .map_err(|e| MontyException::runtime_error(format!("invalid name lookup result: {e}")))?;
 
                     // Cache the resolved value in the appropriate slot
                     let slot = self.namespace_slot as usize;
@@ -454,7 +453,6 @@ impl<T: ResourceTracker> ResolveFutures<T> {
 
             // Now check for invalid call_ids after VM is restored.
             if let Some(call_id) = invalid_call_id {
-                vm.cleanup();
                 return Err(MontyException::runtime_error(format!(
                     "unknown call_id {call_id}, expected one of: {pending_call_ids:?}"
                 )));
@@ -475,7 +473,6 @@ impl<T: ResourceTracker> ResolveFutures<T> {
 
             // Check if the current task has failed.
             if let Some(error) = vm.take_failed_task_error() {
-                vm.cleanup();
                 return Err(error.into_python_exception(&executor.interns, &executor.code));
             }
 
@@ -485,7 +482,6 @@ impl<T: ResourceTracker> ResolveFutures<T> {
             let loaded_task = match vm.load_ready_task_if_needed() {
                 Ok(loaded) => loaded,
                 Err(e) => {
-                    vm.cleanup();
                     return Err(e.into_python_exception(&executor.interns, &executor.code));
                 }
             };
@@ -749,15 +745,14 @@ pub(crate) fn convert_frame_exit(
 /// Decides whether to snapshot or clean up the VM based on the converted exit.
 ///
 /// Consumes the VM. Returns `Some(VMSnapshot)` for suspendable exits, `None` for
-/// completion/error (in which case the VM is cleaned up).
+/// completion/error (in which case the VM's `Drop` impl handles cleanup).
 pub(crate) fn check_snapshot_from_converted(
     converted: &ConvertedExit,
-    mut vm: VM<'_, '_, impl ResourceTracker>,
+    vm: VM<'_, '_, impl ResourceTracker>,
 ) -> Option<VMSnapshot> {
     if converted.needs_snapshot() {
         Some(vm.snapshot())
     } else {
-        vm.cleanup();
         None
     }
 }


### PR DESCRIPTION
It should be the case that when the VM is dropped without snapshotting, in-flight execution state is always cleaned up properly.