### PR TITLE
fix GC tracking for `datetime.tzinfo`

### DIFF
--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -1454,6 +1454,15 @@ fn collect_child_ids(data: &HeapData, work_list: &mut Vec<HeapId>) {
                 }
             }
         }
+        HeapData::DateTime(dt) => {
+            // Aware datetimes retain a heap reference to the tzinfo object so that
+            // `dt.tzinfo is tz` identity is preserved across attribute lookups.
+            // GC must follow that reference, otherwise the timezone gets swept
+            // while the datetime still points at the freed slot.
+            if let Some(tz_id) = dt.tzinfo_ref() {
+                work_list.push(tz_id);
+            }
+        }
         // Leaf types with no heap references
         _ => {}
     }
@@ -1506,6 +1515,13 @@ fn py_dec_ref_ids_for_data(data: &mut HeapData, stack: &mut Vec<HeapId>) {
             // Decrement ref count for result values that are heap references
             for result in gather.results.iter_mut().flatten() {
                 result.py_dec_ref_ids(stack);
+            }
+        }
+        HeapData::DateTime(dt) => {
+            // Mirror `collect_child_ids`: when an aware datetime is freed we must
+            // also drop the retained tzinfo reference so its refcount is balanced.
+            if let Some(tz_id) = dt.tzinfo_ref() {
+                stack.push(tz_id);
             }
         }
         // other types have no nested heap references

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -50,6 +50,18 @@ pub(crate) struct DateTime {
     tzinfo_ref: Option<HeapId>,
 }
 
+impl DateTime {
+    /// Returns the retained `tzinfo` heap reference, if this datetime is timezone-aware.
+    ///
+    /// Used by GC traversal (`collect_child_ids`) and ref-count cascade
+    /// (`py_dec_ref_ids_for_data`) so that the timezone object stays alive as long
+    /// as the datetime references it. Without this, `gc.collect` cannot reach the
+    /// tzinfo and may sweep it while the datetime still points at the freed slot.
+    pub(crate) fn tzinfo_ref(&self) -> Option<HeapId> {
+        self.tzinfo_ref
+    }
+}
+
 impl Hash for DateTime {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // Hash must be consistent with equality (py_eq).

--- a/crates/monty/test_cases/datetime__core.py
+++ b/crates/monty/test_cases/datetime__core.py
@@ -1183,25 +1183,20 @@ except TypeError as e:
 
 
 # === GC must follow datetime.tzinfo_ref ===
-# Regression: an aware datetime retains the tzinfo as a private heap reference
-# (so `dt.tzinfo is tz` identity holds across attribute lookups). Without GC
-# tracking that reference, a cycle-triggered collection could sweep the
-# tzinfo while the datetime still pointed at the freed slot, panicking on
-# the next `dt.tzinfo` access with `HeapEntries::get - data already freed`.
+# Regression: aware datetimes retain the tzinfo as a private heap reference,
+# so the GC mark phase must follow it. Without that, a cycle-triggered
+# collection sweeps the tzinfo while the datetime still points at the freed
+# slot, causing the next `dt.tzinfo` access to either panic with
+# `HeapEntries::get - data already freed` or read whatever was reallocated
+# into the slot.
 tz_keepalive = datetime.timezone(datetime.timedelta(hours=5))
 dt_keepalive = datetime.datetime(2024, 1, 1, tzinfo=tz_keepalive)
 tz_keepalive = None  # only `dt_keepalive` keeps the timezone alive now
 
-# Force the cycle-detecting GC to run: a self-referential list flips
-# `may_have_cycles`, and crossing the GC_INTERVAL allocation threshold
-# (100_000 GC-tracked allocations) triggers a mark-and-sweep pass.
+# Flip `may_have_cycles=true` and trigger one allocation; under
+# `--features memory-model-checks` (CI default) GC fires on every alloc.
 gc_seed = []
 gc_seed.append(gc_seed)
-for _i in range(100_100):
-    _x = [_i]
+_ = []  # triggers GC
 
-# After GC, the tzinfo must still be reachable through the datetime.
 assert str(dt_keepalive.tzinfo) == 'UTC+05:00', 'datetime tzinfo must survive GC'
-assert dt_keepalive.tzinfo == datetime.timezone(datetime.timedelta(hours=5)), (
-    'datetime tzinfo must round-trip equal after GC'
-)

--- a/crates/monty/test_cases/datetime__core.py
+++ b/crates/monty/test_cases/datetime__core.py
@@ -1180,3 +1180,28 @@ try:
     assert False, 'datetime with duplicate month should raise TypeError'
 except TypeError as e:
     assert str(e) == "argument for function given by name ('month') and position (2)", f'dt dup month: {e}'
+
+
+# === GC must follow datetime.tzinfo_ref ===
+# Regression: an aware datetime retains the tzinfo as a private heap reference
+# (so `dt.tzinfo is tz` identity holds across attribute lookups). Without GC
+# tracking that reference, a cycle-triggered collection could sweep the
+# tzinfo while the datetime still pointed at the freed slot, panicking on
+# the next `dt.tzinfo` access with `HeapEntries::get - data already freed`.
+tz_keepalive = datetime.timezone(datetime.timedelta(hours=5))
+dt_keepalive = datetime.datetime(2024, 1, 1, tzinfo=tz_keepalive)
+tz_keepalive = None  # only `dt_keepalive` keeps the timezone alive now
+
+# Force the cycle-detecting GC to run: a self-referential list flips
+# `may_have_cycles`, and crossing the GC_INTERVAL allocation threshold
+# (100_000 GC-tracked allocations) triggers a mark-and-sweep pass.
+gc_seed = []
+gc_seed.append(gc_seed)
+for _i in range(100_100):
+    _x = [_i]
+
+# After GC, the tzinfo must still be reachable through the datetime.
+assert str(dt_keepalive.tzinfo) == 'UTC+05:00', 'datetime tzinfo must survive GC'
+assert dt_keepalive.tzinfo == datetime.timezone(datetime.timedelta(hours=5)), (
+    'datetime tzinfo must round-trip equal after GC'
+)


### PR DESCRIPTION
Closes #396

## Summary

Aware `datetime` objects retain a heap reference to their `tzinfo`
(`DateTime.tzinfo_ref`) so that `dt.tzinfo is tz` identity holds across
attribute lookups. The mark-and-sweep GC was not following that reference,
so a cycle-triggered collection could sweep the timezone while the
datetime still pointed at the freed slot. The next `dt.tzinfo` access
panicked in `Heap::inc_ref` with `HeapEntries::get - data already freed`.

## Fix

- Add `HeapData::DateTime` arms to both `collect_child_ids` (GC mark) and
  `py_dec_ref_ids_for_data` (drop cascade) in `heap.rs`, each visiting
  `tzinfo_ref`.
- Expose `DateTime::tzinfo_ref()` as a `pub(crate)` accessor so `heap.rs`
  doesn't need to reach into the private field directly.
- Regression test added to `datetime__core.py`.

## Before

```
$ cargo run -p monty-cli -- repro.py
thread 'main' panicked at crates/monty/src/heap.rs:938:34:
HeapEntries::get - data already freed
```

## After

```
$ cargo run -p monty-cli -- repro.py
UTC+05:00
```

## Test plan

- [x] Original reproducer runs to completion and prints `UTC+05:00`
- [x] New regression test in `datetime__core.py` (GC-must-follow-tzinfo section) passes under `--features memory-model-checks`
- [x] All 50 `refcount__*` tests pass
- [x] All 8 `pyobject__cycle_*` tests pass
- [x] `cargo fmt` and `cargo clippy` clean
