### PR TITLE
fix exception stack corruption in various `raise` cases

### DIFF
--- a/crates/monty/src/bytecode/code.rs
+++ b/crates/monty/src/bytecode/code.rs
@@ -276,17 +276,30 @@ pub struct ExceptionEntry {
     /// The VM pops values until the stack reaches this depth, then
     /// pushes the exception value.
     stack_depth: u16,
+
+    /// Number of THIS frame's exceptions that should be on `exception_stack`
+    /// when execution is inside this try region — i.e., the
+    /// `except_handler_depth` recorded by the compiler at the try-region
+    /// entry. Used by the VM during exception unwind to pop entries left
+    /// behind by handlers that the new exception is propagating past
+    /// (e.g. `try: raise; except: raise NewError` — the inner except's
+    /// entry needs to be dropped because the inner handler is abandoned
+    /// even though its trailer is dead code). Without this, a later bare
+    /// `raise` could resurrect an exception whose handler had been
+    /// abandoned via `raise`/`return`/`break`/`continue`.
+    exception_stack_count: u16,
 }
 
 impl ExceptionEntry {
     /// Creates a new exception table entry.
     #[must_use]
-    pub fn new(start: u32, end: u32, handler: u32, stack_depth: u16) -> Self {
+    pub fn new(start: u32, end: u32, handler: u32, stack_depth: u16, exception_stack_count: u16) -> Self {
         Self {
             start,
             end,
             handler,
             stack_depth,
+            exception_stack_count,
         }
     }
 
@@ -300,6 +313,13 @@ impl ExceptionEntry {
     #[must_use]
     pub fn stack_depth(&self) -> u16 {
         self.stack_depth
+    }
+
+    /// Returns the number of this-frame `exception_stack` entries expected
+    /// at the try region — see the field docs.
+    #[must_use]
+    pub fn exception_stack_count(&self) -> u16 {
+        self.exception_stack_count
     }
 
     /// Returns true if the given bytecode offset is within this entry's protected range.

--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -135,6 +135,14 @@ struct FinallyTarget {
     /// The loop depth when this finally was entered.
     /// Used to determine if break/continue targets a loop outside this finally.
     loop_depth_at_entry: usize,
+    /// `except_handler_depth` at the try-statement entry — i.e. the number
+    /// of enclosing `except` clauses that are still alive while control is
+    /// inside this finally's protected region. A `return` that crosses
+    /// this finally must NOT pop those handlers' exception state (the
+    /// finally body might reference them); cleanup of handlers between
+    /// here and the next-outer finally is the responsibility of this
+    /// finally's emit_return_routing trailer.
+    except_handler_depth_at_entry: usize,
 }
 
 /// Result of module compilation: the module code and all compiled functions.
@@ -243,12 +251,7 @@ impl<'a> Compiler<'a> {
                 self.code.emit(Opcode::Pop); // Discard result
             }
             Node::Return(expr) => {
-                self.compile_expr(expr)?;
-                self.compile_return();
-            }
-            Node::ReturnNone => {
-                self.code.emit(Opcode::LoadNone);
-                self.compile_return();
+                self.compile_return(expr.as_ref())?;
             }
             Node::Assign { target, object } => {
                 self.compile_expr(object)?;
@@ -2778,21 +2781,56 @@ impl<'a> Compiler<'a> {
     // Exception Handling Compilation
     // ========================================================================
 
-    /// Compiles a return statement, handling finally blocks properly.
+    /// Compiles a return statement.
     ///
-    /// If we're inside a try-finally block, the return value is kept on the stack
-    /// and we jump to a "finally with return" section that runs finally then returns.
-    /// Otherwise, we emit a direct `ReturnValue`.
-    fn compile_return(&mut self) {
+    /// `expr` is the expression after `return` (`None` for a bare `return`).
+    ///
+    /// Clears active-exception state for every `except` handler we're
+    /// exiting up to (but not past) the next enclosing finally — finally
+    /// bodies between us and the next-outer finally need to run with their
+    /// textually-enclosing exception state intact, e.g.:
+    ///
+    /// ```python
+    /// try:
+    ///     raise ValueError
+    /// except ValueError:
+    ///     try:
+    ///         return  # inner finally below must STILL see ValueError as
+    ///     finally:    # the active exception so bare `raise` re-raises it.
+    ///         ...
+    /// ```
+    ///
+    /// The remaining handlers are cleared further out by the finally
+    /// trailers in [`compile_try`] as control flows through them.
+    fn compile_return(&mut self, expr: Option<&ExprLoc>) -> Result<(), CompileError> {
+        // `return` never falls through; preserve the statement-entry depth
+        // for any unreachable code that follows in the same block.
+        let dead_code_depth = self.code.stack_depth();
+
+        let target_depth = self
+            .finally_targets
+            .last()
+            .map_or(0, |t| t.except_handler_depth_at_entry);
+        for _ in 0..(self.except_handler_depth - target_depth) {
+            self.code.emit(Opcode::ClearException);
+            self.code.emit(Opcode::Pop);
+        }
+
+        if let Some(expr) = expr {
+            self.compile_expr(expr)?;
+        } else {
+            self.code.emit(Opcode::LoadNone);
+        }
+
         if let Some(finally_target) = self.finally_targets.last_mut() {
-            // Inside a try-finally: jump to finally, then return
-            // Return value is already on stack
             let jump = self.code.emit_jump(Opcode::Jump);
             finally_target.return_jumps.push(jump);
         } else {
-            // Normal return
             self.code.emit(Opcode::ReturnValue);
         }
+
+        self.code.set_stack_depth(dead_code_depth);
+        Ok(())
     }
 
     /// Compiles a try/except/else/finally block.
@@ -2835,6 +2873,11 @@ impl<'a> Compiler<'a> {
 
         // Record stack depth at try entry (for unwinding on exception)
         let stack_depth = self.code.stack_depth();
+        // Record `except_handler_depth` at try entry — the count of this
+        // frame's exception_stack entries that should be active inside the
+        // try body. The VM uses this on unwind to drain entries left
+        // behind by abandoned-but-trailer-skipped handlers.
+        let try_exc_stack_count = u16::try_from(self.except_handler_depth).expect("except_handler_depth exceeds u16");
 
         // If there's a finally block, track returns/break/continue inside try/handlers/else
         if has_finally {
@@ -2843,6 +2886,7 @@ impl<'a> Compiler<'a> {
                 break_jumps: Vec::new(),
                 continue_jumps: Vec::new(),
                 loop_depth_at_entry: self.loop_stack.len(),
+                except_handler_depth_at_entry: self.except_handler_depth,
             });
         }
 
@@ -2918,7 +2962,28 @@ impl<'a> Compiler<'a> {
                 // Return value is on stack, stack = stack_depth + 1
                 self.code.set_stack_depth(stack_depth + 1);
                 self.compile_block(&try_block.finally)?;
-                self.compile_return();
+
+                // After the finally body, clear any except handlers between
+                // this try's entry depth and the next-outer finally (or 0).
+                // The return value is on top of the stack from the upstream
+                // Jump, so `Rot2` brings each handler's exception value to
+                // the top before `Pop`.
+                let target_depth = self
+                    .finally_targets
+                    .last()
+                    .map_or(0, |t| t.except_handler_depth_at_entry);
+                for _ in 0..(self.except_handler_depth - target_depth) {
+                    self.code.emit(Opcode::ClearException);
+                    self.code.emit(Opcode::Rot2);
+                    self.code.emit(Opcode::Pop);
+                }
+
+                if let Some(outer_finally) = self.finally_targets.last_mut() {
+                    let jump = self.code.emit_jump(Opcode::Jump);
+                    outer_finally.return_jumps.push(jump);
+                } else {
+                    self.code.emit(Opcode::ReturnValue);
+                }
                 Some(start)
             };
 
@@ -2980,24 +3045,30 @@ impl<'a> Compiler<'a> {
         // === Add exception table entries ===
         // Order matters: entries are searched in order, so inner entries must come first.
 
-        // Entry 1: Try body -> handler dispatch
+        // Entry 1: Try body -> handler dispatch.
+        // exception_stack_count = try_exc_stack_count: entering the try body
+        // adds no handler entries.
         if has_handlers || has_finally {
             self.code.add_exception_entry(ExceptionEntry::new(
                 u32::try_from(try_start).expect("bytecode offset exceeds u32"),
                 u32::try_from(try_end).expect("bytecode offset exceeds u32") + 3, // +3 to include the JUMP instruction
                 u32::try_from(handler_start).expect("bytecode offset exceeds u32"),
                 stack_depth,
+                try_exc_stack_count,
             ));
         }
 
-        // Entry 2: Handler dispatch -> finally cleanup (only if has_finally)
-        // This ensures finally runs when RERAISE is executed or any exception occurs in handlers
+        // Entry 2: Handler dispatch -> finally cleanup (only if has_finally).
+        // exception_stack_count = try_exc_stack_count + 1: the original
+        // exception was pushed onto exception_stack by entry 1's catch and
+        // is still active throughout handler dispatch.
         if let Some(cleanup_start) = finally_cleanup_start {
             self.code.add_exception_entry(ExceptionEntry::new(
                 u32::try_from(handler_start).expect("bytecode offset exceeds u32"),
                 u32::try_from(handler_dispatch_end).expect("bytecode offset exceeds u32"),
                 u32::try_from(cleanup_start).expect("bytecode offset exceeds u32"),
                 stack_depth,
+                try_exc_stack_count + 1,
             ));
         }
 
@@ -3009,17 +3080,20 @@ impl<'a> Compiler<'a> {
                 u32::try_from(else_start).expect("bytecode offset exceeds u32"), // End at else_start (before else block)
                 u32::try_from(cleanup_start).expect("bytecode offset exceeds u32"),
                 stack_depth,
+                try_exc_stack_count,
             ));
         }
 
-        // Entry 4: Else block -> finally cleanup (only if has_finally and has_else)
-        // Exceptions in else block should go through finally
+        // Entry 4: Else block -> finally cleanup (only if has_finally and
+        // has_else). Else runs when no exception was raised, so no handler
+        // pushed an entry: exception_stack_count = try_exc_stack_count.
         if has_else && let Some(cleanup_start) = finally_cleanup_start {
             self.code.add_exception_entry(ExceptionEntry::new(
                 u32::try_from(else_start).expect("bytecode offset exceeds u32"),
                 u32::try_from(else_end).expect("bytecode offset exceeds u32"),
                 u32::try_from(cleanup_start).expect("bytecode offset exceeds u32"),
                 stack_depth,
+                try_exc_stack_count,
             ));
         }
 

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -283,10 +283,12 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         self.stack.extend(namespace_values);
 
         // Push frame to execute the coroutine
+        let exc_stack_base = self.exception_stack.len();
         self.push_frame(CallFrame::new_function(
             &func.code,
             stack_base,
             locals_count,
+            exc_stack_base,
             func_id,
             call_position,
         ))?;
@@ -552,6 +554,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
                 ip: f.ip,
                 stack_base: f.stack_base,
                 locals_count: f.locals_count,
+                exception_stack_base: f.exception_stack_base,
                 call_position: f.call_position,
             })
             .collect();
@@ -614,6 +617,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
                         ip: sf.ip,
                         stack_base: sf.stack_base,
                         locals_count: sf.locals_count,
+                        exception_stack_base: sf.exception_stack_base,
                         function_id: sf.function_id,
                         call_position: sf.call_position,
                         should_return: false,
@@ -694,10 +698,12 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         let stack_base = self.stack.len();
         self.stack.extend(namespace_values);
 
+        let exc_stack_base = self.exception_stack.len();
         self.push_frame(CallFrame::new_function(
             &func.code,
             stack_base,
             locals_count,
+            exc_stack_base,
             func_id,
             None, // No call position — this is the root frame for a spawned task
         ))?;

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -758,10 +758,12 @@ impl<T: ResourceTracker> VM<'_, T> {
         let (namespace, this) = namespace_guard.into_parts();
         this.stack.extend(namespace);
 
+        let exc_stack_base = this.exception_stack.len();
         this.push_frame(CallFrame::new_function(
             code,
             stack_base,
             locals_count,
+            exc_stack_base,
             func_id,
             call_position,
         ))?;

--- a/crates/monty/src/bytecode/vm/exceptions.rs
+++ b/crates/monty/src/bytecode/vm/exceptions.rs
@@ -159,10 +159,22 @@ impl<T: ResourceTracker> VM<'_, T> {
                 // Found a handler! Unwind stack and jump to it.
                 let handler_offset = usize::try_from(entry.handler()).expect("handler offset exceeds usize");
                 let target_stack_depth = frame.stack_base + frame.locals_count as usize + entry.stack_depth() as usize;
+                let target_exc_stack_depth = frame.exception_stack_base + entry.exception_stack_count() as usize;
 
                 // Unwind stack to target depth (drop excess values)
                 while this.stack.len() > target_stack_depth {
                     let value = this.stack.pop().unwrap();
+                    value.drop_with_heap(this);
+                }
+
+                // Drop any `exception_stack` entries left behind by handlers
+                // the propagating exception is bypassing — without this, a
+                // handler whose body terminated via `raise`/`return`/`break`/
+                // `continue` (so its trailer's `ClearException` is dead code)
+                // would leak its exception onto `exception_stack`, where a
+                // later bare `raise` could resurrect it.
+                while this.exception_stack.len() > target_exc_stack_depth {
+                    let value = this.exception_stack.pop().unwrap();
                     value.drop_with_heap(this);
                 }
 
@@ -173,8 +185,9 @@ impl<T: ResourceTracker> VM<'_, T> {
                 // Reclaim exc_value from guard - it's being pushed onto exception_stack
                 let (exc_value, this) = exc_guard.into_parts();
 
-                // Push exception onto the exception_stack for bare raise
-                // This allows nested except handlers to restore outer exception context
+                // Push exception onto the exception_stack for bare raise.
+                // This allows nested except handlers to restore outer
+                // exception context.
                 this.exception_stack.push(exc_value);
 
                 // Jump to handler

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -352,6 +352,19 @@ pub struct CallFrame<'code> {
     /// For function frames, this equals `func.namespace_size`.
     locals_count: u16,
 
+    /// Base index into the VM-wide `exception_stack` for this frame.
+    ///
+    /// Entries pushed by `except` handlers in this frame live at
+    /// `exception_stack[exception_stack_base..]`, while
+    /// `exception_stack[..exception_stack_base]` belongs to caller frames.
+    /// `ExceptionEntry.exception_stack_count` is relative to this base —
+    /// on exception unwind, the VM drains entries down to
+    /// `exception_stack_base + entry.exception_stack_count()` so that
+    /// handlers abandoned by the propagating exception (whose
+    /// fall-through trailers are dead code) don't leave residue that a
+    /// later bare `raise` would resurrect.
+    exception_stack_base: usize,
+
     /// Function ID (for tracebacks). None for module-level code.
     function_id: Option<FunctionId>,
 
@@ -368,12 +381,13 @@ impl<'code> CallFrame<'code> {
     ///
     /// Module frames have `locals_count = 0` because module-level variables
     /// are stored in the VM's `globals` vec, not in the stack.
-    pub fn new_module(code: &'code Code) -> Self {
+    pub fn new_module(code: &'code Code, exception_stack_base: usize) -> Self {
         Self {
             code,
             ip: 0,
             stack_base: 0,
             locals_count: 0,
+            exception_stack_base,
             function_id: None,
             call_position: None,
             should_return: false,
@@ -388,6 +402,7 @@ impl<'code> CallFrame<'code> {
         code: &'code Code,
         stack_base: usize,
         locals_count: u16,
+        exception_stack_base: usize,
         function_id: FunctionId,
         call_position: Option<CodeRange>,
     ) -> Self {
@@ -396,6 +411,7 @@ impl<'code> CallFrame<'code> {
             ip: 0,
             stack_base,
             locals_count,
+            exception_stack_base,
             function_id: Some(function_id),
             call_position,
             should_return: false,
@@ -447,6 +463,10 @@ pub struct SerializedFrame {
     /// Number of local variable slots (0 for module-level frames).
     locals_count: u16,
 
+    /// Base index into the VM-wide `exception_stack` for this frame.
+    /// See `CallFrame.exception_stack_base`.
+    exception_stack_base: usize,
+
     /// Call site position (for tracebacks).
     call_position: Option<CodeRange>,
 }
@@ -463,6 +483,7 @@ impl CallFrame<'_> {
             ip: self.ip,
             stack_base: self.stack_base,
             locals_count: self.locals_count,
+            exception_stack_base: self.exception_stack_base,
             call_position: self.call_position,
         }
     }
@@ -645,6 +666,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
                     ip: sf.ip,
                     stack_base: sf.stack_base,
                     locals_count: sf.locals_count,
+                    exception_stack_base: sf.exception_stack_base,
                     function_id: sf.function_id,
                     call_position: sf.call_position,
                     should_return: false,
@@ -703,7 +725,8 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
     pub fn run_module(&mut self, code: &'h Code) -> Result<FrameExit, RunError> {
         // Store module code for restoring main task frames during task switching
         self.module_code = Some(code);
-        self.push_frame(CallFrame::new_module(code))?;
+        let exc_stack_base = self.exception_stack.len();
+        self.push_frame(CallFrame::new_module(code, exc_stack_base))?;
         self.run()
     }
 
@@ -1417,9 +1440,17 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
                     catch_sync!(self, cached_frame, error);
                 }
                 Opcode::Reraise => {
-                    // Pop the current exception from the stack to re-raise it
-                    // If caught, handle_exception will push it back
-                    let error = if let Some(exc) = self.exception_stack.pop() {
+                    // Re-raise the currently-being-handled exception (top of
+                    // exception_stack), keeping the original entry in place
+                    // — popping would lose track of the enclosing handler
+                    // when the bare raise is locally caught (the local
+                    // handler's `ClearException` would otherwise pop the
+                    // enclosing entry instead of its own new one). When the
+                    // re-raised exception propagates past handler boundaries,
+                    // the unwind drain via `exception_stack_count` cleans up
+                    // any leftover entries.
+                    let error = if let Some(exc) = self.exception_stack.last() {
+                        let exc = exc.clone_with_heap(self.heap);
                         self.make_exception(exc, true) // is_raise=true for reraise
                     } else {
                         // No active exception - create a RuntimeError

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -124,6 +124,9 @@ pub(crate) struct SerializedTaskFrame {
     pub stack_base: usize,
     /// Number of local variable slots (0 for module-level frames).
     pub locals_count: u16,
+    /// Base index into the VM-wide `exception_stack` for this frame.
+    /// See `CallFrame.exception_stack_base`.
+    pub exception_stack_base: usize,
     /// Call site position (for tracebacks).
     pub call_position: Option<CodeRange>,
 }

--- a/crates/monty/src/expressions.rs
+++ b/crates/monty/src/expressions.rs
@@ -501,8 +501,7 @@ pub enum Node<F> {
     /// No-op statement. Only present in parsed form, filtered out during prepare.
     Pass,
     Expr(ExprLoc),
-    Return(ExprLoc),
-    ReturnNone,
+    Return(Option<ExprLoc>),
     Raise(Option<ExprLoc>),
     Assert {
         test: ExprLoc,

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -283,10 +283,10 @@ impl<'a> Parser<'a> {
                 "class definitions",
                 self.convert_range(c.range),
             )),
-            Stmt::Return(ast::StmtReturn { value, .. }) => match value {
-                Some(value) => Ok(Node::Return(self.parse_expression(*value)?)),
-                None => Ok(Node::ReturnNone),
-            },
+            Stmt::Return(ast::StmtReturn { value, .. }) => Ok(Node::Return(match value {
+                Some(value) => Some(self.parse_expression(*value)?),
+                None => None,
+            })),
             Stmt::Delete(d) => Err(ParseError::not_implemented(
                 "the 'del' statement",
                 self.convert_range(d.range),

--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -56,7 +56,7 @@ pub(crate) fn prepare(parse_result: ParseResult, input_names: Vec<String>) -> Re
     {
         let new_expr_loc = expr_loc.clone();
         prepared_nodes.pop();
-        prepared_nodes.push(Node::Return(new_expr_loc));
+        prepared_nodes.push(Node::Return(Some(new_expr_loc)));
     }
 
     Ok(PrepareResult {
@@ -85,7 +85,7 @@ pub(crate) fn prepare_with_existing_names(
     {
         let new_expr_loc = expr_loc.clone();
         prepared_nodes.pop();
-        prepared_nodes.push(Node::Return(new_expr_loc));
+        prepared_nodes.push(Node::Return(Some(new_expr_loc)));
     }
 
     Ok(PrepareResult {
@@ -314,8 +314,10 @@ impl<'i> Prepare<'i> {
             match node {
                 Node::Pass => (),
                 Node::Expr(expr) => new_nodes.push(Node::Expr(self.prepare_expression(expr)?)),
-                Node::Return(expr) => new_nodes.push(Node::Return(self.prepare_expression(expr)?)),
-                Node::ReturnNone => new_nodes.push(Node::ReturnNone),
+                Node::Return(expr) => new_nodes.push(Node::Return(match expr {
+                    Some(expr) => Some(self.prepare_expression(expr)?),
+                    None => None,
+                })),
                 Node::Raise(exc) => {
                     let expr = match exc {
                         Some(expr) => {
@@ -1480,7 +1482,7 @@ impl<'i> Prepare<'i> {
         );
 
         // Wrap the body expression as a return statement for scope analysis
-        let body_as_node: ParseNode = Node::Return(body.clone());
+        let body_as_node: ParseNode = Node::Return(Some(body.clone()));
         let body_nodes = vec![body_as_node];
 
         // Extract param names from the parsed signature for scope analysis
@@ -2159,10 +2161,7 @@ fn collect_scope_info_from_node(
             }
         }
         // Statements with expressions that may contain walrus operators
-        Node::Expr(expr) | Node::Return(expr) => {
-            collect_assigned_names_from_expr(expr, assigned_names, interner);
-        }
-        Node::Raise(Some(expr)) => {
+        Node::Expr(expr) | Node::Return(Some(expr)) | Node::Raise(Some(expr)) => {
             collect_assigned_names_from_expr(expr, assigned_names, interner);
         }
         Node::Assert { test, msg } => {
@@ -2172,7 +2171,7 @@ fn collect_scope_info_from_node(
             }
         }
         // These don't create new names
-        Node::Pass | Node::ReturnNone | Node::Raise(None) | Node::Break { .. } | Node::Continue { .. } => {}
+        Node::Pass | Node::Return(None) | Node::Raise(None) | Node::Break { .. } | Node::Continue { .. } => {}
     }
 }
 
@@ -2457,9 +2456,10 @@ fn collect_cell_vars_from_node(
             }
         }
         // Handle expressions that may contain lambdas
-        Node::Expr(expr) | Node::Return(expr) => {
+        Node::Expr(expr) | Node::Return(Some(expr)) => {
             collect_cell_vars_from_expr(expr, our_locals, cell_vars, interner);
         }
+        Node::Return(None) => {}
         Node::Assign { object, .. } | Node::UnpackAssign { object, .. } => {
             collect_cell_vars_from_expr(object, our_locals, cell_vars, interner);
         }
@@ -2724,10 +2724,10 @@ fn collect_cell_vars_from_args(
 /// This is used to find what names a nested function references from enclosing scopes.
 fn collect_referenced_names_from_node(node: &ParseNode, referenced: &mut AHashSet<String>, interner: &InternerBuilder) {
     match node {
-        Node::Expr(expr) => collect_referenced_names_from_expr(expr, referenced, interner),
-        Node::Return(expr) => collect_referenced_names_from_expr(expr, referenced, interner),
-        Node::Raise(Some(expr)) => collect_referenced_names_from_expr(expr, referenced, interner),
-        Node::Raise(None) => {}
+        Node::Expr(expr) | Node::Return(Some(expr)) | Node::Raise(Some(expr)) => {
+            collect_referenced_names_from_expr(expr, referenced, interner);
+        }
+        Node::Return(None) | Node::Raise(None) => {}
         Node::Assert { test, msg } => {
             collect_referenced_names_from_expr(test, referenced, interner);
             if let Some(m) = msg {
@@ -2832,12 +2832,7 @@ fn collect_referenced_names_from_node(node: &ParseNode, referenced: &mut AHashSe
         }
         // Imports create bindings but don't reference names
         Node::Import { .. } | Node::ImportFrom { .. } => {}
-        Node::Pass
-        | Node::ReturnNone
-        | Node::Global { .. }
-        | Node::Nonlocal { .. }
-        | Node::Break { .. }
-        | Node::Continue { .. } => {}
+        Node::Pass | Node::Global { .. } | Node::Nonlocal { .. } | Node::Break { .. } | Node::Continue { .. } => {}
     }
 }
 

--- a/crates/monty/test_cases/try_except__all.py
+++ b/crates/monty/test_cases/try_except__all.py
@@ -470,3 +470,227 @@ try:
 except (ValueError, BaseException):
     caught_by_tuple_with_base = True
 assert caught_by_tuple_with_base, 'tuple with BaseException should catch KeyboardInterrupt'
+
+
+# === Exception state cleared on `return` from inside an except handler ===
+# When `return` exits an except clause, the exception is cleared from the
+# active-exception state before any surrounding finally runs and before
+# control returns to the caller. A bare `raise` inside that finally (or
+# in subsequent code in the caller) must therefore see `RuntimeError(
+# "No active exception to reraise")` rather than re-raising the exception
+# the except clause had just been handling.
+
+
+# Bare raise inside a try/except inside a finally that runs after
+# return-from-except: should be caught as RuntimeError, not ValueError.
+def _return_from_except_then_bare_raise_in_finally() -> None:
+    try:
+        try:
+            raise ValueError('original')
+        except ValueError:
+            return
+    finally:
+        try:
+            raise  # bare reraise — exception should already be cleared
+        except ValueError:
+            assert False, '`return` from except must clear the exception before finally runs'
+        except RuntimeError as exc:
+            assert str(exc) == 'No active exception to reraise'
+
+
+_return_from_except_then_bare_raise_in_finally()
+
+
+# Return from a doubly-nested except handler should clear EVERY enclosing
+# handler's exception state, not just the innermost.
+def _return_from_doubly_nested_except() -> None:
+    try:
+        try:
+            try:
+                raise ValueError('inner')
+            except ValueError:
+                raise TypeError('middle')
+        except TypeError:
+            return
+    finally:
+        try:
+            raise
+        except (ValueError, TypeError):
+            assert False, "`return` from doubly-nested except must clear every handler's exception state"
+        except RuntimeError as exc:
+            assert str(exc) == 'No active exception to reraise'
+
+
+_return_from_doubly_nested_except()
+
+
+# After a function returns from inside an except clause, the caller's
+# active-exception state should NOT contain that function's exception.
+def _returns_from_except_no_finally() -> str:
+    try:
+        raise ValueError('original')
+    except ValueError:
+        return 'returned'
+
+
+assert _returns_from_except_no_finally() == 'returned'
+try:
+    raise  # bare raise in caller — no exception should be active here
+except ValueError:
+    assert False, "caller should not see inner function's exception as current"
+except RuntimeError as exc:
+    assert str(exc) == 'No active exception to reraise'
+
+
+# === Exception state cleared when an exception propagates past handlers ===
+# When an exception is raised from inside an except clause and is caught
+# by a sibling/outer handler, the inner (abandoned) handler's exception
+# must be cleared from the active-exception state — its trailer that
+# would normally pop it is dead code (the handler body terminated via
+# raise rather than falling through). Without this, a bare `raise` later
+# resurrects the abandoned exception instead of producing
+# `RuntimeError("No active exception to reraise")`.
+
+# Triple-nested: `raise X` → `raise Y` → `raise Z`, then bare raise outside.
+# Each abandoned handler should be cleared.
+try:
+    try:
+        try:
+            raise ValueError('first')
+        except ValueError:
+            raise TypeError('second')
+    except TypeError:
+        raise KeyError('third')
+except KeyError as third:
+    assert str(third) == "'third'"
+
+try:
+    raise
+except RuntimeError as exc:
+    assert str(exc) == 'No active exception to reraise'
+
+
+# Raising from a NESTED try body inside an except clause must NOT clear
+# the surrounding handler's exception — the inner raise is caught locally
+# and the outer handler is still active. After the inner try-except
+# completes, a bare `raise` in the outer handler should re-raise the
+# outer's original exception, not produce RuntimeError.
+try:
+    raise ValueError('outer')
+except ValueError as caught:
+    try:
+        raise KeyError('inner')
+    except KeyError:
+        pass  # inner caught locally; outer's ValueError should remain active
+
+    # Bare raise here should re-raise the outer's ValueError.
+    try:
+        raise
+    except ValueError as bare:
+        assert str(bare) == 'outer', 'bare raise should re-raise outer exception, not be cleared by inner raise'
+
+
+# Function-call boundary: an exception raised and caught inside a callee
+# must not leak active-exception state back to the caller. Probe via bare
+# `raise` in the caller after the callee returns.
+def _callee_raises_and_handles():
+    try:
+        raise ValueError('callee internal')
+    except ValueError:
+        pass
+
+
+_callee_raises_and_handles()
+try:
+    raise
+except RuntimeError as exc:
+    assert str(exc) == 'No active exception to reraise'
+
+
+# === Return through inner try-finally inside an except keeps outer exception ===
+# When `return` is inside a try-finally nested inside an except handler,
+# the inner finally must run with the OUTER except's exception still
+# active — a bare `raise` inside the inner finally should re-raise the
+# outer exception, not produce RuntimeError. The active-exception cleanup
+# for the outer except must be deferred until after the inner finally
+# completes.
+
+_return_through_inner_finally_log: list[tuple[str, str]] = []
+
+
+def _return_through_inner_finally() -> str:
+    try:
+        raise ValueError('outer')
+    except ValueError:
+        try:
+            return 'done'
+        finally:
+            try:
+                raise  # outer ValueError should still be the active exception
+            except ValueError as caught:
+                _return_through_inner_finally_log.append(('ValueError', str(caught)))
+            except RuntimeError as e:
+                _return_through_inner_finally_log.append(('RuntimeError', str(e)))
+    return 'unreachable'
+
+
+assert _return_through_inner_finally() == 'done'
+assert _return_through_inner_finally_log == [('ValueError', 'outer')], (
+    f'expected outer ValueError to remain active inside inner finally, got {_return_through_inner_finally_log!r}'
+)
+
+
+# After the function returns, the caller's active-exception state must
+# still be clean — the outer except's exception was cleared on return.
+try:
+    raise
+except RuntimeError as exc:
+    assert str(exc) == 'No active exception to reraise'
+
+
+# === Return through TWO nested finallys inside two excepts ===
+# Each finally runs with the textually-active exception still on top
+# of `exception_stack` — the inner finally sees the inner except's
+# exception, the outer finally sees the outer except's exception.
+# This exercises both the per-finally cleanup boundary in
+# `emit_return_routing` and the clone-not-pop behavior of bare `raise`
+# (without which the inner finally's locally-caught reraise would
+# strand the outer except's entry).
+
+_two_finally_log: list[tuple[str, str, str]] = []
+
+
+def _return_through_two_finallys() -> str:
+    try:
+        raise ValueError('A')
+    except ValueError:
+        try:  # outer try has finally
+            try:
+                raise TypeError('B')
+            except TypeError:
+                try:  # inner try has finally
+                    return 'done'
+                finally:
+                    try:
+                        raise  # outer=A and inner=B both active; reraises B
+                    except TypeError as t:
+                        _two_finally_log.append(('inner_finally', 'TypeError', str(t)))
+                    except ValueError as v:
+                        _two_finally_log.append(('inner_finally', 'ValueError', str(v)))
+        finally:
+            try:
+                raise  # only A is still active here; B was bound to the inner except that we exited
+            except ValueError as v:
+                _two_finally_log.append(('outer_finally', 'ValueError', str(v)))
+            except TypeError as t:
+                _two_finally_log.append(('outer_finally', 'TypeError', str(t)))
+            except RuntimeError as r:
+                _two_finally_log.append(('outer_finally', 'RuntimeError', str(r)))
+    return 'fallback'
+
+
+assert _return_through_two_finallys() == 'done'
+assert _two_finally_log == [
+    ('inner_finally', 'TypeError', 'B'),
+    ('outer_finally', 'ValueError', 'A'),
+], f'unexpected log {_two_finally_log!r}'


### PR DESCRIPTION
Found while trying to fix bugs in #372

This resolves a bunch of edge cases around VM state corruption around `raise` - see the new tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes exception-state corruption in the VM for `raise` and `return` paths, so bare raises, returns from `except`, and nested try/finally behave correctly and don’t resurrect abandoned exceptions. Aligns behavior with Python: bare `raise` without an active exception now reliably raises `RuntimeError("No active exception to reraise")`.

- **Bug Fixes**
  - Clear the active exception on `return` from `except` before any `finally` runs and before returning to the caller.
  - Drain stale handler entries when an exception propagates past inner handlers, preventing later bare `raise` from reviving them.
  - Preserve the outer exception across inner try/finally during `return`; bare `raise` in the inner `finally` re-raises the outer exception.
  - Make bare `raise` clone (not pop) the current exception so nested handlers and local catches work reliably.

- **Refactors**
  - Added `exception_stack_count` to exception table entries and per-frame `exception_stack_base`; VM unwinds both value stack and `exception_stack` to precise depths during handler dispatch.
  - Compiler tracks `except_handler_depth_at_entry` and updates return routing/finally trailers to clear exception state only up to the next enclosing finally boundary.
  - Simplified AST to `Return(Option<ExprLoc>)`; updated parser and prepare phase.
  - Set and serialize `exception_stack_base` for all frames (module, function, async/spawn).
  - Expanded tests in `try_except__all.py` to cover returns from `except`, nested raises, and multi-finally flows.

<sup>Written for commit 5b770d1c15a10050a63df1aa0a64794cac16c973. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

