### PR TITLE
fix: avoid panic when list.sort() key callback mutates the list

### DIFF
--- a/crates/monty/src/builtins/sorted.rs
+++ b/crates/monty/src/builtins/sorted.rs
@@ -1,7 +1,5 @@
 //! Implementation of the sorted() builtin function.
 
-use itertools::Itertools;
-
 use crate::{
     args::ArgValues,
     bytecode::VM,
@@ -9,7 +7,7 @@ use crate::{
     exception_private::{ExcType, RunResult, SimpleException},
     heap::{DropWithHeap, HeapData, HeapGuard},
     resource::ResourceTracker,
-    sorting::{apply_permutation, sort_indices},
+    sorting::sort_values,
     types::{List, MontyIter, PyTrait},
     value::Value,
 };
@@ -27,36 +25,7 @@ pub fn builtin_sorted(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) ->
     let mut items_guard = HeapGuard::new(items, vm);
     let (items, vm) = items_guard.as_parts_mut();
 
-    {
-        // Compute key values if a key function was provided, otherwise we'll sort by the items themselves
-        let mut keys_guard;
-        let (compare_values, vm) = if let Some(f) = key_fn {
-            let keys: Vec<Value> = Vec::with_capacity(items.len());
-            // Use a HeapGuard to ensure that if key function evaluation fails partway through,
-            // we clean up any keys that were successfully computed
-            keys_guard = HeapGuard::new(keys, vm);
-            let (keys, vm) = keys_guard.as_parts_mut();
-            items
-                .iter()
-                .map(|item| {
-                    let item = item.clone_with_heap(vm);
-                    vm.evaluate_function("sorted() key argument", f, ArgValues::One(item))
-                })
-                .process_results(|keys_iter| keys.extend(keys_iter))?;
-            keys_guard.as_parts()
-        } else {
-            (&*items, vm)
-        };
-
-        // Sort indices by comparing key values (or items themselves if no key)
-        let len = compare_values.len();
-        let mut indices: Vec<usize> = (0..len).collect();
-
-        sort_indices(&mut indices, compare_values, reverse, vm)?;
-
-        // Rearrange items in-place according to the sorted permutation
-        apply_permutation(items, &mut indices);
-    }
+    sort_values(items, key_fn.as_ref(), reverse, vm)?;
 
     let (items, vm) = items_guard.into_parts();
     let heap_id = vm.heap.allocate(HeapData::List(List::new(items)))?;

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1230,6 +1230,18 @@ impl ExcType {
         SimpleException::new_msg(Self::ValueError, "list.remove(x): x not in list").into()
     }
 
+    /// Creates a ValueError for `list.sort()` when the list was reentrantly
+    /// mutated by a user-supplied `key` callback (or comparison) during the sort.
+    ///
+    /// CPython detaches the list's storage for the duration of the sort so the
+    /// list looks empty to reentrant code, then raises this error if the user
+    /// re-populated the list while the sort was in progress. Matches CPython's
+    /// exact message: `ValueError: list modified during sort`.
+    #[must_use]
+    pub(crate) fn value_error_list_modified_during_sort() -> RunError {
+        SimpleException::new_msg(Self::ValueError, "list modified during sort").into()
+    }
+
     /// Creates an IndexError for popping from an empty list.
     ///
     /// Matches CPython's format: `IndexError: pop from empty list`

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1230,18 +1230,6 @@ impl ExcType {
         SimpleException::new_msg(Self::ValueError, "list.remove(x): x not in list").into()
     }
 
-    /// Creates a ValueError for `list.sort()` when the list was reentrantly
-    /// mutated by a user-supplied `key` callback (or comparison) during the sort.
-    ///
-    /// CPython detaches the list's storage for the duration of the sort so the
-    /// list looks empty to reentrant code, then raises this error if the user
-    /// re-populated the list while the sort was in progress. Matches CPython's
-    /// exact message: `ValueError: list modified during sort`.
-    #[must_use]
-    pub(crate) fn value_error_list_modified_during_sort() -> RunError {
-        SimpleException::new_msg(Self::ValueError, "list modified during sort").into()
-    }
-
     /// Creates an IndexError for popping from an empty list.
     ///
     /// Matches CPython's format: `IndexError: pop from empty list`

--- a/crates/monty/src/sorting.rs
+++ b/crates/monty/src/sorting.rs
@@ -11,12 +11,48 @@
 use std::cmp::Ordering;
 
 use crate::{
+    args::ArgValues,
     bytecode::VM,
-    exception_private::{ExcType, RunError},
+    defer_drop_mut,
+    exception_private::{ExcType, RunError, RunResult},
     resource::ResourceTracker,
     types::PyTrait,
     value::Value,
 };
+
+/// Sorts a vector of values, with optional key function.
+pub fn sort_values(
+    values: &mut [Value],
+    key_fn: Option<&Value>,
+    reverse: bool,
+    vm: &mut VM<'_, impl ResourceTracker>,
+) -> RunResult<()> {
+    if let Some(f) = key_fn {
+        // Sort by key function: compute all the keys, sort an index buffer, then
+        // rearrange the original values in-place according to the sorted indices.
+        let mut indices = (0..values.len()).collect::<Vec<_>>();
+        let keys: Vec<Value> = Vec::with_capacity(values.len());
+        defer_drop_mut!(keys, vm);
+
+        for item in values.iter() {
+            let item = item.clone_with_heap(vm);
+            keys.push(vm.evaluate_function("sorted() key argument", f, ArgValues::One(item))?);
+        }
+
+        // 2. Sort indices by comparing key values (or values themselves if no key)
+        sort_indices(&mut indices, keys, reverse, vm)?;
+
+        // 3. Rearrange values in-place in the detached buffer.
+        apply_permutation(values, &mut indices);
+
+        Ok(())
+    } else {
+        // With no key function can sort directly on the original array
+        let mut sort_result: RunResult<()> = Ok(());
+        values.sort_by(|a, b| compare_values(a, b, reverse, &mut sort_result, vm));
+        sort_result
+    }
+}
 
 /// Sorts a vector of indices by comparing items at those positions.
 ///
@@ -32,43 +68,9 @@ pub fn sort_indices(
     reverse: bool,
     vm: &mut VM<'_, impl ResourceTracker>,
 ) -> Result<(), RunError> {
-    let mut sort_error: Option<RunError> = None;
-
-    indices.sort_by(|&a, &b| {
-        if sort_error.is_some() {
-            return Ordering::Equal;
-        }
-        if let Err(e) = vm.heap.check_time() {
-            sort_error = Some(e.into());
-            return Ordering::Equal;
-        }
-        match values[a].py_cmp(&values[b], vm) {
-            Ok(Some(ord)) => {
-                if reverse {
-                    ord.reverse()
-                } else {
-                    ord
-                }
-            }
-            Ok(None) => {
-                sort_error = Some(ExcType::type_error(format!(
-                    "'<' not supported between instances of '{}' and '{}'",
-                    values[a].py_type(vm),
-                    values[b].py_type(vm)
-                )));
-                Ordering::Equal
-            }
-            Err(e) => {
-                sort_error = Some(e.into());
-                Ordering::Equal
-            }
-        }
-    });
-
-    match sort_error {
-        Some(err) => Err(err),
-        None => Ok(()),
-    }
+    let mut sort_result: RunResult<()> = Ok(());
+    indices.sort_by(|&a, &b| compare_values(&values[a], &values[b], reverse, &mut sort_result, vm));
+    sort_result
 }
 
 /// Rearranges `items` in-place according to a permutation of indices.
@@ -98,4 +100,33 @@ pub fn apply_permutation<T>(items: &mut [T], indices: &mut [usize]) {
             current = target;
         }
     }
+}
+
+/// Helper for the sort functions which compares two values, handling any exceptions and timeouts.
+fn compare_values(
+    a: &Value,
+    b: &Value,
+    reverse: bool,
+    sort_result: &mut RunResult<()>,
+    vm: &mut VM<'_, impl ResourceTracker>,
+) -> Ordering {
+    if sort_result.is_err() {
+        // short-circuit if we've already encountered an error in a previous comparison
+        return Ordering::Equal;
+    }
+    if let Err(e) = vm.heap.check_time() {
+        *sort_result = Err(e.into());
+        return Ordering::Equal;
+    }
+    let err = match a.py_cmp(b, vm) {
+        Ok(Some(ord)) => return if reverse { ord.reverse() } else { ord },
+        Ok(None) => ExcType::type_error(format!(
+            "'<' not supported between instances of '{}' and '{}'",
+            a.py_type(vm),
+            b.py_type(vm)
+        )),
+        Err(e) => e.into(),
+    };
+    *sort_result = Err(err);
+    Ordering::Equal
 }

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -8,7 +8,7 @@ use crate::{
     args::ArgValues,
     bytecode::{CallResult, VM},
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, RunError, RunResult},
+    exception_private::{ExcType, RunError, RunResult, SimpleException},
     heap::{DropWithHeap, Heap, HeapData, HeapGuard, HeapId, HeapItem, HeapRead, HeapReadOutput, HeapReader},
     intern::StaticStrings,
     resource::{ResourceError, ResourceTracker},
@@ -703,13 +703,10 @@ fn list_count<'h>(
 /// methods) that may reentrantly mutate the same list, we follow CPython's
 /// strategy: the list's `items` vector is **detached** for the duration of the
 /// sort so the list looks empty to any reentrant code. All sort work is then
-/// performed on the detached buffer. After sorting, if the list is still empty
-/// we restore the (now sorted) buffer; if the user repopulated the list during
-/// the sort we discard our buffer and raise
-/// `ValueError: list modified during sort`, matching CPython exactly.
-///
-/// This avoids the previous panic where a stale loop-bound captured before
-/// iteration could index past the live list's length after a callback shrank it.
+/// performed on the detached buffer, which is always swapped back into the
+/// list afterwards. If the user mutated the live (empty) list during the
+/// sort, we additionally raise `ValueError: list modified during sort`,
+/// matching CPython exactly.
 fn do_list_sort<'h>(
     list: &mut HeapRead<'h, List>,
     args: ArgValues,
@@ -738,85 +735,60 @@ fn do_list_sort<'h>(
     defer_drop!(key_fn, vm);
 
     // Detach the list's items so reentrant access via the list's heap id sees
-    // an empty list. The detached items still carry their existing refcounts;
-    // we'll either move them back into the list (success) or drop them
-    // (mutation detected / error during sort).
+    // an empty list. The detached buffer is always swapped back into the list
+    // when we're done.
     let items = mem::take(&mut list.get_mut(vm.heap).items);
     let mut items_guard = HeapGuard::new(items, vm);
     let (items, vm) = items_guard.as_parts_mut();
 
-    let sort_result = sort_detached_items(items, key_fn.as_ref(), reverse, vm);
+    // 1. Compute key values if a key function was provided, otherwise we'll
+    // sort by the items themselves.
+    let sort_result = (|| -> Result<(), RunError> {
+        let compare_values = if let Some(f) = key_fn.as_ref() {
+            let keys: Vec<Value> = Vec::with_capacity(items.len());
+            // Use a HeapGuard to ensure that if key function evaluation fails partway through,
+            // we clean up any keys that were successfully computed
+            let mut keys_guard = HeapGuard::new(keys, vm);
+            let (keys, vm) = keys_guard.as_parts_mut();
+            for item in items.iter() {
+                let item = item.clone_with_heap(vm);
+                keys.push(vm.evaluate_function("sorted() key argument", f, ArgValues::One(item))?);
+            }
+            keys_guard.into_inner()
+        } else {
+            items.iter().map(|item| item.clone_with_heap(vm.heap)).collect()
+        };
+        defer_drop!(compare_values, vm);
 
-    // Re-attach the detached items. CPython's semantics: regardless of whether
-    // the user mutated the list during the sort, we always restore the detached
-    // buffer (which holds the original refs sorted-or-partially-sorted) so
-    // refcounts stay consistent. If the user *did* mutate the list, we drop
-    // their interleaved values first, then put our buffer back, then surface
-    // the `ValueError: list modified during sort` after any pre-existing sort
-    // error.
-    let (items, vm) = items_guard.into_parts();
-    let was_modified = !list.get(vm.heap).items.is_empty();
-    if was_modified {
-        // Discard whatever the user appended/inserted on the empty live list.
-        mem::take(&mut list.get_mut(vm.heap).items).drop_with_heap(vm);
-    }
-    // Restore the detached buffer (sorted on success, partially-permuted on
-    // sort error). The `contains_refs` flag was not cleared by `mem::take`
-    // (only the Vec was taken), so it correctly still describes the buffer
-    // being put back.
-    *list.get_mut(vm.heap).as_vec_mut() = items;
+        // 2. Sort indices by comparing key values (or items themselves if no key)
+        let len = compare_values.len();
+        let mut indices: Vec<usize> = (0..len).collect();
+
+        sort_indices(&mut indices, compare_values, reverse, vm)?;
+
+        // 3. Rearrange items in-place in the detached buffer.
+        apply_permutation(items, &mut indices);
+
+        Ok(())
+    })();
+
+    // Swap our (sorted) buffer back into the list. Whatever the user placed
+    // on the live empty list during the sort ends up in `user_items`; if
+    // it's not empty, the user mutated the list. The `contains_refs` flag
+    // survives `mem::take`, so it still describes the buffer being swapped
+    // back.
+    let (mut user_items, vm) = items_guard.into_parts();
+    mem::swap(list.get_mut(vm.heap).as_vec_mut(), &mut user_items);
+    let was_modified = !user_items.is_empty();
+    user_items.drop_with_heap(vm);
 
     // Surface any sort error first; otherwise the modification error (if any).
     sort_result?;
     if was_modified {
-        Err(ExcType::value_error_list_modified_during_sort())
+        Err(SimpleException::new_msg(ExcType::ValueError, "list modified during sort").into())
     } else {
         Ok(())
     }
-}
-
-/// Performs the actual sort work on a detached items buffer.
-///
-/// Extracted from [`do_list_sort`] so the caller can use a single
-/// detach/re-attach scope around the work and uniformly handle reentrant
-/// list mutation regardless of where in the sort it occurred.
-fn sort_detached_items(
-    items: &mut [Value],
-    key_fn: Option<&Value>,
-    reverse: bool,
-    vm: &mut VM<'_, impl ResourceTracker>,
-) -> Result<(), RunError> {
-    // 1. Compute key values if a key function was provided, otherwise we'll
-    // sort by the items themselves.
-    let compare_values = if let Some(f) = key_fn {
-        let keys: Vec<Value> = Vec::with_capacity(items.len());
-        // Use a HeapGuard to ensure that if key function evaluation fails partway through,
-        // we clean up any keys that were successfully computed
-        let mut keys_guard = HeapGuard::new(keys, vm);
-        let (keys, vm) = keys_guard.as_parts_mut();
-        // Iterate the detached buffer directly. Reentrant mutation via the
-        // list's heap id targets the empty live list, not this buffer, so we
-        // never observe a shifting length here.
-        for item in items.iter() {
-            let item = item.clone_with_heap(vm);
-            keys.push(vm.evaluate_function("sorted() key argument", f, ArgValues::One(item))?);
-        }
-        keys_guard.into_inner()
-    } else {
-        items.iter().map(|item| item.clone_with_heap(vm.heap)).collect()
-    };
-    defer_drop!(compare_values, vm);
-
-    // 2. Sort indices by comparing key values (or items themselves if no key)
-    let len = compare_values.len();
-    let mut indices: Vec<usize> = (0..len).collect();
-
-    sort_indices(&mut indices, compare_values, reverse, vm)?;
-
-    // 3. Rearrange items in-place in the detached buffer.
-    apply_permutation(items, &mut indices);
-
-    Ok(())
 }
 
 /// Writes a formatted sequence of values to a formatter.

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -12,7 +12,7 @@ use crate::{
     heap::{DropWithHeap, Heap, HeapData, HeapGuard, HeapId, HeapItem, HeapRead, HeapReadOutput, HeapReader},
     intern::StaticStrings,
     resource::{ResourceError, ResourceTracker},
-    sorting::{apply_permutation, sort_indices},
+    sorting::sort_values,
     types::{
         Type,
         slice::{normalize_sequence_index, slice_collect_iterator},
@@ -738,56 +738,23 @@ fn do_list_sort<'h>(
     // an empty list. The detached buffer is always swapped back into the list
     // when we're done.
     let items = mem::take(&mut list.get_mut(vm.heap).items);
-    let mut items_guard = HeapGuard::new(items, vm);
-    let (items, vm) = items_guard.as_parts_mut();
+    defer_drop_mut!(items, vm);
 
-    // 1. Compute key values if a key function was provided, otherwise we'll
-    // sort by the items themselves.
-    let sort_result = (|| -> Result<(), RunError> {
-        let compare_values = if let Some(f) = key_fn.as_ref() {
-            let keys: Vec<Value> = Vec::with_capacity(items.len());
-            // Use a HeapGuard to ensure that if key function evaluation fails partway through,
-            // we clean up any keys that were successfully computed
-            let mut keys_guard = HeapGuard::new(keys, vm);
-            let (keys, vm) = keys_guard.as_parts_mut();
-            for item in items.iter() {
-                let item = item.clone_with_heap(vm);
-                keys.push(vm.evaluate_function("sorted() key argument", f, ArgValues::One(item))?);
-            }
-            keys_guard.into_inner()
-        } else {
-            items.iter().map(|item| item.clone_with_heap(vm.heap)).collect()
-        };
-        defer_drop!(compare_values, vm);
-
-        // 2. Sort indices by comparing key values (or items themselves if no key)
-        let len = compare_values.len();
-        let mut indices: Vec<usize> = (0..len).collect();
-
-        sort_indices(&mut indices, compare_values, reverse, vm)?;
-
-        // 3. Rearrange items in-place in the detached buffer.
-        apply_permutation(items, &mut indices);
-
-        Ok(())
-    })();
+    let sort_result = sort_values(items, key_fn.as_ref(), reverse, vm);
 
     // Swap our (sorted) buffer back into the list. Whatever the user placed
-    // on the live empty list during the sort ends up in `user_items`; if
+    // on the live empty list during the sort ends up in `items`; if
     // it's not empty, the user mutated the list. The `contains_refs` flag
     // survives `mem::take`, so it still describes the buffer being swapped
     // back.
-    let (mut user_items, vm) = items_guard.into_parts();
-    mem::swap(list.get_mut(vm.heap).as_vec_mut(), &mut user_items);
-    let was_modified = !user_items.is_empty();
-    user_items.drop_with_heap(vm);
+    mem::swap(list.get_mut(vm.heap).as_vec_mut(), items);
 
     // Surface any sort error first; otherwise the modification error (if any).
     sort_result?;
-    if was_modified {
-        Err(SimpleException::new_msg(ExcType::ValueError, "list modified during sort").into())
-    } else {
+    if items.is_empty() {
         Ok(())
+    } else {
+        Err(SimpleException::new_msg(ExcType::ValueError, "list modified during sort").into())
     }
 }
 

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -698,6 +698,18 @@ fn list_count<'h>(
 }
 
 /// Performs an in-place sort on a list with optional key function and reverse flag.
+///
+/// To safely support user-supplied `key` callbacks (and rich-comparison `__lt__`
+/// methods) that may reentrantly mutate the same list, we follow CPython's
+/// strategy: the list's `items` vector is **detached** for the duration of the
+/// sort so the list looks empty to any reentrant code. All sort work is then
+/// performed on the detached buffer. After sorting, if the list is still empty
+/// we restore the (now sorted) buffer; if the user repopulated the list during
+/// the sort we discard our buffer and raise
+/// `ValueError: list modified during sort`, matching CPython exactly.
+///
+/// This avoids the previous panic where a stale loop-bound captured before
+/// iteration could index past the live list's length after a callback shrank it.
 fn do_list_sort<'h>(
     list: &mut HeapRead<'h, List>,
     args: ArgValues,
@@ -725,25 +737,73 @@ fn do_list_sort<'h>(
     };
     defer_drop!(key_fn, vm);
 
-    // 1. Compute key values if a key function was provided, otherwise we'll sort by the items themselves
+    // Detach the list's items so reentrant access via the list's heap id sees
+    // an empty list. The detached items still carry their existing refcounts;
+    // we'll either move them back into the list (success) or drop them
+    // (mutation detected / error during sort).
+    let items = mem::take(&mut list.get_mut(vm.heap).items);
+    let mut items_guard = HeapGuard::new(items, vm);
+    let (items, vm) = items_guard.as_parts_mut();
+
+    let sort_result = sort_detached_items(items, key_fn.as_ref(), reverse, vm);
+
+    // Re-attach the detached items. CPython's semantics: regardless of whether
+    // the user mutated the list during the sort, we always restore the detached
+    // buffer (which holds the original refs sorted-or-partially-sorted) so
+    // refcounts stay consistent. If the user *did* mutate the list, we drop
+    // their interleaved values first, then put our buffer back, then surface
+    // the `ValueError: list modified during sort` after any pre-existing sort
+    // error.
+    let (items, vm) = items_guard.into_parts();
+    let was_modified = !list.get(vm.heap).items.is_empty();
+    if was_modified {
+        // Discard whatever the user appended/inserted on the empty live list.
+        mem::take(&mut list.get_mut(vm.heap).items).drop_with_heap(vm);
+    }
+    // Restore the detached buffer (sorted on success, partially-permuted on
+    // sort error). The `contains_refs` flag was not cleared by `mem::take`
+    // (only the Vec was taken), so it correctly still describes the buffer
+    // being put back.
+    *list.get_mut(vm.heap).as_vec_mut() = items;
+
+    // Surface any sort error first; otherwise the modification error (if any).
+    sort_result?;
+    if was_modified {
+        Err(ExcType::value_error_list_modified_during_sort())
+    } else {
+        Ok(())
+    }
+}
+
+/// Performs the actual sort work on a detached items buffer.
+///
+/// Extracted from [`do_list_sort`] so the caller can use a single
+/// detach/re-attach scope around the work and uniformly handle reentrant
+/// list mutation regardless of where in the sort it occurred.
+fn sort_detached_items(
+    items: &mut [Value],
+    key_fn: Option<&Value>,
+    reverse: bool,
+    vm: &mut VM<'_, impl ResourceTracker>,
+) -> Result<(), RunError> {
+    // 1. Compute key values if a key function was provided, otherwise we'll
+    // sort by the items themselves.
     let compare_values = if let Some(f) = key_fn {
-        let len = list.get(vm.heap).items.len();
-        let keys: Vec<Value> = Vec::with_capacity(len);
+        let keys: Vec<Value> = Vec::with_capacity(items.len());
         // Use a HeapGuard to ensure that if key function evaluation fails partway through,
         // we clean up any keys that were successfully computed
         let mut keys_guard = HeapGuard::new(keys, vm);
         let (keys, vm) = keys_guard.as_parts_mut();
-        for i in 0..len {
-            let item = list.get(vm.heap).items[i].clone_with_heap(vm);
+        // Iterate the detached buffer directly. Reentrant mutation via the
+        // list's heap id targets the empty live list, not this buffer, so we
+        // never observe a shifting length here.
+        for item in items.iter() {
+            let item = item.clone_with_heap(vm);
             keys.push(vm.evaluate_function("sorted() key argument", f, ArgValues::One(item))?);
         }
         keys_guard.into_inner()
     } else {
-        list.get(vm.heap)
-            .items
-            .iter()
-            .map(|item| item.clone_with_heap(vm.heap))
-            .collect()
+        items.iter().map(|item| item.clone_with_heap(vm.heap)).collect()
     };
     defer_drop!(compare_values, vm);
 
@@ -753,8 +813,9 @@ fn do_list_sort<'h>(
 
     sort_indices(&mut indices, compare_values, reverse, vm)?;
 
-    // 3. Rearrange items in-place according to the sorted permutation
-    apply_permutation(&mut list.get_mut(vm.heap).items, &mut indices);
+    // 3. Rearrange items in-place in the detached buffer.
+    apply_permutation(items, &mut indices);
+
     Ok(())
 }
 

--- a/crates/monty/test_cases/list__ops.py
+++ b/crates/monty/test_cases/list__ops.py
@@ -326,53 +326,37 @@ except IndexError:
 
 
 # === list.sort() reentrant mutation by key callback (issue #411) ===
-# Key callbacks that clear the same list during sort must not panic.
 # CPython detaches the list during sort so reentrant access sees an empty
-# list, then raises ValueError if the user repopulated it. After a successful
-# sort the list is restored to the sorted order.
+# list. If the user re-populates the live list, sort raises ValueError after
+# restoring the detached (sorted) buffer.
 
-# clear() during key extraction - list looks empty to the callback
+# Key callback observes empty list during sort
 xs1 = [3, 2, 1]
 
 
-def clear_key(value):
-    xs1.clear()
+def empty_key(value):
+    assert len(xs1) == 0
     return value
 
 
-xs1.sort(key=clear_key)
-assert xs1 == [1, 2, 3], 'sort with key that clears the list still produces sorted output'
+xs1.sort(key=empty_key)
+assert xs1 == [1, 2, 3], 'sort with key that observes empty list still produces sorted output'
 
-# pop() during key extraction - same: callback sees an empty list
+# Repopulating the list during sort must raise ValueError
 xs2 = [3, 2, 1]
 
 
-def pop_key(value):
-    if xs2:
-        xs2.pop()
-    return value
-
-
-xs2.sort(key=pop_key)
-assert xs2 == [1, 2, 3], 'sort with key that pops from the list still produces sorted output'
-
-# Repopulating the list during sort must raise ValueError
-xs3 = [3, 2, 1]
-
-
 def repopulate_key(value):
-    xs3.append(99)
+    xs2.append(99)
     return value
 
 
 try:
-    xs3.sort(key=repopulate_key)
+    xs2.sort(key=repopulate_key)
     assert False, 'expected ValueError when key callback repopulates the list'
 except ValueError as exc:
     assert str(exc) == 'list modified during sort', 'sort raises ValueError when list is modified'
-# CPython restores the (sorted) detached buffer and discards the user's
-# interleaved appends, so the list ends up sorted even though we raised.
-assert xs3 == [1, 2, 3], 'list is restored to sorted state after ValueError'
+assert xs2 == [1, 2, 3], 'list is restored to sorted state after ValueError'
 
 
 # === List assignment (setitem) ===

--- a/crates/monty/test_cases/list__ops.py
+++ b/crates/monty/test_cases/list__ops.py
@@ -325,6 +325,56 @@ except IndexError:
     pass  # expected since last_char('') raises IndexError
 
 
+# === list.sort() reentrant mutation by key callback (issue #411) ===
+# Key callbacks that clear the same list during sort must not panic.
+# CPython detaches the list during sort so reentrant access sees an empty
+# list, then raises ValueError if the user repopulated it. After a successful
+# sort the list is restored to the sorted order.
+
+# clear() during key extraction - list looks empty to the callback
+xs1 = [3, 2, 1]
+
+
+def clear_key(value):
+    xs1.clear()
+    return value
+
+
+xs1.sort(key=clear_key)
+assert xs1 == [1, 2, 3], 'sort with key that clears the list still produces sorted output'
+
+# pop() during key extraction - same: callback sees an empty list
+xs2 = [3, 2, 1]
+
+
+def pop_key(value):
+    if xs2:
+        xs2.pop()
+    return value
+
+
+xs2.sort(key=pop_key)
+assert xs2 == [1, 2, 3], 'sort with key that pops from the list still produces sorted output'
+
+# Repopulating the list during sort must raise ValueError
+xs3 = [3, 2, 1]
+
+
+def repopulate_key(value):
+    xs3.append(99)
+    return value
+
+
+try:
+    xs3.sort(key=repopulate_key)
+    assert False, 'expected ValueError when key callback repopulates the list'
+except ValueError as exc:
+    assert str(exc) == 'list modified during sort', 'sort raises ValueError when list is modified'
+# CPython restores the (sorted) detached buffer and discards the user's
+# interleaved appends, so the list ends up sorted even though we raised.
+assert xs3 == [1, 2, 3], 'list is restored to sorted state after ValueError'
+
+
 # === List assignment (setitem) ===
 # Basic assignment
 lst = [1, 2, 3]


### PR DESCRIPTION
Closes #411.

`do_list_sort` snapshotted the list's length and then iterated `for i in 0..len` while user-controlled `key` callbacks were still allowed to mutate the same list. Once a callback shrank the list, `items[i]` indexed past the new end and panicked.

This change follows CPython's strategy: detach the list's `items` vector for the duration of the sort so reentrant access via the list's heap id sees an empty list, run all key extraction / comparison / permutation work on the detached buffer, and afterwards either restore the sorted buffer (success) or - if the user repopulated the empty list during sort - drop their interleaved mutations, restore the (sorted-or-partially-permuted) buffer to keep refcount invariants intact, and raise `ValueError: list modified during sort` matching CPython exactly.

Regression tests added to `crates/monty/test_cases/list__ops.py` for the two repros from the issue (`clear()` and `pop()` in the key callback) plus the repopulation case that should raise `ValueError`.