### PR TITLE
Clean up compiler - no longer emit dead code, simpler exception handlers, ensure jumps hit the same depth

### DIFF
--- a/crates/monty/src/bytecode/builder.rs
+++ b/crates/monty/src/bytecode/builder.rs
@@ -7,91 +7,23 @@ use std::collections::HashSet;
 
 use super::{
     code::{Code, ConstPool, ExceptionEntry, LocationEntry},
-    op::Opcode,
+    op::{Opcode, Operand},
 };
 use crate::{intern::StringId, parse::CodeRange, value::Value};
-
-/// State of the abstract operand-stack tracker as the builder emits bytecode.
-///
-/// The compiler tracks "what the operand stack looks like at the point we're
-/// about to emit the next opcode" so that it can record correct stack depths
-/// in `ExceptionEntry` and check the merge invariant at jump patches. Control
-/// flow makes that tracker into a small state machine:
-///
-/// * `Live(depth)` — the most recently emitted opcode falls through to the
-///   next byte. `depth` is the operand-stack height there. `adjust_stack`
-///   updates `depth`; `set_stack_depth` overrides it absolutely.
-/// * `Dead` — the most recently emitted opcode unconditionally diverts
-///   control flow (`Jump`, `ReturnValue`, `Raise`, `Reraise`), so subsequent
-///   bytes are unreachable via fall-through. The depth has no meaningful
-///   value until something re-establishes it: a `patch_jump` whose label
-///   carries the jump-taken target depth, or an explicit `set_stack_depth`
-///   for code reached via the exception table (handler entries).
-///
-/// Modeling this explicitly removes the need for compilers to manually save
-/// and restore `dead_code_depth` around terminating statements — emit-of-
-/// terminator transitions to `Dead`, and `patch_jump` transitions back to
-/// `Live` from the label's recorded target depth. Stack-effect adjustments
-/// in `Dead` are no-ops, so dead code can compile freely without poisoning
-/// the tracker.
-#[derive(Debug, Clone, Copy)]
-enum TrackerState {
-    Live(u16),
-    Dead,
-}
-
-impl Default for TrackerState {
-    fn default() -> Self {
-        Self::Live(0)
-    }
-}
-
-/// Operand bundle paired with an opcode at emit time.
-///
-/// Every linear (non-jump) emit funnels through `emit_with_operand(op, operand)`,
-/// which writes the bytes for `operand` and consults `stack_effect_for(op, &operand)`
-/// for the stack adjustment. Carrying the operand through this enum makes
-/// stack-effect computation a single, exhaustive match — variable-effect
-/// opcodes without an explicit arm panic instead of silently drifting.
-#[derive(Debug)]
-enum Operand<'a> {
-    /// No operand bytes (e.g. `Pop`, `BinaryAdd`).
-    None,
-    /// Single u8 operand (e.g. `LoadLocal`, `CallFunction`).
-    U8(u8),
-    /// Single i8 operand.
-    I8(i8),
-    /// Single u16 operand, little-endian (e.g. `LoadConst`, `BuildList`).
-    U16(u16),
-    /// Two u8 operands (e.g. `UnpackEx`, `CallBuiltinFunction`).
-    U8U8(u8, u8),
-    /// u8 then u16 little-endian (e.g. `LoadLocalCallable`).
-    U8U16(u8, u16),
-    /// u16 little-endian then u8 (e.g. `MakeFunction`, `CallAttr`).
-    U16U8(u16, u8),
-    /// Two u16 little-endian (e.g. `LoadLocalCallableW`, `LoadGlobalCallable`).
-    U16U16(u16, u16),
-    /// u16 then two u8s (e.g. `MakeClosure`).
-    U16U8U8(u16, u8, u8),
-    /// `CallFunctionKw` shape: pos_count (u8), kw_count (u8), kw_count * name_id (u16 each).
-    CallKw { pos_count: u8, kwname_ids: &'a [u16] },
-    /// `CallAttrKw` shape: attr_name_id (u16), pos_count (u8), kw_count (u8), kw_count * name_id (u16 each).
-    CallAttrKw {
-        attr_name_id: u16,
-        pos_count: u8,
-        kwname_ids: &'a [u16],
-    },
-}
 
 /// Builder for emitting bytecode during compilation.
 ///
 /// Handles encoding opcodes and operands into raw bytes, managing forward jumps
 /// that need patching, and tracking source locations for traceback generation.
 ///
+/// The builder maintains an internal "dead code" state; during dead code emission
+/// no bytes are written and no work is done.
+///
 /// # Usage
 ///
 /// ```ignore
 /// let mut builder = CodeBuilder::new();
+/// builder.enter_region(0); // open the initial region at depth 0
 /// builder.set_location(some_range, None);
 /// builder.emit(Opcode::LoadNone);
 /// builder.emit_u8(Opcode::LoadLocal, 0);
@@ -120,8 +52,12 @@ pub struct CodeBuilder {
     /// Current focus location within the source range.
     current_focus: Option<CodeRange>,
 
-    /// Current operand-stack tracker state — see `TrackerState`.
-    tracker: TrackerState,
+    /// Operand-stack depth at the point the next opcode will be emitted, or
+    /// `None` if not emitting a code region.
+    ///
+    /// Unconditional terminators (`Jump`, `ReturnValue`, `Raise`, `Reraise`)
+    /// finish code regions, transitioning the builder to the dead-code state.
+    current_stack_depth: Option<u16>,
 
     /// Maximum stack depth seen during compilation.
     max_stack_depth: u16,
@@ -140,7 +76,9 @@ pub struct CodeBuilder {
 }
 
 impl CodeBuilder {
-    /// Creates a new empty CodeBuilder.
+    /// Creates a new empty `CodeBuilder` in the dead-code state — no region
+    /// is open yet. Call `enter_region(0)` (or another depth, for an
+    /// exception-table-reached region) before emitting.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
@@ -158,77 +96,85 @@ impl CodeBuilder {
 
     /// Emits a no-operand instruction and updates stack depth tracking.
     pub fn emit(&mut self, op: Opcode) {
-        self.emit_with_operand(op, &Operand::None);
+        self.emit_with_operand(op, Operand::None);
     }
 
-    /// Emits an instruction with a u8 operand.
+    /// Emits an instruction with a u8 operand and updates stack depth tracking.
     pub fn emit_u8(&mut self, op: Opcode, operand: u8) {
-        self.emit_with_operand(op, &Operand::U8(operand));
+        self.emit_with_operand(op, Operand::U8(operand));
     }
 
-    /// Emits an instruction with an i8 operand.
+    /// Emits an instruction with an i8 operand and updates stack depth tracking.
     pub fn emit_i8(&mut self, op: Opcode, operand: i8) {
-        self.emit_with_operand(op, &Operand::I8(operand));
+        self.emit_with_operand(op, Operand::I8(operand));
     }
 
-    /// Emits an instruction with two u8 operands.
+    /// Emits an instruction with two u8 operands and updates stack depth tracking.
     ///
-    /// Used for `UnpackEx`: before_count + after_count.
+    /// Used for UnpackEx: before_count (u8) + after_count (u8)
     pub fn emit_u8_u8(&mut self, op: Opcode, operand1: u8, operand2: u8) {
-        self.emit_with_operand(op, &Operand::U8U8(operand1, operand2));
+        self.emit_with_operand(op, Operand::U8U8(operand1, operand2));
     }
 
-    /// Emits an instruction with a u16 operand (little-endian).
+    /// Emits an instruction with a u16 operand (little-endian) and updates stack depth tracking.
     pub fn emit_u16(&mut self, op: Opcode, operand: u16) {
-        self.emit_with_operand(op, &Operand::U16(operand));
+        self.emit_with_operand(op, Operand::U16(operand));
     }
 
     /// Emits an instruction with a u16 operand followed by a u8 operand.
     ///
     /// Used for `MakeFunction`, `CallAttr`, `CallAttrExtended`.
     pub fn emit_u16_u8(&mut self, op: Opcode, operand1: u16, operand2: u8) {
-        self.emit_with_operand(op, &Operand::U16U8(operand1, operand2));
+        self.emit_with_operand(op, Operand::U16U8(operand1, operand2));
     }
 
     /// Emits an instruction with a u16 operand followed by two u8 operands.
     ///
-    /// Used for `MakeClosure`: func_id + defaults_count + cell_count.
+    /// Used for MakeClosure: func_id (u16) + defaults_count (u8) + cell_count (u8)
     pub fn emit_u16_u8_u8(&mut self, op: Opcode, operand1: u16, operand2: u8, operand3: u8) {
-        self.emit_with_operand(op, &Operand::U16U8U8(operand1, operand2, operand3));
+        self.emit_with_operand(op, Operand::U16U8U8(operand1, operand2, operand3));
     }
 
-    /// Emits `CallBuiltinFunction`: builtin_id (u8) + arg_count (u8).
+    /// Emits `CallBuiltinFunction` instruction.
+    ///
+    /// Operands: builtin_id (u8) + arg_count (u8)
     ///
     /// The builtin_id is the `#[repr(u8)]` discriminant of `BuiltinsFunctions`.
     /// This is an optimization that avoids constant pool lookup and stack manipulation.
     pub fn emit_call_builtin_function(&mut self, builtin_id: u8, arg_count: u8) {
-        self.emit_with_operand(Opcode::CallBuiltinFunction, &Operand::U8U8(builtin_id, arg_count));
+        self.emit_with_operand(Opcode::CallBuiltinFunction, Operand::U8U8(builtin_id, arg_count));
     }
 
-    /// Emits `CallBuiltinType`: type_id (u8) + arg_count (u8).
+    /// Emits `CallBuiltinType` instruction.
+    ///
+    /// Operands: type_id (u8) + arg_count (u8)
     ///
     /// The type_id is the `#[repr(u8)]` discriminant of `BuiltinsTypes`.
     /// This is an optimization for type constructors like `list()`, `int()`, `str()`.
     pub fn emit_call_builtin_type(&mut self, type_id: u8, arg_count: u8) {
-        self.emit_with_operand(Opcode::CallBuiltinType, &Operand::U8U8(type_id, arg_count));
+        self.emit_with_operand(Opcode::CallBuiltinType, Operand::U8U8(type_id, arg_count));
     }
 
-    /// Emits `CallFunctionKw` with inline keyword names.
+    /// Emits CallFunctionKw with inline keyword names.
     ///
-    /// Operands: pos_count (u8) + kw_count (u8) + kw_count * name_id (u16 each).
-    /// `kwname_ids` is the StringId for each keyword argument, in the order
-    /// the values were pushed onto the operand stack.
+    /// Operands: pos_count (u8) + kw_count (u8) + kw_count * name_id (u16 each)
+    ///
+    /// The kwname_ids slice contains StringId indices for each keyword argument
+    /// name, in order matching how the values were pushed to the stack.
     pub fn emit_call_function_kw(&mut self, pos_count: u8, kwname_ids: &[u16]) {
-        self.emit_with_operand(Opcode::CallFunctionKw, &Operand::CallKw { pos_count, kwname_ids });
+        self.emit_with_operand(Opcode::CallFunctionKw, Operand::CallKw { pos_count, kwname_ids });
     }
 
-    /// Emits `CallAttrKw` with inline keyword names.
+    /// Emits CallAttrKw with inline keyword names.
     ///
-    /// Operands: attr_name_id (u16) + pos_count (u8) + kw_count (u8) + kw_count * name_id (u16 each).
+    /// Operands: attr_name_id (u16) + pos_count (u8) + kw_count (u8) + kw_count * name_id (u16 each)
+    ///
+    /// The kwname_ids slice contains StringId indices for each keyword argument
+    /// name, in order matching how the values were pushed to the stack.
     pub fn emit_call_attr_kw(&mut self, attr_name_id: u16, pos_count: u8, kwname_ids: &[u16]) {
         self.emit_with_operand(
             Opcode::CallAttrKw,
-            &Operand::CallAttrKw {
+            Operand::CallAttrKw {
                 attr_name_id,
                 pos_count,
                 kwname_ids,
@@ -238,144 +184,133 @@ impl CodeBuilder {
 
     /// Emits a forward jump instruction, returning a label to patch later.
     ///
-    /// The jump offset is initially set to 0 and must be patched with
-    /// `patch_jump()` once the target location is known.
-    ///
-    /// The returned label carries the bytecode offset to patch and the stack
-    /// depth that the *jump-taken* path leaves on the stack at the patch
-    /// target. `patch_jump` uses that depth to enforce the merge invariant
-    /// (every branch arriving at the patch point agrees on stack depth) and
-    /// to transition the tracker out of `Dead` when fall-through is
-    /// unreachable. Forward jumps differ in how they affect the two paths:
-    ///
-    /// | Opcode                                 | fall-through effect | jump-taken target depth |
-    /// |----------------------------------------|---------------------|-------------------------|
-    /// | `Jump`                                 | n/a (dead)          | unchanged from pre-emit |
-    /// | `JumpIfTrue` / `JumpIfFalse`           | `-1` (cond popped)  | pre-emit `- 1`          |
-    /// | `JumpIfTrueOrPop` / `JumpIfFalseOrPop` | `-1` (cond popped)  | pre-emit (cond kept)    |
-    /// | `ForIter`                              | `+1` (value pushed) | pre-emit `- 1` (iter popped) |
-    ///
-    /// After `Jump` the tracker becomes `Dead` (it's unconditional). All
-    /// other jumps continue to fall through.
+    /// After `Jump` the tracker transitions to dead (it's unconditional).
+    /// All other jumps continue to fall through.
     ///
     /// # Panics
     ///
-    /// Panics if called from the `Dead` state — emitting a jump in dead code
-    /// produces unreachable bytecode and obscures the merge invariant.
-    /// Callers must guard with `is_dead()` if they may reach this from a
-    /// terminating block (see e.g. `compile_if`'s if-else bridge).
+    /// - Panics if the jump-taken target depth (current depth + `op.jump_taken_stack_effect()`)
+    ///   exceeds u16 range, which indicates a compiler bug in stack effect annotations or an
+    ///   unreasonably large function.
+    /// - Panics on non-jump opcodes.
     #[must_use]
     pub fn emit_jump(&mut self, op: Opcode) -> JumpLabel {
-        let TrackerState::Live(pre_depth) = self.tracker else {
-            panic!("emit_jump({op:?}) called from Dead state — guard with is_dead() at the call site")
+        let Some(pre_depth) = self.current_stack_depth else {
+            return JumpLabel { inner: None };
         };
-
-        self.record_location();
-        let offset = self.bytecode.len();
-        self.bytecode.push(op as u8);
-        // Placeholder for i16 offset (will be patched)
-        self.bytecode.extend_from_slice(&0i16.to_le_bytes());
-
-        let (fallthrough_effect, target_depth): (i16, u16) = match op {
-            Opcode::Jump => (0, pre_depth),
-            Opcode::JumpIfTrue | Opcode::JumpIfFalse => (-1, pre_depth.saturating_sub(1)),
-            Opcode::JumpIfTrueOrPop | Opcode::JumpIfFalseOrPop => (-1, pre_depth),
-            Opcode::ForIter => (1, pre_depth.saturating_sub(1)),
-            _ => panic!("emit_jump called with non-jump opcode {op:?}"),
-        };
-        self.adjust_stack(fallthrough_effect);
-
-        if op == Opcode::Jump {
-            self.mark_dead();
+        // Capture the opcode position (where patch_jump will overwrite the i16)
+        // before `emit_with_operand` pushes the bytes.
+        let offset = self.current_offset();
+        // Jump-taken target depth. `jump_taken_delta` panics for non-jumps.
+        let target_depth = u16::try_from(i32::from(pre_depth) + i32::from(op.jump_taken_stack_effect()))
+            .expect("jump target depth out of u16 range");
+        // Use the current position as a self-referential placeholder target.
+        // `patch_jump` will overwrite the encoded bytes with the real target
+        // once it's known; `#[must_use]` on the returned `JumpLabel` ensures
+        // the caller can't silently skip patching.
+        self.emit_with_operand(op, Operand::Offset(offset));
+        JumpLabel {
+            inner: Some(JumpLabelInner { offset, target_depth }),
         }
-
-        JumpLabel { offset, target_depth }
     }
 
     /// Patches a forward jump to point to the current bytecode location.
     ///
-    /// The offset is calculated relative to the position after the jump
-    /// instruction's operand (i.e., where execution would continue if
-    /// the jump is not taken).
-    ///
-    /// Tracker state transitions: if the tracker is `Dead` (because the
-    /// last live emission was a terminator), `patch_jump` re-establishes
-    /// `Live(label.target_depth)` from the label. If the tracker is already
-    /// `Live`, it asserts agreement — the merge invariant.
+    /// State transitions: if the builder is emitting dead code, `patch_jump`
+    /// re-establishes the live depth from `label.target_depth`. If the code
+    /// is live, it asserts the current stack depth matches the jump label
+    /// stack depth.
     ///
     /// # Panics
     ///
-    /// - In debug builds, panics if the tracker is `Live` and disagrees with
-    ///   `label.target_depth` — this means two reachable paths arrive at the
-    ///   patch point with different stack heights.
+    /// - In debug builds, panics if the tracker is live and disagrees with
+    ///   the label's target depth — this means two reachable paths arrive at
+    ///   the patch point with different stack heights.
     /// - Always panics if the jump offset exceeds i16 range (-32768..32767),
     ///   which indicates the function is too large. This is a compile-time
     ///   error rather than silent truncation.
     pub fn patch_jump(&mut self, label: JumpLabel) {
+        // If the emit_jump ran from dead code, nothing to patch.
+        let Some(label) = label.inner else { return };
         let target = self.bytecode.len();
         // Offset is relative to position after the jump instruction (opcode + i16 = 3 bytes)
         let target_i64 = i64::try_from(target).expect("bytecode target exceeds i64");
-        let label_i64 = i64::try_from(label.offset).expect("bytecode label exceeds i64");
+        let label_i64 = i64::try_from(label.offset.0).expect("bytecode label exceeds i64");
         let raw_offset = target_i64 - label_i64 - 3;
         let offset =
             i16::try_from(raw_offset).expect("jump offset exceeds i16 range (-32768..32767); function too large");
         let bytes = offset.to_le_bytes();
-        self.bytecode[label.offset + 1] = bytes[0];
-        self.bytecode[label.offset + 2] = bytes[1];
+        self.bytecode[label.offset.0 + 1] = bytes[0];
+        self.bytecode[label.offset.0 + 2] = bytes[1];
 
-        match self.tracker {
-            TrackerState::Live(d) => debug_assert_eq!(
+        match self.current_stack_depth {
+            Some(d) => debug_assert_eq!(
                 d, label.target_depth,
                 "stack-depth mismatch at jump merge: builder tracker is {d} but jump label expects {}; \
                  branches reaching this merge point disagree on stack state",
                 label.target_depth,
             ),
-            TrackerState::Dead => self.set_stack_depth(label.target_depth),
+            None => self.new_code_region(label.target_depth),
         }
     }
 
-    /// Emits a backward jump to a known target offset.
+    /// Emits a backward jump to a known target. Any jump opcode is accepted;
+    /// `Opcode::jump_taken_delta` is the shared source of truth for the
+    /// jump-taken stack effect (and panics for non-jump opcodes).
     ///
-    /// Unlike forward jumps, backward jumps have a known target at emit time,
-    /// so no patching is needed. Only fixed-effect opcodes are supported here
-    /// (in practice, just `Jump` and the conditional jumps used for
-    /// comprehension filters); branch-dependent jumps like `ForIter` or the
-    /// `OrPop` variants would need per-branch target depths that this
-    /// label-less path can't carry — panic if misused.
-    ///
-    /// After `Jump` (unconditional), the tracker transitions to `Dead`.
-    /// Panics if called from `Dead` — emitting a backward jump in dead code
-    /// produces unreachable bytecode and is always a compiler bug.
-    pub fn emit_jump_to(&mut self, op: Opcode, target: usize) {
-        assert!(
-            !self.is_dead(),
-            "emit_jump_to({op:?}) called from Dead state — guard with is_dead() at the call site"
-        );
-        self.record_location();
-        let current = self.bytecode.len();
-        // Offset is relative to position after this instruction (current + 3)
-        let target_i64 = i64::try_from(target).expect("bytecode target exceeds i64");
-        let current_i64 = i64::try_from(current).expect("bytecode offset exceeds i64");
-        let raw_offset = target_i64 - (current_i64 + 3);
-        let offset =
-            i16::try_from(raw_offset).expect("jump offset exceeds i16 range (-32768..32767); function too large");
-        self.bytecode.push(op as u8);
-        self.bytecode.extend_from_slice(&offset.to_le_bytes());
-        let effect = op.stack_effect().unwrap_or_else(|| {
-            panic!("variable-effect opcode {op:?} emitted via emit_jump_to — only fixed-effect jumps are supported on the backward-jump path")
-        });
-        self.adjust_stack(effect);
-        if op == Opcode::Jump {
-            self.mark_dead();
+    /// # Panics
+    /// - Panics if the jump target was emitted in dead code, and the current
+    ///   code is live.
+    /// - In debug builds, panics if the current stack depth plus the jump's stack
+    ///   effect do not match the jump target stack depth.
+    /// - Panics on non-jump opcodes.
+    pub fn emit_jump_to(&mut self, op: Opcode, target: JumpTarget) {
+        let Some(target) = target.inner else {
+            // Target was captured in the dead-code state. If we're also dead
+            // here, this is a benign no-op (nothing would be emitted anyway).
+            // If we're live, this is a compiler bug — we'd be jumping into a
+            // region whose bytes weren't emitted because they were dead at
+            // capture time.
+            assert!(
+                self.is_dead(),
+                "emit_jump_to: cannot jump from live code into a target captured in the dead-code state"
+            );
+            return;
+        };
+        // Backward-jump merge invariant: the jump-taken arrival depth must
+        // equal the depth at the target. Skip the check in the dead-code
+        // state — `emit_with_operand` will no-op the emission anyway.
+        if let Some(current) = self.current_stack_depth {
+            let arrival = i32::from(current) + i32::from(op.jump_taken_stack_effect());
+            debug_assert_eq!(
+                arrival,
+                i32::from(target.depth),
+                "backward jump merge: arriving at depth {arrival} but target captured depth {}",
+                target.depth,
+            );
         }
+        self.emit_with_operand(op, Operand::Offset(target.offset));
     }
 
-    /// Returns the current bytecode offset.
+    /// Returns the current bytecode position as an opaque `Offset`.
     ///
-    /// Use this to record loop start positions for backward jumps.
+    /// Use this to capture the bounds of try/except/finally regions for
+    /// `ExceptionEntry::new`.
     #[must_use]
-    pub fn current_offset(&self) -> usize {
-        self.bytecode.len()
+    pub fn current_offset(&self) -> Offset {
+        Offset(self.bytecode.len())
+    }
+
+    /// Returns a `JumpTarget` capturing both the current bytecode position and
+    /// the stack depth at that position.
+    #[must_use]
+    pub fn current_jump_target(&self) -> JumpTarget {
+        JumpTarget {
+            inner: self.current_stack_depth.map(|depth| JumpTargetInner {
+                offset: self.current_offset(),
+                depth,
+            }),
+        }
     }
 
     /// Emits `LoadLocal`, using specialized opcodes for slots 0-3.
@@ -434,9 +369,9 @@ impl CodeBuilder {
     pub fn emit_load_local_callable(&mut self, slot: u16, name_id: StringId) {
         let name_id_u16 = u16::try_from(name_id.index()).expect("name_id exceeds u16");
         if let Ok(s) = u8::try_from(slot) {
-            self.emit_with_operand(Opcode::LoadLocalCallable, &Operand::U8U16(s, name_id_u16));
+            self.emit_with_operand(Opcode::LoadLocalCallable, Operand::U8U16(s, name_id_u16));
         } else {
-            self.emit_with_operand(Opcode::LoadLocalCallableW, &Operand::U16U16(slot, name_id_u16));
+            self.emit_with_operand(Opcode::LoadLocalCallableW, Operand::U16U16(slot, name_id_u16));
         }
     }
 
@@ -447,7 +382,7 @@ impl CodeBuilder {
     /// and local slots use different namespaces).
     pub fn emit_load_global_callable(&mut self, slot: u16, name_id: StringId) {
         let name_id_u16 = u16::try_from(name_id.index()).expect("name_id exceeds u16");
-        self.emit_with_operand(Opcode::LoadGlobalCallable, &Operand::U16U16(slot, name_id_u16));
+        self.emit_with_operand(Opcode::LoadGlobalCallable, Operand::U16U16(slot, name_id_u16));
     }
 
     /// Emits `StoreLocal`, using wide variant for slots > 255.
@@ -484,18 +419,14 @@ impl CodeBuilder {
     ///
     /// # Panics
     ///
-    /// Panics if the tracker is in the `Dead` state. Callers that capture
+    /// Panics if the tracker is in the dead-code state. Callers that capture
     /// depth (e.g. `compile_for`'s `loop_exit_depth`) only ever do so from
-    /// reachable code, so being `Dead` here indicates a compiler bug.
+    /// reachable code, so being dead here indicates a compiler bug.
     #[must_use]
     pub fn stack_depth(&self) -> u16 {
-        match self.tracker {
-            TrackerState::Live(d) => d,
-            TrackerState::Dead => panic!(
-                "stack_depth() called while tracker is in Dead state — \
-                 callers should only read depth from reachable code"
-            ),
-        }
+        self.current_stack_depth.expect(
+            "stack_depth() called while in dead-code state — callers should only read depth from reachable code",
+        )
     }
 
     /// Reports whether the tracker is in the dead-code state.
@@ -504,7 +435,7 @@ impl CodeBuilder {
     /// helpers to decide whether to bother computing live target depths.
     #[must_use]
     pub fn is_dead(&self) -> bool {
-        matches!(self.tracker, TrackerState::Dead)
+        self.current_stack_depth.is_none()
     }
 
     /// Builds the final Code object.
@@ -538,28 +469,34 @@ impl CodeBuilder {
         }
     }
 
-    /// Sets the current stack depth to an absolute value, transitioning to
-    /// `Live` regardless of prior state.
+    /// Opens a new code region at the given stack depth.
     ///
-    /// Use this for points reached via the exception table (handler entries,
-    /// finally cleanup) where the depth comes from outside the fall-through
-    /// graph. For ordinary forward-jump merges, `patch_jump` is enough — it
-    /// transitions `Dead → Live` automatically using the label's recorded
-    /// target depth.
-    pub fn set_stack_depth(&mut self, depth: u16) {
-        self.tracker = TrackerState::Live(depth);
+    /// Use this:
+    /// - After `CodeBuilder::new()`, with `depth = 0`, to start the initial
+    ///   region (the top of a function or module body).
+    /// - For points reached via the exception table (handler entries with the
+    ///   exception on stack at `base + 1`, finally cleanup) where the depth
+    ///   comes from outside the fall-through graph.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the builder is currently emitting live code.
+    pub fn new_code_region(&mut self, depth: u16) {
+        assert!(
+            self.is_dead(),
+            "enter_region: must be called from the dead-code state — use `patch_jump` to merge a forward jump's depth into live code",
+        );
+        self.current_stack_depth = Some(depth);
         self.max_stack_depth = self.max_stack_depth.max(depth);
     }
 
     /// Adjusts the stack depth by the given delta.
     ///
     /// Positive values indicate pushes, negative values indicate pops.
-    /// In the `Dead` state this is a no-op: dead code can be emitted freely
-    /// without poisoning the tracker, since the depth there is meaningless
-    /// until re-established by a patch or `set_stack_depth`. Updates
-    /// `max_stack_depth` if the new live depth exceeds it.
+    /// In the dead-code state this is a no-op: dead code can be emitted
+    /// freely.
     fn adjust_stack(&mut self, delta: i16) {
-        let TrackerState::Live(depth) = self.tracker else {
+        let Some(depth) = self.current_stack_depth else {
             return;
         };
         let new_depth = i32::from(depth) + i32::from(delta);
@@ -567,47 +504,57 @@ impl CodeBuilder {
         debug_assert!(new_depth >= 0, "Stack depth went negative: {new_depth}");
         // Safe cast: new_depth is non-negative and stack won't exceed u16::MAX in practice
         let new_depth = u16::try_from(new_depth.max(0)).unwrap_or(u16::MAX);
-        self.tracker = TrackerState::Live(new_depth);
+        self.current_stack_depth = Some(new_depth);
         self.max_stack_depth = self.max_stack_depth.max(new_depth);
     }
 
-    /// Transitions the tracker to the `Dead` state.
+    /// Single-source-of-truth emit path for all bytecode emission: records
+    /// location, writes opcode + operand bytes, applies the stack-effect
+    /// computed by `Opcode::stack_effect`, and transitions the tracker to
+    /// dead for unconditional terminators (`Jump`, `ReturnValue`, `Raise`,
+    /// `Reraise`).
     ///
-    /// Called internally after emitting unconditional terminators (`Jump`,
-    /// `ReturnValue`, `Raise`, `Reraise`). Subsequent emits will not affect
-    /// `current_stack_depth` until `patch_jump` or `set_stack_depth`
-    /// re-establishes a live arrival depth.
-    fn mark_dead(&mut self) {
-        self.tracker = TrackerState::Dead;
-    }
-
-    /// Single-source-of-truth emit path: records location, writes opcode +
-    /// operand bytes, applies the stack-effect computed by `stack_effect_for`,
-    /// and transitions the tracker to `Dead` for unconditional terminators
-    /// (`ReturnValue`, `Raise`, `Reraise`).
+    /// In the dead-code state the method silently no-ops. This lets the
+    /// compiler drive emission uniformly without gating individual emits
+    /// on reachability — dead trailers, epilogues, and orphaned cleanup
+    /// pairs all vanish naturally.
     ///
-    /// `emit_jump` and `emit_jump_to` do *not* go through this path — they
-    /// have branch-dependent effects and target-depth bookkeeping that don't
-    /// fit the linear-emit shape.
-    fn emit_with_operand(&mut self, op: Opcode, operand: &Operand<'_>) {
+    /// `emit_jump` and `emit_jump_to` route their byte emission through here;
+    /// `emit_jump` additionally captures the pre-emit offset and computes the
+    /// jump-taken target depth for the returned `JumpLabel`.
+    fn emit_with_operand(&mut self, op: Opcode, operand: Operand<'_>) {
+        if self.is_dead() {
+            return;
+        }
         self.record_location();
+        let opcode_pos = self.bytecode.len();
         self.bytecode.push(op as u8);
         match operand {
             Operand::None => {}
-            Operand::U8(b) => self.bytecode.push(*b),
+            Operand::U8(b) => self.bytecode.push(b),
             Operand::I8(b) => self.bytecode.push(b.to_ne_bytes()[0]),
             Operand::U16(w) => self.bytecode.extend_from_slice(&w.to_le_bytes()),
+            Operand::Offset(target) => {
+                // Encode as a signed i16 relative to the position after the
+                // jump's 3-byte instruction (opcode + i16).
+                let target_i64 = i64::try_from(target.0).expect("bytecode target exceeds i64");
+                let after_jump_i64 = i64::try_from(opcode_pos + 3).expect("bytecode position exceeds i64");
+                let raw_offset = target_i64 - after_jump_i64;
+                let relative = i16::try_from(raw_offset)
+                    .expect("jump offset exceeds i16 range (-32768..32767); function too large");
+                self.bytecode.extend_from_slice(&relative.to_le_bytes());
+            }
             Operand::U8U8(a, b) => {
-                self.bytecode.push(*a);
-                self.bytecode.push(*b);
+                self.bytecode.push(a);
+                self.bytecode.push(b);
             }
             Operand::U8U16(a, w) => {
-                self.bytecode.push(*a);
+                self.bytecode.push(a);
                 self.bytecode.extend_from_slice(&w.to_le_bytes());
             }
             Operand::U16U8(w, b) => {
                 self.bytecode.extend_from_slice(&w.to_le_bytes());
-                self.bytecode.push(*b);
+                self.bytecode.push(b);
             }
             Operand::U16U16(w1, w2) => {
                 self.bytecode.extend_from_slice(&w1.to_le_bytes());
@@ -615,14 +562,14 @@ impl CodeBuilder {
             }
             Operand::U16U8U8(w, b1, b2) => {
                 self.bytecode.extend_from_slice(&w.to_le_bytes());
-                self.bytecode.push(*b1);
-                self.bytecode.push(*b2);
+                self.bytecode.push(b1);
+                self.bytecode.push(b2);
             }
             Operand::CallKw { pos_count, kwname_ids } => {
-                self.bytecode.push(*pos_count);
+                self.bytecode.push(pos_count);
                 self.bytecode
                     .push(u8::try_from(kwname_ids.len()).expect("keyword count exceeds u8"));
-                for &name_id in *kwname_ids {
+                for &name_id in kwname_ids {
                     self.bytecode.extend_from_slice(&name_id.to_le_bytes());
                 }
             }
@@ -632,106 +579,82 @@ impl CodeBuilder {
                 kwname_ids,
             } => {
                 self.bytecode.extend_from_slice(&attr_name_id.to_le_bytes());
-                self.bytecode.push(*pos_count);
+                self.bytecode.push(pos_count);
                 self.bytecode
                     .push(u8::try_from(kwname_ids.len()).expect("keyword count exceeds u8"));
-                for &name_id in *kwname_ids {
+                for &name_id in kwname_ids {
                     self.bytecode.extend_from_slice(&name_id.to_le_bytes());
                 }
             }
         }
-        self.adjust_stack(stack_effect_for(op, operand));
-        if matches!(op, Opcode::ReturnValue | Opcode::Raise | Opcode::Reraise) {
-            self.mark_dead();
+        self.adjust_stack(op.stack_effect(operand));
+        if matches!(op, Opcode::ReturnValue | Opcode::Raise | Opcode::Reraise | Opcode::Jump) {
+            self.current_stack_depth = None;
         }
-    }
-}
-
-/// Computes the operand-stack effect of `op` paired with `operand`.
-///
-/// All variable-effect opcodes get an explicit match arm. Fixed-effect opcodes
-/// fall through to `op.stack_effect()`, which is `Some(_)` for them. A
-/// variable-effect opcode that reaches the fallback (because its operand
-/// shape doesn't match any enumerated arm) panics — preventing silent drift
-/// when a new variable-effect opcode is added.
-///
-/// `MakeFunction`/`MakeClosure` have explicit arms even though `stack_effect()`
-/// returns `Some(1)` for them — that fixed value is only correct with zero
-/// defaults, so we override with `1 - defaults_count` for the general case.
-fn stack_effect_for(op: Opcode, operand: &Operand<'_>) -> i16 {
-    match (op, operand) {
-        // === U8 operand, variable effect ===
-        (Opcode::CallFunction, &Operand::U8(arg_count)) => -i16::from(arg_count),
-        (Opcode::CallFunctionExtended, &Operand::U8(flags)) => -(1 + i16::from(flags & 0x01)),
-        (Opcode::FormatValue, &Operand::U8(flags)) => {
-            if flags & 0x04 != 0 {
-                -1
-            } else {
-                0
-            }
-        }
-        (Opcode::UnpackSequence, &Operand::U8(n)) => i16::from(n) - 1,
-
-        // === U16 operand, variable effect ===
-        (Opcode::BuildList | Opcode::BuildTuple | Opcode::BuildSet | Opcode::BuildFString, &Operand::U16(n)) => {
-            1 - n.cast_signed()
-        }
-        (Opcode::BuildDict, &Operand::U16(n)) => 1 - 2 * n.cast_signed(),
-
-        // === U8U8 operand, variable effect ===
-        // UnpackEx: pops 1, pushes (before + 1 + after) → before + after.
-        (Opcode::UnpackEx, &Operand::U8U8(before, after)) => i16::from(before) + i16::from(after),
-        // Builtin calls: no callable on stack, pops args, pushes result → 1 - arg_count.
-        (Opcode::CallBuiltinFunction | Opcode::CallBuiltinType, &Operand::U8U8(_, arg_count)) => {
-            1 - i16::from(arg_count)
-        }
-
-        // === U16U8 operand, variable effect ===
-        (Opcode::MakeFunction, &Operand::U16U8(_, defaults)) => 1 - i16::from(defaults),
-        (Opcode::CallAttr, &Operand::U16U8(_, arg_count)) => -i16::from(arg_count),
-        (Opcode::CallAttrExtended, &Operand::U16U8(_, flags)) => -(1 + i16::from(flags & 0x01)),
-
-        // === U16U8U8 operand, variable effect ===
-        (Opcode::MakeClosure, &Operand::U16U8U8(_, defaults, _)) => 1 - i16::from(defaults),
-
-        // === Variable-length kw operands ===
-        // pops callable + pos_args + kw_args, pushes result → -(pos_count + kw_count).
-        (Opcode::CallFunctionKw, Operand::CallKw { pos_count, kwname_ids }) => {
-            let kw_count = i16::try_from(kwname_ids.len()).expect("keyword count exceeds i16");
-            -(i16::from(*pos_count) + kw_count)
-        }
-        (
-            Opcode::CallAttrKw,
-            Operand::CallAttrKw {
-                pos_count, kwname_ids, ..
-            },
-        ) => {
-            let kw_count = i16::try_from(kwname_ids.len()).expect("keyword count exceeds i16");
-            -(i16::from(*pos_count) + kw_count)
-        }
-
-        // Fixed-effect fallback. Variable-effect opcodes (where stack_effect()
-        // returns None) without an arm above hit the panic — keeps the tracker
-        // honest if a new variable-effect opcode is added.
-        (op, _) => op.stack_effect().unwrap_or_else(|| {
-            panic!("stack_effect_for: variable-effect opcode {op:?} has no handler for operand variant {operand:?}")
-        }),
     }
 }
 
 /// Label for a forward jump that needs patching.
-///
-/// Carries the bytecode offset where the jump instruction was emitted, plus
-/// the stack depth that the jump-taken path leaves on the stack at the patch
-/// target. `emit_jump` only runs in the live tracker state (panicking
-/// otherwise), so this depth is always known when the label is constructed.
-/// `patch_jump` uses it to enforce the merge invariant and to transition the
-/// tracker back to `Live` when fall-through to the patch point is
-/// unreachable.
 #[derive(Debug, Clone, Copy)]
 pub struct JumpLabel {
-    offset: usize,
+    /// `Option` is none to allow for the dead code case, in which case
+    /// the jump is unreachable and patch_jump needs do no work.
+    inner: Option<JumpLabelInner>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct JumpLabelInner {
+    /// Position of the jump's opcode byte. `patch_jump` writes the relative
+    /// i16 at `offset.0 + 1`.
+    offset: Offset,
+    /// The stack depth that the jump-taken path leaves on the stack
+    /// when the jump is taken to the target.
+    ///
+    /// This is used by `patch_jump` to enforce the merge invariant (all paths
+    /// arriving at the jump label must agree on the stack depth).
     target_depth: u16,
+}
+
+/// A position in the bytecode stream.
+///
+/// Returned by `CodeBuilder::current_offset` and consumed by `emit_jump_to`
+/// (as a backward-jump target) and `ExceptionEntry::new` (as the bounds of
+/// try/except/finally regions). The wrapped `usize` is intentionally private:
+/// `Offset` values can only originate from the builder, which prevents
+/// arbitrary integers from being used in places where the bytecode position
+/// is a load-bearing invariant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Offset(usize);
+
+impl Offset {
+    /// Returns the offset as a `u32` — the serialized form used by
+    /// `ExceptionEntry` and `LocationEntry`.
+    ///
+    /// Panics if the bytecode position exceeds `u32::MAX`, which would mean
+    /// the compiled function is unreasonably large.
+    #[must_use]
+    pub fn as_u32(self) -> u32 {
+        u32::try_from(self.0).expect("bytecode offset exceeds u32")
+    }
+}
+
+/// Target for a backward jump — bundles a bytecode position with the stack
+/// depth at that position, so `emit_jump_to` can enforce the merge invariant
+/// (the jump-taken arrival depth must equal the depth recorded at the target).
+///
+/// Returned by `CodeBuilder::current_jump_target`. In the dead-code state the
+/// returned `JumpTarget` is a no-op placeholder (`inner: None`): valid to use
+/// from another dead-code call site, but a compiler bug if used from live
+/// code (would jump into bytes that were never emitted).
+#[derive(Debug, Clone, Copy)]
+pub struct JumpTarget {
+    inner: Option<JumpTargetInner>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct JumpTargetInner {
+    offset: Offset,
+    depth: u16,
 }
 
 #[cfg(test)]
@@ -741,6 +664,7 @@ mod tests {
     #[test]
     fn test_emit_basic() {
         let mut builder = CodeBuilder::new();
+        builder.new_code_region(0);
         builder.emit(Opcode::LoadNone);
         builder.emit(Opcode::Pop);
 
@@ -751,6 +675,7 @@ mod tests {
     #[test]
     fn test_emit_u8_operand() {
         let mut builder = CodeBuilder::new();
+        builder.new_code_region(0);
         builder.emit_u8(Opcode::LoadLocal, 42);
 
         let code = builder.build(0);
@@ -760,6 +685,7 @@ mod tests {
     #[test]
     fn test_emit_u16_operand() {
         let mut builder = CodeBuilder::new();
+        builder.new_code_region(0);
         builder.emit_u16(Opcode::LoadConst, 0x1234);
 
         let code = builder.build(0);
@@ -769,29 +695,27 @@ mod tests {
     #[test]
     fn test_forward_jump() {
         let mut builder = CodeBuilder::new();
+        builder.new_code_region(0);
         let jump = builder.emit_jump(Opcode::Jump);
         // The two LoadNones below are dead code (unconditional Jump above);
-        // adjust_stack is a no-op in the Dead state, so they don't poison
-        // tracking. patch_jump transitions the tracker back to Live using
-        // the label's recorded target depth (0 here, unchanged from before
-        // the Jump).
-        builder.emit(Opcode::LoadNone); // 1 byte, skipped by jump
-        builder.emit(Opcode::LoadNone); // 1 byte, skipped by jump
+        // `emit_with_operand` no-ops in the Dead state, so they don't get
+        // written to bytecode. `patch_jump` then transitions the tracker back
+        // to live from the label's recorded target depth (0 here).
+        builder.emit(Opcode::LoadNone); // dead, skipped
+        builder.emit(Opcode::LoadNone); // dead, skipped
         builder.patch_jump(jump);
         builder.emit(Opcode::LoadNone); // Return value
         builder.emit(Opcode::ReturnValue);
 
         let code = builder.build(0);
-        // Jump at offset 0, target at offset 5 (after 2x LoadNone)
-        // Offset = 5 - 0 - 3 = 2
+        // Jump at offset 0, target at offset 3 (immediately after Jump's bytes).
+        // Offset = 3 - 0 - 3 = 0.
         assert_eq!(
             code.bytecode(),
             &[
                 Opcode::Jump as u8,
-                2,
-                0, // i16 little-endian = 2
-                Opcode::LoadNone as u8,
-                Opcode::LoadNone as u8,
+                0,
+                0, // i16 little-endian = 0
                 Opcode::LoadNone as u8,
                 Opcode::ReturnValue as u8,
             ]
@@ -801,7 +725,8 @@ mod tests {
     #[test]
     fn test_backward_jump() {
         let mut builder = CodeBuilder::new();
-        let loop_start = builder.current_offset();
+        builder.new_code_region(0);
+        let loop_start = builder.current_jump_target();
         builder.emit(Opcode::LoadNone); // offset 0, 1 byte
         builder.emit(Opcode::Pop); // offset 1, 1 byte
         builder.emit_jump_to(Opcode::Jump, loop_start); // offset 2, target 0
@@ -825,6 +750,7 @@ mod tests {
     #[test]
     fn test_load_local_specialization() {
         let mut builder = CodeBuilder::new();
+        builder.new_code_region(0);
         builder.emit_load_local(0);
         builder.emit_load_local(1);
         builder.emit_load_local(2);
@@ -852,6 +778,7 @@ mod tests {
     #[test]
     fn test_add_const() {
         let mut builder = CodeBuilder::new();
+        builder.new_code_region(0);
         let idx1 = builder.add_const(Value::Int(42));
         let idx2 = builder.add_const(Value::None);
 

--- a/crates/monty/src/bytecode/builder.rs
+++ b/crates/monty/src/bytecode/builder.rs
@@ -11,6 +11,41 @@ use super::{
 };
 use crate::{intern::StringId, parse::CodeRange, value::Value};
 
+/// State of the abstract operand-stack tracker as the builder emits bytecode.
+///
+/// The compiler tracks "what the operand stack looks like at the point we're
+/// about to emit the next opcode" so that it can record correct stack depths
+/// in `ExceptionEntry` and check the merge invariant at jump patches. Control
+/// flow makes that tracker into a small state machine:
+///
+/// * `Live(depth)` — the most recently emitted opcode falls through to the
+///   next byte. `depth` is the operand-stack height there. `adjust_stack`
+///   updates `depth`; `set_stack_depth` overrides it absolutely.
+/// * `Dead` — the most recently emitted opcode unconditionally diverts
+///   control flow (`Jump`, `ReturnValue`, `Raise`, `Reraise`), so subsequent
+///   bytes are unreachable via fall-through. The depth has no meaningful
+///   value until something re-establishes it: a `patch_jump` whose label
+///   carries the jump-taken target depth, or an explicit `set_stack_depth`
+///   for code reached via the exception table (handler entries).
+///
+/// Modeling this explicitly removes the need for compilers to manually save
+/// and restore `dead_code_depth` around terminating statements — emit-of-
+/// terminator transitions to `Dead`, and `patch_jump` transitions back to
+/// `Live` from the label's recorded target depth. Stack-effect adjustments
+/// in `Dead` are no-ops, so dead code can compile freely without poisoning
+/// the tracker.
+#[derive(Debug, Clone, Copy)]
+enum TrackerState {
+    Live(u16),
+    Dead,
+}
+
+impl Default for TrackerState {
+    fn default() -> Self {
+        Self::Live(0)
+    }
+}
+
 /// Builder for emitting bytecode during compilation.
 ///
 /// Handles encoding opcodes and operands into raw bytes, managing forward jumps
@@ -48,8 +83,8 @@ pub struct CodeBuilder {
     /// Current focus location within the source range.
     current_focus: Option<CodeRange>,
 
-    /// Current stack depth for tracking max stack usage.
-    current_stack_depth: u16,
+    /// Current operand-stack tracker state — see `TrackerState`.
+    tracker: TrackerState,
 
     /// Maximum stack depth seen during compilation.
     max_stack_depth: u16,
@@ -89,6 +124,10 @@ impl CodeBuilder {
     /// All variable-effect opcodes (where `Opcode::stack_effect()` returns
     /// `None`) take operands, so calling this with one is a compiler bug —
     /// hence the panic on `None` rather than silently defaulting to `0`.
+    ///
+    /// Terminator opcodes (`ReturnValue`, `Raise`, `Reraise`) transition the
+    /// tracker to `Dead` after emission so subsequent fall-through emits
+    /// don't disturb live tracking.
     pub fn emit(&mut self, op: Opcode) {
         self.record_location();
         self.bytecode.push(op as u8);
@@ -96,6 +135,9 @@ impl CodeBuilder {
             panic!("variable-effect opcode {op:?} emitted via emit (no operand) — variable-effect ops require an operand-aware emit helper")
         });
         self.adjust_stack(effect);
+        if matches!(op, Opcode::ReturnValue | Opcode::Raise | Opcode::Reraise) {
+            self.mark_dead();
+        }
     }
 
     /// Emits an instruction with a u8 operand and updates stack depth tracking.
@@ -288,29 +330,41 @@ impl CodeBuilder {
     /// The jump offset is initially set to 0 and must be patched with
     /// `patch_jump()` once the target location is known.
     ///
-    /// The returned label carries both the bytecode offset to patch and the
-    /// stack depth that the *jump-taken* path will leave on the stack at the
-    /// patch target. `patch_jump` uses that depth to enforce the merge
-    /// invariant (every branch arriving at the patch point agrees on stack
-    /// depth). Forward jumps differ in how they affect the two paths:
+    /// The returned label carries the bytecode offset to patch and the stack
+    /// depth that the *jump-taken* path leaves on the stack at the patch
+    /// target. `patch_jump` uses that depth to enforce the merge invariant
+    /// (every branch arriving at the patch point agrees on stack depth) and
+    /// to transition the tracker out of `Dead` when fall-through is
+    /// unreachable. Forward jumps differ in how they affect the two paths:
     ///
-    /// | Opcode                              | fall-through effect | jump-taken target depth |
-    /// |-------------------------------------|---------------------|-------------------------|
-    /// | `Jump`                              | `0` (dead)          | unchanged from pre-emit |
-    /// | `JumpIfTrue` / `JumpIfFalse`        | `-1` (cond popped)  | pre-emit `- 1`          |
-    /// | `JumpIfTrueOrPop` / `JumpIfFalseOrPop` | `-1` (cond popped) | pre-emit (cond kept)    |
-    /// | `ForIter`                           | `+1` (value pushed) | pre-emit `- 1` (iter popped) |
+    /// | Opcode                                 | fall-through effect | jump-taken target depth |
+    /// |----------------------------------------|---------------------|-------------------------|
+    /// | `Jump`                                 | n/a (dead)          | unchanged from pre-emit |
+    /// | `JumpIfTrue` / `JumpIfFalse`           | `-1` (cond popped)  | pre-emit `- 1`          |
+    /// | `JumpIfTrueOrPop` / `JumpIfFalseOrPop` | `-1` (cond popped)  | pre-emit (cond kept)    |
+    /// | `ForIter`                              | `+1` (value pushed) | pre-emit `- 1` (iter popped) |
+    ///
+    /// After `Jump` the tracker becomes `Dead` (it's unconditional). All
+    /// other jumps continue to fall through.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called from the `Dead` state — emitting a jump in dead code
+    /// produces unreachable bytecode and obscures the merge invariant.
+    /// Callers must guard with `is_dead()` if they may reach this from a
+    /// terminating block (see e.g. `compile_if`'s if-else bridge).
     #[must_use]
     pub fn emit_jump(&mut self, op: Opcode) -> JumpLabel {
+        let TrackerState::Live(pre_depth) = self.tracker else {
+            panic!("emit_jump({op:?}) called from Dead state — guard with is_dead() at the call site")
+        };
+
         self.record_location();
-        let pre_depth = self.current_stack_depth;
         let offset = self.bytecode.len();
         self.bytecode.push(op as u8);
         // Placeholder for i16 offset (will be patched)
         self.bytecode.extend_from_slice(&0i16.to_le_bytes());
 
-        // Determine fall-through stack effect and jump-taken target depth.
-        // See the table on the docstring above for the per-opcode semantics.
         let (fallthrough_effect, target_depth): (i16, u16) = match op {
             Opcode::Jump => (0, pre_depth),
             Opcode::JumpIfTrue | Opcode::JumpIfFalse => (-1, pre_depth.saturating_sub(1)),
@@ -319,6 +373,10 @@ impl CodeBuilder {
             _ => panic!("emit_jump called with non-jump opcode {op:?}"),
         };
         self.adjust_stack(fallthrough_effect);
+
+        if op == Opcode::Jump {
+            self.mark_dead();
+        }
 
         JumpLabel { offset, target_depth }
     }
@@ -329,29 +387,20 @@ impl CodeBuilder {
     /// instruction's operand (i.e., where execution would continue if
     /// the jump is not taken).
     ///
-    /// In debug builds, asserts that the builder's tracked stack depth at the
-    /// patch point matches the depth that the jump-taken path leaves on the
-    /// stack (recorded by `emit_jump` in the label). When fall-through reaches
-    /// the patch point, this catches branches that disagree on depth — a
-    /// recurring class of compiler bug. When fall-through is unreachable
-    /// (because of an upstream unconditional `Jump` or `Reraise`), callers
-    /// must pre-align the tracker via `set_stack_depth` so the assertion
-    /// reflects the live (jump-taken) path.
+    /// Tracker state transitions: if the tracker is `Dead` (because the
+    /// last live emission was a terminator), `patch_jump` re-establishes
+    /// `Live(label.target_depth)` from the label. If the tracker is already
+    /// `Live`, it asserts agreement — the merge invariant.
     ///
     /// # Panics
     ///
-    /// - In debug builds, panics if the tracker disagrees with
-    ///   `label.target_depth`.
+    /// - In debug builds, panics if the tracker is `Live` and disagrees with
+    ///   `label.target_depth` — this means two reachable paths arrive at the
+    ///   patch point with different stack heights.
     /// - Always panics if the jump offset exceeds i16 range (-32768..32767),
     ///   which indicates the function is too large. This is a compile-time
     ///   error rather than silent truncation.
     pub fn patch_jump(&mut self, label: JumpLabel) {
-        debug_assert_eq!(
-            self.current_stack_depth, label.target_depth,
-            "stack-depth mismatch at jump merge: builder tracker is {} but jump label expects {}; \
-             branches reaching this merge point disagree on stack state",
-            self.current_stack_depth, label.target_depth,
-        );
         let target = self.bytecode.len();
         // Offset is relative to position after the jump instruction (opcode + i16 = 3 bytes)
         let target_i64 = i64::try_from(target).expect("bytecode target exceeds i64");
@@ -362,13 +411,35 @@ impl CodeBuilder {
         let bytes = offset.to_le_bytes();
         self.bytecode[label.offset + 1] = bytes[0];
         self.bytecode[label.offset + 2] = bytes[1];
+
+        match self.tracker {
+            TrackerState::Live(d) => debug_assert_eq!(
+                d, label.target_depth,
+                "stack-depth mismatch at jump merge: builder tracker is {d} but jump label expects {}; \
+                 branches reaching this merge point disagree on stack state",
+                label.target_depth,
+            ),
+            TrackerState::Dead => self.set_stack_depth(label.target_depth),
+        }
     }
 
     /// Emits a backward jump to a known target offset.
     ///
     /// Unlike forward jumps, backward jumps have a known target at emit time,
-    /// so no patching is needed.
+    /// so no patching is needed. Only fixed-effect opcodes are supported here
+    /// (in practice, just `Jump` and the conditional jumps used for
+    /// comprehension filters); branch-dependent jumps like `ForIter` or the
+    /// `OrPop` variants would need per-branch target depths that this
+    /// label-less path can't carry — panic if misused.
+    ///
+    /// After `Jump` (unconditional), the tracker transitions to `Dead`.
+    /// Panics if called from `Dead` — emitting a backward jump in dead code
+    /// produces unreachable bytecode and is always a compiler bug.
     pub fn emit_jump_to(&mut self, op: Opcode, target: usize) {
+        assert!(
+            !self.is_dead(),
+            "emit_jump_to({op:?}) called from Dead state — guard with is_dead() at the call site"
+        );
         self.record_location();
         let current = self.bytecode.len();
         // Offset is relative to position after this instruction (current + 3)
@@ -379,17 +450,13 @@ impl CodeBuilder {
             i16::try_from(raw_offset).expect("jump offset exceeds i16 range (-32768..32767); function too large");
         self.bytecode.push(op as u8);
         self.bytecode.extend_from_slice(&offset.to_le_bytes());
-        // Track stack effect. `emit_jump_to` is only used for unconditional
-        // backward jumps (e.g. loop continuation), where the only valid
-        // opcode is `Jump` with a fixed effect of 0. Any opcode whose effect
-        // depends on which branch is taken (`ForIter`, `JumpIfTrueOrPop`,
-        // etc.) cannot be encoded as a backward jump because we don't have a
-        // patch label to record per-branch target depths — panic loudly if
-        // misused rather than silently defaulting to `0`.
         let effect = op.stack_effect().unwrap_or_else(|| {
             panic!("variable-effect opcode {op:?} emitted via emit_jump_to — only fixed-effect jumps are supported on the backward-jump path")
         });
         self.adjust_stack(effect);
+        if op == Opcode::Jump {
+            self.mark_dead();
+        }
     }
 
     /// Returns the current bytecode offset.
@@ -517,9 +584,30 @@ impl CodeBuilder {
     }
 
     /// Returns the current tracked stack depth.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the tracker is in the `Dead` state. Callers that capture
+    /// depth (e.g. `compile_for`'s `loop_exit_depth`) only ever do so from
+    /// reachable code, so being `Dead` here indicates a compiler bug.
     #[must_use]
     pub fn stack_depth(&self) -> u16 {
-        self.current_stack_depth
+        match self.tracker {
+            TrackerState::Live(d) => d,
+            TrackerState::Dead => panic!(
+                "stack_depth() called while tracker is in Dead state — \
+                 callers should only read depth from reachable code"
+            ),
+        }
+    }
+
+    /// Reports whether the tracker is in the dead-code state.
+    ///
+    /// Used by compile_block to stop emitting after a terminator and by emit
+    /// helpers to decide whether to bother computing live target depths.
+    #[must_use]
+    pub fn is_dead(&self) -> bool {
+        matches!(self.tracker, TrackerState::Dead)
     }
 
     /// Builds the final Code object.
@@ -553,27 +641,47 @@ impl CodeBuilder {
         }
     }
 
-    /// Sets the current stack depth to an absolute value.
+    /// Sets the current stack depth to an absolute value, transitioning to
+    /// `Live` regardless of prior state.
     ///
-    /// Used when compiling code paths that branch and reconverge with different
-    /// stack states (e.g., break/continue through finally blocks).
-    /// Updates `max_stack_depth` if the new depth exceeds it.
+    /// Use this for points reached via the exception table (handler entries,
+    /// finally cleanup) where the depth comes from outside the fall-through
+    /// graph. For ordinary forward-jump merges, `patch_jump` is enough — it
+    /// transitions `Dead → Live` automatically using the label's recorded
+    /// target depth.
     pub fn set_stack_depth(&mut self, depth: u16) {
-        self.current_stack_depth = depth;
+        self.tracker = TrackerState::Live(depth);
         self.max_stack_depth = self.max_stack_depth.max(depth);
     }
 
     /// Adjusts the stack depth by the given delta.
     ///
     /// Positive values indicate pushes, negative values indicate pops.
-    /// Updates `max_stack_depth` if the new depth exceeds it.
+    /// In the `Dead` state this is a no-op: dead code can be emitted freely
+    /// without poisoning the tracker, since the depth there is meaningless
+    /// until re-established by a patch or `set_stack_depth`. Updates
+    /// `max_stack_depth` if the new live depth exceeds it.
     fn adjust_stack(&mut self, delta: i16) {
-        let new_depth = i32::from(self.current_stack_depth) + i32::from(delta);
+        let TrackerState::Live(depth) = self.tracker else {
+            return;
+        };
+        let new_depth = i32::from(depth) + i32::from(delta);
         // Stack depth shouldn't go negative (indicates compiler bug)
         debug_assert!(new_depth >= 0, "Stack depth went negative: {new_depth}");
         // Safe cast: new_depth is non-negative and stack won't exceed u16::MAX in practice
-        self.current_stack_depth = u16::try_from(new_depth.max(0)).unwrap_or(u16::MAX);
-        self.max_stack_depth = self.max_stack_depth.max(self.current_stack_depth);
+        let new_depth = u16::try_from(new_depth.max(0)).unwrap_or(u16::MAX);
+        self.tracker = TrackerState::Live(new_depth);
+        self.max_stack_depth = self.max_stack_depth.max(new_depth);
+    }
+
+    /// Transitions the tracker to the `Dead` state.
+    ///
+    /// Called internally after emitting unconditional terminators (`Jump`,
+    /// `ReturnValue`, `Raise`, `Reraise`). Subsequent emits will not affect
+    /// `current_stack_depth` until `patch_jump` or `set_stack_depth`
+    /// re-establishes a live arrival depth.
+    fn mark_dead(&mut self) {
+        self.tracker = TrackerState::Dead;
     }
 
     /// Tracks stack effect for opcodes with u8 operand.
@@ -639,25 +747,17 @@ impl CodeBuilder {
         };
         self.adjust_stack(effect);
     }
-
-    /// Manually adjust stack depth for complex scenarios.
-    ///
-    /// Use this when the compiler knows the exact stack effect that can't
-    /// be determined from the opcode alone (e.g., exception handlers pushing
-    /// an exception value).
-    pub fn adjust_stack_depth(&mut self, delta: i16) {
-        self.adjust_stack(delta);
-    }
 }
 
 /// Label for a forward jump that needs patching.
 ///
 /// Carries the bytecode offset where the jump instruction was emitted, plus
 /// the stack depth that the jump-taken path leaves on the stack at the patch
-/// target. The depth is computed by `emit_jump` from the per-opcode semantics
-/// of the jump (see that method's docs) and used by `patch_jump` to assert
-/// the merge invariant — every branch reaching the patch point must agree on
-/// stack depth. Pass this to `patch_jump()` once the target location is known.
+/// target. `emit_jump` only runs in the live tracker state (panicking
+/// otherwise), so this depth is always known when the label is constructed.
+/// `patch_jump` uses it to enforce the merge invariant and to transition the
+/// tracker back to `Live` when fall-through to the patch point is
+/// unreachable.
 #[derive(Debug, Clone, Copy)]
 pub struct JumpLabel {
     offset: usize,
@@ -700,14 +800,13 @@ mod tests {
     fn test_forward_jump() {
         let mut builder = CodeBuilder::new();
         let jump = builder.emit_jump(Opcode::Jump);
-        // The two LoadNones below are dead code (unconditional Jump above), but
-        // they still get emitted to exercise the offset patching. Reset the
-        // builder's tracker before patching so the merge invariant in
-        // `patch_jump` reflects the live (jump-taken) path, where stack depth
-        // is unchanged from before the Jump.
+        // The two LoadNones below are dead code (unconditional Jump above);
+        // adjust_stack is a no-op in the Dead state, so they don't poison
+        // tracking. patch_jump transitions the tracker back to Live using
+        // the label's recorded target depth (0 here, unchanged from before
+        // the Jump).
         builder.emit(Opcode::LoadNone); // 1 byte, skipped by jump
         builder.emit(Opcode::LoadNone); // 1 byte, skipped by jump
-        builder.set_stack_depth(0);
         builder.patch_jump(jump);
         builder.emit(Opcode::LoadNone); // Return value
         builder.emit(Opcode::ReturnValue);

--- a/crates/monty/src/bytecode/builder.rs
+++ b/crates/monty/src/bytecode/builder.rs
@@ -85,13 +85,17 @@ impl CodeBuilder {
     }
 
     /// Emits a no-operand instruction and updates stack depth tracking.
+    ///
+    /// All variable-effect opcodes (where `Opcode::stack_effect()` returns
+    /// `None`) take operands, so calling this with one is a compiler bug —
+    /// hence the panic on `None` rather than silently defaulting to `0`.
     pub fn emit(&mut self, op: Opcode) {
         self.record_location();
         self.bytecode.push(op as u8);
-        // Track stack effect for opcodes with known fixed effects
-        if let Some(effect) = op.stack_effect() {
-            self.adjust_stack(effect);
-        }
+        let effect = op.stack_effect().unwrap_or_else(|| {
+            panic!("variable-effect opcode {op:?} emitted via emit (no operand) — variable-effect ops require an operand-aware emit helper")
+        });
+        self.adjust_stack(effect);
     }
 
     /// Emits an instruction with a u8 operand and updates stack depth tracking.
@@ -109,10 +113,10 @@ impl CodeBuilder {
         self.bytecode.push(op as u8);
         // Reinterpret i8 as u8 for bytecode encoding
         self.bytecode.push(operand.to_ne_bytes()[0]);
-        // Track stack effect for opcodes with known fixed effects
-        if let Some(effect) = op.stack_effect() {
-            self.adjust_stack(effect);
-        }
+        let effect = op.stack_effect().unwrap_or_else(|| {
+            panic!("variable-effect opcode {op:?} emitted via emit_i8 without a stack-effect override")
+        });
+        self.adjust_stack(effect);
     }
 
     /// Emits an instruction with two u8 operands and updates stack depth tracking.
@@ -127,7 +131,10 @@ impl CodeBuilder {
         // Net effect: before + after
         if op == Opcode::UnpackEx {
             self.adjust_stack(i16::from(operand1) + i16::from(operand2));
-        } else if let Some(effect) = op.stack_effect() {
+        } else {
+            let effect = op.stack_effect().unwrap_or_else(|| {
+                panic!("variable-effect opcode {op:?} emitted via emit_u8_u8 without a stack-effect override")
+            });
             self.adjust_stack(effect);
         }
     }
@@ -150,7 +157,9 @@ impl CodeBuilder {
         self.bytecode.push(op as u8);
         self.bytecode.extend_from_slice(&operand1.to_le_bytes());
         self.bytecode.push(operand2);
-        // Track stack effects based on opcode
+        // Track stack effects based on opcode. Variable-effect opcodes that
+        // aren't enumerated below will hit the panic in the fallback rather
+        // than silently defaulting to `0` (which would drift the tracker).
         match op {
             Opcode::MakeFunction => {
                 // pops defaults_count defaults, pushes function: 1 - defaults_count
@@ -160,10 +169,17 @@ impl CodeBuilder {
                 // pops obj + args, pushes result: 1 - (1 + arg_count) = -arg_count
                 self.adjust_stack(-i16::from(operand2));
             }
+            Opcode::CallAttrExtended => {
+                // pops receiver + args_tuple (+ kwargs_dict if flag bit 0),
+                // pushes result. operand2 is the u8 flags: 0 or 1.
+                // Effect: -(1 + has_kwargs).
+                self.adjust_stack(-(1 + i16::from(operand2 & 0x01)));
+            }
             _ => {
-                if let Some(effect) = op.stack_effect() {
-                    self.adjust_stack(effect);
-                }
+                let effect = op.stack_effect().unwrap_or_else(|| {
+                    panic!("variable-effect opcode {op:?} emitted via emit_u16_u8 without a stack-effect override")
+                });
+                self.adjust_stack(effect);
             }
         }
     }
@@ -182,7 +198,10 @@ impl CodeBuilder {
         // Stack effect: 1 - defaults_count
         if op == Opcode::MakeClosure {
             self.adjust_stack(1 - i16::from(operand2));
-        } else if let Some(effect) = op.stack_effect() {
+        } else {
+            let effect = op.stack_effect().unwrap_or_else(|| {
+                panic!("variable-effect opcode {op:?} emitted via emit_u16_u8_u8 without a stack-effect override")
+            });
             self.adjust_stack(effect);
         }
     }
@@ -268,27 +287,40 @@ impl CodeBuilder {
     ///
     /// The jump offset is initially set to 0 and must be patched with
     /// `patch_jump()` once the target location is known.
+    ///
+    /// The returned label carries both the bytecode offset to patch and the
+    /// stack depth that the *jump-taken* path will leave on the stack at the
+    /// patch target. `patch_jump` uses that depth to enforce the merge
+    /// invariant (every branch arriving at the patch point agrees on stack
+    /// depth). Forward jumps differ in how they affect the two paths:
+    ///
+    /// | Opcode                              | fall-through effect | jump-taken target depth |
+    /// |-------------------------------------|---------------------|-------------------------|
+    /// | `Jump`                              | `0` (dead)          | unchanged from pre-emit |
+    /// | `JumpIfTrue` / `JumpIfFalse`        | `-1` (cond popped)  | pre-emit `- 1`          |
+    /// | `JumpIfTrueOrPop` / `JumpIfFalseOrPop` | `-1` (cond popped) | pre-emit (cond kept)    |
+    /// | `ForIter`                           | `+1` (value pushed) | pre-emit `- 1` (iter popped) |
     #[must_use]
     pub fn emit_jump(&mut self, op: Opcode) -> JumpLabel {
         self.record_location();
-        let label = JumpLabel(self.bytecode.len());
+        let pre_depth = self.current_stack_depth;
+        let offset = self.bytecode.len();
         self.bytecode.push(op as u8);
         // Placeholder for i16 offset (will be patched)
         self.bytecode.extend_from_slice(&0i16.to_le_bytes());
-        // Track stack effect
-        match op {
-            // ForIter: when successful (not jumping), pushes next value (+1)
-            // When exhausted (jumping), pops iterator (-1), but that's after loop
-            Opcode::ForIter => self.adjust_stack(1),
-            // JumpIfTrueOrPop/JumpIfFalseOrPop: pops when not jumping (fallthrough)
-            Opcode::JumpIfTrueOrPop | Opcode::JumpIfFalseOrPop => self.adjust_stack(-1),
-            _ => {
-                if let Some(effect) = op.stack_effect() {
-                    self.adjust_stack(effect);
-                }
-            }
-        }
-        label
+
+        // Determine fall-through stack effect and jump-taken target depth.
+        // See the table on the docstring above for the per-opcode semantics.
+        let (fallthrough_effect, target_depth): (i16, u16) = match op {
+            Opcode::Jump => (0, pre_depth),
+            Opcode::JumpIfTrue | Opcode::JumpIfFalse => (-1, pre_depth.saturating_sub(1)),
+            Opcode::JumpIfTrueOrPop | Opcode::JumpIfFalseOrPop => (-1, pre_depth),
+            Opcode::ForIter => (1, pre_depth.saturating_sub(1)),
+            _ => panic!("emit_jump called with non-jump opcode {op:?}"),
+        };
+        self.adjust_stack(fallthrough_effect);
+
+        JumpLabel { offset, target_depth }
     }
 
     /// Patches a forward jump to point to the current bytecode location.
@@ -297,22 +329,39 @@ impl CodeBuilder {
     /// instruction's operand (i.e., where execution would continue if
     /// the jump is not taken).
     ///
+    /// In debug builds, asserts that the builder's tracked stack depth at the
+    /// patch point matches the depth that the jump-taken path leaves on the
+    /// stack (recorded by `emit_jump` in the label). When fall-through reaches
+    /// the patch point, this catches branches that disagree on depth — a
+    /// recurring class of compiler bug. When fall-through is unreachable
+    /// (because of an upstream unconditional `Jump` or `Reraise`), callers
+    /// must pre-align the tracker via `set_stack_depth` so the assertion
+    /// reflects the live (jump-taken) path.
+    ///
     /// # Panics
     ///
-    /// Panics if the jump offset exceeds i16 range (-32768..32767), which
-    /// indicates the function is too large. This is a compile-time error
-    /// rather than silent truncation.
+    /// - In debug builds, panics if the tracker disagrees with
+    ///   `label.target_depth`.
+    /// - Always panics if the jump offset exceeds i16 range (-32768..32767),
+    ///   which indicates the function is too large. This is a compile-time
+    ///   error rather than silent truncation.
     pub fn patch_jump(&mut self, label: JumpLabel) {
+        debug_assert_eq!(
+            self.current_stack_depth, label.target_depth,
+            "stack-depth mismatch at jump merge: builder tracker is {} but jump label expects {}; \
+             branches reaching this merge point disagree on stack state",
+            self.current_stack_depth, label.target_depth,
+        );
         let target = self.bytecode.len();
         // Offset is relative to position after the jump instruction (opcode + i16 = 3 bytes)
         let target_i64 = i64::try_from(target).expect("bytecode target exceeds i64");
-        let label_i64 = i64::try_from(label.0).expect("bytecode label exceeds i64");
+        let label_i64 = i64::try_from(label.offset).expect("bytecode label exceeds i64");
         let raw_offset = target_i64 - label_i64 - 3;
         let offset =
             i16::try_from(raw_offset).expect("jump offset exceeds i16 range (-32768..32767); function too large");
         let bytes = offset.to_le_bytes();
-        self.bytecode[label.0 + 1] = bytes[0];
-        self.bytecode[label.0 + 2] = bytes[1];
+        self.bytecode[label.offset + 1] = bytes[0];
+        self.bytecode[label.offset + 2] = bytes[1];
     }
 
     /// Emits a backward jump to a known target offset.
@@ -330,10 +379,17 @@ impl CodeBuilder {
             i16::try_from(raw_offset).expect("jump offset exceeds i16 range (-32768..32767); function too large");
         self.bytecode.push(op as u8);
         self.bytecode.extend_from_slice(&offset.to_le_bytes());
-        // Track stack effect (jump instructions pop condition)
-        if let Some(effect) = op.stack_effect() {
-            self.adjust_stack(effect);
-        }
+        // Track stack effect. `emit_jump_to` is only used for unconditional
+        // backward jumps (e.g. loop continuation), where the only valid
+        // opcode is `Jump` with a fixed effect of 0. Any opcode whose effect
+        // depends on which branch is taken (`ForIter`, `JumpIfTrueOrPop`,
+        // etc.) cannot be encoded as a backward jump because we don't have a
+        // patch label to record per-branch target depths — panic loudly if
+        // misused rather than silently defaulting to `0`.
+        let effect = op.stack_effect().unwrap_or_else(|| {
+            panic!("variable-effect opcode {op:?} emitted via emit_jump_to — only fixed-effect jumps are supported on the backward-jump path")
+        });
+        self.adjust_stack(effect);
     }
 
     /// Returns the current bytecode offset.
@@ -523,19 +579,40 @@ impl CodeBuilder {
     /// Tracks stack effect for opcodes with u8 operand.
     ///
     /// For opcodes with variable effects (like `CallFunction`, `BuildList`),
-    /// calculates the effect based on the operand.
+    /// calculates the effect based on the operand. For variable-effect opcodes
+    /// not enumerated here, falling through to `op.stack_effect()` would
+    /// silently default to `0` for `None` returns and drift the tracker — so
+    /// the fallback panics instead.
     fn track_stack_effect_u8(&mut self, op: Opcode, operand: u8) {
         let effect: i16 = match op {
             // CallFunction pops (callable + args), pushes result: -(1 + arg_count) + 1 = -arg_count
             Opcode::CallFunction => -i16::from(operand),
+            // CallFunctionExtended pops callable + args_tuple (+ kwargs_dict if flag bit 0),
+            // pushes result. flags is 0 (no kwargs) or 1 (has kwargs). Effect: -(1 + has_kwargs).
+            Opcode::CallFunctionExtended => -(1 + i16::from(operand & 0x01)),
+            // FormatValue: bit 2 (0x04) of flags indicates a format spec on stack.
+            // Without spec: pop value, push result = 0. With spec: pop value + spec,
+            // push result = -1.
+            Opcode::FormatValue => {
+                if operand & 0x04 != 0 {
+                    -1
+                } else {
+                    0
+                }
+            }
             // UnpackSequence pops 1, pushes n: n - 1
             Opcode::UnpackSequence => i16::from(operand) - 1,
             // ListAppend/SetAdd pop value: -1 (depth operand doesn't affect stack count)
             Opcode::ListAppend | Opcode::SetAdd => -1,
             // DictSetItem pops key and value: -2
             Opcode::DictSetItem => -2,
-            // Default: use fixed effect if available
-            _ => op.stack_effect().unwrap_or(0),
+            // Default: use fixed effect; panic if the opcode declares a
+            // variable effect (`stack_effect()` returns `None`) but isn't
+            // handled above — this is a forcing function so new variable-effect
+            // opcodes can't silently drift the tracker.
+            _ => op
+                .stack_effect()
+                .unwrap_or_else(|| panic!("variable-effect opcode {op:?} emitted via emit_u8 without a stack-effect override in track_stack_effect_u8")),
         };
         self.adjust_stack(effect);
     }
@@ -543,7 +620,9 @@ impl CodeBuilder {
     /// Tracks stack effect for opcodes with u16 operand.
     ///
     /// For opcodes with variable effects (like `BuildList`, `BuildTuple`),
-    /// calculates the effect based on the operand.
+    /// calculates the effect based on the operand. Variable-effect opcodes
+    /// not enumerated here trigger a panic in the fallback rather than
+    /// silently defaulting to `0`.
     fn track_stack_effect_u16(&mut self, op: Opcode, operand: u16) {
         // Safe cast: operand won't exceed i16::MAX in practice (would be a huge list)
         let operand_i16 = operand.cast_signed();
@@ -554,8 +633,9 @@ impl CodeBuilder {
             Opcode::BuildDict => 1 - 2 * operand_i16,
             // BuildFString: pop n parts, push 1: 1 - n
             Opcode::BuildFString => 1 - operand_i16,
-            // Default: use fixed effect if available
-            _ => op.stack_effect().unwrap_or(0),
+            _ => op.stack_effect().unwrap_or_else(|| {
+                panic!("variable-effect opcode {op:?} emitted via emit_u16 without a stack-effect override in track_stack_effect_u16")
+            }),
         };
         self.adjust_stack(effect);
     }
@@ -572,10 +652,17 @@ impl CodeBuilder {
 
 /// Label for a forward jump that needs patching.
 ///
-/// Stores the bytecode offset where the jump instruction was emitted.
-/// Pass this to `patch_jump()` once the target location is known.
+/// Carries the bytecode offset where the jump instruction was emitted, plus
+/// the stack depth that the jump-taken path leaves on the stack at the patch
+/// target. The depth is computed by `emit_jump` from the per-opcode semantics
+/// of the jump (see that method's docs) and used by `patch_jump` to assert
+/// the merge invariant — every branch reaching the patch point must agree on
+/// stack depth. Pass this to `patch_jump()` once the target location is known.
 #[derive(Debug, Clone, Copy)]
-pub struct JumpLabel(usize);
+pub struct JumpLabel {
+    offset: usize,
+    target_depth: u16,
+}
 
 #[cfg(test)]
 mod tests {
@@ -613,8 +700,14 @@ mod tests {
     fn test_forward_jump() {
         let mut builder = CodeBuilder::new();
         let jump = builder.emit_jump(Opcode::Jump);
+        // The two LoadNones below are dead code (unconditional Jump above), but
+        // they still get emitted to exercise the offset patching. Reset the
+        // builder's tracker before patching so the merge invariant in
+        // `patch_jump` reflects the live (jump-taken) path, where stack depth
+        // is unchanged from before the Jump.
         builder.emit(Opcode::LoadNone); // 1 byte, skipped by jump
         builder.emit(Opcode::LoadNone); // 1 byte, skipped by jump
+        builder.set_stack_depth(0);
         builder.patch_jump(jump);
         builder.emit(Opcode::LoadNone); // Return value
         builder.emit(Opcode::ReturnValue);

--- a/crates/monty/src/bytecode/builder.rs
+++ b/crates/monty/src/bytecode/builder.rs
@@ -588,7 +588,10 @@ impl CodeBuilder {
             }
         }
         self.adjust_stack(op.stack_effect(operand));
-        if matches!(op, Opcode::ReturnValue | Opcode::Raise | Opcode::Reraise | Opcode::Jump) {
+        if matches!(
+            op,
+            Opcode::ReturnValue | Opcode::Raise | Opcode::Reraise | Opcode::RaiseImportError | Opcode::Jump
+        ) {
             self.current_stack_depth = None;
         }
     }

--- a/crates/monty/src/bytecode/builder.rs
+++ b/crates/monty/src/bytecode/builder.rs
@@ -46,6 +46,43 @@ impl Default for TrackerState {
     }
 }
 
+/// Operand bundle paired with an opcode at emit time.
+///
+/// Every linear (non-jump) emit funnels through `emit_with_operand(op, operand)`,
+/// which writes the bytes for `operand` and consults `stack_effect_for(op, &operand)`
+/// for the stack adjustment. Carrying the operand through this enum makes
+/// stack-effect computation a single, exhaustive match — variable-effect
+/// opcodes without an explicit arm panic instead of silently drifting.
+#[derive(Debug)]
+enum Operand<'a> {
+    /// No operand bytes (e.g. `Pop`, `BinaryAdd`).
+    None,
+    /// Single u8 operand (e.g. `LoadLocal`, `CallFunction`).
+    U8(u8),
+    /// Single i8 operand.
+    I8(i8),
+    /// Single u16 operand, little-endian (e.g. `LoadConst`, `BuildList`).
+    U16(u16),
+    /// Two u8 operands (e.g. `UnpackEx`, `CallBuiltinFunction`).
+    U8U8(u8, u8),
+    /// u8 then u16 little-endian (e.g. `LoadLocalCallable`).
+    U8U16(u8, u16),
+    /// u16 little-endian then u8 (e.g. `MakeFunction`, `CallAttr`).
+    U16U8(u16, u8),
+    /// Two u16 little-endian (e.g. `LoadLocalCallableW`, `LoadGlobalCallable`).
+    U16U16(u16, u16),
+    /// u16 then two u8s (e.g. `MakeClosure`).
+    U16U8U8(u16, u8, u8),
+    /// `CallFunctionKw` shape: pos_count (u8), kw_count (u8), kw_count * name_id (u16 each).
+    CallKw { pos_count: u8, kwname_ids: &'a [u16] },
+    /// `CallAttrKw` shape: attr_name_id (u16), pos_count (u8), kw_count (u8), kw_count * name_id (u16 each).
+    CallAttrKw {
+        attr_name_id: u16,
+        pos_count: u8,
+        kwname_ids: &'a [u16],
+    },
+}
+
 /// Builder for emitting bytecode during compilation.
 ///
 /// Handles encoding opcodes and operands into raw bytes, managing forward jumps
@@ -120,209 +157,83 @@ impl CodeBuilder {
     }
 
     /// Emits a no-operand instruction and updates stack depth tracking.
-    ///
-    /// All variable-effect opcodes (where `Opcode::stack_effect()` returns
-    /// `None`) take operands, so calling this with one is a compiler bug —
-    /// hence the panic on `None` rather than silently defaulting to `0`.
-    ///
-    /// Terminator opcodes (`ReturnValue`, `Raise`, `Reraise`) transition the
-    /// tracker to `Dead` after emission so subsequent fall-through emits
-    /// don't disturb live tracking.
     pub fn emit(&mut self, op: Opcode) {
-        self.record_location();
-        self.bytecode.push(op as u8);
-        let effect = op.stack_effect().unwrap_or_else(|| {
-            panic!("variable-effect opcode {op:?} emitted via emit (no operand) — variable-effect ops require an operand-aware emit helper")
-        });
-        self.adjust_stack(effect);
-        if matches!(op, Opcode::ReturnValue | Opcode::Raise | Opcode::Reraise) {
-            self.mark_dead();
-        }
+        self.emit_with_operand(op, &Operand::None);
     }
 
-    /// Emits an instruction with a u8 operand and updates stack depth tracking.
+    /// Emits an instruction with a u8 operand.
     pub fn emit_u8(&mut self, op: Opcode, operand: u8) {
-        self.record_location();
-        self.bytecode.push(op as u8);
-        self.bytecode.push(operand);
-        // Track stack effect - some need operand-based calculation
-        self.track_stack_effect_u8(op, operand);
+        self.emit_with_operand(op, &Operand::U8(operand));
     }
 
-    /// Emits an instruction with an i8 operand and updates stack depth tracking.
+    /// Emits an instruction with an i8 operand.
     pub fn emit_i8(&mut self, op: Opcode, operand: i8) {
-        self.record_location();
-        self.bytecode.push(op as u8);
-        // Reinterpret i8 as u8 for bytecode encoding
-        self.bytecode.push(operand.to_ne_bytes()[0]);
-        let effect = op.stack_effect().unwrap_or_else(|| {
-            panic!("variable-effect opcode {op:?} emitted via emit_i8 without a stack-effect override")
-        });
-        self.adjust_stack(effect);
+        self.emit_with_operand(op, &Operand::I8(operand));
     }
 
-    /// Emits an instruction with two u8 operands and updates stack depth tracking.
+    /// Emits an instruction with two u8 operands.
     ///
-    /// Used for UnpackEx: before_count (u8) + after_count (u8)
+    /// Used for `UnpackEx`: before_count + after_count.
     pub fn emit_u8_u8(&mut self, op: Opcode, operand1: u8, operand2: u8) {
-        self.record_location();
-        self.bytecode.push(op as u8);
-        self.bytecode.push(operand1);
-        self.bytecode.push(operand2);
-        // UnpackEx: pops 1, pushes (before + 1 + after) = before + after + 1
-        // Net effect: before + after
-        if op == Opcode::UnpackEx {
-            self.adjust_stack(i16::from(operand1) + i16::from(operand2));
-        } else {
-            let effect = op.stack_effect().unwrap_or_else(|| {
-                panic!("variable-effect opcode {op:?} emitted via emit_u8_u8 without a stack-effect override")
-            });
-            self.adjust_stack(effect);
-        }
+        self.emit_with_operand(op, &Operand::U8U8(operand1, operand2));
     }
 
-    /// Emits an instruction with a u16 operand (little-endian) and updates stack depth tracking.
+    /// Emits an instruction with a u16 operand (little-endian).
     pub fn emit_u16(&mut self, op: Opcode, operand: u16) {
-        self.record_location();
-        self.bytecode.push(op as u8);
-        self.bytecode.extend_from_slice(&operand.to_le_bytes());
-        // Track stack effect - some need operand-based calculation
-        self.track_stack_effect_u16(op, operand);
+        self.emit_with_operand(op, &Operand::U16(operand));
     }
 
     /// Emits an instruction with a u16 operand followed by a u8 operand.
     ///
-    /// Used for MakeFunction: func_id (u16) + defaults_count (u8)
-    /// Used for CallAttr: attr_name_id (u16) + arg_count (u8)
+    /// Used for `MakeFunction`, `CallAttr`, `CallAttrExtended`.
     pub fn emit_u16_u8(&mut self, op: Opcode, operand1: u16, operand2: u8) {
-        self.record_location();
-        self.bytecode.push(op as u8);
-        self.bytecode.extend_from_slice(&operand1.to_le_bytes());
-        self.bytecode.push(operand2);
-        // Track stack effects based on opcode. Variable-effect opcodes that
-        // aren't enumerated below will hit the panic in the fallback rather
-        // than silently defaulting to `0` (which would drift the tracker).
-        match op {
-            Opcode::MakeFunction => {
-                // pops defaults_count defaults, pushes function: 1 - defaults_count
-                self.adjust_stack(1 - i16::from(operand2));
-            }
-            Opcode::CallAttr => {
-                // pops obj + args, pushes result: 1 - (1 + arg_count) = -arg_count
-                self.adjust_stack(-i16::from(operand2));
-            }
-            Opcode::CallAttrExtended => {
-                // pops receiver + args_tuple (+ kwargs_dict if flag bit 0),
-                // pushes result. operand2 is the u8 flags: 0 or 1.
-                // Effect: -(1 + has_kwargs).
-                self.adjust_stack(-(1 + i16::from(operand2 & 0x01)));
-            }
-            _ => {
-                let effect = op.stack_effect().unwrap_or_else(|| {
-                    panic!("variable-effect opcode {op:?} emitted via emit_u16_u8 without a stack-effect override")
-                });
-                self.adjust_stack(effect);
-            }
-        }
+        self.emit_with_operand(op, &Operand::U16U8(operand1, operand2));
     }
 
     /// Emits an instruction with a u16 operand followed by two u8 operands.
     ///
-    /// Used for MakeClosure: func_id (u16) + defaults_count (u8) + cell_count (u8)
+    /// Used for `MakeClosure`: func_id + defaults_count + cell_count.
     pub fn emit_u16_u8_u8(&mut self, op: Opcode, operand1: u16, operand2: u8, operand3: u8) {
-        self.record_location();
-        self.bytecode.push(op as u8);
-        self.bytecode.extend_from_slice(&operand1.to_le_bytes());
-        self.bytecode.push(operand2);
-        self.bytecode.push(operand3);
-        // MakeClosure: pops defaults_count defaults, pushes closure
-        // Cell values are captured from locals, not popped from stack
-        // Stack effect: 1 - defaults_count
-        if op == Opcode::MakeClosure {
-            self.adjust_stack(1 - i16::from(operand2));
-        } else {
-            let effect = op.stack_effect().unwrap_or_else(|| {
-                panic!("variable-effect opcode {op:?} emitted via emit_u16_u8_u8 without a stack-effect override")
-            });
-            self.adjust_stack(effect);
-        }
+        self.emit_with_operand(op, &Operand::U16U8U8(operand1, operand2, operand3));
     }
 
-    /// Emits `CallBuiltinFunction` instruction.
-    ///
-    /// Operands: builtin_id (u8) + arg_count (u8)
+    /// Emits `CallBuiltinFunction`: builtin_id (u8) + arg_count (u8).
     ///
     /// The builtin_id is the `#[repr(u8)]` discriminant of `BuiltinsFunctions`.
     /// This is an optimization that avoids constant pool lookup and stack manipulation.
     pub fn emit_call_builtin_function(&mut self, builtin_id: u8, arg_count: u8) {
-        self.record_location();
-        self.bytecode.push(Opcode::CallBuiltinFunction as u8);
-        self.bytecode.push(builtin_id);
-        self.bytecode.push(arg_count);
-        // CallBuiltinFunction: pops args, pushes result. No callable on stack.
-        // Stack effect: 1 - arg_count
-        self.adjust_stack(1 - i16::from(arg_count));
+        self.emit_with_operand(Opcode::CallBuiltinFunction, &Operand::U8U8(builtin_id, arg_count));
     }
 
-    /// Emits `CallBuiltinType` instruction.
-    ///
-    /// Operands: type_id (u8) + arg_count (u8)
+    /// Emits `CallBuiltinType`: type_id (u8) + arg_count (u8).
     ///
     /// The type_id is the `#[repr(u8)]` discriminant of `BuiltinsTypes`.
     /// This is an optimization for type constructors like `list()`, `int()`, `str()`.
     pub fn emit_call_builtin_type(&mut self, type_id: u8, arg_count: u8) {
-        self.record_location();
-        self.bytecode.push(Opcode::CallBuiltinType as u8);
-        self.bytecode.push(type_id);
-        self.bytecode.push(arg_count);
-        // CallBuiltinType: pops args, pushes result. No callable on stack.
-        // Stack effect: 1 - arg_count
-        self.adjust_stack(1 - i16::from(arg_count));
+        self.emit_with_operand(Opcode::CallBuiltinType, &Operand::U8U8(type_id, arg_count));
     }
 
-    /// Emits CallFunctionKw with inline keyword names.
+    /// Emits `CallFunctionKw` with inline keyword names.
     ///
-    /// Operands: pos_count (u8) + kw_count (u8) + kw_count * name_id (u16 each)
-    ///
-    /// The kwname_ids slice contains StringId indices for each keyword argument
-    /// name, in order matching how the values were pushed to the stack.
+    /// Operands: pos_count (u8) + kw_count (u8) + kw_count * name_id (u16 each).
+    /// `kwname_ids` is the StringId for each keyword argument, in the order
+    /// the values were pushed onto the operand stack.
     pub fn emit_call_function_kw(&mut self, pos_count: u8, kwname_ids: &[u16]) {
-        self.record_location();
-        self.bytecode.push(Opcode::CallFunctionKw as u8);
-        self.bytecode.push(pos_count);
-        self.bytecode
-            .push(u8::try_from(kwname_ids.len()).expect("keyword count exceeds u8"));
-        for &name_id in kwname_ids {
-            self.bytecode.extend_from_slice(&name_id.to_le_bytes());
-        }
-        // CallFunctionKw: pops callable + pos_args + kw_args, pushes result
-        // Stack effect: 1 - (1 + pos_count + kw_count) = -pos_count - kw_count
-        let kw_count = i16::try_from(kwname_ids.len()).expect("keyword count exceeds i16");
-        let total_args = i16::from(pos_count) + kw_count;
-        self.adjust_stack(-total_args);
+        self.emit_with_operand(Opcode::CallFunctionKw, &Operand::CallKw { pos_count, kwname_ids });
     }
 
-    /// Emits CallAttrKw with inline keyword names.
+    /// Emits `CallAttrKw` with inline keyword names.
     ///
-    /// Operands: attr_name_id (u16) + pos_count (u8) + kw_count (u8) + kw_count * name_id (u16 each)
-    ///
-    /// The kwname_ids slice contains StringId indices for each keyword argument
-    /// name, in order matching how the values were pushed to the stack.
+    /// Operands: attr_name_id (u16) + pos_count (u8) + kw_count (u8) + kw_count * name_id (u16 each).
     pub fn emit_call_attr_kw(&mut self, attr_name_id: u16, pos_count: u8, kwname_ids: &[u16]) {
-        self.record_location();
-        self.bytecode.push(Opcode::CallAttrKw as u8);
-        self.bytecode.extend_from_slice(&attr_name_id.to_le_bytes());
-        self.bytecode.push(pos_count);
-        self.bytecode
-            .push(u8::try_from(kwname_ids.len()).expect("keyword count exceeds u8"));
-        for &name_id in kwname_ids {
-            self.bytecode.extend_from_slice(&name_id.to_le_bytes());
-        }
-        // CallAttrKw: pops obj + pos_args + kw_args, pushes result
-        // Stack effect: 1 - (1 + pos_count + kw_count) = -pos_count - kw_count
-        let kw_count = i16::try_from(kwname_ids.len()).expect("keyword count exceeds i16");
-        let total_args = i16::from(pos_count) + kw_count;
-        self.adjust_stack(-total_args);
+        self.emit_with_operand(
+            Opcode::CallAttrKw,
+            &Operand::CallAttrKw {
+                attr_name_id,
+                pos_count,
+                kwname_ids,
+            },
+        );
     }
 
     /// Emits a forward jump instruction, returning a label to patch later.
@@ -523,19 +434,9 @@ impl CodeBuilder {
     pub fn emit_load_local_callable(&mut self, slot: u16, name_id: StringId) {
         let name_id_u16 = u16::try_from(name_id.index()).expect("name_id exceeds u16");
         if let Ok(s) = u8::try_from(slot) {
-            // Emit LoadLocalCallable with u8 slot + u16 name_id
-            self.record_location();
-            self.bytecode.push(Opcode::LoadLocalCallable as u8);
-            self.bytecode.push(s);
-            self.bytecode.extend_from_slice(&name_id_u16.to_le_bytes());
-            self.adjust_stack(1);
+            self.emit_with_operand(Opcode::LoadLocalCallable, &Operand::U8U16(s, name_id_u16));
         } else {
-            // Emit LoadLocalCallableW with u16 slot + u16 name_id
-            self.record_location();
-            self.bytecode.push(Opcode::LoadLocalCallableW as u8);
-            self.bytecode.extend_from_slice(&slot.to_le_bytes());
-            self.bytecode.extend_from_slice(&name_id_u16.to_le_bytes());
-            self.adjust_stack(1);
+            self.emit_with_operand(Opcode::LoadLocalCallableW, &Operand::U16U16(slot, name_id_u16));
         }
     }
 
@@ -546,11 +447,7 @@ impl CodeBuilder {
     /// and local slots use different namespaces).
     pub fn emit_load_global_callable(&mut self, slot: u16, name_id: StringId) {
         let name_id_u16 = u16::try_from(name_id.index()).expect("name_id exceeds u16");
-        self.record_location();
-        self.bytecode.push(Opcode::LoadGlobalCallable as u8);
-        self.bytecode.extend_from_slice(&slot.to_le_bytes());
-        self.bytecode.extend_from_slice(&name_id_u16.to_le_bytes());
-        self.adjust_stack(1);
+        self.emit_with_operand(Opcode::LoadGlobalCallable, &Operand::U16U16(slot, name_id_u16));
     }
 
     /// Emits `StoreLocal`, using wide variant for slots > 255.
@@ -684,68 +581,141 @@ impl CodeBuilder {
         self.tracker = TrackerState::Dead;
     }
 
-    /// Tracks stack effect for opcodes with u8 operand.
+    /// Single-source-of-truth emit path: records location, writes opcode +
+    /// operand bytes, applies the stack-effect computed by `stack_effect_for`,
+    /// and transitions the tracker to `Dead` for unconditional terminators
+    /// (`ReturnValue`, `Raise`, `Reraise`).
     ///
-    /// For opcodes with variable effects (like `CallFunction`, `BuildList`),
-    /// calculates the effect based on the operand. For variable-effect opcodes
-    /// not enumerated here, falling through to `op.stack_effect()` would
-    /// silently default to `0` for `None` returns and drift the tracker — so
-    /// the fallback panics instead.
-    fn track_stack_effect_u8(&mut self, op: Opcode, operand: u8) {
-        let effect: i16 = match op {
-            // CallFunction pops (callable + args), pushes result: -(1 + arg_count) + 1 = -arg_count
-            Opcode::CallFunction => -i16::from(operand),
-            // CallFunctionExtended pops callable + args_tuple (+ kwargs_dict if flag bit 0),
-            // pushes result. flags is 0 (no kwargs) or 1 (has kwargs). Effect: -(1 + has_kwargs).
-            Opcode::CallFunctionExtended => -(1 + i16::from(operand & 0x01)),
-            // FormatValue: bit 2 (0x04) of flags indicates a format spec on stack.
-            // Without spec: pop value, push result = 0. With spec: pop value + spec,
-            // push result = -1.
-            Opcode::FormatValue => {
-                if operand & 0x04 != 0 {
-                    -1
-                } else {
-                    0
+    /// `emit_jump` and `emit_jump_to` do *not* go through this path — they
+    /// have branch-dependent effects and target-depth bookkeeping that don't
+    /// fit the linear-emit shape.
+    fn emit_with_operand(&mut self, op: Opcode, operand: &Operand<'_>) {
+        self.record_location();
+        self.bytecode.push(op as u8);
+        match operand {
+            Operand::None => {}
+            Operand::U8(b) => self.bytecode.push(*b),
+            Operand::I8(b) => self.bytecode.push(b.to_ne_bytes()[0]),
+            Operand::U16(w) => self.bytecode.extend_from_slice(&w.to_le_bytes()),
+            Operand::U8U8(a, b) => {
+                self.bytecode.push(*a);
+                self.bytecode.push(*b);
+            }
+            Operand::U8U16(a, w) => {
+                self.bytecode.push(*a);
+                self.bytecode.extend_from_slice(&w.to_le_bytes());
+            }
+            Operand::U16U8(w, b) => {
+                self.bytecode.extend_from_slice(&w.to_le_bytes());
+                self.bytecode.push(*b);
+            }
+            Operand::U16U16(w1, w2) => {
+                self.bytecode.extend_from_slice(&w1.to_le_bytes());
+                self.bytecode.extend_from_slice(&w2.to_le_bytes());
+            }
+            Operand::U16U8U8(w, b1, b2) => {
+                self.bytecode.extend_from_slice(&w.to_le_bytes());
+                self.bytecode.push(*b1);
+                self.bytecode.push(*b2);
+            }
+            Operand::CallKw { pos_count, kwname_ids } => {
+                self.bytecode.push(*pos_count);
+                self.bytecode
+                    .push(u8::try_from(kwname_ids.len()).expect("keyword count exceeds u8"));
+                for &name_id in *kwname_ids {
+                    self.bytecode.extend_from_slice(&name_id.to_le_bytes());
                 }
             }
-            // UnpackSequence pops 1, pushes n: n - 1
-            Opcode::UnpackSequence => i16::from(operand) - 1,
-            // ListAppend/SetAdd pop value: -1 (depth operand doesn't affect stack count)
-            Opcode::ListAppend | Opcode::SetAdd => -1,
-            // DictSetItem pops key and value: -2
-            Opcode::DictSetItem => -2,
-            // Default: use fixed effect; panic if the opcode declares a
-            // variable effect (`stack_effect()` returns `None`) but isn't
-            // handled above — this is a forcing function so new variable-effect
-            // opcodes can't silently drift the tracker.
-            _ => op
-                .stack_effect()
-                .unwrap_or_else(|| panic!("variable-effect opcode {op:?} emitted via emit_u8 without a stack-effect override in track_stack_effect_u8")),
-        };
-        self.adjust_stack(effect);
+            Operand::CallAttrKw {
+                attr_name_id,
+                pos_count,
+                kwname_ids,
+            } => {
+                self.bytecode.extend_from_slice(&attr_name_id.to_le_bytes());
+                self.bytecode.push(*pos_count);
+                self.bytecode
+                    .push(u8::try_from(kwname_ids.len()).expect("keyword count exceeds u8"));
+                for &name_id in *kwname_ids {
+                    self.bytecode.extend_from_slice(&name_id.to_le_bytes());
+                }
+            }
+        }
+        self.adjust_stack(stack_effect_for(op, operand));
+        if matches!(op, Opcode::ReturnValue | Opcode::Raise | Opcode::Reraise) {
+            self.mark_dead();
+        }
     }
+}
 
-    /// Tracks stack effect for opcodes with u16 operand.
-    ///
-    /// For opcodes with variable effects (like `BuildList`, `BuildTuple`),
-    /// calculates the effect based on the operand. Variable-effect opcodes
-    /// not enumerated here trigger a panic in the fallback rather than
-    /// silently defaulting to `0`.
-    fn track_stack_effect_u16(&mut self, op: Opcode, operand: u16) {
-        // Safe cast: operand won't exceed i16::MAX in practice (would be a huge list)
-        let operand_i16 = operand.cast_signed();
-        let effect: i16 = match op {
-            // BuildList/BuildTuple/BuildSet: pop n, push 1: -(n - 1) = 1 - n
-            Opcode::BuildList | Opcode::BuildTuple | Opcode::BuildSet => 1 - operand_i16,
-            // BuildDict: pop 2n (key-value pairs), push 1: 1 - 2n
-            Opcode::BuildDict => 1 - 2 * operand_i16,
-            // BuildFString: pop n parts, push 1: 1 - n
-            Opcode::BuildFString => 1 - operand_i16,
-            _ => op.stack_effect().unwrap_or_else(|| {
-                panic!("variable-effect opcode {op:?} emitted via emit_u16 without a stack-effect override in track_stack_effect_u16")
-            }),
-        };
-        self.adjust_stack(effect);
+/// Computes the operand-stack effect of `op` paired with `operand`.
+///
+/// All variable-effect opcodes get an explicit match arm. Fixed-effect opcodes
+/// fall through to `op.stack_effect()`, which is `Some(_)` for them. A
+/// variable-effect opcode that reaches the fallback (because its operand
+/// shape doesn't match any enumerated arm) panics — preventing silent drift
+/// when a new variable-effect opcode is added.
+///
+/// `MakeFunction`/`MakeClosure` have explicit arms even though `stack_effect()`
+/// returns `Some(1)` for them — that fixed value is only correct with zero
+/// defaults, so we override with `1 - defaults_count` for the general case.
+fn stack_effect_for(op: Opcode, operand: &Operand<'_>) -> i16 {
+    match (op, operand) {
+        // === U8 operand, variable effect ===
+        (Opcode::CallFunction, &Operand::U8(arg_count)) => -i16::from(arg_count),
+        (Opcode::CallFunctionExtended, &Operand::U8(flags)) => -(1 + i16::from(flags & 0x01)),
+        (Opcode::FormatValue, &Operand::U8(flags)) => {
+            if flags & 0x04 != 0 {
+                -1
+            } else {
+                0
+            }
+        }
+        (Opcode::UnpackSequence, &Operand::U8(n)) => i16::from(n) - 1,
+
+        // === U16 operand, variable effect ===
+        (Opcode::BuildList | Opcode::BuildTuple | Opcode::BuildSet | Opcode::BuildFString, &Operand::U16(n)) => {
+            1 - n.cast_signed()
+        }
+        (Opcode::BuildDict, &Operand::U16(n)) => 1 - 2 * n.cast_signed(),
+
+        // === U8U8 operand, variable effect ===
+        // UnpackEx: pops 1, pushes (before + 1 + after) → before + after.
+        (Opcode::UnpackEx, &Operand::U8U8(before, after)) => i16::from(before) + i16::from(after),
+        // Builtin calls: no callable on stack, pops args, pushes result → 1 - arg_count.
+        (Opcode::CallBuiltinFunction | Opcode::CallBuiltinType, &Operand::U8U8(_, arg_count)) => {
+            1 - i16::from(arg_count)
+        }
+
+        // === U16U8 operand, variable effect ===
+        (Opcode::MakeFunction, &Operand::U16U8(_, defaults)) => 1 - i16::from(defaults),
+        (Opcode::CallAttr, &Operand::U16U8(_, arg_count)) => -i16::from(arg_count),
+        (Opcode::CallAttrExtended, &Operand::U16U8(_, flags)) => -(1 + i16::from(flags & 0x01)),
+
+        // === U16U8U8 operand, variable effect ===
+        (Opcode::MakeClosure, &Operand::U16U8U8(_, defaults, _)) => 1 - i16::from(defaults),
+
+        // === Variable-length kw operands ===
+        // pops callable + pos_args + kw_args, pushes result → -(pos_count + kw_count).
+        (Opcode::CallFunctionKw, Operand::CallKw { pos_count, kwname_ids }) => {
+            let kw_count = i16::try_from(kwname_ids.len()).expect("keyword count exceeds i16");
+            -(i16::from(*pos_count) + kw_count)
+        }
+        (
+            Opcode::CallAttrKw,
+            Operand::CallAttrKw {
+                pos_count, kwname_ids, ..
+            },
+        ) => {
+            let kw_count = i16::try_from(kwname_ids.len()).expect("keyword count exceeds i16");
+            -(i16::from(*pos_count) + kw_count)
+        }
+
+        // Fixed-effect fallback. Variable-effect opcodes (where stack_effect()
+        // returns None) without an arm above hit the panic — keeps the tracker
+        // honest if a new variable-effect opcode is added.
+        (op, _) => op.stack_effect().unwrap_or_else(|| {
+            panic!("stack_effect_for: variable-effect opcode {op:?} has no handler for operand variant {operand:?}")
+        }),
     }
 }
 

--- a/crates/monty/src/bytecode/code.rs
+++ b/crates/monty/src/bytecode/code.rs
@@ -6,6 +6,7 @@
 
 use std::collections::HashSet;
 
+use super::builder::Offset;
 use crate::{intern::StringId, parse::CodeRange, value::Value};
 
 /// Compiled bytecode for a function or module.
@@ -280,12 +281,16 @@ pub struct ExceptionEntry {
 
 impl ExceptionEntry {
     /// Creates a new exception table entry.
+    ///
+    /// Takes `Offset` values produced by `CodeBuilder::current_offset` so that
+    /// the bounds of try / handler / cleanup regions can't be confused with
+    /// arbitrary integers.
     #[must_use]
-    pub fn new(start: u32, end: u32, handler: u32, stack_depth: u16) -> Self {
+    pub fn new(start: Offset, end: Offset, handler: Offset, stack_depth: u16) -> Self {
         Self {
-            start,
-            end,
-            handler,
+            start: start.as_u32(),
+            end: end.as_u32(),
+            handler: handler.as_u32(),
             stack_depth,
         }
     }

--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -11,7 +11,7 @@
 use std::{borrow::Cow, mem};
 
 use super::{
-    builder::{CodeBuilder, JumpLabel},
+    builder::{CodeBuilder, JumpLabel, JumpTarget},
     code::{Code, ExceptionEntry},
     op::Opcode,
 };
@@ -100,9 +100,12 @@ pub struct Compiler<'a> {
 /// - `has_iterator_on_stack`: whether this loop has an iterator on the stack that
 ///   needs to be popped on break (true for `for` loops, false for `while` loops)
 struct LoopInfo {
-    /// Bytecode offset of loop start (for continue).
-    start: usize,
+    /// Bytecode position + stack depth at loop start (for continue).
+    /// `emit_jump_to` uses the depth to enforce the backward-jump merge invariant.
+    start: JumpTarget,
     /// Jump labels that need patching to loop end (for break).
+    /// Entries from breaks emitted in dead state are no-op labels — `patch_jump`
+    /// ignores them silently.
     break_jumps: Vec<JumpLabel>,
     /// Whether this loop has an iterator on the stack.
     /// True for `for` loops, false for `while` loops.
@@ -115,7 +118,8 @@ struct LoopInfo {
 /// before executing the break/continue. This struct tracks the jump and which
 /// loop it targets.
 struct BreakContinueThruFinally {
-    /// The jump instruction that needs to be patched.
+    /// The jump instruction that needs to be patched. A no-op label if the
+    /// break/continue was emitted from dead state; `patch_jump` ignores it.
     jump: JumpLabel,
     /// The loop depth (index in loop_stack) being targeted.
     target_loop_depth: usize,
@@ -148,8 +152,10 @@ pub struct CompileResult {
 impl<'a> Compiler<'a> {
     /// Creates a new compiler with access to the string interner.
     fn new(interns: &'a Interns, functions: Vec<Function>) -> Self {
+        let mut code = CodeBuilder::new();
+        code.new_code_region(0);
         Self {
-            code: CodeBuilder::new(),
+            code,
             interns,
             functions,
             loop_stack: Vec::new(),
@@ -188,14 +194,9 @@ impl<'a> Compiler<'a> {
         compiler.is_module_scope = true;
         compiler.compile_block(nodes)?;
 
-        // Module returns None if no explicit return. Skip the implicit
-        // return when the body already terminates (e.g. ends with raise) —
-        // the tracker is `Dead` and emitting more would just produce dead
-        // bytes.
-        if !compiler.code.is_dead() {
-            compiler.code.emit(Opcode::LoadNone);
-            compiler.code.emit(Opcode::ReturnValue);
-        }
+        // Module returns None if no explicit return
+        compiler.code.emit(Opcode::LoadNone);
+        compiler.code.emit(Opcode::ReturnValue);
 
         Ok(CompileResult {
             code: compiler.code.build(num_locals),
@@ -220,29 +221,18 @@ impl<'a> Compiler<'a> {
         let mut compiler = Compiler::new(interns, functions);
         compiler.compile_block(body)?;
 
-        // Implicit `return None` if the body doesn't already terminate.
-        if !compiler.code.is_dead() {
-            compiler.code.emit(Opcode::LoadNone);
-            compiler.code.emit(Opcode::ReturnValue);
-        }
+        // Implicit return None if no explicit return
+        compiler.code.emit(Opcode::LoadNone);
+        compiler.code.emit(Opcode::ReturnValue);
 
         Ok((compiler.code.build(num_locals), compiler.functions))
     }
 
     /// Compiles a block of statements.
-    /// Compiles a sequence of statements, stopping at the first one that
-    /// transitions the tracker to `Dead` (i.e. an unconditional terminator
-    /// such as `return`, `break`, `continue`, `raise`).
-    ///
-    /// Anything in `nodes` after a terminator is dead code — emitting it
-    /// would produce unreachable bytecode and force every emit helper to
-    /// special-case the dead state. Stopping here is the same dead-code
-    /// elimination CPython performs and removes the need for callers to
-    /// save/restore depth around terminating statements (see PR #268's
-    /// `Stack depth went negative` regression).
     fn compile_block(&mut self, nodes: &[PreparedNode]) -> Result<(), CompileError> {
         for node in nodes {
             if self.code.is_dead() {
+                // Don't bother compiling dead code
                 break;
             }
             self.compile_stmt(node)?;
@@ -1201,11 +1191,7 @@ impl<'a> Compiler<'a> {
             }
         }
 
-        // Jump past cleanup (result already on stack). After this Jump the
-        // tracker is `Dead`; the first cleanup `patch_jump` below will
-        // transition it back to `Live(base_depth + 2)` from the label
-        // (`JumpIfFalseOrPop` keeps the False result on the stack, so the
-        // jump-taken arrival depth is base_depth + 2).
+        // Jump past cleanup (result already on stack).
         let end_jump = self.code.emit_jump(Opcode::Jump);
 
         // Cleanup: remove the saved intermediate value, keep False result.
@@ -1213,11 +1199,9 @@ impl<'a> Compiler<'a> {
             self.code.patch_jump(jump);
         }
         self.code.emit(Opcode::Rot2); // [False, intermediate]
-        self.code.emit(Opcode::Pop); // [False] — tracker now base_depth + 1
+        self.code.emit(Opcode::Pop); // [False]
 
         self.code.patch_jump(end_jump);
-        // Final result is on stack at base_depth + 1.
-
         Ok(())
     }
 
@@ -1226,12 +1210,6 @@ impl<'a> Compiler<'a> {
     // ========================================================================
 
     /// Compiles an if/else statement.
-    ///
-    /// The bridge `Jump` past the else branch is only emitted when the body
-    /// falls through. If the body terminates (e.g. ends with `return`), the
-    /// bridge would be unreachable bytecode, so we skip it — and `patch_jump`
-    /// for `else_jump` re-establishes the live tracker for the orelse branch
-    /// from the label.
     fn compile_if(
         &mut self,
         test: &ExprLoc,
@@ -1241,28 +1219,23 @@ impl<'a> Compiler<'a> {
         self.compile_expr(test)?;
 
         if or_else.is_empty() {
+            // Simple if without else
             let end_jump = self.code.emit_jump(Opcode::JumpIfFalse);
             self.compile_block(body)?;
             self.code.patch_jump(end_jump);
         } else {
+            // If with else
             let else_jump = self.code.emit_jump(Opcode::JumpIfFalse);
             self.compile_block(body)?;
-            let end_jump = (!self.code.is_dead()).then(|| self.code.emit_jump(Opcode::Jump));
+            let end_jump = self.code.emit_jump(Opcode::Jump);
             self.code.patch_jump(else_jump);
             self.compile_block(or_else)?;
-            if let Some(end_jump) = end_jump {
-                self.code.patch_jump(end_jump);
-            }
+            self.code.patch_jump(end_jump);
         }
         Ok(())
     }
 
     /// Compiles a ternary conditional expression.
-    ///
-    /// After `emit_jump(Jump)` for `end_jump` the tracker is `Dead`, so the
-    /// body branch's push doesn't poison the orelse branch. The first
-    /// `patch_jump(else_jump)` re-establishes `Live` at the else-branch
-    /// entry depth from the label.
     fn compile_if_else_expr(&mut self, test: &ExprLoc, body: &ExprLoc, orelse: &ExprLoc) -> Result<(), CompileError> {
         self.compile_expr(test)?;
         let else_jump = self.code.emit_jump(Opcode::JumpIfFalse);
@@ -2126,7 +2099,7 @@ impl<'a> Compiler<'a> {
         self.code.emit(Opcode::GetIter);
 
         // Loop start
-        let loop_start = self.code.current_offset();
+        let loop_start = self.code.current_jump_target();
 
         // Push loop info for break/continue
         self.loop_stack.push(LoopInfo {
@@ -2144,12 +2117,9 @@ impl<'a> Compiler<'a> {
         // Compile body
         self.compile_block(body)?;
 
-        // Jump back to loop start, unless the body terminated (in which case
-        // a backward jump would be unreachable). `patch_jump(end_jump)`
-        // transitions Dead → Live(loop_exit_depth) from the `ForIter` label.
-        if !self.code.is_dead() {
-            self.code.emit_jump_to(Opcode::Jump, loop_start);
-        }
+        // Jump back to loop start
+        self.code.emit_jump_to(Opcode::Jump, loop_start);
+        // End of loop - ForIter jumps here when iterator is exhausted
         self.code.patch_jump(end_jump);
 
         // Pop loop info before compiling else block
@@ -2193,7 +2163,7 @@ impl<'a> Compiler<'a> {
         body: &[PreparedNode],
         or_else: &[PreparedNode],
     ) -> Result<(), CompileError> {
-        let loop_start = self.code.current_offset();
+        let loop_start = self.code.current_jump_target();
 
         self.loop_stack.push(LoopInfo {
             start: loop_start,
@@ -2205,10 +2175,7 @@ impl<'a> Compiler<'a> {
         let end_jump = self.code.emit_jump(Opcode::JumpIfFalse);
 
         self.compile_block(body)?;
-        // Skip the backward jump if body terminated — it would be unreachable.
-        if !self.code.is_dead() {
-            self.code.emit_jump_to(Opcode::Jump, loop_start);
-        }
+        self.code.emit_jump_to(Opcode::Jump, loop_start);
 
         self.code.patch_jump(end_jump);
         let loop_info = self.loop_stack.pop().expect("loop stack underflow");
@@ -2260,21 +2227,24 @@ impl<'a> Compiler<'a> {
             self.code.emit(Opcode::Pop);
         }
 
-        // Emit the Jump (auto-marks the tracker `Dead`, so subsequent
-        // statements in the enclosing block are skipped by `compile_block`).
-        // If breaking out of a try-finally, route through the finally path.
+        // Check if we need to go through any finally blocks
+        // We need to run finally if break crosses the try boundary, i.e., if
+        // we're breaking from a loop that existed before the try started.
         if let Some(finally_target) = self.finally_targets.last_mut()
             && target_loop_depth < finally_target.loop_depth_at_entry
         {
+            // Breaking from a loop that's outside (or at the start of) this try-finally,
+            // so finally must run before the break
             let jump = self.code.emit_jump(Opcode::Jump);
             finally_target.break_jumps.push(BreakContinueThruFinally {
                 jump,
                 target_loop_depth,
             });
-        } else {
-            let jump = self.code.emit_jump(Opcode::Jump);
-            self.loop_stack[target_loop_depth].break_jumps.push(jump);
+            return Ok(());
         }
+        // No finally to go through, jump directly to loop end
+        let jump = self.code.emit_jump(Opcode::Jump);
+        self.loop_stack[target_loop_depth].break_jumps.push(jump);
 
         Ok(())
     }
@@ -2299,21 +2269,23 @@ impl<'a> Compiler<'a> {
             self.code.emit(Opcode::Pop); // Pop the exception value
         }
 
-        // Emit the Jump (auto-marks the tracker `Dead`, so subsequent
-        // statements in the enclosing block are skipped by `compile_block`).
+        // Check if we need to go through any finally blocks
+        // We need to run finally if continue crosses the try boundary
         if let Some(finally_target) = self.finally_targets.last_mut()
             && target_loop_depth < finally_target.loop_depth_at_entry
         {
-            // Continue out of a try-finally — route through the finally path.
+            // Continuing a loop that's outside (or at the start of) this try-finally,
+            // so finally must run before the continue
             let jump = self.code.emit_jump(Opcode::Jump);
             finally_target.continue_jumps.push(BreakContinueThruFinally {
                 jump,
                 target_loop_depth,
             });
-        } else {
-            let loop_start = self.loop_stack[target_loop_depth].start;
-            self.code.emit_jump_to(Opcode::Jump, loop_start);
         }
+
+        // No finally to go through, jump directly to loop start
+        let loop_start = self.loop_stack[target_loop_depth].start;
+        self.code.emit_jump_to(Opcode::Jump, loop_start);
 
         Ok(())
     }
@@ -2328,11 +2300,6 @@ impl<'a> Compiler<'a> {
     /// have the same starting point. After finally runs, we need to route each
     /// to its target loop, potentially through more finally blocks.
     fn compile_control_flow_after_finally(&mut self, items: &[BreakContinueThruFinally], is_break: bool) {
-        // If the finally body terminated, the post-finally control-flow
-        // dispatch is unreachable — skip the emission entirely.
-        if self.code.is_dead() {
-            return;
-        }
         // All items went through the same finally, now we need to dispatch to
         // potentially different loops. For simplicity, we assume all items in
         // a single finally target the same loop (the innermost one at the time).
@@ -2471,7 +2438,7 @@ impl<'a> Compiler<'a> {
         self.code.emit(Opcode::GetIter);
 
         // Loop start
-        let loop_start = self.code.current_offset();
+        let loop_start = self.code.current_jump_target();
 
         // FOR_ITER: advance iterator or jump to end
         let end_jump = self.code.emit_jump(Opcode::ForIter);
@@ -2495,9 +2462,7 @@ impl<'a> Compiler<'a> {
             body_fn(self)?;
         }
 
-        // Jump back to loop start. The tracker becomes `Dead`; the
-        // `patch_jump(end_jump)` below transitions to
-        // `Live(loop_exit_depth)` via the ForIter label.
+        // Jump back to loop start
         self.code.emit_jump_to(Opcode::Jump, loop_start);
         self.code.patch_jump(end_jump);
 
@@ -2790,12 +2755,6 @@ impl<'a> Compiler<'a> {
     /// and we jump to a "finally with return" section that runs finally then returns.
     /// Otherwise, we emit a direct `ReturnValue`.
     fn compile_return(&mut self) {
-        // Callers like the try-finally return-path emit `compile_return`
-        // after a finally block that may itself have terminated; skip
-        // emission in that case.
-        if self.code.is_dead() {
-            return;
-        }
         if let Some(finally_target) = self.finally_targets.last_mut() {
             // Inside a try-finally: jump to finally, then return
             // Return value is already on stack
@@ -2862,10 +2821,8 @@ impl<'a> Compiler<'a> {
         let try_start = self.code.current_offset();
         self.compile_block(&try_block.body)?;
 
-        // Jump to else/finally if no exception (skip handlers). If the body
-        // terminated (e.g. ends with `return`), there's no fall-through to
-        // skip — emitting the Jump would just produce dead bytes.
-        let after_try_jump = (!self.code.is_dead()).then(|| self.code.emit_jump(Opcode::Jump));
+        // Jump to else/finally if no exception (skip handlers)
+        let after_try_jump = self.code.emit_jump(Opcode::Jump);
         // End of the try-body region for the exception table. This is past
         // the `after_try_jump` if it was emitted, so an exception that fires
         // up to and including that Jump still routes to the handler.
@@ -2874,21 +2831,10 @@ impl<'a> Compiler<'a> {
         // === Handler dispatch starts here ===
         let handler_start = self.code.current_offset();
 
-        // The handler is reached via the exception table (not via fall-through
-        // from the try body's after_try_jump, which is unconditional and
-        // marked the tracker Dead). The VM pushes the exception onto the
-        // stack before jumping here, so set the tracker to Live(stack_depth + 1).
-        self.code.set_stack_depth(stack_depth + 1);
-
         // Track jumps that go to finally (for patching later)
         let mut finally_jumps: Vec<JumpLabel> = Vec::new();
 
-        if has_handlers {
-            self.compile_exception_handlers(&try_block.handlers, &mut finally_jumps)?;
-        } else {
-            // No handlers - just reraise (this only happens with try-finally)
-            self.code.emit(Opcode::Reraise);
-        }
+        self.compile_exception_handlers(stack_depth, &try_block.handlers, &mut finally_jumps)?;
 
         // After handler dispatch, each handler path either:
         // 1. Matched and popped the exception (via Pop), then jumped to finally
@@ -2905,7 +2851,7 @@ impl<'a> Compiler<'a> {
         let finally_cleanup_start = if has_finally {
             let cleanup_start = self.code.current_offset();
             // Exception value is on stack (pushed by VM), so stack = stack_depth + 1
-            self.code.set_stack_depth(stack_depth + 1);
+            self.code.new_code_region(stack_depth + 1);
             // We need to pop it, run finally, then reraise
             // But we can't easily save the exception, so we use a different approach:
             // The exception is already on the exception_stack from handle_exception,
@@ -2924,10 +2870,6 @@ impl<'a> Compiler<'a> {
             let finally_target = self.finally_targets.pop().expect("finally_targets should not be empty");
 
             // === Finally with return path ===
-            // Each return jump arrives with the return value on stack
-            // (depth = stack_depth + 1). The first `patch_jump` transitions
-            // the tracker from `Dead` (left by the prior section's
-            // terminator) to `Live(stack_depth + 1)` via the label.
             let return_start = if finally_target.return_jumps.is_empty() {
                 None
             } else {
@@ -2944,10 +2886,6 @@ impl<'a> Compiler<'a> {
             // For each break, run finally then either:
             // - Jump to outer finally's break path (if there's an outer finally between us and the loop)
             // - Jump directly to the loop's break target
-            //
-            // Break already popped the iterator (depth at jump-emit was
-            // stack_depth - 1); `patch_jump` transitions Dead → Live(that)
-            // from the label.
             if !finally_target.break_jumps.is_empty() {
                 for break_info in &finally_target.break_jumps {
                     self.code.patch_jump(break_info.jump);
@@ -2958,8 +2896,6 @@ impl<'a> Compiler<'a> {
             }
 
             // === Finally with continue path ===
-            // Continue doesn't pop the iterator; depth at jump-emit was
-            // stack_depth, restored by `patch_jump`.
             if !finally_target.continue_jumps.is_empty() {
                 for continue_info in &finally_target.continue_jumps {
                     self.code.patch_jump(continue_info.jump);
@@ -2975,14 +2911,7 @@ impl<'a> Compiler<'a> {
         };
 
         // === Else block (runs if no exception) ===
-        // `after_try_jump` was only emitted when the body falls through. If
-        // it exists, patching it transitions Dead → Live(stack_depth) for
-        // the else branch; if not, the else block is unreachable and
-        // `compile_block` will skip it (the tracker is still Dead from the
-        // handler section's terminator).
-        if let Some(after_try_jump) = after_try_jump {
-            self.code.patch_jump(after_try_jump);
-        }
+        self.code.patch_jump(after_try_jump);
         let else_start = self.code.current_offset();
         if has_else {
             self.compile_block(&try_block.or_else)?;
@@ -2990,12 +2919,7 @@ impl<'a> Compiler<'a> {
         let else_end = self.code.current_offset();
 
         // === Normal finally path (no exception pending, no return) ===
-        // Patch all jumps from handlers to go here. Each handler popped the
-        // exception before its Jump, so the labels carry
-        // `target_depth = stack_depth`. The first live-sourced patch
-        // transitions Dead → Live(stack_depth); the else-block's
-        // fall-through (when reachable) already left the tracker there, so
-        // either way the merge invariant holds.
+        // Patch all jumps from handlers to go here
         for jump in finally_jumps {
             self.code.patch_jump(jump);
         }
@@ -3007,26 +2931,19 @@ impl<'a> Compiler<'a> {
         // === Add exception table entries ===
         // Order matters: entries are searched in order, so inner entries must come first.
 
-        // Entry 1: Try body -> handler dispatch.
-        // `try_end` already includes the `after_try_jump` Jump instruction
-        // when one was emitted, so the exception range covers the body and
-        // (if reachable) the bridge Jump.
+        // Entry 1: Try body -> handler dispatch
         if has_handlers || has_finally {
-            self.code.add_exception_entry(ExceptionEntry::new(
-                u32::try_from(try_start).expect("bytecode offset exceeds u32"),
-                u32::try_from(try_end).expect("bytecode offset exceeds u32"),
-                u32::try_from(handler_start).expect("bytecode offset exceeds u32"),
-                stack_depth,
-            ));
+            self.code
+                .add_exception_entry(ExceptionEntry::new(try_start, try_end, handler_start, stack_depth));
         }
 
         // Entry 2: Handler dispatch -> finally cleanup (only if has_finally)
         // This ensures finally runs when RERAISE is executed or any exception occurs in handlers
         if let Some(cleanup_start) = finally_cleanup_start {
             self.code.add_exception_entry(ExceptionEntry::new(
-                u32::try_from(handler_start).expect("bytecode offset exceeds u32"),
-                u32::try_from(handler_dispatch_end).expect("bytecode offset exceeds u32"),
-                u32::try_from(cleanup_start).expect("bytecode offset exceeds u32"),
+                handler_start,
+                handler_dispatch_end,
+                cleanup_start,
                 stack_depth,
             ));
         }
@@ -3034,10 +2951,11 @@ impl<'a> Compiler<'a> {
         // Entry 3: Finally with return -> finally cleanup
         // If an exception occurs while running finally (in the return path), catch it
         if let (Some(return_start), Some(cleanup_start)) = (finally_with_return_start, finally_cleanup_start) {
+            // End at else_start (before else block).
             self.code.add_exception_entry(ExceptionEntry::new(
-                u32::try_from(return_start).expect("bytecode offset exceeds u32"),
-                u32::try_from(else_start).expect("bytecode offset exceeds u32"), // End at else_start (before else block)
-                u32::try_from(cleanup_start).expect("bytecode offset exceeds u32"),
+                return_start,
+                else_start,
+                cleanup_start,
                 stack_depth,
             ));
         }
@@ -3045,12 +2963,8 @@ impl<'a> Compiler<'a> {
         // Entry 4: Else block -> finally cleanup (only if has_finally and has_else)
         // Exceptions in else block should go through finally
         if has_else && let Some(cleanup_start) = finally_cleanup_start {
-            self.code.add_exception_entry(ExceptionEntry::new(
-                u32::try_from(else_start).expect("bytecode offset exceeds u32"),
-                u32::try_from(else_end).expect("bytecode offset exceeds u32"),
-                u32::try_from(cleanup_start).expect("bytecode offset exceeds u32"),
-                stack_depth,
-            ));
+            self.code
+                .add_exception_entry(ExceptionEntry::new(else_start, else_end, cleanup_start, stack_depth));
         }
 
         Ok(())
@@ -3061,26 +2975,30 @@ impl<'a> Compiler<'a> {
     /// Each handler checks if the exception matches its type, and if so,
     /// executes the handler body. If no handler matches, the exception is re-raised.
     ///
-    /// The caller is responsible for calling `set_stack_depth(stack_depth + 1)`
-    /// before invoking this — the entry point is reached via the exception
-    /// table, not fall-through, so the tracker needs an explicit Live state
-    /// reflecting the exception value the VM has pushed.
+    /// The caller is responsible for calling this from a dead-code region; otherwise
+    /// the attempt to create a new code region will panic.
+    ///
+    /// The region is closed at the end of this function, so the caller will need
+    /// to start a new code region for any code that follows the handlers.
     fn compile_exception_handlers(
         &mut self,
+        stack_depth: u16,
         handlers: &[ExceptHandler<PreparedNode>],
         finally_jumps: &mut Vec<JumpLabel>,
     ) -> Result<(), CompileError> {
+        // Start a new code region for the exception handlers, +1 for
+        // the exception value pushed by the VM on entry to the handler dispatch
+        self.code.new_code_region(stack_depth + 1);
+
         // Track jumps from non-matching handlers to next handler
         let mut next_handler_jumps: Vec<JumpLabel> = Vec::new();
 
         for (i, handler) in handlers.iter().enumerate() {
             let is_last = i == handlers.len() - 1;
 
-            // Patch jumps from previous handler's non-match to here.
-            // The previous handler ended with `emit_jump(Jump)` to finally,
-            // marking the tracker `Dead`. The jump-taken arrival here
-            // (from JumpIfFalse no-match) leaves [exc, exc] on stack;
-            // `patch_jump` transitions Dead → Live(that depth) from the label.
+            // Patch jumps from previous handler's non-match to here
+            // If jumping from a previous handler's no-match, stack has [exc, exc] (duplicate)
+            // We need to pop the duplicate before starting this handler's check
             if !next_handler_jumps.is_empty() {
                 for jump in next_handler_jumps.drain(..) {
                     self.code.patch_jump(jump);
@@ -3140,30 +3058,19 @@ impl<'a> Compiler<'a> {
                 // Exit except handler context
                 self.except_handler_depth -= 1;
 
-                // If the handler body terminated (e.g. ends with `return`),
-                // the cleanup trailer below is unreachable — skip it.
-                if !self.code.is_dead() {
-                    // Delete exception variable (Python 3 behavior)
-                    if let Some(name) = &handler.name {
-                        self.compile_delete(name);
-                    }
-                    // Clear current_exception, pop the exception from stack,
-                    // and jump to the finally / merge point.
-                    self.code.emit(Opcode::ClearException);
-                    self.code.emit(Opcode::Pop);
-                    finally_jumps.push(self.code.emit_jump(Opcode::Jump));
+                // Delete exception variable (Python 3 behavior)
+                if let Some(name) = &handler.name {
+                    self.compile_delete(name);
                 }
+                self.code.emit(Opcode::ClearException);
+                self.code.emit(Opcode::Pop);
+                finally_jumps.push(self.code.emit_jump(Opcode::Jump));
 
-                // If this was the last handler and no match, we need to
-                // reraise. The patch target is reached only via JumpIfFalse's
-                // no-match path (stack [exception, exception]); fall-through
-                // is dead because of the `emit_jump(Jump)` to finally above.
-                // `patch_jump` transitions Dead → Live from the label.
+                // If this was last handler and no match, we need to reraise
                 if is_last {
                     self.code.patch_jump(no_match_jump);
                     // We need to pop the duplicate before reraising
                     self.code.emit(Opcode::Pop);
-                    self.code.emit(Opcode::Reraise);
                 }
             } else {
                 // Bare except: catches everything
@@ -3184,17 +3091,25 @@ impl<'a> Compiler<'a> {
                 // Exit except handler context
                 self.except_handler_depth -= 1;
 
-                // Skip the cleanup trailer if the handler body terminated.
-                if !self.code.is_dead() {
-                    if let Some(name) = &handler.name {
-                        self.compile_delete(name);
-                    }
-                    self.code.emit(Opcode::ClearException);
-                    self.code.emit(Opcode::Pop);
-                    finally_jumps.push(self.code.emit_jump(Opcode::Jump));
+                // Delete exception variable
+                if let Some(name) = &handler.name {
+                    self.compile_delete(name);
                 }
+
+                // Clear current_exception
+                self.code.emit(Opcode::ClearException);
+
+                // Pop the exception from stack
+                self.code.emit(Opcode::Pop);
+
+                // Jump to finally
+                finally_jumps.push(self.code.emit_jump(Opcode::Jump));
+                return Ok(());
             }
         }
+
+        // No handler matched - reraise the exception
+        self.code.emit(Opcode::Reraise);
 
         Ok(())
     }

--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -243,12 +243,24 @@ impl<'a> Compiler<'a> {
                 self.code.emit(Opcode::Pop); // Discard result
             }
             Node::Return(expr) => {
+                // `return` is terminating: any subsequent statement in the same
+                // block compiles as dead code. Capture the statement-entry depth
+                // and restore it after `compile_return` so the tracker reflects
+                // what fall-through (if it were live) would arrive at, rather
+                // than carrying the return value's residue. Inside a
+                // try-finally, `compile_return` emits a Jump leaving the value
+                // on the stack — without this restore, the inflated tracker
+                // poisons later jumps' merge invariants.
+                let dead_code_depth = self.code.stack_depth();
                 self.compile_expr(expr)?;
                 self.compile_return();
+                self.code.set_stack_depth(dead_code_depth);
             }
             Node::ReturnNone => {
+                let dead_code_depth = self.code.stack_depth();
                 self.code.emit(Opcode::LoadNone);
                 self.compile_return();
+                self.code.set_stack_depth(dead_code_depth);
             }
             Node::Assign { target, object } => {
                 self.compile_expr(object)?;
@@ -1187,19 +1199,22 @@ impl<'a> Compiler<'a> {
         // Jump past cleanup (result already on stack)
         let end_jump = self.code.emit_jump(Opcode::Jump);
 
-        // Cleanup: remove the saved intermediate value, keep False result
+        // Cleanup: remove the saved intermediate value, keep False result.
         // The cleanup is only reached via JumpIfFalseOrPop which doesn't pop,
-        // so the stack has: [intermediate, False] (2 extra items from base)
+        // so the stack has: [intermediate, False] (2 extra items from base).
+        // Reset the tracker BEFORE the patch so `patch_jump`'s merge-invariant
+        // assertion sees the live (jump-taken) depth — fall-through here is
+        // dead because of the unconditional Jump just emitted.
+        self.code.set_stack_depth(base_depth + 2); // [intermediate, False]
         for jump in cleanup_jumps {
             self.code.patch_jump(jump);
         }
-        self.code.set_stack_depth(base_depth + 2); // [intermediate, False]
         self.code.emit(Opcode::Rot2); // [False, intermediate]
-        self.code.emit(Opcode::Pop); // [False]
+        self.code.emit(Opcode::Pop); // [False] — tracker now base_depth + 1
 
         self.code.patch_jump(end_jump);
-        // Final result is on stack: base_depth + 1
-        self.code.set_stack_depth(base_depth + 1);
+        // Final result is on stack: base_depth + 1 (verified by patch_jump
+        // assertion above; no manual reset needed).
 
         Ok(())
     }
@@ -1235,11 +1250,22 @@ impl<'a> Compiler<'a> {
     }
 
     /// Compiles a ternary conditional expression.
+    ///
+    /// Both branches push exactly one value, but the compiler's stack-depth
+    /// tracker would naively double-count those pushes (it sees the body
+    /// branch push, then the orelse branch push, as if both ran). Reset the
+    /// tracker between branches so the merge invariant holds at each
+    /// `patch_jump`.
     fn compile_if_else_expr(&mut self, test: &ExprLoc, body: &ExprLoc, orelse: &ExprLoc) -> Result<(), CompileError> {
         self.compile_expr(test)?;
         let else_jump = self.code.emit_jump(Opcode::JumpIfFalse);
+        // Depth at the start of either branch (cond was popped by JumpIfFalse).
+        let branch_entry_depth = self.code.stack_depth();
         self.compile_expr(body)?;
         let end_jump = self.code.emit_jump(Opcode::Jump);
+        // Body's push is dead beyond `end_jump`; reset to branch-entry depth
+        // for the orelse branch (and to satisfy `patch_jump`'s assertion).
+        self.code.set_stack_depth(branch_entry_depth);
         self.code.patch_jump(else_jump);
         self.compile_expr(orelse)?;
         self.code.patch_jump(end_jump);
@@ -2123,10 +2149,12 @@ impl<'a> Compiler<'a> {
         // Jump back to loop start
         self.code.emit_jump_to(Opcode::Jump, loop_start);
 
-        // End of loop - ForIter jumps here when iterator is exhausted
-        self.code.patch_jump(end_jump);
-        // Iterator is popped when loop ends normally, so restore depth to before loop
+        // End of loop. Fall-through is dead (Jump above is unconditional);
+        // the patch target is reached only via ForIter's exhausted path,
+        // which pops the iterator — so the live depth is `loop_exit_depth`.
+        // Reset before patching so the merge invariant holds.
         self.code.set_stack_depth(loop_exit_depth);
+        self.code.patch_jump(end_jump);
 
         // Pop loop info before compiling else block
         let loop_info = self.loop_stack.pop().expect("loop stack underflow");
@@ -2490,10 +2518,12 @@ impl<'a> Compiler<'a> {
         // Jump back to loop start
         self.code.emit_jump_to(Opcode::Jump, loop_start);
 
-        // End of loop
-        self.code.patch_jump(end_jump);
-        // Iterator is popped when loop ends normally, so restore depth to before loop
+        // End of loop. Fall-through is dead (Jump above); only ForIter's
+        // exhausted path reaches the patch target, with the iterator already
+        // popped — depth is `loop_exit_depth`. Reset before patching to
+        // uphold the merge invariant.
         self.code.set_stack_depth(loop_exit_depth);
+        self.code.patch_jump(end_jump);
 
         Ok(())
     }
@@ -2908,15 +2938,17 @@ impl<'a> Compiler<'a> {
             let finally_target = self.finally_targets.pop().expect("finally_targets should not be empty");
 
             // === Finally with return path ===
+            // Each return jump arrives with the return value on stack, so
+            // depth = stack_depth + 1. Reset BEFORE patching so the merge
+            // invariant holds.
             let return_start = if finally_target.return_jumps.is_empty() {
                 None
             } else {
                 let start = self.code.current_offset();
+                self.code.set_stack_depth(stack_depth + 1);
                 for jump in finally_target.return_jumps {
                     self.code.patch_jump(jump);
                 }
-                // Return value is on stack, stack = stack_depth + 1
-                self.code.set_stack_depth(stack_depth + 1);
                 self.compile_block(&try_block.finally)?;
                 self.compile_return();
                 Some(start)
@@ -2926,25 +2958,28 @@ impl<'a> Compiler<'a> {
             // For each break, run finally then either:
             // - Jump to outer finally's break path (if there's an outer finally between us and the loop)
             // - Jump directly to the loop's break target
+            //
+            // Break already popped the iterator, so stack = stack_depth - 1
+            // (the iterator was on stack at try entry, break removed it).
+            // Reset BEFORE patching to uphold the merge invariant.
             if !finally_target.break_jumps.is_empty() {
+                self.code.set_stack_depth(stack_depth.saturating_sub(1));
                 for break_info in &finally_target.break_jumps {
                     self.code.patch_jump(break_info.jump);
                 }
-                // Break already popped the iterator, so stack = stack_depth - 1
-                // (the iterator was on stack at try entry, break removed it)
-                self.code.set_stack_depth(stack_depth.saturating_sub(1));
                 self.compile_block(&try_block.finally)?;
                 // After finally, compile the break again (handles nested finally or direct jump)
                 self.compile_control_flow_after_finally(&finally_target.break_jumps, true);
             }
 
             // === Finally with continue path ===
+            // Continue doesn't pop the iterator, stack = stack_depth. Reset
+            // BEFORE patching to uphold the merge invariant.
             if !finally_target.continue_jumps.is_empty() {
+                self.code.set_stack_depth(stack_depth);
                 for continue_info in &finally_target.continue_jumps {
                     self.code.patch_jump(continue_info.jump);
                 }
-                // Continue doesn't pop the iterator, stack = stack_depth
-                self.code.set_stack_depth(stack_depth);
                 self.compile_block(&try_block.finally)?;
                 // After finally, compile the continue again (handles nested finally or direct jump)
                 self.compile_control_flow_after_finally(&finally_target.continue_jumps, false);
@@ -2956,9 +2991,11 @@ impl<'a> Compiler<'a> {
         };
 
         // === Else block (runs if no exception) ===
-        self.code.patch_jump(after_try_jump);
-        // Normal path from try body, stack = stack_depth
+        // The after_try_jump is taken from the end of the try body when no
+        // exception was raised, so stack = stack_depth at the patch target.
+        // Reset BEFORE patching to uphold the merge invariant.
         self.code.set_stack_depth(stack_depth);
+        self.code.patch_jump(after_try_jump);
         let else_start = self.code.current_offset();
         if has_else {
             self.compile_block(&try_block.or_else)?;
@@ -2966,14 +3003,18 @@ impl<'a> Compiler<'a> {
         let else_end = self.code.current_offset();
 
         // === Normal finally path (no exception pending, no return) ===
-        // Patch all jumps from handlers to go here
+        // Patch all jumps from handlers to go here. Each handler popped the
+        // exception before its Jump, so depth = stack_depth at the patch
+        // target. Reset BEFORE patching to uphold the merge invariant.
+        // (Note: tracker may already equal stack_depth via fall-through from
+        // the else block, but resetting is a no-op in that case and makes
+        // the invariant hold whether there is an else block or not.)
+        self.code.set_stack_depth(stack_depth);
         for jump in finally_jumps {
             self.code.patch_jump(jump);
         }
 
         if has_finally {
-            // Stack = stack_depth (no exception, no return value)
-            self.code.set_stack_depth(stack_depth);
             self.compile_block(&try_block.finally)?;
         }
 
@@ -3045,15 +3086,16 @@ impl<'a> Compiler<'a> {
         for (i, handler) in handlers.iter().enumerate() {
             let is_last = i == handlers.len() - 1;
 
-            // Patch jumps from previous handler's non-match to here
-            // If jumping from a previous handler's no-match, stack has [exc, exc] (duplicate)
-            // We need to pop the duplicate before starting this handler's check
+            // Patch jumps from previous handler's non-match to here.
+            // If jumping from a previous handler's no-match, stack has
+            // [exc, exc] (duplicate kept by the JumpIfFalse no-match path) =
+            // handler_entry_depth + 1. Reset the tracker BEFORE patching so
+            // `patch_jump`'s merge invariant sees the live (jump-taken) depth.
             if !next_handler_jumps.is_empty() {
+                self.code.set_stack_depth(handler_entry_depth + 1);
                 for jump in next_handler_jumps.drain(..) {
                     self.code.patch_jump(jump);
                 }
-                // Reset stack depth for jump target: [exc, exc] = handler_entry_depth + 1
-                self.code.set_stack_depth(handler_entry_depth + 1);
                 // Pop the duplicate from previous handler's check
                 self.code.emit(Opcode::Pop);
             }
@@ -3123,12 +3165,14 @@ impl<'a> Compiler<'a> {
                 // Jump to finally
                 finally_jumps.push(self.code.emit_jump(Opcode::Jump));
 
-                // If this was last handler and no match, we need to reraise
+                // If this was last handler and no match, we need to reraise.
+                // The patch target is reached only via JumpIfFalse's no-match
+                // path — stack [exception, exception] = handler_entry_depth + 1.
+                // Fall-through is dead (we just emitted an unconditional Jump
+                // to finally above), so reset the tracker BEFORE patching.
                 if is_last {
-                    self.code.patch_jump(no_match_jump);
-                    // Coming from JumpIfFalse no-match path, stack has [exception, exception]
-                    // Reset stack depth for jump target
                     self.code.set_stack_depth(handler_entry_depth + 1);
+                    self.code.patch_jump(no_match_jump);
                     // We need to pop the duplicate before reraising
                     self.code.emit(Opcode::Pop);
                     self.code.emit(Opcode::Reraise);

--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -77,8 +77,11 @@ pub struct Compiler<'a> {
     /// Tracks nesting depth inside exception handlers.
     ///
     /// When break/continue/return is inside an except handler, we need to
-    /// clear the current exception (`ClearException`) and pop the exception
-    /// value from the stack before jumping to the finally path or loop target.
+    /// emit one `ClearException` per enclosing handler to drain the per-handler
+    /// `exception_stack` entries before jumping to the finally path or loop
+    /// target. The exception *value* is already off the operand stack — it's
+    /// consumed eagerly at handler entry (stored to the `as` binding or
+    /// popped) — so no operand-stack Pop is needed here.
     except_handler_depth: usize,
 
     /// Whether the compiler is currently compiling module-level code.
@@ -2213,12 +2216,10 @@ impl<'a> Compiler<'a> {
 
         let target_loop_depth = self.loop_stack.len() - 1;
 
-        // If inside except handlers, clean up ALL exception states
-        // Each nested except handler has pushed an exception onto the stack,
-        // so we need to clear/pop each one when breaking out
+        // If inside except handlers, clear each enclosing exception_stack
+        // entry.
         for _ in 0..self.except_handler_depth {
             self.code.emit(Opcode::ClearException);
-            self.code.emit(Opcode::Pop); // Pop the exception value
         }
 
         // Pop the iterator only for `for` loops (has iterator on stack)
@@ -2261,12 +2262,10 @@ impl<'a> Compiler<'a> {
 
         let target_loop_depth = self.loop_stack.len() - 1;
 
-        // If inside except handlers, clean up ALL exception states
-        // Each nested except handler has pushed an exception onto the stack,
-        // so we need to clear/pop each one when continuing
+        // If inside except handlers, clear each enclosing exception_stack
+        // entry.
         for _ in 0..self.except_handler_depth {
             self.code.emit(Opcode::ClearException);
-            self.code.emit(Opcode::Pop); // Pop the exception value
         }
 
         // Check if we need to go through any finally blocks
@@ -2990,121 +2989,43 @@ impl<'a> Compiler<'a> {
         // the exception value pushed by the VM on entry to the handler dispatch
         self.code.new_code_region(stack_depth + 1);
 
-        // Track jumps from non-matching handlers to next handler
-        let mut next_handler_jumps: Vec<JumpLabel> = Vec::new();
+        for handler in handlers {
+            let no_match_jump = if let Some(exc_type) = &handler.exc_type {
+                // Typed handler: `except ExcType:` or `except ExcType as e:`.
+                // Stack on entry: [exception]. `CheckExcMatch` peeks the
+                // exception (doesn't pop it), so [exception] stays on the
+                // stack across the check on both match and no-match paths.
+                self.compile_expr(exc_type)?;
+                self.code.emit(Opcode::CheckExcMatch);
+                Some(self.code.emit_jump(Opcode::JumpIfFalse))
+            } else {
+                // Bare `except:` (must be the last handler per Python rules).
+                None
+            };
 
-        for (i, handler) in handlers.iter().enumerate() {
-            let is_last = i == handlers.len() - 1;
-
-            // Patch jumps from previous handler's non-match to here
-            // If jumping from a previous handler's no-match, stack has [exc, exc] (duplicate)
-            // We need to pop the duplicate before starting this handler's check
-            if !next_handler_jumps.is_empty() {
-                for jump in next_handler_jumps.drain(..) {
-                    self.code.patch_jump(jump);
-                }
-                // Pop the duplicate from previous handler's check
+            // Match path: consume exception from the stack and store
+            // to target if present.
+            if let Some(name) = &handler.name {
+                self.compile_store(name);
+            } else {
                 self.code.emit(Opcode::Pop);
             }
 
-            if let Some(exc_type) = &handler.exc_type {
-                // Typed handler: except ExcType: or except ExcType as e:
-                // Stack: [exception]
+            self.except_handler_depth += 1;
+            self.compile_block(&handler.body)?;
+            self.except_handler_depth -= 1;
 
-                // Duplicate exception for type check
-                self.code.emit(Opcode::Dup);
-                // Stack: [exception, exception]
+            if let Some(name) = &handler.name {
+                self.compile_delete(name);
+            }
 
-                // Load the exception type to match against
-                self.compile_expr(exc_type)?;
-                // Stack: [exception, exception, exc_type]
+            self.code.emit(Opcode::ClearException);
+            finally_jumps.push(self.code.emit_jump(Opcode::Jump));
 
-                // Check if exception matches the type
-                // This validates exc_type is a valid exception type and performs the match
-                // CheckExcMatch pops exc_type, peeks exception, pushes bool
-                self.code.emit(Opcode::CheckExcMatch);
-                // Stack: [exception, exception, bool]
-
-                // Jump to next handler if match returned False
-                // JumpIfFalse pops the bool, leaving [exception, exception]
-                let no_match_jump = self.code.emit_jump(Opcode::JumpIfFalse);
-
-                if is_last {
-                    // Last handler - if no match, reraise
-                    // But first we need to handle the exception var cleanup
-                } else {
-                    next_handler_jumps.push(no_match_jump);
-                }
-
-                // After JumpIfFalse (match succeeded), stack is [exception, exception]
-                // Pop the duplicate that was used for the type check
-                self.code.emit(Opcode::Pop);
-                // Stack: [exception]
-
-                // Exception matched! Bind to variable if needed
-                if let Some(name) = &handler.name {
-                    // Stack: [exception]
-                    // Store to variable (don't pop - we still need it for current_exception)
-                    self.code.emit(Opcode::Dup);
-                    self.compile_store(name);
-                }
-
-                // Track that we're inside an except handler (for break/continue cleanup)
-                self.except_handler_depth += 1;
-
-                // Compile handler body
-                self.compile_block(&handler.body)?;
-
-                // Exit except handler context
-                self.except_handler_depth -= 1;
-
-                // Delete exception variable (Python 3 behavior)
-                if let Some(name) = &handler.name {
-                    self.compile_delete(name);
-                }
-                self.code.emit(Opcode::ClearException);
-                self.code.emit(Opcode::Pop);
-                finally_jumps.push(self.code.emit_jump(Opcode::Jump));
-
-                // If this was last handler and no match, we need to reraise
-                if is_last {
-                    self.code.patch_jump(no_match_jump);
-                    // We need to pop the duplicate before reraising
-                    self.code.emit(Opcode::Pop);
-                }
-            } else {
-                // Bare except: catches everything
-                // Stack: [exception]
-
-                // Bind to variable if needed
-                if let Some(name) = &handler.name {
-                    self.code.emit(Opcode::Dup);
-                    self.compile_store(name);
-                }
-
-                // Track that we're inside an except handler (for break/continue cleanup)
-                self.except_handler_depth += 1;
-
-                // Compile handler body
-                self.compile_block(&handler.body)?;
-
-                // Exit except handler context
-                self.except_handler_depth -= 1;
-
-                // Delete exception variable
-                if let Some(name) = &handler.name {
-                    self.compile_delete(name);
-                }
-
-                // Clear current_exception
-                self.code.emit(Opcode::ClearException);
-
-                // Pop the exception from stack
-                self.code.emit(Opcode::Pop);
-
-                // Jump to finally
-                finally_jumps.push(self.code.emit_jump(Opcode::Jump));
-                return Ok(());
+            if let Some(no_match_jump) = no_match_jump {
+                // No-match landing: stack is [exception]. Falls through into
+                // the next handler's check (or the post-loop `Reraise`).
+                self.code.patch_jump(no_match_jump);
             }
         }
 

--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -188,9 +188,14 @@ impl<'a> Compiler<'a> {
         compiler.is_module_scope = true;
         compiler.compile_block(nodes)?;
 
-        // Module returns None if no explicit return
-        compiler.code.emit(Opcode::LoadNone);
-        compiler.code.emit(Opcode::ReturnValue);
+        // Module returns None if no explicit return. Skip the implicit
+        // return when the body already terminates (e.g. ends with raise) —
+        // the tracker is `Dead` and emitting more would just produce dead
+        // bytes.
+        if !compiler.code.is_dead() {
+            compiler.code.emit(Opcode::LoadNone);
+            compiler.code.emit(Opcode::ReturnValue);
+        }
 
         Ok(CompileResult {
             code: compiler.code.build(num_locals),
@@ -215,16 +220,31 @@ impl<'a> Compiler<'a> {
         let mut compiler = Compiler::new(interns, functions);
         compiler.compile_block(body)?;
 
-        // Implicit return None if no explicit return
-        compiler.code.emit(Opcode::LoadNone);
-        compiler.code.emit(Opcode::ReturnValue);
+        // Implicit `return None` if the body doesn't already terminate.
+        if !compiler.code.is_dead() {
+            compiler.code.emit(Opcode::LoadNone);
+            compiler.code.emit(Opcode::ReturnValue);
+        }
 
         Ok((compiler.code.build(num_locals), compiler.functions))
     }
 
     /// Compiles a block of statements.
+    /// Compiles a sequence of statements, stopping at the first one that
+    /// transitions the tracker to `Dead` (i.e. an unconditional terminator
+    /// such as `return`, `break`, `continue`, `raise`).
+    ///
+    /// Anything in `nodes` after a terminator is dead code — emitting it
+    /// would produce unreachable bytecode and force every emit helper to
+    /// special-case the dead state. Stopping here is the same dead-code
+    /// elimination CPython performs and removes the need for callers to
+    /// save/restore depth around terminating statements (see PR #268's
+    /// `Stack depth went negative` regression).
     fn compile_block(&mut self, nodes: &[PreparedNode]) -> Result<(), CompileError> {
         for node in nodes {
+            if self.code.is_dead() {
+                break;
+            }
             self.compile_stmt(node)?;
         }
         Ok(())
@@ -243,24 +263,12 @@ impl<'a> Compiler<'a> {
                 self.code.emit(Opcode::Pop); // Discard result
             }
             Node::Return(expr) => {
-                // `return` is terminating: any subsequent statement in the same
-                // block compiles as dead code. Capture the statement-entry depth
-                // and restore it after `compile_return` so the tracker reflects
-                // what fall-through (if it were live) would arrive at, rather
-                // than carrying the return value's residue. Inside a
-                // try-finally, `compile_return` emits a Jump leaving the value
-                // on the stack — without this restore, the inflated tracker
-                // poisons later jumps' merge invariants.
-                let dead_code_depth = self.code.stack_depth();
                 self.compile_expr(expr)?;
                 self.compile_return();
-                self.code.set_stack_depth(dead_code_depth);
             }
             Node::ReturnNone => {
-                let dead_code_depth = self.code.stack_depth();
                 self.code.emit(Opcode::LoadNone);
                 self.compile_return();
-                self.code.set_stack_depth(dead_code_depth);
             }
             Node::Assign { target, object } => {
                 self.compile_expr(object)?;
@@ -1158,9 +1166,6 @@ impl<'a> Compiler<'a> {
     ) -> Result<(), CompileError> {
         let n = comparisons.len();
 
-        // Remember stack depth before the chain for cleanup calculation
-        let base_depth = self.code.stack_depth();
-
         // Compile leftmost operand
         self.compile_expr(left)?;
 
@@ -1196,16 +1201,14 @@ impl<'a> Compiler<'a> {
             }
         }
 
-        // Jump past cleanup (result already on stack)
+        // Jump past cleanup (result already on stack). After this Jump the
+        // tracker is `Dead`; the first cleanup `patch_jump` below will
+        // transition it back to `Live(base_depth + 2)` from the label
+        // (`JumpIfFalseOrPop` keeps the False result on the stack, so the
+        // jump-taken arrival depth is base_depth + 2).
         let end_jump = self.code.emit_jump(Opcode::Jump);
 
         // Cleanup: remove the saved intermediate value, keep False result.
-        // The cleanup is only reached via JumpIfFalseOrPop which doesn't pop,
-        // so the stack has: [intermediate, False] (2 extra items from base).
-        // Reset the tracker BEFORE the patch so `patch_jump`'s merge-invariant
-        // assertion sees the live (jump-taken) depth — fall-through here is
-        // dead because of the unconditional Jump just emitted.
-        self.code.set_stack_depth(base_depth + 2); // [intermediate, False]
         for jump in cleanup_jumps {
             self.code.patch_jump(jump);
         }
@@ -1213,8 +1216,7 @@ impl<'a> Compiler<'a> {
         self.code.emit(Opcode::Pop); // [False] — tracker now base_depth + 1
 
         self.code.patch_jump(end_jump);
-        // Final result is on stack: base_depth + 1 (verified by patch_jump
-        // assertion above; no manual reset needed).
+        // Final result is on stack at base_depth + 1.
 
         Ok(())
     }
@@ -1224,6 +1226,12 @@ impl<'a> Compiler<'a> {
     // ========================================================================
 
     /// Compiles an if/else statement.
+    ///
+    /// The bridge `Jump` past the else branch is only emitted when the body
+    /// falls through. If the body terminates (e.g. ends with `return`), the
+    /// bridge would be unreachable bytecode, so we skip it — and `patch_jump`
+    /// for `else_jump` re-establishes the live tracker for the orelse branch
+    /// from the label.
     fn compile_if(
         &mut self,
         test: &ExprLoc,
@@ -1233,39 +1241,33 @@ impl<'a> Compiler<'a> {
         self.compile_expr(test)?;
 
         if or_else.is_empty() {
-            // Simple if without else
             let end_jump = self.code.emit_jump(Opcode::JumpIfFalse);
             self.compile_block(body)?;
             self.code.patch_jump(end_jump);
         } else {
-            // If with else
             let else_jump = self.code.emit_jump(Opcode::JumpIfFalse);
             self.compile_block(body)?;
-            let end_jump = self.code.emit_jump(Opcode::Jump);
+            let end_jump = (!self.code.is_dead()).then(|| self.code.emit_jump(Opcode::Jump));
             self.code.patch_jump(else_jump);
             self.compile_block(or_else)?;
-            self.code.patch_jump(end_jump);
+            if let Some(end_jump) = end_jump {
+                self.code.patch_jump(end_jump);
+            }
         }
         Ok(())
     }
 
     /// Compiles a ternary conditional expression.
     ///
-    /// Both branches push exactly one value, but the compiler's stack-depth
-    /// tracker would naively double-count those pushes (it sees the body
-    /// branch push, then the orelse branch push, as if both ran). Reset the
-    /// tracker between branches so the merge invariant holds at each
-    /// `patch_jump`.
+    /// After `emit_jump(Jump)` for `end_jump` the tracker is `Dead`, so the
+    /// body branch's push doesn't poison the orelse branch. The first
+    /// `patch_jump(else_jump)` re-establishes `Live` at the else-branch
+    /// entry depth from the label.
     fn compile_if_else_expr(&mut self, test: &ExprLoc, body: &ExprLoc, orelse: &ExprLoc) -> Result<(), CompileError> {
         self.compile_expr(test)?;
         let else_jump = self.code.emit_jump(Opcode::JumpIfFalse);
-        // Depth at the start of either branch (cond was popped by JumpIfFalse).
-        let branch_entry_depth = self.code.stack_depth();
         self.compile_expr(body)?;
         let end_jump = self.code.emit_jump(Opcode::Jump);
-        // Body's push is dead beyond `end_jump`; reset to branch-entry depth
-        // for the orelse branch (and to satisfy `patch_jump`'s assertion).
-        self.code.set_stack_depth(branch_entry_depth);
         self.code.patch_jump(else_jump);
         self.compile_expr(orelse)?;
         self.code.patch_jump(end_jump);
@@ -2118,10 +2120,6 @@ impl<'a> Compiler<'a> {
         body: &[PreparedNode],
         or_else: &[PreparedNode],
     ) -> Result<(), CompileError> {
-        // Record stack depth at loop start (before iterator is pushed)
-        // This is the depth we return to when the loop finishes (iterator popped)
-        let loop_exit_depth = self.code.stack_depth();
-
         // Compile iterator expression
         self.compile_expr(iter)?;
         // Convert to iterator
@@ -2146,14 +2144,12 @@ impl<'a> Compiler<'a> {
         // Compile body
         self.compile_block(body)?;
 
-        // Jump back to loop start
-        self.code.emit_jump_to(Opcode::Jump, loop_start);
-
-        // End of loop. Fall-through is dead (Jump above is unconditional);
-        // the patch target is reached only via ForIter's exhausted path,
-        // which pops the iterator — so the live depth is `loop_exit_depth`.
-        // Reset before patching so the merge invariant holds.
-        self.code.set_stack_depth(loop_exit_depth);
+        // Jump back to loop start, unless the body terminated (in which case
+        // a backward jump would be unreachable). `patch_jump(end_jump)`
+        // transitions Dead → Live(loop_exit_depth) from the `ForIter` label.
+        if !self.code.is_dead() {
+            self.code.emit_jump_to(Opcode::Jump, loop_start);
+        }
         self.code.patch_jump(end_jump);
 
         // Pop loop info before compiling else block
@@ -2209,7 +2205,10 @@ impl<'a> Compiler<'a> {
         let end_jump = self.code.emit_jump(Opcode::JumpIfFalse);
 
         self.compile_block(body)?;
-        self.code.emit_jump_to(Opcode::Jump, loop_start);
+        // Skip the backward jump if body terminated — it would be unreachable.
+        if !self.code.is_dead() {
+            self.code.emit_jump_to(Opcode::Jump, loop_start);
+        }
 
         self.code.patch_jump(end_jump);
         let loop_info = self.loop_stack.pop().expect("loop stack underflow");
@@ -2245,10 +2244,6 @@ impl<'a> Compiler<'a> {
             return Err(CompileError::new("'break' outside loop", position));
         }
 
-        // `break` never falls through, but we still compile following statements in the same
-        // block. Preserve the statement-entry depth for that unreachable compilation so
-        // stack-effect tracking remains stable across dead code.
-        let dead_code_depth = self.code.stack_depth();
         let target_loop_depth = self.loop_stack.len() - 1;
 
         // If inside except handlers, clean up ALL exception states
@@ -2265,28 +2260,21 @@ impl<'a> Compiler<'a> {
             self.code.emit(Opcode::Pop);
         }
 
-        // Check if we need to go through any finally blocks
-        // We need to run finally if break crosses the try boundary, i.e., if
-        // we're breaking from a loop that existed before the try started.
+        // Emit the Jump (auto-marks the tracker `Dead`, so subsequent
+        // statements in the enclosing block are skipped by `compile_block`).
+        // If breaking out of a try-finally, route through the finally path.
         if let Some(finally_target) = self.finally_targets.last_mut()
             && target_loop_depth < finally_target.loop_depth_at_entry
         {
-            // Breaking from a loop that's outside (or at the start of) this try-finally,
-            // so finally must run before the break
             let jump = self.code.emit_jump(Opcode::Jump);
             finally_target.break_jumps.push(BreakContinueThruFinally {
                 jump,
                 target_loop_depth,
             });
-            self.code.set_stack_depth(dead_code_depth);
-            return Ok(());
+        } else {
+            let jump = self.code.emit_jump(Opcode::Jump);
+            self.loop_stack[target_loop_depth].break_jumps.push(jump);
         }
-
-        // No finally to go through, jump directly to loop end
-        let jump = self.code.emit_jump(Opcode::Jump);
-        self.loop_stack[target_loop_depth].break_jumps.push(jump);
-
-        self.code.set_stack_depth(dead_code_depth);
 
         Ok(())
     }
@@ -2301,9 +2289,6 @@ impl<'a> Compiler<'a> {
             return Err(CompileError::new("'continue' not properly in loop", position));
         }
 
-        // `continue` never falls through. Preserve the statement-entry stack depth so
-        // subsequent dead statements in this block are compiled with the right abstract stack.
-        let dead_code_depth = self.code.stack_depth();
         let target_loop_depth = self.loop_stack.len() - 1;
 
         // If inside except handlers, clean up ALL exception states
@@ -2314,27 +2299,21 @@ impl<'a> Compiler<'a> {
             self.code.emit(Opcode::Pop); // Pop the exception value
         }
 
-        // Check if we need to go through any finally blocks
-        // We need to run finally if continue crosses the try boundary
+        // Emit the Jump (auto-marks the tracker `Dead`, so subsequent
+        // statements in the enclosing block are skipped by `compile_block`).
         if let Some(finally_target) = self.finally_targets.last_mut()
             && target_loop_depth < finally_target.loop_depth_at_entry
         {
-            // Continuing a loop that's outside (or at the start of) this try-finally,
-            // so finally must run before the continue
+            // Continue out of a try-finally — route through the finally path.
             let jump = self.code.emit_jump(Opcode::Jump);
             finally_target.continue_jumps.push(BreakContinueThruFinally {
                 jump,
                 target_loop_depth,
             });
-            self.code.set_stack_depth(dead_code_depth);
-            return Ok(());
+        } else {
+            let loop_start = self.loop_stack[target_loop_depth].start;
+            self.code.emit_jump_to(Opcode::Jump, loop_start);
         }
-
-        // No finally to go through, jump directly to loop start
-        let loop_start = self.loop_stack[target_loop_depth].start;
-        self.code.emit_jump_to(Opcode::Jump, loop_start);
-
-        self.code.set_stack_depth(dead_code_depth);
 
         Ok(())
     }
@@ -2349,6 +2328,11 @@ impl<'a> Compiler<'a> {
     /// have the same starting point. After finally runs, we need to route each
     /// to its target loop, potentially through more finally blocks.
     fn compile_control_flow_after_finally(&mut self, items: &[BreakContinueThruFinally], is_break: bool) {
+        // If the finally body terminated, the post-finally control-flow
+        // dispatch is unreachable — skip the emission entirely.
+        if self.code.is_dead() {
+            return;
+        }
         // All items went through the same finally, now we need to dispatch to
         // potentially different loops. For simplicity, we assume all items in
         // a single finally target the same loop (the innermost one at the time).
@@ -2482,10 +2466,6 @@ impl<'a> Compiler<'a> {
     ) -> Result<(), CompileError> {
         let generator = &generators[index];
 
-        // Record stack depth before iterator expression
-        // This is the depth we return to when the loop finishes (iterator popped)
-        let loop_exit_depth = self.code.stack_depth();
-
         // Compile iterator expression
         self.compile_expr(&generator.iter)?;
         self.code.emit(Opcode::GetIter);
@@ -2515,14 +2495,10 @@ impl<'a> Compiler<'a> {
             body_fn(self)?;
         }
 
-        // Jump back to loop start
+        // Jump back to loop start. The tracker becomes `Dead`; the
+        // `patch_jump(end_jump)` below transitions to
+        // `Live(loop_exit_depth)` via the ForIter label.
         self.code.emit_jump_to(Opcode::Jump, loop_start);
-
-        // End of loop. Fall-through is dead (Jump above); only ForIter's
-        // exhausted path reaches the patch target, with the iterator already
-        // popped — depth is `loop_exit_depth`. Reset before patching to
-        // uphold the merge invariant.
-        self.code.set_stack_depth(loop_exit_depth);
         self.code.patch_jump(end_jump);
 
         Ok(())
@@ -2814,6 +2790,12 @@ impl<'a> Compiler<'a> {
     /// and we jump to a "finally with return" section that runs finally then returns.
     /// Otherwise, we emit a direct `ReturnValue`.
     fn compile_return(&mut self) {
+        // Callers like the try-finally return-path emit `compile_return`
+        // after a finally block that may itself have terminated; skip
+        // emission in that case.
+        if self.code.is_dead() {
+            return;
+        }
         if let Some(finally_target) = self.finally_targets.last_mut() {
             // Inside a try-finally: jump to finally, then return
             // Return value is already on stack
@@ -2879,26 +2861,30 @@ impl<'a> Compiler<'a> {
         // === Compile try body ===
         let try_start = self.code.current_offset();
         self.compile_block(&try_block.body)?;
-        let try_end = self.code.current_offset();
 
-        // Jump to else/finally if no exception (skip handlers)
-        let after_try_jump = self.code.emit_jump(Opcode::Jump);
+        // Jump to else/finally if no exception (skip handlers). If the body
+        // terminated (e.g. ends with `return`), there's no fall-through to
+        // skip — emitting the Jump would just produce dead bytes.
+        let after_try_jump = (!self.code.is_dead()).then(|| self.code.emit_jump(Opcode::Jump));
+        // End of the try-body region for the exception table. This is past
+        // the `after_try_jump` if it was emitted, so an exception that fires
+        // up to and including that Jump still routes to the handler.
+        let try_end = self.code.current_offset();
 
         // === Handler dispatch starts here ===
         let handler_start = self.code.current_offset();
 
-        // VM pushes exception onto stack when entering handler.
-        // Adjust compiler's stack depth tracking to reflect this.
-        self.code.adjust_stack_depth(1);
+        // The handler is reached via the exception table (not via fall-through
+        // from the try body's after_try_jump, which is unconditional and
+        // marked the tracker Dead). The VM pushes the exception onto the
+        // stack before jumping here, so set the tracker to Live(stack_depth + 1).
+        self.code.set_stack_depth(stack_depth + 1);
 
         // Track jumps that go to finally (for patching later)
         let mut finally_jumps: Vec<JumpLabel> = Vec::new();
 
         if has_handlers {
-            // Compile exception handlers
-            // handler_entry_depth = stack_depth + 1 (exception on stack)
-            let handler_entry_depth = stack_depth + 1;
-            self.compile_exception_handlers(&try_block.handlers, &mut finally_jumps, handler_entry_depth)?;
+            self.compile_exception_handlers(&try_block.handlers, &mut finally_jumps)?;
         } else {
             // No handlers - just reraise (this only happens with try-finally)
             self.code.emit(Opcode::Reraise);
@@ -2938,14 +2924,14 @@ impl<'a> Compiler<'a> {
             let finally_target = self.finally_targets.pop().expect("finally_targets should not be empty");
 
             // === Finally with return path ===
-            // Each return jump arrives with the return value on stack, so
-            // depth = stack_depth + 1. Reset BEFORE patching so the merge
-            // invariant holds.
+            // Each return jump arrives with the return value on stack
+            // (depth = stack_depth + 1). The first `patch_jump` transitions
+            // the tracker from `Dead` (left by the prior section's
+            // terminator) to `Live(stack_depth + 1)` via the label.
             let return_start = if finally_target.return_jumps.is_empty() {
                 None
             } else {
                 let start = self.code.current_offset();
-                self.code.set_stack_depth(stack_depth + 1);
                 for jump in finally_target.return_jumps {
                     self.code.patch_jump(jump);
                 }
@@ -2959,11 +2945,10 @@ impl<'a> Compiler<'a> {
             // - Jump to outer finally's break path (if there's an outer finally between us and the loop)
             // - Jump directly to the loop's break target
             //
-            // Break already popped the iterator, so stack = stack_depth - 1
-            // (the iterator was on stack at try entry, break removed it).
-            // Reset BEFORE patching to uphold the merge invariant.
+            // Break already popped the iterator (depth at jump-emit was
+            // stack_depth - 1); `patch_jump` transitions Dead → Live(that)
+            // from the label.
             if !finally_target.break_jumps.is_empty() {
-                self.code.set_stack_depth(stack_depth.saturating_sub(1));
                 for break_info in &finally_target.break_jumps {
                     self.code.patch_jump(break_info.jump);
                 }
@@ -2973,10 +2958,9 @@ impl<'a> Compiler<'a> {
             }
 
             // === Finally with continue path ===
-            // Continue doesn't pop the iterator, stack = stack_depth. Reset
-            // BEFORE patching to uphold the merge invariant.
+            // Continue doesn't pop the iterator; depth at jump-emit was
+            // stack_depth, restored by `patch_jump`.
             if !finally_target.continue_jumps.is_empty() {
-                self.code.set_stack_depth(stack_depth);
                 for continue_info in &finally_target.continue_jumps {
                     self.code.patch_jump(continue_info.jump);
                 }
@@ -2991,11 +2975,14 @@ impl<'a> Compiler<'a> {
         };
 
         // === Else block (runs if no exception) ===
-        // The after_try_jump is taken from the end of the try body when no
-        // exception was raised, so stack = stack_depth at the patch target.
-        // Reset BEFORE patching to uphold the merge invariant.
-        self.code.set_stack_depth(stack_depth);
-        self.code.patch_jump(after_try_jump);
+        // `after_try_jump` was only emitted when the body falls through. If
+        // it exists, patching it transitions Dead → Live(stack_depth) for
+        // the else branch; if not, the else block is unreachable and
+        // `compile_block` will skip it (the tracker is still Dead from the
+        // handler section's terminator).
+        if let Some(after_try_jump) = after_try_jump {
+            self.code.patch_jump(after_try_jump);
+        }
         let else_start = self.code.current_offset();
         if has_else {
             self.compile_block(&try_block.or_else)?;
@@ -3004,12 +2991,11 @@ impl<'a> Compiler<'a> {
 
         // === Normal finally path (no exception pending, no return) ===
         // Patch all jumps from handlers to go here. Each handler popped the
-        // exception before its Jump, so depth = stack_depth at the patch
-        // target. Reset BEFORE patching to uphold the merge invariant.
-        // (Note: tracker may already equal stack_depth via fall-through from
-        // the else block, but resetting is a no-op in that case and makes
-        // the invariant hold whether there is an else block or not.)
-        self.code.set_stack_depth(stack_depth);
+        // exception before its Jump, so the labels carry
+        // `target_depth = stack_depth`. The first live-sourced patch
+        // transitions Dead → Live(stack_depth); the else-block's
+        // fall-through (when reachable) already left the tracker there, so
+        // either way the merge invariant holds.
         for jump in finally_jumps {
             self.code.patch_jump(jump);
         }
@@ -3021,11 +3007,14 @@ impl<'a> Compiler<'a> {
         // === Add exception table entries ===
         // Order matters: entries are searched in order, so inner entries must come first.
 
-        // Entry 1: Try body -> handler dispatch
+        // Entry 1: Try body -> handler dispatch.
+        // `try_end` already includes the `after_try_jump` Jump instruction
+        // when one was emitted, so the exception range covers the body and
+        // (if reachable) the bridge Jump.
         if has_handlers || has_finally {
             self.code.add_exception_entry(ExceptionEntry::new(
                 u32::try_from(try_start).expect("bytecode offset exceeds u32"),
-                u32::try_from(try_end).expect("bytecode offset exceeds u32") + 3, // +3 to include the JUMP instruction
+                u32::try_from(try_end).expect("bytecode offset exceeds u32"),
                 u32::try_from(handler_start).expect("bytecode offset exceeds u32"),
                 stack_depth,
             ));
@@ -3072,13 +3061,14 @@ impl<'a> Compiler<'a> {
     /// Each handler checks if the exception matches its type, and if so,
     /// executes the handler body. If no handler matches, the exception is re-raised.
     ///
-    /// `handler_entry_depth` is the stack depth when entering handler dispatch
-    /// (i.e., base stack_depth + 1 for the exception value).
+    /// The caller is responsible for calling `set_stack_depth(stack_depth + 1)`
+    /// before invoking this — the entry point is reached via the exception
+    /// table, not fall-through, so the tracker needs an explicit Live state
+    /// reflecting the exception value the VM has pushed.
     fn compile_exception_handlers(
         &mut self,
         handlers: &[ExceptHandler<PreparedNode>],
         finally_jumps: &mut Vec<JumpLabel>,
-        handler_entry_depth: u16,
     ) -> Result<(), CompileError> {
         // Track jumps from non-matching handlers to next handler
         let mut next_handler_jumps: Vec<JumpLabel> = Vec::new();
@@ -3087,12 +3077,11 @@ impl<'a> Compiler<'a> {
             let is_last = i == handlers.len() - 1;
 
             // Patch jumps from previous handler's non-match to here.
-            // If jumping from a previous handler's no-match, stack has
-            // [exc, exc] (duplicate kept by the JumpIfFalse no-match path) =
-            // handler_entry_depth + 1. Reset the tracker BEFORE patching so
-            // `patch_jump`'s merge invariant sees the live (jump-taken) depth.
+            // The previous handler ended with `emit_jump(Jump)` to finally,
+            // marking the tracker `Dead`. The jump-taken arrival here
+            // (from JumpIfFalse no-match) leaves [exc, exc] on stack;
+            // `patch_jump` transitions Dead → Live(that depth) from the label.
             if !next_handler_jumps.is_empty() {
-                self.code.set_stack_depth(handler_entry_depth + 1);
                 for jump in next_handler_jumps.drain(..) {
                     self.code.patch_jump(jump);
                 }
@@ -3151,27 +3140,26 @@ impl<'a> Compiler<'a> {
                 // Exit except handler context
                 self.except_handler_depth -= 1;
 
-                // Delete exception variable (Python 3 behavior)
-                if let Some(name) = &handler.name {
-                    self.compile_delete(name);
+                // If the handler body terminated (e.g. ends with `return`),
+                // the cleanup trailer below is unreachable — skip it.
+                if !self.code.is_dead() {
+                    // Delete exception variable (Python 3 behavior)
+                    if let Some(name) = &handler.name {
+                        self.compile_delete(name);
+                    }
+                    // Clear current_exception, pop the exception from stack,
+                    // and jump to the finally / merge point.
+                    self.code.emit(Opcode::ClearException);
+                    self.code.emit(Opcode::Pop);
+                    finally_jumps.push(self.code.emit_jump(Opcode::Jump));
                 }
 
-                // Clear current_exception
-                self.code.emit(Opcode::ClearException);
-
-                // Pop the exception from stack
-                self.code.emit(Opcode::Pop);
-
-                // Jump to finally
-                finally_jumps.push(self.code.emit_jump(Opcode::Jump));
-
-                // If this was last handler and no match, we need to reraise.
-                // The patch target is reached only via JumpIfFalse's no-match
-                // path — stack [exception, exception] = handler_entry_depth + 1.
-                // Fall-through is dead (we just emitted an unconditional Jump
-                // to finally above), so reset the tracker BEFORE patching.
+                // If this was the last handler and no match, we need to
+                // reraise. The patch target is reached only via JumpIfFalse's
+                // no-match path (stack [exception, exception]); fall-through
+                // is dead because of the `emit_jump(Jump)` to finally above.
+                // `patch_jump` transitions Dead → Live from the label.
                 if is_last {
-                    self.code.set_stack_depth(handler_entry_depth + 1);
                     self.code.patch_jump(no_match_jump);
                     // We need to pop the duplicate before reraising
                     self.code.emit(Opcode::Pop);
@@ -3196,19 +3184,15 @@ impl<'a> Compiler<'a> {
                 // Exit except handler context
                 self.except_handler_depth -= 1;
 
-                // Delete exception variable
-                if let Some(name) = &handler.name {
-                    self.compile_delete(name);
+                // Skip the cleanup trailer if the handler body terminated.
+                if !self.code.is_dead() {
+                    if let Some(name) = &handler.name {
+                        self.compile_delete(name);
+                    }
+                    self.code.emit(Opcode::ClearException);
+                    self.code.emit(Opcode::Pop);
+                    finally_jumps.push(self.code.emit_jump(Opcode::Jump));
                 }
-
-                // Clear current_exception
-                self.code.emit(Opcode::ClearException);
-
-                // Pop the exception from stack
-                self.code.emit(Opcode::Pop);
-
-                // Jump to finally
-                finally_jumps.push(self.code.emit_jump(Opcode::Jump));
             }
         }
 

--- a/crates/monty/src/bytecode/op.rs
+++ b/crates/monty/src/bytecode/op.rs
@@ -14,6 +14,8 @@ use std::{error, fmt};
 
 use strum::FromRepr;
 
+use super::builder::Offset;
+
 /// Opcode discriminant - just identifies the instruction type.
 ///
 /// Operands (if any) follow in the bytecode stream and are fetched separately.
@@ -450,117 +452,236 @@ impl TryFrom<u8> for Opcode {
     }
 }
 
+/// Operand bundle, to be paired with an `Opcode` at emit time.
+///
+/// `Opcode::stack_effect` consumes this to compute the operand-stack delta in
+/// a single exhaustive match. The variants describe the *byte shape* of the
+/// in-stream operand — `emit_with_operand` writes the bytes for each variant
+/// and the same enum drives stack-effect computation, so byte emission and
+/// stack tracking can't drift apart.
+///
+/// `Operand` is `Copy` (largest variant is ~24 bytes), so it's passed by value
+/// throughout.
+#[derive(Debug, Clone, Copy)]
+pub enum Operand<'a> {
+    /// No operand bytes (e.g. `Pop`, `BinaryAdd`).
+    None,
+    /// Single u8 operand (e.g. `LoadLocal`, `CallFunction`).
+    U8(u8),
+    /// Single i8 operand.
+    I8(i8),
+    /// Single u16 operand, little-endian (e.g. `LoadConst`, `BuildList`).
+    U16(u16),
+    /// Absolute jump target. `emit_with_operand` computes the signed i16
+    /// relative offset (`target - (jump_start + 3)`) and writes it to bytecode
+    /// as a little-endian i16. Required for jump opcodes: `Jump`, `JumpIfTrue`,
+    /// `JumpIfFalse`, `JumpIfTrueOrPop`, `JumpIfFalseOrPop`, `ForIter`.
+    ///
+    /// Forward jumps pass `current_offset()` as a self-referential placeholder
+    /// (yielding a -3 relative offset); `patch_jump` overwrites it once the
+    /// real target is known. The placeholder is harmless because `#[must_use]`
+    /// on `JumpLabel` catches the "forgot to patch" case at compile time.
+    Offset(Offset),
+    /// Two u8 operands (e.g. `UnpackEx`, `CallBuiltinFunction`).
+    U8U8(u8, u8),
+    /// u8 then u16 little-endian (e.g. `LoadLocalCallable`).
+    U8U16(u8, u16),
+    /// u16 little-endian then u8 (e.g. `MakeFunction`, `CallAttr`).
+    U16U8(u16, u8),
+    /// Two u16 little-endian (e.g. `LoadLocalCallableW`, `LoadGlobalCallable`).
+    U16U16(u16, u16),
+    /// u16 then two u8s (e.g. `MakeClosure`).
+    U16U8U8(u16, u8, u8),
+    /// `CallFunctionKw` shape: pos_count (u8), kw_count (u8), kw_count * name_id (u16 each).
+    CallKw { pos_count: u8, kwname_ids: &'a [u16] },
+    /// `CallAttrKw` shape: attr_name_id (u16), pos_count (u8), kw_count (u8), kw_count * name_id (u16 each).
+    CallAttrKw {
+        attr_name_id: u16,
+        pos_count: u8,
+        kwname_ids: &'a [u16],
+    },
+}
+
 impl Opcode {
-    /// Returns the stack effect of this opcode (positive = push, negative = pop).
+    /// Returns the operand-stack effect of this opcode paired with `operand`
+    /// (positive = push, negative = pop).
     ///
-    /// Some opcodes have variable effects (e.g., `BuildList` depends on its operand).
-    /// For those, this returns `None` and the caller must compute the effect.
+    /// Variable-effect opcodes have explicit `(opcode, operand-variant)` arms;
+    /// fixed-effect opcodes match on the opcode alone and ignore the operand
+    /// variant. A variable-effect opcode whose operand variant doesn't match
+    /// any enumerated arm hits the catch-all panic — this keeps the tracker
+    /// honest when a new variable-effect opcode is added without a matching
+    /// arm.
     ///
-    /// For opcodes that have known, fixed stack effects, returns `Some(i16)`.
+    /// `MakeFunction`/`MakeClosure` have explicit variable arms even though
+    /// the "push the function" effect is +1 — the actual effect is
+    /// `1 - defaults_count` because defaults are popped from the stack, which
+    /// only equals +1 when no defaults are present.
+    ///
+    /// `emit_jump_to`'s backward-jump path computes its own effect inline
+    /// because it doesn't have an `Operand` to pass (the operand is a raw
+    /// i16 offset, not a stack-effect-bearing shape).
     #[must_use]
-    pub const fn stack_effect(self) -> Option<i16> {
+    pub fn stack_effect(self, operand: Operand<'_>) -> i16 {
         #![expect(clippy::allow_attributes, reason = "expect seems broken with enum_glob_use")]
         #[allow(clippy::enum_glob_use, reason = "simplifies churn")]
         use Opcode::*; // allow local import
-        Some(match self {
-            // Stack operations
-            Pop => -1,
-            Dup => 1,
-            Dup2 => 2,
-            Rot2 | Rot3 => 0, // reorder, no net change
+        match (self, operand) {
+            // === Variable-effect: U8 operand ===
+            (CallFunction, Operand::U8(arg_count)) => -i16::from(arg_count),
+            (CallFunctionExtended, Operand::U8(flags)) => -(1 + i16::from(flags & 0x01)),
+            (FormatValue, Operand::U8(flags)) => {
+                if flags & 0x04 != 0 {
+                    -1
+                } else {
+                    0
+                }
+            }
+            (UnpackSequence, Operand::U8(n)) => i16::from(n) - 1,
 
-            // Constants & Literals (all push 1)
-            LoadConst | LoadNone | LoadTrue | LoadFalse | LoadSmallInt => 1,
+            // === Variable-effect: U16 operand ===
+            (BuildList | BuildTuple | BuildSet | BuildFString, Operand::U16(n)) => 1 - n.cast_signed(),
+            (BuildDict, Operand::U16(n)) => 1 - 2 * n.cast_signed(),
 
-            // Variables - loads push, stores pop
-            LoadLocal0 | LoadLocal1 | LoadLocal2 | LoadLocal3 => 1,
-            LoadLocal | LoadLocalW | LoadLocalCallable | LoadLocalCallableW | LoadGlobal | LoadGlobalCallable
-            | LoadCell => 1,
-            StoreLocal | StoreLocalW | StoreGlobal | StoreCell => -1,
-            DeleteLocal | DeleteGlobal => 0, // doesn't affect stack
+            // === Variable-effect: U8U8 operand ===
+            // UnpackEx: pops 1, pushes (before + 1 + after) → before + after.
+            (UnpackEx, Operand::U8U8(before, after)) => i16::from(before) + i16::from(after),
+            // Builtin calls: no callable on stack, pops args, pushes result → 1 - arg_count.
+            (CallBuiltinFunction | CallBuiltinType, Operand::U8U8(_, arg_count)) => 1 - i16::from(arg_count),
 
-            // Binary operations: pop 2, push 1 = -1
-            BinaryAdd | BinarySub | BinaryMul | BinaryDiv | BinaryFloorDiv | BinaryMod | BinaryPow | BinaryAnd
-            | BinaryOr | BinaryXor | BinaryLShift | BinaryRShift | BinaryMatMul => -1,
+            // === Variable-effect: U16U8 operand ===
+            (MakeFunction, Operand::U16U8(_, defaults)) => 1 - i16::from(defaults),
+            (CallAttr, Operand::U16U8(_, arg_count)) => -i16::from(arg_count),
+            (CallAttrExtended, Operand::U16U8(_, flags)) => -(1 + i16::from(flags & 0x01)),
 
-            // Comparisons: pop 2, push 1 = -1
-            CompareEq | CompareNe | CompareLt | CompareLe | CompareGt | CompareGe | CompareIs | CompareIsNot
-            | CompareIn | CompareNotIn | CompareModEq => -1,
+            // === Variable-effect: U16U8U8 operand ===
+            (MakeClosure, Operand::U16U8U8(_, defaults, _)) => 1 - i16::from(defaults),
 
-            // Unary operations: pop 1, push 1 = 0
-            UnaryNot | UnaryNeg | UnaryPos | UnaryInvert => 0,
+            // === Variable-effect: variable-length kw operands ===
+            // pops callable + pos_args + kw_args, pushes result → -(pos_count + kw_count).
+            (CallFunctionKw, Operand::CallKw { pos_count, kwname_ids }) => {
+                let kw_count = i16::try_from(kwname_ids.len()).expect("keyword count exceeds i16");
+                -(i16::from(pos_count) + kw_count)
+            }
+            (
+                CallAttrKw,
+                Operand::CallAttrKw {
+                    pos_count, kwname_ids, ..
+                },
+            ) => {
+                let kw_count = i16::try_from(kwname_ids.len()).expect("keyword count exceeds i16");
+                -(i16::from(pos_count) + kw_count)
+            }
 
-            // In-place operations: pop 1 (rhs), leave target on stack = -1
-            InplaceAdd | InplaceSub | InplaceMul | InplaceDiv | InplaceFloorDiv | InplaceMod | InplacePow
-            | InplaceAnd | InplaceOr | InplaceXor | InplaceLShift | InplaceRShift => -1,
+            // === Fixed-effect, no operand ===
+            (Pop, Operand::None) => -1,
+            (Dup, Operand::None) => 1,
+            (Dup2, Operand::None) => 2,
+            (Rot2 | Rot3, Operand::None) => 0,
+            (LoadNone | LoadTrue | LoadFalse, Operand::None) => 1,
+            (LoadLocal0 | LoadLocal1 | LoadLocal2 | LoadLocal3, Operand::None) => 1,
+            (
+                BinaryAdd | BinarySub | BinaryMul | BinaryDiv | BinaryFloorDiv | BinaryMod | BinaryPow | BinaryAnd
+                | BinaryOr | BinaryXor | BinaryLShift | BinaryRShift | BinaryMatMul,
+                Operand::None,
+            ) => -1,
+            (
+                CompareEq | CompareNe | CompareLt | CompareLe | CompareGt | CompareGe | CompareIs | CompareIsNot
+                | CompareIn | CompareNotIn,
+                Operand::None,
+            ) => -1,
+            (UnaryNot | UnaryNeg | UnaryPos | UnaryInvert, Operand::None) => 0,
+            (
+                InplaceAdd | InplaceSub | InplaceMul | InplaceDiv | InplaceFloorDiv | InplaceMod | InplacePow
+                | InplaceAnd | InplaceOr | InplaceXor | InplaceLShift | InplaceRShift,
+                Operand::None,
+            ) => -1,
+            (BuildSlice, Operand::None) => -2,
+            (ListExtend, Operand::None) => -1,
+            (ListToTuple, Operand::None) => 0,
+            (BinarySubscr, Operand::None) => -1,
+            (StoreSubscr, Operand::None) => -3,
+            (GetIter | Await, Operand::None) => 0,
+            (Raise, Operand::None) => -1,
+            (Reraise | ClearException | CheckExcMatch, Operand::None) => 0,
+            (ReturnValue, Operand::None) => -1,
+            (Nop, Operand::None) => 0,
 
-            // Collection building - depends on operand, return None
-            BuildList | BuildTuple | BuildDict | BuildSet | BuildFString => return None,
-            // FormatValue: pops 1 value (+ optional fmt_spec), pushes 1. Variable.
-            FormatValue => return None,
-            // BuildSlice: pop 3, push 1 = -2
-            BuildSlice => -2,
-            // ListExtend: pop 2 (iterable + list), push 1 (list) = -1
-            ListExtend => -1,
-            // ListToTuple: pop 1, push 1 = 0
-            ListToTuple => 0,
-            // DictMerge: pop 2, push 1 = -1
-            DictMerge => -1,
+            // === Fixed-effect, I8 operand ===
+            (LoadSmallInt, Operand::I8(_)) => 1,
 
-            // Comprehension building - pops value, no push (stores in collection below)
-            ListAppend | SetAdd => -1,
-            DictSetItem => -2, // pops key and value
+            // === Fixed-effect, U8 operand ===
+            (LoadLocal | LoadModule, Operand::U8(_)) => 1,
+            (StoreLocal, Operand::U8(_)) => -1,
+            (DeleteLocal, Operand::U8(_)) => 0,
+            // `ListAppend`/`SetAdd`/`DictSetItem` carry a u8 stack-depth operand
+            // that names which collection below TOS to extend; the stack
+            // effect itself is fixed.
+            (ListAppend | SetAdd, Operand::U8(_)) => -1,
+            (DictSetItem, Operand::U8(_)) => -2,
+            // `DictUpdate`/`SetExtend` also take a u8 stack-depth operand.
+            (DictUpdate | SetExtend, Operand::U8(_)) => -1,
 
-            // Subscript & Attribute
-            BinarySubscr => -1,             // pop 2, push 1
-            StoreSubscr => -3,              // pop 3, push 0
-            LoadAttr | LoadAttrImport => 0, // pop 1, push 1
-            StoreAttr => -2,                // pop 2, push 0
+            // === Fixed-effect, U16 operand ===
+            (LoadConst, Operand::U16(_)) => 1,
+            (LoadLocalW | LoadGlobal | LoadCell, Operand::U16(_)) => 1,
+            (StoreLocalW | StoreGlobal | StoreCell, Operand::U16(_)) => -1,
+            (DeleteGlobal, Operand::U16(_)) => 0,
+            (CompareModEq, Operand::U16(_)) => -1,
+            (LoadAttr | LoadAttrImport, Operand::U16(_)) => 0,
+            (StoreAttr, Operand::U16(_)) => -2,
+            // `DictMerge` takes a u16 operand carrying the func_name_id for
+            // the duplicate-key TypeError message.
+            (DictMerge, Operand::U16(_)) => -1,
+            // `RaiseImportError` takes a u16 const_id naming the missing module.
+            (RaiseImportError, Operand::U16(_)) => 0,
 
-            // Function calls - depend on arg count
-            CallFunction | CallBuiltinFunction | CallBuiltinType | CallFunctionKw | CallAttr | CallAttrKw
-            | CallFunctionExtended | CallAttrExtended => return None,
+            // === Fixed-effect, U8U16 operand ===
+            (LoadLocalCallable, Operand::U8U16(..)) => 1,
 
-            // Control flow - no stack effect (jumps don't push/pop)
-            Jump => 0,
-            JumpIfTrue | JumpIfFalse => -1,                    // always pop condition
-            JumpIfTrueOrPop | JumpIfFalseOrPop => return None, // variable (0 or -1)
+            // === Fixed-effect, U16U16 operand ===
+            (LoadLocalCallableW | LoadGlobalCallable, Operand::U16U16(..)) => 1,
 
-            // Iteration
-            GetIter => 0,           // pop iterable, push iterator
-            ForIter => return None, // pushes value or jumps (variable)
+            // === Jumps: fall-through effect (what the tracker absorbs after the bytes are written).
+            // Use `Offset` arguments to sanity check that jumps are correctly paired with offsets. ===
 
-            // Async/await
-            Await => 0, // pop awaitable, push result
+            // `Jump` is unconditional and makes the code dead; the 0 here is correct for
+            // the moment before that transition.
+            (Jump, Operand::Offset(_)) => 0,
+            // Conditional jumps pop the condition on either path, so the tracker absorbs the pop immediately.
+            (JumpIfTrue | JumpIfFalse | JumpIfTrueOrPop | JumpIfFalseOrPop, Operand::Offset(_)) => -1,
+            // `ForIter` adds the the value yielded by the iterator to the stack.
+            (ForIter, Operand::Offset(_)) => 1,
 
-            // Function definition - push 1 (the function/closure)
-            MakeFunction | MakeClosure => 1,
+            // Catch-all: opcode emitted with the wrong operand variant, or a
+            // new opcode added without an arm above. Every opcode has exactly
+            // one valid operand shape; pairing them up here means the wrong
+            // emit_* helper for a given opcode is caught at stack-effect time
+            // rather than producing nonsense bytecode.
+            (op, _) => panic!(
+                "Opcode::stack_effect: opcode {op:?} paired with wrong operand variant {operand:?} (or missing arm)"
+            ),
+        }
+    }
 
-            // Exception handling
-            Raise => -1,         // pop exception
-            Reraise => 0,        // no stack change (reads from exception_stack)
-            ClearException => 0, // clears exception_stack, no operand stack change
-            CheckExcMatch => 0,  // pop exc_type, push bool (net 0, but exc stays)
-
-            // Return
-            ReturnValue => -1,
-
-            // Unpacking - depends on operand
-            UnpackSequence | UnpackEx => return None,
-
-            // Dict/set literal extensions (PEP 448):
-            // DictUpdate: pop mapping, silently merge into dict below = -1
-            DictUpdate => -1,
-            // SetExtend: pop iterable, add all items to set below = -1
-            SetExtend => -1,
-
-            // Special
-            Nop => 0,
-
-            // Module
-            LoadModule => 1,       // push module
-            RaiseImportError => 0, // raises exception, no stack change before that
-        })
+    /// Returns the operand-stack delta applied when *this jump opcode is
+    /// taken*, i.e. the difference between the pre-emit depth and the depth
+    /// that execution arrives at on the jump-taken path.
+    ///
+    /// Panics for non-jump opcodes.
+    #[must_use]
+    pub fn jump_taken_stack_effect(self) -> i16 {
+        match self {
+            // Unconditional jump: stack unchanged on jump-taken.
+            Self::Jump => 0,
+            // Pop condition on either path.
+            Self::JumpIfTrue | Self::JumpIfFalse => -1,
+            // Pop condition on fall-through, keep it on jump-taken.
+            Self::JumpIfTrueOrPop | Self::JumpIfFalseOrPop => 0,
+            // Pop iterator on jump-taken (no value pushed).
+            Self::ForIter => -1,
+            _ => panic!("Opcode::jump_taken_delta: {self:?} is not a jump opcode"),
+        }
     }
 }
 

--- a/crates/monty/src/bytecode/op.rs
+++ b/crates/monty/src/bytecode/op.rs
@@ -555,7 +555,9 @@ impl Opcode {
             (CallAttrExtended, Operand::U16U8(_, flags)) => -(1 + i16::from(flags & 0x01)),
 
             // === Variable-effect: U16U8U8 operand ===
-            (MakeClosure, Operand::U16U8U8(_, defaults, _)) => 1 - i16::from(defaults),
+            // MakeClosure: pops `cell_count` cells AND `defaults_count` defaults,
+            // pushes the closure → 1 - defaults - cells.
+            (MakeClosure, Operand::U16U8U8(_, defaults, cells)) => 1 - i16::from(defaults) - i16::from(cells),
 
             // === Variable-effect: variable-length kw operands ===
             // pops callable + pos_args + kw_args, pushes result → -(pos_count + kw_count).


### PR DESCRIPTION
Done this on the way to resolving #372 

This is a large cleanup to the compiler to attempt to guarantee by construction that jumps have the right stack depth across all paths that might reach the jump. This, for example, was the cause of #268 and #246, and could easily happen again without this kind construction.

At the same time it became possible to drop dead code on the floor and shrink exception handlers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked bytecode emission to guarantee stack-depth correctness for all jumps and to drop unreachable code. Simplified exception handlers and enforced merge invariants to prevent stack-effect bugs.

- **Refactors**
  - Unified emission through a single `emit_with_operand` path using `Operand`; stack deltas now come from `Opcode::stack_effect(operand)`.
  - Added dead-code regions; unconditional terminators end regions, `patch_jump` reopens with the label’s target depth, and `compile_block` stops emitting when dead.
  - Enforced depth checks on all jumps: `emit_jump` uses `Opcode::jump_taken_stack_effect`; backward jumps use `JumpTarget` and assert merge depth.
  - Introduced `Offset`; `ExceptionEntry::new` now takes `Offset`; builder exposes `current_offset()` and `current_jump_target()`.
  - Simplified `except` handlers: start a new region at `stack_depth + 1`, consume the exception on match (store or pop), use `ClearException` only, and route returns via a shared path.

- **Bug Fixes**
  - Jumps now always land at matching stack depth; forward merges validated at patch time and backward merges asserted.
  - Unreachable bytes after `Jump`/`ReturnValue`/`Raise`/`Reraise`/`RaiseImportError` are no longer emitted.
  - Break/continue/return from `except` clear handler state without popping an exception value; corrected stack-effect accounting for calls, unpacking, and `ForIter` under the new model.
  - Fixed `MakeClosure` stack effect to account for captured cells: now `1 - defaults_count - cell_count`.

<sup>Written for commit 06c78c9ab73ec021bbe0b5da6f678852df07b61f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

