### PR TITLE
Fix async external function exception propagation

### DIFF
--- a/crates/monty-datatest/src/main.rs
+++ b/crates/monty-datatest/src/main.rs
@@ -369,13 +369,19 @@ fn ensure_python_modules_imported() {
 /// Result from dispatching an external function call.
 ///
 /// Distinguishes between synchronous calls (return immediately) and
-/// asynchronous calls (return a future that needs later resolution).
+/// asynchronous calls (return a future that needs later resolution), and
+/// further splits async calls into success and failure variants so the
+/// harness can exercise both `ExtFunctionResult::Return` and
+/// `ExtFunctionResult::Error` resolution paths for external futures.
 enum DispatchResult {
     /// Synchronous result - pass directly to `state.run()`.
     Sync(ExtFunctionResult),
-    /// Asynchronous call - use `state.run_pending()` and resolve later.
-    /// Contains the value to resolve the future with.
+    /// Asynchronous call - use `state.run_pending()` and resolve later
+    /// with `ExtFunctionResult::Return(value)`.
     Async(MontyObject),
+    /// Asynchronous call that fails - use `state.run_pending()` and
+    /// resolve later with `ExtFunctionResult::Error(exception)`.
+    AsyncFail(MontyException),
 }
 
 /// Dispatches an external function call to the appropriate test implementation.
@@ -501,6 +507,21 @@ fn dispatch_external_call(name: &str, args: Vec<MontyObject>) -> DispatchResult 
             // This is an async function - use run_pending() and resolve later
             assert!(args.len() == 1, "async_call requires 1 argument");
             DispatchResult::Async(args.into_iter().next().unwrap())
+        }
+        "async_fail" => {
+            // async_fail(exc_type: str, message: str) -> coroutine that raises.
+            // Mirrors `raise_error` for the async path.
+            assert!(args.len() == 2, "async_fail requires 2 arguments");
+            let exc_type_str = String::try_from(&args[0]).expect("async_fail: first arg must be str");
+            let message = String::try_from(&args[1]).expect("async_fail: second arg must be str");
+            let exc_type = match exc_type_str.as_str() {
+                "ValueError" => ExcType::ValueError,
+                "TypeError" => ExcType::TypeError,
+                "KeyError" => ExcType::KeyError,
+                "RuntimeError" => ExcType::RuntimeError,
+                _ => panic!("async_fail: unsupported exception type: {exc_type_str}"),
+            };
+            DispatchResult::AsyncFail(MontyException::new(exc_type, Some(message)))
         }
         _ => panic!("Unknown external function: {name}"),
     }
@@ -1741,8 +1762,11 @@ fn run_iter_loop(exec: MontyRun, gc_interval: Option<usize>) -> Result<MontyObje
     let limits = build_test_limits(gc_interval);
     let mut progress = exec.start(vec![], LimitedTracker::new(limits), PrintWriter::Stdout)?;
 
-    // Track pending async calls: (call_id, result_value)
-    let mut pending_results: Vec<(u32, MontyObject)> = Vec::new();
+    // Track pending async calls: (call_id, pre-built ExtFunctionResult).
+    // Successful async calls produce `Return(value)`; `async_fail` produces
+    // `Error(exception)`. The pre-built result is handed back verbatim at
+    // `ResolveFutures` so the harness exercises both resolution branches.
+    let mut pending_results: Vec<(u32, ExtFunctionResult)> = Vec::new();
 
     loop {
         // Test serialization round-trip at each step (skip when memory-model-checks is enabled
@@ -1769,23 +1793,29 @@ fn run_iter_loop(exec: MontyRun, gc_interval: Option<usize>) -> Result<MontyObje
                         progress = call.resume(return_value, PrintWriter::Stdout)?;
                     }
                     DispatchResult::Async(result_value) => {
-                        // Store the result for later resolution
-                        pending_results.push((call.call_id, result_value));
+                        // Store the success result for later resolution
+                        pending_results.push((call.call_id, ExtFunctionResult::Return(result_value)));
                         // Continue execution with a pending future
+                        progress = call.resume_pending(PrintWriter::Stdout)?;
+                    }
+                    DispatchResult::AsyncFail(exception) => {
+                        // Store the error for later resolution
+                        pending_results.push((call.call_id, ExtFunctionResult::Error(exception)));
                         progress = call.resume_pending(PrintWriter::Stdout)?;
                     }
                 }
             }
             RunProgress::ResolveFutures(state) => {
-                // Resolve all pending futures that we have results for
+                // Hand back each pending result verbatim (Return or Error) so
+                // `ResolveFutures::resume` sees both success and failure cases.
                 let results: Vec<(u32, ExtFunctionResult)> = state
                     .pending_call_ids()
                     .iter()
                     .filter_map(|p| {
-                        pending_results.iter().position(|(id, _)| id == p).map(|idx| {
-                            let (call_id, value) = pending_results.remove(idx);
-                            (call_id, ExtFunctionResult::Return(value))
-                        })
+                        pending_results
+                            .iter()
+                            .position(|(id, _)| id == p)
+                            .map(|idx| pending_results.remove(idx))
                     })
                     .collect();
 
@@ -1801,7 +1831,7 @@ fn run_iter_loop(exec: MontyRun, gc_interval: Option<usize>) -> Result<MontyObje
                 let result = match lookup.name.as_str() {
                     // External functions — resolved as callable Function objects
                     "add_ints" | "concat_strings" | "return_value" | "get_list" | "raise_error" | "make_point"
-                    | "make_mutable_point" | "make_user" | "make_empty" | "async_call" => {
+                    | "make_mutable_point" | "make_user" | "make_empty" | "async_call" | "async_fail" => {
                         NameLookupResult::Value(MontyObject::Function {
                             name: lookup.name.clone(),
                             docstring: None,

--- a/crates/monty-python/tests/test_external_async.py
+++ b/crates/monty-python/tests/test_external_async.py
@@ -1,0 +1,60 @@
+"""Tests for the async external-function surface of the Python bindings."""
+
+import pytest
+from inline_snapshot import snapshot
+
+import pydantic_monty
+
+
+async def test_async_external_function_raises_surfaces_as_monty_runtime_error():
+    """An uncaught exception from an awaited async callback surfaces as
+    ``MontyRuntimeError`` with the original exception preserved in
+    ``exc.exception()``."""
+    m = pydantic_monty.Monty('await fail()')
+
+    async def fail():
+        raise ValueError('intentional error')
+
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        await m.run_async(external_functions={'fail': fail})
+    inner = exc_info.value.exception()
+    assert isinstance(inner, ValueError)
+    assert inner.args[0] == snapshot('intentional error')
+
+
+async def test_async_external_function_return_lone_surrogate_catchable_inside_monty():
+    """An async callback returning a string with a lone surrogate surfaces inside Monty
+    as a ``ValueError`` that can be caught, not as a raw ``PyErr`` escaping to the caller."""
+    code = """
+try:
+    await get_str()
+    result = 'no error'
+except ValueError:
+    result = 'caught'
+result
+"""
+    m = pydantic_monty.Monty(code)
+
+    async def get_str():
+        return '\ud83d'
+
+    assert await m.run_async(external_functions={'get_str': get_str}) == snapshot('caught')
+
+
+async def test_async_external_function_return_unconvertible_catchable_inside_monty():
+    """An async callback returning an unconvertible object surfaces inside Monty as a
+    ``TypeError`` that can be caught."""
+    code = """
+try:
+    await get_thing()
+    result = 'no error'
+except TypeError:
+    result = 'caught'
+result
+"""
+    m = pydantic_monty.Monty(code)
+
+    async def get_thing():
+        return object()
+
+    assert await m.run_async(external_functions={'get_thing': get_thing}) == snapshot('caught')

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -882,11 +882,12 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
 
             match task.state {
                 TaskState::Failed(_) => {
-                    // Current task failed - propagate error to caller
+                    // Current task failed - resume with exception so it can be caught by
+                    // surrounding `try/except`.
                     let TaskState::Failed(err) = mem::replace(&mut task.state, TaskState::Ready) else {
                         unreachable!();
                     };
-                    return Err(err);
+                    return self.resume_with_exception(err);
                 }
                 TaskState::BlockedOnCall(_) | TaskState::BlockedOnGather(_) => {
                     // Current task is still blocked on unresolved futures.

--- a/crates/monty/test_cases/async__ext_exc.py
+++ b/crates/monty/test_cases/async__ext_exc.py
@@ -1,0 +1,264 @@
+# call-external
+# run-async
+# === Async external function exceptions ===
+# Tests for exceptions raised by awaited external async functions. Mirrors
+# `ext_call__ext_exc.py` section-by-section via `async_fail`, then appends
+# async-specific call shapes (asyncio.gather, user-defined async wrappers,
+# gathered coroutines).
+import asyncio
+
+# === Basic exception propagation ===
+
+# External function raising ValueError
+caught_value_error = False
+try:
+    await async_fail('ValueError', 'test error')  # pyright: ignore
+    assert False, 'should not reach here'
+except ValueError:
+    caught_value_error = True
+assert caught_value_error, 'ValueError was caught'
+
+# External function raising TypeError
+caught_type_error = False
+try:
+    await async_fail('TypeError', 'type error message')  # pyright: ignore
+    assert False, 'should not reach here'
+except TypeError:
+    caught_type_error = True
+assert caught_type_error, 'TypeError was caught'
+
+# External function raising KeyError
+caught_key_error = False
+try:
+    await async_fail('KeyError', 'missing key')  # pyright: ignore
+    assert False, 'should not reach here'
+except KeyError:
+    caught_key_error = True
+assert caught_key_error, 'KeyError was caught'
+
+# External function raising RuntimeError
+caught_runtime_error = False
+try:
+    await async_fail('RuntimeError', 'runtime error')  # pyright: ignore
+    assert False, 'should not reach here'
+except RuntimeError:
+    caught_runtime_error = True
+assert caught_runtime_error, 'RuntimeError was caught'
+
+# === Exception not caught by wrong handler ===
+
+# ValueError not caught by TypeError handler
+caught_outer = False
+try:
+    try:
+        await async_fail('ValueError', 'inner error')  # pyright: ignore
+    except TypeError:
+        assert False, 'TypeError should not catch ValueError'
+except ValueError:
+    caught_outer = True
+assert caught_outer, 'ValueError caught by outer handler'
+
+# === Exception in expression with multiple ext calls ===
+
+# Awaited external call raises mid-expression — surrounding ops don't run
+try:
+    x = 1 + (await async_fail('ValueError', 'mid-expr')) + 2  # pyright: ignore
+    assert False, 'should not reach here'
+except ValueError:
+    pass  # Expected
+
+# First ext call raises, second should not be called
+try:
+    x = (await async_fail('ValueError', 'first')) + add_ints(1, 2)  # pyright: ignore
+    assert False, 'should not reach here'
+except ValueError:
+    pass  # Expected
+
+# === External exception in try body with finally ===
+
+finally_ran = False
+try:
+    await async_fail('ValueError', 'in try')  # pyright: ignore
+except ValueError:
+    pass  # Caught
+finally:
+    finally_ran = True
+assert finally_ran, 'finally ran after external exception caught'
+
+# External exception propagating through finally
+outer_caught = False
+finally_ran2 = False
+try:
+    try:
+        await async_fail('KeyError', 'will propagate')  # pyright: ignore
+    except ValueError:
+        assert False, 'ValueError should not catch KeyError'
+    finally:
+        finally_ran2 = True
+except KeyError:
+    outer_caught = True
+assert finally_ran2, 'finally ran before exception propagated'
+assert outer_caught, 'exception propagated after finally'
+
+# === Mix of normal returns and exceptions ===
+
+# Normal return, then exception
+value1 = await async_call(30)  # pyright: ignore
+assert value1 == 30, 'first async call returned normally'
+try:
+    await async_fail('ValueError', 'after success')  # pyright: ignore
+    assert False, 'should not reach here'
+except ValueError:
+    pass  # Expected
+
+# Exception, then normal return (after catching)
+caught_exc = False
+try:
+    await async_fail('TypeError', 'will be caught')  # pyright: ignore
+except TypeError:
+    caught_exc = True
+value2 = await async_call(10)  # pyright: ignore
+assert caught_exc, 'exception was caught'
+assert value2 == 10, 'async call after caught exception returned normally'
+
+# === Exception in except handler from external function ===
+
+outer_catch = False
+try:
+    try:
+        raise ValueError('inner')
+    except ValueError:
+        await async_fail('TypeError', 'from handler')  # pyright: ignore
+except TypeError:
+    outer_catch = True
+assert outer_catch, 'exception from handler caught by outer'
+
+# === Exception in else block from external function ===
+
+else_exc_caught = False
+try:
+    try:
+        pass  # No exception
+    except:
+        assert False, 'should not reach except'
+    else:
+        await async_fail('RuntimeError', 'from else')  # pyright: ignore
+except RuntimeError:
+    else_exc_caught = True
+assert else_exc_caught, 'exception from else block caught'
+
+# === Exception in finally block ===
+
+# Note: exception in finally replaces any pending exception
+finally_exc_caught = False
+try:
+    try:
+        pass
+    finally:
+        await async_fail('ValueError', 'from finally')  # pyright: ignore
+except ValueError:
+    finally_exc_caught = True
+assert finally_exc_caught, 'exception from finally caught'
+
+# === Nested try blocks with external exceptions ===
+
+inner_handled = False
+outer_handled = False
+finally_count = 0
+try:
+    try:
+        await async_fail('ValueError', 'inner error')  # pyright: ignore
+    except ValueError:
+        inner_handled = True
+        await async_fail('TypeError', 'from inner handler')  # pyright: ignore
+    finally:
+        finally_count += 1
+except TypeError:
+    outer_handled = True
+finally:
+    finally_count += 1
+
+assert inner_handled, 'inner exception was handled'
+assert outer_handled, 'exception from inner handler was caught by outer'
+assert finally_count == 2, 'both finally blocks ran'
+
+# === Tests with no sync counterpart in `ext_call__ext_exc.py`. ===
+
+# === Exception message is preserved across async boundary ===
+try:
+    await async_fail('ValueError', 'exact message')  # pyright: ignore
+    assert False, 'should not reach here'
+except ValueError as e:
+    assert str(e) == 'exact message', f'message preserved through await: {e}'
+
+
+# === Bare raise re-raises across an async frame boundary ===
+async def wrapper_rereraise():
+    try:
+        await async_fail('ValueError', 're-raised')
+    except ValueError:
+        raise
+
+
+outer_reraised = False
+try:
+    await wrapper_rereraise()  # pyright: ignore
+except ValueError as e:
+    assert str(e) == 're-raised'
+    outer_reraised = True
+assert outer_reraised, 'bare raise re-propagated to outer handler'
+
+
+# === Exception unwinds through user-defined async wrapper ===
+async def wrapper_catches():
+    try:
+        await async_fail('ValueError', 'inside wrapper')
+        return 'no error'
+    except ValueError as e:
+        return 'caught: ' + str(e)
+
+
+wrapper_result = await wrapper_catches()  # pyright: ignore
+assert wrapper_result == 'caught: inside wrapper', f'caught inside async wrapper: {wrapper_result}'
+
+
+# === Exception unwinds through multiple async wrapper frames ===
+async def inner_wrapper():
+    await async_fail('ValueError', 'deep')
+
+
+async def outer_wrapper():
+    await inner_wrapper()
+
+
+nested_caught = None
+try:
+    await outer_wrapper()  # pyright: ignore
+except ValueError as e:
+    nested_caught = str(e)
+assert nested_caught == 'deep', 'exception caught through two async frames'
+
+# === asyncio.gather: failure propagates out ===
+caught_gather = None
+try:
+    await asyncio.gather(async_call(1), async_fail('ValueError', 'gather failure'))  # pyright: ignore
+except ValueError as e:
+    caught_gather = str(e)
+assert caught_gather == 'gather failure', 'gather failure caught at await site'
+
+
+# === Gathered coroutine: child failure surfaces at the main task's gather ===
+async def get_a():
+    return await async_fail('ValueError', 'async boom')
+
+
+async def get_b():
+    return await async_call('b')
+
+
+gathered_coro_caught = None
+try:
+    await asyncio.gather(get_a(), get_b())  # pyright: ignore
+except ValueError as e:
+    gathered_coro_caught = str(e)
+assert gathered_coro_caught == 'async boom', f'gathered child exception caught at gather: {gathered_coro_caught}'

--- a/scripts/iter_test_methods.py
+++ b/scripts/iter_test_methods.py
@@ -123,6 +123,20 @@ async def async_call(x: object) -> object:
     return x
 
 
+async def async_fail(exc_type: str, message: str) -> None:
+    """Async function that raises the requested exception.
+
+    Mirrors `raise_error` for the async path.
+    """
+    exc_types: dict[str, type[Exception]] = {
+        'ValueError': ValueError,
+        'TypeError': TypeError,
+        'KeyError': KeyError,
+        'RuntimeError': RuntimeError,
+    }
+    raise exc_types[exc_type](message)
+
+
 # =============================================================================
 # Virtual Filesystem for OS Call Tests
 # =============================================================================
@@ -546,4 +560,5 @@ ITER_MODE_GLOBALS: dict[str, object] = {
     'make_user': make_user,
     'make_empty': make_empty,
     'async_call': async_call,
+    'async_fail': async_fail,
 }


### PR DESCRIPTION
Resolves https://github.com/pydantic/monty/issues/323

Based somewhat on https://github.com/pydantic/monty/pull/386

Added tests to mirror the sync external function exception handling, plus a few async-specific tests for asyncio.gather, asyncio.run, and user-defined async wrappers.

The fix routes failed awaited futures through `resume_with_exception` instead of returning the error directly. That allows `try`/`except` around an `await` to catch the exception. Uncaught exceptions still propagate out to the host unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes exception propagation for awaited async external callbacks so Monty try/except can catch them; uncaught exceptions (including in `asyncio.gather` and nested coroutines) still bubble to the host unchanged. Fixes pydantic/monty#323.

- **Bug Fixes**
  - VM: route failures from awaited externals through `resume_with_exception(err)` instead of returning `Err(err)` so surrounding `try/except` can catch them; uncaught behavior is unchanged.
  - Datatest harness: add `DispatchResult::AsyncFail(MontyException)` and store pending futures as pre-built `ExtFunctionResult` so `ResolveFutures` handles both `Return` and `Error`; add and wire `async_fail` into name lookup.
  - Tests: add `crates/monty/test_cases/async__ext_exc.py` mirroring sync cases plus `asyncio.gather` and wrapper shapes; add `crates/monty-python/tests/test_external_async.py` for host `MontyRuntimeError` and return-conversion errors; expose `async_fail` in `scripts/iter_test_methods.py`.

<sup>Written for commit 848cc4f496afa4462469fa5f2e939317e84588e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

