### PR TITLE
fix panic on duplicate parameter names

### DIFF
--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -249,10 +249,7 @@ impl<'i> Prepare<'i> {
         let mut name_map = AHashMap::with_capacity(capacity);
         for (index, string_id) in params.iter().enumerate() {
             let name_str = interner.get_str(*string_id);
-            if name_map
-                .insert(name_str.to_string(), NamespaceId::new(index))
-                .is_some()
-            {
+            if name_map.insert(name_str.to_string(), NamespaceId::new(index)).is_some() {
                 return Err(ParseError::syntax(
                     format!("duplicate argument '{name_str}' in function definition"),
                     position,

--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -230,6 +230,7 @@ impl<'i> Prepare<'i> {
     fn new_function(
         capacity: usize,
         params: &[StringId],
+        position: CodeRange,
         assigned_names: AHashSet<String>,
         global_names: AHashSet<String>,
         nonlocal_names: AHashSet<String>,
@@ -238,10 +239,25 @@ impl<'i> Prepare<'i> {
         enclosing_locals: Option<AHashSet<String>>,
         cell_var_names: AHashSet<String>,
         interner: &'i InternerBuilder,
-    ) -> Self {
+    ) -> Result<Self, ParseError> {
+        // Reject duplicate parameter names while building the name_map.
+        // Ruff's parser accepts `def f(x, x)` that CPython rejects at compile
+        // time; without this check, `name_map` is deduplicated by HashMap
+        // semantics but each `NamespaceId` comes from the positional index,
+        // so the duplicate slot lands past the allocated stack region and
+        // panics `load_local` at runtime.
         let mut name_map = AHashMap::with_capacity(capacity);
         for (index, string_id) in params.iter().enumerate() {
-            name_map.insert(interner.get_str(*string_id).to_string(), NamespaceId::new(index));
+            let name_str = interner.get_str(*string_id);
+            if name_map
+                .insert(name_str.to_string(), NamespaceId::new(index))
+                .is_some()
+            {
+                return Err(ParseError::syntax(
+                    format!("duplicate argument '{name_str}' in function definition"),
+                    position,
+                ));
+            }
         }
         let namespace_size = name_map.len();
 
@@ -281,7 +297,7 @@ impl<'i> Prepare<'i> {
             free_var_map.insert(name, NamespaceId::new(slot));
         }
 
-        Self {
+        Ok(Self {
             interner,
             name_map,
             namespace_size,
@@ -294,7 +310,7 @@ impl<'i> Prepare<'i> {
             free_var_map,
             cell_var_map,
             unassigned_ref_names: AHashSet::new(),
-        }
+        })
     }
 
     /// Recursively prepares a sequence of AST nodes by resolving names and transforming expressions.
@@ -1267,15 +1283,12 @@ impl<'i> Prepare<'i> {
         // Register the function name in the current scope
         let (name, _) = self.get_id(name);
 
-        // Extract param names from the parsed signature for scope analysis
+        // Extract param names from the parsed signature for scope analysis.
+        // Duplicate names (`def f(x, x)`) are rejected inside `new_function`
+        // when it builds the namespace `name_map`, since duplicates would
+        // desynchronize `name_map.len()` from the positional `NamespaceId`
+        // and later panic `load_local` at runtime.
         let param_names: Vec<StringId> = parsed_sig.param_names().collect();
-
-        // Reject duplicate parameter names. CPython raises `SyntaxError` at compile
-        // time; accepting them here desynchronizes the namespace layout built by
-        // `new_function` (`name_map` is deduplicated by HashMap semantics but each
-        // `NamespaceId` comes from the positional index), which later panics
-        // `load_local` at runtime.
-        reject_duplicate_params(&param_names, self.interner, name.position)?;
 
         // Pass 1: Collect scope information from the function body
         let scope_info = collect_function_scope_info(&body, &param_names, self.interner);
@@ -1317,6 +1330,7 @@ impl<'i> Prepare<'i> {
         let mut inner_prepare = Prepare::new_function(
             body.len(),
             &param_names,
+            name.position,
             scope_info.assigned_names,
             scope_info.global_names,
             scope_info.nonlocal_names,
@@ -1325,7 +1339,7 @@ impl<'i> Prepare<'i> {
             Some(enclosing_locals),
             scope_info.cell_var_names,
             self.interner,
-        );
+        )?;
 
         // Prepare the function body
         let prepared_body = inner_prepare.prepare_nodes(body)?;
@@ -1490,11 +1504,9 @@ impl<'i> Prepare<'i> {
         let body_as_node: ParseNode = Node::Return(body.clone());
         let body_nodes = vec![body_as_node];
 
-        // Extract param names from the parsed signature for scope analysis
+        // Extract param names from the parsed signature for scope analysis.
+        // Duplicates are rejected inside `new_function` (see its doc).
         let param_names: Vec<StringId> = parsed_sig.param_names().collect();
-
-        // Reject duplicate parameter names (see `prepare_function_def` for the rationale).
-        reject_duplicate_params(&param_names, self.interner, position)?;
 
         // Pass 1: Collect scope information from the lambda body
         // (Lambdas can't have global/nonlocal declarations, but can have nested functions)
@@ -1534,6 +1546,7 @@ impl<'i> Prepare<'i> {
         let mut inner_prepare = Prepare::new_function(
             body_nodes.len(),
             &param_names,
+            position,
             scope_info.assigned_names,
             scope_info.global_names,
             scope_info.nonlocal_names,
@@ -1542,7 +1555,7 @@ impl<'i> Prepare<'i> {
             Some(enclosing_locals),
             scope_info.cell_var_names,
             self.interner,
-        );
+        )?;
 
         // Prepare the lambda body
         let prepared_body = inner_prepare.prepare_nodes(body_nodes)?;
@@ -1928,32 +1941,6 @@ struct FunctionScopeInfo {
     /// OR they may be builtin/global reads. The actual implicit captures are determined
     /// by filtering against enclosing_locals in new_function.
     potential_captures: AHashSet<String>,
-}
-
-/// Validates that a function's parameter list has no duplicate names.
-///
-/// Ruff's parser accepts duplicate parameter names (e.g. `def f(x, x)`) that CPython
-/// rejects at compile time. Accepting them here would desynchronize the namespace
-/// layout: `name_map.len()` counts unique names while each `NamespaceId` comes
-/// from the positional index, so the duplicate resolves to a slot past the
-/// allocated stack region and panics `load_local` at runtime. Rejecting at the
-/// prepare phase matches CPython's compile-time check.
-fn reject_duplicate_params(
-    param_names: &[StringId],
-    interner: &InternerBuilder,
-    position: CodeRange,
-) -> Result<(), ParseError> {
-    let mut seen = AHashSet::with_capacity(param_names.len());
-    for string_id in param_names {
-        if !seen.insert(*string_id) {
-            let name_str = interner.get_str(*string_id);
-            return Err(ParseError::syntax(
-                format!("duplicate argument '{name_str}' in function definition"),
-                position,
-            ));
-        }
-    }
-    Ok(())
 }
 
 /// Scans a function body to collect scope information (first phase of preparation).

--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -1280,11 +1280,7 @@ impl<'i> Prepare<'i> {
         // Register the function name in the current scope
         let (name, _) = self.get_id(name);
 
-        // Extract param names from the parsed signature for scope analysis.
-        // Duplicate names (`def f(x, x)`) are rejected inside `new_function`
-        // when it builds the namespace `name_map`, since duplicates would
-        // desynchronize `name_map.len()` from the positional `NamespaceId`
-        // and later panic `load_local` at runtime.
+        // Extract param names from the parsed signature for scope analysis
         let param_names: Vec<StringId> = parsed_sig.param_names().collect();
 
         // Pass 1: Collect scope information from the function body
@@ -1501,8 +1497,7 @@ impl<'i> Prepare<'i> {
         let body_as_node: ParseNode = Node::Return(body.clone());
         let body_nodes = vec![body_as_node];
 
-        // Extract param names from the parsed signature for scope analysis.
-        // Duplicates are rejected inside `new_function` (see its doc).
+        // Extract param names from the parsed signature for scope analysis
         let param_names: Vec<StringId> = parsed_sig.param_names().collect();
 
         // Pass 1: Collect scope information from the lambda body

--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -1270,6 +1270,13 @@ impl<'i> Prepare<'i> {
         // Extract param names from the parsed signature for scope analysis
         let param_names: Vec<StringId> = parsed_sig.param_names().collect();
 
+        // Reject duplicate parameter names. CPython raises `SyntaxError` at compile
+        // time; accepting them here desynchronizes the namespace layout built by
+        // `new_function` (`name_map` is deduplicated by HashMap semantics but each
+        // `NamespaceId` comes from the positional index), which later panics
+        // `load_local` at runtime.
+        reject_duplicate_params(&param_names, self.interner, name.position)?;
+
         // Pass 1: Collect scope information from the function body
         let scope_info = collect_function_scope_info(&body, &param_names, self.interner);
 
@@ -1485,6 +1492,9 @@ impl<'i> Prepare<'i> {
 
         // Extract param names from the parsed signature for scope analysis
         let param_names: Vec<StringId> = parsed_sig.param_names().collect();
+
+        // Reject duplicate parameter names (see `prepare_function_def` for the rationale).
+        reject_duplicate_params(&param_names, self.interner, position)?;
 
         // Pass 1: Collect scope information from the lambda body
         // (Lambdas can't have global/nonlocal declarations, but can have nested functions)
@@ -1918,6 +1928,32 @@ struct FunctionScopeInfo {
     /// OR they may be builtin/global reads. The actual implicit captures are determined
     /// by filtering against enclosing_locals in new_function.
     potential_captures: AHashSet<String>,
+}
+
+/// Validates that a function's parameter list has no duplicate names.
+///
+/// Ruff's parser accepts duplicate parameter names (e.g. `def f(x, x)`) that CPython
+/// rejects at compile time. Accepting them here would desynchronize the namespace
+/// layout: `name_map.len()` counts unique names while each `NamespaceId` comes
+/// from the positional index, so the duplicate resolves to a slot past the
+/// allocated stack region and panics `load_local` at runtime. Rejecting at the
+/// prepare phase matches CPython's compile-time check.
+fn reject_duplicate_params(
+    param_names: &[StringId],
+    interner: &InternerBuilder,
+    position: CodeRange,
+) -> Result<(), ParseError> {
+    let mut seen = AHashSet::with_capacity(param_names.len());
+    for string_id in param_names {
+        if !seen.insert(*string_id) {
+            let name_str = interner.get_str(*string_id);
+            return Err(ParseError::syntax(
+                format!("duplicate argument '{name_str}' in function definition"),
+                position,
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Scans a function body to collect scope information (first phase of preparation).

--- a/crates/monty/test_cases/function__err_duplicate_param.py
+++ b/crates/monty/test_cases/function__err_duplicate_param.py
@@ -1,0 +1,8 @@
+# Duplicate parameter names in a function definition are a SyntaxError.
+# Previously this panicked the VM at call time because `prepare.rs` sized
+# the frame's namespace from the unique name count (HashMap::len) but
+# resolved the duplicate to a NamespaceId from the positional index,
+# so `load_local` indexed past the allocated stack slots.
+def f(x, x):
+    return x
+# Raise=SyntaxError("duplicate argument 'x' in function definition")

--- a/crates/monty/tests/parse_errors.rs
+++ b/crates/monty/tests/parse_errors.rs
@@ -441,6 +441,45 @@ fn del_statement_returns_not_implemented_error() {
 }
 
 #[test]
+fn duplicate_positional_parameter_returns_syntax_error() {
+    // https://github.com/pydantic/monty/issues/377
+    //
+    // Ruff's parser accepts `def f(x, x)` though CPython rejects it at compile time.
+    // Without an explicit check, `Prepare::new_function` would size the frame from
+    // the unique-name count (HashMap::len) while resolving the duplicate to a
+    // positional NamespaceId that points past the allocated stack region, panicking
+    // `load_local` at call time.
+    let result = MontyRun::new("def f(x, x): return x\nf(1, 2)".to_owned(), "test.py", vec![]);
+    let exc = result.expect_err("expected compile error");
+    assert_eq!(exc.exc_type(), ExcType::SyntaxError);
+    assert_eq!(exc.message(), Some("duplicate argument 'x' in function definition"));
+}
+
+#[test]
+fn duplicate_keyword_only_parameter_returns_syntax_error() {
+    let result = MontyRun::new("def f(*, x, x): return x".to_owned(), "test.py", vec![]);
+    let exc = result.expect_err("expected compile error");
+    assert_eq!(exc.exc_type(), ExcType::SyntaxError);
+    assert_eq!(exc.message(), Some("duplicate argument 'x' in function definition"));
+}
+
+#[test]
+fn duplicate_mixed_positional_and_keyword_only_parameter_returns_syntax_error() {
+    let result = MontyRun::new("def f(x, *, x=1): return x".to_owned(), "test.py", vec![]);
+    let exc = result.expect_err("expected compile error");
+    assert_eq!(exc.exc_type(), ExcType::SyntaxError);
+    assert_eq!(exc.message(), Some("duplicate argument 'x' in function definition"));
+}
+
+#[test]
+fn duplicate_lambda_parameter_returns_syntax_error() {
+    let result = MontyRun::new("f = lambda x, x: x".to_owned(), "test.py", vec![]);
+    let exc = result.expect_err("expected compile error");
+    assert_eq!(exc.exc_type(), ExcType::SyntaxError);
+    assert_eq!(exc.message(), Some("duplicate argument 'x' in function definition"));
+}
+
+#[test]
 fn long_source_line_does_not_overflow_column() {
     // https://github.com/pydantic/monty/issues/341
     //

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ include = [
 ]
 # Exclude files with intentional syntax errors or special formatting requirements
 extend-exclude = [
+    "crates/monty/test_cases/function__err_duplicate_param.py",
     "crates/monty/test_cases/nonlocal__error_module_level.py",
     "crates/monty/test_cases/traceback__nonlocal_module_scope.py",
     # These files test specific quote styles in error messages and must not be reformatted
@@ -96,6 +97,8 @@ include = ["scripts", "crates/monty/test_cases", "crates/monty-python", "crates/
 exclude = [
     "crates/monty-type-checking/tests/bad_types.py",
     "crates/monty-type-checking/tests/reveal_types.py",
+    # duplicate parameter name test intentionally has a syntax error
+    "crates/monty/test_cases/function__err_duplicate_param.py",
     # break/continue outside loop tests intentionally test error handling
     "crates/monty/test_cases/loop__break_outside_error.py",
     "crates/monty/test_cases/loop__continue_outside_error.py",


### PR DESCRIPTION
Fixes #377.

Ruff accepts `def f(x, x): return x` (and kw-only / mixed / varargs / kwargs / pos-only / lambda variants) while CPython rejects all of them at compile time. Monty's `Prepare::new_function` builds `name_map` as an `AHashMap`, so duplicates collapse to one entry; `namespace_size` is sourced from `name_map.len()` but each `NamespaceId` comes from the positional `enumerate()` index. With any duplicate name the resolved `NamespaceId` points past the allocated frame, and `load_local` at `vm/mod.rs` indexes past the end of the stack region and panics.

This adds `reject_duplicate_params` and calls it from `prepare_function_def` and `prepare_lambda`. The message matches CPython's `duplicate argument '{name}' in function definition` verbatim.

## Tests

- `parse_errors::duplicate_positional_parameter_returns_syntax_error`
- `parse_errors::duplicate_keyword_only_parameter_returns_syntax_error`
- `parse_errors::duplicate_mixed_positional_and_keyword_only_parameter_returns_syntax_error`
- `parse_errors::duplicate_lambda_parameter_returns_syntax_error`
- `crates/monty/test_cases/function__err_duplicate_param.py` (datatest harness, `# Raise=` format)

Also verified end-to-end against `monty-cli` on: positional dup, kw-only dup, mixed, lambda, `*args`/positional collision, `**kwargs`/positional collision, pos-only/positional collision, `*args`/`**kwargs` collision, triple dup, multi-collision. All raise the same CPython-matching `SyntaxError`.

## Caret position

CPython points at the duplicate parameter's position; the error points at the function name (`name.position` for `def`, the lambda `position` for `lambda`). Parameter-level position isn't threaded through `ParsedParam`. Sharper caret would need adding `position: CodeRange` there. Separate refactor.

## Not covered

`def f[T, T](...)` (duplicate type parameters) is a separate code path not addressed here. CPython raises `SyntaxError: duplicate type parameter 'T'`; Monty accepts it silently. Separate ticket.
