### PR TITLE
experiment with `StringBuilder` to guard strings under construction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,29 @@ iter.drop_with_heap(self); // single path, no branching
 
 Avoid manual `drop_with_heap` whenever there are multiple code paths (branching, `?`, `continue`, early returns) between acquiring and releasing the value — that is exactly where `defer_drop!` or `HeapGuard` prevent leaks by guaranteeing cleanup on every path.
 
+### Resource-tracked string construction (`StringBuilder`)
+
+Any code that builds a `String` whose final size is not already bounded by an already-tracked input **must** use `StringBuilder` (in `crates/monty/src/string_builder.rs`) rather than `String::with_capacity(...).push(...)`. Intermediate `String`s live on the Rust heap *outside* the `ResourceTracker`, so a loop-built string can OOM the host before `allocate_string` ever consults the tracker — this is exactly the class of bug that hit `str.expandtabs` (huge `tabsize` amplifying a single tab into a multi-gigabyte allocation).
+
+`StringBuilder` actively *reserves* bytes with the tracker (via `on_grow`) as it grows, not just previews. This matters for nested builds: a `str.join` that invokes user-defined `__str__` methods, an f-string spec that evaluates an inner expression, etc. With a preview-only check, each builder would only see the *committed* memory and miss the outer's in-progress buffer — together they could exceed the limit. Reservations are released on `Drop` (cleanup on `?` / early-return paths) or in `finish(heap)` (which folds the handoff to `allocate_string` into the builder so the final size is re-added via `on_allocate` exactly once). Growth is amortized via 2× doubling:
+
+```rust
+// Bounded size known up front (padding to a given width):
+let mut builder = StringBuilder::with_capacity(width * fillchar.len_utf8(), vm.heap.tracker())?;
+builder.push_str(s)?;
+for _ in 0..pad { builder.push(fillchar)?; }
+builder.finish(vm.heap)
+
+// Size not bounded up front (e.g. attacker-controlled multiplier):
+let mut builder = StringBuilder::new(vm.heap.tracker());
+for c in input.chars() { builder.push(c)?; }
+builder.finish(vm.heap)
+```
+
+`StringBuilder` also implements `fmt::Write`, so `write!(builder, ...)`, `format_args!`, and the existing `py_repr_fmt(f, ...)` machinery work against a tracker-protected buffer. `fmt::Error` is payload-free, so any `ResourceError` raised by a write is stashed on the builder and surfaced by `finish(heap)` — callers using `write!` don't need to thread the tracker error themselves.
+
+When the input *is* already bounded (e.g. `s.to_lowercase()`, slicing, `to_owned()` of an existing tracked string), passing a plain `String` / `&str` to `allocate_string` is fine — the result is bounded by a known multiple of an already-tracked input, so no amplification is possible.
+
 ## Dev Commands
 
 **IMPORTANT**: before running `cargo build` or `cargo run`, it is likely necessary to run `make install-py` to ensure that the Python virtual environment is available for build.

--- a/crates/monty/src/lib.rs
+++ b/crates/monty/src/lib.rs
@@ -30,6 +30,7 @@ mod run;
 mod run_progress;
 mod signature;
 mod sorting;
+mod string_builder;
 mod types;
 mod value;
 

--- a/crates/monty/src/string_builder.rs
+++ b/crates/monty/src/string_builder.rs
@@ -1,0 +1,216 @@
+//! Resource-tracked builder for `String` values.
+//!
+//! `StringBuilder` is the canonical way to build a Python-visible string whose
+//! final size is *not* already bounded by an already-tracked input. Operations
+//! that grow a `String` in a loop — padding methods (`ljust`, `center`, …),
+//! tab expansion, string repetition, container `repr()`, etc. — must use
+//! `StringBuilder` rather than `String::with_capacity(...).push(...)`, because
+//! the intermediate `String` lives on the Rust heap *outside* the
+//! [`ResourceTracker`]. Without a builder, a malicious script can amplify a
+//! small tracked input into a multi-gigabyte intermediate before the final
+//! [`allocate_string`](crate::types::str::allocate_string) ever consults the
+//! tracker — bypassing the configured memory limit and OOMing the host.
+//!
+//! # Active reservation, not preview
+//!
+//! Each growth actively *reserves* bytes with the tracker via
+//! [`ResourceTracker::on_grow`]. This matters because Monty allows nested
+//! operations: a [`str.join`](crate::types::str) over arbitrary objects can
+//! invoke user-defined `__str__`/`__repr__` methods, which may themselves
+//! build strings. A preview-only check (`check_estimated_size`) would let the
+//! inner build pass against the *committed* memory state while ignoring the
+//! outer builder's in-progress buffer — so the two could collectively exceed
+//! the configured memory limit. By reserving instead, the outer builder's
+//! bytes are visible to every nested operation, and the limit applies
+//! cumulatively. Reservations are released on drop (cleanup on `?` /
+//! early-return paths) or in [`finish`](StringBuilder::finish), which folds
+//! the handoff to [`allocate_string`](crate::types::str::allocate_string)
+//! into a single method so the final size is re-added via `on_allocate`
+//! without double-counting and without exposing the brief release window to
+//! callers.
+//!
+//! # Growth policy
+//!
+//! Capacity doubles on each growth (matching `Vec`'s policy), so an `n`-byte
+//! build incurs `O(log n)` tracker calls rather than `O(n)`. Use
+//! [`with_capacity`](StringBuilder::with_capacity) when an upper bound is
+//! known up front (e.g. padding to a width) — a single reservation covers
+//! every subsequent push. Use [`new`](StringBuilder::new) when the size is
+//! not bounded up front.
+//!
+//! # Two APIs: direct push and `fmt::Write`
+//!
+//! Callers that build strings imperatively use [`push`](StringBuilder::push)
+//! and [`push_str`](StringBuilder::push_str), which return [`ResourceError`]
+//! directly. Callers that need to plug into `fmt::Write`-based machinery
+//! (`write!`, `format_args!`, the existing `py_repr_fmt` recursion) use the
+//! builder's [`fmt::Write`] impl, which captures any [`ResourceError`] into
+//! an internal slot since `fmt::Error` is payload-free. The stored error is
+//! surfaced automatically by [`finish`](StringBuilder::finish), so the
+//! tracker error reaches the caller even when the intermediate
+//! `fmt::Error` is swallowed by a downstream formatter.
+
+use std::{fmt, mem};
+
+use crate::{
+    exception_private::RunResult,
+    heap::Heap,
+    resource::{ResourceError, ResourceTracker},
+    types::str::allocate_string,
+    value::Value,
+};
+
+/// Resource-tracked builder for a `String`.
+///
+/// Holds an inner `String`, a tracker reference, and the byte count currently
+/// reserved with the tracker. Growth calls [`ResourceTracker::on_grow`] to
+/// reserve additional bytes (which fails fast if the memory limit would be
+/// exceeded), and [`Drop`] / [`finish`](Self::finish) release the reservation
+/// via [`ResourceTracker::on_free`].
+///
+/// Typical use:
+///
+/// ```ignore
+/// let mut builder = StringBuilder::with_capacity(cap, vm.heap.tracker())?;
+/// builder.push_str(prefix)?;
+/// for _ in 0..pad { builder.push(fill)?; }
+/// builder.finish(vm.heap)
+/// ```
+pub struct StringBuilder<'t, T: ResourceTracker> {
+    inner: String,
+    tracker: &'t T,
+    /// Bytes currently reserved with `tracker` via `on_grow`. Always released
+    /// before the builder ceases to exist — either in `finish` (so the
+    /// follow-up `allocate_string` can re-add the final size without
+    /// double-counting) or in `Drop` (for early-return paths).
+    reserved: usize,
+    /// Tracker error captured during a [`fmt::Write`] call. `fmt::Error` is
+    /// payload-free, so we stash the real error here and surface it via
+    /// [`finish`](Self::finish) or [`take_error`](Self::take_error). Direct
+    /// callers of [`push`](Self::push) / [`push_str`](Self::push_str) never
+    /// set this — they receive the [`ResourceError`] in the return value.
+    pending_error: Option<ResourceError>,
+}
+
+impl<'t, T: ResourceTracker> StringBuilder<'t, T> {
+    /// Creates an empty builder with no pre-approved capacity.
+    ///
+    /// Use when the final size is not bounded up front. The builder will
+    /// request additional reservation from the tracker on each 2× growth.
+    pub fn new(tracker: &'t T) -> Self {
+        Self {
+            inner: String::new(),
+            tracker,
+            reserved: 0,
+            pending_error: None,
+        }
+    }
+
+    /// Creates a builder with `capacity` bytes reserved up front.
+    ///
+    /// Use when the final size is known or bounded (e.g. padding to a given
+    /// width). One up-front `on_grow` call covers every subsequent push that
+    /// stays within `capacity`.
+    pub fn with_capacity(capacity: usize, tracker: &'t T) -> Result<Self, ResourceError> {
+        tracker.on_grow(capacity)?;
+        Ok(Self {
+            inner: String::with_capacity(capacity),
+            tracker,
+            reserved: capacity,
+            pending_error: None,
+        })
+    }
+
+    /// Appends a single character, reserving more capacity from the tracker if
+    /// the resulting length would exceed the currently reserved bytes.
+    pub fn push(&mut self, c: char) -> Result<(), ResourceError> {
+        let needed = self.inner.len().saturating_add(c.len_utf8());
+        self.ensure(needed)?;
+        self.inner.push(c);
+        Ok(())
+    }
+
+    /// Appends a string slice, reserving more capacity from the tracker if the
+    /// resulting length would exceed the currently reserved bytes.
+    pub fn push_str(&mut self, s: &str) -> Result<(), ResourceError> {
+        let needed = self.inner.len().saturating_add(s.len());
+        self.ensure(needed)?;
+        self.inner.push_str(s);
+        Ok(())
+    }
+
+    /// Consumes the builder and allocates the resulting string in `heap`.
+    ///
+    /// Releases the tracker reservation, then hands off to
+    /// [`allocate_string`] which re-adds the final size via `on_allocate`
+    /// (or interns the result for empty / single-ASCII strings). If a prior
+    /// [`fmt::Write`] call captured a tracker error, that error is returned
+    /// here rather than the (now-stale) inner string.
+    pub fn finish(mut self, heap: &Heap<T>) -> RunResult<Value> {
+        if let Some(e) = self.pending_error.take() {
+            // The reservation is released by Drop when `self` goes out of
+            // scope at function return — no need to release here.
+            return Err(e.into());
+        }
+        self.release();
+        Ok(allocate_string(mem::take(&mut self.inner), heap)?)
+    }
+
+    fn ensure(&mut self, needed: usize) -> Result<(), ResourceError> {
+        if needed > self.reserved {
+            // Double the reservation (saturating) but at least to `needed`.
+            // Matches `Vec`'s growth policy so an `n`-byte build incurs
+            // `O(log n)` tracker calls rather than `O(n)`.
+            let new_reserved = self.reserved.saturating_mul(2).max(needed);
+            let additional = new_reserved - self.reserved;
+            self.tracker.on_grow(additional)?;
+            self.reserved = new_reserved;
+        }
+        Ok(())
+    }
+
+    fn release(&mut self) {
+        if self.reserved > 0 {
+            let reserved = self.reserved;
+            self.tracker.on_free(|| reserved);
+            self.reserved = 0;
+        }
+    }
+}
+
+/// `fmt::Write` impl so `write!(builder, ...)` and `format_args!` work
+/// against any tracker-protected builder. A tracker rejection is converted
+/// into the payload-free [`fmt::Error`] and stashed in `pending_error`;
+/// short-circuits subsequent writes so a partially-built string doesn't keep
+/// accruing reservations after the limit has been hit.
+impl<T: ResourceTracker> fmt::Write for StringBuilder<'_, T> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        if self.pending_error.is_some() {
+            return Err(fmt::Error);
+        }
+        self.push_str(s).map_err(|e| {
+            self.pending_error = Some(e);
+            fmt::Error
+        })
+    }
+
+    fn write_char(&mut self, c: char) -> fmt::Result {
+        if self.pending_error.is_some() {
+            return Err(fmt::Error);
+        }
+        self.push(c).map_err(|e| {
+            self.pending_error = Some(e);
+            fmt::Error
+        })
+    }
+}
+
+impl<T: ResourceTracker> Drop for StringBuilder<'_, T> {
+    fn drop(&mut self) {
+        // Release any outstanding reservation if the builder is dropped without
+        // finishing (e.g. an early return via `?` during a push, or a stashed
+        // `pending_error` short-circuiting `finish`). `finish`'s success path
+        // zeroes `reserved` before this runs, so it's a no-op there.
+        self.release();
+    }
+}

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -169,6 +169,18 @@ pub trait PyTrait<'h> {
     /// Returns the Python `repr()` string for this value.
     ///
     /// Convenience wrapper around `py_repr_fmt` that returns an owned string.
+    ///
+    /// TODO: the intermediate `String` here is *not* tracked, so recursive
+    /// `repr()` of nested containers can amplify into a multi-gigabyte
+    /// host-side buffer before `allocate_string` consults the tracker.
+    /// `StringBuilder` is the canonical fix, but plugging it in requires
+    /// either (a) restructuring so `py_repr_fmt` no longer needs `&mut vm`
+    /// while the builder is alive, or (b) refactoring `py_str` / `py_repr`
+    /// to return `Value` directly so the builder can be consumed via
+    /// `StringBuilder::finish` *outside* the recursive call. Today's
+    /// per-type protections (`INT_MAX_STR_DIGITS`, `check_repeat_size`, etc.)
+    /// blunt the worst amplifications but don't fully cover container
+    /// `repr()`.
     fn py_repr(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         let mut s = String::new();
         let mut heap_ids = AHashSet::new();
@@ -177,6 +189,15 @@ pub trait PyTrait<'h> {
     }
 
     /// Returns the Python `str()` string for this value.
+    ///
+    /// TODO: should return a `Value` rather than `Cow<'static, str>` — see
+    /// the TODO on [`py_repr`](Self::py_repr). For `Value::InternString` /
+    /// heap `str` values, today's `Cow::Owned` impl clones the underlying
+    /// bytes; a `Value`-returning impl could just hand back the same
+    /// `Value`. Callers that need a `&str` (f-string formatters, the print
+    /// writer, error messages) would resolve the `Value` to `&str` via the
+    /// interns table / heap — equivalent to the existing `EitherStr`
+    /// accessor pattern.
     fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
         self.py_repr(vm)
     }

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -16,7 +16,8 @@ use crate::{
     hash::{HashValue, hash_python_str},
     heap::{DropWithHeap, Heap, HeapData, HeapGuard, HeapId, HeapItem, HeapRead, heap_read_ref_as_field},
     intern::{StaticStrings, StringId},
-    resource::{ResourceError, ResourceTracker, check_repeat_size, check_replace_size},
+    resource::{ResourceError, ResourceTracker, check_replace_size},
+    string_builder::StringBuilder,
     types::{
         Type,
         slice::{normalize_sequence_index, slice_collect_iterator},
@@ -1749,25 +1750,27 @@ fn str_center<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl R
     let s = s.get(vm.heap);
     let len = s.chars().count();
 
-    let result = if width <= len {
-        s.to_owned()
+    if width <= len {
+        Ok(allocate_string(s, vm.heap)?)
     } else {
-        check_repeat_size(width, fillchar.len_utf8(), vm.heap.tracker())?;
+        // Upper bound on result bytes: `width` characters of at most
+        // `fillchar.len_utf8()` bytes each. Pre-approving with the builder is
+        // tighter than `s.len() + pad * fillchar.len_utf8()` and matches the
+        // bound used by `ljust` / `rjust`.
+        let capacity = width.saturating_mul(fillchar.len_utf8());
+        let mut builder = StringBuilder::with_capacity(capacity, vm.heap.tracker())?;
         let total_pad = width - len;
         let left_pad = total_pad / 2;
         let right_pad = total_pad - left_pad;
-        let mut result = String::with_capacity(width);
         for _ in 0..left_pad {
-            result.push(fillchar);
+            builder.push(fillchar)?;
         }
-        result.push_str(s);
+        builder.push_str(s)?;
         for _ in 0..right_pad {
-            result.push(fillchar);
+            builder.push(fillchar)?;
         }
-        result
-    };
-
-    Ok(allocate_string(result, vm.heap)?)
+        builder.finish(vm.heap)
+    }
 }
 
 /// Implements Python's `str.ljust(width, fillchar?)` method.
@@ -1778,20 +1781,18 @@ fn str_ljust<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl Re
     let s = s.get(vm.heap);
     let len = s.chars().count();
 
-    let result = if width <= len {
-        s.to_owned()
+    if width <= len {
+        Ok(allocate_string(s, vm.heap)?)
     } else {
-        check_repeat_size(width, fillchar.len_utf8(), vm.heap.tracker())?;
+        let capacity = width.saturating_mul(fillchar.len_utf8());
+        let mut builder = StringBuilder::with_capacity(capacity, vm.heap.tracker())?;
         let pad = width - len;
-        let mut result = String::with_capacity(width);
-        result.push_str(s);
+        builder.push_str(s)?;
         for _ in 0..pad {
-            result.push(fillchar);
+            builder.push(fillchar)?;
         }
-        result
-    };
-
-    Ok(allocate_string(result, vm.heap)?)
+        builder.finish(vm.heap)
+    }
 }
 
 /// Implements Python's `str.rjust(width, fillchar?)` method.
@@ -1802,20 +1803,18 @@ fn str_rjust<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl Re
     let s = s.get(vm.heap);
     let len = s.chars().count();
 
-    let result = if width <= len {
-        s.to_owned()
+    if width <= len {
+        Ok(allocate_string(s, vm.heap)?)
     } else {
-        check_repeat_size(width, fillchar.len_utf8(), vm.heap.tracker())?;
+        let capacity = width.saturating_mul(fillchar.len_utf8());
+        let mut builder = StringBuilder::with_capacity(capacity, vm.heap.tracker())?;
         let pad = width - len;
-        let mut result = String::with_capacity(width);
         for _ in 0..pad {
-            result.push(fillchar);
+            builder.push(fillchar)?;
         }
-        result.push_str(s);
-        result
-    };
-
-    Ok(allocate_string(result, vm.heap)?)
+        builder.push_str(s)?;
+        builder.finish(vm.heap)
+    }
 }
 
 /// Parses arguments for justify methods (center, ljust, rjust).
@@ -1873,34 +1872,32 @@ fn str_zfill<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl Re
     let s = s.get(vm.heap);
     let len = s.chars().count();
 
-    let result = if width <= len {
-        s.to_owned()
+    if width <= len {
+        Ok(allocate_string(s, vm.heap)?)
     } else {
-        // zfill always pads with ASCII '0' (1 byte)
-        check_repeat_size(width, 1, vm.heap.tracker())?;
+        // zfill always pads with ASCII '0' (1 byte) and the result is exactly
+        // `width` bytes, so a single up-front approval covers every push.
+        let mut builder = StringBuilder::with_capacity(width, vm.heap.tracker())?;
         let pad = width - len;
         let mut chars = s.chars();
         let first = chars.next();
 
-        let mut result = String::with_capacity(width);
-
-        // Handle sign prefix
         if matches!(first, Some('+' | '-')) {
-            result.push(first.unwrap());
+            builder.push(first.unwrap())?;
             for _ in 0..pad {
-                result.push('0');
+                builder.push('0')?;
             }
-            result.extend(chars);
+            for c in chars {
+                builder.push(c)?;
+            }
         } else {
             for _ in 0..pad {
-                result.push('0');
+                builder.push('0')?;
             }
-            result.push_str(s);
+            builder.push_str(s)?;
         }
-        result
-    };
-
-    Ok(allocate_string(result, vm.heap)?)
+        builder.finish(vm.heap)
+    }
 }
 
 /// Implements Python's `str.expandtabs(tabsize=8)` method.
@@ -1927,20 +1924,25 @@ fn str_expandtabs<'h>(
         }
     };
 
-    let mut result = String::with_capacity(s.get(vm.heap).len());
+    let s = s.get(vm.heap);
+    // `tabsize` is attacker-controlled (saturates to `usize::MAX`) and we don't
+    // know the result size up front, so use the unbounded builder — its 2×
+    // growth policy rejects the build at the first push that would exceed the
+    // memory limit, capping wasted intermediate allocation to `O(limit)`.
+    let mut builder = StringBuilder::new(vm.heap.tracker());
     let mut column = 0;
 
-    for c in s.get(vm.heap).chars() {
+    for c in s.chars() {
         if c == '\t' {
             if tabsize > 0 {
                 let spaces = tabsize - (column % tabsize);
                 for _ in 0..spaces {
-                    result.push(' ');
+                    builder.push(' ')?;
                 }
                 column += spaces;
             }
         } else {
-            result.push(c);
+            builder.push(c)?;
             if c == '\n' || c == '\r' {
                 column = 0;
             } else {
@@ -1949,7 +1951,7 @@ fn str_expandtabs<'h>(
         }
     }
 
-    Ok(allocate_string(result, vm.heap)?)
+    builder.finish(vm.heap)
 }
 
 /// Implements Python's `str.encode(encoding='utf-8', errors='strict')` method.

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -1753,13 +1753,12 @@ fn str_center<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl R
     if width <= len {
         Ok(allocate_string(s, vm.heap)?)
     } else {
-        // Upper bound on result bytes: `width` characters of at most
-        // `fillchar.len_utf8()` bytes each. Pre-approving with the builder is
-        // tighter than `s.len() + pad * fillchar.len_utf8()` and matches the
-        // bound used by `ljust` / `rjust`.
-        let capacity = width.saturating_mul(fillchar.len_utf8());
-        let mut builder = StringBuilder::with_capacity(capacity, vm.heap.tracker())?;
+        // Exact byte capacity: the original string (`s.len()` bytes, possibly
+        // multibyte) plus `pad` fillchars of `fillchar.len_utf8()` bytes each.
+        // `width * fillchar.len_utf8()` would mis-charge the `s`-slot bytes.
         let total_pad = width - len;
+        let capacity = s.len().saturating_add(total_pad.saturating_mul(fillchar.len_utf8()));
+        let mut builder = StringBuilder::with_capacity(capacity, vm.heap.tracker())?;
         let left_pad = total_pad / 2;
         let right_pad = total_pad - left_pad;
         for _ in 0..left_pad {
@@ -1784,9 +1783,9 @@ fn str_ljust<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl Re
     if width <= len {
         Ok(allocate_string(s, vm.heap)?)
     } else {
-        let capacity = width.saturating_mul(fillchar.len_utf8());
-        let mut builder = StringBuilder::with_capacity(capacity, vm.heap.tracker())?;
         let pad = width - len;
+        let capacity = s.len().saturating_add(pad.saturating_mul(fillchar.len_utf8()));
+        let mut builder = StringBuilder::with_capacity(capacity, vm.heap.tracker())?;
         builder.push_str(s)?;
         for _ in 0..pad {
             builder.push(fillchar)?;
@@ -1806,9 +1805,9 @@ fn str_rjust<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl Re
     if width <= len {
         Ok(allocate_string(s, vm.heap)?)
     } else {
-        let capacity = width.saturating_mul(fillchar.len_utf8());
-        let mut builder = StringBuilder::with_capacity(capacity, vm.heap.tracker())?;
         let pad = width - len;
+        let capacity = s.len().saturating_add(pad.saturating_mul(fillchar.len_utf8()));
+        let mut builder = StringBuilder::with_capacity(capacity, vm.heap.tracker())?;
         for _ in 0..pad {
             builder.push(fillchar)?;
         }
@@ -1875,10 +1874,12 @@ fn str_zfill<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h, impl Re
     if width <= len {
         Ok(allocate_string(s, vm.heap)?)
     } else {
-        // zfill always pads with ASCII '0' (1 byte) and the result is exactly
-        // `width` bytes, so a single up-front approval covers every push.
-        let mut builder = StringBuilder::with_capacity(width, vm.heap.tracker())?;
+        // Exact byte capacity: zfill pads with ASCII '0' (1 byte each), so the
+        // result is `s.len() + pad` bytes — `s.len()` (possibly multibyte)
+        // rather than `width` (character count).
         let pad = width - len;
+        let capacity = s.len().saturating_add(pad);
+        let mut builder = StringBuilder::with_capacity(capacity, vm.heap.tracker())?;
         let mut chars = s.chars();
         let first = chars.next();
 

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -1661,6 +1661,24 @@ fn bytes_zfill_memory_limit() {
     assert_eq!(exc.exc_type(), ExcType::MemoryError);
 }
 
+/// Test that `str.expandtabs` with a huge tabsize is rejected before expansion.
+///
+/// Regression test for an unbounded-allocation bypass: `tabsize` saturates to
+/// `usize::MAX`, and without a pre-check each tab would expand into ~`tabsize`
+/// spaces on the Rust heap before `allocate_string` consulted the tracker.
+#[test]
+fn str_expandtabs_memory_limit() {
+    let code = "'\\t'.expandtabs(10**9)";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+
+    let limits = ResourceLimits::new().max_memory(100_000);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    assert!(result.is_err(), "str.expandtabs with huge tabsize should be rejected");
+    let exc = result.unwrap_err();
+    assert_eq!(exc.exc_type(), ExcType::MemoryError);
+}
+
 /// Test that f-string formatting with huge width is rejected before allocation.
 #[test]
 fn fstring_dynamic_width_memory_limit() {


### PR DESCRIPTION
WIP, pushing to see pipeline feedback.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce `StringBuilder` to enforce resource-tracked string growth and prevent OOMs from unbounded intermediates. Adopt it in string padding and tab expansion so oversized builds fail fast with `MemoryError`.

- **New Features**
  - Added `string_builder::StringBuilder` that reserves bytes with the `ResourceTracker` as it grows, and releases on drop/finish; 2× growth reduces tracker calls.
  - Implements `fmt::Write`; tracker errors surface via `finish`. Added TODOs in `py_repr`/`py_str` to route repr/str building through `StringBuilder`.

- **Bug Fixes**
  - `str.expandtabs`, `center`, `ljust`, `rjust`, and `zfill` now build via `StringBuilder`, with exact-capacity reservations for bounded paths (`s.len()` + pad) and safe 2× growth for unbounded `expandtabs`.
  - Added `str_expandtabs_memory_limit` test; expanded `CLAUDE.md` with builder guidance.

<sup>Written for commit 6aeb9cdffe63f39b802f34fae30374a07cdd6922. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

