### PR TITLE
fix further panics in integer operations

### DIFF
--- a/crates/monty/src/builtins/pow.rs
+++ b/crates/monty/src/builtins/pow.rs
@@ -1,5 +1,7 @@
 //! Implementation of the pow() builtin function.
 
+use std::num::NonZero;
+
 use num_bigint::BigInt;
 use num_traits::{Signed, ToPrimitive, Zero};
 
@@ -36,16 +38,20 @@ pub fn builtin_pow(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> Ru
             // Three-argument pow: modular exponentiation
             match (base, exp, m) {
                 (Value::Int(b), Value::Int(e), Value::Int(m_val)) => {
-                    if let Ok(e) = u64::try_from(*e) {
-                        Ok(Value::Int(mod_pow(*b, e, *m_val)?))
-                    } else {
+                    let Some(m_nz) = NonZero::new(*m_val) else {
+                        return Err(
+                            SimpleException::new_msg(ExcType::ValueError, "pow() 3rd argument cannot be 0").into(),
+                        );
+                    };
+                    let Ok(e) = u64::try_from(*e) else {
                         debug_assert!(*e < 0, "i64 -> u64 succeeds for all non-negative values");
-                        Err(SimpleException::new_msg(
+                        return Err(SimpleException::new_msg(
                             ExcType::ValueError,
                             "pow() 2nd argument cannot be negative when 3rd argument specified",
                         )
-                        .into())
-                    }
+                        .into());
+                    };
+                    Ok(Value::Int(mod_pow(*b, e, m_nz)))
                 }
                 _ => Err(SimpleException::new_msg(
                     ExcType::TypeError,
@@ -78,23 +84,19 @@ fn normalize_bool(value: &Value) -> &Value {
 
 /// Computes (base^exp) % modulo using binary exponentiation.
 ///
-/// Handles negative bases correctly using Python's modulo semantics, and
-/// matches CPython's behavior for the trivial modulus cases:
-///
-/// * `modulo == 0` raises `ValueError` (zero division for `pow`).
-/// * `|modulo| == 1` always yields `0`, including `exp == 0` where the loop
-///   below would otherwise leave `result` at `1`.
-fn mod_pow(base: i64, exp: u64, modulo: i64) -> RunResult<i64> {
-    if modulo == 0 {
-        return Err(SimpleException::new_msg(ExcType::ValueError, "pow() 3rd argument cannot be 0").into());
-    }
+/// Matches CPython for `|modulo| == 1`: the result is always `0`, including
+/// the `exp == 0` corner case where the loop would otherwise leave
+/// `result` at `1`.
+fn mod_pow(base: i64, exp: u64, modulo: NonZero<i64>) -> i64 {
+    let modulo = modulo.get();
 
     // The `|modulo| == 1` short-circuit is also load-bearing for panic safety:
     // without it, `base.rem_euclid(modulo)` panics when `base == i64::MIN` and
     // `modulo == -1` (the intermediate `i64::MIN / -1` overflows). Filtering
-    // `modulo ∈ {-1, 0, 1}` up front guarantees `rem_euclid` cannot panic.
+    // `modulo ∈ {-1, 1}` up front (combined with the `NonZero` guarantee)
+    // ensures `rem_euclid` cannot panic.
     if modulo == 1 || modulo == -1 {
-        return Ok(0);
+        return 0;
     }
 
     // `modulo` is now neither 0 nor ±1, so `rem_euclid` cannot panic and
@@ -115,9 +117,9 @@ fn mod_pow(base: i64, exp: u64, modulo: i64) -> RunResult<i64> {
     // `result < modulo_u <= 2^63`, so the conversion to i64 always succeeds.
     let result_i64 = i64::try_from(result).expect("mod_pow result exceeds i64::MAX");
     if modulo < 0 && result_i64 > 0 {
-        Ok(result_i64 + modulo)
+        result_i64 + modulo
     } else {
-        Ok(result_i64)
+        result_i64
     }
 }
 

--- a/crates/monty/src/builtins/pow.rs
+++ b/crates/monty/src/builtins/pow.rs
@@ -36,11 +36,8 @@ pub fn builtin_pow(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> Ru
             // Three-argument pow: modular exponentiation
             match (base, exp, m) {
                 (Value::Int(b), Value::Int(e), Value::Int(m_val)) => {
-                    if *m_val == 0 {
-                        Err(SimpleException::new_msg(ExcType::ValueError, "pow() 3rd argument cannot be 0").into())
-                    } else if let Ok(e) = u64::try_from(*e) {
-                        // Use modular exponentiation
-                        Ok(Value::Int(mod_pow(*b, e, *m_val)))
+                    if let Ok(e) = u64::try_from(*e) {
+                        Ok(Value::Int(mod_pow(*b, e, *m_val)?))
                     } else {
                         debug_assert!(*e < 0, "i64 -> u64 succeeds for all non-negative values");
                         Err(SimpleException::new_msg(
@@ -81,12 +78,27 @@ fn normalize_bool(value: &Value) -> &Value {
 
 /// Computes (base^exp) % modulo using binary exponentiation.
 ///
-/// Handles negative bases correctly using Python's modulo semantics.
-fn mod_pow(base: i64, exp: u64, modulo: i64) -> i64 {
-    if modulo == 1 {
-        return 0;
+/// Handles negative bases correctly using Python's modulo semantics, and
+/// matches CPython's behavior for the trivial modulus cases:
+///
+/// * `modulo == 0` raises `ValueError` (zero division for `pow`).
+/// * `|modulo| == 1` always yields `0`, including `exp == 0` where the loop
+///   below would otherwise leave `result` at `1`.
+fn mod_pow(base: i64, exp: u64, modulo: i64) -> RunResult<i64> {
+    if modulo == 0 {
+        return Err(SimpleException::new_msg(ExcType::ValueError, "pow() 3rd argument cannot be 0").into());
     }
 
+    // The `|modulo| == 1` short-circuit is also load-bearing for panic safety:
+    // without it, `base.rem_euclid(modulo)` panics when `base == i64::MIN` and
+    // `modulo == -1` (the intermediate `i64::MIN / -1` overflows). Filtering
+    // `modulo ∈ {-1, 0, 1}` up front guarantees `rem_euclid` cannot panic.
+    if modulo == 1 || modulo == -1 {
+        return Ok(0);
+    }
+
+    // `modulo` is now neither 0 nor ±1, so `rem_euclid` cannot panic and
+    // `modulo_u` is in `2..=2^63`.
     let modulo_u = u128::from(modulo.unsigned_abs());
     let mut result: u128 = 1;
     let mut b = base.rem_euclid(modulo) as u128;
@@ -100,13 +112,12 @@ fn mod_pow(base: i64, exp: u64, modulo: i64) -> i64 {
         b = (b * b) % modulo_u;
     }
 
-    // Convert back to signed, handling negative modulo
-    // result < modulo_u <= i64::MAX as u128, so this conversion is safe
+    // `result < modulo_u <= 2^63`, so the conversion to i64 always succeeds.
     let result_i64 = i64::try_from(result).expect("mod_pow result exceeds i64::MAX");
     if modulo < 0 && result_i64 > 0 {
-        result_i64 + modulo
+        Ok(result_i64 + modulo)
     } else {
-        result_i64
+        Ok(result_i64)
     }
 }
 

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1087,6 +1087,15 @@ impl ExcType {
         SimpleException::new_msg(Self::OverflowError, "Python int too large to convert to C ssize_t").into()
     }
 
+    /// Creates an OverflowError when a Python int doesn't fit into a C `int` (i32).
+    ///
+    /// Matches CPython's format: `OverflowError: Python int too large to convert to C int`
+    /// Used by builtins (e.g. `bytes.hex`) that parse arguments via the `i` format code.
+    #[must_use]
+    pub(crate) fn overflow_c_int() -> RunError {
+        SimpleException::new_msg(Self::OverflowError, "Python int too large to convert to C int").into()
+    }
+
     /// Creates a TypeError for unsupported binary operations.
     ///
     /// For `+` or `+=` with str/list on the left side, uses CPython's special format:

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -65,7 +65,13 @@
 /// - `expandtabs(tabsize=8)` - Tab expansion
 /// - `translate(table[, delete])` - Character translation
 /// - `maketrans(frm, to)` - Create translation table (staticmethod)
-use std::{cell::Cell, cmp::Ordering, fmt, fmt::Write, mem, ops, str};
+use std::{
+    cell::Cell,
+    cmp::Ordering,
+    ffi::c_int,
+    fmt::{self, Write},
+    mem, ops, str,
+};
 
 use ahash::AHashSet;
 use smallvec::smallvec;
@@ -2105,8 +2111,13 @@ fn bytes_hex<'h>(
         if bytes_per_sep == 0 || bytes.is_empty() {
             hex_chars.iter().collect()
         } else {
-            // Insert separator every `bytes_per_sep` bytes (2*bytes_per_sep hex chars)
-            let chars_per_group = usize::try_from(bytes_per_sep.unsigned_abs()).unwrap_or(usize::MAX) * 2;
+            // Insert separator every `bytes_per_sep` bytes (2*bytes_per_sep hex chars).
+            // `saturating_mul` guards against overflow when `bytes_per_sep == i64::MIN`,
+            // whose `unsigned_abs()` is `2^63` and would wrap `* 2` to zero, triggering
+            // a panic in `chunks(0)` below.
+            let chars_per_group = usize::try_from(bytes_per_sep.unsigned_abs())
+                .unwrap_or(usize::MAX)
+                .saturating_mul(2);
             let mut result = String::new();
 
             if bytes_per_sep > 0 {
@@ -2171,7 +2182,10 @@ fn parse_bytes_hex_args(args: ArgValues, vm: &mut VM<'_, impl ResourceTracker>) 
     };
 
     let bytes_per_sep = if let Some(bps_value) = bps_value {
-        bps_value.as_int(vm)?
+        // CPython parses `bytes_per_sep` with the `i` format (C int), so values outside
+        // c_int range raise OverflowError before any computation happens.
+        let raw = bps_value.as_int(vm)?;
+        c_int::try_from(raw).map_err(|_| ExcType::overflow_c_int())?.into()
     } else {
         1
     };

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -95,21 +95,21 @@ impl Range {
     ///
     /// A value is contained if it falls within the range bounds and is aligned
     /// with the step (i.e., `(n - start) % step == 0`).
+    ///
+    /// The subtraction is widened to `i128` because `n - self.start` would
+    /// overflow `i64` for ranges spanning the full integer span (e.g.
+    /// `range(i64::MIN, i64::MAX, k)` checked against any positive `n`).
     #[must_use]
     pub fn contains(&self, n: i64) -> bool {
-        if self.step > 0 {
-            // Forward range: start <= n < stop
-            if n < self.start || n >= self.stop {
-                return false;
-            }
+        let in_bounds = if self.step > 0 {
+            n >= self.start && n < self.stop
         } else {
-            // Backward range: stop < n <= start
-            if n > self.start || n <= self.stop {
-                return false;
-            }
+            n <= self.start && n > self.stop
+        };
+        if !in_bounds {
+            return false;
         }
-        // Check if n is on the step grid
-        (n - self.start) % self.step == 0
+        (i128::from(n) - i128::from(self.start)) % i128::from(self.step) == 0
     }
 
     /// Creates a range from the `range()` constructor call.
@@ -156,21 +156,26 @@ impl Range {
         let range_len = self.len();
         let (start, stop, step) = slice.indices(range_len)?;
 
-        // Calculate the new range parameters
-        // new_start = self.start + start * self.step
-        // new_step = self.step * slice_step
-        // new_stop needs to be computed based on the number of elements
+        // All intermediate arithmetic is done in `i128` to avoid saturating during
+        // calculation. If any of the resulting `start`, `stop`, or `step`
+        // values do not fit in `i64`, we raise `OverflowError` — Monty's `Range`
+        // stores `i64`, so unlike CPython we cannot represent a range whose
+        // parameters exceed that span.
+        let self_step = i128::from(self.step);
+        let self_start = i128::from(self.start);
+        let slice_step = i128::from(step);
 
-        let new_step = self.step.saturating_mul(step);
-        let new_start = self.start.saturating_add(start.saturating_mul(self.step));
+        let new_step_i128 = self_step * slice_step;
+        let new_start_i128 = self_start + i128::from(start) * self_step;
 
-        // Calculate the number of elements in the sliced range
-        // The guarantee on slice.indices will be that stop and start can at most be range_len apart,
-        // so the subtraction won't overflow.
-        let num_elements = div_ceil(stop - start, step);
+        // The guarantee on `slice.indices` is that `stop` and `start` are at most
+        // `range_len` apart, so the subtraction won't overflow.
+        let num_elements = div_ceil(i128::from(stop) - i128::from(start), slice_step);
+        let new_stop_i128 = new_start_i128 + num_elements * new_step_i128;
 
-        // new_stop = new_start + num_elements * new_step
-        let new_stop = new_start.saturating_add(num_elements.saturating_mul(new_step));
+        let new_step = i64::try_from(new_step_i128).map_err(|_| ExcType::overflow_c_ssize_t())?;
+        let new_start = i64::try_from(new_start_i128).map_err(|_| ExcType::overflow_c_ssize_t())?;
+        let new_stop = i64::try_from(new_stop_i128).map_err(|_| ExcType::overflow_c_ssize_t())?;
 
         let new_range = Self::new(new_start, new_stop, new_step);
         Ok(Value::Ref(heap.allocate(HeapData::Range(new_range))?))
@@ -218,11 +223,14 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Range> {
             return Err(ExcType::range_index_error());
         }
 
-        // Calculate: start + normalized * step
+        // Calculate: start + normalized * step.
+        //
+        // Mathematically `offset` falls within `[min(start, stop), max(start, stop))`
+        // — within i64 — when the `Range` invariant holds (every element is a valid
+        // i64). The fallible conversion below is defence-in-depth so that an invariant
+        // violation surfaces as a Python `OverflowError` rather than a host panic.
         let offset = i128::from(range.start) + (normalized * i128::from(range.step));
-
-        // because start / stop / step are i64, the result must always fit in i64 as well
-        let offset_i64 = offset.try_into().expect("calculated range index should fit in i64");
+        let offset_i64 = i64::try_from(offset).map_err(|_| ExcType::overflow_c_ssize_t())?;
         Ok(Value::Int(offset_i64))
     }
 

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -1478,15 +1478,14 @@ fn rsplit_whitespace_n(s: &str, maxsplit: usize) -> Vec<&str> {
     let mut remaining = s.trim_end();
     let mut count = 0;
 
-    for (idx, c) in remaining.char_indices().rev() {
-        if c.is_whitespace() {
-            let ws_len = c.len_utf8();
-            parts.push(&remaining[idx + ws_len..]);
-            remaining = remaining[..idx].trim_end();
+    while !remaining.is_empty() && count < maxsplit {
+        if let Some(start) = remaining.rfind(|c: char| c.is_whitespace()) {
+            let ws_len = remaining[start..].chars().next().unwrap().len_utf8();
+            parts.push(&remaining[start + ws_len..]);
+            remaining = remaining[..start].trim_end();
             count += 1;
-            if count >= maxsplit {
-                break;
-            }
+        } else {
+            break;
         }
     }
 

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -1478,13 +1478,15 @@ fn rsplit_whitespace_n(s: &str, maxsplit: usize) -> Vec<&str> {
     let mut remaining = s.trim_end();
     let mut count = 0;
 
-    while !remaining.is_empty() && count < maxsplit {
-        if let Some(start) = remaining.rfind(|c: char| c.is_whitespace()) {
-            parts.push(&remaining[start + 1..]);
-            remaining = remaining[..start].trim_end();
+    for (idx, c) in remaining.char_indices().rev() {
+        if c.is_whitespace() {
+            let ws_len = c.len_utf8();
+            parts.push(&remaining[idx + ws_len..]);
+            remaining = remaining[..idx].trim_end();
             count += 1;
-        } else {
-            break;
+            if count >= maxsplit {
+                break;
+            }
         }
     }
 

--- a/crates/monty/test_cases/builtin__math_funcs.py
+++ b/crates/monty/test_cases/builtin__math_funcs.py
@@ -134,6 +134,16 @@ assert pow(7, 256, 13) == 9, 'pow modular large exp'
 # Modular exponentiation edge cases
 assert pow(2, 0, 5) == 1, 'pow x^0 mod n'
 assert pow(0, 5, 3) == 0, 'pow 0^n mod m'
+
+# |modulo| == 1 always returns 0, including the exp == 0 corner case
+assert pow(5, 3, 1) == 0, 'pow n mod 1 is always 0'
+assert pow(5, 3, -1) == 0, 'pow n mod -1 is always 0'
+assert pow(5, 0, 1) == 0, 'pow x^0 mod 1 is 0, not 1'
+assert pow(5, 0, -1) == 0, 'pow x^0 mod -1 is 0, not 1'
+
+# i64::MIN base with modulo == -1 used to panic via rem_euclid overflow
+assert pow(-9223372036854775808, 1, -1) == 0, 'pow i64::MIN mod -1 does not panic'
+assert pow(-9223372036854775808, 7, -1) == 0, 'pow i64::MIN^n mod -1 does not panic'
 assert pow(True, 2) == 1, 'pow handles bool base'
 assert pow(2, True) == 2, 'pow handles bool exponent'
 assert pow(True, True) == 1, 'pow handles bool base and exponent'

--- a/crates/monty/test_cases/bytes__methods.py
+++ b/crates/monty/test_cases/bytes__methods.py
@@ -282,6 +282,20 @@ assert b'\x01\x02\x03'.hex(':', 2) == '01:0203', 'hex +2 three bytes'
 # Test negative bytes_per_sep (partial group at end)
 assert b'\x01\x02\x03\x04\x05'.hex(':', -2) == '0102:0304:05', 'hex -2 odd bytes'
 assert b'\x01\x02\x03'.hex(':', -2) == '0102:03', 'hex -2 three bytes'
+# bytes_per_sep is parsed as a C int by CPython; out-of-range values raise OverflowError.
+try:
+    b'A'.hex(':', -9223372036854775808)
+    assert False, 'expected OverflowError for i64::MIN'
+except OverflowError as exc:
+    assert str(exc) == 'Python int too large to convert to C int', 'overflow message i64::MIN'
+try:
+    b'A'.hex(':', 2147483648)
+    assert False, 'expected OverflowError for i32::MAX + 1'
+except OverflowError as exc:
+    assert str(exc) == 'Python int too large to convert to C int', 'overflow message i32::MAX+1'
+# Values at the i32 boundary are still accepted and processed as a single chunk.
+assert b'\x01\x02\x03'.hex(':', -2147483648) == '010203', 'hex i32::MIN three bytes'
+assert b'\x01\x02\x03'.hex(':', 2147483647) == '010203', 'hex i32::MAX three bytes'
 
 # === bytes.fromhex() ===
 assert bytes.fromhex('deadbeef') == b'\xde\xad\xbe\xef', 'fromhex basic'

--- a/crates/monty/test_cases/range__ops.py
+++ b/crates/monty/test_cases/range__ops.py
@@ -244,3 +244,13 @@ assert True not in range(0), 'True not in empty range'
 # Large ranges which can hit monty's range i64 limits should not panic
 assert range(-(2**63), 2**63 - 1)[0] == -(2**63), 'range with len exceeding i64::MAX get first item'
 assert range(-(2**63), 2**63 - 1, 2**63 - 1)[2] == 2**63 - 2, 'range with step exceeding i64::MAX get last item'
+
+# === Check that containment doesn't overflow i64 calculation ===
+assert 100 in range(-(2**63), 2**63 - 1, 3), '100 in range across full i64 span step 3'
+assert 101 not in range(-(2**63), 2**63 - 1, 3), '101 not in range across full i64 span step 3'
+assert -(2**63) in range(-(2**63), 2**63 - 1, 1), 'i64::MIN in range(i64::MIN, i64::MAX)'
+assert (2**63 - 2) in range(-(2**63), 2**63 - 1, 1), 'last element in range(i64::MIN, i64::MAX)'
+assert (2**63 - 1) not in range(-(2**63), 2**63 - 1, 1), 'stop excluded from range(i64::MIN, i64::MAX)'
+assert -1 in range(2**63 - 1, -(2**63), -1), '-1 in backward span'
+assert (2**63 - 1) in range(2**63 - 1, -(2**63), -1), 'start in backward span'
+assert -(2**63) not in range(2**63 - 1, -(2**63), -1), 'stop excluded from backward span'

--- a/crates/monty/test_cases/range__slice_overflow.py
+++ b/crates/monty/test_cases/range__slice_overflow.py
@@ -1,0 +1,12 @@
+# xfail=cpython
+# CPython represents range parameters as arbitrary-precision integers, so a
+# slice whose computed start/stop/step exceeds i64 simply produces a bigint
+# range and succeeds. Monty's Range stores i64 and cannot represent those
+# values, so we raise OverflowError instead — this divergence is intentional
+# and acceptable.
+
+try:
+    _sliced = range(0, 2**63 - 1, 2)[:: 2**63 - 1]
+    assert False, 'expected OverflowError from slice with overflowing step'
+except OverflowError as e:
+    assert str(e) == 'Python int too large to convert to C ssize_t', str(e)

--- a/crates/monty/test_cases/str__methods.py
+++ b/crates/monty/test_cases/str__methods.py
@@ -186,6 +186,10 @@ assert 'hello'.split('x') == ['hello'], 'split not found'
 assert 'a b c'.rsplit() == ['a', 'b', 'c'], 'rsplit whitespace'
 assert 'a,b,c'.rsplit(',') == ['a', 'b', 'c'], 'rsplit comma'
 assert 'a,b,c'.rsplit(',', 1) == ['a,b', 'c'], 'rsplit maxsplit'
+# Multi-byte whitespace must not panic on UTF-8 boundary (U+00A0, U+3000).
+assert 'hello world'.rsplit(maxsplit=1) == ['hello', 'world'], 'rsplit maxsplit nbsp'
+assert 'a　b　c'.rsplit(maxsplit=1) == ['a　b', 'c'], 'rsplit maxsplit ideographic space'
+assert 'a b c'.rsplit(maxsplit=2) == ['a', 'b', 'c'], 'rsplit maxsplit=2 nbsp'
 
 # splitlines()
 assert 'a\nb\nc'.splitlines() == ['a', 'b', 'c'], 'splitlines basic'

--- a/crates/monty/test_cases/str__methods.py
+++ b/crates/monty/test_cases/str__methods.py
@@ -190,6 +190,11 @@ assert 'a,b,c'.rsplit(',', 1) == ['a,b', 'c'], 'rsplit maxsplit'
 assert 'hello world'.rsplit(maxsplit=1) == ['hello', 'world'], 'rsplit maxsplit nbsp'
 assert 'a　b　c'.rsplit(maxsplit=1) == ['a　b', 'c'], 'rsplit maxsplit ideographic space'
 assert 'a b c'.rsplit(maxsplit=2) == ['a', 'b', 'c'], 'rsplit maxsplit=2 nbsp'
+assert 'a b c'.rsplit(maxsplit=0) == ['a b c'], 'rsplit maxsplit=0 does no splits'
+# Runs of whitespace count as one separator.
+assert 'a  b'.rsplit(maxsplit=2) == ['a', 'b'], 'rsplit consecutive ascii whitespace'
+assert 'a\xa0\xa0b'.rsplit(maxsplit=2) == ['a', 'b'], 'rsplit consecutive nbsp'
+assert '  a  b  '.rsplit(maxsplit=1) == ['  a', 'b'], 'rsplit trailing whitespace trimmed'
 
 # splitlines()
 assert 'a\nb\nc'.splitlines() == ['a', 'b', 'c'], 'splitlines basic'


### PR DESCRIPTION
Avoids more possible panics

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents panics in integer-heavy paths (pow, range, bytes.hex, rsplit) and returns proper Python errors for edge cases. Behavior now matches CPython for modulus and argument parsing quirks.

- **Bug Fixes**
  - `pow(x, y, m)`: `m == 0` raises `ValueError`; `|m| == 1` returns `0`; negative exponent with a modulo raises `ValueError`; avoids `rem_euclid` overflow on `i64::MIN` with negative `m`.
  - `bytes.hex(sep, bytes_per_sep)`: parse `bytes_per_sep` as C `int`; out-of-range values raise `OverflowError: Python int too large to convert to C int`; prevent overflow when computing group size.
  - `range`: containment and slicing computed in `i128` to avoid overflow; slicing raises `OverflowError` when results can’t fit in `i64`; indexing guarded to return `OverflowError` instead of panicking.
  - `str.rsplit(maxsplit)`: correctly handles multi-byte whitespace and respects `maxsplit` without panics.
  - Added tests for these edge cases, including full `i64` spans and the intentional CPython divergence for overflowing `range` slices.

<sup>Written for commit 4c2cfa3d4a76b6e337c794e1d60bf8c8729e1509. Summary will update on new commits. <a href="https://cubic.dev/pr/pydantic/monty/pull/444?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

