### PR TITLE
Bound AST depth produced by folding flat elif and bool-op chains

### DIFF
--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -196,22 +196,40 @@ impl<'a> Parser<'a> {
         Ok(out)
     }
 
+    /// Folds a flat list of `elif`/`else` clauses into a right-nested `Node::If` tree.
+    ///
+    /// Ruff hands us the clauses as a flat `Vec`, but the prepared AST and the
+    /// bytecode compiler both walk the resulting tree recursively. Each `elif`
+    /// clause is therefore counted against the same depth budget that bounds
+    /// explicitly nested source constructs — without this, a long flat chain
+    /// would produce an AST far deeper than [`MAX_NESTING_DEPTH`] and overflow
+    /// the host's native stack during the prepare or compile phases.
+    ///
+    /// The depth budget consumed during the fold is restored on success so
+    /// sibling statements are not penalized. On parse errors the budget is
+    /// left decremented; this is harmless because the parser aborts entirely
+    /// and `depth_remaining` is never consulted again.
     fn parse_elif_else_clauses(&mut self, clauses: Vec<ElifElseClause>) -> Result<Vec<ParseNode>, ParseError> {
         let mut tail: Vec<ParseNode> = Vec::new();
+        let mut levels: u16 = 0;
         for clause in clauses.into_iter().rev() {
             match clause.test {
                 Some(test) => {
+                    // Account for the extra nesting level this clause adds to
+                    // the result tree.
+                    self.decr_depth_remaining(|| test.range())?;
+                    levels += 1;
                     let test = self.parse_expression(test)?;
                     let body = self.parse_statements(clause.body)?;
                     let or_else = tail;
-                    let nested = Node::If { test, body, or_else };
-                    tail = vec![nested];
+                    tail = vec![Node::If { test, body, or_else }];
                 }
                 None => {
                     tail = self.parse_statements(clause.body)?;
                 }
             }
         }
+        self.depth_remaining += levels;
         Ok(tail)
     }
 
@@ -682,7 +700,14 @@ impl<'a> Parser<'a> {
         match expression {
             AstExpr::BoolOp(ast::ExprBoolOp { op, values, range, .. }) => {
                 // Handle chained boolean operations like `a and b and c` by right-folding
-                // into nested binary operations: `a and (b and c)`
+                // into nested binary operations: `a and (b and c)`.
+                //
+                // Ruff hands the operands over as a flat `Vec`, but the fold
+                // produces a right-nested `Expr::Op` tree that the prepare and
+                // compile phases walk recursively. Count each fold step against
+                // the same depth budget that bounds explicitly nested source so
+                // a long flat chain cannot overflow the host's native stack
+                // downstream. The budget is restored once the fold completes.
                 let rust_op = convert_bool_op(op);
                 let position = self.convert_range(range);
                 let mut values_iter = values.into_iter().rev();
@@ -692,7 +717,10 @@ impl<'a> Parser<'a> {
                 let mut result = self.parse_expression(last_value)?;
 
                 // Fold from right to left
+                let mut levels: u16 = 0;
                 for value in values_iter {
+                    self.decr_depth_remaining(|| value.range())?;
+                    levels += 1;
                     let left = Box::new(self.parse_expression(value)?);
                     result = ExprLoc::new(
                         position,
@@ -703,6 +731,7 @@ impl<'a> Parser<'a> {
                         },
                     );
                 }
+                self.depth_remaining += levels;
                 Ok(result)
             }
             AstExpr::Named(ast::ExprNamed {

--- a/crates/monty/tests/parse_errors.rs
+++ b/crates/monty/tests/parse_errors.rs
@@ -499,3 +499,59 @@ fn for_loop_attribute_target_has_clean_message() {
     assert_eq!(exc.exc_type(), ExcType::SyntaxError);
     assert_snapshot!(exc.message().expect("has message"), @"invalid unpacking target: attribute");
 }
+
+#[test]
+fn many_elif_clauses_exceed_limit() {
+    // A long flat chain of `elif` clauses folds into a deeply right-nested
+    // `Node::If` tree that the prepare and compile phases walk recursively.
+    // Each clause is counted against the parser's nesting-depth budget so the
+    // result is a SyntaxError rather than a native stack overflow downstream.
+    let mut code = "if 0:\n    pass\n".to_owned();
+    for _ in 0..400 {
+        code.push_str("elif 0:\n    pass\n");
+    }
+    let result = MontyRun::new(code, "test.py", vec![]);
+    let err = result.expect_err("expected parse error");
+    assert_eq!(err.exc_type(), ExcType::SyntaxError);
+    assert_eq!(
+        err.message(),
+        Some("too many nested parentheses"),
+        "error message should match CPython, got: {:?}",
+        err.message()
+    );
+}
+
+#[test]
+fn moderate_elif_chain_within_limit() {
+    let mut code = "if 0:\n    pass\n".to_owned();
+    for _ in 0..20 {
+        code.push_str("elif 0:\n    pass\n");
+    }
+    code.push_str("else:\n    pass\n");
+    let result = MontyRun::new(code, "test.py", vec![]);
+    assert!(result.is_ok(), "moderate elif chain should succeed: {result:?}");
+}
+
+#[test]
+fn many_bool_op_operands_exceed_limit() {
+    // A long chain of `and`/`or` operands folds into a deeply right-nested
+    // `Expr::Op` tree. Each fold step is counted against the parser's
+    // nesting-depth budget.
+    let mut code = "x = 1".to_owned();
+    for _ in 0..400 {
+        code.push_str(" and 1");
+    }
+    let result = MontyRun::new(code, "test.py", vec![]);
+    let err = result.expect_err("expected parse error");
+    assert_eq!(err.exc_type(), ExcType::SyntaxError);
+}
+
+#[test]
+fn moderate_bool_op_chain_within_limit() {
+    let mut code = "1".to_owned();
+    for _ in 0..20 {
+        code.push_str(" and 1");
+    }
+    let result = MontyRun::new(code, "test.py", vec![]);
+    assert!(result.is_ok(), "moderate bool-op chain should succeed: {result:?}");
+}


### PR DESCRIPTION
Ruff hands the parser a flat list of elif/else clauses and bool-op operands. Folding them into right-nested If and Op trees produced an AST whose depth was not counted against the parser's nesting limit, so a long flat chain could yield an AST far deeper than the limit intended to permit. The prepare and compile phases walk that tree recursively, overflowing the host's native stack before any sandbox limits are active.

Count each fold step against the existing nesting-depth budget so the resulting AST depth stays bounded and an oversized chain produces a SyntaxError at parse time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound AST depth when folding flat `elif`/`else` and boolean-op chains. Long chains now respect the parser nesting limit and raise SyntaxError at parse time instead of risking native stack overflow.

- **Bug Fixes**
  - Count each fold step against the existing depth budget in `parse_elif_else_clauses` and `BoolOp` folding; restore the budget after a successful fold.
  - Added tests that reject oversized chains and accept moderate ones; `elif` overrun uses a CPython-compatible error message.

<sup>Written for commit b0f06c0f6c76df5d0d1d5691ece5c68334db6cdb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

