### PR TITLE
fix: parse errors must not leak ruff AST Debug formatting

### DIFF
--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -1249,13 +1249,10 @@ impl<'a> Parser<'a> {
     fn parse_identifier(&mut self, ast: AstExpr) -> Result<Identifier, ParseError> {
         match ast {
             AstExpr::Name(ast::ExprName { id, range, .. }) => Ok(self.identifier(&id, range)),
-            other => {
-                let kind = describe_expr_kind(&other);
-                Err(ParseError::syntax(
-                    format!("Expected name, got {kind}"),
-                    self.convert_range(other.range()),
-                ))
-            }
+            other => Err(ParseError::syntax(
+                format!("Expected name, got {}", describe_expr_kind(&other)),
+                self.convert_range(other.range()),
+            )),
         }
     }
 
@@ -1353,13 +1350,10 @@ impl<'a> Parser<'a> {
                 }
                 Ok(UnpackTarget::Tuple { targets, position })
             }
-            other => {
-                let kind = describe_expr_kind(&other);
-                Err(ParseError::syntax(
-                    format!("invalid unpacking target: {kind}"),
-                    self.convert_range(other.range()),
-                ))
-            }
+            other => Err(ParseError::syntax(
+                format!("invalid unpacking target: {}", describe_expr_kind(&other)),
+                self.convert_range(other.range()),
+            )),
         }
     }
 

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -171,48 +171,6 @@ pub struct Parser<'a> {
     depth_remaining: u16,
 }
 
-/// Short human-readable name for an `AstExpr` variant, for use in
-/// user-facing parse errors. Avoids the Rust `Debug` formatting of the
-/// node, which would leak internal field names, ranges, and struct
-/// layout of `ruff_python_ast` into the HTTP error body.
-fn describe_expr_kind(expr: &AstExpr) -> &'static str {
-    match expr {
-        AstExpr::Name(_) => "name",
-        AstExpr::Starred(_) => "starred expression",
-        AstExpr::Attribute(_) => "attribute",
-        AstExpr::Subscript(_) => "subscript",
-        AstExpr::Call(_) => "function call",
-        AstExpr::Tuple(_) => "tuple",
-        AstExpr::List(_) => "list",
-        AstExpr::Set(_) => "set",
-        AstExpr::Dict(_) => "dict",
-        AstExpr::NumberLiteral(_) => "number literal",
-        AstExpr::StringLiteral(_) => "string literal",
-        AstExpr::BytesLiteral(_) => "bytes literal",
-        AstExpr::BooleanLiteral(_) => "boolean literal",
-        AstExpr::NoneLiteral(_) => "None",
-        AstExpr::EllipsisLiteral(_) => "...",
-        AstExpr::FString(_) => "f-string",
-        AstExpr::TString(_) => "t-string",
-        AstExpr::Lambda(_) => "lambda",
-        AstExpr::If(_) => "conditional expression",
-        AstExpr::BoolOp(_) => "boolean expression",
-        AstExpr::BinOp(_) => "binary expression",
-        AstExpr::UnaryOp(_) => "unary expression",
-        AstExpr::Compare(_) => "comparison",
-        AstExpr::Named(_) => "named expression",
-        AstExpr::Yield(_) => "yield expression",
-        AstExpr::YieldFrom(_) => "yield from expression",
-        AstExpr::Await(_) => "await expression",
-        AstExpr::ListComp(_) => "list comprehension",
-        AstExpr::SetComp(_) => "set comprehension",
-        AstExpr::DictComp(_) => "dict comprehension",
-        AstExpr::Generator(_) => "generator expression",
-        AstExpr::Slice(_) => "slice",
-        AstExpr::IpyEscapeCommand(_) => "IPython escape command",
-    }
-}
-
 impl<'a> Parser<'a> {
     fn new(code: &'a str, filename: &'a str, mut interner: InternerBuilder) -> Self {
         let filename_id = interner.intern(filename);
@@ -1656,6 +1614,48 @@ fn convert_conversion_flag(flag: RuffConversionFlag) -> ConversionFlag {
         RuffConversionFlag::Str => ConversionFlag::Str,
         RuffConversionFlag::Repr => ConversionFlag::Repr,
         RuffConversionFlag::Ascii => ConversionFlag::Ascii,
+    }
+}
+
+/// Short human-readable name for an `AstExpr` variant, for use in
+/// user-facing parse errors. Avoids the Rust `Debug` formatting of the
+/// node, which would leak internal field names, ranges, and struct
+/// layout of `ruff_python_ast` into the error message.
+fn describe_expr_kind(expr: &AstExpr) -> &'static str {
+    match expr {
+        AstExpr::Name(_) => "name",
+        AstExpr::Starred(_) => "starred expression",
+        AstExpr::Attribute(_) => "attribute",
+        AstExpr::Subscript(_) => "subscript",
+        AstExpr::Call(_) => "function call",
+        AstExpr::Tuple(_) => "tuple",
+        AstExpr::List(_) => "list",
+        AstExpr::Set(_) => "set",
+        AstExpr::Dict(_) => "dict",
+        AstExpr::NumberLiteral(_) => "number literal",
+        AstExpr::StringLiteral(_) => "string literal",
+        AstExpr::BytesLiteral(_) => "bytes literal",
+        AstExpr::BooleanLiteral(_) => "boolean literal",
+        AstExpr::NoneLiteral(_) => "None",
+        AstExpr::EllipsisLiteral(_) => "...",
+        AstExpr::FString(_) => "f-string",
+        AstExpr::TString(_) => "t-string",
+        AstExpr::Lambda(_) => "lambda",
+        AstExpr::If(_) => "conditional expression",
+        AstExpr::BoolOp(_) => "boolean expression",
+        AstExpr::BinOp(_) => "binary expression",
+        AstExpr::UnaryOp(_) => "unary expression",
+        AstExpr::Compare(_) => "comparison",
+        AstExpr::Named(_) => "named expression",
+        AstExpr::Yield(_) => "yield expression",
+        AstExpr::YieldFrom(_) => "yield from expression",
+        AstExpr::Await(_) => "await expression",
+        AstExpr::ListComp(_) => "list comprehension",
+        AstExpr::SetComp(_) => "set comprehension",
+        AstExpr::DictComp(_) => "dict comprehension",
+        AstExpr::Generator(_) => "generator expression",
+        AstExpr::Slice(_) => "slice",
+        AstExpr::IpyEscapeCommand(_) => "IPython escape command",
     }
 }
 

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -171,6 +171,48 @@ pub struct Parser<'a> {
     depth_remaining: u16,
 }
 
+/// Short human-readable name for an `AstExpr` variant, for use in
+/// user-facing parse errors. Avoids the Rust `Debug` formatting of the
+/// node, which would leak internal field names, ranges, and struct
+/// layout of `ruff_python_ast` into the HTTP error body.
+fn describe_expr_kind(expr: &AstExpr) -> &'static str {
+    match expr {
+        AstExpr::Name(_) => "name",
+        AstExpr::Starred(_) => "starred expression",
+        AstExpr::Attribute(_) => "attribute",
+        AstExpr::Subscript(_) => "subscript",
+        AstExpr::Call(_) => "function call",
+        AstExpr::Tuple(_) => "tuple",
+        AstExpr::List(_) => "list",
+        AstExpr::Set(_) => "set",
+        AstExpr::Dict(_) => "dict",
+        AstExpr::NumberLiteral(_) => "number literal",
+        AstExpr::StringLiteral(_) => "string literal",
+        AstExpr::BytesLiteral(_) => "bytes literal",
+        AstExpr::BooleanLiteral(_) => "boolean literal",
+        AstExpr::NoneLiteral(_) => "None",
+        AstExpr::EllipsisLiteral(_) => "...",
+        AstExpr::FString(_) => "f-string",
+        AstExpr::TString(_) => "t-string",
+        AstExpr::Lambda(_) => "lambda",
+        AstExpr::If(_) => "conditional expression",
+        AstExpr::BoolOp(_) => "boolean expression",
+        AstExpr::BinOp(_) => "binary expression",
+        AstExpr::UnaryOp(_) => "unary expression",
+        AstExpr::Compare(_) => "comparison",
+        AstExpr::Named(_) => "named expression",
+        AstExpr::Yield(_) => "yield expression",
+        AstExpr::YieldFrom(_) => "yield from expression",
+        AstExpr::Await(_) => "await expression",
+        AstExpr::ListComp(_) => "list comprehension",
+        AstExpr::SetComp(_) => "set comprehension",
+        AstExpr::DictComp(_) => "dict comprehension",
+        AstExpr::Generator(_) => "generator expression",
+        AstExpr::Slice(_) => "slice",
+        AstExpr::IpyEscapeCommand(_) => "IPython escape command",
+    }
+}
+
 impl<'a> Parser<'a> {
     fn new(code: &'a str, filename: &'a str, mut interner: InternerBuilder) -> Self {
         let filename_id = interner.intern(filename);
@@ -1249,10 +1291,13 @@ impl<'a> Parser<'a> {
     fn parse_identifier(&mut self, ast: AstExpr) -> Result<Identifier, ParseError> {
         match ast {
             AstExpr::Name(ast::ExprName { id, range, .. }) => Ok(self.identifier(&id, range)),
-            other => Err(ParseError::syntax(
-                format!("Expected name, got {other:?}"),
-                self.convert_range(other.range()),
-            )),
+            other => {
+                let kind = describe_expr_kind(&other);
+                Err(ParseError::syntax(
+                    format!("Expected name, got {kind}"),
+                    self.convert_range(other.range()),
+                ))
+            }
         }
     }
 
@@ -1350,10 +1395,13 @@ impl<'a> Parser<'a> {
                 }
                 Ok(UnpackTarget::Tuple { targets, position })
             }
-            other => Err(ParseError::syntax(
-                format!("invalid unpacking target: {other:?}"),
-                self.convert_range(other.range()),
-            )),
+            other => {
+                let kind = describe_expr_kind(&other);
+                Err(ParseError::syntax(
+                    format!("invalid unpacking target: {kind}"),
+                    self.convert_range(other.range()),
+                ))
+            }
         }
     }
 

--- a/crates/monty/tests/parse_errors.rs
+++ b/crates/monty/tests/parse_errors.rs
@@ -450,3 +450,82 @@ fn long_source_line_does_not_overflow_column() {
     let result = run.run_no_limits(vec![]);
     assert!(result.is_ok(), "long line should run: {result:?}");
 }
+
+// === Parse error messages must not leak ruff_python_ast Debug formatting ===
+//
+// These guard the previously observed info-disclosure where compile-time
+// parse errors returned the Rust `Debug` formatting of the offending AST
+// node verbatim in the HTTP response body (`ExprStarred { node_index:
+// NodeIndex(None), range: ..., ... }`). The messages should now be short
+// human prose that does not expose ruff's internal struct layout.
+
+/// Asserts an error message is present, contains the expected prose,
+/// and does not leak any telltale `ruff_python_ast` Debug tokens.
+fn assert_no_debug_leak(msg: Option<&str>, expected_substr: &str) {
+    let msg = msg.expect("error should have a message");
+    assert!(
+        msg.contains(expected_substr),
+        "expected message to contain {expected_substr:?}, got: {msg:?}"
+    );
+    for tok in [
+        "ExprStarred",
+        "ExprName",
+        "ExprAttribute",
+        "ExprSubscript",
+        "ExprNumberLiteral",
+        "NodeIndex",
+        "node_index",
+        "ctx: Store",
+        "ctx: Load",
+    ] {
+        assert!(
+            !msg.contains(tok),
+            "parse error must not leak ruff AST Debug token {tok:?}, got: {msg:?}"
+        );
+    }
+}
+
+#[test]
+fn starred_assignment_target_name_has_clean_message() {
+    // `*a = [1, 2]`: Ruff parses the LHS as a bare starred target, which
+    // Monty rejects at `parse_identifier`. The message must not embed the
+    // Debug format of the `ExprStarred` node.
+    let result = MontyRun::new("*a = [1, 2]".to_owned(), "test.py", vec![]);
+    let exc = result.expect_err("expected parse error");
+    assert_eq!(exc.exc_type(), ExcType::SyntaxError);
+    assert_no_debug_leak(exc.message(), "starred expression");
+}
+
+#[test]
+fn starred_attribute_target_has_clean_message() {
+    // `*x.y = 1`: starred target wrapping an attribute. Same rejection
+    // path, different inner node shape. Message must not leak
+    // `ExprAttribute` / `Identifier` Debug.
+    let result = MontyRun::new("*x.y = 1".to_owned(), "test.py", vec![]);
+    let exc = result.expect_err("expected parse error");
+    assert_eq!(exc.exc_type(), ExcType::SyntaxError);
+    assert_no_debug_leak(exc.message(), "starred expression");
+}
+
+#[test]
+fn starred_subscript_target_has_clean_message() {
+    // `*x[0] = 1`: starred target wrapping a subscript. Must not leak
+    // `ExprSubscript` / `ExprNumberLiteral` Debug.
+    let result = MontyRun::new("*x[0] = 1".to_owned(), "test.py", vec![]);
+    let exc = result.expect_err("expected parse error");
+    assert_eq!(exc.exc_type(), ExcType::SyntaxError);
+    assert_no_debug_leak(exc.message(), "starred expression");
+}
+
+#[test]
+fn for_loop_attribute_target_has_clean_message() {
+    // `for x.y in [1]: pass`: attribute as a for-loop target. CPython
+    // accepts this; Monty currently rejects at `parse_unpack_target_impl`
+    // with a generic "invalid unpacking target" error. That rejection of
+    // valid Python is a separate issue; this test locks only that the
+    // error message does not leak `ExprAttribute` Debug.
+    let result = MontyRun::new("for x.y in [1]: pass".to_owned(), "test.py", vec![]);
+    let exc = result.expect_err("expected parse error");
+    assert_eq!(exc.exc_type(), ExcType::SyntaxError);
+    assert_no_debug_leak(exc.message(), "attribute");
+}

--- a/crates/monty/tests/parse_errors.rs
+++ b/crates/monty/tests/parse_errors.rs
@@ -1,5 +1,6 @@
 use std::fmt::Write;
 
+use insta::assert_snapshot;
 use monty::{ExcType, MontyException, MontyRun};
 
 /// Helper to extract the exception type from a parse error.
@@ -453,79 +454,48 @@ fn long_source_line_does_not_overflow_column() {
 
 // === Parse error messages must not leak ruff_python_ast Debug formatting ===
 //
-// These guard the previously observed info-disclosure where compile-time
-// parse errors returned the Rust `Debug` formatting of the offending AST
-// node verbatim in the HTTP response body (`ExprStarred { node_index:
-// NodeIndex(None), range: ..., ... }`). The messages should now be short
-// human prose that does not expose ruff's internal struct layout.
-
-/// Asserts an error message is present, contains the expected prose,
-/// and does not leak any telltale `ruff_python_ast` Debug tokens.
-fn assert_no_debug_leak(msg: Option<&str>, expected_substr: &str) {
-    let msg = msg.expect("error should have a message");
-    assert!(
-        msg.contains(expected_substr),
-        "expected message to contain {expected_substr:?}, got: {msg:?}"
-    );
-    for tok in [
-        "ExprStarred",
-        "ExprName",
-        "ExprAttribute",
-        "ExprSubscript",
-        "ExprNumberLiteral",
-        "NodeIndex",
-        "node_index",
-        "ctx: Store",
-        "ctx: Load",
-    ] {
-        assert!(
-            !msg.contains(tok),
-            "parse error must not leak ruff AST Debug token {tok:?}, got: {msg:?}"
-        );
-    }
-}
+// These snapshot the full error message for each trigger so any future
+// regression that reintroduces Debug formatting of AST nodes (struct
+// names, `node_index`, `range`, `ctx: Store`, etc.) fails the snapshot
+// diff loudly.
 
 #[test]
-fn starred_assignment_target_name_has_clean_message() {
+fn starred_name_target_has_clean_message() {
     // `*a = [1, 2]`: Ruff parses the LHS as a bare starred target, which
-    // Monty rejects at `parse_identifier`. The message must not embed the
-    // Debug format of the `ExprStarred` node.
+    // Monty rejects at `parse_identifier`.
     let result = MontyRun::new("*a = [1, 2]".to_owned(), "test.py", vec![]);
     let exc = result.expect_err("expected parse error");
     assert_eq!(exc.exc_type(), ExcType::SyntaxError);
-    assert_no_debug_leak(exc.message(), "starred expression");
+    assert_snapshot!(exc.message().expect("has message"), @"Expected name, got starred expression");
 }
 
 #[test]
 fn starred_attribute_target_has_clean_message() {
     // `*x.y = 1`: starred target wrapping an attribute. Same rejection
-    // path, different inner node shape. Message must not leak
-    // `ExprAttribute` / `Identifier` Debug.
+    // path, different inner node shape.
     let result = MontyRun::new("*x.y = 1".to_owned(), "test.py", vec![]);
     let exc = result.expect_err("expected parse error");
     assert_eq!(exc.exc_type(), ExcType::SyntaxError);
-    assert_no_debug_leak(exc.message(), "starred expression");
+    assert_snapshot!(exc.message().expect("has message"), @"Expected name, got starred expression");
 }
 
 #[test]
 fn starred_subscript_target_has_clean_message() {
-    // `*x[0] = 1`: starred target wrapping a subscript. Must not leak
-    // `ExprSubscript` / `ExprNumberLiteral` Debug.
+    // `*x[0] = 1`: starred target wrapping a subscript.
     let result = MontyRun::new("*x[0] = 1".to_owned(), "test.py", vec![]);
     let exc = result.expect_err("expected parse error");
     assert_eq!(exc.exc_type(), ExcType::SyntaxError);
-    assert_no_debug_leak(exc.message(), "starred expression");
+    assert_snapshot!(exc.message().expect("has message"), @"Expected name, got starred expression");
 }
 
 #[test]
 fn for_loop_attribute_target_has_clean_message() {
     // `for x.y in [1]: pass`: attribute as a for-loop target. CPython
-    // accepts this; Monty currently rejects at `parse_unpack_target_impl`
-    // with a generic "invalid unpacking target" error. That rejection of
-    // valid Python is a separate issue; this test locks only that the
-    // error message does not leak `ExprAttribute` Debug.
+    // accepts this; Monty currently rejects at `parse_unpack_target_impl`.
+    // That rejection of valid Python is a separate issue; this test locks
+    // only that the error message does not leak `ExprAttribute` Debug.
     let result = MontyRun::new("for x.y in [1]: pass".to_owned(), "test.py", vec![]);
     let exc = result.expect_err("expected parse error");
     assert_eq!(exc.exc_type(), ExcType::SyntaxError);
-    assert_no_debug_leak(exc.message(), "attribute");
+    assert_snapshot!(exc.message().expect("has message"), @"invalid unpacking target: attribute");
 }


### PR DESCRIPTION
`parse_identifier` and `parse_unpack_target_impl` format the offending AST node through Rust `Debug` when rejecting a target. The resulting error message is the full Debug representation of the `ruff_python_ast` node - struct name, `node_index`, `range`, nested `value`, `ctx`, etc. Anything that surfaces `MontyException::message()` reads that text verbatim.

## What the error looks like today

```python
>>> pydantic_monty.Monty("*a = [1, 2]").run()
# MontySyntaxError: Expected name, got Starred(ExprStarred { node_index: NodeIndex(None),
#   range: 0..2, value: Name(ExprName { node_index: NodeIndex(None),
#   range: 1..2, id: Name("a"), ctx: Store }), ctx: Store })
```

Same shape for `*x.y = 1`, `*x[0] = 1`, `for x.y in [1]: pass`. Each dumps the full nested AST struct instead of a human description.

## Fix

Adds `describe_expr_kind(&AstExpr) -> &'static str`: a match over all 33 `AstExpr` variants returning a short human description (`"starred expression"`, `"attribute"`, `"subscript"`, `"list comprehension"`, and so on). The two call sites format this string instead of the Debug of the node.

```
before: "Expected name, got Starred(ExprStarred { node_index: ... })"
after:  "Expected name, got starred expression"

before: "invalid unpacking target: Attribute(ExprAttribute { ... })"
after:  "invalid unpacking target: attribute"
```

Exhaustive match, no catch-all: if ruff adds a new `Expr` variant, the compiler forces an update instead of silently falling back to Debug.

## Tests

New in `crates/monty/tests/parse_errors.rs`, one per trigger shape:

- `starred_name_target_has_clean_message` - `*a = [1, 2]`
- `starred_attribute_target_has_clean_message` - `*x.y = 1`
- `starred_subscript_target_has_clean_message` - `*x[0] = 1`
- `for_loop_attribute_target_has_clean_message` - `for x.y in [1]: pass`

Each snapshots the full error message via `insta::assert_snapshot!` so any regression that reintroduces Debug formatting of AST nodes (struct names, `node_index`, `range`, `ctx: Store`, etc.) fails the snapshot diff loudly.

## Not covered

`for x.y in [1]: pass` is valid Python. CPython 3.11 through 3.14 accept it. Monty rejects it at `parse_unpack_target_impl` because attribute / subscript targets are not implemented for for-loops. That rejection is a separate issue; this PR only cleans up the error message emitted along the existing path. Separate ticket.

CPython's own messages (`"starred assignment target must be in a list or tuple"`, etc.) are not adopted verbatim here to keep the diff minimal. Switching to CPython prose verbatim is a separate follow-up.
