### PR TITLE
Fix async await exception propagation

### DIFF
--- a/crates/monty-python/tests/test_start.py
+++ b/crates/monty-python/tests/test_start.py
@@ -1218,6 +1218,30 @@ def test_future_snapshot_preserved_on_invalid_results():
     assert final.output == snapshot(42)
 
 
+def test_future_snapshot_resume_exception_caught_at_await():
+    """Exceptions used to resume a future are raised at the `await` expression."""
+    code = """
+try:
+    await fetch()
+    result = 'not caught'
+except ValueError as exc:
+    result = 'caught: ' + str(exc)
+
+result
+"""
+    progress = Monty(code).start()
+    assert isinstance(progress, pydantic_monty.FunctionSnapshot)
+    assert progress.function_name == snapshot('fetch')
+    call_id = progress.call_id
+
+    progress = progress.resume({'future': ...})
+    assert isinstance(progress, pydantic_monty.FutureSnapshot)
+
+    final = progress.resume({call_id: {'exception': ValueError('async boom')}})
+    assert isinstance(final, pydantic_monty.MontyComplete)
+    assert final.output == snapshot('caught: async boom')
+
+
 def test_name_lookup_resume_lone_surrogate_value():
     """A lone-surrogate string in `value` fails UTF-8 conversion; the caller sees
     `MontyRuntimeError(ValueError)` rather than a raw `UnicodeEncodeError`."""

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -866,11 +866,15 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
 
             match task.state {
                 TaskState::Failed(_) => {
-                    // Current task failed - propagate error to caller
+                    // Current task failed because a future resolved with an
+                    // exception. Route that exception through the normal VM
+                    // machinery so a surrounding `try`/`except` around the
+                    // `await` can catch it; if no handler matches,
+                    // `resume_with_exception` still propagates the error.
                     let TaskState::Failed(err) = mem::replace(&mut task.state, TaskState::Ready) else {
                         unreachable!();
                     };
-                    return Err(err);
+                    return self.resume_with_exception(err);
                 }
                 TaskState::BlockedOnCall(_) | TaskState::BlockedOnGather(_) => {
                     // Current task is still blocked on unresolved futures.


### PR DESCRIPTION
## Summary
- Fixes https://github.com/pydantic/monty/issues/323.
- Route failed awaited futures back through normal VM exception handling so `try`/`except` around `await` can catch them.
- Add a regression test covering `await fetch()` resuming with `ValueError('async boom')` and returning `caught: async boom`.

## Testing
- `make format-rs`
- `make lint-rs`
- `make lint-py`
- `uv run pytest crates/monty-python/tests/test_start.py -q`