### PR TITLE
gc: properly release references held by values in cycles

### DIFF
--- a/crates/monty/Cargo.toml
+++ b/crates/monty/Cargo.toml
@@ -43,7 +43,7 @@ jiter = { version = "0.13.0", features = ["num-bigint"] }
 [features]
 # ref-count-return changes behavior to return information on reference counts to check they're correct
 # should be used for testing only
-ref-count-return = []
+ref-count-return = ["test-hooks"]
 # memory-model-checks enables a Drop implementation on Value which catches heap allocated values that are dropped
 # without being dereferenced, and sets the default GC interval to 1 so garbage collection runs on every
 # GC-tracked allocation.

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -1241,6 +1241,9 @@ impl<T: ResourceTracker> Heap<T> {
             }
         }
 
+        let mut released_child_refs = Vec::new();
+        let mut temp_buffer = Vec::new();
+
         // Sweep phase: free unreachable values
         self.entries.retain(|id, value| {
             if reachable[id] {
@@ -1251,12 +1254,26 @@ impl<T: ResourceTracker> Heap<T> {
             // Notify tracker of freed memory
             self.tracker.on_free(|| value.data.0.get_mut().py_estimate_size());
 
-            // Mark Values as Dereferenced when memory-model-checks is enabled
-            #[cfg(feature = "memory-model-checks")]
-            py_dec_ref_ids_for_data(value.data.0.get_mut(), &mut Vec::new());
+            // Collect child IDs to dec_ref - to avoid overlapping borrows, we have to wait until after retain finishes to do the
+            // dec_ref calls since they can mutate the heap
+            py_dec_ref_ids_for_data(value.data.0.get_mut(), &mut temp_buffer);
+
+            // collect into temp_buffer and then filter reachable ones into released_child_refs
+            // to minimise the amount of allocation we do while retaining
+            for child_id in temp_buffer.drain(..) {
+                if reachable[child_id.index()] {
+                    released_child_refs.push(child_id);
+                }
+            }
 
             false
         });
+
+        for released_id in released_child_refs {
+            // refcount cannot underflow because these were all reachable values, so they could
+            // be reached from outside of cycles
+            self.entries.get(released_id.index()).refcount.update(|r| r - 1);
+        }
 
         // Reset cycle flag after GC - cycles have been collected
         self.may_have_cycles.set(false);

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -422,6 +422,8 @@ impl Executor {
             self.populate_inputs(inputs, &mut vm)?;
             let frame_exit_result = vm.run_module(&self.module_code);
 
+            vm.__force_gc_for_tests();
+
             // Take globals out of the VM so we can inspect them, but keep VM alive
             // for heap access and later conversion.
             let globals = vm.take_globals();

--- a/crates/monty/test_cases/refcount__cycle_external_ref.py
+++ b/crates/monty/test_cases/refcount__cycle_external_ref.py
@@ -1,0 +1,11 @@
+# GC should free references held by cycles when they are cleared
+external = {}
+
+# this is a clumsy way to build a cycle due to Monty not supporting `del` yet
+values = [[external], [external]]
+values[0].append(values[1])
+values[1].append(values[0])
+
+values.clear()
+
+# ref-counts={'external': 1, 'values': 1}


### PR DESCRIPTION
Before this PR, when the GC clears cycles, it just removes the heap items without clearing any references they might themselves point to. This leads to reference leaks for every outbound edge from the cycles back into reachable values.

This PR makes the bookkeeping be done properly inside the GC and adds a test which fails on main.