### PR TITLE
merge lifetimes in `VM` to a single lifetime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,7 +123,7 @@ Type methods are implemented as `impl<'h> HeapRead<'h, T>` blocks. The `PyTrait<
 ```rust
 // Methods on a heap type
 impl<'h> HeapRead<'h, List> {
-    pub fn append(&mut self, vm: &mut VM<'h, '_, impl ResourceTracker>, item: Value) -> RunResult<()> {
+    pub fn append(&mut self, vm: &mut VM<'h, impl ResourceTracker>, item: Value) -> RunResult<()> {
         self.get_mut(vm.heap).items.push(item);
         Ok(())
     }
@@ -131,8 +131,8 @@ impl<'h> HeapRead<'h, List> {
 
 // PyTrait implementation
 impl<'h> PyTrait<'h> for HeapRead<'h, List> {
-    fn py_type(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Type { Type::List }
-    fn py_len(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_type(&self, vm: &VM<'h, impl ResourceTracker>) -> Type { Type::List }
+    fn py_len(&self, vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         Some(self.get(vm.heap).items.len())
     }
     // ...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,15 +85,20 @@ All heap-allocated Python objects (lists, dicts, strings, etc.) are stored in a 
 
 #### Core concepts
 
-- **`HeapReader<'a, T>`** — A scoped borrow of the heap that produces `HeapRead` handles. Created exclusively via `HeapReader::with(heap, |heap| { ... })`. The `for<'a>` closure bound makes the lifetime `'a` universally quantified, so `HeapRead` pointers cannot escape the closure.
+- **`HeapReader<'a, T>`** — A scoped borrow of the heap that produces `HeapRead` handles. Created exclusively via `HeapReader::with`, which takes a `for<'a>` closure bound makes the lifetime `'a` universally quantified, so `HeapRead` pointers cannot escape the closure.
 - **`HeapRead<'a, T>`** — A typed handle to a specific heap entry. Created by `heap.read(id)` which returns a `HeapReadOutput<'a>` enum that you match on. Tracks a reader count that prevents the entry from being freed while the handle exists.
 - **`HeapReadOutput<'a>`** — Enum over all `HeapRead<'a, T>` variants (one per `HeapData` variant). Pattern match to get the typed handle.
 
 #### Reading and mutating heap data
 
 ```rust
-// Scoped heap access
-HeapReader::with(heap, |heap| {
+// Scoped heap access.
+// The second argument allows for extra data to be
+// passed into the closure, will be rebranded as
+// `&'a mut ...` to match the `'a` lifetime of the
+// `HeapRead` handle, so the closure can have additional
+// context while still having the `for <'a>` safety guarantee.
+HeapReader::with(heap, &mut (), |heap, ()| {
     let output = heap.read(some_id);  // returns HeapReadOutput<'a>
     match output {
         HeapReadOutput::List(list) => {

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ insta = "1.47"
 
 [workspace.lints.rust]
 # codspeed cfg is set by codspeed-criterion-compat when running in CodSpeed environment
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(codspeed)', 'cfg(heap_reader_compile_fail_tests)', 'cfg(heap_reader_compile_fail_test_read_while_ref_alive)', 'cfg(heap_reader_compile_fail_test_dec_ref_while_reading)', 'cfg(heap_reader_compile_fail_test_smuggle_heap_read)', 'cfg(heap_reader_compile_fail_test_double_get_mut)', 'cfg(heap_reader_compile_fail_test_heap_mutation_while_reading)', 'cfg(heap_reader_compile_fail_test_mutation_in_map_closure)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(codspeed)', 'cfg(heap_reader_compile_fail_tests)', 'cfg(heap_reader_compile_fail_test_read_while_ref_alive)', 'cfg(heap_reader_compile_fail_test_dec_ref_while_reading)', 'cfg(heap_reader_compile_fail_test_smuggle_heap_read)', 'cfg(heap_reader_compile_fail_test_double_get_mut)', 'cfg(heap_reader_compile_fail_test_heap_mutation_while_reading)', 'cfg(heap_reader_compile_fail_test_mutation_in_map_closure)', 'cfg(heap_reader_compile_fail_test_smuggle_vm)', 'cfg(heap_reader_compile_fail_test_smuggle_and_swap_reader)'] }
 
 [workspace.lints.rustdoc]
 invalid_codeblock_attributes = "allow"

--- a/crates/monty/src/args.rs
+++ b/crates/monty/src/args.rs
@@ -312,7 +312,7 @@ impl ArgValues {
     /// This is used when passing arguments to external functions.
     pub fn into_py_objects(
         self,
-        vm: &mut VM<'_, '_, impl ResourceTracker>,
+        vm: &mut VM<'_, impl ResourceTracker>,
     ) -> (Vec<MontyObject>, Vec<(MontyObject, MontyObject)>) {
         match self {
             Self::Empty => (vec![], vec![]),
@@ -486,7 +486,7 @@ impl KwargsValues {
     /// Converts the arguments into a Vec of MontyObjects.
     ///
     /// This is used when passing arguments to external functions.
-    fn into_py_objects(self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> Vec<(MontyObject, MontyObject)> {
+    fn into_py_objects(self, vm: &mut VM<'_, impl ResourceTracker>) -> Vec<(MontyObject, MontyObject)> {
         match self {
             Self::Empty => vec![],
             Self::Inline(kvs) => kvs

--- a/crates/monty/src/builtins/abs.rs
+++ b/crates/monty/src/builtins/abs.rs
@@ -18,7 +18,7 @@ use crate::{
 ///
 /// Returns the absolute value of a number. Works with integers, floats, and LongInts.
 /// For `i64::MIN`, which overflows on negation, promotes to LongInt.
-pub fn builtin_abs(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_abs(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("abs", vm.heap)?;
     defer_drop!(value, vm);
 

--- a/crates/monty/src/builtins/all.rs
+++ b/crates/monty/src/builtins/all.rs
@@ -14,7 +14,7 @@ use crate::{
 ///
 /// Returns True if all elements of the iterable are true (or if the iterable is empty).
 /// Short-circuits on the first falsy value.
-pub fn builtin_all(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_all(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let iterable = args.get_one_arg("all", vm.heap)?;
     let iter = MontyIter::new(iterable, vm)?;
     defer_drop_mut!(iter, vm);

--- a/crates/monty/src/builtins/any.rs
+++ b/crates/monty/src/builtins/any.rs
@@ -14,7 +14,7 @@ use crate::{
 ///
 /// Returns True if any element of the iterable is true.
 /// Returns False for an empty iterable. Short-circuits on the first truthy value.
-pub fn builtin_any(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_any(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let iterable = args.get_one_arg("any", vm.heap)?;
     let iter = MontyIter::new(iterable, vm)?;
     defer_drop_mut!(iter, vm);

--- a/crates/monty/src/builtins/bin.rs
+++ b/crates/monty/src/builtins/bin.rs
@@ -18,7 +18,7 @@ use crate::{
 ///
 /// Converts an integer to a binary string prefixed with '0b'.
 /// Supports both i64 and BigInt integers.
-pub fn builtin_bin(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_bin(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("bin", vm.heap)?;
     defer_drop!(value, vm);
 

--- a/crates/monty/src/builtins/chr.rs
+++ b/crates/monty/src/builtins/chr.rs
@@ -14,7 +14,7 @@ use crate::{
 ///
 /// Returns a string representing a character whose Unicode code point is the integer.
 /// The valid range for the argument is from 0 through 1,114,111 (0x10FFFF).
-pub fn builtin_chr(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_chr(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("chr", vm.heap)?;
     defer_drop!(value, vm);
 

--- a/crates/monty/src/builtins/divmod.rs
+++ b/crates/monty/src/builtins/divmod.rs
@@ -19,7 +19,7 @@ use crate::{
 ///
 /// Returns a tuple (quotient, remainder) from integer division.
 /// Equivalent to (a // b, a % b).
-pub fn builtin_divmod(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_divmod(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (a, b) = args.get_two_args("divmod", vm.heap)?;
     let a = super::round::normalize_bool_to_int(a);
     let b = super::round::normalize_bool_to_int(b);

--- a/crates/monty/src/builtins/enumerate.rs
+++ b/crates/monty/src/builtins/enumerate.rs
@@ -17,7 +17,7 @@ use crate::{
 ///
 /// Returns a list of (index, value) tuples.
 /// Note: In Python this returns an iterator, but we return a list for simplicity.
-pub fn builtin_enumerate(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_enumerate(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (iterable, start) = args.get_one_two_args("enumerate", vm.heap)?;
     let iter = MontyIter::new(iterable, vm)?;
     defer_drop_mut!(iter, vm);

--- a/crates/monty/src/builtins/filter.rs
+++ b/crates/monty/src/builtins/filter.rs
@@ -30,7 +30,7 @@ use crate::{
 /// filter(lambda x: x > 0, [-1, 0, 1, 2])  # [1, 2]
 /// filter(None, [0, 1, False, True, ''])   # [1, True]
 /// ```
-pub fn builtin_filter(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_filter(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (function, iterable) = args.get_two_args("filter", vm.heap)?;
     defer_drop!(function, vm);
 

--- a/crates/monty/src/builtins/getattr.rs
+++ b/crates/monty/src/builtins/getattr.rs
@@ -27,7 +27,7 @@ use crate::{
 /// getattr(obj, 'y', None)       # Get obj.y or None if not found
 /// getattr(module, 'function')   # Get module.function
 /// ```
-pub fn builtin_getattr(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_getattr(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let positional = args.into_pos_only("getattr", vm.heap)?;
     defer_drop!(positional, vm);
 

--- a/crates/monty/src/builtins/hasattr.rs
+++ b/crates/monty/src/builtins/hasattr.rs
@@ -27,7 +27,7 @@ use crate::{
 /// hasattr(slice(1, 10), 'start') # True - slice has start attribute
 /// hasattr(42, 'nonexistent')    # False - int has no such attribute
 /// ```
-pub fn builtin_hasattr(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_hasattr(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let positional = args.into_pos_only("hasattr", vm.heap)?;
     defer_drop!(positional, vm);
 

--- a/crates/monty/src/builtins/hash.rs
+++ b/crates/monty/src/builtins/hash.rs
@@ -14,7 +14,7 @@ use crate::{
 ///
 /// Returns the hash value of an object (if it has one).
 /// Raises TypeError for unhashable types like lists and dicts.
-pub fn builtin_hash(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_hash(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("hash", vm.heap)?;
     defer_drop!(value, vm);
     match value.py_hash(vm)? {

--- a/crates/monty/src/builtins/hex.rs
+++ b/crates/monty/src/builtins/hex.rs
@@ -18,7 +18,7 @@ use crate::{
 ///
 /// Converts an integer to a lowercase hexadecimal string prefixed with '0x'.
 /// Supports both i64 and BigInt integers.
-pub fn builtin_hex(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_hex(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("hex", vm.heap)?;
     defer_drop!(value, vm);
     let heap = &mut *vm.heap;

--- a/crates/monty/src/builtins/id.rs
+++ b/crates/monty/src/builtins/id.rs
@@ -7,7 +7,7 @@ use crate::{
 /// Implementation of the id() builtin function.
 ///
 /// Returns the identity of an object (unique integer for the object's lifetime).
-pub fn builtin_id(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_id(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("id", vm.heap)?;
     defer_drop!(value, vm);
 

--- a/crates/monty/src/builtins/isinstance.rs
+++ b/crates/monty/src/builtins/isinstance.rs
@@ -15,7 +15,7 @@ use crate::{
 /// Implementation of the isinstance() builtin function.
 ///
 /// Checks if an object is an instance of a class or a tuple of classes.
-pub fn builtin_isinstance(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_isinstance(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (obj, classinfo) = args.get_two_args("isinstance", vm.heap)?;
     defer_drop!(obj, vm);
     defer_drop!(classinfo, vm);

--- a/crates/monty/src/builtins/len.rs
+++ b/crates/monty/src/builtins/len.rs
@@ -13,7 +13,7 @@ use crate::{
 /// Implementation of the len() builtin function.
 ///
 /// Returns the length of an object (number of items in a container).
-pub fn builtin_len(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_len(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("len", vm.heap)?;
     defer_drop!(value, vm);
     if let Some(len) = value.py_len(vm) {

--- a/crates/monty/src/builtins/map.rs
+++ b/crates/monty/src/builtins/map.rs
@@ -27,7 +27,7 @@ use crate::{
 /// map(pow, [2, 3], [3, 2])          # [8, 9]
 /// map(str, [1, 2, 3])               # ['1', '2', '3']
 /// ```
-pub fn builtin_map(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_map(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (positional, kwargs) = args.into_parts();
     defer_drop_mut!(positional, vm);
 

--- a/crates/monty/src/builtins/min_max.rs
+++ b/crates/monty/src/builtins/min_max.rs
@@ -20,7 +20,7 @@ use crate::{
 /// Supports two forms:
 /// - `min(iterable)` - returns smallest item from iterable
 /// - `min(arg1, arg2, ...)` - returns smallest of the arguments
-pub fn builtin_min(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_min(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     builtin_min_max(vm, args, true)
 }
 
@@ -30,14 +30,14 @@ pub fn builtin_min(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -
 /// Supports two forms:
 /// - `max(iterable)` - returns largest item from iterable
 /// - `max(arg1, arg2, ...)` - returns largest of the arguments
-pub fn builtin_max(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_max(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     builtin_min_max(vm, args, false)
 }
 
 /// Shared implementation for min() and max().
 ///
 /// When `is_min` is true, returns the minimum; otherwise returns the maximum.
-fn builtin_min_max(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues, is_min: bool) -> RunResult<Value> {
+fn builtin_min_max(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues, is_min: bool) -> RunResult<Value> {
     let func_name = if is_min { "min" } else { "max" };
     let key_context = if is_min {
         "min() key argument"
@@ -175,7 +175,7 @@ fn builtin_min_max(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues, i
 fn parse_min_max_kwargs(
     kwargs: KwargsValues,
     func_name: &str,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<(Option<Value>, Option<Value>)> {
     let (key_fn, default_value) = kwargs.parse_named_kwargs_pair(
         func_name,
@@ -206,7 +206,7 @@ fn evaluate_key(
     item: Value,
     key_fn: &Value,
     key_context: &'static str,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<Value> {
     vm.evaluate_function(key_context, key_fn, ArgValues::One(item))
 }
@@ -220,7 +220,7 @@ fn candidate_wins(
     current: &Value,
     candidate: &Value,
     is_min: bool,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<bool> {
     let Some(ordering) = candidate.py_cmp(current, vm)? else {
         return Err(ord_not_supported(candidate, current, is_min, vm));
@@ -240,7 +240,7 @@ fn default_with_multiple_args(func_name: &str) -> RunError {
 }
 
 #[cold]
-fn ord_not_supported(left: &Value, right: &Value, is_min: bool, vm: &VM<'_, '_, impl ResourceTracker>) -> RunError {
+fn ord_not_supported(left: &Value, right: &Value, is_min: bool, vm: &VM<'_, impl ResourceTracker>) -> RunError {
     let left_type = left.py_type(vm);
     let right_type = right.py_type(vm);
     let operator = if is_min { '<' } else { '>' };

--- a/crates/monty/src/builtins/mod.rs
+++ b/crates/monty/src/builtins/mod.rs
@@ -63,7 +63,7 @@ pub(crate) enum Builtins {
 
 impl Builtins {
     /// Calls this builtin with the given arguments.
-    pub fn call(self, vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub fn call(self, vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         match self {
             Self::Function(b) => b.call(vm, args),
             Self::ExcType(exc) => exc.call(vm, args),
@@ -212,7 +212,7 @@ impl BuiltinsFunctions {
     ///
     /// All builtins receive the full VM context, which provides access to the heap,
     /// interned strings, and print output.
-    pub(crate) fn call(self, vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub(crate) fn call(self, vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         match self {
             Self::Abs => abs::builtin_abs(vm, args),
             Self::All => all::builtin_all(vm, args),

--- a/crates/monty/src/builtins/next.rs
+++ b/crates/monty/src/builtins/next.rs
@@ -14,7 +14,7 @@ use crate::{
 ///   `StopIteration` when the iterator is exhausted.
 /// - `next(iterator, default)` - Returns the next item from the iterator, or
 ///   `default` if the iterator is exhausted.
-pub fn builtin_next(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_next(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (iterator, default) = args.get_one_two_args("next", vm.heap)?;
     defer_drop!(iterator, vm);
     iterator_next(iterator, default, vm)

--- a/crates/monty/src/builtins/oct.rs
+++ b/crates/monty/src/builtins/oct.rs
@@ -18,7 +18,7 @@ use crate::{
 ///
 /// Converts an integer to an octal string prefixed with '0o'.
 /// Supports both i64 and BigInt integers.
-pub fn builtin_oct(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_oct(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("oct", vm.heap)?;
     defer_drop!(value, vm);
 

--- a/crates/monty/src/builtins/ord.rs
+++ b/crates/monty/src/builtins/ord.rs
@@ -14,7 +14,7 @@ use crate::{
 /// Implementation of the ord() builtin function.
 ///
 /// Returns the Unicode code point of a one-character string.
-pub fn builtin_ord(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_ord(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("ord", vm.heap)?;
     defer_drop!(value, vm);
 

--- a/crates/monty/src/builtins/pow.rs
+++ b/crates/monty/src/builtins/pow.rs
@@ -18,7 +18,7 @@ use crate::{
 ///
 /// Returns base to the power exp. With three arguments, returns (base ** exp) % mod.
 /// Handles negative exponents by returning a float.
-pub fn builtin_pow(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_pow(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     // pow() accepts 2 or 3 arguments
     let positional = args.into_pos_only("pow", vm.heap)?;
     defer_drop!(positional, vm);
@@ -133,7 +133,7 @@ fn checked_pow_i64(mut base: i64, mut exp: u32) -> Option<i64> {
 /// Implements two-argument pow with LongInt support.
 ///
 /// On overflow, promotes to LongInt instead of returning an error.
-fn two_arg_pow(base: &Value, exp: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Value> {
+fn two_arg_pow(base: &Value, exp: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Value> {
     match (base, exp) {
         (Value::Int(b), Value::Int(e)) => int_pow_int(*b, *e, vm.heap),
         (Value::Int(b), Value::Ref(id)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {

--- a/crates/monty/src/builtins/print.rs
+++ b/crates/monty/src/builtins/print.rs
@@ -19,7 +19,7 @@ use crate::{
 /// - `flush`: whether to flush the stream (accepted but ignored)
 ///
 /// The `file` kwarg is not supported.
-pub fn builtin_print(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_print(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     // Split into positional args and kwargs
     let (positional, kwargs) = args.into_parts();
     defer_drop!(positional, vm);
@@ -57,7 +57,7 @@ pub fn builtin_print(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues)
 /// Returns (sep, end) where each is Some if provided.
 fn extract_print_kwargs(
     kwargs: KwargsValues,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<(Option<String>, Option<String>)> {
     let mut sep: Option<String> = None;
     let mut end: Option<String> = None;
@@ -112,7 +112,7 @@ fn extract_print_kwargs(
 ///
 /// The kwarg can be None (returns None) or a string (returns Some).
 /// Raises TypeError for other types.
-fn extract_string_kwarg(value: &Value, name: &str, vm: &VM<'_, '_, impl ResourceTracker>) -> RunResult<Option<String>> {
+fn extract_string_kwarg(value: &Value, name: &str, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Option<String>> {
     match value {
         Value::None => Ok(None),
         Value::InternString(string_id) => Ok(Some(vm.interns.get_str(*string_id).to_owned())),

--- a/crates/monty/src/builtins/repr.rs
+++ b/crates/monty/src/builtins/repr.rs
@@ -8,7 +8,7 @@ use crate::{
 /// Implementation of the repr() builtin function.
 ///
 /// Returns a string containing a printable representation of an object.
-pub fn builtin_repr(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_repr(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("repr", vm.heap)?;
     defer_drop!(value, vm);
     let s = value.py_repr(vm)?.into_owned();

--- a/crates/monty/src/builtins/reversed.rs
+++ b/crates/monty/src/builtins/reversed.rs
@@ -14,7 +14,7 @@ use crate::{
 ///
 /// Returns a list with elements in reverse order.
 /// Note: In Python this returns an iterator, but we return a list for simplicity.
-pub fn builtin_reversed(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_reversed(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("reversed", vm.heap)?;
 
     // Collect all items

--- a/crates/monty/src/builtins/round.rs
+++ b/crates/monty/src/builtins/round.rs
@@ -22,7 +22,7 @@ pub fn normalize_bool_to_int(value: Value) -> Value {
 /// Rounds a number to a given precision in decimal digits.
 /// If ndigits is omitted or None, returns the nearest integer.
 /// Uses banker's rounding (round half to even).
-pub fn builtin_round(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_round(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (number, ndigits) = args.get_one_two_args("round", vm.heap)?;
     let number = normalize_bool_to_int(number);
     defer_drop!(number, vm);

--- a/crates/monty/src/builtins/setattr.rs
+++ b/crates/monty/src/builtins/setattr.rs
@@ -21,7 +21,7 @@ use crate::{
 /// setattr(obj, 'x', 42)      # Set obj.x = 42
 /// setattr(obj, 'name', 'foo') # Set obj.name = 'foo'
 /// ```
-pub fn builtin_setattr(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_setattr(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let positional = args.into_pos_only("setattr", vm.heap)?;
     defer_drop!(positional, vm);
 

--- a/crates/monty/src/builtins/sorted.rs
+++ b/crates/monty/src/builtins/sorted.rs
@@ -19,7 +19,7 @@ use crate::{
 /// Returns a new sorted list from the items in an iterable.
 /// Supports `key` and `reverse` keyword arguments matching Python's
 /// `sorted(iterable, /, *, key=None, reverse=False)` signature.
-pub fn builtin_sorted(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_sorted(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (iterable, key_fn, reverse) = parse_sorted_args(args, vm)?;
     defer_drop!(key_fn, vm);
 
@@ -70,7 +70,7 @@ pub fn builtin_sorted(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues
 /// to `false`.
 fn parse_sorted_args(
     args: ArgValues,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<(Value, Option<Value>, bool)> {
     let (mut positional, kwargs) = args.into_parts();
 

--- a/crates/monty/src/builtins/sum.rs
+++ b/crates/monty/src/builtins/sum.rs
@@ -18,7 +18,7 @@ use crate::{
 /// Sums the items of an iterable from left to right with an optional start value.
 /// The default start value is 0. String start values are explicitly rejected
 /// (use `''.join(seq)` instead for string concatenation).
-pub fn builtin_sum(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_sum(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (iterable, start) = args.get_one_two_args("sum", vm.heap)?;
     defer_drop_mut!(start, vm);
 

--- a/crates/monty/src/builtins/type_.rs
+++ b/crates/monty/src/builtins/type_.rs
@@ -9,7 +9,7 @@ use crate::{
 /// Implementation of the type() builtin function.
 ///
 /// Returns the type of an object.
-pub fn builtin_type(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_type(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("type", vm.heap)?;
     defer_drop!(value, vm);
     Ok(Value::Builtin(Builtins::Type(value.py_type(vm))))

--- a/crates/monty/src/builtins/zip.rs
+++ b/crates/monty/src/builtins/zip.rs
@@ -17,7 +17,7 @@ use crate::{
 /// from each of the argument iterables. Stops when the shortest iterable is exhausted.
 /// When `strict=True`, raises `ValueError` if any iterable has a different length.
 /// Note: In Python this returns an iterator, but we return a list for simplicity.
-pub fn builtin_zip(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub fn builtin_zip(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (positional, kwargs) = args.into_parts();
     defer_drop_mut!(positional, vm);
 
@@ -88,7 +88,7 @@ pub fn builtin_zip(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -
 ///
 /// Accepts any truthy/falsy value for `strict`, matching CPython behavior.
 /// Raises `TypeError` for unexpected keyword arguments.
-fn extract_zip_strict(kwargs: KwargsValues, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
+fn extract_zip_strict(kwargs: KwargsValues, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<bool> {
     let mut strict = false;
     let mut error: Option<RunError> = None;
 

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -24,7 +24,7 @@ use crate::{
     value::Value,
 };
 
-impl<'h, T: ResourceTracker> VM<'h, '_, T> {
+impl<'h, T: ResourceTracker> VM<'h, T> {
     /// Executes the Await opcode.
     ///
     /// Pops the awaitable from the stack and handles it based on its type:

--- a/crates/monty/src/bytecode/vm/attr.rs
+++ b/crates/monty/src/bytecode/vm/attr.rs
@@ -10,7 +10,7 @@ use crate::{
     value::EitherStr,
 };
 
-impl<T: ResourceTracker> VM<'_, '_, T> {
+impl<T: ResourceTracker> VM<'_, T> {
     /// Loads an attribute from an object and pushes it onto the stack.
     ///
     /// Returns an AttributeError if the attribute doesn't exist.

--- a/crates/monty/src/bytecode/vm/binary.rs
+++ b/crates/monty/src/bytecode/vm/binary.rs
@@ -10,7 +10,7 @@ use crate::{
     value::{BitwiseOp, Value},
 };
 
-impl<T: ResourceTracker> VM<'_, '_, T> {
+impl<T: ResourceTracker> VM<'_, T> {
     /// Binary addition with proper refcount handling.
     ///
     /// Uses lazy type capture: only calls `py_type()` in error paths to avoid
@@ -430,7 +430,7 @@ fn apply_dict_view_binary_op(
     lhs: &Set,
     rhs: &Set,
     op: DictViewBinaryOp,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> Result<Set, RunError> {
     let mut result = match op {
         DictViewBinaryOp::And => Set::with_capacity(lhs.len().min(rhs.len())),

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -58,7 +58,7 @@ pub(crate) enum CallResult {
     AwaitValue(Value),
 }
 
-impl<T: ResourceTracker> VM<'_, '_, T> {
+impl<T: ResourceTracker> VM<'_, T> {
     // ========================================================================
     // Call Opcode Executors
     // ========================================================================

--- a/crates/monty/src/bytecode/vm/collections.rs
+++ b/crates/monty/src/bytecode/vm/collections.rs
@@ -11,7 +11,7 @@ use crate::{
     value::{VALUE_SIZE, Value},
 };
 
-impl<T: ResourceTracker> VM<'_, '_, T> {
+impl<T: ResourceTracker> VM<'_, T> {
     /// Builds a list from the top n stack values.
     pub(super) fn build_list(&mut self, count: usize) -> Result<(), RunError> {
         let items = self.pop_n(count);

--- a/crates/monty/src/bytecode/vm/compare.rs
+++ b/crates/monty/src/bytecode/vm/compare.rs
@@ -11,7 +11,7 @@ use crate::{
     value::Value,
 };
 
-impl<T: ResourceTracker> VM<'_, '_, T> {
+impl<T: ResourceTracker> VM<'_, T> {
     /// Equality comparison.
     pub(super) fn compare_eq(&mut self) -> Result<(), RunError> {
         let this = self;

--- a/crates/monty/src/bytecode/vm/exceptions.rs
+++ b/crates/monty/src/bytecode/vm/exceptions.rs
@@ -12,7 +12,7 @@ use crate::{
     value::Value,
 };
 
-impl<T: ResourceTracker> VM<'_, '_, T> {
+impl<T: ResourceTracker> VM<'_, T> {
     /// Returns the current frame's name for traceback generation.
     ///
     /// Returns the function name for user-defined functions, or `<module>` for

--- a/crates/monty/src/bytecode/vm/format.rs
+++ b/crates/monty/src/bytecode/vm/format.rs
@@ -10,7 +10,7 @@ use crate::{
     value::Value,
 };
 
-impl<T: ResourceTracker> VM<'_, '_, T> {
+impl<T: ResourceTracker> VM<'_, T> {
     /// Builds an f-string by concatenating n string parts from the stack.
     pub(super) fn build_fstring(&mut self, count: usize) -> Result<(), RunError> {
         let this = self;

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -518,11 +518,7 @@ pub struct VMSnapshot {
 /// Executes compiled bytecode using a stack-based execution model.
 /// The instruction pointer (IP) lives in each `CallFrame`, not here,
 /// to avoid sync bugs on call/return.
-///
-/// # Lifetimes
-/// * `'a` - Lifetime of the heap, namespaces, and interns
-/// * `'p` - Lifetime of the print writer's internal references
-pub struct VM<'h, 'a, T: ResourceTracker> {
+pub struct VM<'h, T: ResourceTracker> {
     /// Operand stack — locals and operands interleaved per frame.
     ///
     /// Each function frame's locals occupy `stack[frame.stack_base..frame.stack_base + frame.locals_count]`,
@@ -538,16 +534,16 @@ pub struct VM<'h, 'a, T: ResourceTracker> {
     pub(crate) globals: Vec<Value>,
 
     /// Call stack — function frames (each frame has its own IP).
-    frames: Vec<CallFrame<'a>>,
+    frames: Vec<CallFrame<'h>>,
 
     /// Heap for reference-counted objects.
     pub(crate) heap: &'h mut HeapReader<'h, T>,
 
     /// Interned strings/bytes.
-    pub(crate) interns: &'a Interns,
+    pub(crate) interns: &'h Interns,
 
     /// Print output writer, borrowed so callers retain access to collected output.
-    pub(crate) print_writer: PrintWriter<'a>,
+    pub(crate) print_writer: PrintWriter<'h>,
 
     /// Stack of exceptions being handled for nested except blocks.
     ///
@@ -574,7 +570,7 @@ pub struct VM<'h, 'a, T: ResourceTracker> {
     ///
     /// Stored here because the main task's frames have `function_id: None` and
     /// need a reference to the module code when being restored after task switching.
-    module_code: Option<&'a Code>,
+    module_code: Option<&'h Code>,
 
     /// Bytecode IP of the most recent `LoadGlobalCallable`/`LoadLocalCallable` that
     /// pushed an `ExtFunction` for an undefined name.
@@ -592,13 +588,13 @@ pub struct VM<'h, 'a, T: ResourceTracker> {
     pub(crate) json_string_cache: JsonStringCache,
 }
 
-impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
+impl<'h, T: ResourceTracker> VM<'h, T> {
     /// Creates a new VM with the given runtime context.
     pub fn new(
         globals: Vec<Value>,
         heap: &'h mut HeapReader<'h, T>,
-        interns: &'a Interns,
-        print_writer: PrintWriter<'a>,
+        interns: &'h Interns,
+        print_writer: PrintWriter<'h>,
     ) -> Self {
         Self {
             stack: Vec::with_capacity(64),
@@ -630,10 +626,10 @@ impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
     /// * `print_writer` - Writer for print output
     pub fn restore(
         snapshot: VMSnapshot,
-        module_code: &'a Code,
+        module_code: &'h Code,
         heap: &'h mut HeapReader<'h, T>,
-        interns: &'a Interns,
-        print_writer: PrintWriter<'a>,
+        interns: &'h Interns,
+        print_writer: PrintWriter<'h>,
     ) -> Self {
         // Reconstruct call frames from serialized form
         let frames: Vec<CallFrame<'_>> = snapshot
@@ -704,7 +700,7 @@ impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
     }
 
     /// Pushes an initial frame for module-level code and runs the VM.
-    pub fn run_module(&mut self, code: &'a Code) -> Result<FrameExit, RunError> {
+    pub fn run_module(&mut self, code: &'h Code) -> Result<FrameExit, RunError> {
         // Store module code for restoring main task frames during task switching
         self.module_code = Some(code);
         self.push_frame(CallFrame::new_module(code))?;
@@ -756,8 +752,8 @@ impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
     /// is reloaded after any operation that modifies the frame stack.
     pub fn run(&mut self) -> Result<FrameExit, RunError> {
         // Cache frame state locally to avoid repeated frames.last_mut() calls.
-        // The Code reference has lifetime 'a (lives in Interns), independent of frame borrow.
-        let mut cached_frame: CachedFrame<'a> = self.new_cached_frame();
+        // The Code reference has lifetime 'h (lives in Interns), independent of frame borrow.
+        let mut cached_frame: CachedFrame<'h> = self.new_cached_frame();
 
         loop {
             // Check time limit and trigger GC if needed at each instruction.
@@ -1624,26 +1620,26 @@ impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
 
     /// Returns a reference to the current (topmost) call frame.
     #[inline]
-    pub(crate) fn current_frame(&self) -> &CallFrame<'a> {
+    pub(crate) fn current_frame(&self) -> &CallFrame<'h> {
         self.frames.last().expect("no active frame")
     }
 
     /// Creates a new cached frame from the current frame.
     #[inline]
-    pub(super) fn new_cached_frame(&self) -> CachedFrame<'a> {
+    pub(super) fn new_cached_frame(&self) -> CachedFrame<'h> {
         self.current_frame().into()
     }
 
     /// Returns a mutable reference to the current call frame.
     #[inline]
-    pub(super) fn current_frame_mut(&mut self) -> &mut CallFrame<'a> {
+    pub(super) fn current_frame_mut(&mut self) -> &mut CallFrame<'h> {
         self.frames.last_mut().expect("no active frame")
     }
 
     /// Pushes the given frame onto the call stack.
     ///
     /// Returns an error if the recursion depth limit is exceeded by pushing this frame.
-    pub(super) fn push_frame(&mut self, frame: CallFrame<'a>) -> RunResult<()> {
+    pub(super) fn push_frame(&mut self, frame: CallFrame<'h>) -> RunResult<()> {
         // root frame doesn't count towards recursion depth, so only check if there's already a frame on the stack
         if !self.frames.is_empty()
             && let Err(e) = self.heap.incr_recursion_depth()
@@ -1764,7 +1760,7 @@ impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
     ///
     /// Returns `Ok(None)` for normal loads, `Ok(Some(FrameExit::NameLookup))` when
     /// the host needs to resolve an unknown name, or `Err` for true unbound locals.
-    fn load_local(&mut self, cached_frame: &CachedFrame<'a>, slot: u16) -> Result<Option<FrameExit>, RunError> {
+    fn load_local(&mut self, cached_frame: &CachedFrame<'h>, slot: u16) -> Result<Option<FrameExit>, RunError> {
         let value = &self.stack[cached_frame.stack_base + slot as usize];
 
         // Check for undefined value — raise appropriate error based on whether
@@ -1793,7 +1789,7 @@ impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
     /// Unlike `load_local`, this never yields `NameLookup`. When the variable is undefined
     /// (a `LocalUnassigned` name), it pushes `Value::ExtFunction(name_id)` so that the
     /// subsequent `CallFunction` opcode can yield `FunctionCall` instead.
-    fn load_local_callable(&mut self, cached_frame: &CachedFrame<'a>, slot: u16, name_id: StringId) {
+    fn load_local_callable(&mut self, cached_frame: &CachedFrame<'h>, slot: u16, name_id: StringId) {
         let value = &self.stack[cached_frame.stack_base + slot as usize];
 
         if matches!(value, Value::Undefined) {
@@ -1841,7 +1837,7 @@ impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
     }
 
     /// Pops the top of stack and stores it in a local variable.
-    fn store_local(&mut self, cached_frame: &CachedFrame<'a>, slot: u16) {
+    fn store_local(&mut self, cached_frame: &CachedFrame<'h>, slot: u16) {
         let value = self.pop();
         let target = &mut self.stack[cached_frame.stack_base + slot as usize];
         let old_value = mem::replace(target, value);
@@ -1849,7 +1845,7 @@ impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
     }
 
     /// Deletes a local variable (sets it to Undefined).
-    fn delete_local(&mut self, cached_frame: &CachedFrame<'a>, slot: u16) {
+    fn delete_local(&mut self, cached_frame: &CachedFrame<'h>, slot: u16) {
         let target = &mut self.stack[cached_frame.stack_base + slot as usize];
         let old_value = mem::replace(target, Value::Undefined);
         old_value.drop_with_heap(self);
@@ -1907,7 +1903,7 @@ impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
     /// The cell `HeapId` is read from the frame's local variable slot on the stack
     /// (cells are stored as `Value::Ref(cell_id)` at known positions in the locals region).
     /// Returns a `NameError` if the cell value is undefined (free variable not bound).
-    fn load_cell(&mut self, cached_frame: &CachedFrame<'a>, slot: u16) -> RunResult<()> {
+    fn load_cell(&mut self, cached_frame: &CachedFrame<'h>, slot: u16) -> RunResult<()> {
         let cell_id = self.cell_id_from_local(cached_frame, slot);
         let value = match self.heap.get(cell_id) {
             HeapData::Cell(c) => c.0.clone_with_heap(self),
@@ -1962,7 +1958,7 @@ impl<'h, 'a, T: ResourceTracker> VM<'h, 'a, T> {
 }
 
 // `heap` is not a public field on VM, so this implementation needs to go here rather than in `heap.rs`
-impl<T: ResourceTracker> ContainsHeap for VM<'_, '_, T> {
+impl<T: ResourceTracker> ContainsHeap for VM<'_, T> {
     type ResourceTracker = T;
     fn heap(&self) -> &Heap<T> {
         self.heap
@@ -1978,7 +1974,7 @@ impl<T: ResourceTracker> ContainsHeap for VM<'_, '_, T> {
 /// string cache — all of which may hold heap references that need their
 /// ref-counts decremented. Fields that were already emptied (e.g. by
 /// `take_globals`) are harmlessly drained as empty.
-impl<T: ResourceTracker> Drop for VM<'_, '_, T> {
+impl<T: ResourceTracker> Drop for VM<'_, T> {
     fn drop(&mut self) {
         self.exception_stack.drain(..).drop_with_heap(self.heap);
         self.cleanup_current_task();

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -184,7 +184,7 @@ impl ExcType {
     ///
     /// The `interns` parameter provides access to interned string content.
     /// Returns a heap-allocated exception value.
-    pub(crate) fn call(self, vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub(crate) fn call(self, vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         defer_drop!(args, vm);
         let exc = match args {
             ArgValues::Empty => Ok(SimpleException::new_none(self)),
@@ -324,7 +324,7 @@ impl ExcType {
     /// If the key's string conversion fails (e.g. huge LongInt exceeding
     /// `INT_MAX_STR_DIGITS`), falls back to the type name so that a
     /// `KeyError` is always raised rather than a spurious `ValueError`.
-    pub(crate) fn key_error(key: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunError {
+    pub(crate) fn key_error(key: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunError {
         let key_str = match key.py_str(vm) {
             Ok(s) => s.into_owned(),
             Err(_) => format!("<{}>", key.py_type(vm)),
@@ -1441,7 +1441,7 @@ impl SimpleException {
 }
 
 impl<'h> HeapRead<'h, SimpleException> {
-    pub(crate) fn py_type(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    pub(crate) fn py_type(&self, vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::Exception(self.get(vm.heap).exc_type)
     }
 }
@@ -1481,11 +1481,7 @@ impl<'h> HeapRead<'h, SimpleException> {
     ///
     /// Handles the `.args` attribute by allocating a tuple containing the message.
     /// Returns `Err(AttributeError)` for all other attributes.
-    pub fn py_getattr(
-        &self,
-        attr: &EitherStr,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> RunResult<Option<CallResult>> {
+    pub fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
         // Fast path: interned strings can be matched by ID
         let is_args = attr
             .static_string()

--- a/crates/monty/src/fstring.rs
+++ b/crates/monty/src/fstring.rs
@@ -260,7 +260,7 @@ impl fmt::Display for FormatError {
 pub fn format_with_spec(
     value: &Value,
     spec: &ParsedFormatSpec,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> Result<String, RunError> {
     let value_type = value.py_type(vm);
 

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -123,11 +123,24 @@ impl<T: ResourceTracker> HeapReader<'_, T> {
     /// The ONLY way to get a `HeapReader`. By only providing an API which takes a closure which
     /// must be satisfied for all `'a`, it's impossible to create other `HeapReader` with the
     /// exact same lifetime `'a`.
-    pub fn with<R>(heap: &mut Heap<T>, f: impl for<'a> FnOnce(&'a mut HeapReader<'a, T>) -> R) -> R {
-        f(&mut HeapReader {
-            heap: &mut *heap,
-            phantom: PhantomData,
-        })
+    ///
+    /// To allow other data to be borrowed alongside the `HeapReader`, the closure is given a
+    /// `&'a mut D` with the same lifetime as the `HeapReader`, which is forwarded from the
+    /// `&mut D` passed to this function. This rebranding lets callers (most notably the
+    /// `VM`) hold borrows whose lifetime matches the `HeapReader`'s invariant brand `'a`,
+    /// which is what allows the `VM` to be parameterized by a single lifetime.
+    pub fn with<R, D: ?Sized>(
+        heap: &mut Heap<T>,
+        data: &mut D,
+        f: impl for<'a> FnOnce(&'a mut HeapReader<'a, T>, &'a mut D) -> R,
+    ) -> R {
+        f(
+            &mut HeapReader {
+                heap: &mut *heap,
+                phantom: PhantomData,
+            },
+            data,
+        )
     }
 }
 
@@ -987,7 +1000,7 @@ impl<T: ResourceTracker> Heap<T> {
     ///
     /// # Panics
     /// Panics if the value ID is invalid or the value has already been freed.
-    pub fn get_or_compute_hash(vm: &mut VM<'_, '_, T>, id: HeapId) -> Result<Option<u64>, ResourceError> {
+    pub fn get_or_compute_hash(vm: &mut VM<'_, T>, id: HeapId) -> Result<Option<u64>, ResourceError> {
         // TODO: it should be possible to refactor the triple lookup to just one, probably by having an
         // internal `vm.heap.read_entry` method which can then derive the `HeapReadOutput` for `py_hash`
         // later, and can live without a VM borrow to allow reading / writing the hash.

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -428,7 +428,7 @@ impl HeapItem for GatherFuture {
 }
 
 impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
-    fn py_bool(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         match self {
             Self::Str(s) => s.py_bool(vm),
             Self::Bytes(b) => b.py_bool(vm),
@@ -463,7 +463,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
     fn py_call_attr(
         &mut self,
         self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> Result<CallResult, RunError> {
@@ -495,7 +495,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         }
     }
 
-    fn py_type(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, vm: &VM<'h, impl ResourceTracker>) -> Type {
         match self {
             Self::Str(s) => s.py_type(vm),
             Self::Bytes(b) => b.py_type(vm),
@@ -528,7 +528,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         }
     }
 
-    fn py_len(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         match self {
             Self::Str(s) => s.py_len(vm),
             Self::Bytes(b) => b.py_len(vm),
@@ -551,7 +551,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         }
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, crate::ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, crate::ResourceError> {
         match (self, other) {
             // Simple types: compare with shared borrows (no &mut VM needed)
             (HeapReadOutput::Str(a), HeapReadOutput::Str(b)) => Ok(a.get(vm.heap).as_str() == b.get(vm.heap).as_str()),
@@ -644,11 +644,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
     /// `FunctionDefaults`, `Cell`, `LongInt`, `ExtFunction`), the hash is
     /// computed inline here. Variants left in the catch-all `_ => Ok(None)`
     /// arm are unhashable.
-    fn py_hash(
-        &self,
-        self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
         match self {
             Self::Str(s) => s.py_hash(self_id, vm),
             Self::Bytes(b) => b.py_hash(self_id, vm),
@@ -698,7 +694,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         match self {
@@ -750,7 +746,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         }
     }
 
-    fn py_str(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         match self {
             // Strings return their value directly without quotes
             Self::Str(s) => Ok(Cow::Owned(s.get(vm.heap).as_str().to_owned())),
@@ -777,7 +773,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
     fn py_add(
         &self,
         other: &Self,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
     ) -> Result<Option<Value>, crate::ResourceError> {
         match (self, other) {
             (HeapReadOutput::Str(a), HeapReadOutput::Str(b)) => {
@@ -827,7 +823,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
     fn py_sub(
         &self,
         other: &Self,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
     ) -> Result<Option<Value>, crate::ResourceError> {
         match (self, other) {
             (HeapReadOutput::LongInt(a), HeapReadOutput::LongInt(b)) => {
@@ -869,7 +865,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         }
     }
 
-    fn py_mod(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<Value>> {
+    fn py_mod(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<Value>> {
         match (self, other) {
             (HeapReadOutput::LongInt(a), HeapReadOutput::LongInt(b)) => {
                 if b.get(vm.heap).is_zero() {
@@ -886,7 +882,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
     fn py_iadd(
         &mut self,
         other: &Value,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         self_id: Option<HeapId>,
     ) -> Result<bool, crate::ResourceError> {
         match self {
@@ -895,7 +891,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         }
     }
 
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+    fn py_getitem(&self, key: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         match self {
             Self::Str(s) => s.py_getitem(key, vm),
             Self::Bytes(b) => b.py_getitem(key, vm),
@@ -909,7 +905,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         }
     }
 
-    fn py_setitem(&mut self, key: Value, value: Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<()> {
+    fn py_setitem(&mut self, key: Value, value: Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<()> {
         match self {
             Self::List(l) => l.py_setitem(key, value, vm),
             Self::Dict(d) => d.py_setitem(key, value, vm),
@@ -921,7 +917,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         }
     }
 
-    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
+    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
         match self {
             Self::Str(s) => s.py_getattr(attr, vm),
             Self::Bytes(b) => b.py_getattr(attr, vm),

--- a/crates/monty/src/modules/asyncio.rs
+++ b/crates/monty/src/modules/asyncio.rs
@@ -39,7 +39,7 @@ pub(crate) enum AsyncioFunctions {
 ///
 /// # Panics
 /// Panics if the required strings have not been pre-interned during prepare phase.
-pub fn create_module(vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
+pub fn create_module(vm: &mut VM<'_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
     let mut module = Module::new(StaticStrings::Asyncio);
 
     module.set_attr(

--- a/crates/monty/src/modules/datetime.rs
+++ b/crates/monty/src/modules/datetime.rs
@@ -26,7 +26,7 @@ use crate::{
 /// # Panics
 ///
 /// Panics if the required strings have not been pre-interned during prepare phase.
-pub fn create_module(vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
+pub fn create_module(vm: &mut VM<'_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
     let mut module = Module::new(StaticStrings::Datetime);
 
     module.set_attr(StaticStrings::Date, Value::Builtin(Builtins::Type(Type::Date)), vm);

--- a/crates/monty/src/modules/json/dump.rs
+++ b/crates/monty/src/modules/json/dump.rs
@@ -83,7 +83,7 @@ impl JsonDumpsConfig {
     ///
     /// Unsupported keyword names and not-yet-implemented CPython kwargs raise
     /// immediately so typos or dropped behavior do not go unnoticed.
-    fn parse_kwargs(kwargs: KwargsValues, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Self> {
+    fn parse_kwargs(kwargs: KwargsValues, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Self> {
         let kwargs_iter = kwargs.into_iter();
         defer_drop_mut!(kwargs_iter, vm);
 
@@ -208,7 +208,7 @@ impl JsonDumpsConfig {
 ///
 /// CPython kwargs `cls`, `default`, and `check_circular` are intentionally
 /// unsupported and will raise `TypeError` if passed.
-pub(super) fn call_dumps(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub(super) fn call_dumps(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (mut pos, kwargs) = args.into_parts();
 
     let Some(obj) = pos.next() else {
@@ -244,7 +244,7 @@ pub(super) fn call_dumps(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgVal
 /// spaces per nesting level (with zero and negative values enabling newline-
 /// only pretty printing), and
 /// strings are repeated once per depth level exactly like CPython.
-fn parse_indent_value(value: Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Option<String>> {
+fn parse_indent_value(value: Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Option<String>> {
     let mut value_guard = HeapGuard::new(value, vm);
     let (value, vm) = value_guard.as_parts_mut();
 
@@ -283,10 +283,7 @@ fn spaces_from_indent_count(count: i64) -> RunResult<Option<String>> {
 ///
 /// `None` leaves the default separators intact. Otherwise the value must be a
 /// two-item list or tuple of strings representing the item and key separators.
-fn parse_separators_value(
-    value: Value,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
-) -> RunResult<Option<(String, String)>> {
+fn parse_separators_value(value: Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Option<(String, String)>> {
     let mut value_guard = HeapGuard::new(value, vm);
     let (value, vm) = value_guard.as_parts_mut();
 
@@ -352,7 +349,7 @@ fn check_separators_length(len: usize) -> RunResult<()> {
 /// their positional argument index in `make_encoder()`. The `role` parameter
 /// selects the matching CPython argument number (6 for `item_separator`,
 /// 5 for `key_separator`) so the error message matches CPython exactly.
-fn json_separator_to_string(value: &Value, role: &str, vm: &VM<'_, '_, impl ResourceTracker>) -> RunResult<String> {
+fn json_separator_to_string(value: &Value, role: &str, vm: &VM<'_, impl ResourceTracker>) -> RunResult<String> {
     let arg_num = if role == "item_separator" { 6 } else { 5 };
     match value {
         Value::InternString(string_id) => Ok(vm.interns.get_str(*string_id).to_owned()),
@@ -380,7 +377,7 @@ fn serialize_value(
     config: &JsonDumpsConfig,
     depth: usize,
     active_containers: &mut Vec<HeapId>,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<()> {
     match value {
         Value::None => {
@@ -475,7 +472,7 @@ fn serialize_sequence(
     config: &JsonDumpsConfig,
     depth: usize,
     active_containers: &mut Vec<HeapId>,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<()> {
     out.push('[');
     if items.is_empty() {
@@ -514,7 +511,7 @@ fn serialize_dict(
     config: &JsonDumpsConfig,
     depth: usize,
     active_containers: &mut Vec<HeapId>,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<()> {
     if config.skipkeys() {
         skip_disallowed_dict_keys(entries, vm);
@@ -554,7 +551,7 @@ fn serialize_dict(
 /// The implementation mirrors the error style used by `sorted()` and
 /// `list.sort()`: when two keys are not orderable, it raises
 /// `TypeError: '<' not supported between instances of ...`.
-fn sort_dict_entries(entries: &mut Vec<(Value, Value)>, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<()> {
+fn sort_dict_entries(entries: &mut Vec<(Value, Value)>, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<()> {
     let mut indices: Vec<usize> = (0..entries.len()).collect();
     let compare_values: Vec<Value> = entries.iter().map(|(key, _)| key.clone_with_heap(vm)).collect();
     let mut compare_values_guard = HeapGuard::new(compare_values, vm);
@@ -570,7 +567,7 @@ fn sort_dict_entries(entries: &mut Vec<(Value, Value)>, vm: &mut VM<'_, '_, impl
 /// order of the retained pairs. A two-pointer compaction avoids the repeated
 /// shifting cost of `Vec::remove(i)` while still cleaning up skipped `Value`
 /// references with `drop_with_heap`.
-fn skip_disallowed_dict_keys(entries: &mut Vec<(Value, Value)>, vm: &mut VM<'_, '_, impl ResourceTracker>) {
+fn skip_disallowed_dict_keys(entries: &mut Vec<(Value, Value)>, vm: &mut VM<'_, impl ResourceTracker>) {
     let mut write = 0;
     for read in 0..entries.len() {
         if is_json_key_allowed(&entries[read].0, vm) {
@@ -591,7 +588,7 @@ fn skip_disallowed_dict_keys(entries: &mut Vec<(Value, Value)>, vm: &mut VM<'_, 
 ///
 /// CPython accepts strings, integers, floats, booleans, and `None`, then
 /// coerces the non-string cases to JSON strings during output.
-fn is_json_key_allowed(value: &Value, vm: &VM<'_, '_, impl ResourceTracker>) -> bool {
+fn is_json_key_allowed(value: &Value, vm: &VM<'_, impl ResourceTracker>) -> bool {
     matches!(
         value,
         Value::None | Value::Bool(_) | Value::Int(_) | Value::Float(_) | Value::InternString(_)
@@ -606,7 +603,7 @@ fn write_json_key(
     key: &Value,
     out: &mut String,
     config: &JsonDumpsConfig,
-    vm: &VM<'_, '_, impl ResourceTracker>,
+    vm: &VM<'_, impl ResourceTracker>,
 ) -> RunResult<()> {
     let ensure_ascii = config.ensure_ascii();
     match key {

--- a/crates/monty/src/modules/json/load.rs
+++ b/crates/monty/src/modules/json/load.rs
@@ -70,7 +70,7 @@ const JSON_RECURSION_LIMIT: usize = 200;
 /// CPython kwargs `cls`, `object_hook`, `parse_float`, `parse_int`,
 /// `parse_constant`, and `object_pairs_hook` are intentionally unsupported
 /// and will raise `TypeError` if passed.
-pub(super) fn call_loads(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+pub(super) fn call_loads(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (mut pos, kwargs) = args.into_parts();
     if let Some((key, value)) = kwargs.into_iter().next() {
         defer_drop!(key, vm);
@@ -105,7 +105,7 @@ pub(super) fn call_loads(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgVal
 /// The parser works directly on the underlying byte slice. Decoded strings from
 /// `jiter` are copied into Monty's heap immediately before any further parser
 /// movement so borrowed tape-backed data never escapes.
-fn parse_json_input(value: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Value> {
+fn parse_json_input(value: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Value> {
     let bytes: Cow<'_, [u8]> = match value {
         Value::InternString(string_id) => Cow::Borrowed(vm.interns.get_str(*string_id).as_bytes()),
         Value::InternBytes(bytes_id) => Cow::Borrowed(vm.interns.get_bytes(*bytes_id)),
@@ -127,7 +127,7 @@ fn parse_json_input(value: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) ->
 ///
 /// Syntax errors are wrapped in `json.JSONDecodeError` using the same
 /// line/column/character suffix as CPython.
-fn parse_json_bytes(bytes: &[u8], vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Value> {
+fn parse_json_bytes(bytes: &[u8], vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Value> {
     let mut jiter = Jiter::new(bytes).with_allow_inf_nan();
     // Take the cache out of the VM so we can pass it alongside &mut VM
     // without conflicting borrows. `mem::take` leaves `Default` in its place.
@@ -157,7 +157,7 @@ fn parse_json_value(
     jiter: &mut Jiter<'_>,
     depth: usize,
     cache: &mut JsonStringCache,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> ParseResult<Value> {
     let peek = jiter.peek()?;
     parse_json_value_from_peek(peek, jiter, depth, cache, vm)
@@ -172,7 +172,7 @@ fn parse_json_value_from_peek(
     jiter: &mut Jiter<'_>,
     depth: usize,
     cache: &mut JsonStringCache,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> ParseResult<Value> {
     match peek {
         Peek::Null => {
@@ -212,11 +212,7 @@ fn allocate_cached_string(
 /// Integer tokens are counted directly from the source bytes so
 /// `INT_MAX_STR_DIGITS` errors report the same digit count as CPython without
 /// first allocating an oversized decimal string.
-fn parse_json_number(
-    peek: Peek,
-    jiter: &mut Jiter<'_>,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
-) -> ParseResult<Value> {
+fn parse_json_number(peek: Peek, jiter: &mut Jiter<'_>, vm: &mut VM<'_, impl ResourceTracker>) -> ParseResult<Value> {
     let start = jiter.current_index();
     match jiter.known_number(peek) {
         Ok(NumberAny::Int(NumberInt::Int(value))) => Ok(Value::Int(value)),
@@ -238,7 +234,7 @@ fn parse_json_array(
     jiter: &mut Jiter<'_>,
     depth: usize,
     cache: &mut JsonStringCache,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> ParseResult<Value> {
     check_json_recursion_limit(jiter, depth)?;
 
@@ -281,7 +277,7 @@ fn parse_json_object(
     jiter: &mut Jiter<'_>,
     depth: usize,
     cache: &mut JsonStringCache,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> ParseResult<Value> {
     check_json_recursion_limit(jiter, depth)?;
 

--- a/crates/monty/src/modules/json/mod.rs
+++ b/crates/monty/src/modules/json/mod.rs
@@ -48,7 +48,7 @@ pub(crate) enum JsonFunctions {
 /// The module exposes `loads`, `dumps`, and `JSONDecodeError`. These are the
 /// most widely used parts of CPython's `json` module and are sufficient for
 /// common data interchange and round-tripping use cases inside the sandbox.
-pub fn create_module(vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
+pub fn create_module(vm: &mut VM<'_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
     let mut module = Module::new(StaticStrings::Json);
     module.set_attr(
         StaticStrings::Loads,
@@ -73,7 +73,7 @@ pub fn create_module(vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<HeapId
 /// Both functions are pure computations that return ordinary Monty values and
 /// never need host involvement, so the dispatcher returns `Value` directly.
 pub(super) fn call(
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
     function: JsonFunctions,
     args: ArgValues,
 ) -> RunResult<Value> {

--- a/crates/monty/src/modules/math.rs
+++ b/crates/monty/src/modules/math.rs
@@ -181,7 +181,7 @@ pub(crate) enum MathFunctions {
 ///
 /// # Panics
 /// Panics if the required strings have not been pre-interned during prepare phase.
-pub fn create_module(vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
+pub fn create_module(vm: &mut VM<'_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
     let mut module = Module::new(StaticStrings::Math);
 
     // Register all math functions
@@ -268,7 +268,7 @@ const MATH_FUNCTIONS: &[(StaticStrings, MathFunctions)] = &[
 ///
 /// All math functions are pure computations and return `Value` directly.
 pub(super) fn call(
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
     function: MathFunctions,
     args: ArgValues,
 ) -> RunResult<Value> {
@@ -345,7 +345,7 @@ pub(super) fn call(
 ///
 /// Accepts int, float, or bool. Returns int.
 /// Raises `OverflowError` for infinity, `ValueError` for NaN.
-fn math_floor(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_floor(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.floor", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -364,7 +364,7 @@ fn math_floor(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Run
 ///
 /// Accepts int, float, or bool. Returns int.
 /// Raises `OverflowError` for infinity, `ValueError` for NaN.
-fn math_ceil(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_ceil(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.ceil", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -382,7 +382,7 @@ fn math_ceil(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunR
 /// `math.trunc(x)` — truncates x to the nearest integer toward zero.
 ///
 /// Accepts int, float, or bool. Returns int.
-fn math_trunc(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_trunc(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.trunc", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -405,7 +405,7 @@ fn math_trunc(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Run
 ///
 /// Always returns a float. Raises `ValueError` for negative inputs with a
 /// descriptive message matching CPython 3.14: "expected a nonnegative input, got <x>".
-fn math_sqrt(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_sqrt(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.sqrt", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -421,7 +421,7 @@ fn math_sqrt(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunR
 ///
 /// Returns the largest integer `r` such that `r * r <= n`.
 /// Only accepts non-negative integers (and bools).
-fn math_isqrt(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_isqrt(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.isqrt", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -457,7 +457,7 @@ fn math_isqrt(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Run
 /// `math.cbrt(x)` — returns the cube root of x.
 ///
 /// Always returns a float. Unlike `sqrt`, works for negative inputs.
-fn math_cbrt(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_cbrt(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.cbrt", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -470,7 +470,7 @@ fn math_cbrt(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunR
 /// Always returns a float. Unlike the builtin `pow()`, does not support
 /// three-argument modular exponentiation. Raises `ValueError` for
 /// negative base with non-integer exponent.
-fn math_pow(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_pow(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (x_val, y_val) = args.get_two_args("math.pow", vm.heap)?;
     defer_drop!(x_val, vm);
     defer_drop!(y_val, vm);
@@ -493,7 +493,7 @@ fn math_pow(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunRe
 }
 
 /// `math.exp(x)` — returns e raised to the power x.
-fn math_exp(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_exp(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.exp", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -504,7 +504,7 @@ fn math_exp(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunRe
 }
 
 /// `math.exp2(x)` — returns 2 raised to the power x.
-fn math_exp2(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_exp2(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.exp2", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -517,7 +517,7 @@ fn math_exp2(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunR
 /// `math.expm1(x)` — returns e**x - 1.
 ///
 /// More accurate than `exp(x) - 1` for small values of x.
-fn math_expm1(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_expm1(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.expm1", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -536,7 +536,7 @@ fn math_expm1(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Run
 /// With one argument, returns the natural logarithm (base e).
 /// With two arguments, returns `log(x) / log(base)`.
 /// Raises `ValueError` for non-positive inputs (CPython 3.14: "expected a positive input").
-fn math_log(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_log(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (x_val, base_val) = args.get_one_two_args("math.log", vm.heap)?;
     defer_drop!(x_val, vm);
     defer_drop!(base_val, vm);
@@ -571,7 +571,7 @@ fn math_log(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunRe
 ///
 /// More accurate than `log(1 + x)` for small values of x.
 /// CPython 3.14 raises ValueError with "expected argument value > -1, got <x>".
-fn math_log1p(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_log1p(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.log1p", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -588,7 +588,7 @@ fn math_log1p(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Run
 ///
 /// Returns `inf` for positive infinity, `nan` for NaN.
 /// Raises `ValueError` for non-positive finite inputs.
-fn math_log2(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_log2(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.log2", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -604,7 +604,7 @@ fn math_log2(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunR
 ///
 /// Returns `inf` for positive infinity, `nan` for NaN.
 /// Raises `ValueError` for non-positive finite inputs.
-fn math_log10(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_log10(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.log10", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -623,7 +623,7 @@ fn math_log10(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Run
 /// `math.fabs(x)` — returns the absolute value as a float.
 ///
 /// Unlike the builtin `abs()`, always returns a float.
-fn math_fabs(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_fabs(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.fabs", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -632,7 +632,7 @@ fn math_fabs(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunR
 }
 
 /// `math.isnan(x)` — returns True if x is NaN.
-fn math_isnan(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_isnan(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.isnan", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -641,7 +641,7 @@ fn math_isnan(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Run
 }
 
 /// `math.isinf(x)` — returns True if x is positive or negative infinity.
-fn math_isinf(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_isinf(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.isinf", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -650,7 +650,7 @@ fn math_isinf(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Run
 }
 
 /// `math.isfinite(x)` — returns True if x is neither infinity nor NaN.
-fn math_isfinite(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_isfinite(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.isfinite", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -661,7 +661,7 @@ fn math_isfinite(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> 
 /// `math.copysign(x, y)` — returns x with the sign of y.
 ///
 /// Always returns a float.
-fn math_copysign(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_copysign(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (x_val, y_val) = args.get_two_args("math.copysign", vm.heap)?;
     defer_drop!(x_val, vm);
     defer_drop!(y_val, vm);
@@ -675,7 +675,7 @@ fn math_copysign(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> 
 ///
 /// Supports keyword-only `rel_tol` and `abs_tol` parameters matching CPython.
 /// Raises `ValueError` if either tolerance is negative.
-fn math_isclose(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_isclose(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (positional, kwargs) = args.into_parts();
     defer_drop_mut!(positional, vm);
 
@@ -729,7 +729,7 @@ fn math_isclose(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> R
 /// Extracts `rel_tol` and `abs_tol` keyword arguments for `math.isclose`.
 ///
 /// Returns `(rel_tol, abs_tol)` with defaults of `(1e-9, 0.0)`.
-fn extract_isclose_kwargs(kwargs: KwargsValues, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<(f64, f64)> {
+fn extract_isclose_kwargs(kwargs: KwargsValues, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<(f64, f64)> {
     let mut rel_tol: f64 = 1e-9;
     let mut abs_tol: f64 = 0.0;
 
@@ -765,7 +765,7 @@ fn extract_isclose_kwargs(kwargs: KwargsValues, vm: &mut VM<'_, '_, impl Resourc
 }
 
 /// `math.nextafter(x, y)` — returns the next float after x towards y.
-fn math_nextafter(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_nextafter(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (x_val, y_val) = args.get_two_args("math.nextafter", vm.heap)?;
     defer_drop!(x_val, vm);
     defer_drop!(y_val, vm);
@@ -780,7 +780,7 @@ fn math_nextafter(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) ->
 ///
 /// For finite non-zero x, returns the smallest float `u` such that `x + u != x`.
 /// Special cases: `ulp(nan)` returns nan, `ulp(inf)` returns inf.
-fn math_ulp(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_ulp(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.ulp", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -808,7 +808,7 @@ fn math_ulp(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunRe
 /// `math.sin(x)` — returns the sine of x (in radians).
 ///
 /// CPython 3.14 raises ValueError for infinity: "expected a finite input, got inf".
-fn math_sin(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_sin(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.sin", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -818,7 +818,7 @@ fn math_sin(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunRe
 }
 
 /// `math.cos(x)` — returns the cosine of x (in radians).
-fn math_cos(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_cos(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.cos", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -828,7 +828,7 @@ fn math_cos(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunRe
 }
 
 /// `math.tan(x)` — returns the tangent of x (in radians).
-fn math_tan(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_tan(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.tan", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -840,7 +840,7 @@ fn math_tan(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunRe
 /// `math.asin(x)` — returns the arc sine of x (in radians).
 ///
 /// CPython 3.14: "expected a number in range from -1 up to 1, got <x>".
-fn math_asin(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_asin(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.asin", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -852,7 +852,7 @@ fn math_asin(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunR
 /// `math.acos(x)` — returns the arc cosine of x (in radians).
 ///
 /// CPython 3.14: "expected a number in range from -1 up to 1, got <x>".
-fn math_acos(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_acos(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.acos", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -862,7 +862,7 @@ fn math_acos(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunR
 }
 
 /// `math.atan(x)` — returns the arc tangent of x (in radians).
-fn math_atan(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_atan(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.atan", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -872,7 +872,7 @@ fn math_atan(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunR
 
 /// `math.atan2(y, x)` — returns atan(y/x) in radians, using the signs of both
 /// to determine the correct quadrant.
-fn math_atan2(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_atan2(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (y_val, x_val) = args.get_two_args("math.atan2", vm.heap)?;
     defer_drop!(y_val, vm);
     defer_drop!(x_val, vm);
@@ -887,7 +887,7 @@ fn math_atan2(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Run
 // ==========================
 
 /// `math.sinh(x)` — returns the hyperbolic sine of x.
-fn math_sinh(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_sinh(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.sinh", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -898,7 +898,7 @@ fn math_sinh(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunR
 }
 
 /// `math.cosh(x)` — returns the hyperbolic cosine of x.
-fn math_cosh(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_cosh(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.cosh", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -909,7 +909,7 @@ fn math_cosh(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunR
 }
 
 /// `math.tanh(x)` — returns the hyperbolic tangent of x.
-fn math_tanh(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_tanh(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.tanh", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -918,7 +918,7 @@ fn math_tanh(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunR
 }
 
 /// `math.asinh(x)` — returns the inverse hyperbolic sine of x.
-fn math_asinh(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_asinh(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.asinh", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -929,7 +929,7 @@ fn math_asinh(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Run
 /// `math.acosh(x)` — returns the inverse hyperbolic cosine of x.
 ///
 /// CPython 3.14: "expected argument value not less than 1, got <x>".
-fn math_acosh(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_acosh(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.acosh", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -947,7 +947,7 @@ fn math_acosh(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Run
 /// `math.atanh(x)` — returns the inverse hyperbolic tangent of x.
 ///
 /// CPython 3.14: "expected a number between -1 and 1, got <x>".
-fn math_atanh(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_atanh(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.atanh", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -967,7 +967,7 @@ fn math_atanh(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Run
 // ==========================
 
 /// `math.degrees(x)` — converts angle x from radians to degrees.
-fn math_degrees(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_degrees(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.degrees", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -976,7 +976,7 @@ fn math_degrees(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> R
 }
 
 /// `math.radians(x)` — converts angle x from degrees to radians.
-fn math_radians(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_radians(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.radians", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -992,7 +992,7 @@ fn math_radians(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> R
 ///
 /// Only accepts non-negative integers (and bools). Raises `ValueError` for
 /// negative values, `TypeError` for non-integer types.
-fn math_factorial(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_factorial(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.factorial", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -1035,7 +1035,7 @@ fn math_factorial(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) ->
 /// Supports 0 or more arguments, matching CPython 3.9+. `gcd()` returns 0,
 /// `gcd(n)` returns `abs(n)`, and for multiple args reduces pairwise.
 /// The result is always non-negative.
-fn math_gcd(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_gcd(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let positional = args.into_pos_only("math.gcd", vm.heap)?;
     defer_drop_mut!(positional, vm);
 
@@ -1053,7 +1053,7 @@ fn math_gcd(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunRe
 /// Supports 0 or more arguments, matching CPython 3.9+. `lcm()` returns 1,
 /// `lcm(n)` returns `abs(n)`, and for multiple args reduces pairwise.
 /// The result is always non-negative. Returns 0 if any argument is 0.
-fn math_lcm(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_lcm(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let positional = args.into_pos_only("math.lcm", vm.heap)?;
     defer_drop_mut!(positional, vm);
 
@@ -1077,7 +1077,7 @@ fn math_lcm(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunRe
 /// `math.comb(n, k)` — returns the number of ways to choose k items from n.
 ///
 /// Both arguments must be non-negative integers.
-fn math_comb(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_comb(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (n_val, k_val) = args.get_two_args("math.comb", vm.heap)?;
     defer_drop!(n_val, vm);
     defer_drop!(k_val, vm);
@@ -1129,7 +1129,7 @@ fn math_comb(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunR
 ///
 /// Both arguments must be non-negative integers. When `k` is omitted, defaults to `n`
 /// (i.e., `perm(n)` returns `n!`), matching CPython behavior.
-fn math_perm(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_perm(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (n_val, k_val) = args.get_one_two_args("math.perm", vm.heap)?;
     defer_drop!(n_val, vm);
 
@@ -1179,7 +1179,7 @@ fn math_perm(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunR
 ///
 /// Unlike `x % y`, the result has the same sign as x. Raises `ValueError`
 /// when y is zero (CPython: "math domain error").
-fn math_fmod(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_fmod(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (x_val, y_val) = args.get_two_args("math.fmod", vm.heap)?;
     defer_drop!(x_val, vm);
     defer_drop!(y_val, vm);
@@ -1200,7 +1200,7 @@ fn math_fmod(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunR
 /// `math.remainder(x, y)` — IEEE 754 remainder of x with respect to y.
 ///
 /// The result is `x - n*y` where n is the closest integer to `x/y`.
-fn math_remainder(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_remainder(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (x_val, y_val) = args.get_two_args("math.remainder", vm.heap)?;
     defer_drop!(x_val, vm);
     defer_drop!(y_val, vm);
@@ -1228,7 +1228,7 @@ fn math_remainder(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) ->
 /// `math.modf(x)` — returns the fractional and integer parts of x as a tuple.
 ///
 /// Both values carry the sign of x. Returns `(fractional, integer)`.
-fn math_modf(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_modf(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.modf", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -1242,7 +1242,7 @@ fn math_modf(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunR
 ///
 /// The mantissa is always in the range [0.5, 1.0) or zero.
 /// Returns a tuple `(float, int)`.
-fn math_frexp(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_frexp(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.frexp", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -1257,7 +1257,7 @@ fn math_frexp(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Run
 /// Clamps the exponent to `i32` range before calling `libm::ldexp`, which is safe
 /// because IEEE 754 double exponents only span -1074 to +1023 — any `i64` outside
 /// `i32` range would trivially overflow or underflow anyway.
-fn math_ldexp(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_ldexp(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (x_val, i_val) = args.get_two_args("math.ldexp", vm.heap)?;
     defer_drop!(x_val, vm);
     defer_drop!(i_val, vm);
@@ -1291,7 +1291,7 @@ fn math_ldexp(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Run
 ///
 /// CPython 3.14 raises ValueError for non-positive integers:
 /// "expected a noninteger or positive integer, got <x>".
-fn math_gamma(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_gamma(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.gamma", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -1312,7 +1312,7 @@ fn math_gamma(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Run
 }
 
 /// `math.lgamma(x)` — returns the natural log of the absolute value of Gamma(x).
-fn math_lgamma(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_lgamma(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.lgamma", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -1325,7 +1325,7 @@ fn math_lgamma(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Ru
 }
 
 /// `math.erf(x)` — returns the error function at x.
-fn math_erf(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_erf(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.erf", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -1336,7 +1336,7 @@ fn math_erf(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunRe
 /// `math.erfc(x)` — returns the complementary error function at x (1 - erf(x)).
 ///
 /// More accurate than `1 - erf(x)` for large x.
-fn math_erfc(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn math_erfc(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("math.erfc", vm.heap)?;
     defer_drop!(value, vm);
 
@@ -1390,7 +1390,7 @@ fn float_to_int_checked(rounded: f64, original: f64, heap: &mut Heap<impl Resour
     clippy::cast_precision_loss,
     reason = "i64-to-f64 can lose precision for large integers (beyond 2^53), but this matches CPython's conversion semantics"
 )]
-fn value_to_float(value: &Value, vm: &VM<'_, '_, impl ResourceTracker>) -> RunResult<f64> {
+fn value_to_float(value: &Value, vm: &VM<'_, impl ResourceTracker>) -> RunResult<f64> {
     match value {
         Value::Float(f) => Ok(*f),
         Value::Int(n) => Ok(*n as f64),
@@ -1406,7 +1406,7 @@ fn value_to_float(value: &Value, vm: &VM<'_, '_, impl ResourceTracker>) -> RunRe
 ///
 /// Accepts `Int` and `Bool` values. For other types, raises a `TypeError`
 /// with a message matching CPython's format.
-fn value_to_int(value: &Value, vm: &VM<'_, '_, impl ResourceTracker>) -> RunResult<i64> {
+fn value_to_int(value: &Value, vm: &VM<'_, impl ResourceTracker>) -> RunResult<i64> {
     match value {
         Value::Int(n) => Ok(*n),
         Value::Bool(b) => Ok(i64::from(*b)),

--- a/crates/monty/src/modules/mod.rs
+++ b/crates/monty/src/modules/mod.rs
@@ -74,7 +74,7 @@ impl StandardLib {
     /// # Panics
     ///
     /// Panics if the required strings have not been pre-interned during prepare phase.
-    pub fn create(self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
+    pub fn create(self, vm: &mut VM<'_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
         match self {
             Self::Sys => sys::create_module(vm),
             Self::Typing => typing::create_module(vm),
@@ -116,7 +116,7 @@ impl ModuleFunctions {
     ///
     /// Returns `CallResult` to support both immediate values and OS calls that
     /// require host involvement (e.g., `os.getenv()` needs the host to provide environment variables).
-    pub fn call(self, vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<CallResult> {
+    pub fn call(self, vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<CallResult> {
         match self {
             Self::Asyncio(functions) => asyncio::call(vm.heap, functions, args),
             Self::Json(functions) => json::call(vm, functions, args).map(CallResult::Value),

--- a/crates/monty/src/modules/os.rs
+++ b/crates/monty/src/modules/os.rs
@@ -41,7 +41,7 @@ pub(crate) enum OsFunctions {
 ///
 /// # Panics
 /// Panics if the required strings have not been pre-interned during prepare phase.
-pub fn create_module(vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
+pub fn create_module(vm: &mut VM<'_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
     let mut module = Module::new(StaticStrings::Os);
 
     // os.getenv - function to get a single environment variable
@@ -66,7 +66,7 @@ pub fn create_module(vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<HeapId
 /// Returns `CallResult::OsCall` for functions that need host involvement,
 /// or `CallResult::Value` for functions that can be computed immediately.
 pub(super) fn call(
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
     functions: OsFunctions,
     args: ArgValues,
 ) -> RunResult<CallResult> {
@@ -93,7 +93,7 @@ pub(super) fn call(
 /// - No arguments are provided
 /// - More than 2 arguments are provided
 /// - `key` is not a string
-fn getenv(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<CallResult> {
+fn getenv(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<CallResult> {
     // getenv(key, default=None) - accepts 1 or 2 positional arguments
     let (key, default) = args.get_one_two_args("os.getenv", vm.heap)?;
 

--- a/crates/monty/src/modules/pathlib.rs
+++ b/crates/monty/src/modules/pathlib.rs
@@ -23,7 +23,7 @@ use crate::{
 /// # Panics
 ///
 /// Panics if the required strings have not been pre-interned during prepare phase.
-pub fn create_module(vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
+pub fn create_module(vm: &mut VM<'_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
     let mut module = Module::new(StaticStrings::Pathlib);
 
     // pathlib.Path - the Path class (callable to create Path instances)

--- a/crates/monty/src/modules/re.rs
+++ b/crates/monty/src/modules/re.rs
@@ -89,7 +89,7 @@ pub(crate) enum ReFunctions {
 ///
 /// # Panics
 /// Panics if the required strings have not been pre-interned during prepare phase.
-pub fn create_module(vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
+pub fn create_module(vm: &mut VM<'_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
     let mut module = Module::new(StaticStrings::Re);
 
     // Functions
@@ -184,7 +184,7 @@ pub fn create_module(vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<HeapId
 /// `RePattern` method. All functions return `CallResult::Value` since regex
 /// operations don't need host involvement.
 pub(super) fn call(
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
     function: ReFunctions,
     args: ArgValues,
 ) -> RunResult<CallResult> {
@@ -205,7 +205,7 @@ pub(super) fn call(
 ///
 /// Returns a `re.Pattern` object that can be reused for multiple match operations.
 /// The pattern is compiled once and stored, avoiding recompilation overhead.
-fn call_compile(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn call_compile(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (pattern_val, flags) = extract_pattern_and_flags(args, "re.compile", vm)?;
     let compiled = RePattern::compile(pattern_val, flags)?;
     Ok(Value::Ref(vm.heap.allocate(HeapData::RePattern(Box::new(compiled)))?))
@@ -215,7 +215,7 @@ fn call_compile(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> R
 ///
 /// Compiles the pattern, then delegates to `RePattern::search`. Returns a `re.Match`
 /// object on success, or `None` if no position in the string matches.
-fn call_search(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn call_search(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (pattern, text, flags) = extract_pattern_string_flags(args, "re.search", vm)?;
     let compiled = RePattern::compile(pattern, flags)?;
     compiled.search(&text, vm.heap)
@@ -225,7 +225,7 @@ fn call_search(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Ru
 ///
 /// Compiles the pattern, then delegates to `RePattern::match_start`. Returns a `re.Match`
 /// object if the pattern matches at position 0, or `None` otherwise.
-fn call_match(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn call_match(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (pattern, text, flags) = extract_pattern_string_flags(args, "re.match", vm)?;
     let compiled = RePattern::compile(pattern, flags)?;
     compiled.match_start(&text, vm.heap)
@@ -235,7 +235,7 @@ fn call_match(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Run
 ///
 /// Compiles the pattern, then delegates to `RePattern::fullmatch`. Returns a `re.Match`
 /// object if the pattern matches the whole string, or `None` otherwise.
-fn call_fullmatch(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn call_fullmatch(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (pattern, text, flags) = extract_pattern_string_flags(args, "re.fullmatch", vm)?;
     let compiled = RePattern::compile(pattern, flags)?;
     compiled.fullmatch(&text, vm.heap)
@@ -245,7 +245,7 @@ fn call_fullmatch(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) ->
 ///
 /// Compiles the pattern, then delegates to `RePattern::findall`. Returns a list of
 /// strings or tuples depending on the number of capture groups (matching CPython semantics).
-fn call_findall(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn call_findall(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (pattern, text, flags) = extract_pattern_string_flags(args, "re.findall", vm)?;
     let compiled = RePattern::compile(pattern, flags)?;
     compiled.findall(&text, vm.heap)
@@ -256,7 +256,7 @@ fn call_findall(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> R
 /// Compiles the pattern, then delegates to `RePattern::sub`. Replaces occurrences of the
 /// pattern with the replacement string. When `count` is 0, all matches are replaced.
 /// Supports both positional and keyword arguments for `count` and `flags`.
-fn call_sub(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn call_sub(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (pos, kwargs) = args.into_parts();
     defer_drop_mut!(pos, vm);
     let kwargs = kwargs.into_iter();
@@ -369,7 +369,7 @@ fn call_sub(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunRe
 /// Returns a list of strings. If `maxsplit` is non-zero, at most `maxsplit` splits occur
 /// and the remainder of the string is returned as the final list element.
 /// Supports both positional and keyword arguments for `maxsplit` and `flags`.
-fn call_split(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn call_split(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (pos, kwargs) = args.into_parts();
     defer_drop_mut!(pos, vm);
     let kwargs = kwargs.into_iter();
@@ -444,7 +444,7 @@ fn call_split(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> Run
 /// Eagerly collects all match objects into a list. When the user iterates with
 /// `for m in re.finditer(...)`, the VM's `GetIter` opcode handles iteration
 /// over the returned list automatically.
-fn call_finditer(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn call_finditer(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (pattern, text, flags) = extract_pattern_string_flags(args, "re.finditer", vm)?;
     let compiled = RePattern::compile(pattern, flags)?;
     compiled.finditer(&text, vm.heap)
@@ -457,7 +457,7 @@ fn call_finditer(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> 
 /// escaped, matching CPython 3.7+ behavior.
 ///
 /// Escaped characters: `\t \n \v \f \r   # $ & ( ) * + - . ? [ \ ] ^ { | } ~`
-fn call_escape(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+fn call_escape(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let arg = args.get_one_arg("re.escape", vm.heap)?;
     defer_drop!(arg, vm);
     let text = value_to_str(arg, vm)?.into_owned();
@@ -509,7 +509,7 @@ fn should_escape(c: char) -> bool {
 /// Extracts a `maxsplit` value from an optional `Value`.
 ///
 /// Returns 0 if not provided. Negative values are treated as 0 (split all).
-fn extract_maxsplit(val: Option<Value>, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<usize> {
+fn extract_maxsplit(val: Option<Value>, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<usize> {
     match val {
         None => Ok(0),
         Some(Value::Int(n)) if n <= 0 => Ok(0),
@@ -535,7 +535,7 @@ fn extract_maxsplit(val: Option<Value>, vm: &mut VM<'_, '_, impl ResourceTracker
 fn extract_pattern_and_flags(
     args: ArgValues,
     func_name: &str,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<(String, u16)> {
     let (pattern_val, flags_val) = args.get_one_two_args(func_name, vm.heap)?;
     defer_drop!(pattern_val, vm);
@@ -548,7 +548,7 @@ fn extract_pattern_and_flags(
 
 /// Extracts a flags value from an optional `Value`, validating it is a non-negative integer
 /// that fits in a `u16`.
-fn extract_flags(flags_val: Option<Value>, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<u16> {
+fn extract_flags(flags_val: Option<Value>, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<u16> {
     match flags_val {
         Some(Value::Int(n)) => {
             u16::try_from(n).map_err(|_| ExcType::type_error("flags must be a non-negative integer"))
@@ -571,7 +571,7 @@ fn extract_flags(flags_val: Option<Value>, vm: &mut VM<'_, '_, impl ResourceTrac
 fn extract_pattern_string_flags(
     args: ArgValues,
     func_name: &str,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<(String, Cow<'static, str>, u16)> {
     let pos = args.into_pos_only(func_name, vm.heap)?;
     defer_drop_mut!(pos, vm);

--- a/crates/monty/src/modules/sys.rs
+++ b/crates/monty/src/modules/sys.rs
@@ -23,7 +23,7 @@ use crate::{
 /// # Panics
 ///
 /// Panics if the required strings have not been pre-interned during prepare phase.
-pub fn create_module(vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
+pub fn create_module(vm: &mut VM<'_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
     let mut module = Module::new(StaticStrings::Sys);
 
     // sys.platform

--- a/crates/monty/src/modules/typing.rs
+++ b/crates/monty/src/modules/typing.rs
@@ -23,7 +23,7 @@ use crate::{
 /// # Panics
 ///
 /// Panics if the required strings have not been pre-interned during prepare phase.
-pub fn create_module(vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
+pub fn create_module(vm: &mut VM<'_, impl ResourceTracker>) -> Result<HeapId, ResourceError> {
     let mut module = Module::new(StaticStrings::Typing);
 
     // typing.TYPE_CHECKING - always False

--- a/crates/monty/src/object.rs
+++ b/crates/monty/src/object.rs
@@ -352,7 +352,7 @@ impl MontyObject {
     /// then properly drops the Value via `drop_with_heap` to maintain reference counting.
     ///
     /// The `interns` parameter is used to look up interned string/bytes content.
-    pub(crate) fn new(value: Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> Self {
+    pub(crate) fn new(value: Value, vm: &mut VM<'_, impl ResourceTracker>) -> Self {
         let py_obj = Self::from_value(&value, vm);
         value.drop_with_heap(vm);
         py_obj
@@ -372,7 +372,7 @@ impl MontyObject {
     /// # Errors
     /// Returns `InvalidInputError` if called on the `Repr` variant,
     /// as it is only valid as an output from code execution, not as an input.
-    pub(crate) fn to_value(self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<Value, InvalidInputError> {
+    pub(crate) fn to_value(self, vm: &mut VM<'_, impl ResourceTracker>) -> Result<Value, InvalidInputError> {
         match self {
             Self::Ellipsis => Ok(Value::Ellipsis),
             Self::None => Ok(Value::None),
@@ -535,7 +535,7 @@ impl MontyObject {
 
     /// Top-level entry into [`from_value_inner`], allocating the visited-set used
     /// for cycle detection.
-    fn from_value(object: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> Self {
+    fn from_value(object: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> Self {
         let mut visited = AHashSet::new();
         Self::from_value_inner(object, vm, &mut visited)
     }
@@ -550,11 +550,7 @@ impl MontyObject {
     /// `clone_with_heap` the next child before recursing — the `inc_ref` makes
     /// it safe for a future user-defined `__repr__` to mutate the surrounding
     /// container during the recursive call without freeing the value mid-format.
-    fn from_value_inner(
-        object: &Value,
-        vm: &mut VM<'_, '_, impl ResourceTracker>,
-        visited: &mut AHashSet<HeapId>,
-    ) -> Self {
+    fn from_value_inner(object: &Value, vm: &mut VM<'_, impl ResourceTracker>, visited: &mut AHashSet<HeapId>) -> Self {
         // Check depth limit before processing
         let Ok(token) = vm.heap.incr_recursion_depth() else {
             return Self::Repr("<deeply nested>".to_owned());
@@ -818,7 +814,7 @@ impl MontyObject {
 
 /// Converts a value to its repr string for `MontyObject`, falling back to a
 /// descriptive error message if `py_repr` fails (e.g. INT_MAX_STR_DIGITS).
-fn repr_or_error(value: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> MontyObject {
+fn repr_or_error(value: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> MontyObject {
     match value.py_repr(vm) {
         Ok(s) => MontyObject::Repr(s.into_owned()),
         Err(e) => {

--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -127,7 +127,7 @@ impl<T: ResourceTracker> MontyRepl<T> {
         self,
         code: &str,
         inputs: Vec<(String, MontyObject)>,
-        mut print: PrintWriter<'_>,
+        print: PrintWriter<'_>,
     ) -> Result<ReplProgress<T>, Box<ReplStartError<T>>> {
         let mut this = self;
         if code.is_empty() {
@@ -155,11 +155,16 @@ impl<T: ResourceTracker> MontyRepl<T> {
 
         this.ensure_globals_size(executor.namespace_size);
 
-        match HeapReader::with(&mut this.heap, |heap| {
-            let mut vm = VM::new(mem::take(&mut this.globals), heap, &executor.interns, print.reborrow());
+        match HeapReader::with(&mut this.heap, &mut (&executor, print), |reader, (executor, print)| {
+            let mut vm = VM::new(
+                mem::take(&mut this.globals),
+                reader,
+                &executor.interns,
+                print.reborrow(),
+            );
 
             // Inject inputs with VM alive
-            if let Err(error) = inject_inputs_into_vm(&executor, input_values, &mut vm) {
+            if let Err(error) = inject_inputs_into_vm(executor, input_values, &mut vm) {
                 this.globals = vm.take_globals();
                 return Err(error);
             }
@@ -195,7 +200,7 @@ impl<T: ResourceTracker> MontyRepl<T> {
         &mut self,
         code: &str,
         inputs: Vec<(String, MontyObject)>,
-        mut print: PrintWriter<'_>,
+        print: PrintWriter<'_>,
     ) -> Result<MontyObject, MontyException> {
         if code.is_empty() {
             return Ok(MontyObject::None);
@@ -219,10 +224,15 @@ impl<T: ResourceTracker> MontyRepl<T> {
 
         self.ensure_globals_size(executor.namespace_size);
 
-        let result = HeapReader::with(&mut self.heap, |heap| {
-            let mut vm = VM::new(mem::take(&mut self.globals), heap, &executor.interns, print.reborrow());
+        let result = HeapReader::with(&mut self.heap, &mut (&executor, print), |reader, (executor, print)| {
+            let mut vm = VM::new(
+                mem::take(&mut self.globals),
+                reader,
+                &executor.interns,
+                print.reborrow(),
+            );
 
-            if let Err(e) = inject_inputs_into_vm(&executor, input_values, &mut vm) {
+            if let Err(e) = inject_inputs_into_vm(executor, input_values, &mut vm) {
                 self.globals = vm.take_globals();
                 return Err(e);
             }
@@ -258,38 +268,42 @@ impl<T: ResourceTracker> MontyRepl<T> {
         &mut self,
         name: &str,
         args: Vec<MontyObject>,
-        mut print: PrintWriter<'_>,
+        print: PrintWriter<'_>,
     ) -> Result<MontyObject, MontyException> {
         let Some(slot_idx) = self.global_name_map.get(name) else {
             return Err(RunError::from(ExcType::name_error(name))
                 .into_python_exception(&self.interns, |fname| self.sources.get(fname).map(String::as_str)));
         };
 
-        HeapReader::with(&mut self.heap, |heap| {
-            let vm = &mut VM::new(mem::take(&mut self.globals), heap, &self.interns, print.reborrow());
+        HeapReader::with(
+            &mut self.heap,
+            &mut (&self.interns, print),
+            |reader, (interns, print)| {
+                let vm = &mut VM::new(mem::take(&mut self.globals), reader, interns, print.reborrow());
 
-            let callable = vm.globals[slot_idx.index()].clone_with_heap(vm);
-            defer_drop!(callable, vm);
+                let callable = vm.globals[slot_idx.index()].clone_with_heap(vm);
+                defer_drop!(callable, vm);
 
-            let arg_values = match convert_args(args, vm) {
-                Ok(av) => av,
-                Err(e) => {
-                    self.globals = vm.take_globals();
-                    return Err(e);
-                }
-            };
+                let arg_values = match convert_args(args, vm) {
+                    Ok(av) => av,
+                    Err(e) => {
+                        self.globals = vm.take_globals();
+                        return Err(e);
+                    }
+                };
 
-            let result = match vm.evaluate_function("MontyRepl::call_function", callable, arg_values) {
-                Ok(value) => Ok(MontyObject::new(value, vm)),
-                Err(e) => {
-                    Err(e.into_python_exception(&self.interns, |fname| self.sources.get(fname).map(String::as_str)))
-                }
-            };
+                let result = match vm.evaluate_function("MontyRepl::call_function", callable, arg_values) {
+                    Ok(value) => Ok(MontyObject::new(value, vm)),
+                    Err(e) => {
+                        Err(e.into_python_exception(&self.interns, |fname| self.sources.get(fname).map(String::as_str)))
+                    }
+                };
 
-            self.globals = vm.take_globals();
+                self.globals = vm.take_globals();
 
-            result
-        })
+                result
+            },
+        )
     }
 
     /// Returns a list of all callable function names defined in the session.
@@ -621,7 +635,7 @@ impl<T: ResourceTracker> ReplNameLookup<T> {
     pub fn resume(
         self,
         result: NameLookupResult,
-        mut print: PrintWriter<'_>,
+        print: PrintWriter<'_>,
     ) -> Result<ReplProgress<T>, Box<ReplStartError<T>>> {
         let Self {
             name,
@@ -636,12 +650,12 @@ impl<T: ResourceTracker> ReplNameLookup<T> {
             vm_state,
         } = snapshot;
 
-        match HeapReader::with(&mut repl.heap, |heap| {
+        match HeapReader::with(&mut repl.heap, &mut (&executor, print), |reader, (executor, print)| {
             // Restore the VM first, then convert inside its lifetime
             let mut vm = VM::restore(
                 vm_state,
                 &executor.module_code,
-                heap,
+                reader,
                 &executor.interns,
                 print.reborrow(),
             );
@@ -748,7 +762,7 @@ impl<T: ResourceTracker> ReplResolveFutures<T> {
     pub fn resume(
         self,
         results: Vec<(u32, ExtFunctionResult)>,
-        mut print: PrintWriter<'_>,
+        print: PrintWriter<'_>,
     ) -> Result<ReplProgress<T>, Box<ReplStartError<T>>> {
         let Self {
             mut repl,
@@ -762,11 +776,11 @@ impl<T: ResourceTracker> ReplResolveFutures<T> {
             .find(|(call_id, _)| !pending_call_ids.contains(call_id))
             .map(|(call_id, _)| *call_id);
 
-        match HeapReader::with(&mut repl.heap, |heap| {
+        match HeapReader::with(&mut repl.heap, &mut (&executor, print), |reader, (executor, print)| {
             let mut vm = VM::restore(
                 vm_state,
                 &executor.module_code,
-                heap,
+                reader,
                 &executor.interns,
                 print.reborrow(),
             );
@@ -886,7 +900,7 @@ impl<T: ResourceTracker> ReplSnapshot<T> {
     fn run(
         self,
         result: impl Into<ExtFunctionResult>,
-        mut print: PrintWriter<'_>,
+        print: PrintWriter<'_>,
     ) -> Result<ReplProgress<T>, Box<ReplStartError<T>>> {
         let Self {
             mut repl,
@@ -896,39 +910,40 @@ impl<T: ResourceTracker> ReplSnapshot<T> {
 
         let ext_result = result.into();
 
-        let (converted, vm_state) = HeapReader::with(&mut repl.heap, |heap| {
-            let mut vm = VM::restore(
-                vm_state,
-                &executor.module_code,
-                heap,
-                &executor.interns,
-                print.reborrow(),
-            );
+        let (converted, vm_state) =
+            HeapReader::with(&mut repl.heap, &mut (&executor, print), |reader, (executor, print)| {
+                let mut vm = VM::restore(
+                    vm_state,
+                    &executor.module_code,
+                    reader,
+                    &executor.interns,
+                    print.reborrow(),
+                );
 
-            let vm_result = match ext_result {
-                ExtFunctionResult::Return(obj) => vm.resume(obj),
-                ExtFunctionResult::Error(exc) => vm.resume_with_exception(exc.into()),
-                ExtFunctionResult::Future(raw_call_id) => {
-                    let call_id = CallId::new(raw_call_id);
-                    vm.add_pending_call(call_id);
-                    vm.push(Value::ExternalFuture(call_id));
-                    vm.run()
-                }
-                ExtFunctionResult::NotFound(function_name) => {
-                    vm.resume_with_exception(ExtFunctionResult::not_found_exc(&function_name))
-                }
-            };
+                let vm_result = match ext_result {
+                    ExtFunctionResult::Return(obj) => vm.resume(obj),
+                    ExtFunctionResult::Error(exc) => vm.resume_with_exception(exc.into()),
+                    ExtFunctionResult::Future(raw_call_id) => {
+                        let call_id = CallId::new(raw_call_id);
+                        vm.add_pending_call(call_id);
+                        vm.push(Value::ExternalFuture(call_id));
+                        vm.run()
+                    }
+                    ExtFunctionResult::NotFound(function_name) => {
+                        vm.resume_with_exception(ExtFunctionResult::not_found_exc(&function_name))
+                    }
+                };
 
-            // Convert while VM alive, then snapshot or reclaim globals
-            let converted = convert_frame_exit(vm_result, &mut vm);
-            let vm_state = if converted.needs_snapshot() {
-                Some(vm.snapshot())
-            } else {
-                repl.globals = vm.take_globals();
-                None
-            };
-            (converted, vm_state)
-        });
+                // Convert while VM alive, then snapshot or reclaim globals
+                let converted = convert_frame_exit(vm_result, &mut vm);
+                let vm_state = if converted.needs_snapshot() {
+                    Some(vm.snapshot())
+                } else {
+                    repl.globals = vm.take_globals();
+                    None
+                };
+                (converted, vm_state)
+            });
         build_repl_progress(converted, vm_state, executor, repl)
     }
 }
@@ -944,7 +959,7 @@ impl<T: ResourceTracker> ReplSnapshot<T> {
 fn inject_inputs_into_vm(
     executor: &Executor,
     input_values: Vec<MontyObject>,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> Result<(), MontyException> {
     for (name, obj) in executor.input_names.iter().zip(input_values) {
         let slot = executor
@@ -1051,10 +1066,7 @@ fn build_repl_progress<T: ResourceTracker>(
 }
 
 /// Converts `Vec<MontyObject>` to internal `ArgValues` for function calls.
-fn convert_args(
-    args: Vec<MontyObject>,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
-) -> Result<ArgValues, MontyException> {
+fn convert_args(args: Vec<MontyObject>, vm: &mut VM<'_, impl ResourceTracker>) -> Result<ArgValues, MontyException> {
     match args.len() {
         0 => Ok(ArgValues::Empty),
         1 => {

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -155,25 +155,26 @@ impl MontyRun {
         self,
         inputs: Vec<MontyObject>,
         resource_tracker: T,
-        mut print: PrintWriter<'_>,
+        print: PrintWriter<'_>,
     ) -> Result<RunProgress<T>, MontyException> {
         let executor = self.executor;
 
         // Create heap and VM with empty globals, then populate inputs with VM alive
         let mut heap = Heap::new(executor.namespace_size, resource_tracker);
         let globals = executor.empty_globals();
-        let (converted, vm_state) = HeapReader::with(&mut heap, |heap| {
-            let mut vm = VM::new(globals, heap, &executor.interns, print.reborrow());
-            executor.populate_inputs(inputs, &mut vm)?;
+        let (converted, vm_state) =
+            HeapReader::with(&mut heap, &mut (&executor, print), |reader, (executor, print)| {
+                let mut vm = VM::new(globals, reader, &executor.interns, print.reborrow());
+                executor.populate_inputs(inputs, &mut vm)?;
 
-            // Start execution
-            let vm_result = vm.run_module(&executor.module_code);
+                // Start execution
+                let vm_result = vm.run_module(&executor.module_code);
 
-            // Three-phase conversion: convert while VM alive, then snapshot, then build progress
-            let converted = convert_frame_exit(vm_result, &mut vm);
-            let vm_state = check_snapshot_from_converted(&converted, vm);
-            Ok((converted, vm_state))
-        })?;
+                // Three-phase conversion: convert while VM alive, then snapshot, then build progress
+                let converted = convert_frame_exit(vm_result, &mut vm);
+                let vm_state = check_snapshot_from_converted(&converted, vm);
+                Ok((converted, vm_state))
+            })?;
         build_run_progress(converted, vm_state, executor, heap)
     }
 }
@@ -317,17 +318,17 @@ impl Executor {
         &self,
         inputs: Vec<MontyObject>,
         resource_tracker: impl ResourceTracker,
-        mut print: PrintWriter<'_>,
+        print: PrintWriter<'_>,
     ) -> Result<MontyObject, MontyException> {
         let heap_capacity = self.heap_capacity.load(Ordering::Relaxed);
         let mut heap = Heap::new(heap_capacity, resource_tracker);
         let globals = self.empty_globals();
 
         // Create VM first, then populate inputs with VM alive
-        let result = HeapReader::with(&mut heap, |heap| {
-            let mut vm = VM::new(globals, heap, &self.interns, print.reborrow());
-            self.populate_inputs(inputs, &mut vm)?;
-            self.run_to_completion(&mut vm)
+        let result = HeapReader::with(&mut heap, &mut (self, print), |reader, (executor, print)| {
+            let mut vm = VM::new(globals, reader, &executor.interns, print.reborrow());
+            executor.populate_inputs(inputs, &mut vm)?;
+            executor.run_to_completion(&mut vm)
         });
 
         if heap.size() > heap_capacity {
@@ -347,7 +348,7 @@ impl Executor {
     ///
     /// This is the shared non-iterative execution core used by both the standard
     /// `run` path and the REPL's `feed_run` path.
-    pub(crate) fn run_to_completion<'a>(&'a self, vm: &mut VM<'_, 'a, impl ResourceTracker>) -> RunResult<MontyObject> {
+    pub(crate) fn run_to_completion<'h>(&'h self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<MontyObject> {
         let mut frame_exit_result = vm.run_module(&self.module_code);
 
         // Handle NameLookup and ExternalCall exits by raising NameError through the VM
@@ -416,11 +417,11 @@ impl Executor {
         let mut heap = Heap::new(self.namespace_size, resource_tracker);
         let globals = self.empty_globals();
 
-        HeapReader::with(&mut heap, |heap| {
+        HeapReader::with(&mut heap, &mut &*self, |reader, executor| {
             // Create VM, populate inputs, and run
-            let mut vm = VM::new(globals, heap, &self.interns, PrintWriter::Stdout);
-            self.populate_inputs(inputs, &mut vm)?;
-            let frame_exit_result = vm.run_module(&self.module_code);
+            let mut vm = VM::new(globals, reader, &executor.interns, PrintWriter::Stdout);
+            executor.populate_inputs(inputs, &mut vm)?;
+            let frame_exit_result = vm.run_module(&executor.module_code);
 
             vm.__force_gc_for_tests();
 
@@ -433,7 +434,7 @@ impl Executor {
             let mut counts = ahash::AHashMap::new();
             let mut unique_ids = HashSet::new();
 
-            for (name, &namespace_id) in &self.name_map {
+            for (name, &namespace_id) in &executor.name_map {
                 let idx = namespace_id.index();
                 if idx < globals.len()
                     && let Value::Ref(id) = &globals[idx]
@@ -446,9 +447,9 @@ impl Executor {
             let heap_count = vm.heap.entry_count();
 
             // Convert return value while VM is still alive (needs access to interns).
-            // Non-REPL: single source, so every frame resolves to `self.code`.
+            // Non-REPL: single source, so every frame resolves to `executor.code`.
             let py_object = frame_exit_to_object(frame_exit_result, &mut vm)
-                .map_err(|e| e.into_python_exception(&self.interns, |_| Some(self.code.as_str())))?;
+                .map_err(|e| e.into_python_exception(&executor.interns, |_| Some(executor.code.as_str())))?;
 
             // Drop globals with proper ref counting
             for value in globals {
@@ -484,7 +485,7 @@ impl Executor {
     pub(crate) fn populate_inputs(
         &self,
         inputs: Vec<MontyObject>,
-        vm: &mut VM<'_, '_, impl ResourceTracker>,
+        vm: &mut VM<'_, impl ResourceTracker>,
     ) -> Result<(), MontyException> {
         if inputs.len() > self.namespace_size {
             return Err(MontyException::runtime_error("too many inputs for namespace"));
@@ -505,7 +506,7 @@ impl Executor {
 /// name lookups) are not supported and should produce errors.
 pub(crate) fn frame_exit_to_object(
     frame_exit_result: RunResult<FrameExit>,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<MontyObject> {
     match frame_exit_result? {
         FrameExit::Return(return_value) => Ok(MontyObject::new(return_value, vm)),

--- a/crates/monty/src/run_progress.rs
+++ b/crates/monty/src/run_progress.rs
@@ -313,57 +313,67 @@ impl<T: ResourceTracker> NameLookup<T> {
     /// * `result` — The resolved value or `Undefined`.
     /// * `print` — Writer for print output.
     pub fn resume(
-        mut self,
+        self,
         result: impl Into<NameLookupResult>,
-        mut print: PrintWriter<'_>,
+        print: PrintWriter<'_>,
     ) -> Result<RunProgress<T>, MontyException> {
         let result = result.into();
 
-        let (converted, vm_state) = HeapReader::with(&mut self.snapshot.heap, |heap| {
-            // Restore the VM first, then convert inside its lifetime
-            let mut vm = VM::restore(
-                self.snapshot.vm_state,
-                &self.snapshot.executor.module_code,
-                heap,
-                &self.snapshot.executor.interns,
-                print.reborrow(),
-            );
+        let Snapshot {
+            mut heap,
+            executor,
+            vm_state: snapshot_vm_state,
+        } = self.snapshot;
+        let namespace_slot = self.namespace_slot;
+        let is_global = self.is_global;
+        let name = self.name;
 
-            // Resolve the name lookup result with the VM alive
-            let vm_result = match result {
-                NameLookupResult::Value(obj) => {
-                    let value = obj
-                        .to_value(&mut vm)
-                        .map_err(|e| MontyException::runtime_error(format!("invalid name lookup result: {e}")))?;
+        let (converted, vm_state) =
+            HeapReader::with(&mut heap, &mut (&executor, print), |reader, (executor, print)| {
+                // Restore the VM first, then convert inside its lifetime
+                let mut vm = VM::restore(
+                    snapshot_vm_state,
+                    &executor.module_code,
+                    reader,
+                    &executor.interns,
+                    print.reborrow(),
+                );
 
-                    // Cache the resolved value in the appropriate slot
-                    let slot = self.namespace_slot as usize;
-                    if self.is_global {
-                        let cloned = value.clone_with_heap(&vm);
-                        let old = mem::replace(&mut vm.globals[slot], cloned);
-                        old.drop_with_heap(&mut vm);
-                    } else {
-                        let stack_base = vm.current_stack_base();
-                        let cloned = value.clone_with_heap(&vm);
-                        let old = mem::replace(&mut vm.stack[stack_base + slot], cloned);
-                        old.drop_with_heap(&mut vm);
+                // Resolve the name lookup result with the VM alive
+                let vm_result = match result {
+                    NameLookupResult::Value(obj) => {
+                        let value = obj
+                            .to_value(&mut vm)
+                            .map_err(|e| MontyException::runtime_error(format!("invalid name lookup result: {e}")))?;
+
+                        // Cache the resolved value in the appropriate slot
+                        let slot = namespace_slot as usize;
+                        if is_global {
+                            let cloned = value.clone_with_heap(&vm);
+                            let old = mem::replace(&mut vm.globals[slot], cloned);
+                            old.drop_with_heap(&mut vm);
+                        } else {
+                            let stack_base = vm.current_stack_base();
+                            let cloned = value.clone_with_heap(&vm);
+                            let old = mem::replace(&mut vm.stack[stack_base + slot], cloned);
+                            old.drop_with_heap(&mut vm);
+                        }
+
+                        vm.push(value);
+                        vm.run()
                     }
+                    NameLookupResult::Undefined => {
+                        let err = ExcType::name_error(&name);
+                        vm.resume_with_exception(err.into())
+                    }
+                };
 
-                    vm.push(value);
-                    vm.run()
-                }
-                NameLookupResult::Undefined => {
-                    let err = ExcType::name_error(&self.name);
-                    vm.resume_with_exception(err.into())
-                }
-            };
-
-            // Three-phase: convert while VM alive, snapshot, build progress
-            let converted = convert_frame_exit(vm_result, &mut vm);
-            let vm_state = check_snapshot_from_converted(&converted, vm);
-            Ok((converted, vm_state))
-        })?;
-        build_run_progress(converted, vm_state, self.snapshot.executor, self.snapshot.heap)
+                // Three-phase: convert while VM alive, snapshot, build progress
+                let converted = convert_frame_exit(vm_result, &mut vm);
+                let vm_state = check_snapshot_from_converted(&converted, vm);
+                Ok((converted, vm_state))
+            })?;
+        build_run_progress(converted, vm_state, executor, heap)
     }
 }
 
@@ -425,11 +435,11 @@ impl<T: ResourceTracker> ResolveFutures<T> {
             pending_call_ids,
         } = self;
 
-        let vm_state = HeapReader::with(&mut heap, |heap| {
+        let vm_state = HeapReader::with(&mut heap, &mut &executor, |reader, executor| {
             let mut vm = VM::restore(
                 vm_state,
                 &executor.module_code,
-                heap,
+                reader,
                 &executor.interns,
                 PrintWriter::Stdout,
             );
@@ -458,7 +468,7 @@ impl<T: ResourceTracker> ResolveFutures<T> {
     pub fn resume(
         self,
         results: Vec<(u32, ExtFunctionResult)>,
-        mut print: PrintWriter<'_>,
+        print: PrintWriter<'_>,
     ) -> Result<RunProgress<T>, MontyException> {
         let Self {
             executor,
@@ -473,30 +483,31 @@ impl<T: ResourceTracker> ResolveFutures<T> {
             .find(|(call_id, _)| !pending_call_ids.contains(call_id))
             .map(|(call_id, _)| *call_id);
 
-        let (converted, vm_state) = HeapReader::with(&mut heap, |heap| {
-            // Restore the VM from the snapshot (must happen before any error return to clean up properly).
-            let mut vm = VM::restore(
-                vm_state,
-                &executor.module_code,
-                heap,
-                &executor.interns,
-                print.reborrow(),
-            );
+        let (converted, vm_state) =
+            HeapReader::with(&mut heap, &mut (&executor, print), |reader, (executor, print)| {
+                // Restore the VM from the snapshot (must happen before any error return to clean up properly).
+                let mut vm = VM::restore(
+                    vm_state,
+                    &executor.module_code,
+                    reader,
+                    &executor.interns,
+                    print.reborrow(),
+                );
 
-            // Now check for invalid call_ids after VM is restored.
-            if let Some(call_id) = invalid_call_id {
-                return Err(MontyException::runtime_error(format!(
-                    "unknown call_id {call_id}, expected one of: {pending_call_ids:?}"
-                )));
-            }
+                // Now check for invalid call_ids after VM is restored.
+                if let Some(call_id) = invalid_call_id {
+                    return Err(MontyException::runtime_error(format!(
+                        "unknown call_id {call_id}, expected one of: {pending_call_ids:?}"
+                    )));
+                }
 
-            let result = vm.resume_with_resolved_futures(results);
+                let result = vm.resume_with_resolved_futures(results);
 
-            // Three-phase: convert while VM alive, snapshot, build progress
-            let converted = convert_frame_exit(result, &mut vm);
-            let vm_state = check_snapshot_from_converted(&converted, vm);
-            Ok((converted, vm_state))
-        })?;
+                // Three-phase: convert while VM alive, snapshot, build progress
+                let converted = convert_frame_exit(result, &mut vm);
+                let vm_state = check_snapshot_from_converted(&converted, vm);
+                Ok((converted, vm_state))
+            })?;
         build_run_progress(converted, vm_state, executor, heap)
     }
 }
@@ -524,41 +535,48 @@ pub(crate) struct Snapshot<T: ResourceTracker> {
 impl<T: ResourceTracker> Snapshot<T> {
     /// Continues execution with the return value or exception from the external call.
     pub(crate) fn run(
-        mut self,
+        self,
         result: impl Into<ExtFunctionResult>,
-        mut print: PrintWriter<'_>,
+        print: PrintWriter<'_>,
     ) -> Result<RunProgress<T>, MontyException> {
         let ext_result = result.into();
 
-        let (converted, vm_state) = HeapReader::with(&mut self.heap, |heap| {
-            let mut vm = VM::restore(
-                self.vm_state,
-                &self.executor.module_code,
-                heap,
-                &self.executor.interns,
-                print.reborrow(),
-            );
+        let Self {
+            executor,
+            vm_state,
+            mut heap,
+        } = self;
 
-            let vm_result = match ext_result {
-                ExtFunctionResult::Return(obj) => vm.resume(obj),
-                ExtFunctionResult::Error(exc) => vm.resume_with_exception(exc.into()),
-                ExtFunctionResult::Future(raw_call_id) => {
-                    let call_id = CallId::new(raw_call_id);
-                    vm.add_pending_call(call_id);
-                    vm.push(Value::ExternalFuture(call_id));
-                    vm.run()
-                }
-                ExtFunctionResult::NotFound(function_name) => {
-                    vm.resume_with_exception(ExtFunctionResult::not_found_exc(&function_name))
-                }
-            };
+        let (converted, vm_state) =
+            HeapReader::with(&mut heap, &mut (&executor, print), |reader, (executor, print)| {
+                let mut vm = VM::restore(
+                    vm_state,
+                    &executor.module_code,
+                    reader,
+                    &executor.interns,
+                    print.reborrow(),
+                );
 
-            // Three-phase: convert while VM alive, snapshot, build progress
-            let converted = convert_frame_exit(vm_result, &mut vm);
-            let vm_state = check_snapshot_from_converted(&converted, vm);
-            (converted, vm_state)
-        });
-        build_run_progress(converted, vm_state, self.executor, self.heap)
+                let vm_result = match ext_result {
+                    ExtFunctionResult::Return(obj) => vm.resume(obj),
+                    ExtFunctionResult::Error(exc) => vm.resume_with_exception(exc.into()),
+                    ExtFunctionResult::Future(raw_call_id) => {
+                        let call_id = CallId::new(raw_call_id);
+                        vm.add_pending_call(call_id);
+                        vm.push(Value::ExternalFuture(call_id));
+                        vm.run()
+                    }
+                    ExtFunctionResult::NotFound(function_name) => {
+                        vm.resume_with_exception(ExtFunctionResult::not_found_exc(&function_name))
+                    }
+                };
+
+                // Three-phase: convert while VM alive, snapshot, build progress
+                let converted = convert_frame_exit(vm_result, &mut vm);
+                let vm_state = check_snapshot_from_converted(&converted, vm);
+                (converted, vm_state)
+            });
+        build_run_progress(converted, vm_state, executor, heap)
     }
 }
 
@@ -667,10 +685,7 @@ impl ConvertedExit {
 ///
 /// All `Value` → `MontyObject` and `StringId` → `String` conversions happen here,
 /// while the VM (and its heap/interns) are still accessible.
-pub(crate) fn convert_frame_exit(
-    result: RunResult<FrameExit>,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
-) -> ConvertedExit {
+pub(crate) fn convert_frame_exit(result: RunResult<FrameExit>, vm: &mut VM<'_, impl ResourceTracker>) -> ConvertedExit {
     match result {
         Ok(FrameExit::Return(value)) => ConvertedExit::Complete(MontyObject::new(value, vm)),
         Ok(FrameExit::ExternalCall {
@@ -742,7 +757,7 @@ pub(crate) fn convert_frame_exit(
 /// completion/error (in which case the VM's `Drop` impl handles cleanup).
 pub(crate) fn check_snapshot_from_converted(
     converted: &ConvertedExit,
-    vm: VM<'_, '_, impl ResourceTracker>,
+    vm: VM<'_, impl ResourceTracker>,
 ) -> Option<VMSnapshot> {
     if converted.needs_snapshot() {
         Some(vm.snapshot())

--- a/crates/monty/src/signature.rs
+++ b/crates/monty/src/signature.rs
@@ -204,7 +204,7 @@ impl Signature {
         &self,
         args: ArgValues,
         defaults: &[Value],
-        vm: &mut VM<'_, '_, impl ResourceTracker>,
+        vm: &mut VM<'_, impl ResourceTracker>,
         func_name: Identifier,
         namespace: &mut Vec<Value>,
     ) -> RunResult<()> {

--- a/crates/monty/src/sorting.rs
+++ b/crates/monty/src/sorting.rs
@@ -30,7 +30,7 @@ pub fn sort_indices(
     indices: &mut [usize],
     values: &[Value],
     reverse: bool,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> Result<(), RunError> {
     let mut sort_error: Option<RunError> = None;
 

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -151,7 +151,7 @@ impl Bytes {
     /// - `bytes(bytes)` returns a copy of the bytes
     ///
     /// Note: Full Python semantics for bytes() are more complex (encoding, errors params).
-    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub fn init(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         let value = args.get_zero_one_named_arg("bytes", StaticStrings::Source, vm.heap, vm.interns)?;
         defer_drop!(value, vm);
         let new_data = match value {
@@ -210,15 +210,15 @@ impl ops::Deref for Bytes {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, Bytes> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::Bytes
     }
 
-    fn py_len(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         Some(self.get(vm.heap).0.len())
     }
 
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+    fn py_getitem(&self, key: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         // Check for slice first (Value::Ref pointing to HeapData::Slice)
         if let Value::Ref(id) = key
             && let HeapData::Slice(slice) = vm.heap.get(*id)
@@ -238,15 +238,11 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Bytes> {
         Ok(Value::Int(i64::from(byte)))
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         Ok(self.get(vm.heap).0 == other.get(vm.heap).0)
     }
 
-    fn py_hash(
-        &self,
-        _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
         // Must match `Value::InternBytes` so the same content hashes equally
         // regardless of whether the bytes live on the heap or in the intern table.
         let mut hasher = DefaultHasher::new();
@@ -254,22 +250,18 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Bytes> {
         Ok(Some(hasher.finish()))
     }
 
-    fn py_cmp(
-        &self,
-        other: &Self,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<Ordering>, ResourceError> {
+    fn py_cmp(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Ordering>, ResourceError> {
         Ok(Some(self.get(vm.heap).0.cmp(&other.get(vm.heap).0)))
     }
 
-    fn py_bool(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         !self.get(vm.heap).0.is_empty()
     }
 
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         Ok(bytes_repr_fmt(&self.get(vm.heap).0, f)?)
@@ -278,7 +270,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Bytes> {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<CallResult> {
@@ -311,7 +303,7 @@ pub fn call_bytes_method(
     bytes: &[u8],
     method_id: StringId,
     args: ArgValues,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let Some(method) = StaticStrings::from_string_id(method_id) else {
         args.drop_with_heap(vm);
@@ -329,7 +321,7 @@ fn call_bytes_method_impl<'h>(
     bytes: &HeapRead<'h, [u8]>,
     method: StaticStrings,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     match method {
         // Decode method
@@ -480,7 +472,7 @@ pub fn bytes_repr(bytes: &[u8]) -> String {
 fn bytes_decode<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let (encoding, errors) = args.get_zero_one_two_args("bytes.decode", vm.heap)?;
     defer_drop!(encoding, vm);
@@ -509,7 +501,7 @@ fn bytes_decode<'h>(
 }
 
 /// Helper function to extract encoding string from a value.
-fn get_encoding_str<'a>(encoding: &Value, vm: &'a VM<'_, '_, impl ResourceTracker>) -> RunResult<&'a str> {
+fn get_encoding_str<'a>(encoding: &Value, vm: &'a VM<'_, impl ResourceTracker>) -> RunResult<&'a str> {
     match encoding {
         Value::InternString(id) => Ok(vm.interns.get_str(*id)),
         Value::Ref(id) => match vm.heap.get(*id) {
@@ -529,7 +521,7 @@ fn get_encoding_str<'a>(encoding: &Value, vm: &'a VM<'_, '_, impl ResourceTracke
 fn bytes_count<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let len = bytes.get(vm.heap).len();
     let (sub, start, end) = parse_bytes_sub_args("bytes.count", len, args, vm)?;
@@ -567,7 +559,7 @@ fn count_non_overlapping(haystack: &[u8], needle: &[u8]) -> usize {
 fn bytes_find<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let len = bytes.get(vm.heap).len();
     let (sub, start, end) = parse_bytes_sub_args("bytes.find", len, args, vm)?;
@@ -598,7 +590,7 @@ fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 fn bytes_index<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let len = bytes.get(vm.heap).len();
     let (sub, start, end) = parse_bytes_sub_args("bytes.index", len, args, vm)?;
@@ -628,7 +620,7 @@ fn bytes_index<'h>(
 fn bytes_startswith<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let len = bytes.get(vm.heap).len();
     let (prefix_arg, start, end) = parse_bytes_prefix_suffix_args("bytes.startswith", len, args, vm)?;
@@ -649,7 +641,7 @@ fn bytes_startswith<'h>(
 fn bytes_endswith<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let len = bytes.get(vm.heap).len();
     let (suffix_arg, start, end) = parse_bytes_prefix_suffix_args("bytes.endswith", len, args, vm)?;
@@ -682,7 +674,7 @@ fn parse_bytes_prefix_suffix_args(
     method: &str,
     len: usize,
     args: ArgValues,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<(PrefixSuffixArg, usize, usize)> {
     let pos = args.into_pos_only(method, vm.heap)?;
     defer_drop!(pos, vm);
@@ -718,7 +710,7 @@ fn parse_bytes_prefix_suffix_args(
 fn extract_bytes_for_prefix_suffix(
     value: &Value,
     method: &str,
-    vm: &VM<'_, '_, impl ResourceTracker>,
+    vm: &VM<'_, impl ResourceTracker>,
 ) -> RunResult<PrefixSuffixArg> {
     // Extract the method name (e.g., "startswith" from "bytes.startswith")
     let method_name = method.strip_prefix("bytes.").unwrap_or(method);
@@ -763,7 +755,7 @@ fn extract_bytes_for_prefix_suffix(
 }
 
 /// Extracts a single bytes value for tuple element in startswith/endswith.
-fn extract_single_bytes_for_prefix_suffix(value: &Value, vm: &VM<'_, '_, impl ResourceTracker>) -> RunResult<Vec<u8>> {
+fn extract_single_bytes_for_prefix_suffix(value: &Value, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Vec<u8>> {
     match value {
         Value::InternBytes(id) => Ok(vm.interns.get_bytes(*id).to_vec()),
         Value::InternString(_) => Err(ExcType::type_error("expected bytes, not str")),
@@ -779,7 +771,7 @@ fn extract_single_bytes_for_prefix_suffix(value: &Value, vm: &VM<'_, '_, impl Re
 ///
 /// CPython raises `TypeError: a bytes-like object is required, not 'str'` when
 /// a str is passed to bytes methods like find, count, index, startswith, endswith.
-fn extract_bytes_only<'a>(value: &Value, vm: &'a VM<'_, '_, impl ResourceTracker>) -> RunResult<&'a [u8]> {
+fn extract_bytes_only<'a>(value: &Value, vm: &'a VM<'_, impl ResourceTracker>) -> RunResult<&'a [u8]> {
     match value {
         Value::InternBytes(id) => Ok(vm.interns.get_bytes(*id)),
         Value::InternString(_) => Err(ExcType::type_error("a bytes-like object is required, not 'str'")),
@@ -800,7 +792,7 @@ fn parse_bytes_sub_args(
     method: &str,
     len: usize,
     args: ArgValues,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<(Vec<u8>, usize, usize)> {
     let pos = args.into_pos_only(method, vm.heap)?;
     defer_drop!(pos, vm);
@@ -836,7 +828,7 @@ fn parse_bytes_sub_args(
 /// Implements Python's `bytes.lower()` method.
 ///
 /// Returns a copy of the bytes with all ASCII uppercase characters converted to lowercase.
-fn bytes_lower<'h>(bytes: &HeapRead<'h, [u8]>, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+fn bytes_lower<'h>(bytes: &HeapRead<'h, [u8]>, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let result: Vec<u8> = bytes.get(vm.heap).iter().map(|&b| b.to_ascii_lowercase()).collect();
     allocate_bytes(result, vm.heap)
 }
@@ -844,7 +836,7 @@ fn bytes_lower<'h>(bytes: &HeapRead<'h, [u8]>, vm: &mut VM<'h, '_, impl Resource
 /// Implements Python's `bytes.upper()` method.
 ///
 /// Returns a copy of the bytes with all ASCII lowercase characters converted to uppercase.
-fn bytes_upper<'h>(bytes: &HeapRead<'h, [u8]>, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+fn bytes_upper<'h>(bytes: &HeapRead<'h, [u8]>, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let result: Vec<u8> = bytes.get(vm.heap).iter().map(|&b| b.to_ascii_uppercase()).collect();
     allocate_bytes(result, vm.heap)
 }
@@ -853,7 +845,7 @@ fn bytes_upper<'h>(bytes: &HeapRead<'h, [u8]>, vm: &mut VM<'h, '_, impl Resource
 ///
 /// Returns a copy of the bytes with the first byte capitalized (if ASCII) and
 /// the rest lowercased.
-fn bytes_capitalize<'h>(bytes: &HeapRead<'h, [u8]>, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+fn bytes_capitalize<'h>(bytes: &HeapRead<'h, [u8]>, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let bytes = bytes.get(vm.heap);
     let mut result = Vec::with_capacity(bytes.len());
     if let Some((&first, rest)) = bytes.split_first() {
@@ -869,7 +861,7 @@ fn bytes_capitalize<'h>(bytes: &HeapRead<'h, [u8]>, vm: &mut VM<'h, '_, impl Res
 ///
 /// Returns a titlecased version of the bytes where words start with an uppercase
 /// ASCII character and the remaining characters are lowercase.
-fn bytes_title<'h>(bytes: &HeapRead<'h, [u8]>, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+fn bytes_title<'h>(bytes: &HeapRead<'h, [u8]>, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let bytes = bytes.get(vm.heap);
     let mut result = Vec::with_capacity(bytes.len());
     let mut prev_is_cased = false;
@@ -890,7 +882,7 @@ fn bytes_title<'h>(bytes: &HeapRead<'h, [u8]>, vm: &mut VM<'h, '_, impl Resource
 ///
 /// Returns a copy of the bytes with ASCII uppercase characters converted to
 /// lowercase and vice versa.
-fn bytes_swapcase<'h>(bytes: &HeapRead<'h, [u8]>, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+fn bytes_swapcase<'h>(bytes: &HeapRead<'h, [u8]>, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let result: Vec<u8> = bytes
         .get(vm.heap)
         .iter()
@@ -1014,7 +1006,7 @@ fn bytes_istitle(bytes: &[u8]) -> bool {
 fn bytes_rfind<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let len = bytes.get(vm.heap).len();
     let (sub, start, end) = parse_bytes_sub_args("bytes.rfind", len, args, vm)?;
@@ -1048,7 +1040,7 @@ fn rfind_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 fn bytes_rindex<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let len = bytes.get(vm.heap).len();
     let (sub, start, end) = parse_bytes_sub_args("bytes.rindex", len, args, vm)?;
@@ -1080,7 +1072,7 @@ fn bytes_rindex<'h>(
 fn bytes_strip<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let value = args.get_zero_one_arg("bytes.strip", vm.heap)?;
     defer_drop!(value, vm);
@@ -1097,7 +1089,7 @@ fn bytes_strip<'h>(
 fn bytes_lstrip<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let value = args.get_zero_one_arg("bytes.lstrip", vm.heap)?;
     defer_drop!(value, vm);
@@ -1114,7 +1106,7 @@ fn bytes_lstrip<'h>(
 fn bytes_rstrip<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let value = args.get_zero_one_arg("bytes.rstrip", vm.heap)?;
     defer_drop!(value, vm);
@@ -1179,7 +1171,7 @@ fn bytes_strip_whitespace_end(bytes: &[u8]) -> &[u8] {
 fn bytes_removeprefix<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let prefix_value = args.get_one_arg("bytes.removeprefix", vm.heap)?;
     defer_drop!(prefix_value, vm);
@@ -1201,7 +1193,7 @@ fn bytes_removeprefix<'h>(
 fn bytes_removesuffix<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let suffix_value = args.get_one_arg("bytes.removesuffix", vm.heap)?;
     defer_drop!(suffix_value, vm);
@@ -1226,7 +1218,7 @@ fn bytes_removesuffix<'h>(
 fn bytes_split<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let (sep, maxsplit) = parse_bytes_split_args("bytes.split", args, vm)?;
 
@@ -1270,7 +1262,7 @@ fn bytes_split<'h>(
 fn bytes_rsplit<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let (sep, maxsplit) = parse_bytes_split_args("bytes.rsplit", args, vm)?;
 
@@ -1312,7 +1304,7 @@ fn bytes_rsplit<'h>(
 fn parse_bytes_split_args(
     method: &str,
     args: ArgValues,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<(Option<Vec<u8>>, i64)> {
     let (pos_iter, kwargs) = args.into_parts();
     defer_drop_mut!(pos_iter, vm);
@@ -1530,7 +1522,7 @@ fn bytes_rsplitn_whitespace(bytes: &[u8], maxsplit: usize) -> Vec<&[u8]> {
 fn bytes_splitlines<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let keepends = parse_bytes_splitlines_args(args, vm)?;
 
@@ -1582,7 +1574,7 @@ fn bytes_splitlines<'h>(
 }
 
 /// Parses arguments for bytes.splitlines method.
-fn parse_bytes_splitlines_args(args: ArgValues, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
+fn parse_bytes_splitlines_args(args: ArgValues, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<bool> {
     let val = args.get_zero_one_named_arg("bytes.splitlines", StaticStrings::Keepends, vm.heap, vm.interns)?;
     let keepends = if let Some(v) = val {
         let result = v.py_bool(vm);
@@ -1600,7 +1592,7 @@ fn parse_bytes_splitlines_args(args: ArgValues, vm: &mut VM<'_, '_, impl Resourc
 fn bytes_partition<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let sep_value = args.get_one_arg("bytes.partition", vm.heap)?;
     defer_drop!(sep_value, vm);
@@ -1632,7 +1624,7 @@ fn bytes_partition<'h>(
 fn bytes_rpartition<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let sep_value = args.get_one_arg("bytes.rpartition", vm.heap)?;
     defer_drop!(sep_value, vm);
@@ -1668,7 +1660,7 @@ fn bytes_rpartition<'h>(
 fn bytes_replace<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let (old, new, count) = parse_bytes_replace_args("bytes.replace", args, vm)?;
 
@@ -1690,7 +1682,7 @@ fn bytes_replace<'h>(
 fn parse_bytes_replace_args(
     method: &str,
     args: ArgValues,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<(Vec<u8>, Vec<u8>, i64)> {
     let (pos_iter, kwargs) = args.into_parts();
     defer_drop_mut!(pos_iter, vm);
@@ -1841,7 +1833,7 @@ fn bytes_replace_n(
 fn bytes_center<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let (width, fillbyte) = parse_bytes_justify_args("bytes.center", args, vm)?;
 
@@ -1875,7 +1867,7 @@ fn bytes_center<'h>(
 fn bytes_ljust<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let (width, fillbyte) = parse_bytes_justify_args("bytes.ljust", args, vm)?;
 
@@ -1904,7 +1896,7 @@ fn bytes_ljust<'h>(
 fn bytes_rjust<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let (width, fillbyte) = parse_bytes_justify_args("bytes.rjust", args, vm)?;
 
@@ -1931,7 +1923,7 @@ fn bytes_rjust<'h>(
 fn parse_bytes_justify_args(
     method: &str,
     args: ArgValues,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<(usize, u8)> {
     let pos = args.into_pos_only(method, vm.heap)?;
     defer_drop!(pos, vm);
@@ -1970,7 +1962,7 @@ fn parse_bytes_justify_args(
 fn bytes_zfill<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let width_value = args.get_one_arg("bytes.zfill", vm.heap)?;
     defer_drop!(width_value, vm);
@@ -2017,7 +2009,7 @@ fn bytes_zfill<'h>(
 fn bytes_join<'h>(
     separator: &HeapRead<'h, [u8]>,
     iterable: Value,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let Ok(iter) = MontyIter::new(iterable, vm) else {
         return Err(ExcType::type_error_join_not_iterable());
@@ -2072,7 +2064,7 @@ fn bytes_join<'h>(
 fn bytes_hex<'h>(
     bytes: &HeapRead<'h, [u8]>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let (sep, bytes_per_sep) = parse_bytes_hex_args(args, vm)?;
 
@@ -2138,7 +2130,7 @@ fn bytes_hex<'h>(
 }
 
 /// Parses arguments for bytes.hex method.
-fn parse_bytes_hex_args(args: ArgValues, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<(Option<char>, i64)> {
+fn parse_bytes_hex_args(args: ArgValues, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<(Option<char>, i64)> {
     let pos = args.into_pos_only("bytes.hex", vm.heap)?;
     defer_drop!(pos, vm);
 
@@ -2182,7 +2174,7 @@ fn parse_bytes_hex_args(args: ArgValues, vm: &mut VM<'_, '_, impl ResourceTracke
 ///
 /// Creates bytes from a hexadecimal string. Whitespace is allowed between byte pairs,
 /// but not between the two digits of a byte.
-pub fn bytes_fromhex(args: ArgValues, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Value> {
+pub fn bytes_fromhex(args: ArgValues, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Value> {
     let hex_value = args.get_one_arg("bytes.fromhex", vm.heap)?;
     defer_drop!(hex_value, vm);
 

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -138,7 +138,7 @@ impl<'h> HeapRead<'h, Dataclass> {
         &mut self,
         name: Value,
         value: Value,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
     ) -> RunResult<Option<Value>> {
         if self.get(vm.heap).frozen {
             // Get attribute name for error message
@@ -164,16 +164,16 @@ impl<'h> HeapRead<'h, Dataclass> {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::Dataclass
     }
 
-    fn py_len(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, _vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         // Dataclasses don't have a length
         None
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         // Dataclasses are equal if they have the same name and equal attrs
         Ok(self.get(vm.heap).name == other.get(vm.heap).name && self.attrs().py_eq(&other.attrs(), vm)?)
     }
@@ -181,11 +181,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
     /// Hashes a frozen dataclass by its class name and the values of declared fields.
     ///
     /// Mutable (non-frozen) dataclasses return `None` (unhashable).
-    fn py_hash(
-        &self,
-        _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
         // Only frozen (immutable) dataclasses are hashable
         if !self.get(vm.heap).frozen {
             return Ok(None);
@@ -212,7 +208,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
         Ok(Some(hasher.finish()))
     }
 
-    fn py_bool(&self, _vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, _vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         // Dataclass instances are always truthy (like Python objects)
         true
     }
@@ -220,7 +216,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         // Check depth limit before recursing
@@ -271,7 +267,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
     fn py_call_attr(
         &mut self,
         self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<CallResult> {
@@ -309,7 +305,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
         }
     }
 
-    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
+    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
         let attr_name = attr.as_str(vm.interns);
         match self.get(vm.heap).attrs.get_by_str(attr_name, vm.heap, vm.interns) {
             Some(value) => Ok(Some(CallResult::Value(value.clone_with_heap(vm.heap)))),

--- a/crates/monty/src/types/date.rs
+++ b/crates/monty/src/types/date.rs
@@ -248,44 +248,36 @@ impl HeapItem for Date {
 /// `HeapRead`-based dispatch for `Date`, enabling the `HeapReadOutput` enum to
 /// delegate `PyTrait` calls to heap-resident dates.
 impl<'h> PyTrait<'h> for HeapRead<'h, Date> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::Date
     }
 
-    fn py_len(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, _vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         None
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         Ok(*self.get(vm.heap) == *other.get(vm.heap))
     }
 
-    fn py_hash(
-        &self,
-        _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(hasher.finish()))
     }
 
-    fn py_cmp(
-        &self,
-        other: &Self,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<Ordering>, ResourceError> {
+    fn py_cmp(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Ordering>, ResourceError> {
         Ok(self.get(vm.heap).partial_cmp(other.get(vm.heap)))
     }
 
-    fn py_bool(&self, _vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, _vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         true
     }
 
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         let (year, month, day) = to_ymd(*self.get(vm.heap));
@@ -293,7 +285,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Date> {
         Ok(())
     }
 
-    fn py_str(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         let (year, month, day) = to_ymd(*self.get(vm.heap));
         Ok(Cow::Owned(format!("{year:04}-{month:02}-{day:02}")))
     }
@@ -301,7 +293,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Date> {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<CallResult> {
@@ -346,7 +338,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Date> {
         }
     }
 
-    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
+    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
         let (year, month, day) = to_ymd(*self.get(vm.heap));
         match attr.string_id() {
             Some(id) if id == StaticStrings::Year => Ok(Some(CallResult::Value(Value::Int(i64::from(year))))),

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -984,15 +984,15 @@ impl HeapItem for DateTime {
 /// `HeapRead`-based dispatch for `DateTime`, enabling the `HeapReadOutput` enum to
 /// delegate `PyTrait` calls to heap-resident datetimes.
 impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::DateTime
     }
 
-    fn py_len(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, _vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         None
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         let a = self.get(vm.heap);
         let b = other.get(vm.heap);
         if is_aware(a) != is_aware(b) {
@@ -1004,21 +1004,13 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
         Ok(local_micros(a) == local_micros(b))
     }
 
-    fn py_hash(
-        &self,
-        _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(hasher.finish()))
     }
 
-    fn py_cmp(
-        &self,
-        other: &Self,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<Ordering>, ResourceError> {
+    fn py_cmp(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Ordering>, ResourceError> {
         let a = self.get(vm.heap);
         let b = other.get(vm.heap);
         if is_aware(a) != is_aware(b) {
@@ -1030,14 +1022,14 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
         Ok(local_micros(a).partial_cmp(&local_micros(b)))
     }
 
-    fn py_bool(&self, _vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, _vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         true
     }
 
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         let dt = self.get(vm.heap);
@@ -1069,7 +1061,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
         Ok(())
     }
 
-    fn py_str(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         let dt = self.get(vm.heap);
         let Some((year, month, day, hour, minute, second, microsecond)) = to_components(dt) else {
             return Ok(Cow::Borrowed("<out of range>"));
@@ -1087,7 +1079,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<CallResult> {
@@ -1141,7 +1133,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
         }
     }
 
-    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
+    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
         // Clone to release the HeapRead borrow before accessing attributes
         // that may need to allocate (e.g. tzinfo).
         let dt = self.get(vm.heap).clone();

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -115,7 +115,7 @@ impl Dict {
     /// Assumes the caller is transferring ownership of all keys and values in the pairs.
     /// Does NOT increment reference counts since ownership is being transferred.
     /// Returns Err if any key is unhashable (e.g., list, dict).
-    pub fn from_pairs(pairs: Vec<(Value, Value)>, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Self> {
+    pub fn from_pairs(pairs: Vec<(Value, Value)>, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Self> {
         let pairs_iter = pairs.into_iter();
         defer_drop_mut!(pairs_iter, vm);
         let dict = Self::with_capacity(pairs_iter.len());
@@ -140,7 +140,7 @@ impl Dict {
         &mut self,
         key: Value,
         value: Value,
-        vm: &mut VM<'_, '_, impl ResourceTracker>,
+        vm: &mut VM<'_, impl ResourceTracker>,
     ) -> RunResult<Option<Value>> {
         debug_assert!(json_key_string_slice(&key, vm.heap, vm.interns).is_some());
 
@@ -228,7 +228,7 @@ impl<'h> HeapRead<'h, Dict> {
     pub(crate) fn dict_get<'a>(
         &'a self,
         key: &Value,
-        vm: &'a mut VM<'h, '_, impl ResourceTracker>,
+        vm: &'a mut VM<'h, impl ResourceTracker>,
     ) -> RunResult<Option<Value>> {
         let (opt_index, _hash) = self.find_index_hash(key, vm)?;
         if let Some(index) = opt_index {
@@ -278,12 +278,7 @@ impl Dict {
     /// If the key already exists, replaces the old value and returns it (caller now
     /// owns the old value and is responsible for its refcount).
     /// Returns Err if key is unhashable.
-    pub fn set(
-        &mut self,
-        key: Value,
-        value: Value,
-        vm: &mut VM<'_, '_, impl ResourceTracker>,
-    ) -> RunResult<Option<Value>> {
+    pub fn set(&mut self, key: Value, value: Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Option<Value>> {
         vm.heap.protect_mut(self).set(key, value, vm)
     }
 }
@@ -298,12 +293,7 @@ impl<'h> HeapRead<'h, Dict> {
     /// If the key already exists, replaces the old value and returns it (caller now
     /// owns the old value and is responsible for its refcount).
     /// Returns Err if key is unhashable.
-    pub fn set(
-        &mut self,
-        key: Value,
-        value: Value,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> RunResult<Option<Value>> {
+    pub fn set(&mut self, key: Value, value: Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<Value>> {
         // Track if we're adding a reference for GC optimization
         if matches!(key, Value::Ref(_)) || matches!(value, Value::Ref(_)) {
             self.get_mut(vm.heap).contains_refs = true;
@@ -349,7 +339,7 @@ impl<'h> HeapRead<'h, Dict> {
     ///
     /// Reference counting: does not decrement refcounts for removed key and value;
     /// caller assumes ownership and is responsible for managing their refcounts.
-    pub fn pop(&mut self, key: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<(Value, Value)>> {
+    pub fn pop(&mut self, key: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<(Value, Value)>> {
         // Find the key using the candidate-based lookup
         let (opt_index, _hash) = self.find_index_hash(key, vm)?;
 
@@ -424,7 +414,7 @@ impl Dict {
     ///
     /// For now, only real `dict` values use mapping-copy semantics; other values
     /// are interpreted as iterables of pairs.
-    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub fn init(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         let dict = Self::new();
         let mut dict_guard = HeapGuard::new(dict, vm);
 
@@ -454,11 +444,7 @@ impl Dict {
 }
 
 impl<'h> HeapRead<'h, Dict> {
-    fn find_index_hash(
-        &self,
-        key: &Value,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> RunResult<(Option<usize>, u64)> {
+    fn find_index_hash(&self, key: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<(Option<usize>, u64)> {
         let hash = key
             .py_hash(vm)?
             .ok_or_else(|| ExcType::type_error_unhashable_dict_key(key.py_type(vm)))?;
@@ -489,7 +475,7 @@ impl<'h> HeapRead<'h, Dict> {
     }
 
     /// Checks whether the dict contains a given key.
-    pub(crate) fn contains_key(&self, key: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<bool> {
+    pub(crate) fn contains_key(&self, key: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
         let (opt_index, _hash) = self.find_index_hash(key, vm)?;
         Ok(opt_index.is_some())
     }
@@ -498,7 +484,7 @@ impl<'h> HeapRead<'h, Dict> {
     ///
     /// For dict sources, uses HeapReader::read() to access the source dict through
     /// the heap, enabling self-referential updates like `d.update(d)`.
-    fn merge_from_value(&mut self, other_value: Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<()> {
+    fn merge_from_value(&mut self, other_value: Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<()> {
         let mut guard = HeapGuard::new(other_value, vm);
         let (other_value, vm) = guard.as_parts_mut();
         if let Value::Ref(id) = other_value {
@@ -524,11 +510,7 @@ impl<'h> HeapRead<'h, Dict> {
     }
 
     /// Merges key-value pairs from an iterable of 2-item pairs.
-    fn merge_from_iterable_pairs(
-        &mut self,
-        iterable: Value,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> RunResult<()> {
+    fn merge_from_iterable_pairs(&mut self, iterable: Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<()> {
         let iter = MontyIter::new(iterable, vm)?;
         defer_drop_mut!(iter, vm);
 
@@ -569,7 +551,7 @@ impl<'h> HeapRead<'h, Dict> {
     }
 
     /// Merges kwargs into self.
-    fn merge_from_kwargs(&mut self, kwargs: KwargsValues, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<()> {
+    fn merge_from_kwargs(&mut self, kwargs: KwargsValues, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<()> {
         let kwargs_iter = kwargs.into_iter();
         defer_drop_mut!(kwargs_iter, vm);
         for (key, value) in kwargs_iter {
@@ -629,15 +611,15 @@ impl IntoIterator for Dict {
 /// `self.get(vm.heap)`, and mutation methods use `self.get_mut(vm.heap)`. This avoids
 /// taking the dict out of the heap, enabling self-referential operations like `d.update(d)`.
 impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::Dict
     }
 
-    fn py_len(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         Some(self.get(vm.heap).len())
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         if self.get(vm.heap).len() != other.get(vm.heap).len() {
             return Ok(false);
         }
@@ -663,14 +645,14 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
         Ok(true)
     }
 
-    fn py_bool(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         !self.get(vm.heap).is_empty()
     }
 
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         if self.get(vm.heap).is_empty() {
@@ -714,14 +696,14 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
         Ok(())
     }
 
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+    fn py_getitem(&self, key: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         match self.dict_get(key, vm)? {
             Some(value) => Ok(value),
             None => Err(ExcType::key_error(key, vm)),
         }
     }
 
-    fn py_setitem(&mut self, key: Value, value: Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<()> {
+    fn py_setitem(&mut self, key: Value, value: Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<()> {
         // Drop the old value if one was replaced
         if let Some(old_value) = self.set(key, value, vm)? {
             old_value.drop_with_heap(vm);
@@ -732,7 +714,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
     fn py_call_attr(
         &mut self,
         self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<CallResult> {
@@ -863,7 +845,7 @@ impl DropWithHeap for DictEntry {
 /// Implements Python's `dict.clear()` method.
 ///
 /// Removes all items from the dict.
-fn dict_clear<'h>(dict: &mut HeapRead<'h, Dict>, vm: &mut VM<'h, '_, impl ResourceTracker>) {
+fn dict_clear<'h>(dict: &mut HeapRead<'h, Dict>, vm: &mut VM<'h, impl ResourceTracker>) {
     dict.get_mut(vm.heap).indices.clear();
     mem::take(&mut dict.get_mut(vm.heap).entries).drop_with_heap(vm.heap);
     // Note: contains_refs stays true even if all refs removed, per conservative GC strategy
@@ -872,7 +854,7 @@ fn dict_clear<'h>(dict: &mut HeapRead<'h, Dict>, vm: &mut VM<'h, '_, impl Resour
 /// Implements Python's `dict.copy()` method.
 ///
 /// Returns a shallow copy of the dict.
-fn dict_copy<'h>(dict: &mut HeapRead<'h, Dict>, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+fn dict_copy<'h>(dict: &mut HeapRead<'h, Dict>, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     // Copy all key-value pairs (incrementing refcounts)
     let pairs: Vec<(Value, Value)> = dict
         .get(vm.heap)
@@ -894,7 +876,7 @@ fn dict_copy<'h>(dict: &mut HeapRead<'h, Dict>, vm: &mut VM<'h, '_, impl Resourc
 fn dict_update<'h>(
     dict: &mut HeapRead<'h, Dict>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let (pos_iter, kwargs) = args.into_parts();
     defer_drop_mut!(pos_iter, vm);
@@ -918,11 +900,7 @@ fn dict_update<'h>(
 ///
 /// This is shared between `dict()` construction and `dict.update()` so both
 /// entry points follow identical positional-source semantics.
-fn dict_merge_from_value(
-    dict: &mut Dict,
-    other_value: Value,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
-) -> RunResult<()> {
+fn dict_merge_from_value(dict: &mut Dict, other_value: Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<()> {
     let mut other_value_guard = HeapGuard::new(other_value, vm);
     {
         let (other_value, vm) = other_value_guard.as_parts();
@@ -956,7 +934,7 @@ fn dict_merge_from_value(
 fn dict_merge_from_iterable_pairs(
     dict: &mut Dict,
     iterable: Value,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<()> {
     let iter = MontyIter::new(iterable, vm)?;
     defer_drop_mut!(iter, vm);
@@ -1005,7 +983,7 @@ fn dict_merge_from_iterable_pairs(
 fn dict_merge_from_kwargs(
     dict: &mut Dict,
     kwargs: KwargsValues,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<()> {
     let kwargs_iter = kwargs.into_iter();
     defer_drop_mut!(kwargs_iter, vm);
@@ -1023,7 +1001,7 @@ fn dict_merge_from_kwargs(
 fn dict_setdefault<'h>(
     dict: &mut HeapRead<'h, Dict>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let (key, default) = args.get_one_two_args("setdefault", vm.heap)?;
     let default = default.unwrap_or(Value::None);
@@ -1049,7 +1027,7 @@ fn dict_setdefault<'h>(
 ///
 /// Removes and returns the last inserted key-value pair as a tuple.
 /// Raises KeyError if the dict is empty.
-fn dict_popitem<'h>(dict: &mut HeapRead<'h, Dict>, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+fn dict_popitem<'h>(dict: &mut HeapRead<'h, Dict>, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let this = dict.get_mut(vm.heap);
     if this.is_empty() {
         return Err(ExcType::key_error_popitem_empty_dict());
@@ -1114,7 +1092,7 @@ impl<'de> serde::Deserialize<'de> for Dict {
 /// dict.fromkeys(['a', 'b', 'c'])  # {'a': None, 'b': None, 'c': None}
 /// dict.fromkeys(['a', 'b'], 0)    # {'a': 0, 'b': 0}
 /// ```
-pub fn dict_fromkeys(args: ArgValues, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Value> {
+pub fn dict_fromkeys(args: ArgValues, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Value> {
     let (iterable, default) = args.get_one_two_args("dict.fromkeys", vm.heap)?;
     let default = default.unwrap_or(Value::None);
     defer_drop!(default, vm);

--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -59,7 +59,7 @@ impl DictKeysView {
 }
 
 impl<'h> HeapRead<'h, DictKeysView> {
-    fn dict(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> HeapRead<'h, Dict> {
+    fn dict(&self, vm: &mut VM<'h, impl ResourceTracker>) -> HeapRead<'h, Dict> {
         let HeapReadOutput::Dict(dict) = vm.heap.read(self.get(vm.heap).dict_id) else {
             panic!("dict_keys view must always reference a dict");
         };
@@ -70,7 +70,7 @@ impl<'h> HeapRead<'h, DictKeysView> {
     pub(crate) fn eq_set(
         &self,
         other: &HeapRead<'h, Set>,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
     ) -> Result<bool, ResourceError> {
         dict_keys_eq_set_like(
             &self.dict(vm),
@@ -84,7 +84,7 @@ impl<'h> HeapRead<'h, DictKeysView> {
     pub(crate) fn eq_frozenset(
         &self,
         other: &HeapRead<'h, FrozenSet>,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
     ) -> Result<bool, ResourceError> {
         dict_keys_eq_set_like(
             &self.dict(vm),
@@ -99,7 +99,7 @@ impl<'h> HeapRead<'h, DictKeysView> {
     /// Dict-view operators always produce ordinary `set` results in CPython,
     /// so the VM uses this helper as the left-hand-side snapshot for `& | ^ -`
     /// and for `isdisjoint(...)`.
-    pub(crate) fn to_set(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Set> {
+    pub(crate) fn to_set(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Set> {
         let dict = self.dict(vm);
         let len = dict.get(vm.heap).len();
         let mut result = Set::with_capacity(len);
@@ -114,7 +114,7 @@ impl<'h> HeapRead<'h, DictKeysView> {
     pub(crate) fn isdisjoint_from_value(
         &self,
         other: &Value,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
     ) -> RunResult<bool> {
         let self_set = self.to_set(vm)?;
         defer_drop!(self_set, vm);
@@ -131,15 +131,15 @@ impl DictView for DictKeysView {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, DictKeysView> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::DictKeys
     }
 
-    fn py_len(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         Some(self.get(vm.heap).dict(vm.heap).len())
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         if self.get(vm.heap).dict_id == other.get(vm.heap).dict_id {
             return Ok(true);
         }
@@ -157,7 +157,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictKeysView> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         f.write_str("dict_keys([")?;
@@ -168,7 +168,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictKeysView> {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<CallResult> {
@@ -218,7 +218,7 @@ impl DictItemsView {
 }
 
 impl<'h> HeapRead<'h, DictItemsView> {
-    fn dict(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> HeapRead<'h, Dict> {
+    fn dict(&self, vm: &mut VM<'h, impl ResourceTracker>) -> HeapRead<'h, Dict> {
         let HeapReadOutput::Dict(dict) = vm.heap.read(self.get(vm.heap).dict_id) else {
             panic!("dict_items view must always reference a dict");
         };
@@ -229,7 +229,7 @@ impl<'h> HeapRead<'h, DictItemsView> {
     pub(crate) fn eq_set(
         &self,
         other: &HeapRead<'h, Set>,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
     ) -> Result<bool, ResourceError> {
         dict_items_eq_set_like(
             &self.dict(vm),
@@ -243,7 +243,7 @@ impl<'h> HeapRead<'h, DictItemsView> {
     pub(crate) fn eq_frozenset(
         &self,
         other: &HeapRead<'h, FrozenSet>,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
     ) -> Result<bool, ResourceError> {
         dict_items_eq_set_like(
             &self.dict(vm),
@@ -257,7 +257,7 @@ impl<'h> HeapRead<'h, DictItemsView> {
     ///
     /// Each item is allocated as a 2-tuple so later set-like operators and
     /// membership checks observe standard Python tuple semantics.
-    pub(crate) fn to_set(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Set> {
+    pub(crate) fn to_set(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Set> {
         let dict = self.dict(vm);
         let len = dict.get(vm.heap).len();
         let mut result = Set::with_capacity(len);
@@ -273,7 +273,7 @@ impl<'h> HeapRead<'h, DictItemsView> {
     pub(crate) fn isdisjoint_from_value(
         &self,
         other: &Value,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
     ) -> RunResult<bool> {
         let self_set = self.to_set(vm)?;
         defer_drop!(self_set, vm);
@@ -290,15 +290,15 @@ impl DictView for DictItemsView {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, DictItemsView> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::DictItems
     }
 
-    fn py_len(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         Some(self.get(vm.heap).dict(vm.heap).len())
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         if self.get(vm.heap).dict_id == other.get(vm.heap).dict_id {
             return Ok(true);
         }
@@ -311,7 +311,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictItemsView> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         f.write_str("dict_items([")?;
@@ -322,7 +322,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictItemsView> {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<CallResult> {
@@ -378,7 +378,7 @@ impl DictView for DictValuesView {
 }
 
 impl<'h> HeapRead<'h, DictValuesView> {
-    fn dict(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> HeapRead<'h, Dict> {
+    fn dict(&self, vm: &mut VM<'h, impl ResourceTracker>) -> HeapRead<'h, Dict> {
         let HeapReadOutput::Dict(dict) = vm.heap.read(self.get(vm.heap).dict_id) else {
             panic!("dict_values view must always reference a dict");
         };
@@ -387,22 +387,22 @@ impl<'h> HeapRead<'h, DictValuesView> {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, DictValuesView> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::DictValues
     }
 
-    fn py_len(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         Some(self.get(vm.heap).dict(vm.heap).len())
     }
 
-    fn py_eq(&self, _other: &Self, _vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, _other: &Self, _vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         Ok(false)
     }
 
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         f.write_str("dict_values([")?;
@@ -425,8 +425,8 @@ impl HeapItem for DictValuesView {
 fn dict_keys_eq_set_like<'h, T: ResourceTracker>(
     dict: &HeapRead<'h, Dict>,
     other_len: usize,
-    mut contains: impl FnMut(&Value, &mut VM<'h, '_, T>) -> bool,
-    vm: &mut VM<'h, '_, T>,
+    mut contains: impl FnMut(&Value, &mut VM<'h, T>) -> bool,
+    vm: &mut VM<'h, T>,
 ) -> Result<bool, ResourceError> {
     if dict.get(vm.heap).len() != other_len {
         return Ok(false);
@@ -450,8 +450,8 @@ fn dict_keys_eq_set_like<'h, T: ResourceTracker>(
 fn dict_items_eq_set_like<'h, T: ResourceTracker>(
     dict: &HeapRead<'h, Dict>,
     other_len: usize,
-    mut contains: impl FnMut(&Value, &mut VM<'h, '_, T>) -> bool,
-    vm: &mut VM<'h, '_, T>,
+    mut contains: impl FnMut(&Value, &mut VM<'h, T>) -> bool,
+    vm: &mut VM<'h, T>,
 ) -> Result<bool, ResourceError> {
     if dict.get(vm.heap).len() != other_len {
         return Ok(false);
@@ -476,7 +476,7 @@ fn dict_items_eq_set_like<'h, T: ResourceTracker>(
 fn write_dict_keys_contents<'h>(
     f: &mut impl Write,
     dict: &HeapRead<'h, Dict>,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
     heap_ids: &mut AHashSet<HeapId>,
 ) -> RunResult<()> {
     let len = dict.get(vm.heap).len();
@@ -499,7 +499,7 @@ fn write_dict_keys_contents<'h>(
 fn write_dict_items_contents<'h>(
     f: &mut impl Write,
     dict: &HeapRead<'h, Dict>,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
     heap_ids: &mut AHashSet<HeapId>,
 ) -> RunResult<()> {
     let len = dict.get(vm.heap).len();
@@ -532,7 +532,7 @@ fn write_dict_items_contents<'h>(
 fn write_dict_values_contents<'h>(
     f: &mut impl Write,
     dict: &HeapRead<'h, Dict>,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
     heap_ids: &mut AHashSet<HeapId>,
 ) -> RunResult<()> {
     let len = dict.get(vm.heap).len();
@@ -556,10 +556,7 @@ fn write_dict_values_contents<'h>(
 /// Dict-view operators accept any iterable on the right-hand side in CPython,
 /// including one-shot iterator objects. Reusing the same collection path keeps
 /// binary operators and `isdisjoint(...)` consistent with each other.
-pub(crate) fn collect_iterable_to_set(
-    value: Value,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
-) -> Result<Set, RunError> {
+pub(crate) fn collect_iterable_to_set(value: Value, vm: &mut VM<'_, impl ResourceTracker>) -> Result<Set, RunError> {
     let mut value_guard = HeapGuard::new(value, vm);
     let (value, vm) = value_guard.as_parts_mut();
 
@@ -587,7 +584,7 @@ pub(crate) fn collect_iterable_to_set(
 }
 
 /// Returns whether two temporary sets have no elements in common.
-fn sets_are_disjoint(left: &Set, right: &Set, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
+fn sets_are_disjoint(left: &Set, right: &Set, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<bool> {
     let (smaller, larger) = if left.len() <= right.len() {
         (left, right)
     } else {

--- a/crates/monty/src/types/iter.rs
+++ b/crates/monty/src/types/iter.rs
@@ -49,7 +49,7 @@ impl MontyIter {
     /// - `iter(iterable)` - Returns an iterator for the iterable. If the argument is
     ///   already an iterator, returns the same object.
     /// - `iter(callable, sentinel)` - Not yet supported.
-    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub fn init(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         let (iterable, sentinel) = args.get_one_two_args("iter", vm.heap)?;
 
         if let Some(s) = sentinel {
@@ -79,7 +79,7 @@ impl MontyIter {
     /// Returns an error if the value is not iterable.
     /// For strings, copies the string content for byte-offset based iteration.
     /// For ranges, the data is copied so the heap reference is dropped immediately.
-    pub fn new(mut value: Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Self> {
+    pub fn new(mut value: Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Self> {
         if let Some(iter_value) = IterValue::new(&value, vm) {
             // For Range, we copy next/step/len into ForIterValue::Range, so we don't need
             // to keep the heap object alive during iteration. Drop it immediately to avoid
@@ -132,7 +132,7 @@ impl MontyIter {
     /// Returns `Ok(None)` when the iterator is exhausted.
     /// Returns `Err` if allocation fails (for string character iteration) or if
     /// a dict/set changes size during iteration (RuntimeError).
-    pub fn for_next(&mut self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Option<Value>> {
+    pub fn for_next(&mut self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Option<Value>> {
         // Check timeout on every iteration step. For NoLimitTracker this is
         // inlined as a no-op. For LimitTracker it ensures that Rust-side loops
         // (sum, sorted, min, max, etc.) cannot bypass the VM's per-instruction
@@ -226,16 +226,16 @@ impl MontyIter {
     /// and similar constructors that need to materialize all items.
     ///
     /// Pre-allocates capacity based on `size_hint()` for better performance.
-    pub fn collect<T: FromIterator<Value>>(self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<T> {
+    pub fn collect<T: FromIterator<Value>>(self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<T> {
         let mut guard = HeapGuard::new(self, vm);
         let (this, vm) = guard.as_parts_mut();
         HeapedMontyIter(this, vm).collect()
     }
 }
 
-struct HeapedMontyIter<'this, 'a, 'p, T: ResourceTracker>(&'this mut MontyIter, &'this mut VM<'a, 'p, T>);
+struct HeapedMontyIter<'this, 'h, T: ResourceTracker>(&'this mut MontyIter, &'this mut VM<'h, T>);
 
-impl<T: ResourceTracker> Iterator for HeapedMontyIter<'_, '_, '_, T> {
+impl<T: ResourceTracker> Iterator for HeapedMontyIter<'_, '_, T> {
     type Item = RunResult<Value>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -253,7 +253,7 @@ impl<'h> HeapRead<'h, MontyIter> {
     ///
     /// Returns `Ok(None)` when the iterator is exhausted.
     /// Returns `Err` for dict/set size changes or allocation failures.
-    pub(crate) fn advance(&mut self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<Value>> {
+    pub(crate) fn advance(&mut self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<Value>> {
         let this = self.get_mut(vm.heap);
         match &mut this.iter_value {
             IterValue::Range { next, step, len } => {
@@ -326,7 +326,7 @@ impl<'h> HeapRead<'h, MontyIter> {
 /// Returns `Ok(None)` if the index is out of bounds (for lists that shrunk during iteration).
 /// Returns `Err` if a dict/set changed size during iteration (RuntimeError).
 fn get_heap_item(
-    vm: &VM<'_, '_, impl ResourceTracker>,
+    vm: &VM<'_, impl ResourceTracker>,
     heap_id: HeapId,
     index: usize,
     expected_len: Option<usize>,
@@ -432,7 +432,7 @@ fn get_heap_item(
 pub fn iterator_next(
     iter_value: &Value,
     default: Option<Value>,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let mut default_guard = HeapGuard::new(default, vm);
     let vm = default_guard.heap();
@@ -507,7 +507,7 @@ enum IterValue {
 }
 
 impl IterValue {
-    fn new(value: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> Option<Self> {
+    fn new(value: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> Option<Self> {
         match &value {
             Value::InternString(string_id) => Some(Self::from_str(vm.interns.get_str(*string_id))),
             Value::InternBytes(bytes_id) => Some(Self::from_intern_bytes(*bytes_id, vm.interns)),

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -127,7 +127,7 @@ impl<'h> HeapRead<'h, List> {
     /// The caller transfers ownership of `item` to the list. The item's refcount
     /// is NOT incremented here - the caller is responsible for ensuring the refcount
     /// was already incremented (e.g., via `clone_with_heap` or `evaluate_use`).
-    pub fn append(&mut self, vm: &mut VM<'h, '_, impl ResourceTracker>, item: Value) -> RunResult<()> {
+    pub fn append(&mut self, vm: &mut VM<'h, impl ResourceTracker>, item: Value) -> RunResult<()> {
         // Check memory limit before growing the internal Vec
         vm.heap.track_growth(VALUE_SIZE)?;
         // Track if we're adding a reference and mark potential cycle
@@ -149,7 +149,7 @@ impl<'h> HeapRead<'h, List> {
     /// # Arguments
     /// * `index` - The position to insert at (0-based). If index >= len(),
     ///   the item is appended to the end (matching Python semantics).
-    pub fn insert(&mut self, vm: &mut VM<'h, '_, impl ResourceTracker>, index: usize, item: Value) -> RunResult<()> {
+    pub fn insert(&mut self, vm: &mut VM<'h, impl ResourceTracker>, index: usize, item: Value) -> RunResult<()> {
         // Check memory limit before growing the internal Vec
         vm.heap.track_growth(VALUE_SIZE)?;
         // Track if we're adding a reference and mark potential cycle
@@ -174,7 +174,7 @@ impl List {
     ///
     /// - `list()` with no args returns an empty list
     /// - `list(iterable)` creates a list from any iterable (list, tuple, range, str, bytes, dict)
-    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub fn init(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         let value = args.get_zero_one_arg("list", vm.heap)?;
         match value {
             None => {
@@ -194,7 +194,7 @@ impl<'h> HeapRead<'h, List> {
     /// Handles slice-based indexing for lists.
     ///
     /// Returns a new list containing the selected elements.
-    fn getitem_slice(&self, slice: &super::Slice, vm: &VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+    fn getitem_slice(&self, slice: &super::Slice, vm: &VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         let items = slice_collect_iterator(vm, slice, self.get(vm.heap).items.iter(), |item| {
             item.clone_with_heap(vm.heap)
         })?;
@@ -203,12 +203,12 @@ impl<'h> HeapRead<'h, List> {
     }
 
     /// Clones the item at the given index with proper refcount management.
-    pub(crate) fn clone_item(&self, index: usize, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Value {
+    pub(crate) fn clone_item(&self, index: usize, vm: &mut VM<'h, impl ResourceTracker>) -> Value {
         self.get(vm.heap).items[index].clone_with_heap(vm.heap)
     }
 
     /// Clones all items from this list with proper refcount management.
-    fn clone_all_items(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Vec<Value> {
+    fn clone_all_items(&self, vm: &mut VM<'h, impl ResourceTracker>) -> Vec<Value> {
         let len = self.get(vm.heap).items.len();
         let mut result = Vec::with_capacity(len);
         for i in 0..len {
@@ -219,15 +219,15 @@ impl<'h> HeapRead<'h, List> {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, List> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::List
     }
 
-    fn py_len(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         Some(self.get(vm.heap).items.len())
     }
 
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+    fn py_getitem(&self, key: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         // Check for slice first (Value::Ref pointing to HeapData::Slice)
         if let Value::Ref(id) = key
             && let HeapData::Slice(slice) = vm.heap.get(*id)
@@ -253,7 +253,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
         Ok(self.get(vm.heap).items[idx].clone_with_heap(vm))
     }
 
-    fn py_setitem(&mut self, key: Value, value: Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<()> {
+    fn py_setitem(&mut self, key: Value, value: Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<()> {
         defer_drop!(key, vm);
         defer_drop_mut!(value, vm);
 
@@ -307,7 +307,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
         Ok(())
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         let a_len = self.get(vm.heap).items.len();
         if a_len != other.get(vm.heap).items.len() {
             return Ok(false);
@@ -328,21 +328,21 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
         Ok(true)
     }
 
-    fn py_bool(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         !self.get(vm.heap).items.is_empty()
     }
 
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         let len = self.get(vm.heap).len();
         repr_sequence_fmt('[', ']', len, |heap, i| &self.get(heap).as_slice()[i], f, vm, heap_ids)
     }
 
-    fn py_add(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<Option<Value>, ResourceError> {
+    fn py_add(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Value>, ResourceError> {
         let mut items = self.clone_all_items(vm);
         items.extend(other.clone_all_items(vm));
         let id = vm.heap.allocate(HeapData::List(List::new(items)))?;
@@ -352,7 +352,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
     fn py_iadd(
         &mut self,
         other: &Value,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         self_id: Option<HeapId>,
     ) -> Result<bool, ResourceError> {
         let Value::Ref(other_id) = other else {
@@ -396,7 +396,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<CallResult> {
@@ -447,7 +447,7 @@ fn call_list_method<'h>(
     list: &mut HeapRead<'h, List>,
     method: StaticStrings,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let heap = &mut *vm.heap;
     match method {
@@ -488,7 +488,7 @@ fn call_list_method<'h>(
 fn list_insert<'h>(
     list: &mut HeapRead<'h, List>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let (index_obj, item) = args.get_two_args("insert", vm.heap)?;
     defer_drop!(index_obj, vm);
@@ -520,7 +520,7 @@ fn list_insert<'h>(
 fn list_pop<'h>(
     list: &mut HeapRead<'h, List>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let index_arg = args.get_zero_one_arg("list.pop", vm.heap)?;
 
@@ -560,7 +560,7 @@ fn list_pop<'h>(
 fn list_remove<'h>(
     list: &mut HeapRead<'h, List>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let value = args.get_one_arg("list.remove", vm.heap)?;
     defer_drop!(value, vm);
@@ -592,7 +592,7 @@ fn list_remove<'h>(
 /// Implements Python's `list.clear()` method.
 ///
 /// Removes all items from the list.
-fn list_clear<'h>(list: &mut HeapRead<'h, List>, vm: &mut VM<'h, '_, impl ResourceTracker>) {
+fn list_clear<'h>(list: &mut HeapRead<'h, List>, vm: &mut VM<'h, impl ResourceTracker>) {
     mem::take(&mut list.get_mut(vm.heap).items).drop_with_heap(vm);
     // Note: contains_refs stays true even if all refs removed, per conservative GC strategy
 }
@@ -612,7 +612,7 @@ fn list_copy(list: &List, heap: &Heap<impl ResourceTracker>) -> Result<Value, Re
 fn list_extend<'h>(
     list: &mut HeapRead<'h, List>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let iterable = args.get_one_arg("list.extend", vm.heap)?;
     let items: SmallVec<[_; 2]> = MontyIter::new(iterable, vm)?.collect(vm)?;
@@ -636,7 +636,7 @@ fn list_extend<'h>(
 fn list_index<'h>(
     list: &HeapRead<'h, List>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let pos_args = args.into_pos_only("list.index", vm.heap)?;
     defer_drop!(pos_args, vm);
@@ -677,7 +677,7 @@ fn list_index<'h>(
 fn list_count<'h>(
     list: &HeapRead<'h, List>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let value = args.get_one_arg("list.count", vm.heap)?;
     defer_drop!(value, vm);
@@ -701,7 +701,7 @@ fn list_count<'h>(
 fn do_list_sort<'h>(
     list: &mut HeapRead<'h, List>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> Result<(), RunError> {
     // Parse keyword-only arguments: key and reverse
     let (key_arg, reverse_arg) = args.extract_keyword_only_pair("list.sort", "key", "reverse", vm.heap, vm.interns)?;
@@ -777,7 +777,7 @@ pub(crate) fn repr_sequence_fmt<'h, T: ResourceTracker>(
     len: usize,
     get_item: impl for<'r> Fn(&'r HeapReader<'h, T>, usize) -> &'r Value,
     f: &mut impl Write,
-    vm: &mut VM<'h, '_, T>,
+    vm: &mut VM<'h, T>,
     heap_ids: &mut AHashSet<HeapId>,
 ) -> RunResult<()> {
     // Check depth limit before recursing
@@ -847,14 +847,14 @@ mod tests {
     fn py_setitem_longint_fits_in_i64() {
         let (mut heap, list_id, index_id) =
             create_heap_with_list_and_longint(vec![Value::Int(10), Value::Int(20), Value::Int(30)], BigInt::from(1));
-        let interns = create_test_interns();
+        let mut interns = create_test_interns();
 
         let key = Value::Ref(index_id);
         let new_value = Value::Int(99);
         heap.inc_ref(index_id);
 
-        let result = HeapReader::with(&mut heap, |heap| {
-            let mut vm = VM::new(Vec::new(), heap, &interns, PrintWriter::Disabled);
+        let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
+            let mut vm = VM::new(Vec::new(), reader, interns, PrintWriter::Disabled);
             let HeapReadOutput::List(mut list) = vm.heap.read(list_id) else {
                 panic!("expected list");
             };
@@ -880,14 +880,14 @@ mod tests {
             vec![Value::Int(10), Value::Int(20), Value::Int(30)],
             BigInt::from(-1), // Last element
         );
-        let interns = create_test_interns();
+        let mut interns = create_test_interns();
 
         let key = Value::Ref(index_id);
         let new_value = Value::Int(99);
         heap.inc_ref(index_id);
 
-        let result = HeapReader::with(&mut heap, |heap| {
-            let mut vm = VM::new(Vec::new(), heap, &interns, PrintWriter::Disabled);
+        let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
+            let mut vm = VM::new(Vec::new(), reader, interns, PrintWriter::Disabled);
             let HeapReadOutput::List(mut list) = vm.heap.read(list_id) else {
                 panic!("expected list");
             };
@@ -910,15 +910,14 @@ mod tests {
     fn py_setitem_longint_at_i64_max() {
         let (mut heap, list_id, index_id) =
             create_heap_with_list_and_longint(vec![Value::Int(10)], BigInt::from(i64::MAX));
-        let interns = create_test_interns();
+        let mut interns = create_test_interns();
 
         let key = Value::Ref(index_id);
         let new_value = Value::Int(99);
         heap.inc_ref(index_id);
 
-        // This should fail with IndexError because i64::MAX is out of bounds for a 1-element list
-        let result = HeapReader::with(&mut heap, |heap| {
-            let mut vm = VM::new(Vec::new(), heap, &interns, PrintWriter::Disabled);
+        let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
+            let mut vm = VM::new(Vec::new(), reader, interns, PrintWriter::Disabled);
             let HeapReadOutput::List(mut list) = vm.heap.read(list_id) else {
                 panic!("expected list");
             };

--- a/crates/monty/src/types/module.rs
+++ b/crates/monty/src/types/module.rs
@@ -59,7 +59,7 @@ impl Module {
     /// # Panics
     ///
     /// Panics if the attribute name string has not been pre-interned.
-    pub fn set_attr(&mut self, name: impl Into<StringId>, value: Value, vm: &mut VM<'_, '_, impl ResourceTracker>) {
+    pub fn set_attr(&mut self, name: impl Into<StringId>, value: Value, vm: &mut VM<'_, impl ResourceTracker>) {
         let key = Value::InternString(name.into());
         // Unwrap is safe because InternString keys are always hashable
         self.attrs.set(key, value, vm).unwrap();
@@ -82,7 +82,7 @@ impl<'h> HeapRead<'h, Module> {
     /// Returns the attribute value if found, or `None` if the attribute doesn't exist.
     /// For `Property` values, invokes the property getter rather than returning
     /// the Property itself - this implements Python's descriptor protocol.
-    pub fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Option<CallResult> {
+    pub fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, impl ResourceTracker>) -> Option<CallResult> {
         let value = self
             .get(vm.heap)
             .attrs
@@ -106,7 +106,7 @@ impl<'h> HeapRead<'h, Module> {
     pub fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<CallResult> {

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -145,7 +145,7 @@ impl<'h> HeapRead<'h, NamedTuple> {
     /// Returns `Some(value)` if the index is in bounds, `None` otherwise.
     /// Uses `index + len` instead of `-index` to avoid overflow on `i64::MIN`.
     #[must_use]
-    pub fn get_by_index<'a>(&'a self, vm: &'a VM<'h, '_, impl ResourceTracker>, index: i64) -> Option<&'a Value> {
+    pub fn get_by_index<'a>(&'a self, vm: &'a VM<'h, impl ResourceTracker>, index: i64) -> Option<&'a Value> {
         let len = i64::try_from(self.get(vm.heap).items.len()).ok()?;
         let normalized = if index < 0 { index + len } else { index };
         if normalized < 0 || normalized >= len {
@@ -155,7 +155,7 @@ impl<'h> HeapRead<'h, NamedTuple> {
     }
 
     /// Clones a single item.
-    pub(crate) fn clone_item(&self, index: usize, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Value {
+    pub(crate) fn clone_item(&self, index: usize, vm: &mut VM<'h, impl ResourceTracker>) -> Value {
         self.get(vm.heap).items[index].clone_with_heap(vm)
     }
 
@@ -166,7 +166,7 @@ impl<'h> HeapRead<'h, NamedTuple> {
     pub(crate) fn eq_tuple(
         &self,
         other: &HeapRead<'h, super::Tuple>,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
     ) -> Result<bool, ResourceError> {
         let a_len = self.get(vm.heap).len();
         if a_len != other.get(vm.heap).as_slice().len() {
@@ -192,15 +192,15 @@ impl<'h> HeapRead<'h, NamedTuple> {
 /// `PyTrait` implementation for `HeapRead<NamedTuple>`, providing all Python operations
 /// on heap-allocated named tuples via short-lived borrow patterns.
 impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::NamedTuple
     }
 
-    fn py_len(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         Some(self.get(vm.heap).len())
     }
 
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+    fn py_getitem(&self, key: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         // Extract integer index from key, returning TypeError if not an int
         let index = match key {
             Value::Int(i) => *i,
@@ -214,7 +214,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
         }
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         let a_len = self.get(vm.heap).len();
         if a_len != other.get(vm.heap).len() {
             return Ok(false);
@@ -237,11 +237,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
 
     /// Hashes by element only (not by class name), matching `Tuple::py_hash`
     /// so a `NamedTuple` and a `Tuple` with equal elements share the same hash.
-    fn py_hash(
-        &self,
-        _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
         let token = vm.heap.incr_recursion_depth()?;
         defer_drop!(token, vm);
         let len = self.get(vm.heap).len();
@@ -257,14 +253,14 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
         Ok(Some(hasher.finish()))
     }
 
-    fn py_bool(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         self.get(vm.heap).len() > 0
     }
 
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         // Check depth limit before recursing
@@ -291,7 +287,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
         Ok(())
     }
 
-    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
+    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
         let attr_name = attr.as_str(vm.interns);
         if let Some(value) = self.get(vm.heap).get_by_name(attr_name, vm.interns) {
             Ok(Some(CallResult::Value(value.clone_with_heap(vm.heap))))

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -266,7 +266,7 @@ impl Path {
     /// - `Path('a')` returns `Path('a')`
     /// - `Path('a', 'b', 'c')` returns `Path('a/b/c')`
     /// - If an absolute path appears, it replaces everything before it.
-    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub fn init(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         let pos_args = args.into_pos_only("Path", vm.heap)?;
         defer_drop!(pos_args, vm);
 
@@ -289,7 +289,7 @@ impl Path {
 }
 
 /// Extracts a string from a Value for use as a path.
-fn extract_path_string<'a>(val: &Value, vm: &'a VM<'_, '_, impl ResourceTracker>) -> RunResult<&'a str> {
+fn extract_path_string<'a>(val: &Value, vm: &'a VM<'_, impl ResourceTracker>) -> RunResult<&'a str> {
     match val {
         Value::InternString(string_id) => Ok(vm.interns.get_str(*string_id)),
         Value::Ref(heap_id) => match vm.heap.get(*heap_id) {
@@ -307,7 +307,7 @@ fn extract_path_string<'a>(val: &Value, vm: &'a VM<'_, '_, impl ResourceTracker>
     }
 }
 
-fn fold_joinpath(mut path: Path, parts: &[Value], vm: &VM<'_, '_, impl ResourceTracker>) -> RunResult<Path> {
+fn fold_joinpath(mut path: Path, parts: &[Value], vm: &VM<'_, impl ResourceTracker>) -> RunResult<Path> {
     for part in parts {
         path = Path::new(path.joinpath(extract_path_string(part, vm)?));
     }
@@ -479,30 +479,26 @@ impl Path {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, Path> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::Path
     }
 
-    fn py_len(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, _vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         // Paths don't have a length in Python
         None
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         Ok(self.get(vm.heap).path == other.get(vm.heap).path)
     }
 
-    fn py_hash(
-        &self,
-        _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).as_str().hash(&mut hasher);
         Ok(Some(hasher.finish()))
     }
 
-    fn py_bool(&self, _vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, _vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         // Paths are always truthy (even empty paths)
         true
     }
@@ -510,7 +506,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Path> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         // Format like: PosixPath('/usr/bin')
@@ -526,7 +522,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Path> {
     fn py_call_attr(
         &mut self,
         self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<CallResult> {
@@ -599,7 +595,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Path> {
         value.map(CallResult::Value)
     }
 
-    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
+    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
         // Fast path: interned strings can be matched by ID without string comparison
         if let Some(ss) = attr.static_string() {
             if let Some(v) = self.get(vm.heap).getattr_by_static(ss, vm.heap)? {

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -87,13 +87,13 @@ pub trait PyTrait<'h> {
     ///
     /// Used for error messages and the `type()` builtin.
     /// Takes heap reference for cases where nested Value lookups are needed.
-    fn py_type(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Type;
+    fn py_type(&self, vm: &VM<'h, impl ResourceTracker>) -> Type;
 
     /// Returns the number of elements in this container.
     ///
     /// For interns, returns the number of Unicode codepoints (characters), matching Python.
     /// Returns `None` if the type doesn't support `len()`.
-    fn py_len(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize>;
+    fn py_len(&self, vm: &VM<'h, impl ResourceTracker>) -> Option<usize>;
 
     /// Computes the hash for this Python value, used for dict and set keys.
     ///
@@ -110,11 +110,7 @@ pub trait PyTrait<'h> {
     /// `Cell` that hash by identity. Most implementations ignore it.
     ///
     /// The default implementation returns `Ok(None)` (unhashable).
-    fn py_hash(
-        &self,
-        _self_id: HeapId,
-        _vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, _vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
         Ok(None)
     }
 
@@ -128,7 +124,7 @@ pub trait PyTrait<'h> {
     ///
     /// Returns `Ok(true)` if equal, `Ok(false)` if not equal, or
     /// `Err(ResourceError::Recursion)` if maximum depth is exceeded.
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError>;
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError>;
 
     /// Python comparison (`<`, `>`, etc.).
     ///
@@ -140,18 +136,14 @@ pub trait PyTrait<'h> {
     ///
     /// Returns `Ok(Some(Ordering))` for comparable values, `Ok(None)` if not comparable,
     /// or `Err(ResourceError::Recursion)` if maximum depth is exceeded.
-    fn py_cmp(
-        &self,
-        _other: &Self,
-        _vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<Ordering>, ResourceError> {
+    fn py_cmp(&self, _other: &Self, _vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Ordering>, ResourceError> {
         Ok(None)
     }
 
     /// Returns the truthiness of the value following Python semantics.
     ///
     /// Container types should typically report `false` when empty.
-    fn py_bool(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         self.py_len(vm) != Some(0)
     }
 
@@ -170,14 +162,14 @@ pub trait PyTrait<'h> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()>;
 
     /// Returns the Python `repr()` string for this value.
     ///
     /// Convenience wrapper around `py_repr_fmt` that returns an owned string.
-    fn py_repr(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_repr(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         let mut s = String::new();
         let mut heap_ids = AHashSet::new();
         self.py_repr_fmt(&mut s, vm, &mut heap_ids)?;
@@ -185,7 +177,7 @@ pub trait PyTrait<'h> {
     }
 
     /// Returns the Python `str()` string for this value.
-    fn py_str(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         self.py_repr(vm)
     }
 
@@ -193,11 +185,7 @@ pub trait PyTrait<'h> {
     ///
     /// Returns `Ok(None)` if the operation is not supported for these types,
     /// `Ok(Some(value))` on success, or `Err(ResourceError)` if allocation fails.
-    fn py_add(
-        &self,
-        _other: &Self,
-        _vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<Value>, ResourceError> {
+    fn py_add(&self, _other: &Self, _vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Value>, ResourceError> {
         Ok(None)
     }
 
@@ -205,11 +193,7 @@ pub trait PyTrait<'h> {
     ///
     /// Returns `Ok(None)` if the operation is not supported for these types,
     /// `Ok(Some(value))` on success, or `Err(ResourceError)` if allocation fails.
-    fn py_sub(
-        &self,
-        _other: &Self,
-        _vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<Value>, ResourceError> {
+    fn py_sub(&self, _other: &Self, _vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Value>, ResourceError> {
         Ok(None)
     }
 
@@ -217,7 +201,7 @@ pub trait PyTrait<'h> {
     ///
     /// Returns `Ok(None)` if the operation is not supported for these types,
     /// `Ok(Some(value))` on success, or `Err(RunError)` if an error occurs.
-    fn py_mod(&self, _other: &Self, _vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<Value>> {
+    fn py_mod(&self, _other: &Self, _vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<Value>> {
         Ok(None)
     }
 
@@ -235,7 +219,7 @@ pub trait PyTrait<'h> {
     fn py_iadd(
         &mut self,
         _other: &Value,
-        _vm: &mut VM<'h, '_, impl ResourceTracker>,
+        _vm: &mut VM<'h, impl ResourceTracker>,
         _self_id: Option<HeapId>,
     ) -> Result<bool, ResourceError> {
         Ok(false)
@@ -246,7 +230,7 @@ pub trait PyTrait<'h> {
     /// Returns `Ok(None)` if the operation is not supported for these types.
     /// For numeric types: Int * Int, Float * Float, Int * Float, etc.
     /// For sequences: str * int, list * int for repetition.
-    fn py_mult(&self, _other: &Self, _vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<Value>> {
+    fn py_mult(&self, _other: &Self, _vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<Value>> {
         Ok(None)
     }
 
@@ -254,7 +238,7 @@ pub trait PyTrait<'h> {
     ///
     /// Always returns float for numeric types. Returns `Ok(None)` if not supported.
     /// Returns `Err(ZeroDivisionError)` for division by zero.
-    fn py_div(&self, _other: &Self, _vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<Value>> {
+    fn py_div(&self, _other: &Self, _vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<Value>> {
         Ok(None)
     }
 
@@ -263,7 +247,7 @@ pub trait PyTrait<'h> {
     /// Returns int for int//int, float for float operations.
     /// Returns `Ok(None)` if not supported.
     /// Returns `Err(ZeroDivisionError)` for division by zero.
-    fn py_floordiv(&self, _other: &Self, _vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<Value>> {
+    fn py_floordiv(&self, _other: &Self, _vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<Value>> {
         Ok(None)
     }
 
@@ -272,7 +256,7 @@ pub trait PyTrait<'h> {
     /// Int ** positive_int returns int, int ** negative_int returns float.
     /// Returns `Ok(None)` if not supported.
     /// Returns `Err(ZeroDivisionError)` for 0 ** negative.
-    fn py_pow(&self, _other: &Self, _vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<Value>> {
+    fn py_pow(&self, _other: &Self, _vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<Value>> {
         Ok(None)
     }
 
@@ -302,7 +286,7 @@ pub trait PyTrait<'h> {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<CallResult> {
@@ -323,7 +307,7 @@ pub trait PyTrait<'h> {
     /// and access to interned string content.
     ///
     /// Default implementation returns TypeError.
-    fn py_getitem(&self, _key: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+    fn py_getitem(&self, _key: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         Err(ExcType::type_error_not_sub(self.py_type(vm)))
     }
 
@@ -333,7 +317,7 @@ pub trait PyTrait<'h> {
     /// or the type doesn't support subscript assignment.
     ///
     /// Default implementation returns TypeError.
-    fn py_setitem(&mut self, key: Value, value: Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<()> {
+    fn py_setitem(&mut self, key: Value, value: Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<()> {
         key.drop_with_heap(vm);
         value.drop_with_heap(vm);
         Err(SimpleException::new_msg(
@@ -359,11 +343,7 @@ pub trait PyTrait<'h> {
     ///
     /// Default implementation returns `Ok(None)`, indicating the type doesn't support
     /// attribute access and a generic `AttributeError` should be raised by the caller.
-    fn py_getattr(
-        &self,
-        _attr: &EitherStr,
-        _vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> RunResult<Option<CallResult>> {
+    fn py_getattr(&self, _attr: &EitherStr, _vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
         Ok(None)
     }
 }

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -115,7 +115,7 @@ impl Range {
     /// - `range(stop)` - range from 0 to stop
     /// - `range(start, stop)` - range from start to stop
     /// - `range(start, stop, step)` - range with custom step
-    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub fn init(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         let pos_args = args.into_pos_only("range", vm.heap)?;
         defer_drop!(pos_args, vm);
 
@@ -181,15 +181,15 @@ impl Default for Range {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, Range> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::Range
     }
 
-    fn py_len(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         Some(self.get(vm.heap).len())
     }
 
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+    fn py_getitem(&self, key: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         // Check for slice first (Value::Ref pointing to HeapData::Slice)
         if let Value::Ref(id) = key
             && let HeapData::Slice(slice) = vm.heap.get(*id)
@@ -221,7 +221,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Range> {
         Ok(Value::Int(offset))
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         let a = self.get(vm.heap);
         let b = other.get(vm.heap);
         // Compare ranges by their actual sequences, not parameters.
@@ -238,24 +238,20 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Range> {
         Ok(a.start == b.start && a.step == b.step)
     }
 
-    fn py_hash(
-        &self,
-        _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(hasher.finish()))
     }
 
-    fn py_bool(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         !self.get(vm.heap).is_empty()
     }
 
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         let this = self.get(vm.heap);

--- a/crates/monty/src/types/re_match.rs
+++ b/crates/monty/src/types/re_match.rs
@@ -174,7 +174,7 @@ impl<'h> HeapRead<'h, ReMatch> {
     ///
     /// Groups that didn't participate in the match have the `default` value
     /// (typically `None`).
-    fn get_groupdict(&self, default: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+    fn get_groupdict(&self, default: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         let this = self.get(vm.heap);
         let mut pairs = Vec::with_capacity(this.named_groups.len());
         for (name, idx) in &this.named_groups {
@@ -286,20 +286,20 @@ impl ReMatch {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::ReMatch
     }
 
-    fn py_len(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, _vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         None
     }
 
-    fn py_eq(&self, _other: &Self, _vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, _other: &Self, _vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         // Match objects are not comparable
         Ok(false)
     }
 
-    fn py_bool(&self, _vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, _vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         // Match objects are always truthy
         true
     }
@@ -307,7 +307,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         let m = self.get(vm.heap);
@@ -316,7 +316,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
         Ok(f.write_char('>')?)
     }
 
-    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
+    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
         match attr.static_string() {
             Some(StaticStrings::StringAttr) => {
                 let s = Str::new(self.get(vm.heap).input_string.clone());
@@ -330,7 +330,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<CallResult> {
@@ -365,7 +365,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
         Ok(CallResult::Value(result))
     }
 
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+    fn py_getitem(&self, key: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         match key {
             Value::Int(n) => self.get(vm.heap).get_group(*n, vm.heap),
             Value::Bool(b) => self.get(vm.heap).get_group(i64::from(*b), vm.heap),
@@ -416,7 +416,7 @@ impl HeapItem for ReMatch {
 fn call_group<'h>(
     m: &HeapRead<'h, ReMatch>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     match args {
         ArgValues::Empty => m.get(vm.heap).get_group(0, vm.heap),
@@ -446,7 +446,7 @@ fn call_group<'h>(
 }
 
 /// Resolves a single group argument — integer, bool, or string (named group).
-fn resolve_group_arg(m: &ReMatch, val: &Value, vm: &VM<'_, '_, impl ResourceTracker>) -> RunResult<Value> {
+fn resolve_group_arg(m: &ReMatch, val: &Value, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> {
     match val {
         Value::Int(n) => m.get_group(*n, vm.heap),
         Value::Bool(b) => m.get_group(i64::from(*b), vm.heap),

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -267,19 +267,19 @@ impl RePattern {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, RePattern> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::RePattern
     }
 
-    fn py_len(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, _vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         None
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         Ok(self.get(vm.heap) == other.get(vm.heap))
     }
 
-    fn py_bool(&self, _vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, _vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         // Pattern objects are always truthy (matching CPython).
         true
     }
@@ -287,7 +287,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, RePattern> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         let this = self.get(vm.heap);
@@ -312,7 +312,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, RePattern> {
         Ok(write!(f, ")")?)
     }
 
-    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
+    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
         match attr.static_string() {
             Some(StaticStrings::PatternAttr) => {
                 let s = Str::new(self.get(vm.heap).pattern.clone());
@@ -327,7 +327,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, RePattern> {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<CallResult> {
@@ -388,7 +388,7 @@ impl HeapItem for RePattern {
 fn call_pattern_sub<'h>(
     pattern: &HeapRead<'h, RePattern>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let (pos, kwargs) = args.into_parts();
     defer_drop_mut!(pos, vm);
@@ -479,7 +479,7 @@ fn call_pattern_sub<'h>(
 fn call_pattern_split<'h>(
     pattern: &HeapRead<'h, RePattern>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let (pos, kwargs) = args.into_parts();
     defer_drop_mut!(pos, vm);
@@ -534,7 +534,7 @@ fn call_pattern_split<'h>(
 /// Extracts a `maxsplit` value from an optional `Value`.
 ///
 /// Returns 0 if not provided. Negative values are treated as 0 (split all).
-fn extract_maxsplit(val: Option<Value>, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<usize> {
+fn extract_maxsplit(val: Option<Value>, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<usize> {
     match val {
         None => Ok(0),
         Some(Value::Int(n)) if n <= 0 => Ok(0),
@@ -697,7 +697,7 @@ fn translate_g_backref(chars: &mut iter::Peekable<str::Chars<'_>>, result: &mut 
 /// Extracts a string from a `Value`, supporting both interned and heap strings.
 ///
 /// Returns a `Cow<str>` to avoid unnecessary copies for interned strings.
-pub(crate) fn value_to_str<'a>(val: &'a Value, vm: &'a VM<'_, '_, impl ResourceTracker>) -> RunResult<Cow<'a, str>> {
+pub(crate) fn value_to_str<'a>(val: &'a Value, vm: &'a VM<'_, impl ResourceTracker>) -> RunResult<Cow<'a, str>> {
     match val {
         Value::InternString(string_id) => Ok(Cow::Borrowed(vm.interns.get_str(*string_id))),
         Value::Ref(heap_id) => match vm.heap.get(*heap_id) {

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -101,7 +101,7 @@ impl SetStorage {
     ///
     /// The caller transfers ownership of `value`. If the value is already in
     /// the set, it will be dropped.
-    fn add(&mut self, value: Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
+    fn add(&mut self, value: Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<bool> {
         let hash = match value.py_hash(vm) {
             Ok(Some(h)) => h,
             Ok(None) => {
@@ -141,7 +141,7 @@ impl<'h> HeapRead<'h, SetStorage> {
     ///
     /// Returns `Ok(true)` if the element was removed, `Ok(false)` if not found.
     /// Returns `Err` if the key is unhashable.
-    fn remove(&mut self, value: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<bool> {
+    fn remove(&mut self, value: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
         let hash = value
             .py_hash(vm)?
             .ok_or_else(|| ExcType::type_error_unhashable_set_element(value.py_type(vm)))?;
@@ -186,7 +186,7 @@ impl<'h> HeapRead<'h, SetStorage> {
     /// Removes an element from the set without raising an error if not found.
     ///
     /// Returns `Ok(())` always (unless the key is unhashable).
-    fn discard(&mut self, value: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<()> {
+    fn discard(&mut self, value: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<()> {
         self.remove(value, vm)?;
         Ok(())
     }
@@ -194,7 +194,7 @@ impl<'h> HeapRead<'h, SetStorage> {
     /// Removes and returns an arbitrary element from the set.
     ///
     /// Returns `Err(KeyError)` if the set is empty.
-    fn pop(&mut self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+    fn pop(&mut self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         if self.get(vm.heap).is_empty() {
             return Err(ExcType::key_error_pop_empty_set());
         }
@@ -214,7 +214,7 @@ impl<'h> HeapRead<'h, SetStorage> {
     }
 
     /// Removes all elements from the set.
-    fn clear(&mut self, vm: &mut VM<'h, '_, impl ResourceTracker>) {
+    fn clear(&mut self, vm: &mut VM<'h, impl ResourceTracker>) {
         let entries: Vec<SetEntry> = self.get_mut(vm.heap).entries.drain(..).collect();
         self.get_mut(vm.heap).indices.clear();
         entries.drop_with_heap(vm);
@@ -240,7 +240,7 @@ impl SetStorage {
 
 impl<'h> HeapRead<'h, SetStorage> {
     /// Checks if the set contains a value.
-    pub fn contains(&self, value: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<bool> {
+    pub fn contains(&self, value: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
         let hash = value
             .py_hash(vm)?
             .ok_or_else(|| ExcType::type_error_unhashable_set_element(value.py_type(vm)))?;
@@ -295,7 +295,7 @@ impl SetStorage {
 
 impl<'h> HeapRead<'h, SetStorage> {
     /// Compares two sets for equality.
-    fn eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         if self.get(vm.heap).len() != other.get(vm.heap).len() {
             return Ok(false);
         }
@@ -316,7 +316,7 @@ impl<'h> HeapRead<'h, SetStorage> {
 
 impl SetStorage {
     /// Returns true if this set is a subset of other.
-    fn is_subset(&self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
+    fn is_subset(&self, other: &Self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<bool> {
         for entry in &self.entries {
             if !vm.heap.protect(other).contains(&entry.value, vm)? {
                 return Ok(false);
@@ -326,12 +326,12 @@ impl SetStorage {
     }
 
     /// Returns true if this set is a superset of other.
-    fn is_superset(&self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
+    fn is_superset(&self, other: &Self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<bool> {
         other.is_subset(self, vm)
     }
 
     /// Returns true if this set has no elements in common with other.
-    fn is_disjoint(&self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
+    fn is_disjoint(&self, other: &Self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<bool> {
         // Iterate over the smaller set for efficiency
         let (smaller, larger) = if self.len() <= other.len() {
             (self, other)
@@ -350,7 +350,7 @@ impl SetStorage {
 
 impl<'h> HeapRead<'h, SetStorage> {
     /// Returns a new set containing elements in either set (union).
-    fn union(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<SetStorage> {
+    fn union(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<SetStorage> {
         let mut result_guard = HeapGuard::new(self.get(vm.heap).clone_with_heap(vm), vm);
         let (result, vm) = result_guard.as_parts_mut();
         let len = other.get(vm.heap).len();
@@ -362,7 +362,7 @@ impl<'h> HeapRead<'h, SetStorage> {
     }
 
     /// Returns a new set containing elements in both sets (intersection).
-    fn intersection(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<SetStorage> {
+    fn intersection(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<SetStorage> {
         let mut result_guard = HeapGuard::new(SetStorage::new(), vm);
         let (result, vm) = result_guard.as_parts_mut();
         // Iterate over the smaller set for efficiency
@@ -386,7 +386,7 @@ impl<'h> HeapRead<'h, SetStorage> {
     }
 
     /// Returns a new set containing elements in self but not in other (difference).
-    fn difference(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<SetStorage> {
+    fn difference(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<SetStorage> {
         let mut result_guard = HeapGuard::new(SetStorage::new(), vm);
         let (result, vm) = result_guard.as_parts_mut();
         let len = self.get(vm.heap).len();
@@ -403,7 +403,7 @@ impl<'h> HeapRead<'h, SetStorage> {
     }
 
     /// Returns a new set containing elements in either set but not both (symmetric difference).
-    fn symmetric_difference(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<SetStorage> {
+    fn symmetric_difference(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<SetStorage> {
         let mut result_guard = HeapGuard::new(SetStorage::new(), vm);
         let (result, vm) = result_guard.as_parts_mut();
 
@@ -440,7 +440,7 @@ impl<'h> HeapRead<'h, SetStorage> {
     fn repr_fmt<T: ResourceTracker>(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, T>,
+        vm: &mut VM<'h, T>,
         heap_ids: &mut AHashSet<HeapId>,
         type_name: &str,
     ) -> RunResult<()> {
@@ -548,7 +548,7 @@ impl Set {
     /// Adds an element to the set, transferring ownership.
     ///
     /// Returns `Ok(true)` if added, `Ok(false)` if already present.
-    pub fn add(&mut self, value: Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
+    pub fn add(&mut self, value: Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<bool> {
         self.0.add(value, vm)
     }
 }
@@ -557,7 +557,7 @@ impl<'h> HeapRead<'h, Set> {
     /// Removes an element from the set.
     ///
     /// Returns `Err(KeyError)` if the element is not present.
-    pub fn remove(&mut self, value: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<()> {
+    pub fn remove(&mut self, value: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<()> {
         if self.peel_mut().remove(value, vm)? {
             Ok(())
         } else {
@@ -568,25 +568,25 @@ impl<'h> HeapRead<'h, Set> {
     /// Removes an element from the set if present.
     ///
     /// Does not raise an error if the element is not found.
-    pub fn discard(&mut self, value: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<()> {
+    pub fn discard(&mut self, value: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<()> {
         self.peel_mut().discard(value, vm)
     }
 
     /// Removes and returns an arbitrary element from the set.
     ///
     /// Returns `Err(KeyError)` if the set is empty.
-    pub fn pop(&mut self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+    pub fn pop(&mut self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         self.peel_mut().pop(vm)
     }
 
     /// Removes all elements from the set.
-    pub fn clear(&mut self, vm: &mut VM<'h, '_, impl ResourceTracker>) {
+    pub fn clear(&mut self, vm: &mut VM<'h, impl ResourceTracker>) {
         self.peel_mut().clear(vm);
     }
 
     /// Returns a shallow copy of the set.
     #[must_use]
-    pub fn copy(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Set {
+    pub fn copy(&self, vm: &VM<'h, impl ResourceTracker>) -> Set {
         Set(self.get(vm.heap).0.clone_with_heap(vm.heap))
     }
 }
@@ -610,7 +610,7 @@ impl Set {
     ///
     /// - `set()` with no args returns an empty set
     /// - `set(iterable)` creates a set from any iterable (list, tuple, set, dict, range, str, bytes)
-    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub fn init(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         let value = args.get_zero_one_arg("set", vm.heap)?;
         let set = match value {
             None => Self::new(),
@@ -624,7 +624,7 @@ impl Set {
     ///
     /// Unlike list/tuple which can just collect into a Vec, sets need to add
     /// each element individually to handle duplicates and compute hashes.
-    fn from_iterator(iter: MontyIter, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Self> {
+    fn from_iterator(iter: MontyIter, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Self> {
         defer_drop_mut!(iter, vm);
         let mut set = Self::with_capacity(iter.size_hint(vm.heap));
         while let Some(item) = iter.for_next(vm)? {
@@ -637,7 +637,7 @@ impl Set {
     ///
     /// This is a convenience method used by helper methods that need to convert
     /// arbitrary iterables to sets. It uses `MontyIter` internally.
-    fn from_iterable(iterable: Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Self> {
+    fn from_iterable(iterable: Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Self> {
         let iter = MontyIter::new(iterable, vm)?;
         let set = Self::from_iterator(iter, vm)?;
         Ok(set)
@@ -653,7 +653,7 @@ impl<'h> HeapRead<'h, Set> {
     ///
     /// Uses a two-phase lookup (collect candidates, then compare) to avoid
     /// holding a borrow on the set storage during `py_eq` calls.
-    pub fn add(&mut self, value: Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<bool> {
+    pub fn add(&mut self, value: Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
         let hash = match value.py_hash(vm) {
             Ok(Some(h)) => h,
             Ok(None) => {
@@ -701,12 +701,12 @@ impl<'h> HeapRead<'h, Set> {
         Ok(true)
     }
 
-    pub(crate) fn contains(&self, value: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<bool> {
+    pub(crate) fn contains(&self, value: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
         self.peel_ref().contains(value, vm)
     }
 
     /// `set.update(iterable)` via HeapRead.
-    fn hr_update(&mut self, other: Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<()> {
+    fn hr_update(&mut self, other: Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<()> {
         // Try direct extraction from Set/FrozenSet
         let entries_opt = {
             match &other {
@@ -739,7 +739,7 @@ impl<'h> HeapRead<'h, Set> {
     /// Set algebra operations (union, intersection, difference, symmetric_difference)
     /// via HeapRead. Clones self's storage once, then calls the existing `SetStorage`
     /// methods on the standalone copy.
-    fn set_algebra(&self, other: Value, op: SetAlgebra, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+    fn set_algebra(&self, other: Value, op: SetAlgebra, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         let other_storage = Set::get_storage_from_value(other, vm)?;
         defer_drop!(other_storage, vm);
         let other_storage = vm.heap.protect(other_storage);
@@ -761,7 +761,7 @@ impl<'h> HeapRead<'h, Set> {
         &self,
         other: &Value,
         op: SetComparison,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
     ) -> RunResult<bool> {
         // Get other's storage
         let entries_opt = match other {
@@ -830,7 +830,7 @@ impl DropWithHeap for FrozenSet {
 impl<'h> HeapRead<'h, FrozenSet> {
     /// Checks if the frozenset contains a value, using the candidate collection pattern
     /// to avoid holding a borrow on the storage during `py_eq` calls.
-    pub(crate) fn contains(&self, value: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<bool> {
+    pub(crate) fn contains(&self, value: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
         let hash = value
             .py_hash(vm)?
             .ok_or_else(|| ExcType::type_error_unhashable_set_element(value.py_type(vm)))?;
@@ -864,7 +864,7 @@ impl<'h> HeapRead<'h, FrozenSet> {
         &self,
         other: &Value,
         op: SetBinaryOp,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
     ) -> RunResult<Option<FrozenSet>> {
         let Some(other_storage) = get_storage_from_set_operand(other, vm)? else {
             return Ok(None);
@@ -882,7 +882,7 @@ impl<'h> HeapRead<'h, FrozenSet> {
     }
 
     /// Set algebra operations for frozenset via HeapRead.
-    fn set_algebra(&self, other: Value, op: SetAlgebra, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+    fn set_algebra(&self, other: Value, op: SetAlgebra, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         let other_storage = Set::get_storage_from_value(other, vm)?;
         defer_drop!(other_storage, vm);
         let other_storage = vm.heap.protect(other_storage);
@@ -903,7 +903,7 @@ impl<'h> HeapRead<'h, FrozenSet> {
         &self,
         other: &Value,
         op: SetComparison,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
     ) -> RunResult<bool> {
         let entries_opt = match other {
             Value::Ref(id) => match vm.heap.get(*id) {
@@ -940,26 +940,26 @@ impl DropWithHeap for SetEntry {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, Set> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::Set
     }
 
-    fn py_len(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         Some(self.get(vm.heap).len())
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         self.peel_ref().eq(other.peel_ref(), vm)
     }
 
-    fn py_bool(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         !self.get(vm.heap).is_empty()
     }
 
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         self.peel_ref().repr_fmt(f, vm, heap_ids, "set")
@@ -968,7 +968,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Set> {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<CallResult> {
@@ -1072,7 +1072,7 @@ impl<'h> HeapRead<'h, Set> {
         &self,
         other: &Value,
         op: SetBinaryOp,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
     ) -> RunResult<Option<Set>> {
         let Some(other_storage) = get_storage_from_set_operand(other, vm)? else {
             return Ok(None);
@@ -1092,7 +1092,7 @@ impl<'h> HeapRead<'h, Set> {
 
 impl Set {
     /// Helper to get SetStorage from a Value (either directly or by conversion).
-    fn get_storage_from_value(value: Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<SetStorage> {
+    fn get_storage_from_value(value: Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<SetStorage> {
         // Try to get entries from a Set/FrozenSet directly
         let entries_opt = match &value {
             Value::Ref(id) => match vm.heap.get(*id) {
@@ -1183,7 +1183,7 @@ impl FrozenSet {
     ///
     /// - `frozenset()` with no args returns an empty frozenset
     /// - `frozenset(iterable)` creates a frozenset from any iterable (list, tuple, set, dict, range, str, bytes)
-    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub fn init(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         let value = args.get_zero_one_arg("frozenset", vm.heap)?;
         let frozenset = match value {
             None => Self::new(),
@@ -1195,15 +1195,15 @@ impl FrozenSet {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::FrozenSet
     }
 
-    fn py_len(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         Some(self.get(vm.heap).len())
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         self.peel_ref().eq(other.peel_ref(), vm)
     }
 
@@ -1211,11 +1211,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
     ///
     /// XOR is commutative, so the hash is independent of insertion order — two
     /// frozensets with the same members hash equally regardless of how they were built.
-    fn py_hash(
-        &self,
-        _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
         let token = vm.heap.incr_recursion_depth()?;
         defer_drop!(token, vm);
         let mut hash: u64 = 0;
@@ -1232,14 +1228,14 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
         Ok(Some(hash))
     }
 
-    fn py_bool(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         !self.get(vm.heap).is_empty()
     }
 
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         self.peel_ref().repr_fmt(f, vm, heap_ids, "frozenset")
@@ -1248,7 +1244,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<CallResult> {
@@ -1314,10 +1310,7 @@ impl HeapItem for FrozenSet {
 /// This is stricter than `Set::get_storage_from_value(...)`: operator forms
 /// only accept CPython's set-like operands (`set`, `frozenset`, `dict_keys`,
 /// and `dict_items`), while method forms accept any iterable.
-fn get_storage_from_set_operand(
-    value: &Value,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
-) -> RunResult<Option<SetStorage>> {
+fn get_storage_from_set_operand(value: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Option<SetStorage>> {
     let Value::Ref(id) = value else {
         return Ok(None);
     };

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -58,7 +58,7 @@ impl Slice {
     /// - `slice(start, stop, step)` - slice with all three components
     ///
     /// Each argument can be None to indicate "use default".
-    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub fn init(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         let heap = &mut *vm.heap;
         let pos_args = args.into_pos_only("slice", heap)?;
         defer_drop!(pos_args, heap);
@@ -160,32 +160,28 @@ fn normalize_index(index: i64, length: i64, lower: i64, upper: i64) -> i64 {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, Slice> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::Slice
     }
 
-    fn py_len(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, _vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         // Slices don't have a length in Python
         None
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         let a = self.get(vm.heap);
         let b = other.get(vm.heap);
         Ok(a.start == b.start && a.stop == b.stop && a.step == b.step)
     }
 
-    fn py_hash(
-        &self,
-        _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(hasher.finish()))
     }
 
-    fn py_bool(&self, _vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, _vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         // Slice always truthy
         true
     }
@@ -193,7 +189,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Slice> {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         f.write_str("slice(")?;
@@ -205,7 +201,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Slice> {
         Ok(f.write_char(')')?)
     }
 
-    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
+    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
         let this = self.get(vm.heap);
         // Fast path: interned strings can be matched by ID without string comparison
         if let Some(ss) = attr.static_string() {
@@ -264,7 +260,7 @@ fn format_option_i64(f: &mut impl Write, value: Option<i64>) -> fmt::Result {
 /// (e.g. `clone_with_heap` for heap-allocated `Value`s) only runs on items
 /// that survive the slice. Use `|x| x` when no transform is needed.
 pub(crate) fn slice_collect_iterator<Iter: DoubleEndedIterator + Clone, U, T: FromIterator<U>>(
-    vm: &VM<'_, '_, impl ResourceTracker>,
+    vm: &VM<'_, impl ResourceTracker>,
     slice: &Slice,
     iter: Iter,
     collect_map: impl Fn(Iter::Item) -> U,

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -61,7 +61,7 @@ impl Str {
     ///
     /// - `str()` with no args returns an empty string
     /// - `str(x)` converts x to its string representation using `py_str`
-    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub fn init(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         let value = args.get_zero_one_named_arg("str", StaticStrings::Object, vm.heap, vm.interns)?;
         match value {
             None => Ok(Value::InternString(StaticStrings::EmptyString.into())),
@@ -76,7 +76,7 @@ impl Str {
     /// Handles slice-based indexing for strings.
     ///
     /// Returns a new string containing the selected characters (Unicode-aware).
-    fn getitem_slice(&self, vm: &VM<'_, '_, impl ResourceTracker>, slice: &super::Slice) -> RunResult<Value> {
+    fn getitem_slice(&self, vm: &VM<'_, impl ResourceTracker>, slice: &super::Slice) -> RunResult<Value> {
         let result_str = slice_collect_iterator(vm, slice, self.0.chars(), |c| c)?;
         let heap_id = vm.heap.allocate(HeapData::Str(Self(result_str)))?;
         Ok(Value::Ref(heap_id))
@@ -168,16 +168,16 @@ impl ops::Deref for Str {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::Str
     }
 
-    fn py_len(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         // Count Unicode characters, not bytes, to match Python semantics
         Some(self.get(vm.heap).0.chars().count())
     }
 
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+    fn py_getitem(&self, key: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         // Check for slice first (Value::Ref pointing to HeapData::Slice)
         if let Value::Ref(id) = key
             && let HeapData::Slice(slice) = vm.heap.get(*id)
@@ -194,15 +194,11 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
         Ok(allocate_char(c, vm.heap)?)
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         Ok(self.get(vm.heap).0 == other.get(vm.heap).0)
     }
 
-    fn py_hash(
-        &self,
-        _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
         // Must match `Value::InternString` so the same characters hash equally
         // regardless of whether the string lives on the heap or in the intern table.
         let mut hasher = DefaultHasher::new();
@@ -210,32 +206,28 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
         Ok(Some(hasher.finish()))
     }
 
-    fn py_bool(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         !self.get(vm.heap).0.is_empty()
     }
 
-    fn py_cmp(
-        &self,
-        other: &Self,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<Ordering>, ResourceError> {
+    fn py_cmp(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Ordering>, ResourceError> {
         Ok(Some(self.get(vm.heap).0.cmp(&other.get(vm.heap).0)))
     }
 
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         Ok(string_repr_fmt(&self.get(vm.heap).0, f)?)
     }
 
-    fn py_str(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         Ok(self.get(vm.heap).0.clone().into_string().into())
     }
 
-    fn py_add(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<Option<Value>, ResourceError> {
+    fn py_add(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Value>, ResourceError> {
         let self_str = self.get(vm.heap).0.clone();
         let other_str = other.get(vm.heap).0.clone();
         let result = format!("{self_str}{other_str}");
@@ -246,7 +238,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<CallResult> {
@@ -279,7 +271,7 @@ pub fn call_str_method(
     s: &str,
     method_id: StringId,
     args: ArgValues,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let args_guard = HeapGuard::new(args, vm.heap);
     let Some(method) = StaticStrings::from_string_id(method_id) else {
@@ -312,7 +304,7 @@ fn call_str_method_impl<'h>(
     s: &HeapRead<'h, str>,
     method: StaticStrings,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     match method {
         // Simple transformations (no arguments)
@@ -442,7 +434,7 @@ fn call_str_method_impl<'h>(
 fn str_join<'h>(
     separator: &HeapRead<'h, str>,
     iterable: Value,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     // Create MontyIter from the iterable, with join-specific error message
     let Ok(iter) = MontyIter::new(iterable, vm) else {
@@ -539,19 +531,19 @@ impl fmt::Display for StringRepr<'_> {
 // =============================================================================
 
 /// Implements Python's `str.lower()` method.
-fn str_lower(s: &str, vm: &VM<'_, '_, impl ResourceTracker>) -> RunResult<Value> {
+fn str_lower(s: &str, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> {
     allocate_string(s.to_lowercase(), vm.heap)
 }
 
 /// Implements Python's `str.upper()` method.
-fn str_upper(s: &str, vm: &VM<'_, '_, impl ResourceTracker>) -> RunResult<Value> {
+fn str_upper(s: &str, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> {
     allocate_string(s.to_uppercase(), vm.heap)
 }
 
 /// Implements Python's `str.capitalize()` method.
 ///
 /// Returns a copy of the string with its first character capitalized and the rest lowercased.
-fn str_capitalize(s: &str, vm: &VM<'_, '_, impl ResourceTracker>) -> RunResult<Value> {
+fn str_capitalize(s: &str, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> {
     let mut chars = s.chars();
     let result = match chars.next() {
         None => String::new(),
@@ -570,7 +562,7 @@ fn str_capitalize(s: &str, vm: &VM<'_, '_, impl ResourceTracker>) -> RunResult<V
 ///
 /// Returns a titlecased version of the string where words start with an uppercase
 /// character and the remaining characters are lowercase.
-fn str_title(s: &str, vm: &VM<'_, '_, impl ResourceTracker>) -> RunResult<Value> {
+fn str_title(s: &str, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> {
     let mut result = String::with_capacity(s.len());
     let mut prev_is_cased = false;
 
@@ -589,7 +581,7 @@ fn str_title(s: &str, vm: &VM<'_, '_, impl ResourceTracker>) -> RunResult<Value>
 /// Implements Python's `str.swapcase()` method.
 ///
 /// Returns a copy of the string with uppercase characters converted to lowercase and vice versa.
-fn str_swapcase(s: &str, vm: &VM<'_, '_, impl ResourceTracker>) -> RunResult<Value> {
+fn str_swapcase(s: &str, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> {
     let mut result = String::with_capacity(s.len());
 
     for c in s.chars() {
@@ -609,7 +601,7 @@ fn str_swapcase(s: &str, vm: &VM<'_, '_, impl ResourceTracker>) -> RunResult<Val
 ///
 /// Returns a casefolded copy of the string. Casefolding is similar to lowercasing
 /// but more aggressive because it is intended for caseless string matching.
-fn str_casefold(s: &str, vm: &VM<'_, '_, impl ResourceTracker>) -> RunResult<Value> {
+fn str_casefold(s: &str, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> {
     // Rust's to_lowercase() is equivalent to Unicode casefolding for most purposes
     allocate_string(s.to_lowercase(), vm.heap)
 }
@@ -874,7 +866,7 @@ fn is_unicode_digit(c: char) -> bool {
 ///
 /// Returns the lowest index in the string where substring sub is found within
 /// the slice s[start:end]. Returns -1 if sub is not found.
-fn str_find<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+fn str_find<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let str_len = s.get(vm.heap).chars().count();
     let (sub, start, end) = parse_search_args("str.find", str_len, args, vm)?;
     let s = s.get(vm.heap);
@@ -894,11 +886,7 @@ fn str_find<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, '_, impl
 ///
 /// Returns the highest index in the string where substring sub is found within
 /// the slice s[start:end]. Returns -1 if sub is not found.
-fn str_rfind<'h>(
-    s: &HeapRead<'h, str>,
-    args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
-) -> RunResult<Value> {
+fn str_rfind<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let str_len = s.get(vm.heap).chars().count();
     let (sub, start, end) = parse_search_args("str.rfind", str_len, args, vm)?;
     let s = s.get(vm.heap);
@@ -917,11 +905,7 @@ fn str_rfind<'h>(
 /// Implements Python's `str.index(sub, start?, end?)` method.
 ///
 /// Like find(), but raises ValueError when the substring is not found.
-fn str_index<'h>(
-    s: &HeapRead<'h, str>,
-    args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
-) -> RunResult<Value> {
+fn str_index<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let str_len = s.get(vm.heap).chars().count();
     let (sub, start, end) = parse_search_args("str.index", str_len, args, vm)?;
     let s = s.get(vm.heap);
@@ -939,11 +923,7 @@ fn str_index<'h>(
 /// Implements Python's `str.rindex(sub, start?, end?)` method.
 ///
 /// Like rfind(), but raises ValueError when the substring is not found.
-fn str_rindex<'h>(
-    s: &HeapRead<'h, str>,
-    args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
-) -> RunResult<Value> {
+fn str_rindex<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let str_len = s.get(vm.heap).chars().count();
     let (sub, start, end) = parse_search_args("str.rindex", str_len, args, vm)?;
     let s = s.get(vm.heap);
@@ -962,11 +942,7 @@ fn str_rindex<'h>(
 ///
 /// Returns the number of non-overlapping occurrences of substring sub in
 /// the string s[start:end].
-fn str_count<'h>(
-    s: &HeapRead<'h, str>,
-    args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
-) -> RunResult<Value> {
+fn str_count<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let str_len = s.get(vm.heap).chars().count();
     let (sub, start, end) = parse_search_args("str.count", str_len, args, vm)?;
     let s = s.get(vm.heap);
@@ -988,7 +964,7 @@ fn str_count<'h>(
 fn str_startswith<'h>(
     s: &HeapRead<'h, str>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let str_len = s.get(vm.heap).chars().count();
     let (prefixes, start, end) = parse_prefix_suffix_args("str.startswith", str_len, args, vm)?;
@@ -1002,11 +978,7 @@ fn str_startswith<'h>(
 ///
 /// Returns True if the string ends with the suffix, otherwise returns False.
 /// The suffix argument can be a string or a tuple of strings.
-fn str_endswith<'h>(
-    s: &HeapRead<'h, str>,
-    args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
-) -> RunResult<Value> {
+fn str_endswith<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let str_len = s.get(vm.heap).chars().count();
     let (suffixes, start, end) = parse_prefix_suffix_args("str.endswith", str_len, args, vm)?;
     let s = s.get(vm.heap);
@@ -1022,7 +994,7 @@ fn parse_search_args(
     method: &str,
     str_len: usize,
     args: ArgValues,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<(String, usize, usize)> {
     let pos = args.into_pos_only(method, vm.heap)?;
     defer_drop!(pos, vm);
@@ -1055,7 +1027,7 @@ fn parse_prefix_suffix_args(
     method: &str,
     str_len: usize,
     args: ArgValues,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<(Vec<String>, usize, usize)> {
     let pos = args.into_pos_only(method, vm.heap)?;
     defer_drop!(pos, vm);
@@ -1084,7 +1056,7 @@ fn parse_prefix_suffix_args(
 ///
 /// Returns a Vec of strings - a single-element Vec if given a string,
 /// or multiple elements if given a tuple of strings.
-fn extract_str_or_tuple_of_str(value: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Vec<String>> {
+fn extract_str_or_tuple_of_str(value: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Vec<String>> {
     match value {
         Value::InternString(id) => Ok(vec![vm.interns.get_str(*id).to_owned()]),
         Value::Ref(heap_id) => match vm.heap.get(*heap_id) {
@@ -1118,7 +1090,7 @@ fn extract_str_or_tuple_of_str(value: &Value, vm: &mut VM<'_, '_, impl ResourceT
 }
 
 /// Extracts a string from a Value, returning an error if not a string.
-fn extract_string_arg(value: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<String> {
+fn extract_string_arg(value: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<String> {
     match value {
         Value::InternString(id) => Ok(vm.interns.get_str(*id).to_owned()),
         Value::Ref(heap_id) => {
@@ -1133,7 +1105,7 @@ fn extract_string_arg(value: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) 
 }
 
 /// Extracts an integer from a Value, returning an error if not an integer.
-fn extract_int_arg(value: &Value, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<i64> {
+fn extract_int_arg(value: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<i64> {
     match value {
         Value::Int(i) => Ok(*i),
         Value::Ref(heap_id) => {
@@ -1156,7 +1128,7 @@ fn optional_index(
     value: &Value,
     default: usize,
     str_len: usize,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<usize> {
     if matches!(value, Value::None) {
         Ok(default)
@@ -1195,11 +1167,7 @@ fn slice_string(s: &str, start: usize, end: usize) -> &str {
 ///
 /// Returns a copy of the string with leading and trailing characters removed.
 /// If chars is not specified, whitespace characters are removed.
-fn str_strip<'h>(
-    s: &HeapRead<'h, str>,
-    args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
-) -> RunResult<Value> {
+fn str_strip<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let chars = parse_strip_arg("str.strip", args, vm)?;
     let s = s.get(vm.heap);
     let result = match &chars {
@@ -1212,11 +1180,7 @@ fn str_strip<'h>(
 /// Implements Python's `str.lstrip(chars?)` method.
 ///
 /// Returns a copy of the string with leading characters removed.
-fn str_lstrip<'h>(
-    s: &HeapRead<'h, str>,
-    args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
-) -> RunResult<Value> {
+fn str_lstrip<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let chars = parse_strip_arg("str.lstrip", args, vm)?;
     let s = s.get(vm.heap);
     let result = match &chars {
@@ -1229,11 +1193,7 @@ fn str_lstrip<'h>(
 /// Implements Python's `str.rstrip(chars?)` method.
 ///
 /// Returns a copy of the string with trailing characters removed.
-fn str_rstrip<'h>(
-    s: &HeapRead<'h, str>,
-    args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
-) -> RunResult<Value> {
+fn str_rstrip<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let chars = parse_strip_arg("str.rstrip", args, vm)?;
     let s = s.get(vm.heap);
     let result = match &chars {
@@ -1246,11 +1206,7 @@ fn str_rstrip<'h>(
 /// Parses the optional chars argument for strip methods.
 ///
 /// Accepts None as a value meaning "use default whitespace stripping".
-fn parse_strip_arg(
-    method: &str,
-    args: ArgValues,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
-) -> RunResult<Option<String>> {
+fn parse_strip_arg(method: &str, args: ArgValues, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Option<String>> {
     let value = args.get_zero_one_arg(method, vm.heap)?;
     match value {
         None => Ok(None),
@@ -1270,7 +1226,7 @@ fn parse_strip_arg(
 fn str_removeprefix<'h>(
     s: &HeapRead<'h, str>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let prefix_value = args.get_one_arg("str.removeprefix", vm.heap)?;
     defer_drop!(prefix_value, vm);
@@ -1288,7 +1244,7 @@ fn str_removeprefix<'h>(
 fn str_removesuffix<'h>(
     s: &HeapRead<'h, str>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let suffix_value = args.get_one_arg("str.removesuffix", vm.heap)?;
     defer_drop!(suffix_value, vm);
@@ -1306,11 +1262,7 @@ fn str_removesuffix<'h>(
 /// Implements Python's `str.split(sep?, maxsplit?)` method.
 ///
 /// Returns a list of the words in the string, using sep as the delimiter string.
-fn str_split<'h>(
-    s: &HeapRead<'h, str>,
-    args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
-) -> RunResult<Value> {
+fn str_split<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let (sep, maxsplit) = parse_split_args("str.split", args, vm)?;
     let s = s.get(vm.heap);
 
@@ -1356,11 +1308,7 @@ fn str_split<'h>(
 ///
 /// Returns a list of the words in the string, using sep as the delimiter string,
 /// splitting from the right.
-fn str_rsplit<'h>(
-    s: &HeapRead<'h, str>,
-    args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
-) -> RunResult<Value> {
+fn str_rsplit<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let (sep, maxsplit) = parse_split_args("str.rsplit", args, vm)?;
     let s = s.get(vm.heap);
 
@@ -1410,7 +1358,7 @@ fn str_rsplit<'h>(
 fn parse_split_args(
     method: &str,
     args: ArgValues,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<(Option<String>, i64)> {
     let (pos, kwargs) = args.into_parts();
     let kwargs_iter = kwargs.into_iter();
@@ -1545,7 +1493,7 @@ fn rsplit_whitespace_n(s: &str, maxsplit: usize) -> Vec<&str> {
 fn str_splitlines<'h>(
     s: &HeapRead<'h, str>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let keepends = parse_splitlines_args(args, vm)?;
     let s = s.get(vm.heap);
@@ -1600,7 +1548,7 @@ fn str_splitlines<'h>(
 /// Parses arguments for splitlines method.
 ///
 /// Supports both positional and keyword arguments for keepends.
-fn parse_splitlines_args(args: ArgValues, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
+fn parse_splitlines_args(args: ArgValues, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<bool> {
     let val = args.get_zero_one_named_arg("str.splitlines", StaticStrings::Keepends, vm.heap, vm.interns)?;
     let keepends = if let Some(v) = val {
         let result = value_is_truthy(&v);
@@ -1629,7 +1577,7 @@ fn value_is_truthy(v: &Value) -> bool {
 fn str_partition<'h>(
     s: &HeapRead<'h, str>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let sep_value = args.get_one_arg("str.partition", vm.heap)?;
     defer_drop!(sep_value, vm);
@@ -1662,7 +1610,7 @@ fn str_partition<'h>(
 fn str_rpartition<'h>(
     s: &HeapRead<'h, str>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let sep_value = args.get_one_arg("str.rpartition", vm.heap)?;
     defer_drop!(sep_value, vm);
@@ -1696,11 +1644,7 @@ fn str_rpartition<'h>(
 ///
 /// Returns a copy with all occurrences of substring old replaced by new.
 /// If count is given, only the first count occurrences are replaced.
-fn str_replace<'h>(
-    s: &HeapRead<'h, str>,
-    args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
-) -> RunResult<Value> {
+fn str_replace<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let (old, new, count) = parse_replace_args("str.replace", args, vm)?;
     let s = s.get(vm.heap);
 
@@ -1723,7 +1667,7 @@ fn str_replace<'h>(
 fn parse_replace_args(
     method: &str,
     args: ArgValues,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<(String, String, i64)> {
     let (pos, kwargs) = args.into_parts();
     let kwargs_iter = kwargs.into_iter();
@@ -1790,11 +1734,7 @@ fn parse_replace_args(
 ///
 /// Returns centered in a string of length width. Padding is done using the
 /// specified fill character (default is a space).
-fn str_center<'h>(
-    s: &HeapRead<'h, str>,
-    args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
-) -> RunResult<Value> {
+fn str_center<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let (width, fillchar) = parse_justify_args("str.center", args, vm)?;
     let s = s.get(vm.heap);
     let len = s.chars().count();
@@ -1823,11 +1763,7 @@ fn str_center<'h>(
 /// Implements Python's `str.ljust(width, fillchar?)` method.
 ///
 /// Returns left-justified in a string of length width.
-fn str_ljust<'h>(
-    s: &HeapRead<'h, str>,
-    args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
-) -> RunResult<Value> {
+fn str_ljust<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let (width, fillchar) = parse_justify_args("str.ljust", args, vm)?;
     let s = s.get(vm.heap);
     let len = s.chars().count();
@@ -1851,11 +1787,7 @@ fn str_ljust<'h>(
 /// Implements Python's `str.rjust(width, fillchar?)` method.
 ///
 /// Returns right-justified in a string of length width.
-fn str_rjust<'h>(
-    s: &HeapRead<'h, str>,
-    args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
-) -> RunResult<Value> {
+fn str_rjust<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let (width, fillchar) = parse_justify_args("str.rjust", args, vm)?;
     let s = s.get(vm.heap);
     let len = s.chars().count();
@@ -1880,7 +1812,7 @@ fn str_rjust<'h>(
 fn parse_justify_args(
     method: &str,
     args: ArgValues,
-    vm: &mut VM<'_, '_, impl ResourceTracker>,
+    vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<(usize, char)> {
     let pos = args.into_pos_only(method, vm.heap)?;
     defer_drop!(pos, vm);
@@ -1917,11 +1849,7 @@ fn parse_justify_args(
 ///
 /// Returns a copy of the string left filled with ASCII '0' digits to make a
 /// string of length width. A sign prefix is handled correctly.
-fn str_zfill<'h>(
-    s: &HeapRead<'h, str>,
-    args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
-) -> RunResult<Value> {
+fn str_zfill<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let width_value = args.get_one_arg("str.zfill", vm.heap)?;
     defer_drop!(width_value, vm);
     let width_i64 = extract_int_arg(width_value, vm)?;
@@ -1972,7 +1900,7 @@ fn str_zfill<'h>(
 fn str_expandtabs<'h>(
     s: &HeapRead<'h, str>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let tabsize_val = args.get_zero_one_named_arg("str.expandtabs", StaticStrings::Tabsize, vm.heap, vm.interns)?;
 
@@ -2018,11 +1946,7 @@ fn str_expandtabs<'h>(
 ///
 /// Returns an encoded version of the string as a bytes object. Only supports
 /// UTF-8 encoding (the native encoding for Rust strings).
-fn str_encode<'h>(
-    s: &HeapRead<'h, str>,
-    args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
-) -> RunResult<Value> {
+fn str_encode<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
     let (encoding, errors) = parse_encode_args(args, vm)?;
 
     // Only UTF-8 is supported - Rust strings are always valid UTF-8
@@ -2045,7 +1969,7 @@ fn str_encode<'h>(
 /// Parses arguments for `str.encode()`.
 ///
 /// Returns (encoding, errors) with defaults "utf-8" and "strict".
-fn parse_encode_args(args: ArgValues, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<(String, String)> {
+fn parse_encode_args(args: ArgValues, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<(String, String)> {
     let (first, second) = args.get_zero_one_two_args("str.encode", vm.heap)?;
 
     let encoding = if let Some(v) = first {

--- a/crates/monty/src/types/timedelta.rs
+++ b/crates/monty/src/types/timedelta.rs
@@ -329,51 +329,43 @@ impl HeapItem for TimeDelta {
 /// `HeapRead`-based dispatch for `TimeDelta`, enabling the `HeapReadOutput` enum to
 /// delegate `PyTrait` calls to heap-resident timedeltas.
 impl<'h> PyTrait<'h> for HeapRead<'h, TimeDelta> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::TimeDelta
     }
 
-    fn py_len(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, _vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         None
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         Ok(total_microseconds(self.get(vm.heap)) == total_microseconds(other.get(vm.heap)))
     }
 
-    fn py_hash(
-        &self,
-        _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(hasher.finish()))
     }
 
-    fn py_cmp(
-        &self,
-        other: &Self,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<Ordering>, ResourceError> {
+    fn py_cmp(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Ordering>, ResourceError> {
         Ok(total_microseconds(self.get(vm.heap)).partial_cmp(&total_microseconds(other.get(vm.heap))))
     }
 
-    fn py_bool(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         total_microseconds(self.get(vm.heap)) != 0
     }
 
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         f.write_str(&format_repr(self.get(vm.heap)))?;
         Ok(())
     }
 
-    fn py_str(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         let (days, seconds, microseconds) = components(self.get(vm.heap));
         let hours = seconds / SECONDS_PER_HOUR;
         let minutes = (seconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE;
@@ -395,7 +387,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeDelta> {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<CallResult> {
@@ -408,7 +400,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeDelta> {
         Err(ExcType::attribute_error(Type::TimeDelta, attr.as_str(vm.interns)))
     }
 
-    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
+    fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
         let (days, seconds, microseconds) = components(self.get(vm.heap));
         match attr.string_id() {
             Some(id) if id == StaticStrings::Days => Ok(Some(CallResult::Value(Value::Int(i64::from(days))))),

--- a/crates/monty/src/types/timezone.rs
+++ b/crates/monty/src/types/timezone.rs
@@ -249,36 +249,32 @@ impl HeapItem for TimeZone {
 /// `HeapRead`-based dispatch for `TimeZone`, enabling the `HeapReadOutput` enum to
 /// delegate `PyTrait` calls to heap-resident timezone objects.
 impl<'h> PyTrait<'h> for HeapRead<'h, TimeZone> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::TimeZone
     }
 
-    fn py_len(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, _vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         None
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         Ok(self.get(vm.heap).offset_seconds == other.get(vm.heap).offset_seconds)
     }
 
-    fn py_hash(
-        &self,
-        _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(hasher.finish()))
     }
 
-    fn py_bool(&self, _vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, _vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         true
     }
 
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         let tz = self.get(vm.heap);
@@ -296,7 +292,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeZone> {
         Ok(())
     }
 
-    fn py_str(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         let tz = self.get(vm.heap);
         if let Some(name) = &tz.name {
             return Ok(Cow::Owned(name.clone()));

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -107,7 +107,7 @@ impl Tuple {
     ///
     /// - `tuple()` with no args returns an empty tuple (singleton)
     /// - `tuple(iterable)` creates a tuple from any iterable (list, tuple, range, str, bytes, dict)
-    pub fn init(vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub fn init(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         let value = args.get_zero_one_arg("tuple", vm.heap)?;
         match value {
             None => {
@@ -163,12 +163,12 @@ pub fn allocate_tuple(
 
 impl<'h> HeapRead<'h, Tuple> {
     /// Clones the item at the given index with proper refcount management.
-    pub(crate) fn clone_item(&self, index: usize, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Value {
+    pub(crate) fn clone_item(&self, index: usize, vm: &mut VM<'h, impl ResourceTracker>) -> Value {
         self.get(vm.heap).items[index].clone_with_heap(vm)
     }
 
     /// Clones all items from this tuple with proper refcount management.
-    fn clone_all_items(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> TupleVec {
+    fn clone_all_items(&self, vm: &mut VM<'h, impl ResourceTracker>) -> TupleVec {
         let len = self.get(vm.heap).items.len();
         let mut result = TupleVec::with_capacity(len);
         for i in 0..len {
@@ -179,15 +179,15 @@ impl<'h> HeapRead<'h, Tuple> {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
-    fn py_type(&self, _vm: &VM<'h, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
         Type::Tuple
     }
 
-    fn py_len(&self, vm: &VM<'h, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
         Some(self.get(vm.heap).items.len())
     }
 
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h, '_, impl ResourceTracker>) -> RunResult<Value> {
+    fn py_getitem(&self, key: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         // Check for slice first (Value::Ref pointing to HeapData::Slice)
         if let Value::Ref(key_id) = key
             && let HeapData::Slice(slice_obj) = vm.heap.get(*key_id)
@@ -211,7 +211,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         Ok(self.clone_item(idx, vm))
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
         let a_len = self.get(vm.heap).items.len();
         if a_len != other.get(vm.heap).items.len() {
             return Ok(false);
@@ -237,11 +237,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
     /// Identical to `NamedTuple::py_hash`, so a `Tuple` and a `NamedTuple` with
     /// the same elements hash equally — required because they compare equal
     /// (matching CPython, where `NamedTuple` is a `tuple` subclass).
-    fn py_hash(
-        &self,
-        _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
         let token = vm.heap.incr_recursion_depth()?;
         defer_drop!(token, vm);
         let len = self.get(vm.heap).items.len();
@@ -265,11 +261,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
     /// `(1, 2) < (1, 2, 3)` is `True`.
     ///
     /// Returns `None` if any element pair is incomparable (e.g. `int` vs `str`).
-    fn py_cmp(
-        &self,
-        other: &Self,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
-    ) -> Result<Option<Ordering>, ResourceError> {
+    fn py_cmp(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Ordering>, ResourceError> {
         let a_len = self.get(vm.heap).items.len();
         let b_len = other.get(vm.heap).items.len();
         let min_len = a_len.min(b_len);
@@ -298,7 +290,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         Ok(Some(a_len.cmp(&b_len)))
     }
 
-    fn py_add(&self, other: &Self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> Result<Option<Value>, ResourceError> {
+    fn py_add(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Value>, ResourceError> {
         let mut items = self.clone_all_items(vm);
         items.extend(other.clone_all_items(vm));
         Ok(Some(allocate_tuple(items, vm.heap)?))
@@ -307,7 +299,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
     fn py_call_attr(
         &mut self,
         _self_id: HeapId,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         attr: &EitherStr,
         args: ArgValues,
     ) -> RunResult<CallResult> {
@@ -321,14 +313,14 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         }
     }
 
-    fn py_bool(&self, vm: &mut VM<'h, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {
         !self.get(vm.heap).items.is_empty()
     }
 
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'h, '_, impl ResourceTracker>,
+        vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         let len = self.get(vm.heap).as_slice().len();
@@ -378,7 +370,7 @@ impl HeapItem for Tuple {
 fn tuple_index<'h>(
     tuple: &HeapRead<'h, Tuple>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let pos_args = args.into_pos_only("tuple.index", vm.heap)?;
     defer_drop!(pos_args, vm);
@@ -417,7 +409,7 @@ fn tuple_index<'h>(
 fn tuple_count<'h>(
     tuple: &HeapRead<'h, Tuple>,
     args: ArgValues,
-    vm: &mut VM<'h, '_, impl ResourceTracker>,
+    vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<Value> {
     let value = args.get_one_arg("tuple.count", vm.heap)?;
     defer_drop!(value, vm);

--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -251,7 +251,7 @@ impl Type {
         self,
         method_id: StringId,
         args: ArgValues,
-        vm: &mut VM<'_, '_, impl ResourceTracker>,
+        vm: &mut VM<'_, impl ResourceTracker>,
     ) -> RunResult<AttrCallResult> {
         match (self, method_id) {
             (Self::Dict, m) if m == StaticStrings::Fromkeys => dict_fromkeys(args, vm).map(AttrCallResult::Value),
@@ -279,7 +279,7 @@ impl Type {
     ///
     /// Dispatches to the appropriate type's init method for container types,
     /// or handles primitive type conversions inline.
-    pub(crate) fn call(self, vm: &mut VM<'_, '_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    pub(crate) fn call(self, vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         match self {
             // Container types - delegate to init methods
             Self::List => List::init(vm, args),

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -131,7 +131,7 @@ impl From<bool> for Value {
 }
 
 impl PyTrait<'_> for Value {
-    fn py_type(&self, vm: &VM<'_, '_, impl ResourceTracker>) -> Type {
+    fn py_type(&self, vm: &VM<'_, impl ResourceTracker>) -> Type {
         match self {
             Self::Undefined => panic!("Cannot get type of undefined value"),
             Self::Ellipsis => Type::Ellipsis,
@@ -153,7 +153,7 @@ impl PyTrait<'_> for Value {
         }
     }
 
-    fn py_len(&self, vm: &VM<'_, '_, impl ResourceTracker>) -> Option<usize> {
+    fn py_len(&self, vm: &VM<'_, impl ResourceTracker>) -> Option<usize> {
         match self {
             // Count Unicode characters, not bytes, to match Python semantics
             Self::InternString(string_id) => Some(vm.interns.get_str(*string_id).chars().count()),
@@ -163,7 +163,7 @@ impl PyTrait<'_> for Value {
         }
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<bool, ResourceError> {
+    fn py_eq(&self, other: &Self, vm: &mut VM<'_, impl ResourceTracker>) -> Result<bool, ResourceError> {
         let interns = vm.interns;
         match (self, other) {
             (Self::Undefined, _) => Ok(false),
@@ -234,11 +234,7 @@ impl PyTrait<'_> for Value {
         }
     }
 
-    fn py_cmp(
-        &self,
-        other: &Self,
-        vm: &mut VM<'_, '_, impl ResourceTracker>,
-    ) -> Result<Option<Ordering>, ResourceError> {
+    fn py_cmp(&self, other: &Self, vm: &mut VM<'_, impl ResourceTracker>) -> Result<Option<Ordering>, ResourceError> {
         let interns = vm.interns;
         // py_cmp handles numbers, strings, bytes, and tuples.
         // Recursion depth tracking for tuples is handled in Tuple::py_cmp.
@@ -293,7 +289,7 @@ impl PyTrait<'_> for Value {
         }
     }
 
-    fn py_bool(&self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> bool {
+    fn py_bool(&self, vm: &mut VM<'_, impl ResourceTracker>) -> bool {
         match self {
             Self::Undefined => false,
             Self::Ellipsis => true,
@@ -319,7 +315,7 @@ impl PyTrait<'_> for Value {
     fn py_repr_fmt(
         &self,
         f: &mut impl Write,
-        vm: &mut VM<'_, '_, impl ResourceTracker>,
+        vm: &mut VM<'_, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         let interns = vm.interns;
@@ -374,7 +370,7 @@ impl PyTrait<'_> for Value {
         }
     }
 
-    fn py_str(&self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         match self {
             Self::InternString(string_id) => Ok(vm.interns.get_str(*string_id).to_owned().into()),
             Self::Ref(id) => vm.heap.read(*id).py_str(vm),
@@ -382,7 +378,7 @@ impl PyTrait<'_> for Value {
         }
     }
 
-    fn py_add(&self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<Option<Value>, ResourceError> {
+    fn py_add(&self, other: &Self, vm: &mut VM<'_, impl ResourceTracker>) -> Result<Option<Value>, ResourceError> {
         let interns = vm.interns;
         match (self, other) {
             // Int + Int with overflow detection
@@ -451,7 +447,7 @@ impl PyTrait<'_> for Value {
         }
     }
 
-    fn py_sub(&self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<Option<Self>, ResourceError> {
+    fn py_sub(&self, other: &Self, vm: &mut VM<'_, impl ResourceTracker>) -> Result<Option<Self>, ResourceError> {
         match (self, other) {
             // Int - Int with overflow detection
             (Self::Int(a), Self::Int(b)) => {
@@ -488,7 +484,7 @@ impl PyTrait<'_> for Value {
         }
     }
 
-    fn py_mod(&self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Option<Self>> {
+    fn py_mod(&self, other: &Self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Option<Self>> {
         match (self, other) {
             (Self::Int(a), Self::Int(b)) => {
                 if *b == 0 {
@@ -571,7 +567,7 @@ impl PyTrait<'_> for Value {
     fn py_iadd(
         &mut self,
         other: &Self,
-        vm: &mut VM<'_, '_, impl ResourceTracker>,
+        vm: &mut VM<'_, impl ResourceTracker>,
         _self_id: Option<HeapId>,
     ) -> Result<bool, ResourceError> {
         let interns = vm.interns;
@@ -633,7 +629,7 @@ impl PyTrait<'_> for Value {
         }
     }
 
-    fn py_mult(&self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Option<Value>> {
+    fn py_mult(&self, other: &Self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Option<Value>> {
         let interns = vm.interns;
         match (self, other) {
             // Numeric multiplication with overflow promotion to LongInt
@@ -841,7 +837,7 @@ impl PyTrait<'_> for Value {
         }
     }
 
-    fn py_div(&self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Option<Value>> {
+    fn py_div(&self, other: &Self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Option<Value>> {
         let interns = vm.interns;
         match (self, other) {
             // True division always returns float
@@ -999,7 +995,7 @@ impl PyTrait<'_> for Value {
         }
     }
 
-    fn py_floordiv(&self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Option<Value>> {
+    fn py_floordiv(&self, other: &Self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Option<Value>> {
         match (self, other) {
             // Floor division: int // int returns int
             (Self::Int(a), Self::Int(b)) => {
@@ -1128,7 +1124,7 @@ impl PyTrait<'_> for Value {
         }
     }
 
-    fn py_pow(&self, other: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Option<Value>> {
+    fn py_pow(&self, other: &Self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Option<Value>> {
         match (self, other) {
             (Self::Int(base), Self::Int(exp)) => {
                 if *base == 0 && *exp < 0 {
@@ -1336,7 +1332,7 @@ impl PyTrait<'_> for Value {
         }
     }
 
-    fn py_getitem(&self, key: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<Self> {
+    fn py_getitem(&self, key: &Self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Self> {
         let interns = vm.interns;
         match self {
             Self::Ref(id) => vm.heap.read(*id).py_getitem(key, vm),
@@ -1388,7 +1384,7 @@ impl PyTrait<'_> for Value {
         }
     }
 
-    fn py_setitem(&mut self, key: Self, value: Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<()> {
+    fn py_setitem(&mut self, key: Self, value: Self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<()> {
         match self {
             Self::Ref(id) => vm.heap.read(*id).py_setitem(key, value, vm),
             _ => Err(ExcType::type_error(format!(
@@ -1487,7 +1483,7 @@ impl Value {
     /// Returns the module name if this value is a module, otherwise returns "<unknown>".
     ///
     /// Used for error messages in `from module import name` when the name doesn't exist.
-    pub fn module_name(&self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> String {
+    pub fn module_name(&self, vm: &mut VM<'_, impl ResourceTracker>) -> String {
         match self {
             Self::Ref(id) => match vm.heap.get(*id) {
                 HeapData::Module(module) => vm.interns.get_str(module.name()).to_string(),
@@ -1513,7 +1509,7 @@ impl Value {
     ///
     /// For heap-allocated values (Ref variant), this computes the hash lazily
     /// on first use and caches it for subsequent calls.
-    pub fn py_hash(&self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
+    pub fn py_hash(&self, vm: &mut VM<'_, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
         let mut hasher = DefaultHasher::new();
         match self {
             // Hash just the actual string or bytes content for consistency with heap Str/Bytes
@@ -1582,7 +1578,7 @@ impl Value {
     /// - Dict: key lookup
     /// - Set/FrozenSet: element lookup
     /// - Str: substring search
-    pub fn py_contains(&self, item: &Self, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<bool> {
+    pub fn py_contains(&self, item: &Self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<bool> {
         match self {
             Self::Ref(heap_id) => {
                 let output = vm.heap.read(*heap_id);
@@ -1723,7 +1719,7 @@ impl Value {
     /// Accepts `EitherStr` to support both interned and heap-allocated attribute names.
     ///
     /// Returns `AttributeError` for other types or unknown attributes.
-    pub fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'_, '_, impl ResourceTracker>) -> RunResult<CallResult> {
+    pub fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<CallResult> {
         match self {
             Self::Ref(heap_id) => {
                 if let Some(call_result) = vm.heap.read(*heap_id).py_getattr(attr, vm)? {
@@ -1758,12 +1754,7 @@ impl Value {
     ///
     /// Takes ownership of `value` and drops it on error.
     /// On success, drops the old attribute value if one existed.
-    pub fn py_set_attr(
-        &self,
-        name: &EitherStr,
-        value: Self,
-        vm: &mut VM<'_, '_, impl ResourceTracker>,
-    ) -> RunResult<()> {
+    pub fn py_set_attr(&self, name: &EitherStr, value: Self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<()> {
         if let Self::Ref(heap_id) = self {
             match vm.heap.read(*heap_id) {
                 HeapReadOutput::Dataclass(mut dc) => {
@@ -1799,7 +1790,7 @@ impl Value {
     /// heap-allocated `LongInt` values always exceed i64 range because `LongInt::into_value()`
     /// automatically demotes i64-fitting values to `Value::Int`. However, this path could be
     /// reached via deserialization of crafted snapshot data.
-    pub fn as_int(&self, vm: &VM<'_, '_, impl ResourceTracker>) -> RunResult<i64> {
+    pub fn as_int(&self, vm: &VM<'_, impl ResourceTracker>) -> RunResult<i64> {
         match self {
             Self::Int(i) => Ok(*i),
             Self::Ref(heap_id) => {
@@ -1827,7 +1818,7 @@ impl Value {
     /// heap-allocated `LongInt` values always exceed i64 range because `LongInt::into_value()`
     /// automatically demotes i64-fitting values to `Value::Int`. However, this path could be
     /// reached via deserialization of crafted snapshot data.
-    pub fn as_index(&self, vm: &VM<'_, '_, impl ResourceTracker>, container_type: Type) -> RunResult<i64> {
+    pub fn as_index(&self, vm: &VM<'_, impl ResourceTracker>, container_type: Type) -> RunResult<i64> {
         match self {
             Self::Int(i) => Ok(*i),
             Self::Bool(b) => Ok(i64::from(*b)),
@@ -1855,7 +1846,7 @@ impl Value {
         &self,
         other: &Self,
         op: BitwiseOp,
-        vm: &mut VM<'_, '_, impl ResourceTracker>,
+        vm: &mut VM<'_, impl ResourceTracker>,
     ) -> Result<Self, RunError> {
         // Capture types for error messages
         let lhs_type = self.py_type(vm);
@@ -2564,9 +2555,9 @@ mod tests {
         let (mut heap, heap_id) = create_heap_with_longint(BigInt::from(42));
         let value = Value::Ref(heap_id);
 
-        let result = HeapReader::with(&mut heap, |heap| {
-            let interns = create_test_interns();
-            let vm = VM::new(Vec::new(), heap, &interns, PrintWriter::Disabled);
+        let mut interns = create_test_interns();
+        let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
+            let vm = VM::new(Vec::new(), reader, interns, PrintWriter::Disabled);
             value.as_index(&vm, Type::List)
         });
         assert_eq!(result.unwrap(), 42);
@@ -2579,9 +2570,9 @@ mod tests {
         let (mut heap, heap_id) = create_heap_with_longint(BigInt::from(-100));
         let value = Value::Ref(heap_id);
 
-        let result = HeapReader::with(&mut heap, |heap| {
-            let interns = create_test_interns();
-            let vm = VM::new(Vec::new(), heap, &interns, PrintWriter::Disabled);
+        let mut interns = create_test_interns();
+        let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
+            let vm = VM::new(Vec::new(), reader, interns, PrintWriter::Disabled);
             value.as_index(&vm, Type::List)
         });
         assert_eq!(result.unwrap(), -100);
@@ -2596,9 +2587,9 @@ mod tests {
         let (mut heap, heap_id) = create_heap_with_longint(big_value);
         let value = Value::Ref(heap_id);
 
-        let result = HeapReader::with(&mut heap, |heap| {
-            let interns = create_test_interns();
-            let vm = VM::new(Vec::new(), heap, &interns, PrintWriter::Disabled);
+        let mut interns = create_test_interns();
+        let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
+            let vm = VM::new(Vec::new(), reader, interns, PrintWriter::Disabled);
             value.as_index(&vm, Type::List)
         });
         assert!(result.is_err());
@@ -2613,9 +2604,9 @@ mod tests {
         let (mut heap, heap_id) = create_heap_with_longint(BigInt::from(12345));
         let value = Value::Ref(heap_id);
 
-        let result = HeapReader::with(&mut heap, |heap| {
-            let interns = create_test_interns();
-            let vm = VM::new(Vec::new(), heap, &interns, PrintWriter::Disabled);
+        let mut interns = create_test_interns();
+        let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
+            let vm = VM::new(Vec::new(), reader, interns, PrintWriter::Disabled);
             value.as_int(&vm)
         });
         assert_eq!(result.unwrap(), 12345);
@@ -2629,9 +2620,9 @@ mod tests {
         let (mut heap, heap_id) = create_heap_with_longint(big_value);
         let value = Value::Ref(heap_id);
 
-        let result = HeapReader::with(&mut heap, |heap| {
-            let interns = create_test_interns();
-            let vm = VM::new(Vec::new(), heap, &interns, PrintWriter::Disabled);
+        let mut interns = create_test_interns();
+        let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
+            let vm = VM::new(Vec::new(), reader, interns, PrintWriter::Disabled);
             value.as_int(&vm)
         });
         assert!(result.is_err());
@@ -2644,9 +2635,9 @@ mod tests {
         let (mut heap, heap_id) = create_heap_with_longint(BigInt::from(i64::MAX));
         let value = Value::Ref(heap_id);
 
-        let result = HeapReader::with(&mut heap, |heap| {
-            let interns = create_test_interns();
-            let vm = VM::new(Vec::new(), heap, &interns, PrintWriter::Disabled);
+        let mut interns = create_test_interns();
+        let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
+            let vm = VM::new(Vec::new(), reader, interns, PrintWriter::Disabled);
             value.as_index(&vm, Type::List)
         });
         assert_eq!(result.unwrap(), i64::MAX);
@@ -2659,9 +2650,9 @@ mod tests {
         let (mut heap, heap_id) = create_heap_with_longint(BigInt::from(i64::MIN));
         let value = Value::Ref(heap_id);
 
-        let result = HeapReader::with(&mut heap, |heap| {
-            let interns = create_test_interns();
-            let vm = VM::new(Vec::new(), heap, &interns, PrintWriter::Disabled);
+        let mut interns = create_test_interns();
+        let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
+            let vm = VM::new(Vec::new(), reader, interns, PrintWriter::Disabled);
             value.as_index(&vm, Type::List)
         });
         assert_eq!(result.unwrap(), i64::MIN);
@@ -2675,9 +2666,9 @@ mod tests {
         let (mut heap, heap_id) = create_heap_with_longint(big_value);
         let value = Value::Ref(heap_id);
 
-        let result = HeapReader::with(&mut heap, |heap| {
-            let interns = create_test_interns();
-            let vm = VM::new(Vec::new(), heap, &interns, PrintWriter::Disabled);
+        let mut interns = create_test_interns();
+        let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
+            let vm = VM::new(Vec::new(), reader, interns, PrintWriter::Disabled);
             value.as_index(&vm, Type::List)
         });
         assert!(result.is_err());
@@ -2691,9 +2682,9 @@ mod tests {
         let (mut heap, heap_id) = create_heap_with_longint(big_value);
         let value = Value::Ref(heap_id);
 
-        let result = HeapReader::with(&mut heap, |heap| {
-            let interns = create_test_interns();
-            let vm = VM::new(Vec::new(), heap, &interns, PrintWriter::Disabled);
+        let mut interns = create_test_interns();
+        let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
+            let vm = VM::new(Vec::new(), reader, interns, PrintWriter::Disabled);
             value.as_index(&vm, Type::List)
         });
         assert!(result.is_err());

--- a/crates/monty/tests/heap_reader_compile_fail.rs
+++ b/crates/monty/tests/heap_reader_compile_fail.rs
@@ -141,3 +141,15 @@ fn smuggle_heap_read() {
 fn mutation_in_map_closure() {
     check_compile_fail("mutation_in_map_closure");
 }
+
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn smuggle_vm() {
+    check_compile_fail("smuggle_vm");
+}
+
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn smuggle_and_swap_reader() {
+    check_compile_fail("smuggle_and_swap_reader");
+}

--- a/crates/monty/tests/heap_reader_compile_fail_cases/cases.rs
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/cases.rs
@@ -19,7 +19,7 @@ use super::*;
 /// Expected: E0502 (cannot borrow `*heap` as mutable because it is also borrowed as immutable)
 #[cfg(heap_reader_compile_fail_test_heap_mutation_while_reading)]
 fn heap_mutation_while_reading(list_id: HeapId, heap: &mut Heap<impl ResourceTracker>) {
-    HeapReader::with(heap, |heap| {
+    HeapReader::with(heap, &mut (), |heap, ()| {
         let a = match heap.read(list_id) {
             HeapReadOutput::List(list) => list,
             _ => unreachable!(),
@@ -38,7 +38,7 @@ fn heap_mutation_while_reading(list_id: HeapId, heap: &mut Heap<impl ResourceTra
 /// Expected: E0499 (cannot borrow `*heap` as mutable more than once at a time)
 #[cfg(heap_reader_compile_fail_test_double_get_mut)]
 fn double_get_mut(list_id: HeapId, heap: &mut Heap<impl ResourceTracker>) {
-    HeapReader::with(heap, |heap| {
+    HeapReader::with(heap, &mut (), |heap, ()| {
         let mut a = match heap.read(list_id) {
             HeapReadOutput::List(list) => list,
             _ => unreachable!(),
@@ -61,7 +61,7 @@ fn double_get_mut(list_id: HeapId, heap: &mut Heap<impl ResourceTracker>) {
 /// Expected: E0502 (cannot borrow `*heap` as mutable because it is also borrowed as immutable)
 #[cfg(heap_reader_compile_fail_test_dec_ref_while_reading)]
 fn dec_ref_while_reading(list_id: HeapId, heap: &mut Heap<impl ResourceTracker>) {
-    HeapReader::with(heap, |heap| {
+    HeapReader::with(heap, &mut (), |heap, ()| {
         let a = match heap.read(list_id) {
             HeapReadOutput::List(list) => list,
             _ => unreachable!(),
@@ -81,7 +81,7 @@ fn dec_ref_while_reading(list_id: HeapId, heap: &mut Heap<impl ResourceTracker>)
 #[cfg(heap_reader_compile_fail_test_smuggle_heap_read)]
 fn smuggle_heap_read(list_id: HeapId, heap: &mut Heap<impl ResourceTracker>) {
     let mut smuggled: Option<HeapRead<'_, List>> = None;
-    HeapReader::with(heap, |heap| {
+    HeapReader::with(heap, &mut (), |heap, ()| {
         let a = match heap.read(list_id) {
             HeapReadOutput::List(list) => list,
             _ => unreachable!(),
@@ -100,7 +100,7 @@ fn smuggle_heap_read(list_id: HeapId, heap: &mut Heap<impl ResourceTracker>) {
 /// Expected: E0500 (closure requires unique access to `*heap` but it is already borrowed)
 #[cfg(heap_reader_compile_fail_test_mutation_in_map_closure)]
 fn mutation_in_map_closure(list_id: HeapId, other_id: HeapId, heap: &mut Heap<impl ResourceTracker>) {
-    HeapReader::with(heap, |heap| {
+    HeapReader::with(heap, &mut (), |heap, ()| {
         let a = match heap.read(list_id) {
             HeapReadOutput::List(list) => list,
             _ => unreachable!(),
@@ -124,7 +124,7 @@ fn mutation_in_map_closure(list_id: HeapId, other_id: HeapId, heap: &mut Heap<im
 /// Expected: E0502 (cannot borrow `*heap` as mutable because it is also borrowed as immutable)
 #[cfg(heap_reader_compile_fail_test_read_while_ref_alive)]
 fn read_while_ref_alive(id_a: HeapId, id_b: HeapId, heap: &mut Heap<impl ResourceTracker>) {
-    HeapReader::with(heap, |heap| {
+    HeapReader::with(heap, &mut (), |heap, ()| {
         let a = match heap.read(id_a) {
             HeapReadOutput::List(list) => list,
             _ => unreachable!(),
@@ -132,5 +132,55 @@ fn read_while_ref_alive(id_a: HeapId, id_b: HeapId, heap: &mut Heap<impl Resourc
         let a_ref = a.get(heap);
         let _b = heap.read(id_b);
         let _ = a_ref.as_slice();
+    });
+}
+
+/// Must not compile: returning the `VM` itself out of a `HeapReader::with` closure.
+///
+/// `VM<'h, T>` has invariant `'h`, and the closure's HRTB makes `'h` universally
+/// quantified. Returning a value containing `'h` would require it to satisfy any
+/// caller-chosen lifetime — in particular `'static`, as in this test — which is
+/// impossible because the heap reader is bound to the with-call's stack frame.
+///
+/// Expected: a borrow-check error preventing the VM from escaping.
+#[cfg(heap_reader_compile_fail_test_smuggle_vm)]
+fn smuggle_vm<T: ResourceTracker>(
+    heap: &mut Heap<T>,
+    interns: &crate::intern::Interns,
+) -> crate::bytecode::VM<'static, T> {
+    use crate::bytecode::VM;
+    HeapReader::with(
+        heap,
+        &mut (interns, crate::io::PrintWriter::Disabled),
+        |reader, (interns, print)| VM::new(Vec::new(), reader, *interns, print.reborrow()),
+    )
+}
+
+/// Must not compile: smuggling an outer `HeapReader` into an inner
+/// `HeapReader::with` call via the `data` channel and trying to `mem::swap` the
+/// two readers.
+///
+/// The outer call brands its reader with one HRTB lifetime; the inner call brands
+/// its reader with a fresh, independent HRTB lifetime. Both lifetimes are
+/// invariant on `HeapReader`, so even though the structs are otherwise identical,
+/// `HeapReader<'outer, T>` and `HeapReader<'inner, T>` are distinct types and
+/// `mem::swap` cannot unify them.
+///
+/// If this attack worked, an attacker could swap the underlying `&mut Heap`
+/// references between the two readers, letting `HeapRead<'outer, _>` from the
+/// outer reader resolve into the inner reader's heap (or vice versa) — a
+/// type-confusion across heap arenas.
+///
+/// Expected: lifetime/type mismatch error from `mem::swap` — the inner closure's
+/// universally-quantified lifetime cannot be unified with the outer call's.
+#[cfg(heap_reader_compile_fail_test_smuggle_and_swap_reader)]
+fn smuggle_and_swap_reader<T: ResourceTracker>(heap_a: &mut Heap<T>, heap_b: &mut Heap<T>) {
+    HeapReader::with(heap_a, &mut (), |reader_a, ()| {
+        HeapReader::with(heap_b, reader_a, |reader_b, smuggled| {
+            // `reader_b: &'inner mut HeapReader<'inner, T>` and
+            // `smuggled: &'inner mut HeapReader<'outer, T>` — invariant lifetimes
+            // prevent unification, so this swap must be rejected.
+            std::mem::swap(reader_b, smuggled);
+        });
     });
 }

--- a/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_and_swap_reader.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_and_swap_reader.stderr
@@ -1,0 +1,15 @@
+error[E0521]: borrowed data escapes outside of closure
+   --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:183:13
+    |
+179 |         HeapReader::with(heap_b, reader_a, |reader_b, smuggled| {
+    |                                             --------  -------- `smuggled` declared here, outside of the closure body
+    |                                             |
+    |                                             `reader_b` is a reference that is only valid in the closure body
+...
+183 |             std::mem::swap(reader_b, smuggled);
+    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `reader_b` escapes the closure body here
+    |
+    = note: requirement occurs because of a mutable reference to `heap::HeapReader<'_, T>`
+    = note: mutable references are invariant over their type parameter
+    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+For more information about this error, try `rustc --explain E0521`.

--- a/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_heap_read.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_heap_read.stderr
@@ -3,8 +3,8 @@ error[E0521]: borrowed data escapes outside of closure
    |
 83 |     let mut smuggled: Option<HeapRead<'_, List>> = None;
    |         ------------ `smuggled` declared here, outside of the closure body
-84 |     HeapReader::with(heap, |heap| {
-   |                             ---- `heap` is a reference that is only valid in the closure body
+84 |     HeapReader::with(heap, &mut (), |heap, ()| {
+   |                                      ---- `heap` is a reference that is only valid in the closure body
 ...
 89 |         smuggled = Some(a);
    |         ^^^^^^^^ `heap` escapes the closure body here

--- a/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_vm.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_vm.stderr
@@ -1,0 +1,28 @@
+error: lifetime may not live long enough
+   --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:155:36
+    |
+155 |         |reader, (interns, print)| VM::new(Vec::new(), reader, *interns, print.reborrow()),
+    |          ------                  - ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
+    |          |                       |
+    |          |                       return type of closure is VM<'2, T>
+    |          has type `&'1 mut heap::HeapReader<'1, T>`
+    |
+    = note: requirement occurs because of the type `VM<'_, T>`, which makes the generic argument `'_` invariant
+    = note: the struct `VM<'h, T>` is invariant over the parameter `'h`
+    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
+error: lifetime may not live long enough
+   --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:152:5
+    |
+149 |       interns: &crate::intern::Interns,
+    |                - let's call the lifetime of this reference `'1`
+...
+152 | /     HeapReader::with(
+153 | |         heap,
+154 | |         &mut (interns, crate::io::PrintWriter::Disabled),
+155 | |         |reader, (interns, print)| VM::new(Vec::new(), reader, *interns, print.reborrow()),
+156 | |     )
+    | |_____^ returning this value requires that `'1` must outlive `'static`
+    |
+    = note: requirement occurs because of the type `VM<'_, T>`, which makes the generic argument `'_` invariant
+    = note: the struct `VM<'h, T>` is invariant over the parameter `'h`
+    = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [manifest]
 members = [
     "monty-workspace",
@@ -443,6 +447,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]


### PR DESCRIPTION
This adjusts construction of `VM` to unify all borrowed inputs to a single lifetime, so that `VM` only needs a single lifetime parameter.

This is essentially a code cleanup; makes for easier reading.