### PR TITLE
avoid unbounded recursion in two tuple traversal cases

### DIFF
--- a/crates/monty-datatest/src/main.rs
+++ b/crates/monty-datatest/src/main.rs
@@ -45,19 +45,16 @@ static CANONICAL_WS_DIR: LazyLock<PathBuf> =
 /// * and, stack overflows in debug rust (if it's too high)
 const TEST_RECURSION_LIMIT: usize = 50;
 
-/// Builds the `ResourceLimits` used by each datatest run.
+/// The `ResourceLimits` applied to every datatest run when the fixture omits
+/// `# gc-interval=` / `# max-recursion-depth=` directives.
 ///
-/// Applies the standard recursion-depth cap and, if the fixture specified
-/// `# gc-interval=<N>`, overrides the default GC interval. The underlying
-/// default is `DEFAULT_GC_INTERVAL` in `crates/monty/src/heap.rs`, which is 1
-/// under `memory-model-checks` and 100_000 otherwise — some tests need a
-/// larger value to stay within the test timeout.
-fn build_test_limits(gc_interval: Option<usize>) -> ResourceLimits {
-    let mut limits = ResourceLimits::new().max_recursion_depth(Some(TEST_RECURSION_LIMIT));
-    if let Some(interval) = gc_interval {
-        limits = limits.gc_interval(interval);
-    }
-    limits
+/// Caps recursion at `TEST_RECURSION_LIMIT` and otherwise leaves limits at their
+/// builder defaults. The underlying default GC interval is `DEFAULT_GC_INTERVAL`
+/// in `crates/monty/src/heap.rs`, which is 1 under `memory-model-checks` and
+/// 100_000 otherwise — tests that need a larger value to stay within the
+/// timeout opt into it via `# gc-interval=<N>`.
+fn default_test_limits() -> ResourceLimits {
+    ResourceLimits::new().max_recursion_depth(Some(TEST_RECURSION_LIMIT))
 }
 
 /// Test configuration parsed from directive comments.
@@ -74,7 +71,7 @@ fn build_test_limits(gc_interval: Option<usize>) -> ResourceLimits {
 ///   Used for tests that rely on POSIX path semantics which Monty's sandbox always
 ///   provides but Windows CPython does not.
 /// - `xfail=monty,cpython` - Expected to fail on both interpreters
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 #[expect(clippy::struct_excessive_bools)]
 struct TestConfig {
     /// When true, test is expected to fail on Monty (strict xfail).
@@ -94,14 +91,26 @@ struct TestConfig {
     /// path semantics (e.g. pathlib tests using `/` paths) which are correct for
     /// Monty's always-POSIX sandbox but behave differently on Windows CPython.
     skip_cpython_windows: bool,
-    /// When set, overrides the default GC allocation interval used when constructing
-    /// `ResourceLimits` for this test. Parsed from `# gc-interval=<N>`.
-    ///
-    /// The underlying default is `DEFAULT_GC_INTERVAL` (1 under `memory-model-checks`,
-    /// 100_000 otherwise). Some tests — especially recursive ones — run very slowly
-    /// under a gc_interval of 1, so this directive lets them opt into a larger value
-    /// to stay within the test timeout. Only the Monty runner reads this.
-    gc_interval: Option<usize>,
+    /// Resource limits applied to this test's Monty run. Defaults to
+    /// `default_test_limits()`; directives like `# gc-interval=<N>` and
+    /// `# max-recursion-depth=<N>` mutate this in `parse_fixture`. Only the
+    /// Monty runner reads this; CPython continues to use its own default
+    /// limits.
+    limits: ResourceLimits,
+}
+
+impl Default for TestConfig {
+    fn default() -> Self {
+        Self {
+            xfail_monty: false,
+            xfail_cpython: false,
+            iter_mode: false,
+            async_mode: false,
+            mount_fs: false,
+            skip_cpython_windows: false,
+            limits: default_test_limits(),
+        }
+    }
 }
 
 /// Represents the expected outcome of a test fixture
@@ -191,17 +200,14 @@ fn parse_fixture(content: &str) -> (String, Expectation, TestConfig) {
         config.xfail_cpython = xfail_str.contains("cpython");
     }
 
-    // Check for "gc-interval=<N>" directive. Overrides the default GC allocation
-    // interval for this test only. Parse until whitespace or end of line so that
-    // trailing comment text like "# gc-interval=100  recursive test" works.
-    if let Some(&gc_line) = comment_lines.iter().find(|line| line.starts_with("gc-interval=")) {
-        let value = &gc_line["gc-interval=".len()..];
-        let value_end = value.find(|c: char| c.is_whitespace()).unwrap_or(value.len());
-        let value_str = value[..value_end].trim();
-        let parsed: usize = value_str
-            .parse()
-            .unwrap_or_else(|e| panic!("invalid gc-interval directive {value_str:?}: {e}"));
-        config.gc_interval = Some(parsed);
+    // Parse resource-limit directives. `config.limits` starts as
+    // `default_test_limits()`; each directive overrides one field, preserving
+    // the standard test recursion cap unless explicitly overridden.
+    if let Some(interval) = parse_usize_directive(&comment_lines, "gc-interval=") {
+        config.limits.gc_interval = Some(interval);
+    }
+    if let Some(depth) = parse_usize_directive(&comment_lines, "max-recursion-depth=") {
+        config.limits.max_recursion_depth = Some(depth);
     }
 
     // Check for TRACEBACK expectation (triple-quoted string at end of file)
@@ -237,6 +243,24 @@ fn parse_fixture(content: &str) -> (String, Expectation, TestConfig) {
     let code = code_lines.join("\n");
 
     (code, expectation, config)
+}
+
+/// Parses a `# <prefix><usize>` directive, ignoring trailing whitespace and
+/// trailing comment text so `# gc-interval=100  recursive test` works.
+///
+/// Panics if a directive is present but the value isn't a valid `usize` — these
+/// are author-controlled, so a malformed directive is a test bug, not a runtime
+/// error to be surfaced gracefully.
+fn parse_usize_directive(comment_lines: &[&str], prefix: &str) -> Option<usize> {
+    let line = comment_lines.iter().find(|line| line.starts_with(prefix))?;
+    let value = &line[prefix.len()..];
+    let value_end = value.find(|c: char| c.is_whitespace()).unwrap_or(value.len());
+    let value_str = value[..value_end].trim();
+    Some(
+        value_str
+            .parse()
+            .unwrap_or_else(|e| panic!("invalid {prefix}{value_str:?} directive: {e}")),
+    )
 }
 
 /// Parses a TRACEBACK expectation from the end of a fixture file.
@@ -1275,12 +1299,7 @@ impl fmt::Display for TestFailure {
 ///
 /// This function executes Python code via the MontyRun and validates the result
 /// against the expected outcome specified in the fixture.
-fn try_run_test(
-    path: &Path,
-    code: &str,
-    expectation: &Expectation,
-    gc_interval: Option<usize>,
-) -> Result<(), TestFailure> {
+fn try_run_test(path: &Path, code: &str, expectation: &Expectation, limits: ResourceLimits) -> Result<(), TestFailure> {
     let test_name = path
         .strip_prefix(TEST_CASES_RELATIVE_DIR)
         .unwrap_or(path)
@@ -1345,7 +1364,6 @@ fn try_run_test(
 
     match MontyRun::new(code.to_owned(), &test_name, vec![]) {
         Ok(ex) => {
-            let limits = build_test_limits(gc_interval);
             let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
             match result {
                 Ok(obj) => match expectation {
@@ -1474,7 +1492,7 @@ fn try_run_iter_test(
     path: &Path,
     code: &str,
     expectation: &Expectation,
-    gc_interval: Option<usize>,
+    limits: ResourceLimits,
 ) -> Result<(), TestFailure> {
     let test_name = path
         .strip_prefix(TEST_CASES_RELATIVE_DIR)
@@ -1532,7 +1550,7 @@ fn try_run_iter_test(
     };
 
     // Run execution loop, handling external function calls until complete
-    let result = run_iter_loop(exec, gc_interval);
+    let result = run_iter_loop(exec, limits);
 
     match result {
         Ok(obj) => match expectation {
@@ -1623,7 +1641,7 @@ fn try_run_mount_fs_test(
     path: &Path,
     code: &str,
     expectation: &Expectation,
-    gc_interval: Option<usize>,
+    limits: ResourceLimits,
 ) -> Result<(), TestFailure> {
     let test_name = path
         .strip_prefix(TEST_CASES_RELATIVE_DIR)
@@ -1654,7 +1672,7 @@ fn try_run_mount_fs_test(
         }
     };
 
-    let result = run_mount_fs_iter_loop(exec, &mut mount_table, gc_interval);
+    let result = run_mount_fs_iter_loop(exec, &mut mount_table, limits);
 
     match result {
         Ok(_) => match expectation {
@@ -1710,9 +1728,8 @@ fn try_run_mount_fs_test(
 fn run_mount_fs_iter_loop(
     exec: MontyRun,
     mount_table: &mut MountTable,
-    gc_interval: Option<usize>,
+    limits: ResourceLimits,
 ) -> Result<MontyObject, MontyException> {
-    let limits = build_test_limits(gc_interval);
     let mut progress = exec.start(vec![], LimitedTracker::new(limits), PrintWriter::Stdout)?;
 
     loop {
@@ -1758,8 +1775,7 @@ fn run_mount_fs_iter_loop(
 /// Supports both synchronous and asynchronous external functions:
 /// - Sync functions: result is passed immediately via `state.run()`
 /// - Async functions: `state.run_pending()` creates a future, resolved via `ResolveFutures`
-fn run_iter_loop(exec: MontyRun, gc_interval: Option<usize>) -> Result<MontyObject, MontyException> {
-    let limits = build_test_limits(gc_interval);
+fn run_iter_loop(exec: MontyRun, limits: ResourceLimits) -> Result<MontyObject, MontyException> {
     let mut progress = exec.start(vec![], LimitedTracker::new(limits), PrintWriter::Stdout)?;
 
     // Track pending async calls: (call_id, pre-built ExtFunctionResult).
@@ -2343,15 +2359,15 @@ fn run_test_cases_monty(path: &Path) -> Result<(), Box<dyn Error>> {
     let path_owned = path.to_owned();
     let iter_mode = config.iter_mode;
     let mount_fs = config.mount_fs;
-    let gc_interval = config.gc_interval;
+    let limits = config.limits;
 
     let result = run_with_timeout(TEST_TIMEOUT, move || {
         if mount_fs {
-            try_run_mount_fs_test(&path_owned, &code, &expectation, gc_interval)
+            try_run_mount_fs_test(&path_owned, &code, &expectation, limits)
         } else if iter_mode {
-            try_run_iter_test(&path_owned, &code, &expectation, gc_interval)
+            try_run_iter_test(&path_owned, &code, &expectation, limits)
         } else {
-            try_run_test(&path_owned, &code, &expectation, gc_interval)
+            try_run_test(&path_owned, &code, &expectation, limits)
         }
     });
 

--- a/crates/monty/src/builtins/isinstance.rs
+++ b/crates/monty/src/builtins/isinstance.rs
@@ -6,9 +6,9 @@ use crate::{
     bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult},
-    heap::{Heap, HeapData},
+    heap::{HeapRead, HeapReadOutput},
     resource::ResourceTracker,
-    types::{PyTrait, Type},
+    types::{PyTrait, Tuple, Type},
     value::Value,
 };
 
@@ -20,48 +20,58 @@ pub fn builtin_isinstance(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues
     defer_drop!(obj, vm);
     defer_drop!(classinfo, vm);
     let obj_type = obj.py_type(vm);
-    let heap = &mut *vm.heap;
 
-    match isinstance_check(obj_type, classinfo, heap) {
-        Ok(result) => Ok(Value::Bool(result)),
-        Err(()) => Err(ExcType::isinstance_arg2_error()),
-    }
+    isinstance_check(obj_type, classinfo, vm).map(Value::Bool)
 }
 
-/// Recursively checks if obj_type matches classinfo for isinstance().
-///
-/// Returns `Ok(true)` if the type matches, `Ok(false)` if it doesn't,
-/// or `Err(())` if classinfo is invalid (not a type or tuple of types).
+/// Checks if `obj_type` matches a single classinfo entry.
 ///
 /// Supports:
 /// - Single types: `isinstance(x, int)`
 /// - Exception types: `isinstance(err, ValueError)`
 /// - Exception hierarchy: `isinstance(err, LookupError)` for KeyError/IndexError
-/// - Nested tuples: `isinstance(x, (int, (str, bytes)))`
-fn isinstance_check(obj_type: Type, classinfo: &Value, heap: &Heap<impl ResourceTracker>) -> Result<bool, ()> {
+/// - Tuples (possibly nested) of the above
+fn isinstance_check(obj_type: Type, classinfo: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<bool> {
     match classinfo {
-        // Single type: isinstance(x, int)
         Value::Builtin(Builtins::Type(t)) => Ok(obj_type.is_instance_of(*t)),
-
-        // Exception type: isinstance(err, ValueError) or isinstance(err, LookupError)
         Value::Builtin(Builtins::ExcType(handler_type)) => {
-            // Check exception hierarchy using is_subclass_of
             Ok(matches!(obj_type, Type::Exception(exc_type) if exc_type.is_subclass_of(*handler_type)))
         }
-
-        // Tuple of types (possibly nested): isinstance(x, (int, (str, bytes)))
-        Value::Ref(id) => {
-            if let HeapData::Tuple(tuple) = heap.get(*id) {
-                for v in tuple.as_slice() {
-                    if isinstance_check(obj_type, v, heap)? {
-                        return Ok(true);
-                    }
-                }
-                Ok(false)
-            } else {
-                Err(()) // Not a tuple - invalid
-            }
+        Value::Ref(id) if let HeapReadOutput::Tuple(tuple) = vm.heap.read(*id) => {
+            isinstance_check_tuple(obj_type, &tuple, vm)
         }
-        _ => Err(()), // Invalid classinfo
+        _ => Err(ExcType::isinstance_arg2_error()),
     }
+}
+
+/// Recursively walks a tuple of classinfo entries.
+fn isinstance_check_tuple<'h>(
+    obj_type: Type,
+    tuple: &HeapRead<'h, Tuple>,
+    vm: &mut VM<'h, impl ResourceTracker>,
+) -> RunResult<bool> {
+    let len = tuple.get(vm.heap).as_slice().len();
+    let token = vm.heap.incr_recursion_depth()?;
+    defer_drop!(token, vm);
+    for i in 0..len {
+        match &tuple.get(vm.heap).as_slice()[i] {
+            Value::Builtin(Builtins::Type(t)) => {
+                if obj_type.is_instance_of(*t) {
+                    return Ok(true);
+                }
+            }
+            Value::Builtin(Builtins::ExcType(exc)) => {
+                if matches!(obj_type, Type::Exception(et) if et.is_subclass_of(*exc)) {
+                    return Ok(true);
+                }
+            }
+            Value::Ref(nested_id) if let HeapReadOutput::Tuple(tuple) = vm.heap.read(*nested_id) => {
+                if isinstance_check_tuple(obj_type, &tuple, vm)? {
+                    return Ok(true);
+                }
+            }
+            _ => return Err(ExcType::isinstance_arg2_error()),
+        }
+    }
+    Ok(false)
 }

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -348,9 +348,16 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
 
         if len == 1 {
             // Special case for single-element tuples: include the trailing comma
+            //
+            // Match `repr_sequence_fmt`'s depth handling so nested one-element
+            // tuples can't bypass `max_recursion_depth` and overflow the stack.
+            let Ok(token) = vm.heap.incr_recursion_depth() else {
+                return Ok(f.write_str("...")?);
+            };
+            defer_drop!(token, vm);
+            write!(f, "(")?;
             let item = self.clone_item(0, vm);
             defer_drop!(item, vm);
-            write!(f, "(")?;
             item.py_repr_fmt(f, vm, heap_ids)?;
             write!(f, ",)")?;
             return Ok(());

--- a/crates/monty/test_cases/recursion__deep_isinstance.py
+++ b/crates/monty/test_cases/recursion__deep_isinstance.py
@@ -1,0 +1,26 @@
+# gc-interval=200
+
+# Test that isinstance() with deeply-nested classinfo tuples raises
+# RecursionError instead of overflowing the Rust stack.
+
+# === Deeply nested classinfo tuple ===
+classinfo = (int,)
+for _ in range(10000):
+    classinfo = (classinfo,)
+
+try:
+    result = isinstance(1, classinfo)
+    assert result == True, 'shallow enough nesting should still match int'
+except RecursionError:
+    pass  # acceptable when depth guard triggers
+
+# === Mismatch through deep nesting ===
+classinfo2 = (str,)
+for _ in range(10000):
+    classinfo2 = (classinfo2,)
+
+try:
+    result2 = isinstance(1, classinfo2)
+    assert result2 == False, 'int does not match deeply-nested str classinfo'
+except RecursionError:
+    pass  # acceptable when depth guard triggers

--- a/crates/monty/test_cases/recursion__deep_repr.py
+++ b/crates/monty/test_cases/recursion__deep_repr.py
@@ -1,12 +1,26 @@
-# Test that deeply nested lists don't crash during repr()
-# Monty truncates with "..." at depth limit, CPython handles in C code
+# max-recursion-depth=10
+
+# Test that deeply nested lists don't crash during repr().
+# The `max-recursion-depth` directive caps Monty's limit at 10, so any input
+# deeper than that exercises the truncation path. CPython has its own (much
+# higher) default limit and produces a full repr — the assertion accepts
+# both shapes.
 x = []
-for _ in range(200):
+for _ in range(20):
     x = [x]
 
-# Should not crash - either returns full repr or truncated with "..."
 result = repr(x)
 assert isinstance(result, str), 'repr should return a string'
 assert result.startswith('['), 'repr should start with ['
-# Either full repr or truncated
 assert result.endswith(']') or '...' in result, 'repr should end with ] or contain ...'
+
+# Deeply nested one-element tuples must hit the same depth guard, otherwise
+# `repr()` recurses unbounded and overflows the host Rust stack.
+t = (0,)
+for _ in range(20):
+    t = (t,)
+
+result2 = repr(t)
+assert isinstance(result2, str), 'tuple repr should return a string'
+assert result2.startswith('('), 'tuple repr should start with ('
+assert result2.endswith(')') or '...' in result2, 'tuple repr should end with ) or contain ...'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents unbounded recursion when walking nested tuples in isinstance() and tuple repr, enforcing the recursion-depth limit to avoid Rust stack overflows. Adds tests and per-fixture limits so deep cases either succeed or raise RecursionError cleanly.

- **Bug Fixes**
  - `isinstance`: safely traverse tuple `classinfo` via heap reads with recursion-depth tokens; raise TypeError on invalid entries; raise RecursionError at depth limit.
  - Tuple `repr`: single-element tuples now honor the recursion guard, truncating with "..." instead of overflowing.

- **Test Harness**
  - Replaced per-test `gc_interval` with `limits: ResourceLimits` initialized by `default_test_limits()`. Added `# gc-interval=<N>` and `# max-recursion-depth=<N>` directives and threaded limits through all runners.
  - Added `recursion__deep_isinstance.py` and expanded `recursion__deep_repr.py` to cover deep nesting and tuple cases.

<sup>Written for commit 35a2c59fcc7b282c93703553399d4fc5979eba39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

