### PR TITLE
wrap input unicode conversion errors as `MontyRuntimeError`

### DIFF
--- a/crates/monty-python/src/async_dispatch.rs
+++ b/crates/monty-python/src/async_dispatch.rs
@@ -26,7 +26,7 @@ use tokio::{
 };
 
 use crate::{
-    convert::{get_docstring, monty_to_py, py_to_monty},
+    convert::{get_docstring, monty_to_py, py_to_monty_value},
     dataclass::DcRegistry,
     exceptions::{MontyError, exc_py_to_monty},
     external::{
@@ -389,9 +389,9 @@ fn dispatch_os_call_py(
                     Ok(_) => {}
                     Err(err) => return ExtFunctionResult::Error(exc_py_to_monty(py, &err)),
                 }
-                match py_to_monty(&result, dc_registry) {
+                match py_to_monty_value(&result, dc_registry) {
                     Ok(obj) => ExtFunctionResult::Return(obj),
-                    Err(err) => ExtFunctionResult::Error(exc_py_to_monty(py, &err)),
+                    Err(exc) => ExtFunctionResult::Error(exc),
                 }
             }
             Err(err) => ExtFunctionResult::Error(exc_py_to_monty(py, &err)),
@@ -436,7 +436,7 @@ fn spawn_coroutine_task(
         match future.await {
             Ok(py_result) => Python::attach(|py| {
                 let bound = py_result.bind(py);
-                (call_id, py_obj_to_ext_result(py, bound, &dc_registry))
+                (call_id, py_obj_to_ext_result(bound, &dc_registry))
             }),
             Err(err) => Python::attach(|py| (call_id, py_err_to_ext_result(py, &err))),
         }

--- a/crates/monty-python/src/convert.rs
+++ b/crates/monty-python/src/convert.rs
@@ -20,8 +20,19 @@ use pyo3::{
 
 use crate::{
     dataclass::{DcRegistry, dataclass_to_monty, dataclass_to_py, is_dataclass},
-    exceptions::{exc_monty_to_py, exc_to_monty_object},
+    exceptions::{exc_monty_to_py, exc_py_to_monty, exc_to_monty_object},
 };
+
+/// Like `py_to_monty`, but converts any `PyErr` into a `MontyException`.
+///
+/// Use this at every boundary where an untrusted host value flows into Monty
+/// (inputs, external/OS return values, snapshot resume values). Callers then
+/// wrap the `MontyException` as they see fit — `MontyError::new_err(py, e)` for
+/// Python-API returns, or `ExtFunctionResult::Error(e)` for mid-execution
+/// dispatch — so raw PyO3 errors like `UnicodeEncodeError` never escape.
+pub fn py_to_monty_value(obj: &Bound<'_, PyAny>, dc_registry: &DcRegistry) -> Result<MontyObject, MontyException> {
+    py_to_monty(obj, dc_registry).map_err(|e| exc_py_to_monty(obj.py(), &e))
+}
 
 /// Converts a Python object to Monty's `MontyObject` representation.
 ///

--- a/crates/monty-python/src/external.rs
+++ b/crates/monty-python/src/external.rs
@@ -12,7 +12,7 @@ use pyo3::{
 };
 
 use crate::{
-    convert::{monty_to_py, py_to_monty},
+    convert::{monty_to_py, py_to_monty, py_to_monty_value},
     dataclass::DcRegistry,
     exceptions::exc_py_to_monty,
 };
@@ -294,9 +294,9 @@ fn result_to_call_result(py: Python<'_>, result: &Bound<'_, PyAny>, dc_registry:
     if is_coroutine(py, result) {
         CallResult::Coroutine(result.clone().unbind())
     } else {
-        match py_to_monty(result, dc_registry) {
+        match py_to_monty_value(result, dc_registry) {
             Ok(monty_obj) => CallResult::Sync(ExtFunctionResult::Return(monty_obj)),
-            Err(err) => CallResult::Sync(ExtFunctionResult::Error(exc_py_to_monty(py, &err))),
+            Err(exc) => CallResult::Sync(ExtFunctionResult::Error(exc)),
         }
     }
 }
@@ -320,12 +320,12 @@ pub fn py_err_to_ext_result(py: Python<'_>, err: &PyErr) -> ExtFunctionResult {
 /// Converts a Python object from an async external function result into an `ExtFunctionResult`.
 ///
 /// Used by the async dispatch loop when a spawned coroutine completes successfully.
-/// Uses `exc_py_to_monty` for conversion errors, matching the sync path in
-/// `result_to_call_result` so that the same bad return value produces the same
-/// exception shape regardless of whether the external function was sync or async.
-pub fn py_obj_to_ext_result(py: Python<'_>, obj: &Bound<'_, PyAny>, dc_registry: &DcRegistry) -> ExtFunctionResult {
-    match py_to_monty(obj, dc_registry) {
+/// Routes conversion failures through `py_to_monty_value` so that the same bad
+/// return value produces the same exception shape regardless of whether the
+/// external function was sync or async.
+pub fn py_obj_to_ext_result(obj: &Bound<'_, PyAny>, dc_registry: &DcRegistry) -> ExtFunctionResult {
+    match py_to_monty_value(obj, dc_registry) {
         Ok(monty_obj) => ExtFunctionResult::Return(monty_obj),
-        Err(err) => ExtFunctionResult::Error(exc_py_to_monty(py, &err)),
+        Err(exc) => ExtFunctionResult::Error(exc),
     }
 }

--- a/crates/monty-python/src/monty_cls.rs
+++ b/crates/monty-python/src/monty_cls.rs
@@ -23,7 +23,7 @@ use pyo3_async_runtimes::tokio::future_into_py;
 
 use crate::{
     async_dispatch::{await_run_transition, dispatch_loop_run},
-    convert::{get_docstring, monty_to_py, py_to_monty},
+    convert::{get_docstring, monty_to_py, py_to_monty_value},
     dataclass::DcRegistry,
     exceptions::{MontyError, MontyTypingError, exc_py_to_monty},
     external::{ExternalFunctionRegistry, dispatch_method_call},
@@ -451,23 +451,16 @@ impl PyMonty {
             )));
         };
 
-        // Extract values in declaration order.
-        //
-        // Conversion errors from `py_to_monty` (e.g. `UnicodeEncodeError` for a
-        // string containing lone surrogates) are wrapped as `MontyRuntimeError`
-        // so input-value failures mirror the way external-function return
-        // values surface — the caller sees a single, consistent exception type
-        // rather than a raw PyO3 error like `UnicodeEncodeError`.
+        // Extract values in declaration order. `py_to_monty_value` converts any
+        // PyErr (e.g. `UnicodeEncodeError` for a lone-surrogate string) into a
+        // `MontyException`, which we then raise as `MontyRuntimeError`.
         self.input_names
             .iter()
             .map(|name| {
                 let value = inputs
                     .get_item(name)?
                     .ok_or_else(|| PyKeyError::new_err(format!("Missing required input: '{name}'")))?;
-                py_to_monty(&value, dc_registry).map_err(|e| {
-                    let py = value.py();
-                    MontyError::new_err(py, exc_py_to_monty(py, &e))
-                })
+                py_to_monty_value(&value, dc_registry).map_err(|e| MontyError::new_err(value.py(), e))
             })
             .collect::<PyResult<_>>()
     }
@@ -1480,7 +1473,8 @@ impl PyNameLookupSnapshot {
         let lookup_result = if let Some(kwargs) = kwargs
             && let Some(value) = kwargs.get_item(intern!(py, "value"))?
         {
-            NameLookupResult::Value(py_to_monty(&value, &self.dc_registry)?)
+            let monty_value = py_to_monty_value(&value, &self.dc_registry).map_err(|e| MontyError::new_err(py, e))?;
+            NameLookupResult::Value(monty_value)
         } else {
             NameLookupResult::Undefined
         };
@@ -2001,8 +1995,11 @@ fn extract_external_result(
     if dict.len() != 1 {
         Err(PyTypeError::new_err(ARGS_ERROR))
     } else if let Some(rv) = dict.get_item(intern!(py, "return_value"))? {
-        // Return value provided
-        Ok(py_to_monty(&rv, dc_registry)?.into())
+        // Return value provided. Wrap conversion failures (e.g. lone
+        // surrogates) as `MontyRuntimeError` rather than letting a raw PyErr
+        // escape the pymethod.
+        let monty_value = py_to_monty_value(&rv, dc_registry).map_err(|e| MontyError::new_err(py, e))?;
+        Ok(monty_value.into())
     } else if let Some(exc) = dict.get_item(intern!(py, "exception"))? {
         // Exception provided
         if PyBaseException::type_check(&exc) {
@@ -2179,7 +2176,13 @@ pub(crate) fn call_os_callback_parts(
             if result.is(not_handled) {
                 Ok(on_not_handled())
             } else {
-                Ok(py_to_monty(&result, dc_registry)?.into())
+                // A conversion failure on the callback's return value surfaces
+                // inside Monty execution as `ExtFunctionResult::Error`, matching
+                // how a raised exception from the callback is handled below.
+                match py_to_monty_value(&result, dc_registry) {
+                    Ok(v) => Ok(v.into()),
+                    Err(e) => Ok(ExtFunctionResult::Error(e)),
+                }
             }
         }
         Err(err) => Ok(exc_py_to_monty(py, &err).into()),

--- a/crates/monty-python/src/monty_cls.rs
+++ b/crates/monty-python/src/monty_cls.rs
@@ -1473,8 +1473,9 @@ impl PyNameLookupSnapshot {
         let lookup_result = if let Some(kwargs) = kwargs
             && let Some(value) = kwargs.get_item(intern!(py, "value"))?
         {
-            let monty_value = py_to_monty_value(&value, &self.dc_registry).map_err(|e| MontyError::new_err(py, e))?;
-            NameLookupResult::Value(monty_value)
+            NameLookupResult::Value(
+                py_to_monty_value(&value, &self.dc_registry).map_err(|e| MontyError::new_err(py, e))?,
+            )
         } else {
             NameLookupResult::Undefined
         };
@@ -1996,10 +1997,11 @@ fn extract_external_result(
         Err(PyTypeError::new_err(ARGS_ERROR))
     } else if let Some(rv) = dict.get_item(intern!(py, "return_value"))? {
         // Return value provided. Wrap conversion failures (e.g. lone
-        // surrogates) as `MontyRuntimeError` rather than letting a raw PyErr
-        // escape the pymethod.
-        let monty_value = py_to_monty_value(&rv, dc_registry).map_err(|e| MontyError::new_err(py, e))?;
-        Ok(monty_value.into())
+        // surrogates, unconvertible types) as `MontyRuntimeError` rather than
+        // letting a raw PyErr escape the pymethod.
+        Ok(py_to_monty_value(&rv, dc_registry)
+            .map_err(|e| MontyError::new_err(py, e))?
+            .into())
     } else if let Some(exc) = dict.get_item(intern!(py, "exception"))? {
         // Exception provided
         if PyBaseException::type_check(&exc) {

--- a/crates/monty-python/src/monty_cls.rs
+++ b/crates/monty-python/src/monty_cls.rs
@@ -451,14 +451,23 @@ impl PyMonty {
             )));
         };
 
-        // Extract values in declaration order
+        // Extract values in declaration order.
+        //
+        // Conversion errors from `py_to_monty` (e.g. `UnicodeEncodeError` for a
+        // string containing lone surrogates) are wrapped as `MontyRuntimeError`
+        // so input-value failures mirror the way external-function return
+        // values surface — the caller sees a single, consistent exception type
+        // rather than a raw PyO3 error like `UnicodeEncodeError`.
         self.input_names
             .iter()
             .map(|name| {
                 let value = inputs
                     .get_item(name)?
                     .ok_or_else(|| PyKeyError::new_err(format!("Missing required input: '{name}'")))?;
-                py_to_monty(&value, dc_registry)
+                py_to_monty(&value, dc_registry).map_err(|e| {
+                    let py = value.py();
+                    MontyError::new_err(py, exc_py_to_monty(py, &e))
+                })
             })
             .collect::<PyResult<_>>()
     }

--- a/crates/monty-python/src/repl.rs
+++ b/crates/monty-python/src/repl.rs
@@ -22,7 +22,7 @@ use crate::{
     async_dispatch::{ReplCleanupNotifier, await_repl_transition, dispatch_loop_repl},
     convert::{get_docstring, monty_to_py, py_to_monty},
     dataclass::DcRegistry,
-    exceptions::MontyError,
+    exceptions::{MontyError, exc_py_to_monty},
     external::{ExternalFunctionRegistry, dispatch_method_call},
     limits::{CancellationFlag, FutureCancellationGuard, PySignalTracker, extract_limits},
     monty_cls::{EitherProgress, call_os_callback_parts, extract_source_code, py_type_check},
@@ -1000,11 +1000,19 @@ fn extract_repl_inputs(
     let Some(inputs) = inputs else {
         return Ok(vec![]);
     };
+    // Conversion errors from `py_to_monty` (e.g. `UnicodeEncodeError` for a
+    // string containing lone surrogates) are wrapped as `MontyRuntimeError` so
+    // input-value failures mirror the way external-function return values
+    // surface — the caller sees a single, consistent exception type rather
+    // than a raw PyO3 error like `UnicodeEncodeError`.
     inputs
         .iter()
         .map(|(key, value)| {
             let name = key.extract::<String>()?;
-            let obj = py_to_monty(&value, dc_registry)?;
+            let obj = py_to_monty(&value, dc_registry).map_err(|e| {
+                let py = value.py();
+                MontyError::new_err(py, exc_py_to_monty(py, &e))
+            })?;
             Ok((name, obj))
         })
         .collect::<PyResult<_>>()

--- a/crates/monty-python/src/repl.rs
+++ b/crates/monty-python/src/repl.rs
@@ -20,7 +20,7 @@ use pyo3_async_runtimes::tokio::future_into_py;
 
 use crate::{
     async_dispatch::{ReplCleanupNotifier, await_repl_transition, dispatch_loop_repl},
-    convert::{get_docstring, monty_to_py, py_to_monty},
+    convert::{get_docstring, monty_to_py, py_to_monty_value},
     dataclass::DcRegistry,
     exceptions::{MontyError, exc_py_to_monty},
     external::{ExternalFunctionRegistry, dispatch_method_call},
@@ -1000,19 +1000,17 @@ fn extract_repl_inputs(
     let Some(inputs) = inputs else {
         return Ok(vec![]);
     };
-    // Conversion errors from `py_to_monty` (e.g. `UnicodeEncodeError` for a
-    // string containing lone surrogates) are wrapped as `MontyRuntimeError` so
-    // input-value failures mirror the way external-function return values
-    // surface — the caller sees a single, consistent exception type rather
-    // than a raw PyO3 error like `UnicodeEncodeError`.
+    // Both the key and the value are untrusted host values, so conversion
+    // failures (e.g. lone surrogates, non-string keys) surface as
+    // `MontyRuntimeError` rather than raw PyErrs.
     inputs
         .iter()
         .map(|(key, value)| {
-            let name = key.extract::<String>()?;
-            let obj = py_to_monty(&value, dc_registry).map_err(|e| {
-                let py = value.py();
-                MontyError::new_err(py, exc_py_to_monty(py, &e))
-            })?;
+            let py = key.py();
+            let name = key
+                .extract::<String>()
+                .map_err(|e| MontyError::new_err(py, exc_py_to_monty(py, &e)))?;
+            let obj = py_to_monty_value(&value, dc_registry).map_err(|e| MontyError::new_err(py, e))?;
             Ok((name, obj))
         })
         .collect::<PyResult<_>>()

--- a/crates/monty-python/tests/test_async.py
+++ b/crates/monty-python/tests/test_async.py
@@ -1391,3 +1391,38 @@ async def test_run_repl_async_os_not_callable():
 
     with pytest.raises(TypeError, match='not callable'):
         await repl.feed_run_async('1 + 1', os=42)  # pyright: ignore[reportArgumentType]
+
+
+async def test_run_async_sync_external_return_lone_surrogate():
+    """A sync callback returning a lone-surrogate string surfaces inside Monty
+    as a catchable ValueError via the async dispatch path."""
+    code = """
+try:
+    get_str()
+    result = 'no error'
+except ValueError:
+    result = 'caught'
+result
+"""
+    m = pydantic_monty.Monty(code)
+    result = await m.run_async(external_functions={'get_str': lambda: '\ud83d'})
+    assert result == snapshot('caught')
+
+
+async def test_run_async_async_external_return_lone_surrogate():
+    """An async callback returning a lone-surrogate string surfaces as
+    `MontyRuntimeError(ValueError)` rather than a raw `UnicodeEncodeError`.
+
+    Note: coroutine exceptions currently propagate out of the dispatch loop
+    rather than being caught by an in-Monty `try/except` at the `await` site
+    (a pre-existing asymmetry vs. the sync path), so we only assert the
+    top-level exception shape here.
+    """
+
+    async def get_str() -> str:
+        return '\ud83d'
+
+    m = pydantic_monty.Monty('await get_str()')
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        await m.run_async(external_functions={'get_str': get_str})
+    assert isinstance(exc_info.value.exception(), ValueError)

--- a/crates/monty-python/tests/test_exceptions.py
+++ b/crates/monty-python/tests/test_exceptions.py
@@ -140,6 +140,21 @@ def test_syntax_error_lone_surrogate():
     assert isinstance(inner, SyntaxError)
 
 
+def test_runtime_error_input_value_lone_surrogate():
+    # An input string containing a lone surrogate fails UTF-8 conversion during
+    # `py_to_monty`. We wrap the resulting `UnicodeEncodeError` as a
+    # `MontyRuntimeError(ValueError)` so input-value failures surface the same
+    # way as failures when an external function returns such a string.
+    m = pydantic_monty.Monty('x', inputs=['x'])
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        m.run(inputs={'x': '\ud83d'})
+    assert str(exc_info.value) == snapshot(
+        "ValueError: 'utf-8' codec can't encode character '\\ud83d' in position 0: surrogates not allowed"
+    )
+    inner = exc_info.value.exception()
+    assert isinstance(inner, ValueError)
+
+
 # === Catching with base class ===
 
 

--- a/crates/monty-python/tests/test_external.py
+++ b/crates/monty-python/tests/test_external.py
@@ -365,3 +365,34 @@ finally_ran
 
     result = m.run(external_functions={'fail': fail})
     assert result == snapshot(True)
+
+
+def test_external_function_return_lone_surrogate_catchable_inside_monty():
+    """A callback returning a string with a lone surrogate surfaces inside
+    Monty as a `ValueError` that can be caught, not as a raw PyErr escaping
+    to the caller."""
+    code = """
+try:
+    get_str()
+    result = 'no error'
+except ValueError:
+    result = 'caught'
+result
+"""
+    m = pydantic_monty.Monty(code)
+    assert m.run(external_functions={'get_str': lambda: '\ud83d'}) == snapshot('caught')
+
+
+def test_external_function_return_unconvertible_catchable_inside_monty():
+    """A callback returning an unconvertible object surfaces inside Monty as a
+    `TypeError` that can be caught."""
+    code = """
+try:
+    get_thing()
+    result = 'no error'
+except TypeError:
+    result = 'caught'
+result
+"""
+    m = pydantic_monty.Monty(code)
+    assert m.run(external_functions={'get_thing': lambda: object()}) == snapshot('caught')

--- a/crates/monty-python/tests/test_mount_table.py
+++ b/crates/monty-python/tests/test_mount_table.py
@@ -485,19 +485,43 @@ def test_run_mount_released_after_callback_marshalling_error(test_dir: Path):
     """Monty.run() puts mounts back when the os= callback returns an unconvertible value.
 
     The fallback callback returns an object that cannot be converted back into a
-    Monty value, so `py_to_monty` raises TypeError mid-OS-dispatch. The mount
-    must still be returned to its shared slot.
+    Monty value, so the conversion failure is surfaced inside Monty as a
+    `TypeError` wrapped in `MontyRuntimeError`. The mount must still be
+    returned to its shared slot on that error path.
     """
     md = MountDir('/data', str(test_dir), mode='read-only')
 
     def os_cb(func: object, args: tuple[object, ...], kwargs: dict[str, object]) -> object:
-        return object()  # unconvertible — triggers TypeError in py_to_monty
+        return object()  # unconvertible — surfaces inside Monty as TypeError
 
     # Path is outside the mount so it falls through to the os= fallback.
     code = "from pathlib import Path; Path('/outside/path.txt').exists()"
-    with pytest.raises(TypeError):
+    with pytest.raises(MontyRuntimeError) as exc_info:
         Monty(code).run(mount=md, os=os_cb)
+    assert isinstance(exc_info.value.exception(), TypeError)
     assert_mount_reusable(md)
+
+
+def test_os_callback_lone_surrogate_return_surfaces_inside_monty(test_dir: Path):
+    """An os= callback returning a lone-surrogate string surfaces inside Monty
+    as a catchable `ValueError` rather than escaping as a raw `UnicodeEncodeError`."""
+    md = MountDir('/data', str(test_dir), mode='read-only')
+
+    def os_cb(func: object, args: tuple[object, ...], kwargs: dict[str, object]) -> object:
+        return '\ud83d'  # unconvertible UTF-8 — surfaces as ValueError inside Monty
+
+    # Catching inside Monty proves the error arrives as an in-VM exception rather
+    # than propagating out as a raw PyErr.
+    code = (
+        'from pathlib import Path\n'
+        'try:\n'
+        "    Path('/outside/path.txt').read_text()\n"
+        "    result = 'no error'\n"
+        'except ValueError as e:\n'
+        "    result = 'caught'\n"
+        'result'
+    )
+    assert Monty(code).run(mount=md, os=os_cb) == snapshot('caught')
 
 
 def test_repl_feed_run_mount_and_repl_released_after_callback_marshalling_error(test_dir: Path):
@@ -512,11 +536,12 @@ def test_repl_feed_run_mount_and_repl_released_after_callback_marshalling_error(
     repl.feed_run('x = 42')
 
     def os_cb(func: object, args: tuple[object, ...], kwargs: dict[str, object]) -> object:
-        return object()  # unconvertible — triggers TypeError in py_to_monty
+        return object()  # unconvertible — surfaces inside Monty as TypeError
 
     code = "from pathlib import Path; Path('/outside/path.txt').exists()"
-    with pytest.raises(TypeError):
+    with pytest.raises(MontyRuntimeError) as exc_info:
         repl.feed_run(code, mount=md, os=os_cb)
+    assert isinstance(exc_info.value.exception(), TypeError)
     # REPL state must still be intact — `x` is visible in a later snippet.
     assert repl.feed_run('x') == snapshot(42)
     assert_mount_reusable(md)

--- a/crates/monty-python/tests/test_repl.py
+++ b/crates/monty-python/tests/test_repl.py
@@ -201,6 +201,15 @@ def test_runtime_error_input_value_lone_surrogate():
     )
 
 
+def test_runtime_error_input_key_lone_surrogate():
+    # An input *key* containing a lone surrogate also goes through UTF-8
+    # conversion; wrap it the same way.
+    repl = pydantic_monty.MontyRepl()
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        repl.feed_run('x', inputs={'\ud83d': 1})
+    assert isinstance(exc_info.value.exception(), ValueError)
+
+
 def test_runtime_error_preserves_state():
     """A runtime error should not destroy previously defined state."""
     repl = pydantic_monty.MontyRepl()
@@ -1248,3 +1257,52 @@ result = (value, content)
     assert isinstance(result, pydantic_monty.MontyComplete)
     assert result.output is False
     assert repl.feed_run('x') == snapshot(42)
+
+
+def test_repl_name_lookup_resume_lone_surrogate_value():
+    """REPL NameLookupSnapshot.resume(value=...) with a lone-surrogate string
+    surfaces as `MontyRuntimeError(ValueError)` and leaves the snapshot intact
+    for retry, matching the existing early-validation contract."""
+    repl = pydantic_monty.MontyRepl()
+    p = repl.feed_start('my_name + 1')
+    assert isinstance(p, pydantic_monty.NameLookupSnapshot)
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        p.resume(value='\ud83d')
+    assert isinstance(exc_info.value.exception(), ValueError)
+    final = p.resume(value=41)
+    assert isinstance(final, pydantic_monty.MontyComplete)
+    assert final.output == snapshot(42)
+    assert repl.feed_run('1 + 1') == snapshot(2)
+
+
+def test_repl_function_snapshot_resume_lone_surrogate_return_value():
+    """REPL FunctionSnapshot.resume({'return_value': <lone surrogate>}) surfaces
+    as `MontyRuntimeError(ValueError)` and leaves the snapshot intact for retry."""
+    repl = pydantic_monty.MontyRepl()
+    p = repl.feed_start('fetch() + 1')
+    assert isinstance(p, pydantic_monty.FunctionSnapshot)
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        p.resume({'return_value': '\ud83d'})
+    assert isinstance(exc_info.value.exception(), ValueError)
+    final = p.resume({'return_value': 41})
+    assert isinstance(final, pydantic_monty.MontyComplete)
+    assert final.output == snapshot(42)
+    assert repl.feed_run('1 + 1') == snapshot(2)
+
+
+def test_repl_future_snapshot_resume_lone_surrogate_return_value():
+    """REPL FutureSnapshot.resume with a lone-surrogate `return_value` surfaces
+    as `MontyRuntimeError(ValueError)` and leaves the snapshot intact for retry."""
+    repl = pydantic_monty.MontyRepl()
+    p = repl.feed_start('await fetch()')
+    assert isinstance(p, pydantic_monty.FunctionSnapshot)
+    call_id = p.call_id
+    p = p.resume({'future': ...})
+    assert isinstance(p, pydantic_monty.FutureSnapshot)
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        p.resume({call_id: {'return_value': '\ud83d'}})
+    assert isinstance(exc_info.value.exception(), ValueError)
+    final = p.resume({call_id: {'return_value': 42}})
+    assert isinstance(final, pydantic_monty.MontyComplete)
+    assert final.output == snapshot(42)
+    assert repl.feed_run('1 + 1') == snapshot(2)

--- a/crates/monty-python/tests/test_repl.py
+++ b/crates/monty-python/tests/test_repl.py
@@ -188,6 +188,19 @@ def test_syntax_error_lone_surrogate():
     assert str(exc_info.value) == snapshot('source code is not valid UTF-8 (contains lone surrogates)')
 
 
+def test_runtime_error_input_value_lone_surrogate():
+    # An input string containing a lone surrogate fails UTF-8 conversion during
+    # `py_to_monty`. We wrap the resulting `UnicodeEncodeError` as a
+    # `MontyRuntimeError(ValueError)` so input-value failures surface the same
+    # way as failures when an external function returns such a string.
+    repl = pydantic_monty.MontyRepl()
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        repl.feed_run('x', inputs={'x': '\ud83d'})
+    assert str(exc_info.value) == snapshot(
+        "ValueError: 'utf-8' codec can't encode character '\\ud83d' in position 0: surrogates not allowed"
+    )
+
+
 def test_runtime_error_preserves_state():
     """A runtime error should not destroy previously defined state."""
     repl = pydantic_monty.MontyRepl()

--- a/crates/monty-python/tests/test_start.py
+++ b/crates/monty-python/tests/test_start.py
@@ -1187,9 +1187,10 @@ def test_name_lookup_snapshot_preserved_on_invalid_value():
     p1 = Monty('x = my_name; x').start()
     assert isinstance(p1, pydantic_monty.NameLookupSnapshot)
 
-    # Custom non-convertible object → TypeError from py_to_monty, snapshot intact.
-    with pytest.raises(TypeError):
+    # Custom non-convertible object → MontyRuntimeError(TypeError), snapshot intact.
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
         p1.resume(value=Custom())
+    assert isinstance(exc_info.value.exception(), TypeError)
 
     final = p1.resume(value=42)
     assert isinstance(final, pydantic_monty.MontyComplete)
@@ -1215,3 +1216,36 @@ def test_future_snapshot_preserved_on_invalid_results():
     final = progress.resume({call_id: {'return_value': 42}})
     assert isinstance(final, pydantic_monty.MontyComplete)
     assert final.output == snapshot(42)
+
+
+def test_name_lookup_resume_lone_surrogate_value():
+    """A lone-surrogate string in `value` fails UTF-8 conversion; the caller sees
+    `MontyRuntimeError(ValueError)` rather than a raw `UnicodeEncodeError`."""
+    p = Monty('my_name').start()
+    assert isinstance(p, pydantic_monty.NameLookupSnapshot)
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        p.resume(value='\ud83d')
+    assert isinstance(exc_info.value.exception(), ValueError)
+
+
+def test_function_snapshot_resume_lone_surrogate_return_value():
+    """A lone-surrogate string as `return_value` on a FunctionSnapshot surfaces
+    as `MontyRuntimeError(ValueError)` rather than a raw `UnicodeEncodeError`."""
+    p = Monty('fetch()').start()
+    assert isinstance(p, pydantic_monty.FunctionSnapshot)
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        p.resume({'return_value': '\ud83d'})
+    assert isinstance(exc_info.value.exception(), ValueError)
+
+
+def test_future_snapshot_resume_lone_surrogate_return_value():
+    """A lone-surrogate string as `return_value` inside a FutureSnapshot's
+    results dict surfaces as `MontyRuntimeError(ValueError)`."""
+    p = Monty('x = await fetch(); x').start()
+    assert isinstance(p, pydantic_monty.FunctionSnapshot)
+    call_id = p.call_id
+    p = p.resume({'future': ...})
+    assert isinstance(p, pydantic_monty.FutureSnapshot)
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        p.resume({call_id: {'return_value': '\ud83d'}})
+    assert isinstance(exc_info.value.exception(), ValueError)

--- a/crates/monty-python/tests/test_types.py
+++ b/crates/monty-python/tests/test_types.py
@@ -610,8 +610,9 @@ def test_namedtuple_custom_missing_attr_error():
 def test_unsupported_type_raises_type_error():
     """Passing an unsupported type raises TypeError during conversion."""
     m = pydantic_monty.Monty('x', inputs=['x'])
-    with pytest.raises(TypeError, match='Cannot convert'):
+    with pytest.raises(pydantic_monty.MontyRuntimeError, match='Cannot convert') as exc_info:
         m.run(inputs={'x': re.compile('foo')})
+    assert isinstance(exc_info.value.exception(), TypeError)
 
 
 # === Callable/function input ===
@@ -740,8 +741,9 @@ def test_zoneinfo_standalone_raises_type_error():
     """Standalone ZoneInfo objects (without a datetime) are not convertible."""
     m = pydantic_monty.Monty('x', inputs=['x'])
     tz = zoneinfo.ZoneInfo('America/New_York')
-    with pytest.raises(TypeError, match='Cannot convert'):
+    with pytest.raises(pydantic_monty.MontyRuntimeError, match='Cannot convert') as exc_info:
         m.run(inputs={'x': tz})
+    assert isinstance(exc_info.value.exception(), TypeError)
 
 
 # === Timedelta edge cases ===


### PR DESCRIPTION
Input values that fail `py_to_monty` conversion (e.g. strings with lone surrogates, unsupported types) previously bubbled out as raw PyO3 errors like `UnicodeEncodeError`. Wrap them via `exc_py_to_monty` so they surface as `MontyRuntimeError`, matching how external-function return values already behave.