### PR TITLE
Bound container pre-allocation driven by iterator size hints

### DIFF
--- a/crates/monty/src/builtins/map.rs
+++ b/crates/monty/src/builtins/map.rs
@@ -1,6 +1,6 @@
 //! Implementation of the map() builtin function.
 
-use std::iter;
+use std::{iter, mem};
 
 use crate::{
     args::{ArgValues, KwargsValues},
@@ -51,7 +51,10 @@ pub fn builtin_map(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> Ru
         extra_iterators.push(MontyIter::new(iterable, vm)?);
     }
 
-    let mut out = Vec::with_capacity(first_iter.size_hint(vm.heap));
+    // `preallocation_hint` validates the requested capacity against the
+    // resource tracker and clamps it so an attacker-controlled iterable length
+    // cannot drive an unbounded native pre-allocation.
+    let mut out = Vec::with_capacity(first_iter.preallocation_hint(mem::size_of::<Value>(), vm)?);
 
     // map function over iterables until the shortest iter is exhausted
     match extra_iterators.as_mut_slice() {

--- a/crates/monty/src/fstring.rs
+++ b/crates/monty/src/fstring.rs
@@ -13,7 +13,7 @@ use crate::{
     exception_private::{ExcType, RunError, SimpleException},
     expressions::ExprLoc,
     intern::StringId,
-    resource::ResourceTracker,
+    resource::{ResourceTracker, check_repeat_size},
     types::{PyTrait, Type},
     value::Value,
 };
@@ -263,6 +263,18 @@ pub fn format_with_spec(
     vm: &mut VM<'_, impl ResourceTracker>,
 ) -> Result<String, RunError> {
     let value_type = value.py_type(vm);
+
+    // `spec.width` is the minimum field width; every formatter below pads the
+    // value out to it with `spec.fill` via `pad_string`/`iter::repeat_n`, which
+    // build a native `String` through the global allocator — invisible to the
+    // resource tracker until the finished string reaches the heap. A literal
+    // width is clamped to 16 bits by the bytecode encoding, but a *dynamic*
+    // width (`f"{v:>{w}}"`, `w` a runtime value) is not, so an over-large `w`
+    // would materialize gigabytes of padding before the post-construction
+    // check, OOM-ing or aborting the host. Reject an over-budget width here,
+    // up front, using the same guard sequence repeats and `str.ljust`/`zfill`
+    // already use. The check is free below `LARGE_RESULT_THRESHOLD`.
+    check_repeat_size(spec.fill.len_utf8(), spec.width, vm.heap.tracker())?;
 
     match (value, spec.type_char) {
         // Integer formatting

--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -575,7 +575,11 @@ pub(crate) fn collect_iterable_to_set(value: Value, vm: &mut VM<'_, impl Resourc
     let (value, vm) = value_guard.into_parts();
     let iter = MontyIter::new(value, vm)?;
     defer_drop_mut!(iter, vm);
-    let mut set_guard = HeapGuard::new(Set::with_capacity(iter.size_hint(vm.heap)), vm);
+    // `preallocation_hint` validates the requested capacity against the
+    // resource tracker and clamps it so an attacker-controlled iterable length
+    // cannot drive an unbounded native pre-allocation.
+    let cap = iter.preallocation_hint(mem::size_of::<Value>() * 2, vm)?;
+    let mut set_guard = HeapGuard::new(Set::with_capacity(cap), vm);
     let (set, vm) = set_guard.as_parts_mut();
     while let Some(item) = iter.for_next(vm)? {
         set.add(item, vm)?;

--- a/crates/monty/src/types/iter.rs
+++ b/crates/monty/src/types/iter.rs
@@ -24,7 +24,7 @@ use crate::{
     intern::{BytesId, Interns},
     resource::{ResourceError, ResourceTracker, check_estimated_size},
     types::{PyTrait, Range, dict_view::DictView, str::allocate_char},
-    value::Value,
+    value::{VALUE_SIZE, Value},
 };
 
 /// Iterator state for Python for loops.
@@ -242,30 +242,91 @@ impl MontyIter {
         Ok(hint.min(MAX_PREALLOCATION_HINT))
     }
 
-    /// Collects all remaining items from the iterator into a Vec.
+    /// Materializes all remaining items into a `T` (typically `Vec<Value>`).
     ///
     /// Consumes the iterator and returns all items. Used by `list()`, `tuple()`,
-    /// and similar constructors that need to materialize all items.
+    /// `sorted()`, `reversed()`, and similar constructors that need every item.
     ///
-    /// Pre-allocates capacity based on `size_hint()` for better performance.
+    /// # Resource safety
+    ///
+    /// The destination `T` is backed by the global Rust allocator, *outside*
+    /// Monty's resource tracker. The tracker would otherwise only see the
+    /// finished buffer when it is wrapped into a heap object — far too late for
+    /// a cheap-to-represent but enormous iterable like `list(range(10**12))` or
+    /// `tuple(x for x in ...)`, where the whole native buffer is built first and
+    /// the host is driven to OOM or a capacity-overflow abort before that
+    /// post-construction check ever runs (an uncatchable sandbox escape).
+    ///
+    /// [`HeapedMontyIter`] therefore re-estimates the projected buffer size
+    /// after every element and runs it through the tracker, so an over-budget
+    /// collection fails *during* accumulation, near the configured limit,
+    /// rather than after full materialization. This is the only sanctioned way
+    /// to drain a `MontyIter` into a native container — `MontyIter`
+    /// deliberately does not implement [`Iterator`] so callers cannot bypass
+    /// this check with a plain `.collect()`.
     pub fn collect<T: FromIterator<Value>>(self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<T> {
         let mut guard = HeapGuard::new(self, vm);
         let (this, vm) = guard.as_parts_mut();
-        HeapedMontyIter(this, vm).collect()
+        HeapedMontyIter {
+            iter: this,
+            vm,
+            yielded: 0,
+        }
+        .collect()
     }
 }
 
-struct HeapedMontyIter<'this, 'h, T: ResourceTracker>(&'this mut MontyIter, &'this mut VM<'h, T>);
+/// Adapter that drives a [`MontyIter`] as a standard [`Iterator`] so it can be
+/// fed to `collect()`, while enforcing the memory budget *incrementally*.
+///
+/// `collect()` builds a native `Vec`/`SmallVec` whose backing storage is
+/// allocated by the global Rust allocator and is invisible to Monty's resource
+/// tracker until the finished object is handed to the heap. Each [`next`] call
+/// therefore re-estimates the projected buffer size (`yielded * VALUE_SIZE`)
+/// and validates it against the tracker via [`check_estimated_size`], so a
+/// runaway collection is rejected near the limit instead of after it has
+/// already exhausted host memory. The check is free below
+/// `LARGE_RESULT_THRESHOLD` (a single multiply and comparison), matching the
+/// policy used by [`MontyIter::preallocation_hint`].
+///
+/// [`next`]: Iterator::next
+struct HeapedMontyIter<'this, 'h, T: ResourceTracker> {
+    /// The underlying iterator being drained.
+    iter: &'this mut MontyIter,
+    /// VM handle, needed both to advance `iter` and to reach the tracker.
+    vm: &'this mut VM<'h, T>,
+    /// Count of elements yielded so far; drives the running size estimate.
+    yielded: usize,
+}
 
 impl<T: ResourceTracker> Iterator for HeapedMontyIter<'_, '_, T> {
     type Item = RunResult<Value>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.for_next(self.1).transpose()
+        match self.iter.for_next(self.vm) {
+            Ok(None) => None,
+            Err(e) => Some(Err(e)),
+            Ok(Some(value)) => {
+                self.yielded += 1;
+                let estimated = self.yielded.saturating_mul(VALUE_SIZE);
+                // Borrow order matters: `for_next` took `&mut vm` above and has
+                // already returned, so the immutable tracker borrow here is fine.
+                match check_estimated_size(estimated, self.vm.heap.tracker()) {
+                    Ok(()) => Some(Ok(value)),
+                    // Over budget mid-collection. The partially built buffer is
+                    // dropped without `drop_with_heap`, leaking the refcounts of
+                    // `value` and the already-collected items. This is the
+                    // existing, explicitly sanctioned behaviour for resource
+                    // errors (terminal; heap state is discarded — see CLAUDE.md
+                    // and the `Heap` resource-limit docs).
+                    Err(e) => Some(Err(e.into())),
+                }
+            }
+        }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.0.size_hint(self.1.heap);
+        let remaining = self.iter.size_hint(self.vm.heap);
         (remaining, Some(remaining))
     }
 }

--- a/crates/monty/src/types/iter.rs
+++ b/crates/monty/src/types/iter.rs
@@ -22,7 +22,7 @@ use crate::{
     exception_private::{ExcType, RunResult},
     heap::{ContainsHeap, DropWithHeap, Heap, HeapData, HeapGuard, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{BytesId, Interns},
-    resource::ResourceTracker,
+    resource::{ResourceError, ResourceTracker, check_estimated_size},
     types::{PyTrait, Range, dict_view::DictView, str::allocate_char},
     value::Value,
 };
@@ -209,6 +209,37 @@ impl MontyIter {
             }
         };
         len.saturating_sub(self.index)
+    }
+
+    /// Returns a capacity hint that is safe to pass to `with_capacity` and friends.
+    ///
+    /// `size_hint()` reports the exact remaining length of the iterable, which for
+    /// `range(huge)` can be astronomically large. Passing that straight to a
+    /// container constructor calls the global allocator before the resource tracker
+    /// can reject it; the allocator either aborts the process on failure (which is
+    /// not catchable) or succeeds and the host is OOM-killed when the pages are
+    /// touched. Both outcomes bypass the configured memory limit entirely.
+    ///
+    /// This helper validates the requested allocation against the resource tracker
+    /// (raising `MemoryError` if it would exceed the budget) and clamps the result
+    /// to a small fixed bound. The clamp makes the pre-allocation defensively safe
+    /// even when no limits are configured: the container still grows naturally as
+    /// elements are appended, with each element tracked individually, so the hint
+    /// only matters for performance, never for correctness.
+    pub fn preallocation_hint(
+        &self,
+        elem_size: usize,
+        vm: &VM<'_, impl ResourceTracker>,
+    ) -> Result<usize, ResourceError> {
+        /// Upper bound on the number of slots we are willing to reserve up front.
+        ///
+        /// Chosen so the worst-case pre-allocation (a few MiB) is small relative
+        /// to any realistic memory budget, while still avoiding repeated
+        /// reallocations for the common case of building moderate containers.
+        const MAX_PREALLOCATION_HINT: usize = 65_536;
+        let hint = self.size_hint(vm.heap);
+        check_estimated_size(hint.saturating_mul(elem_size), vm.heap.tracker())?;
+        Ok(hint.min(MAX_PREALLOCATION_HINT))
     }
 
     /// Collects all remaining items from the iterator into a Vec.

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -605,7 +605,10 @@ impl Set {
     /// each element individually to handle duplicates and compute hashes.
     fn from_iterator(iter: MontyIter, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Self> {
         defer_drop_mut!(iter, vm);
-        let mut set = Self::with_capacity(iter.size_hint(vm.heap));
+        // `preallocation_hint` validates the requested capacity against the
+        // resource tracker and clamps it so an attacker-controlled iterable
+        // length cannot drive an unbounded native pre-allocation.
+        let mut set = Self::with_capacity(iter.preallocation_hint(mem::size_of::<SetEntry>(), vm)?);
         while let Some(item) = iter.for_next(vm)? {
             set.add(item, vm)?;
         }

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -2087,6 +2087,37 @@ fn map_over_huge_range_memory_limit() {
     assert_eq!(result.unwrap_err().exc_type(), ExcType::MemoryError);
 }
 
+/// Test that dict-view set operations over a huge iterable are bounded by the
+/// memory limit.
+///
+/// `dict.keys().isdisjoint(...)` collects the right-hand iterable into a
+/// temporary set with capacity drawn from the iterator's size hint, which goes
+/// through the same pre-allocation guard as `set()`.
+#[test]
+fn dict_view_isdisjoint_huge_range_memory_limit() {
+    let code = "{1: 1}.keys().isdisjoint(range(10 ** 9))";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+
+    let limits = ResourceLimits::new().max_memory(100_000);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    assert!(result.is_err(), "huge dict-view pre-allocation should be rejected");
+    assert_eq!(result.unwrap_err().exc_type(), ExcType::MemoryError);
+}
+
+/// Test that small dict-view `isdisjoint` over an iterable still succeeds.
+#[test]
+fn dict_view_isdisjoint_within_limit() {
+    let code = "{1: 1}.keys().isdisjoint(range(2, 5))";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+
+    let limits = ResourceLimits::new().max_memory(100_000);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    assert!(result.is_ok(), "small dict-view isdisjoint should succeed: {result:?}");
+    assert_eq!(result.unwrap(), MontyObject::Bool(true));
+}
+
 /// Test that small set/map construction still succeeds within limits.
 #[test]
 fn set_from_range_within_limit() {

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -252,6 +252,56 @@ result
     );
 }
 
+/// Regression: materializing a cheap-to-represent but enormous lazy iterable
+/// via `list()`/`tuple()`/`sorted()`/`reversed()` (and generator collection)
+/// must be rejected *during* collection, near the configured memory limit —
+/// not after the entire native buffer has been built.
+///
+/// `MontyIter::collect` builds the result in a native `Vec` that is invisible
+/// to the resource tracker until the finished object reaches the heap. Before
+/// the incremental check, `range(10**9)` would allocate ~16 GiB of native
+/// buffer before any limit check, OOM-killing or aborting the host (an
+/// uncatchable sandbox escape). The fix estimates the projected size after
+/// each element, so the limit fires while the buffer is still tiny.
+#[test]
+fn collect_constructors_bounded_during_collection() {
+    for code in [
+        "list(range(10**9))",
+        "tuple(range(10**9))",
+        "sorted(range(10**9))",
+        "reversed(range(10**9))",
+        "list(x for x in range(10**9))",
+    ] {
+        let ex = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+        // 1 MiB memory budget; a generous time limit so a timeout cannot mask
+        // a missing memory check.
+        let limits = ResourceLimits::new()
+            .max_memory(1_048_576)
+            .max_duration(Duration::from_secs(30));
+        let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+        let exc = result
+            .err()
+            .unwrap_or_else(|| panic!("{code}: should exceed the memory limit"));
+        assert_eq!(exc.exc_type(), ExcType::MemoryError, "{code}: wrong exc type");
+
+        // Parse "memory limit exceeded: <used> bytes > <limit> bytes". The fix
+        // must trip while the buffer is still small; before the fix `used` was
+        // the full materialized size (~16 GB for range(10**9)).
+        let msg = exc.message().expect("memory error carries a message");
+        let used: usize = msg
+            .strip_prefix("memory limit exceeded: ")
+            .and_then(|m| m.split(" bytes").next())
+            .and_then(|n| n.parse().ok())
+            .unwrap_or_else(|| panic!("{code}: unexpected message {msg:?}"));
+        assert!(
+            used < 16 * 1_048_576,
+            "{code}: rejected at {used} bytes — collection is not bounded \
+             incrementally (expected to trip near the 1 MiB limit)"
+        );
+    }
+}
+
 #[test]
 fn memory_limit_zero() {
     let code = "x = 1 + 2\nx";

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -302,6 +302,44 @@ fn collect_constructors_bounded_during_collection() {
     }
 }
 
+/// Regression: an f-string with a large *dynamic* field width must be
+/// rejected by the memory limit before the padding string is materialized.
+///
+/// A literal width is clamped to 16 bits by the bytecode encoding, but a
+/// runtime width (`f"{v:>{w}}"`) is not. `pad_string`/`iter::repeat_n` build
+/// the padding in a native `String` invisible to the tracker until the
+/// finished string reaches the heap, so before the guard `w = 10**11` would
+/// allocate ~100 GB before any check, OOM-ing or aborting the host.
+#[test]
+fn fstring_dynamic_width_memory_bounded() {
+    for code in [
+        "w = 999_999_999\nf'{0:>{w}}'",
+        "w = 999_999_999\nf'{0:0>{w}}'",
+        "w = 999_999_999\nf'{1.5:^{w}}'",
+        "w = 999_999_999\nf'{\"x\":<{w}}'",
+    ] {
+        let ex = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+        let limits = ResourceLimits::new()
+            .max_memory(1_048_576)
+            .max_duration(Duration::from_secs(30));
+        let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+        let exc = result
+            .err()
+            .unwrap_or_else(|| panic!("{code:?}: should exceed the memory limit"));
+        assert_eq!(exc.exc_type(), ExcType::MemoryError, "{code:?}: wrong exc type");
+    }
+
+    // A small dynamic width is unaffected and still formats correctly.
+    let ex = MontyRun::new("w = 5\nf'{42:>{w}}'".to_owned(), "test.py", vec![]).unwrap();
+    let limits = ResourceLimits::new().max_memory(1_048_576);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+    assert_eq!(
+        result.expect("small dynamic width should succeed"),
+        MontyObject::String("   42".to_owned())
+    );
+}
+
 #[test]
 fn memory_limit_zero() {
     let code = "x = 1 + 2\nx";

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -2039,3 +2039,63 @@ len(x) + len(d) + len(s)
     );
     assert_eq!(result.unwrap(), MontyObject::Int(300));
 }
+
+// === Iterator pre-allocation resource-limit tests ===
+
+/// Test that constructing a set from a huge `range` is bounded by the memory limit.
+///
+/// `range` reports its full remaining length as the iterator size hint. Container
+/// constructors that pre-allocate from the hint must validate it against the
+/// resource tracker before reaching for the global allocator, since an allocation
+/// failure aborts the host instead of raising MemoryError.
+#[test]
+fn set_from_huge_range_memory_limit() {
+    let code = "set(range(10 ** 9))";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+
+    let limits = ResourceLimits::new().max_memory(100_000);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    assert!(result.is_err(), "huge set pre-allocation should be rejected");
+    let exc = result.unwrap_err();
+    assert_eq!(exc.exc_type(), ExcType::MemoryError);
+}
+
+/// Test that `frozenset` from a huge `range` is bounded by the memory limit.
+#[test]
+fn frozenset_from_huge_range_memory_limit() {
+    let code = "frozenset(range(10 ** 9))";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+
+    let limits = ResourceLimits::new().max_memory(100_000);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    assert!(result.is_err(), "huge frozenset pre-allocation should be rejected");
+    assert_eq!(result.unwrap_err().exc_type(), ExcType::MemoryError);
+}
+
+/// Test that `map()` over a huge `range` is bounded by the memory limit.
+#[test]
+fn map_over_huge_range_memory_limit() {
+    let code = "list(map(str, range(10 ** 9)))";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+
+    let limits = ResourceLimits::new().max_memory(100_000);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    assert!(result.is_err(), "huge map pre-allocation should be rejected");
+    assert_eq!(result.unwrap_err().exc_type(), ExcType::MemoryError);
+}
+
+/// Test that small set/map construction still succeeds within limits.
+#[test]
+fn set_from_range_within_limit() {
+    let code = "len(set(range(50))) + len(list(map(str, range(20))))";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+
+    let limits = ResourceLimits::new().max_memory(100_000);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    assert!(result.is_ok(), "small set/map construction should succeed: {result:?}");
+    assert_eq!(result.unwrap(), MontyObject::Int(70));
+}


### PR DESCRIPTION
Constructing a set, frozenset, or map result eagerly pre-allocates a container with capacity drawn from the iterator's size hint. The hint for an iterable like a large range is its full remaining length, so the pre-allocation can reach the global allocator with a request far beyond the configured memory budget. An allocation failure aborts the host rather than raising a catchable exception.

Add a preallocation helper on the iterator that validates the requested capacity against the resource tracker (raising MemoryError when it would exceed the budget) and clamps the result to a small bound so the pre-allocation is defensively safe even when no limits are configured.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents unbounded allocations from large iterables and dynamic f-string widths. All pre-allocation and collection are checked against the resource tracker; over-budget raises MemoryError instead of crashing.

- **Bug Fixes**
  - Added `MontyIter::preallocation_hint` and used it in set/frozenset/dict-view and `map()`; validates via `check_estimated_size` and clamps to 65,536.
  - Bounded `MontyIter::collect` incrementally so `list()`, `tuple()`, `sorted()`, `reversed()`, and generator builds stop near the limit.
  - Guarded f-string dynamic field width with `check_repeat_size` before padding; expanded resource-limit tests for these paths; small cases still succeed.

<sup>Written for commit 42c446950cf83a4847efd538849d413b87400e16. Summary will update on new commits. <a href="https://cubic.dev/pr/pydantic/monty/pull/434?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

