### PR TITLE
inline hash caching directly into relevant types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,20 +336,6 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
-dependencies = [
- "bytemuck_derive",
-]
-
-[[package]]
-name = "bytemuck_derive"
-version = "1.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "byteorder"
@@ -1788,7 +1774,6 @@ name = "monty"
 version = "0.0.17"
 dependencies = [
  "ahash",
- "bytemuck",
  "chrono",
  "fancy-regex 0.17.0",
  "hashbrown 0.16.1",

--- a/crates/monty/Cargo.toml
+++ b/crates/monty/Cargo.toml
@@ -37,7 +37,6 @@ libm = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
 speedate = "0.17.0"
 itertools = "0.14.0"
-bytemuck = { version = "1.25.0", features = ["derive"] }
 jiter = { version = "0.13.0", features = ["num-bigint"] }
 
 [features]

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -8,7 +8,6 @@ use std::{
     vec,
 };
 
-use bytemuck::TransparentWrapper;
 use serde::ser::SerializeStruct;
 
 // Re-export items moved to `heap_traits` so that `crate::heap::HeapGuard` etc. continue
@@ -17,15 +16,13 @@ pub(crate) use crate::heap_data::HeapData;
 pub(crate) use crate::heap_traits::{ContainsHeap, DropWithHeap, HeapGuard, HeapItem};
 use crate::{
     asyncio::{Coroutine, GatherFuture, GatherItem},
-    bytecode::VM,
-    exception_private::{RunResult, SimpleException},
-    hash::HashValue,
+    exception_private::SimpleException,
     heap_data::{CellValue, Closure, FunctionDefaults},
     resource::{ResourceError, ResourceTracker},
     types::{
         Bytes, Dataclass, Dict, DictItemsView, DictKeysView, DictValuesView, FrozenSet, List, LongInt, Module,
-        MontyIter, NamedTuple, Path, PyTrait, Range, ReMatch, RePattern, Set, Slice, Str, TimeZone, Tuple, date,
-        datetime, timedelta, timezone,
+        MontyIter, NamedTuple, Path, Range, ReMatch, RePattern, Set, Slice, Str, TimeZone, Tuple, date, datetime,
+        timedelta, timezone,
     },
     value::Value,
 };
@@ -54,59 +51,6 @@ impl HeapId {
 
 /// The empty tuple is a singleton which is allocated at startup.
 const EMPTY_TUPLE_ID: HeapId = HeapId(0);
-
-/// Hash caching state stored alongside each heap entry.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-enum HashState {
-    /// Hash has not yet been computed but the value might be hashable.
-    Unknown,
-    /// Cached hash value for immutable types that have been hashed at least once.
-    Cached(HashValue),
-    /// Value is unhashable (mutable types or tuples containing unhashables).
-    Unhashable,
-}
-
-impl HashState {
-    fn for_data(data: &HeapData) -> Self {
-        match data {
-            // Cells are hashable by identity (like all Python objects without __hash__ override)
-            // FrozenSet is immutable and hashable
-            // Range is immutable and hashable
-            // Slice is immutable and hashable (like in CPython)
-            // LongInt is immutable and hashable
-            // NamedTuple is immutable and hashable (like Tuple)
-            HeapData::Str(_)
-            | HeapData::Bytes(_)
-            | HeapData::Tuple(_)
-            | HeapData::NamedTuple(_)
-            | HeapData::FrozenSet(_)
-            | HeapData::Cell(_)
-            | HeapData::Closure(_)
-            | HeapData::FunctionDefaults(_)
-            | HeapData::Range(_)
-            | HeapData::Slice(_)
-            | HeapData::LongInt(_)
-            | HeapData::Date(_)
-            | HeapData::DateTime(_)
-            | HeapData::TimeDelta(_)
-            | HeapData::TimeZone(_) => Self::Unknown,
-            // Dataclass hashability depends on the mutable flag
-            HeapData::Dataclass(dc) => {
-                if dc.is_frozen() {
-                    Self::Unknown
-                } else {
-                    Self::Unhashable
-                }
-            }
-            // Path is immutable and hashable
-            HeapData::Path(_) => Self::Unknown,
-            // ExtFunction is hashable (by identity, like closures)
-            HeapData::ExtFunction(_) => Self::Unknown,
-            // other types are unhashable
-            _ => Self::Unhashable,
-        }
-    }
-}
 
 /// This structure allows for reading into the heap more efficiently than repeated calls to `Heap::get` and
 /// `Heap::get_mut` by performing the indexing and type lookup once, and then using the borrow checker to
@@ -382,28 +326,6 @@ impl<'a, T: ?Sized> HeapRead<'a, T> {
         unsafe { self.value.as_mut() }
     }
 
-    /// Cast this reader around some type T which is a transparent wrapper around U
-    /// to its inner type. Name peel comes from `TransparentWrapper::peel` method.
-    pub fn peel_ref<U>(&self) -> &HeapRead<'a, U>
-    where
-        T: TransparentWrapper<U>,
-    {
-        // SAFETY: (DH) all `HeapRead` have the same layout, T and U pointers are
-        // equivalent due to the `#[repr(transparent)] struct T(U)`
-        unsafe { NonNull::from(self).cast().as_ref() }
-    }
-
-    /// Cast this reader around some type T which is a transparent wrapper around U
-    /// to its inner type. Name peel comes from `TransparentWrapper::peel` method.
-    pub fn peel_mut<U>(&mut self) -> &mut HeapRead<'a, U>
-    where
-        T: TransparentWrapper<U>,
-    {
-        // SAFETY: (DH) all `HeapRead` have the same layout, T and U pointers are
-        // equivalent due to the `#[repr(transparent)] struct T(U)`
-        unsafe { NonNull::from(self).cast().as_mut() }
-    }
-
     /// Casts this reader to a field of type `U` at some `offset` within the struct.
     ///
     /// Transfers ownership of the reader count from `self` to the returned `HeapRead`.
@@ -562,17 +484,14 @@ macro_rules! heap_read_ref_as_field_mut {
 
 pub(crate) use heap_read_ref_as_field_mut;
 
-/// A single entry inside the heap arena, storing refcount, payload, and hash metadata.
+/// A single entry inside the heap arena, storing refcount and payload.
 ///
-/// The `hash_state` field tracks whether the heap entry is hashable and, if so,
-/// caches the computed hash. Mutable types (List, Dict) start as `Unhashable` and
-/// will raise TypeError if used as dict keys.
-///
-/// The `data` field is an Option to support temporary borrowing: when methods like
-/// `with_entry_mut` or `call_attr` need mutable access to both the data and the heap,
-/// they can `.take()` the data out (leaving `None`), pass `&mut Heap` to user code,
-/// then restore the data. This avoids unsafe code while keeping `refcount` accessible
-/// for `inc_ref`/`dec_ref` during the borrow.
+/// Hashing state lives on the per-type structs that benefit from it
+/// ([`Str`], [`Bytes`], [`Tuple`], [`NamedTuple`], [`FrozenSet`] (via
+/// `SetStorage`), [`Path`]). Cheap-to-hash types ([`Range`], [`Slice`],
+/// dates etc.) recompute on demand. Unhashable types ([`List`], [`Dict`],
+/// [`Set`]) return `None` from `py_hash` directly. None of these need
+/// per-entry metadata.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct HeapEntry {
     refcount: Cell<usize>,
@@ -586,8 +505,6 @@ pub struct HeapEntry {
     readers: Cell<usize>,
     /// The payload data
     data: UnsafeHeapData,
-    /// Current hashing status / cached hash value
-    hash_state: Cell<HashState>,
 }
 
 /// This wrapper containing `UnsafeCell` exists to allow for data inside of `HeapValue`
@@ -755,12 +672,10 @@ impl<T: ResourceTracker> Heap<T> {
         };
 
         let empty_tuple = HeapData::Tuple(Tuple::default());
-        let hash_state = HashState::for_data(&empty_tuple);
         let new_entry = HeapEntry {
             refcount: Cell::new(1),
             readers: Cell::new(0),
             data: UnsafeHeapData(UnsafeCell::new(empty_tuple)),
-            hash_state: Cell::new(hash_state),
         };
 
         let empty_tuple = this.entries.allocate(new_entry);
@@ -895,12 +810,10 @@ impl<T: ResourceTracker> Heap<T> {
             }
         }
 
-        let hash_state = HashState::for_data(&data);
         let new_entry = HeapEntry {
             refcount: Cell::new(1),
             readers: Cell::new(0),
             data: UnsafeHeapData(UnsafeCell::new(data)),
-            hash_state: Cell::new(hash_state),
         };
 
         let id = self.entries.allocate(new_entry);
@@ -1001,40 +914,6 @@ impl<T: ResourceTracker> Heap<T> {
         let data = &self.entries.get(id).data;
         // SAFETY: (DH) no mutable references into `HeapData` is possible while the heap is borrowed
         unsafe { &*data.0.get() }
-    }
-
-    /// Returns or computes the hash for the heap entry at the given ID.
-    ///
-    /// Hashes are computed lazily on first use and then cached. Returns
-    /// `Ok(Some(hash))` for immutable types, `Ok(None)` for mutable types,
-    /// or `Err(ResourceError::Recursion)` if the recursion limit is exceeded.
-    ///
-    /// # Panics
-    /// Panics if the value ID is invalid or the value has already been freed.
-    pub fn get_or_compute_hash(vm: &mut VM<'_, T>, id: HeapId) -> RunResult<Option<HashValue>> {
-        // TODO: it should be possible to refactor the triple lookup to just one, probably by having an
-        // internal `vm.heap.read_entry` method which can then derive the `HeapReadOutput` for `py_hash`
-        // later, and can live without a VM borrow to allow reading / writing the hash.
-        //
-        // That only matters before the hash is cached, so not the worst thing for performance.
-
-        let entry = vm.heap.entries.get(id);
-
-        match entry.hash_state.get() {
-            HashState::Unhashable => return Ok(None),
-            HashState::Cached(hash) => return Ok(Some(hash)),
-            HashState::Unknown => {}
-        }
-
-        let hash = vm.heap.read(id).py_hash(id, vm)?;
-
-        // Cache the result
-        let entry = vm.heap.entries.get(id);
-        entry.hash_state.set(match hash {
-            Some(value) => HashState::Cached(value),
-            None => HashState::Unhashable,
-        });
-        Ok(hash)
     }
 
     /// Returns the reference count for the heap entry at the given ID.

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -65,7 +65,7 @@
 /// - `expandtabs(tabsize=8)` - Tab expansion
 /// - `translate(table[, delete])` - Character translation
 /// - `maketrans(frm, to)` - Create translation table (staticmethod)
-use std::{cmp::Ordering, fmt, fmt::Write, mem, ops, str};
+use std::{cell::Cell, cmp::Ordering, fmt, fmt::Write, mem, ops, str};
 
 use ahash::AHashSet;
 use smallvec::smallvec;
@@ -121,14 +121,25 @@ pub fn get_byte_at_index(bytes: &[u8], index: i64) -> Option<u8> {
 ///
 /// Wraps a `Vec<u8>` and provides Python-compatible operations.
 /// See the module-level documentation for implemented and unimplemented methods.
-#[derive(Debug, Clone, PartialEq, Default, serde::Serialize, serde::Deserialize)]
-pub(crate) struct Bytes(Vec<u8>);
+///
+/// Carries an inline `cached_hash` field (skipped on serde) so a `Bytes` only
+/// computes its Python hash once. See [`super::Str`] for the same pattern.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub(crate) struct Bytes(Vec<u8>, #[serde(skip)] Cell<Option<HashValue>>);
+
+impl PartialEq for Bytes {
+    /// Compares only the byte content — `cached_hash` is a pure optimisation.
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
 
 impl Bytes {
     /// Creates a new Bytes from a byte vector.
     #[must_use]
     pub fn new(bytes: Vec<u8>) -> Self {
-        Self(bytes)
+        Self(bytes, Cell::new(None))
     }
 
     /// Returns a reference to the inner byte slice.
@@ -179,13 +190,13 @@ impl Bytes {
 
 impl From<Vec<u8>> for Bytes {
     fn from(bytes: Vec<u8>) -> Self {
-        Self(bytes)
+        Self::new(bytes)
     }
 }
 
 impl From<&[u8]> for Bytes {
     fn from(bytes: &[u8]) -> Self {
-        Self(bytes.to_vec())
+        Self::new(bytes.to_vec())
     }
 }
 
@@ -237,7 +248,16 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Bytes> {
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
-        Ok(Some(hash_python_bytes(self.get(vm.heap).as_slice())))
+        let b = self.get(vm.heap);
+        if let Some(cached) = b.1.get() {
+            return Ok(Some(cached));
+        }
+        // Delegates to the canonical helper used by both heap and intern paths;
+        // an interned `b"foo"` and a heap `b"foo"` must hash identically for
+        // dict lookup to work.
+        let hash = hash_python_bytes(b.as_slice());
+        b.1.set(Some(hash));
+        Ok(Some(hash))
     }
 
     fn py_cmp(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Ordering>, ResourceError> {

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -16,6 +16,7 @@
 /// This type is used for `sys.version_info` and similar structured tuples where
 /// named access improves usability and readability.
 use std::{
+    cell::Cell,
     collections::hash_map::DefaultHasher,
     fmt::Write,
     hash::{Hash, Hasher},
@@ -63,6 +64,9 @@ pub(crate) struct NamedTuple {
     items: Vec<Value>,
     /// True if any item is a `Value::Ref`. Set at creation time since named tuples are immutable.
     contains_refs: bool,
+    /// Lazily-computed Python hash. Same rationale as [`super::Tuple::cached_hash`].
+    #[serde(skip)]
+    cached_hash: Cell<Option<HashValue>>,
 }
 
 impl NamedTuple {
@@ -90,6 +94,7 @@ impl NamedTuple {
             field_names,
             items,
             contains_refs,
+            cached_hash: Cell::new(None),
         }
     }
 
@@ -238,7 +243,12 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
 
     /// Hashes by element only (not by class name), matching `Tuple::py_hash`
     /// so a `NamedTuple` and a `Tuple` with equal elements share the same hash.
+    /// Caches the computed hash on first call (see `Tuple::py_hash` for the
+    /// caching rationale).
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
+        if let Some(cached) = self.get(vm.heap).cached_hash.get() {
+            return Ok(Some(cached));
+        }
         let token = vm.heap.incr_recursion_depth()?;
         defer_drop!(token, vm);
         let len = self.get(vm.heap).len();
@@ -251,7 +261,9 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
                 None => return Ok(None),
             }
         }
-        Ok(Some(HashValue::new(hasher.finish())))
+        let hash = HashValue::new(hasher.finish());
+        self.get(vm.heap).cached_hash.set(Some(hash));
+        Ok(Some(hash))
     }
 
     fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -5,6 +5,7 @@
 //! while filesystem methods yield external function calls for the host to resolve.
 
 use std::{
+    cell::Cell,
     collections::hash_map::DefaultHasher,
     fmt::Write,
     hash::{Hash, Hasher},
@@ -35,10 +36,22 @@ use crate::{
 ///
 /// The path is immutable - all operations that would modify the path return
 /// new `Path` objects or strings.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub(crate) struct Path {
     /// The normalized path string.
     path: String,
+    /// Lazily-computed Python hash. Paths are immutable (all "modifying"
+    /// operations return new `Path` objects). Skipped on serde — see
+    /// [`super::Str::cached_hash`] for the rationale.
+    #[serde(skip)]
+    cached_hash: Cell<Option<HashValue>>,
+}
+
+impl PartialEq for Path {
+    /// Compares only the path string — `cached_hash` is a pure optimisation.
+    fn eq(&self, other: &Self) -> bool {
+        self.path == other.path
+    }
 }
 
 impl Path {
@@ -51,6 +64,7 @@ impl Path {
     pub fn new(path: String) -> Self {
         Self {
             path: normalize_path(path),
+            cached_hash: Cell::new(None),
         }
     }
 
@@ -494,9 +508,15 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Path> {
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
+        let p = self.get(vm.heap);
+        if let Some(cached) = p.cached_hash.get() {
+            return Ok(Some(cached));
+        }
         let mut hasher = DefaultHasher::new();
-        self.get(vm.heap).as_str().hash(&mut hasher);
-        Ok(Some(HashValue::new(hasher.finish())))
+        p.as_str().hash(&mut hasher);
+        let hash = HashValue::new(hasher.finish());
+        p.cached_hash.set(Some(hash));
+        Ok(Some(hash))
     }
 
     fn py_bool(&self, _vm: &mut VM<'h, impl ResourceTracker>) -> bool {

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -100,12 +100,11 @@ pub trait PyTrait<'h> {
     ///
     /// Returns `Ok(Some(hash))` for hashable types, `Ok(None)` for unhashable
     /// types (such as `list` and `dict`), or `Err(ResourceError::Recursion)` if
-    /// the recursion limit is exceeded while hashing nested containers.
+    /// the recursion limit is exceeded while hashing nested containers.`
     ///
     /// Container implementations should track recursion depth via
     /// `heap.incr_recursion_depth()` and recurse through `Value::py_hash` for
-    /// nested values, which dispatches via `Heap::get_or_compute_hash` so that
-    /// the per-entry hash cache is shared.
+    /// nested values.
     ///
     /// `self_id` is the heap ID of this value; it is required for types like
     /// `Cell` that hash by identity. Most implementations ignore it.

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -1,7 +1,6 @@
-use std::{fmt::Write, mem};
+use std::{cell::Cell, fmt::Write, mem};
 
 use ahash::AHashSet;
-use bytemuck::TransparentWrapper;
 use hashbrown::HashTable;
 use smallvec::SmallVec;
 
@@ -12,7 +11,10 @@ use crate::{
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult},
     hash::HashValue,
-    heap::{ContainsHeap, DropWithHeap, HeapData, HeapGuard, HeapId, HeapItem, HeapRead, HeapReadOutput},
+    heap::{
+        BorrowedHeapRead, BorrowedHeapReadMut, ContainsHeap, DropWithHeap, HeapData, HeapGuard, HeapId, HeapItem,
+        HeapRead, HeapReadOutput, heap_read_ref_as_field, heap_read_ref_as_field_mut,
+    },
     intern::StaticStrings,
     resource::{ResourceError, ResourceTracker},
     types::Type,
@@ -494,8 +496,7 @@ impl SetStorage {
 /// When values are added, their reference counts are NOT incremented by the set -
 /// the caller transfers ownership. When values are removed or the set is cleared,
 /// their reference counts are decremented.
-#[derive(Debug, Default, TransparentWrapper)]
-#[repr(transparent)]
+#[derive(Debug, Default)]
 pub(crate) struct Set(SetStorage);
 
 impl Set {
@@ -545,7 +546,7 @@ impl<'h> HeapRead<'h, Set> {
     ///
     /// Returns `Err(KeyError)` if the element is not present.
     pub fn remove(&mut self, value: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<()> {
-        if self.peel_mut().remove(value, vm)? {
+        if self.storage_mut().remove(value, vm)? {
             Ok(())
         } else {
             Err(ExcType::key_error(value, vm))
@@ -556,25 +557,33 @@ impl<'h> HeapRead<'h, Set> {
     ///
     /// Does not raise an error if the element is not found.
     pub fn discard(&mut self, value: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<()> {
-        self.peel_mut().discard(value, vm)
+        self.storage_mut().discard(value, vm)
     }
 
     /// Removes and returns an arbitrary element from the set.
     ///
     /// Returns `Err(KeyError)` if the set is empty.
     pub fn pop(&mut self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
-        self.peel_mut().pop(vm)
+        self.storage_mut().pop(vm)
     }
 
     /// Removes all elements from the set.
     pub fn clear(&mut self, vm: &mut VM<'h, impl ResourceTracker>) {
-        self.peel_mut().clear(vm);
+        self.storage_mut().clear(vm);
     }
 
     /// Returns a shallow copy of the set.
     #[must_use]
     pub fn copy(&self, vm: &VM<'h, impl ResourceTracker>) -> Set {
         Set(self.get(vm.heap).0.clone_with_heap(vm.heap))
+    }
+
+    fn storage(&self) -> BorrowedHeapRead<'_, 'h, SetStorage> {
+        heap_read_ref_as_field!(self, Set, 0)
+    }
+
+    fn storage_mut(&mut self) -> BorrowedHeapReadMut<'_, 'h, SetStorage> {
+        heap_read_ref_as_field_mut!(self, Set, 0)
     }
 }
 
@@ -679,7 +688,7 @@ impl<'h> HeapRead<'h, Set> {
     }
 
     pub(crate) fn contains(&self, value: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        self.peel_ref().contains(value, vm)
+        self.storage().contains(value, vm)
     }
 
     /// `set.update(iterable)` via HeapRead.
@@ -689,7 +698,7 @@ impl<'h> HeapRead<'h, Set> {
             match &other {
                 Value::Ref(id) => match vm.heap.get(*id) {
                     HeapData::Set(s) => Some(s.0.clone_entries(vm.heap)),
-                    HeapData::FrozenSet(fs) => Some(fs.0.clone_entries(vm.heap)),
+                    HeapData::FrozenSet(fs) => Some(fs.storage.clone_entries(vm.heap)),
                     _ => None,
                 },
                 _ => None,
@@ -722,10 +731,10 @@ impl<'h> HeapRead<'h, Set> {
         let other_storage = vm.heap.protect(other_storage);
 
         let result = match op {
-            SetAlgebra::Union => self.peel_ref().union(&other_storage, vm)?,
-            SetAlgebra::Intersection => self.peel_ref().intersection(&other_storage, vm)?,
-            SetAlgebra::Difference => self.peel_ref().difference(&other_storage, vm)?,
-            SetAlgebra::SymmetricDifference => self.peel_ref().symmetric_difference(&other_storage, vm)?,
+            SetAlgebra::Union => self.storage().union(&other_storage, vm)?,
+            SetAlgebra::Intersection => self.storage().intersection(&other_storage, vm)?,
+            SetAlgebra::Difference => self.storage().difference(&other_storage, vm)?,
+            SetAlgebra::SymmetricDifference => self.storage().symmetric_difference(&other_storage, vm)?,
         };
 
         let heap_id = vm.heap.allocate(HeapData::Set(Set(result)))?;
@@ -744,7 +753,7 @@ impl<'h> HeapRead<'h, Set> {
         let entries_opt = match other {
             Value::Ref(id) => match vm.heap.get(*id) {
                 HeapData::Set(s) => Some(s.0.clone_entries(vm.heap)),
-                HeapData::FrozenSet(fs) => Some(fs.0.clone_entries(vm.heap)),
+                HeapData::FrozenSet(fs) => Some(fs.storage.clone_entries(vm.heap)),
                 _ => None,
             },
             _ => None,
@@ -800,7 +809,7 @@ impl DropWithHeap for SetStorage {
 
 impl DropWithHeap for FrozenSet {
     fn drop_with_heap<H: ContainsHeap>(self, heap: &mut H) {
-        self.0.drop_with_heap(heap);
+        self.storage.drop_with_heap(heap);
     }
 }
 
@@ -808,30 +817,7 @@ impl<'h> HeapRead<'h, FrozenSet> {
     /// Checks if the frozenset contains a value, using the candidate collection pattern
     /// to avoid holding a borrow on the storage during `py_eq` calls.
     pub(crate) fn contains(&self, value: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        let hash = value
-            .py_hash(vm)?
-            .ok_or_else(|| ExcType::type_error_unhashable_set_element(value.py_type(vm)))?
-            .raw();
-
-        // Collect candidate indices (hash match only) via shared borrow
-        let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
-        let storage = &self.get(vm.heap).0;
-        storage.indices.find(hash, |&idx| {
-            if storage.entries[idx].hash == hash {
-                candidates.push(idx);
-            }
-            false
-        });
-
-        for candidate_index in candidates {
-            let candidate_value = self.get(vm.heap).0.entries[candidate_index].value.clone_with_heap(vm);
-            defer_drop!(candidate_value, vm);
-            if value.py_eq(candidate_value, vm)? {
-                return Ok(true);
-            }
-        }
-
-        Ok(false)
+        self.storage().contains(value, vm)
     }
 
     /// Binary set operation via HeapRead. Creates a new frozenset from the result.
@@ -851,10 +837,10 @@ impl<'h> HeapRead<'h, FrozenSet> {
         let other_storage = vm.heap.protect(other_storage);
 
         let result = match op {
-            SetBinaryOp::And => FrozenSet(self.peel_ref().intersection(&other_storage, vm)?),
-            SetBinaryOp::Or => FrozenSet(self.peel_ref().union(&other_storage, vm)?),
-            SetBinaryOp::Xor => FrozenSet(self.peel_ref().symmetric_difference(&other_storage, vm)?),
-            SetBinaryOp::Sub => FrozenSet(self.peel_ref().difference(&other_storage, vm)?),
+            SetBinaryOp::And => FrozenSet::wrap(self.storage().intersection(&other_storage, vm)?),
+            SetBinaryOp::Or => FrozenSet::wrap(self.storage().union(&other_storage, vm)?),
+            SetBinaryOp::Xor => FrozenSet::wrap(self.storage().symmetric_difference(&other_storage, vm)?),
+            SetBinaryOp::Sub => FrozenSet::wrap(self.storage().difference(&other_storage, vm)?),
         };
         Ok(Some(result))
     }
@@ -866,13 +852,13 @@ impl<'h> HeapRead<'h, FrozenSet> {
         let other_storage = vm.heap.protect(other_storage);
 
         let result = match op {
-            SetAlgebra::Union => self.peel_ref().union(&other_storage, vm)?,
-            SetAlgebra::Intersection => self.peel_ref().intersection(&other_storage, vm)?,
-            SetAlgebra::Difference => self.peel_ref().difference(&other_storage, vm)?,
-            SetAlgebra::SymmetricDifference => self.peel_ref().symmetric_difference(&other_storage, vm)?,
+            SetAlgebra::Union => self.storage().union(&other_storage, vm)?,
+            SetAlgebra::Intersection => self.storage().intersection(&other_storage, vm)?,
+            SetAlgebra::Difference => self.storage().difference(&other_storage, vm)?,
+            SetAlgebra::SymmetricDifference => self.storage().symmetric_difference(&other_storage, vm)?,
         };
 
-        let heap_id = vm.heap.allocate(HeapData::FrozenSet(FrozenSet(result)))?;
+        let heap_id = vm.heap.allocate(HeapData::FrozenSet(FrozenSet::wrap(result)))?;
         Ok(Value::Ref(heap_id))
     }
 
@@ -886,7 +872,7 @@ impl<'h> HeapRead<'h, FrozenSet> {
         let entries_opt = match other {
             Value::Ref(id) => match vm.heap.get(*id) {
                 HeapData::Set(s) => Some(s.0.clone_entries(vm.heap)),
-                HeapData::FrozenSet(fs) => Some(fs.0.clone_entries(vm.heap)),
+                HeapData::FrozenSet(fs) => Some(fs.storage.clone_entries(vm.heap)),
                 _ => None,
             },
             _ => None,
@@ -900,7 +886,7 @@ impl<'h> HeapRead<'h, FrozenSet> {
         };
         defer_drop!(other_storage, vm);
 
-        let self_storage = self.get(vm.heap).0.clone_with_heap(vm.heap);
+        let self_storage = self.get(vm.heap).storage.clone_with_heap(vm.heap);
         defer_drop!(self_storage, vm);
 
         match op {
@@ -908,6 +894,10 @@ impl<'h> HeapRead<'h, FrozenSet> {
             SetComparison::Superset => self_storage.is_superset(other_storage, vm),
             SetComparison::Disjoint => self_storage.is_disjoint(other_storage, vm),
         }
+    }
+
+    fn storage(&self) -> BorrowedHeapRead<'_, 'h, SetStorage> {
+        heap_read_ref_as_field!(self, FrozenSet, storage)
     }
 }
 
@@ -927,7 +917,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Set> {
     }
 
     fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
-        self.peel_ref().eq(other.peel_ref(), vm)
+        self.storage().eq(&other.storage(), vm)
     }
 
     fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {
@@ -940,7 +930,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Set> {
         vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
-        self.peel_ref().repr_fmt(f, vm, heap_ids, "set")
+        self.storage().repr_fmt(f, vm, heap_ids, "set")
     }
 
     fn py_call_attr(
@@ -1059,10 +1049,10 @@ impl<'h> HeapRead<'h, Set> {
         let other_storage = vm.heap.protect(other_storage);
 
         let result = match op {
-            SetBinaryOp::And => Set(self.peel_ref().intersection(&other_storage, vm)?),
-            SetBinaryOp::Or => Set(self.peel_ref().union(&other_storage, vm)?),
-            SetBinaryOp::Xor => Set(self.peel_ref().symmetric_difference(&other_storage, vm)?),
-            SetBinaryOp::Sub => Set(self.peel_ref().difference(&other_storage, vm)?),
+            SetBinaryOp::And => Set(self.storage().intersection(&other_storage, vm)?),
+            SetBinaryOp::Or => Set(self.storage().union(&other_storage, vm)?),
+            SetBinaryOp::Xor => Set(self.storage().symmetric_difference(&other_storage, vm)?),
+            SetBinaryOp::Sub => Set(self.storage().difference(&other_storage, vm)?),
         };
         Ok(Some(result))
     }
@@ -1075,7 +1065,7 @@ impl Set {
         let entries_opt = match &value {
             Value::Ref(id) => match vm.heap.get(*id) {
                 HeapData::Set(set) => Some(set.0.clone_entries(vm.heap)),
-                HeapData::FrozenSet(set) => Some(set.0.clone_entries(vm.heap)),
+                HeapData::FrozenSet(set) => Some(set.storage.clone_entries(vm.heap)),
                 _ => None,
             },
             _ => None,
@@ -1110,27 +1100,44 @@ impl HeapItem for Set {
 /// # Hashability
 /// Unlike mutable sets, frozensets can be used as dict keys or set elements because
 /// they are immutable. The hash is computed as the XOR of element hashes (order-independent).
-#[derive(Debug, Default, TransparentWrapper)]
-#[repr(transparent)]
-pub(crate) struct FrozenSet(SetStorage);
+#[derive(Debug, Default)]
+pub(crate) struct FrozenSet {
+    storage: SetStorage,
+    /// Lazily-computed Python hash.
+    cached_hash: Cell<Option<HashValue>>,
+}
 
 impl FrozenSet {
+    /// Wraps an existing `SetStorage` as a frozenset.
+    ///
+    /// The freshly-wrapped frozenset starts with an empty hash cache; the
+    /// hash is computed lazily on first `py_hash` call. Inherited cache
+    /// state is *not* propagated from a source frozenset — each instance
+    /// manages its own cache.
+    #[must_use]
+    pub fn wrap(storage: SetStorage) -> Self {
+        Self {
+            storage,
+            cached_hash: Cell::new(None),
+        }
+    }
+
     /// Creates a new empty frozenset.
     #[must_use]
     pub fn new() -> Self {
-        Self(SetStorage::new())
+        Self::wrap(SetStorage::new())
     }
 
     /// Returns the number of elements in the frozenset.
     #[must_use]
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.storage.len()
     }
 
     /// Returns true if the frozenset is empty.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.storage.is_empty()
     }
 
     /// Returns whether this frozenset contains any heap references (`Value::Ref`).
@@ -1139,12 +1146,12 @@ impl FrozenSet {
     #[inline]
     #[must_use]
     pub fn has_refs(&self) -> bool {
-        self.0.has_refs()
+        self.storage.has_refs()
     }
 
     /// Returns the internal storage.
     pub(crate) fn storage(&self) -> &SetStorage {
-        &self.0
+        &self.storage
     }
 }
 
@@ -1154,7 +1161,7 @@ impl FrozenSet {
     /// This is used when we need to convert a mutable set to an immutable frozenset
     /// without cloning.
     pub fn from_set(set: Set) -> Self {
-        Self(set.0)
+        Self::wrap(set.0)
     }
 
     /// Creates a frozenset from the `frozenset()` constructor call.
@@ -1182,24 +1189,30 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
     }
 
     fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
-        self.peel_ref().eq(other.peel_ref(), vm)
+        self.storage().eq(&other.storage(), vm)
     }
 
     /// Hashes the frozenset by XORing all element hashes.
     ///
     /// XOR is commutative, so the hash is independent of insertion order — two
     /// frozensets with the same members hash equally regardless of how they were built.
+    /// Caches the computed hash on first call (frozensets are immutable).
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
+        if let Some(cached) = self.get(vm.heap).cached_hash.get() {
+            return Ok(Some(cached));
+        }
         let token = vm.heap.incr_recursion_depth()?;
         defer_drop!(token, vm);
         let mut hash: u64 = 0;
-        let len = self.get(vm.heap).0.entries.len();
+        let len = self.get(vm.heap).storage.entries.len();
         for idx in 0..len {
-            let item = self.get(vm.heap).0.entries[idx].value.clone_with_heap(vm);
+            let item = self.get(vm.heap).storage.entries[idx].value.clone_with_heap(vm);
             defer_drop!(item, vm);
             hash ^= set_element_hash(item, vm)?;
         }
-        Ok(Some(HashValue::new(hash)))
+        let hash = HashValue::new(hash);
+        self.get(vm.heap).cached_hash.set(Some(hash));
+        Ok(Some(hash))
     }
 
     fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {
@@ -1212,7 +1225,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
         vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
-        self.peel_ref().repr_fmt(f, vm, heap_ids, "frozenset")
+        self.storage().repr_fmt(f, vm, heap_ids, "frozenset")
     }
 
     fn py_call_attr(
@@ -1225,8 +1238,8 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
         let value = match attr.static_string() {
             Some(StaticStrings::Copy) => {
                 args.check_zero_args("frozenset.copy", vm.heap)?;
-                let cloned = self.get(vm.heap).0.clone_with_heap(vm.heap);
-                let heap_id = vm.heap.allocate(HeapData::FrozenSet(FrozenSet(cloned)))?;
+                let cloned = self.get(vm.heap).storage.clone_with_heap(vm.heap);
+                let heap_id = vm.heap.allocate(HeapData::FrozenSet(FrozenSet::wrap(cloned)))?;
                 Ok(Value::Ref(heap_id))
             }
             Some(StaticStrings::Union) => {
@@ -1271,11 +1284,11 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
 
 impl HeapItem for FrozenSet {
     fn py_estimate_size(&self) -> usize {
-        self.0.estimate_size()
+        self.storage.estimate_size()
     }
 
     fn py_dec_ref_ids(&mut self, stack: &mut Vec<HeapId>) {
-        self.0.collect_dec_ref_ids(stack);
+        self.storage.collect_dec_ref_ids(stack);
     }
 }
 
@@ -1294,7 +1307,7 @@ fn get_storage_from_set_operand(value: &Value, vm: &mut VM<'_, impl ResourceTrac
             set.get(vm.heap).0.clone_entries(vm.heap),
         ))),
         HeapReadOutput::FrozenSet(set) => Ok(Some(SetStorage::from_entries(
-            set.get(vm.heap).0.clone_entries(vm.heap),
+            set.get(vm.heap).storage.clone_entries(vm.heap),
         ))),
         HeapReadOutput::DictKeysView(view) => {
             let Set(storage) = view.to_set(vm)?;
@@ -1343,13 +1356,15 @@ impl<'de> serde::Deserialize<'de> for Set {
 
 impl serde::Serialize for FrozenSet {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.0.serialize(serializer)
+        // Skip `cached_hash` — it's recomputable from the entries and we
+        // don't want to lock the snapshot format to the current hash function.
+        self.storage.serialize(serializer)
     }
 }
 
 impl<'de> serde::Deserialize<'de> for FrozenSet {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(Self(SetStorage::deserialize(deserializer)?))
+        Ok(Self::wrap(SetStorage::deserialize(deserializer)?))
     }
 }
 

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -2,7 +2,7 @@
 ///
 /// This type provides Python string semantics. Currently supports basic
 /// operations like length and equality comparison.
-use std::{borrow::Cow, cmp::Ordering, fmt, fmt::Write, mem, ops};
+use std::{borrow::Cow, cell::Cell, cmp::Ordering, fmt, fmt::Write, mem, ops};
 
 use ahash::AHashSet;
 use smallvec::smallvec;
@@ -28,20 +28,32 @@ use crate::{
 ///
 /// Wraps a Rust `String` and provides Python-compatible operations.
 /// `len()` returns the number of Unicode codepoints (characters), matching Python semantics.
-#[derive(Debug, Clone, PartialEq, Default, serde::Serialize, serde::Deserialize)]
-pub(crate) struct Str(Box<str>);
+///
+/// Carries an inline `cached_hash` field so a `Str` only computes its Python
+/// hash once.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub(crate) struct Str(Box<str>, #[serde(skip)] Cell<Option<HashValue>>);
+
+impl PartialEq for Str {
+    /// Compares only the string content — the `cached_hash` field is a pure
+    /// optimisation and must not affect equality.
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
 
 impl Str {
     /// Creates a new Str from a Rust String.
     #[must_use]
     pub fn new(s: String) -> Self {
-        Self(s.into())
+        Self(s.into(), Cell::new(None))
     }
 
     /// Creates a new Str from a Rust Box<str>.
     #[must_use]
     pub fn from_boxed(s: Box<str>) -> Self {
-        Self(s)
+        Self(s, Cell::new(None))
     }
 
     /// Returns a reference to the inner string.
@@ -70,21 +82,21 @@ impl Str {
     ///
     /// Returns a new string containing the selected characters (Unicode-aware).
     fn getitem_slice(&self, vm: &VM<'_, impl ResourceTracker>, slice: &super::Slice) -> RunResult<Value> {
-        let result_str = slice_collect_iterator(vm, slice, self.0.chars(), |c| c)?;
-        let heap_id = vm.heap.allocate(HeapData::Str(Self(result_str)))?;
+        let result_str: Box<str> = slice_collect_iterator(vm, slice, self.0.chars(), |c| c)?;
+        let heap_id = vm.heap.allocate(HeapData::Str(Self::from_boxed(result_str)))?;
         Ok(Value::Ref(heap_id))
     }
 }
 
 impl From<String> for Str {
     fn from(s: String) -> Self {
-        Self(s.into())
+        Self::new(s)
     }
 }
 
 impl From<&str> for Str {
     fn from(s: &str) -> Self {
-        Self(s.into())
+        Self::from_boxed(s.into())
     }
 }
 
@@ -192,7 +204,16 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
-        Ok(Some(hash_python_str(self.get(vm.heap).as_str())))
+        let s = self.get(vm.heap);
+        if let Some(cached) = s.1.get() {
+            return Ok(Some(cached));
+        }
+        // Delegates to the canonical helper used by both heap and intern paths;
+        // an interned `"foo"` and a heap `"foo"` must hash identically for dict
+        // lookup to work.
+        let hash = hash_python_str(s.as_str());
+        s.1.set(Some(hash));
+        Ok(Some(hash))
     }
 
     fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -15,6 +15,7 @@
 ///
 /// All tuple methods from Python's builtins are implemented.
 use std::{
+    cell::Cell,
     cmp::Ordering,
     collections::hash_map::DefaultHasher,
     fmt::Write,
@@ -70,6 +71,12 @@ pub(crate) struct Tuple {
     /// True if any item in the tuple is a `Value::Ref`. Set at creation time
     /// since tuples are immutable.
     contains_refs: bool,
+    /// Lazily-computed Python hash. Tuples are immutable so this is
+    /// computed on first `py_hash` and reused thereafter. Skipped on
+    /// serde — recomputable from `items` and we don't want to lock the
+    /// snapshot format to the current hash function.
+    #[serde(skip)]
+    cached_hash: Cell<Option<HashValue>>,
 }
 
 impl Tuple {
@@ -86,7 +93,11 @@ impl Tuple {
     #[must_use]
     fn new(items: TupleVec) -> Self {
         let contains_refs = items.iter().any(|v| matches!(v, Value::Ref(_)));
-        Self { items, contains_refs }
+        Self {
+            items,
+            contains_refs,
+            cached_hash: Cell::new(None),
+        }
     }
 
     /// Returns a reference to the underlying SmallVec.
@@ -238,7 +249,14 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
     /// Identical to `NamedTuple::py_hash`, so a `Tuple` and a `NamedTuple` with
     /// the same elements hash equally — required because they compare equal
     /// (matching CPython, where `NamedTuple` is a `tuple` subclass).
+    ///
+    /// Caches the computed hash on first call. We only cache the `Some(_)`
+    /// outcome — `None` (unhashable child) is uncommon and skipping it
+    /// keeps the cache slot free of a 3-state encoding.
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
+        if let Some(cached) = self.get(vm.heap).cached_hash.get() {
+            return Ok(Some(cached));
+        }
         let token = vm.heap.incr_recursion_depth()?;
         defer_drop!(token, vm);
         let len = self.get(vm.heap).items.len();
@@ -251,7 +269,9 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
                 None => return Ok(None),
             }
         }
-        Ok(Some(HashValue::new(hasher.finish())))
+        let hash = HashValue::new(hasher.finish());
+        self.get(vm.heap).cached_hash.set(Some(hash));
+        Ok(Some(hash))
     }
 
     /// Lexicographic comparison for tuples.

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -1531,8 +1531,11 @@ impl Value {
                     }
                 };
             }
-            // For heap-allocated values (includes Range and Exception), compute hash lazily and cache it
-            Self::Ref(id) => return Heap::get_or_compute_hash(vm, *id),
+            // For heap-allocated values, dispatch to the per-type `py_hash`
+            // impl. Types that benefit from caching (Str/Bytes/Tuple/
+            // NamedTuple/FrozenSet/Path) carry an inline `cached_hash`;
+            // cheap-to-hash types recompute each call.
+            Self::Ref(id) => return vm.heap.read(*id).py_hash(*id, vm),
             // Singleton values can be hashed directly
             Self::Undefined | Self::Ellipsis | Self::None => discriminant(self).hash(&mut hasher),
             Self::Builtin(b) => b.hash(&mut hasher),


### PR DESCRIPTION
This moves code out of `heap.rs` (which is a safety domain and I'd like as small as possible).