### PR TITLE
make `Task` have owning references to its coroutine / gather

### DIFF
--- a/crates/monty/src/asyncio.rs
+++ b/crates/monty/src/asyncio.rs
@@ -43,12 +43,6 @@ impl TaskId {
         Self(id)
     }
 
-    /// Returns the raw u32 value.
-    #[inline]
-    pub fn raw(self) -> u32 {
-        self.0
-    }
-
     /// Returns true if this is the main task (task 0).
     #[inline]
     pub fn is_main(self) -> bool {

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -10,7 +10,7 @@ use std::mem;
 
 use super::{AwaitResult, CallFrame, FrameExit, VM};
 use crate::{
-    InvalidInputError, MontyException, MontyObject,
+    MontyException,
     args::ArgValues,
     asyncio::{CallId, CoroutineState, GatherItem, TaskId},
     bytecode::vm::scheduler::{PendingCallData, SerializedTaskFrame, TaskState},
@@ -130,23 +130,22 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
             return Ok(AwaitResult::ValueReady(Value::Ref(list_id)));
         }
 
-        // Set waiter and clone items to process
-        // Note: We clone instead of mem::take because GatherItem::Coroutine holds HeapIds
-        // that need to stay in gather.items for proper ref counting when the gather is dropped.
+        // Set waiter and walk the items.
+        //
+        // Coroutine spawns are buffered and applied after the `gather_mut` borrow
+        // ends, because `Scheduler::spawn` borrows the heap to call `inc_ref` on
+        // the new task's owning references.
         let current_task = this.scheduler.current_task_id();
         let gather_mut = gather.get_mut(this.heap);
         gather_mut.waiter = current_task;
 
-        // Process each item
-        let mut task_ids = Vec::new();
         let mut pending_calls = Vec::new();
+        let mut coroutines_to_spawn: Vec<(HeapId, usize)> = Vec::new();
 
         for (idx, item) in gather_mut.items.iter().enumerate() {
             match item {
                 GatherItem::Coroutine(coro_id) => {
-                    // Spawn as task with the item index as result index
-                    let task_id = this.scheduler.spawn(*coro_id, Some(heap_id), Some(idx));
-                    task_ids.push(task_id);
+                    coroutines_to_spawn.push((*coro_id, idx));
                 }
                 GatherItem::ExternalFuture(call_id) => {
                     // Check if already resolved
@@ -165,9 +164,18 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
             }
         }
 
-        // Store task IDs and pending calls in the gather
-        gather_mut.task_ids = task_ids;
         gather_mut.pending_calls = pending_calls;
+
+        // Spawn the coroutine tasks; each spawn inc_refs the coroutine and gather.
+        let mut task_ids = Vec::with_capacity(coroutines_to_spawn.len());
+        for (coro_id, idx) in coroutines_to_spawn {
+            let task_id = this.scheduler.spawn(this.heap, coro_id, Some(heap_id), Some(idx));
+            task_ids.push(task_id);
+        }
+
+        // Re-acquire mutable access to the gather to store the spawned task ids.
+        let gather_mut = gather.get_mut(this.heap);
+        gather_mut.task_ids = task_ids;
 
         // Check if all items are already complete (only external futures, all resolved)
         let all_complete = gather_mut.task_ids.is_empty() && gather_mut.pending_calls.is_empty();
@@ -341,63 +349,77 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
             let all_complete = all_tasks_complete && all_external_resolved;
 
             if all_complete {
-                // First check if any task failed
-                let failed_task = gather
-                    .get(self.heap)
-                    .task_ids
-                    .iter()
-                    .find(|tid| matches!(self.scheduler.get_task(**tid).state, TaskState::Failed(_)));
-
-                if let Some(&failed_tid) = failed_task {
-                    // Get the error from the failed task
-                    let task = self.scheduler.get_task_mut(failed_tid);
-                    if let TaskState::Failed(err) = mem::replace(&mut task.state, TaskState::Ready) {
-                        self.heap.dec_ref(gid);
-
-                        // Switch to waiter so error is raised in its context
-                        if let Some(waiter_id) = gather.get(self.heap).waiter {
-                            self.cleanup_current_task();
-                            self.scheduler.set_current_task(Some(waiter_id));
-                            self.load_or_init_task(waiter_id)?;
-                        }
-
-                        return Err(err);
-                    }
-                }
-
-                // Steal results from gather using mem::take - avoids refcount dance
-                // (copy + inc_ref + dec_ref on gather drop). Since gather is being
-                // destroyed, we can take ownership of the values directly.
-                let results: Vec<Value> = mem::take(&mut gather.get_mut(self.heap).results)
-                    .into_iter()
-                    .map(|r| r.expect("all results should be filled when gather is complete"))
-                    .collect();
-
-                // Create result list
-                let list_id = self.heap.allocate(HeapData::List(List::new(results)))?;
-
-                // Release the GatherFuture - this will cascade to release coroutines
+                // Take the spawned task ids and waiter while gather is still
+                // readable; we'll drop the gather and remove the tasks below.
                 let waiter = gather.get(self.heap).waiter;
+                let task_ids = mem::take(&mut gather.get_mut(self.heap).task_ids);
+                let results = mem::take(&mut gather.get_mut(self.heap).results);
+
+                // Release the gather itself
                 drop(gather);
                 self.heap.dec_ref(gid);
 
-                // Unblock waiter and switch to it
-                if let Some(waiter_id) = waiter {
-                    self.scheduler.make_ready(waiter_id);
-                    // Remove from ready queue since we're switching directly to it
-                    self.scheduler.remove_from_ready_queue(waiter_id);
-                    // Clear current task's state since it's done
-                    self.cleanup_current_task();
-                    // Switch to waiter
-                    self.scheduler.set_current_task(Some(waiter_id));
-                    self.load_or_init_task(waiter_id)?;
-                    // Push the result onto the waiter's stack
-                    self.push(Value::Ref(list_id));
-                    return Ok(AwaitResult::FramePushed);
+                // First check if any task failed
+                let failed_task = task_ids.iter().find_map(|tid| {
+                    let task = self.scheduler.get_task_mut(*tid);
+                    match &task.state {
+                        TaskState::Failed(_) => {
+                            let TaskState::Failed(err) = mem::replace(&mut task.state, TaskState::Ready) else {
+                                unreachable!()
+                            };
+                            Some(err)
+                        }
+                        _ => None,
+                    }
+                });
+
+                let result = if let Some(err) = failed_task {
+                    // Switch to waiter so error is raised in its context
+                    if let Some(waiter_id) = waiter {
+                        self.cleanup_current_task();
+                        self.scheduler.set_current_task(Some(waiter_id));
+                        self.load_or_init_task(waiter_id)?;
+                    }
+
+                    Err(err)
+                } else {
+                    let results: Vec<Value> = results
+                        .into_iter()
+                        .map(|r| r.expect("all results should be filled when gather is complete"))
+                        .collect();
+
+                    // Create result list
+                    let list_id = self.heap.allocate(HeapData::List(List::new(results)))?;
+
+                    // Unblock waiter and switch to it
+                    let progress = if let Some(waiter_id) = waiter {
+                        self.scheduler.make_ready(waiter_id);
+                        // Remove from ready queue since we're switching directly to it
+                        self.scheduler.remove_from_ready_queue(waiter_id);
+                        // Clear current task's state since it's done
+                        self.cleanup_current_task();
+                        // Switch to waiter
+                        self.scheduler.set_current_task(Some(waiter_id));
+                        self.load_or_init_task(waiter_id)?;
+                        // Push the result onto the waiter's stack
+                        self.push(Value::Ref(list_id));
+                        AwaitResult::FramePushed
+                    } else {
+                        // No waiter (shouldn't happen but handle gracefully)
+                        AwaitResult::ValueReady(Value::Ref(list_id))
+                    };
+
+                    Ok(progress)
+                };
+
+                // Release every spawned task; this drops their owning
+                // refs to the gather and coroutines, freeing the gather
+                // (and its items) once the last task ref goes away.
+                for tid in task_ids {
+                    self.scheduler.cancel_task(tid, self.heap);
                 }
 
-                // No waiter (shouldn't happen but handle gracefully)
-                return Ok(AwaitResult::ValueReady(Value::Ref(list_id)));
+                return result;
             }
         } else {
             // Drop the result (it's stored in the task state now)
@@ -467,25 +489,40 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
             self.scheduler.fail_task(task_id, error);
 
             // Cancel sibling tasks (filter out self and already-finished tasks inline)
-            for sibling_id in task_ids {
-                if sibling_id != task_id && !self.scheduler.get_task(sibling_id).is_finished() {
-                    self.scheduler.cancel_task(sibling_id, self.heap);
+            for sibling_id in &task_ids {
+                if *sibling_id != task_id && !self.scheduler.get_task(*sibling_id).is_finished() {
+                    self.scheduler.cancel_task(*sibling_id, self.heap);
                 }
             }
 
-            // Clean up the gather
+            // Clean up the gather's logical "alive awaitable" reference. Spawned
+            // tasks still hold their owning refs until removed below.
             self.heap.dec_ref(gid);
 
             // Switch to waiter and propagate the error
-            if let Some(waiter_id) = waiter {
+            let propagated_err = if let Some(waiter_id) = waiter {
                 self.cleanup_current_task();
                 self.scheduler.set_current_task(Some(waiter_id));
                 self.load_or_init_task(waiter_id)?;
                 // Get error back from task state to return
                 let task = self.scheduler.get_task_mut(task_id);
                 if let TaskState::Failed(err) = mem::replace(&mut task.state, TaskState::Ready) {
-                    return Err(err);
+                    Some(err)
+                } else {
+                    None
                 }
+            } else {
+                None
+            };
+
+            // Release every spawned task; the last `remove_task` drops the
+            // final owning ref and frees the gather + its coroutines.
+            for tid in task_ids {
+                self.scheduler.cancel_task(tid, self.heap);
+            }
+
+            if let Some(err) = propagated_err {
+                return Err(err);
             }
         } else {
             // No gather - just mark task as failed (ignore returned gather_id which is None)
@@ -663,27 +700,31 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
     ///
     /// If the task that created this call has been cancelled or failed,
     /// the result is silently ignored and the value is dropped.
-    pub fn resolve_future(&mut self, call_id: u32, obj: MontyObject) -> Result<(), InvalidInputError> {
+    pub fn resolve_future(&mut self, call_id: u32, value: Value) -> RunResult<()> {
+        let mut value_guard = HeapGuard::new(value, self);
+        let this = value_guard.heap();
+
         let call_id = CallId::new(call_id);
         // Check if the creator task has been cancelled/failed
-        if let Some(creator_task) = self.scheduler.get_pending_call_creator(call_id)
-            && self.scheduler.is_task_failed(creator_task)
+        if let Some(creator_task) = this.scheduler.get_pending_call_creator(call_id)
+            && this.scheduler.is_task_failed(creator_task)
         {
             // Task was cancelled - silently ignore the result
             return Ok(());
         }
-        let value = obj.to_value(self)?;
 
         // Check if a gather is waiting on this CallId
-        if let Some((gather_id, result_idx)) = self.scheduler.take_gather_waiter(call_id) {
-            self.scheduler.remove_pending_call(call_id);
+        if let Some((gather_id, result_idx)) = this.scheduler.take_gather_waiter(call_id) {
+            this.scheduler.remove_pending_call(call_id);
 
             // Store result directly in gather (move, not clone) and check completion
-            let HeapReadOutput::GatherFuture(mut gather) = self.heap.read(gather_id) else {
+            let HeapReadOutput::GatherFuture(mut gather) = this.heap.read(gather_id) else {
                 panic!("gather_id doesn't point to a GatherFuture")
             };
+            let value = value_guard.into_inner();
             let gather_mut = gather.get_mut(self.heap);
-            gather_mut.results[result_idx] = Some(value); // Move value directly, no clone needed
+            gather_mut.results[result_idx] = Some(value);
+
             // Remove from pending_calls
             gather_mut.pending_calls.retain(|&cid| cid != call_id);
             let pending_empty = gather_mut.pending_calls.is_empty();
@@ -699,6 +740,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
                 if all_tasks_complete {
                     // Gather is complete - build result and push to waiter's stack
                     let waiter = gather.get(self.heap).waiter;
+                    let task_ids = mem::take(&mut gather.get_mut(self.heap).task_ids);
                     // Steal results from gather using mem::take - avoids refcount dance
                     // (copy + inc_ref + dec_ref on gather drop). Since gather is being
                     // destroyed, we can take ownership of the values directly.
@@ -709,36 +751,39 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
                     // Drop the HeapRead before dec_ref which may free the object
                     drop(gather);
 
+                    // Release every child task
+                    for tid in task_ids {
+                        self.scheduler.cancel_task(tid, self.heap);
+                    }
+
                     if let Some(waiter_id) = waiter {
-                        // Create result list - if this fails, we can't do much, just skip
-                        if let Ok(list_id) = self.heap.allocate(HeapData::List(List::new(results))) {
-                            // Release the GatherFuture (results already taken, so no double-drop)
-                            self.heap.dec_ref(gather_id);
+                        let list_id = self.heap.allocate(HeapData::List(List::new(results)))?;
+                        self.heap.dec_ref(gather_id);
 
-                            // Push result onto waiter's stack and mark as ready.
-                            // Check if the waiter's context is currently in the VM (frames not saved
-                            // to the task). This is the case when the waiter is the current task
-                            // and hasn't been switched away from (e.g., external-only gather).
-                            let waiter_context_in_vm =
-                                self.scheduler.current_task_id() == Some(waiter_id) && !self.frames.is_empty();
+                        // Push result onto waiter's stack and mark as ready.
+                        // Check if the waiter's context is currently in the VM (frames not saved
+                        // to the task). This is the case when the waiter is the current task
+                        // and hasn't been switched away from (e.g., external-only gather).
+                        let waiter_context_in_vm =
+                            self.scheduler.current_task_id() == Some(waiter_id) && !self.frames.is_empty();
 
-                            if waiter_context_in_vm {
-                                // Waiter's frames are in the VM - push directly onto VM stack
-                                self.stack.push(Value::Ref(list_id));
-                                // Mark as ready but don't add to ready_queue
-                                self.scheduler.get_task_mut(waiter_id).state = TaskState::Ready;
-                            } else {
-                                // Waiter's context is saved in the task (either spawned task,
-                                // or main task that was saved when switching to spawned tasks)
-                                self.scheduler.get_task_mut(waiter_id).stack.push(Value::Ref(list_id));
-                                self.scheduler.make_ready(waiter_id);
-                            }
+                        if waiter_context_in_vm {
+                            // Waiter's frames are in the VM - push directly onto VM stack
+                            self.stack.push(Value::Ref(list_id));
+                            // Mark as ready but don't add to ready_queue
+                            self.scheduler.get_task_mut(waiter_id).state = TaskState::Ready;
+                        } else {
+                            // Waiter's context is saved in the task (either spawned task,
+                            // or main task that was saved when switching to spawned tasks)
+                            self.scheduler.get_task_mut(waiter_id).stack.push(Value::Ref(list_id));
+                            self.scheduler.make_ready(waiter_id);
                         }
                     }
                 }
             }
         } else {
             // Normal resolution for single awaiter
+            let value = value_guard.into_inner();
             self.scheduler.resolve(call_id, value);
         }
         Ok(())
@@ -782,15 +827,23 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
             }
 
             // Cancel all sibling tasks in the gather
-            for sibling_id in task_ids {
-                self.scheduler.cancel_task(sibling_id, self.heap);
+            for sibling_id in &task_ids {
+                self.scheduler.cancel_task(*sibling_id, self.heap);
             }
 
             // Fail the waiter task (the task that awaited the gather)
             if let Some(waiter_id) = waiter {
                 self.scheduler.fail_task(waiter_id, error);
-                // Release the GatherFuture
+                // Release the GatherFuture's logical "alive awaitable" ref.
+                // Spawned tasks still hold owning refs until removed below.
                 self.heap.dec_ref(gather_id);
+            }
+
+            // Release every spawned task; the last `remove_task` frees the
+            // gather and its coroutines. The waiter is *not* removed — it has
+            // been failed and still needs to run for the failure to propagate.
+            for tid in task_ids {
+                self.scheduler.cancel_task(tid, self.heap);
             }
         } else if let Some((task_id, Some(gid))) = self.scheduler.fail_for_call(call_id, error) {
             // Original path: task is directly BlockedOnCall and part of a gather
@@ -847,11 +900,12 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
         for (call_id, ext_result) in results {
             match ext_result {
                 ExtFunctionResult::Return(obj) => {
-                    self.resolve_future(call_id, obj).map_err(|e| {
+                    let value = obj.to_value(self).map_err(|e| {
                         RunError::from(MontyException::runtime_error(format!(
-                            "Invalid return type for call {call_id}: {e}"
+                            "Invalid return value for call {call_id}: {e}"
                         )))
                     })?;
+                    self.resolve_future(call_id, value)?;
                 }
                 ExtFunctionResult::Error(exc) => self.fail_future(call_id, RunError::from(exc)),
                 ExtFunctionResult::Future(_) => {}

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -322,13 +322,15 @@ impl<'h, T: ResourceTracker> VM<'h, '_, T> {
                 };
                 let task_ids = mem::take(&mut gather.get_mut(self.heap).task_ids);
                 let results = mem::take(&mut gather.get_mut(self.heap).results);
+                let mut results_guard = HeapGuard::new(results, self);
+                let this = results_guard.heap();
 
                 // Drop the reader before any operations that may free heap objects (e.g., cancelling tasks)
                 drop(gather);
 
                 // First check if any task failed
                 let failed_task = task_ids.iter().find_map(|tid| {
-                    let task = self.scheduler.get_task_mut(*tid);
+                    let task = this.scheduler.get_task_mut(*tid);
                     match &task.state {
                         TaskState::Failed(_) => {
                             let TaskState::Failed(err) = mem::replace(&mut task.state, TaskState::Ready) else {
@@ -342,19 +344,20 @@ impl<'h, T: ResourceTracker> VM<'h, '_, T> {
 
                 // Release every spawned task
                 for tid in task_ids {
-                    self.scheduler.cancel_task(tid, self.heap);
+                    this.scheduler.cancel_task(tid, this.heap);
                 }
 
                 // Make waiter ready but don't add to ready queue since we're switching directly to it
-                self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
-                self.cleanup_current_task();
-                self.scheduler.set_current_task(Some(waiter_id));
-                self.load_or_init_task(waiter_id)?;
+                this.scheduler.set_state(waiter_id, TaskState::Ready, this.heap);
+                this.cleanup_current_task();
+                this.scheduler.set_current_task(Some(waiter_id));
+                this.load_or_init_task(waiter_id)?;
 
                 return if let Some(err) = failed_task {
                     // Error is raised in waiter context
                     Err(err)
                 } else {
+                    let results = results_guard.into_inner();
                     let results: Vec<Value> = results
                         .into_iter()
                         .map(|r| r.expect("all results should be filled when gather is complete"))
@@ -658,7 +661,9 @@ impl<'h, T: ResourceTracker> VM<'h, '_, T> {
                 });
                 if all_tasks_complete {
                     // Gather is complete - build result and push to waiter's stack
-                    let waiter = gather.get(self.heap).waiter;
+                    let Some(waiter_id) = gather.get(self.heap).waiter else {
+                        panic!("gather future has no waiter when gather is complete")
+                    };
                     let task_ids = mem::take(&mut gather.get_mut(self.heap).task_ids);
                     // Steal results from gather using mem::take - avoids refcount dance
                     // (copy + inc_ref + dec_ref on gather drop). Since gather is being
@@ -675,27 +680,25 @@ impl<'h, T: ResourceTracker> VM<'h, '_, T> {
                         self.scheduler.cancel_task(tid, self.heap);
                     }
 
-                    if let Some(waiter_id) = waiter {
-                        let list_id = self.heap.allocate(HeapData::List(List::new(results)))?;
+                    let list_id = self.heap.allocate(HeapData::List(List::new(results)))?;
 
-                        // Push result onto waiter's stack and mark as ready.
-                        // Check if the waiter's context is currently in the VM (frames not saved
-                        // to the task). This is the case when the waiter is the current task
-                        // and hasn't been switched away from (e.g., external-only gather).
-                        let waiter_context_in_vm =
-                            self.scheduler.current_task_id() == Some(waiter_id) && !self.frames.is_empty();
+                    // Push result onto waiter's stack and mark as ready.
+                    // Check if the waiter's context is currently in the VM (frames not saved
+                    // to the task). This is the case when the waiter is the current task
+                    // and hasn't been switched away from (e.g., external-only gather).
+                    let waiter_context_in_vm =
+                        self.scheduler.current_task_id() == Some(waiter_id) && !self.frames.is_empty();
 
-                        if waiter_context_in_vm {
-                            // Waiter's frames are in the VM - push directly onto VM stack
-                            self.stack.push(Value::Ref(list_id));
-                            // Mark as ready but don't add to ready_queue.
-                            self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
-                        } else {
-                            // Waiter's context is saved in the task (either spawned task,
-                            // or main task that was saved when switching to spawned tasks)
-                            self.scheduler.get_task_mut(waiter_id).stack.push(Value::Ref(list_id));
-                            self.scheduler.make_ready(waiter_id, self.heap);
-                        }
+                    if waiter_context_in_vm {
+                        // Waiter's frames are in the VM - push directly onto VM stack
+                        self.stack.push(Value::Ref(list_id));
+                        // Mark as ready but don't add to ready_queue.
+                        self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
+                    } else {
+                        // Waiter's context is saved in the task (either spawned task,
+                        // or main task that was saved when switching to spawned tasks)
+                        self.scheduler.get_task_mut(waiter_id).stack.push(Value::Ref(list_id));
+                        self.scheduler.make_ready(waiter_id, self.heap);
                     }
                 }
             }
@@ -715,61 +718,7 @@ impl<'h, T: ResourceTracker> VM<'h, '_, T> {
     pub fn fail_future(&mut self, call_id: u32, error: RunError) {
         let call_id = CallId::new(call_id);
 
-        // Check if a gather is waiting on this CallId
-        if let Some((gather_id, _result_idx)) = self.scheduler.take_gather_waiter(call_id) {
-            // Remove from pending_calls so it doesn't appear in get_pending_call_ids()
-            // (fail_for_call handles this for the non-gather case)
-            self.scheduler.remove_pending_call(call_id);
-
-            // Get the gather's waiter, task_ids, and OTHER pending calls
-            // We need to remove all pending calls for this gather from gather_waiters
-            // before we dec_ref the gather, otherwise subsequent errors for the same
-            // gather would try to access a freed heap object.
-            // Use get_mut and take to avoid allocations - gather is being destroyed anyway.
-            let HeapReadOutput::GatherFuture(mut gather) = self.heap.read(gather_id) else {
-                panic!("gather_id doesn't point to a GatherFuture")
-            };
-            let gather_mut = gather.get_mut(self.heap);
-            let mut other_pending_calls = mem::take(&mut gather_mut.pending_calls);
-            other_pending_calls.retain(|&cid| cid != call_id);
-            let waiter = gather_mut.waiter;
-            let task_ids = mem::take(&mut gather_mut.task_ids);
-            // Drop the HeapRead before operations that may free heap objects
-            drop(gather);
-
-            // Remove all other pending calls for this gather from gather_waiters and pending_calls
-            // This prevents subsequent errors from trying to access the freed gather
-            for other_call_id in other_pending_calls {
-                self.scheduler.take_gather_waiter(other_call_id);
-                self.scheduler.remove_pending_call(other_call_id);
-            }
-
-            // Cancel all sibling tasks in the gather
-            for sibling_id in task_ids {
-                self.scheduler.cancel_task(sibling_id, self.heap);
-            }
-
-            // Fail the waiter task (the task that awaited the gather)
-            if let Some(waiter_id) = waiter {
-                self.scheduler.fail_task(waiter_id, error, self.heap);
-            }
-        } else if let Some((task_id, Some(gid))) = self.scheduler.fail_for_call(call_id, error, self.heap) {
-            // Original path: task is directly BlockedOnCall and part of a gather
-            // Take task_ids from GatherFuture - gather is being destroyed anyway
-            let HeapReadOutput::GatherFuture(mut gather) = self.heap.read(gid) else {
-                panic!("gather_id doesn't point to a GatherFuture")
-            };
-            let task_ids = mem::take(&mut gather.get_mut(self.heap).task_ids);
-            // Drop the HeapRead before cancel_task which may free heap objects
-            drop(gather);
-
-            // Cancel sibling tasks (filter out self and already-finished tasks)
-            for sibling_id in task_ids {
-                if sibling_id != task_id && !self.scheduler.get_task(sibling_id).is_finished() {
-                    self.scheduler.cancel_task(sibling_id, self.heap);
-                }
-            }
-        }
+        self.scheduler.fail_for_call(call_id, error, self.heap);
     }
 
     /// Adds pending call data for an external function call.

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -12,11 +12,11 @@ use super::{AwaitResult, CallFrame, FrameExit, VM};
 use crate::{
     MontyException,
     args::ArgValues,
-    asyncio::{CallId, CoroutineState, GatherItem, TaskId},
+    asyncio::{CallId, Coroutine, CoroutineState, GatherFuture, GatherItem, TaskId},
     bytecode::vm::scheduler::{PendingCallData, SerializedTaskFrame, TaskState},
     defer_drop,
     exception_private::{ExcType, RunError, RunResult, SimpleException},
-    heap::{HeapData, HeapGuard, HeapId, HeapReadOutput},
+    heap::{HeapData, HeapGuard, HeapId, HeapRead, HeapReadOutput},
     intern::FunctionId,
     resource::ResourceTracker,
     run_progress::ExtFunctionResult,
@@ -24,7 +24,7 @@ use crate::{
     value::Value,
 };
 
-impl<T: ResourceTracker> VM<'_, '_, T> {
+impl<'h, T: ResourceTracker> VM<'h, '_, T> {
     /// Executes the Await opcode.
     ///
     /// Pops the awaitable from the stack and handles it based on its type:
@@ -34,30 +34,17 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
     ///
     /// Returns `AwaitResult` indicating what action the VM should take.
     pub(super) fn exec_get_awaitable(&mut self) -> Result<AwaitResult, RunError> {
-        let awaitable = self.pop();
-
-        let mut awaitable_guard = HeapGuard::new(awaitable, self);
-        let (awaitable, this) = awaitable_guard.as_parts();
+        let this = self;
+        let awaitable = this.pop();
+        defer_drop!(awaitable, this);
 
         match awaitable {
             Value::Ref(heap_id) => {
                 let heap_id = *heap_id;
-                let heap_data_type = match this.heap.get(heap_id) {
-                    HeapData::Coroutine(_) => Some(AwaitableType::Coroutine),
-                    HeapData::GatherFuture(_) => Some(AwaitableType::GatherFuture),
-                    _ => None,
-                };
-
-                match heap_data_type {
-                    Some(AwaitableType::Coroutine) => {
-                        let (awaitable, this) = awaitable_guard.into_parts();
-                        this.await_coroutine(heap_id, awaitable)
-                    }
-                    Some(AwaitableType::GatherFuture) => {
-                        let (awaitable, this) = awaitable_guard.into_parts();
-                        this.await_gather_future(heap_id, awaitable)
-                    }
-                    None => Err(ExcType::object_not_awaitable(awaitable.py_type(this))),
+                match this.heap.read(heap_id) {
+                    HeapReadOutput::Coroutine(coro) => this.await_coroutine(coro),
+                    HeapReadOutput::GatherFuture(gather) => this.await_gather_future(heap_id, gather),
+                    _ => Err(ExcType::object_not_awaitable(awaitable.py_type(this))),
                 }
             }
             &Value::ExternalFuture(call_id) => this.await_external_future(call_id),
@@ -69,35 +56,28 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
     ///
     /// Validates the coroutine is in `New` state, extracts its captured namespace
     /// and cells, marks it as `Running`, and pushes a frame to execute the coroutine body.
-    fn await_coroutine(&mut self, heap_id: HeapId, awaitable: Value) -> Result<AwaitResult, RunError> {
-        let this = self;
-        defer_drop!(awaitable, this);
-
-        let HeapReadOutput::Coroutine(mut coro) = this.heap.read(heap_id) else {
-            unreachable!("await_coroutine called with non-coroutine heap_id")
-        };
-
+    fn await_coroutine(&mut self, mut coro: HeapRead<'h, Coroutine>) -> Result<AwaitResult, RunError> {
         // Check if coroutine can be awaited (must be New)
-        if coro.get(this.heap).state != CoroutineState::New {
+        if coro.get(self.heap).state != CoroutineState::New {
             return Err(
                 SimpleException::new_msg(ExcType::RuntimeError, "cannot reuse already awaited coroutine").into(),
             );
         }
 
         // Extract coroutine data before mutating
-        let func_id = coro.get(this.heap).func_id;
+        let func_id = coro.get(self.heap).func_id;
         let namespace_values: Vec<Value> = coro
-            .get(this.heap)
+            .get(self.heap)
             .namespace
             .iter()
-            .map(|v| v.clone_with_heap(this))
+            .map(|v| v.clone_with_heap(self))
             .collect();
 
         // Mark coroutine as Running
-        coro.get_mut(this.heap).state = CoroutineState::Running;
+        coro.get_mut(self.heap).state = CoroutineState::Running;
 
         // Create namespace and push frame (guard drops awaitable at scope exit)
-        this.start_coroutine_frame(func_id, namespace_values)?;
+        self.start_coroutine_frame(func_id, namespace_values)?;
 
         Ok(AwaitResult::FramePushed)
     }
@@ -110,23 +90,19 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
     ///
     /// If all items are already resolved, returns immediately. Otherwise blocks
     /// the current task and switches to a ready task or yields to the host.
-    fn await_gather_future(&mut self, heap_id: HeapId, awaitable: Value) -> Result<AwaitResult, RunError> {
-        let this = self;
-        let mut awaitable_guard = HeapGuard::new(awaitable, this);
-        let (_, this) = awaitable_guard.as_parts();
-
-        let HeapReadOutput::GatherFuture(mut gather) = this.heap.read(heap_id) else {
-            unreachable!("await_gather_future called with non-gather heap_id")
-        };
-
+    fn await_gather_future(
+        &mut self,
+        heap_id: HeapId,
+        mut gather: HeapRead<'h, GatherFuture>,
+    ) -> Result<AwaitResult, RunError> {
         // Check if already being waited on (double-await)
-        if gather.get(this.heap).waiter.is_some() {
+        if gather.get(self.heap).waiter.is_some() {
             return Err(SimpleException::new_msg(ExcType::RuntimeError, "cannot reuse already awaited gather").into());
         }
 
         // If no items to gather, return empty list immediately
-        if gather.get(this.heap).item_count() == 0 {
-            let list_id = this.heap.allocate(HeapData::List(List::new(vec![])))?;
+        if gather.get(self.heap).item_count() == 0 {
+            let list_id = self.heap.allocate(HeapData::List(List::new(vec![])))?;
             return Ok(AwaitResult::ValueReady(Value::Ref(list_id)));
         }
 
@@ -135,8 +111,8 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
         // Coroutine spawns are buffered and applied after the `gather_mut` borrow
         // ends, because `Scheduler::spawn` borrows the heap to call `inc_ref` on
         // the new task's owning references.
-        let current_task = this.scheduler.current_task_id();
-        let gather_mut = gather.get_mut(this.heap);
+        let current_task = self.scheduler.current_task_id();
+        let gather_mut = gather.get_mut(self.heap);
         gather_mut.waiter = current_task;
 
         let mut pending_calls = Vec::new();
@@ -149,16 +125,16 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
                 }
                 GatherItem::ExternalFuture(call_id) => {
                     // Check if already resolved
-                    this.scheduler.mark_consumed(*call_id);
+                    self.scheduler.mark_consumed(*call_id);
 
-                    if let Some(value) = this.scheduler.take_resolved(*call_id) {
+                    if let Some(value) = self.scheduler.take_resolved(*call_id) {
                         // Already resolved - store result immediately
                         gather_mut.results[idx] = Some(value);
                     } else {
                         // Not resolved yet - track it
                         pending_calls.push(*call_id);
-                        // Register gather as waiting on this call
-                        this.scheduler.register_gather_for_call(*call_id, heap_id, idx);
+                        // Register gather as waiting on self call
+                        self.scheduler.register_gather_for_call(*call_id, heap_id, idx);
                     }
                 }
             }
@@ -169,12 +145,12 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
         // Spawn the coroutine tasks; each spawn inc_refs the coroutine and gather.
         let mut task_ids = Vec::with_capacity(coroutines_to_spawn.len());
         for (coro_id, idx) in coroutines_to_spawn {
-            let task_id = this.scheduler.spawn(this.heap, coro_id, Some(heap_id), Some(idx));
+            let task_id = self.scheduler.spawn(self.heap, coro_id, Some(heap_id), Some(idx));
             task_ids.push(task_id);
         }
 
         // Re-acquire mutable access to the gather to store the spawned task ids.
-        let gather_mut = gather.get_mut(this.heap);
+        let gather_mut = gather.get_mut(self.heap);
         gather_mut.task_ids = task_ids;
 
         // Check if all items are already complete (only external futures, all resolved)
@@ -187,25 +163,15 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
                 .map(|r| r.expect("all results should be filled"))
                 .collect();
 
-            let list_id = this.heap.allocate(HeapData::List(List::new(results)))?;
+            let list_id = self.heap.allocate(HeapData::List(List::new(results)))?;
             return Ok(AwaitResult::ValueReady(Value::Ref(list_id)));
         }
 
         // Block current task on this gather
-        this.scheduler.block_current_on_gather(heap_id);
-
-        // Consume the awaitable without decrementing refcount - the GatherFuture
-        // must stay alive for result collection. It will be dec_ref'd when
-        // the gather completes (in handle_task_completion).
-        let (awaitable, this) = awaitable_guard.into_parts();
-        #[cfg_attr(
-            not(feature = "memory-model-checks"),
-            expect(clippy::forget_non_drop, reason = "has Drop with memory-model-checks feature")
-        )]
-        mem::forget(awaitable);
+        self.scheduler.block_current_on_gather(heap_id, self.heap);
 
         // Switch to next ready task (spawned tasks) or yield for external futures
-        this.switch_or_yield()
+        self.switch_or_yield()
     }
 
     /// Awaits an external future by blocking until it's resolved.
@@ -323,7 +289,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
 
         // Mark task as completed and store result in task state
         let task_result = result.clone_with_heap(self.heap);
-        self.scheduler.complete_task(task_id, task_result);
+        self.scheduler.complete_task(task_id, task_result, self.heap);
 
         // If task belongs to a gather, store result and check if gather is complete
         if let Some(gid) = gather_id {
@@ -351,13 +317,14 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
             if all_complete {
                 // Take the spawned task ids and waiter while gather is still
                 // readable; we'll drop the gather and remove the tasks below.
-                let waiter = gather.get(self.heap).waiter;
+                let Some(waiter_id) = gather.get(self.heap).waiter else {
+                    panic!("gather future has no waiter when gather is complete")
+                };
                 let task_ids = mem::take(&mut gather.get_mut(self.heap).task_ids);
                 let results = mem::take(&mut gather.get_mut(self.heap).results);
 
-                // Release the gather itself
+                // Drop the reader before any operations that may free heap objects (e.g., cancelling tasks)
                 drop(gather);
-                self.heap.dec_ref(gid);
 
                 // First check if any task failed
                 let failed_task = task_ids.iter().find_map(|tid| {
@@ -373,14 +340,19 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
                     }
                 });
 
-                let result = if let Some(err) = failed_task {
-                    // Switch to waiter so error is raised in its context
-                    if let Some(waiter_id) = waiter {
-                        self.cleanup_current_task();
-                        self.scheduler.set_current_task(Some(waiter_id));
-                        self.load_or_init_task(waiter_id)?;
-                    }
+                // Release every spawned task
+                for tid in task_ids {
+                    self.scheduler.cancel_task(tid, self.heap);
+                }
 
+                // Make waiter ready but don't add to ready queue since we're switching directly to it
+                self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
+                self.cleanup_current_task();
+                self.scheduler.set_current_task(Some(waiter_id));
+                self.load_or_init_task(waiter_id)?;
+
+                return if let Some(err) = failed_task {
+                    // Error is raised in waiter context
                     Err(err)
                 } else {
                     let results: Vec<Value> = results
@@ -391,35 +363,10 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
                     // Create result list
                     let list_id = self.heap.allocate(HeapData::List(List::new(results)))?;
 
-                    // Unblock waiter and switch to it
-                    let progress = if let Some(waiter_id) = waiter {
-                        self.scheduler.make_ready(waiter_id);
-                        // Remove from ready queue since we're switching directly to it
-                        self.scheduler.remove_from_ready_queue(waiter_id);
-                        // Clear current task's state since it's done
-                        self.cleanup_current_task();
-                        // Switch to waiter
-                        self.scheduler.set_current_task(Some(waiter_id));
-                        self.load_or_init_task(waiter_id)?;
-                        // Push the result onto the waiter's stack
-                        self.push(Value::Ref(list_id));
-                        AwaitResult::FramePushed
-                    } else {
-                        // No waiter (shouldn't happen but handle gracefully)
-                        AwaitResult::ValueReady(Value::Ref(list_id))
-                    };
-
-                    Ok(progress)
+                    // Push the result onto the waiter's stack
+                    self.push(Value::Ref(list_id));
+                    Ok(AwaitResult::FramePushed)
                 };
-
-                // Release every spawned task; this drops their owning
-                // refs to the gather and coroutines, freeing the gather
-                // (and its items) once the last task ref goes away.
-                for tid in task_ids {
-                    self.scheduler.cancel_task(tid, self.heap);
-                }
-
-                return result;
             }
         } else {
             // Drop the result (it's stored in the task state now)
@@ -481,55 +428,27 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
             };
             let gather_mut = gather.get_mut(self.heap);
             let task_ids = mem::take(&mut gather_mut.task_ids);
-            let waiter = gather_mut.waiter;
-            // Drop the HeapRead before operations that may free heap objects
+            let Some(waiter_id) = gather_mut.waiter else {
+                panic!("gather future has no waiter when handling task failure")
+            };
+            // Drop the reader before any dec_ref that could free the gather.
             drop(gather);
 
-            // Mark task as failed
-            self.scheduler.fail_task(task_id, error);
-
-            // Cancel sibling tasks (filter out self and already-finished tasks inline)
-            for sibling_id in &task_ids {
-                if *sibling_id != task_id && !self.scheduler.get_task(*sibling_id).is_finished() {
-                    self.scheduler.cancel_task(*sibling_id, self.heap);
-                }
-            }
-
-            // Clean up the gather's logical "alive awaitable" reference. Spawned
-            // tasks still hold their owning refs until removed below.
-            self.heap.dec_ref(gid);
-
-            // Switch to waiter and propagate the error
-            let propagated_err = if let Some(waiter_id) = waiter {
-                self.cleanup_current_task();
-                self.scheduler.set_current_task(Some(waiter_id));
-                self.load_or_init_task(waiter_id)?;
-                // Get error back from task state to return
-                let task = self.scheduler.get_task_mut(task_id);
-                if let TaskState::Failed(err) = mem::replace(&mut task.state, TaskState::Ready) {
-                    Some(err)
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-
-            // Release every spawned task; the last `remove_task` drops the
-            // final owning ref and frees the gather + its coroutines.
+            // Release all tasks owned by this gather
             for tid in task_ids {
                 self.scheduler.cancel_task(tid, self.heap);
             }
 
-            if let Some(err) = propagated_err {
-                return Err(err);
-            }
-        } else {
-            // No gather - just mark task as failed (ignore returned gather_id which is None)
-            let _ = self.scheduler.fail_task(task_id, error);
+            // Switch to waiter and propagate the error
+            self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
+            self.cleanup_current_task();
+            self.scheduler.set_current_task(Some(waiter_id));
+            self.load_or_init_task(waiter_id)?;
+            return Err(error);
         }
 
-        // No gather or no waiter - switch to next task
+        // No gather - just mark task as failed, switch to next task
+        self.scheduler.fail_task(task_id, error, self.heap);
         self.cleanup_current_task();
         self.scheduler.set_current_task(None);
         if let Some(next_task_id) = self.scheduler.next_ready_task() {
@@ -748,7 +667,7 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
                         .into_iter()
                         .map(|r| r.expect("all results should be filled when gather is complete"))
                         .collect();
-                    // Drop the HeapRead before dec_ref which may free the object
+                    // Drop the HeapRead before cancellation, which may free the gather
                     drop(gather);
 
                     // Release every child task
@@ -758,7 +677,6 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
 
                     if let Some(waiter_id) = waiter {
                         let list_id = self.heap.allocate(HeapData::List(List::new(results)))?;
-                        self.heap.dec_ref(gather_id);
 
                         // Push result onto waiter's stack and mark as ready.
                         // Check if the waiter's context is currently in the VM (frames not saved
@@ -770,13 +688,13 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
                         if waiter_context_in_vm {
                             // Waiter's frames are in the VM - push directly onto VM stack
                             self.stack.push(Value::Ref(list_id));
-                            // Mark as ready but don't add to ready_queue
-                            self.scheduler.get_task_mut(waiter_id).state = TaskState::Ready;
+                            // Mark as ready but don't add to ready_queue.
+                            self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
                         } else {
                             // Waiter's context is saved in the task (either spawned task,
                             // or main task that was saved when switching to spawned tasks)
                             self.scheduler.get_task_mut(waiter_id).stack.push(Value::Ref(list_id));
-                            self.scheduler.make_ready(waiter_id);
+                            self.scheduler.make_ready(waiter_id, self.heap);
                         }
                     }
                 }
@@ -827,25 +745,15 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
             }
 
             // Cancel all sibling tasks in the gather
-            for sibling_id in &task_ids {
-                self.scheduler.cancel_task(*sibling_id, self.heap);
+            for sibling_id in task_ids {
+                self.scheduler.cancel_task(sibling_id, self.heap);
             }
 
             // Fail the waiter task (the task that awaited the gather)
             if let Some(waiter_id) = waiter {
-                self.scheduler.fail_task(waiter_id, error);
-                // Release the GatherFuture's logical "alive awaitable" ref.
-                // Spawned tasks still hold owning refs until removed below.
-                self.heap.dec_ref(gather_id);
+                self.scheduler.fail_task(waiter_id, error, self.heap);
             }
-
-            // Release every spawned task; the last `remove_task` frees the
-            // gather and its coroutines. The waiter is *not* removed — it has
-            // been failed and still needs to run for the failure to propagate.
-            for tid in task_ids {
-                self.scheduler.cancel_task(tid, self.heap);
-            }
-        } else if let Some((task_id, Some(gid))) = self.scheduler.fail_for_call(call_id, error) {
+        } else if let Some((task_id, Some(gid))) = self.scheduler.fail_for_call(call_id, error, self.heap) {
             // Original path: task is directly BlockedOnCall and part of a gather
             // Take task_ids from GatherFuture - gather is being destroyed anyway
             let HeapReadOutput::GatherFuture(mut gather) = self.heap.read(gid) else {
@@ -966,14 +874,4 @@ impl<T: ResourceTracker> VM<'_, '_, T> {
 
         Ok(FrameExit::ResolveFutures(pending_call_ids))
     }
-}
-
-/// Internal enum for dispatching await operations by heap data type.
-///
-/// Used in `exec_get_awaitable` to determine which handler to call after
-/// inspecting the heap data type. This avoids borrow conflicts between
-/// the heap reference and `&mut self` needed by the handler methods.
-enum AwaitableType {
-    Coroutine,
-    GatherFuture,
 }

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -14,7 +14,7 @@ use crate::{
     args::ArgValues,
     asyncio::{CallId, TaskId},
     exception_private::RunError,
-    heap::{ContainsHeap, DropWithHeap, Heap, HeapData, HeapId},
+    heap::{ContainsHeap, DropWithHeap, Heap, HeapData, HeapId, HeapReadOutput, HeapReader},
     intern::FunctionId,
     parse::CodeRange,
     resource::ResourceTracker,
@@ -583,24 +583,54 @@ impl Scheduler {
     }
 
     /// Fails the task blocked on a specific CallId with an error.
-    ///
-    /// Used when an external function returns an error via `FutureSnapshot::resume`.
-    /// Uses `pending_calls` for O(1) lookup of the blocked task.
-    ///
-    /// # Returns
-    /// A tuple of (task_id, gather_id) if a task was found,
-    /// or None if no task was blocked on this CallId.
-    /// Callers should get siblings from `GatherFuture.task_ids` if gather_id is Some.
-    pub fn fail_for_call(
-        &mut self,
-        call_id: CallId,
-        error: RunError,
-        heap: &mut Heap<impl ResourceTracker>,
-    ) -> Option<(TaskId, Option<HeapId>)> {
+    pub fn fail_for_call(&mut self, call_id: CallId, error: RunError, heap: &mut HeapReader<'_, impl ResourceTracker>) {
         // Get blocked task from pending_calls (O(1) lookup)
-        let task_id = self.pending_calls.remove(&call_id)?.creator_task;
-        let gather_id = self.fail_task(task_id, error, heap);
-        Some((task_id, gather_id))
+        let task_id = self
+            .pending_calls
+            .remove(&call_id)
+            .expect("attempted to fail nonexistent task")
+            .creator_task;
+
+        // Check if a gather is waiting on this CallId
+        if let Some((gather_id, _result_idx)) = self.take_gather_waiter(call_id) {
+            self.remove_pending_call(call_id);
+
+            // Get the gather's waiter, task_ids, and OTHER pending calls
+            // We need to remove all pending calls for this gather from gather_waiters
+            // before we dec_ref the gather, otherwise subsequent errors for the same
+            // gather would try to access a freed heap object.
+            // Use get_mut and take to avoid allocations - gather is being destroyed anyway.
+            let HeapReadOutput::GatherFuture(mut gather) = heap.read(gather_id) else {
+                panic!("gather_id doesn't point to a GatherFuture")
+            };
+            let gather_mut = gather.get_mut(heap);
+            let mut other_pending_calls = mem::take(&mut gather_mut.pending_calls);
+            other_pending_calls.retain(|&cid| cid != call_id);
+            let Some(waiter_id) = gather_mut.waiter else {
+                panic!("gather has no waiter task")
+            };
+            let task_ids = mem::take(&mut gather_mut.task_ids);
+            // Drop the HeapRead before operations that may free heap objects
+            drop(gather);
+
+            // Remove all other pending calls for this gather from gather_waiters and pending_calls
+            // This prevents subsequent errors from trying to access the freed gather
+            for other_call_id in other_pending_calls {
+                self.take_gather_waiter(other_call_id);
+                self.remove_pending_call(other_call_id);
+            }
+
+            // Cancel all sibling tasks in the gather
+            for sibling_id in task_ids {
+                self.cancel_task(sibling_id, heap);
+            }
+
+            // Fail the waiter task (the task that awaited the gather)
+            self.fail_task(waiter_id, error, heap);
+        } else {
+            // Not a gather-related error - just fail the blocked task.
+            self.fail_task(task_id, error, heap);
+        }
     }
 
     /// Returns the task that created a specific pending call.

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -585,11 +585,12 @@ impl Scheduler {
     /// Fails the task blocked on a specific CallId with an error.
     pub fn fail_for_call(&mut self, call_id: CallId, error: RunError, heap: &mut HeapReader<'_, impl ResourceTracker>) {
         // Get blocked task from pending_calls (O(1) lookup)
-        let task_id = self
-            .pending_calls
-            .remove(&call_id)
-            .expect("attempted to fail nonexistent task")
-            .creator_task;
+        let Some(pending_call) = self.pending_calls.remove(&call_id) else {
+            // No pending call found - nothing to fail. Possibly cancelled by a sibling task failure.
+            return;
+        };
+
+        let task_id = pending_call.creator_task;
 
         // Check if a gather is waiting on this CallId
         if let Some((gather_id, _result_idx)) = self.take_gather_waiter(call_id) {

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -14,7 +14,7 @@ use crate::{
     args::ArgValues,
     asyncio::{CallId, TaskId},
     exception_private::RunError,
-    heap::{DropWithHeap, Heap, HeapData, HeapId, HeapReader},
+    heap::{ContainsHeap, DropWithHeap, Heap, HeapData, HeapId},
     intern::FunctionId,
     parse::CodeRange,
     resource::ResourceTracker,
@@ -37,6 +37,16 @@ pub(crate) enum TaskState {
     Completed(Value),
     /// Task failed with an error.
     Failed(RunError),
+}
+
+impl DropWithHeap for TaskState {
+    fn drop_with_heap<H: ContainsHeap>(self, heap: &mut H) {
+        match self {
+            Self::Ready | Self::BlockedOnCall(_) | Self::Failed(_) => {}
+            Self::BlockedOnGather(gather_id) => heap.heap_mut().dec_ref(gather_id),
+            Self::Completed(value) => value.drop_with_heap(heap),
+        }
+    }
 }
 
 /// A single async task with its own execution context.
@@ -77,6 +87,24 @@ pub(crate) struct Task {
     /// CallId that unblocked this task (set when task transitions from Blocked to Ready).
     /// Used to retrieve the resolved value when the task resumes.
     pub unblocked_by: Option<CallId>,
+}
+
+impl DropWithHeap for Task {
+    fn drop_with_heap<H: ContainsHeap>(mut self, heap: &mut H) {
+        for value in self.stack.drain(..) {
+            value.drop_with_heap(heap);
+        }
+        for value in self.exception_stack.drain(..) {
+            value.drop_with_heap(heap);
+        }
+        self.state.drop_with_heap(heap);
+        if let Some(coro_id) = self.coroutine_id.take() {
+            heap.heap_mut().dec_ref(coro_id);
+        }
+        if let Some(gid) = self.gather_id.take() {
+            heap.heap_mut().dec_ref(gid);
+        }
+    }
 }
 
 /// Serialized call frame for task storage.
@@ -199,11 +227,6 @@ impl PendingCallData {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct Scheduler {
     /// All tasks keyed by their `TaskId`.
-    ///
-    /// Sparse storage so that finished tasks can be removed during execution
-    /// without invalidating outstanding `TaskId`s. `TaskId`s are monotonically
-    /// allocated (never reused), so a `HashMap` keeps memory bounded — a
-    /// `Vec<Option<Task>>` would grow without bound across long-running sessions.
     tasks: AHashMap<TaskId, Task>,
     /// Queue of task IDs ready to execute.
     ready_queue: VecDeque<TaskId>,
@@ -410,9 +433,10 @@ impl Scheduler {
     /// Marks the current task as blocked on a GatherFuture.
     ///
     /// The task will be unblocked when all gathered tasks complete.
-    pub fn block_current_on_gather(&mut self, gather_id: HeapId) {
+    pub fn block_current_on_gather(&mut self, gather_id: HeapId, heap: &Heap<impl ResourceTracker>) {
         if let Some(task_id) = self.current_task {
             let task = self.get_task_mut(task_id);
+            heap.inc_ref(gather_id);
             task.state = TaskState::BlockedOnGather(gather_id);
         }
     }
@@ -479,10 +503,17 @@ impl Scheduler {
         self.ready_queue.pop_front()
     }
 
-    /// Adds a task back to the ready queue.
-    pub fn make_ready(&mut self, task_id: TaskId) {
+    /// Replaces a task's state, properly releasing any heap references owned
+    /// by the previous state.
+    pub fn set_state(&mut self, task_id: TaskId, new_state: TaskState, heap: &mut Heap<impl ResourceTracker>) {
         let task = self.get_task_mut(task_id);
-        task.state = TaskState::Ready;
+        let old_state = mem::replace(&mut task.state, new_state);
+        old_state.drop_with_heap(heap);
+    }
+
+    /// Adds a task back to the ready queue.
+    pub fn make_ready(&mut self, task_id: TaskId, heap: &mut Heap<impl ResourceTracker>) {
+        self.set_state(task_id, TaskState::Ready, heap);
         self.ready_queue.push_back(task_id);
     }
 
@@ -495,10 +526,8 @@ impl Scheduler {
     ///
     /// If the task is part of a gather, updates the gather's results.
     /// If this completes the gather, unblocks the waiting task.
-    pub fn complete_task(&mut self, task_id: TaskId, result: Value) {
-        let task = self.get_task_mut(task_id);
-        task.state = TaskState::Completed(result);
-        // Note: gather wake-up logic will be implemented when gather is fully integrated
+    pub fn complete_task(&mut self, task_id: TaskId, result: Value, heap: &mut Heap<impl ResourceTracker>) {
+        self.set_state(task_id, TaskState::Completed(result), heap);
     }
 
     /// Marks a task as failed with an error.
@@ -508,10 +537,14 @@ impl Scheduler {
     ///
     /// # Returns
     /// The gather_id if this task belongs to a gather (for sibling lookup).
-    pub fn fail_task(&mut self, task_id: TaskId, error: RunError) -> Option<HeapId> {
-        let task = self.get_task_mut(task_id);
-        let gather_id = task.gather_id;
-        task.state = TaskState::Failed(error);
+    pub fn fail_task(
+        &mut self,
+        task_id: TaskId,
+        error: RunError,
+        heap: &mut Heap<impl ResourceTracker>,
+    ) -> Option<HeapId> {
+        let gather_id = self.get_task(task_id).gather_id;
+        self.set_state(task_id, TaskState::Failed(error), heap);
         gather_id
     }
 
@@ -523,50 +556,30 @@ impl Scheduler {
     /// call the task no longer exists in `Scheduler::tasks`; its owning
     /// references to its coroutine and (outer) gather are released by
     /// [`Scheduler::remove_task`].
-    pub fn cancel_task(&mut self, task_id: TaskId, heap: &mut HeapReader<'_, impl ResourceTracker>) {
+    pub fn cancel_task(&mut self, task_id: TaskId, heap: &mut Heap<impl ResourceTracker>) {
         // No-op if the task has already been removed (idempotent — finalization
         // sites may iterate task ids that include already-cancelled siblings).
-        let Some(task) = self.tasks.get(&task_id) else {
+        let Some(task) = self.tasks.remove(&task_id) else {
             return;
         };
-        // Already finished: just remove (drops any Completed value alongside
-        // the rest of the per-task state).
-        if task.is_finished() {
-            self.remove_task(task_id, heap);
-            return;
-        }
 
-        // Remove from ready queue if present (do this before getting mutable task reference)
-        self.ready_queue.retain(|&id| id != task_id);
+        if !task.is_finished() {
+            // Remove from ready queue if present (do this before getting mutable task reference)
+            self.ready_queue.retain(|&id| id != task_id);
 
-        // If blocked on a nested gather, recursively cancel inner tasks first.
-        // Each recursive cancel_task ends in remove_task, which dec_refs that
-        // task's owning ref to the inner gather and its coroutine.
-        let inner_gather_info = {
-            let task = self.get_task(task_id);
+            // If blocked on a nested gather, recursively cancel inner tasks first.
             if let TaskState::BlockedOnGather(gather_id) = task.state {
-                if let HeapData::GatherFuture(gather) = heap.get(gather_id) {
-                    Some((gather_id, gather.task_ids.clone()))
-                } else {
-                    None
+                let HeapData::GatherFuture(gather) = heap.get(gather_id) else {
+                    panic!("Scheduler::cancel_task: expected GatherFuture heap entry for gather_id {gather_id:?}");
+                };
+                let inner_task_ids = gather.task_ids.clone();
+                for inner_task_id in inner_task_ids {
+                    self.cancel_task(inner_task_id, heap);
                 }
-            } else {
-                None
             }
-        };
-
-        if let Some((inner_gather_id, inner_task_ids)) = inner_gather_info {
-            for inner_task_id in inner_task_ids {
-                self.cancel_task(inner_task_id, heap);
-            }
-            // Per-task owning refs to the inner gather have already been
-            // released by the recursive cancellations. Drop the inner gather's
-            // logical "alive awaitable" reference; the cascade frees its
-            // remaining items and any partial results.
-            heap.dec_ref(inner_gather_id);
         }
 
-        self.remove_task(task_id, heap);
+        task.drop_with_heap(heap);
     }
 
     /// Fails the task blocked on a specific CallId with an error.
@@ -578,10 +591,15 @@ impl Scheduler {
     /// A tuple of (task_id, gather_id) if a task was found,
     /// or None if no task was blocked on this CallId.
     /// Callers should get siblings from `GatherFuture.task_ids` if gather_id is Some.
-    pub fn fail_for_call(&mut self, call_id: CallId, error: RunError) -> Option<(TaskId, Option<HeapId>)> {
+    pub fn fail_for_call(
+        &mut self,
+        call_id: CallId,
+        error: RunError,
+        heap: &mut Heap<impl ResourceTracker>,
+    ) -> Option<(TaskId, Option<HeapId>)> {
         // Get blocked task from pending_calls (O(1) lookup)
         let task_id = self.pending_calls.remove(&call_id)?.creator_task;
-        let gather_id = self.fail_task(task_id, error);
+        let gather_id = self.fail_task(task_id, error, heap);
         Some((task_id, gather_id))
     }
 
@@ -601,39 +619,6 @@ impl Scheduler {
             .is_some_and(|task| matches!(task.state, TaskState::Failed(_)))
     }
 
-    /// Removes a task from the scheduler, dropping all of its owned resources.
-    ///
-    /// Drops the task's stack values, exception stack, any pending `Completed`
-    /// result, and `dec_ref`s the owning `coroutine_id` / `gather_id` references
-    /// established by [`Scheduler::spawn`].
-    ///
-    /// No-op if the task id is unknown.
-    ///
-    /// # Caller responsibility
-    /// Callers must ensure no other code path still holds the `TaskId` (e.g.,
-    /// `current_task` has been swapped to a different task, the task is no
-    /// longer in any `gather.task_ids`, no pending call references it).
-    fn remove_task(&mut self, task_id: TaskId, heap: &mut Heap<impl ResourceTracker>) {
-        let Some(mut task) = self.tasks.remove(&task_id) else {
-            return;
-        };
-        for value in mem::take(&mut task.stack) {
-            value.drop_with_heap(heap);
-        }
-        for value in mem::take(&mut task.exception_stack) {
-            value.drop_with_heap(heap);
-        }
-        if let TaskState::Completed(value) = mem::replace(&mut task.state, TaskState::Ready) {
-            value.drop_with_heap(heap);
-        }
-        if let Some(coro_id) = task.coroutine_id.take() {
-            heap.dec_ref(coro_id);
-        }
-        if let Some(gid) = task.gather_id.take() {
-            heap.dec_ref(gid);
-        }
-    }
-
     /// Cleans up all scheduler resources: pending calls, resolved values, and
     /// every remaining task (via [`Scheduler::remove_task`]).
     pub fn cleanup(&mut self, heap: &mut Heap<impl ResourceTracker>) {
@@ -649,7 +634,7 @@ impl Scheduler {
         // cleanup uniformly via `remove_task`.
         let task_ids: Vec<TaskId> = self.tasks.keys().copied().collect();
         for task_id in task_ids {
-            self.remove_task(task_id, heap);
+            self.cancel_task(task_id, heap);
         }
     }
 }

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -12,9 +12,9 @@ use ahash::{AHashMap, AHashSet};
 
 use crate::{
     args::ArgValues,
-    asyncio::{CallId, GatherItem, TaskId},
-    exception_private::{ExcType, RunError, SimpleException},
-    heap::{DropWithHeap, Heap, HeapData, HeapId, HeapReadOutput, HeapReader},
+    asyncio::{CallId, TaskId},
+    exception_private::RunError,
+    heap::{DropWithHeap, Heap, HeapData, HeapId, HeapReader},
     intern::FunctionId,
     parse::CodeRange,
     resource::ResourceTracker,
@@ -135,7 +135,9 @@ impl Task {
     /// Suspended tasks keep their operand stack and exception stack outside the
     /// live VM state. GC must therefore walk both the saved values and the task's
     /// scheduler metadata, otherwise reachable heap entries can be swept while the
-    /// task is blocked.
+    /// task is blocked. `coroutine_id` and `gather_id` are owning references
+    /// (inc_ref'd in [`Scheduler::spawn`], dec_ref'd in [`Scheduler::remove_task`])
+    /// so they participate in the root set.
     fn extend_gc_roots(&self, roots: &mut Vec<HeapId>) {
         roots.extend(self.stack.iter().filter_map(Value::ref_id));
         roots.extend(self.exception_stack.iter().filter_map(Value::ref_id));
@@ -196,8 +198,13 @@ impl PendingCallData {
 /// (the VM holds it). Spawned tasks (1+) store their context in the Task struct.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct Scheduler {
-    /// All tasks (main task at index 0, spawned tasks follow).
-    tasks: Vec<Task>,
+    /// All tasks keyed by their `TaskId`.
+    ///
+    /// Sparse storage so that finished tasks can be removed during execution
+    /// without invalidating outstanding `TaskId`s. `TaskId`s are monotonically
+    /// allocated (never reused), so a `HashMap` keeps memory bounded — a
+    /// `Vec<Option<Task>>` would grow without bound across long-running sessions.
+    tasks: AHashMap<TaskId, Task>,
     /// Queue of task IDs ready to execute.
     ready_queue: VecDeque<TaskId>,
     /// Currently executing task (None only during task switching).
@@ -226,13 +233,16 @@ impl Scheduler {
     /// It starts as the current task (not in the ready queue) since it runs
     /// immediately without needing to be scheduled.
     pub fn new() -> Self {
-        let mut main_task = Task::new(TaskId::default(), None, None, None);
+        let main_task_id = TaskId::default();
+        let mut main_task = Task::new(main_task_id, None, None, None);
         // Main task starts Running, not Ready (it's the current task, not waiting)
         main_task.state = TaskState::Ready; // Will be set properly when it blocks
+        let mut tasks = AHashMap::new();
+        tasks.insert(main_task_id, main_task);
         Self {
-            tasks: vec![main_task],
+            tasks,
             ready_queue: VecDeque::new(), // Main task is current, not in ready queue
-            current_task: Some(TaskId::default()),
+            current_task: Some(main_task_id),
             next_task_id: 1,
             next_call_id: 0,
             pending_calls: AHashMap::new(),
@@ -248,7 +258,7 @@ impl Scheduler {
     /// blocked tasks, resolved futures, and gather bookkeeping all live in the
     /// scheduler and must therefore participate in the GC root set.
     pub(crate) fn extend_gc_roots(&self, roots: &mut Vec<HeapId>) {
-        for task in &self.tasks {
+        for task in self.tasks.values() {
             task.extend_gc_roots(roots);
         }
         for data in self.pending_calls.values() {
@@ -272,7 +282,7 @@ impl Scheduler {
     /// Panics if the task ID doesn't exist.
     #[inline]
     pub fn get_task(&self, task_id: TaskId) -> &Task {
-        &self.tasks[task_id.raw() as usize]
+        self.tasks.get(&task_id).expect("Scheduler::get_task: task not found")
     }
 
     /// Returns a mutable reference to a task by ID.
@@ -281,7 +291,9 @@ impl Scheduler {
     /// Panics if the task ID doesn't exist.
     #[inline]
     pub fn get_task_mut(&mut self, task_id: TaskId) -> &mut Task {
-        &mut self.tasks[task_id.raw() as usize]
+        self.tasks
+            .get_mut(&task_id)
+            .expect("Scheduler::get_task_mut: task not found")
     }
 
     /// Allocates a new CallId for an external function call.
@@ -374,7 +386,10 @@ impl Scheduler {
     /// for that call and clears the `unblocked_by` field.
     /// Returns `None` if the task wasn't unblocked by a resolved call.
     pub fn take_resolved_for_task(&mut self, task_id: TaskId) -> Option<Value> {
-        let task = &mut self.tasks[task_id.raw() as usize];
+        let task = self
+            .tasks
+            .get_mut(&task_id)
+            .expect("Scheduler::take_resolved_for_task: task not found");
         if let Some(call_id) = task.unblocked_by.take() {
             self.resolved.remove(&call_id)
         } else {
@@ -420,7 +435,13 @@ impl Scheduler {
     /// Creates a new task that will execute the given coroutine when scheduled.
     /// The task is added to the ready queue.
     ///
+    /// Both `coroutine_id` and `gather_id` (when present) become **owning**
+    /// references held by the new task — `inc_ref` is called on each before
+    /// storing. The matching `dec_ref` happens in [`Scheduler::remove_task`]
+    /// when the task is eventually removed (typically at gather finalization).
+    ///
     /// # Arguments
+    /// * `heap` - Heap to increment reference counts in
     /// * `coroutine_id` - HeapId of the coroutine to execute
     /// * `gather_id` - Optional HeapId of the GatherFuture this task belongs to
     /// * `gather_result_idx` - Optional index in the gather's results for this task
@@ -429,6 +450,7 @@ impl Scheduler {
     /// The TaskId of the newly created task.
     pub fn spawn(
         &mut self,
+        heap: &Heap<impl ResourceTracker>,
         coroutine_id: HeapId,
         gather_id: Option<HeapId>,
         gather_result_idx: Option<usize>,
@@ -436,8 +458,15 @@ impl Scheduler {
         let task_id = TaskId::new(self.next_task_id);
         self.next_task_id += 1;
 
+        // Take ownership of the heap references — the task now holds an inc_ref'd
+        // pointer to its coroutine and (if applicable) its enclosing gather.
+        heap.inc_ref(coroutine_id);
+        if let Some(gid) = gather_id {
+            heap.inc_ref(gid);
+        }
+
         let task = Task::new(task_id, Some(coroutine_id), gather_id, gather_result_idx);
-        self.tasks.push(task);
+        self.tasks.insert(task_id, task);
         self.ready_queue.push_back(task_id);
 
         task_id
@@ -486,40 +515,36 @@ impl Scheduler {
         gather_id
     }
 
-    /// Cancels a task, cleaning up its resources.
+    /// Cancels a task, fully releasing its resources and removing it from the
+    /// scheduler.
     ///
-    /// This marks the task as Failed with a cancellation error and cleans up:
-    /// - Stack values
-    /// - Exception stack values
-    /// - Frame cell references
-    /// - Frame namespaces
-    /// - Nested gathers (if the task was blocked on one)
-    /// - Completed task results (if task finished before cancellation)
-    ///
-    /// The caller is responsible for cleaning up the task's coroutine on the heap.
-    ///
-    /// # Arguments
-    /// * `task_id` - ID of the task to cancel
-    /// * `heap` - Heap for dropping values and cell cleanup
+    /// Drops the task's stack, exception stack, any pending `Completed` result,
+    /// and recursively cancels any inner gather it was blocked on. After this
+    /// call the task no longer exists in `Scheduler::tasks`; its owning
+    /// references to its coroutine and (outer) gather are released by
+    /// [`Scheduler::remove_task`].
     pub fn cancel_task(&mut self, task_id: TaskId, heap: &mut HeapReader<'_, impl ResourceTracker>) {
-        // If task already finished, clean up its result value and return
-        if self.get_task(task_id).is_finished() {
-            let task = self.get_task_mut(task_id);
-            if let TaskState::Completed(value) = mem::replace(&mut task.state, TaskState::Ready) {
-                value.drop_with_heap(heap);
-            }
-            // Note: Failed tasks don't have values to clean up (RunError doesn't contain Values)
+        // No-op if the task has already been removed (idempotent — finalization
+        // sites may iterate task ids that include already-cancelled siblings).
+        let Some(task) = self.tasks.get(&task_id) else {
+            return;
+        };
+        // Already finished: just remove (drops any Completed value alongside
+        // the rest of the per-task state).
+        if task.is_finished() {
+            self.remove_task(task_id, heap);
             return;
         }
 
         // Remove from ready queue if present (do this before getting mutable task reference)
         self.ready_queue.retain(|&id| id != task_id);
 
-        // Check if task is blocked on a gather and get the gather info before mutating task
+        // If blocked on a nested gather, recursively cancel inner tasks first.
+        // Each recursive cancel_task ends in remove_task, which dec_refs that
+        // task's owning ref to the inner gather and its coroutine.
         let inner_gather_info = {
             let task = self.get_task(task_id);
             if let TaskState::BlockedOnGather(gather_id) = task.state {
-                // Get inner gather's task IDs from heap
                 if let HeapData::GatherFuture(gather) = heap.get(gather_id) {
                     Some((gather_id, gather.task_ids.clone()))
                 } else {
@@ -530,57 +555,18 @@ impl Scheduler {
             }
         };
 
-        // Recursively cancel inner gather's tasks first
         if let Some((inner_gather_id, inner_task_ids)) = inner_gather_info {
             for inner_task_id in inner_task_ids {
                 self.cancel_task(inner_task_id, heap);
             }
-
-            // Cleanup the inner GatherFuture
-            let HeapReadOutput::GatherFuture(mut gather) = heap.read(inner_gather_id) else {
-                panic!("inner_gather_id doesn't point to a GatherFuture")
-            };
-            let gather_mut = gather.get_mut(heap);
-            let items = mem::take(&mut gather_mut.items);
-            let results = mem::take(&mut gather_mut.results);
-
-            // Now cleanup the extracted data with mutable heap access
-            for item in items {
-                if let GatherItem::Coroutine(coro_id) = item {
-                    heap.dec_ref(coro_id);
-                }
-            }
-            for value in results.into_iter().flatten() {
-                value.drop_with_heap(heap);
-            }
-
-            // Dec_ref the gather itself
-            drop(gather);
+            // Per-task owning refs to the inner gather have already been
+            // released by the recursive cancellations. Drop the inner gather's
+            // logical "alive awaitable" reference; the cascade frees its
+            // remaining items and any partial results.
             heap.dec_ref(inner_gather_id);
         }
 
-        // Now get mutable reference to the task for cleanup
-        let task = self.get_task_mut(task_id);
-
-        // Clean up stack values
-        for value in mem::take(&mut task.stack) {
-            value.drop_with_heap(heap);
-        }
-
-        // Clean up exception stack values
-        for value in mem::take(&mut task.exception_stack) {
-            value.drop_with_heap(heap);
-        }
-
-        // Restore this task's depth contribution before cleanup,
-        // since save_task_context subtracted it.
-        let task_depth = task.frames.len();
-        let global_depth = heap.get_recursion_depth();
-        heap.set_recursion_depth(global_depth + task_depth);
-        task.frames.clear();
-
-        // Mark as failed with a cancellation error
-        task.state = TaskState::Failed(SimpleException::new_msg(ExcType::RuntimeError, "task was cancelled").into());
+        self.remove_task(task_id, heap);
     }
 
     /// Fails the task blocked on a specific CallId with an error.
@@ -610,15 +596,46 @@ impl Scheduler {
     /// Returns true if a task has been cancelled or failed.
     #[inline]
     pub fn is_task_failed(&self, task_id: TaskId) -> bool {
-        matches!(self.tasks.get(task_id.raw() as usize), Some(task) if matches!(task.state, TaskState::Failed(_)))
+        self.tasks
+            .get(&task_id)
+            .is_some_and(|task| matches!(task.state, TaskState::Failed(_)))
     }
 
-    /// Cleans up all scheduler resources: pending calls, resolved values, task
-    /// stacks/exception stacks, completed results, and task frame cell references.
+    /// Removes a task from the scheduler, dropping all of its owned resources.
     ///
-    /// Each task's `recursion_depth` is restored to the global counter before
-    /// dropping cells, because `save_task_context` subtracted the recursion depth
-    /// and cleanup needs the correct depth to avoid underflow.
+    /// Drops the task's stack values, exception stack, any pending `Completed`
+    /// result, and `dec_ref`s the owning `coroutine_id` / `gather_id` references
+    /// established by [`Scheduler::spawn`].
+    ///
+    /// No-op if the task id is unknown.
+    ///
+    /// # Caller responsibility
+    /// Callers must ensure no other code path still holds the `TaskId` (e.g.,
+    /// `current_task` has been swapped to a different task, the task is no
+    /// longer in any `gather.task_ids`, no pending call references it).
+    fn remove_task(&mut self, task_id: TaskId, heap: &mut Heap<impl ResourceTracker>) {
+        let Some(mut task) = self.tasks.remove(&task_id) else {
+            return;
+        };
+        for value in mem::take(&mut task.stack) {
+            value.drop_with_heap(heap);
+        }
+        for value in mem::take(&mut task.exception_stack) {
+            value.drop_with_heap(heap);
+        }
+        if let TaskState::Completed(value) = mem::replace(&mut task.state, TaskState::Ready) {
+            value.drop_with_heap(heap);
+        }
+        if let Some(coro_id) = task.coroutine_id.take() {
+            heap.dec_ref(coro_id);
+        }
+        if let Some(gid) = task.gather_id.take() {
+            heap.dec_ref(gid);
+        }
+    }
+
+    /// Cleans up all scheduler resources: pending calls, resolved values, and
+    /// every remaining task (via [`Scheduler::remove_task`]).
     pub fn cleanup(&mut self, heap: &mut Heap<impl ResourceTracker>) {
         // Drop pending call arguments
         for (_, data) in mem::take(&mut self.pending_calls) {
@@ -628,22 +645,11 @@ impl Scheduler {
         for (_, value) in mem::take(&mut self.resolved) {
             value.drop_with_heap(heap);
         }
-        // Drop task stack/exception values and completed results
-        for task in &mut self.tasks {
-            for value in mem::take(&mut task.stack) {
-                value.drop_with_heap(heap);
-            }
-            for value in mem::take(&mut task.exception_stack) {
-                value.drop_with_heap(heap);
-            }
-            if let TaskState::Completed(value) = mem::replace(&mut task.state, TaskState::Ready) {
-                value.drop_with_heap(heap);
-            }
-            // Restore recursion depth and clear frames
-            let task_depth = task.frames.len();
-            let global_depth = heap.get_recursion_depth();
-            heap.set_recursion_depth(global_depth + task_depth);
-            task.frames.clear();
+        // Remove every remaining task — drains the map and runs the per-task
+        // cleanup uniformly via `remove_task`.
+        let task_ids: Vec<TaskId> = self.tasks.keys().copied().collect();
+        for task_id in task_ids {
+            self.remove_task(task_id, heap);
         }
     }
 }

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -1236,9 +1236,7 @@ impl<T: ResourceTracker> Heap<T> {
             reachable[idx] = true;
 
             // Add children to work list
-            if let Some(entry) = self.entries.get_mut(idx) {
-                collect_child_ids(entry.data.0.get_mut(), &mut work_list);
-            }
+            collect_child_ids(self.get(id), &mut work_list);
         }
 
         // Sweep phase: free unreachable values


### PR DESCRIPTION
I was tightening up `collect_garbage` in heap.rs to expect that all heap IDs traversed are real. Turns out when I did this that it's possible for an async `Task` to have dangling references to coroutines / gathers.

Almost certainly a bug, so I changed the code to have `Task` and `TaskState` have ownership of their contained `HeapId` references. This makes refcounting cleaner across the async code.