### PR TITLE
Enforce a recursion-depth ceiling in json.dumps serialization

### DIFF
--- a/crates/monty/src/modules/json/dump.rs
+++ b/crates/monty/src/modules/json/dump.rs
@@ -15,7 +15,7 @@ use crate::{
     exception_private::{ExcType, RunResult},
     heap::{DropWithHeap, HeapData, HeapGuard, HeapId, HeapReadOutput},
     intern::StaticStrings,
-    resource::ResourceTracker,
+    resource::{ResourceError, ResourceTracker},
     sorting::{apply_permutation, sort_indices},
     types::{PyTrait, long_int::check_bigint_str_digits_limit, str::allocate_string},
     value::Value,
@@ -367,6 +367,15 @@ fn json_separator_to_string(value: &Value, role: &str, vm: &VM<'_, impl Resource
     }
 }
 
+/// Maximum nesting depth accepted by `json.dumps()`.
+///
+/// Mirrors `JSON_RECURSION_LIMIT` on the `json.loads()` side: serialization is
+/// mutually recursive across `serialize_value`/`serialize_sequence`/`serialize_dict`
+/// and would otherwise overflow the host's native stack on a deep (acyclic)
+/// structure that the cycle detector cannot catch. CPython raises a catchable
+/// `RecursionError` here; we map the depth-limit `ResourceError` to the same.
+const JSON_DUMP_RECURSION_LIMIT: usize = 200;
+
 /// Serializes a Monty value into JSON text.
 ///
 /// The function handles immediate primitives directly and delegates to
@@ -379,6 +388,13 @@ fn serialize_value(
     active_containers: &mut Vec<HeapId>,
     vm: &mut VM<'_, impl ResourceTracker>,
 ) -> RunResult<()> {
+    if depth > JSON_DUMP_RECURSION_LIMIT {
+        return Err(ResourceError::Recursion {
+            limit: JSON_DUMP_RECURSION_LIMIT,
+            depth,
+        }
+        .into());
+    }
     match value {
         Value::None => {
             out.push_str("null");

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -2039,3 +2039,48 @@ len(x) + len(d) + len(s)
     );
     assert_eq!(result.unwrap(), MontyObject::Int(300));
 }
+
+// === json.dumps resource-limit tests ===
+
+/// Test that serializing a deeply-nested (acyclic) structure raises a catchable
+/// `RecursionError` rather than overflowing the host's native stack.
+///
+/// `json.dumps` is mutually recursive across the value/sequence/dict serializers
+/// and runs entirely inside one bytecode instruction, so the per-instruction
+/// recursion-depth check never fires. The serializer must enforce its own depth
+/// ceiling, mirroring the one applied by `json.loads`.
+#[test]
+fn json_dumps_deep_nesting_recursion_limit() {
+    let code = r"
+import json
+x = []
+for _ in range(500):
+    x = [x]
+try:
+    json.dumps(x)
+    out = 'no error'
+except RecursionError:
+    out = 'recursion error'
+out
+";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+    let result = ex.run_no_limits(vec![]);
+    assert!(result.is_ok(), "{result:?}");
+    assert_eq!(result.unwrap(), MontyObject::String("recursion error".to_owned()));
+}
+
+/// Test that moderate nesting in `json.dumps` succeeds.
+#[test]
+fn json_dumps_moderate_nesting_within_limit() {
+    let code = r"
+import json
+x = []
+for _ in range(50):
+    x = [x]
+json.dumps(x)[:5]
+";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+    let result = ex.run_no_limits(vec![]);
+    assert!(result.is_ok(), "{result:?}");
+    assert_eq!(result.unwrap(), MontyObject::String("[[[[[".to_owned()));
+}


### PR DESCRIPTION
The serialize_value/serialize_sequence/serialize_dict helpers are mutually recursive and run entirely within one bytecode instruction, so the VM's per-instruction recursion check never fires. The cycle detector catches reference loops but not deep acyclic chains, which can overflow the host's native stack.

Add a depth ceiling matching the JSON_RECURSION_LIMIT already used by json.loads, raising a catchable RecursionError once exceeded.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a recursion-depth ceiling to `json.dumps` to prevent native stack overflows on deeply nested acyclic structures. Matches the `json.loads` limit and raises a catchable `RecursionError` when exceeded.

- **Bug Fixes**
  - Enforce `JSON_DUMP_RECURSION_LIMIT` (200) in the serializer and map overflow to `RecursionError`.
  - Add tests: deep nesting triggers the error; moderate nesting stays within the limit.

<sup>Written for commit 058201206c421e63797f643ab70660abc45d6ab9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

