### PR TITLE
feat: implement datetime.time (#331)

### DIFF
--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -26,7 +26,7 @@ use crate::{
     types::{
         Bytes, Dataclass, Dict, DictItemsView, DictKeysView, DictValuesView, FrozenSet, List, LongInt, Module,
         MontyIter, NamedTuple, Path, Range, ReMatch, RePattern, Set, Slice, Str, TimeZone, Tuple, allocate_tuple, date,
-        datetime, timedelta, timezone,
+        datetime, time, timedelta, timezone,
     },
     value::Value,
 };
@@ -88,6 +88,7 @@ impl HashState {
             | HeapData::LongInt(_)
             | HeapData::Date(_)
             | HeapData::DateTime(_)
+            | HeapData::Time(_)
             | HeapData::TimeDelta(_)
             | HeapData::TimeZone(_) => Self::Unknown,
             // Dataclass hashability depends on the mutable flag
@@ -232,6 +233,7 @@ impl<'a, T: ResourceTracker> HeapReader<'a, T> {
             HeapData::ReMatch(re_match) => HeapReadOutput::ReMatch(heap_read(base, re_match, readers)),
             HeapData::Date(d) => HeapReadOutput::Date(heap_read(base, d, readers)),
             HeapData::DateTime(d) => HeapReadOutput::DateTime(heap_read(base, d, readers)),
+            HeapData::Time(t) => HeapReadOutput::Time(heap_read(base, t, readers)),
             HeapData::TimeDelta(d) => HeapReadOutput::TimeDelta(heap_read(base, d, readers)),
             HeapData::TimeZone(d) => HeapReadOutput::TimeZone(heap_read(base, d, readers)),
         }
@@ -317,6 +319,7 @@ pub enum HeapReadOutput<'a> {
     ReMatch(HeapRead<'a, ReMatch>),
     Date(HeapRead<'a, date::Date>),
     DateTime(HeapRead<'a, datetime::DateTime>),
+    Time(HeapRead<'a, time::Time>),
     TimeDelta(HeapRead<'a, timedelta::TimeDelta>),
     TimeZone(HeapRead<'a, timezone::TimeZone>),
 }
@@ -1406,6 +1409,12 @@ fn compute_hash_from_read<'h>(
             let mut hasher = DefaultHasher::new();
             heap_disc(vm.heap, id).hash(&mut hasher);
             d.get(vm.heap).hash(&mut hasher);
+            Ok(Some(hasher.finish()))
+        }
+        HeapReadOutput::Time(t) => {
+            let mut hasher = DefaultHasher::new();
+            heap_disc(vm.heap, id).hash(&mut hasher);
+            t.get(vm.heap).hash(&mut hasher);
             Ok(Some(hasher.finish()))
         }
         HeapReadOutput::TimeDelta(d) => {

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -14,7 +14,7 @@ use crate::{
     types::{
         Bytes, Dataclass, Dict, DictItemsView, DictKeysView, DictValuesView, FrozenSet, List, LongInt, Module,
         MontyIter, NamedTuple, Path, PyTrait, Range, ReMatch, RePattern, Set, Slice, Str, Tuple, Type, date, datetime,
-        dict_view::DictView, timedelta, timezone,
+        dict_view::DictView, time, timedelta, timezone,
     },
     value::{EitherStr, Value},
 };
@@ -119,6 +119,8 @@ pub(crate) enum HeapData {
     Date(date::Date),
     /// A `datetime.datetime` value stored with chrono primitives.
     DateTime(datetime::DateTime),
+    /// A `datetime.time` value stored with narrow integer fields.
+    Time(time::Time),
     /// A `datetime.timedelta` duration value stored with `chrono::TimeDelta`.
     TimeDelta(timedelta::TimeDelta),
     /// A fixed-offset `datetime.timezone` value.
@@ -238,6 +240,7 @@ impl HeapData {
             Self::ReMatch(_) => Type::ReMatch,
             Self::Date(_) => Type::Date,
             Self::DateTime(_) => Type::DateTime,
+            Self::Time(_) => Type::Time,
             Self::TimeDelta(_) => Type::TimeDelta,
             Self::TimeZone(_) => Type::TimeZone,
         }
@@ -274,6 +277,7 @@ impl HeapData {
             Self::ExtFunction(s) => mem::size_of::<String>() + s.len(),
             Self::Date(d) => d.py_estimate_size(),
             Self::DateTime(d) => d.py_estimate_size(),
+            Self::Time(t) => t.py_estimate_size(),
             Self::TimeDelta(d) => d.py_estimate_size(),
             Self::TimeZone(d) => d.py_estimate_size(),
         }
@@ -449,7 +453,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
             Self::ReMatch(m) => m.py_bool(vm),
             Self::RePattern(p) => p.py_bool(vm),
             Self::TimeDelta(td) => td.py_bool(vm),
-            Self::Date(_) | Self::DateTime(_) | Self::TimeZone(_) => true,
+            Self::Date(_) | Self::DateTime(_) | Self::Time(_) | Self::TimeZone(_) => true,
         }
     }
 
@@ -479,6 +483,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
             HeapReadOutput::TimeDelta(td) => Ok(td.py_call_attr(self_id, vm, attr, args)?),
             HeapReadOutput::Date(d) => Ok(d.py_call_attr(self_id, vm, attr, args)?),
             HeapReadOutput::DateTime(dt) => Ok(dt.py_call_attr(self_id, vm, attr, args)?),
+            HeapReadOutput::Time(t) => Ok(t.py_call_attr(self_id, vm, attr, args)?),
             // Types without methods — return AttributeError
             _ => {
                 args.drop_with_heap(vm);
@@ -516,6 +521,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
             Self::RePattern(p) => p.py_type(vm),
             Self::Date(d) => d.py_type(vm),
             Self::DateTime(d) => d.py_type(vm),
+            Self::Time(t) => t.py_type(vm),
             Self::TimeDelta(d) => d.py_type(vm),
             Self::TimeZone(d) => d.py_type(vm),
         }
@@ -647,6 +653,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
             // Datetime types
             (HeapReadOutput::Date(a), HeapReadOutput::Date(b)) => a.py_eq(b, vm),
             (HeapReadOutput::DateTime(a), HeapReadOutput::DateTime(b)) => a.py_eq(b, vm),
+            (HeapReadOutput::Time(a), HeapReadOutput::Time(b)) => a.py_eq(b, vm),
             (HeapReadOutput::TimeDelta(a), HeapReadOutput::TimeDelta(b)) => a.py_eq(b, vm),
             (HeapReadOutput::TimeZone(a), HeapReadOutput::TimeZone(b)) => a.py_eq(b, vm),
             // Identity-only types (handled by HeapId comparison above)
@@ -713,6 +720,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
             Self::ExtFunction(name) => Ok(write!(f, "<function '{}' external>", name.get(vm.heap))?),
             Self::Date(d) => d.py_repr_fmt(f, vm, heap_ids),
             Self::DateTime(d) => d.py_repr_fmt(f, vm, heap_ids),
+            Self::Time(t) => t.py_repr_fmt(f, vm, heap_ids),
             Self::TimeDelta(d) => d.py_repr_fmt(f, vm, heap_ids),
             Self::TimeZone(d) => d.py_repr_fmt(f, vm, heap_ids),
         }
@@ -735,6 +743,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
             // Datetime types have their own str output
             Self::Date(d) => d.py_str(vm),
             Self::DateTime(d) => d.py_str(vm),
+            Self::Time(t) => t.py_str(vm),
             Self::TimeDelta(d) => d.py_str(vm),
             Self::TimeZone(d) => d.py_str(vm),
             // All other types use repr
@@ -912,6 +921,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
             Self::Path(p) => p.py_getattr(attr, vm),
             Self::Date(d) => d.py_getattr(attr, vm),
             Self::DateTime(dt) => dt.py_getattr(attr, vm),
+            Self::Time(t) => t.py_getattr(attr, vm),
             Self::TimeDelta(td) => td.py_getattr(attr, vm),
             _ => Ok(None),
         }

--- a/crates/monty/src/intern.rs
+++ b/crates/monty/src/intern.rs
@@ -469,6 +469,8 @@ pub enum StaticStrings {
     // datetime module strings
     Datetime,
     Date,
+    /// `datetime.time` class name and attribute on `datetime.datetime`.
+    Time,
     Timedelta,
     Timezone,
     Today,
@@ -484,6 +486,8 @@ pub enum StaticStrings {
     Minute,
     Second,
     Microsecond,
+    /// `datetime.time.fold` attribute / `time(fold=...)` keyword.
+    Fold,
     // timedelta constructor/attribute names
     Days,
     Seconds,

--- a/crates/monty/src/modules/datetime.rs
+++ b/crates/monty/src/modules/datetime.rs
@@ -3,6 +3,7 @@
 //! This module exposes a minimal phase-1 surface:
 //! - `date`
 //! - `datetime`
+//! - `time`
 //! - `timedelta`
 //! - `timezone`
 //!
@@ -35,6 +36,7 @@ pub fn create_module(vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<HeapId
         Value::Builtin(Builtins::Type(Type::DateTime)),
         vm,
     );
+    module.set_attr(StaticStrings::Time, Value::Builtin(Builtins::Type(Type::Time)), vm);
     module.set_attr(
         StaticStrings::Timedelta,
         Value::Builtin(Builtins::Type(Type::TimeDelta)),

--- a/crates/monty/src/object.rs
+++ b/crates/monty/src/object.rs
@@ -675,6 +675,11 @@ impl MontyObject {
                         offset_seconds: tz.offset_seconds,
                         name: tz.name.clone(),
                     }),
+                    // Phase 1: `time` has no dedicated `MontyObject` variant yet;
+                    // round-tripping it through the public API falls back to a repr
+                    // placeholder. We can add a `MontyTime` variant in a future phase
+                    // once host bindings need it.
+                    HeapData::Time(_) => repr_or_error(object, vm),
                     // Cells are internal closure implementation details
                     HeapData::Cell(cell) => {
                         // Show the cell's contents

--- a/crates/monty/src/types/mod.rs
+++ b/crates/monty/src/types/mod.rs
@@ -25,6 +25,7 @@ pub mod re_pattern;
 pub mod set;
 pub mod slice;
 pub mod str;
+pub mod time;
 pub mod timedelta;
 pub mod timezone;
 pub mod tuple;

--- a/crates/monty/src/types/time.rs
+++ b/crates/monty/src/types/time.rs
@@ -37,7 +37,11 @@ use crate::{
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead},
     intern::{Interns, StaticStrings},
     resource::{ResourceError, ResourceTracker},
-    types::{PyTrait, TimeZone, Type, str::Str, str::StringRepr, timezone, value_to_i32},
+    types::{
+        PyTrait, TimeZone, Type,
+        str::{Str, StringRepr},
+        timezone, value_to_i32,
+    },
     value::{EitherStr, Value},
 };
 

--- a/crates/monty/src/types/time.rs
+++ b/crates/monty/src/types/time.rs
@@ -1,0 +1,560 @@
+//! Python `datetime.time` implementation.
+//!
+//! Monty stores times as `(hour, minute, second, microsecond, fold, tzinfo)` and
+//! layers CPython-compatible constructor validation, repr/str formatting, and
+//! comparison semantics. Like `datetime.datetime`, an optional `tzinfo` may be
+//! attached as a `TimeZone` instance — CPython's full `tzinfo` ABC is not
+//! supported in phase 1, matching the existing `datetime.datetime` scope.
+//!
+//! This is phase-1 only: the full CPython surface (`replace`, `strftime`,
+//! `fromisoformat`, `utcoffset`, `tzname`, `dst`, `__format__`) is not yet
+//! implemented. Minimum viable surface:
+//! - Constructor with validation and `tzinfo`/`fold`
+//! - Attribute access: `hour`, `minute`, `second`, `microsecond`, `tzinfo`, `fold`
+//! - `__eq__`, `__lt__`/`__le__`/`__gt__`/`__ge__`, `__hash__`, `__repr__`, `__str__`
+//! - `isoformat()`
+//!
+//! Like `datetime.datetime`, aware and naive time values never compare equal
+//! (they also cannot be ordered against each other). Two aware times with the
+//! same offset are compared by their local clock fields, *not* by shifting to
+//! UTC, because a bare time has no date to shift against — matching CPython.
+
+use std::{
+    borrow::Cow,
+    cmp::Ordering,
+    fmt::Write,
+    hash::{Hash, Hasher},
+    mem,
+};
+
+use ahash::AHashSet;
+
+use crate::{
+    args::ArgValues,
+    bytecode::{CallResult, VM},
+    defer_drop, defer_drop_mut,
+    exception_private::{ExcType, RunResult, SimpleException},
+    heap::{Heap, HeapData, HeapId, HeapItem, HeapRead},
+    intern::{Interns, StaticStrings},
+    resource::{ResourceError, ResourceTracker},
+    types::{PyTrait, TimeZone, Type, str::Str, str::StringRepr, timezone, value_to_i32},
+    value::{EitherStr, Value},
+};
+
+/// `datetime.time` storage.
+///
+/// Time fields are kept in the narrowest integer widths that can represent the
+/// validated ranges, keeping the struct compact. `offset_seconds` + `timezone_name`
+/// mirror `DateTime`'s fixed-offset tzinfo representation, and `tzinfo_ref`
+/// preserves the original `tzinfo` object identity so `t.tzinfo is input_tz`
+/// works across attribute access, matching CPython.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct Time {
+    /// Hour in `0..=23`.
+    hour: u8,
+    /// Minute in `0..=59`.
+    minute: u8,
+    /// Second in `0..=59`.
+    second: u8,
+    /// Microsecond in `0..=999_999`.
+    microsecond: u32,
+    /// Fold flag: 0 or 1. Used by CPython to disambiguate repeated wall clocks
+    /// during DST fall-back transitions; Monty stores it for round-trip fidelity
+    /// but does not interpret it.
+    fold: u8,
+    /// Fixed UTC offset seconds for aware times (`None` for naive).
+    offset_seconds: Option<i32>,
+    /// Optional display name for the attached timezone.
+    timezone_name: Option<String>,
+    /// Stable tzinfo object identity for aware times.
+    ///
+    /// CPython preserves `t.tzinfo is input_tz` and repeated `t.tzinfo` access
+    /// returns the same object. We store a retained heap reference so attribute
+    /// lookup returns a stable object instead of allocating each time.
+    #[serde(default)]
+    tzinfo_ref: Option<HeapId>,
+}
+
+impl PartialEq for Time {
+    fn eq(&self, other: &Self) -> bool {
+        // Like CPython, aware and naive times never compare equal. For aware
+        // pairs we compare by offset-adjusted microseconds — but because `time`
+        // has no date, this is equivalent to comparing local-clock fields when
+        // the offsets match. CPython does normalize by subtracting offsets, so
+        // we do the same here to handle two aware times with different offsets
+        // that represent the same wall-clock instant.
+        if self.offset_seconds.is_some() != other.offset_seconds.is_some() {
+            return false;
+        }
+        micros_of_day_adjusted(self) == micros_of_day_adjusted(other)
+    }
+}
+
+impl Eq for Time {}
+
+impl Hash for Time {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Hash must be consistent with equality: aware times hash by
+        // offset-adjusted microseconds; naive times hash by local microseconds.
+        // Whether the time is aware is mixed in so that aware/naive with the
+        // same numeric micros still get different hashes (though equality
+        // already rules them out).
+        self.offset_seconds.is_some().hash(state);
+        micros_of_day_adjusted(self).hash(state);
+    }
+}
+
+/// Returns the microsecond-of-day minus the offset (if aware) as an `i64`.
+///
+/// Used by equality and hashing so two aware times with different offsets but
+/// the same UTC-equivalent wall clock compare equal. Uses `i64` to comfortably
+/// hold 86_400_000_000 ± 86399 * 1_000_000.
+fn micros_of_day_adjusted(time: &Time) -> i64 {
+    let local = i64::from(time.hour) * 3_600_000_000
+        + i64::from(time.minute) * 60_000_000
+        + i64::from(time.second) * 1_000_000
+        + i64::from(time.microsecond);
+    match time.offset_seconds {
+        Some(offset) => local - i64::from(offset) * 1_000_000,
+        None => local,
+    }
+}
+
+/// Constructor for `time(hour=0, minute=0, second=0, microsecond=0, tzinfo=None, *, fold=0)`.
+///
+/// Matches CPython's argument semantics: all components default to 0, `tzinfo`
+/// defaults to `None` and may be `None` or a `TimeZone` instance, and `fold` is
+/// keyword-only with a default of 0 (must be 0 or 1). Raises `ValueError` when
+/// any component is out of range, and `TypeError` for unknown keywords or a
+/// non-tzinfo value for `tzinfo`.
+pub(crate) fn init(heap: &mut Heap<impl ResourceTracker>, args: ArgValues, interns: &Interns) -> RunResult<Value> {
+    let (pos, kwargs) = args.into_parts();
+    defer_drop_mut!(pos, heap);
+    let kwargs = kwargs.into_iter();
+    defer_drop_mut!(kwargs, heap);
+    // Keep the provided tzinfo object alive across argument parsing so we can
+    // safely retain its identity in the constructed time.
+    let retained_tzinfo = Value::None;
+    defer_drop_mut!(retained_tzinfo, heap);
+
+    let mut hour: i32 = 0;
+    let mut minute: i32 = 0;
+    let mut second: i32 = 0;
+    let mut microsecond: i32 = 0;
+    let mut fold: i32 = 0;
+    let mut tzinfo: Option<TimeZone> = None;
+    let mut tzinfo_ref: Option<HeapId> = None;
+    let mut seen_hour = false;
+    let mut seen_minute = false;
+    let mut seen_second = false;
+    let mut seen_microsecond = false;
+    let mut seen_tzinfo = false;
+    let mut seen_fold = false;
+
+    for (index, arg) in pos.by_ref().enumerate() {
+        defer_drop!(arg, heap);
+        match index {
+            0 => {
+                hour = value_to_i32(arg)?;
+                seen_hour = true;
+            }
+            1 => {
+                minute = value_to_i32(arg)?;
+                seen_minute = true;
+            }
+            2 => {
+                second = value_to_i32(arg)?;
+                seen_second = true;
+            }
+            3 => {
+                microsecond = value_to_i32(arg)?;
+                seen_microsecond = true;
+            }
+            4 => {
+                let (value_tzinfo, value_tzinfo_ref) = tzinfo_from_value(arg, heap)?;
+                update_retained_tzinfo(retained_tzinfo, value_tzinfo_ref, heap);
+                tzinfo = value_tzinfo;
+                tzinfo_ref = value_tzinfo_ref;
+                seen_tzinfo = true;
+            }
+            _ => {
+                return Err(SimpleException::new_msg(
+                    ExcType::TypeError,
+                    format!("function takes at most 5 positional arguments ({} given)", index + 1),
+                )
+                .into());
+            }
+        }
+    }
+
+    for (key, value) in kwargs {
+        defer_drop!(key, heap);
+        defer_drop!(value, heap);
+        let Some(key_name) = key.as_either_str(heap) else {
+            return Err(ExcType::type_error_kwargs_nonstring_key());
+        };
+        match key_name.string_id() {
+            Some(id) if id == StaticStrings::Hour => {
+                if seen_hour {
+                    return Err(ExcType::type_error_positional_keyword_conflict("function", "hour", 1));
+                }
+                hour = value_to_i32(value)?;
+                seen_hour = true;
+            }
+            Some(id) if id == StaticStrings::Minute => {
+                if seen_minute {
+                    return Err(ExcType::type_error_positional_keyword_conflict("function", "minute", 2));
+                }
+                minute = value_to_i32(value)?;
+                seen_minute = true;
+            }
+            Some(id) if id == StaticStrings::Second => {
+                if seen_second {
+                    return Err(ExcType::type_error_positional_keyword_conflict("function", "second", 3));
+                }
+                second = value_to_i32(value)?;
+                seen_second = true;
+            }
+            Some(id) if id == StaticStrings::Microsecond => {
+                if seen_microsecond {
+                    return Err(ExcType::type_error_positional_keyword_conflict(
+                        "function",
+                        "microsecond",
+                        4,
+                    ));
+                }
+                microsecond = value_to_i32(value)?;
+                seen_microsecond = true;
+            }
+            Some(id) if id == StaticStrings::Tzinfo => {
+                if seen_tzinfo {
+                    return Err(ExcType::type_error_positional_keyword_conflict("function", "tzinfo", 5));
+                }
+                let (value_tzinfo, value_tzinfo_ref) = tzinfo_from_value(value, heap)?;
+                update_retained_tzinfo(retained_tzinfo, value_tzinfo_ref, heap);
+                tzinfo = value_tzinfo;
+                tzinfo_ref = value_tzinfo_ref;
+                seen_tzinfo = true;
+            }
+            Some(id) if id == StaticStrings::Fold => {
+                if seen_fold {
+                    return Err(ExcType::type_error_positional_keyword_conflict("function", "fold", 6));
+                }
+                fold = value_to_i32(value)?;
+                seen_fold = true;
+            }
+            _ => {
+                return Err(ExcType::type_error_c_unexpected_keyword(key_name.as_str(interns)));
+            }
+        }
+    }
+
+    let time = from_components(hour, minute, second, microsecond, fold, tzinfo, tzinfo_ref, heap)?;
+    Ok(Value::Ref(heap.allocate(HeapData::Time(time))?))
+}
+
+/// Creates a `Time` from validated civil components and optional tzinfo.
+///
+/// Validates each component's range with CPython-compatible error messages and
+/// allocates a stable `tzinfo_ref` when the provided timezone object isn't
+/// preserved verbatim.
+#[expect(clippy::too_many_arguments)]
+fn from_components(
+    hour: i32,
+    minute: i32,
+    second: i32,
+    microsecond: i32,
+    fold: i32,
+    tzinfo: Option<TimeZone>,
+    tzinfo_ref: Option<HeapId>,
+    heap: &mut Heap<impl ResourceTracker>,
+) -> RunResult<Time> {
+    if !(0..=23).contains(&hour) {
+        return Err(SimpleException::new_msg(ExcType::ValueError, format!("hour must be in 0..23, not {hour}")).into());
+    }
+    if !(0..=59).contains(&minute) {
+        return Err(
+            SimpleException::new_msg(ExcType::ValueError, format!("minute must be in 0..59, not {minute}")).into(),
+        );
+    }
+    if !(0..=59).contains(&second) {
+        return Err(
+            SimpleException::new_msg(ExcType::ValueError, format!("second must be in 0..59, not {second}")).into(),
+        );
+    }
+    if !(0..=999_999).contains(&microsecond) {
+        return Err(SimpleException::new_msg(
+            ExcType::ValueError,
+            format!("microsecond must be in 0..999999, not {microsecond}"),
+        )
+        .into());
+    }
+    if fold != 0 && fold != 1 {
+        return Err(
+            SimpleException::new_msg(ExcType::ValueError, format!("fold must be either 0 or 1, not {fold}")).into(),
+        );
+    }
+
+    let (offset_seconds, timezone_name) = match tzinfo {
+        Some(tz) => (Some(tz.offset_seconds), tz.name),
+        None => (None, None),
+    };
+
+    let mut time = Time {
+        hour: u8::try_from(hour).expect("hour validated to 0..=23"),
+        minute: u8::try_from(minute).expect("minute validated to 0..=59"),
+        second: u8::try_from(second).expect("second validated to 0..=59"),
+        microsecond: u32::try_from(microsecond).expect("microsecond validated to 0..=999_999"),
+        fold: u8::try_from(fold).expect("fold validated to 0..=1"),
+        offset_seconds,
+        timezone_name,
+        tzinfo_ref: None,
+    };
+
+    attach_or_allocate_tzinfo_ref(&mut time, tzinfo_ref, heap)?;
+    Ok(time)
+}
+
+/// Validates a constructor tzinfo argument and extracts timezone data.
+///
+/// Returns `(None, None)` for `Value::None` and `(Some(TimeZone), Some(id))` for
+/// a `TimeZone` heap value. Rejects all other types with `TypeError` matching
+/// CPython's wording. `time` does not yet support the full `tzinfo` ABC — only
+/// the built-in `timezone` class — mirroring the existing `datetime` scope.
+fn tzinfo_from_value(
+    value: &Value,
+    heap: &Heap<impl ResourceTracker>,
+) -> RunResult<(Option<TimeZone>, Option<HeapId>)> {
+    match value {
+        Value::None => Ok((None, None)),
+        Value::Ref(id) => match heap.get(*id) {
+            HeapData::TimeZone(tz) => Ok((Some(tz.clone()), Some(*id))),
+            other => Err(ExcType::type_error_tzinfo(other.py_type())),
+        },
+        _ => Err(ExcType::type_error_tzinfo(value.py_type_shallow())),
+    }
+}
+
+/// Keeps a tzinfo heap value alive during constructor arg parsing.
+///
+/// Matches the pattern used by `datetime.rs`: before each argument is dropped
+/// we inc-ref the currently selected tzinfo so it survives defer_drop of the
+/// original argument, and can be inc-ref'd again when attached to the result.
+fn update_retained_tzinfo(
+    retained_tzinfo: &mut Value,
+    tzinfo_ref: Option<HeapId>,
+    heap: &mut Heap<impl ResourceTracker>,
+) {
+    let old = mem::replace(retained_tzinfo, Value::None);
+    old.drop_with_heap(heap);
+    *retained_tzinfo = if let Some(tzinfo_ref) = tzinfo_ref {
+        heap.inc_ref(tzinfo_ref);
+        Value::Ref(tzinfo_ref)
+    } else {
+        Value::None
+    };
+}
+
+/// Attaches a stable tzinfo identity to the aware time, preserving the original
+/// object identity when one was provided so `t.tzinfo is input_tz` holds.
+fn attach_or_allocate_tzinfo_ref(
+    time: &mut Time,
+    preferred_tzinfo_ref: Option<HeapId>,
+    heap: &mut Heap<impl ResourceTracker>,
+) -> Result<(), ResourceError> {
+    let Some(offset_seconds) = time.offset_seconds else {
+        time.tzinfo_ref = None;
+        return Ok(());
+    };
+
+    let tzinfo_ref = if let Some(tzinfo_ref) = preferred_tzinfo_ref {
+        heap.inc_ref(tzinfo_ref);
+        tzinfo_ref
+    } else {
+        allocate_tzinfo_ref(offset_seconds, time.timezone_name.clone(), heap)?
+    };
+    time.tzinfo_ref = Some(tzinfo_ref);
+    Ok(())
+}
+
+/// Allocates a timezone object for time storage, canonicalizing UTC to the
+/// shared singleton object.
+fn allocate_tzinfo_ref(
+    offset_seconds: i32,
+    timezone_name: Option<String>,
+    heap: &mut Heap<impl ResourceTracker>,
+) -> Result<HeapId, ResourceError> {
+    if offset_seconds == 0 && timezone_name.is_none() {
+        let utc = heap.get_timezone_utc()?;
+        defer_drop!(utc, heap);
+        let Value::Ref(id) = utc else {
+            unreachable!("timezone.utc must be heap-allocated");
+        };
+        heap.inc_ref(*id);
+        return Ok(*id);
+    }
+    let tz = TimeZone {
+        offset_seconds,
+        name: timezone_name,
+    };
+    heap.allocate(HeapData::TimeZone(tz))
+}
+
+/// Formats a `Time` as `HH:MM:SS[.ffffff][±HH:MM]`, matching CPython's
+/// `time.isoformat()`/`str(time)`.
+fn format_isoformat(time: &Time) -> String {
+    let mut s = format!("{:02}:{:02}:{:02}", time.hour, time.minute, time.second);
+    if time.microsecond != 0 {
+        write!(s, ".{:06}", time.microsecond).expect("writing to String cannot fail");
+    }
+    if let Some(offset) = time.offset_seconds {
+        s.push_str(&timezone::format_offset_hms(offset));
+    }
+    s
+}
+
+impl HeapItem for Time {
+    fn py_estimate_size(&self) -> usize {
+        mem::size_of::<Self>() + self.timezone_name.as_ref().map_or(0, String::len)
+    }
+
+    fn py_dec_ref_ids(&mut self, stack: &mut Vec<HeapId>) {
+        if let Some(tzinfo_ref) = self.tzinfo_ref {
+            stack.push(tzinfo_ref);
+        }
+    }
+}
+
+/// `HeapRead`-based dispatch for `Time`, enabling the `HeapReadOutput` enum to
+/// delegate `PyTrait` calls to heap-resident times.
+impl<'h> PyTrait<'h> for HeapRead<'h, Time> {
+    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+        Type::Time
+    }
+
+    fn py_len(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+        None
+    }
+
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+        Ok(self.get(vm.heap) == other.get(vm.heap))
+    }
+
+    fn py_cmp(
+        &self,
+        other: &Self,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
+    ) -> Result<Option<Ordering>, ResourceError> {
+        let a = self.get(vm.heap);
+        let b = other.get(vm.heap);
+        // CPython refuses to compare aware vs naive times. Returning None here
+        // propagates as `NotImplemented` in py_cmp callers.
+        if a.offset_seconds.is_some() != b.offset_seconds.is_some() {
+            return Ok(None);
+        }
+        Ok(micros_of_day_adjusted(a).partial_cmp(&micros_of_day_adjusted(b)))
+    }
+
+    fn py_bool(&self, _vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+        // Unlike `timedelta`, a `datetime.time` is always truthy — even
+        // `time(0, 0)` — matching CPython.
+        true
+    }
+
+    fn py_repr_fmt(
+        &self,
+        f: &mut impl Write,
+        vm: &VM<'h, '_, impl ResourceTracker>,
+        _heap_ids: &mut AHashSet<HeapId>,
+    ) -> RunResult<()> {
+        let t = self.get(vm.heap);
+        // CPython omits trailing zero `second`/`microsecond` fields for a cleaner
+        // repr; `minute` is always printed so the shortest form is e.g.
+        // `datetime.time(0, 0)`.
+        write!(f, "datetime.time({}, {}", t.hour, t.minute)?;
+        if t.second != 0 || t.microsecond != 0 {
+            write!(f, ", {}", t.second)?;
+        }
+        if t.microsecond != 0 {
+            write!(f, ", {}", t.microsecond)?;
+        }
+        if let Some(offset) = t.offset_seconds {
+            if offset == 0 && t.timezone_name.is_none() {
+                f.write_str(", tzinfo=datetime.timezone.utc")?;
+            } else {
+                let timedelta_repr = timezone::format_offset_timedelta_repr(offset);
+                write!(f, ", tzinfo=datetime.timezone({timedelta_repr}")?;
+                if let Some(name) = &t.timezone_name {
+                    write!(f, ", {}", StringRepr(name))?;
+                }
+                f.write_char(')')?;
+            }
+        }
+        if t.fold != 0 {
+            write!(f, ", fold={}", t.fold)?;
+        }
+        f.write_char(')')?;
+        Ok(())
+    }
+
+    fn py_str(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+        Ok(Cow::Owned(format_isoformat(self.get(vm.heap))))
+    }
+
+    fn py_call_attr(
+        &mut self,
+        _self_id: HeapId,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        attr: &EitherStr,
+        args: ArgValues,
+    ) -> RunResult<CallResult> {
+        // Clone so the HeapRead borrow is released before we may allocate a
+        // string to return.
+        let t = self.get(vm.heap).clone();
+        match attr.string_id() {
+            Some(id) if id == StaticStrings::Isoformat => {
+                args.check_zero_args("time.isoformat", vm.heap)?;
+                let s = format_isoformat(&t);
+                Ok(CallResult::Value(Value::Ref(
+                    vm.heap.allocate(HeapData::Str(Str::new(s)))?,
+                )))
+            }
+            _ => Err(ExcType::attribute_error(Type::Time, attr.as_str(vm.interns))),
+        }
+    }
+
+    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
+        // Clone so the HeapRead borrow is released before we might allocate a
+        // timezone value for the `tzinfo` attribute.
+        let t = self.get(vm.heap).clone();
+        match attr.string_id() {
+            Some(id) if id == StaticStrings::Hour => Ok(Some(CallResult::Value(Value::Int(i64::from(t.hour))))),
+            Some(id) if id == StaticStrings::Minute => Ok(Some(CallResult::Value(Value::Int(i64::from(t.minute))))),
+            Some(id) if id == StaticStrings::Second => Ok(Some(CallResult::Value(Value::Int(i64::from(t.second))))),
+            Some(id) if id == StaticStrings::Microsecond => {
+                Ok(Some(CallResult::Value(Value::Int(i64::from(t.microsecond)))))
+            }
+            Some(id) if id == StaticStrings::Fold => Ok(Some(CallResult::Value(Value::Int(i64::from(t.fold))))),
+            Some(id) if id == StaticStrings::Tzinfo => {
+                if let Some(tzinfo_ref) = t.tzinfo_ref {
+                    vm.heap.inc_ref(tzinfo_ref);
+                    return Ok(Some(CallResult::Value(Value::Ref(tzinfo_ref))));
+                }
+                if let Some(offset_seconds) = t.offset_seconds {
+                    if offset_seconds == 0 && t.timezone_name.is_none() {
+                        return Ok(Some(CallResult::Value(vm.heap.get_timezone_utc()?)));
+                    }
+                    let tz = TimeZone {
+                        offset_seconds,
+                        name: t.timezone_name,
+                    };
+                    return Ok(Some(CallResult::Value(Value::Ref(
+                        vm.heap.allocate(HeapData::TimeZone(tz))?,
+                    ))));
+                }
+                Ok(Some(CallResult::Value(Value::None)))
+            }
+            _ => Ok(None),
+        }
+    }
+}

--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -13,7 +13,7 @@ use crate::{
     types::{
         AttrCallResult, Bytes, Dict, FrozenSet, List, LongInt, MontyIter, Path, PyTrait, Range, Set, Slice, Str,
         TimeZone, Tuple, bytes::bytes_fromhex, date, datetime, dict::dict_fromkeys, long_int::INT_MAX_STR_DIGITS,
-        str::StringRepr, timedelta,
+        str::StringRepr, time, timedelta,
     },
     value::Value,
 };
@@ -37,6 +37,7 @@ pub enum Type {
     Slice,
     Date,
     DateTime,
+    Time,
     TimeDelta,
     TimeZone,
     Str,
@@ -86,6 +87,7 @@ impl fmt::Display for Type {
             Self::Slice => f.write_str("slice"),
             Self::Date => f.write_str("date"),
             Self::DateTime => f.write_str("datetime.datetime"),
+            Self::Time => f.write_str("datetime.time"),
             Self::TimeDelta => f.write_str("timedelta"),
             Self::TimeZone => f.write_str("timezone"),
             Self::Str => f.write_str("str"),
@@ -293,6 +295,7 @@ impl Type {
             Self::Slice => Slice::init(vm, args),
             Self::Date => date::init(vm.heap, args, vm.interns),
             Self::DateTime => datetime::init(vm.heap, args, vm.interns),
+            Self::Time => time::init(vm.heap, args, vm.interns),
             Self::TimeDelta => timedelta::init(vm.heap, args, vm.interns),
             Self::TimeZone => TimeZone::init(vm.heap, args, vm.interns),
             Self::Iterator => MontyIter::init(vm, args),

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -297,6 +297,7 @@ impl PyTrait<'_> for Value {
                 (HeapReadOutput::Tuple(a), HeapReadOutput::Tuple(b)) => a.py_cmp(&b, vm),
                 (HeapReadOutput::Date(a), HeapReadOutput::Date(b)) => Ok(a.get(vm.heap).partial_cmp(b.get(vm.heap))),
                 (HeapReadOutput::DateTime(a), HeapReadOutput::DateTime(b)) => a.py_cmp(&b, vm),
+                (HeapReadOutput::Time(a), HeapReadOutput::Time(b)) => a.py_cmp(&b, vm),
                 (HeapReadOutput::TimeDelta(a), HeapReadOutput::TimeDelta(b)) => {
                     Ok(a.get(vm.heap).partial_cmp(b.get(vm.heap)))
                 }

--- a/crates/monty/test_cases/time__core.py
+++ b/crates/monty/test_cases/time__core.py
@@ -1,0 +1,186 @@
+from datetime import time, timedelta, timezone
+
+# === import / basic construction ===
+assert isinstance(time(), time), 'time() should construct a time instance'
+assert isinstance(time(12), time), 'time(hour) should construct a time instance'
+assert isinstance(time(12, 30), time), 'time(hour, minute) should construct a time instance'
+assert isinstance(time(12, 30, 45), time), 'time(hour, minute, second) should construct a time instance'
+assert isinstance(time(12, 30, 45, 123456), time), (
+    'time(hour, minute, second, microsecond) should construct a time instance'
+)
+
+# === attribute access ===
+t = time(14, 30, 45, 123456)
+assert t.hour == 14, 'time.hour should return hour'
+assert t.minute == 30, 'time.minute should return minute'
+assert t.second == 45, 'time.second should return second'
+assert t.microsecond == 123456, 'time.microsecond should return microsecond'
+assert t.tzinfo is None, 'naive time.tzinfo should be None'
+assert t.fold == 0, 'default time.fold should be 0'
+
+# === default construction ===
+t_default = time()
+assert t_default.hour == 0, 'default time.hour should be 0'
+assert t_default.minute == 0, 'default time.minute should be 0'
+assert t_default.second == 0, 'default time.second should be 0'
+assert t_default.microsecond == 0, 'default time.microsecond should be 0'
+assert t_default.tzinfo is None, 'default time.tzinfo should be None'
+assert t_default.fold == 0, 'default time.fold should be 0'
+
+# === boundary values ===
+t_min = time(0, 0, 0, 0)
+assert t_min.hour == 0, 'time(0, 0, 0, 0).hour'
+assert t_min.microsecond == 0, 'time(0, 0, 0, 0).microsecond'
+
+t_max = time(23, 59, 59, 999999)
+assert t_max.hour == 23, 'time(23, 59, 59, 999999).hour'
+assert t_max.minute == 59, 'time(23, 59, 59, 999999).minute'
+assert t_max.second == 59, 'time(23, 59, 59, 999999).second'
+assert t_max.microsecond == 999999, 'time(23, 59, 59, 999999).microsecond'
+
+# === keyword construction ===
+assert time(hour=12, minute=30) == time(12, 30), 'time keyword construction'
+assert time(12, minute=30, second=45) == time(12, 30, 45), 'time mixed positional/keyword construction'
+assert time(microsecond=123) == time(0, 0, 0, 123), 'time(microsecond=...) keyword-only style'
+
+# === repr/str ===
+assert repr(time(0, 0)) == 'datetime.time(0, 0)', 'repr of midnight time'
+assert repr(time(12, 30)) == 'datetime.time(12, 30)', 'repr of time without seconds'
+assert repr(time(12, 30, 45)) == 'datetime.time(12, 30, 45)', 'repr of time with seconds'
+assert repr(time(12, 30, 45, 123456)) == 'datetime.time(12, 30, 45, 123456)', 'repr of time with microseconds'
+assert repr(time(0, 0, 0, 123456)) == 'datetime.time(0, 0, 0, 123456)', 'repr of time with only microseconds'
+
+assert str(time(0, 0)) == '00:00:00', 'str of midnight time'
+assert str(time(12, 30)) == '12:30:00', 'str of time without seconds'
+assert str(time(12, 30, 45)) == '12:30:45', 'str of time with seconds'
+assert str(time(12, 30, 45, 123456)) == '12:30:45.123456', 'str of time with microseconds'
+
+# === isoformat ===
+assert time(0, 0).isoformat() == '00:00:00', 'isoformat of midnight'
+assert time(12, 30, 45).isoformat() == '12:30:45', 'isoformat with seconds'
+assert time(12, 30, 45, 123456).isoformat() == '12:30:45.123456', 'isoformat with microseconds'
+
+# === equality ===
+assert time(12, 30) == time(12, 30), 'time equality, same values'
+assert time(12, 30) == time(12, 30, 0, 0), 'time equality, implicit defaults'
+assert time(12, 30) != time(12, 31), 'time inequality'
+assert time(12, 30, 45) != time(12, 30, 45, 1), 'time microseconds matter'
+assert time(0, 0) != time(0, 0, 1), 'time seconds matter'
+
+# === ordering comparisons (naive times) ===
+assert time(10, 0) < time(11, 0), 'time < comparison'
+assert time(11, 0) > time(10, 0), 'time > comparison'
+assert time(10, 0) <= time(10, 0), 'time <= equal'
+assert time(10, 0) >= time(10, 0), 'time >= equal'
+assert not (time(10, 0) > time(11, 0)), 'time not >'
+assert time(0, 0) < time(23, 59, 59, 999999), 'min < max'
+
+# === hashability ===
+assert hash(time(12, 30)) == hash(time(12, 30)), 'equal times should hash equal'
+assert {time(12, 30)} == {time(12, 30)}, 'time in set'
+assert {time(12, 30): 'a'}[time(12, 30)] == 'a', 'time as dict key'
+
+# === truthiness: all time objects are truthy (including midnight) ===
+# CPython: time(0, 0) is truthy because only timedelta(0) is falsy.
+assert bool(time(0, 0)), 'time(0, 0) should be truthy'
+assert bool(time(12, 30)), 'time(12, 30) should be truthy'
+
+# === aware time with tzinfo ===
+utc = timezone.utc
+t_utc = time(12, 30, tzinfo=utc)
+assert t_utc.tzinfo is utc, 'time.tzinfo should preserve the timezone object identity'
+assert t_utc.hour == 12, 'aware time.hour'
+assert t_utc.minute == 30, 'aware time.minute'
+
+plus1 = timezone(timedelta(hours=1), 'P1')
+t_plus1 = time(12, 30, tzinfo=plus1)
+assert t_plus1.tzinfo is plus1, 'time.tzinfo should preserve named tz identity'
+assert repr(t_plus1) == "datetime.time(12, 30, tzinfo=datetime.timezone(datetime.timedelta(seconds=3600), 'P1'))", (
+    'aware time repr should include tzinfo'
+)
+assert repr(t_utc) == 'datetime.time(12, 30, tzinfo=datetime.timezone.utc)', 'aware UTC time repr'
+assert str(t_utc) == '12:30:00+00:00', 'aware time str should include offset'
+assert t_utc.isoformat() == '12:30:00+00:00', 'aware time isoformat should include offset'
+assert str(t_plus1) == '12:30:00+01:00', 'aware time str with +01:00 offset'
+
+# === aware/naive equality: naive != aware ===
+assert (time(12, 30) == t_utc) is False, 'naive time should not equal aware time'
+assert (time(12, 30) != t_utc) is True, 'naive/aware inequality should be True'
+
+# === aware time equality: different tz but same offset should compare equal ===
+utc2 = timezone(timedelta(0))
+t_utc2 = time(12, 30, tzinfo=utc2)
+assert t_utc == t_utc2, 'aware times with equal offsets should compare equal'
+
+# === tzinfo identity stability across attribute access ===
+t_id = time(1, 2, 3, tzinfo=plus1)
+assert t_id.tzinfo is t_id.tzinfo, 'time.tzinfo should be stable across repeated attribute access'
+
+# === argument validation ===
+try:
+    time(24)
+    assert False, 'hour 24 should raise ValueError'
+except ValueError as e:
+    assert str(e) == 'hour must be in 0..23, not 24', f'hour OOB message: {e}'
+
+try:
+    time(-1)
+    assert False, 'hour -1 should raise ValueError'
+except ValueError as e:
+    assert str(e) == 'hour must be in 0..23, not -1', f'hour negative message: {e}'
+
+try:
+    time(0, 60)
+    assert False, 'minute 60 should raise ValueError'
+except ValueError as e:
+    assert str(e) == 'minute must be in 0..59, not 60', f'minute OOB message: {e}'
+
+try:
+    time(0, -1)
+    assert False, 'minute -1 should raise ValueError'
+except ValueError as e:
+    assert str(e) == 'minute must be in 0..59, not -1', f'minute negative message: {e}'
+
+try:
+    time(0, 0, 60)
+    assert False, 'second 60 should raise ValueError'
+except ValueError as e:
+    assert str(e) == 'second must be in 0..59, not 60', f'second OOB message: {e}'
+
+try:
+    time(0, 0, 0, 1000000)
+    assert False, 'microsecond 1000000 should raise ValueError'
+except ValueError as e:
+    assert str(e) == 'microsecond must be in 0..999999, not 1000000', f'microsecond OOB message: {e}'
+
+try:
+    time(0, 0, 0, -1)
+    assert False, 'microsecond -1 should raise ValueError'
+except ValueError as e:
+    assert str(e) == 'microsecond must be in 0..999999, not -1', f'microsecond negative message: {e}'
+
+# === unknown keyword argument ===
+try:
+    time(0, foo=1)
+    assert False, 'unknown kwarg should raise TypeError'
+except TypeError as e:
+    assert str(e) == "this function got an unexpected keyword argument 'foo'", f'time unknown kwarg: {e}'
+
+# === tzinfo type validation ===
+try:
+    time(0, 0, tzinfo='UTC')
+    assert False, 'string tzinfo should raise TypeError'
+except TypeError as e:
+    assert str(e) == "tzinfo argument must be None or of a tzinfo subclass, not type 'str'", f'time tzinfo type: {e}'
+
+# === fold argument ===
+assert time(12, 0, fold=0).fold == 0, 'time with fold=0'
+assert time(12, 0, fold=1).fold == 1, 'time with fold=1'
+assert repr(time(12, 0, fold=1)) == 'datetime.time(12, 0, fold=1)', 'fold=1 should appear in repr'
+assert repr(time(12, 0, fold=0)) == 'datetime.time(12, 0)', 'fold=0 should not appear in repr'
+
+try:
+    time(12, 0, fold=2)
+    assert False, 'fold=2 should raise ValueError'
+except ValueError as e:
+    assert str(e) == 'fold must be either 0 or 1, not 2', f'time fold OOB: {e}'


### PR DESCRIPTION
## Summary
- Fixes pydantic/monty#331: `from datetime import time` no longer raises `ImportError`.
- Adds `Type::Time`, `crates/monty/src/types/time.rs`, `StaticStrings::Time` / `Fold`, and wires `time` into the `datetime` module.
- Phase-1 surface mirrors the existing `datetime` type's scope.

## Design choices
- **tzinfo:** accepts `None` or a `TimeZone` instance, matching the existing `datetime` type. Stores the `HeapId` so `t.tzinfo is input_tz` holds. A full `tzinfo` ABC is out of scope (consistent with `datetime`).
- **fold:** keyword-only, validated to `0..=1`, exposed on `.fold`, included in repr when non-zero (matches CPython 3.14). Monty does not interpret fold (no DST model) — round-trip only.
- **Out of scope (phase-1):** `replace()`, `strftime()`, `fromisoformat()`, `utcoffset()`, `tzname()`, `dst()`, `__format__`, `min`/`max`/`resolution`, and `MontyTime` in the public `MontyObject` serde enum (falls back to repr at the PyO3/JS boundary).

## Test plan
- [x] New `crates/monty/test_cases/time__core.py` covers construction, attribute access, `isoformat()`, repr/str, equality/ordering, hashability, truthiness, aware `tzinfo` semantics, `fold`, and CPython-compatible error messages — passes on Monty and CPython.
- [x] Full datatest suite: 930 passed.
- [x] `cargo test -p monty --features ref-count-panic`: 596 passed, 19 ignored.
- [x] `cargo clippy --workspace --tests --all-features -- -D warnings` clean.
- [x] `cargo fmt --check`, `ruff check`/`ruff format --check` clean.