### PR TITLE
convert `py_repr` methods to take `&mut VM`

### DIFF
--- a/crates/monty/src/builtins/print.rs
+++ b/crates/monty/src/builtins/print.rs
@@ -37,7 +37,8 @@ pub fn builtin_print(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues)
         } else {
             vm.print_writer.stdout_push(' ')?;
         }
-        vm.print_writer.stdout_write(value.py_str(vm)?)?;
+        let s = value.py_str(vm)?;
+        vm.print_writer.stdout_write(s)?;
     }
 
     // Append end string

--- a/crates/monty/src/bytecode/vm/format.rs
+++ b/crates/monty/src/bytecode/vm/format.rs
@@ -105,7 +105,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
     ///
     /// The `value_for_error` parameter is used to include the value type in error messages.
     /// Uses lazy type capture: only calls `py_type()` in error paths.
-    fn get_format_spec(&self, spec_value: &Value, value_for_error: &Value) -> Result<ParsedFormatSpec, RunError> {
+    fn get_format_spec(&mut self, spec_value: &Value, value_for_error: &Value) -> Result<ParsedFormatSpec, RunError> {
         match spec_value {
             Value::Int(n) if *n < 0 => {
                 // Decode the encoded format spec; n < 0 ensures (-n - 1) >= 0

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -324,7 +324,7 @@ impl ExcType {
     /// If the key's string conversion fails (e.g. huge LongInt exceeding
     /// `INT_MAX_STR_DIGITS`), falls back to the type name so that a
     /// `KeyError` is always raised rather than a spurious `ValueError`.
-    pub(crate) fn key_error(key: &Value, vm: &VM<'_, '_, impl ResourceTracker>) -> RunError {
+    pub(crate) fn key_error(key: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunError {
         let key_str = match key.py_str(vm) {
             Ok(s) => s.into_owned(),
             Err(_) => format!("<{}>", key.py_type(vm)),

--- a/crates/monty/src/fstring.rs
+++ b/crates/monty/src/fstring.rs
@@ -260,7 +260,7 @@ impl fmt::Display for FormatError {
 pub fn format_with_spec(
     value: &Value,
     spec: &ParsedFormatSpec,
-    vm: &VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, '_, impl ResourceTracker>,
 ) -> Result<String, RunError> {
     let value_type = value.py_type(vm);
 

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -15,7 +15,7 @@ use smallvec::SmallVec;
 // Re-export items moved to `heap_traits` so that `crate::heap::HeapGuard` etc. continue
 // to resolve (used by the `defer_drop!` macros and throughout the codebase).
 pub(crate) use crate::heap_data::HeapData;
-pub(crate) use crate::heap_traits::{ContainsHeap, DropWithHeap, HeapGuard, HeapItem, ImmutableHeapGuard};
+pub(crate) use crate::heap_traits::{ContainsHeap, DropWithHeap, HeapGuard, HeapItem};
 use crate::{
     asyncio::{Coroutine, GatherFuture, GatherItem},
     bytecode::VM,
@@ -619,13 +619,8 @@ impl<'de> serde::Deserialize<'de> for UnsafeHeapData {
 /// Zero-size token returned by [`Heap::incr_recursion_depth`].
 ///
 /// Represents one level of recursion depth that must be released when the
-/// recursive operation completes. There are two ways to release the token:
-///
-/// - **`DropWithHeap`** — for `&mut Heap` paths (e.g., `py_eq`). Compatible with
-///   `defer_drop!` and `HeapGuard` for automatic cleanup on all code paths.
-/// - **`DropWithImmutableHeap`** — for `&Heap` paths (e.g., `py_repr_fmt`) where
-///   only shared access is available. Compatible with `defer_drop_immutable_heap!`
-///   and `ImmutableHeapGuard`.
+/// recursive operation completes. Released via [`DropWithHeap`] — compatible
+/// with [`defer_drop!`] and [`HeapGuard`] for automatic cleanup on all code paths.
 #[derive(Debug)]
 pub(crate) struct RecursionToken(());
 
@@ -788,8 +783,8 @@ impl<T: ResourceTracker> Heap<T> {
     /// Increments the recursion depth and checks the limit via the `ResourceTracker`.
     ///
     /// Returns `Ok(RecursionToken)` if within limits. The caller must ensure the
-    /// token is released on all code paths — either via `defer_drop!`/`HeapGuard`
-    /// (for `&mut Heap` contexts) or via `RecursionToken::release()` (for `&Heap` contexts).
+    /// token is released on all code paths — typically via `defer_drop!` or `HeapGuard`,
+    /// which call [`DropWithHeap::drop_with_heap`] on the token.
     ///
     /// Returns `Err(ResourceError::Recursion)` if the limit would be exceeded.
     #[inline]
@@ -798,16 +793,6 @@ impl<T: ResourceTracker> Heap<T> {
         self.tracker.check_recursion_depth(depth)?;
         self.recursion_depth.set(depth + 1);
         Ok(RecursionToken(()))
-    }
-
-    /// Increments the recursion depth, returning `Some(RecursionToken)` if within
-    /// limits, or `None` if the limit is exceeded.
-    ///
-    /// Use this in repr-like contexts where exceeding the limit should produce
-    /// truncated output (e.g., `[...]`) rather than an error.
-    #[inline]
-    pub fn incr_recursion_depth_for_repr(&self) -> Option<RecursionToken> {
-        self.incr_recursion_depth().ok()
     }
 
     /// Decrements the recursion depth.

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -698,7 +698,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         match self {
@@ -750,7 +750,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         }
     }
 
-    fn py_str(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         match self {
             // Strings return their value directly without quotes
             Self::Str(s) => Ok(Cow::Owned(s.get(vm.heap).as_str().to_owned())),

--- a/crates/monty/src/heap_traits.rs
+++ b/crates/monty/src/heap_traits.rs
@@ -8,7 +8,7 @@ use smallvec::SmallVec;
 
 use crate::{
     ResourceTracker,
-    heap::{Heap, HeapId, RecursionToken},
+    heap::{Heap, HeapId},
     value::Value,
 };
 
@@ -157,67 +157,6 @@ impl<U: DropWithHeap, V: DropWithHeap> DropWithHeap for (U, V) {
     }
 }
 
-/// Trait for types that require only an immutable heap reference for cleanup.
-///
-/// Unlike [`DropWithHeap`], which requires `&mut Heap`, this trait works with `&Heap`.
-/// This is needed for cleanup in contexts that only have shared access to the heap,
-/// such as `py_repr_fmt` and `py_str` formatting methods.
-///
-/// Currently implemented for [`RecursionToken`], which decrements the recursion depth
-/// counter via interior mutability (`Cell`).
-pub(crate) trait DropWithImmutableHeap {
-    /// Consume `self` and perform cleanup using an immutable heap reference.
-    fn drop_with_immutable_heap<T: ResourceTracker>(self, heap: &Heap<T>);
-}
-
-impl DropWithImmutableHeap for RecursionToken {
-    #[inline]
-    fn drop_with_immutable_heap<T: ResourceTracker>(self, heap: &Heap<T>) {
-        heap.decr_recursion_depth();
-    }
-}
-
-/// RAII guard that ensures a [`DropWithImmutableHeap`] value is cleaned up on every code path.
-///
-/// Like [`HeapGuard`], but holds an immutable `&Heap<T>` instead of requiring `&mut` access
-/// via [`ContainsHeap`]. This is useful in contexts that only have shared access to the heap,
-/// such as `py_repr_fmt` formatting methods.
-///
-/// On the normal path, the guarded value can be borrowed via [`as_parts`](Self::as_parts).
-/// The guard's `Drop` impl calls [`DropWithImmutableHeap::drop_with_immutable_heap`]
-/// automatically, so cleanup happens on all exit paths.
-pub(crate) struct ImmutableHeapGuard<'a, H: ContainsHeap, V: DropWithImmutableHeap> {
-    value: ManuallyDrop<V>,
-    heap: &'a H,
-}
-
-impl<'a, H: ContainsHeap, V: DropWithImmutableHeap> ImmutableHeapGuard<'a, H, V> {
-    /// Creates a new `ImmutableHeapGuard` for the given value and immutable heap reference.
-    #[inline]
-    pub fn new(value: V, heap: &'a H) -> Self {
-        Self {
-            value: ManuallyDrop::new(value),
-            heap,
-        }
-    }
-
-    /// Borrows the value (immutably) and heap (immutably) out of the guard.
-    ///
-    /// This is what [`defer_drop_immutable_heap!`] calls internally. The returned
-    /// references are tied to the guard's lifetime, so the value cannot escape.
-    #[inline]
-    pub fn as_parts(&self) -> (&V, &'a H) {
-        (&self.value, self.heap)
-    }
-}
-
-impl<H: ContainsHeap, V: DropWithImmutableHeap> Drop for ImmutableHeapGuard<'_, H, V> {
-    fn drop(&mut self) {
-        // SAFETY: [DH] - value is never manually dropped until this point
-        unsafe { ManuallyDrop::take(&mut self.value) }.drop_with_immutable_heap(self.heap.heap());
-    }
-}
-
 /// RAII guard that ensures a [`DropWithHeap`] value is cleaned up on every code path.
 ///
 /// The guard's `Drop` impl calls [`DropWithHeap::drop_with_heap`] automatically, so
@@ -345,25 +284,5 @@ macro_rules! defer_drop_mut {
         )]
         #[allow(unused_variables)]
         let ($value, $heap) = _guard.as_parts_mut();
-    };
-}
-
-/// Like [`defer_drop!`], but for [`DropWithImmutableHeap`] values that only need `&Heap`
-/// for cleanup.
-///
-/// Creates an [`ImmutableHeapGuard`] and immediately rebinds `$value` as `&V` and `$heap`
-/// as `&Heap<T>`. The guard will call [`DropWithImmutableHeap::drop_with_immutable_heap`]
-/// when scope exits. Use this for values like [`RecursionToken`] in contexts that only have
-/// shared access to the heap (e.g., `py_repr_fmt` formatting methods).
-#[macro_export]
-macro_rules! defer_drop_immutable_heap {
-    ($value:ident, $heap:ident) => {
-        let _guard = $crate::heap::ImmutableHeapGuard::new($value, $heap);
-        #[allow(
-            clippy::allow_attributes,
-            reason = "the reborrowed parts may not both be used in every case, so allow unused vars to avoid warnings"
-        )]
-        #[allow(unused_variables)]
-        let ($value, $heap) = _guard.as_parts();
     };
 }

--- a/crates/monty/src/object.rs
+++ b/crates/monty/src/object.rs
@@ -16,8 +16,9 @@ use num_traits::Zero;
 use crate::{
     builtins::{Builtins, BuiltinsFunctions},
     bytecode::VM,
+    defer_drop,
     exception_private::{ExcType, RunError, SimpleException},
-    heap::{HeapData, HeapId},
+    heap::{HeapData, HeapId, HeapReadOutput},
     resource::{ResourceError, ResourceTracker},
     types::{
         Dataclass, LongInt, NamedTuple, Path, PyTrait, TimeZone, Type, allocate_tuple,
@@ -532,24 +533,35 @@ impl MontyObject {
         }
     }
 
-    fn from_value(object: &Value, vm: &VM<'_, '_, impl ResourceTracker>) -> Self {
+    /// Top-level entry into [`from_value_inner`], allocating the visited-set used
+    /// for cycle detection.
+    fn from_value(object: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> Self {
         let mut visited = AHashSet::new();
         Self::from_value_inner(object, vm, &mut visited)
     }
 
     /// Internal helper for converting Value to MontyObject with cycle detection.
     ///
-    /// The `visited` set tracks HeapIds we're currently processing. When we encounter
-    /// a HeapId already in the set, we've found a cycle and return `MontyObject::Cycle`
-    /// with an appropriate placeholder string.
-    ///
-    /// Recursion depth is tracked via `heap.incr_recursion_depth_for_repr()`.
-    fn from_value_inner(object: &Value, vm: &VM<'_, '_, impl ResourceTracker>, visited: &mut AHashSet<HeapId>) -> Self {
+    /// Non-`Ref` variants are produced inline using only the interner — they
+    /// never recurse through the heap. `Ref` variants dispatch via
+    /// `vm.heap.read(id)` so the resulting [`HeapRead`] keeps the heap entry
+    /// alive (through its reader count) without retaining a borrow on
+    /// `vm.heap`. Container children are walked via short-lived borrows that
+    /// `clone_with_heap` the next child before recursing — the `inc_ref` makes
+    /// it safe for a future user-defined `__repr__` to mutate the surrounding
+    /// container during the recursive call without freeing the value mid-format.
+    fn from_value_inner(
+        object: &Value,
+        vm: &mut VM<'_, '_, impl ResourceTracker>,
+        visited: &mut AHashSet<HeapId>,
+    ) -> Self {
         // Check depth limit before processing
-        let Some(token) = vm.heap.incr_recursion_depth_for_repr() else {
+        let Ok(token) = vm.heap.incr_recursion_depth() else {
             return Self::Repr("<deeply nested>".to_owned());
         };
-        crate::defer_drop_immutable_heap!(token, vm);
+        defer_drop!(token, vm);
+
+        let interns = vm.interns;
         match object {
             Value::Undefined => panic!("Undefined found while converting to MontyObject"),
             Value::Ellipsis => Self::Ellipsis,
@@ -557,8 +569,9 @@ impl MontyObject {
             Value::Bool(b) => Self::Bool(*b),
             Value::Int(i) => Self::Int(*i),
             Value::Float(f) => Self::Float(*f),
-            Value::InternString(string_id) => Self::String(vm.interns.get_str(*string_id).to_owned()),
-            Value::InternBytes(bytes_id) => Self::Bytes(vm.interns.get_bytes(*bytes_id).to_owned()),
+            Value::InternString(string_id) => Self::String(interns.get_str(*string_id).to_owned()),
+            Value::InternBytes(bytes_id) => Self::Bytes(interns.get_bytes(*bytes_id).to_owned()),
+            Value::InternLongInt(li_id) => Self::BigInt(interns.get_long_int(*li_id).clone()),
             Value::Ref(id) => {
                 // Check for cycle
                 if visited.contains(id) {
@@ -574,69 +587,120 @@ impl MontyObject {
                 // Mark this id as being visited
                 visited.insert(*id);
 
-                let result = match vm.heap.get(*id) {
-                    HeapData::Str(s) => Self::String(s.as_str().to_owned()),
-                    HeapData::Bytes(b) => Self::Bytes(b.as_slice().to_owned()),
-                    HeapData::List(list) => Self::List(
-                        list.as_slice()
-                            .iter()
-                            .map(|obj| Self::from_value_inner(obj, vm, visited))
-                            .collect(),
-                    ),
-                    HeapData::Tuple(tuple) => Self::Tuple(
-                        tuple
-                            .as_slice()
-                            .iter()
-                            .map(|obj| Self::from_value_inner(obj, vm, visited))
-                            .collect(),
-                    ),
-                    HeapData::NamedTuple(nt) => Self::NamedTuple {
-                        type_name: nt.name(vm.interns).to_owned(),
-                        field_names: nt
+                let result = match vm.heap.read(*id) {
+                    HeapReadOutput::Str(s) => Self::String(s.get(vm.heap).as_str().to_owned()),
+                    HeapReadOutput::Bytes(b) => Self::Bytes(b.get(vm.heap).as_slice().to_owned()),
+                    HeapReadOutput::List(list) => {
+                        let len = list.get(vm.heap).len();
+                        let mut items = Vec::with_capacity(len);
+                        for i in 0..len {
+                            let item = list.get(vm.heap).as_slice()[i].clone_with_heap(vm.heap);
+                            defer_drop!(item, vm);
+                            items.push(Self::from_value_inner(item, vm, visited));
+                        }
+                        Self::List(items)
+                    }
+                    HeapReadOutput::Tuple(tuple) => {
+                        let len = tuple.get(vm.heap).as_slice().len();
+                        let mut items = Vec::with_capacity(len);
+                        for i in 0..len {
+                            let item = tuple.get(vm.heap).as_slice()[i].clone_with_heap(vm.heap);
+                            defer_drop!(item, vm);
+                            items.push(Self::from_value_inner(item, vm, visited));
+                        }
+                        Self::Tuple(items)
+                    }
+                    HeapReadOutput::NamedTuple(nt) => {
+                        let type_name = nt.get(vm.heap).name(vm.interns).to_owned();
+                        let field_names = nt
+                            .get(vm.heap)
                             .field_names()
                             .iter()
-                            .map(|field_name| field_name.as_str(vm.interns).to_owned())
-                            .collect(),
-                        values: nt
-                            .as_vec()
-                            .iter()
-                            .map(|obj| Self::from_value_inner(obj, vm, visited))
-                            .collect(),
-                    },
-                    HeapData::Dict(dict) => Self::Dict(DictPairs(
-                        dict.into_iter()
-                            .map(|(k, v)| {
-                                (
-                                    Self::from_value_inner(k, vm, visited),
-                                    Self::from_value_inner(v, vm, visited),
-                                )
-                            })
-                            .collect(),
-                    )),
-                    HeapData::Set(set) => Self::Set(
-                        set.storage()
-                            .iter()
-                            .map(|obj| Self::from_value_inner(obj, vm, visited))
-                            .collect(),
-                    ),
-                    HeapData::FrozenSet(frozenset) => Self::FrozenSet(
-                        frozenset
-                            .storage()
-                            .iter()
-                            .map(|obj| Self::from_value_inner(obj, vm, visited))
-                            .collect(),
-                    ),
-                    HeapData::Date(date) => {
-                        let (year, month, day) = date_type::to_ymd(*date);
+                            .map(|fname| fname.as_str(vm.interns).to_owned())
+                            .collect::<Vec<_>>();
+                        let len = nt.get(vm.heap).len();
+                        let mut values = Vec::with_capacity(len);
+                        for i in 0..len {
+                            let item = nt.get(vm.heap).as_vec()[i].clone_with_heap(vm.heap);
+                            defer_drop!(item, vm);
+                            values.push(Self::from_value_inner(item, vm, visited));
+                        }
+                        Self::NamedTuple {
+                            type_name,
+                            field_names,
+                            values,
+                        }
+                    }
+                    HeapReadOutput::Dict(dict) => {
+                        let len = dict.get(vm.heap).len();
+                        let mut pairs = Vec::with_capacity(len);
+                        for i in 0..len {
+                            let key = dict
+                                .get(vm.heap)
+                                .key_at(i)
+                                .expect("index in range")
+                                .clone_with_heap(vm.heap);
+                            defer_drop!(key, vm);
+                            let k = Self::from_value_inner(key, vm, visited);
+                            let value = dict
+                                .get(vm.heap)
+                                .value_at(i)
+                                .expect("index in range")
+                                .clone_with_heap(vm.heap);
+                            defer_drop!(value, vm);
+                            let v = Self::from_value_inner(value, vm, visited);
+                            pairs.push((k, v));
+                        }
+                        Self::Dict(DictPairs(pairs))
+                    }
+                    HeapReadOutput::Set(set) => {
+                        let len = set.get(vm.heap).len();
+                        let mut items = Vec::with_capacity(len);
+                        for i in 0..len {
+                            let item = set
+                                .get(vm.heap)
+                                .storage()
+                                .value_at(i)
+                                .expect("index in range")
+                                .clone_with_heap(vm.heap);
+                            defer_drop!(item, vm);
+                            items.push(Self::from_value_inner(item, vm, visited));
+                        }
+                        Self::Set(items)
+                    }
+                    HeapReadOutput::FrozenSet(fs) => {
+                        let len = fs.get(vm.heap).len();
+                        let mut items = Vec::with_capacity(len);
+                        for i in 0..len {
+                            let item = fs
+                                .get(vm.heap)
+                                .storage()
+                                .value_at(i)
+                                .expect("index in range")
+                                .clone_with_heap(vm.heap);
+                            defer_drop!(item, vm);
+                            items.push(Self::from_value_inner(item, vm, visited));
+                        }
+                        Self::FrozenSet(items)
+                    }
+                    // Cells are internal closure implementation details — show
+                    // the contents directly without exposing the wrapper.
+                    HeapReadOutput::Cell(cell) => {
+                        let inner = cell.get(vm.heap).0.clone_with_heap(vm.heap);
+                        defer_drop!(inner, vm);
+                        Self::from_value_inner(inner, vm, visited)
+                    }
+                    HeapReadOutput::Date(d) => {
+                        let (year, month, day) = date_type::to_ymd(*d.get(vm.heap));
                         Self::Date(MontyDate {
                             year,
                             month: u8::try_from(month).expect("month is always 1..=12"),
                             day: u8::try_from(day).expect("day is always 1..=31"),
                         })
                     }
-                    HeapData::DateTime(datetime) => {
+                    HeapReadOutput::DateTime(dt) => {
                         if let Some((year, month, day, hour, minute, second, microsecond)) =
-                            datetime_type::to_components(datetime)
+                            datetime_type::to_components(dt.get(vm.heap))
                         {
                             Self::DateTime(MontyDateTime {
                                 year,
@@ -646,86 +710,96 @@ impl MontyObject {
                                 minute,
                                 second,
                                 microsecond,
-                                offset_seconds: datetime_type::offset_seconds(datetime),
-                                timezone_name: datetime_type::timezone_info(datetime).and_then(|tz| tz.name),
+                                offset_seconds: datetime_type::offset_seconds(dt.get(vm.heap)),
+                                timezone_name: datetime_type::timezone_info(dt.get(vm.heap)).and_then(|tz| tz.name),
                             })
                         } else {
                             repr_or_error(object, vm)
                         }
                     }
-                    HeapData::TimeDelta(delta) => {
-                        let (days, seconds, microseconds) = timedelta_type::components(delta);
+                    HeapReadOutput::TimeDelta(td) => {
+                        let (days, seconds, microseconds) = timedelta_type::components(td.get(vm.heap));
                         Self::TimeDelta(MontyTimeDelta {
                             days,
                             seconds,
                             microseconds,
                         })
                     }
-                    HeapData::TimeZone(tz) => Self::TimeZone(MontyTimeZone {
-                        offset_seconds: tz.offset_seconds,
-                        name: tz.name.clone(),
-                    }),
-                    // Cells are internal closure implementation details
-                    HeapData::Cell(cell) => {
-                        // Show the cell's contents
-                        Self::from_value_inner(&cell.0, vm, visited)
+                    HeapReadOutput::TimeZone(tz) => {
+                        let tz_ref = tz.get(vm.heap);
+                        Self::TimeZone(MontyTimeZone {
+                            offset_seconds: tz_ref.offset_seconds,
+                            name: tz_ref.name.clone(),
+                        })
                     }
-                    HeapData::Closure(..) | HeapData::FunctionDefaults(..) => repr_or_error(object, vm),
-                    HeapData::Range(_) => repr_or_error(object, vm),
-                    HeapData::Exception(exc) => Self::Exception {
-                        exc_type: exc.exc_type(),
-                        arg: exc.arg().map(ToString::to_string),
-                    },
-                    HeapData::Dataclass(dc) => {
-                        // Convert attrs to DictPairs
-                        let attrs = DictPairs(
-                            dc.attrs()
-                                .into_iter()
-                                .map(|(k, v)| {
-                                    (
-                                        Self::from_value_inner(k, vm, visited),
-                                        Self::from_value_inner(v, vm, visited),
-                                    )
-                                })
-                                .collect(),
-                        );
-                        Self::Dataclass {
-                            name: dc.name(vm.interns).to_owned(),
-                            type_id: dc.type_id(),
-                            field_names: dc.field_names().to_vec(),
-                            attrs,
-                            frozen: dc.is_frozen(),
+                    HeapReadOutput::Exception(exc) => {
+                        let exc_ref = exc.get(vm.heap);
+                        Self::Exception {
+                            exc_type: exc_ref.exc_type(),
+                            arg: exc_ref.arg().map(ToString::to_string),
                         }
                     }
-                    HeapData::Iter(_) => {
-                        // Iterators are internal objects - represent as a type string
-                        Self::Repr("<iterator>".to_owned())
+                    HeapReadOutput::Dataclass(dc) => {
+                        let (name, type_id, field_names, frozen, attrs_len) = {
+                            let dc_ref = dc.get(vm.heap);
+                            (
+                                dc_ref.name(vm.interns).to_owned(),
+                                dc_ref.type_id(),
+                                dc_ref.field_names().to_vec(),
+                                dc_ref.is_frozen(),
+                                dc_ref.attrs().len(),
+                            )
+                        };
+                        let mut pairs = Vec::with_capacity(attrs_len);
+                        for i in 0..attrs_len {
+                            let key = dc
+                                .get(vm.heap)
+                                .attrs()
+                                .key_at(i)
+                                .expect("index in range")
+                                .clone_with_heap(vm.heap);
+                            defer_drop!(key, vm);
+                            let k = Self::from_value_inner(key, vm, visited);
+                            let value = dc
+                                .get(vm.heap)
+                                .attrs()
+                                .value_at(i)
+                                .expect("index in range")
+                                .clone_with_heap(vm.heap);
+                            defer_drop!(value, vm);
+                            let v = Self::from_value_inner(value, vm, visited);
+                            pairs.push((k, v));
+                        }
+                        Self::Dataclass {
+                            name,
+                            type_id,
+                            field_names,
+                            attrs: DictPairs(pairs),
+                            frozen,
+                        }
                     }
-                    HeapData::DictKeysView(_) | HeapData::DictItemsView(_) | HeapData::DictValuesView(_) => {
-                        repr_or_error(object, vm)
+                    // Iterators are internal objects — represent as a fixed type
+                    // string rather than recursing.
+                    HeapReadOutput::Iter(_) => Self::Repr("<iterator>".to_owned()),
+                    HeapReadOutput::LongInt(li) => Self::BigInt(li.get(vm.heap).inner().clone()),
+                    HeapReadOutput::Module(m) => {
+                        Self::Repr(format!("<module '{}'>", vm.interns.get_str(m.get(vm.heap).name())))
                     }
-                    HeapData::LongInt(li) => Self::BigInt(li.inner().clone()),
-                    HeapData::Module(m) => {
-                        // Modules are represented as a repr string
-                        Self::Repr(format!("<module '{}'>", vm.interns.get_str(m.name())))
-                    }
-                    HeapData::Slice(_) => repr_or_error(object, vm),
-                    HeapData::Coroutine(coro) => {
-                        // Coroutines are represented as a repr string
-                        let func = vm.interns.get_function(coro.func_id);
+                    HeapReadOutput::Coroutine(coro) => {
+                        let func_id = coro.get(vm.heap).func_id;
+                        let func = vm.interns.get_function(func_id);
                         let name = vm.interns.get_str(func.name.name_id);
                         Self::Repr(format!("<coroutine object {name}>"))
                     }
-                    HeapData::GatherFuture(gather) => {
-                        // GatherFutures are represented as a repr string
-                        Self::Repr(format!("<gather({})>", gather.item_count()))
+                    HeapReadOutput::GatherFuture(gather) => {
+                        Self::Repr(format!("<gather({})>", gather.get(vm.heap).item_count()))
                     }
-                    HeapData::Path(path) => Self::Path(path.as_str().to_owned()),
-                    HeapData::RePattern(_) | HeapData::ReMatch(_) => repr_or_error(object, vm),
-                    HeapData::ExtFunction(name) => Self::Function {
-                        name: name.clone(),
+                    HeapReadOutput::Path(path) => Self::Path(path.get(vm.heap).as_str().to_owned()),
+                    HeapReadOutput::ExtFunction(name) => Self::Function {
+                        name: name.get(vm.heap).clone(),
                         docstring: None,
                     },
+                    _ => repr_or_error(object, vm),
                 };
 
                 // Remove from visited set after processing
@@ -744,7 +818,7 @@ impl MontyObject {
 
 /// Converts a value to its repr string for `MontyObject`, falling back to a
 /// descriptive error message if `py_repr` fails (e.g. INT_MAX_STR_DIGITS).
-fn repr_or_error(value: &Value, vm: &VM<'_, '_, impl ResourceTracker>) -> MontyObject {
+fn repr_or_error(value: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> MontyObject {
     match value.py_repr(vm) {
         Ok(s) => MontyObject::Repr(s.into_owned()),
         Err(e) => {

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -269,7 +269,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Bytes> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         Ok(bytes_repr_fmt(&self.get(vm.heap).0, f)?)

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -220,15 +220,14 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         // Check depth limit before recursing
-        let heap = &*vm.heap;
-        let Some(token) = heap.incr_recursion_depth_for_repr() else {
+        let Ok(token) = vm.heap.incr_recursion_depth() else {
             return Ok(f.write_str("...")?);
         };
-        crate::defer_drop_immutable_heap!(token, heap);
+        defer_drop!(token, vm);
 
         // Format: ClassName(field1=value1, field2=value2, ...)
         // Only declared fields are shown, not dynamically added attributes
@@ -236,19 +235,21 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
         f.write_str(dc.name(vm.interns))?;
         f.write_char('(')?;
 
-        let mut first = true;
-        for field_name in &dc.field_names {
-            if !first {
+        let field_count = self.get(vm.heap).field_names.len();
+        let interns = vm.interns;
+        for i in 0..field_count {
+            if i > 0 {
                 f.write_str(", ")?;
             }
-            first = false;
-
             // Write field name
+            let field_name = &self.get(vm.heap).field_names[i];
             f.write_str(field_name)?;
             f.write_char('=')?;
 
             // Look up value in attrs
-            if let Some(value) = self.get(vm.heap).attrs.get_by_str(field_name, heap, vm.interns) {
+            if let Some(value) = self.get(vm.heap).attrs.get_by_str(field_name, vm.heap, interns) {
+                let value = value.clone_with_heap(vm.heap);
+                defer_drop!(value, vm);
                 value.py_repr_fmt(f, vm, heap_ids)?;
             } else {
                 // Field not found - shouldn't happen for well-formed dataclasses

--- a/crates/monty/src/types/date.rs
+++ b/crates/monty/src/types/date.rs
@@ -285,7 +285,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Date> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         let (year, month, day) = to_ymd(*self.get(vm.heap));
@@ -293,7 +293,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Date> {
         Ok(())
     }
 
-    fn py_str(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         let (year, month, day) = to_ymd(*self.get(vm.heap));
         Ok(Cow::Owned(format!("{year:04}-{month:02}-{day:02}")))
     }

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -1037,7 +1037,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         let dt = self.get(vm.heap);
@@ -1069,7 +1069,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
         Ok(())
     }
 
-    fn py_str(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         let dt = self.get(vm.heap);
         let Some((year, month, day, hour, minute, second, microsecond)) = to_components(dt) else {
             return Ok(Cow::Borrowed("<out of range>"));

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -670,34 +670,44 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         if self.get(vm.heap).is_empty() {
             return Ok(f.write_str("{}")?);
         }
 
-        let heap = &*vm.heap;
         // Check depth limit before recursing
-        let Some(token) = heap.incr_recursion_depth_for_repr() else {
+        let Ok(token) = vm.heap.incr_recursion_depth() else {
             return Ok(f.write_str("{...}")?);
         };
-        crate::defer_drop_immutable_heap!(token, heap);
+        defer_drop!(token, vm);
 
         f.write_char('{')?;
-        let mut first = true;
-        for entry in &self.get(heap).entries {
-            if !first {
-                if heap.check_time().is_err() {
+        let len = self.get(vm.heap).len();
+        for i in 0..len {
+            if i > 0 {
+                if vm.heap.check_time().is_err() {
                     f.write_str(", ...[timeout]")?;
                     break;
                 }
                 f.write_str(", ")?;
             }
-            first = false;
-            entry.key.py_repr_fmt(f, vm, heap_ids)?;
+            let key = self
+                .get(vm.heap)
+                .key_at(i)
+                .expect("index in range")
+                .clone_with_heap(vm.heap);
+            defer_drop!(key, vm);
+            key.py_repr_fmt(f, vm, heap_ids)?;
             f.write_str(": ")?;
-            entry.value.py_repr_fmt(f, vm, heap_ids)?;
+            let value = self
+                .get(vm.heap)
+                .value_at(i)
+                .expect("index in range")
+                .clone_with_heap(vm.heap);
+            defer_drop!(value, vm);
+            value.py_repr_fmt(f, vm, heap_ids)?;
         }
         f.write_char('}')?;
 

--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -157,11 +157,11 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictKeysView> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         f.write_str("dict_keys([")?;
-        write_dict_keys_contents(f, self.get(vm.heap).dict(vm.heap), vm, heap_ids)?;
+        write_dict_keys_contents(f, &self.dict(vm), vm, heap_ids)?;
         Ok(f.write_str("])")?)
     }
 
@@ -311,11 +311,11 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictItemsView> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         f.write_str("dict_items([")?;
-        write_dict_items_contents(f, self.get(vm.heap).dict(vm.heap), vm, heap_ids)?;
+        write_dict_items_contents(f, &self.dict(vm), vm, heap_ids)?;
         Ok(f.write_str("])")?)
     }
 
@@ -377,6 +377,15 @@ impl DictView for DictValuesView {
     }
 }
 
+impl<'h> HeapRead<'h, DictValuesView> {
+    fn dict(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> HeapRead<'h, Dict> {
+        let HeapReadOutput::Dict(dict) = vm.heap.read(self.get(vm.heap).dict_id) else {
+            panic!("dict_values view must always reference a dict");
+        };
+        dict
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapRead<'h, DictValuesView> {
     fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
         Type::DictValues
@@ -393,11 +402,11 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictValuesView> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         f.write_str("dict_values([")?;
-        write_dict_values_contents(f, self.get(vm.heap).dict(vm.heap), vm, heap_ids)?;
+        write_dict_values_contents(f, &self.dict(vm), vm, heap_ids)?;
         Ok(f.write_str("])")?)
     }
 }
@@ -464,39 +473,55 @@ fn dict_items_eq_set_like<'h, T: ResourceTracker>(
 }
 
 /// Writes the repr payload for a keys view without its outer wrapper.
-fn write_dict_keys_contents(
+fn write_dict_keys_contents<'h>(
     f: &mut impl Write,
-    dict: &Dict,
-    vm: &VM<'_, '_, impl ResourceTracker>,
+    dict: &HeapRead<'h, Dict>,
+    vm: &mut VM<'h, '_, impl ResourceTracker>,
     heap_ids: &mut AHashSet<HeapId>,
 ) -> RunResult<()> {
-    let mut first = true;
-    for (key, _) in dict {
-        if !first {
+    let len = dict.get(vm.heap).len();
+    for i in 0..len {
+        if i > 0 {
             f.write_str(", ")?;
         }
-        first = false;
+        let key = dict
+            .get(vm.heap)
+            .key_at(i)
+            .expect("index in range")
+            .clone_with_heap(vm.heap);
+        defer_drop!(key, vm);
         key.py_repr_fmt(f, vm, heap_ids)?;
     }
     Ok(())
 }
 
 /// Writes the repr payload for an items view without its outer wrapper.
-fn write_dict_items_contents(
+fn write_dict_items_contents<'h>(
     f: &mut impl Write,
-    dict: &Dict,
-    vm: &VM<'_, '_, impl ResourceTracker>,
+    dict: &HeapRead<'h, Dict>,
+    vm: &mut VM<'h, '_, impl ResourceTracker>,
     heap_ids: &mut AHashSet<HeapId>,
 ) -> RunResult<()> {
-    let mut first = true;
-    for (key, value) in dict {
-        if !first {
+    let len = dict.get(vm.heap).len();
+    for i in 0..len {
+        if i > 0 {
             f.write_str(", ")?;
         }
-        first = false;
         f.write_char('(')?;
+        let key = dict
+            .get(vm.heap)
+            .key_at(i)
+            .expect("index in range")
+            .clone_with_heap(vm.heap);
+        defer_drop!(key, vm);
         key.py_repr_fmt(f, vm, heap_ids)?;
         f.write_str(", ")?;
+        let value = dict
+            .get(vm.heap)
+            .value_at(i)
+            .expect("index in range")
+            .clone_with_heap(vm.heap);
+        defer_drop!(value, vm);
         value.py_repr_fmt(f, vm, heap_ids)?;
         f.write_char(')')?;
     }
@@ -504,18 +529,23 @@ fn write_dict_items_contents(
 }
 
 /// Writes the repr payload for a values view without its outer wrapper.
-fn write_dict_values_contents(
+fn write_dict_values_contents<'h>(
     f: &mut impl Write,
-    dict: &Dict,
-    vm: &VM<'_, '_, impl ResourceTracker>,
+    dict: &HeapRead<'h, Dict>,
+    vm: &mut VM<'h, '_, impl ResourceTracker>,
     heap_ids: &mut AHashSet<HeapId>,
 ) -> RunResult<()> {
-    let mut first = true;
-    for (_, value) in dict {
-        if !first {
+    let len = dict.get(vm.heap).len();
+    for i in 0..len {
+        if i > 0 {
             f.write_str(", ")?;
         }
-        first = false;
+        let value = dict
+            .get(vm.heap)
+            .value_at(i)
+            .expect("index in range")
+            .clone_with_heap(vm.heap);
+        defer_drop!(value, vm);
         value.py_repr_fmt(f, vm, heap_ids)?;
     }
     Ok(())

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -9,7 +9,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunError, RunResult},
-    heap::{DropWithHeap, Heap, HeapData, HeapGuard, HeapId, HeapItem, HeapRead, HeapReadOutput},
+    heap::{DropWithHeap, Heap, HeapData, HeapGuard, HeapId, HeapItem, HeapRead, HeapReadOutput, HeapReader},
     intern::StaticStrings,
     resource::{ResourceError, ResourceTracker},
     sorting::{apply_permutation, sort_indices},
@@ -335,10 +335,11 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
-        repr_sequence_fmt('[', ']', &self.get(vm.heap).items, f, vm, heap_ids)
+        let len = self.get(vm.heap).len();
+        repr_sequence_fmt('[', ']', len, |heap, i| &self.get(heap).as_slice()[i], f, vm, heap_ids)
     }
 
     fn py_add(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<Option<Value>, ResourceError> {
@@ -765,37 +766,38 @@ fn do_list_sort<'h>(
 /// # Arguments
 /// * `start` - The opening character (e.g., '[' for lists, '(' for tuples)
 /// * `end` - The closing character (e.g., ']' for lists, ')' for tuples)
-/// * `items` - The slice of values to format
+/// * `len` - The number of items to format
+/// * `get_item` - Returns the i-th value via brief immutable heap access
 /// * `f` - The formatter to write to
 /// * `vm` - The VM for resolving value references and looking up interned strings
 /// * `heap_ids` - Set of heap IDs being repr'd (for cycle detection)
-pub(crate) fn repr_sequence_fmt(
+pub(crate) fn repr_sequence_fmt<'h, T: ResourceTracker>(
     start: char,
     end: char,
-    items: &[Value],
+    len: usize,
+    get_item: impl for<'r> Fn(&'r HeapReader<'h, T>, usize) -> &'r Value,
     f: &mut impl Write,
-    vm: &VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, '_, T>,
     heap_ids: &mut AHashSet<HeapId>,
 ) -> RunResult<()> {
     // Check depth limit before recursing
-    let heap = &*vm.heap;
-    let Some(token) = heap.incr_recursion_depth_for_repr() else {
+    let Ok(token) = vm.heap.incr_recursion_depth() else {
         return Ok(f.write_str("...")?);
     };
-    crate::defer_drop_immutable_heap!(token, heap);
+    defer_drop!(token, vm);
 
     f.write_char(start)?;
-    let mut iter = items.iter();
-    if let Some(first) = iter.next() {
-        first.py_repr_fmt(f, vm, heap_ids)?;
-        for item in iter {
-            if heap.check_time().is_err() {
+    for i in 0..len {
+        if i > 0 {
+            if vm.heap.check_time().is_err() {
                 f.write_str(", ...[timeout]")?;
                 break;
             }
             f.write_str(", ")?;
-            item.py_repr_fmt(f, vm, heap_ids)?;
         }
+        let item = get_item(vm.heap, i).clone_with_heap(vm.heap);
+        defer_drop!(item, vm);
+        item.py_repr_fmt(f, vm, heap_ids)?;
     }
     f.write_char(end)?;
 

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -264,26 +264,26 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         // Check depth limit before recursing
-        let heap = &*vm.heap;
-        let Some(token) = heap.incr_recursion_depth_for_repr() else {
+        let Ok(token) = vm.heap.incr_recursion_depth() else {
             return Ok(f.write_str("...")?);
         };
-        crate::defer_drop_immutable_heap!(token, heap);
+        defer_drop!(token, vm);
 
         write!(f, "{}(", self.get(vm.heap).name.as_str(vm.interns))?;
 
-        let mut first = true;
-        for (field_name, value) in self.get(vm.heap).field_names.iter().zip(&self.get(vm.heap).items) {
-            if !first {
+        let len = self.get(vm.heap).items.len();
+        for i in 0..len {
+            if i > 0 {
                 f.write_str(", ")?;
             }
-            first = false;
-            f.write_str(field_name.as_str(vm.interns))?;
+            f.write_str(self.get(vm.heap).field_names[i].as_str(vm.interns))?;
             f.write_char('=')?;
+            let value = self.clone_item(i, vm);
+            defer_drop!(value, vm);
             value.py_repr_fmt(f, vm, heap_ids)?;
         }
 

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -510,7 +510,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Path> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         // Format like: PosixPath('/usr/bin')

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -161,7 +161,7 @@ pub trait PyTrait<'h> {
     /// visited heap IDs. When a cycle is detected (ID already in `heap_ids`), implementations
     /// should write an ellipsis (e.g., `[...]` for lists, `{...}` for dicts).
     ///
-    /// Recursion depth is tracked via `heap.incr_recursion_depth_for_repr()`.
+    /// Recursion depth is tracked via `heap.incr_recursion_depth()`.
     ///
     /// # Arguments
     /// * `f` - The formatter to write to
@@ -170,14 +170,14 @@ pub trait PyTrait<'h> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()>;
 
     /// Returns the Python `repr()` string for this value.
     ///
     /// Convenience wrapper around `py_repr_fmt` that returns an owned string.
-    fn py_repr(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_repr(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         let mut s = String::new();
         let mut heap_ids = AHashSet::new();
         self.py_repr_fmt(&mut s, vm, &mut heap_ids)?;
@@ -185,7 +185,7 @@ pub trait PyTrait<'h> {
     }
 
     /// Returns the Python `str()` string for this value.
-    fn py_str(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         self.py_repr(vm)
     }
 

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -255,7 +255,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Range> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         let this = self.get(vm.heap);

--- a/crates/monty/src/types/re_match.rs
+++ b/crates/monty/src/types/re_match.rs
@@ -285,23 +285,6 @@ impl ReMatch {
     }
 }
 
-impl ReMatch {
-    /// Formats this match for `repr()` output.
-    ///
-    /// Kept as an inherent method so `HeapData` can call it without going
-    /// through a `HeapRead` handle.
-    pub fn py_repr_fmt(
-        &self,
-        f: &mut impl Write,
-        _vm: &VM<'_, '_, impl ResourceTracker>,
-        _heap_ids: &mut AHashSet<HeapId>,
-    ) -> RunResult<()> {
-        write!(f, "<re.Match object; span=({}, {}), match=", self.start, self.end)?;
-        string_repr_fmt(&self.full_match, f)?;
-        Ok(f.write_char('>')?)
-    }
-}
-
 impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
     fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
         Type::ReMatch
@@ -324,10 +307,13 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
-        heap_ids: &mut AHashSet<HeapId>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
-        self.get(vm.heap).py_repr_fmt(f, vm, heap_ids)
+        let m = self.get(vm.heap);
+        write!(f, "<re.Match object; span=({}, {}), match=", m.start, m.end)?;
+        string_repr_fmt(&m.full_match, f)?;
+        Ok(f.write_char('>')?)
     }
 
     fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<CallResult>> {

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -287,7 +287,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, RePattern> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         let this = self.get(vm.heap);

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -435,27 +435,25 @@ impl<'h> HeapRead<'h, SetStorage> {
     }
 }
 
-impl SetStorage {
+impl<'h> HeapRead<'h, SetStorage> {
     /// Writes the repr format to a formatter.
-    ///
-    /// For sets, outputs `{elem1, elem2, ...}` (no type prefix).
-    /// For frozensets, outputs `frozenset({elem1, elem2, ...})`.
-    fn repr_fmt(
+    fn repr_fmt<T: ResourceTracker>(
         &self,
         f: &mut impl Write,
-        vm: &VM<'_, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, T>,
         heap_ids: &mut AHashSet<HeapId>,
         type_name: &str,
     ) -> RunResult<()> {
-        if self.is_empty() {
+        let len = self.get(vm.heap).len();
+        if len == 0 {
             return Ok(write!(f, "{type_name}()")?);
         }
 
         // Check depth limit before recursing
-        let Some(token) = vm.heap.incr_recursion_depth_for_repr() else {
+        let Ok(token) = vm.heap.incr_recursion_depth() else {
             return Ok(f.write_str("{...}")?);
         };
-        crate::defer_drop_immutable_heap!(token, vm);
+        defer_drop!(token, vm);
 
         // frozenset needs type prefix: frozenset({...}), but set doesn't: {...}
         let needs_prefix = type_name != "set";
@@ -464,17 +462,23 @@ impl SetStorage {
         }
 
         f.write_char('{')?;
-        let mut first = true;
-        for entry in &self.entries {
-            if !first {
+        for i in 0..len {
+            if i > 0 {
                 if vm.heap.check_time().is_err() {
                     f.write_str(", ...[timeout]")?;
                     break;
                 }
                 f.write_str(", ")?;
             }
-            first = false;
-            entry.value.py_repr_fmt(f, vm, heap_ids)?;
+            // Refcount-bump each element before recursing so a user-defined
+            // `__repr__` mutating the set can't free the entry mid-format.
+            let value = self
+                .get(vm.heap)
+                .value_at(i)
+                .expect("index in range")
+                .clone_with_heap(vm.heap);
+            defer_drop!(value, vm);
+            value.py_repr_fmt(f, vm, heap_ids)?;
         }
         f.write_char('}')?;
 
@@ -484,7 +488,9 @@ impl SetStorage {
 
         Ok(())
     }
+}
 
+impl SetStorage {
     /// Estimates the memory size of this storage.
     fn estimate_size(&self) -> usize {
         mem::size_of::<Self>() + self.len() * mem::size_of::<SetEntry>()
@@ -953,10 +959,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Set> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
-        self.get(vm.heap).0.repr_fmt(f, vm, heap_ids, "set")
+        self.peel_ref().repr_fmt(f, vm, heap_ids, "set")
     }
 
     fn py_call_attr(
@@ -1233,10 +1239,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
-        self.get(vm.heap).0.repr_fmt(f, vm, heap_ids, "frozenset")
+        self.peel_ref().repr_fmt(f, vm, heap_ids, "frozenset")
     }
 
     fn py_call_attr(

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -193,7 +193,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Slice> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         f.write_str("slice(")?;

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -225,13 +225,13 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         Ok(string_repr_fmt(&self.get(vm.heap).0, f)?)
     }
 
-    fn py_str(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         Ok(self.get(vm.heap).0.clone().into_string().into())
     }
 

--- a/crates/monty/src/types/timedelta.rs
+++ b/crates/monty/src/types/timedelta.rs
@@ -366,14 +366,14 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeDelta> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         f.write_str(&format_repr(self.get(vm.heap)))?;
         Ok(())
     }
 
-    fn py_str(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         let (days, seconds, microseconds) = components(self.get(vm.heap));
         let hours = seconds / SECONDS_PER_HOUR;
         let minutes = (seconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE;

--- a/crates/monty/src/types/timezone.rs
+++ b/crates/monty/src/types/timezone.rs
@@ -278,7 +278,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeZone> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         let tz = self.get(vm.heap);
@@ -296,7 +296,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeZone> {
         Ok(())
     }
 
-    fn py_str(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         let tz = self.get(vm.heap);
         if let Some(name) = &tz.name {
             return Ok(Cow::Owned(name.clone()));

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -328,10 +328,11 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, '_, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
-        repr_sequence_fmt('(', ')', &self.get(vm.heap).items, f, vm, heap_ids)
+        let len = self.get(vm.heap).as_slice().len();
+        repr_sequence_fmt('(', ')', len, |heap, i| &self.get(heap).as_slice()[i], f, vm, heap_ids)
     }
 }
 

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -332,6 +332,17 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         let len = self.get(vm.heap).as_slice().len();
+
+        if len == 1 {
+            // Special case for single-element tuples: include the trailing comma
+            let item = self.clone_item(0, vm);
+            defer_drop!(item, vm);
+            write!(f, "(")?;
+            item.py_repr_fmt(f, vm, heap_ids)?;
+            write!(f, ",)")?;
+            return Ok(());
+        }
+
         repr_sequence_fmt('(', ')', len, |heap, i| &self.get(heap).as_slice()[i], f, vm, heap_ids)
     }
 }

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -315,7 +315,7 @@ impl PyTrait<'_> for Value {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &VM<'_, '_, impl ResourceTracker>,
+        vm: &mut VM<'_, '_, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         let interns = vm.interns;
@@ -370,7 +370,7 @@ impl PyTrait<'_> for Value {
         }
     }
 
-    fn py_str(&self, vm: &VM<'_, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         match self {
             Self::InternString(string_id) => Ok(vm.interns.get_str(*string_id).to_owned().into()),
             Self::Ref(id) => vm.heap.read(*id).py_str(vm),
@@ -2073,7 +2073,7 @@ impl Marker {
     /// System markers have special repr formats ("<stdout>", "<stderr>").
     /// `typing.Union` uses `<class 'typing.Union'>` format (matching CPython).
     /// Other typing markers are prefixed with "typing." (e.g., "typing.Any").
-    fn py_repr_fmt(self, f: &mut impl Write) -> fmt::Result {
+    pub(crate) fn py_repr_fmt(self, f: &mut impl Write) -> fmt::Result {
         let s: &'static str = self.0.into();
         match self.0 {
             StaticStrings::Stdout => f.write_str("<stdout>")?,

--- a/crates/monty/test_cases/tuple__ops.py
+++ b/crates/monty/test_cases/tuple__ops.py
@@ -131,3 +131,9 @@ assert not () < (), 'empty tuples not lt'
 assert () <= (), 'empty tuples le'
 assert () >= (), 'empty tuples ge'
 assert not () > (), 'empty tuples not gt'
+
+# === Tuple reprs ===
+assert repr(()) == '()', 'empty tuple repr'
+assert repr((1,)) == '(1,)', 'single element tuple repr'
+assert repr((1, 2)) == '(1, 2)', 'multi element tuple repr'
+assert repr((1, (2, 3))) == '(1, (2, 3))', 'nested tuple repr'


### PR DESCRIPTION
This changes the `py_repr` family of methods to take `&mut VM` instead of `&VM`.

A few justifications for this:
- All the other methods take `&mut VM`, so this is a positive consistency change.
- If user-defined types with `__repr__` are eventually supported, this will be necessary anyway.
- It allows removal of `DropWithImmutableHeap` and `ImmutableHeapGuard`, including the `unsafe` code within it.