### PR TITLE
deduplicate source lines in tracebacks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ num-traits = "0.2"
 num-integer = "0.1"
 # others
 indexmap = { version = "2.9", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 postcard = { version = "1.1", features = ["alloc"] }
 sha2 = "0.10"

--- a/crates/monty-js/__test__/exceptions.spec.ts
+++ b/crates/monty-js/__test__/exceptions.spec.ts
@@ -231,6 +231,36 @@ outer()
   t.true(display.includes('ValueError: error'))
 })
 
+test('traceback() on deep recursion with long preview line is memory-bounded', (t) => {
+  // Frames produced by a single traceback() call that resolve to the same
+  // source line must share one V8 string allocation. Without sharing, a 1 MiB
+  // preview line on a recursive call site with depth=200 would put ~200 MiB
+  // of strings on the heap; with sharing it should stay around 1 MiB plus
+  // the Frame objects themselves. Verify by walking 200 frames with a long
+  // preview and asserting heap growth stays well below the unbounded worst
+  // case.
+  const pad = 'A'.repeat(1024 * 1024)
+  const code = `def recurse(n):\n    return recurse(n - 1)  # ${pad}\nrecurse(2000)\n`
+  const m = new Monty(code)
+  const error = t.throws(() => m.run({ limits: { maxRecursionDepth: 200 } }), isRuntimeError)
+
+  if (global.gc) global.gc()
+  const before = process.memoryUsage().heapUsed
+  const frames = error.traceback()
+  if (global.gc) global.gc()
+  const after = process.memoryUsage().heapUsed
+
+  const recurseFrames = frames.filter((f) => f.functionName === 'recurse')
+  t.true(recurseFrames.length >= 100, `expected many recursive frames, got ${recurseFrames.length}`)
+  t.true(recurseFrames[0].sourceLine!.includes(pad), 'preview line should include the padding')
+
+  // Unbounded worst case for depth=200 with a 1 MiB line is ~200 MiB. A
+  // generous ceiling of 20 MiB still proves the amplification is gone while
+  // tolerating GC slack and the unavoidable ~1 MiB shared string itself.
+  const growth = after - before
+  t.true(growth < 20 * 1024 * 1024, `heap grew by ${growth} bytes; expected <20 MiB`)
+})
+
 // =============================================================================
 // MontyError base class tests
 // =============================================================================

--- a/crates/monty-js/src/exceptions.rs
+++ b/crates/monty-js/src/exceptions.rs
@@ -14,11 +14,11 @@
 //! - `MontyTypingError`: Wraps `TypeCheckingDiagnostics` for static type checking errors.
 //!   This is separate because type errors come from static analysis, not Python execution.
 
-use std::fmt;
+use std::{collections::HashMap, fmt, sync::Arc};
 
-use monty::{ExcType, StackFrame};
+use monty::ExcType;
 use monty_type_checking::TypeCheckingDiagnostics;
-use napi::bindgen_prelude::*;
+use napi::{bindgen_prelude::*, JsString};
 use napi_derive::napi;
 use serde::{Deserialize, Serialize};
 
@@ -66,9 +66,43 @@ impl JsMontyException {
     ///
     /// For syntax errors, this will be an empty array.
     /// For runtime errors, this contains the stack frames where the error occurred.
+    ///
+    /// `Frame.source_line` is built as a `JsString` shared across frames that
+    /// resolve to the same source line. For deep recursion where every frame
+    /// points at the same line this creates a single V8 string referenced by
+    /// every frame, instead of one copy per frame.
     #[napi]
-    pub fn traceback(&self) -> Vec<Frame> {
-        self.0.traceback().iter().map(Frame::from_stack_frame).collect()
+    pub fn traceback<'env>(&self, env: &'env Env) -> Result<Vec<Frame<'env>>> {
+        let stack_frames = self.0.traceback();
+        let mut line_cache: HashMap<usize, JsString<'env>> = HashMap::new();
+        stack_frames
+            .iter()
+            .map(|f| {
+                let source_line = f
+                    .preview_line
+                    .as_ref()
+                    .map(|arc| -> Result<JsString<'env>> {
+                        let key = Arc::as_ptr(arc).cast::<()>() as usize;
+                        if let Some(s) = line_cache.get(&key) {
+                            Ok(*s)
+                        } else {
+                            let s = env.create_string(arc)?;
+                            line_cache.insert(key, s);
+                            Ok(s)
+                        }
+                    })
+                    .transpose()?;
+                Ok(Frame {
+                    filename: f.filename.clone(),
+                    line: f.start.line,
+                    column: f.start.column,
+                    end_line: f.end.line,
+                    end_column: f.end.column,
+                    function_name: f.frame_name.clone(),
+                    source_line,
+                })
+            })
+            .collect()
     }
 
     /// Returns formatted exception string.
@@ -219,9 +253,14 @@ pub struct ExceptionInfo {
 ///
 /// Contains all the information needed to display a traceback line:
 /// the file location, function name, and optional source code preview.
+///
+/// `source_line` is a `JsString` borrowed from the env scope of the
+/// `traceback()` call that produced this frame. Frames produced by the same
+/// `traceback()` call that resolve to the same source location share one V8
+/// string allocation. The lifetime parameter ties the frame to that env
+/// scope, since `JsString<'env>` is a non-owning handle.
 #[napi(object)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Frame {
+pub struct Frame<'env> {
     /// The filename where the code is located.
     pub filename: String,
     /// Line number (1-based).
@@ -235,23 +274,7 @@ pub struct Frame {
     /// The name of the function, or null for module-level code.
     pub function_name: Option<String>,
     /// The source code line for preview in the traceback.
-    pub source_line: Option<String>,
-}
-
-impl Frame {
-    /// Creates a `Frame` from Monty's `StackFrame`.
-    #[must_use]
-    pub fn from_stack_frame(frame: &StackFrame) -> Self {
-        Self {
-            filename: frame.filename.clone(),
-            line: frame.start.line,
-            column: frame.start.column,
-            end_line: frame.end.line,
-            end_column: frame.end.column,
-            function_name: frame.frame_name.clone(),
-            source_line: frame.preview_line.clone(),
-        }
-    }
+    pub source_line: Option<JsString<'env>>,
 }
 
 /// Converts a javascript error into a MontyException.

--- a/crates/monty-python/src/exceptions.rs
+++ b/crates/monty-python/src/exceptions.rs
@@ -13,12 +13,15 @@
 //! └── MontyTypingError         # Raised when type checking finds errors in the code
 //! ```
 
-use ::monty::{ExcType, MontyException, StackFrame};
+use std::{collections::HashMap, sync::Arc};
+
+use ::monty::{ExcType, MontyException};
 use monty_type_checking::TypeCheckingDiagnostics;
 use pyo3::{
     PyClassInitializer, PyTypeCheck,
     exceptions::{self},
     prelude::*,
+    py_format,
     sync::PyOnceLock,
     types::{PyDict, PyList, PyString},
 };
@@ -206,33 +209,32 @@ impl MontyTypingError {
 ///
 /// Inherits from `MontyError`. Additionally provides `traceback()` to access
 /// the Monty stack frames where the error occurred.
+///
+/// `PyFrame` objects are materialized lazily on the first `traceback()` call
+/// rather than at exception-construction time. This bounds the cost of
+/// exception propagation: an attacker submitting deeply recursive code
+/// referencing a very long line cannot force the embedder to allocate
+/// `O(depth × line_len)` bytes simply by triggering the exception — the cost
+/// is paid only if the embedder explicitly walks the traceback. The result
+/// is cached so subsequent calls reuse the same `Frame` and source-line
+/// objects, matching the stable-object semantics of CPython's
+/// `exc.__traceback__`.
 #[pyclass(extends=MontyError, module="pydantic_monty")]
 pub struct MontyRuntimeError {
-    /// The traceback frames where the error occurred (pre-converted to Python objects).
-    frames: Vec<Py<PyFrame>>,
+    traceback: PyOnceLock<Py<PyList>>,
 }
 
 impl MontyRuntimeError {
     /// Creates a new `MontyRuntimeError` from the given exception data.
+    ///
+    /// This is O(1) — the underlying `MontyException` is stored on the base
+    /// class and frames are built on demand by `traceback()`.
     #[must_use]
     pub fn new_err(py: Python<'_>, exc: MontyException) -> PyErr {
-        // Convert stack frames to PyFrame objects
-        let frames_result: PyResult<Vec<Py<PyFrame>>> = exc
-            .traceback()
-            .iter()
-            .map(|f| Py::new(py, PyFrame::from_stack_frame(f)))
-            .collect();
-
-        let frames = match frames_result {
-            Ok(frames) => frames,
-            Err(e) => return e,
-        };
-
         let base_error = MontyError::new(exc);
-        // Create the MontyRuntimeError with proper initialization
-        let runtime_error = Self { frames };
-
-        let init = pyo3::PyClassInitializer::from(base_error).add_subclass(runtime_error);
+        let init = PyClassInitializer::from(base_error).add_subclass(Self {
+            traceback: PyOnceLock::new(),
+        });
         match Py::new(py, init) {
             Ok(err) => PyErr::from_value(err.into_bound(py).into_any()),
             Err(e) => e,
@@ -243,10 +245,46 @@ impl MontyRuntimeError {
 #[pymethods]
 impl MontyRuntimeError {
     /// Returns the Monty traceback as a list of Frame objects.
-    fn traceback(&self, py: Python<'_>) -> Py<PyList> {
-        PyList::new(py, &self.frames)
-            .expect("failed to create frames list")
-            .unbind()
+    ///
+    /// `Frame.source_line` is backed by a `Py<PyString>` that is deduplicated
+    /// across frames resolving to the same source line. For deep recursion
+    /// where every frame points at the same line, this allocates one
+    /// `PyString` instead of one per frame.
+    ///
+    /// The list is built on the first call and cached, so repeated calls
+    /// return the same list, frame, and source-line objects.
+    #[expect(clippy::needless_pass_by_value, reason = "required by macro")]
+    fn traceback(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<Py<PyList>> {
+        let list = slf.traceback.get_or_try_init(py, || {
+            let stack_frames = slf.as_super().exc.traceback();
+            let mut line_cache: HashMap<usize, Py<PyString>> = HashMap::new();
+            let frames: Vec<Py<PyFrame>> = stack_frames
+                .iter()
+                .map(|f| {
+                    let source_line = f.preview_line.as_ref().map(|arc| {
+                        let key = Arc::as_ptr(arc).cast::<()>() as usize;
+                        line_cache
+                            .entry(key)
+                            .or_insert_with(|| PyString::new(py, arc).unbind())
+                            .clone_ref(py)
+                    });
+                    Py::new(
+                        py,
+                        PyFrame {
+                            filename: f.filename.clone(),
+                            line: f.start.line,
+                            column: f.start.column,
+                            end_line: f.end.line,
+                            end_column: f.end.column,
+                            function_name: f.frame_name.clone(),
+                            source_line,
+                        },
+                    )
+                })
+                .collect::<PyResult<_>>()?;
+            Ok::<_, PyErr>(PyList::new(py, &frames)?.unbind())
+        })?;
+        Ok(list.clone_ref(py))
     }
 
     /// Returns formatted exception string.
@@ -294,8 +332,13 @@ impl MontyRuntimeError {
 ///
 /// Contains all the information needed to display a traceback line:
 /// the file location, function name, and optional source code preview.
+///
+/// `source_line` is stored as `Py<PyString>` so that frames built from the
+/// same underlying source line in a single `traceback()` call share one
+/// Python string object. For a recursion with a long preview line this turns
+/// what would be `O(depth × line_len)` peak memory into a single allocation.
 #[pyclass(name = "Frame", module = "pydantic_monty", frozen, skip_from_py_object)]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct PyFrame {
     /// The filename where the code is located.
     #[pyo3(get)]
@@ -317,45 +360,34 @@ pub struct PyFrame {
     pub function_name: Option<String>,
     /// The source code line for preview in the traceback.
     #[pyo3(get)]
-    pub source_line: Option<String>,
+    pub source_line: Option<Py<PyString>>,
 }
 
 #[pymethods]
 impl PyFrame {
-    fn dict(&self, py: Python<'_>) -> Py<PyDict> {
+    fn dict<'py>(&self, py: Python<'py>) -> Bound<'py, PyDict> {
         let dict = PyDict::new(py);
-        dict.set_item("filename", self.filename.clone()).unwrap();
+        dict.set_item("filename", &self.filename).unwrap();
         dict.set_item("line", self.line).unwrap();
         dict.set_item("column", self.column).unwrap();
         dict.set_item("end_line", self.end_line).unwrap();
         dict.set_item("end_column", self.end_column).unwrap();
-        dict.set_item("function_name", self.function_name.clone()).unwrap();
-        dict.set_item("source_line", self.source_line.clone()).unwrap();
-        dict.unbind()
+        dict.set_item("function_name", self.function_name.as_ref()).unwrap();
+
+        dict.set_item("source_line", self.source_line.as_ref()).unwrap();
+        dict
     }
 
-    fn __repr__(&self) -> String {
-        let func = self.function_name.as_ref().map_or("<module>".to_string(), Clone::clone);
-        format!(
+    fn __repr__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyString>> {
+        let func = self.function_name.as_deref().unwrap_or("<module>");
+        py_format!(
+            py,
             "Frame(filename='{}', line={}, column={}, function_name='{}')",
-            self.filename, self.line, self.column, func
+            self.filename,
+            self.line,
+            self.column,
+            func
         )
-    }
-}
-
-impl PyFrame {
-    /// Creates a `PyFrame` from Monty's `StackFrame`.
-    #[must_use]
-    pub fn from_stack_frame(frame: &StackFrame) -> Self {
-        Self {
-            filename: frame.filename.clone(),
-            line: frame.start.line,
-            column: frame.start.column,
-            end_line: frame.end.line,
-            end_column: frame.end.column,
-            function_name: frame.frame_name.clone(),
-            source_line: frame.preview_line.clone(),
-        }
     }
 }
 

--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -3163,12 +3163,12 @@ impl CompileError {
     /// - SyntaxError: hides the `, in <module>` part (CPython's format)
     /// - ModuleNotFoundError: hides caret markers (CPython doesn't show them)
     pub fn into_python_exc(self, filename: &str, source: &str) -> MontyException {
-        let source_map = SourceMap::new(source);
+        let mut source_map = SourceMap::new(source);
         let mut frame = if self.exc_type == ExcType::SyntaxError {
             // SyntaxError uses different format: no `, in <module>`
-            StackFrame::from_position_syntax_error(self.position, filename, &source_map)
+            StackFrame::from_position_syntax_error(self.position, filename, &mut source_map)
         } else {
-            StackFrame::from_position(self.position, filename, &source_map)
+            StackFrame::from_position(self.position, filename, &mut source_map)
         };
         // CPython doesn't show carets for module not found errors
         if self.exc_type == ExcType::ModuleNotFoundError {

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1618,7 +1618,7 @@ impl ExceptionRaise {
                         cache.push((fname_id, SourceMap::new(src)));
                         cache.len() - 1
                     };
-                    frames.push(StackFrame::from_raw(f, interns, &cache[sm_idx].1));
+                    frames.push(StackFrame::from_raw(f, interns, &mut cache[sm_idx].1));
                     current = f.parent.as_deref();
                 }
                 // Reverse so outermost frame is first (Python's "most recent call last" ordering)

--- a/crates/monty/src/exception_public.rs
+++ b/crates/monty/src/exception_public.rs
@@ -1,6 +1,8 @@
 use std::{
+    collections::HashMap,
     error,
     fmt::{self, Write},
+    sync::Arc,
 };
 
 use crate::{
@@ -189,7 +191,16 @@ pub struct StackFrame {
     /// The name of the frame (function name, or None for module-level code).
     pub frame_name: Option<String>,
     /// The source code line for preview in the traceback.
-    pub preview_line: Option<String>,
+    ///
+    /// Stored as `Arc<str>` rather than `String` so that consecutive frames
+    /// referencing the same source line — typical of recursion and tight
+    /// helper-function loops — share a single allocation. Without sharing, a
+    /// 1000-deep recursive call into code on a long line would clone the
+    /// entire line into each frame and amplify memory usage by the call
+    /// depth. Serialization roundtrips lose the sharing (each frame gets
+    /// its own `Arc`), but that is bounded by the wire size of the
+    /// traceback so does not regress the amplification.
+    pub preview_line: Option<Arc<str>>,
     /// Whether to hide the caret marker in the traceback for this frame.
     ///
     /// Set to `true` for:
@@ -250,7 +261,7 @@ impl StackFrame {
     /// Resolves the raw filename/frame-name `StringId`s via `interns` and
     /// expands the position's byte offsets to line/column and a preview
     /// line via `source_map`.
-    pub(crate) fn from_raw(f: &RawStackFrame, interns: &Interns, source_map: &SourceMap<'_>) -> Self {
+    pub(crate) fn from_raw(f: &RawStackFrame, interns: &Interns, source_map: &mut SourceMap<'_>) -> Self {
         let filename = interns.get_str(f.position.filename).to_string();
         let (start, end, preview_line) = source_map.resolve_range(f.position);
         Self {
@@ -268,7 +279,11 @@ impl StackFrame {
     ///
     /// Sets `hide_frame_name: true` because CPython's SyntaxError format
     /// omits the trailing `, in <module>` part.
-    pub(crate) fn from_position_syntax_error(position: CodeRange, filename: &str, source_map: &SourceMap<'_>) -> Self {
+    pub(crate) fn from_position_syntax_error(
+        position: CodeRange,
+        filename: &str,
+        source_map: &mut SourceMap<'_>,
+    ) -> Self {
         let (start, end, preview_line) = source_map.resolve_range(position);
         Self {
             filename: filename.to_string(),
@@ -286,7 +301,7 @@ impl StackFrame {
     /// Used for runtime-style errors raised outside the VM's frame tracking
     /// (e.g. parse-phase `NotImplementedError`) where caret markers and the
     /// `, in <module>` suffix are both shown.
-    pub(crate) fn from_position(position: CodeRange, filename: &str, source_map: &SourceMap<'_>) -> Self {
+    pub(crate) fn from_position(position: CodeRange, filename: &str, source_map: &mut SourceMap<'_>) -> Self {
         let (start, end, preview_line) = source_map.resolve_range(position);
         Self {
             filename: filename.to_string(),
@@ -303,7 +318,7 @@ impl StackFrame {
     ///
     /// Used for errors like `ImportError` and `ModuleNotFoundError`, where
     /// CPython shows the source preview line but no `~~~` carets beneath it.
-    pub(crate) fn from_position_no_caret(position: CodeRange, filename: &str, source_map: &SourceMap<'_>) -> Self {
+    pub(crate) fn from_position_no_caret(position: CodeRange, filename: &str, source_map: &mut SourceMap<'_>) -> Self {
         let (start, end, preview_line) = source_map.resolve_range(position);
         Self {
             filename: filename.to_string(),
@@ -373,6 +388,15 @@ pub struct SourceMap<'s> {
     /// Byte offset of the start of each line. Length equals the number of
     /// lines; `line_starts[0]` is always 0.
     line_starts: Vec<u32>,
+    /// Cache of preview lines, keyed by 0-based line index.
+    ///
+    /// Lets every `StackFrame` referencing the same source line share a
+    /// single `Arc<str>` allocation rather than each cloning the line into
+    /// its own `String`. This matters for deep recursion: without the
+    /// cache, a 1 MiB line referenced by 1000 frames would allocate ~1 GiB;
+    /// with the cache it allocates ~1 MiB. Built lazily — entries materialize
+    /// only as `resolve_range` actually requests them.
+    line_cache: HashMap<usize, Arc<str>>,
 }
 
 impl<'s> SourceMap<'s> {
@@ -391,22 +415,34 @@ impl<'s> SourceMap<'s> {
                 line_starts.push(start);
             }
         }
-        Self { source, line_starts }
+        Self {
+            source,
+            line_starts,
+            line_cache: HashMap::new(),
+        }
     }
 
     /// Resolves a `CodeRange` into `(start, end, preview_line)`.
     ///
     /// `preview_line` is `Some(line)` only when `start` and `end` lie on the
     /// same line — matching the previous semantics where multi-line ranges
-    /// have no single preview to highlight.
-    pub(crate) fn resolve_range(&self, range: CodeRange) -> (CodeLoc, CodeLoc, Option<String>) {
+    /// have no single preview to highlight. The returned `Arc<str>` is
+    /// shared with any other frame in this traceback resolving to the same
+    /// line, so repeated lookups for the same line are O(1) and allocate
+    /// only on the first lookup.
+    pub(crate) fn resolve_range(&mut self, range: CodeRange) -> (CodeLoc, CodeLoc, Option<Arc<str>>) {
         let (start_line_idx, start) = self.resolve_byte(range.start_byte);
         let (end_line_idx, end) = self.resolve_byte(range.end_byte);
-        let preview_line = if start_line_idx == end_line_idx {
-            Some(self.line_text(start_line_idx).to_string())
-        } else {
-            None
-        };
+        let preview_line = (start_line_idx == end_line_idx).then(|| {
+            // Cache materializes lazily — first request for a given line allocates
+            // the `Arc<str>`, subsequent requests for the same line clone the Arc.
+            let line_text = self.line_text(start_line_idx);
+            Arc::clone(
+                self.line_cache
+                    .entry(start_line_idx)
+                    .or_insert_with(|| Arc::from(line_text)),
+            )
+        });
         (start, end, preview_line)
     }
 

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -1775,27 +1775,31 @@ impl ParseError {
 
 impl ParseError {
     pub fn into_python_exc(self, filename: &str, source: &str) -> MontyException {
-        let source_map = SourceMap::new(source);
+        let mut source_map = SourceMap::new(source);
         match self {
             Self::Syntax { msg, position } => MontyException::new_full(
                 ExcType::SyntaxError,
                 Some(msg.into_owned()),
-                vec![StackFrame::from_position_syntax_error(position, filename, &source_map)],
+                vec![StackFrame::from_position_syntax_error(
+                    position,
+                    filename,
+                    &mut source_map,
+                )],
             ),
             Self::NotImplemented { msg, position } => MontyException::new_full(
                 ExcType::NotImplementedError,
                 Some(format!("The monty syntax parser does not yet support {msg}")),
-                vec![StackFrame::from_position(position, filename, &source_map)],
+                vec![StackFrame::from_position(position, filename, &mut source_map)],
             ),
             Self::NotSupported { msg, position } => MontyException::new_full(
                 ExcType::NotImplementedError,
                 Some(msg.into_owned()),
-                vec![StackFrame::from_position(position, filename, &source_map)],
+                vec![StackFrame::from_position(position, filename, &mut source_map)],
             ),
             Self::Import { msg, position } => MontyException::new_full(
                 ExcType::ImportError,
                 Some(msg.into_owned()),
-                vec![StackFrame::from_position_no_caret(position, filename, &source_map)],
+                vec![StackFrame::from_position_no_caret(position, filename, &mut source_map)],
             ),
         }
     }

--- a/crates/monty/tests/error_locations.rs
+++ b/crates/monty/tests/error_locations.rs
@@ -1,6 +1,8 @@
 // Monty does not yet implement `__traceback__`, so this test cannot be a datatest.
 
-use monty::{ExcType, MontyRun};
+use std::sync::Arc;
+
+use monty::{ExcType, LimitedTracker, MontyRun, PrintWriter, ResourceLimits};
 
 #[test]
 fn non_ascii_earlier_line_does_not_shift_column() {
@@ -31,4 +33,46 @@ fn non_ascii_char_column_location() {
     assert_eq!(frame.start.line, 1);
     assert_eq!(frame.start.column, 7);
     assert_eq!(frame.end.column, 21);
+}
+
+#[test]
+fn recursive_frames_share_preview_line_allocation() {
+    // Frames at the same source location must share a single `Arc<str>`
+    // backing `preview_line`. Without sharing, a 1 MiB line on the error
+    // site with 1000 recursive frames would allocate ~1 GiB during
+    // exception construction — outside the VM's resource accounting, since
+    // these allocations are in standard Rust memory rather than the managed
+    // heap. Arc sharing keeps the worst case at ~1 MiB.
+    let code = r"
+def recurse(n):
+    return recurse(n - 1)
+recurse(50)
+";
+    let run = MontyRun::new(code.to_string(), "test.py", vec![]).expect("should parse");
+    let limits = ResourceLimits::new().max_recursion_depth(Some(10));
+    let err = run
+        .run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout)
+        .expect_err("should exceed recursion depth");
+
+    assert_eq!(err.exc_type(), ExcType::RecursionError);
+
+    let recurse_frames: Vec<_> = err
+        .traceback()
+        .iter()
+        .filter(|f| f.frame_name.as_deref() == Some("recurse"))
+        .collect();
+    assert!(
+        recurse_frames.len() >= 5,
+        "expected several recursive frames, got {}",
+        recurse_frames.len()
+    );
+
+    let first = recurse_frames[0].preview_line.as_ref().expect("preview line present");
+    for frame in &recurse_frames[1..] {
+        let other = frame.preview_line.as_ref().expect("preview line present");
+        assert!(
+            Arc::ptr_eq(first, other),
+            "frames at the same source line should share a single Arc<str> allocation",
+        );
+    }
 }


### PR DESCRIPTION
This avoids `MontyException` containing full copies of input source lines, which can have prohibitively high memory usage if a large source line is recursed through aggressively.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates source preview lines in traceback frames to prevent memory blow-ups on deep recursion with long lines. Frames that point to the same line now share one string, and Python frames are built lazily on first traceback access.

- **Bug Fixes**
  - Cache preview lines in `SourceMap` and store them as `Arc<str>` in `StackFrame.preview_line` to share allocations across frames.
  - Python: build frames on the first `traceback()` call, cache the list, and deduplicate `PyString` per source line.
  - JS: `Frame.source_line` uses shared `JsString` handles per source line within a traceback.
  - Make error paths use a mutable `SourceMap` so caching is effective.
  - Add Rust and JS tests to verify sharing and bounded heap growth.

- **Dependencies**
  - Enable `serde` feature `rc` to support serializing `Arc<str>`.

<sup>Written for commit 4dfc9b7ab71cb7e848f2b853d3356509da1e2c38. Summary will update on new commits. <a href="https://cubic.dev/pr/pydantic/monty/pull/443?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

