### PR TITLE
raise `MontySyntaxError` for source with lone surrogates

### DIFF
--- a/crates/monty-python/python/pydantic_monty/__init__.py
+++ b/crates/monty-python/python/pydantic_monty/__init__.py
@@ -188,7 +188,7 @@ ExcType = Literal[
 Used by `ExternalExceptionData` to identify an exception by name rather than
 passing a concrete Python exception instance. Names match Python's built-in
 exception classes, except for `json.JSONDecodeError` and `re.PatternError`
-which are dotted to disambiguate from their `ValueError` / `RuntimeError`
+which are dotted to disambiguate from their `ValueError` / `Exception`
 parents.
 """
 

--- a/crates/monty-python/src/monty_cls.rs
+++ b/crates/monty-python/src/monty_cls.rs
@@ -17,7 +17,7 @@ use pyo3::{
     exceptions::{PyBaseException, PyKeyError, PyRuntimeError, PyTypeError, PyValueError},
     intern,
     prelude::*,
-    types::{PyBytes, PyDict, PyList, PyTuple, PyType},
+    types::{PyBytes, PyDict, PyList, PyString, PyTuple, PyType},
 };
 use pyo3_async_runtimes::tokio::future_into_py;
 
@@ -69,7 +69,7 @@ impl PyMonty {
     #[pyo3(signature = (code, *, script_name="main.py", inputs=None, type_check=false, type_check_stubs=None, dataclass_registry=None))]
     fn new(
         py: Python<'_>,
-        code: String,
+        code: &Bound<'_, PyString>,
         script_name: &str,
         inputs: Option<&Bound<'_, PyList>>,
         type_check: bool,
@@ -77,6 +77,7 @@ impl PyMonty {
         dataclass_registry: Option<&Bound<'_, PyList>>,
     ) -> PyResult<Self> {
         let input_names = list_str(inputs, "inputs")?;
+        let code = extract_source_code(py, code)?;
 
         if type_check {
             py_type_check(py, &code, script_name, type_check_stubs, "type_stubs.pyi")?;
@@ -1886,6 +1887,26 @@ impl PyMontyComplete {
 
     fn __repr__(&self) -> String {
         format!("MontyComplete(output={})", self.monty_output.py_repr())
+    }
+}
+
+/// Extracts Python source code from a `PyString`, converting encoding failures
+/// into a `MontySyntaxError` rather than letting the raw `UnicodeEncodeError`
+/// bubble up.
+///
+/// Python strings may contain lone surrogates (e.g. `'\ud83d'`) that cannot be
+/// encoded as UTF-8. Such strings are not valid Python source, so we report
+/// them as a syntax error instead of an encoding error.
+pub(crate) fn extract_source_code(py: Python<'_>, code: &Bound<'_, PyString>) -> PyResult<String> {
+    match code.to_str() {
+        Ok(s) => Ok(s.to_owned()),
+        Err(_) => Err(MontyError::new_err(
+            py,
+            MontyException::new(
+                ExcType::SyntaxError,
+                Some("source code is not valid UTF-8 (contains lone surrogates)".to_string()),
+            ),
+        )),
     }
 }
 

--- a/crates/monty-python/src/repl.rs
+++ b/crates/monty-python/src/repl.rs
@@ -14,7 +14,7 @@ use pyo3::{
     exceptions::{PyRuntimeError, PyTypeError, PyValueError},
     prelude::*,
     sync::PyOnceLock,
-    types::{PyBytes, PyDict, PyList, PyModule, PyType},
+    types::{PyBytes, PyDict, PyList, PyModule, PyString, PyType},
 };
 use pyo3_async_runtimes::tokio::future_into_py;
 
@@ -25,7 +25,7 @@ use crate::{
     exceptions::MontyError,
     external::{ExternalFunctionRegistry, dispatch_method_call},
     limits::{CancellationFlag, FutureCancellationGuard, PySignalTracker, extract_limits},
-    monty_cls::{EitherProgress, call_os_callback_parts, py_type_check},
+    monty_cls::{EitherProgress, call_os_callback_parts, extract_source_code, py_type_check},
     mount::OsHandler,
     print_target::PrintTarget,
 };
@@ -144,8 +144,9 @@ impl PyMontyRepl {
     /// This does not use the accumulated code from previous `feed_run` calls —
     /// use `prefix_code` to provide any needed declarations.
     #[pyo3(signature = (code, prefix_code=None))]
-    fn type_check(&self, py: Python<'_>, code: &str, prefix_code: Option<&str>) -> PyResult<()> {
-        py_type_check(py, code, &self.script_name, prefix_code, "type_stubs.pyi")
+    fn type_check(&self, py: Python<'_>, code: &Bound<'_, PyString>, prefix_code: Option<&str>) -> PyResult<()> {
+        let code = extract_source_code(py, code)?;
+        py_type_check(py, &code, &self.script_name, prefix_code, "type_stubs.pyi")
     }
 
     /// Feeds and executes a single incremental REPL snippet.
@@ -161,7 +162,7 @@ impl PyMontyRepl {
     fn feed_run<'py>(
         &self,
         py: Python<'py>,
-        code: &str,
+        code: &Bound<'_, PyString>,
         inputs: Option<&Bound<'_, PyDict>>,
         external_functions: Option<&Bound<'_, PyDict>>,
         print_callback: Option<&Bound<'_, PyAny>>,
@@ -169,6 +170,8 @@ impl PyMontyRepl {
         os: Option<&Bound<'_, PyAny>>,
         skip_type_check: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
+        let code_owned = extract_source_code(py, code)?;
+        let code = code_owned.as_str();
         self.run_type_check_if_enabled(py, code, skip_type_check)?;
         let input_values = extract_repl_inputs(inputs, &self.dc_registry)?;
 
@@ -238,7 +241,7 @@ impl PyMontyRepl {
     fn feed_start<'py>(
         slf: &Bound<'py, Self>,
         py: Python<'py>,
-        code: &str,
+        code: &Bound<'_, PyString>,
         inputs: Option<&Bound<'_, PyDict>>,
         print_callback: Option<&Bound<'_, PyAny>>,
         mount: Option<&Bound<'_, PyAny>>,
@@ -246,7 +249,8 @@ impl PyMontyRepl {
         skip_type_check: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         let this = slf.get();
-        this.run_type_check_if_enabled(py, code, skip_type_check)?;
+        let code = extract_source_code(py, code)?;
+        this.run_type_check_if_enabled(py, &code, skip_type_check)?;
         let input_values = extract_repl_inputs(inputs, &this.dc_registry)?;
 
         let print_target = PrintTarget::from_py(print_callback)?;
@@ -257,11 +261,10 @@ impl PyMontyRepl {
 
         let repl = this.take_repl()?;
         if !skip_type_check {
-            this.set_pending_type_check(code);
+            this.set_pending_type_check(&code);
         }
         let repl_owner: Py<Self> = slf.clone().unbind();
 
-        let code_owned = code.to_owned();
         let inputs_owned = input_values;
         let dc_registry = this.dc_registry.clone_ref(py);
         let script_name = this.script_name.clone();
@@ -270,8 +273,8 @@ impl PyMontyRepl {
         // collector lock is only held during the VM call.
         macro_rules! feed_start_impl {
             ($repl:expr, $variant:ident) => {{
-                let result = py
-                    .detach(|| print_target.with_writer(|writer| $repl.feed_start(&code_owned, inputs_owned, writer)));
+                let result =
+                    py.detach(|| print_target.with_writer(|writer| $repl.feed_start(&code, inputs_owned, writer)));
                 let progress = match result {
                     Ok(p) => p,
                     Err(e) => {
@@ -331,7 +334,7 @@ impl PyMontyRepl {
     fn feed_run_async<'py>(
         slf: &Bound<'py, Self>,
         py: Python<'py>,
-        code: &str,
+        code: &Bound<'_, PyString>,
         inputs: Option<&Bound<'_, PyDict>>,
         external_functions: Option<&Bound<'_, PyDict>>,
         print_callback: Option<&Bound<'_, PyAny>>,
@@ -347,22 +350,22 @@ impl PyMontyRepl {
         }
 
         let this = slf.get();
-        this.run_type_check_if_enabled(py, code, skip_type_check)?;
+        let code = extract_source_code(py, code)?;
+        this.run_type_check_if_enabled(py, &code, skip_type_check)?;
         if !skip_type_check {
-            this.set_pending_type_check(code);
+            this.set_pending_type_check(&code);
         }
         let input_values = extract_repl_inputs(inputs, &this.dc_registry)?;
         let dc_registry = this.dc_registry.clone_ref(py);
         let ext_fns = external_functions.map(|d| d.clone().unbind());
         let repl_owner: Py<Self> = slf.clone().unbind();
-        let code_owned = code.to_owned();
         let print_target = PrintTarget::from_py(print_callback)?;
 
         PyReplAsyncAwaitable::new_py_any(
             py,
             ReplAsyncStart {
                 repl_owner,
-                code: code_owned,
+                code,
                 input_values,
                 external_functions: ext_fns,
                 os,
@@ -858,12 +861,10 @@ impl PyMontyRepl {
             }};
         }
 
-        let code_owned = code.to_owned();
-        let mut progress =
-            match py.detach(|| print_target.with_writer(|w| repl.feed_start(&code_owned, input_values, w))) {
-                Ok(p) => p,
-                Err(e) => restore_err!(e),
-            };
+        let mut progress = match py.detach(|| print_target.with_writer(|w| repl.feed_start(code, input_values, w))) {
+            Ok(p) => p,
+            Err(e) => restore_err!(e),
+        };
 
         loop {
             match progress {

--- a/crates/monty-python/tests/test_exceptions.py
+++ b/crates/monty-python/tests/test_exceptions.py
@@ -129,6 +129,17 @@ def test_syntax_error_invalid_syntax():
     assert isinstance(inner, SyntaxError)
 
 
+def test_syntax_error_lone_surrogate():
+    # Lone surrogates cannot be encoded as UTF-8, so they are not valid Python
+    # source. We report this as MontySyntaxError rather than letting PyO3's raw
+    # UnicodeEncodeError bubble out.
+    with pytest.raises(pydantic_monty.MontySyntaxError) as exc_info:
+        pydantic_monty.Monty('\ud83d')
+    assert str(exc_info.value) == snapshot('source code is not valid UTF-8 (contains lone surrogates)')
+    inner = exc_info.value.exception()
+    assert isinstance(inner, SyntaxError)
+
+
 # === Catching with base class ===
 
 

--- a/crates/monty-python/tests/test_repl.py
+++ b/crates/monty-python/tests/test_repl.py
@@ -178,6 +178,16 @@ def test_syntax_error():
         repl.feed_run('def')
 
 
+def test_syntax_error_lone_surrogate():
+    # Lone surrogates cannot be encoded as UTF-8, so they are not valid Python
+    # source. feed_run reports this as MontySyntaxError rather than letting
+    # PyO3's raw UnicodeEncodeError bubble out.
+    repl = pydantic_monty.MontyRepl()
+    with pytest.raises(pydantic_monty.MontySyntaxError) as exc_info:
+        repl.feed_run('\ud83d')
+    assert str(exc_info.value) == snapshot('source code is not valid UTF-8 (contains lone surrogates)')
+
+
 def test_runtime_error_preserves_state():
     """A runtime error should not destroy previously defined state."""
     repl = pydantic_monty.MontyRepl()

--- a/crates/monty-python/tests/test_start.py
+++ b/crates/monty-python/tests/test_start.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import tempfile
 from collections.abc import Generator
@@ -423,8 +424,6 @@ def test_resume_with_exc_type_data_propagates_uncaught():
 @pytest.mark.skipif(sys.version_info < (3, 13), reason='re.PatternError was added in Python 3.13')
 def test_resume_with_exc_type_data_dotted_name():
     """Dotted ExcType names like `re.PatternError` map to the right Python subclass."""
-    import re
-
     m = pydantic_monty.Monty('external_func()')
     progress = m.start()
     assert isinstance(progress, pydantic_monty.FunctionSnapshot)


### PR DESCRIPTION
Python strings may contain lone surrogates (e.g. `'\ud83d'`) that cannot be encoded as UTF-8, so PyO3's `String` extraction raised a raw `UnicodeEncodeError` from `Monty(...)` and the `MontyRepl.feed_*` / `type_check` entry points. Such input is not valid Python source, so report it as `MontySyntaxError` instead.