### PR TITLE
Pre-check requested size in bytes(int) constructor against resource l…

### DIFF
--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -166,6 +166,12 @@ impl Bytes {
                     return Err(ExcType::value_error_negative_bytes_count());
                 }
                 let size = usize::try_from(*n).expect("bytes count validated non-negative");
+                // Pre-check the requested size against resource limits before
+                // touching the global allocator. Without this, `bytes(n)` for a
+                // very large `n` would attempt the native allocation directly
+                // and abort the host on failure rather than raising MemoryError.
+                // Mirrors the guard already used by `bytes.ljust`/`zfill`/`*`.
+                check_repeat_size(size, 1, vm.heap.tracker())?;
                 vec![0u8; size]
             }
             Some(Value::InternString(string_id)) => {

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -946,6 +946,40 @@ fn bytes_mult_within_limit() {
     assert_eq!(result.unwrap(), MontyObject::Bool(true));
 }
 
+/// Test that `bytes(n)` is rejected before allocation when `n` exceeds the memory limit.
+///
+/// The integer constructor allocates a zero-filled buffer; the requested size must
+/// be validated against the resource tracker before the native allocation occurs.
+#[test]
+fn bytes_int_constructor_memory_limit() {
+    let code = "bytes(1000000)";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+
+    let limits = ResourceLimits::new().max_memory(100_000);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    assert!(result.is_err(), "large bytes(n) should be rejected");
+    let exc = result.unwrap_err();
+    assert_eq!(exc.exc_type(), ExcType::MemoryError);
+    assert!(
+        exc.message().is_some_and(|m| m.contains("memory limit exceeded")),
+        "expected memory limit error, got: {exc}"
+    );
+}
+
+/// Test that small `bytes(n)` works within limits.
+#[test]
+fn bytes_int_constructor_within_limit() {
+    let code = "len(bytes(100))";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+
+    let limits = ResourceLimits::new().max_memory(100_000);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    assert!(result.is_ok(), "small bytes(n) should succeed");
+    assert_eq!(result.unwrap(), MontyObject::Int(100));
+}
+
 /// Test that string multiplication is rejected before allocation via check_large_result.
 #[test]
 fn string_mult_rejected_before_allocation() {


### PR DESCRIPTION

The integer-argument form of bytes() allocated a zero-filled buffer proportional to the supplied count without consulting the resource tracker first. Add the same check_repeat_size guard used by the sibling padding/repeat operations so a configured memory limit raises MemoryError before the native allocation is attempted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-checks memory limits for the `bytes(int)` constructor so large `bytes(n)` raises MemoryError before allocation, matching other repeat/padding ops and preventing host aborts.

- **Bug Fixes**
  - Guard `bytes(n)` with `check_repeat_size(size, 1, vm.heap.tracker())` before allocating the zero-filled buffer.
  - Added tests to reject over-limit `bytes(1_000_000)` and allow `bytes(100)` within limits.

<sup>Written for commit a6b570681647823c31efee125c8c2c90f77a43e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

