### PR TITLE
cache the hash value of interned / static strings

### DIFF
--- a/crates/monty/src/builtins/hash.rs
+++ b/crates/monty/src/builtins/hash.rs
@@ -20,8 +20,7 @@ pub fn builtin_hash(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> R
     match value.py_hash(vm)? {
         Some(hash) => {
             // Python's hash() returns a signed integer; reinterpret bits for large values
-            let hash_i64 = i64::from_ne_bytes(hash.to_ne_bytes());
-            Ok(Value::Int(hash_i64))
+            Ok(Value::Int(hash.raw().cast_signed()))
         }
         None => Err(ExcType::type_error_unhashable(value.py_type(vm))),
     }

--- a/crates/monty/src/hash.rs
+++ b/crates/monty/src/hash.rs
@@ -1,0 +1,323 @@
+//! Single source of truth for hashing Python values.
+//!
+//! Defines:
+//!
+//! * [`HashValue`] — a verified Python hash. Construction goes through
+//!   [`HashValue::from_raw`]; storing or comparing hashes anywhere in the
+//!   runtime should use this type rather than a bare `u64` so the invariant
+//!   is enforced by the type system.
+//!
+//!   Internally backed by a [`NonZero<u64>`] holding the **bit-inverse** of
+//!   the raw hash. The inversion is invisible to callers (`from_raw` /
+//!   `get` translate at the boundary) but means `Option<HashValue>` is
+//!   niche-packed into 8 bytes — `None` is the bit pattern `0`, the inverse
+//!   of the reserved `u64::MAX` sentinel.
+//! * [`hash_python_str`] / [`hash_python_bytes`] / [`hash_python_long_int`]
+//!   — the canonical hash functions for `str`, `bytes` and arbitrary-precision
+//!   `int`. Routing every `str`/`bytes`/`int` hash through these helpers
+//!   keeps the invariant "interned and heap values with equal content hash
+//!   identically" local rather than scattered, since otherwise dict lookups
+//!   would silently miss.
+//! * [`ASCII_HASHES`] / [`STATIC_HASHES`] — precomputed hashes for the
+//!   pre-interned ASCII single-character and [`StaticStrings`] tables,
+//!   built via `LazyLock` on first access (one-time cost, dwarfed by parse
+//!   time for any non-trivial program).
+
+use std::{
+    collections::hash_map::DefaultHasher,
+    fmt,
+    hash::{Hash, Hasher},
+    num::NonZero,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use num_bigint::BigInt;
+use num_traits::ToPrimitive;
+use strum::EnumCount;
+
+use crate::intern::StaticStrings;
+
+/// A verified Python hash value.
+///
+/// Internally a [`NonZero<u64>`] holding the bit-inverse of the raw hash, so
+/// `Option<HashValue>` niche-packs into 8 bytes. Construct via
+/// [`HashValue::from_raw`]; extract via [`HashValue::get`] (both translate
+/// the inversion at the boundary).
+///
+/// The bit-inversion is purely an implementation detail of the niche
+/// packing — none of the public traits leak it. [`Hash`], [`fmt::Debug`],
+/// [`serde::Serialize`] and [`serde::Deserialize`] all hand-translate to/from
+/// the raw `u64` form, so:
+///
+/// * Composite hashes that fold a `HashValue` see the same bytes `get()`
+///   returns (independent of storage layout — a future change to e.g.
+///   `NonMaxU64` would leave tuple/dict hashes invariant).
+/// * Debug output shows the raw hash (`HashValue(5)`, not the inverted bits).
+/// * Snapshots store the raw hash, so the wire format is decoupled from the
+///   niche-packing representation.
+///
+/// Stored in interner hash tables, returned by `Value::py_hash`, and used
+/// wherever a known-good hash needs to be passed around.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub(crate) struct HashValue(NonZero<u64>);
+
+impl HashValue {
+    /// Wraps a freshly-computed raw hash.
+    ///
+    /// Bit-inverts and stores as `NonZero<u64>`. The single edge case where
+    /// `!hash == 0` (i.e. raw `hash == u64::MAX`) maps to
+    /// [`NonZero::<u64>::MIN`] — equivalent to bumping the raw hash by 1.
+    /// Mirrors CPython's reservation of `Py_hash_t = -1`. Bias: 1 in 2^64,
+    /// no impact on common hashes like `hash(0) == 0`.
+    #[inline]
+    #[must_use]
+    pub const fn new(hash: u64) -> Self {
+        Self(match NonZero::new(!hash) {
+            Some(nz) => nz,
+            None => NonZero::<u64>::MIN,
+        })
+    }
+
+    /// Returns the underlying `u64` for use in modulo arithmetic, hashbrown
+    /// indexing, and other places that need a bare hash.
+    #[inline]
+    #[must_use]
+    pub const fn raw(self) -> u64 {
+        !self.0.get()
+    }
+}
+
+impl Hash for HashValue {
+    /// Folds the raw hash (not the stored, inverted form) so that
+    /// composite hashes are independent of the niche-packing representation.
+    /// Without this, a future change to the internal layout would silently
+    /// alter every tuple / namedtuple / dataclass hash.
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.raw().hash(state);
+    }
+}
+
+impl fmt::Debug for HashValue {
+    /// Prints the raw hash, not the stored bit-inverted form, so debugging
+    /// output matches `get()`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("HashValue").field(&self.raw()).finish()
+    }
+}
+
+impl serde::Serialize for HashValue {
+    /// Emits the raw hash so the wire format is decoupled from the
+    /// niche-packing representation.
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.raw().serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for HashValue {
+    /// Reads a raw `u64` and reconstructs via [`HashValue::from_raw`], so
+    /// even a pathological wire value of `u64::MAX` is handled by the same
+    /// sentinel-collision path as fresh hashes.
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Self::new(u64::deserialize(deserializer)?))
+    }
+}
+
+/// Hashes a string using the canonical Python-string hash function.
+///
+/// Both heap-allocated `Str` values and interned strings must use this so
+/// that an interned `"foo"` and a heap `"foo"` hash identically — required
+/// for dict-key consistency.
+#[inline]
+pub(crate) fn hash_python_str(s: &str) -> HashValue {
+    let mut hasher = DefaultHasher::new();
+    s.hash(&mut hasher);
+    HashValue::new(hasher.finish())
+}
+
+/// Hashes a bytes value using the canonical Python-bytes hash function.
+///
+/// Counterpart to [`hash_python_str`] for `bytes`. Used by both heap `Bytes`
+/// and the interned bytes table.
+#[inline]
+pub(crate) fn hash_python_bytes(b: &[u8]) -> HashValue {
+    let mut hasher = DefaultHasher::new();
+    b.hash(&mut hasher);
+    HashValue::new(hasher.finish())
+}
+
+/// Hashes a `BigInt` consistently with Python's `int` hash.
+///
+/// For values that fit in `i64`, returns `i.cast_unsigned()` so that
+/// `hash(LongInt(5)) == hash(Value::Int(5))`. For larger values, falls back
+/// to hashing `(sign, little-endian bytes)` via [`DefaultHasher`].
+///
+/// Used by heap `LongInt::py_hash` and by `Interns::long_int_hash` so that
+/// interned and heap-allocated long ints with equal value hash identically.
+#[inline]
+pub(crate) fn hash_python_long_int(bi: &BigInt) -> HashValue {
+    if let Some(i) = bi.to_i64() {
+        HashValue::new(i.cast_unsigned())
+    } else {
+        let mut hasher = DefaultHasher::new();
+        let (sign, bytes) = bi.to_bytes_le();
+        sign.hash(&mut hasher);
+        bytes.hash(&mut hasher);
+        HashValue::new(hasher.finish())
+    }
+}
+
+/// A value paired with its precomputed Python [`HashValue`].
+///
+/// Used in the interner storage so each entry carries its own hash next to
+/// the value — push-the-pair instead of parallel arrays. This makes it
+/// impossible to forget to keep the value and hash in sync, and makes
+/// serde recompute-on-deserialise local to this type.
+///
+/// Constructors and `Deserialize` impls are provided for the three concrete
+/// `T` we use ([`String`], `Vec<u8>`, [`BigInt`]). Adding a fourth would
+/// require its own `WithHash<NewT>` constructor and `Deserialize` impl.
+///
+/// # Wire format
+///
+/// `Serialize` is a hand-written passthrough — the on-the-wire form is
+/// exactly `T`'s serialised form (the hash is recomputable). `Deserialize`
+/// reads `T` and rebuilds the hash via the appropriate `hash_python_*`
+/// helper. Round-tripping through serde is therefore lossless and any
+/// deserialiser-supplied bytes always produce a hash consistent with the
+/// canonical helpers.
+#[derive(Debug, Clone)]
+pub(crate) struct WithHash<T> {
+    value: T,
+    hash: HashValue,
+}
+
+impl<T> WithHash<T> {
+    /// Borrow the wrapped value.
+    #[inline]
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+
+    /// The precomputed [`HashValue`].
+    #[inline]
+    pub fn hash(&self) -> HashValue {
+        self.hash
+    }
+}
+
+impl WithHash<String> {
+    /// Construct from an owned `String`, hashing via [`hash_python_str`].
+    #[inline]
+    pub fn for_str(value: String) -> Self {
+        let hash = hash_python_str(&value);
+        Self { value, hash }
+    }
+}
+
+impl WithHash<Vec<u8>> {
+    /// Construct from an owned `Vec<u8>`, hashing via [`hash_python_bytes`].
+    #[inline]
+    pub fn for_bytes(value: Vec<u8>) -> Self {
+        let hash = hash_python_bytes(&value);
+        Self { value, hash }
+    }
+}
+
+impl WithHash<BigInt> {
+    /// Construct from an owned `BigInt`, hashing via [`hash_python_long_int`].
+    #[inline]
+    pub fn for_long_int(value: BigInt) -> Self {
+        let hash = hash_python_long_int(&value);
+        Self { value, hash }
+    }
+}
+
+// `Serialize` is generic: just emit the inner value. The hash is recomputable
+// from the value during deserialisation, so we don't waste bytes encoding it
+// (and we don't risk locking the snapshot format to the current hash function).
+impl<T: serde::Serialize> serde::Serialize for WithHash<T> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.value.serialize(serializer)
+    }
+}
+
+// `Deserialize` is hand-written per concrete `T` so the right
+// `hash_python_*` helper is invoked.
+impl<'de> serde::Deserialize<'de> for WithHash<String> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Self::for_str(String::deserialize(deserializer)?))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for WithHash<Vec<u8>> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Self::for_bytes(Vec::<u8>::deserialize(deserializer)?))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for WithHash<BigInt> {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Self::for_long_int(BigInt::deserialize(deserializer)?))
+    }
+}
+
+/// Per-slot lazy `static` hash table.
+///
+/// `[AtomicU64; N]` storing the inner bits of [`HashValue`] (i.e. the
+/// bit-inverted raw hash). `0` is the "uncomputed" sentinel — naturally
+/// equivalent to [`Option<HashValue>`]'s `None` since `HashValue`'s niche
+/// is exactly `0`.
+///
+/// On the first access of slot `i` the closure is invoked, the result is
+/// stored, and subsequent accesses return it directly. Two threads racing
+/// to fill the same slot is benign: they compute the same value and one
+/// wins the store; the other's store overwrites with the same bits.
+///
+/// Used for `static` precomputed-hash tables (ASCII / `StaticStrings`).
+/// `Cell<Option<HashValue>>` would be the equivalent for non-`static` /
+/// per-instance use (Phase 2's per-type heap caches).
+pub(crate) struct LazyHashTable<const N: usize> {
+    cells: [AtomicU64; N],
+}
+
+impl<const N: usize> LazyHashTable<N> {
+    /// Construct an empty table — every slot starts uncomputed (`0`).
+    pub const fn new() -> Self {
+        Self {
+            cells: [const { AtomicU64::new(0) }; N],
+        }
+    }
+
+    /// Returns the cached [`HashValue`] for `index`, or computes and stores it.
+    ///
+    /// `Ordering::Relaxed` suffices: the only invariant is "any non-zero
+    /// value observed is a valid `HashValue`'s inner bits" — true by
+    /// construction since we only store `HashValue::0.get()` (which is
+    /// guaranteed non-zero by `NonZero<u64>`).
+    #[inline]
+    pub fn get_or_compute(&self, index: usize, compute: impl FnOnce() -> HashValue) -> HashValue {
+        if let Some(stored) = NonZero::new(self.cells[index].load(Ordering::Relaxed)) {
+            HashValue(stored)
+        } else {
+            let h = compute();
+            self.cells[index].store(h.0.get(), Ordering::Relaxed);
+            h
+        }
+    }
+}
+
+/// Per-slot lazy hashes for the 128 ASCII single-character strings.
+///
+/// Indexed by the byte value (`0..128`). Each slot is filled on first
+/// access via [`hash_python_str`] applied to the matching entry of
+/// [`ASCII_STRS`].
+pub(crate) static ASCII_HASHES: LazyHashTable<128> = LazyHashTable::new();
+
+/// Per-slot lazy hashes for every [`StaticStrings`] variant.
+///
+/// Indexed by the variant's discriminant (`StaticStrings as usize`). Each
+/// slot is filled on first access from the variant's `&'static str`
+/// representation.
+pub(crate) static STATIC_HASHES: LazyHashTable<{ StaticStrings::COUNT }> = LazyHashTable::new();

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -18,7 +18,8 @@ pub(crate) use crate::heap_traits::{ContainsHeap, DropWithHeap, HeapGuard, HeapI
 use crate::{
     asyncio::{Coroutine, GatherFuture, GatherItem},
     bytecode::VM,
-    exception_private::SimpleException,
+    exception_private::{RunResult, SimpleException},
+    hash::HashValue,
     heap_data::{CellValue, Closure, FunctionDefaults},
     resource::{ResourceError, ResourceTracker},
     types::{
@@ -60,7 +61,7 @@ enum HashState {
     /// Hash has not yet been computed but the value might be hashable.
     Unknown,
     /// Cached hash value for immutable types that have been hashed at least once.
-    Cached(u64),
+    Cached(HashValue),
     /// Value is unhashable (mutable types or tuples containing unhashables).
     Unhashable,
 }
@@ -1010,7 +1011,7 @@ impl<T: ResourceTracker> Heap<T> {
     ///
     /// # Panics
     /// Panics if the value ID is invalid or the value has already been freed.
-    pub fn get_or_compute_hash(vm: &mut VM<'_, T>, id: HeapId) -> Result<Option<u64>, ResourceError> {
+    pub fn get_or_compute_hash(vm: &mut VM<'_, T>, id: HeapId) -> RunResult<Option<HashValue>> {
         // TODO: it should be possible to refactor the triple lookup to just one, probably by having an
         // internal `vm.heap.read_entry` method which can then derive the `HeapReadOutput` for `py_hash`
         // later, and can live without a VM borrow to allow reading / writing the hash.

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -11,11 +11,12 @@ use ahash::AHashSet;
 use num_integer::Integer;
 
 use crate::{
-    ExcType, ResourceError, ResourceTracker,
+    ExcType, ResourceTracker,
     args::ArgValues,
     asyncio::{CallId, Coroutine, GatherFuture, GatherItem},
     bytecode::{CallResult, VM},
     exception_private::{RunError, RunResult, SimpleException},
+    hash::HashValue,
     heap::{DropWithHeap, HeapId, HeapItem, HeapReadOutput},
     intern::FunctionId,
     types::{
@@ -644,7 +645,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
     /// `FunctionDefaults`, `Cell`, `LongInt`, `ExtFunction`), the hash is
     /// computed inline here. Variants left in the catch-all `_ => Ok(None)`
     /// arm are unhashable.
-    fn py_hash(&self, self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
         match self {
             Self::Str(s) => s.py_hash(self_id, vm),
             Self::Bytes(b) => b.py_hash(self_id, vm),
@@ -664,18 +665,18 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
             Self::Closure(c) => {
                 let mut hasher = DefaultHasher::new();
                 c.get(vm.heap).func_id.hash(&mut hasher);
-                Ok(Some(hasher.finish()))
+                Ok(Some(HashValue::new(hasher.finish())))
             }
             Self::FunctionDefaults(fd) => {
                 let mut hasher = DefaultHasher::new();
                 fd.get(vm.heap).func_id.hash(&mut hasher);
-                Ok(Some(hasher.finish()))
+                Ok(Some(HashValue::new(hasher.finish())))
             }
             // Cell uses identity hashing (matches Python's default for cell objects).
             Self::Cell(_) => {
                 let mut hasher = DefaultHasher::new();
                 self_id.hash(&mut hasher);
-                Ok(Some(hasher.finish()))
+                Ok(Some(HashValue::new(hasher.finish())))
             }
             // LongInt's hash matches `Value::InternLongInt`'s, since they are
             // both Python `int` values and must hash equally when equal.
@@ -683,7 +684,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
             Self::ExtFunction(name) => {
                 let mut hasher = DefaultHasher::new();
                 name.get(vm.heap).hash(&mut hasher);
-                Ok(Some(hasher.finish()))
+                Ok(Some(HashValue::new(hasher.finish())))
             }
             // Unhashable: List, Dict, Set, the dict views, Iter, Module,
             // Exception, Coroutine, GatherFuture, RePattern, ReMatch.

--- a/crates/monty/src/intern.rs
+++ b/crates/monty/src/intern.rs
@@ -16,9 +16,13 @@ use std::{array, str::FromStr, sync::LazyLock};
 
 use ahash::AHashMap;
 use num_bigint::BigInt;
-use strum::{EnumString, FromRepr, IntoStaticStr};
+use strum::{EnumCount, EnumString, FromRepr, IntoStaticStr};
 
-use crate::{function::Function, value::Value};
+use crate::{
+    function::Function,
+    hash::{ASCII_HASHES, HashValue, STATIC_HASHES, WithHash, hash_python_str},
+    value::Value,
+};
 
 /// Index into the string interner's storage.
 ///
@@ -58,7 +62,10 @@ const INTERN_STRING_ID_OFFSET: usize = 10_000;
 ///
 /// Uses `LazyLock` to build the array at runtime (once), leaking the strings to get
 /// `'static` lifetime. The leak is intentional and bounded (128 single-byte strings).
-static ASCII_STRS: LazyLock<[&'static str; 128]> = LazyLock::new(|| {
+///
+/// Exposed `pub(crate)` so the [`crate::hash::ASCII_HASHES`] table can hash
+/// them in lockstep — both tables must agree on the same `&str` per byte.
+pub(crate) static ASCII_STRS: LazyLock<[&'static str; 128]> = LazyLock::new(|| {
     array::from_fn(|i| {
         // Safe: i is always 0-127 for a 128-element array
         let s = char::from(u8::try_from(i).expect("index out of u8 range")).to_string();
@@ -71,7 +78,18 @@ static ASCII_STRS: LazyLock<[&'static str; 128]> = LazyLock::new(|| {
 /// Static string values which are known at compile time and don't need to be interned.
 #[repr(u16)]
 #[derive(
-    Debug, Clone, Copy, FromRepr, EnumString, IntoStaticStr, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    FromRepr,
+    EnumCount,
+    EnumString,
+    IntoStaticStr,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
 )]
 #[strum(serialize_all = "snake_case")]
 pub enum StaticStrings {
@@ -697,14 +715,18 @@ impl FunctionId {
 pub struct InternerBuilder {
     /// Maps strings to their indices for deduplication during interning.
     string_map: AHashMap<String, StringId>,
-    /// Storage for interned interns, indexed by `StringId`.
-    strings: Vec<String>,
-    /// Storage for interned bytes literals, indexed by `BytesId`.
+    /// Storage for interned strings, indexed by `StringId`. Each entry pairs
+    /// the string with its precomputed [`HashValue`] (see [`WithHash`]) so
+    /// `str_hash(id)` is a plain index lookup at runtime.
+    strings: Vec<WithHash<String>>,
+    /// Storage for interned bytes literals, indexed by `BytesId`. Each
+    /// entry carries its precomputed [`HashValue`].
     /// Not deduplicated since bytes literals are rare.
-    bytes: Vec<Vec<u8>>,
+    bytes: Vec<WithHash<Vec<u8>>>,
     /// Storage for interned long integer literals, indexed by `LongIntId`.
+    /// Each entry carries its precomputed [`HashValue`].
     /// Not deduplicated since long integer literals are rare.
-    long_ints: Vec<BigInt>,
+    long_ints: Vec<WithHash<BigInt>>,
 }
 
 impl InternerBuilder {
@@ -748,11 +770,11 @@ impl InternerBuilder {
             .strings
             .iter()
             .enumerate()
-            .map(|(index, value)| {
+            .map(|(index, entry)| {
                 let id = StringId(
                     u32::try_from(INTERN_STRING_ID_OFFSET + index).expect("StringId overflow while seeding interner"),
                 );
-                (value.clone(), id)
+                (entry.value().clone(), id)
             })
             .collect();
         builder
@@ -773,7 +795,7 @@ impl InternerBuilder {
             *self.string_map.entry(s.to_owned()).or_insert_with(|| {
                 let string_id = self.strings.len() + INTERN_STRING_ID_OFFSET;
                 let id = StringId(string_id.try_into().expect("StringId overflow"));
-                self.strings.push(s.to_owned());
+                self.strings.push(WithHash::for_str(s.to_owned()));
                 id
             })
         }
@@ -784,7 +806,7 @@ impl InternerBuilder {
     /// Unlike interns, bytes are not deduplicated (bytes literals are rare).
     pub fn intern_bytes(&mut self, b: &[u8]) -> BytesId {
         let id = BytesId(self.bytes.len().try_into().expect("BytesId overflow"));
-        self.bytes.push(b.to_vec());
+        self.bytes.push(WithHash::for_bytes(b.to_vec()));
         id
     }
 
@@ -793,7 +815,7 @@ impl InternerBuilder {
     /// Big integers are not deduplicated since literals exceeding i64 are rare.
     pub fn intern_long_int(&mut self, bi: BigInt) -> LongIntId {
         let id = LongIntId(self.long_ints.len().try_into().expect("LongIntId overflow"));
-        self.long_ints.push(bi);
+        self.long_ints.push(WithHash::for_long_int(bi));
         id
     }
 
@@ -809,11 +831,11 @@ impl InternerBuilder {
 /// # Panics
 ///
 /// Panics if the `StringId` is invalid - not from this interner or ascii chars or StaticStrings.
-fn get_str(strings: &[String], id: StringId) -> &str {
+fn get_str(strings: &[WithHash<String>], id: StringId) -> &str {
     if let Ok(c) = u8::try_from(id.0) {
         ASCII_STRS[c as usize]
     } else if let Some(intern_index) = id.index().checked_sub(INTERN_STRING_ID_OFFSET) {
-        &strings[intern_index]
+        strings[intern_index].value()
     } else {
         let static_str = StaticStrings::from_string_id(id).expect("Invalid static string ID");
         static_str.into()
@@ -823,11 +845,18 @@ fn get_str(strings: &[String], id: StringId) -> &str {
 /// Read-only storage for interned strings, bytes, and long integers.
 ///
 /// This provides lookup by `StringId`, `BytesId`, `LongIntId` and `FunctionId` for interned literals and functions.
+///
+/// # Hash tables
+///
+/// Each entry in `strings`/`bytes`/`long_ints` is a [`WithHash`] pairing
+/// the value with its precomputed [`HashValue`] — populated eagerly at
+/// intern time by [`InternerBuilder`]. `str_hash` / `bytes_hash` /
+/// `long_int_hash` are plain index lookups.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub(crate) struct Interns {
-    strings: Vec<String>,
-    bytes: Vec<Vec<u8>>,
-    long_ints: Vec<BigInt>,
+    strings: Vec<WithHash<String>>,
+    bytes: Vec<WithHash<Vec<u8>>>,
+    long_ints: Vec<WithHash<BigInt>>,
     functions: Vec<Function>,
 }
 
@@ -858,7 +887,7 @@ impl Interns {
     /// Panics if the `BytesId` is invalid.
     #[inline]
     pub fn get_bytes(&self, id: BytesId) -> &[u8] {
-        &self.bytes[id.index()]
+        self.bytes[id.index()].value()
     }
 
     /// Looks up a long integer by its `LongIntId`.
@@ -868,7 +897,7 @@ impl Interns {
     /// Panics if the `LongIntId` is invalid.
     #[inline]
     pub fn get_long_int(&self, id: LongIntId) -> &BigInt {
-        &self.long_ints[id.index()]
+        self.long_ints[id.index()].value()
     }
 
     /// Lookup a function by its `FunctionId`
@@ -879,6 +908,68 @@ impl Interns {
     #[inline]
     pub fn get_function(&self, id: FunctionId) -> &Function {
         self.functions.get(id.index()).expect("Function not found")
+    }
+
+    /// Returns the Python hash for an interned string.
+    ///
+    /// Dispatches by id range:
+    /// * ASCII (`id < 128`): looks up [`ASCII_HASHES`] (per-slot lazy);
+    ///   computes via [`hash_python_str`] on first use of that byte.
+    /// * Static (`id < INTERN_STRING_ID_OFFSET`): looks up [`STATIC_HASHES`]
+    ///   (per-slot lazy); computes from the variant's `&'static str` on
+    ///   first use of that variant.
+    /// * Interned (`id >= INTERN_STRING_ID_OFFSET`): reads the [`HashValue`]
+    ///   from the corresponding [`WithHash`] entry — populated eagerly at
+    ///   intern time.
+    ///
+    /// All three paths must agree with [`hash_python_str`] applied to the
+    /// underlying `&str` — interned and heap strings with equal contents
+    /// must hash identically.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `StringId` is invalid (same as [`Self::get_str`]).
+    #[inline]
+    pub fn str_hash(&self, id: StringId) -> HashValue {
+        if let Ok(c) = u8::try_from(id.0) {
+            ASCII_HASHES.get_or_compute(c as usize, || hash_python_str(ASCII_STRS[c as usize]))
+        } else if let Some(intern_index) = id.index().checked_sub(INTERN_STRING_ID_OFFSET) {
+            self.strings[intern_index].hash()
+        } else {
+            let static_str = StaticStrings::from_string_id(id).expect("Invalid static string ID");
+            STATIC_HASHES.get_or_compute(static_str as usize, || hash_python_str(static_str.into()))
+        }
+    }
+
+    /// Returns the Python hash for interned bytes.
+    ///
+    /// Reads the [`HashValue`] from the corresponding [`WithHash`] entry
+    /// (populated at intern time). Must agree with [`hash_python_bytes`]
+    /// applied to the underlying `&[u8]`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `BytesId` is invalid.
+    #[inline]
+    pub fn bytes_hash(&self, id: BytesId) -> HashValue {
+        self.bytes[id.index()].hash()
+    }
+
+    /// Returns the Python hash for an interned long integer.
+    ///
+    /// Reads the [`HashValue`] from the corresponding [`WithHash`] entry
+    /// (populated at intern time). Must agree with [`hash_python_long_int`].
+    /// Note that interned long ints are only created for values that don't
+    /// fit in `i64` (see `parse.rs`), so the `to_i64()` fast path inside
+    /// `hash_python_long_int` is a defensive consistency guarantee rather
+    /// than a hot path.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `LongIntId` is invalid.
+    #[inline]
+    pub fn long_int_hash(&self, id: LongIntId) -> HashValue {
+        self.long_ints[id.index()].hash()
     }
 
     /// Looks up the `StringId` for a string, checking ASCII, static strings, and interned strings.
@@ -899,7 +990,7 @@ impl Interns {
         }
         // Check interned strings
         for (i, interned) in self.strings.iter().enumerate() {
-            if interned == s {
+            if interned.value() == s {
                 return u32::try_from(INTERN_STRING_ID_OFFSET + i).ok().map(StringId);
             }
         }

--- a/crates/monty/src/lib.rs
+++ b/crates/monty/src/lib.rs
@@ -13,6 +13,7 @@ mod expressions;
 pub mod fs;
 mod fstring;
 mod function;
+mod hash;
 mod heap_data;
 mod intern;
 mod io;

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -65,14 +65,7 @@
 /// - `expandtabs(tabsize=8)` - Tab expansion
 /// - `translate(table[, delete])` - Character translation
 /// - `maketrans(frm, to)` - Create translation table (staticmethod)
-use std::{
-    cmp::Ordering,
-    collections::hash_map::DefaultHasher,
-    fmt,
-    fmt::Write,
-    hash::{Hash, Hasher},
-    mem, ops, str,
-};
+use std::{cmp::Ordering, fmt, fmt::Write, mem, ops, str};
 
 use ahash::AHashSet;
 use smallvec::smallvec;
@@ -83,6 +76,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult, SimpleException},
+    hash::{HashValue, hash_python_bytes},
     heap::{DropWithHeap, Heap, HeapData, HeapGuard, HeapId, HeapItem, HeapRead, heap_read_ref_as_field},
     intern::{StaticStrings, StringId},
     resource::{ResourceError, ResourceTracker, check_repeat_size, check_replace_size},
@@ -242,12 +236,8 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Bytes> {
         Ok(self.get(vm.heap).0 == other.get(vm.heap).0)
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
-        // Must match `Value::InternBytes` so the same content hashes equally
-        // regardless of whether the bytes live on the heap or in the intern table.
-        let mut hasher = DefaultHasher::new();
-        self.get(vm.heap).as_slice().hash(&mut hasher);
-        Ok(Some(hasher.finish()))
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
+        Ok(Some(hash_python_bytes(self.get(vm.heap).as_slice())))
     }
 
     fn py_cmp(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Ordering>, ResourceError> {

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -13,6 +13,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
+    hash::HashValue,
     heap::{
         BorrowedHeapRead, BorrowedHeapReadMut, HeapId, HeapItem, HeapRead, heap_read_ref_as_field,
         heap_read_ref_as_field_mut,
@@ -181,7 +182,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
     /// Hashes a frozen dataclass by its class name and the values of declared fields.
     ///
     /// Mutable (non-frozen) dataclasses return `None` (unhashable).
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
         // Only frozen (immutable) dataclasses are hashable
         if !self.get(vm.heap).frozen {
             return Ok(None);
@@ -205,7 +206,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
                 }
             }
         }
-        Ok(Some(hasher.finish()))
+        Ok(Some(HashValue::new(hasher.finish())))
     }
 
     fn py_bool(&self, _vm: &mut VM<'h, impl ResourceTracker>) -> bool {

--- a/crates/monty/src/types/date.rs
+++ b/crates/monty/src/types/date.rs
@@ -20,6 +20,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunError, RunResult, SimpleException},
+    hash::HashValue,
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead},
     intern::{Interns, StaticStrings},
     os::OsFunction,
@@ -260,10 +261,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Date> {
         Ok(*self.get(vm.heap) == *other.get(vm.heap))
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
-        Ok(Some(hasher.finish()))
+        Ok(Some(HashValue::new(hasher.finish())))
     }
 
     fn py_cmp(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Ordering>, ResourceError> {

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -20,6 +20,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult, SimpleException},
+    hash::HashValue,
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead},
     intern::{Interns, StaticStrings},
     os::OsFunction,
@@ -1004,10 +1005,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
         Ok(local_micros(a) == local_micros(b))
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
-        Ok(Some(hasher.finish()))
+        Ok(Some(HashValue::new(hasher.finish())))
     }
 
     fn py_cmp(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Ordering>, ResourceError> {

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -148,7 +148,10 @@ impl Dict {
             self.contains_refs = true;
         }
 
-        let hash = key.py_hash(vm)?.expect("json object keys are always hashable strings");
+        let hash = key
+            .py_hash(vm)?
+            .expect("json object keys are always hashable strings")
+            .raw();
         let opt_index = self.find_json_string_key_index(hash, &key, vm.heap, vm.interns);
 
         let entry = DictEntry { key, value, hash };
@@ -447,7 +450,8 @@ impl<'h> HeapRead<'h, Dict> {
     fn find_index_hash(&self, key: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<(Option<usize>, u64)> {
         let hash = key
             .py_hash(vm)?
-            .ok_or_else(|| ExcType::type_error_unhashable_dict_key(key.py_type(vm)))?;
+            .ok_or_else(|| ExcType::type_error_unhashable_dict_key(key.py_type(vm)))?
+            .raw();
 
         // Dict keys are typically shallow (strings, ints, tuples of primitives),
         // so recursion errors are unlikely. If one occurs, treat it as "not equal" -

--- a/crates/monty/src/types/long_int.rs
+++ b/crates/monty/src/types/long_int.rs
@@ -9,9 +9,7 @@
 //! having freestanding functions scattered across the codebase.
 
 use std::{
-    collections::hash_map::DefaultHasher,
     fmt::{self, Display},
-    hash::{Hash, Hasher},
     mem,
     ops::{Add, Mul, Neg, Sub},
     sync::OnceLock,
@@ -22,6 +20,7 @@ use num_traits::{Signed, ToPrimitive, Zero};
 
 use crate::{
     exception_private::{ExcType, RunResult},
+    hash::{HashValue, hash_python_long_int},
     heap::{Heap, HeapData},
     resource::{ResourceError, ResourceTracker},
     value::Value,
@@ -80,20 +79,10 @@ impl LongInt {
     ///
     /// Critical: For values that fit in i64, this must return the same hash as
     /// hashing the i64 directly. This ensures dict key consistency - e.g.,
-    /// `hash(5)` must equal `hash(LongInt(5))`.
-    pub fn hash(&self) -> u64 {
-        // If the LongInt fits in i64, hash as i64 for consistency
-        if let Some(i) = self.0.to_i64() {
-            i.cast_unsigned()
-        } else {
-            // For LongInts outside i64 range, use byte representation
-            let mut hasher = DefaultHasher::new();
-            // Use a unique discriminant for LongInt (we use the LongInt's sign and bytes)
-            let (sign, bytes) = self.0.to_bytes_le();
-            sign.hash(&mut hasher);
-            bytes.hash(&mut hasher);
-            hasher.finish()
-        }
+    /// `hash(5)` must equal `hash(LongInt(5))`. Delegates to the canonical
+    /// helper so that interned and heap `int` values hash identically.
+    pub fn hash(&self) -> HashValue {
+        hash_python_long_int(&self.0)
     }
 
     /// Estimates memory size in bytes.

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -29,6 +29,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{ExcType, RunResult},
+    hash::HashValue,
     heap::{HeapId, HeapItem, HeapRead},
     intern::{Interns, StringId},
     resource::{ResourceError, ResourceTracker},
@@ -237,7 +238,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
 
     /// Hashes by element only (not by class name), matching `Tuple::py_hash`
     /// so a `NamedTuple` and a `Tuple` with equal elements share the same hash.
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
         let token = vm.heap.incr_recursion_depth()?;
         defer_drop!(token, vm);
         let len = self.get(vm.heap).len();
@@ -250,7 +251,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
                 None => return Ok(None),
             }
         }
-        Ok(Some(hasher.finish()))
+        Ok(Some(HashValue::new(hasher.finish())))
     }
 
     fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -19,6 +19,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
+    hash::HashValue,
     heap::{DropWithHeap, Heap, HeapData, HeapId, HeapItem, HeapRead},
     intern::{Interns, StaticStrings},
     os::OsFunction,
@@ -492,10 +493,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Path> {
         Ok(self.get(vm.heap).path == other.get(vm.heap).path)
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).as_str().hash(&mut hasher);
-        Ok(Some(hasher.finish()))
+        Ok(Some(HashValue::new(hasher.finish())))
     }
 
     fn py_bool(&self, _vm: &mut VM<'h, impl ResourceTracker>) -> bool {

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -20,6 +20,7 @@ use crate::{
     args::ArgValues,
     bytecode::{CallResult, VM},
     exception_private::{ExcType, RunResult, SimpleException},
+    hash::HashValue,
     heap::{DropWithHeap, HeapId},
     intern::StringId,
     os::OsFunction,
@@ -110,7 +111,7 @@ pub trait PyTrait<'h> {
     /// `Cell` that hash by identity. Most implementations ignore it.
     ///
     /// The default implementation returns `Ok(None)` (unhashable).
-    fn py_hash(&self, _self_id: HeapId, _vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, _vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
         Ok(None)
     }
 

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -18,6 +18,7 @@ use crate::{
     bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult},
+    hash::HashValue,
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead},
     resource::{ResourceError, ResourceTracker},
     types::{PyTrait, Type},
@@ -238,10 +239,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Range> {
         Ok(a.start == b.start && a.step == b.step)
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
-        Ok(Some(hasher.finish()))
+        Ok(Some(HashValue::new(hasher.finish())))
     }
 
     fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -11,6 +11,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult},
+    hash::HashValue,
     heap::{ContainsHeap, DropWithHeap, HeapData, HeapGuard, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     resource::{ResourceError, ResourceTracker},
@@ -102,18 +103,9 @@ impl SetStorage {
     /// The caller transfers ownership of `value`. If the value is already in
     /// the set, it will be dropped.
     fn add(&mut self, value: Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<bool> {
-        let hash = match value.py_hash(vm) {
-            Ok(Some(h)) => h,
-            Ok(None) => {
-                let err = ExcType::type_error_unhashable_set_element(value.py_type(vm));
-                value.drop_with_heap(vm);
-                return Err(err);
-            }
-            Err(e) => {
-                value.drop_with_heap(vm);
-                return Err(e.into());
-            }
-        };
+        let mut value_guard = HeapGuard::new(value, vm);
+        let (value, vm) = value_guard.as_parts_mut();
+        let hash = set_element_hash(value, vm)?;
 
         // Check if value already exists.
         let existing = self
@@ -121,14 +113,13 @@ impl SetStorage {
             .find(hash, |&idx| value.py_eq(&self.entries[idx].value, vm).unwrap_or(false));
 
         if existing.is_some() {
-            // Value already in set, drop the new value
-            value.drop_with_heap(vm);
             Ok(false)
         } else {
             // Track memory growth before adding the new entry.
             // Growth unit matches SetStorage::estimate_size which uses size_of::<SetEntry>().
             vm.heap.track_growth(mem::size_of::<SetEntry>())?;
             let index = self.entries.len();
+            let value = value_guard.into_inner();
             self.entries.push(SetEntry { value, hash });
             self.indices.insert_unique(hash, index, |&idx| self.entries[idx].hash);
             Ok(true)
@@ -142,9 +133,7 @@ impl<'h> HeapRead<'h, SetStorage> {
     /// Returns `Ok(true)` if the element was removed, `Ok(false)` if not found.
     /// Returns `Err` if the key is unhashable.
     fn remove(&mut self, value: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        let hash = value
-            .py_hash(vm)?
-            .ok_or_else(|| ExcType::type_error_unhashable_set_element(value.py_type(vm)))?;
+        let hash = set_element_hash(value, vm)?;
 
         // Collect candidates by hash
         let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
@@ -241,9 +230,7 @@ impl SetStorage {
 impl<'h> HeapRead<'h, SetStorage> {
     /// Checks if the set contains a value.
     pub fn contains(&self, value: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        let hash = value
-            .py_hash(vm)?
-            .ok_or_else(|| ExcType::type_error_unhashable_set_element(value.py_type(vm)))?;
+        let hash = set_element_hash(value, vm)?;
 
         // Collect candidates by hash
         let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
@@ -654,18 +641,9 @@ impl<'h> HeapRead<'h, Set> {
     /// Uses a two-phase lookup (collect candidates, then compare) to avoid
     /// holding a borrow on the set storage during `py_eq` calls.
     pub fn add(&mut self, value: Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        let hash = match value.py_hash(vm) {
-            Ok(Some(h)) => h,
-            Ok(None) => {
-                let err = ExcType::type_error_unhashable_set_element(value.py_type(vm));
-                value.drop_with_heap(vm);
-                return Err(err);
-            }
-            Err(e) => {
-                value.drop_with_heap(vm);
-                return Err(e.into());
-            }
-        };
+        let mut value_guard = HeapGuard::new(value, vm);
+        let (value, vm) = value_guard.as_parts();
+        let hash = set_element_hash(value, vm)?;
 
         // Collect candidate indices to avoid borrow conflict between set storage and py_eq
         let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
@@ -681,8 +659,6 @@ impl<'h> HeapRead<'h, Set> {
             let candidate_value = self.get(vm.heap).0.entries[candidate_index].value.clone_with_heap(vm);
             defer_drop!(candidate_value, vm);
             if value.py_eq(candidate_value, vm)? {
-                // Value already in set, drop the new value
-                value.drop_with_heap(vm);
                 return Ok(false);
             }
         }
@@ -692,6 +668,7 @@ impl<'h> HeapRead<'h, Set> {
         vm.heap.track_growth(mem::size_of::<SetEntry>())?;
 
         // Add new entry
+        let (value, vm) = value_guard.into_parts();
         let storage = &mut self.get_mut(vm.heap).0;
         let index = storage.entries.len();
         storage.entries.push(SetEntry { value, hash });
@@ -833,7 +810,8 @@ impl<'h> HeapRead<'h, FrozenSet> {
     pub(crate) fn contains(&self, value: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
         let hash = value
             .py_hash(vm)?
-            .ok_or_else(|| ExcType::type_error_unhashable_set_element(value.py_type(vm)))?;
+            .ok_or_else(|| ExcType::type_error_unhashable_set_element(value.py_type(vm)))?
+            .raw();
 
         // Collect candidate indices (hash match only) via shared borrow
         let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
@@ -1211,7 +1189,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
     ///
     /// XOR is commutative, so the hash is independent of insertion order — two
     /// frozensets with the same members hash equally regardless of how they were built.
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
         let token = vm.heap.incr_recursion_depth()?;
         defer_drop!(token, vm);
         let mut hash: u64 = 0;
@@ -1219,13 +1197,9 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
         for idx in 0..len {
             let item = self.get(vm.heap).0.entries[idx].value.clone_with_heap(vm);
             defer_drop!(item, vm);
-            // All elements must be hashable (enforced at construction)
-            match item.py_hash(vm)? {
-                Some(h) => hash ^= h,
-                None => return Ok(None),
-            }
+            hash ^= set_element_hash(item, vm)?;
         }
-        Ok(Some(hash))
+        Ok(Some(HashValue::new(hash)))
     }
 
     fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {
@@ -1376,5 +1350,12 @@ impl serde::Serialize for FrozenSet {
 impl<'de> serde::Deserialize<'de> for FrozenSet {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Ok(Self(SetStorage::deserialize(deserializer)?))
+    }
+}
+
+fn set_element_hash(value: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<u64> {
+    match value.py_hash(vm)? {
+        Some(h) => Ok(h.raw()),
+        None => Err(ExcType::type_error_unhashable_set_element(value.py_type(vm))),
     }
 }

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -18,6 +18,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{ExcType, RunResult},
+    hash::HashValue,
     heap::{HeapData, HeapId, HeapItem, HeapRead},
     intern::StaticStrings,
     resource::{ResourceError, ResourceTracker},
@@ -175,10 +176,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Slice> {
         Ok(a.start == b.start && a.stop == b.stop && a.step == b.step)
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
-        Ok(Some(hasher.finish()))
+        Ok(Some(HashValue::new(hasher.finish())))
     }
 
     fn py_bool(&self, _vm: &mut VM<'h, impl ResourceTracker>) -> bool {

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -2,15 +2,7 @@
 ///
 /// This type provides Python string semantics. Currently supports basic
 /// operations like length and equality comparison.
-use std::{
-    borrow::Cow,
-    cmp::Ordering,
-    collections::hash_map::DefaultHasher,
-    fmt,
-    fmt::Write,
-    hash::{Hash, Hasher},
-    mem, ops,
-};
+use std::{borrow::Cow, cmp::Ordering, fmt, fmt::Write, mem, ops};
 
 use ahash::AHashSet;
 use smallvec::smallvec;
@@ -21,6 +13,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult},
+    hash::{HashValue, hash_python_str},
     heap::{DropWithHeap, Heap, HeapData, HeapGuard, HeapId, HeapItem, HeapRead, heap_read_ref_as_field},
     intern::{StaticStrings, StringId},
     resource::{ResourceError, ResourceTracker, check_repeat_size, check_replace_size},
@@ -198,12 +191,8 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
         Ok(self.get(vm.heap).0 == other.get(vm.heap).0)
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
-        // Must match `Value::InternString` so the same characters hash equally
-        // regardless of whether the string lives on the heap or in the intern table.
-        let mut hasher = DefaultHasher::new();
-        self.get(vm.heap).as_str().hash(&mut hasher);
-        Ok(Some(hasher.finish()))
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
+        Ok(Some(hash_python_str(self.get(vm.heap).as_str())))
     }
 
     fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {

--- a/crates/monty/src/types/timedelta.rs
+++ b/crates/monty/src/types/timedelta.rs
@@ -21,6 +21,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult, SimpleException},
+    hash::HashValue,
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead},
     intern::{Interns, StaticStrings},
     resource::{ResourceError, ResourceTracker},
@@ -341,10 +342,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeDelta> {
         Ok(total_microseconds(self.get(vm.heap)) == total_microseconds(other.get(vm.heap)))
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
-        Ok(Some(hasher.finish()))
+        Ok(Some(HashValue::new(hasher.finish())))
     }
 
     fn py_cmp(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Ordering>, ResourceError> {

--- a/crates/monty/src/types/timezone.rs
+++ b/crates/monty/src/types/timezone.rs
@@ -17,6 +17,7 @@ use crate::{
     bytecode::VM,
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult, SimpleException},
+    hash::HashValue,
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead},
     intern::{Interns, StaticStrings},
     resource::{ResourceError, ResourceTracker},
@@ -261,10 +262,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeZone> {
         Ok(self.get(vm.heap).offset_seconds == other.get(vm.heap).offset_seconds)
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
-        Ok(Some(hasher.finish()))
+        Ok(Some(HashValue::new(hasher.finish())))
     }
 
     fn py_bool(&self, _vm: &mut VM<'h, impl ResourceTracker>) -> bool {

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -31,6 +31,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{ExcType, RunResult},
+    hash::HashValue,
     heap::{DropWithHeap, Heap, HeapData, HeapId, HeapItem, HeapRead},
     intern::StaticStrings,
     resource::{ResourceError, ResourceTracker},
@@ -237,7 +238,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
     /// Identical to `NamedTuple::py_hash`, so a `Tuple` and a `NamedTuple` with
     /// the same elements hash equally — required because they compare equal
     /// (matching CPython, where `NamedTuple` is a `tuple` subclass).
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
         let token = vm.heap.incr_recursion_depth()?;
         defer_drop!(token, vm);
         let len = self.get(vm.heap).items.len();
@@ -250,7 +251,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
                 None => return Ok(None),
             }
         }
-        Ok(Some(hasher.finish()))
+        Ok(Some(HashValue::new(hasher.finish())))
     }
 
     /// Lexicographic comparison for tuples.

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -19,6 +19,7 @@ use crate::{
     builtins::Builtins,
     bytecode::{CallResult, VM},
     exception_private::{ExcType, RunError, RunResult, SimpleException},
+    hash::HashValue,
     heap::{ContainsHeap, DropWithHeap, Heap, HeapData, HeapGuard, HeapId, HeapReadOutput},
     intern::{BytesId, FunctionId, Interns, LongIntId, StaticStrings, StringId},
     modules::ModuleFunctions,
@@ -1509,44 +1510,26 @@ impl Value {
     ///
     /// For heap-allocated values (Ref variant), this computes the hash lazily
     /// on first use and caches it for subsequent calls.
-    pub fn py_hash(&self, vm: &mut VM<'_, impl ResourceTracker>) -> Result<Option<u64>, ResourceError> {
+    pub fn py_hash(&self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         match self {
-            // Hash just the actual string or bytes content for consistency with heap Str/Bytes
-            // hence we don't include the discriminant
-            Self::InternString(string_id) => {
-                let mut hasher = DefaultHasher::new();
-                vm.interns.get_str(*string_id).hash(&mut hasher);
-                return Ok(Some(hasher.finish()));
-            }
-            Self::InternBytes(bytes_id) => {
-                let mut hasher = DefaultHasher::new();
-                vm.interns.get_bytes(*bytes_id).hash(&mut hasher);
-                return Ok(Some(hasher.finish()));
-            }
+            Self::InternString(string_id) => return Ok(Some(vm.interns.str_hash(*string_id))),
+            Self::InternBytes(bytes_id) => return Ok(Some(vm.interns.bytes_hash(*bytes_id))),
+            Self::InternLongInt(long_int_id) => return Ok(Some(vm.interns.long_int_hash(*long_int_id))),
             // Bool and int hash directly as their value, and are equivalent
-            Self::Bool(b) => return Ok(Some((*b).into())),
-            Self::Int(i) => return Ok(Some(i.cast_unsigned())),
+            Self::Bool(b) => return Ok(Some(HashValue::new((*b).into()))),
+            Self::Int(i) => return Ok(Some(HashValue::new(i.cast_unsigned()))),
             Self::Float(f) => {
                 return {
                     if f.fract() == 0.0 && *f >= (i64::MIN as f64) && *f <= (i64::MAX as f64) {
                         // Hash floats that are mathematically integers the same as Ints (e.g., 1.0 hashes the same as 1)
                         #[expect(clippy::cast_possible_truncation)]
-                        Ok(Some((*f as i64).cast_unsigned()))
+                        Ok(Some(HashValue::new((*f as i64).cast_unsigned())))
                     } else {
                         // Hash the bit representation of the float
-                        Ok(Some(f.to_bits()))
+                        Ok(Some(HashValue::new(f.to_bits())))
                     }
                 };
-            }
-            // Hash BigInt consistently with LongInt (using sign and bytes for large values)
-            Self::InternLongInt(long_int_id) => {
-                let bi = vm.interns.get_long_int(*long_int_id);
-                let mut hasher = DefaultHasher::new();
-                let (sign, bytes) = bi.to_bytes_le();
-                sign.hash(&mut hasher);
-                bytes.hash(&mut hasher);
-                return Ok(Some(hasher.finish()));
             }
             // For heap-allocated values (includes Range and Exception), compute hash lazily and cache it
             Self::Ref(id) => return Heap::get_or_compute_hash(vm, *id),
@@ -1567,7 +1550,7 @@ impl Value {
             Self::Dereferenced => panic!("Cannot access Dereferenced object"),
         }
 
-        Ok(Some(hasher.finish()))
+        Ok(Some(HashValue::new(hasher.finish())))
     }
 
     /// TODO this doesn't have many tests!!! also doesn't cover bytes


### PR DESCRIPTION
I noticed that we had a couple of deficiencies with hashing, fixed in this PR:
- CPython forbids `-1` as a hash value; we now do the same for consistency (abstracted by the `HashValue` type).
- We don't cache the hash of interned strings, which is potentially expensive, so I introduce caching for them here.