### PR TITLE
refactor `GatherFuture` to be a state machine

### DIFF
--- a/crates/monty/src/asyncio.rs
+++ b/crates/monty/src/asyncio.rs
@@ -179,9 +179,8 @@ pub(crate) enum GatherState {
     /// returns it.
     Completed(HeapId),
     /// A child task failed (or an external future was rejected). The error
-    /// is cached so subsequent awaits re-raise it. `RunError` is not `Clone`
-    /// by default; use [`crate::exception_private::RunError::duplicate`] when
-    /// transitioning into this state.
+    /// is cached so subsequent awaits re-raise it. `RunError` implements
+    /// `Clone`; clone the error when transitioning into this state.
     Failed(RunError),
 }
 

--- a/crates/monty/src/asyncio.rs
+++ b/crates/monty/src/asyncio.rs
@@ -4,7 +4,9 @@
 //! and task identifiers. The host acts as the event loop - external function
 //! calls return `ExternalFuture` objects that can be awaited.
 
-use crate::{heap::HeapId, intern::FunctionId, value::Value};
+use ahash::AHashMap;
+
+use crate::{exception_private::RunError, heap::HeapId, intern::FunctionId, value::Value};
 
 /// Unique identifier for external function calls.
 ///
@@ -123,30 +125,92 @@ pub(crate) enum GatherItem {
 ///
 /// # Lifecycle
 ///
-/// 1. **Creation**: `gather(coro1, coro2, ...)` stores coroutine HeapIds and external CallIds
-/// 2. **Await**: `await gather_future` spawns tasks and blocks the current task
-/// 3. **Completion**: As tasks/futures complete, results are stored in order
-/// 4. **Return**: When all items complete, returns list of results
+/// The lifecycle is encoded in [`GatherState`]:
 ///
-/// # Error Handling
+/// 1. **`Pending`** — created by `gather(coro1, coro2, ...)` but not yet awaited.
+///    Only `items` carries data; the per-await bookkeeping does not yet exist.
+/// 2. **`Awaited(AwaitedGather)`** — entered by the `Await` opcode. Spawned task
+///    ids, the waiter, the per-slot results, and any external futures still
+///    being waited on all live inside the [`AwaitedGather`] payload. Tasks and
+///    external resolutions write into `results` slots while in this state.
+/// 3. **`Completed(list_id)`** — all children completed successfully. The
+///    `list_id` is an inc_ref'd `HeapData::List` holding the gathered results;
+///    re-awaiting the gather returns this same list, matching CPython's
+///    behavior of caching a Future's result.
+/// 4. **`Failed(error)`** — a child task or external future raised. The error
+///    was propagated to the original waiter on first await, and is cached here
+///    so re-awaits re-raise the same exception (again matching CPython).
 ///
-/// On any task failure, sibling tasks are cancelled and the exception propagates
-/// to the task that awaited the gather.
+/// Encoding the phases as a `match`-able enum lets every site that touches a
+/// gather state-transition explicitly, instead of inferring "have we been
+/// awaited?" / "are we done?" from emptiness checks across several `Vec`s.
+///
+/// # Re-await semantics
+///
+/// `Completed` and `Failed` gathers can be awaited any number of times — each
+/// await yields the same cached result or exception. Re-awaiting a gather that
+/// is still in `Awaited` state (in-flight, the original waiter has not finished
+/// driving it to completion) is currently rejected; supporting that would
+/// require a list of waiters and is left as future work.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct GatherFuture {
     /// Items to gather (coroutines or external futures).
+    ///
+    /// Set once at construction and never mutated. The gather inc_refs each
+    /// unique `GatherItem::Coroutine` HeapId and is the owner until drop, so
+    /// GC must always walk this vector regardless of `state`.
     pub items: Vec<GatherItem>,
-    /// TaskIds of spawned tasks (only for coroutine items, set when awaited).
-    /// Length matches the number of Coroutine items.
-    pub task_ids: Vec<TaskId>,
-    /// Results from each item, in order (filled as items complete).
-    /// Indices align with `items`.
+    /// Phase of the gather lifecycle. See [`GatherState`].
+    pub state: GatherState,
+}
+
+/// Lifecycle phase of a [`GatherFuture`].
+///
+/// See the `GatherFuture` docs for the transition rules.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) enum GatherState {
+    /// Created but never awaited. No spawned tasks, no results, no waiter.
+    Pending,
+    /// Currently being awaited. `AwaitedGather` carries every per-await field.
+    Awaited(AwaitedGather),
+    /// All children completed successfully. The contained `HeapId` is an
+    /// inc_ref'd `HeapData::List` of results; the gather is its owner and
+    /// dec_refs it on drop. Re-awaiting the gather inc_refs this list and
+    /// returns it.
+    Completed(HeapId),
+    /// A child task failed (or an external future was rejected). The error
+    /// is cached so subsequent awaits re-raise it. `RunError` is not `Clone`
+    /// by default; use [`crate::exception_private::RunError::duplicate`] when
+    /// transitioning into this state.
+    Failed(RunError),
+}
+
+/// Per-await bookkeeping for a [`GatherFuture`] in the `Awaited` phase.
+///
+/// All fields are populated when the gather is first awaited (in
+/// `await_gather_future`) and progressively consumed as children resolve.
+///
+/// The gather is the single source of truth for "what awaitables I'm waiting
+/// on and where their values go". Both maps follow the same lifecycle: each
+/// entry is removed as the corresponding child resolves, and the gather is
+/// done when both maps are empty.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct AwaitedGather {
+    /// Task that called `await` on the enclosing gather. Always present in this
+    /// phase — there is no "awaited but no waiter" sub-state.
+    pub waiter: TaskId,
+    /// Spawned tasks → slots they fill in `results`. One entry per *unique*
+    /// coroutine in `items` (duplicates collapse to a single task with
+    /// multiple slot indices). Entries are removed as the corresponding
+    /// task completes; the task is then immediately cancelled from the
+    /// scheduler so refcounts get released eagerly.
+    pub pending_tasks: AHashMap<TaskId, Vec<usize>>,
+    /// External futures → slots they fill in `results`. Entries are removed
+    /// as `resolve_future` resolves each call.
+    pub pending_calls: AHashMap<CallId, Vec<usize>>,
+    /// Results from each gather item, in order. Indices align with
+    /// `GatherFuture::items`. Filled as tasks complete and externals resolve.
     pub results: Vec<Option<Value>>,
-    /// Task waiting on this gather (set when awaited).
-    pub waiter: Option<TaskId>,
-    /// CallIds of external futures we're waiting on.
-    /// Used to check if all external futures have resolved.
-    pub pending_calls: Vec<CallId>,
 }
 
 impl GatherFuture {
@@ -155,13 +219,9 @@ impl GatherFuture {
     /// # Arguments
     /// * `items` - Coroutines or external futures to run concurrently
     pub fn new(items: Vec<GatherItem>) -> Self {
-        let count = items.len();
         Self {
             items,
-            task_ids: Vec::new(),
-            results: (0..count).map(|_| None).collect(),
-            waiter: None,
-            pending_calls: Vec::new(),
+            state: GatherState::Pending,
         }
     }
 
@@ -169,5 +229,25 @@ impl GatherFuture {
     #[inline]
     pub fn item_count(&self) -> usize {
         self.items.len()
+    }
+
+    /// Returns the per-await bookkeeping if the gather is in the `Awaited`
+    /// phase. Convenience for read-only inspection sites that don't need to
+    /// distinguish the other phases from one another.
+    #[inline]
+    pub fn as_awaited(&self) -> Option<&AwaitedGather> {
+        match &self.state {
+            GatherState::Awaited(awaited) => Some(awaited),
+            GatherState::Pending | GatherState::Completed(_) | GatherState::Failed(_) => None,
+        }
+    }
+
+    /// Mutable counterpart to [`Self::as_awaited`].
+    #[inline]
+    pub fn as_awaited_mut(&mut self) -> Option<&mut AwaitedGather> {
+        match &mut self.state {
+            GatherState::Awaited(awaited) => Some(awaited),
+            GatherState::Pending | GatherState::Completed(_) | GatherState::Failed(_) => None,
+        }
     }
 }

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -14,11 +14,11 @@ use super::{AwaitResult, CallFrame, FrameExit, VM};
 use crate::{
     MontyException,
     args::ArgValues,
-    asyncio::{CallId, Coroutine, CoroutineState, GatherFuture, GatherItem, TaskId},
-    bytecode::vm::scheduler::{PendingCallData, SerializedTaskFrame, TaskState},
+    asyncio::{AwaitedGather, CallId, Coroutine, CoroutineState, GatherFuture, GatherItem, GatherState, TaskId},
+    bytecode::vm::scheduler::{PendingCallData, Scheduler, SerializedTaskFrame, TaskState},
     defer_drop,
     exception_private::{ExcType, RunError, RunResult, SimpleException},
-    heap::{HeapData, HeapGuard, HeapId, HeapRead, HeapReadOutput},
+    heap::{DropWithHeap, HeapData, HeapGuard, HeapId, HeapRead, HeapReadOutput, HeapReader},
     intern::FunctionId,
     resource::ResourceTracker,
     run_progress::ExtFunctionResult,
@@ -97,28 +97,46 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         heap_id: HeapId,
         mut gather: HeapRead<'h, GatherFuture>,
     ) -> Result<AwaitResult, RunError> {
-        // Check if already being waited on (double-await)
-        if gather.get(self.heap).waiter.is_some() {
-            return Err(SimpleException::new_msg(ExcType::RuntimeError, "cannot reuse already awaited gather").into());
+        // Re-await fast paths
+        match &gather.get(self.heap).state {
+            GatherState::Pending => {}
+            GatherState::Completed(list_id) => {
+                let id = *list_id;
+                self.heap.inc_ref(id);
+                return Ok(AwaitResult::ValueReady(Value::Ref(id)));
+            }
+            GatherState::Failed(err) => return Err(err.clone()),
+            // TODO: needs proper support for this case, CPython allows it
+            GatherState::Awaited(_) => {
+                return Err(SimpleException::new_msg(
+                    ExcType::RuntimeError,
+                    "cannot reuse gather that is currently being awaited",
+                )
+                .into());
+            }
         }
 
-        // If no items to gather, return empty list immediately
-        if gather.get(self.heap).item_count() == 0 {
+        // Empty gather shortcut. Allocate the empty list, store it as the
+        // cached `Completed` result, and return an inc_ref'd reference. Future
+        // awaits will hit the `Completed` fast path above.
+        let item_count = gather.get(self.heap).item_count();
+        if item_count == 0 {
             let list_id = self.heap.allocate(HeapData::List(List::new(vec![])))?;
+            gather.cache_result(self.heap, list_id);
             return Ok(AwaitResult::ValueReady(Value::Ref(list_id)));
         }
 
         // Reject any external future that has already been awaited (directly or
         // via another gather). Without this check, sibling gathers sharing a
-        // future would silently overwrite each other in `gather_waiters`,
-        // leaving the first gather permanently blocked on a CallId that has
-        // already been resolved or is registered against a different gather.
-        // This mirrors the existing `is_consumed` check in `await_external_future`
-        // so that direct double-await and gather-mediated double-await behave
-        // consistently. The dedup pass below ensures intra-gather duplicates
-        // (`gather(f, f)`) are not flagged: each unique CallId is only marked
-        // consumed once, so the first await of a freshly-created future passes
-        // even when it appears in multiple slots.
+        // future would silently overwrite each other in the pending-call gather
+        // routing, leaving the first gather permanently blocked on a CallId
+        // that has already been resolved or is registered against a different
+        // gather. This mirrors the existing `is_consumed` check in
+        // `await_external_future` so direct double-await and gather-mediated
+        // double-await behave consistently. The dedup pass below ensures
+        // intra-gather duplicates (`gather(f, f)`) are not flagged: each unique
+        // CallId is only marked consumed once, so the first await of a freshly
+        // created future passes even when it appears in multiple slots.
         for item in &gather.get(self.heap).items {
             if let GatherItem::ExternalFuture(call_id) = item
                 && self.scheduler.is_consumed(*call_id)
@@ -129,114 +147,83 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             }
         }
 
-        // Set waiter and walk the items, deduplicating by identity so that the
-        // same coroutine or external future passed multiple times runs once and
-        // its result is fanned out to every gather slot. This matches CPython's
-        // `arg_to_fut` mapping in `asyncio.tasks.gather`.
-        //
-        // Coroutine spawns are buffered and applied after the `gather_mut` borrow
-        // ends, because `Scheduler::spawn` borrows the heap to call `inc_ref` on
-        // the new task's owning references. Already-resolved external futures are
-        // also fanned out after dropping the borrow because cloning their value
-        // requires mutable heap access.
-        let current_task = self.scheduler.current_task_id();
-        let gather_mut = gather.get_mut(self.heap);
-        gather_mut.waiter = current_task;
+        let current_task = self
+            .scheduler
+            .current_task_id()
+            .expect("await_gather_future called without a current task");
 
-        // Per-unique entries with the list of gather slots they should fill.
-        // Order of first occurrence is preserved so spawn order matches argument order.
-        let mut coro_spawn_plan: Vec<(HeapId, Vec<usize>)> = Vec::new();
-        let mut coro_seen: AHashMap<HeapId, usize> = AHashMap::new();
-        let mut external_plan: Vec<(CallId, Vec<usize>)> = Vec::new();
-        let mut external_seen: AHashMap<CallId, usize> = AHashMap::new();
+        // Single pass over items: spawn / register / write resolved values
+        // into `results` directly. Dedup by identity so `gather(c, c)` runs
+        // the coroutine once and fans its result out to every matching slot.
+        let mut pending_tasks: AHashMap<TaskId, Vec<usize>> = AHashMap::new();
+        let mut coro_to_task: AHashMap<HeapId, TaskId> = AHashMap::new();
+        let mut pending_calls: AHashMap<CallId, Vec<usize>> = AHashMap::new();
+        // For an external that resolved synchronously, remember the first
+        // slot that received the moved-in value; later duplicate slots clone
+        // from there.
+        let mut resolved_first_slot: AHashMap<CallId, usize> = AHashMap::new();
+        let mut results: Vec<Option<Value>> = (0..item_count).map(|_| None).collect();
 
-        for (idx, item) in gather_mut.items.iter().enumerate() {
-            match item {
+        for (idx, item) in gather.get(self.heap).items.iter().enumerate() {
+            match *item {
                 GatherItem::Coroutine(coro_id) => {
-                    if let Some(&plan_idx) = coro_seen.get(coro_id) {
-                        coro_spawn_plan[plan_idx].1.push(idx);
-                    } else {
-                        coro_seen.insert(*coro_id, coro_spawn_plan.len());
-                        coro_spawn_plan.push((*coro_id, vec![idx]));
-                    }
+                    let task_id = *coro_to_task
+                        .entry(coro_id)
+                        .or_insert_with(|| self.scheduler.spawn(self.heap, coro_id, Some(heap_id)));
+                    pending_tasks.entry(task_id).or_default().push(idx);
                 }
                 GatherItem::ExternalFuture(call_id) => {
-                    if let Some(&plan_idx) = external_seen.get(call_id) {
-                        external_plan[plan_idx].1.push(idx);
+                    if let Some(indices) = pending_calls.get_mut(&call_id) {
+                        // Duplicate of a still-pending external — append.
+                        indices.push(idx);
+                    } else if let Some(&first_idx) = resolved_first_slot.get(&call_id) {
+                        // Duplicate of an already-resolved external — clone
+                        // from the slot that owns the original.
+                        let cloned = results[first_idx]
+                            .as_ref()
+                            .expect("first occurrence holds the resolved value")
+                            .clone_with_heap(self.heap);
+                        results[idx] = Some(cloned);
                     } else {
-                        external_seen.insert(*call_id, external_plan.len());
-                        external_plan.push((*call_id, vec![idx]));
+                        // First time seeing this CallId.
+                        self.scheduler.mark_consumed(call_id);
+                        if let Some(value) = self.scheduler.take_resolved(call_id) {
+                            results[idx] = Some(value);
+                            resolved_first_slot.insert(call_id, idx);
+                        } else {
+                            self.scheduler.register_gather_for_call(call_id, heap_id);
+                            pending_calls.insert(call_id, vec![idx]);
+                        }
                     }
                 }
             }
         }
 
-        // Process external futures: mark consumed, then either take an existing
-        // resolved value or register the call as pending with all its indices.
-        let mut pending_calls = Vec::new();
-        let mut already_resolved: Vec<(Vec<usize>, Value)> = Vec::new();
-        for (call_id, indices) in external_plan {
-            self.scheduler.mark_consumed(call_id);
-            if let Some(value) = self.scheduler.take_resolved(call_id) {
-                already_resolved.push((indices, value));
-            } else {
-                pending_calls.push(call_id);
-                self.scheduler.register_gather_for_call(call_id, heap_id, indices);
-            }
-        }
-
-        // Spawn one task per unique coroutine; each spawn inc_refs the coroutine
-        // and the gather. The task carries the full list of slot indices so that
-        // its result is fanned out at completion time.
-        let mut task_ids = Vec::with_capacity(coro_spawn_plan.len());
-        for (coro_id, indices) in coro_spawn_plan {
-            let task_id = self.scheduler.spawn(self.heap, coro_id, Some(heap_id), indices);
-            task_ids.push(task_id);
-        }
-
-        // Fan out already-resolved external futures into gather.results. Each
-        // duplicate slot needs an independent inc_ref via `clone_with_heap`; the
-        // last slot moves the original value to avoid an unnecessary clone+drop.
-        // Clones must happen while no `HeapRead<GatherFuture>` borrow is held.
-        let mut resolved_writes: Vec<(usize, Value)> = Vec::new();
-        for (indices, value) in already_resolved {
-            let Some((last, init)) = indices.split_last() else {
-                value.drop_with_heap(self.heap);
-                continue;
-            };
-            for &idx in init {
-                resolved_writes.push((idx, value.clone_with_heap(self.heap)));
-            }
-            resolved_writes.push((*last, value));
-        }
-
-        // Re-acquire mutable access to the gather to store pending calls, task
-        // ids, and any already-resolved values fanned out above.
-        let gather_mut = gather.get_mut(self.heap);
-        gather_mut.pending_calls = pending_calls;
-        gather_mut.task_ids = task_ids;
-        for (idx, value) in resolved_writes {
-            gather_mut.results[idx] = Some(value);
-        }
-
-        // Check if all items are already complete (only external futures, all resolved)
-        let all_complete = gather_mut.task_ids.is_empty() && gather_mut.pending_calls.is_empty();
-
-        if all_complete {
-            // All external futures were already resolved - return results immediately
-            let results: Vec<Value> = mem::take(&mut gather_mut.results)
+        // Synchronous-completion shortcut: external-only gather where every
+        // call was already resolved. Allocate the result list and cache it on
+        // the gather (Pending → Completed) so re-awaits replay the same list.
+        if pending_tasks.is_empty() && pending_calls.is_empty() {
+            let results: Vec<Value> = results
                 .into_iter()
-                .map(|r| r.expect("all results should be filled"))
+                .map(|r| r.expect("all results filled for synchronous gather completion"))
                 .collect();
-
             let list_id = self.heap.allocate(HeapData::List(List::new(results)))?;
+            gather.cache_result(self.heap, list_id);
             return Ok(AwaitResult::ValueReady(Value::Ref(list_id)));
         }
 
-        // Block current task on this gather
-        self.scheduler.block_current_on_gather(heap_id, self.heap);
+        // Transition Pending → Awaited.
+        gather.get_mut(self.heap).state = GatherState::Awaited(AwaitedGather {
+            waiter: current_task,
+            pending_tasks,
+            pending_calls,
+            results,
+        });
+        drop(gather);
 
-        // Switch to next ready task (spawned tasks) or yield for external futures
+        // Block current task on this gather, then switch to a spawned task or
+        // yield to the host for external futures.
+        self.scheduler.block_current_on_gather(heap_id, self.heap);
         self.switch_or_yield()
     }
 
@@ -335,17 +322,22 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
     /// 3. If gather is complete, unblocks the waiter and provides the collected results
     /// 4. Otherwise, switches to the next ready task
     pub(super) fn handle_task_completion(&mut self, result: Value) -> Result<AwaitResult, RunError> {
-        // Get task info
+        // Get task info. Every spawned task belongs to a gather (the only
+        // call site of `Scheduler::spawn` is `await_gather_future`), so
+        // `gather_id` is unconditionally `Some`.
         let task_id = self
             .scheduler
             .current_task_id()
             .expect("handle_task_completion called without current task");
-        let task = self.scheduler.get_task_mut(task_id);
-        let gather_id = task.gather_id;
-        let gather_result_indices = mem::take(&mut task.gather_result_indices);
+        let task = self.scheduler.get_task(task_id);
+        let gid = task
+            .gather_id
+            .expect("handle_task_completion: spawned task without a gather");
         let coroutine_id = task.coroutine_id;
 
-        // Mark coroutine as completed
+        // Mark the coroutine as Completed before the task is cancelled —
+        // direct `await` of this coroutine elsewhere needs to see the new
+        // state, not the `Running` it had until now.
         if let Some(coro_id) = coroutine_id {
             let HeapReadOutput::Coroutine(mut coro) = self.heap.read(coro_id) else {
                 panic!("task coroutine_id doesn't point to a Coroutine")
@@ -353,109 +345,38 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             coro.get_mut(self.heap).state = CoroutineState::Completed;
         }
 
-        // Mark task as completed and store result in task state
-        let task_result = result.clone_with_heap(self.heap);
-        self.scheduler.complete_task(task_id, task_result, self.heap);
+        // Record the result on the gather and check whether it's now complete.
+        // `resolve_child` does the fan-out for duplicate slots (`gather(c, c)`)
+        // and the final state transition; it must run BEFORE we release any
+        // inc_refs the gather is holding (cancelling children, dropping the
+        // waiter's `BlockedOnGather`) — otherwise the gather can be freed
+        // while we're still about to write its cached state.
+        let HeapReadOutput::GatherFuture(mut gather) = self.heap.read(gid) else {
+            panic!("task gather_id doesn't point to a GatherFuture")
+        };
+        let resolution = gather.resolve_child(self, ChildSource::Task(task_id), result)?;
+        drop(gather);
 
-        // When the same coroutine was passed multiple times to gather, this
-        // task owns several slots; clone the result for all but the last and
-        // move into the last so refcounts stay balanced.
-        if let Some(gid) = gather_id {
-            let mut writes: Vec<(usize, Value)> = Vec::with_capacity(gather_result_indices.len());
-            if let Some((last, init)) = gather_result_indices.split_last() {
-                for &idx in init {
-                    writes.push((idx, result.clone_with_heap(self.heap)));
-                }
-                writes.push((*last, result));
-            } else {
-                result.drop_with_heap(self.heap);
-            }
+        // The just-completed task is no longer in the gather's
+        // `pending_tasks` map. Cancel it now to release its inc_refs on the
+        // coroutine and gather; otherwise it would linger in the scheduler.
+        self.scheduler.cancel_task(task_id, self.heap);
 
-            let HeapReadOutput::GatherFuture(mut gather) = self.heap.read(gid) else {
-                panic!("task gather_id doesn't point to a GatherFuture")
-            };
-
-            let gather_mut = gather.get_mut(self.heap);
-            for (idx, value) in writes {
-                gather_mut.results[idx] = Some(value);
-            }
-
-            // Check if all tasks are complete AND all external futures are resolved
-            let all_tasks_complete = gather.get(self.heap).task_ids.iter().all(|tid| {
-                matches!(
-                    self.scheduler.get_task(*tid).state,
-                    TaskState::Completed(_) | TaskState::Failed(_)
-                )
-            });
-            let all_external_resolved = gather.get(self.heap).pending_calls.is_empty();
-            let all_complete = all_tasks_complete && all_external_resolved;
-
-            if all_complete {
-                // Take the spawned task ids and waiter while gather is still
-                // readable; we'll drop the gather and remove the tasks below.
-                let Some(waiter_id) = gather.get(self.heap).waiter else {
-                    panic!("gather future has no waiter when gather is complete")
-                };
-                let task_ids = mem::take(&mut gather.get_mut(self.heap).task_ids);
-                let results = mem::take(&mut gather.get_mut(self.heap).results);
-                let mut results_guard = HeapGuard::new(results, self);
-                let this = results_guard.heap();
-
-                // Drop the reader before any operations that may free heap objects (e.g., cancelling tasks)
-                drop(gather);
-
-                // First check if any task failed
-                let failed_task = task_ids.iter().find_map(|tid| {
-                    let task = this.scheduler.get_task_mut(*tid);
-                    match &task.state {
-                        TaskState::Failed(_) => {
-                            let TaskState::Failed(err) = mem::replace(&mut task.state, TaskState::Ready) else {
-                                unreachable!()
-                            };
-                            Some(err)
-                        }
-                        _ => None,
-                    }
-                });
-
-                // Release every spawned task
-                for tid in task_ids {
-                    this.scheduler.cancel_task(tid, this.heap);
-                }
-
-                // Make waiter ready but don't add to ready queue since we're switching directly to it
-                this.scheduler.set_state(waiter_id, TaskState::Ready, this.heap);
-                this.cleanup_current_task();
-                this.scheduler.set_current_task(Some(waiter_id));
-                this.load_or_init_task(waiter_id)?;
-
-                return if let Some(err) = failed_task {
-                    // Error is raised in waiter context
-                    Err(err)
-                } else {
-                    let results = results_guard.into_inner();
-                    let results: Vec<Value> = results
-                        .into_iter()
-                        .map(|r| r.expect("all results should be filled when gather is complete"))
-                        .collect();
-
-                    // Create result list
-                    let list_id = self.heap.allocate(HeapData::List(List::new(results)))?;
-
-                    // Push the result onto the waiter's stack
-                    self.push(Value::Ref(list_id));
-                    Ok(AwaitResult::FramePushed)
-                };
-            }
-        } else {
-            // Drop the result (it's stored in the task state now)
-            result.drop_with_heap(self.heap);
+        if let Some(GatherResolution { list_id, waiter_id }) = resolution {
+            // Make waiter ready but don't add to ready queue — we're
+            // switching directly into its context. Replacing
+            // `BlockedOnGather` here releases the last gather inc_ref;
+            // the cached state is what keeps the result list alive.
+            self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
+            self.cleanup_current_task();
+            self.scheduler.set_current_task(Some(waiter_id));
+            self.load_or_init_task(waiter_id)?;
+            self.push(Value::Ref(list_id));
+            return Ok(AwaitResult::FramePushed);
         }
 
-        // Gather not complete or no gather - switch to next task
+        // Gather not complete — switch to next ready task.
         self.cleanup_current_task();
-
-        // Get next ready task
         self.scheduler.set_current_task(None);
         if let Some(next_task_id) = self.scheduler.next_ready_task() {
             self.scheduler.set_current_task(Some(next_task_id));
@@ -499,26 +420,16 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         // Get task's gather_id before marking failed
         let gather_id = self.scheduler.get_task(task_id).gather_id;
 
-        // If part of a gather, propagate error to waiter
+        // If part of a gather, tear the gather down (caches the error,
+        // cancels siblings, clears pending external routing) and switch into
+        // the waiter to propagate the error.
         if let Some(gid) = gather_id {
-            // Take task_ids from GatherFuture - gather is being destroyed anyway
             let HeapReadOutput::GatherFuture(mut gather) = self.heap.read(gid) else {
                 panic!("task gather_id doesn't point to a GatherFuture")
             };
-            let gather_mut = gather.get_mut(self.heap);
-            let task_ids = mem::take(&mut gather_mut.task_ids);
-            let Some(waiter_id) = gather_mut.waiter else {
-                panic!("gather future has no waiter when handling task failure")
-            };
-            // Drop the reader before any dec_ref that could free the gather.
+            let waiter_id = gather.fail(&mut self.scheduler, self.heap, &error);
             drop(gather);
 
-            // Release all tasks owned by this gather
-            for tid in task_ids {
-                self.scheduler.cancel_task(tid, self.heap);
-            }
-
-            // Switch to waiter and propagate the error
             self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
             self.cleanup_current_task();
             self.scheduler.set_current_task(Some(waiter_id));
@@ -726,85 +637,39 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             return Ok(());
         }
 
-        // Check if a gather is waiting on this CallId
-        if let Some((gather_id, result_indices)) = this.scheduler.take_gather_waiter(call_id) {
-            this.scheduler.remove_pending_call(call_id);
-
-            // Fan the resolved value out to every gather slot waiting on this
-            // CallId. Each duplicate slot needs an independent inc_ref via
-            // `clone_with_heap`; the last slot moves the original value.
-            let mut writes: Vec<(usize, Value)> = Vec::with_capacity(result_indices.len());
+        // Check if this call is gather-routed. `take_gather_for_call` removes
+        // the pending entry; the gather's own `pending_calls` map carries the
+        // slot indices `resolve_child` looks up below.
+        if let Some(gather_id) = this.scheduler.take_gather_for_call(call_id) {
             let value = value_guard.into_inner();
-            if let Some((last, init)) = result_indices.split_last() {
-                for &idx in init {
-                    writes.push((idx, value.clone_with_heap(self.heap)));
-                }
-                writes.push((*last, value));
-            } else {
-                value.drop_with_heap(self.heap);
-            }
-
             let HeapReadOutput::GatherFuture(mut gather) = self.heap.read(gather_id) else {
                 panic!("gather_id doesn't point to a GatherFuture")
             };
-            let gather_mut = gather.get_mut(self.heap);
-            for (idx, v) in writes {
-                gather_mut.results[idx] = Some(v);
-            }
 
-            // Remove from pending_calls
-            gather_mut.pending_calls.retain(|&cid| cid != call_id);
-            let pending_empty = gather_mut.pending_calls.is_empty();
+            // Record the resolution on the gather. `resolve_child` fans out to
+            // duplicate slots, clears the resolved CallId from `pending_calls`,
+            // and finalizes the gather if it's now done. By the time we get
+            // here all child tasks have already cleaned themselves up via
+            // `handle_task_completion`, so there's nothing extra to cancel.
+            if let Some(GatherResolution { list_id, waiter_id }) =
+                gather.resolve_child(self, ChildSource::ExternalCall(call_id), value)?
+            {
+                drop(gather);
 
-            // Check if gather is now complete (all external futures resolved and all tasks complete)
-            if pending_empty {
-                let all_tasks_complete = gather.get(self.heap).task_ids.iter().all(|tid| {
-                    matches!(
-                        self.scheduler.get_task(*tid).state,
-                        TaskState::Completed(_) | TaskState::Failed(_)
-                    )
-                });
-                if all_tasks_complete {
-                    // Gather is complete - build result and push to waiter's stack
-                    let Some(waiter_id) = gather.get(self.heap).waiter else {
-                        panic!("gather future has no waiter when gather is complete")
-                    };
-                    let task_ids = mem::take(&mut gather.get_mut(self.heap).task_ids);
-                    // Steal results from gather using mem::take - avoids refcount dance
-                    // (copy + inc_ref + dec_ref on gather drop). Since gather is being
-                    // destroyed, we can take ownership of the values directly.
-                    let results: Vec<Value> = mem::take(&mut gather.get_mut(self.heap).results)
-                        .into_iter()
-                        .map(|r| r.expect("all results should be filled when gather is complete"))
-                        .collect();
-                    // Drop the HeapRead before cancellation, which may free the gather
-                    drop(gather);
+                // External-future resolution can fire while either the waiter
+                // is itself the current task (frames live in the VM — e.g.
+                // external-only gather where the waiter never switched away)
+                // or the waiter's context is parked. We pick the right push
+                // target based on that.
+                let waiter_context_in_vm =
+                    self.scheduler.current_task_id() == Some(waiter_id) && !self.frames.is_empty();
 
-                    // Release every child task
-                    for tid in task_ids {
-                        self.scheduler.cancel_task(tid, self.heap);
-                    }
-
-                    let list_id = self.heap.allocate(HeapData::List(List::new(results)))?;
-
-                    // Push result onto waiter's stack and mark as ready.
-                    // Check if the waiter's context is currently in the VM (frames not saved
-                    // to the task). This is the case when the waiter is the current task
-                    // and hasn't been switched away from (e.g., external-only gather).
-                    let waiter_context_in_vm =
-                        self.scheduler.current_task_id() == Some(waiter_id) && !self.frames.is_empty();
-
-                    if waiter_context_in_vm {
-                        // Waiter's frames are in the VM - push directly onto VM stack
-                        self.stack.push(Value::Ref(list_id));
-                        // Mark as ready but don't add to ready_queue.
-                        self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
-                    } else {
-                        // Waiter's context is saved in the task (either spawned task,
-                        // or main task that was saved when switching to spawned tasks)
-                        self.scheduler.get_task_mut(waiter_id).stack.push(Value::Ref(list_id));
-                        self.scheduler.make_ready(waiter_id, self.heap);
-                    }
+                if waiter_context_in_vm {
+                    self.stack.push(Value::Ref(list_id));
+                    self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
+                } else {
+                    self.scheduler.get_task_mut(waiter_id).stack.push(Value::Ref(list_id));
+                    self.scheduler.make_ready(waiter_id, self.heap);
                 }
             }
         } else {
@@ -842,6 +707,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             PendingCallData {
                 args: ArgValues::Empty,
                 creator_task: current_task,
+                gather: None,
             },
         );
     }
@@ -927,5 +793,186 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         );
 
         Ok(FrameExit::ResolveFutures(pending_call_ids))
+    }
+}
+
+/// Outcome of [`HeapRead::resolve_child`] when a gather has finished driving
+/// its children. `list_id` is the cached result list to hand back to user
+/// code; `waiter_id` is the task that originally awaited this gather and
+/// must be made runnable.
+///
+/// `resolve_child` only handles the success path. Failures are propagated
+/// eagerly: a coroutine task that raises goes through
+/// [`VM::handle_task_failure`] and a rejected external future through
+/// [`Scheduler::fail_for_call`]. Both tear the gather down and transition
+/// its state to `Failed` before any other call site can run.
+pub(crate) struct GatherResolution {
+    pub list_id: HeapId,
+    pub waiter_id: TaskId,
+}
+
+/// Identifies which child of a gather just produced a value.
+///
+/// Used by [`HeapRead::resolve_child`] to look up the child's slot indices
+/// from the gather's own `pending_tasks` / `pending_calls` maps and, in the
+/// external-future case, to clear the resolved entry.
+#[derive(Clone, Copy)]
+pub(crate) enum ChildSource {
+    /// A spawned coroutine task completed with a value.
+    Task(TaskId),
+    /// An external future was resolved with a value by the host.
+    ExternalCall(CallId),
+}
+
+impl<'h> HeapRead<'h, GatherFuture> {
+    /// Caches `list_id` as the gather's successful result.
+    ///
+    /// Inc_refs `list_id` so the cached state and the caller both own a ref
+    /// to the resulting list, then overwrites the state with
+    /// `GatherState::Completed(list_id)`. Used directly by
+    /// [`VM::await_gather_future`] for the synchronous-completion paths
+    /// (empty gather, all externals already resolved); on the async path the
+    /// transition happens inside [`Self::resolve_child`].
+    pub(crate) fn cache_result(&mut self, heap: &mut HeapReader<'h, impl ResourceTracker>, list_id: HeapId) {
+        heap.inc_ref(list_id);
+        self.get_mut(heap).state = GatherState::Completed(list_id);
+    }
+
+    /// Records one child's resolution on this gather and, if everything has
+    /// now settled, transitions to `Completed`.
+    ///
+    /// The child's slot-index mapping is read from (and removed from) the
+    /// gather's own `pending_tasks` / `pending_calls` map. Membership in
+    /// those maps is the "still in flight" signal: the completeness check
+    /// just tests `pending_tasks.is_empty() && pending_calls.is_empty()`.
+    ///
+    /// Returns `None` while children are still in flight; on the final child
+    /// resolution returns `Some(GatherResolution)` and the gather has been
+    /// transitioned to `Completed`. The caller is responsible for waking
+    /// `waiter_id` and pushing `list_id` onto the waiter's stack.
+    ///
+    /// Failure has no analogue here — child task failures and external-future
+    /// rejection both short-circuit the gather via [`Self::fail`].
+    fn resolve_child(
+        &mut self,
+        vm: &mut VM<'h, impl ResourceTracker>,
+        source: ChildSource,
+        value: Value,
+    ) -> RunResult<Option<GatherResolution>> {
+        // Remove this child's slot-index mapping. Removing on completion
+        // (rather than scanning task states) keeps the gather as the single
+        // source of truth for "what's still in flight".
+        let indices: Vec<usize> = {
+            let awaited = self
+                .get_mut(vm.heap)
+                .as_awaited_mut()
+                .expect("resolve_child called on non-Awaited gather");
+            match source {
+                ChildSource::Task(tid) => awaited
+                    .pending_tasks
+                    .remove(&tid)
+                    .expect("resolve_child: task not registered with this gather"),
+                ChildSource::ExternalCall(cid) => awaited
+                    .pending_calls
+                    .remove(&cid)
+                    .expect("resolve_child: external call not registered with this gather"),
+            }
+        };
+
+        // Fan the value out into a local Vec, before borrowing the gather
+        // mutably for the writes — `clone_with_heap` needs `&mut HeapReader`,
+        // which would otherwise conflict with the awaited-mut borrow.
+        let writes: Vec<(usize, Value)> = if let Some((last, init)) = indices.split_last() {
+            let mut writes = Vec::with_capacity(indices.len());
+            for &idx in init {
+                writes.push((idx, value.clone_with_heap(vm.heap)));
+            }
+            writes.push((*last, value));
+            writes
+        } else {
+            value.drop_with_heap(vm.heap);
+            Vec::new()
+        };
+
+        // Commit the writes; bail out early if the gather isn't done yet.
+        let waiter_id = {
+            let awaited = self
+                .get_mut(vm.heap)
+                .as_awaited_mut()
+                .expect("gather still Awaited after recording child resolution");
+            for (idx, v) in writes {
+                awaited.results[idx] = Some(v);
+            }
+            if !awaited.pending_tasks.is_empty() || !awaited.pending_calls.is_empty() {
+                return Ok(None);
+            }
+            awaited.waiter
+        };
+
+        // All children have resolved — take the results out and commit
+        // the transition to `Completed`.
+        let results = mem::take(
+            &mut self
+                .get_mut(vm.heap)
+                .as_awaited_mut()
+                .expect("checked Awaited above")
+                .results,
+        );
+        let results: Vec<Value> = results
+            .into_iter()
+            .map(|r| r.expect("all results filled when gather is complete"))
+            .collect();
+        let list_id = vm.heap.allocate(HeapData::List(List::new(results)))?;
+        self.cache_result(vm.heap, list_id);
+
+        Ok(Some(GatherResolution { list_id, waiter_id }))
+    }
+
+    /// Tear the gather down with `error` and return its waiter.
+    ///
+    /// Takes `&mut Scheduler` + `&mut HeapReader` rather than `&mut VM` so
+    /// this works from both `VM::handle_task_failure` (has a VM, splits
+    /// borrows on its fields) and `Scheduler::fail_for_call` (only has a
+    /// scheduler + heap reader).
+    pub(crate) fn fail(
+        &mut self,
+        scheduler: &mut Scheduler,
+        heap: &mut HeapReader<'h, impl ResourceTracker>,
+        error: &RunError,
+    ) -> TaskId {
+        // Take the Awaited bookkeeping. The state stays `Awaited` (with empty
+        // fields) until the state replace below commits the transition.
+        let (waiter_id, pending_tasks, pending_calls, results) = {
+            let awaited = self
+                .get_mut(heap)
+                .as_awaited_mut()
+                .expect("fail called on non-Awaited gather");
+            (
+                awaited.waiter,
+                mem::take(&mut awaited.pending_tasks),
+                mem::take(&mut awaited.pending_calls),
+                mem::take(&mut awaited.results),
+            )
+        };
+
+        // Cache a clone so re-awaits replay the same exception.
+        self.get_mut(heap).state = GatherState::Failed(error.clone());
+
+        // Drop fanned-out result Values that won't reach the waiter.
+        results.drop_with_heap(heap);
+
+        // Drop pending-call routing so late host-side resolutions don't reach
+        // a stale gather entry. `remove_pending_call` is a no-op when the
+        // entry has already been cleared (e.g. by `take_gather_for_call`).
+        for cid in pending_calls.into_keys() {
+            scheduler.remove_pending_call(cid);
+        }
+
+        // Release all tasks owned by this gather.
+        for tid in pending_tasks.into_keys() {
+            scheduler.cancel_task(tid, heap);
+        }
+
+        waiter_id
     }
 }

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -364,28 +364,43 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         // coroutine and gather; otherwise it would linger in the scheduler.
         self.scheduler.cancel_task(task_id, self.heap);
 
-        if let Some(GatherResolution { list_id, waiter_id }) = resolution {
-            // Make waiter ready but don't add to ready queue — we're
-            // switching directly into its context. Replacing
-            // `BlockedOnGather` here releases the last gather inc_ref;
-            // the cached state is what keeps the result list alive.
-            self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
-            self.cleanup_current_task();
-            self.scheduler.set_current_task(Some(waiter_id));
-            self.load_or_init_task(waiter_id)?;
-            self.push(Value::Ref(list_id));
-            return Ok(AwaitResult::FramePushed);
-        }
-
-        // Gather not complete — switch to next ready task.
-        self.cleanup_current_task();
-        self.scheduler.set_current_task(None);
-        if let Some(next_task_id) = self.scheduler.next_ready_task() {
-            self.scheduler.set_current_task(Some(next_task_id));
-            self.load_or_init_task(next_task_id)?;
-            Ok(AwaitResult::FramePushed)
-        } else {
-            Ok(AwaitResult::Yield(self.scheduler.pending_call_ids()))
+        match resolution {
+            Some(GatherResolution::Success { list_id, waiter_id }) => {
+                // Make waiter ready but don't add to ready queue — we're
+                // switching directly into its context. Replacing
+                // `BlockedOnGather` here releases the last gather inc_ref;
+                // the cached state is what keeps the result list alive.
+                self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
+                self.cleanup_current_task();
+                self.scheduler.set_current_task(Some(waiter_id));
+                self.load_or_init_task(waiter_id)?;
+                self.push(Value::Ref(list_id));
+                Ok(AwaitResult::FramePushed)
+            }
+            Some(GatherResolution::Failure { error, waiter_id }) => {
+                // Switch into the waiter's frame and surface the error
+                // there. The run loop's `catch_sync!` will dispatch through
+                // the waiter's exception table — this is how a sibling's
+                // failure ends up at the user's `try` / `except` around the
+                // gather await.
+                self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
+                self.cleanup_current_task();
+                self.scheduler.set_current_task(Some(waiter_id));
+                self.load_or_init_task(waiter_id)?;
+                Err(error)
+            }
+            None => {
+                // Gather not complete — switch to next ready task.
+                self.cleanup_current_task();
+                self.scheduler.set_current_task(None);
+                if let Some(next_task_id) = self.scheduler.next_ready_task() {
+                    self.scheduler.set_current_task(Some(next_task_id));
+                    self.load_or_init_task(next_task_id)?;
+                    Ok(AwaitResult::FramePushed)
+                } else {
+                    Ok(AwaitResult::Yield(self.scheduler.pending_call_ids()))
+                }
+            }
         }
     }
 
@@ -660,29 +675,41 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
 
             // Record the resolution on the gather. `resolve_child` fans out to
             // duplicate slots, clears the resolved CallId from `pending_calls`,
-            // and finalizes the gather if it's now done. By the time we get
-            // here all child tasks have already cleaned themselves up via
-            // `handle_task_completion`, so there's nothing extra to cancel.
-            if let Some(GatherResolution { list_id, waiter_id }) =
-                gather.resolve_child(self, ChildSource::ExternalCall(call_id), value)?
-            {
-                drop(gather);
+            // and finalizes the gather (Success or Failure) if it's now done.
+            match gather.resolve_child(self, ChildSource::ExternalCall(call_id), value)? {
+                Some(GatherResolution::Success { list_id, waiter_id }) => {
+                    drop(gather);
 
-                // External-future resolution can fire while either the waiter
-                // is itself the current task (frames live in the VM — e.g.
-                // external-only gather where the waiter never switched away)
-                // or the waiter's context is parked. We pick the right push
-                // target based on that.
-                let waiter_context_in_vm =
-                    self.scheduler.current_task_id() == Some(waiter_id) && !self.frames.is_empty();
+                    // External-future resolution can fire while either the
+                    // waiter is itself the current task (frames live in the
+                    // VM — e.g. external-only gather where the waiter never
+                    // switched away) or the waiter's context is parked. We
+                    // pick the right push target based on that.
+                    let waiter_context_in_vm =
+                        self.scheduler.current_task_id() == Some(waiter_id) && !self.frames.is_empty();
 
-                if waiter_context_in_vm {
-                    self.stack.push(Value::Ref(list_id));
-                    self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
-                } else {
-                    self.scheduler.get_task_mut(waiter_id).stack.push(Value::Ref(list_id));
-                    self.scheduler.make_ready(waiter_id, self.heap);
+                    if waiter_context_in_vm {
+                        self.stack.push(Value::Ref(list_id));
+                        self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
+                    } else {
+                        self.scheduler.get_task_mut(waiter_id).stack.push(Value::Ref(list_id));
+                        self.scheduler.make_ready(waiter_id, self.heap);
+                    }
                 }
+                Some(GatherResolution::Failure { error, waiter_id }) => {
+                    drop(gather);
+
+                    // Switch VM context into the waiter so the post-loop check
+                    // in `resume_with_resolved_futures` sees `current=waiter`
+                    // with state `Failed`, then calls `resume_with_exception`
+                    // — which raises in the waiter's frame and lets the
+                    // user's `try` / `except` catch it.
+                    self.cleanup_current_task();
+                    self.scheduler.set_current_task(Some(waiter_id));
+                    self.load_or_init_task(waiter_id)?;
+                    self.scheduler.set_state(waiter_id, TaskState::Failed(error), self.heap);
+                }
+                None => {}
             }
         } else {
             // Normal resolution for a single awaiter.
@@ -816,18 +843,20 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
 }
 
 /// Outcome of [`HeapRead::resolve_child`] when a gather has finished driving
-/// its children. `list_id` is the cached result list to hand back to user
-/// code; `waiter_id` is the task that originally awaited this gather and
-/// must be made runnable.
+/// its children.
 ///
-/// `resolve_child` only handles the success path. Failures are propagated
-/// eagerly: a coroutine task that raises goes through
-/// [`VM::handle_task_failure`] and a rejected external future through
-/// [`Scheduler::fail_for_call`]. Both tear the gather down and transition
-/// its state to `Failed` before any other call site can run.
-pub(crate) struct GatherResolution {
-    pub list_id: HeapId,
-    pub waiter_id: TaskId,
+/// - `Success`: every child resolved with a value. `list_id` is the cached
+///   result list to hand back; `waiter_id` is the task that awaited the
+///   gather.
+/// - `Failure`: a sibling task ended up `TaskState::Failed` (typically
+///   because an external it was waiting on was rejected by the host —
+///   `Scheduler::fail_for_call`'s "indirect" branch sets that state). The
+///   gather has been torn down via [`HeapRead::fail`]; the caller is
+///   responsible for switching VM context to `waiter_id` and propagating
+///   `error` through its frame's exception handler.
+pub(crate) enum GatherResolution {
+    Success { list_id: HeapId, waiter_id: TaskId },
+    Failure { error: RunError, waiter_id: TaskId },
 }
 
 /// Identifies which child of a gather just produced a value.
@@ -841,6 +870,19 @@ pub(crate) enum ChildSource {
     Task(TaskId),
     /// An external future was resolved with a value by the host.
     ExternalCall(CallId),
+}
+
+/// Internal enum used by [`HeapRead::resolve_child`] to thread the
+/// completion-analysis result out from a borrow-scoped block.
+enum ResolvePhase {
+    /// At least one child is still in flight (pending external call or task
+    /// not yet completed).
+    NotDone,
+    /// A sibling task is in `TaskState::Failed` — the gather should be torn
+    /// down and the cached error replayed via the waiter.
+    FailedSibling { tid: TaskId },
+    /// Every child has completed successfully — finalize as `Completed`.
+    Done { waiter_id: TaskId },
 }
 
 impl<'h> HeapRead<'h, GatherFuture> {
@@ -858,29 +900,30 @@ impl<'h> HeapRead<'h, GatherFuture> {
     }
 
     /// Records one child's resolution on this gather and, if everything has
-    /// now settled, transitions to `Completed`.
+    /// now settled, transitions the gather to `Completed` (success) or
+    /// `Failed` (sibling failure detected).
     ///
-    /// The child's slot-index mapping is read from (and removed from) the
-    /// gather's own `pending_tasks` / `pending_calls` map. Membership in
-    /// those maps is the "still in flight" signal: the completeness check
-    /// just tests `pending_tasks.is_empty() && pending_calls.is_empty()`.
+    /// The child's slot-index mapping is removed from the gather's own
+    /// `pending_tasks` / `pending_calls` map. Membership in those maps is
+    /// the "still in flight" signal.
     ///
-    /// Returns `None` while children are still in flight; on the final child
-    /// resolution returns `Some(GatherResolution)` and the gather has been
-    /// transitioned to `Completed`. The caller is responsible for waking
-    /// `waiter_id` and pushing `list_id` onto the waiter's stack.
+    /// Failure detection: a child task can end up in `TaskState::Failed`
+    /// without the gather being torn down — this happens when an external
+    /// call inside a gather child raises (`Scheduler::fail_for_call`'s
+    /// indirect branch). Such Failed siblings linger in `pending_tasks`
+    /// until *another* child completes and brings us through this scan,
+    /// which then propagates via `self.fail`.
     ///
-    /// Failure has no analogue here — child task failures and external-future
-    /// rejection both short-circuit the gather via [`Self::fail`].
+    /// Returns `None` while children are still in flight; otherwise
+    /// `Some(GatherResolution::Success | Failure)`. In both cases the
+    /// gather has been transitioned to a terminal state.
     fn resolve_child(
         &mut self,
         vm: &mut VM<'h, impl ResourceTracker>,
         source: ChildSource,
         value: Value,
     ) -> RunResult<Option<GatherResolution>> {
-        // Remove this child's slot-index mapping. Removing on completion
-        // (rather than scanning task states) keeps the gather as the single
-        // source of truth for "what's still in flight".
+        // Remove this child's slot-index mapping.
         let indices: Vec<usize> = {
             let awaited = self
                 .get_mut(vm.heap)
@@ -913,8 +956,8 @@ impl<'h> HeapRead<'h, GatherFuture> {
             Vec::new()
         };
 
-        // Commit the writes; bail out early if the gather isn't done yet.
-        let waiter_id = {
+        // Commit the writes, then look for a Failed sibling or check completion.
+        let phase = {
             let awaited = self
                 .get_mut(vm.heap)
                 .as_awaited_mut()
@@ -922,29 +965,55 @@ impl<'h> HeapRead<'h, GatherFuture> {
             for (idx, v) in writes {
                 awaited.results[idx] = Some(v);
             }
-            if !awaited.pending_tasks.is_empty() || !awaited.pending_calls.is_empty() {
-                return Ok(None);
+            if !awaited.pending_calls.is_empty() {
+                ResolvePhase::NotDone
+            } else if let Some(&tid) = awaited
+                .pending_tasks
+                .keys()
+                .find(|tid| matches!(vm.scheduler.get_task(**tid).state, TaskState::Failed(_)))
+            {
+                ResolvePhase::FailedSibling { tid }
+            } else if !awaited.pending_tasks.is_empty() {
+                ResolvePhase::NotDone
+            } else {
+                ResolvePhase::Done {
+                    waiter_id: awaited.waiter,
+                }
             }
-            awaited.waiter
         };
 
-        // All children have resolved — take the results out and commit
-        // the transition to `Completed`.
-        let results = mem::take(
-            &mut self
-                .get_mut(vm.heap)
-                .as_awaited_mut()
-                .expect("checked Awaited above")
-                .results,
-        );
-        let results: Vec<Value> = results
-            .into_iter()
-            .map(|r| r.expect("all results filled when gather is complete"))
-            .collect();
-        let list_id = vm.heap.allocate(HeapData::List(List::new(results)))?;
-        self.cache_result(vm.heap, list_id);
-
-        Ok(Some(GatherResolution { list_id, waiter_id }))
+        match phase {
+            ResolvePhase::NotDone => Ok(None),
+            ResolvePhase::FailedSibling { tid } => {
+                // Take the error out of the failed task's state, then tear
+                // the gather down. `self.fail` cancels every remaining
+                // child (including `tid` itself) and caches the error on
+                // the gather for replay on re-await.
+                let task = vm.scheduler.get_task_mut(tid);
+                let TaskState::Failed(error) = mem::replace(&mut task.state, TaskState::Ready) else {
+                    unreachable!("scanned Failed above")
+                };
+                let waiter_id = self.fail(&mut vm.scheduler, vm.heap, &error);
+                Ok(Some(GatherResolution::Failure { error, waiter_id }))
+            }
+            ResolvePhase::Done { waiter_id } => {
+                // All children resolved successfully — build the result list.
+                let results = mem::take(
+                    &mut self
+                        .get_mut(vm.heap)
+                        .as_awaited_mut()
+                        .expect("checked Awaited above")
+                        .results,
+                );
+                let results: Vec<Value> = results
+                    .into_iter()
+                    .map(|r| r.expect("all results filled when gather is complete"))
+                    .collect();
+                let list_id = vm.heap.allocate(HeapData::List(List::new(results)))?;
+                self.cache_result(vm.heap, list_id);
+                Ok(Some(GatherResolution::Success { list_id, waiter_id }))
+            }
+        }
     }
 
     /// Tear the gather down with `error` and return its waiter.

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -872,19 +872,6 @@ pub(crate) enum ChildSource {
     ExternalCall(CallId),
 }
 
-/// Internal enum used by [`HeapRead::resolve_child`] to thread the
-/// completion-analysis result out from a borrow-scoped block.
-enum ResolvePhase {
-    /// At least one child is still in flight (pending external call or task
-    /// not yet completed).
-    NotDone,
-    /// A sibling task is in `TaskState::Failed` — the gather should be torn
-    /// down and the cached error replayed via the waiter.
-    FailedSibling { tid: TaskId },
-    /// Every child has completed successfully — finalize as `Completed`.
-    Done { waiter_id: TaskId },
-}
-
 impl<'h> HeapRead<'h, GatherFuture> {
     /// Caches `list_id` as the gather's successful result.
     ///
@@ -941,79 +928,63 @@ impl<'h> HeapRead<'h, GatherFuture> {
             }
         };
 
-        // Fan the value out into a local Vec, before borrowing the gather
-        // mutably for the writes — `clone_with_heap` needs `&mut HeapReader`,
-        // which would otherwise conflict with the awaited-mut borrow.
-        let writes: Vec<(usize, Value)> = if let Some((last, init)) = indices.split_last() {
-            let mut writes = Vec::with_capacity(indices.len());
-            for &idx in init {
-                writes.push((idx, value.clone_with_heap(vm.heap)));
-            }
-            writes.push((*last, value));
-            writes
-        } else {
-            value.drop_with_heap(vm.heap);
-            Vec::new()
-        };
-
-        // Commit the writes, then look for a Failed sibling or check completion.
-        let phase = {
-            let awaited = self
+        // Take `results` out so the writes can do their clones (which need
+        // `&Heap` access) without fighting the `&mut`-chain that
+        // `as_awaited_mut` requires. We put it back into the gather right
+        // after, before the completion scan.
+        let mut results = mem::take(
+            &mut self
                 .get_mut(vm.heap)
                 .as_awaited_mut()
-                .expect("gather still Awaited after recording child resolution");
-            for (idx, v) in writes {
-                awaited.results[idx] = Some(v);
+                .expect("resolve_child called on non-Awaited gather")
+                .results,
+        );
+        if let Some((last, init)) = indices.split_last() {
+            for &idx in init {
+                results[idx] = Some(value.clone_with_heap(vm.heap));
             }
-            if !awaited.pending_calls.is_empty() {
-                ResolvePhase::NotDone
-            } else if let Some(&tid) = awaited
-                .pending_tasks
-                .keys()
-                .find(|tid| matches!(vm.scheduler.get_task(**tid).state, TaskState::Failed(_)))
-            {
-                ResolvePhase::FailedSibling { tid }
-            } else if !awaited.pending_tasks.is_empty() {
-                ResolvePhase::NotDone
-            } else {
-                ResolvePhase::Done {
-                    waiter_id: awaited.waiter,
-                }
-            }
-        };
-
-        match phase {
-            ResolvePhase::NotDone => Ok(None),
-            ResolvePhase::FailedSibling { tid } => {
-                // Take the error out of the failed task's state, then tear
-                // the gather down. `self.fail` cancels every remaining
-                // child (including `tid` itself) and caches the error on
-                // the gather for replay on re-await.
-                let task = vm.scheduler.get_task_mut(tid);
-                let TaskState::Failed(error) = mem::replace(&mut task.state, TaskState::Ready) else {
-                    unreachable!("scanned Failed above")
-                };
-                let waiter_id = self.fail(&mut vm.scheduler, vm.heap, &error);
-                Ok(Some(GatherResolution::Failure { error, waiter_id }))
-            }
-            ResolvePhase::Done { waiter_id } => {
-                // All children resolved successfully — build the result list.
-                let results = mem::take(
-                    &mut self
-                        .get_mut(vm.heap)
-                        .as_awaited_mut()
-                        .expect("checked Awaited above")
-                        .results,
-                );
-                let results: Vec<Value> = results
-                    .into_iter()
-                    .map(|r| r.expect("all results filled when gather is complete"))
-                    .collect();
-                let list_id = vm.heap.allocate(HeapData::List(List::new(results)))?;
-                self.cache_result(vm.heap, list_id);
-                Ok(Some(GatherResolution::Success { list_id, waiter_id }))
-            }
+            results[*last] = Some(value);
+        } else {
+            value.drop_with_heap(vm.heap);
         }
+
+        // Restore results and look for a Failed sibling or check completion.
+        let awaited = self
+            .get_mut(vm.heap)
+            .as_awaited_mut()
+            .expect("gather still Awaited after recording child resolution");
+        awaited.results = results;
+
+        // Check for failed siblings after recording the result.
+        if let Some(&tid) = awaited
+            .pending_tasks
+            .keys()
+            .find(|tid| matches!(vm.scheduler.get_task(**tid).state, TaskState::Failed(_)))
+        {
+            // Take the error out of the failed task's state, then tear
+            // the gather down. `self.fail` cancels every remaining
+            // child (including `tid` itself) and caches the error on
+            // the gather for replay on re-await.
+            let task = vm.scheduler.get_task_mut(tid);
+            let TaskState::Failed(error) = mem::replace(&mut task.state, TaskState::Ready) else {
+                unreachable!("scanned Failed above")
+            };
+            let waiter_id = self.fail(&mut vm.scheduler, vm.heap, &error);
+            return Ok(Some(GatherResolution::Failure { error, waiter_id }));
+        } else if !awaited.pending_tasks.is_empty() || !awaited.pending_calls.is_empty() {
+            return Ok(None);
+        }
+
+        // All children resolved successfully — build the result list.
+        let results = mem::take(&mut awaited.results);
+        let waiter_id = awaited.waiter;
+        let results: Vec<Value> = results
+            .into_iter()
+            .map(|r| r.expect("all results filled when gather is complete"))
+            .collect();
+        let list_id = vm.heap.allocate(HeapData::List(List::new(results)))?;
+        self.cache_result(vm.heap, list_id);
+        Ok(Some(GatherResolution::Success { list_id, waiter_id }))
     }
 
     /// Tear the gather down with `error` and return its waiter.

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -627,20 +627,26 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
     pub fn resolve_future(&mut self, call_id: u32, value: Value) -> RunResult<()> {
         let mut value_guard = HeapGuard::new(value, self);
         let this = value_guard.heap();
-
         let call_id = CallId::new(call_id);
-        // Check if the creator task has been cancelled/failed
-        if let Some(creator_task) = this.scheduler.get_pending_call_creator(call_id)
-            && this.scheduler.is_task_failed(creator_task)
-        {
-            // Task was cancelled - silently ignore the result
+
+        // Pop the pending entry. A `None` here means the gather that was
+        // routing this call has been torn down (`HeapRead::fail` clears its
+        // pending entries) — drop the value, since `mark_consumed` was set
+        // when the gather awaited so no future `await` of the same call can
+        // pick it up. (Pre-refactor stored these in `resolved`; the value
+        // was unreachable and only released at `Scheduler::cleanup`.)
+        let Some(pending) = this.scheduler.take_pending_call(call_id) else {
+            return Ok(());
+        };
+
+        // If the creator task of a non-gather call has failed, also drop the
+        // result. (Gather-routed calls don't reach here in the failure case —
+        // teardown removes the pending entry first.)
+        if pending.gather.is_none() && this.scheduler.is_task_failed(pending.creator_task) {
             return Ok(());
         }
 
-        // Check if this call is gather-routed. `take_gather_for_call` removes
-        // the pending entry; the gather's own `pending_calls` map carries the
-        // slot indices `resolve_child` looks up below.
-        if let Some(gather_id) = this.scheduler.take_gather_for_call(call_id) {
+        if let Some(gather_id) = pending.gather {
             let value = value_guard.into_inner();
             let HeapReadOutput::GatherFuture(mut gather) = self.heap.read(gather_id) else {
                 panic!("gather_id doesn't point to a GatherFuture")
@@ -673,9 +679,15 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
                 }
             }
         } else {
-            // Normal resolution for single awaiter
+            // Normal resolution for a single awaiter.
             let value = value_guard.into_inner();
-            self.scheduler.resolve(call_id, value);
+            self.scheduler.record_resolved(call_id, value);
+            // Unblock the waiting task, if it's still waiting.
+            let task = self.scheduler.get_task_mut(pending.creator_task);
+            if matches!(task.state, TaskState::BlockedOnCall(cid) if cid == call_id) {
+                task.unblocked_by = Some(call_id);
+            }
+            self.scheduler.make_ready(pending.creator_task, self.heap);
         }
         Ok(())
     }
@@ -962,10 +974,11 @@ impl<'h> HeapRead<'h, GatherFuture> {
         results.drop_with_heap(heap);
 
         // Drop pending-call routing so late host-side resolutions don't reach
-        // a stale gather entry. `remove_pending_call` is a no-op when the
-        // entry has already been cleared (e.g. by `take_gather_for_call`).
+        // a stale gather entry. `take_pending_call` is a no-op when the entry
+        // has already been cleared (e.g. by `Scheduler::fail_for_call` having
+        // already removed the entry it was driving).
         for cid in pending_calls.into_keys() {
-            scheduler.remove_pending_call(cid);
+            scheduler.take_pending_call(cid);
         }
 
         // Release all tasks owned by this gather.

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -6,10 +6,7 @@
 //! - Spawned tasks (1+) store their own execution context in the Task struct
 //! - When switching tasks, the scheduler swaps contexts with the VM
 
-use std::{
-    collections::{VecDeque, hash_map::Entry},
-    mem,
-};
+use std::{collections::VecDeque, mem};
 
 use ahash::{AHashMap, AHashSet};
 
@@ -272,12 +269,14 @@ impl Scheduler {
         self.pending_calls.insert(call_id, data);
     }
 
-    /// Removes a call_id from the pending_calls map.
+    /// Removes the pending-call entry for `call_id` and returns its data, if
+    /// present.
     ///
-    /// Called when resolving a gather's external future - the call is no longer
-    /// pending once the result has been stored in the gather's results.
-    pub fn remove_pending_call(&mut self, call_id: CallId) {
-        self.pending_calls.remove(&call_id);
+    /// Callers that only want to remove the entry can ignore the return
+    /// value (e.g. `HeapRead::fail` clearing every external the gather was
+    /// waiting on).
+    pub fn take_pending_call(&mut self, call_id: CallId) -> Option<PendingCallData> {
+        self.pending_calls.remove(&call_id)
     }
 
     /// Returns true if a CallId has already been awaited (consumed).
@@ -317,45 +316,9 @@ impl Scheduler {
         data.gather = Some(gather_id);
     }
 
-    /// If the pending call for `call_id` is routed to a gather, removes the
-    /// entire pending entry and returns the gather's `HeapId`; otherwise
-    /// returns `None` and leaves the entry in place so [`Scheduler::resolve`]
-    /// can wake the blocked task.
-    ///
-    /// Used by external future resolution (`resolve_future`, `fail_for_call`)
-    /// to dispatch between gather-fanout and normal single-awaiter paths.
-    /// The slot indices to fan into live on the gather and are looked up by
-    /// the caller from `AwaitedGather::pending_calls`.
-    pub fn take_gather_for_call(&mut self, call_id: CallId) -> Option<HeapId> {
-        match self.pending_calls.entry(call_id) {
-            Entry::Occupied(entry) if entry.get().gather.is_some() => entry.remove().gather,
-            _ => None,
-        }
-    }
-
-    /// Resolves a CallId with a value.
-    ///
-    /// Stores the value for later retrieval when the future is awaited.
-    /// If a task is blocked on this call, it will be unblocked.
-    ///
-    /// Uses `pending_calls` for O(1) lookup of the blocked task instead of
-    /// scanning all tasks.
-    pub fn resolve(&mut self, call_id: CallId, value: Value) {
-        // Get blocked task from pending_calls before removing (O(1) lookup)
-        let blocked_task = self.pending_calls.remove(&call_id).map(|data| data.creator_task);
-
-        // Store the resolved value
+    /// Records a resolved value for `call_id`.
+    pub fn record_resolved(&mut self, call_id: CallId, value: Value) {
         self.resolved.insert(call_id, value);
-
-        // Unblock the task if found
-        if let Some(task_id) = blocked_task {
-            let task = self.get_task_mut(task_id);
-            if matches!(task.state, TaskState::BlockedOnCall(cid) if cid == call_id) {
-                task.state = TaskState::Ready;
-                task.unblocked_by = Some(call_id);
-                self.ready_queue.push_back(task_id);
-            }
-        }
     }
 
     /// Takes the resolved value for a CallId, if available.
@@ -543,20 +506,13 @@ impl Scheduler {
 
     /// Fails the task blocked on a specific CallId with an error.
     pub fn fail_for_call(&mut self, call_id: CallId, error: RunError, heap: &mut HeapReader<'_, impl ResourceTracker>) {
-        // Peek the pending call to find the creator task and gather routing
-        // (if any) without consuming the entry yet — `take_gather_for_call`
-        // below removes it cleanly when the call is gather-routed.
-        let Some(pending_call) = self.pending_calls.get(&call_id) else {
-            // No pending call found — nothing to fail. Possibly cancelled
-            // already by a sibling task failure in the same gather.
+        let Some(pending) = self.pending_calls.remove(&call_id) else {
+            // Typically means the call was already resolved or cancelled; no task to fail.
             return;
         };
-        let task_id = pending_call.creator_task;
-
-        // Gather-routed failure: tear the whole gather down via `fail`, then
-        // fail its waiter with the original error. `take_gather_for_call`
-        // already removed this CallId's pending entry.
-        if let Some(gather_id) = self.take_gather_for_call(call_id) {
+        if let Some(gather_id) = pending.gather {
+            // Gather-routed failure: tear the whole gather down via `fail`,
+            // then fail its waiter with the original error.
             let HeapReadOutput::GatherFuture(mut gather) = heap.read(gather_id) else {
                 panic!("gather_id doesn't point to a GatherFuture")
             };
@@ -564,19 +520,8 @@ impl Scheduler {
             drop(gather);
             self.fail_task(waiter_id, error, heap);
         } else {
-            // Not a gather-related error — just fail the blocked task. Remove
-            // the pending entry inline since we no longer need its data.
-            self.pending_calls.remove(&call_id);
-            self.fail_task(task_id, error, heap);
+            self.fail_task(pending.creator_task, error, heap);
         }
-    }
-
-    /// Returns the task that created a specific pending call.
-    ///
-    /// Used to check if a pending call's creator task has been cancelled.
-    #[inline]
-    pub fn get_pending_call_creator(&self, call_id: CallId) -> Option<TaskId> {
-        self.pending_calls.get(&call_id).map(|data| data.creator_task)
     }
 
     /// Returns true if a task has been cancelled or failed.

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -494,11 +494,23 @@ impl Scheduler {
             // Remove from ready queue if present (do this before getting mutable task reference)
             self.ready_queue.retain(|&id| id != task_id);
 
-            // Drop any external calls this task was the creator of. The host
-            // may still respond to them later; with the entry gone,
-            // `take_pending_call` returns `None` and `resolve_future` drops
-            // the resolved value instead of trying to wake a removed task.
-            self.pending_calls.retain(|_, data| data.creator_task != task_id);
+            // Drop any *non-gather-routed* external calls this task was the
+            // creator of. The host may still respond to them later; with the
+            // entry gone, `take_pending_call` returns `None` and
+            // `resolve_future` drops the resolved value instead of trying
+            // to wake a removed task.
+            //
+            // Gather-routed entries are kept: even though `task_id` made the
+            // call, ownership effectively transferred to the gather when
+            // `register_gather_for_call` set `data.gather`. Dropping them
+            // would orphan the gather (its own `pending_calls` map still
+            // references the CallId, so it would wait forever for a
+            // resolution that we'd silently drop). Gather-routed entries are
+            // cleaned up either by the gather completing successfully
+            // (`resolve_child` removes them on resolution) or by the gather
+            // failing (`HeapRead::fail` drains them on tear-down).
+            self.pending_calls
+                .retain(|_, data| data.creator_task != task_id || data.gather.is_some());
 
             // If blocked on a nested gather, recursively cancel inner tasks first.
             // Only an `Awaited` gather has spawned tasks — a `Pending` gather

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -6,7 +6,10 @@
 //! - Spawned tasks (1+) store their own execution context in the Task struct
 //! - When switching tasks, the scheduler swaps contexts with the VM
 
-use std::{collections::VecDeque, mem};
+use std::{
+    collections::{VecDeque, hash_map::Entry},
+    mem,
+};
 
 use ahash::{AHashMap, AHashSet};
 
@@ -77,14 +80,9 @@ pub(crate) struct Task {
     /// Used to mark the coroutine as Completed when the task finishes.
     pub coroutine_id: Option<HeapId>,
     /// GatherFuture this task belongs to (if spawned by gather).
-    /// Used to cancel sibling tasks when this task fails.
+    /// Used to cancel sibling tasks when this task fails. The gather itself
+    /// stores the slot-index mapping under `AwaitedGather::pending_tasks`.
     pub gather_id: Option<HeapId>,
-    /// Indices in the gather's results where this task's result should be stored.
-    ///
-    /// A single task may map to multiple gather slots when the same coroutine
-    /// is passed to `asyncio.gather` more than once: e.g. `gather(c, c)` spawns
-    /// one task that fills slots `[0, 1]`. Empty for non-gather tasks.
-    pub gather_result_indices: Vec<usize>,
     /// Current execution state.
     pub state: TaskState,
     /// CallId that unblocked this task (set when task transitions from Blocked to Ready).
@@ -135,15 +133,7 @@ impl Task {
     /// * `id` - Unique task identifier
     /// * `coroutine_id` - Optional HeapId of the coroutine being executed
     /// * `gather_id` - Optional HeapId of the GatherFuture this task belongs to
-    /// * `gather_result_indices` - Slots in the gather's results this task fills
-    ///   (empty for non-gather tasks; multiple when the same coroutine appears
-    ///   more than once in the gather)
-    pub fn new(
-        id: TaskId,
-        coroutine_id: Option<HeapId>,
-        gather_id: Option<HeapId>,
-        gather_result_indices: Vec<usize>,
-    ) -> Self {
+    pub fn new(id: TaskId, coroutine_id: Option<HeapId>, gather_id: Option<HeapId>) -> Self {
         Self {
             id,
             frames: Vec::new(),
@@ -152,7 +142,6 @@ impl Task {
             instruction_ip: 0,
             coroutine_id,
             gather_id,
-            gather_result_indices,
             state: TaskState::Ready,
             unblocked_by: None,
         }
@@ -175,6 +164,9 @@ pub(crate) struct PendingCallData {
     pub args: ArgValues,
     /// Task that created this call (for ignoring results if task is cancelled).
     pub creator_task: TaskId,
+    /// If `Some`, the resolved value should be fanned into the named
+    /// `GatherFuture` instead of directly unblocking `creator_task`.
+    pub gather: Option<HeapId>,
 }
 
 /// Scheduler for managing call IDs, async tasks, and external call tracking.
@@ -209,12 +201,6 @@ pub(crate) struct Scheduler {
     resolved: AHashMap<CallId, Value>,
     /// CallIds that have been awaited (to detect double-await).
     consumed: AHashSet<CallId>,
-    /// Maps CallId -> (gather_heap_id, result_indices) for gathers waiting on external futures.
-    ///
-    /// When a CallId is resolved, the result is stored in the gather's results at every
-    /// listed index. Multiple indices arise when the same external future is passed to
-    /// `asyncio.gather` more than once, e.g. `gather(f, f)`.
-    gather_waiters: AHashMap<CallId, (HeapId, Vec<usize>)>,
 }
 
 impl Scheduler {
@@ -225,7 +211,7 @@ impl Scheduler {
     /// immediately without needing to be scheduled.
     pub fn new() -> Self {
         let main_task_id = TaskId::default();
-        let mut main_task = Task::new(main_task_id, None, None, Vec::new());
+        let mut main_task = Task::new(main_task_id, None, None);
         // Main task starts Running, not Ready (it's the current task, not waiting)
         main_task.state = TaskState::Ready; // Will be set properly when it blocks
         let mut tasks = AHashMap::new();
@@ -239,7 +225,6 @@ impl Scheduler {
             pending_calls: AHashMap::new(),
             resolved: AHashMap::new(),
             consumed: AHashSet::new(),
-            gather_waiters: AHashMap::new(),
         }
     }
 
@@ -308,19 +293,44 @@ impl Scheduler {
 
     /// Registers a gather as waiting on an external future.
     ///
-    /// When the CallId is resolved, the result will be stored in the gather's results
-    /// at every index in `result_indices`. Multiple indices arise when the same
-    /// external future is passed to `gather` more than once.
-    pub fn register_gather_for_call(&mut self, call_id: CallId, gather_id: HeapId, result_indices: Vec<usize>) {
-        self.gather_waiters.insert(call_id, (gather_id, result_indices));
+    /// Mutates the existing `PendingCallData` entry to attach the gather
+    /// pointer. The CallId must already be present in `pending_calls` — the
+    /// host adds it via `add_pending_call` when it returns
+    /// `ExtFunctionResult::Future` for the original call, and gather routing
+    /// is registered later when the gather is awaited.
+    ///
+    /// The slot indices the resolved value should fan into live on the
+    /// gather itself, under `AwaitedGather::pending_calls`.
+    ///
+    /// # Panics
+    /// Panics if the CallId is not in `pending_calls` or is already routed
+    /// to a gather (would indicate a bug in await-side bookkeeping).
+    pub fn register_gather_for_call(&mut self, call_id: CallId, gather_id: HeapId) {
+        let data = self
+            .pending_calls
+            .get_mut(&call_id)
+            .expect("register_gather_for_call: CallId must already be a pending call");
+        debug_assert!(
+            data.gather.is_none(),
+            "register_gather_for_call: CallId already routed to a gather",
+        );
+        data.gather = Some(gather_id);
     }
 
-    /// Returns gather info if a gather is waiting on this CallId.
+    /// If the pending call for `call_id` is routed to a gather, removes the
+    /// entire pending entry and returns the gather's `HeapId`; otherwise
+    /// returns `None` and leaves the entry in place so [`Scheduler::resolve`]
+    /// can wake the blocked task.
     ///
-    /// Returns `(gather_heap_id, result_indices)` if found, `None` otherwise.
-    /// Removes the entry from `gather_waiters`.
-    pub fn take_gather_waiter(&mut self, call_id: CallId) -> Option<(HeapId, Vec<usize>)> {
-        self.gather_waiters.remove(&call_id)
+    /// Used by external future resolution (`resolve_future`, `fail_for_call`)
+    /// to dispatch between gather-fanout and normal single-awaiter paths.
+    /// The slot indices to fan into live on the gather and are looked up by
+    /// the caller from `AwaitedGather::pending_calls`.
+    pub fn take_gather_for_call(&mut self, call_id: CallId) -> Option<HeapId> {
+        match self.pending_calls.entry(call_id) {
+            Entry::Occupied(entry) if entry.get().gather.is_some() => entry.remove().gather,
+            _ => None,
+        }
     }
 
     /// Resolves a CallId with a value.
@@ -421,8 +431,6 @@ impl Scheduler {
     /// * `heap` - Heap to increment reference counts in
     /// * `coroutine_id` - HeapId of the coroutine to execute
     /// * `gather_id` - Optional HeapId of the GatherFuture this task belongs to
-    /// * `gather_result_indices` - Indices in the gather's results for this task
-    ///   (multiple when the same coroutine appears more than once in the gather)
     ///
     /// # Returns
     /// The TaskId of the newly created task.
@@ -431,7 +439,6 @@ impl Scheduler {
         heap: &Heap<impl ResourceTracker>,
         coroutine_id: HeapId,
         gather_id: Option<HeapId>,
-        gather_result_indices: Vec<usize>,
     ) -> TaskId {
         let task_id = TaskId::new(self.next_task_id);
         self.next_task_id += 1;
@@ -443,7 +450,7 @@ impl Scheduler {
             heap.inc_ref(gid);
         }
 
-        let task = Task::new(task_id, Some(coroutine_id), gather_id, gather_result_indices);
+        let task = Task::new(task_id, Some(coroutine_id), gather_id);
         self.tasks.insert(task_id, task);
         self.ready_queue.push_back(task_id);
 
@@ -476,18 +483,10 @@ impl Scheduler {
         self.current_task = task_id;
     }
 
-    /// Marks a task as completed with a result value.
-    ///
-    /// If the task is part of a gather, updates the gather's results.
-    /// If this completes the gather, unblocks the waiting task.
-    pub fn complete_task(&mut self, task_id: TaskId, result: Value, heap: &mut Heap<impl ResourceTracker>) {
-        self.set_state(task_id, TaskState::Completed(result), heap);
-    }
-
     /// Marks a task as failed with an error.
     ///
     /// If the task is part of a gather, returns the gather_id so the caller
-    /// can collect siblings from `GatherFuture.task_ids` on the heap.
+    /// can collect siblings from the gather on the heap.
     ///
     /// # Returns
     /// The gather_id if this task belongs to a gather (for sibling lookup).
@@ -522,11 +521,17 @@ impl Scheduler {
             self.ready_queue.retain(|&id| id != task_id);
 
             // If blocked on a nested gather, recursively cancel inner tasks first.
+            // Only an `Awaited` gather has spawned tasks — a `Pending` gather
+            // has never run, and `Completed`/`Failed` mean the gather has
+            // already shed its child tasks.
             if let TaskState::BlockedOnGather(gather_id) = task.state {
                 let HeapData::GatherFuture(gather) = heap.get(gather_id) else {
                     panic!("Scheduler::cancel_task: expected GatherFuture heap entry for gather_id {gather_id:?}");
                 };
-                let inner_task_ids = gather.task_ids.clone();
+                let inner_task_ids: Vec<TaskId> = gather
+                    .as_awaited()
+                    .map(|awaited| awaited.pending_tasks.keys().copied().collect())
+                    .unwrap_or_default();
                 for inner_task_id in inner_task_ids {
                     self.cancel_task(inner_task_id, heap);
                 }
@@ -538,52 +543,30 @@ impl Scheduler {
 
     /// Fails the task blocked on a specific CallId with an error.
     pub fn fail_for_call(&mut self, call_id: CallId, error: RunError, heap: &mut HeapReader<'_, impl ResourceTracker>) {
-        // Get blocked task from pending_calls (O(1) lookup)
-        let Some(pending_call) = self.pending_calls.remove(&call_id) else {
-            // No pending call found - nothing to fail. Possibly cancelled by a sibling task failure.
+        // Peek the pending call to find the creator task and gather routing
+        // (if any) without consuming the entry yet — `take_gather_for_call`
+        // below removes it cleanly when the call is gather-routed.
+        let Some(pending_call) = self.pending_calls.get(&call_id) else {
+            // No pending call found — nothing to fail. Possibly cancelled
+            // already by a sibling task failure in the same gather.
             return;
         };
-
         let task_id = pending_call.creator_task;
 
-        // Check if a gather is waiting on this CallId
-        if let Some((gather_id, _result_indices)) = self.take_gather_waiter(call_id) {
-            self.remove_pending_call(call_id);
-
-            // Get the gather's waiter, task_ids, and OTHER pending calls
-            // We need to remove all pending calls for this gather from gather_waiters
-            // before we dec_ref the gather, otherwise subsequent errors for the same
-            // gather would try to access a freed heap object.
-            // Use get_mut and take to avoid allocations - gather is being destroyed anyway.
+        // Gather-routed failure: tear the whole gather down via `fail`, then
+        // fail its waiter with the original error. `take_gather_for_call`
+        // already removed this CallId's pending entry.
+        if let Some(gather_id) = self.take_gather_for_call(call_id) {
             let HeapReadOutput::GatherFuture(mut gather) = heap.read(gather_id) else {
                 panic!("gather_id doesn't point to a GatherFuture")
             };
-            let gather_mut = gather.get_mut(heap);
-            let mut other_pending_calls = mem::take(&mut gather_mut.pending_calls);
-            other_pending_calls.retain(|&cid| cid != call_id);
-            let Some(waiter_id) = gather_mut.waiter else {
-                panic!("gather has no waiter task")
-            };
-            let task_ids = mem::take(&mut gather_mut.task_ids);
-            // Drop the HeapRead before operations that may free heap objects
+            let waiter_id = gather.fail(self, heap, &error);
             drop(gather);
-
-            // Remove all other pending calls for this gather from gather_waiters and pending_calls
-            // This prevents subsequent errors from trying to access the freed gather
-            for other_call_id in other_pending_calls {
-                self.take_gather_waiter(other_call_id);
-                self.remove_pending_call(other_call_id);
-            }
-
-            // Cancel all sibling tasks in the gather
-            for sibling_id in task_ids {
-                self.cancel_task(sibling_id, heap);
-            }
-
-            // Fail the waiter task (the task that awaited the gather)
             self.fail_task(waiter_id, error, heap);
         } else {
-            // Not a gather-related error - just fail the blocked task.
+            // Not a gather-related error — just fail the blocked task. Remove
+            // the pending entry inline since we no longer need its data.
+            self.pending_calls.remove(&call_id);
             self.fail_task(task_id, error, heap);
         }
     }

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -482,9 +482,23 @@ impl Scheduler {
             return;
         };
 
+        // If we're cancelling the current task, clear `current_task` so callers
+        // don't try to look up a task that's about to be dropped (e.g.
+        // `resume_with_resolved_futures` after `fail_for_call` tore down the
+        // gather containing the previously-current task).
+        if self.current_task == Some(task_id) {
+            self.current_task = None;
+        }
+
         if !task.is_finished() {
             // Remove from ready queue if present (do this before getting mutable task reference)
             self.ready_queue.retain(|&id| id != task_id);
+
+            // Drop any external calls this task was the creator of. The host
+            // may still respond to them later; with the entry gone,
+            // `take_pending_call` returns `None` and `resolve_future` drops
+            // the resolved value instead of trying to wake a removed task.
+            self.pending_calls.retain(|_, data| data.creator_task != task_id);
 
             // If blocked on a nested gather, recursively cancel inner tasks first.
             // Only an `Awaited` gather has spawned tasks — a `Pending` gather
@@ -508,14 +522,21 @@ impl Scheduler {
     }
 
     /// Fails the task blocked on a specific CallId with an error.
+    ///
+    /// For a gather-routed call, tears the gather down eagerly via
+    /// [`HeapRead::fail`]. For an "indirect" failure (the call was made by a
+    /// task that's a child of a gather), just sets the creator task's state
+    /// to `Failed`; the failure is then surfaced when a sibling completes
+    /// and `HeapRead::resolve_child`'s completion scan finds the Failed
+    /// task. (The two-phase pattern keeps gather teardown anchored in the
+    /// run-loop side, where exception propagation through the waiter's
+    /// frame is straightforward.)
     pub fn fail_for_call(&mut self, call_id: CallId, error: RunError, heap: &mut HeapReader<'_, impl ResourceTracker>) {
         let Some(pending) = self.pending_calls.remove(&call_id) else {
             // Typically means the call was already resolved or cancelled; no task to fail.
             return;
         };
         if let Some(gather_id) = pending.gather {
-            // Gather-routed failure: tear the whole gather down via `fail`,
-            // then fail its waiter with the original error.
             let HeapReadOutput::GatherFuture(mut gather) = heap.read(gather_id) else {
                 panic!("gather_id doesn't point to a GatherFuture")
             };

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1686,7 +1686,12 @@ impl RawStackFrame {
 /// - `Internal`: Bug in interpreter implementation (static message)
 /// - `Exc`: Python exception that can be caught by try/except (when implemented)
 /// - `UncatchableExc`: Python exception from resource limits that CANNOT be caught
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+///
+/// `Clone` is implemented so an error can be cached for later re-raising
+/// (e.g. a failed `GatherFuture` replaying the same exception on every
+/// re-await). Inner data is shallow-clonable: `Cow<'static, str>` is cheap,
+/// and `ExceptionRaise` already derives `Clone`.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub(crate) enum RunError {
     /// Internal interpreter error - indicates a bug in Monty, not user code.
     Internal(Cow<'static, str>),

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -14,7 +14,7 @@ use serde::ser::SerializeStruct;
 pub(crate) use crate::heap_data::HeapData;
 pub(crate) use crate::heap_traits::{ContainsHeap, DropWithHeap, HeapGuard, HeapItem};
 use crate::{
-    asyncio::{Coroutine, GatherFuture, GatherItem},
+    asyncio::{Coroutine, GatherFuture, GatherItem, GatherState},
     exception_private::SimpleException,
     heap_data::{CellValue, Closure, FunctionDefaults},
     resource::{ResourceError, ResourceTracker},
@@ -1431,17 +1431,27 @@ fn collect_child_ids(data: &HeapData, work_list: &mut Vec<HeapId>) {
             }
         }
         HeapData::GatherFuture(gather) => {
-            // Add coroutine HeapIds to work list
+            // Add coroutine HeapIds to work list. `items` carries the gather's
+            // owning inc_ref on each unique coroutine and is populated for the
+            // entire lifecycle.
             for item in &gather.items {
                 if let GatherItem::Coroutine(coro_id) = item {
                     work_list.push(*coro_id);
                 }
             }
-            // Add result values that are heap references
-            for result in gather.results.iter().flatten() {
-                if let Value::Ref(id) = result {
-                    work_list.push(*id);
+            // Walk per-state heap refs: in-flight slot results, or the cached
+            // result list once the gather has completed successfully. `Pending`
+            // and `Failed` carry no heap refs.
+            match &gather.state {
+                GatherState::Awaited(awaited) => {
+                    for result in awaited.results.iter().flatten() {
+                        if let Value::Ref(id) = result {
+                            work_list.push(*id);
+                        }
+                    }
                 }
+                GatherState::Completed(list_id) => work_list.push(*list_id),
+                GatherState::Pending | GatherState::Failed(_) => {}
             }
         }
         HeapData::DateTime(dt) => {
@@ -1496,15 +1506,23 @@ fn py_dec_ref_ids_for_data(data: &mut HeapData, stack: &mut Vec<HeapId>) {
             }
         }
         HeapData::GatherFuture(gather) => {
-            // Decrement ref count for coroutine HeapIds
+            // Decrement ref count for coroutine HeapIds (always present in `items`).
             for item in &gather.items {
                 if let GatherItem::Coroutine(id) = item {
                     stack.push(*id);
                 }
             }
-            // Decrement ref count for result values that are heap references
-            for result in gather.results.iter_mut().flatten() {
-                result.py_dec_ref_ids(stack);
+            // Release per-state heap refs: in-flight slot results, or the
+            // cached result list once the gather has completed successfully.
+            // `Pending` and `Failed` carry no heap refs.
+            match &mut gather.state {
+                GatherState::Awaited(awaited) => {
+                    for result in awaited.results.iter_mut().flatten() {
+                        result.py_dec_ref_ids(stack);
+                    }
+                }
+                GatherState::Completed(list_id) => stack.push(*list_id),
+                GatherState::Pending | GatherState::Failed(_) => {}
             }
         }
         HeapData::DateTime(dt) => {

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -13,7 +13,7 @@ use num_integer::Integer;
 use crate::{
     ExcType, ResourceTracker,
     args::ArgValues,
-    asyncio::{CallId, Coroutine, GatherFuture, GatherItem},
+    asyncio::{CallId, Coroutine, GatherFuture, GatherItem, GatherState, TaskId},
     bytecode::{CallResult, VM},
     exception_private::{RunError, RunResult, SimpleException},
     hash::HashValue,
@@ -367,22 +367,40 @@ impl HeapItem for Coroutine {
 
 impl HeapItem for GatherFuture {
     fn py_estimate_size(&self) -> usize {
-        mem::size_of::<Self>()
-            + self.items.len() * mem::size_of::<GatherItem>()
-            + self.results.len() * mem::size_of::<Option<Value>>()
-            + self.pending_calls.len() * mem::size_of::<CallId>()
+        let state_size = match &self.state {
+            GatherState::Awaited(awaited) => {
+                // Rough sizing — entry slots plus per-entry storage. The map's
+                // bucket array overhead is intentionally elided; we only
+                // estimate dynamically-allocated content tied to user code.
+                let pending_tasks_size =
+                    awaited.pending_tasks.len() * (mem::size_of::<TaskId>() + mem::size_of::<Vec<usize>>());
+                let pending_calls_size =
+                    awaited.pending_calls.len() * (mem::size_of::<CallId>() + mem::size_of::<Vec<usize>>());
+                awaited.results.len() * mem::size_of::<Option<Value>>() + pending_tasks_size + pending_calls_size
+            }
+            GatherState::Pending | GatherState::Completed(_) | GatherState::Failed(_) => 0,
+        };
+        mem::size_of::<Self>() + self.items.len() * mem::size_of::<GatherItem>() + state_size
     }
 
     fn py_dec_ref_ids(&mut self, stack: &mut Vec<HeapId>) {
-        // Decrement ref count for coroutine HeapIds
+        // Decrement ref count for coroutine HeapIds (always present in `items`).
         for item in &self.items {
             if let GatherItem::Coroutine(id) = item {
                 stack.push(*id);
             }
         }
-        // Decrement ref count for result values that are heap references
-        for result in self.results.iter_mut().flatten() {
-            result.py_dec_ref_ids(stack);
+        // Release per-state heap refs: in-flight slot results, or the cached
+        // result list once the gather has completed successfully. `Pending` and
+        // `Failed` carry no heap refs.
+        match &mut self.state {
+            GatherState::Awaited(awaited) => {
+                for result in awaited.results.iter_mut().flatten() {
+                    result.py_dec_ref_ids(stack);
+                }
+            }
+            GatherState::Completed(list_id) => stack.push(*list_id),
+            GatherState::Pending | GatherState::Failed(_) => {}
         }
     }
 }

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -372,10 +372,20 @@ impl HeapItem for GatherFuture {
                 // Rough sizing — entry slots plus per-entry storage. The map's
                 // bucket array overhead is intentionally elided; we only
                 // estimate dynamically-allocated content tied to user code.
-                let pending_tasks_size =
-                    awaited.pending_tasks.len() * (mem::size_of::<TaskId>() + mem::size_of::<Vec<usize>>());
-                let pending_calls_size =
-                    awaited.pending_calls.len() * (mem::size_of::<CallId>() + mem::size_of::<Vec<usize>>());
+                let pending_tasks_size = awaited
+                    .pending_tasks
+                    .iter()
+                    .map(|(_, slots)| {
+                        mem::size_of::<TaskId>() + mem::size_of::<Vec<usize>>() + slots.len() * mem::size_of::<usize>()
+                    })
+                    .sum::<usize>();
+                let pending_calls_size = awaited
+                    .pending_calls
+                    .iter()
+                    .map(|(_, slots)| {
+                        mem::size_of::<CallId>() + mem::size_of::<Vec<usize>>() + slots.len() * mem::size_of::<usize>()
+                    })
+                    .sum::<usize>();
                 awaited.results.len() * mem::size_of::<Option<Value>>() + pending_tasks_size + pending_calls_size
             }
             GatherState::Pending | GatherState::Completed(_) | GatherState::Failed(_) => 0,

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -374,15 +374,15 @@ impl HeapItem for GatherFuture {
                 // estimate dynamically-allocated content tied to user code.
                 let pending_tasks_size = awaited
                     .pending_tasks
-                    .iter()
-                    .map(|(_, slots)| {
+                    .values()
+                    .map(|slots| {
                         mem::size_of::<TaskId>() + mem::size_of::<Vec<usize>>() + slots.len() * mem::size_of::<usize>()
                     })
                     .sum::<usize>();
                 let pending_calls_size = awaited
                     .pending_calls
-                    .iter()
-                    .map(|(_, slots)| {
+                    .values()
+                    .map(|slots| {
                         mem::size_of::<CallId>() + mem::size_of::<Vec<usize>>() + slots.len() * mem::size_of::<usize>()
                     })
                     .sum::<usize>();

--- a/crates/monty/test_cases/async__gather_all.py
+++ b/crates/monty/test_cases/async__gather_all.py
@@ -136,3 +136,60 @@ try:
     assert False, 'should have raised RuntimeError'
 except RuntimeError as e:
     assert str(e) == 'cannot reuse already awaited coroutine', f'unexpected error: {e}'
+
+
+# === Re-awaiting a completed gather returns the cached result list ===
+# CPython's _GatheringFuture is a Future that stores its result; every await
+# returns the same list. Monty caches the result on the GatherFuture so this
+# matches.
+
+
+async def reawait_member():
+    return 7
+
+
+g = asyncio.gather(reawait_member(), reawait_member())
+first = await g  # pyright: ignore
+second = await g  # pyright: ignore
+third = await g  # pyright: ignore
+assert first == [7, 7], f'first await: {first}'
+assert second == [7, 7], f'second await: {second}'
+assert third == [7, 7], f'third await: {third}'
+# Identity: every re-await yields the same list object (CPython behavior).
+assert first is second, 're-await should return the cached list, not a new one'
+assert second is third, 're-await should return the same list every time'
+
+
+# === Re-awaiting an empty gather returns the same empty list ===
+g_empty = asyncio.gather()
+e1 = await g_empty  # pyright: ignore
+e2 = await g_empty  # pyright: ignore
+assert e1 == [] and e2 == [], 'empty gather re-await: both empty'
+assert e1 is e2, 'empty gather re-await should yield the same list'
+
+
+# === Re-awaiting a failed gather re-raises the same exception ===
+
+
+async def boom():
+    raise ValueError('detonate')
+
+
+g_fail = asyncio.gather(boom())
+try:
+    await g_fail  # pyright: ignore
+    assert False, 'first await should have raised'
+except ValueError as e:
+    assert str(e) == 'detonate', f'first await message: {e}'
+
+try:
+    await g_fail  # pyright: ignore
+    assert False, 'second await should have raised'
+except ValueError as e:
+    assert str(e) == 'detonate', f'second await message: {e}'
+
+try:
+    await g_fail  # pyright: ignore
+    assert False, 'third await should have raised'
+except ValueError as e:
+    assert str(e) == 'detonate', f'third await message: {e}'


### PR DESCRIPTION
Trying to make sure that reference count leaks / UAFs can't happen in async code. First step seemed to be to refactor `GatherFuture` to have proper state transitions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `GatherFuture` into an explicit state machine with cached results/errors, fixing failure propagation and making external-future routing safe. Re-await now matches CPython: completed gathers return the same list (including empties), and failed gathers re-raise the same exception.

- **Refactors**
  - New states: `Pending` → `Awaited` (`waiter`, `results`, `pending_tasks`/`pending_calls`) → `Completed`/`Failed`; dedups coroutines and externals, and tracks fan-out inside the gather.
  - Re-await paths: `Completed` returns the cached list, `Failed` re-raises; re-await while `Awaited` is rejected; external-only gathers resolve immediately and cache the list.
  - Moved lifecycle logic into `GatherFuture`: `cache_result`, `resolve_child` (fan-out, completion scan), and `fail` (teardown and cache error).
  - Routing changes: tag `PendingCallData.gather`; added `register_gather_for_call`, `record_resolved`, `take_pending_call`; removed `gather_waiters` and per-task slot indices; simplified `spawn`; updated GC traversal/size; made `RunError` `Clone`.

- **Bug Fixes**
  - Correct failure propagation: detect failed siblings during resolution (including indirect external-call failures), cache the error for re-awaits, cancel siblings, clear pending-call routing, and switch into the waiter to raise once.
  - Safer teardown and cleanup: mark coroutine `Completed` before cancelling its task; `cancel_task` now drops non-gather pending calls and recursively cancels nested gathers; late host results are dropped if the gather/task is gone.
  - Tests assert re-await returns the same list object for completed/empty gathers and re-raises the same exception for failed gathers.

<sup>Written for commit 4ff8cbad3955e229514366c4490a11cceed2817d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

