### PR TITLE
fix typo in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,7 @@ Avoid manual `drop_with_heap` whenever there are multiple code paths (branching,
 
 ## Dev Commands
 
-**IMPORTANT**: before running `cago build` or `cargo run`, it is likely necessary to run `make install-py` to ensure that the Python virtual environment is available for build.
+**IMPORTANT**: before running `cargo build` or `cargo run`, it is likely necessary to run `make install-py` to ensure that the Python virtual environment is available for build.
 
 Instead use the following `make` commands:
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a typo in CLAUDE.md: changes "cago build" to "cargo build" in the Dev Commands section for accurate setup instructions. Helps avoid confusion when running `cargo build`/`cargo run` after `make install-py`.

<sup>Written for commit c0a4ca0087e64db2cc170ce7a185dbfd1abaf4e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

