### PR TITLE
move all `String` heap allocation to go through `allocate_string` helper

### DIFF
--- a/crates/monty/src/builtins/bin.rs
+++ b/crates/monty/src/builtins/bin.rs
@@ -10,7 +10,7 @@ use crate::{
     exception_private::{ExcType, RunResult},
     heap::HeapData,
     resource::ResourceTracker,
-    types::{PyTrait, Str},
+    types::{PyTrait, str::allocate_string_no_interning},
     value::Value,
 };
 
@@ -26,20 +26,15 @@ pub fn builtin_bin(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> Ru
         Value::Int(n) => {
             let abs_digits = format!("{:b}", n.unsigned_abs());
             let prefix = if *n < 0 { "-0b" } else { "0b" };
-            let heap_id = vm
-                .heap
-                .allocate(HeapData::Str(Str::new(format!("{prefix}{abs_digits}"))))?;
-            Ok(Value::Ref(heap_id))
+            Ok(allocate_string_no_interning(format!("{prefix}{abs_digits}"), vm.heap)?)
         }
         Value::Bool(b) => {
             let s = if *b { "0b1" } else { "0b0" };
-            let heap_id = vm.heap.allocate(HeapData::Str(Str::new(s.to_string())))?;
-            Ok(Value::Ref(heap_id))
+            Ok(allocate_string_no_interning(s.to_string(), vm.heap)?)
         }
         Value::Ref(id) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
             let bin_str = format_bigint_bin(li.inner());
-            let heap_id = vm.heap.allocate(HeapData::Str(Str::new(bin_str)))?;
-            Ok(Value::Ref(heap_id))
+            Ok(allocate_string_no_interning(bin_str, vm.heap)?)
         }
         _ => Err(ExcType::type_error_not_integer(value.py_type(vm))),
     }

--- a/crates/monty/src/builtins/hex.rs
+++ b/crates/monty/src/builtins/hex.rs
@@ -10,7 +10,7 @@ use crate::{
     exception_private::{ExcType, RunResult},
     heap::HeapData,
     resource::ResourceTracker,
-    types::{PyTrait, Str},
+    types::{PyTrait, str::allocate_string_no_interning},
     value::Value,
 };
 
@@ -27,18 +27,15 @@ pub fn builtin_hex(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> Ru
         Value::Int(n) => {
             let abs_digits = format!("{:x}", n.unsigned_abs());
             let prefix = if *n < 0 { "-0x" } else { "0x" };
-            let heap_id = heap.allocate(HeapData::Str(Str::new(format!("{prefix}{abs_digits}"))))?;
-            Ok(Value::Ref(heap_id))
+            Ok(allocate_string_no_interning(format!("{prefix}{abs_digits}"), heap)?)
         }
         Value::Bool(b) => {
             let s = if *b { "0x1" } else { "0x0" };
-            let heap_id = heap.allocate(HeapData::Str(Str::new(s.to_string())))?;
-            Ok(Value::Ref(heap_id))
+            Ok(allocate_string_no_interning(s.to_string(), heap)?)
         }
         Value::Ref(id) if let HeapData::LongInt(li) = heap.get(*id) => {
             let hex_str = format_bigint_hex(li.inner());
-            let heap_id = heap.allocate(HeapData::Str(Str::new(hex_str)))?;
-            Ok(Value::Ref(heap_id))
+            Ok(allocate_string_no_interning(hex_str, heap)?)
         }
         _ => Err(ExcType::type_error_not_integer(value.py_type(vm))),
     }

--- a/crates/monty/src/builtins/oct.rs
+++ b/crates/monty/src/builtins/oct.rs
@@ -10,7 +10,7 @@ use crate::{
     exception_private::{ExcType, RunResult},
     heap::HeapData,
     resource::ResourceTracker,
-    types::{PyTrait, Str},
+    types::{PyTrait, str::allocate_string_no_interning},
     value::Value,
 };
 
@@ -26,20 +26,15 @@ pub fn builtin_oct(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> Ru
         Value::Int(n) => {
             let abs_digits = format!("{:o}", n.unsigned_abs());
             let prefix = if *n < 0 { "-0o" } else { "0o" };
-            let heap_id = vm
-                .heap
-                .allocate(HeapData::Str(Str::new(format!("{prefix}{abs_digits}"))))?;
-            Ok(Value::Ref(heap_id))
+            Ok(allocate_string_no_interning(format!("{prefix}{abs_digits}"), vm.heap)?)
         }
         Value::Bool(b) => {
             let s = if *b { "0o1" } else { "0o0" };
-            let heap_id = vm.heap.allocate(HeapData::Str(Str::new(s.to_string())))?;
-            Ok(Value::Ref(heap_id))
+            Ok(allocate_string_no_interning(s.to_string(), vm.heap)?)
         }
         Value::Ref(id) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
             let oct_str = format_bigint_oct(li.inner());
-            let heap_id = vm.heap.allocate(HeapData::Str(Str::new(oct_str)))?;
-            Ok(Value::Ref(heap_id))
+            Ok(allocate_string_no_interning(oct_str, vm.heap)?)
         }
         _ => Err(ExcType::type_error_not_integer(value.py_type(vm))),
     }

--- a/crates/monty/src/builtins/repr.rs
+++ b/crates/monty/src/builtins/repr.rs
@@ -1,8 +1,13 @@
 //! Implementation of the repr() builtin function.
 
 use crate::{
-    args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, heap::HeapData, resource::ResourceTracker,
-    types::PyTrait, value::Value,
+    args::ArgValues,
+    bytecode::VM,
+    defer_drop,
+    exception_private::RunResult,
+    resource::ResourceTracker,
+    types::{PyTrait, str::allocate_string},
+    value::Value,
 };
 
 /// Implementation of the repr() builtin function.
@@ -12,6 +17,5 @@ pub fn builtin_repr(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> R
     let value = args.get_one_arg("repr", vm.heap)?;
     defer_drop!(value, vm);
     let s = value.py_repr(vm)?.into_owned();
-    let heap_id = vm.heap.allocate(HeapData::Str(s.into()))?;
-    Ok(Value::Ref(heap_id))
+    Ok(allocate_string(s, vm.heap)?)
 }

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -18,9 +18,9 @@ use crate::{
     parse::CodeRange,
     resource::ResourceTracker,
     types::{
-        PyTrait, Str, Type, allocate_tuple,
+        PyTrait, Type, allocate_tuple,
         long_int::INT_MAX_STR_DIGITS,
-        str::{StringRepr, string_repr_fmt},
+        str::{StringRepr, allocate_string, string_repr_fmt},
     },
     value::{EitherStr, Value},
 };
@@ -1490,8 +1490,7 @@ impl<'h> HeapRead<'h, SimpleException> {
         if is_args {
             // Construct tuple with 0 or 1 elements based on whether arg exists
             let elements = if let Some(arg_str) = &self.get(vm.heap).arg {
-                let str_id = vm.heap.allocate(HeapData::Str(Str::from(arg_str.clone())))?;
-                smallvec![Value::Ref(str_id)]
+                smallvec![allocate_string(arg_str.as_str(), vm.heap)?]
             } else {
                 smallvec![]
             };

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -22,7 +22,7 @@ use crate::{
     types::{
         Bytes, Dataclass, Dict, DictItemsView, DictKeysView, DictValuesView, FrozenSet, List, LongInt, Module,
         MontyIter, NamedTuple, Path, PyTrait, Range, ReMatch, RePattern, Set, Slice, Str, Tuple, Type, date, datetime,
-        timedelta, timezone,
+        str::allocate_string, timedelta, timezone,
     },
     value::{EitherStr, Value},
 };
@@ -738,7 +738,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         match (self, other) {
             (HeapReadOutput::Str(a), HeapReadOutput::Str(b)) => {
                 let concat = format!("{}{}", a.get(vm.heap).as_str(), b.get(vm.heap).as_str());
-                Ok(Some(Value::Ref(vm.heap.allocate(HeapData::Str(concat.into()))?)))
+                Ok(Some(allocate_string(concat, vm.heap)?))
             }
             (HeapReadOutput::Bytes(a), HeapReadOutput::Bytes(b)) => {
                 let a_bytes = a.get(vm.heap).as_slice();

--- a/crates/monty/src/modules/json/dump.rs
+++ b/crates/monty/src/modules/json/dump.rs
@@ -235,7 +235,7 @@ pub(super) fn call_dumps(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues)
 
     let (obj, vm) = obj_guard.into_parts();
     obj.drop_with_heap(vm);
-    allocate_string(output, vm.heap)
+    Ok(allocate_string(output, vm.heap)?)
 }
 
 /// Parses the `indent=` value for `json.dumps()`.

--- a/crates/monty/src/modules/json/string_cache.rs
+++ b/crates/monty/src/modules/json/string_cache.rs
@@ -21,9 +21,9 @@ use std::iter;
 use ahash::RandomState;
 
 use crate::{
-    heap::{ContainsHeap, HeapData, HeapReader},
+    heap::{ContainsHeap, HeapReader},
     resource::{ResourceError, ResourceTracker},
-    types::str::Str,
+    types::str::{allocate_string, allocate_string_no_interning},
     value::Value,
 };
 
@@ -88,8 +88,7 @@ impl JsonStringCache {
     ) -> Result<Value, ResourceError> {
         let len = s.len();
         if !(MIN_LEN..=MAX_LEN).contains(&len) {
-            let heap_id = heap.heap().allocate(HeapData::Str(Str::new(s)))?;
-            return Ok(Value::Ref(heap_id));
+            return allocate_string(s, heap.heap());
         }
 
         let inner = self.inner.get_or_insert_with(CacheInner::new);
@@ -156,8 +155,8 @@ impl CacheInner {
             }
         }
         // All 5 probe slots occupied — allocate without caching.
-        let heap_id = heap.heap().allocate(HeapData::Str(Str::new(s)))?;
-        Ok(Value::Ref(heap_id))
+        // Length is in [MIN_LEN..=MAX_LEN] here so interning would never apply.
+        allocate_string_no_interning(s, heap.heap())
     }
 
     /// Allocates `s` on the heap, stores a clone in `entries[index]`, and
@@ -170,8 +169,8 @@ impl CacheInner {
         heap: &HeapReader<'_, impl ResourceTracker>,
     ) -> Result<Value, ResourceError> {
         let key = s.clone().into_boxed_str();
-        let heap_id = heap.heap().allocate(HeapData::Str(Str::new(s)))?;
-        let value = Value::Ref(heap_id);
+        // Length is in [MIN_LEN..=MAX_LEN] here so interning would never apply.
+        let value = allocate_string_no_interning(s, heap.heap())?;
         let cached = value.clone_with_heap(heap);
         self.entries[index] = Some((hash, key, cached));
         Ok(value)

--- a/crates/monty/src/modules/re.rs
+++ b/crates/monty/src/modules/re.rs
@@ -36,7 +36,7 @@ use crate::{
     intern::StaticStrings,
     modules::ModuleFunctions,
     resource::{ResourceError, ResourceTracker},
-    types::{Module, PyTrait, RePattern, Str, Type, re_pattern::value_to_str},
+    types::{Module, PyTrait, RePattern, Type, re_pattern::value_to_str, str::allocate_string},
     value::Value,
 };
 
@@ -331,11 +331,14 @@ fn call_sub(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult
         Some(Value::Int(n)) if n >= 0 => n as usize,
         Some(Value::Bool(b)) => usize::from(b),
         Some(Value::Int(_)) => {
-            // Negative count — return original string unchanged
+            // Negative count — re.sub returns the input string unchanged, so
+            // just typecheck and bump the refcount; no need to re-allocate.
             let _flags = extract_flags(flags_val, vm)?;
-            let text = value_to_str(string_val, vm)?.into_owned();
-            let s = Str::new(text);
-            return Ok(Value::Ref(vm.heap.allocate(HeapData::Str(s))?));
+            if !string_val.is_str(vm.heap) {
+                let t = string_val.py_type(vm);
+                return Err(ExcType::type_error(format!("expected string, not {t}")));
+            }
+            return Ok(string_val.clone_with_heap(vm.heap));
         }
         Some(other) => {
             let t = other.py_type(vm);
@@ -470,8 +473,7 @@ fn call_escape(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunRes
         result.push(c);
     }
 
-    let s = Str::new(result);
-    Ok(Value::Ref(vm.heap.allocate(HeapData::Str(s))?))
+    Ok(allocate_string(result, vm.heap)?)
 }
 
 /// Returns whether a character should be escaped by `re.escape()`.

--- a/crates/monty/src/object.rs
+++ b/crates/monty/src/object.rs
@@ -27,7 +27,7 @@ use crate::{
         dict::Dict,
         list::List,
         set::{FrozenSet, Set},
-        str::{Str, StringRepr, string_repr_fmt},
+        str::{StringRepr, allocate_string, string_repr_fmt},
         timedelta as timedelta_type, timezone as timezone_type,
     },
     value::{EitherStr, Value},
@@ -380,7 +380,7 @@ impl MontyObject {
             Self::Int(i) => Ok(Value::Int(i)),
             Self::BigInt(bi) => Ok(LongInt::new(bi).into_value(vm.heap)?),
             Self::Float(f) => Ok(Value::Float(f)),
-            Self::String(s) => Ok(Value::Ref(vm.heap.allocate(HeapData::Str(Str::new(s)))?)),
+            Self::String(s) => Ok(allocate_string(s, vm.heap)?),
             Self::Bytes(b) => Ok(Value::Ref(vm.heap.allocate(HeapData::Bytes(Bytes::new(b)))?)),
             Self::List(items) => {
                 let values: Vec<Value> = items

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -70,7 +70,7 @@ use std::{cell::Cell, cmp::Ordering, fmt, fmt::Write, mem, ops, str};
 use ahash::AHashSet;
 use smallvec::smallvec;
 
-use super::{MontyIter, PyTrait, Type, str::Str};
+use super::{MontyIter, PyTrait, Type};
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, VM},
@@ -502,10 +502,7 @@ fn bytes_decode<'h>(
 
     // Decode as UTF-8
     match str::from_utf8(bytes.get(vm.heap)) {
-        Ok(s) => {
-            let heap_id = vm.heap.allocate(HeapData::Str(Str::from(s.to_owned())))?;
-            Ok(Value::Ref(heap_id))
-        }
+        Ok(s) => Ok(super::str::allocate_string(s, vm.heap)?),
         Err(_) => Err(ExcType::unicode_decode_error_invalid_utf8()),
     }
 }
@@ -2136,7 +2133,7 @@ fn bytes_hex<'h>(
         hex_chars.iter().collect()
     };
 
-    super::str::allocate_string(result, vm.heap)
+    Ok(super::str::allocate_string(result, vm.heap)?)
 }
 
 /// Parses arguments for bytes.hex method.

--- a/crates/monty/src/types/date.rs
+++ b/crates/monty/src/types/date.rs
@@ -25,7 +25,11 @@ use crate::{
     intern::{Interns, StaticStrings},
     os::OsFunction,
     resource::{ResourceError, ResourceTracker},
-    types::{AttrCallResult, PyTrait, TimeDelta, Type, str::Str, timedelta, value_to_i32},
+    types::{
+        AttrCallResult, PyTrait, TimeDelta, Type,
+        str::{allocate_string, allocate_string_no_interning},
+        timedelta, value_to_i32,
+    },
     value::{EitherStr, Value},
 };
 
@@ -303,16 +307,15 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Date> {
             Some(id) if id == StaticStrings::Isoformat => {
                 args.check_zero_args("date.isoformat", vm.heap)?;
                 let (year, month, day) = to_ymd(date);
-                Ok(CallResult::Value(Value::Ref(vm.heap.allocate(HeapData::Str(
-                    Str::new(format!("{year:04}-{month:02}-{day:02}")),
-                ))?)))
+                Ok(CallResult::Value(allocate_string_no_interning(
+                    format!("{year:04}-{month:02}-{day:02}"),
+                    vm.heap,
+                )?))
             }
             Some(id) if id == StaticStrings::Strftime => {
                 let fmt = extract_strftime_arg(args, "date.strftime", vm.heap, vm.interns)?;
                 let formatted = date.0.format(&fmt).to_string();
-                Ok(CallResult::Value(Value::Ref(
-                    vm.heap.allocate(HeapData::Str(Str::new(formatted)))?,
-                )))
+                Ok(CallResult::Value(allocate_string(formatted, vm.heap)?))
             }
             Some(id) if id == StaticStrings::Replace => {
                 let (year, month, day) = to_ymd(date);

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -26,8 +26,9 @@ use crate::{
     os::OsFunction,
     resource::{ResourceError, ResourceTracker},
     types::{
-        AttrCallResult, PyTrait, TimeDelta, TimeZone, Type, date, str, str::StringRepr, timedelta, timezone,
-        value_to_i32,
+        AttrCallResult, PyTrait, TimeDelta, TimeZone, Type, date,
+        str::{StringRepr, allocate_string, allocate_string_no_interning},
+        timedelta, timezone, value_to_i32,
     },
     value::{EitherStr, Value},
 };
@@ -1089,16 +1090,12 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
             Some(id) if id == StaticStrings::Isoformat => {
                 args.check_zero_args("datetime.isoformat", vm.heap)?;
                 let s = format_isoformat(&dt, 'T');
-                Ok(CallResult::Value(Value::Ref(
-                    vm.heap.allocate(HeapData::Str(str::Str::new(s)))?,
-                )))
+                Ok(CallResult::Value(allocate_string_no_interning(s, vm.heap)?))
             }
             Some(id) if id == StaticStrings::Strftime => {
                 let fmt = date::extract_strftime_arg(args, "datetime.strftime", vm.heap, vm.interns)?;
                 let formatted = dt.naive.format(&fmt).to_string();
-                Ok(CallResult::Value(Value::Ref(
-                    vm.heap.allocate(HeapData::Str(str::Str::new(formatted)))?,
-                )))
+                Ok(CallResult::Value(allocate_string(formatted, vm.heap)?))
             }
             Some(id) if id == StaticStrings::Replace => {
                 let result = extract_datetime_replace_kwargs(args, &dt, vm.heap, vm.interns)?;

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -25,7 +25,7 @@ use crate::{
     intern::{Interns, StaticStrings},
     os::OsFunction,
     resource::{ResourceError, ResourceTracker},
-    types::{PyTrait, Str, Type, allocate_tuple},
+    types::{PyTrait, Type, allocate_tuple, str::allocate_string},
     value::{EitherStr, Value},
 };
 
@@ -445,10 +445,7 @@ impl Path {
         heap: &Heap<impl ResourceTracker>,
     ) -> RunResult<Option<Value>> {
         let v = match ss {
-            StaticStrings::Name => {
-                let name = self.name();
-                Value::Ref(heap.allocate(HeapData::Str(Str::new(name.to_owned())))?)
-            }
+            StaticStrings::Name => allocate_string(self.name(), heap)?,
             StaticStrings::Parent => {
                 if let Some(parent) = self.parent() {
                     let parent_path = Self::new(parent.to_owned());
@@ -459,22 +456,15 @@ impl Path {
                     Value::Ref(heap.allocate(HeapData::Path(same_path))?)
                 }
             }
-            StaticStrings::Stem => {
-                let stem = self.stem();
-                Value::Ref(heap.allocate(HeapData::Str(Str::new(stem.to_owned())))?)
-            }
-            StaticStrings::Suffix => {
-                let suffix = self.suffix();
-                Value::Ref(heap.allocate(HeapData::Str(Str::new(suffix.to_owned())))?)
-            }
+            StaticStrings::Stem => allocate_string(self.stem(), heap)?,
+            StaticStrings::Suffix => allocate_string(self.suffix(), heap)?,
             StaticStrings::Suffixes => {
                 use crate::types::List;
 
                 let suffixes = self.suffixes();
                 let mut items = Vec::with_capacity(suffixes.len());
                 for suffix in suffixes {
-                    let str_id = heap.allocate(HeapData::Str(Str::new(suffix.to_owned())))?;
-                    items.push(Value::Ref(str_id));
+                    items.push(allocate_string(suffix, heap)?);
                 }
                 Value::Ref(heap.allocate(HeapData::List(List::new(items)))?)
             }
@@ -482,8 +472,7 @@ impl Path {
                 let parts = self.parts();
                 let mut items = SmallVec::with_capacity(parts.len());
                 for part in parts {
-                    let str_id = heap.allocate(HeapData::Str(Str::new(part.to_owned())))?;
-                    items.push(Value::Ref(str_id));
+                    items.push(allocate_string(part, heap)?);
                 }
                 allocate_tuple(items, heap)?
             }
@@ -604,9 +593,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Path> {
             }
             StaticStrings::AsPosix | StaticStrings::Fspath => {
                 args.check_zero_args(method.into(), vm.heap)?;
-                Ok(Value::Ref(vm.heap.allocate(HeapData::Str(Str::new(
-                    self.get(vm.heap).as_posix().to_owned(),
-                )))?))
+                Ok(allocate_string(self.get(vm.heap).as_posix(), vm.heap)?)
             }
             _ => {
                 args.drop_with_heap(vm);

--- a/crates/monty/src/types/re_match.rs
+++ b/crates/monty/src/types/re_match.rs
@@ -21,7 +21,10 @@ use crate::{
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead},
     intern::StaticStrings,
     resource::{ResourceError, ResourceTracker},
-    types::{Dict, PyTrait, Str, Type, allocate_tuple, str::string_repr_fmt},
+    types::{
+        Dict, PyTrait, Type, allocate_tuple,
+        str::{allocate_string, string_repr_fmt},
+    },
     value::{EitherStr, Value},
 };
 
@@ -133,10 +136,7 @@ impl ReMatch {
     /// Raises `IndexError` for invalid group numbers.
     fn get_group(&self, n: i64, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
         match n.cmp(&0) {
-            Ordering::Equal => {
-                let s = Str::new(self.full_match.clone());
-                Ok(Value::Ref(heap.allocate(HeapData::Str(s))?))
-            }
+            Ordering::Equal => Ok(allocate_string(self.full_match.as_str(), heap)?),
             Ordering::Less => Err(ExcType::re_match_group_index_error()),
             Ordering::Greater => {
                 let idx = group_index(n);
@@ -144,10 +144,7 @@ impl ReMatch {
                     return Err(ExcType::re_match_group_index_error());
                 }
                 match &self.groups[idx] {
-                    Some(s) => {
-                        let s = Str::new(s.clone());
-                        Ok(Value::Ref(heap.allocate(HeapData::Str(s))?))
-                    }
+                    Some(s) => Ok(allocate_string(s.as_str(), heap)?),
                     None => Ok(Value::None),
                 }
             }
@@ -178,15 +175,11 @@ impl<'h> HeapRead<'h, ReMatch> {
         let this = self.get(vm.heap);
         let mut pairs = Vec::with_capacity(this.named_groups.len());
         for (name, idx) in &this.named_groups {
-            let key_str = Str::new(name.clone());
-            let key = Value::Ref(vm.heap.allocate(HeapData::Str(key_str))?);
+            let key = allocate_string(name.as_str(), vm.heap)?;
             // idx is 1-based, groups vec is 0-based (index 0 = group 1)
             let value = if *idx > 0 && (*idx - 1) < this.groups.len() {
                 match &this.groups[*idx - 1] {
-                    Some(s) => {
-                        let s = Str::new(s.clone());
-                        Value::Ref(vm.heap.allocate(HeapData::Str(s))?)
-                    }
+                    Some(s) => allocate_string(s.as_str(), vm.heap)?,
                     None => default.clone_with_heap(vm),
                 }
             } else {
@@ -207,10 +200,7 @@ impl ReMatch {
         let mut elements = smallvec![];
         for group in &self.groups {
             match group {
-                Some(s) => {
-                    let s = Str::new(s.clone());
-                    elements.push(Value::Ref(heap.allocate(HeapData::Str(s))?));
-                }
+                Some(s) => elements.push(allocate_string(s.as_str(), heap)?),
                 None => elements.push(Value::None),
             }
         }
@@ -319,8 +309,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
     fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
         match attr.static_string() {
             Some(StaticStrings::StringAttr) => {
-                let s = Str::new(self.get(vm.heap).input_string.clone());
-                let v = Value::Ref(vm.heap.allocate(HeapData::Str(s))?);
+                let v = allocate_string(self.get(vm.heap).input_string.as_str(), vm.heap)?;
                 Ok(Some(CallResult::Value(v)))
             }
             _ => Err(ExcType::attribute_error(Type::ReMatch, attr.as_str(vm.interns))),

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -25,7 +25,10 @@ use crate::{
     intern::StaticStrings,
     modules::re::{ASCII, DOTALL, IGNORECASE, MULTILINE},
     resource::{ResourceError, ResourceTracker, check_estimated_size},
-    types::{List, PyTrait, ReMatch, Str, Type, allocate_tuple, str::string_repr_fmt},
+    types::{
+        List, PyTrait, ReMatch, Type, allocate_tuple,
+        str::{allocate_string, string_repr_fmt},
+    },
     value::{EitherStr, Value},
 };
 
@@ -155,17 +158,16 @@ impl RePattern {
             // No capture groups — return list of full match strings
             0 | 1 => {
                 for m in self.compiled.find_iter(text) {
-                    let s = Str::new(m.map_err(ExcType::re_pattern_error)?.as_str().to_owned());
-                    results.push(Value::Ref(heap.allocate(HeapData::Str(s))?));
+                    let val = m.map_err(ExcType::re_pattern_error)?.as_str();
+                    results.push(allocate_string(val, heap)?);
                 }
             }
             // One capture group — return list of the group's strings
             2 => {
                 for caps in self.compiled.captures_iter(text) {
                     let caps = caps.map_err(ExcType::re_pattern_error)?;
-                    let val = caps.get(1).map(|m| m.as_str().to_owned()).unwrap_or_default();
-                    let s = Str::new(val);
-                    results.push(Value::Ref(heap.allocate(HeapData::Str(s))?));
+                    let val = caps.get(1).map_or("", |m| m.as_str());
+                    results.push(allocate_string(val, heap)?);
                 }
             }
             // Multiple capture groups — return list of tuples
@@ -174,9 +176,8 @@ impl RePattern {
                     let caps = caps.map_err(ExcType::re_pattern_error)?;
                     let mut elements: SmallVec<[Value; 3]> = SmallVec::with_capacity(cap_count - 1);
                     for cap in caps.iter().skip(1) {
-                        let val = cap.map(|m| m.as_str().to_owned()).unwrap_or_default();
-                        let s = Str::new(val);
-                        elements.push(Value::Ref(heap.allocate(HeapData::Str(s))?));
+                        let val = cap.map_or("", |m| m.as_str());
+                        elements.push(allocate_string(val, heap)?);
                     }
                     results.push(allocate_tuple(elements, heap)?);
                 }
@@ -217,8 +218,7 @@ impl RePattern {
         }
 
         result.push_str(&text[last_end..]);
-        let s = Str::new(result);
-        Ok(Value::Ref(heap.allocate(HeapData::Str(s))?))
+        Ok(allocate_string(result, heap)?)
     }
 
     /// `pattern.split(string, maxsplit=0)` — split string by pattern occurrences.
@@ -240,8 +240,7 @@ impl RePattern {
 
         let mut results = Vec::with_capacity(pieces.len());
         for piece in pieces {
-            let s = Str::new(piece.to_owned());
-            results.push(Value::Ref(heap.allocate(HeapData::Str(s))?));
+            results.push(allocate_string(piece, heap)?);
         }
 
         let list = List::new(results);
@@ -315,8 +314,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, RePattern> {
     fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
         match attr.static_string() {
             Some(StaticStrings::PatternAttr) => {
-                let s = Str::new(self.get(vm.heap).pattern.clone());
-                let v = Value::Ref(vm.heap.allocate(HeapData::Str(s))?);
+                let v = allocate_string(self.get(vm.heap).pattern.as_str(), vm.heap)?;
                 Ok(Some(CallResult::Value(v)))
             }
             Some(StaticStrings::Flags) => Ok(Some(CallResult::Value(Value::Int(i64::from(self.get(vm.heap).flags))))),
@@ -450,9 +448,13 @@ fn call_pattern_sub<'h>(
         Some(Value::Int(n)) if n >= 0 => n as usize,
         Some(Value::Bool(b)) => usize::from(b),
         Some(Value::Int(_)) => {
-            let text = value_to_str(string_val, vm)?.into_owned();
-            let s = Str::new(text);
-            return Ok(Value::Ref(vm.heap.allocate(HeapData::Str(s))?));
+            // Negative count — Pattern.sub returns the input string unchanged,
+            // so just typecheck and bump the refcount; no need to re-allocate.
+            if !string_val.is_str(vm.heap) {
+                let t = string_val.py_type(vm);
+                return Err(ExcType::type_error(format!("expected string, not {t}")));
+            }
+            return Ok(string_val.clone_with_heap(vm.heap));
         }
         Some(other) => {
             let t = other.py_type(vm);

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -44,16 +44,12 @@ impl PartialEq for Str {
 }
 
 impl Str {
-    /// Creates a new Str from a Rust String.
+    /// Creates a new Str from anything convertible into a `Box<str>`.
+    ///
+    /// Private — use [`allocate_string`] or [`allocate_string_no_interning`] instead.
     #[must_use]
-    pub fn new(s: String) -> Self {
+    fn new(s: impl Into<Box<str>>) -> Self {
         Self(s.into(), Cell::new(None))
-    }
-
-    /// Creates a new Str from a Rust Box<str>.
-    #[must_use]
-    pub fn from_boxed(s: Box<str>) -> Self {
-        Self(s, Cell::new(None))
     }
 
     /// Returns a reference to the inner string.
@@ -73,7 +69,7 @@ impl Str {
             Some(v) => {
                 defer_drop!(v, vm);
                 let s = v.py_str(vm)?.into_owned();
-                allocate_string(s, vm.heap)
+                Ok(allocate_string(s, vm.heap)?)
             }
         }
     }
@@ -83,26 +79,7 @@ impl Str {
     /// Returns a new string containing the selected characters (Unicode-aware).
     fn getitem_slice(&self, vm: &VM<'_, impl ResourceTracker>, slice: &super::Slice) -> RunResult<Value> {
         let result_str: Box<str> = slice_collect_iterator(vm, slice, self.0.chars(), |c| c)?;
-        let heap_id = vm.heap.allocate(HeapData::Str(Self::from_boxed(result_str)))?;
-        Ok(Value::Ref(heap_id))
-    }
-}
-
-impl From<String> for Str {
-    fn from(s: String) -> Self {
-        Self::new(s)
-    }
-}
-
-impl From<&str> for Str {
-    fn from(s: &str) -> Self {
-        Self::from_boxed(s.into())
-    }
-}
-
-impl From<Str> for String {
-    fn from(value: Str) -> Self {
-        value.0.into_string()
+        Ok(allocate_string(result_str, vm.heap)?)
     }
 }
 
@@ -114,20 +91,44 @@ impl From<Str> for String {
 /// - Other strings are allocated on the heap
 ///
 /// This avoids heap allocation for common cases like results from `strip()`,
-/// `split()`, string iteration, etc.
-pub fn allocate_string(s: String, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
-    match s.len() {
+/// `split()`, string iteration, etc. Prefer this over manual `Str` construction
+/// so callsites consistently benefit from interning. When the caller can prove
+/// the string is longer than one byte, [`allocate_string_no_interning`] avoids
+/// the length branch.
+///
+/// The dual bound `AsRef<str> + Into<Box<str>>` lets the function peek the
+/// length via the borrow before committing to a conversion. Callers with an
+/// owned `String`/`Box<str>` move the value in (consumed only on the heap
+/// path), and borrowed `&str` callers avoid an upfront `to_owned()` —
+/// allocation happens only when the string actually needs heap storage.
+///
+/// Returns `Result<_, ResourceError>` so the function composes with
+/// `RunResult` and other error types that implement `From<ResourceError>`.
+pub fn allocate_string(
+    s: impl AsRef<str> + Into<Box<str>>,
+    heap: &Heap<impl ResourceTracker>,
+) -> Result<Value, ResourceError> {
+    let bytes = s.as_ref().as_bytes();
+    match bytes.len() {
         0 => Ok(Value::InternString(StaticStrings::EmptyString.into())),
-        1 => {
-            // Single byte means single ASCII character
-            let byte = s.as_bytes()[0];
-            Ok(Value::InternString(StringId::from_ascii(byte)))
-        }
-        _ => {
-            let heap_id = heap.allocate(HeapData::Str(Str::new(s)))?;
-            Ok(Value::Ref(heap_id))
-        }
+        1 => Ok(Value::InternString(StringId::from_ascii(bytes[0]))),
+        _ => allocate_string_no_interning(s, heap),
     }
+}
+
+/// Allocates a string directly on the heap, skipping the intern check.
+///
+/// Use this only when the caller can guarantee the string is longer than one
+/// byte (e.g. always contains a fixed prefix like `"0x"`, `"0o"`, or a
+/// formatted date). For inputs of unknown length, use [`allocate_string`].
+///
+/// Accepts `impl Into<Box<str>>` for the same reasons as [`allocate_string`].
+pub fn allocate_string_no_interning(
+    s: impl Into<Box<str>>,
+    heap: &Heap<impl ResourceTracker>,
+) -> Result<Value, ResourceError> {
+    let heap_id = heap.allocate(HeapData::Str(Str::new(s)))?;
+    Ok(Value::Ref(heap_id))
 }
 
 /// Allocates a single character as a string value.
@@ -241,8 +242,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
         let self_str = self.get(vm.heap).0.clone();
         let other_str = other.get(vm.heap).0.clone();
         let result = format!("{self_str}{other_str}");
-        let id = vm.heap.allocate(HeapData::Str(result.into()))?;
-        Ok(Some(Value::Ref(id)))
+        Ok(Some(allocate_string(result, vm.heap)?))
     }
 
     fn py_call_attr(
@@ -484,7 +484,7 @@ fn str_join<'h>(
     }
 
     // Allocate result (uses interned empty string if result is empty)
-    allocate_string(result, vm.heap)
+    Ok(allocate_string(result, vm.heap)?)
 }
 
 /// Writes a Python repr() string for a given string slice to a formatter.
@@ -542,12 +542,12 @@ impl fmt::Display for StringRepr<'_> {
 
 /// Implements Python's `str.lower()` method.
 fn str_lower(s: &str, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> {
-    allocate_string(s.to_lowercase(), vm.heap)
+    Ok(allocate_string(s.to_lowercase(), vm.heap)?)
 }
 
 /// Implements Python's `str.upper()` method.
 fn str_upper(s: &str, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> {
-    allocate_string(s.to_uppercase(), vm.heap)
+    Ok(allocate_string(s.to_uppercase(), vm.heap)?)
 }
 
 /// Implements Python's `str.capitalize()` method.
@@ -565,7 +565,7 @@ fn str_capitalize(s: &str, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value
             result
         }
     };
-    allocate_string(result, vm.heap)
+    Ok(allocate_string(result, vm.heap)?)
 }
 
 /// Implements Python's `str.title()` method.
@@ -585,7 +585,7 @@ fn str_title(s: &str, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> {
         prev_is_cased = c.is_alphabetic();
     }
 
-    allocate_string(result, vm.heap)
+    Ok(allocate_string(result, vm.heap)?)
 }
 
 /// Implements Python's `str.swapcase()` method.
@@ -604,7 +604,7 @@ fn str_swapcase(s: &str, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> 
         }
     }
 
-    allocate_string(result, vm.heap)
+    Ok(allocate_string(result, vm.heap)?)
 }
 
 /// Implements Python's `str.casefold()` method.
@@ -613,7 +613,7 @@ fn str_swapcase(s: &str, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> 
 /// but more aggressive because it is intended for caseless string matching.
 fn str_casefold(s: &str, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> {
     // Rust's to_lowercase() is equivalent to Unicode casefolding for most purposes
-    allocate_string(s.to_lowercase(), vm.heap)
+    Ok(allocate_string(s.to_lowercase(), vm.heap)?)
 }
 
 // =============================================================================
@@ -1184,7 +1184,7 @@ fn str_strip<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl Re
         Some(c) => s.trim_matches(|ch| c.contains(ch)).to_owned(),
         None => s.trim().to_owned(),
     };
-    allocate_string(result, vm.heap)
+    Ok(allocate_string(result, vm.heap)?)
 }
 
 /// Implements Python's `str.lstrip(chars?)` method.
@@ -1197,7 +1197,7 @@ fn str_lstrip<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl R
         Some(c) => s.trim_start_matches(|ch| c.contains(ch)).to_owned(),
         None => s.trim_start().to_owned(),
     };
-    allocate_string(result, vm.heap)
+    Ok(allocate_string(result, vm.heap)?)
 }
 
 /// Implements Python's `str.rstrip(chars?)` method.
@@ -1210,7 +1210,7 @@ fn str_rstrip<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl R
         Some(c) => s.trim_end_matches(|ch| c.contains(ch)).to_owned(),
         None => s.trim_end().to_owned(),
     };
-    allocate_string(result, vm.heap)
+    Ok(allocate_string(result, vm.heap)?)
 }
 
 /// Parses the optional chars argument for strip methods.
@@ -1244,7 +1244,7 @@ fn str_removeprefix<'h>(
 
     let s = s.get(vm.heap);
     let result = s.strip_prefix(&prefix).unwrap_or(s).to_owned();
-    allocate_string(result, vm.heap)
+    Ok(allocate_string(result, vm.heap)?)
 }
 
 /// Implements Python's `str.removesuffix(suffix)` method.
@@ -1262,7 +1262,7 @@ fn str_removesuffix<'h>(
 
     let s = s.get(vm.heap);
     let result = s.strip_suffix(&suffix).unwrap_or(s).to_owned();
-    allocate_string(result, vm.heap)
+    Ok(allocate_string(result, vm.heap)?)
 }
 
 // =============================================================================
@@ -1306,7 +1306,7 @@ fn str_split<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl Re
     let mut list_items = Vec::with_capacity(parts.len());
     for part in parts {
         vm.heap.check_time()?;
-        list_items.push(allocate_string(part.to_owned(), vm.heap)?);
+        list_items.push(allocate_string(part, vm.heap)?);
     }
 
     let list = super::List::new(list_items);
@@ -1354,7 +1354,7 @@ fn str_rsplit<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl R
     let mut list_items = Vec::with_capacity(parts.len());
     for part in parts {
         vm.heap.check_time()?;
-        list_items.push(allocate_string(part.to_owned(), vm.heap)?);
+        list_items.push(allocate_string(part, vm.heap)?);
     }
 
     let list = super::List::new(list_items);
@@ -1545,7 +1545,7 @@ fn str_splitlines<'h>(
 
         let line = if keepends { &s[start..end] } else { &s[start..line_end] };
 
-        lines.push(allocate_string(line.to_owned(), vm.heap)?);
+        lines.push(allocate_string(line, vm.heap)?);
 
         start = end;
     }
@@ -1603,9 +1603,9 @@ fn str_partition<'h>(
         None => (s, "", ""),
     };
 
-    let before_val = allocate_string(before.to_owned(), vm.heap)?;
-    let sep_val = allocate_string(sep_found.to_owned(), vm.heap)?;
-    let after_val = allocate_string(after.to_owned(), vm.heap)?;
+    let before_val = allocate_string(before, vm.heap)?;
+    let sep_val = allocate_string(sep_found, vm.heap)?;
+    let after_val = allocate_string(after, vm.heap)?;
 
     Ok(super::allocate_tuple(
         smallvec![before_val, sep_val, after_val],
@@ -1636,9 +1636,9 @@ fn str_rpartition<'h>(
         None => ("", "", s),
     };
 
-    let before_val = allocate_string(before.to_owned(), vm.heap)?;
-    let sep_val = allocate_string(sep_found.to_owned(), vm.heap)?;
-    let after_val = allocate_string(after.to_owned(), vm.heap)?;
+    let before_val = allocate_string(before, vm.heap)?;
+    let sep_val = allocate_string(sep_found, vm.heap)?;
+    let after_val = allocate_string(after, vm.heap)?;
 
     Ok(super::allocate_tuple(
         smallvec![before_val, sep_val, after_val],
@@ -1668,7 +1668,7 @@ fn str_replace<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl 
         s.replacen(&old, &new, n)
     };
 
-    allocate_string(result, vm.heap)
+    Ok(allocate_string(result, vm.heap)?)
 }
 
 /// Parses arguments for the replace method.
@@ -1767,7 +1767,7 @@ fn str_center<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl R
         result
     };
 
-    allocate_string(result, vm.heap)
+    Ok(allocate_string(result, vm.heap)?)
 }
 
 /// Implements Python's `str.ljust(width, fillchar?)` method.
@@ -1791,7 +1791,7 @@ fn str_ljust<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl Re
         result
     };
 
-    allocate_string(result, vm.heap)
+    Ok(allocate_string(result, vm.heap)?)
 }
 
 /// Implements Python's `str.rjust(width, fillchar?)` method.
@@ -1815,7 +1815,7 @@ fn str_rjust<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl Re
         result
     };
 
-    allocate_string(result, vm.heap)
+    Ok(allocate_string(result, vm.heap)?)
 }
 
 /// Parses arguments for justify methods (center, ljust, rjust).
@@ -1900,7 +1900,7 @@ fn str_zfill<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl Re
         result
     };
 
-    allocate_string(result, vm.heap)
+    Ok(allocate_string(result, vm.heap)?)
 }
 
 /// Implements Python's `str.expandtabs(tabsize=8)` method.
@@ -1949,7 +1949,7 @@ fn str_expandtabs<'h>(
         }
     }
 
-    allocate_string(result, vm.heap)
+    Ok(allocate_string(result, vm.heap)?)
 }
 
 /// Implements Python's `str.encode(encoding='utf-8', errors='strict')` method.

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -28,12 +28,12 @@ use crate::{
         check_repeat_size,
     },
     types::{
-        Bytes, List, LongInt, Property, PyTrait, Str, Type, allocate_tuple,
+        Bytes, List, LongInt, Property, PyTrait, Type, allocate_tuple,
         bytes::{bytes_repr_fmt, get_byte_at_index},
         long_int::check_bits_str_digits_limit,
         path,
         slice::slice_collect_iterator,
-        str::{allocate_char, get_char_at_index, string_repr_fmt},
+        str::{allocate_char, allocate_string, get_char_at_index, string_repr_fmt},
         timedelta,
     },
 };
@@ -410,16 +410,16 @@ impl PyTrait<'_> for Value {
             }
             (Self::InternString(s1), Self::InternString(s2)) => {
                 let concat = format!("{}{}", interns.get_str(*s1), interns.get_str(*s2));
-                Ok(Some(Self::Ref(vm.heap.allocate(HeapData::Str(concat.into()))?)))
+                Ok(Some(allocate_string(concat, vm.heap)?))
             }
             // for strings we need to account for the fact they might be either interned or not
             (Self::InternString(string_id), Self::Ref(id2)) if let HeapData::Str(s2) = vm.heap.get(*id2) => {
                 let concat = format!("{}{}", interns.get_str(*string_id), s2.as_str());
-                Ok(Some(Self::Ref(vm.heap.allocate(HeapData::Str(concat.into()))?)))
+                Ok(Some(allocate_string(concat, vm.heap)?))
             }
             (Self::Ref(id1), Self::InternString(string_id)) if let HeapData::Str(s1) = vm.heap.get(*id1) => {
                 let concat = format!("{}{}", s1.as_str(), interns.get_str(*string_id));
-                Ok(Some(Self::Ref(vm.heap.allocate(HeapData::Str(concat.into()))?)))
+                Ok(Some(allocate_string(concat, vm.heap)?))
             }
             // same for bytes
             (Self::InternBytes(b1), Self::InternBytes(b2)) => {
@@ -589,13 +589,13 @@ impl PyTrait<'_> for Value {
             }
             (Self::InternString(s1), Self::InternString(s2)) => {
                 let concat = format!("{}{}", interns.get_str(*s1), interns.get_str(*s2));
-                *self = Self::Ref(vm.heap.allocate(HeapData::Str(concat.into()))?);
+                *self = allocate_string(concat, vm.heap)?;
                 Ok(true)
             }
             (Self::InternString(string_id), Self::Ref(id2)) => {
                 let result = if let HeapData::Str(s2) = vm.heap.get(*id2) {
                     let concat = format!("{}{}", interns.get_str(*string_id), s2.as_str());
-                    *self = Self::Ref(vm.heap.allocate(HeapData::Str(concat.into()))?);
+                    *self = allocate_string(concat, vm.heap)?;
                     true
                 } else {
                     false
@@ -664,9 +664,8 @@ impl PyTrait<'_> for Value {
                 HeapData::Str(s) => {
                     let count = i64_to_repeat_count(*n)?;
                     check_repeat_size(s.len(), count, vm.heap.tracker())?;
-                    Ok(Some(Self::Ref(
-                        vm.heap.allocate(HeapData::Str(s.as_str().repeat(count).into()))?,
-                    )))
+                    let repeated = s.as_str().repeat(count);
+                    Ok(Some(allocate_string(repeated, vm.heap)?))
                 }
                 HeapData::Bytes(b) => {
                     let count = i64_to_repeat_count(*n)?;
@@ -725,9 +724,8 @@ impl PyTrait<'_> for Value {
                 match vm.heap.get(seq_id) {
                     HeapData::Str(s) => {
                         check_repeat_size(s.len(), count, vm.heap.tracker())?;
-                        Ok(Some(Self::Ref(
-                            vm.heap.allocate(HeapData::Str(s.as_str().repeat(count).into()))?,
-                        )))
+                        let repeated = s.as_str().repeat(count);
+                        Ok(Some(allocate_string(repeated, vm.heap)?))
                     }
                     HeapData::Bytes(b) => {
                         check_repeat_size(b.len(), count, vm.heap.tracker())?;
@@ -800,7 +798,7 @@ impl PyTrait<'_> for Value {
                 let str_ref = interns.get_str(*s);
                 check_repeat_size(str_ref.len(), count, vm.heap.tracker())?;
                 let result = str_ref.repeat(count);
-                Ok(Some(Self::Ref(vm.heap.allocate(HeapData::Str(result.into()))?)))
+                Ok(Some(allocate_string(result, vm.heap)?))
             }
 
             // Bytes repetition: b"ab" * 3 or 3 * b"ab"
@@ -820,7 +818,7 @@ impl PyTrait<'_> for Value {
                 let str_ref = interns.get_str(*s);
                 check_repeat_size(str_ref.len(), count, vm.heap.tracker())?;
                 let result = str_ref.repeat(count);
-                Ok(Some(Self::Ref(vm.heap.allocate(HeapData::Str(result.into()))?)))
+                Ok(Some(allocate_string(result, vm.heap)?))
             }
 
             // Bytes repetition with LongInt: b"ab" * bigint or bigint * b"ab"
@@ -1343,9 +1341,8 @@ impl PyTrait<'_> for Value {
                     && let HeapData::Slice(slice_obj) = vm.heap.get(*key_id)
                 {
                     let s = interns.get_str(*string_id);
-                    let result_str = slice_collect_iterator(vm, slice_obj, s.chars(), |c| c)?;
-                    let heap_id = vm.heap.allocate(HeapData::Str(Str::from_boxed(result_str)))?;
-                    return Ok(Self::Ref(heap_id));
+                    let result_str: Box<str> = slice_collect_iterator(vm, slice_obj, s.chars(), |c| c)?;
+                    return Ok(allocate_string(result_str, vm.heap)?);
                 }
 
                 // Handle interned string indexing, accepting Int and Bool
@@ -1720,8 +1717,7 @@ impl Value {
                 );
                 if is_dunder_name {
                     let name_str = t.to_string();
-                    let str_id = vm.heap.allocate(HeapData::Str(Str::from(name_str)))?;
-                    return Ok(CallResult::Value(Self::Ref(str_id)));
+                    return Ok(CallResult::Value(allocate_string(name_str, vm.heap)?));
                 }
                 if *t == Type::TimeZone && attr.as_str(vm.interns) == "utc" {
                     return Ok(CallResult::Value(vm.heap.get_timezone_utc()?));
@@ -1748,7 +1744,7 @@ impl Value {
                         EitherStr::Interned(string_id) => Self::InternString(*string_id),
                         // TODO: should avoid needing to clone String via `EitherStr` - maybe
                         // `EitherStr` should store a `HeapRead<Str>`?
-                        EitherStr::Heap(s) => Self::Ref(vm.heap.allocate(HeapData::Str(Str::from(s.to_owned())))?),
+                        EitherStr::Heap(s) => allocate_string(s.as_str(), vm.heap)?,
                     };
                     let old_value = dc.set_attr(name_value, value, vm)?;
                     old_value.drop_with_heap(vm);

--- a/crates/monty/test_cases/refcount__re_pattern_sub_error_paths.py
+++ b/crates/monty/test_cases/refcount__re_pattern_sub_error_paths.py
@@ -24,14 +24,24 @@ try:
 except TypeError:
     pass
 
-# Exercise negative count path (early return)
-result = p.sub('repl', 'hello', -1)
-assert result == 'hello', 'negative count returns input unchanged'
+# Negative count path with an INTERNED input: the negative-count short-circuit
+# returns the value untouched (refcount-bumped), so an interned input stays
+# interned — no heap allocation, no entry in the refcount map.
+interned_result = p.sub('repl', 'hello', -1)
+assert interned_result == 'hello', 'negative count returns interned input unchanged'
+
+# Negative count path with a HEAP-allocated input: the short-circuit shares the
+# same heap object back to the caller, so input_str and result alias each other.
+# (Concatenation at runtime defeats compile-time literal interning.)
+input_str = 'hel' + 'lo'
+result = p.sub('repl', input_str, -1)
+assert result == 'hello', 'negative count returns heap input unchanged'
 
 # repl_list: 1 (variable)
 # input_list: 1 (variable)
 # p: 1 (variable)
 # re: 1 (module)
-# result: 2 (variable + final expression)
+# interned_result: not heap-allocated, absent from the map
+# input_str and result reference the same heap string: 2 vars + final expr = 3
 result
-# ref-counts={'repl_list': 1, 'input_list': 1, 'p': 1, 're': 1, 'result': 2}
+# ref-counts={'repl_list': 1, 'input_list': 1, 'p': 1, 're': 1, 'input_str': 3, 'result': 3}

--- a/crates/monty/test_cases/refcount__re_search_match.py
+++ b/crates/monty/test_cases/refcount__re_search_match.py
@@ -20,9 +20,12 @@ full_str = m2.group(0)
 assert full_str == 'hello', 'fullmatch group(0) returns matched text'
 
 # findall returns a list — keep individual elements in variables
-# so strict matching passes (all heap objects must be reachable)
-results = p.findall('a b c')
-assert results == ['a', 'b', 'c'], 'findall returns list of matches'
+# so strict matching passes (all heap objects must be reachable).
+# Use multi-char tokens so each result is heap-allocated; single-ASCII results
+# would be interned (see allocate_string), and interned values don't appear in
+# the ref-counts map.
+results = p.findall('aa bb cc')
+assert results == ['aa', 'bb', 'cc'], 'findall returns list of matches'
 r0 = results[0]
 r1 = results[1]
 r2 = results[2]

--- a/crates/monty/test_cases/refcount__re_sub_error_paths.py
+++ b/crates/monty/test_cases/refcount__re_sub_error_paths.py
@@ -18,14 +18,24 @@ try:
 except TypeError:
     pass
 
-# Exercise negative count path (early return, no regex compilation)
-result = re.sub('pattern', 'repl', 'hello', -1)
-assert result == 'hello', 'negative count returns input unchanged'
+# Negative count path with an INTERNED input: the negative-count short-circuit
+# returns the value untouched (refcount-bumped), so an interned input stays
+# interned — no heap allocation, no entry in the refcount map.
+interned_result = re.sub('pattern', 'repl', 'hello', -1)
+assert interned_result == 'hello', 'negative count returns interned input unchanged'
 
-# All lists should still be alive and reachable
+# Negative count path with a HEAP-allocated input: the short-circuit shares the
+# same heap object back to the caller, so input_str and result alias each other.
+# (Concatenation at runtime defeats compile-time literal interning.)
+input_str = 'hel' + 'lo'
+result = re.sub('pattern', 'repl', input_str, -1)
+assert result == 'hello', 'negative count returns heap input unchanged'
+
+# All lists should still be alive and reachable.
 # repl_list: 1 (variable)
 # input_list: 1 (variable)
 # re: 1 (module)
-# result: 2 (variable + final expression)
+# interned_result: not heap-allocated, absent from the map
+# input_str and result reference the same heap string: 2 vars + final expr = 3
 result
-# ref-counts={'repl_list': 1, 'input_list': 1, 're': 1, 'result': 2}
+# ref-counts={'repl_list': 1, 'input_list': 1, 're': 1, 'input_str': 3, 'result': 3}

--- a/crates/monty/tests/heap_reader_compile_fail_cases/cases.rs
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/cases.rs
@@ -9,6 +9,8 @@
 //! `heap_reader_compile_fail_tests` cfg (plus a per-test cfg) is set.
 
 use super::*;
+#[cfg(heap_reader_compile_fail_test_heap_mutation_while_reading)]
+use crate::types::str::allocate_string;
 
 /// Must not compile: allocating on the heap while holding a reference derived from `HeapRead::get`.
 ///
@@ -25,7 +27,7 @@ fn heap_mutation_while_reading(list_id: HeapId, heap: &mut Heap<impl ResourceTra
             _ => unreachable!(),
         };
         let slice = a.get(heap).as_slice();
-        let _ = heap.heap_mut().allocate(HeapData::Str(Str::new("boom".into())));
+        let _ = allocate_string("boom", heap.heap_mut());
         let _ = slice.len();
     });
 }

--- a/crates/monty/tests/heap_reader_compile_fail_cases/dec_ref_while_reading.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/dec_ref_while_reading.stderr
@@ -1,10 +1,10 @@
 error[E0502]: cannot borrow `*heap` as mutable because it is also borrowed as immutable
-  --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:70:9
+  --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:72:9
    |
-69 |         let list_ref = a.get(heap);
+71 |         let list_ref = a.get(heap);
    |                              ---- immutable borrow occurs here
-70 |         heap.heap_mut().dec_ref(list_id);
+72 |         heap.heap_mut().dec_ref(list_id);
    |         ^^^^^^^^^^^^^^^ mutable borrow occurs here
-71 |         let _ = list_ref.as_slice().len();
+73 |         let _ = list_ref.as_slice().len();
    |                 -------- immutable borrow later used here
 For more information about this error, try `rustc --explain E0502`.

--- a/crates/monty/tests/heap_reader_compile_fail_cases/double_get_mut.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/double_get_mut.stderr
@@ -1,10 +1,10 @@
 error[E0499]: cannot borrow `*heap` as mutable more than once at a time
-  --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:51:31
+  --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:53:31
    |
-50 |         let ref_a = a.get_mut(heap);
+52 |         let ref_a = a.get_mut(heap);
    |                               ---- first mutable borrow occurs here
-51 |         let ref_b = b.get_mut(heap);
+53 |         let ref_b = b.get_mut(heap);
    |                               ^^^^ second mutable borrow occurs here
-52 |         let _ = (ref_a, ref_b);
+54 |         let _ = (ref_a, ref_b);
    |                  ----- first borrow later used here
 For more information about this error, try `rustc --explain E0499`.

--- a/crates/monty/tests/heap_reader_compile_fail_cases/heap_mutation_while_reading.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/heap_mutation_while_reading.stderr
@@ -1,10 +1,10 @@
 error[E0502]: cannot borrow `*heap` as mutable because it is also borrowed as immutable
-  --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:28:17
+  --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:30:41
    |
-27 |         let slice = a.get(heap).as_slice();
+29 |         let slice = a.get(heap).as_slice();
    |                           ---- immutable borrow occurs here
-28 |         let _ = heap.heap_mut().allocate(HeapData::Str(Str::new("boom".into())));
-   |                 ^^^^^^^^^^^^^^^ mutable borrow occurs here
-29 |         let _ = slice.len();
+30 |         let _ = allocate_string("boom", heap.heap_mut());
+   |                                         ^^^^^^^^^^^^^^^ mutable borrow occurs here
+31 |         let _ = slice.len();
    |                 ----- immutable borrow later used here
 For more information about this error, try `rustc --explain E0502`.

--- a/crates/monty/tests/heap_reader_compile_fail_cases/mutation_in_map_closure.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/mutation_in_map_closure.stderr
@@ -1,13 +1,13 @@
 error[E0500]: closure requires unique access to `*heap` but it is already borrowed
-   --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:112:18
+   --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:114:18
     |
-109 |             .get(heap)
+111 |             .get(heap)
     |                  ---- borrow occurs here
 ...
-112 |             .map(|_v| {
+114 |             .map(|_v| {
     |              --- ^^^^ closure construction occurs here
     |              |
     |              first borrow later used by call
-113 |                 heap.heap_mut().dec_ref(other_id);
+115 |                 heap.heap_mut().dec_ref(other_id);
     |                 ---- second borrow occurs due to use of `*heap` in closure
 For more information about this error, try `rustc --explain E0500`.

--- a/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_and_swap_reader.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_and_swap_reader.stderr
@@ -1,12 +1,12 @@
 error[E0521]: borrowed data escapes outside of closure
-   --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:183:13
+   --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:185:13
     |
-179 |         HeapReader::with(heap_b, reader_a, |reader_b, smuggled| {
+181 |         HeapReader::with(heap_b, reader_a, |reader_b, smuggled| {
     |                                             --------  -------- `smuggled` declared here, outside of the closure body
     |                                             |
     |                                             `reader_b` is a reference that is only valid in the closure body
 ...
-183 |             std::mem::swap(reader_b, smuggled);
+185 |             std::mem::swap(reader_b, smuggled);
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `reader_b` escapes the closure body here
     |
     = note: requirement occurs because of a mutable reference to `heap::HeapReader<'_, T>`

--- a/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_heap_read.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_heap_read.stderr
@@ -1,12 +1,12 @@
 error[E0521]: borrowed data escapes outside of closure
-  --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:89:9
+  --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:91:9
    |
-83 |     let mut smuggled: Option<HeapRead<'_, List>> = None;
+85 |     let mut smuggled: Option<HeapRead<'_, List>> = None;
    |         ------------ `smuggled` declared here, outside of the closure body
-84 |     HeapReader::with(heap, &mut (), |heap, ()| {
+86 |     HeapReader::with(heap, &mut (), |heap, ()| {
    |                                      ---- `heap` is a reference that is only valid in the closure body
 ...
-89 |         smuggled = Some(a);
+91 |         smuggled = Some(a);
    |         ^^^^^^^^ `heap` escapes the closure body here
    |
    = note: requirement occurs because of the type `heap::HeapRead<'_, list::List>`, which makes the generic argument `'_` invariant

--- a/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_vm.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_vm.stderr
@@ -1,7 +1,7 @@
 error: lifetime may not live long enough
-   --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:155:36
+   --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:157:36
     |
-155 |         |reader, (interns, print)| VM::new(Vec::new(), reader, *interns, print.reborrow()),
+157 |         |reader, (interns, print)| VM::new(Vec::new(), reader, *interns, print.reborrow()),
     |          ------                  - ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ returning this value requires that `'1` must outlive `'2`
     |          |                       |
     |          |                       return type of closure is VM<'2, T>
@@ -11,16 +11,16 @@ error: lifetime may not live long enough
     = note: the struct `VM<'h, T>` is invariant over the parameter `'h`
     = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance
 error: lifetime may not live long enough
-   --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:152:5
+   --> crates/monty/src/../tests/heap_reader_compile_fail_cases/cases.rs:154:5
     |
-149 |       interns: &crate::intern::Interns,
+151 |       interns: &crate::intern::Interns,
     |                - let's call the lifetime of this reference `'1`
 ...
-152 | /     HeapReader::with(
-153 | |         heap,
-154 | |         &mut (interns, crate::io::PrintWriter::Disabled),
-155 | |         |reader, (interns, print)| VM::new(Vec::new(), reader, *interns, print.reborrow()),
-156 | |     )
+154 | /     HeapReader::with(
+155 | |         heap,
+156 | |         &mut (interns, crate::io::PrintWriter::Disabled),
+157 | |         |reader, (interns, print)| VM::new(Vec::new(), reader, *interns, print.reborrow()),
+158 | |     )
     | |_____^ returning this value requires that `'1` must outlive `'static`
     |
     = note: requirement occurs because of the type `VM<'_, T>`, which makes the generic argument `'_` invariant


### PR DESCRIPTION
This avoids cases where:
- empty or ascii character strings are heap allocated as new strings
- some cases where `Box<str>` is cast to `String` and back
- even caught a couple cases in the regex module where new allocations can be completely avoided

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralize all string creation via `types::str::allocate_string` (and `allocate_string_no_interning`) to intern empty/ASCII strings and cut redundant heap allocations. This removes ad‑hoc `Str::new` usage, standardizes behavior across the VM, and trims avoidable allocations in `re` and JSON paths.

- **Refactors**
  - Added `allocate_string` (interns empty/ASCII) and `allocate_string_no_interning` (fast path for known multi-byte results).
  - Replaced direct `HeapData::Str`/`Str::new` across builtins (`bin`, `oct`, `hex`, `repr`), core types (`str`, `bytes`, `path`, `date`, `datetime`), `value`, `heap_data`, JSON, and `modules/re`.
  - Regex/JSON: removed needless allocations; `re.sub`/`RePattern.sub` with negative count now return the original value without reallocating (preserves interning); updated tests and compile-fail fixtures accordingly.

<sup>Written for commit 587223b9d969e9d7e05571a45b9dfe215825183f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

