### PR TITLE
fix panic when parsing source file with lines larger than u16::MAX

### DIFF
--- a/crates/monty-js/src/exceptions.rs
+++ b/crates/monty-js/src/exceptions.rs
@@ -244,10 +244,10 @@ impl Frame {
     pub fn from_stack_frame(frame: &StackFrame) -> Self {
         Self {
             filename: frame.filename.clone(),
-            line: u32::from(frame.start.line),
-            column: u32::from(frame.start.column),
-            end_line: u32::from(frame.end.line),
-            end_column: u32::from(frame.end.column),
+            line: frame.start.line,
+            column: frame.start.column,
+            end_line: frame.end.line,
+            end_column: frame.end.column,
             function_name: frame.frame_name.clone(),
             source_line: frame.preview_line.clone(),
         }

--- a/crates/monty-python/src/exceptions.rs
+++ b/crates/monty-python/src/exceptions.rs
@@ -302,16 +302,16 @@ pub struct PyFrame {
     pub filename: String,
     /// Line number (1-based).
     #[pyo3(get)]
-    pub line: u16,
+    pub line: u32,
     /// Column number (1-based).
     #[pyo3(get)]
-    pub column: u16,
+    pub column: u32,
     /// End line number (1-based).
     #[pyo3(get)]
-    pub end_line: u16,
+    pub end_line: u32,
     /// End column number (1-based).
     #[pyo3(get)]
-    pub end_column: u16,
+    pub end_column: u32,
     /// The name of the function, or None for module-level code.
     #[pyo3(get)]
     pub function_name: Option<String>,

--- a/crates/monty/src/exception_public.rs
+++ b/crates/monty/src/exception_public.rs
@@ -318,12 +318,15 @@ impl StackFrame {
 /// A line and column position in source code.
 ///
 /// Uses 1-based indexing for both line and column to match Python's conventions.
+///
+/// `u32` matches `ruff_text_size::TextSize`, which underpins all source ranges
+/// returned by the parser, so conversions between the two are zero-cost.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct CodeLoc {
     /// Line number (1-based).
-    pub line: u16,
+    pub line: u32,
     /// Column number (1-based).
-    pub column: u16,
+    pub column: u32,
 }
 
 impl Default for CodeLoc {
@@ -333,17 +336,18 @@ impl Default for CodeLoc {
 }
 
 impl CodeLoc {
-    /// Creates a new CodeLoc from usize values.
+    /// Creates a new CodeLoc from 0-based values.
     ///
     /// Lines and columns numbers are 1-indexed for display, hence `+1`
     ///
     /// # Panics
-    /// Panics if the line or column number overflows `u16`.
+    /// Panics if the 0-based line or column equals `u32::MAX` (i.e. would
+    /// overflow when shifted to 1-based).
     #[must_use]
-    pub fn new(line: usize, column: usize) -> Self {
+    pub fn new(line: u32, column: u32) -> Self {
         Self {
-            line: u16::try_from(line).expect("Line number overflow") + 1,
-            column: u16::try_from(column).expect("Column number overflow") + 1,
+            line: line.checked_add(1).expect("line number overflow"),
+            column: column.checked_add(1).expect("column number overflow"),
         }
     }
 }

--- a/crates/monty/src/exception_public.rs
+++ b/crates/monty/src/exception_public.rs
@@ -338,16 +338,16 @@ impl Default for CodeLoc {
 impl CodeLoc {
     /// Creates a new CodeLoc from 0-based values.
     ///
-    /// Lines and columns numbers are 1-indexed for display, hence `+1`
-    ///
-    /// # Panics
-    /// Panics if the 0-based line or column equals `u32::MAX` (i.e. would
-    /// overflow when shifted to 1-based).
+    /// Lines and columns numbers are 1-indexed for display, hence `+ 1`.
+    /// Saturates at `u32::MAX` rather than panicking — overflow here is
+    /// already unreachable for any source ruff will accept (it caps source
+    /// size at 4 GiB), and saturation keeps the parser panic-free even if
+    /// that ever changes.
     #[must_use]
     pub fn new(line: u32, column: u32) -> Self {
         Self {
-            line: line.checked_add(1).expect("line number overflow"),
-            column: column.checked_add(1).expect("column number overflow"),
+            line: line.saturating_add(1),
+            column: column.saturating_add(1),
         }
     }
 }

--- a/crates/monty/src/exception_public.rs
+++ b/crates/monty/src/exception_public.rs
@@ -325,7 +325,7 @@ impl StackFrame {
 pub struct CodeLoc {
     /// Line number (1-based).
     pub line: u32,
-    /// Column number (1-based).
+    /// Column number (1-based), counted in characters (not bytes).
     pub column: u32,
 }
 

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -8,7 +8,7 @@ use ruff_python_ast::{
     name::Name,
 };
 use ruff_python_parser::parse_module;
-use ruff_text_size::{Ranged, TextRange};
+use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::{
     StackFrame,
@@ -34,7 +34,7 @@ pub const MAX_NESTING_DEPTH: u16 = 200;
 /// (no inlining, debug info, etc.). The limit is set conservatively to prevent
 /// stack overflow while still catching the error before the recursion limit.
 #[cfg(debug_assertions)]
-pub const MAX_NESTING_DEPTH: u16 = 35;
+pub const MAX_NESTING_DEPTH: u16 = 30;
 
 /// A parameter in a function signature with optional default value.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -160,7 +160,11 @@ pub(crate) fn parse_with_interner(
 /// Holds references to the source code and owns a string interner for names.
 /// The filename is interned once at construction and reused for all CodeRanges.
 pub struct Parser<'a> {
-    line_ends: Vec<usize>,
+    /// Byte offsets of every `\n` character in `code`, in order.
+    ///
+    /// Stored as `TextSize` so positions flow through the parser in the same
+    /// `u32` representation that ruff uses for `TextRange`.
+    line_ends: Vec<TextSize>,
     code: &'a str,
     /// Interned filename ID, used for all CodeRanges created by this parser.
     filename_id: StringId,
@@ -174,11 +178,13 @@ pub struct Parser<'a> {
 
 impl<'a> Parser<'a> {
     fn new(code: &'a str, filename: &'a str, mut interner: InternerBuilder) -> Self {
-        // Position of each line in the source code, to convert indexes to line number and column number
+        // Position of each line in the source code, to convert byte offsets
+        // into (line, column) pairs.
         let mut line_ends = vec![];
-        for (i, c) in code.chars().enumerate() {
+        for (i, c) in code.char_indices() {
             if c == '\n' {
-                line_ends.push(i);
+                // Ruff only supports files up to 4 GiB.
+                line_ends.push(TextSize::try_from(i).expect("source exceeds 4 GiB"));
             }
         }
         let filename_id = interner.intern(filename);
@@ -1465,35 +1471,41 @@ impl<'a> Parser<'a> {
     }
 
     fn convert_range(&self, range: TextRange) -> CodeRange {
-        let start = range.start().into();
-        let (start_line_no, start_line_start, _) = self.index_to_position(start);
-        let start = CodeLoc::new(start_line_no, start - start_line_start);
+        let (start_line, start_line_start, _) = self.index_to_position(range.start());
+        let start = CodeLoc::new(start_line, (range.start() - start_line_start).to_u32());
 
-        let end = range.end().into();
-        let (end_line_no, end_line_start, _) = self.index_to_position(end);
-        let end = CodeLoc::new(end_line_no, end - end_line_start);
+        let (end_line, end_line_start, _) = self.index_to_position(range.end());
+        let end = CodeLoc::new(end_line, (range.end() - end_line_start).to_u32());
 
-        // Store line number for single-line ranges, None for multi-line
-        let preview_line = if start_line_no == end_line_no {
-            Some(u32::try_from(start_line_no).expect("line number exceeds u32"))
-        } else {
-            None
-        };
+        // Store the line number only for single-line ranges; multi-line
+        // ranges have no single preview line to highlight.
+        let preview_line = (start_line == end_line).then_some(start_line);
 
         CodeRange::new(self.filename_id, start, end, preview_line)
     }
 
-    fn index_to_position(&self, index: usize) -> (usize, usize, Option<usize>) {
-        let mut line_start = 0;
+    /// Maps a byte offset within `code` to its 0-based line number, the byte
+    /// offset of that line's start, and (if present) the byte offset of the
+    /// terminating newline.
+    fn index_to_position(&self, index: TextSize) -> (u32, TextSize, Option<TextSize>) {
+        let mut line_start = TextSize::new(0);
         for (line_no, line_end) in self.line_ends.iter().enumerate() {
             if index <= *line_end {
-                return (line_no, line_start, Some(*line_end));
+                return (
+                    u32::try_from(line_no).expect("line number exceeds u32"),
+                    line_start,
+                    Some(*line_end),
+                );
             }
-            line_start = *line_end + 1;
+            line_start = *line_end + TextSize::new(1);
         }
-        // Content after the last newline (file without trailing newline)
-        // line_ends.len() gives the correct 0-indexed line number
-        (self.line_ends.len(), line_start, None)
+        // Content after the last newline (file without trailing newline) —
+        // `line_ends.len()` is the correct 0-indexed line number.
+        (
+            u32::try_from(self.line_ends.len()).expect("line number exceeds u32"),
+            line_start,
+            None,
+        )
     }
 
     /// Decrements the depth remaining for nested parentheses.
@@ -1760,5 +1772,39 @@ fn parse_int_literal(s: &str, position: CodeRange) -> Result<BigInt, ParseError>
         cleaned
             .parse::<BigInt>()
             .map_err(|e| ParseError::syntax(format!("invalid integer literal {s:?}, error: {e}"), position))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ExcType, MontyRun};
+
+    #[test]
+    fn non_ascii_earlier_line_does_not_shift_column() {
+        // "x = 'é'\nundefined_name": 'é' is two UTF-8 bytes but one character,
+        // ensure position is correctly calculated
+        let code = "x = 'é'\nundefined_name".to_string();
+        let run = MontyRun::new(code, "test.py", vec![]).expect("should parse");
+        let err = run.run_no_limits(vec![]).expect_err("should raise NameError");
+        assert_eq!(err.exc_type(), ExcType::NameError);
+        let frame = err.traceback().last().expect("traceback has at least one frame");
+        assert_eq!(frame.start.line, 2, "NameError is on line 2");
+        assert_eq!(
+            frame.start.column, 1,
+            "start column should be 1 regardless of non-ASCII on previous line"
+        );
+        assert_eq!(
+            frame.end.column, 15,
+            "end column should be 15 (1-indexed past the 14-char identifier)"
+        );
+    }
+
+    #[test]
+    fn long_source_line_does_not_overflow_column() {
+        // https://github.com/pydantic/monty/issues/341
+        let code = format!("x = \"{}\"\nassert len(x) == 65530", "a".repeat(65530));
+        let run = MontyRun::new(code, "test.py", vec![]).expect("long line should parse without panicking");
+        let result = run.run_no_limits(vec![]);
+        assert!(result.is_ok(), "long line should run: {result:?}");
     }
 }

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -1774,37 +1774,3 @@ fn parse_int_literal(s: &str, position: CodeRange) -> Result<BigInt, ParseError>
             .map_err(|e| ParseError::syntax(format!("invalid integer literal {s:?}, error: {e}"), position))
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use crate::{ExcType, MontyRun};
-
-    #[test]
-    fn non_ascii_earlier_line_does_not_shift_column() {
-        // "x = 'é'\nundefined_name": 'é' is two UTF-8 bytes but one character,
-        // ensure position is correctly calculated
-        let code = "x = 'é'\nundefined_name".to_string();
-        let run = MontyRun::new(code, "test.py", vec![]).expect("should parse");
-        let err = run.run_no_limits(vec![]).expect_err("should raise NameError");
-        assert_eq!(err.exc_type(), ExcType::NameError);
-        let frame = err.traceback().last().expect("traceback has at least one frame");
-        assert_eq!(frame.start.line, 2, "NameError is on line 2");
-        assert_eq!(
-            frame.start.column, 1,
-            "start column should be 1 regardless of non-ASCII on previous line"
-        );
-        assert_eq!(
-            frame.end.column, 15,
-            "end column should be 15 (1-indexed past the 14-char identifier)"
-        );
-    }
-
-    #[test]
-    fn long_source_line_does_not_overflow_column() {
-        // https://github.com/pydantic/monty/issues/341
-        let code = format!("x = \"{}\"\nassert len(x) == 65530", "a".repeat(65530));
-        let run = MontyRun::new(code, "test.py", vec![]).expect("long line should parse without panicking");
-        let result = run.run_no_limits(vec![]);
-        assert!(result.is_ok(), "long line should run: {result:?}");
-    }
-}

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -1472,10 +1472,20 @@ impl<'a> Parser<'a> {
 
     fn convert_range(&self, range: TextRange) -> CodeRange {
         let (start_line, start_line_start, _) = self.index_to_position(range.start());
-        let start = CodeLoc::new(start_line, (range.start() - start_line_start).to_u32());
+        let start_col = self.code[start_line_start.to_usize()..range.start().to_usize()]
+            .chars()
+            .count()
+            .try_into()
+            .expect("column number exceeds u32");
+        let start = CodeLoc::new(start_line, start_col);
 
         let (end_line, end_line_start, _) = self.index_to_position(range.end());
-        let end = CodeLoc::new(end_line, (range.end() - end_line_start).to_u32());
+        let end_col = self.code[end_line_start.to_usize()..range.end().to_usize()]
+            .chars()
+            .count()
+            .try_into()
+            .expect("column number exceeds u32");
+        let end = CodeLoc::new(end_line, end_col);
 
         // Store the line number only for single-line ranges; multi-line
         // ranges have no single preview line to highlight.

--- a/crates/monty/tests/error_locations.rs
+++ b/crates/monty/tests/error_locations.rs
@@ -1,0 +1,24 @@
+// Monty does not yet implement `__traceback__`, so this test cannot be a datatest.
+
+use monty::{ExcType, MontyRun};
+
+#[test]
+fn non_ascii_earlier_line_does_not_shift_column() {
+    // "x = 'é'\nundefined_name": 'é' is two UTF-8 bytes but one character,
+    // so the buggy char-indexed line table reported column 2 for
+    // `undefined_name`; the correct column is 1 (start of line 2).
+    let code = "x = 'é'\nundefined_name".to_string();
+    let run = MontyRun::new(code, "test.py", vec![]).expect("should parse");
+    let err = run.run_no_limits(vec![]).expect_err("should raise NameError");
+    assert_eq!(err.exc_type(), ExcType::NameError);
+    let frame = err.traceback().last().expect("traceback has at least one frame");
+    assert_eq!(frame.start.line, 2, "NameError is on line 2");
+    assert_eq!(
+        frame.start.column, 1,
+        "start column should be 1 regardless of non-ASCII on previous line"
+    );
+    assert_eq!(
+        frame.end.column, 15,
+        "end column should be 15 (1-indexed past the 14-char identifier)"
+    );
+}

--- a/crates/monty/tests/error_locations.rs
+++ b/crates/monty/tests/error_locations.rs
@@ -12,13 +12,23 @@ fn non_ascii_earlier_line_does_not_shift_column() {
     let err = run.run_no_limits(vec![]).expect_err("should raise NameError");
     assert_eq!(err.exc_type(), ExcType::NameError);
     let frame = err.traceback().last().expect("traceback has at least one frame");
-    assert_eq!(frame.start.line, 2, "NameError is on line 2");
-    assert_eq!(
-        frame.start.column, 1,
-        "start column should be 1 regardless of non-ASCII on previous line"
-    );
-    assert_eq!(
-        frame.end.column, 15,
-        "end column should be 15 (1-indexed past the 14-char identifier)"
-    );
+
+    assert_eq!(frame.start.line, 2);
+    assert_eq!(frame.start.column, 1);
+    assert_eq!(frame.end.column, 15);
+}
+
+#[test]
+fn non_ascii_char_column_location() {
+    // "'é' + undefined_name": the non-ASCII char is on the same line as the error,
+    // the nameerror should report on column 7, even though the 'é' is two UTF-8 bytes
+    let code = "'é' + undefined_name".to_string();
+    let run = MontyRun::new(code, "test.py", vec![]).expect("should parse");
+    let err = run.run_no_limits(vec![]).expect_err("should raise NameError");
+    assert_eq!(err.exc_type(), ExcType::NameError);
+    let frame = err.traceback().last().expect("traceback has at least one frame");
+
+    assert_eq!(frame.start.line, 1);
+    assert_eq!(frame.start.column, 7);
+    assert_eq!(frame.end.column, 21);
 }

--- a/crates/monty/tests/parse_errors.rs
+++ b/crates/monty/tests/parse_errors.rs
@@ -439,3 +439,14 @@ fn del_statement_returns_not_implemented_error() {
     let result = MontyRun::new("x = 1\ndel x".to_owned(), "test.py", vec![]);
     assert_eq!(get_exc_type(result), ExcType::NotImplementedError);
 }
+
+#[test]
+fn long_source_line_does_not_overflow_column() {
+    // https://github.com/pydantic/monty/issues/341
+    //
+    // (code locations was previously limited to u16 values for line / col)
+    let code = format!("x = \"{}\"\nassert len(x) == 65530", "a".repeat(65530));
+    let run = MontyRun::new(code, "test.py", vec![]).expect("long line should parse without panicking");
+    let result = run.run_no_limits(vec![]);
+    assert!(result.is_ok(), "long line should run: {result:?}");
+}


### PR DESCRIPTION
Fixes #341 

I changed `CodeLoc` to use `u32` indexing to match ruff. Claude spotted a separate bug related to non-ascii char offsets while analysing this change.