### PR TITLE
reject reusing an already-awaited external future via `gather`

### DIFF
--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -108,6 +108,27 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             return Ok(AwaitResult::ValueReady(Value::Ref(list_id)));
         }
 
+        // Reject any external future that has already been awaited (directly or
+        // via another gather). Without this check, sibling gathers sharing a
+        // future would silently overwrite each other in `gather_waiters`,
+        // leaving the first gather permanently blocked on a CallId that has
+        // already been resolved or is registered against a different gather.
+        // This mirrors the existing `is_consumed` check in `await_external_future`
+        // so that direct double-await and gather-mediated double-await behave
+        // consistently. The dedup pass below ensures intra-gather duplicates
+        // (`gather(f, f)`) are not flagged: each unique CallId is only marked
+        // consumed once, so the first await of a freshly-created future passes
+        // even when it appears in multiple slots.
+        for item in &gather.get(self.heap).items {
+            if let GatherItem::ExternalFuture(call_id) = item
+                && self.scheduler.is_consumed(*call_id)
+            {
+                return Err(
+                    SimpleException::new_msg(ExcType::RuntimeError, "cannot reuse already awaited future").into(),
+                );
+            }
+        }
+
         // Set waiter and walk the items, deduplicating by identity so that the
         // same coroutine or external future passed multiple times runs once and
         // its result is fanned out to every gather slot. This matches CPython's

--- a/crates/monty/test_cases/async__ext_call.py
+++ b/crates/monty/test_cases/async__ext_call.py
@@ -82,3 +82,26 @@ assert results == [7, 7], f'duplicate external future dedup: {results}'
 g = async_call('dup')
 results = await asyncio.gather(async_call('a'), g, async_call('b'), g)  # pyright: ignore
 assert results == ['a', 'dup', 'b', 'dup'], f'mixed external future dedup: {results}'
+
+
+# === Same external future shared across sibling gathers raises ===
+# Two concurrent helpers each await their own gather around the SAME external
+# future. Without rejection, the second gather's `register_gather_for_call`
+# would silently overwrite the first in the scheduler's waiters map, leaving
+# the first gather permanently blocked. We treat the second use as a reuse of
+# an already-awaited future, mirroring direct `await f; await f` behaviour.
+# CPython models the test fixture's `async_call` as `async def`, so it raises
+# `cannot reuse already awaited coroutine` at the same point.
+async def helper(future):
+    return await asyncio.gather(future)
+
+
+shared = async_call(99)
+try:
+    await asyncio.gather(helper(shared), helper(shared))  # pyright: ignore
+    assert False, 'should have raised RuntimeError'
+except RuntimeError as e:
+    assert str(e) in (
+        'cannot reuse already awaited future',  # Monty: ExternalFuture path
+        'cannot reuse already awaited coroutine',  # CPython: coroutine path
+    ), f'unexpected error: {e}'


### PR DESCRIPTION
While working on #410 I noticed a related case at the cross-gather boundary that #410's intra-gather dedup didn't cover.

Repro:

```py
async def helper(future):
    return await asyncio.gather(future)

shared = async_call(99)
await asyncio.gather(helper(shared), helper(shared))
```

The first `helper`'s gather registers as a waiter on `shared`; the second silently overwrites that registration in the scheduler's `gather_waiters` map. When `shared` resolves, only the second helper sees it and the first hangs forever.

This PR rejects the second use up front with the existing `RuntimeError: cannot reuse already awaited future`, matching how direct `await f; await f` already behaves. CPython raises the analogous `cannot reuse already awaited coroutine` at the same point.