### PR TITLE
refactor futures to have state machines like gather

### DIFF
--- a/crates/monty/src/asyncio.rs
+++ b/crates/monty/src/asyncio.rs
@@ -5,8 +5,14 @@
 //! calls return `ExternalFuture` objects that can be awaited.
 
 use ahash::AHashMap;
+use smallvec::SmallVec;
 
-use crate::{exception_private::RunError, heap::HeapId, intern::FunctionId, value::Value};
+use crate::{
+    exception_private::RunError,
+    heap::{ContainsHeap, DropWithHeap, HeapId},
+    intern::FunctionId,
+    value::Value,
+};
 
 /// Unique identifier for external function calls.
 ///
@@ -109,13 +115,86 @@ impl Coroutine {
     }
 }
 
-/// An item that can be gathered - either a coroutine or an external future.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub(crate) enum GatherItem {
-    /// A coroutine to spawn as a task.
-    Coroutine(HeapId),
-    /// An external future to wait for resolution.
-    ExternalFuture(CallId),
+/// An external future driven by the host.
+///
+/// Created when the host returns `ExtFunctionResult::Future(call_id)` in
+/// response to a function call yield. The future starts in `Pending`, and
+/// transitions to `Resolved` (host returned a value) or `Failed` (host
+/// returned an error) when [`VM::resolve_future`] / [`VM::fail_future`]
+/// fires.
+///
+/// # Re-await semantics
+///
+/// `Resolved` / `Failed` futures can be awaited any number of times — each
+/// await yields a clone of the cached value or replays the cached exception,
+/// matching CPython's Future semantics. `Pending` futures still support only
+/// a single in-flight awaiter (the `awaiter: Option<Awaiter>` slot);
+/// multi-awaiter on `Pending` is a planned follow-up that needs the same
+/// wake/raise plumbing as multi-waiter gathers.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct ExternalFuture {
+    /// Host-side identifier. Used by the scheduler's `CallId -> HeapId`
+    /// index so host resolutions can find the heap entry.
+    pub call_id: CallId,
+    /// Current state.
+    pub state: ExternalFutureState,
+}
+
+/// State machine for [`ExternalFuture`].
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) enum ExternalFutureState {
+    /// Awaiting host resolution. `awaiter` is the downstream that should be
+    /// notified on resolution; `None` until someone awaits, `Some(...)` for
+    /// the lifetime of the await.
+    Pending { awaiter: Option<Awaiter> },
+    /// Resolved with a value. Re-awaits clone this Value.
+    Resolved(Value),
+    /// Rejected with an error. Re-awaits replay (clone) this error.
+    Failed(RunError),
+}
+
+impl ExternalFuture {
+    /// Creates a new `ExternalFuture` in the `Pending` state with no awaiter.
+    pub fn new_pending(call_id: CallId) -> Self {
+        Self {
+            call_id,
+            state: ExternalFutureState::Pending { awaiter: None },
+        }
+    }
+}
+
+/// Where the result/error of a completing awaitable should be routed.
+///
+/// Stored as the "downstream" of an awaitable.
+///
+/// - `Task` wakes the named task by setting it `Ready` and pushing the value
+///   (or routing the error through its frame's exception handler). `TaskId`
+///   is just a scheduler-side identifier, not a heap reference, so the
+///   variant owns no inc_ref.
+/// - `GatherSlot` fans the value into the gather at `gather`, looking up the
+///   slot indices it should fill via the awaitable's own `HeapId` (`source`).
+///   The wrapper **owns an inc_ref on `gather`**: storing the awaiter on an
+///   awaitable keeps the gather alive for the in-flight window, so the
+///   awaitable's resolution path can dispatch to it safely without
+///   additional cleanup elsewhere. Drop the owned `Awaiter` via
+///   [`DropWithHeap`] (and clone via [`Self::clone_with_heap`]) so the
+///   `gather` ref count stays balanced.
+///
+/// Not `Copy` / `Clone` on purpose — the inc_ref discipline requires every
+/// duplication to go through `clone_with_heap` and every discard to go
+/// through `drop_with_heap`.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) enum Awaiter {
+    Task(TaskId),
+    GatherSlot { gather: HeapId, source: HeapId },
+}
+
+impl DropWithHeap for Awaiter {
+    fn drop_with_heap<H: ContainsHeap>(self, heap: &mut H) {
+        if let Self::GatherSlot { gather, .. } = self {
+            heap.heap_mut().dec_ref(gather);
+        }
+    }
 }
 
 /// A gather() result tracking multiple coroutines/tasks and external futures.
@@ -154,12 +233,14 @@ pub(crate) enum GatherItem {
 /// require a list of waiters and is left as future work.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct GatherFuture {
-    /// Items to gather (coroutines or external futures).
+    /// Heap ids of items to gather. Each id points to an awaitable
+    /// `HeapData` entry (currently `Coroutine` or `ExternalFuture`); the
+    /// kind is recovered with `heap.read(id)` at gather-await time.
     ///
     /// Set once at construction and never mutated. The gather inc_refs each
-    /// unique `GatherItem::Coroutine` HeapId and is the owner until drop, so
-    /// GC must always walk this vector regardless of `state`.
-    pub items: Vec<GatherItem>,
+    /// id and is the owner until drop, so GC must always walk this vector
+    /// regardless of `state`.
+    pub items: Vec<HeapId>,
     /// Phase of the gather lifecycle. See [`GatherState`].
     pub state: GatherState,
 }
@@ -177,7 +258,7 @@ pub(crate) enum GatherState {
     /// inc_ref'd `HeapData::List` of results; the gather is its owner and
     /// dec_refs it on drop. Re-awaiting the gather inc_refs this list and
     /// returns it.
-    Completed(HeapId),
+    Completed(Value),
     /// A child task failed (or an external future was rejected). The error
     /// is cached so subsequent awaits re-raise it. `RunError` implements
     /// `Clone`; clone the error when transitioning into this state.
@@ -195,29 +276,32 @@ pub(crate) enum GatherState {
 /// done when both maps are empty.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct AwaitedGather {
-    /// Task that called `await` on the enclosing gather. Always present in this
-    /// phase — there is no "awaited but no waiter" sub-state.
-    pub waiter: TaskId,
-    /// Spawned tasks → slots they fill in `results`. One entry per *unique*
-    /// coroutine in `items` (duplicates collapse to a single task with
-    /// multiple slot indices). Entries are removed as the corresponding
-    /// task completes; the task is then immediately cancelled from the
-    /// scheduler so refcounts get released eagerly.
-    pub pending_tasks: AHashMap<TaskId, Vec<usize>>,
-    /// External futures → slots they fill in `results`. Entries are removed
-    /// as `resolve_future` resolves each call.
-    pub pending_calls: AHashMap<CallId, Vec<usize>>,
+    /// Downstream the gather should notify on completion. `Awaiter::Task(t)`
+    /// is the user-level `await gather` case (waker is the task that ran
+    /// the `await`); `Awaiter::GatherSlot { .. }` is the nested-gather case
+    /// (this gather is an item of an outer gather, and its result list
+    /// fans into the outer's slot). Single-waiter for now; the multi-waiter
+    /// form is a planned follow-up.
+    pub awaiter: Awaiter,
+    /// Children → slots they fill in `results`. Keyed by each child's own
+    /// `HeapId` (coroutine or external future). Duplicates from
+    /// `gather(c, c)` produce a single entry whose value is a `SmallVec` of
+    /// multiple indices.
+    ///
+    /// Entries are removed as the corresponding child resolves. The gather
+    /// is done when this map is empty.
+    pub pending_children: AHashMap<HeapId, SmallVec<[usize; 1]>>,
     /// Results from each gather item, in order. Indices align with
     /// `GatherFuture::items`. Filled as tasks complete and externals resolve.
     pub results: Vec<Option<Value>>,
 }
 
 impl GatherFuture {
-    /// Creates a new GatherFuture with the given items.
+    /// Creates a new GatherFuture with the given item heap ids.
     ///
     /// # Arguments
-    /// * `items` - Coroutines or external futures to run concurrently
-    pub fn new(items: Vec<GatherItem>) -> Self {
+    /// * `items` - Heap ids of awaitables (coroutines or external futures)
+    pub fn new(items: Vec<HeapId>) -> Self {
         Self {
             items,
             state: GatherState::Pending,

--- a/crates/monty/src/asyncio.rs
+++ b/crates/monty/src/asyncio.rs
@@ -254,10 +254,8 @@ pub(crate) enum GatherState {
     Pending,
     /// Currently being awaited. `AwaitedGather` carries every per-await field.
     Awaited(AwaitedGather),
-    /// All children completed successfully. The contained `HeapId` is an
-    /// inc_ref'd `HeapData::List` of results; the gather is its owner and
-    /// dec_refs it on drop. Re-awaiting the gather inc_refs this list and
-    /// returns it.
+    /// All children completed successfully. Re-awaiting the gather inc_refs this
+    /// value and returns it.
     Completed(Value),
     /// A child task failed (or an external future was rejected). The error
     /// is cached so subsequent awaits re-raise it. `RunError` implements

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -6,16 +6,19 @@
 //! - Task completion and failure handling
 //! - External future resolution
 
-use std::mem;
+use std::{collections::hash_map::Entry, mem, task::Poll};
 
 use ahash::AHashMap;
+use smallvec::{SmallVec, smallvec};
 
 use super::{AwaitResult, CallFrame, FrameExit, VM};
 use crate::{
     MontyException,
-    args::ArgValues,
-    asyncio::{AwaitedGather, CallId, Coroutine, CoroutineState, GatherFuture, GatherItem, GatherState, TaskId},
-    bytecode::vm::scheduler::{PendingCallData, Scheduler, SerializedTaskFrame, TaskState},
+    asyncio::{
+        AwaitedGather, Awaiter, CallId, Coroutine, CoroutineState, ExternalFuture, ExternalFutureState, GatherFuture,
+        GatherState, TaskId,
+    },
+    bytecode::vm::scheduler::{Scheduler, SerializedTaskFrame, TaskState},
     defer_drop,
     exception_private::{ExcType, RunError, RunResult, SimpleException},
     heap::{DropWithHeap, HeapData, HeapGuard, HeapId, HeapRead, HeapReadOutput, HeapReader},
@@ -40,16 +43,29 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         let awaitable = this.pop();
         defer_drop!(awaitable, this);
 
+        let awaiter = Awaiter::Task(
+            this.scheduler
+                .current_task_id()
+                .expect("exec_get_awaitable called without a current task"),
+        );
+
         match awaitable {
             Value::Ref(heap_id) => {
                 let heap_id = *heap_id;
-                match this.heap.read(heap_id) {
-                    HeapReadOutput::Coroutine(coro) => this.await_coroutine(coro),
-                    HeapReadOutput::GatherFuture(gather) => this.await_gather_future(heap_id, gather),
-                    _ => Err(ExcType::object_not_awaitable(awaitable.py_type(this))),
+                let poll = match this.heap.read(heap_id) {
+                    HeapReadOutput::Coroutine(coro) => return this.await_coroutine(coro),
+                    HeapReadOutput::GatherFuture(gather) => this.await_gather_future(heap_id, gather, awaiter)?,
+                    HeapReadOutput::ExternalFuture(mut fut) => this.await_external_future(&mut fut, awaiter)?,
+                    _ => return Err(ExcType::object_not_awaitable(awaitable.py_type(this))),
+                };
+                match poll {
+                    Poll::Ready(value) => Ok(AwaitResult::ValueReady(value)),
+                    Poll::Pending => {
+                        this.scheduler.block_current_on(heap_id, this.heap);
+                        this.switch_or_yield()
+                    }
                 }
             }
-            &Value::ExternalFuture(call_id) => this.await_external_future(call_id),
             _ => Err(ExcType::object_not_awaitable(awaitable.py_type(this))),
         }
     }
@@ -84,29 +100,24 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         Ok(AwaitResult::FramePushed)
     }
 
-    /// Awaits a gather future by spawning tasks for coroutines and tracking external futures.
-    ///
-    /// For each item in the gather:
-    /// - Coroutines are spawned as tasks
-    /// - External futures are checked for resolution or registered for tracking
-    ///
-    /// If all items are already resolved, returns immediately. Otherwise blocks
-    /// the current task and switches to a ready task or yields to the host.
+    /// Awaits a gather future from the user's `await gather` site.
     fn await_gather_future(
         &mut self,
-        heap_id: HeapId,
+        gather_id: HeapId,
         mut gather: HeapRead<'h, GatherFuture>,
-    ) -> Result<AwaitResult, RunError> {
-        // Re-await fast paths
-        match &gather.get(self.heap).state {
+        awaiter: Awaiter,
+    ) -> Result<Poll<Value>, RunError> {
+        let mut awaiter_guard = HeapGuard::new(awaiter, self);
+        let this = awaiter_guard.heap();
+        match &gather.get(this.heap).state {
             GatherState::Pending => {}
-            GatherState::Completed(list_id) => {
-                let id = *list_id;
-                self.heap.inc_ref(id);
-                return Ok(AwaitResult::ValueReady(Value::Ref(id)));
+            GatherState::Completed(value) => {
+                return Ok(Poll::Ready(value.clone_with_heap(this.heap)));
             }
-            GatherState::Failed(err) => return Err(err.clone()),
-            // TODO: needs proper support for this case, CPython allows it
+            GatherState::Failed(err) => {
+                return Err(err.clone());
+            }
+            // TODO: support concurrent re-await (CPython does).
             GatherState::Awaited(_) => {
                 return Err(SimpleException::new_msg(
                     ExcType::RuntimeError,
@@ -117,138 +128,121 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         }
 
         // Empty gather shortcut. Allocate the empty list, store it as the
-        // cached `Completed` result, and return an inc_ref'd reference. Future
-        // awaits will hit the `Completed` fast path above.
-        let item_count = gather.get(self.heap).item_count();
+        // cached `Completed` result, and return an inc_ref'd reference.
+        let item_count = gather.get(this.heap).item_count();
         if item_count == 0 {
-            let list_id = self.heap.allocate(HeapData::List(List::new(vec![])))?;
-            gather.cache_result(self.heap, list_id);
-            return Ok(AwaitResult::ValueReady(Value::Ref(list_id)));
+            let list_id = this.heap.allocate(HeapData::List(List::new(vec![])))?;
+            gather.cache_result(this.heap, list_id);
+            return Ok(Poll::Ready(Value::Ref(list_id)));
         }
 
-        // Reject any external future that has already been awaited (directly or
-        // via another gather). Without this check, sibling gathers sharing a
-        // future would silently overwrite each other in the pending-call gather
-        // routing, leaving the first gather permanently blocked on a CallId
-        // that has already been resolved or is registered against a different
-        // gather. This mirrors the existing `is_consumed` check in
-        // `await_external_future` so direct double-await and gather-mediated
-        // double-await behave consistently. The dedup pass below ensures
-        // intra-gather duplicates (`gather(f, f)`) are not flagged: each unique
-        // CallId is only marked consumed once, so the first await of a freshly
-        // created future passes even when it appears in multiple slots.
-        for item in &gather.get(self.heap).items {
-            if let GatherItem::ExternalFuture(call_id) = item
-                && self.scheduler.is_consumed(*call_id)
-            {
-                return Err(
-                    SimpleException::new_msg(ExcType::RuntimeError, "cannot reuse already awaited future").into(),
-                );
-            }
-        }
+        // Await all items, storing already resolved state and tracking the rest in `pending_children`.
 
-        let current_task = self
-            .scheduler
-            .current_task_id()
-            .expect("await_gather_future called without a current task");
+        let mut pending_children: AHashMap<HeapId, SmallVec<[usize; 1]>> = AHashMap::new();
+        let results: Vec<Option<Value>> = (0..item_count).map(|_| None).collect();
+        let mut results_guard = HeapGuard::new(results, this);
+        let (results, this) = results_guard.as_parts_mut();
 
-        // Single pass over items: spawn / register / write resolved values
-        // into `results` directly. Dedup by identity so `gather(c, c)` runs
-        // the coroutine once and fans its result out to every matching slot.
-        let mut pending_tasks: AHashMap<TaskId, Vec<usize>> = AHashMap::new();
-        let mut coro_to_task: AHashMap<HeapId, TaskId> = AHashMap::new();
-        let mut pending_calls: AHashMap<CallId, Vec<usize>> = AHashMap::new();
-        // For an external that resolved synchronously, remember the first
-        // slot that received the moved-in value; later duplicate slots clone
-        // from there.
-        let mut resolved_first_slot: AHashMap<CallId, usize> = AHashMap::new();
-        let mut results: Vec<Option<Value>> = (0..item_count).map(|_| None).collect();
-
-        for (idx, item) in gather.get(self.heap).items.iter().enumerate() {
-            match *item {
-                GatherItem::Coroutine(coro_id) => {
-                    let task_id = *coro_to_task
-                        .entry(coro_id)
-                        .or_insert_with(|| self.scheduler.spawn(self.heap, coro_id, Some(heap_id)));
-                    pending_tasks.entry(task_id).or_default().push(idx);
+        for (idx, result) in results.iter_mut().enumerate() {
+            let item_id = gather.get(this.heap).items[idx];
+            let vacant_entry = match pending_children.entry(item_id) {
+                Entry::Occupied(occ) => {
+                    // Dedup: We've already registered this item in this commit pass —
+                    // this is a duplicate item (e.g. `gather(coro, coro)`). Just
+                    // append the new slot index to the existing entry.
+                    occ.into_mut().push(idx);
+                    continue;
                 }
-                GatherItem::ExternalFuture(call_id) => {
-                    if let Some(indices) = pending_calls.get_mut(&call_id) {
-                        // Duplicate of a still-pending external — append.
-                        indices.push(idx);
-                    } else if let Some(&first_idx) = resolved_first_slot.get(&call_id) {
-                        // Duplicate of an already-resolved external — clone
-                        // from the slot that owns the original.
-                        let cloned = results[first_idx]
-                            .as_ref()
-                            .expect("first occurrence holds the resolved value")
-                            .clone_with_heap(self.heap);
-                        results[idx] = Some(cloned);
-                    } else {
-                        // First time seeing this CallId.
-                        self.scheduler.mark_consumed(call_id);
-                        if let Some(value) = self.scheduler.take_resolved(call_id) {
-                            results[idx] = Some(value);
-                            resolved_first_slot.insert(call_id, idx);
-                        } else {
-                            self.scheduler.register_gather_for_call(call_id, heap_id);
-                            pending_calls.insert(call_id, vec![idx]);
-                        }
-                    }
+                Entry::Vacant(vacant) => vacant,
+            };
+
+            let poll = match this.heap.read(item_id) {
+                HeapReadOutput::Coroutine(_) => {
+                    this.scheduler.spawn(this.heap, item_id, Some(gather_id));
+                    Poll::Pending
+                }
+                HeapReadOutput::ExternalFuture(mut fut) => {
+                    this.heap.inc_ref(gather_id);
+                    let sub_awaiter = Awaiter::GatherSlot {
+                        gather: gather_id,
+                        source: item_id,
+                    };
+                    this.await_external_future(&mut fut, sub_awaiter)?
+                }
+                HeapReadOutput::GatherFuture(child_gather) => {
+                    this.heap.inc_ref(gather_id);
+                    let sub_awaiter = Awaiter::GatherSlot {
+                        gather: gather_id,
+                        source: item_id,
+                    };
+                    this.await_gather_future(item_id, child_gather, sub_awaiter)?
+                }
+                _ => panic!("gather item is not a Coroutine, ExternalFuture, or GatherFuture"),
+            };
+
+            match poll {
+                Poll::Ready(value) => {
+                    *result = Some(value);
+                }
+                Poll::Pending => {
+                    vacant_entry.insert(smallvec![idx]);
                 }
             }
         }
 
-        // Synchronous-completion shortcut: external-only gather where every
-        // call was already resolved. Allocate the result list and cache it on
-        // the gather (Pending → Completed) so re-awaits replay the same list.
-        if pending_tasks.is_empty() && pending_calls.is_empty() {
+        if pending_children.is_empty() {
+            // All items resolved synchronously — skip straight to Completed with the result list.
+            let (results, this) = results_guard.into_parts();
             let results: Vec<Value> = results
                 .into_iter()
                 .map(|r| r.expect("all results filled for synchronous gather completion"))
                 .collect();
-            let list_id = self.heap.allocate(HeapData::List(List::new(results)))?;
-            gather.cache_result(self.heap, list_id);
-            return Ok(AwaitResult::ValueReady(Value::Ref(list_id)));
+            let list_id = this.heap.allocate(HeapData::List(List::new(results)))?;
+            gather.cache_result(this.heap, list_id);
+            return Ok(Poll::Ready(Value::Ref(list_id)));
         }
 
-        // Transition Pending → Awaited.
-        gather.get_mut(self.heap).state = GatherState::Awaited(AwaitedGather {
-            waiter: current_task,
-            pending_tasks,
-            pending_calls,
+        let results = results_guard.into_inner();
+        let (awaiter, this) = awaiter_guard.into_parts();
+        gather.get_mut(this.heap).state = GatherState::Awaited(AwaitedGather {
+            awaiter,
+            pending_children,
             results,
         });
-        drop(gather);
 
-        // Block current task on this gather, then switch to a spawned task or
-        // yield to the host for external futures.
-        self.scheduler.block_current_on_gather(heap_id, self.heap);
-        self.switch_or_yield()
+        Ok(Poll::Pending)
     }
 
-    /// Awaits an external future by blocking until it's resolved.
+    /// Awaits an external future by inspecting its heap state.
     ///
-    /// If the future is already resolved, returns the value immediately.
-    /// Otherwise blocks the current task and switches to a ready task or yields to the host.
-    fn await_external_future(&mut self, call_id: CallId) -> Result<AwaitResult, RunError> {
-        // Check if already consumed (double-await error)
-        if self.scheduler.is_consumed(call_id) {
-            return Err(SimpleException::new_msg(ExcType::RuntimeError, "cannot reuse already awaited future").into());
-        }
-
-        // Mark as consumed
-        self.scheduler.mark_consumed(call_id);
-
-        // Check if the future is already resolved
-        if let Some(value) = self.scheduler.take_resolved(call_id) {
-            Ok(AwaitResult::ValueReady(value))
-        } else {
-            // Block current task on this call
-            self.scheduler.block_current_on_call(call_id);
-
-            // Switch to next ready task or yield to host
-            self.switch_or_yield()
+    /// - `Resolved(v)` returns a clone of `v` immediately.
+    /// - `Failed(e)` re-raises a clone of `e`.
+    /// - `Pending { awaiter: None }` installs the current task as the awaiter,
+    ///   and returns `Poll::Pending`.
+    /// - `Pending { awaiter: Some(_) }` is rejected as a double-await — a
+    ///   single-awaiter restriction we keep until multi-awaiter wake/raise
+    ///   plumbing lands.
+    fn await_external_future(
+        &mut self,
+        fut: &mut HeapRead<'h, ExternalFuture>,
+        awaiter: Awaiter,
+    ) -> Result<Poll<Value>, RunError> {
+        let mut awaiter_guard = HeapGuard::new(awaiter, self);
+        let this = awaiter_guard.heap();
+        match &fut.get(this.heap).state {
+            ExternalFutureState::Resolved(value) => {
+                let value = value.clone_with_heap(this);
+                Ok(Poll::Ready(value))
+            }
+            ExternalFutureState::Failed(err) => Err(err.clone()),
+            ExternalFutureState::Pending { awaiter: Some(_) } => {
+                Err(SimpleException::new_msg(ExcType::RuntimeError, "cannot reuse already awaited future").into())
+            }
+            ExternalFutureState::Pending { awaiter: None } => {
+                let awaiter = awaiter_guard.into_inner();
+                fut.get_mut(self.heap).state = ExternalFutureState::Pending { awaiter: Some(awaiter) };
+                Ok(Poll::Pending)
+            }
         }
     }
 
@@ -335,28 +329,31 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         let gid = task
             .gather_id
             .expect("handle_task_completion: spawned task without a gather");
-        let coroutine_id = task.coroutine_id;
+        let coroutine_id = task
+            .coroutine_id
+            .expect("handle_task_completion: spawned task without a coroutine");
 
         // Mark the coroutine as Completed before the task is cancelled —
         // direct `await` of this coroutine elsewhere needs to see the new
         // state, not the `Running` it had until now.
-        if let Some(coro_id) = coroutine_id {
-            let HeapReadOutput::Coroutine(mut coro) = self.heap.read(coro_id) else {
-                panic!("task coroutine_id doesn't point to a Coroutine")
-            };
-            coro.get_mut(self.heap).state = CoroutineState::Completed;
-        }
+        let HeapReadOutput::Coroutine(mut coro) = self.heap.read(coroutine_id) else {
+            panic!("task coroutine_id doesn't point to a Coroutine")
+        };
+        coro.get_mut(self.heap).state = CoroutineState::Completed;
+        drop(coro);
 
         // Record the result on the gather and check whether it's now complete.
         // `resolve_child` does the fan-out for duplicate slots (`gather(c, c)`)
         // and the final state transition; it must run BEFORE we release any
         // inc_refs the gather is holding (cancelling children, dropping the
-        // waiter's `BlockedOnGather`) — otherwise the gather can be freed
-        // while we're still about to write its cached state.
+        // waiter's `Blocked` ref) — otherwise the gather can be freed while
+        // we're still about to write its cached state. The gather keys by
+        // item HeapId, so we pass the coroutine's id rather than the
+        // (kind-specific) task id.
         let HeapReadOutput::GatherFuture(mut gather) = self.heap.read(gid) else {
             panic!("task gather_id doesn't point to a GatherFuture")
         };
-        let resolution = gather.resolve_child(self, ChildSource::Task(task_id), result)?;
+        let resolution = gather.resolve_child(self, coroutine_id, result)?;
         drop(gather);
 
         // The just-completed task is no longer in the gather's
@@ -364,43 +361,30 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         // coroutine and gather; otherwise it would linger in the scheduler.
         self.scheduler.cancel_task(task_id, self.heap);
 
-        match resolution {
-            Some(GatherResolution::Success { list_id, waiter_id }) => {
-                // Make waiter ready but don't add to ready queue — we're
-                // switching directly into its context. Replacing
-                // `BlockedOnGather` here releases the last gather inc_ref;
-                // the cached state is what keeps the result list alive.
-                self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
-                self.cleanup_current_task();
-                self.scheduler.set_current_task(Some(waiter_id));
-                self.load_or_init_task(waiter_id)?;
-                self.push(Value::Ref(list_id));
-                Ok(AwaitResult::FramePushed)
-            }
-            Some(GatherResolution::Failure { error, waiter_id }) => {
-                // Switch into the waiter's frame and surface the error
-                // there. The run loop's `catch_sync!` will dispatch through
-                // the waiter's exception table — this is how a sibling's
-                // failure ends up at the user's `try` / `except` around the
-                // gather await.
-                self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
-                self.cleanup_current_task();
-                self.scheduler.set_current_task(Some(waiter_id));
-                self.load_or_init_task(waiter_id)?;
-                Err(error)
-            }
-            None => {
-                // Gather not complete — switch to next ready task.
-                self.cleanup_current_task();
-                self.scheduler.set_current_task(None);
-                if let Some(next_task_id) = self.scheduler.next_ready_task() {
-                    self.scheduler.set_current_task(Some(next_task_id));
-                    self.load_or_init_task(next_task_id)?;
-                    Ok(AwaitResult::FramePushed)
-                } else {
-                    Ok(AwaitResult::Yield(self.scheduler.pending_call_ids()))
-                }
-            }
+        let delivery = match resolution {
+            Some(success) => self.deliver_awaiter_success(success.awaiter, Value::Ref(success.list_id))?,
+            None => None,
+        };
+
+        let next_task_id = if let Some(waiter_id) = delivery {
+            // `deliver_awaiter_success` already pushed the result onto the
+            // waiter's stack and queued it Ready. Switch directly into the
+            // waiter — `remove_from_ready_queue` cancels the queue entry
+            // since we're not going through the run loop's scheduler pop.
+            self.scheduler.remove_from_ready_queue(waiter_id);
+            Some(waiter_id)
+        } else {
+            self.scheduler.next_ready_task()
+        };
+
+        self.cleanup_current_task();
+
+        if let Some(next_id) = next_task_id {
+            self.scheduler.set_current_task(Some(next_id));
+            self.load_or_init_task(next_id)?;
+            Ok(AwaitResult::FramePushed)
+        } else {
+            Ok(AwaitResult::Yield(self.scheduler.pending_call_ids()))
         }
     }
 
@@ -438,19 +422,26 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         let gather_id = self.scheduler.get_task(task_id).gather_id;
 
         // If part of a gather, tear the gather down (caches the error,
-        // cancels siblings, clears pending external routing) and switch into
-        // the waiter to propagate the error.
+        // cancels siblings, clears pending external routing) and walk the
+        // awaiter chain (which may go through outer nested gathers) to reach
+        // the task that should resume with the exception.
         if let Some(gid) = gather_id {
             let HeapReadOutput::GatherFuture(mut gather) = self.heap.read(gid) else {
                 panic!("task gather_id doesn't point to a GatherFuture")
             };
-            let waiter_id = gather.fail(&mut self.scheduler, self.heap, &error);
+            let awaiter = gather.fail(&mut self.scheduler, self.heap, &error);
             drop(gather);
-
-            self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
-            self.cleanup_current_task();
-            self.scheduler.set_current_task(Some(waiter_id));
-            self.load_or_init_task(waiter_id)?;
+            if let Some(waiter_id) = self.deliver_awaiter_failure(awaiter, error.clone()) {
+                // `deliver_awaiter_failure` set the waiter to `Failed`, but
+                // we propagate the exception via `Err` (the run loop's
+                // `handle_exception` raises in the waiter's frame), so the
+                // task should be running. Override to `Ready` before
+                // switching in.
+                self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
+                self.cleanup_current_task();
+                self.scheduler.set_current_task(Some(waiter_id));
+                self.load_or_init_task(waiter_id)?;
+            }
             return Err(error);
         }
 
@@ -573,13 +564,10 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             panic!("task has no frames and no coroutine_id");
         }
 
-        // If this task was unblocked by a resolved external future, push the
-        // resolved value onto the stack. The AWAIT opcode already advanced the IP
-        // past itself before the task was saved, so execution will continue with
-        // the resolved value on top of the stack.
-        if let Some(value) = self.scheduler.take_resolved_for_task(task_id) {
-            self.push(value);
-        }
+        // Resolutions that landed while this task was parked already pushed
+        // their value onto `task.stack` (via `deliver_value_to_task` or
+        // `handle_task_completion`'s waiter-handoff branch), so the restored
+        // stack above is already in the post-AWAIT shape.
 
         Ok(())
     }
@@ -639,122 +627,181 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
 
     /// Resolves an external future with a value.
     ///
-    /// Called by the host when an async external call completes.
-    /// Stores the result in the scheduler, which will unblock any task
-    /// waiting on this CallId.
-    ///
-    /// If the task that created this call has been cancelled or failed,
-    /// the result is silently ignored and the value is dropped.
+    /// Called by the host when an async external call completes. Looks up
+    /// the `ExternalFuture` heap entry for `call_id`, transitions it to
+    /// `Resolved(value)`, and delivers `value` to the awaiter (if any).
     pub fn resolve_future(&mut self, call_id: u32, value: Value) -> RunResult<()> {
-        let mut value_guard = HeapGuard::new(value, self);
-        let this = value_guard.heap();
         let call_id = CallId::new(call_id);
 
-        // Pop the pending entry. A `None` here means the gather that was
-        // routing this call has been torn down (`HeapRead::fail` clears its
-        // pending entries) — drop the value, since `mark_consumed` was set
-        // when the gather awaited so no future `await` of the same call can
-        // pick it up. (Pre-refactor stored these in `resolved`; the value
-        // was unreachable and only released at `Scheduler::cleanup`.)
-        let Some(pending) = this.scheduler.take_pending_call(call_id) else {
+        let Some(future_id) = self.scheduler.take_pending_external(call_id) else {
+            value.drop_with_heap(self);
             return Ok(());
         };
 
-        // If the creator task of a non-gather call has failed, also drop the
-        // result. (Gather-routed calls don't reach here in the failure case —
-        // teardown removes the pending entry first.)
-        if pending.gather.is_none() && this.scheduler.is_task_failed(pending.creator_task) {
-            return Ok(());
+        // Ensure future cleaned up on all paths
+        let fut_val = Value::Ref(future_id);
+        let this = self;
+        defer_drop!(fut_val, this);
+
+        let mut value_guard = HeapGuard::new(value, this);
+        let (value, this) = value_guard.as_parts_mut();
+
+        let HeapReadOutput::ExternalFuture(mut fut) = this.heap.read(future_id) else {
+            panic!("pending_externals entry doesn't point to an ExternalFuture")
+        };
+
+        let awaiter_and_value = match &mut fut.get_mut(this.heap).state {
+            ExternalFutureState::Pending { awaiter } => awaiter.take().map(|a| (a, value.clone_with_heap(this.heap))),
+            ExternalFutureState::Resolved(_) | ExternalFutureState::Failed(_) => {
+                panic!("resolve_future: future was already resolved")
+            }
+        };
+
+        let (value, this) = value_guard.into_parts();
+        fut.get_mut(this.heap).state = ExternalFutureState::Resolved(value);
+
+        if let Some((awaiter, value)) = awaiter_and_value {
+            this.deliver_awaiter_success(awaiter, value)?;
         }
 
-        if let Some(gather_id) = pending.gather {
-            let value = value_guard.into_inner();
-            let HeapReadOutput::GatherFuture(mut gather) = self.heap.read(gather_id) else {
-                panic!("gather_id doesn't point to a GatherFuture")
-            };
+        Ok(())
+    }
 
-            // Record the resolution on the gather. `resolve_child` fans out to
-            // duplicate slots, clears the resolved CallId from `pending_calls`,
-            // and finalizes the gather (Success or Failure) if it's now done.
-            match gather.resolve_child(self, ChildSource::ExternalCall(call_id), value)? {
-                Some(GatherResolution::Success { list_id, waiter_id }) => {
-                    drop(gather);
+    /// Pushes `value` onto `task_id`'s stack and marks it ready. If the task
+    /// has already been cancelled (no longer in the scheduler) or failed,
+    /// drops `value` instead — the resolution still gets cached on the future,
+    /// but the (now-gone) awaiter doesn't receive it.
+    fn deliver_value_to_task(&mut self, task_id: TaskId, value: Value) {
+        if !self.scheduler.has_task(task_id) || self.scheduler.is_task_failed(task_id) {
+            value.drop_with_heap(self);
+            return;
+        }
 
-                    // External-future resolution can fire while either the
-                    // waiter is itself the current task (frames live in the
-                    // VM — e.g. external-only gather where the waiter never
-                    // switched away) or the waiter's context is parked. We
-                    // pick the right push target based on that.
-                    let waiter_context_in_vm =
-                        self.scheduler.current_task_id() == Some(waiter_id) && !self.frames.is_empty();
+        let task_is_current = self.scheduler.current_task_id() == Some(task_id) && !self.frames.is_empty();
+        if task_is_current {
+            self.stack.push(value);
+        } else {
+            self.scheduler.get_task_mut(task_id).stack.push(value);
+        }
+        self.scheduler.make_ready(task_id, self.heap);
+    }
 
-                    if waiter_context_in_vm {
-                        self.stack.push(Value::Ref(list_id));
-                        self.scheduler.set_state(waiter_id, TaskState::Ready, self.heap);
-                    } else {
-                        self.scheduler.get_task_mut(waiter_id).stack.push(Value::Ref(list_id));
-                        self.scheduler.make_ready(waiter_id, self.heap);
+    /// Delivers `value` along the awaiter chain starting at `awaiter`.
+    ///
+    /// At each `Awaiter::GatherSlot` link, the value is fanned into the
+    /// outer gather via [`HeapRead::resolve_child`]; if that completes the
+    /// outer, the chain continues with the outer's own awaiter and result
+    /// list. At an `Awaiter::Task` terminal, the value is delivered via
+    /// [`Self::deliver_value_to_task`] (push to the task's stack, transition
+    /// to `Ready`, push to ready-queue).
+    ///
+    /// Returns:
+    /// - `Some(task_id)` if delivery reached a live task — the caller may
+    ///   optionally switch VM context into `task_id` (calling
+    ///   `remove_from_ready_queue` first since `deliver_value_to_task`
+    ///   already queued it).
+    /// - `None` if the chain was consumed by an intermediate gather that's
+    ///   still in flight, or if the terminal task is gone (in which case
+    ///   the value is dropped).
+    fn deliver_awaiter_success(&mut self, mut awaiter: Awaiter, mut value: Value) -> RunResult<Option<TaskId>> {
+        let this = self;
+        loop {
+            match awaiter {
+                Awaiter::Task(t) => {
+                    this.deliver_value_to_task(t, value);
+                    return Ok(Some(t));
+                }
+                Awaiter::GatherSlot { gather, source } => {
+                    let gather_val = Value::Ref(gather);
+                    defer_drop!(gather_val, this);
+                    let HeapReadOutput::GatherFuture(mut outer) = this.heap.read(gather) else {
+                        panic!("Awaiter::GatherSlot gather id is not a GatherFuture")
+                    };
+                    let next = outer.resolve_child(this, source, value)?;
+                    match next {
+                        Some(success) => {
+                            awaiter = success.awaiter;
+                            value = Value::Ref(success.list_id);
+                        }
+                        None => return Ok(None),
                     }
                 }
-                Some(GatherResolution::Failure { error, waiter_id }) => {
-                    drop(gather);
-
-                    // Switch VM context into the waiter so the post-loop check
-                    // in `resume_with_resolved_futures` sees `current=waiter`
-                    // with state `Failed`, then calls `resume_with_exception`
-                    // — which raises in the waiter's frame and lets the
-                    // user's `try` / `except` catch it.
-                    self.cleanup_current_task();
-                    self.scheduler.set_current_task(Some(waiter_id));
-                    self.load_or_init_task(waiter_id)?;
-                    self.scheduler.set_state(waiter_id, TaskState::Failed(error), self.heap);
-                }
-                None => {}
             }
-        } else {
-            // Normal resolution for a single awaiter.
-            let value = value_guard.into_inner();
-            self.scheduler.record_resolved(call_id, value);
-            // Unblock the waiting task, if it's still waiting.
-            let task = self.scheduler.get_task_mut(pending.creator_task);
-            if matches!(task.state, TaskState::BlockedOnCall(cid) if cid == call_id) {
-                task.unblocked_by = Some(call_id);
-            }
-            self.scheduler.make_ready(pending.creator_task, self.heap);
         }
-        Ok(())
+    }
+
+    /// Walks the awaiter chain starting at `awaiter`, tearing each
+    /// intermediate gather down with `error`, and fails the terminal task.
+    ///
+    /// Returns:
+    /// - `Some(task_id)` if failure reached a live task — the caller may
+    ///   optionally switch VM context into it; the task's state is already
+    ///   `Failed(error)` so `resume_with_resolved_futures`'s post-loop check
+    ///   will raise the exception when control returns. (Callers that need
+    ///   the task in `Ready` instead — `handle_task_failure` — should
+    ///   `set_state(t, Ready)` before switching, since the exception is
+    ///   propagated by the `Err` return rather than the state check.)
+    /// - `None` if the terminal task is gone.
+    fn deliver_awaiter_failure(&mut self, mut awaiter: Awaiter, error: RunError) -> Option<TaskId> {
+        let target = loop {
+            match awaiter {
+                Awaiter::Task(t) => break t,
+                Awaiter::GatherSlot { gather, .. } => {
+                    let HeapReadOutput::GatherFuture(mut outer) = self.heap.read(gather) else {
+                        panic!("Awaiter::GatherSlot gather id is not a GatherFuture")
+                    };
+                    let next = outer.fail(&mut self.scheduler, self.heap, &error);
+                    drop(outer);
+                    // Release the inc_ref the destructured awaiter owned on
+                    // `gather`; reassign to the next link in the chain.
+                    self.heap.dec_ref(gather);
+                    awaiter = next;
+                }
+            }
+        };
+        if !self.scheduler.has_task(target) {
+            return None;
+        }
+        self.scheduler.fail_task(target, error, self.heap);
+        Some(target)
     }
 
     /// Fails an external future with an error.
     ///
-    /// Called by the host when an async external call fails with an exception.
-    /// Finds the task blocked on this CallId and fails it with the error.
-    /// If the task is part of a gather, cancels sibling tasks.
-    pub fn fail_future(&mut self, call_id: u32, error: RunError) {
+    /// Called by the host when an async external call fails with an
+    /// exception. Asks the scheduler for the awaiter that should receive
+    /// the failure (see `Scheduler::fail_for_call`), walks it via
+    /// [`Self::deliver_awaiter_failure`] (which fails the terminal task),
+    /// and switches VM context into that task if it isn't already current —
+    /// `resume_with_resolved_futures`'s post-loop check then surfaces the
+    /// error through its frame.
+    pub fn fail_future(&mut self, call_id: u32, error: RunError) -> RunResult<()> {
         let call_id = CallId::new(call_id);
-
-        self.scheduler.fail_for_call(call_id, error, self.heap);
+        if let Some(awaiter) = self.scheduler.fail_for_call(call_id, &error, self.heap)
+            && let Some(waiter_id) = self.deliver_awaiter_failure(awaiter, error)
+            && self.scheduler.current_task_id() != Some(waiter_id)
+        {
+            self.cleanup_current_task();
+            self.scheduler.set_current_task(Some(waiter_id));
+            self.load_or_init_task(waiter_id)?;
+        }
+        Ok(())
     }
 
-    /// Adds pending call data for an external function call.
+    /// Allocates an `ExternalFuture` for `call_id` and pushes a `Value::Ref`
+    /// to it on the VM stack.
     ///
-    /// Called by `run_pending()` when the host chooses async resolution.
-    /// This stores the call data in the scheduler so we can:
-    /// 1. Track which task created the call (to ignore results if cancelled)
-    /// 2. Return pending call info when all tasks are blocked
-    ///
-    /// Note: The args are empty because the host already has them from the
-    /// `FunctionCall` return value. We only need to track the creator task.
-    pub fn add_pending_call(&mut self, call_id: CallId) {
-        let current_task = self.scheduler.current_task_id().unwrap_or_default();
-        self.scheduler.add_pending_call(
-            call_id,
-            PendingCallData {
-                args: ArgValues::Empty,
-                creator_task: current_task,
-                gather: None,
-            },
-        );
+    /// The scheduler indexes `call_id -> future_id` (with its own inc_ref) so
+    /// host resolutions can find the heap entry; the `Value::Ref` pushed onto
+    /// the stack is the user's reference, which travels with the value until
+    /// it's awaited or dropped.
+    pub fn add_pending_call(&mut self, call_id: CallId) -> RunResult<()> {
+        let future_id = self
+            .heap
+            .allocate(HeapData::ExternalFuture(ExternalFuture::new_pending(call_id)))?;
+        self.scheduler.add_pending_external(call_id, future_id, self.heap);
+        self.push(Value::Ref(future_id));
+        Ok(())
     }
 
     /// Gets the pending call IDs from the scheduler.
@@ -780,10 +827,10 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
                     })?;
                     self.resolve_future(call_id, value)?;
                 }
-                ExtFunctionResult::Error(exc) => self.fail_future(call_id, RunError::from(exc)),
+                ExtFunctionResult::Error(exc) => self.fail_future(call_id, RunError::from(exc))?,
                 ExtFunctionResult::Future(_) => {}
                 ExtFunctionResult::NotFound(function_name) => {
-                    self.fail_future(call_id, ExtFunctionResult::not_found_exc(&function_name));
+                    self.fail_future(call_id, ExtFunctionResult::not_found_exc(&function_name))?;
                 }
             }
         }
@@ -800,13 +847,10 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
                     };
                     return self.resume_with_exception(err);
                 }
-                TaskState::BlockedOnCall(_) | TaskState::BlockedOnGather(_) => {
+                TaskState::Blocked(_) => {
                     // Current task is still blocked on unresolved futures.
                 }
                 TaskState::Ready => {
-                    if let Some(value) = self.scheduler.take_resolved_for_task(current_task_id) {
-                        self.push(value);
-                    }
                     self.scheduler.remove_from_ready_queue(current_task_id);
                     return self.run();
                 }
@@ -843,33 +887,13 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
 }
 
 /// Outcome of [`HeapRead::resolve_child`] when a gather has finished driving
-/// its children.
+/// its children successfully.
 ///
-/// - `Success`: every child resolved with a value. `list_id` is the cached
-///   result list to hand back; `waiter_id` is the task that awaited the
-///   gather.
-/// - `Failure`: a sibling task ended up `TaskState::Failed` (typically
-///   because an external it was waiting on was rejected by the host —
-///   `Scheduler::fail_for_call`'s "indirect" branch sets that state). The
-///   gather has been torn down via [`HeapRead::fail`]; the caller is
-///   responsible for switching VM context to `waiter_id` and propagating
-///   `error` through its frame's exception handler.
-pub(crate) enum GatherResolution {
-    Success { list_id: HeapId, waiter_id: TaskId },
-    Failure { error: RunError, waiter_id: TaskId },
-}
-
-/// Identifies which child of a gather just produced a value.
-///
-/// Used by [`HeapRead::resolve_child`] to look up the child's slot indices
-/// from the gather's own `pending_tasks` / `pending_calls` maps and, in the
-/// external-future case, to clear the resolved entry.
-#[derive(Clone, Copy)]
-pub(crate) enum ChildSource {
-    /// A spawned coroutine task completed with a value.
-    Task(TaskId),
-    /// An external future was resolved with a value by the host.
-    ExternalCall(CallId),
+/// `list_id` is the cached result list to hand back; `waiter` is the
+/// downstream that should receive it.
+pub(crate) struct GatherSuccess {
+    pub list_id: HeapId,
+    pub awaiter: Awaiter,
 }
 
 impl<'h> HeapRead<'h, GatherFuture> {
@@ -883,50 +907,38 @@ impl<'h> HeapRead<'h, GatherFuture> {
     /// transition happens inside [`Self::resolve_child`].
     pub(crate) fn cache_result(&mut self, heap: &mut HeapReader<'h, impl ResourceTracker>, list_id: HeapId) {
         heap.inc_ref(list_id);
-        self.get_mut(heap).state = GatherState::Completed(list_id);
+        self.get_mut(heap).state = GatherState::Completed(Value::Ref(list_id));
     }
 
     /// Records one child's resolution on this gather and, if everything has
-    /// now settled, transitions the gather to `Completed` (success) or
-    /// `Failed` (sibling failure detected).
+    /// now settled, transitions the gather to `Completed`.
     ///
-    /// The child's slot-index mapping is removed from the gather's own
-    /// `pending_tasks` / `pending_calls` map. Membership in those maps is
-    /// the "still in flight" signal.
+    /// The child's slot-index mapping is removed from the gather's
+    /// `pending_children` map. Membership in that map is the "still in
+    /// flight" signal.
     ///
-    /// Failure detection: a child task can end up in `TaskState::Failed`
-    /// without the gather being torn down — this happens when an external
-    /// call inside a gather child raises (`Scheduler::fail_for_call`'s
-    /// indirect branch). Such Failed siblings linger in `pending_tasks`
-    /// until *another* child completes and brings us through this scan,
-    /// which then propagates via `self.fail`.
+    /// Failure cases never reach this method — sibling failures are routed
+    /// through [`HeapRead::fail`] at the failure site
+    /// (`Scheduler::fail_for_call` for external rejections,
+    /// `VM::handle_task_failure` for in-frame exceptions). Both eagerly tear
+    /// the gather down before any other sibling has a chance to resolve.
     ///
     /// Returns `None` while children are still in flight; otherwise
-    /// `Some(GatherResolution::Success | Failure)`. In both cases the
-    /// gather has been transitioned to a terminal state.
+    /// `Some(GatherResolution::Success)` with the cached result list.
     fn resolve_child(
         &mut self,
         vm: &mut VM<'h, impl ResourceTracker>,
-        source: ChildSource,
+        child_id: HeapId,
         value: Value,
-    ) -> RunResult<Option<GatherResolution>> {
+    ) -> RunResult<Option<GatherSuccess>> {
         // Remove this child's slot-index mapping.
-        let indices: Vec<usize> = {
-            let awaited = self
-                .get_mut(vm.heap)
-                .as_awaited_mut()
-                .expect("resolve_child called on non-Awaited gather");
-            match source {
-                ChildSource::Task(tid) => awaited
-                    .pending_tasks
-                    .remove(&tid)
-                    .expect("resolve_child: task not registered with this gather"),
-                ChildSource::ExternalCall(cid) => awaited
-                    .pending_calls
-                    .remove(&cid)
-                    .expect("resolve_child: external call not registered with this gather"),
-            }
-        };
+        let indices: SmallVec<[usize; 1]> = self
+            .get_mut(vm.heap)
+            .as_awaited_mut()
+            .expect("resolve_child called on non-Awaited gather")
+            .pending_children
+            .remove(&child_id)
+            .expect("resolve_child: child not registered with this gather");
 
         // Take `results` out so the writes can do their clones (which need
         // `&Heap` access) without fighting the `&mut`-chain that
@@ -948,43 +960,32 @@ impl<'h> HeapRead<'h, GatherFuture> {
             value.drop_with_heap(vm.heap);
         }
 
-        // Restore results and look for a Failed sibling or check completion.
+        // Restore results and check completion.
         let awaited = self
             .get_mut(vm.heap)
             .as_awaited_mut()
             .expect("gather still Awaited after recording child resolution");
         awaited.results = results;
 
-        // Check for failed siblings after recording the result.
-        if let Some(&tid) = awaited
-            .pending_tasks
-            .keys()
-            .find(|tid| matches!(vm.scheduler.get_task(**tid).state, TaskState::Failed(_)))
-        {
-            // Take the error out of the failed task's state, then tear
-            // the gather down. `self.fail` cancels every remaining
-            // child (including `tid` itself) and caches the error on
-            // the gather for replay on re-await.
-            let task = vm.scheduler.get_task_mut(tid);
-            let TaskState::Failed(error) = mem::replace(&mut task.state, TaskState::Ready) else {
-                unreachable!("scanned Failed above")
-            };
-            let waiter_id = self.fail(&mut vm.scheduler, vm.heap, &error);
-            return Ok(Some(GatherResolution::Failure { error, waiter_id }));
-        } else if !awaited.pending_tasks.is_empty() || !awaited.pending_calls.is_empty() {
+        if !awaited.pending_children.is_empty() {
             return Ok(None);
         }
 
         // All children resolved successfully — build the result list.
+        // Extract this gather's awaiter (transferred into the returned
+        // `GatherSuccess`); the `Awaited` state remains in place until
+        // `cache_result` overwrites it, but its `awaiter` field is now the
+        // placeholder so dropping the `Awaited` payload won't double-drop
+        // the owned `Awaiter`.
         let results = mem::take(&mut awaited.results);
-        let waiter_id = awaited.waiter;
+        let awaiter = mem::replace(&mut awaited.awaiter, Awaiter::Task(TaskId::default()));
         let results: Vec<Value> = results
             .into_iter()
             .map(|r| r.expect("all results filled when gather is complete"))
             .collect();
         let list_id = vm.heap.allocate(HeapData::List(List::new(results)))?;
         self.cache_result(vm.heap, list_id);
-        Ok(Some(GatherResolution::Success { list_id, waiter_id }))
+        Ok(Some(GatherSuccess { list_id, awaiter }))
     }
 
     /// Tear the gather down with `error` and return its waiter.
@@ -998,18 +999,19 @@ impl<'h> HeapRead<'h, GatherFuture> {
         scheduler: &mut Scheduler,
         heap: &mut HeapReader<'h, impl ResourceTracker>,
         error: &RunError,
-    ) -> TaskId {
-        // Take the Awaited bookkeeping. The state stays `Awaited` (with empty
-        // fields) until the state replace below commits the transition.
-        let (waiter_id, pending_tasks, pending_calls, results) = {
+    ) -> Awaiter {
+        // Take the Awaited bookkeeping. The state stays `Awaited` (with
+        // placeholder fields) until the state replace below commits the
+        // transition. The extracted `awaiter` is transferred to the caller
+        // — it owns any `GatherSlot` inc_ref it carried.
+        let (waiter, pending_children, results) = {
             let awaited = self
                 .get_mut(heap)
                 .as_awaited_mut()
                 .expect("fail called on non-Awaited gather");
             (
-                awaited.waiter,
-                mem::take(&mut awaited.pending_tasks),
-                mem::take(&mut awaited.pending_calls),
+                mem::replace(&mut awaited.awaiter, Awaiter::Task(TaskId::default())),
+                mem::take(&mut awaited.pending_children),
                 mem::take(&mut awaited.results),
             )
         };
@@ -1020,19 +1022,45 @@ impl<'h> HeapRead<'h, GatherFuture> {
         // Drop fanned-out result Values that won't reach the waiter.
         results.drop_with_heap(heap);
 
-        // Drop pending-call routing so late host-side resolutions don't reach
-        // a stale gather entry. `take_pending_call` is a no-op when the entry
-        // has already been cleared (e.g. by `Scheduler::fail_for_call` having
-        // already removed the entry it was driving).
-        for cid in pending_calls.into_keys() {
-            scheduler.take_pending_call(cid);
+        // Walk every child the gather was waiting on and clean it up
+        // appropriately. `heap.read(id)` recovers the kind:
+        // - Coroutine: find its driving task via the scheduler's
+        //   `task_for_coroutine` index and cancel it, releasing the task's
+        //   inc_refs on the gather and coroutine.
+        // - ExternalFuture: clear the awaiter slot so a late host resolution
+        //   doesn't fan into the now-failed gather. The future stays in
+        //   `pending_externals` and a `Pending { awaiter: None }` resolution
+        //   simply caches the value (and a re-await replays it).
+        // - GatherFuture (nested): recurse — tear it down with the same
+        //   error so its own tasks/externals/gathers are cleaned up too.
+        for child_id in pending_children.into_keys() {
+            match heap.read(child_id) {
+                HeapReadOutput::Coroutine(_) => {
+                    if let Some(tid) = scheduler.task_for_coroutine(child_id) {
+                        scheduler.cancel_task(tid, heap);
+                    }
+                }
+                HeapReadOutput::ExternalFuture(mut fut) => {
+                    // Take the awaiter out so the inc_ref it holds on this
+                    // (failing) gather is released.
+                    if let ExternalFutureState::Pending { awaiter } = &mut fut.get_mut(heap).state
+                        && let Some(old) = awaiter.take()
+                    {
+                        old.drop_with_heap(heap);
+                    }
+                }
+                HeapReadOutput::GatherFuture(mut nested) => {
+                    // The nested gather's waiter is `Awaiter::GatherSlot {
+                    // gather: self, .. }` — we own its routing and are now
+                    // gone, so drop the returned awaiter (releasing its
+                    // inc_ref back on us) rather than forwarding the chain.
+                    let nested_awaiter = nested.fail(scheduler, heap, error);
+                    nested_awaiter.drop_with_heap(heap);
+                }
+                _ => panic!("gather pending_children key is not a Coroutine, ExternalFuture, or GatherFuture"),
+            }
         }
 
-        // Release all tasks owned by this gather.
-        for tid in pending_tasks.into_keys() {
-            scheduler.cancel_task(tid, heap);
-        }
-
-        waiter_id
+        waiter
     }
 }

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -8,13 +8,12 @@
 
 use std::{collections::VecDeque, mem};
 
-use ahash::{AHashMap, AHashSet};
+use ahash::AHashMap;
 
 use crate::{
-    args::ArgValues,
-    asyncio::{CallId, TaskId},
+    asyncio::{Awaiter, CallId, ExternalFutureState, TaskId},
     exception_private::RunError,
-    heap::{ContainsHeap, DropWithHeap, Heap, HeapData, HeapId, HeapReadOutput, HeapReader},
+    heap::{ContainsHeap, DropWithHeap, Heap, HeapId, HeapReadOutput, HeapReader},
     intern::FunctionId,
     parse::CodeRange,
     resource::ResourceTracker,
@@ -29,10 +28,15 @@ use crate::{
 pub(crate) enum TaskState {
     /// Task is ready to execute (in the ready queue).
     Ready,
-    /// Task is blocked waiting for an external call to resolve.
-    BlockedOnCall(CallId),
-    /// Task is blocked waiting for a GatherFuture to complete.
-    BlockedOnGather(HeapId),
+    /// Task is blocked waiting for an awaitable on the heap to settle.
+    ///
+    /// Holds an inc_ref on the awaitable (currently `ExternalFuture` or
+    /// `GatherFuture` — `heap.read(id)` recovers the kind) so the heap
+    /// entry stays alive while the task is parked. Resolution dispatches
+    /// via the awaitable's own awaiter slot (`Awaiter::Task(task_id)` on
+    /// `ExternalFuture`, `AwaitedGather.awaiter = Awaiter::Task(task_id)`
+    /// on `GatherFuture`) rather than from the variant tag.
+    Blocked(HeapId),
     /// Task completed successfully with a return value.
     Completed(Value),
     /// Task failed with an error.
@@ -42,8 +46,8 @@ pub(crate) enum TaskState {
 impl DropWithHeap for TaskState {
     fn drop_with_heap<H: ContainsHeap>(self, heap: &mut H) {
         match self {
-            Self::Ready | Self::BlockedOnCall(_) | Self::Failed(_) => {}
-            Self::BlockedOnGather(gather_id) => heap.heap_mut().dec_ref(gather_id),
+            Self::Ready | Self::Failed(_) => {}
+            Self::Blocked(id) => heap.heap_mut().dec_ref(id),
             Self::Completed(value) => value.drop_with_heap(heap),
         }
     }
@@ -78,13 +82,10 @@ pub(crate) struct Task {
     pub coroutine_id: Option<HeapId>,
     /// GatherFuture this task belongs to (if spawned by gather).
     /// Used to cancel sibling tasks when this task fails. The gather itself
-    /// stores the slot-index mapping under `AwaitedGather::pending_tasks`.
+    /// stores the slot-index mapping under `AwaitedGather::pending_children`.
     pub gather_id: Option<HeapId>,
     /// Current execution state.
     pub state: TaskState,
-    /// CallId that unblocked this task (set when task transitions from Blocked to Ready).
-    /// Used to retrieve the resolved value when the task resumes.
-    pub unblocked_by: Option<CallId>,
 }
 
 impl DropWithHeap for Task {
@@ -143,7 +144,6 @@ impl Task {
             coroutine_id,
             gather_id,
             state: TaskState::Ready,
-            unblocked_by: None,
         }
     }
 
@@ -152,21 +152,6 @@ impl Task {
     pub fn is_finished(&self) -> bool {
         matches!(self.state, TaskState::Completed(_) | TaskState::Failed(_))
     }
-}
-
-/// Internal representation of a pending external call.
-///
-/// Stores the data needed to retry or resume an external function call,
-/// along with tracking information for the task that created it.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-pub(crate) struct PendingCallData {
-    /// Arguments for the function (includes both positional and keyword args).
-    pub args: ArgValues,
-    /// Task that created this call (for ignoring results if task is cancelled).
-    pub creator_task: TaskId,
-    /// If `Some`, the resolved value should be fanned into the named
-    /// `GatherFuture` instead of directly unblocking `creator_task`.
-    pub gather: Option<HeapId>,
 }
 
 /// Scheduler for managing call IDs, async tasks, and external call tracking.
@@ -193,14 +178,18 @@ pub(crate) struct Scheduler {
     next_task_id: u32,
     /// Counter for external call IDs (always incremented, even for sync resolution).
     next_call_id: u32,
-    /// Maps CallId -> pending call data for unresolved external calls.
-    /// Populated when host calls `run_pending()`.
-    pending_calls: AHashMap<CallId, PendingCallData>,
-    /// Maps CallId -> resolved Value for futures that have been resolved.
-    /// Entry is removed when the value is consumed by awaiting.
-    resolved: AHashMap<CallId, Value>,
-    /// CallIds that have been awaited (to detect double-await).
-    consumed: AHashSet<CallId>,
+    /// Host-side index mapping each unresolved external call to its
+    /// `HeapData::ExternalFuture` entry. The scheduler holds an inc_ref on
+    /// each value until the host resolves or fails the call — that ref keeps
+    /// the future entry alive between yield and resume even if no awaiter is
+    /// holding a `Value::Ref` to it.
+    pending_externals: AHashMap<CallId, HeapId>,
+    /// Index mapping a spawned coroutine's `HeapId` to the `TaskId` driving
+    /// it. Populated in [`Scheduler::spawn`] and removed in
+    /// [`Scheduler::cancel_task`]. Lets `GatherFuture` and other call sites
+    /// dispatch from coroutine heap id back to the driving task without
+    /// scanning all tasks.
+    coroutine_to_task: AHashMap<HeapId, TaskId>,
 }
 
 impl Scheduler {
@@ -222,9 +211,8 @@ impl Scheduler {
             current_task: Some(main_task_id),
             next_task_id: 1,
             next_call_id: 0,
-            pending_calls: AHashMap::new(),
-            resolved: AHashMap::new(),
-            consumed: AHashSet::new(),
+            pending_externals: AHashMap::new(),
+            coroutine_to_task: AHashMap::new(),
         }
     }
 
@@ -265,114 +253,41 @@ impl Scheduler {
         id
     }
 
-    /// Stores pending call data for an external function call.
+    /// Registers a freshly created `ExternalFuture` for `call_id`.
     ///
-    /// Called when the host uses async resolution (`run_pending()`).
-    pub fn add_pending_call(&mut self, call_id: CallId, data: PendingCallData) {
-        self.pending_calls.insert(call_id, data);
+    /// The scheduler inc_refs `future_id` so the entry stays alive between
+    /// the yield to the host and the matching `resolve_future` / `fail_future`
+    /// call, even if no awaiter holds a `Value::Ref` to it.
+    pub fn add_pending_external(&mut self, call_id: CallId, future_id: HeapId, heap: &Heap<impl ResourceTracker>) {
+        heap.inc_ref(future_id);
+        let prev = self.pending_externals.insert(call_id, future_id);
+        debug_assert!(prev.is_none(), "add_pending_external: CallId already registered");
     }
 
-    /// Removes the pending-call entry for `call_id` and returns its data, if
-    /// present.
+    /// Removes and returns the `ExternalFuture` heap id for `call_id`, if any.
     ///
-    /// Callers that only want to remove the entry can ignore the return
-    /// value (e.g. `HeapRead::fail` clearing every external the gather was
-    /// waiting on).
-    pub fn take_pending_call(&mut self, call_id: CallId) -> Option<PendingCallData> {
-        self.pending_calls.remove(&call_id)
+    /// The caller becomes responsible for the inc_ref previously held by the
+    /// scheduler (typically dec_ref'd once the state transition is committed).
+    pub fn take_pending_external(&mut self, call_id: CallId) -> Option<HeapId> {
+        self.pending_externals.remove(&call_id)
     }
 
-    /// Returns true if a CallId has already been awaited (consumed).
-    #[inline]
-    pub fn is_consumed(&self, call_id: CallId) -> bool {
-        self.consumed.contains(&call_id)
-    }
-
-    /// Marks a CallId as consumed (awaited).
-    pub fn mark_consumed(&mut self, call_id: CallId) {
-        self.consumed.insert(call_id);
-    }
-
-    /// Registers a gather as waiting on an external future.
+    /// Marks the current task as `Blocked` on the awaitable at `awaitable_id`.
     ///
-    /// Mutates the existing `PendingCallData` entry to attach the gather
-    /// pointer. The CallId must already be present in `pending_calls` — the
-    /// host adds it via `add_pending_call` when it returns
-    /// `ExtFunctionResult::Future` for the original call, and gather routing
-    /// is registered later when the gather is awaited.
-    ///
-    /// The slot indices the resolved value should fan into live on the
-    /// gather itself, under `AwaitedGather::pending_calls`.
-    ///
-    /// # Panics
-    /// Panics if the CallId is not in `pending_calls` or is already routed
-    /// to a gather (would indicate a bug in await-side bookkeeping).
-    pub fn register_gather_for_call(&mut self, call_id: CallId, gather_id: HeapId) {
-        let data = self
-            .pending_calls
-            .get_mut(&call_id)
-            .expect("register_gather_for_call: CallId must already be a pending call");
-        debug_assert!(
-            data.gather.is_none(),
-            "register_gather_for_call: CallId already routed to a gather",
-        );
-        data.gather = Some(gather_id);
-    }
-
-    /// Records a resolved value for `call_id`.
-    pub fn record_resolved(&mut self, call_id: CallId, value: Value) {
-        self.resolved.insert(call_id, value);
-    }
-
-    /// Takes the resolved value for a CallId, if available.
-    ///
-    /// Removes the value from the resolved map and returns it.
-    /// Returns `None` if the call hasn't been resolved yet.
-    pub fn take_resolved(&mut self, call_id: CallId) -> Option<Value> {
-        self.resolved.remove(&call_id)
-    }
-
-    /// Takes the resolved value for a task that was unblocked.
-    ///
-    /// If the task has an `unblocked_by` CallId set, takes the resolved value
-    /// for that call and clears the `unblocked_by` field.
-    /// Returns `None` if the task wasn't unblocked by a resolved call.
-    pub fn take_resolved_for_task(&mut self, task_id: TaskId) -> Option<Value> {
-        let task = self
-            .tasks
-            .get_mut(&task_id)
-            .expect("Scheduler::take_resolved_for_task: task not found");
-        if let Some(call_id) = task.unblocked_by.take() {
-            self.resolved.remove(&call_id)
-        } else {
-            None
-        }
-    }
-
-    /// Marks the current task as blocked on an external call.
-    ///
-    /// The task will be unblocked when `resolve()` is called with the matching CallId.
-    pub fn block_current_on_call(&mut self, call_id: CallId) {
+    /// The task will be unblocked when the awaitable settles and its awaiter
+    /// slot routes back here (`Awaiter::Task(task_id)` on either
+    /// `ExternalFuture::Pending` or `AwaitedGather`).
+    pub fn block_current_on(&mut self, awaitable_id: HeapId, heap: &Heap<impl ResourceTracker>) {
         if let Some(task_id) = self.current_task {
             let task = self.get_task_mut(task_id);
-            task.state = TaskState::BlockedOnCall(call_id);
-        }
-    }
-
-    /// Marks the current task as blocked on a GatherFuture.
-    ///
-    /// The task will be unblocked when all gathered tasks complete.
-    pub fn block_current_on_gather(&mut self, gather_id: HeapId, heap: &Heap<impl ResourceTracker>) {
-        if let Some(task_id) = self.current_task {
-            let task = self.get_task_mut(task_id);
-            heap.inc_ref(gather_id);
-            task.state = TaskState::BlockedOnGather(gather_id);
+            heap.inc_ref(awaitable_id);
+            task.state = TaskState::Blocked(awaitable_id);
         }
     }
 
     /// Returns all pending (unresolved) CallIds.
     pub fn pending_call_ids(&self) -> Vec<CallId> {
-        self.pending_calls.keys().copied().collect()
+        self.pending_externals.keys().copied().collect()
     }
 
     /// Removes a task from the ready queue.
@@ -418,9 +333,19 @@ impl Scheduler {
 
         let task = Task::new(task_id, Some(coroutine_id), gather_id);
         self.tasks.insert(task_id, task);
+        self.coroutine_to_task.insert(coroutine_id, task_id);
         self.ready_queue.push_back(task_id);
 
         task_id
+    }
+
+    /// Returns the task driving `coroutine_id`, if any.
+    ///
+    /// Each spawned task owns exactly one coroutine for its lifetime; this
+    /// looks up the inverse mapping populated in [`Scheduler::spawn`].
+    #[inline]
+    pub fn task_for_coroutine(&self, coroutine_id: HeapId) -> Option<TaskId> {
+        self.coroutine_to_task.get(&coroutine_id).copied()
     }
 
     /// Gets the next ready task from the queue.
@@ -470,12 +395,12 @@ impl Scheduler {
     /// Cancels a task, fully releasing its resources and removing it from the
     /// scheduler.
     ///
-    /// Drops the task's stack, exception stack, any pending `Completed` result,
-    /// and recursively cancels any inner gather it was blocked on. After this
+    /// Drops the task's stack, exception stack, any pending `Completed`
+    /// result, and tears down any inner gather it was blocked on. After this
     /// call the task no longer exists in `Scheduler::tasks`; its owning
-    /// references to its coroutine and (outer) gather are released by
-    /// [`Scheduler::remove_task`].
-    pub fn cancel_task(&mut self, task_id: TaskId, heap: &mut Heap<impl ResourceTracker>) {
+    /// references to its coroutine and (outer) gather are released by the
+    /// `Task::drop_with_heap` call at the end.
+    pub fn cancel_task(&mut self, task_id: TaskId, heap: &mut HeapReader<'_, impl ResourceTracker>) {
         // No-op if the task has already been removed (idempotent — finalization
         // sites may iterate task ids that include already-cancelled siblings).
         let Some(task) = self.tasks.remove(&task_id) else {
@@ -490,40 +415,35 @@ impl Scheduler {
             self.current_task = None;
         }
 
+        if let Some(coroutine_id) = task.coroutine_id {
+            self.coroutine_to_task.remove(&coroutine_id);
+        }
+
         if !task.is_finished() {
-            // Remove from ready queue if present (do this before getting mutable task reference)
             self.ready_queue.retain(|&id| id != task_id);
 
-            // Drop any *non-gather-routed* external calls this task was the
-            // creator of. The host may still respond to them later; with the
-            // entry gone, `take_pending_call` returns `None` and
-            // `resolve_future` drops the resolved value instead of trying
-            // to wake a removed task.
-            //
-            // Gather-routed entries are kept: even though `task_id` made the
-            // call, ownership effectively transferred to the gather when
-            // `register_gather_for_call` set `data.gather`. Dropping them
-            // would orphan the gather (its own `pending_calls` map still
-            // references the CallId, so it would wait forever for a
-            // resolution that we'd silently drop). Gather-routed entries are
-            // cleaned up either by the gather completing successfully
-            // (`resolve_child` removes them on resolution) or by the gather
-            // failing (`HeapRead::fail` drains them on tear-down).
-            self.pending_calls
-                .retain(|_, data| data.creator_task != task_id || data.gather.is_some());
-
-            // If blocked on a nested gather, recursively cancel inner tasks first.
-            // Only an `Awaited` gather has spawned tasks — a `Pending` gather
-            // has never run, and `Completed`/`Failed` mean the gather has
-            // already shed its child tasks.
-            if let TaskState::BlockedOnGather(gather_id) = task.state {
-                let HeapData::GatherFuture(gather) = heap.get(gather_id) else {
-                    panic!("Scheduler::cancel_task: expected GatherFuture heap entry for gather_id {gather_id:?}");
-                };
+            // If blocked on an awaitable, dispatch by kind via `heap.read`.
+            // For a gather: recursively cancel its task children — external
+            // children manage themselves via the owning `Awaiter::GatherSlot`
+            // (the gather stays alive until each external resolves and
+            // releases its inc_ref), but spawned tasks have no such anchor
+            // and would otherwise linger in `self.tasks` holding inc_refs.
+            // For an external future: no extra teardown.
+            if let TaskState::Blocked(blocked_id) = task.state
+                && let HeapReadOutput::GatherFuture(gather) = heap.read(blocked_id)
+            {
                 let inner_task_ids: Vec<TaskId> = gather
+                    .get(heap)
                     .as_awaited()
-                    .map(|awaited| awaited.pending_tasks.keys().copied().collect())
+                    .map(|awaited| {
+                        awaited
+                            .pending_children
+                            .keys()
+                            .filter_map(|id| self.coroutine_to_task.get(id).copied())
+                            .collect()
+                    })
                     .unwrap_or_default();
+                drop(gather);
                 for inner_task_id in inner_task_ids {
                     self.cancel_task(inner_task_id, heap);
                 }
@@ -533,30 +453,74 @@ impl Scheduler {
         task.drop_with_heap(heap);
     }
 
-    /// Fails the task blocked on a specific CallId with an error.
+    /// Records a host-side failure for `call_id` and returns the awaiter the
+    /// caller should walk to propagate the error.
     ///
-    /// For a gather-routed call, tears the gather down eagerly via
-    /// [`HeapRead::fail`]. For an "indirect" failure (the call was made by a
-    /// task that's a child of a gather), just sets the creator task's state
-    /// to `Failed`; the failure is then surfaced when a sibling completes
-    /// and `HeapRead::resolve_child`'s completion scan finds the Failed
-    /// task. (The two-phase pattern keeps gather teardown anchored in the
-    /// run-loop side, where exception propagation through the waiter's
-    /// frame is straightforward.)
-    pub fn fail_for_call(&mut self, call_id: CallId, error: RunError, heap: &mut HeapReader<'_, impl ResourceTracker>) {
-        let Some(pending) = self.pending_calls.remove(&call_id) else {
-            // Typically means the call was already resolved or cancelled; no task to fail.
-            return;
+    /// Looks up the `ExternalFuture` heap entry, transitions it to `Failed`
+    /// with a clone of the error, and yields the awaiter that owned the
+    /// future's `Pending` slot — except for `Awaiter::Task(t)` where `t` is a
+    /// child of a gather: in that case we tear the gather down here (rather
+    /// than leaving the parked task `Failed` for a sibling's resolution to
+    /// discover later) and return the gather's awaiter instead, so the
+    /// caller's chain walk picks up at the right level.
+    ///
+    /// The returned `Awaiter` is owned (callers must walk it via
+    /// `deliver_awaiter_failure`, which drops every link).
+    ///
+    /// Returns `None` when there's nothing to propagate (unknown CallId,
+    /// already-resolved future, or the future had no awaiter — the failure
+    /// is simply cached on the future for replay).
+    #[must_use]
+    pub fn fail_for_call(
+        &mut self,
+        call_id: CallId,
+        error: &RunError,
+        heap: &mut HeapReader<'_, impl ResourceTracker>,
+    ) -> Option<Awaiter> {
+        let future_id = self.pending_externals.remove(&call_id)?;
+
+        let HeapReadOutput::ExternalFuture(mut fut) = heap.read(future_id) else {
+            panic!("pending_externals entry doesn't point to an ExternalFuture")
         };
-        if let Some(gather_id) = pending.gather {
-            let HeapReadOutput::GatherFuture(mut gather) = heap.read(gather_id) else {
-                panic!("gather_id doesn't point to a GatherFuture")
-            };
-            let waiter_id = gather.fail(self, heap, &error);
-            drop(gather);
-            self.fail_task(waiter_id, error, heap);
-        } else {
-            self.fail_task(pending.creator_task, error, heap);
+        let awaiter = match mem::replace(&mut fut.get_mut(heap).state, ExternalFutureState::Failed(error.clone())) {
+            ExternalFutureState::Pending { awaiter } => awaiter,
+            ExternalFutureState::Resolved(_) | ExternalFutureState::Failed(_) => {
+                panic!("fail_for_call: future was already resolved")
+            }
+        };
+        drop(fut);
+        heap.dec_ref(future_id);
+
+        match awaiter {
+            None => None,
+            Some(Awaiter::Task(task_id)) => {
+                let gather_id = self.tasks.get(&task_id).and_then(|t| t.gather_id);
+                if let Some(gather_id) = gather_id {
+                    // The task that was awaiting the future is itself in a
+                    // gather. Tear that gather down here so the failure
+                    // anchors at the same site as the resolution; return
+                    // the gather's awaiter for the caller to chain.
+                    let HeapReadOutput::GatherFuture(mut gather_rd) = heap.read(gather_id) else {
+                        panic!("gather_id doesn't point to a GatherFuture")
+                    };
+                    let outer_awaiter = gather_rd.fail(self, heap, error);
+                    drop(gather_rd);
+                    Some(outer_awaiter)
+                } else {
+                    Some(Awaiter::Task(task_id))
+                }
+            }
+            Some(Awaiter::GatherSlot { gather, .. }) => {
+                let HeapReadOutput::GatherFuture(mut gather_rd) = heap.read(gather) else {
+                    panic!("gather_id doesn't point to a GatherFuture")
+                };
+                let outer_awaiter = gather_rd.fail(self, heap, error);
+                drop(gather_rd);
+                // Release the inc_ref the destructured `GatherSlot` owned
+                // on `gather` (we tore that gather down above).
+                heap.dec_ref(gather);
+                Some(outer_awaiter)
+            }
         }
     }
 
@@ -568,19 +532,21 @@ impl Scheduler {
             .is_some_and(|task| matches!(task.state, TaskState::Failed(_)))
     }
 
-    /// Cleans up all scheduler resources: pending calls, resolved values, and
-    /// every remaining task (via [`Scheduler::remove_task`]).
-    pub fn cleanup(&mut self, heap: &mut Heap<impl ResourceTracker>) {
-        // Drop pending call arguments
-        for (_, data) in mem::take(&mut self.pending_calls) {
-            data.args.drop_with_heap(heap);
+    /// Returns true if a task with `task_id` currently exists in the
+    /// scheduler. Cancelled tasks are removed from the map, so this returning
+    /// `false` means the task is gone.
+    #[inline]
+    pub fn has_task(&self, task_id: TaskId) -> bool {
+        self.tasks.contains_key(&task_id)
+    }
+
+    /// Cleans up all scheduler resources: the pending-future inc_refs and
+    /// every remaining task (via [`Scheduler::cancel_task`]).
+    pub fn cleanup(&mut self, heap: &mut HeapReader<'_, impl ResourceTracker>) {
+        // Release the inc_refs the scheduler holds on each pending future.
+        for (_, future_id) in mem::take(&mut self.pending_externals) {
+            heap.dec_ref(future_id);
         }
-        // Drop resolved values
-        for (_, value) in mem::take(&mut self.resolved) {
-            value.drop_with_heap(heap);
-        }
-        // Remove every remaining task — drains the map and runs the per-task
-        // cleanup uniformly via `remove_task`.
         let task_ids: Vec<TaskId> = self.tasks.keys().copied().collect();
         for task_id in task_ids {
             self.cancel_task(task_id, heap);

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -14,7 +14,7 @@ use serde::ser::SerializeStruct;
 pub(crate) use crate::heap_data::HeapData;
 pub(crate) use crate::heap_traits::{ContainsHeap, DropWithHeap, HeapGuard, HeapItem};
 use crate::{
-    asyncio::{Coroutine, GatherFuture, GatherItem, GatherState},
+    asyncio::{Awaiter, Coroutine, ExternalFuture, ExternalFutureState, GatherFuture, GatherState},
     exception_private::SimpleException,
     heap_data::{CellValue, Closure, FunctionDefaults},
     resource::{ResourceError, ResourceTracker},
@@ -218,6 +218,9 @@ impl<'a, T: ResourceTracker> HeapReader<'a, T> {
             HeapData::GatherFuture(gather_future) => {
                 HeapReadOutput::GatherFuture(heap_read(base, gather_future, readers))
             }
+            HeapData::ExternalFuture(external_future) => {
+                HeapReadOutput::ExternalFuture(heap_read(base, external_future, readers))
+            }
             HeapData::Path(path) => HeapReadOutput::Path(heap_read(base, path, readers)),
             HeapData::RePattern(re_pattern) => HeapReadOutput::RePattern(heap_read_boxed(re_pattern, readers)),
             HeapData::ReMatch(re_match) => HeapReadOutput::ReMatch(heap_read(base, re_match, readers)),
@@ -303,6 +306,7 @@ pub enum HeapReadOutput<'a> {
     Module(HeapRead<'a, Module>),
     Coroutine(HeapRead<'a, Coroutine>),
     GatherFuture(HeapRead<'a, GatherFuture>),
+    ExternalFuture(HeapRead<'a, ExternalFuture>),
     Path(HeapRead<'a, Path>),
     RePattern(HeapRead<'a, RePattern>),
     ReMatch(HeapRead<'a, ReMatch>),
@@ -1431,27 +1435,40 @@ fn collect_child_ids(data: &HeapData, work_list: &mut Vec<HeapId>) {
             }
         }
         HeapData::GatherFuture(gather) => {
-            // Add coroutine HeapIds to work list. `items` carries the gather's
-            // owning inc_ref on each unique coroutine and is populated for the
-            // entire lifecycle.
-            for item in &gather.items {
-                if let GatherItem::Coroutine(coro_id) = item {
-                    work_list.push(*coro_id);
-                }
-            }
-            // Walk per-state heap refs: in-flight slot results, or the cached
-            // result list once the gather has completed successfully. `Pending`
-            // and `Failed` carry no heap refs.
+            // Add inc_ref'd item HeapIds to the work list. Both coroutines
+            // and external futures are owned by the gather for its entire
+            // lifecycle.
+            work_list.extend(gather.items.iter().copied());
+            // Walk per-state heap refs: in-flight slot results plus this
+            // gather's own awaiter (if `GatherSlot`, it owns an inc_ref on
+            // the outer gather), or the cached result list once the gather
+            // has completed successfully. `Pending` and `Failed` carry no
+            // heap refs.
             match &gather.state {
                 GatherState::Awaited(awaited) => {
+                    if let Awaiter::GatherSlot { gather, .. } = &awaited.awaiter {
+                        work_list.push(*gather);
+                    }
                     for result in awaited.results.iter().flatten() {
                         if let Value::Ref(id) = result {
                             work_list.push(*id);
                         }
                     }
                 }
-                GatherState::Completed(list_id) => work_list.push(*list_id),
-                GatherState::Pending | GatherState::Failed(_) => {}
+                GatherState::Completed(Value::Ref(id)) => work_list.push(*id),
+                GatherState::Pending | GatherState::Failed(_) | GatherState::Completed(_) => {}
+            }
+        }
+        HeapData::ExternalFuture(fut) => {
+            // `Pending { awaiter: Some(GatherSlot { gather, .. }) }` owns an
+            // inc_ref on `gather`. `Awaiter::Task` / `None` and the `Failed`
+            // state carry no heap refs. `Resolved` owns the cached value.
+            match &fut.state {
+                ExternalFutureState::Resolved(Value::Ref(id)) => work_list.push(*id),
+                ExternalFutureState::Pending {
+                    awaiter: Some(Awaiter::GatherSlot { gather, .. }),
+                } => work_list.push(*gather),
+                _ => {}
             }
         }
         HeapData::DateTime(dt) => {
@@ -1506,25 +1523,37 @@ fn py_dec_ref_ids_for_data(data: &mut HeapData, stack: &mut Vec<HeapId>) {
             }
         }
         HeapData::GatherFuture(gather) => {
-            // Decrement ref count for coroutine HeapIds (always present in `items`).
-            for item in &gather.items {
-                if let GatherItem::Coroutine(id) = item {
-                    stack.push(*id);
-                }
-            }
-            // Release per-state heap refs: in-flight slot results, or the
-            // cached result list once the gather has completed successfully.
-            // `Pending` and `Failed` carry no heap refs.
+            // Decrement ref count for owned item HeapIds (coroutines and
+            // external futures are both owned by the gather).
+            stack.extend(gather.items.iter().copied());
+            // Release per-state heap refs: in-flight slot results plus this
+            // gather's own awaiter (if `GatherSlot`, it owns an inc_ref on
+            // the outer gather), or the cached result list once the gather
+            // has completed successfully. `Pending` and `Failed` carry no
+            // heap refs.
             match &mut gather.state {
                 GatherState::Awaited(awaited) => {
+                    if let Awaiter::GatherSlot { gather, .. } = &awaited.awaiter {
+                        stack.push(*gather);
+                    }
                     for result in awaited.results.iter_mut().flatten() {
                         result.py_dec_ref_ids(stack);
                     }
                 }
-                GatherState::Completed(list_id) => stack.push(*list_id),
+                GatherState::Completed(value) => value.py_dec_ref_ids(stack),
                 GatherState::Pending | GatherState::Failed(_) => {}
             }
         }
+        HeapData::ExternalFuture(fut) => match &mut fut.state {
+            ExternalFutureState::Resolved(value) => value.py_dec_ref_ids(stack),
+            ExternalFutureState::Pending {
+                awaiter: Some(Awaiter::GatherSlot { gather, .. }),
+            } => stack.push(*gather),
+            ExternalFutureState::Pending {
+                awaiter: None | Some(Awaiter::Task(_)),
+            }
+            | ExternalFutureState::Failed(_) => {}
+        },
         HeapData::DateTime(dt) => {
             // Mirror `collect_child_ids`: when an aware datetime is freed we must
             // also drop the retained tzinfo reference so its refcount is balanced.

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -13,7 +13,7 @@ use num_integer::Integer;
 use crate::{
     ExcType, ResourceTracker,
     args::ArgValues,
-    asyncio::{CallId, Coroutine, GatherFuture, GatherItem, GatherState, TaskId},
+    asyncio::{Awaiter, Coroutine, ExternalFuture, ExternalFutureState, GatherFuture, GatherState},
     bytecode::{CallResult, VM},
     exception_private::{RunError, RunResult, SimpleException},
     hash::HashValue,
@@ -100,6 +100,12 @@ pub(crate) enum HeapData {
     ///
     /// Created by asyncio.gather() and spawns tasks when awaited.
     GatherFuture(GatherFuture),
+    /// An external future driven by the host.
+    ///
+    /// Created when the host returns `ExtFunctionResult::Future(call_id)`.
+    /// Holds its own state machine (`Pending`/`Resolved`/`Failed`) so
+    /// re-await yields cached results, matching CPython's Future semantics.
+    ExternalFuture(ExternalFuture),
     /// A filesystem path from `pathlib.Path`.
     ///
     /// Stored on the heap to provide Python-compatible path operations.
@@ -163,13 +169,8 @@ impl HeapData {
                 | Self::Module(_)
                 | Self::Coroutine(_)
                 | Self::GatherFuture(_)
+                | Self::ExternalFuture(_)
         )
-    }
-
-    /// Returns true if this heap data is a coroutine.
-    #[inline]
-    pub fn is_coroutine(&self) -> bool {
-        matches!(self, Self::Coroutine(_))
     }
 
     /// Returns the Python `Type` for this heap data without requiring VM access.
@@ -199,7 +200,7 @@ impl HeapData {
             Self::Iter(_) => Type::Iterator,
             Self::LongInt(_) => Type::Int,
             Self::Module(_) => Type::Module,
-            Self::Coroutine(_) | Self::GatherFuture(_) => Type::Coroutine,
+            Self::Coroutine(_) | Self::GatherFuture(_) | Self::ExternalFuture(_) => Type::Coroutine,
             Self::Path(_) => Type::Path,
             Self::RePattern(_) => Type::RePattern,
             Self::ReMatch(_) => Type::ReMatch,
@@ -235,6 +236,7 @@ impl HeapData {
             Self::Module(m) => m.py_estimate_size(),
             Self::Coroutine(coro) => coro.py_estimate_size(),
             Self::GatherFuture(gather) => gather.py_estimate_size(),
+            Self::ExternalFuture(fut) => fut.py_estimate_size(),
             Self::Path(p) => p.py_estimate_size(),
             Self::ReMatch(m) => m.py_estimate_size(),
             Self::RePattern(p) => p.py_estimate_size(),
@@ -369,48 +371,68 @@ impl HeapItem for GatherFuture {
     fn py_estimate_size(&self) -> usize {
         let state_size = match &self.state {
             GatherState::Awaited(awaited) => {
-                // Rough sizing — entry slots plus per-entry storage. The map's
-                // bucket array overhead is intentionally elided; we only
-                // estimate dynamically-allocated content tied to user code.
-                let pending_tasks_size = awaited
-                    .pending_tasks
+                // Rough sizing — per-entry storage in `pending_children` plus
+                // the result-slot vector. The map's bucket overhead and the
+                // SmallVec inline buffer are elided; we only estimate
+                // dynamically-allocated content tied to user code.
+                let pending_size: usize = awaited
+                    .pending_children
                     .values()
                     .map(|slots| {
-                        mem::size_of::<TaskId>() + mem::size_of::<Vec<usize>>() + slots.len() * mem::size_of::<usize>()
+                        // Spilled SmallVec entries (beyond the inline 1) are heap-allocated.
+                        let spilled = slots.len().saturating_sub(1);
+                        mem::size_of::<HeapId>() + spilled * mem::size_of::<usize>()
                     })
                     .sum::<usize>();
-                let pending_calls_size = awaited
-                    .pending_calls
-                    .values()
-                    .map(|slots| {
-                        mem::size_of::<CallId>() + mem::size_of::<Vec<usize>>() + slots.len() * mem::size_of::<usize>()
-                    })
-                    .sum::<usize>();
-                awaited.results.len() * mem::size_of::<Option<Value>>() + pending_tasks_size + pending_calls_size
+                awaited.results.len() * mem::size_of::<Option<Value>>() + pending_size
             }
             GatherState::Pending | GatherState::Completed(_) | GatherState::Failed(_) => 0,
         };
-        mem::size_of::<Self>() + self.items.len() * mem::size_of::<GatherItem>() + state_size
+        mem::size_of::<Self>() + self.items.len() * mem::size_of::<HeapId>() + state_size
     }
 
     fn py_dec_ref_ids(&mut self, stack: &mut Vec<HeapId>) {
-        // Decrement ref count for coroutine HeapIds (always present in `items`).
-        for item in &self.items {
-            if let GatherItem::Coroutine(id) = item {
-                stack.push(*id);
-            }
-        }
-        // Release per-state heap refs: in-flight slot results, or the cached
-        // result list once the gather has completed successfully. `Pending` and
-        // `Failed` carry no heap refs.
+        // Decrement ref count for items the gather owns (every entry in
+        // `items` is inc_ref'd at construction time).
+        stack.extend(self.items.iter().copied());
+        // Release per-state heap refs: in-flight slot results plus this
+        // gather's own awaiter (if `GatherSlot`, it owns an inc_ref on the
+        // outer gather), or the cached result list once the gather has
+        // completed successfully. `Pending` and `Failed` carry no heap refs.
         match &mut self.state {
             GatherState::Awaited(awaited) => {
+                if let Awaiter::GatherSlot { gather, .. } = &awaited.awaiter {
+                    stack.push(*gather);
+                }
                 for result in awaited.results.iter_mut().flatten() {
                     result.py_dec_ref_ids(stack);
                 }
             }
-            GatherState::Completed(list_id) => stack.push(*list_id),
-            GatherState::Pending | GatherState::Failed(_) => {}
+            GatherState::Completed(Value::Ref(id)) => stack.push(*id),
+            GatherState::Pending | GatherState::Failed(_) | GatherState::Completed(_) => {}
+        }
+    }
+}
+
+impl HeapItem for ExternalFuture {
+    fn py_estimate_size(&self) -> usize {
+        mem::size_of::<Self>()
+    }
+
+    fn py_dec_ref_ids(&mut self, stack: &mut Vec<HeapId>) {
+        // `Pending { awaiter: Some(Awaiter::GatherSlot { gather, .. }) }`
+        // owns an inc_ref on `gather` — release it when this entry is
+        // freed. `Awaiter::Task` and `None` own nothing. `Resolved` owns
+        // the cached value; `Failed` carries no heap refs.
+        match &mut self.state {
+            ExternalFutureState::Resolved(value) => value.py_dec_ref_ids(stack),
+            ExternalFutureState::Pending {
+                awaiter: Some(Awaiter::GatherSlot { gather, .. }),
+            } => stack.push(*gather),
+            ExternalFutureState::Pending {
+                awaiter: None | Some(Awaiter::Task(_)),
+            }
+            | ExternalFutureState::Failed(_) => {}
         }
     }
 }
@@ -440,6 +462,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
             Self::Module(_) => true,
             Self::Coroutine(_) => true,
             Self::GatherFuture(_) => true,
+            Self::ExternalFuture(_) => true,
             Self::Path(p) => p.py_bool(vm),
             Self::ReMatch(m) => m.py_bool(vm),
             Self::RePattern(p) => p.py_bool(vm),
@@ -505,7 +528,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
             Self::Iter(_) => Type::Iterator,
             Self::LongInt(_) => Type::Int,
             Self::Module(_) => Type::Module,
-            Self::Coroutine(_) | Self::GatherFuture(_) => Type::Coroutine,
+            Self::Coroutine(_) | Self::GatherFuture(_) | Self::ExternalFuture(_) => Type::Coroutine,
             Self::Path(p) => p.py_type(vm),
             Self::ReMatch(re) => re.py_type(vm),
             Self::RePattern(p) => p.py_type(vm),
@@ -723,6 +746,11 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
                 Ok(write!(f, "<coroutine object {name}>")?)
             }
             Self::GatherFuture(gather) => Ok(write!(f, "<gather({})>", gather.get(vm.heap).item_count())?),
+            Self::ExternalFuture(fut) => Ok(write!(
+                f,
+                "<coroutine external_future({})>",
+                fut.get(vm.heap).call_id.raw()
+            )?),
             Self::Path(p) => p.py_repr_fmt(f, vm, heap_ids),
             Self::ReMatch(m) => m.py_repr_fmt(f, vm, heap_ids),
             Self::RePattern(p) => p.py_repr_fmt(f, vm, heap_ids),

--- a/crates/monty/src/modules/asyncio.rs
+++ b/crates/monty/src/modules/asyncio.rs
@@ -9,7 +9,7 @@
 
 use crate::{
     args::ArgValues,
-    asyncio::{GatherFuture, GatherItem},
+    asyncio::GatherFuture,
     bytecode::{CallResult, VM},
     defer_drop_mut,
     exception_private::{ExcType, RunResult},
@@ -105,39 +105,42 @@ pub(crate) fn gather(heap: &mut Heap<impl ResourceTracker>, args: ArgValues) -> 
     // TODO: support keyword arguments (e.g. return_exceptions)
     kwargs.not_supported_yet("gather", heap)?;
 
-    // Validate all positional args are awaitable and collect them
-    let mut items = Vec::new();
-    let mut coroutine_ids_to_cleanup: Vec<HeapId> = Vec::new();
+    // Validate all positional args are awaitable and collect their heap ids.
+    // Both coroutines and external futures live on the heap; transfer
+    // ownership of each arg's HeapId into `items` and forget the `Value` so
+    // its `Drop` doesn't dec_ref the entry we just handed to the gather.
+    let mut items: Vec<HeapId> = Vec::new();
 
     #[cfg_attr(not(feature = "memory-model-checks"), expect(unused_mut))]
     for mut arg in pos_args {
-        match &arg {
-            Value::Ref(id) if heap.get(*id).is_coroutine() => {
-                coroutine_ids_to_cleanup.push(*id);
-                items.push(GatherItem::Coroutine(*id));
-                // Transfer ownership to GatherFuture - mark Value as consumed without dec_ref
-                #[cfg(feature = "memory-model-checks")]
-                arg.dec_ref_forget();
+        let id = match &arg {
+            Value::Ref(id)
+                if matches!(
+                    heap.get(*id),
+                    HeapData::Coroutine(_) | HeapData::ExternalFuture(_) | HeapData::GatherFuture(_)
+                ) =>
+            {
+                Some(*id)
             }
-            Value::ExternalFuture(call_id) => {
-                items.push(GatherItem::ExternalFuture(*call_id));
-                // ExternalFuture is Copy, no refcount to manage
+            _ => None,
+        };
+
+        if let Some(id) = id {
+            items.push(id);
+            // Transfer ownership of the heap ref to the gather.
+            #[cfg(feature = "memory-model-checks")]
+            arg.dec_ref_forget();
+        } else {
+            arg.drop_with_heap(heap);
+            for id in items {
+                heap.dec_ref(id);
             }
-            _ => {
-                // Not awaitable - clean up and error
-                arg.drop_with_heap(heap);
-                // Drop already-collected coroutine refs
-                for cid in coroutine_ids_to_cleanup {
-                    heap.dec_ref(cid);
-                }
-                return Err(ExcType::type_error(
-                    "An asyncio.Future, a coroutine or an awaitable is required",
-                ));
-            }
+            return Err(ExcType::type_error(
+                "An asyncio.Future, a coroutine or an awaitable is required",
+            ));
         }
     }
 
-    // Create GatherFuture on heap
     let gather_future = GatherFuture::new(items);
     let id = heap.allocate(HeapData::GatherFuture(gather_future))?;
     Ok(Value::Ref(id))

--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -925,9 +925,10 @@ impl<T: ResourceTracker> ReplSnapshot<T> {
                     ExtFunctionResult::Error(exc) => vm.resume_with_exception(exc.into()),
                     ExtFunctionResult::Future(raw_call_id) => {
                         let call_id = CallId::new(raw_call_id);
-                        vm.add_pending_call(call_id);
-                        vm.push(Value::ExternalFuture(call_id));
-                        vm.run()
+                        match vm.add_pending_call(call_id) {
+                            Ok(()) => vm.run(),
+                            Err(err) => vm.resume_with_exception(err),
+                        }
                     }
                     ExtFunctionResult::NotFound(function_name) => {
                         vm.resume_with_exception(ExtFunctionResult::not_found_exc(&function_name))

--- a/crates/monty/src/run_progress.rs
+++ b/crates/monty/src/run_progress.rs
@@ -21,7 +21,6 @@ use crate::{
     os::OsFunction,
     resource::ResourceTracker,
     run::Executor,
-    value::Value,
 };
 
 // ---------------------------------------------------------------------------
@@ -562,9 +561,10 @@ impl<T: ResourceTracker> Snapshot<T> {
                     ExtFunctionResult::Error(exc) => vm.resume_with_exception(exc.into()),
                     ExtFunctionResult::Future(raw_call_id) => {
                         let call_id = CallId::new(raw_call_id);
-                        vm.add_pending_call(call_id);
-                        vm.push(Value::ExternalFuture(call_id));
-                        vm.run()
+                        match vm.add_pending_call(call_id) {
+                            Ok(()) => vm.run(),
+                            Err(err) => vm.resume_with_exception(err),
+                        }
                     }
                     ExtFunctionResult::NotFound(function_name) => {
                         vm.resume_with_exception(ExtFunctionResult::not_found_exc(&function_name))

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -15,7 +15,6 @@ use num_traits::{ToPrimitive, Zero};
 use smallvec::SmallVec;
 
 use crate::{
-    asyncio::CallId,
     builtins::Builtins,
     bytecode::{CallResult, VM},
     exception_private::{ExcType, RunError, RunResult, SimpleException},
@@ -86,15 +85,6 @@ pub(crate) enum Value {
     /// A property descriptor that computes its value when accessed.
     /// When retrieved via `py_getattr`, the property's getter is invoked.
     Property(Property),
-    /// A pending external function call result.
-    ///
-    /// Created when the host calls `run_pending()` instead of `run(result)` for an
-    /// external function call. The CallId correlates with the call that created it.
-    /// When awaited, blocks the task until the host provides a result via `resume()`.
-    ///
-    /// ExternalFutures follow single-shot semantics like coroutines - awaiting an
-    /// already-awaited ExternalFuture raises RuntimeError.
-    ExternalFuture(CallId),
 
     // Heap-allocated values (stored in arena)
     Ref(HeapId),
@@ -147,7 +137,6 @@ impl PyTrait<'_> for Value {
             Self::DefFunction(_) | Self::ExtFunction(_) => Type::Function,
             Self::Marker(m) => m.py_type(),
             Self::Property(_) => Type::Property,
-            Self::ExternalFuture(_) => Type::Coroutine,
             Self::Ref(id) => vm.heap.read(*id).py_type(vm),
             #[cfg(feature = "memory-model-checks")]
             Self::Dereferenced => panic!("Cannot access Dereferenced object"),
@@ -304,7 +293,6 @@ impl PyTrait<'_> for Value {
             Self::DefFunction(_) | Self::ExtFunction(_) => true, // Functions are always truthy
             Self::Marker(_) => true,                            // Markers are always truthy
             Self::Property(_) => true,                          // Properties are always truthy
-            Self::ExternalFuture(_) => true,                    // ExternalFutures are always truthy
             Self::InternString(string_id) => !vm.interns.get_str(*string_id).is_empty(),
             Self::InternBytes(bytes_id) => !vm.interns.get_bytes(*bytes_id).is_empty(),
             Self::Ref(id) => vm.heap.read(*id).py_bool(vm),
@@ -348,7 +336,6 @@ impl PyTrait<'_> for Value {
             Self::InternBytes(bytes_id) => Ok(bytes_repr_fmt(interns.get_bytes(*bytes_id), f)?),
             Self::Marker(m) => Ok(m.py_repr_fmt(f)?),
             Self::Property(p) => Ok(write!(f, "<property {p:?}>")?),
-            Self::ExternalFuture(call_id) => Ok(write!(f, "<coroutine external_future({})>", call_id.raw())?),
             Self::Ref(id) => {
                 if heap_ids.contains(id) {
                     // Cycle detected - write type-specific placeholder following Python semantics
@@ -1413,7 +1400,6 @@ impl Value {
             Self::ModuleFunction(_) | Self::DefFunction(_) | Self::ExtFunction(_) => Type::Function,
             Self::Marker(_) => Type::SpecialForm,
             Self::Property(_) => Type::Property,
-            Self::ExternalFuture(_) => Type::Coroutine,
             Self::Ref(_) => Type::NoneType, // callers should resolve Ref via HeapData::py_type()
             #[cfg(feature = "memory-model-checks")]
             Self::Dereferenced => Type::NoneType,
@@ -1463,8 +1449,6 @@ impl Value {
             Self::Marker(m) => marker_value_id(*m),
             // Properties get deterministic IDs based on discriminant
             Self::Property(p) => property_value_id(*p),
-            // ExternalFutures get IDs based on their call_id
-            Self::ExternalFuture(call_id) => external_future_value_id(*call_id),
             #[cfg(feature = "memory-model-checks")]
             Self::Dereferenced => panic!("Cannot get id of Dereferenced object"),
         }
@@ -1544,8 +1528,6 @@ impl Value {
             Self::Marker(m) => m.hash(&mut hasher),
             // Properties are hashable based on their OS function discriminant
             Self::Property(p) => p.hash(&mut hasher),
-            // ExternalFutures are hashable based on their call ID
-            Self::ExternalFuture(call_id) => call_id.raw().hash(&mut hasher),
             #[cfg(feature = "memory-model-checks")]
             Self::Dereferenced => panic!("Cannot access Dereferenced object"),
         }
@@ -1974,7 +1956,6 @@ impl Value {
             Self::InternLongInt(bi) => Self::InternLongInt(*bi),
             Self::Marker(m) => Self::Marker(*m),
             Self::Property(p) => Self::Property(*p),
-            Self::ExternalFuture(call_id) => Self::ExternalFuture(*call_id),
             Self::Ref(_) => panic!("Ref clones must go through clone_with_heap to maintain refcounts"),
             #[cfg(feature = "memory-model-checks")]
             Self::Dereferenced => panic!("Cannot copy Dereferenced object"),
@@ -2213,8 +2194,6 @@ const FUNCTION_ID_TAG: usize = 1usize << (usize::BITS - 8);
 const EXTFUNCTION_ID_TAG: usize = 1usize << (usize::BITS - 9);
 /// High-bit tag for Marker value-based IDs (stdout, stderr, etc.).
 const MARKER_ID_TAG: usize = 1usize << (usize::BITS - 10);
-/// High-bit tag for ExternalFuture value-based IDs.
-const EXTERNAL_FUTURE_ID_TAG: usize = 1usize << (usize::BITS - 11);
 /// High-bit tag for ModuleFunction value-based IDs.
 const MODULE_FUNCTION_ID_TAG: usize = 1usize << (usize::BITS - 12);
 /// High-bit tag for interned LongInt `id()` values.
@@ -2229,7 +2208,6 @@ const BUILTIN_ID_MASK: usize = BUILTIN_ID_TAG - 1;
 const FUNCTION_ID_MASK: usize = FUNCTION_ID_TAG - 1;
 const EXTFUNCTION_ID_MASK: usize = EXTFUNCTION_ID_TAG - 1;
 const MARKER_ID_MASK: usize = MARKER_ID_TAG - 1;
-const EXTERNAL_FUTURE_ID_MASK: usize = EXTERNAL_FUTURE_ID_TAG - 1;
 const MODULE_FUNCTION_ID_MASK: usize = MODULE_FUNCTION_ID_TAG - 1;
 const INTERN_LONG_INT_ID_MASK: usize = INTERN_LONG_INT_ID_TAG - 1;
 const PROPERTY_ID_MASK: usize = PROPERTY_ID_TAG - 1;
@@ -2338,12 +2316,6 @@ fn property_value_id(p: Property) -> usize {
         Property::Os(os_fn) => os_fn as usize,
     };
     PROPERTY_ID_TAG | (discriminant & PROPERTY_ID_MASK)
-}
-
-/// Computes a deterministic ID for an external future based on its call ID.
-#[inline]
-fn external_future_value_id(call_id: CallId) -> usize {
-    EXTERNAL_FUTURE_ID_TAG | ((call_id.raw() as usize) & EXTERNAL_FUTURE_ID_MASK)
 }
 
 /// Computes a deterministic ID for a module function based on its discriminant.

--- a/crates/monty/test_cases/async__ext_call.py
+++ b/crates/monty/test_cases/async__ext_call.py
@@ -84,24 +84,40 @@ results = await asyncio.gather(async_call('a'), g, async_call('b'), g)  # pyrigh
 assert results == ['a', 'dup', 'b', 'dup'], f'mixed external future dedup: {results}'
 
 
-# === Same external future shared across sibling gathers raises ===
+# === Same external future shared across sibling gathers ===
 # Two concurrent helpers each await their own gather around the SAME external
-# future. Without rejection, the second gather's `register_gather_for_call`
-# would silently overwrite the first in the scheduler's waiters map, leaving
-# the first gather permanently blocked. We treat the second use as a reuse of
-# an already-awaited future, mirroring direct `await f; await f` behaviour.
-# CPython models the test fixture's `async_call` as `async def`, so it raises
-# `cannot reuse already awaited coroutine` at the same point.
+# future. In Monty the future is still `Pending` at this point so the second
+# gather sees the awaiter slot already taken and raises RuntimeError. In
+# CPython the test harness now returns an already-resolved `asyncio.Future`,
+# which permits multi-await, so both gathers settle with `[99]`. Both
+# outcomes are accepted as they reflect a genuine semantic difference (Monty
+# rejects concurrent awaiters on a `Pending` future; multi-awaiter on
+# `Pending` is a planned follow-up).
 async def helper(future):
     return await asyncio.gather(future)
 
 
 shared = async_call(99)
 try:
-    await asyncio.gather(helper(shared), helper(shared))  # pyright: ignore
-    assert False, 'should have raised RuntimeError'
+    result = await asyncio.gather(helper(shared), helper(shared))  # pyright: ignore
+    assert result == [[99], [99]], f'CPython multi-await of resolved future: {result}'
 except RuntimeError as e:
-    assert str(e) in (
-        'cannot reuse already awaited future',  # Monty: ExternalFuture path
-        'cannot reuse already awaited coroutine',  # CPython: coroutine path
-    ), f'unexpected error: {e}'
+    assert str(e) == 'cannot reuse already awaited future', f'Monty rejection: {e}'
+
+
+# === Re-awaiting a resolved external future returns the cached value ===
+
+reawait_f = async_call('cached')
+first = await reawait_f  # pyright: ignore
+second = await reawait_f  # pyright: ignore
+third = await reawait_f  # pyright: ignore
+assert first == 'cached', f'first await: {first}'
+assert second == 'cached', f'second await: {second}'
+assert third == 'cached', f'third await: {third}'
+
+reawait_list = async_call([1, 2, 3])
+first_list = await reawait_list  # pyright: ignore
+second_list = await reawait_list  # pyright: ignore
+assert first_list is second_list, 're-await returns the same list reference'
+first_list.append(99)
+assert second_list == [1, 2, 3, 99], 'mutation through one re-await is visible through another'

--- a/crates/monty/test_cases/async__ext_exc.py
+++ b/crates/monty/test_cases/async__ext_exc.py
@@ -262,3 +262,18 @@ try:
 except ValueError as e:
     gathered_coro_caught = str(e)
 assert gathered_coro_caught == 'async boom', f'gathered child exception caught at gather: {gathered_coro_caught}'
+
+
+# === Re-awaiting a failed external future re-raises the cached error ===
+
+reawait_fail = async_fail('ValueError', 'cached failure')
+errors = []
+for _ in range(3):
+    try:
+        await reawait_fail  # pyright: ignore
+        assert False, 'await of failed future should raise'
+    except ValueError as e:
+        errors.append(str(e))
+assert errors == ['cached failure', 'cached failure', 'cached failure'], (
+    f'each re-await of a failed future replays the cached error: {errors}'
+)

--- a/crates/monty/test_cases/async__gather_all.py
+++ b/crates/monty/test_cases/async__gather_all.py
@@ -193,3 +193,11 @@ try:
     assert False, 'third await should have raised'
 except ValueError as e:
     assert str(e) == 'detonate', f'third await message: {e}'
+
+
+# === Nested gather ===
+
+nested_1 = asyncio.gather(task1(), task1())
+nested_2 = asyncio.gather(nested_1, nested_1)
+
+assert await nested_2 == [[1, 1], [1, 1]], 'nested gather should return results correctly'  # pyright: ignore

--- a/scripts/iter_test_methods.py
+++ b/scripts/iter_test_methods.py
@@ -11,6 +11,7 @@ This module is shared between:
 
 from __future__ import annotations
 
+import asyncio
 import os
 import stat as stat_module
 from dataclasses import dataclass
@@ -114,19 +115,27 @@ CONST_LIST = [1, 2, 3]
 CONST_NONE = None
 
 
-async def async_call(x: object) -> object:
-    """Async function that returns its argument.
+def async_call(x: object) -> 'asyncio.Future[object]':
+    """Returns a resolved `asyncio.Future` of the given value.
 
-    This is a coroutine - it returns a future that resolves to the given value.
-    Used for testing async external function calls.
+    Mirrors Monty's host-managed `ExternalFuture`: awaiting returns `x` and
+    re-awaiting returns the same cached `x` (matching `Future` semantics in
+    both runtimes). Implemented as a `Future` rather than `async def` so
+    callers can re-await without raising "cannot reuse already awaited
+    coroutine".
     """
-    return x
+    fut: asyncio.Future[object] = asyncio.get_running_loop().create_future()
+    fut.set_result(x)
+    return fut
 
 
-async def async_fail(exc_type: str, message: str) -> None:
-    """Async function that raises the requested exception.
+def async_fail(exc_type: str, message: str) -> 'asyncio.Future[None]':
+    """Returns a Future that raises `exc_type(message)` when awaited.
 
-    Mirrors `raise_error` for the async path.
+    Mirrors `raise_error` for the async path. Returning a Future (rather
+    than a coroutine raising the exception in its body) lets re-await
+    replay the cached exception, matching Monty's `ExternalFuture::Failed`
+    behaviour.
     """
     exc_types: dict[str, type[Exception]] = {
         'ValueError': ValueError,
@@ -134,7 +143,9 @@ async def async_fail(exc_type: str, message: str) -> None:
         'KeyError': KeyError,
         'RuntimeError': RuntimeError,
     }
-    raise exc_types[exc_type](message)
+    fut: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    fut.set_exception(exc_types[exc_type](message))
+    return fut
 
 
 # =============================================================================


### PR DESCRIPTION
Continuation of #433 

Makes it possible to re-await external futures, nest gathers, and generally tightens up refcounting on the async code. Should avoid lots of cases of possible task leading and UAF.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors async futures to be heap-backed state machines like `gather`, enabling safe re-await of host-driven futures and nested gathers. Tightens refcounting and scheduler logic to avoid leaks and UAF.

- **New Features**
  - Re-await `ExternalFuture`: returns cached value; failures re-raise; a second concurrent await while pending is rejected.
  - Nested `asyncio.gather` now works.
  - Reliable mixing of coroutines and external futures.

- **Refactors**
  - Replaced `Value::ExternalFuture(CallId)` with heap `ExternalFuture` (`Pending/Resolved/Failed`) and a single `Awaiter`.
  - Scheduler blocks on heap awaitables and enforces one awaiter; removed call-specific wait paths.
  - VM creates heap futures via `add_pending_call`; errors surface to Python if creation fails.
  - `asyncio.gather` now transfers owned heap ids from args to avoid double dec_ref; tests updated to match re-await semantics and cover failure replay and nested gathers.

<sup>Written for commit 26f4d6799f6cd518eee588de93ae19364ced9ad7. Summary will update on new commits. <a href="https://cubic.dev/pr/pydantic/monty/pull/447?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

