### PR TITLE
note that `make install-py` is often necessary in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,7 @@ Avoid manual `drop_with_heap` whenever there are multiple code paths (branching,
 
 ## Dev Commands
 
-DO NOT run `cargo build` or `cargo run`, it will fail because of issues with Python bindings.
+**IMPORTANT**: before running `cago build` or `cargo run`, it is likely necessary to run `make install-py` to ensure that the Python virtual environment is available for build.
 
 Instead use the following `make` commands:
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarifies dev setup in CLAUDE.md: run `make install-py` before `cargo build` or `cargo run` to ensure the Python venv and bindings are available. Prevents common local build failures.

<sup>Written for commit e1bda51daaa8b348f10f8fd1e40224d26f206063. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

