### PR TITLE
fix: support datetime.now() in standard execution (#330)

### DIFF
--- a/crates/monty/src/os.rs
+++ b/crates/monty/src/os.rs
@@ -10,7 +10,11 @@
 //! I/O, filesystem, or network operations. Instead, the host decides whether to
 //! permit and execute such operations.
 
-use crate::{ExcType, MontyException, MontyObject, intern::StaticStrings, types::str::StringRepr};
+use chrono::{Datelike, Local, Timelike, Utc};
+
+use crate::{
+    ExcType, MontyDate, MontyDateTime, MontyException, MontyObject, intern::StaticStrings, types::str::StringRepr,
+};
 
 /// OS operations that require host system access.
 ///
@@ -283,4 +287,71 @@ pub fn stat_result(
             MontyObject::Float(st_ctime),
         ],
     }
+}
+
+// =============================================================================
+// Host clock helpers
+// =============================================================================
+// These helpers are used by standard (non-iterative) execution to satisfy the
+// `DateToday` and `DateTimeNow` OS calls directly from the host clock, without
+// going through the suspend/resume plumbing. The iterative (`start`/`resume`)
+// path still surfaces these as `RunProgress::OsCall`, so hosts can keep
+// overriding them with deterministic clocks when needed.
+//
+// Reading the host wall-clock is deliberately allowed in the sandbox: it only
+// exposes time-of-day, which untrusted code can already estimate via loop
+// timing. It does not grant access to the filesystem, environment, or any
+// external resources.
+
+/// Returns the host system's local date as a `MontyObject::Date`.
+///
+/// Used by `date.today()` in standard execution. Mirrors the CPython semantics
+/// of returning the local civil date (not UTC).
+#[must_use]
+pub(crate) fn host_date_today() -> MontyObject {
+    let local = Local::now().naive_local();
+    MontyObject::Date(MontyDate {
+        year: local.year(),
+        month: u8::try_from(local.month()).expect("month is always 1..=12"),
+        day: u8::try_from(local.day()).expect("day is always 1..=31"),
+    })
+}
+
+/// Returns the host system's current date/time as a `MontyObject::DateTime`.
+///
+/// Used by `datetime.now(tz=...)` in standard execution. The `tz` argument
+/// determines the returned value:
+/// - `MontyObject::None`: naive datetime using local wall-clock time.
+/// - `MontyObject::TimeZone`: aware datetime, with the host's UTC instant
+///   adjusted by the fixed offset and the original tz metadata retained so the
+///   constructed datetime keeps `tzinfo == tz`.
+///
+/// Any other `tz` variant is treated like `None`; callers in the VM have
+/// already validated the argument, so this is a defensive fallback.
+#[must_use]
+pub(crate) fn host_datetime_now(tz: &MontyObject) -> MontyObject {
+    // For aware tz, compute local civil components by shifting the real UTC
+    // instant by the fixed offset, and preserve the caller's offset/name so
+    // `datetime.tzinfo` stays equal to the supplied tz. For naive/None, fall
+    // back to the host's local wall-clock time.
+    let (local, offset_seconds, timezone_name) = if let MontyObject::TimeZone(tz) = tz {
+        let offset_delta =
+            chrono::TimeDelta::try_seconds(i64::from(tz.offset_seconds)).expect("timezone offset validated");
+        let local = (Utc::now() + offset_delta).naive_utc();
+        (local, Some(tz.offset_seconds), tz.name.clone())
+    } else {
+        (Local::now().naive_local(), None, None)
+    };
+
+    MontyObject::DateTime(MontyDateTime {
+        year: local.year(),
+        month: u8::try_from(local.month()).expect("month is always 1..=12"),
+        day: u8::try_from(local.day()).expect("day is always 1..=31"),
+        hour: u8::try_from(local.hour()).expect("hour is always 0..=23"),
+        minute: u8::try_from(local.minute()).expect("minute is always 0..=59"),
+        second: u8::try_from(local.second()).expect("second is always 0..=59"),
+        microsecond: local.and_utc().timestamp_subsec_micros(),
+        offset_seconds,
+        timezone_name,
+    })
 }

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -12,6 +12,7 @@ use crate::{
     io::PrintWriter,
     namespace::NamespaceId,
     object::MontyObject,
+    os::{OsFunction, host_date_today, host_datetime_now},
     parse::{parse, parse_with_interner},
     prepare::{prepare, prepare_with_existing_names},
     resource::{NoLimitTracker, ResourceTracker},
@@ -324,18 +325,22 @@ impl Executor {
 
     /// Runs module code on an already-configured VM to completion.
     ///
-    /// Executes [`VM::run_module`], then handles `NameLookup` and `ExternalCall`
-    /// exits by raising `NameError` through the VM so tracebacks are properly
-    /// captured. Finally converts the result via [`frame_exit_to_object`].
+    /// Executes [`VM::run_module`], then handles `NameLookup`, `ExternalCall`,
+    /// and host-clock OS exits so the non-iterative path can run code that uses
+    /// `datetime.now()` / `date.today()` without yielding to a host callback.
+    /// Finally converts the result via [`frame_exit_to_object`].
     ///
     /// This is the shared non-iterative execution core used by both the standard
     /// `run` path and the REPL's `feed_run` path.
     pub(crate) fn run_to_completion<'a>(&'a self, vm: &mut VM<'_, 'a, impl ResourceTracker>) -> RunResult<MontyObject> {
         let mut frame_exit_result = vm.run_module(&self.module_code);
 
-        // Handle NameLookup and ExternalCall exits by raising NameError through the VM
-        // so that traceback information is properly captured. In the non-iterative path,
-        // there's no host to resolve names or external functions, so these become NameErrors.
+        // Handle suspendable exits that the standard path can satisfy itself:
+        // - `NameLookup`/`ExternalCall`: no host to consult, so raise `NameError`
+        //   with traceback info preserved.
+        // - `OsCall` with `DateTimeNow`/`DateToday`: read the host clock directly
+        //   and resume, so callers never need to wire up a host callback for the
+        //   common `datetime.now()` / `date.today()` cases.
         loop {
             match frame_exit_result {
                 Ok(FrameExit::NameLookup { name_id, .. }) => {
@@ -360,6 +365,24 @@ impl Executor {
                     args.drop_with_heap(vm);
                     let err = ExcType::name_error(name);
                     frame_exit_result = vm.resume_with_exception(err.into());
+                }
+                Ok(FrameExit::OsCall {
+                    function: function @ (OsFunction::DateTimeNow | OsFunction::DateToday),
+                    args,
+                    ..
+                }) => {
+                    // Convert args to owned MontyObjects (this drops the backing heap refs),
+                    // then compute the result against the host clock and resume.
+                    let (args_py, kwargs_py) = args.into_py_objects(vm);
+                    let result = match function {
+                        OsFunction::DateTimeNow => host_datetime_now(args_py.first().unwrap_or(&MontyObject::None)),
+                        OsFunction::DateToday => host_date_today(),
+                        _ => unreachable!("outer pattern restricts to clock OS calls"),
+                    };
+                    // `kwargs_py` can only be empty for these two OS functions — the
+                    // classmethod builders always use positional `ArgValues`.
+                    debug_assert!(kwargs_py.is_empty(), "clock OS calls never carry kwargs");
+                    frame_exit_result = vm.resume(result);
                 }
                 _ => break,
             }

--- a/crates/monty/test_cases/datetime__now_standard.py
+++ b/crates/monty/test_cases/datetime__now_standard.py
@@ -1,0 +1,47 @@
+import datetime
+
+# === datetime.now() in standard execution (no # call-external marker) ===
+# Regression test for https://github.com/pydantic/monty/issues/330
+# Before the fix, calling datetime.now() in standard (non-suspendable) execution
+# raised NotImplementedError because it was only wired as an OS call that
+# required the iterative host callback path.
+
+# naive datetime
+now_naive = datetime.datetime.now()
+assert isinstance(now_naive, datetime.datetime), 'datetime.now() should return a datetime'
+assert now_naive.tzinfo is None, 'datetime.now() without tz should be naive'
+assert 1 <= now_naive.month <= 12, 'datetime.now() month should be in 1..=12'
+assert 1 <= now_naive.day <= 31, 'datetime.now() day should be in 1..=31'
+assert 0 <= now_naive.hour <= 23, 'datetime.now() hour should be in 0..=23'
+assert 0 <= now_naive.minute <= 59, 'datetime.now() minute should be in 0..=59'
+assert 0 <= now_naive.second <= 59, 'datetime.now() second should be in 0..=59'
+assert now_naive.year >= 2024, 'datetime.now() year should not be in the distant past'
+
+# aware UTC datetime
+now_utc = datetime.datetime.now(datetime.timezone.utc)
+assert isinstance(now_utc, datetime.datetime), 'datetime.now(utc) should return a datetime'
+assert now_utc.tzinfo is datetime.timezone.utc, 'datetime.now(timezone.utc) should preserve the utc singleton'
+
+# aware fixed-offset datetime
+plus_two = datetime.timezone(datetime.timedelta(hours=2))
+now_plus_two = datetime.datetime.now(plus_two)
+assert now_plus_two.tzinfo == plus_two, 'datetime.now(+2h) should preserve the offset'
+
+# keyword tz argument
+now_kw = datetime.datetime.now(tz=datetime.timezone.utc)
+assert now_kw.tzinfo is not None, 'datetime.now(tz=...) should return aware datetime'
+
+# explicit tz=None is equivalent to naive
+now_tz_none = datetime.datetime.now(tz=None)
+assert now_tz_none.tzinfo is None, 'datetime.now(tz=None) should be naive'
+
+# date.today() shares the same OS-call plumbing, so the standard-execution
+# fallback naturally applies to it as well.
+today = datetime.date.today()
+assert isinstance(today, datetime.date), 'date.today() should return a date'
+assert today.year >= 2024, 'date.today() year should not be in the distant past'
+assert 1 <= today.month <= 12, 'date.today() month should be in 1..=12'
+assert 1 <= today.day <= 31, 'date.today() day should be in 1..=31'
+# date.today() and datetime.now().date() should agree on the calendar date
+# when called back-to-back (modulo a vanishingly-rare midnight crossing).
+assert today == datetime.datetime.now().date(), 'date.today() should match datetime.now().date()'


### PR DESCRIPTION
## Summary
- Fixes pydantic/monty#330: `datetime.now()` previously raised `NotImplementedError: OS function 'datetime.now' not implemented with standard execution`.
- Standard (non-iterative) execution now satisfies `OsCall::DateTimeNow` and `OsCall::DateToday` by reading the host wall-clock directly, instead of falling through to the unimplemented path.
- Iterative `start`/`resume` callers are untouched — hosts can still inject a deterministic clock via `RunProgress::OsCall`.

> Draft: opening for upstream visibility. Note overlap in scope with #332, which takes a callback-based approach via `AbstractOS`. Happy to adapt or close in favor of #332.

## Approach
- New `host_date_today()` / `host_datetime_now(tz)` helpers in `crates/monty/src/os.rs` use `chrono` to produce `MontyObject::Date` / `MontyObject::DateTime`. Aware tz mirrors the existing test harness pattern (UTC shifted by fixed offset) and preserves the caller's `tz` so `datetime.tzinfo is tz` holds.
- `Executor::run_to_completion` in `crates/monty/src/run.rs` intercepts only the clock variants of `FrameExit::OsCall`; filesystem/env OS calls still surface as `NotImplementedError`, preserving the sandbox model.

## Test plan
- [x] New `crates/monty/test_cases/datetime__now_standard.py` covers naive, UTC, fixed-offset, `tz=` kwarg, `tz=None`, and `date.today()` — passes on Monty and CPython.
- [x] Pre-fix RED verified: same test failed with the original error.
- [x] Full datatest suite: 930 passed.
- [x] `cargo test -p monty --features ref-count-panic` passes (incl. iterative `os_tests.rs`).
- [x] `make pytest`: 891 passed.
- [x] `cargo clippy ... -D warnings`, `cargo fmt --check`, `make lint-py` all clean.