### PR TITLE
enforce JSON integers do not exceed Monty's BigInt limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,9 +1560,8 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiter"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ba671987d7444d251d3ee5340be1bf4606cd6c0b53e6f4066b5a1ee376b22"
+version = "0.14.0"
+source = "git+https://github.com/pydantic/jiter.git?rev=c023b5d72a747fe911283a6603bf7c9200a4533e#c023b5d72a747fe911283a6603bf7c9200a4533e"
 dependencies = [
  "ahash",
  "bitvec",
@@ -2324,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf3ccafdf54c050be48a3a086d372f77ba6615f5057211607cd30e5ac5cec6d"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
  "indexmap",
  "libc",
@@ -2355,9 +2354,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972720a441c91fd9c49f212a1d2d74c6e3803b231ebc8d66c51efbd7ccab11c8"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "python3-dll-a",
  "target-lexicon",
@@ -2365,9 +2364,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5994456d9dab8934d600d3867571b6410f24fbd6002570ad56356733eb54859b"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2375,9 +2374,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ce9cc8d81b3c4969748807604d92b4eef363c5bb82b1a1bdb34ec6f1093a18"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2387,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.0"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf4b60036a154d23282679b658e3cc7d88d3b8c9a40b43824785f232d2e1b98"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,8 +1560,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiter"
-version = "0.14.0"
-source = "git+https://github.com/pydantic/jiter.git?rev=c023b5d72a747fe911283a6603bf7c9200a4533e#c023b5d72a747fe911283a6603bf7c9200a4533e"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7866f284df68dbc242796251ed9768bde2b58ebc4d7d32cc07cc7fd993e3ed6c"
 dependencies = [
  "ahash",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,12 +67,6 @@ sha2 = "0.10"
 pretty_assertions = "1.4"
 insta = "1.47"
 
-# TEMP: pinned to the jiter branch that exposes `parse_number_bytes` /
-# `known_number_bytes` (https://github.com/pydantic/jiter/pull/250).
-# Remove once that PR lands and the resulting release is published.
-[patch.crates-io]
-jiter = { git = "https://github.com/pydantic/jiter.git", package = "jiter", rev = "c023b5d72a747fe911283a6603bf7c9200a4533e" }
-
 [workspace.lints.rust]
 # codspeed cfg is set by codspeed-criterion-compat when running in CodSpeed environment
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(codspeed)', 'cfg(heap_reader_compile_fail_tests)', 'cfg(heap_reader_compile_fail_test_read_while_ref_alive)', 'cfg(heap_reader_compile_fail_test_dec_ref_while_reading)', 'cfg(heap_reader_compile_fail_test_smuggle_heap_read)', 'cfg(heap_reader_compile_fail_test_double_get_mut)', 'cfg(heap_reader_compile_fail_test_heap_mutation_while_reading)', 'cfg(heap_reader_compile_fail_test_mutation_in_map_closure)', 'cfg(heap_reader_compile_fail_test_smuggle_vm)', 'cfg(heap_reader_compile_fail_test_smuggle_and_swap_reader)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,12 @@ sha2 = "0.10"
 pretty_assertions = "1.4"
 insta = "1.47"
 
+# TEMP: pinned to the jiter branch that exposes `parse_number_bytes` /
+# `known_number_bytes` (https://github.com/pydantic/jiter/pull/250).
+# Remove once that PR lands and the resulting release is published.
+[patch.crates-io]
+jiter = { git = "https://github.com/pydantic/jiter.git", package = "jiter", rev = "c023b5d72a747fe911283a6603bf7c9200a4533e" }
+
 [workspace.lints.rust]
 # codspeed cfg is set by codspeed-criterion-compat when running in CodSpeed environment
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(codspeed)', 'cfg(heap_reader_compile_fail_tests)', 'cfg(heap_reader_compile_fail_test_read_while_ref_alive)', 'cfg(heap_reader_compile_fail_test_dec_ref_while_reading)', 'cfg(heap_reader_compile_fail_test_smuggle_heap_read)', 'cfg(heap_reader_compile_fail_test_double_get_mut)', 'cfg(heap_reader_compile_fail_test_heap_mutation_while_reading)', 'cfg(heap_reader_compile_fail_test_mutation_in_map_closure)', 'cfg(heap_reader_compile_fail_test_smuggle_vm)', 'cfg(heap_reader_compile_fail_test_smuggle_and_swap_reader)'] }

--- a/crates/monty/Cargo.toml
+++ b/crates/monty/Cargo.toml
@@ -37,7 +37,7 @@ libm = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
 speedate = "0.17.0"
 itertools = "0.14.0"
-jiter = { version = "0.13.0", features = ["num-bigint"] }
+jiter = { version = "0.14.0", features = ["num-bigint"] }
 
 [features]
 # ref-count-return changes behavior to return information on reference counts to check they're correct

--- a/crates/monty/Cargo.toml
+++ b/crates/monty/Cargo.toml
@@ -37,7 +37,7 @@ libm = "0.2"
 chrono = { version = "0.4", features = ["serde"] }
 speedate = "0.17.0"
 itertools = "0.14.0"
-jiter = { version = "0.14.0", features = ["num-bigint"] }
+jiter = { version = "0.15.0", features = ["num-bigint"] }
 
 [features]
 # ref-count-return changes behavior to return information on reference counts to check they're correct

--- a/crates/monty/src/modules/json/load.rs
+++ b/crates/monty/src/modules/json/load.rs
@@ -5,7 +5,7 @@
 
 use std::{borrow::Cow, mem};
 
-use jiter::{Jiter, JiterError, JiterErrorType, JsonErrorType, NumberAny, NumberInt, Peek};
+use jiter::{Jiter, JiterError, JiterErrorType, JsonErrorType, NumberAny, NumberInt, Peek, parse_number_bytes};
 
 use super::JsonStringCache;
 use crate::{
@@ -209,20 +209,29 @@ fn allocate_cached_string(
 
 /// Parses a JSON number into the corresponding Monty numeric value.
 ///
-/// Integer tokens are counted directly from the source bytes so
-/// `INT_MAX_STR_DIGITS` errors report the same digit count as CPython without
-/// first allocating an oversized decimal string.
+/// Oversized integers that exceed Monty's digit limit are rejected with a `ValueError`
 fn parse_json_number(peek: Peek, jiter: &mut Jiter<'_>, vm: &mut VM<'_, impl ResourceTracker>) -> ParseResult<Value> {
     let start = jiter.current_index();
-    match jiter.known_number(peek) {
-        Ok(NumberAny::Int(NumberInt::Int(value))) => Ok(Value::Int(value)),
-        Ok(NumberAny::Int(NumberInt::BigInt(value))) => {
-            let digit_count = decimal_digit_count_ascii(jiter.slice_to_current(start));
-            check_decimal_digit_count(digit_count).map_err(JsonLoadError::Run)?;
-            Ok(LongInt::new(value).into_value(vm.heap)?)
-        }
-        Ok(NumberAny::Float(value)) => Ok(Value::Float(value)),
-        Err(error) => Err(error.into()),
+    // Parse to bytes so that we can check the digit count before any BigInt allocation occurs.
+    let token = jiter.known_number_bytes(peek)?;
+    if is_json_integer_token(token) {
+        let digit_count = decimal_digit_count_ascii(token);
+        check_decimal_digit_count(digit_count).map_err(JsonLoadError::Run)?;
+    }
+    // `known_number_bytes` already validated the token, so `parse_number_bytes`
+    // only re-parses the same byte range. Errors here are mapped back into the
+    // outer document's coordinate space so `json_error_to_run_error` reports
+    // the correct line/column.
+    let number = parse_number_bytes(token, true).map_err(|error| {
+        JsonLoadError::Parse(JiterError {
+            error_type: JiterErrorType::JsonError(error.error_type),
+            index: start + error.index,
+        })
+    })?;
+    match number {
+        NumberAny::Int(NumberInt::Int(value)) => Ok(Value::Int(value)),
+        NumberAny::Int(NumberInt::BigInt(value)) => Ok(LongInt::new(value).into_value(vm.heap)?),
+        NumberAny::Float(value) => Ok(Value::Float(value)),
     }
 }
 

--- a/crates/monty/src/modules/json/load.rs
+++ b/crates/monty/src/modules/json/load.rs
@@ -5,7 +5,7 @@
 
 use std::{borrow::Cow, mem};
 
-use jiter::{Jiter, JiterError, JiterErrorType, JsonErrorType, NumberAny, NumberInt, Peek, parse_number_bytes};
+use jiter::{Jiter, JiterError, JiterErrorType, JsonErrorType, NumberAny, NumberInt, Peek};
 
 use super::JsonStringCache;
 use crate::{
@@ -218,11 +218,11 @@ fn parse_json_number(peek: Peek, jiter: &mut Jiter<'_>, vm: &mut VM<'_, impl Res
         let digit_count = decimal_digit_count_ascii(token);
         check_decimal_digit_count(digit_count).map_err(JsonLoadError::Run)?;
     }
-    // `known_number_bytes` already validated the token, so `parse_number_bytes`
+    // `known_number_bytes` already validated the token, so `NumberAny::from_bytes`
     // only re-parses the same byte range. Errors here are mapped back into the
     // outer document's coordinate space so `json_error_to_run_error` reports
     // the correct line/column.
-    let number = parse_number_bytes(token, true).map_err(|error| {
+    let number = NumberAny::from_bytes(token, true).map_err(|error| {
         JsonLoadError::Parse(JiterError {
             error_type: JiterErrorType::JsonError(error.error_type),
             index: start + error.index,

--- a/crates/monty/test_cases/json__int_max_str_digits.py
+++ b/crates/monty/test_cases/json__int_max_str_digits.py
@@ -14,6 +14,20 @@ except ValueError as exc:
         f'loads digit-limit error message mismatch: {msg}'
     )
 
+# === loads rejects multi-million-digit integers without growing a BigInt ===
+# Regression test: the parser must reject by digit count before any BigInt
+# allocation, so this completes in milliseconds rather than spending CPU/memory
+# proportional to the input size.
+huge = '1' * 1_000_000
+try:
+    json.loads(huge)
+    assert False, 'loads should reject multi-million-digit integers'
+except ValueError as exc:
+    msg = str(exc)
+    assert msg.startswith('Exceeds the limit (4300 digits) for integer string conversion: value has 1000000 digits'), (
+        f'loads huge-int error message mismatch: {msg}'
+    )
+
 # === dumps accepts integers at the digit limit ===
 dump_ok = 10**4299
 assert json.dumps(dump_ok) == str(dump_ok), 'dumps should accept 4300-digit integers'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reject oversized JSON integers during parsing by enforcing Monty’s BigInt digit limit before allocation. Prevents CPU/memory blowups and matches CPython’s digit-count errors.

- **Bug Fixes**
  - Check integer digit count from raw bytes via `known_number_bytes`; raise `ValueError` before any BigInt allocation.
  - Re-parse with `NumberAny::from_bytes`; map errors to original offsets for accurate line/column.
  - Add regression test rejecting a 1,000,000-digit integer; `dumps` still accepts values at the 4300-digit limit.

- **Dependencies**
  - Bump `jiter` to `0.15.0`.
  - Bump `pyo3` and related crates to `0.28.3`.

<sup>Written for commit 3275a7dfd3259764387c3989b32ac81f9bd0c536. Summary will update on new commits. <a href="https://cubic.dev/pr/pydantic/monty/pull/431?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

