### PR TITLE
fixes GC interval ignored in ResourceTracker and Heap

### DIFF
--- a/crates/monty-python/src/limits.rs
+++ b/crates/monty-python/src/limits.rs
@@ -227,4 +227,8 @@ impl<T: ResourceTracker> ResourceTracker for PySignalTracker<T> {
     fn on_grow(&self, additional_bytes: usize) -> Result<(), ResourceError> {
         self.inner.on_grow(additional_bytes)
     }
+
+    fn gc_interval(&self) -> Option<usize> {
+        self.inner.gc_interval()
+    }
 }

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -715,7 +715,7 @@ impl<'de, T: ResourceTracker + serde::Deserialize<'de>> serde::Deserialize<'de> 
 ///
 /// This is intentionally infrequent to minimize overhead while still
 /// eventually collecting reference cycles.
-const GC_INTERVAL: usize = 100_000;
+const DEFAULT_GC_INTERVAL: usize = 100_000;
 
 impl<T: ResourceTracker> Heap<T> {
     /// Creates a new heap with the given resource tracker.
@@ -1174,7 +1174,7 @@ impl<T: ResourceTracker> Heap<T> {
     /// and the number of allocations since the last GC exceeds the interval.
     #[inline]
     pub fn should_gc(&self) -> bool {
-        let interval = self.tracker.gc_interval().unwrap_or(GC_INTERVAL);
+        let interval = self.tracker.gc_interval().unwrap_or(DEFAULT_GC_INTERVAL);
         self.may_have_cycles.get() && (self.allocations_since_gc.get() as usize) >= interval
     }
 

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -710,11 +710,12 @@ impl<'de, T: ResourceTracker + serde::Deserialize<'de>> serde::Deserialize<'de> 
     }
 }
 
-/// GC interval - run GC every 100,000 applicable allocations.
+/// Default GC interval - run GC every 100,000 applicable allocations unless
+/// the configured resource tracker overrides it.
 ///
 /// This is intentionally infrequent to minimize overhead while still
 /// eventually collecting reference cycles.
-const GC_INTERVAL: u32 = 100_000;
+const GC_INTERVAL: usize = 100_000;
 
 impl<T: ResourceTracker> Heap<T> {
     /// Creates a new heap with the given resource tracker.
@@ -1169,11 +1170,14 @@ impl<T: ResourceTracker> Heap<T> {
 
     /// Returns whether garbage collection should run.
     ///
-    /// True if reference cycles count exist in the heap
-    /// and the number of allocations since the last GC exceeds the interval.
+    /// GC only runs when reference cycles may exist and the number of
+    /// GC-tracked allocations since the last collection has reached the
+    /// configured interval. If the resource tracker does not override the
+    /// interval, the built-in default is used.
     #[inline]
     pub fn should_gc(&self) -> bool {
-        self.may_have_cycles.get() && self.allocations_since_gc.get() >= GC_INTERVAL
+        let interval = self.tracker.gc_interval().unwrap_or(GC_INTERVAL);
+        self.may_have_cycles.get() && (self.allocations_since_gc.get() as usize) >= interval
     }
 
     /// Runs mark-sweep garbage collection to free unreachable cycles.

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -1170,10 +1170,8 @@ impl<T: ResourceTracker> Heap<T> {
 
     /// Returns whether garbage collection should run.
     ///
-    /// GC only runs when reference cycles may exist and the number of
-    /// GC-tracked allocations since the last collection has reached the
-    /// configured interval. If the resource tracker does not override the
-    /// interval, the built-in default is used.
+    /// True if reference cycles count exist in the heap
+    /// and the number of allocations since the last GC exceeds the interval.
     #[inline]
     pub fn should_gc(&self) -> bool {
         let interval = self.tracker.gc_interval().unwrap_or(GC_INTERVAL);

--- a/crates/monty/src/resource.rs
+++ b/crates/monty/src/resource.rs
@@ -294,6 +294,12 @@ pub trait ResourceTracker: fmt::Debug {
     /// # Arguments
     /// * `additional_bytes` - Approximate additional memory consumed by the growth
     fn on_grow(&self, additional_bytes: usize) -> Result<(), ResourceError>;
+
+    /// Returns the configured garbage collection interval, in GC-tracked allocations.
+    ///
+    /// Implementations that do not expose a configurable GC interval should return `None`,
+    /// which tells the heap to use its built-in default scheduling threshold.
+    fn gc_interval(&self) -> Option<usize>;
 }
 
 /// A resource tracker that imposes no limits except default recursion limit.
@@ -342,6 +348,11 @@ impl ResourceTracker for NoLimitTracker {
     fn check_large_result(&self, _estimated_bytes: usize) -> Result<(), ResourceError> {
         // No limit - always allow operations regardless of result size
         Ok(())
+    }
+
+    #[inline]
+    fn gc_interval(&self) -> Option<usize> {
+        None
     }
 }
 
@@ -599,5 +610,9 @@ impl ResourceTracker for LimitedTracker {
             }
         }
         Ok(())
+    }
+
+    fn gc_interval(&self) -> Option<usize> {
+        self.limits.gc_interval
     }
 }

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -69,6 +69,16 @@ impl MontyRun {
         self.executor.run_ref_counts(inputs)
     }
 
+    /// Executes the code and returns reference count data while using a custom tracker, used for testing only.
+    #[cfg(feature = "ref-count-return")]
+    pub fn run_ref_counts_with_tracker(
+        &self,
+        inputs: Vec<MontyObject>,
+        resource_tracker: impl ResourceTracker,
+    ) -> Result<RefCountOutput, MontyException> {
+        self.executor.run_ref_counts_with_tracker(inputs, resource_tracker)
+    }
+
     /// Executes the code to completion assuming not external functions or snapshotting.
     ///
     /// This is marginally faster than running with snapshotting enabled since we don't need
@@ -369,8 +379,15 @@ impl Executor {
     }
 
     /// Executes the code and returns both the result and reference count data, used for testing only.
+    #[cfg(feature = "ref-count-return")]
+    fn run_ref_counts(&self, inputs: Vec<MontyObject>) -> Result<RefCountOutput, MontyException> {
+        self.run_ref_counts_with_tracker(inputs, NoLimitTracker)
+    }
+
+    /// Executes the code and returns both the result and reference count data with a custom tracker,
+    /// used for testing only.
     ///
-    /// This is used for testing reference counting behavior. Returns:
+    /// This is used for testing reference counting behavior with a custom tracker. Returns:
     /// - The execution result (`Exit`)
     /// - Reference count data as a tuple of:
     ///   - A map from variable names to their reference counts (only for heap-allocated values)
@@ -382,10 +399,14 @@ impl Executor {
     ///
     /// Only available when the `ref-count-return` feature is enabled.
     #[cfg(feature = "ref-count-return")]
-    fn run_ref_counts(&self, inputs: Vec<MontyObject>) -> Result<RefCountOutput, MontyException> {
+    fn run_ref_counts_with_tracker(
+        &self,
+        inputs: Vec<MontyObject>,
+        resource_tracker: impl ResourceTracker,
+    ) -> Result<RefCountOutput, MontyException> {
         use std::collections::HashSet;
 
-        let mut heap = Heap::new(self.namespace_size, NoLimitTracker);
+        let mut heap = Heap::new(self.namespace_size, resource_tracker);
         let globals = self.empty_globals();
 
         HeapReader::with(&mut heap, |heap| {

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -310,6 +310,39 @@ len(result)
 }
 
 #[test]
+#[cfg(feature = "ref-count-return")]
+fn gc_interval_limit_is_respected() {
+    // This test verifies that a custom GC interval is actually used instead of
+    // the built-in default. We create self-referencing list cycles so GC is
+    // eligible to run, then assert that a small configured interval causes a
+    // collection before the default 100,000 allocation threshold.
+    let code = r"
+for i in range(25):
+    a = []
+    a.append(a)
+result = 'done'
+result
+";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+
+    let limits = ResourceLimits::new().gc_interval(10);
+    let output = ex
+        .run_ref_counts_with_tracker(vec![], LimitedTracker::new(limits))
+        .expect("should succeed with custom GC interval");
+
+    assert!(
+        output.allocations_since_gc < 10,
+        "configured GC interval should trigger collections before the default; allocations_since_gc = {}",
+        output.allocations_since_gc
+    );
+    assert!(
+        output.heap_count < 20,
+        "GC should collect most unreachable list cycles: {} heap objects",
+        output.heap_count
+    );
+}
+
+#[test]
 #[cfg_attr(
     feature = "ref-count-panic",
     ignore = "resource exhaustion doesn't guarantee heap state consistency"

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -63,7 +63,7 @@ result
 
     let output = ex.run_ref_counts(vec![]).expect("should succeed");
 
-    // GC_INTERVAL is 100,000. With 200,001 iterations creating dict cycles,
+    // DEFAULT_GC_INTERVAL is 100,000. With 200,001 iterations creating dict cycles,
     // GC must have run at least once, resetting allocations_since_gc.
     // If may_have_cycles was never set (has_refs() disabled), GC never runs
     // and allocations_since_gc would be ~400k (2 dicts per iteration).
@@ -114,7 +114,7 @@ len(result)
 
     let output = ex.run_ref_counts(vec![]).expect("should succeed");
 
-    // GC_INTERVAL is 100,000. With 200,001 iterations creating list cycles,
+    // DEFAULT_GC_INTERVAL is 100,000. With 200,001 iterations creating list cycles,
     // GC must have run at least twice, resetting allocations_since_gc.
     assert!(
         output.allocations_since_gc < 100_000,
@@ -289,24 +289,36 @@ len(result)
 }
 
 #[test]
+#[cfg(feature = "ref-count-return")]
 fn gc_interval_triggers_collection() {
-    // This test verifies that GC can run without crashing
-    // We can't easily verify that GC actually collected anything without
-    // adding more introspection, but we can verify it runs
+    // This test verifies that the built-in GC interval still triggers collection
+    // on real reference cycles even when no custom tracker interval is supplied.
+    // A sufficiently large number of cycles should force collection here.
     let code = r"
-result = []
-for i in range(100):
-    temp = [1, 2, 3]
-    result.append(i)
-len(result)
+result = 'done'
+for i in range(210000):
+    a = []
+    a.append(a)
+result
 ";
     let ex = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
 
-    // Set GC to run every 10 allocations
-    let limits = ResourceLimits::new().gc_interval(10);
-    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+    let output = ex
+        .run_ref_counts(vec![])
+        .expect("should succeed with GC enabled on cycles");
 
-    assert!(result.is_ok(), "should succeed with GC enabled");
+    assert_eq!(output.py_object, MontyObject::String("done".to_owned()));
+    assert!(
+        output.allocations_since_gc < 100_000,
+        "default GC interval should have triggered collection: allocations_since_gc = {}",
+        output.allocations_since_gc
+    );
+    // Expected remaining cycles × 2, with a little slack.
+    assert!(
+        output.heap_count <= 20_000,
+        "GC should collect most unreachable list cycles: {} heap objects",
+        output.heap_count
+    );
 }
 
 #[test]
@@ -330,13 +342,15 @@ result
         .run_ref_counts_with_tracker(vec![], LimitedTracker::new(limits))
         .expect("should succeed with custom GC interval");
 
+    assert_eq!(output.py_object, MontyObject::String("done".to_owned()));
     assert!(
         output.allocations_since_gc < 10,
         "configured GC interval should trigger collections before the default; allocations_since_gc = {}",
         output.allocations_since_gc
     );
+    // Expected remaining cycles × 2, with a little slack.
     assert!(
-        output.heap_count < 20,
+        output.heap_count <= 10,
         "GC should collect most unreachable list cycles: {} heap objects",
         output.heap_count
     );


### PR DESCRIPTION
So a custom GC interval could be set in Python or JS but it was being ignored in favour of a default 100_000. I fixed this with a coding agent and approved its output. Basically, the `ResourceTracker` trait definition now gets a `fn gc_interval(&self) -> Option<usize>` and I implemented this for `PySignalTracker`,  `NoLimitTracker` and `LimitedTracker`. Then, the `Heap` 's `should_gc` now checks the tracker's `gc_interval()` and fires at a suitable interval. I also wrote some test infrastructure to check if the passed parameter is being respected.

 ## Tests passed

   - `make format-rs`
   - `make format-js`
   - `make lint-rs`
   - `make lint-js`
   - `make lint-py`
   - `cargo test -p monty --test resource_limits --features ref-count-return`
   - `make test-js`

