### PR TITLE
move limits in the compiler to return syntax errors rather than panic

### DIFF
--- a/crates/monty/src/bytecode/builder.rs
+++ b/crates/monty/src/bytecode/builder.rs
@@ -214,6 +214,10 @@ impl CodeBuilder {
         // Capture the opcode position (where patch_jump will overwrite the i16)
         // before `emit_with_operand` pushes the bytes.
         let offset = self.current_offset();
+        // Capture the source location now so any later `patch_jump` overflow
+        // anchors the diagnostic at this jump site rather than the (often
+        // unrelated) statement where the patch happens to resolve.
+        let source_position = self.current_location.unwrap_or_default();
         // Jump-taken target depth. `jump_taken_delta` panics for non-jumps.
         let target_depth = u16::try_from(i32::from(pre_depth) + i32::from(op.jump_taken_stack_effect()))
             .map_err(|_| self.stack_too_large())?;
@@ -223,6 +227,7 @@ impl CodeBuilder {
             inner: Some(JumpLabelInner {
                 offset,
                 stack_depth: target_depth,
+                source_position,
             }),
         })
     }
@@ -257,7 +262,7 @@ impl CodeBuilder {
         };
 
         let offset = calculate_jump_offset(label, target)
-            .ok_or_else(|| self.jump_too_large())?
+            .ok_or_else(|| jump_too_large_at(label.source_position))?
             .as_i16();
         let bytes = offset.to_le_bytes();
         self.bytecode[label.offset.0 + 1] = bytes[0];
@@ -289,6 +294,10 @@ impl CodeBuilder {
             stack_depth: target_depth
                 .checked_add_signed(op.jump_taken_stack_effect())
                 .ok_or_else(|| self.stack_too_large())?,
+            // Backward jumps are emitted and resolved at the same spot, so
+            // there's no patch-time/emit-time split; either position is the
+            // same statement.
+            source_position: self.current_location.unwrap_or_default(),
         };
         let Some(target) = target.0 else {
             // Target is dead code
@@ -608,22 +617,23 @@ impl CodeBuilder {
     #[cold]
     #[inline(never)]
     fn jump_too_large(&self) -> CompileError {
-        CompileError::new(
-            "function too large: jump offset exceeds i16 range",
-            self.current_location.unwrap_or_default(),
-        )
+        jump_too_large_at(self.current_location.unwrap_or_default())
     }
 
     /// Builds the `CompileError` for a `StringId` that doesn't fit in the
     /// `u16` operand of a name-bearing opcode. Used by emit helpers that
     /// inline the name id directly (e.g. `LoadLocalCallable`).
+    ///
+    /// The count is `u16::MAX + 1` (`65 536`) because a `u16` operand can
+    /// address indices `0..=u16::MAX`, so the format can name that many
+    /// distinct interned strings before overflowing.
     #[cold]
     #[inline(never)]
     fn name_id_too_large(&self) -> CompileError {
         CompileError::new(
             format!(
-                "module has too many distinct names; the bytecode format supports up to {}",
-                u16::MAX
+                "module has too many distinct names; the bytecode format supports up to {} interned strings",
+                usize::from(u16::MAX) + 1,
             ),
             self.current_location.unwrap_or_default(),
         )
@@ -643,12 +653,16 @@ impl CodeBuilder {
 
     /// Builds the `CompileError` for a `add_const` that would overflow the
     /// per-`Code` constant pool's `u16` index. One function/module body can
-    /// hold at most `u16::MAX + 1` distinct constants.
+    /// hold at most `u16::MAX + 1` distinct constants (the check fires when
+    /// the pool already holds `u16::MAX + 1` entries — indices `0..=u16::MAX`).
     #[cold]
     #[inline(never)]
     fn constant_pool_full(&self) -> CompileError {
         CompileError::new(
-            format!("function has too many constants; maximum is {} per function", u16::MAX),
+            format!(
+                "function has too many constants; maximum is {} per function",
+                usize::from(u16::MAX) + 1,
+            ),
             self.current_location.unwrap_or_default(),
         )
     }
@@ -671,14 +685,30 @@ impl CodeBuilder {
     /// position doesn't fit in the `u32` field of `LocationEntry`. Practically
     /// unreachable because the `i16` jump-offset cap kicks in at ~32 KB of
     /// bytecode, but kept defensive in case future opcodes loosen that limit.
+    /// The count is `u32::MAX + 1` because the check happens on the pre-push
+    /// length and the next byte makes it that many bytes total.
     #[cold]
     #[inline(never)]
     fn bytecode_too_large(&self) -> CompileError {
         CompileError::new(
-            format!("function bytecode too large; maximum is {} bytes", u32::MAX),
+            format!(
+                "function bytecode too large; maximum is {} bytes",
+                u64::from(u32::MAX) + 1,
+            ),
             self.current_location.unwrap_or_default(),
         )
     }
+}
+
+/// Builds the `CompileError` for a jump offset that doesn't fit in `i16`,
+/// anchored to an explicit source position rather than the builder's current
+/// location. Used by `patch_jump` so a forward-jump overflow is reported at
+/// the original `emit_jump` site (captured in `JumpLabelInner::source_position`)
+/// rather than the unrelated statement where the patch happens to resolve.
+#[cold]
+#[inline(never)]
+fn jump_too_large_at(position: CodeRange) -> CompileError {
+    CompileError::new("function too large: jump offset exceeds i16 range", position)
 }
 
 /// Label for a forward jump that needs patching.
@@ -699,6 +729,12 @@ struct JumpLabelInner {
     /// to enforce the invariant that all paths arriving at a given bytecode
     /// position have the same stack depth.
     stack_depth: u16,
+    /// Source location of the jump itself (the statement that emitted it),
+    /// captured at `emit_jump` time. Used by `patch_jump` so an offset
+    /// overflow anchors the diagnostic at the jump site rather than at the
+    /// patch site, which is usually a different (and less informative)
+    /// statement.
+    source_position: CodeRange,
 }
 
 /// A position in the bytecode stream.

--- a/crates/monty/src/bytecode/builder.rs
+++ b/crates/monty/src/bytecode/builder.rs
@@ -7,6 +7,7 @@ use std::collections::HashSet;
 
 use super::{
     code::{Code, ConstPool, ExceptionEntry, LocationEntry},
+    compiler::CompileError,
     op::{Opcode, Operand},
 };
 use crate::{intern::StringId, parse::CodeRange, value::Value};
@@ -95,44 +96,50 @@ impl CodeBuilder {
     }
 
     /// Emits a no-operand instruction and updates stack depth tracking.
-    pub fn emit(&mut self, op: Opcode) {
-        self.emit_with_operand(op, Operand::None);
+    pub fn emit(&mut self, op: Opcode) -> Result<(), CompileError> {
+        self.emit_with_operand(op, Operand::None)
     }
 
     /// Emits an instruction with a u8 operand and updates stack depth tracking.
-    pub fn emit_u8(&mut self, op: Opcode, operand: u8) {
-        self.emit_with_operand(op, Operand::U8(operand));
+    pub fn emit_u8(&mut self, op: Opcode, operand: u8) -> Result<(), CompileError> {
+        self.emit_with_operand(op, Operand::U8(operand))
     }
 
     /// Emits an instruction with an i8 operand and updates stack depth tracking.
-    pub fn emit_i8(&mut self, op: Opcode, operand: i8) {
-        self.emit_with_operand(op, Operand::I8(operand));
+    pub fn emit_i8(&mut self, op: Opcode, operand: i8) -> Result<(), CompileError> {
+        self.emit_with_operand(op, Operand::I8(operand))
     }
 
     /// Emits an instruction with two u8 operands and updates stack depth tracking.
     ///
     /// Used for UnpackEx: before_count (u8) + after_count (u8)
-    pub fn emit_u8_u8(&mut self, op: Opcode, operand1: u8, operand2: u8) {
-        self.emit_with_operand(op, Operand::U8U8(operand1, operand2));
+    pub fn emit_u8_u8(&mut self, op: Opcode, operand1: u8, operand2: u8) -> Result<(), CompileError> {
+        self.emit_with_operand(op, Operand::U8U8(operand1, operand2))
     }
 
     /// Emits an instruction with a u16 operand (little-endian) and updates stack depth tracking.
-    pub fn emit_u16(&mut self, op: Opcode, operand: u16) {
-        self.emit_with_operand(op, Operand::U16(operand));
+    pub fn emit_u16(&mut self, op: Opcode, operand: u16) -> Result<(), CompileError> {
+        self.emit_with_operand(op, Operand::U16(operand))
     }
 
     /// Emits an instruction with a u16 operand followed by a u8 operand.
     ///
     /// Used for `MakeFunction`, `CallAttr`, `CallAttrExtended`.
-    pub fn emit_u16_u8(&mut self, op: Opcode, operand1: u16, operand2: u8) {
-        self.emit_with_operand(op, Operand::U16U8(operand1, operand2));
+    pub fn emit_u16_u8(&mut self, op: Opcode, operand1: u16, operand2: u8) -> Result<(), CompileError> {
+        self.emit_with_operand(op, Operand::U16U8(operand1, operand2))
     }
 
     /// Emits an instruction with a u16 operand followed by two u8 operands.
     ///
     /// Used for MakeClosure: func_id (u16) + defaults_count (u8) + cell_count (u8)
-    pub fn emit_u16_u8_u8(&mut self, op: Opcode, operand1: u16, operand2: u8, operand3: u8) {
-        self.emit_with_operand(op, Operand::U16U8U8(operand1, operand2, operand3));
+    pub fn emit_u16_u8_u8(
+        &mut self,
+        op: Opcode,
+        operand1: u16,
+        operand2: u8,
+        operand3: u8,
+    ) -> Result<(), CompileError> {
+        self.emit_with_operand(op, Operand::U16U8U8(operand1, operand2, operand3))
     }
 
     /// Emits `CallBuiltinFunction` instruction.
@@ -141,8 +148,8 @@ impl CodeBuilder {
     ///
     /// The builtin_id is the `#[repr(u8)]` discriminant of `BuiltinsFunctions`.
     /// This is an optimization that avoids constant pool lookup and stack manipulation.
-    pub fn emit_call_builtin_function(&mut self, builtin_id: u8, arg_count: u8) {
-        self.emit_with_operand(Opcode::CallBuiltinFunction, Operand::U8U8(builtin_id, arg_count));
+    pub fn emit_call_builtin_function(&mut self, builtin_id: u8, arg_count: u8) -> Result<(), CompileError> {
+        self.emit_with_operand(Opcode::CallBuiltinFunction, Operand::U8U8(builtin_id, arg_count))
     }
 
     /// Emits `CallBuiltinType` instruction.
@@ -151,8 +158,8 @@ impl CodeBuilder {
     ///
     /// The type_id is the `#[repr(u8)]` discriminant of `BuiltinsTypes`.
     /// This is an optimization for type constructors like `list()`, `int()`, `str()`.
-    pub fn emit_call_builtin_type(&mut self, type_id: u8, arg_count: u8) {
-        self.emit_with_operand(Opcode::CallBuiltinType, Operand::U8U8(type_id, arg_count));
+    pub fn emit_call_builtin_type(&mut self, type_id: u8, arg_count: u8) -> Result<(), CompileError> {
+        self.emit_with_operand(Opcode::CallBuiltinType, Operand::U8U8(type_id, arg_count))
     }
 
     /// Emits CallFunctionKw with inline keyword names.
@@ -161,8 +168,8 @@ impl CodeBuilder {
     ///
     /// The kwname_ids slice contains StringId indices for each keyword argument
     /// name, in order matching how the values were pushed to the stack.
-    pub fn emit_call_function_kw(&mut self, pos_count: u8, kwname_ids: &[u16]) {
-        self.emit_with_operand(Opcode::CallFunctionKw, Operand::CallKw { pos_count, kwname_ids });
+    pub fn emit_call_function_kw(&mut self, pos_count: u8, kwname_ids: &[u16]) -> Result<(), CompileError> {
+        self.emit_with_operand(Opcode::CallFunctionKw, Operand::CallKw { pos_count, kwname_ids })
     }
 
     /// Emits CallAttrKw with inline keyword names.
@@ -171,7 +178,12 @@ impl CodeBuilder {
     ///
     /// The kwname_ids slice contains StringId indices for each keyword argument
     /// name, in order matching how the values were pushed to the stack.
-    pub fn emit_call_attr_kw(&mut self, attr_name_id: u16, pos_count: u8, kwname_ids: &[u16]) {
+    pub fn emit_call_attr_kw(
+        &mut self,
+        attr_name_id: u16,
+        pos_count: u8,
+        kwname_ids: &[u16],
+    ) -> Result<(), CompileError> {
         self.emit_with_operand(
             Opcode::CallAttrKw,
             Operand::CallAttrKw {
@@ -179,7 +191,7 @@ impl CodeBuilder {
                 pos_count,
                 kwname_ids,
             },
-        );
+        )
     }
 
     /// Emits a forward jump instruction, returning a label to patch later.
@@ -187,49 +199,51 @@ impl CodeBuilder {
     /// After `Jump` the tracker transitions to dead (it's unconditional).
     /// All other jumps continue to fall through.
     ///
+    /// Returns a `CompileError` if the jump-taken target depth doesn't fit
+    /// in `u16`, mirroring the same overflow case `adjust_stack` detects.
+    ///
     /// # Panics
     ///
-    /// - Panics if the jump-taken target depth (current depth + `op.jump_taken_stack_effect()`)
-    ///   exceeds u16 range, which indicates a compiler bug in stack effect annotations or an
-    ///   unreasonably large function.
-    /// - Panics on non-jump opcodes.
-    #[must_use]
-    pub fn emit_jump(&mut self, op: Opcode) -> JumpLabel {
+    /// Panics on non-jump opcodes (`op.jump_taken_stack_effect()` is the
+    /// shared invariant check).
+    pub fn emit_jump(&mut self, op: Opcode) -> Result<JumpLabel, CompileError> {
         let Some(pre_depth) = self.current_stack_depth else {
-            return JumpLabel { inner: None };
+            // Dead code, emit dummy jump label
+            return Ok(JumpLabel { inner: None });
         };
         // Capture the opcode position (where patch_jump will overwrite the i16)
         // before `emit_with_operand` pushes the bytes.
         let offset = self.current_offset();
         // Jump-taken target depth. `jump_taken_delta` panics for non-jumps.
         let target_depth = u16::try_from(i32::from(pre_depth) + i32::from(op.jump_taken_stack_effect()))
-            .expect("jump target depth out of u16 range");
+            .map_err(|_| self.stack_too_large())?;
         // Emit jump with dummy offset; patch_jump is required to fill in the real offset later.
-        self.emit_with_operand(op, Operand::Offset(RelativeOffset(0)));
-        JumpLabel {
+        self.emit_with_operand(op, Operand::Offset(RelativeOffset(0)))?;
+        Ok(JumpLabel {
             inner: Some(JumpLabelInner {
                 offset,
                 stack_depth: target_depth,
             }),
-        }
+        })
     }
 
     /// Patches a forward jump to point to the current bytecode location.
     ///
     /// State transitions: if the builder is emitting dead code, `patch_jump`
-    /// re-establishes the live depth from `label.target_depth`.
+    /// re-establishes the live depth from `label.stack_depth`.
+    ///
+    /// Returns a `CompileError` if the resolved jump offset doesn't fit in
+    /// `i16`, which means the function is too large for our bytecode encoding.
     ///
     /// # Panics
     ///
-    /// - In debug builds, panics if the jump label has a different stack depth
-    ///   compared to the current depth (if live).
-    /// - Always panics if the jump offset exceeds i16 range (-32768..32767),
-    ///   which indicates the function is too large. This is a compile-time
-    ///   error rather than silent truncation.
-    pub fn patch_jump(&mut self, label: JumpLabel) {
+    /// In debug builds, panics if the jump label has a different stack depth
+    /// compared to the current depth (if live) — this indicates a compiler bug
+    /// in stack-effect tracking rather than a user-input-driven overflow.
+    pub fn patch_jump(&mut self, label: JumpLabel) -> Result<(), CompileError> {
         let Some(label) = label.inner else {
             // emit_jump was dead code, nothing to do
-            return;
+            return Ok(());
         };
 
         let stack_depth = self.current_stack_depth.unwrap_or_else(|| {
@@ -242,15 +256,21 @@ impl CodeBuilder {
             stack_depth,
         };
 
-        let offset = calculate_jump_offset(label, target).as_i16();
+        let offset = calculate_jump_offset(label, target)
+            .ok_or_else(|| self.jump_too_large())?
+            .as_i16();
         let bytes = offset.to_le_bytes();
         self.bytecode[label.offset.0 + 1] = bytes[0];
         self.bytecode[label.offset.0 + 2] = bytes[1];
+        Ok(())
     }
 
     /// Emits a backward jump to a known target. Any jump opcode is accepted;
     /// `Opcode::jump_taken_delta` is the shared source of truth for the
     /// jump-taken stack effect (and panics for non-jump opcodes).
+    ///
+    /// Returns a `CompileError` if the jump offset doesn't fit in `i16`,
+    /// which means the function is too large for our bytecode encoding.
     ///
     /// # Panics
     /// - Panics if the jump target was emitted in dead code, and the current
@@ -258,24 +278,25 @@ impl CodeBuilder {
     /// - In debug builds, panics if the current stack depth plus the jump's stack
     ///   effect do not match the jump target stack depth.
     /// - Panics on non-jump opcodes.
-    pub fn emit_jump_to(&mut self, op: Opcode, target: JumpTarget) {
+    pub fn emit_jump_to(&mut self, op: Opcode, target: JumpTarget) -> Result<(), CompileError> {
         let Some(target_depth) = self.current_stack_depth else {
             // Emitting dead code, do no work
-            return;
+            return Ok(());
         };
 
         let label = JumpLabelInner {
             offset: self.current_offset(),
             stack_depth: target_depth
                 .checked_add_signed(op.jump_taken_stack_effect())
-                .expect("stack overflow"),
+                .ok_or_else(|| self.stack_too_large())?,
         };
         let Some(target) = target.0 else {
             // Target is dead code
             unreachable!("emit_jump_to: cannot jump from live code to dead code");
         };
 
-        self.emit_with_operand(op, Operand::Offset(calculate_jump_offset(label, target)));
+        let offset = calculate_jump_offset(label, target).ok_or_else(|| self.jump_too_large())?;
+        self.emit_with_operand(op, Operand::Offset(offset))
     }
 
     /// Returns the current bytecode position as an opaque `Offset`.
@@ -328,7 +349,7 @@ impl CodeBuilder {
     }
 
     /// Emits a `LoadLocal` instruction, using specialized variants for common slots.
-    pub fn emit_load_local(&mut self, slot: u16) {
+    pub fn emit_load_local(&mut self, slot: u16) -> Result<(), CompileError> {
         match slot {
             0 => self.emit(Opcode::LoadLocal0),
             1 => self.emit(Opcode::LoadLocal1),
@@ -336,9 +357,9 @@ impl CodeBuilder {
             3 => self.emit(Opcode::LoadLocal3),
             _ => {
                 if let Ok(s) = u8::try_from(slot) {
-                    self.emit_u8(Opcode::LoadLocal, s);
+                    self.emit_u8(Opcode::LoadLocal, s)
                 } else {
-                    self.emit_u16(Opcode::LoadLocalW, slot);
+                    self.emit_u16(Opcode::LoadLocalW, slot)
                 }
             }
         }
@@ -350,12 +371,12 @@ impl CodeBuilder {
     /// external function calls are rare enough that the optimization isn't worth
     /// the extra opcode slots. The `name_id` is encoded directly in the operand
     /// to avoid needing to look up the name from the code's local_names array.
-    pub fn emit_load_local_callable(&mut self, slot: u16, name_id: StringId) {
-        let name_id_u16 = u16::try_from(name_id.index()).expect("name_id exceeds u16");
+    pub fn emit_load_local_callable(&mut self, slot: u16, name_id: StringId) -> Result<(), CompileError> {
+        let name_id_u16 = u16::try_from(name_id.index()).map_err(|_| self.name_id_too_large())?;
         if let Ok(s) = u8::try_from(slot) {
-            self.emit_with_operand(Opcode::LoadLocalCallable, Operand::U8U16(s, name_id_u16));
+            self.emit_with_operand(Opcode::LoadLocalCallable, Operand::U8U16(s, name_id_u16))
         } else {
-            self.emit_with_operand(Opcode::LoadLocalCallableW, Operand::U16U16(slot, name_id_u16));
+            self.emit_with_operand(Opcode::LoadLocalCallableW, Operand::U16U16(slot, name_id_u16))
         }
     }
 
@@ -364,39 +385,52 @@ impl CodeBuilder {
     /// The `name_id` is encoded directly in the operand to avoid the ambiguity
     /// of looking up global names from a function's local_names array (global slots
     /// and local slots use different namespaces).
-    pub fn emit_load_global_callable(&mut self, slot: u16, name_id: StringId) {
-        let name_id_u16 = u16::try_from(name_id.index()).expect("name_id exceeds u16");
-        self.emit_with_operand(Opcode::LoadGlobalCallable, Operand::U16U16(slot, name_id_u16));
+    pub fn emit_load_global_callable(&mut self, slot: u16, name_id: StringId) -> Result<(), CompileError> {
+        let name_id_u16 = u16::try_from(name_id.index()).map_err(|_| self.name_id_too_large())?;
+        self.emit_with_operand(Opcode::LoadGlobalCallable, Operand::U16U16(slot, name_id_u16))
     }
 
     /// Emits `StoreLocal`, using wide variant for slots > 255.
-    pub fn emit_store_local(&mut self, slot: u16) {
+    pub fn emit_store_local(&mut self, slot: u16) -> Result<(), CompileError> {
         if let Ok(s) = u8::try_from(slot) {
-            self.emit_u8(Opcode::StoreLocal, s);
+            self.emit_u8(Opcode::StoreLocal, s)
         } else {
-            self.emit_u16(Opcode::StoreLocalW, slot);
+            self.emit_u16(Opcode::StoreLocalW, slot)
         }
     }
 
     /// Adds a constant to the pool, returning its index.
     ///
-    /// # Panics
-    ///
-    /// Panics if the constant pool exceeds 65535 entries. This is a compile-time
-    /// error indicating the function has too many constants.
-    #[must_use]
-    pub fn add_const(&mut self, value: Value) -> u16 {
-        let idx = self.constants.len();
-        let idx_u16 = u16::try_from(idx).expect("constant pool exceeds u16 range (65535); too many constants");
+    /// Returns a `CompileError` if the constant pool would exceed `u16::MAX`
+    /// entries — `LoadConst` and related opcodes encode the index in `u16`,
+    /// so any function with more than `65 536` distinct constants exceeds the
+    /// bytecode format.
+    pub fn add_const(&mut self, value: Value) -> Result<u16, CompileError> {
+        let idx_u16 = u16::try_from(self.constants.len()).map_err(|_| self.constant_pool_full())?;
         self.constants.push(value);
-        idx_u16
+        Ok(idx_u16)
     }
 
-    /// Adds an exception handler entry.
+    /// Adds an exception handler entry built from the given region bounds.
     ///
     /// Entries should be added in innermost-first order for nested try blocks.
-    pub fn add_exception_entry(&mut self, entry: ExceptionEntry) {
+    /// Returns a `CompileError` if any of the offsets exceeds the `u32` cap
+    /// in `ExceptionEntry` — practically unreachable given the i16 jump
+    /// limit, but kept honest for the same reason as `bytecode_too_large`.
+    pub fn add_exception_entry(
+        &mut self,
+        start: Offset,
+        end: Offset,
+        handler: Offset,
+        stack_depth: u16,
+        exception_stack_count: u16,
+    ) -> Result<(), CompileError> {
+        let start = start.as_u32().ok_or_else(|| self.bytecode_too_large())?;
+        let end = end.as_u32().ok_or_else(|| self.bytecode_too_large())?;
+        let handler = handler.as_u32().ok_or_else(|| self.bytecode_too_large())?;
+        let entry = ExceptionEntry::new(start, end, handler, stack_depth, exception_stack_count);
         self.exception_table.push(entry);
+        Ok(())
     }
 
     /// Returns the current stack depth, or `None` if not currently emitting a code region.
@@ -437,12 +471,18 @@ impl CodeBuilder {
     }
 
     /// Records the current location in the location table if set.
-    fn record_location(&mut self) {
+    ///
+    /// Returns a `CompileError` if the bytecode offset has grown past
+    /// `u32::MAX` — the i16 jump-offset cap means this is practically
+    /// unreachable, but `LocationEntry`'s offset is `u32` so we surface the
+    /// limit cleanly rather than panic.
+    fn record_location(&mut self) -> Result<(), CompileError> {
         if let Some(range) = self.current_location {
-            let offset = u32::try_from(self.bytecode.len()).expect("bytecode length exceeds u32");
+            let offset = u32::try_from(self.bytecode.len()).map_err(|_| self.bytecode_too_large())?;
             self.location_table
                 .push(LocationEntry::new(offset, range, self.current_focus));
         }
+        Ok(())
     }
 
     /// Opens a new code region at the given stack depth.
@@ -472,17 +512,17 @@ impl CodeBuilder {
     /// Positive values indicate pushes, negative values indicate pops.
     /// In the dead-code state this is a no-op: dead code can be emitted
     /// freely.
-    fn adjust_stack(&mut self, delta: i16) {
+    fn adjust_stack(&mut self, delta: i16) -> Result<(), CompileError> {
         let Some(depth) = self.current_stack_depth else {
-            return;
+            return Ok(());
         };
         let new_depth = i32::from(depth) + i32::from(delta);
         // Stack depth shouldn't go negative (indicates compiler bug)
         debug_assert!(new_depth >= 0, "Stack depth went negative: {new_depth}");
-        // Safe cast: new_depth is non-negative and stack won't exceed u16::MAX in practice
-        let new_depth = u16::try_from(new_depth.max(0)).unwrap_or(u16::MAX);
+        let new_depth = u16::try_from(new_depth.max(0)).map_err(|_| self.stack_too_large())?;
         self.current_stack_depth = Some(new_depth);
         self.max_stack_depth = self.max_stack_depth.max(new_depth);
+        Ok(())
     }
 
     /// Single-source-of-truth emit path for all bytecode emission: records
@@ -499,11 +539,11 @@ impl CodeBuilder {
     /// `emit_jump` and `emit_jump_to` route their byte emission through here;
     /// `emit_jump` additionally captures the pre-emit offset and computes the
     /// jump-taken target depth for the returned `JumpLabel`.
-    fn emit_with_operand(&mut self, op: Opcode, operand: Operand<'_>) {
+    fn emit_with_operand(&mut self, op: Opcode, operand: Operand<'_>) -> Result<(), CompileError> {
         if self.is_dead() {
-            return;
+            return Ok(());
         }
-        self.record_location();
+        self.record_location()?;
         self.bytecode.push(op as u8);
         match operand {
             Operand::None => {}
@@ -533,9 +573,9 @@ impl CodeBuilder {
                 self.bytecode.push(b2);
             }
             Operand::CallKw { pos_count, kwname_ids } => {
+                let kw_count = u8::try_from(kwname_ids.len()).map_err(|_| self.kw_count_too_large())?;
                 self.bytecode.push(pos_count);
-                self.bytecode
-                    .push(u8::try_from(kwname_ids.len()).expect("keyword count exceeds u8"));
+                self.bytecode.push(kw_count);
                 for &name_id in kwname_ids {
                     self.bytecode.extend(name_id.to_le_bytes());
                 }
@@ -545,22 +585,99 @@ impl CodeBuilder {
                 pos_count,
                 kwname_ids,
             } => {
+                let kw_count = u8::try_from(kwname_ids.len()).map_err(|_| self.kw_count_too_large())?;
                 self.bytecode.extend(attr_name_id.to_le_bytes());
                 self.bytecode.push(pos_count);
-                self.bytecode
-                    .push(u8::try_from(kwname_ids.len()).expect("keyword count exceeds u8"));
+                self.bytecode.push(kw_count);
                 for &name_id in kwname_ids {
                     self.bytecode.extend(name_id.to_le_bytes());
                 }
             }
         }
-        self.adjust_stack(op.stack_effect(operand));
+        self.adjust_stack(op.stack_effect(operand))?;
         if matches!(
             op,
             Opcode::ReturnValue | Opcode::Raise | Opcode::Reraise | Opcode::RaiseImportError | Opcode::Jump
         ) {
             self.current_stack_depth = None;
         }
+
+        Ok(())
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn jump_too_large(&self) -> CompileError {
+        CompileError::new(
+            "function too large: jump offset exceeds i16 range",
+            self.current_location.unwrap_or_default(),
+        )
+    }
+
+    /// Builds the `CompileError` for a `StringId` that doesn't fit in the
+    /// `u16` operand of a name-bearing opcode. Used by emit helpers that
+    /// inline the name id directly (e.g. `LoadLocalCallable`).
+    #[cold]
+    #[inline(never)]
+    fn name_id_too_large(&self) -> CompileError {
+        CompileError::new(
+            format!(
+                "module has too many distinct names; the bytecode format supports up to {}",
+                u16::MAX
+            ),
+            self.current_location.unwrap_or_default(),
+        )
+    }
+
+    /// Builds the `CompileError` for a `CallFunctionKw`/`CallAttrKw` keyword
+    /// count that doesn't fit in `u8`. Anchored to the builder's current
+    /// location (the call expression).
+    #[cold]
+    #[inline(never)]
+    fn kw_count_too_large(&self) -> CompileError {
+        CompileError::new(
+            format!("call has too many keyword arguments; maximum is {} per call", u8::MAX),
+            self.current_location.unwrap_or_default(),
+        )
+    }
+
+    /// Builds the `CompileError` for a `add_const` that would overflow the
+    /// per-`Code` constant pool's `u16` index. One function/module body can
+    /// hold at most `u16::MAX + 1` distinct constants.
+    #[cold]
+    #[inline(never)]
+    fn constant_pool_full(&self) -> CompileError {
+        CompileError::new(
+            format!("function has too many constants; maximum is {} per function", u16::MAX),
+            self.current_location.unwrap_or_default(),
+        )
+    }
+
+    /// Builds the `CompileError` for an operand-stack depth or `emit_jump`
+    /// target depth that doesn't fit in `u16`. The same message is used by
+    /// `adjust_stack`, `emit_jump`, and `emit_jump_to` so the user sees one
+    /// consistent diagnostic for "too much stuff pushed" regardless of which
+    /// path detects it.
+    #[cold]
+    #[inline(never)]
+    fn stack_too_large(&self) -> CompileError {
+        CompileError::new(
+            "function too large: required stack exceeds u16::MAX",
+            self.current_location.unwrap_or_default(),
+        )
+    }
+
+    /// Builds the `CompileError` for a `record_location` whose bytecode
+    /// position doesn't fit in the `u32` field of `LocationEntry`. Practically
+    /// unreachable because the `i16` jump-offset cap kicks in at ~32 KB of
+    /// bytecode, but kept defensive in case future opcodes loosen that limit.
+    #[cold]
+    #[inline(never)]
+    fn bytecode_too_large(&self) -> CompileError {
+        CompileError::new(
+            format!("function bytecode too large; maximum is {} bytes", u32::MAX),
+            self.current_location.unwrap_or_default(),
+        )
     }
 }
 
@@ -597,13 +714,17 @@ pub struct Offset(usize);
 
 impl Offset {
     /// Returns the offset as a `u32` — the serialized form used by
-    /// `ExceptionEntry` and `LocationEntry`.
+    /// `ExceptionEntry` and `LocationEntry` — or `None` if the bytecode
+    /// position exceeds `u32::MAX`.
     ///
-    /// Panics if the bytecode position exceeds `u32::MAX`, which would mean
-    /// the compiled function is unreasonably large.
+    /// Reachable only with > 4 GB of generated bytecode in a single function,
+    /// which the `i16` jump-offset cap already prevents in practice. Returns
+    /// `Option` rather than panicking so the rare overflow surfaces through
+    /// the caller's `CompileError` path (see `CodeBuilder::bytecode_too_large`)
+    /// alongside the other limit failures.
     #[must_use]
-    pub fn as_u32(self) -> u32 {
-        u32::try_from(self.0).expect("bytecode offset exceeds u32")
+    pub fn as_u32(self) -> Option<u32> {
+        u32::try_from(self.0).ok()
     }
 }
 
@@ -623,8 +744,10 @@ impl RelativeOffset {
 
 /// Calculate the jump offset from a jump instruction at `from` to a target at `to`.
 ///
-/// Panics if the jump offset exceeds i16 range (-32768..32767), which indicates the function is too large to compile.
-fn calculate_jump_offset(from: JumpLabelInner, to: JumpTargetInner) -> RelativeOffset {
+/// Returns `None` if the offset doesn't fit in `i16` — the caller (always
+/// `&mut self` on the builder) converts that into a `CompileError` anchored
+/// to the current source location via `jump_too_large`.
+fn calculate_jump_offset(from: JumpLabelInner, to: JumpTargetInner) -> Option<RelativeOffset> {
     // All jumps are currently 3 byte instructions: opcode + i16 offset
     const JUMP_BYTECODE_SIZE: usize = size_of::<Opcode>() + size_of::<RelativeOffset>();
 
@@ -641,10 +764,7 @@ fn calculate_jump_offset(from: JumpLabelInner, to: JumpTargetInner) -> RelativeO
     );
 
     let raw_offset = to_i64 - from_i64;
-    RelativeOffset(
-        // FIXME: replace panic with a compile-time error for functions that are too large to compile?
-        i16::try_from(raw_offset).expect("jump offset exceeds i16 range (-32768..32767); function too large"),
-    )
+    i16::try_from(raw_offset).ok().map(RelativeOffset)
 }
 
 /// Target for a backward jump.
@@ -667,8 +787,8 @@ mod tests {
     fn test_emit_basic() {
         let mut builder = CodeBuilder::new();
         builder.new_code_region(0);
-        builder.emit(Opcode::LoadNone);
-        builder.emit(Opcode::Pop);
+        builder.emit(Opcode::LoadNone).unwrap();
+        builder.emit(Opcode::Pop).unwrap();
 
         let code = builder.build(0);
         assert_eq!(code.bytecode(), &[Opcode::LoadNone as u8, Opcode::Pop as u8]);
@@ -678,7 +798,7 @@ mod tests {
     fn test_emit_u8_operand() {
         let mut builder = CodeBuilder::new();
         builder.new_code_region(0);
-        builder.emit_u8(Opcode::LoadLocal, 42);
+        builder.emit_u8(Opcode::LoadLocal, 42).unwrap();
 
         let code = builder.build(0);
         assert_eq!(code.bytecode(), &[Opcode::LoadLocal as u8, 42]);
@@ -688,7 +808,7 @@ mod tests {
     fn test_emit_u16_operand() {
         let mut builder = CodeBuilder::new();
         builder.new_code_region(0);
-        builder.emit_u16(Opcode::LoadConst, 0x1234);
+        builder.emit_u16(Opcode::LoadConst, 0x1234).unwrap();
 
         let code = builder.build(0);
         assert_eq!(code.bytecode(), &[Opcode::LoadConst as u8, 0x34, 0x12]);
@@ -698,13 +818,13 @@ mod tests {
     fn test_forward_jump() {
         let mut builder = CodeBuilder::new();
         builder.new_code_region(0);
-        let jump = builder.emit_jump(Opcode::Jump);
+        let jump = builder.emit_jump(Opcode::Jump).unwrap();
         builder.new_code_region(0);
-        builder.emit(Opcode::LoadNone);
-        builder.emit(Opcode::Pop);
-        builder.patch_jump(jump);
-        builder.emit(Opcode::LoadNone); // Return value
-        builder.emit(Opcode::ReturnValue);
+        builder.emit(Opcode::LoadNone).unwrap();
+        builder.emit(Opcode::Pop).unwrap();
+        builder.patch_jump(jump).unwrap();
+        builder.emit(Opcode::LoadNone).unwrap(); // Return value
+        builder.emit(Opcode::ReturnValue).unwrap();
 
         let code = builder.build(0);
         assert_eq!(
@@ -726,9 +846,9 @@ mod tests {
         let mut builder = CodeBuilder::new();
         builder.new_code_region(0);
         let loop_start = builder.current_jump_target();
-        builder.emit(Opcode::LoadNone); // offset 0, 1 byte
-        builder.emit(Opcode::Pop); // offset 1, 1 byte
-        builder.emit_jump_to(Opcode::Jump, loop_start); // offset 2, target 0
+        builder.emit(Opcode::LoadNone).unwrap(); // offset 0, 1 byte
+        builder.emit(Opcode::Pop).unwrap(); // offset 1, 1 byte
+        builder.emit_jump_to(Opcode::Jump, loop_start).unwrap(); // offset 2, target 0
 
         let code = builder.build(0);
         // Jump at offset 2, target at offset 0
@@ -750,12 +870,12 @@ mod tests {
     fn test_load_local_specialization() {
         let mut builder = CodeBuilder::new();
         builder.new_code_region(0);
-        builder.emit_load_local(0);
-        builder.emit_load_local(1);
-        builder.emit_load_local(2);
-        builder.emit_load_local(3);
-        builder.emit_load_local(4);
-        builder.emit_load_local(256);
+        builder.emit_load_local(0).unwrap();
+        builder.emit_load_local(1).unwrap();
+        builder.emit_load_local(2).unwrap();
+        builder.emit_load_local(3).unwrap();
+        builder.emit_load_local(4).unwrap();
+        builder.emit_load_local(256).unwrap();
 
         let code = builder.build(0);
         assert_eq!(
@@ -778,8 +898,8 @@ mod tests {
     fn test_add_const() {
         let mut builder = CodeBuilder::new();
         builder.new_code_region(0);
-        let idx1 = builder.add_const(Value::Int(42));
-        let idx2 = builder.add_const(Value::None);
+        let idx1 = builder.add_const(Value::Int(42)).unwrap();
+        let idx2 = builder.add_const(Value::None).unwrap();
 
         assert_eq!(idx1, 0);
         assert_eq!(idx2, 1);

--- a/crates/monty/src/bytecode/code.rs
+++ b/crates/monty/src/bytecode/code.rs
@@ -6,7 +6,6 @@
 
 use std::collections::HashSet;
 
-use super::builder::Offset;
 use crate::{intern::StringId, parse::CodeRange, value::Value};
 
 /// Compiled bytecode for a function or module.
@@ -127,13 +126,15 @@ impl Code {
     /// Location entries are recorded at instruction boundaries. This method finds
     /// the most recent entry at or before the given offset.
     ///
-    /// Returns `None` if the location table is empty or the offset is before
-    /// the first recorded location.
+    /// Returns `None` if the location table is empty, the offset is before
+    /// the first recorded location, or the offset exceeds `u32::MAX` (an
+    /// invariant violation; we degrade gracefully rather than panic since
+    /// this is on the traceback hot path).
     #[must_use]
     pub fn location_for_offset(&self, offset: usize) -> Option<&LocationEntry> {
+        let offset_u32 = u32::try_from(offset).ok()?;
         // Location entries are in order by bytecode offset.
         // Find the last entry where bytecode_offset <= offset.
-        let offset_u32 = u32::try_from(offset).expect("bytecode offset exceeds u32");
         self.location_table
             .iter()
             .rev()
@@ -293,16 +294,12 @@ pub struct ExceptionEntry {
 
 impl ExceptionEntry {
     /// Creates a new exception table entry.
-    ///
-    /// Takes `Offset` values produced by `CodeBuilder::current_offset` so that
-    /// the bounds of try / handler / cleanup regions can't be confused with
-    /// arbitrary integers.
     #[must_use]
-    pub fn new(start: Offset, end: Offset, handler: Offset, stack_depth: u16, exception_stack_count: u16) -> Self {
+    pub fn new(start: u32, end: u32, handler: u32, stack_depth: u16, exception_stack_count: u16) -> Self {
         Self {
-            start: start.as_u32(),
-            end: end.as_u32(),
-            handler: handler.as_u32(),
+            start,
+            end,
+            handler,
             stack_depth,
             exception_stack_count,
         }

--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -12,7 +12,7 @@ use std::{borrow::Cow, mem};
 
 use super::{
     builder::{CodeBuilder, JumpLabel, JumpTarget},
-    code::{Code, ExceptionEntry},
+    code::Code,
     op::{FORMAT_VALUE_HAS_SPEC, FORMAT_VALUE_STATIC_SPEC, Opcode},
 };
 use crate::{
@@ -38,6 +38,162 @@ use crate::{
 /// use a u8 operand for the argument count, so max 255. Python itself has no
 /// such limit but we need one for our bytecode encoding.
 const MAX_CALL_ARGS: usize = 255;
+
+/// Maximum number of distinct names in a single namespace (module or function).
+///
+/// `LoadLocal`/`LoadGlobal`/`StoreLocal`/etc. encode the namespace slot in 16
+/// bits, so the slot index must fit in `u16`. CPython has no equivalent limit
+/// but this is intrinsic to our compact bytecode encoding — exceeding it
+/// surfaces to the user as a `SyntaxError`.
+const MAX_NAMESPACE_SIZE: usize = u16::MAX as usize;
+
+/// Maximum number of nested `for`/`if` clauses in a comprehension.
+///
+/// `ListAppend`/`SetAdd`/`DictSetItem` encode the comprehension depth in a
+/// `u8` so the runtime can pop the correct number of intermediate iterators
+/// when appending. 255 nested clauses is far past anything sensible Python
+/// can express, but a sufficiently large parser-generated payload could
+/// reach it.
+const MAX_COMP_GENERATORS: usize = 255;
+
+/// Maximum number of targets in a single tuple-unpacking pattern (e.g.
+/// `a, b, c = it` or the nested form `(a, b), c = it`).
+///
+/// `UnpackSequence` / `UnpackEx` encode the per-level target count in `u8`,
+/// so any individual unpacking level is capped at 255 targets (with
+/// `UnpackEx` splitting that count into before-star and after-star halves).
+const MAX_UNPACK_TARGETS: usize = 255;
+
+/// Converts a `usize` namespace size into the `u16` slot count expected by
+/// the bytecode, surfacing a `CompileError` if the limit is exceeded.
+///
+/// `kind` ("module", "function", or "lambda") is interpolated into the error
+/// message so the user can distinguish which scope hit the cap. The position
+/// is left as the default `CodeRange` because the relevant location is the
+/// whole compile unit — there is no single offending statement to highlight.
+fn check_namespace_size_u16(size: usize, kind: &'static str) -> Result<u16, CompileError> {
+    u16::try_from(size).map_err(|_| namespace_too_large(size, kind))
+}
+
+#[cold]
+#[inline(never)]
+fn namespace_too_large(size: usize, kind: &'static str) -> CompileError {
+    CompileError::new(
+        format!(
+            "{kind} uses too many distinct names ({size}); the bytecode format supports up to {MAX_NAMESPACE_SIZE}"
+        ),
+        CodeRange::default(),
+    )
+}
+
+/// Converts a comprehension's `for`/`if` clause count into the `u8` depth
+/// operand used by `ListAppend`/`SetAdd`/`DictSetItem`.
+///
+/// Anchored to the body expression's position because that's the comprehension's
+/// most stable location to point at in a traceback caret.
+fn check_comp_generators(count: usize, position: CodeRange) -> Result<u8, CompileError> {
+    u8::try_from(count).map_err(|_| too_many_comp_generators(count, position))
+}
+
+#[cold]
+#[inline(never)]
+fn too_many_comp_generators(count: usize, position: CodeRange) -> CompileError {
+    CompileError::new(
+        format!("comprehension has too many nested clauses ({count}); maximum is {MAX_COMP_GENERATORS}"),
+        position,
+    )
+}
+
+/// Converts a tuple-unpacking target count into the `u8` operand for
+/// `UnpackSequence` (or the before/after halves of `UnpackEx`).
+fn check_unpack_targets(count: usize, position: CodeRange) -> Result<u8, CompileError> {
+    u8::try_from(count).map_err(|_| too_many_unpack_targets(count, position))
+}
+
+#[cold]
+#[inline(never)]
+fn too_many_unpack_targets(count: usize, position: CodeRange) -> CompileError {
+    CompileError::new(
+        format!("too many targets in tuple unpacking ({count}); maximum is {MAX_UNPACK_TARGETS}"),
+        position,
+    )
+}
+
+/// Converts an in-memory collection length (list/tuple/dict/set literal element
+/// count, dict pair count) into the `u16` operand of `BuildList`/`BuildTuple`/
+/// `BuildDict`/`BuildSet`.
+fn check_collection_size_u16(count: usize, position: CodeRange) -> Result<u16, CompileError> {
+    u16::try_from(count).map_err(|_| collection_too_large(count, position))
+}
+
+#[cold]
+#[inline(never)]
+fn collection_too_large(count: usize, position: CodeRange) -> CompileError {
+    CompileError::new(
+        format!(
+            "collection literal has too many elements ({count}); maximum is {}",
+            u16::MAX
+        ),
+        position,
+    )
+}
+
+/// Converts the index of a newly-defined function into the `u16` operand used
+/// by `MakeFunction`/`MakeClosure`. The cap is the total number of
+/// `def`/`lambda`/comprehension function objects in the *whole module*, since
+/// `FunctionId`s are allocated linearly across nested scopes.
+fn check_function_count_u16(func_id: usize, position: CodeRange) -> Result<u16, CompileError> {
+    u16::try_from(func_id).map_err(|_| too_many_functions(func_id, position))
+}
+
+#[cold]
+#[inline(never)]
+fn too_many_functions(func_id: usize, position: CodeRange) -> CompileError {
+    CompileError::new(
+        format!(
+            "module defines too many functions/lambdas ({}); maximum is {}",
+            func_id + 1,
+            u16::MAX
+        ),
+        position,
+    )
+}
+
+/// Converts a `StringId` (intern pool index) into the `u16` operand used by
+/// every name-bearing opcode (`LoadAttr`, `StoreAttr`, `LoadGlobal`,
+/// `CallFunctionKw` keyword names, etc.). Called inline at every emission
+/// site — overflow only happens when the intern pool exceeded `u16::MAX`
+/// during parse/prepare, so the error construction is `#[cold]` and the
+/// success path inlines to a single `as u16`.
+fn check_name_index_u16(name_id: StringId, position: CodeRange) -> Result<u16, CompileError> {
+    u16::try_from(name_id.index()).map_err(|_| name_index_too_large(position))
+}
+
+#[cold]
+#[inline(never)]
+fn name_index_too_large(position: CodeRange) -> CompileError {
+    CompileError::new(
+        format!(
+            "module has too many distinct names; the bytecode format supports up to {} interned strings",
+            u16::MAX
+        ),
+        position,
+    )
+}
+
+/// Converts a call-related count (positional args, keyword args, defaults,
+/// closure cells) into the `u8` operand used by the corresponding opcodes.
+/// `kind` (e.g. "default parameter values") is interpolated into the error
+/// message so the diagnostic identifies which kind of count overflowed.
+fn check_call_args_u8(count: usize, kind: &'static str, position: CodeRange) -> Result<u8, CompileError> {
+    u8::try_from(count).map_err(|_| too_many_call_args(count, kind, position))
+}
+
+#[cold]
+#[inline(never)]
+fn too_many_call_args(count: usize, kind: &'static str, position: CodeRange) -> CompileError {
+    CompileError::new(format!("more than {MAX_CALL_ARGS} {kind} ({count})"), position)
+}
 
 /// Compiles prepared AST nodes to bytecode.
 ///
@@ -82,7 +238,7 @@ pub struct Compiler<'a> {
     /// target. The exception *value* is already off the operand stack — it's
     /// consumed eagerly at handler entry (stored to the `as` binding or
     /// popped) — so no operand-stack Pop is needed here.
-    except_handler_depth: usize,
+    except_handler_depth: u16,
 
     /// Whether the compiler is currently compiling module-level code.
     ///
@@ -149,7 +305,7 @@ struct FinallyTarget {
     /// finally body might reference them); cleanup of handlers between
     /// here and the next-outer finally is the responsibility of this
     /// finally's emit_return_routing trailer.
-    except_handler_depth_at_entry: usize,
+    except_handler_depth_at_entry: u16,
 }
 
 /// Result of module compilation: the module code and all compiled functions.
@@ -184,9 +340,9 @@ impl<'a> Compiler<'a> {
     pub fn compile_module(
         nodes: &[PreparedNode],
         interns: &Interns,
-        num_locals: u16,
+        namespace_size: usize,
     ) -> Result<CompileResult, CompileError> {
-        Self::compile_module_with_functions(nodes, interns, num_locals, Vec::new())
+        Self::compile_module_with_functions(nodes, interns, namespace_size, Vec::new())
     }
 
     /// Compiles module-level code while preserving an existing function table prefix.
@@ -197,17 +353,18 @@ impl<'a> Compiler<'a> {
     pub fn compile_module_with_functions(
         nodes: &[PreparedNode],
         interns: &Interns,
-        num_locals: u16,
+        namespace_size: usize,
         existing_functions: Vec<Function>,
     ) -> Result<CompileResult, CompileError> {
+        let num_locals = check_namespace_size_u16(namespace_size, "module")?;
         let mut compiler = Compiler::new(interns, Vec::new());
         compiler.functions = existing_functions;
         compiler.is_module_scope = true;
         compiler.compile_block(nodes)?;
 
         // Module returns None if no explicit return
-        compiler.code.emit(Opcode::LoadNone);
-        compiler.code.emit(Opcode::ReturnValue);
+        compiler.code.emit(Opcode::LoadNone)?;
+        compiler.code.emit(Opcode::ReturnValue)?;
 
         Ok(CompileResult {
             code: compiler.code.build(num_locals),
@@ -233,8 +390,8 @@ impl<'a> Compiler<'a> {
         compiler.compile_block(body)?;
 
         // Implicit return None if no explicit return
-        compiler.code.emit(Opcode::LoadNone);
-        compiler.code.emit(Opcode::ReturnValue);
+        compiler.code.emit(Opcode::LoadNone)?;
+        compiler.code.emit(Opcode::ReturnValue)?;
 
         Ok((compiler.code.build(num_locals), compiler.functions))
     }
@@ -261,14 +418,14 @@ impl<'a> Compiler<'a> {
         match node {
             Node::Expr(expr) => {
                 self.compile_expr(expr)?;
-                self.code.emit(Opcode::Pop); // Discard result
+                self.code.emit(Opcode::Pop)?; // Discard result
             }
             Node::Return(expr) => {
                 self.compile_return(expr.as_ref())?;
             }
             Node::Assign { target, object } => {
                 self.compile_expr(object)?;
-                self.compile_store(target);
+                self.compile_store(target)?;
             }
             Node::UnpackAssign {
                 targets,
@@ -276,7 +433,7 @@ impl<'a> Compiler<'a> {
                 object,
             } => {
                 self.compile_expr(object)?;
-                self.emit_unpack_store(targets, *targets_position);
+                self.emit_unpack_store(targets, *targets_position)?;
             }
             Node::OpAssign { target, op, value } => {
                 let Some(opcode) = operator_to_inplace_opcode(op) else {
@@ -285,10 +442,10 @@ impl<'a> Compiler<'a> {
                         target.position,
                     ));
                 };
-                self.compile_name(target);
+                self.compile_name(target)?;
                 self.compile_expr(value)?;
-                self.code.emit(opcode);
-                self.compile_store(target);
+                self.code.emit(opcode)?;
+                self.compile_store(target)?;
             }
             Node::SubscriptOpAssign {
                 target,
@@ -305,14 +462,14 @@ impl<'a> Compiler<'a> {
                 };
                 self.compile_expr(target)?;
                 self.compile_expr(index)?;
-                self.code.emit(Opcode::Dup2);
+                self.code.emit(Opcode::Dup2)?;
                 self.code.set_location(*target_position, None);
-                self.code.emit(Opcode::BinarySubscr);
+                self.code.emit(Opcode::BinarySubscr)?;
                 self.compile_expr(value)?;
-                self.code.emit(opcode);
-                self.code.emit(Opcode::Rot3);
+                self.code.emit(opcode)?;
+                self.code.emit(Opcode::Rot3)?;
                 self.code.set_location(*target_position, None);
-                self.code.emit(Opcode::StoreSubscr);
+                self.code.emit(Opcode::StoreSubscr)?;
             }
             Node::SubscriptAssign {
                 target,
@@ -337,17 +494,17 @@ impl<'a> Compiler<'a> {
                     ));
                 };
                 let name_id = attr.string_id().expect("LoadAttr requires interned attr name");
-                let name_idx = u16::try_from(name_id.index()).expect("name index exceeds u16");
+                let name_idx = check_name_index_u16(name_id, *target_position)?;
                 // Stack: compile object, dup for later store, load attr, apply op, rotate, store
                 self.compile_expr(object)?; // [obj]
-                self.code.emit(Opcode::Dup); // [obj, obj]
+                self.code.emit(Opcode::Dup)?; // [obj, obj]
                 self.code.set_location(*target_position, None);
-                self.code.emit_u16(Opcode::LoadAttr, name_idx); // [obj, attr_val]
+                self.code.emit_u16(Opcode::LoadAttr, name_idx)?; // [obj, attr_val]
                 self.compile_expr(value)?; // [obj, attr_val, rhs]
-                self.code.emit(opcode); // [obj, result]
-                self.code.emit(Opcode::Rot2); // [result, obj]
+                self.code.emit(opcode)?; // [obj, result]
+                self.code.emit(Opcode::Rot2)?; // [result, obj]
                 self.code.set_location(*target_position, None);
-                self.code.emit_u16(Opcode::StoreAttr, name_idx); // []
+                self.code.emit_u16(Opcode::StoreAttr, name_idx)?; // []
             }
             Node::AttrAssign {
                 object,
@@ -374,12 +531,12 @@ impl<'a> Compiler<'a> {
                 self.compile_expr(object)?;
                 if let Some((last, rest)) = targets.split_last() {
                     for target in rest {
-                        self.code.emit(Opcode::Dup);
+                        self.code.emit(Opcode::Dup)?;
                         self.compile_assign_target(target)?;
                     }
                     self.compile_assign_target(last)?;
                 } else {
-                    self.code.emit(Opcode::Pop);
+                    self.code.emit(Opcode::Pop)?;
                 }
             }
             Node::If { test, body, or_else } => self.compile_if(test, body, or_else)?,
@@ -394,23 +551,23 @@ impl<'a> Compiler<'a> {
             Node::Raise(expr) => {
                 if let Some(exc) = expr {
                     self.compile_expr(exc)?;
-                    self.code.emit(Opcode::Raise);
+                    self.code.emit(Opcode::Raise)?;
                 } else {
-                    self.code.emit(Opcode::Reraise);
+                    self.code.emit(Opcode::Reraise)?;
                 }
             }
             Node::FunctionDef(func_def) => self.compile_function_def(func_def)?,
             Node::Try(try_block) => self.compile_try(try_block)?,
             Node::Import { names } => {
                 for import_name in names {
-                    self.compile_import(import_name.module_name, &import_name.binding);
+                    self.compile_import(import_name.module_name, &import_name.binding)?;
                 }
             }
             Node::ImportFrom {
                 module_name,
                 names,
                 position,
-            } => self.compile_import_from(*module_name, names, *position),
+            } => self.compile_import_from(*module_name, names, *position)?,
             Node::Break { position } => self.compile_break(*position)?,
             Node::Continue { position } => self.compile_continue(*position)?,
             // These are handled during the prepare phase and produce no bytecode
@@ -429,24 +586,15 @@ impl<'a> Compiler<'a> {
     fn compile_function_def(&mut self, func_def: &PreparedFunctionDef) -> Result<(), CompileError> {
         let func_pos = func_def.name.position;
 
-        // Check bytecode operand limits
-        if func_def.default_exprs.len() > MAX_CALL_ARGS {
-            return Err(CompileError::new(
-                format!("more than {MAX_CALL_ARGS} default parameter values"),
-                func_pos,
-            ));
-        }
-        if func_def.free_var_enclosing_slots.len() > MAX_CALL_ARGS {
-            return Err(CompileError::new(
-                format!("more than {MAX_CALL_ARGS} closure variables"),
-                func_pos,
-            ));
-        }
+        // Bound the bytecode-operand counts before compiling — the `u8` casts
+        // below depend on these fitting in 255.
+        let defaults_count = check_call_args_u8(func_def.default_exprs.len(), "default parameter values", func_pos)?;
+        let cell_count = check_call_args_u8(func_def.free_var_enclosing_slots.len(), "closure variables", func_pos)?;
 
         // 1. Compile the function body recursively
         // Take ownership of functions for the recursive compile, then restore
         let functions = mem::take(&mut self.functions);
-        let namespace_size = u16::try_from(func_def.namespace_size).expect("function namespace size exceeds u16");
+        let namespace_size = check_namespace_size_u16(func_def.namespace_size, "function")?;
         let (body_code, mut functions) =
             Self::compile_function_body(&func_def.body, self.interns, functions, namespace_size)?;
 
@@ -472,30 +620,29 @@ impl<'a> Compiler<'a> {
         for default_expr in &func_def.default_exprs {
             self.compile_expr(default_expr)?;
         }
-        let defaults_count =
-            u8::try_from(func_def.default_exprs.len()).expect("function default argument count exceeds u8");
-        let func_id_u16 = u16::try_from(func_id).expect("function count exceeds u16");
+        let func_id_u16 = check_function_count_u16(func_id, func_pos)?;
 
         // 4. Emit MakeFunction or MakeClosure (if has free vars)
         if func_def.free_var_enclosing_slots.is_empty() {
             // MakeFunction: func_id (u16) + defaults_count (u8)
-            self.code.emit_u16_u8(Opcode::MakeFunction, func_id_u16, defaults_count);
+            self.code
+                .emit_u16_u8(Opcode::MakeFunction, func_id_u16, defaults_count)?;
         } else {
             // Push captured cells from enclosing scope
             for &slot in &func_def.free_var_enclosing_slots {
-                // Load the cell reference from the enclosing namespace
-                let slot_u16 = u16::try_from(slot.index()).expect("closure slot index exceeds u16");
-                self.code.emit_load_local(slot_u16);
+                // Load the cell reference from the enclosing namespace.
+                // `slot` is a `NamespaceId` bound by `check_namespace_size_u16`
+                // on the enclosing scope, so the conversion is an invariant
+                // rather than a user-input check (panic-on-failure is fine).
+                self.code.emit_load_local(slot.as_u16())?;
             }
-            let cell_count =
-                u8::try_from(func_def.free_var_enclosing_slots.len()).expect("closure cell count exceeds u8");
             // MakeClosure: func_id (u16) + defaults_count (u8) + cell_count (u8)
             self.code
-                .emit_u16_u8_u8(Opcode::MakeClosure, func_id_u16, defaults_count, cell_count);
+                .emit_u16_u8_u8(Opcode::MakeClosure, func_id_u16, defaults_count, cell_count)?;
         }
 
         // 5. Store the function object to its name slot
-        self.compile_store(&func_def.name);
+        self.compile_store(&func_def.name)?;
 
         Ok(())
     }
@@ -509,23 +656,14 @@ impl<'a> Compiler<'a> {
     fn compile_lambda(&mut self, func_def: &PreparedFunctionDef) -> Result<(), CompileError> {
         let func_pos = func_def.name.position;
 
-        // Check bytecode operand limits
-        if func_def.default_exprs.len() > MAX_CALL_ARGS {
-            return Err(CompileError::new(
-                format!("more than {MAX_CALL_ARGS} default parameter values"),
-                func_pos,
-            ));
-        }
-        if func_def.free_var_enclosing_slots.len() > MAX_CALL_ARGS {
-            return Err(CompileError::new(
-                format!("more than {MAX_CALL_ARGS} closure variables"),
-                func_pos,
-            ));
-        }
+        // Bound the bytecode-operand counts before compiling — the `u8` casts
+        // below depend on these fitting in 255.
+        let defaults_count = check_call_args_u8(func_def.default_exprs.len(), "default parameter values", func_pos)?;
+        let cell_count = check_call_args_u8(func_def.free_var_enclosing_slots.len(), "closure variables", func_pos)?;
 
         // 1. Compile the function body recursively
         let functions = mem::take(&mut self.functions);
-        let namespace_size = u16::try_from(func_def.namespace_size).expect("function namespace size exceeds u16");
+        let namespace_size = check_namespace_size_u16(func_def.namespace_size, "lambda")?;
         let (body_code, mut functions) =
             Self::compile_function_body(&func_def.body, self.interns, functions, namespace_size)?;
 
@@ -551,25 +689,23 @@ impl<'a> Compiler<'a> {
         for default_expr in &func_def.default_exprs {
             self.compile_expr(default_expr)?;
         }
-        let defaults_count =
-            u8::try_from(func_def.default_exprs.len()).expect("function default argument count exceeds u8");
-        let func_id_u16 = u16::try_from(func_id).expect("function count exceeds u16");
+        let func_id_u16 = check_function_count_u16(func_id, func_pos)?;
 
         // 4. Emit MakeFunction or MakeClosure (if has free vars)
         if func_def.free_var_enclosing_slots.is_empty() {
             // MakeFunction: func_id (u16) + defaults_count (u8)
-            self.code.emit_u16_u8(Opcode::MakeFunction, func_id_u16, defaults_count);
+            self.code
+                .emit_u16_u8(Opcode::MakeFunction, func_id_u16, defaults_count)?;
         } else {
-            // Push captured cells from enclosing scope
+            // Push captured cells from enclosing scope. `slot` is a
+            // `NamespaceId` from the enclosing scope, bounded by
+            // `check_namespace_size_u16`; the conversion is an invariant.
             for &slot in &func_def.free_var_enclosing_slots {
-                let slot_u16 = u16::try_from(slot.index()).expect("closure slot index exceeds u16");
-                self.code.emit_load_local(slot_u16);
+                self.code.emit_load_local(slot.as_u16())?;
             }
-            let cell_count =
-                u8::try_from(func_def.free_var_enclosing_slots.len()).expect("closure cell count exceeds u8");
             // MakeClosure: func_id (u16) + defaults_count (u8) + cell_count (u8)
             self.code
-                .emit_u16_u8_u8(Opcode::MakeClosure, func_id_u16, defaults_count, cell_count);
+                .emit_u16_u8_u8(Opcode::MakeClosure, func_id_u16, defaults_count, cell_count)?;
         }
 
         // NOTE: Unlike compile_function_def, we do NOT call compile_store here.
@@ -583,22 +719,23 @@ impl<'a> Compiler<'a> {
     /// Emits `LoadModule` to create the module, then stores it to the binding name.
     /// If the module is unknown, emits `RaiseImportError` to defer the error to runtime.
     /// This allows imports inside `if TYPE_CHECKING:` blocks to compile successfully.
-    fn compile_import(&mut self, module_name: StringId, binding: &Identifier) {
+    fn compile_import(&mut self, module_name: StringId, binding: &Identifier) -> Result<(), CompileError> {
         let position = binding.position;
         self.code.set_location(position, None);
 
         // Look up the module by name
         if let Some(builtin_module) = StandardLib::from_string_id(module_name) {
             // Known module - emit LoadModule
-            self.code.emit_u8(Opcode::LoadModule, builtin_module as u8);
+            self.code.emit_u8(Opcode::LoadModule, builtin_module as u8)?;
             // Store to the binding (respects Local/Global/Cell scope)
-            self.compile_store(binding);
+            self.compile_store(binding)?;
         } else {
             // Unknown module - defer error to runtime with RaiseImportError
             // This allows TYPE_CHECKING imports to compile without error
-            let name_const = self.code.add_const(Value::InternString(module_name));
-            self.code.emit_u16(Opcode::RaiseImportError, name_const);
+            let name_const = self.code.add_const(Value::InternString(module_name))?;
+            self.code.emit_u16(Opcode::RaiseImportError, name_const)?;
         }
+        Ok(())
     }
 
     /// Compiles a `from module import name, ...` statement.
@@ -607,34 +744,40 @@ impl<'a> Compiler<'a> {
     /// Invalid attribute names will raise `AttributeError` at runtime.
     /// If the module is unknown, emits `RaiseImportError` to defer the error to runtime.
     /// This allows imports inside `if TYPE_CHECKING:` blocks to compile successfully.
-    fn compile_import_from(&mut self, module_name: StringId, names: &[(StringId, Identifier)], position: CodeRange) {
+    fn compile_import_from(
+        &mut self,
+        module_name: StringId,
+        names: &[(StringId, Identifier)],
+        position: CodeRange,
+    ) -> Result<(), CompileError> {
         self.code.set_location(position, None);
 
         // Look up the module
         if let Some(builtin_module) = StandardLib::from_string_id(module_name) {
             // Known module - emit LoadModule
-            self.code.emit_u8(Opcode::LoadModule, builtin_module as u8);
+            self.code.emit_u8(Opcode::LoadModule, builtin_module as u8)?;
 
             // For each name to import
             for (i, (import_name, binding)) in names.iter().enumerate() {
                 // Dup the module if this isn't the last import (last one consumes the module)
                 if i < names.len() - 1 {
-                    self.code.emit(Opcode::Dup);
+                    self.code.emit(Opcode::Dup)?;
                 }
 
                 // Load the attribute from the module (raises ImportError if not found)
-                let name_idx = u16::try_from(import_name.index()).expect("name index exceeds u16");
-                self.code.emit_u16(Opcode::LoadAttrImport, name_idx);
+                let name_idx = check_name_index_u16(*import_name, position)?;
+                self.code.emit_u16(Opcode::LoadAttrImport, name_idx)?;
 
                 // Store to the binding
-                self.compile_store(binding);
+                self.compile_store(binding)?;
             }
         } else {
             // Unknown module - defer error to runtime with RaiseImportError
             // This allows TYPE_CHECKING imports to compile without error
-            let name_const = self.code.add_const(Value::InternString(module_name));
-            self.code.emit_u16(Opcode::RaiseImportError, name_const);
+            let name_const = self.code.add_const(Value::InternString(module_name))?;
+            self.code.emit_u16(Opcode::RaiseImportError, name_const)?;
         }
+        Ok(())
     }
 
     // ========================================================================
@@ -647,13 +790,13 @@ impl<'a> Compiler<'a> {
         self.code.set_location(expr_loc.position, None);
 
         match &expr_loc.expr {
-            Expr::Literal(lit) => self.compile_literal(lit),
+            Expr::Literal(lit) => self.compile_literal(lit)?,
 
-            Expr::Name(ident) => self.compile_name(ident),
+            Expr::Name(ident) => self.compile_name(ident)?,
 
             Expr::Builtin(builtin) => {
-                let idx = self.code.add_const(Value::Builtin(*builtin));
-                self.code.emit_u16(Opcode::LoadConst, idx);
+                let idx = self.code.add_const(Value::Builtin(*builtin))?;
+                self.code.emit_u16(Opcode::LoadConst, idx)?;
             }
 
             Expr::Op { left, op, right } => {
@@ -667,10 +810,10 @@ impl<'a> Compiler<'a> {
                 self.code.set_location(expr_loc.position, None);
                 // ModEq needs special handling - it has a constant operand
                 if let CmpOperator::ModEq(value) = op {
-                    let const_idx = self.code.add_const(Value::Int(*value));
-                    self.code.emit_u16(Opcode::CompareModEq, const_idx);
+                    let const_idx = self.code.add_const(Value::Int(*value))?;
+                    self.code.emit_u16(Opcode::CompareModEq, const_idx)?;
                 } else {
-                    self.code.emit(cmp_operator_to_opcode(op));
+                    self.code.emit(cmp_operator_to_opcode(op))?;
                 }
             }
 
@@ -682,43 +825,43 @@ impl<'a> Compiler<'a> {
                 self.compile_expr(operand)?;
                 // Restore the full expression's position for traceback caret range
                 self.code.set_location(expr_loc.position, None);
-                self.code.emit(Opcode::UnaryNot);
+                self.code.emit(Opcode::UnaryNot)?;
             }
 
             Expr::UnaryMinus(operand) => {
                 self.compile_expr(operand)?;
                 // Restore the full expression's position for traceback caret range
                 self.code.set_location(expr_loc.position, None);
-                self.code.emit(Opcode::UnaryNeg);
+                self.code.emit(Opcode::UnaryNeg)?;
             }
 
             Expr::UnaryPlus(operand) => {
                 self.compile_expr(operand)?;
                 // Restore the full expression's position for traceback caret range
                 self.code.set_location(expr_loc.position, None);
-                self.code.emit(Opcode::UnaryPos);
+                self.code.emit(Opcode::UnaryPos)?;
             }
 
             Expr::UnaryInvert(operand) => {
                 self.compile_expr(operand)?;
                 // Restore the full expression's position for traceback caret range
                 self.code.set_location(expr_loc.position, None);
-                self.code.emit(Opcode::UnaryInvert);
+                self.code.emit(Opcode::UnaryInvert)?;
             }
 
             Expr::List(elements) => {
                 if has_unpack_seq(elements) {
                     // Generalized path: build incrementally for PEP 448 *unpacks
-                    self.code.emit_u16(Opcode::BuildList, 0);
+                    self.code.emit_u16(Opcode::BuildList, 0)?;
                     for item in elements {
                         match item {
                             SequenceItem::Value(e) => {
                                 self.compile_expr(e)?;
-                                self.code.emit_u8(Opcode::ListAppend, 0);
+                                self.code.emit_u8(Opcode::ListAppend, 0)?;
                             }
                             SequenceItem::Unpack(e) => {
                                 self.compile_expr(e)?;
-                                self.code.emit(Opcode::ListExtend);
+                                self.code.emit(Opcode::ListExtend)?;
                             }
                         }
                     }
@@ -731,30 +874,28 @@ impl<'a> Compiler<'a> {
                         };
                         self.compile_expr(e)?;
                     }
-                    self.code.emit_u16(
-                        Opcode::BuildList,
-                        u16::try_from(elements.len()).expect("elements count exceeds u16"),
-                    );
+                    let count = check_collection_size_u16(elements.len(), expr_loc.position)?;
+                    self.code.emit_u16(Opcode::BuildList, count)?;
                 }
             }
 
             Expr::Tuple(elements) => {
                 if has_unpack_seq(elements) {
                     // Generalized path: build via list then convert for PEP 448 *unpacks
-                    self.code.emit_u16(Opcode::BuildList, 0);
+                    self.code.emit_u16(Opcode::BuildList, 0)?;
                     for item in elements {
                         match item {
                             SequenceItem::Value(e) => {
                                 self.compile_expr(e)?;
-                                self.code.emit_u8(Opcode::ListAppend, 0);
+                                self.code.emit_u8(Opcode::ListAppend, 0)?;
                             }
                             SequenceItem::Unpack(e) => {
                                 self.compile_expr(e)?;
-                                self.code.emit(Opcode::ListExtend);
+                                self.code.emit(Opcode::ListExtend)?;
                             }
                         }
                     }
-                    self.code.emit(Opcode::ListToTuple);
+                    self.code.emit(Opcode::ListToTuple)?;
                 } else {
                     // Fast path: all values, single BuildTuple.
                     // SAFETY: has_unpack_seq(elements) is false, so every item is Value.
@@ -764,29 +905,27 @@ impl<'a> Compiler<'a> {
                         };
                         self.compile_expr(e)?;
                     }
-                    self.code.emit_u16(
-                        Opcode::BuildTuple,
-                        u16::try_from(elements.len()).expect("elements count exceeds u16"),
-                    );
+                    let count = check_collection_size_u16(elements.len(), expr_loc.position)?;
+                    self.code.emit_u16(Opcode::BuildTuple, count)?;
                 }
             }
 
             Expr::Dict(dict_items) => {
                 if has_unpack_dict(dict_items) {
                     // Generalized path: build incrementally for PEP 448 **unpacks
-                    self.code.emit_u16(Opcode::BuildDict, 0);
+                    self.code.emit_u16(Opcode::BuildDict, 0)?;
                     for item in dict_items {
                         match item {
                             DictItem::Pair(key, value) => {
                                 self.compile_expr(key)?;
                                 self.compile_expr(value)?;
                                 // depth=0: dict is at TOS after key/value are popped
-                                self.code.emit_u8(Opcode::DictSetItem, 0);
+                                self.code.emit_u8(Opcode::DictSetItem, 0)?;
                             }
                             DictItem::Unpack(e) => {
                                 self.compile_expr(e)?;
                                 // depth=0: dict is directly below mapping on stack
-                                self.code.emit_u8(Opcode::DictUpdate, 0);
+                                self.code.emit_u8(Opcode::DictUpdate, 0)?;
                             }
                         }
                     }
@@ -800,26 +939,24 @@ impl<'a> Compiler<'a> {
                         self.compile_expr(key)?;
                         self.compile_expr(value)?;
                     }
-                    self.code.emit_u16(
-                        Opcode::BuildDict,
-                        u16::try_from(dict_items.len()).expect("pairs count exceeds u16"),
-                    );
+                    let count = check_collection_size_u16(dict_items.len(), expr_loc.position)?;
+                    self.code.emit_u16(Opcode::BuildDict, count)?;
                 }
             }
 
             Expr::Set(elements) => {
                 if has_unpack_seq(elements) {
                     // Generalized path: build incrementally for PEP 448 *unpacks
-                    self.code.emit_u16(Opcode::BuildSet, 0);
+                    self.code.emit_u16(Opcode::BuildSet, 0)?;
                     for item in elements {
                         match item {
                             SequenceItem::Value(e) => {
                                 self.compile_expr(e)?;
-                                self.code.emit_u8(Opcode::SetAdd, 0);
+                                self.code.emit_u8(Opcode::SetAdd, 0)?;
                             }
                             SequenceItem::Unpack(e) => {
                                 self.compile_expr(e)?;
-                                self.code.emit_u8(Opcode::SetExtend, 0);
+                                self.code.emit_u8(Opcode::SetExtend, 0)?;
                             }
                         }
                     }
@@ -832,10 +969,8 @@ impl<'a> Compiler<'a> {
                         };
                         self.compile_expr(e)?;
                     }
-                    self.code.emit_u16(
-                        Opcode::BuildSet,
-                        u16::try_from(elements.len()).expect("elements count exceeds u16"),
-                    );
+                    let count = check_collection_size_u16(elements.len(), expr_loc.position)?;
+                    self.code.emit_u16(Opcode::BuildSet, count)?;
                 }
             }
 
@@ -844,7 +979,7 @@ impl<'a> Compiler<'a> {
                 self.compile_expr(index)?;
                 // Restore the full subscript expression's position for traceback
                 self.code.set_location(expr_loc.position, None);
-                self.code.emit(Opcode::BinarySubscr);
+                self.code.emit(Opcode::BinarySubscr)?;
             }
 
             Expr::IfElse { test, body, orelse } => {
@@ -856,10 +991,8 @@ impl<'a> Compiler<'a> {
                 // Restore the full expression's position for traceback caret range
                 self.code.set_location(expr_loc.position, None);
                 let name_id = attr.string_id().expect("LoadAttr requires interned attr name");
-                self.code.emit_u16(
-                    Opcode::LoadAttr,
-                    u16::try_from(name_id.index()).expect("name index exceeds u16"),
-                );
+                let name_idx = check_name_index_u16(name_id, expr_loc.position)?;
+                self.code.emit_u16(Opcode::LoadAttr, name_idx)?;
             }
 
             Expr::Call { callable, args } => {
@@ -885,7 +1018,7 @@ impl<'a> Compiler<'a> {
             Expr::FString(parts) => {
                 // Compile each part and build the f-string
                 let part_count = self.compile_fstring_parts(parts)?;
-                self.code.emit_u16(Opcode::BuildFString, part_count);
+                self.code.emit_u16(Opcode::BuildFString, part_count)?;
             }
 
             Expr::ListComp { elt, generators } => {
@@ -915,7 +1048,7 @@ impl<'a> Compiler<'a> {
                 self.compile_expr(value)?;
                 // Restore the full expression's position for traceback caret range
                 self.code.set_location(expr_loc.position, None);
-                self.code.emit(Opcode::Await);
+                self.code.emit(Opcode::Await)?;
             }
 
             Expr::Slice { lower, upper, step } => {
@@ -923,28 +1056,28 @@ impl<'a> Compiler<'a> {
                 if let Some(lower) = lower {
                     self.compile_expr(lower)?;
                 } else {
-                    self.code.emit(Opcode::LoadNone);
+                    self.code.emit(Opcode::LoadNone)?;
                 }
                 if let Some(upper) = upper {
                     self.compile_expr(upper)?;
                 } else {
-                    self.code.emit(Opcode::LoadNone);
+                    self.code.emit(Opcode::LoadNone)?;
                 }
                 if let Some(step) = step {
                     self.compile_expr(step)?;
                 } else {
-                    self.code.emit(Opcode::LoadNone);
+                    self.code.emit(Opcode::LoadNone)?;
                 }
-                self.code.emit(Opcode::BuildSlice);
+                self.code.emit(Opcode::BuildSlice)?;
             }
 
             Expr::Named { target, value } => {
                 // Compile the value expression (leaves result on stack)
                 self.compile_expr(value)?;
                 // Duplicate so value remains after store
-                self.code.emit(Opcode::Dup);
+                self.code.emit(Opcode::Dup)?;
                 // Store to target (pops one copy)
-                self.compile_store(target);
+                self.compile_store(target)?;
             }
         }
         Ok(())
@@ -955,34 +1088,24 @@ impl<'a> Compiler<'a> {
     // ========================================================================
 
     /// Compiles a literal value.
-    fn compile_literal(&mut self, literal: &Literal) {
+    fn compile_literal(&mut self, literal: &Literal) -> Result<(), CompileError> {
         match literal {
-            Literal::None => {
-                self.code.emit(Opcode::LoadNone);
-            }
-
-            Literal::Bool(true) => {
-                self.code.emit(Opcode::LoadTrue);
-            }
-
-            Literal::Bool(false) => {
-                self.code.emit(Opcode::LoadFalse);
-            }
-
+            Literal::None => self.code.emit(Opcode::LoadNone),
+            Literal::Bool(true) => self.code.emit(Opcode::LoadTrue),
+            Literal::Bool(false) => self.code.emit(Opcode::LoadFalse),
             Literal::Int(n) => {
                 // Use LoadSmallInt for values that fit in i8
                 if let Ok(small) = i8::try_from(*n) {
-                    self.code.emit_i8(Opcode::LoadSmallInt, small);
+                    self.code.emit_i8(Opcode::LoadSmallInt, small)
                 } else {
-                    let idx = self.code.add_const(Value::from(*literal));
-                    self.code.emit_u16(Opcode::LoadConst, idx);
+                    let idx = self.code.add_const(Value::from(*literal))?;
+                    self.code.emit_u16(Opcode::LoadConst, idx)
                 }
             }
-
             // For Float, Str, Bytes, Ellipsis - use LoadConst with Value::from
             _ => {
-                let idx = self.code.add_const(Value::from(*literal));
-                self.code.emit_u16(Opcode::LoadConst, idx);
+                let idx = self.code.add_const(Value::from(*literal))?;
+                self.code.emit_u16(Opcode::LoadConst, idx)
             }
         }
     }
@@ -995,38 +1118,38 @@ impl<'a> Compiler<'a> {
     ///
     /// At module level, `Local` and `LocalUnassigned` scopes emit global opcodes
     /// because module-level locals live in the globals array.
-    fn compile_name(&mut self, ident: &Identifier) {
-        let slot = u16::try_from(ident.namespace_id().index()).expect("local slot exceeds u16");
+    fn compile_name(&mut self, ident: &Identifier) -> Result<(), CompileError> {
+        let slot = ident.namespace_id().as_u16();
         match ident.scope {
             NameScope::Local => {
                 // True local - register name and mark as assigned for UnboundLocalError
                 self.code.register_local_name(slot, ident.name_id);
                 self.code.register_assigned_local(slot);
                 if self.is_module_scope {
-                    self.code.emit_u16(Opcode::LoadGlobal, slot);
+                    self.code.emit_u16(Opcode::LoadGlobal, slot)
                 } else {
-                    self.code.emit_load_local(slot);
+                    self.code.emit_load_local(slot)
                 }
             }
             NameScope::LocalUnassigned => {
                 // Undefined reference - register name but NOT as assigned for NameError
                 self.code.register_local_name(slot, ident.name_id);
                 if self.is_module_scope {
-                    self.code.emit_u16(Opcode::LoadGlobal, slot);
+                    self.code.emit_u16(Opcode::LoadGlobal, slot)
                 } else {
-                    self.code.emit_load_local(slot);
+                    self.code.emit_load_local(slot)
                 }
             }
             NameScope::Global => {
                 // Register the name for NameError/NameLookup messages
                 self.code.register_local_name(slot, ident.name_id);
-                self.code.emit_u16(Opcode::LoadGlobal, slot);
+                self.code.emit_u16(Opcode::LoadGlobal, slot)
             }
             NameScope::Cell => {
                 // Register the name for NameError messages (unbound free variable)
                 self.code.register_local_name(slot, ident.name_id);
                 // Emit local slot index — the VM reads the cell HeapId from the stack
-                self.code.emit_u16(Opcode::LoadCell, slot);
+                self.code.emit_u16(Opcode::LoadCell, slot)
             }
         }
     }
@@ -1040,24 +1163,24 @@ impl<'a> Compiler<'a> {
     ///
     /// For `Local` and `Cell` scopes, delegates to `compile_name` since those can't
     /// be external functions (they're always defined locally or captured).
-    fn compile_name_callable(&mut self, ident: &Identifier) {
-        let slot = u16::try_from(ident.namespace_id().index()).expect("local slot exceeds u16");
+    fn compile_name_callable(&mut self, ident: &Identifier) -> Result<(), CompileError> {
+        let slot = ident.namespace_id().as_u16();
         match ident.scope {
             NameScope::LocalUnassigned => {
                 // Undefined reference in call context - use callable-aware load.
                 // At module level, use global callable since locals are in the globals array.
                 self.code.register_local_name(slot, ident.name_id);
                 if self.is_module_scope {
-                    self.code.emit_load_global_callable(slot, ident.name_id);
+                    self.code.emit_load_global_callable(slot, ident.name_id)
                 } else {
-                    self.code.emit_load_local_callable(slot, ident.name_id);
+                    self.code.emit_load_local_callable(slot, ident.name_id)
                 }
             }
             NameScope::Global => {
                 // Global scope - name_id is encoded in the operand because global slot
                 // indices are in a different namespace from local slots, so looking up
                 // the name from the current frame's local_names would be incorrect
-                self.code.emit_load_global_callable(slot, ident.name_id);
+                self.code.emit_load_global_callable(slot, ident.name_id)
             }
             // Local and Cell can't be external functions - use regular load
             NameScope::Local | NameScope::Cell => self.compile_name(ident),
@@ -1068,23 +1191,21 @@ impl<'a> Compiler<'a> {
     ///
     /// At module level, `Local` and `LocalUnassigned` scopes emit `StoreGlobal`
     /// because module-level locals live in the globals array.
-    fn compile_store(&mut self, target: &Identifier) {
-        let slot = u16::try_from(target.namespace_id().index()).expect("local slot exceeds u16");
+    fn compile_store(&mut self, target: &Identifier) -> Result<(), CompileError> {
+        let slot = target.namespace_id().as_u16();
         match target.scope {
             NameScope::Local | NameScope::LocalUnassigned => {
                 self.code.register_local_name(slot, target.name_id);
                 if self.is_module_scope {
-                    self.code.emit_u16(Opcode::StoreGlobal, slot);
+                    self.code.emit_u16(Opcode::StoreGlobal, slot)
                 } else {
-                    self.code.emit_store_local(slot);
+                    self.code.emit_store_local(slot)
                 }
             }
-            NameScope::Global => {
-                self.code.emit_u16(Opcode::StoreGlobal, slot);
-            }
+            NameScope::Global => self.code.emit_u16(Opcode::StoreGlobal, slot),
             NameScope::Cell => {
                 // Emit local slot index — the VM reads the cell HeapId from the stack
-                self.code.emit_u16(Opcode::StoreCell, slot);
+                self.code.emit_u16(Opcode::StoreCell, slot)
             }
         }
     }
@@ -1108,17 +1229,17 @@ impl<'a> Compiler<'a> {
             // Short-circuit AND: evaluate left, jump if falsy
             Operator::And => {
                 self.compile_expr(left)?;
-                let end_jump = self.code.emit_jump(Opcode::JumpIfFalseOrPop);
+                let end_jump = self.code.emit_jump(Opcode::JumpIfFalseOrPop)?;
                 self.compile_expr(right)?;
-                self.code.patch_jump(end_jump);
+                self.code.patch_jump(end_jump)?;
             }
 
             // Short-circuit OR: evaluate left, jump if truthy
             Operator::Or => {
                 self.compile_expr(left)?;
-                let end_jump = self.code.emit_jump(Opcode::JumpIfTrueOrPop);
+                let end_jump = self.code.emit_jump(Opcode::JumpIfTrueOrPop)?;
                 self.compile_expr(right)?;
-                self.code.patch_jump(end_jump);
+                self.code.patch_jump(end_jump)?;
             }
 
             // Regular binary operators
@@ -1127,7 +1248,7 @@ impl<'a> Compiler<'a> {
                 self.compile_expr(right)?;
                 // Restore the full expression's position for traceback caret range
                 self.code.set_location(parent_pos, None);
-                self.code.emit(operator_to_opcode(op));
+                self.code.emit(operator_to_opcode(op))?;
             }
         }
         Ok(())
@@ -1176,38 +1297,38 @@ impl<'a> Compiler<'a> {
 
             if !is_last {
                 // Keep a copy of the intermediate for the next comparison
-                self.code.emit(Opcode::Dup);
+                self.code.emit(Opcode::Dup)?;
                 // Reorder: [prev, curr, curr] -> [curr, prev, curr]
-                self.code.emit(Opcode::Rot3);
+                self.code.emit(Opcode::Rot3)?;
             }
 
             // Emit comparison
             self.code.set_location(position, None);
             if let CmpOperator::ModEq(value) = op {
-                let const_idx = self.code.add_const(Value::Int(*value));
-                self.code.emit_u16(Opcode::CompareModEq, const_idx);
+                let const_idx = self.code.add_const(Value::Int(*value))?;
+                self.code.emit_u16(Opcode::CompareModEq, const_idx)?;
             } else {
-                self.code.emit(cmp_operator_to_opcode(op));
+                self.code.emit(cmp_operator_to_opcode(op))?;
             }
 
             if !is_last {
                 // Short-circuit: if false, jump to cleanup
-                let jump = self.code.emit_jump(Opcode::JumpIfFalseOrPop);
+                let jump = self.code.emit_jump(Opcode::JumpIfFalseOrPop)?;
                 cleanup_jumps.push(jump);
             }
         }
 
         // Jump past cleanup (result already on stack).
-        let end_jump = self.code.emit_jump(Opcode::Jump);
+        let end_jump = self.code.emit_jump(Opcode::Jump)?;
 
         // Cleanup: remove the saved intermediate value, keep False result.
         for jump in cleanup_jumps {
-            self.code.patch_jump(jump);
+            self.code.patch_jump(jump)?;
         }
-        self.code.emit(Opcode::Rot2); // [False, intermediate]
-        self.code.emit(Opcode::Pop); // [False]
+        self.code.emit(Opcode::Rot2)?; // [False, intermediate]
+        self.code.emit(Opcode::Pop)?; // [False]
 
-        self.code.patch_jump(end_jump);
+        self.code.patch_jump(end_jump)?;
         Ok(())
     }
 
@@ -1226,17 +1347,17 @@ impl<'a> Compiler<'a> {
 
         if or_else.is_empty() {
             // Simple if without else
-            let end_jump = self.code.emit_jump(Opcode::JumpIfFalse);
+            let end_jump = self.code.emit_jump(Opcode::JumpIfFalse)?;
             self.compile_block(body)?;
-            self.code.patch_jump(end_jump);
+            self.code.patch_jump(end_jump)?;
         } else {
             // If with else
-            let else_jump = self.code.emit_jump(Opcode::JumpIfFalse);
+            let else_jump = self.code.emit_jump(Opcode::JumpIfFalse)?;
             self.compile_block(body)?;
-            let end_jump = self.code.emit_jump(Opcode::Jump);
-            self.code.patch_jump(else_jump);
+            let end_jump = self.code.emit_jump(Opcode::Jump)?;
+            self.code.patch_jump(else_jump)?;
             self.compile_block(or_else)?;
-            self.code.patch_jump(end_jump);
+            self.code.patch_jump(end_jump)?;
         }
         Ok(())
     }
@@ -1244,12 +1365,12 @@ impl<'a> Compiler<'a> {
     /// Compiles a ternary conditional expression.
     fn compile_if_else_expr(&mut self, test: &ExprLoc, body: &ExprLoc, orelse: &ExprLoc) -> Result<(), CompileError> {
         self.compile_expr(test)?;
-        let else_jump = self.code.emit_jump(Opcode::JumpIfFalse);
+        let else_jump = self.code.emit_jump(Opcode::JumpIfFalse)?;
         self.compile_expr(body)?;
-        let end_jump = self.code.emit_jump(Opcode::Jump);
-        self.code.patch_jump(else_jump);
+        let end_jump = self.code.emit_jump(Opcode::Jump)?;
+        self.code.patch_jump(else_jump)?;
         self.compile_expr(orelse)?;
-        self.code.patch_jump(end_jump);
+        self.code.patch_jump(end_jump)?;
         Ok(())
     }
 
@@ -1271,7 +1392,7 @@ impl<'a> Compiler<'a> {
         {
             // Optimization applied - CallBuiltinFunction emitted
             self.code.set_location(call_pos, None);
-            self.code.emit_call_builtin_function(*builtin_func as u8, arg_count);
+            self.code.emit_call_builtin_function(*builtin_func as u8, arg_count)?;
             return Ok(());
         }
         // Fall through to standard path for kwargs/unpacking
@@ -1285,7 +1406,7 @@ impl<'a> Compiler<'a> {
         {
             // Optimization applied - CallBuiltinType emitted
             self.code.set_location(call_pos, None);
-            self.code.emit_call_builtin_type(type_id, arg_count);
+            self.code.emit_call_builtin_type(type_id, arg_count)?;
             return Ok(());
         }
         // Fall through to standard path for kwargs/unpacking or non-callable types
@@ -1294,14 +1415,14 @@ impl<'a> Compiler<'a> {
         // Push the callable (use name position for NameError caret range)
         match callable {
             Callable::Builtin(builtin) => {
-                let idx = self.code.add_const(Value::Builtin(*builtin));
-                self.code.emit_u16(Opcode::LoadConst, idx);
+                let idx = self.code.add_const(Value::Builtin(*builtin))?;
+                self.code.emit_u16(Opcode::LoadConst, idx)?;
             }
             Callable::Name(ident) => {
                 // Use callable-aware load opcodes so undefined names produce ExtFunction
                 // instead of yielding NameLookup, allowing CallFunction to yield FunctionCall
                 self.code.set_location(ident.position, None);
-                self.compile_name_callable(ident);
+                self.compile_name_callable(ident)?;
             }
         }
 
@@ -1310,18 +1431,18 @@ impl<'a> Compiler<'a> {
         match args {
             ArgExprs::Empty => {
                 self.code.set_location(call_pos, None);
-                self.code.emit_u8(Opcode::CallFunction, 0);
+                self.code.emit_u8(Opcode::CallFunction, 0)?;
             }
             ArgExprs::One(arg) => {
                 self.compile_expr(arg)?;
                 self.code.set_location(call_pos, None);
-                self.code.emit_u8(Opcode::CallFunction, 1);
+                self.code.emit_u8(Opcode::CallFunction, 1)?;
             }
             ArgExprs::Two(arg1, arg2) => {
                 self.compile_expr(arg1)?;
                 self.compile_expr(arg2)?;
                 self.code.set_location(call_pos, None);
-                self.code.emit_u8(Opcode::CallFunction, 2);
+                self.code.emit_u8(Opcode::CallFunction, 2)?;
             }
             ArgExprs::Args(args) => {
                 // Check argument count limit before compiling
@@ -1336,7 +1457,7 @@ impl<'a> Compiler<'a> {
                 }
                 let arg_count = u8::try_from(args.len()).expect("argument count exceeds u8");
                 self.code.set_location(call_pos, None);
-                self.code.emit_u8(Opcode::CallFunction, arg_count);
+                self.code.emit_u8(Opcode::CallFunction, arg_count)?;
             }
             ArgExprs::Kwargs(kwargs) => {
                 // Check keyword argument count limit
@@ -1350,10 +1471,10 @@ impl<'a> Compiler<'a> {
                 let mut kwname_ids = Vec::with_capacity(kwargs.len());
                 for kwarg in kwargs {
                     self.compile_expr(&kwarg.value)?;
-                    kwname_ids.push(u16::try_from(kwarg.key.name_id.index()).expect("name index exceeds u16"));
+                    kwname_ids.push(check_name_index_u16(kwarg.key.name_id, call_pos)?);
                 }
                 self.code.set_location(call_pos, None);
-                self.code.emit_call_function_kw(0, &kwname_ids);
+                self.code.emit_call_function_kw(0, &kwname_ids)?;
             }
             ArgExprs::ArgsKargs {
                 args,
@@ -1404,7 +1525,7 @@ impl<'a> Compiler<'a> {
                     if let Some(kwargs) = kwargs {
                         for kwarg in kwargs {
                             self.compile_expr(&kwarg.value)?;
-                            kwname_ids.push(u16::try_from(kwarg.key.name_id.index()).expect("name index exceeds u16"));
+                            kwname_ids.push(check_name_index_u16(kwarg.key.name_id, call_pos)?);
                         }
                     }
 
@@ -1412,13 +1533,13 @@ impl<'a> Compiler<'a> {
                     self.code.emit_call_function_kw(
                         u8::try_from(pos_count).expect("positional arg count exceeds u8"),
                         &kwname_ids,
-                    );
+                    )?;
                 }
             }
             ArgExprs::GeneralizedCall { args, kwargs } => {
                 // PEP 448: generalized unpacking — multiple *args or **kwargs.
                 // Callable was already pushed above this match; delegate to the helper.
-                let func_name_id = self.get_callable_name_id(callable);
+                let func_name_id = self.get_callable_name_id(callable)?;
                 self.compile_generalized_call_body(args, kwargs, func_name_id, call_pos)?;
             }
         }
@@ -1433,18 +1554,18 @@ impl<'a> Compiler<'a> {
         match args {
             ArgExprs::Empty => {
                 self.code.set_location(call_pos, None);
-                self.code.emit_u8(Opcode::CallFunction, 0);
+                self.code.emit_u8(Opcode::CallFunction, 0)?;
             }
             ArgExprs::One(arg) => {
                 self.compile_expr(arg)?;
                 self.code.set_location(call_pos, None);
-                self.code.emit_u8(Opcode::CallFunction, 1);
+                self.code.emit_u8(Opcode::CallFunction, 1)?;
             }
             ArgExprs::Two(arg1, arg2) => {
                 self.compile_expr(arg1)?;
                 self.compile_expr(arg2)?;
                 self.code.set_location(call_pos, None);
-                self.code.emit_u8(Opcode::CallFunction, 2);
+                self.code.emit_u8(Opcode::CallFunction, 2)?;
             }
             ArgExprs::Args(args) => {
                 if args.len() > MAX_CALL_ARGS {
@@ -1458,7 +1579,7 @@ impl<'a> Compiler<'a> {
                 }
                 let arg_count = u8::try_from(args.len()).expect("argument count exceeds u8");
                 self.code.set_location(call_pos, None);
-                self.code.emit_u8(Opcode::CallFunction, arg_count);
+                self.code.emit_u8(Opcode::CallFunction, arg_count)?;
             }
             ArgExprs::Kwargs(kwargs) => {
                 if kwargs.len() > MAX_CALL_ARGS {
@@ -1470,10 +1591,10 @@ impl<'a> Compiler<'a> {
                 let mut kwname_ids = Vec::with_capacity(kwargs.len());
                 for kwarg in kwargs {
                     self.compile_expr(&kwarg.value)?;
-                    kwname_ids.push(u16::try_from(kwarg.key.name_id.index()).expect("name index exceeds u16"));
+                    kwname_ids.push(check_name_index_u16(kwarg.key.name_id, call_pos)?);
                 }
                 self.code.set_location(call_pos, None);
-                self.code.emit_call_function_kw(0, &kwname_ids);
+                self.code.emit_call_function_kw(0, &kwname_ids)?;
             }
             ArgExprs::ArgsKargs {
                 args,
@@ -1523,14 +1644,14 @@ impl<'a> Compiler<'a> {
                     let mut kwname_ids = Vec::with_capacity(kw_count);
                     for kwarg in kw_args {
                         self.compile_expr(&kwarg.value)?;
-                        kwname_ids.push(u16::try_from(kwarg.key.name_id.index()).expect("name index exceeds u16"));
+                        kwname_ids.push(check_name_index_u16(kwarg.key.name_id, call_pos)?);
                     }
 
                     self.code.set_location(call_pos, None);
                     self.code.emit_call_function_kw(
                         u8::try_from(pos_count).expect("positional arg count exceeds u8"),
                         &kwname_ids,
-                    );
+                    )?;
                 }
             }
             ArgExprs::GeneralizedCall { args, kwargs } => {
@@ -1564,19 +1685,17 @@ impl<'a> Compiler<'a> {
                 self.compile_expr(arg)?;
             }
         }
-        self.code.emit_u16(
-            Opcode::BuildList,
-            u16::try_from(pos_count).expect("positional arg count exceeds u16"),
-        );
+        let pos_count_u16 = check_collection_size_u16(pos_count, call_pos)?;
+        self.code.emit_u16(Opcode::BuildList, pos_count_u16)?;
 
         // Extend with *args if present
         if let Some(var_args_expr) = var_args {
             self.compile_expr(var_args_expr)?;
-            self.code.emit(Opcode::ListExtend);
+            self.code.emit(Opcode::ListExtend)?;
         }
 
         // Convert list to tuple
-        self.code.emit(Opcode::ListToTuple);
+        self.code.emit(Opcode::ListToTuple)?;
 
         // 2. Build kwargs dict (if we have kwargs or var_kwargs)
         let has_kwargs = kwargs.is_some() || var_kwargs.is_some();
@@ -1586,29 +1705,27 @@ impl<'a> Compiler<'a> {
             if let Some(kwargs) = kwargs {
                 for kwarg in kwargs {
                     // Push key as interned string constant
-                    let key_const = self.code.add_const(Value::InternString(kwarg.key.name_id));
-                    self.code.emit_u16(Opcode::LoadConst, key_const);
+                    let key_const = self.code.add_const(Value::InternString(kwarg.key.name_id))?;
+                    self.code.emit_u16(Opcode::LoadConst, key_const)?;
                     // Push value
                     self.compile_expr(&kwarg.value)?;
                 }
             }
-            self.code.emit_u16(
-                Opcode::BuildDict,
-                u16::try_from(kw_count).expect("keyword count exceeds u16"),
-            );
+            let kw_count_u16 = check_collection_size_u16(kw_count, call_pos)?;
+            self.code.emit_u16(Opcode::BuildDict, kw_count_u16)?;
 
             // Merge **kwargs if present
             // Use 0xFFFF for func_name_id (like builtins) since we don't have a name
             if let Some(var_kwargs_expr) = var_kwargs {
                 self.compile_expr(var_kwargs_expr)?;
-                self.code.emit_u16(Opcode::DictMerge, 0xFFFF);
+                self.code.emit_u16(Opcode::DictMerge, 0xFFFF)?;
             }
         }
 
         // 3. Call the function
         self.code.set_location(call_pos, None);
         let flags = u8::from(has_kwargs);
-        self.code.emit_u8(Opcode::CallFunctionExtended, flags);
+        self.code.emit_u8(Opcode::CallFunctionExtended, flags)?;
         Ok(())
     }
 
@@ -1667,7 +1784,7 @@ impl<'a> Compiler<'a> {
     ) -> Result<(), CompileError> {
         // Get function name for error messages. Builtins use their real interned name
         // so duplicate-kwargs errors from **unpacking match CPython.
-        let func_name_id = self.get_callable_name_id(callable);
+        let func_name_id = self.get_callable_name_id(callable)?;
 
         // 1. Build args tuple
         // Push regular positional args and build list
@@ -1677,19 +1794,17 @@ impl<'a> Compiler<'a> {
                 self.compile_expr(arg)?;
             }
         }
-        self.code.emit_u16(
-            Opcode::BuildList,
-            u16::try_from(pos_count).expect("positional arg count exceeds u16"),
-        );
+        let pos_count_u16 = check_collection_size_u16(pos_count, call_pos)?;
+        self.code.emit_u16(Opcode::BuildList, pos_count_u16)?;
 
         // Extend with *args if present
         if let Some(var_args_expr) = var_args {
             self.compile_expr(var_args_expr)?;
-            self.code.emit(Opcode::ListExtend);
+            self.code.emit(Opcode::ListExtend)?;
         }
 
         // Convert list to tuple
-        self.code.emit(Opcode::ListToTuple);
+        self.code.emit(Opcode::ListToTuple)?;
 
         // 2. Build kwargs dict (if we have kwargs or var_kwargs)
         let has_kwargs = kwargs.is_some() || var_kwargs.is_some();
@@ -1699,28 +1814,26 @@ impl<'a> Compiler<'a> {
             if let Some(kwargs) = kwargs {
                 for kwarg in kwargs {
                     // Push key as interned string constant
-                    let key_const = self.code.add_const(Value::InternString(kwarg.key.name_id));
-                    self.code.emit_u16(Opcode::LoadConst, key_const);
+                    let key_const = self.code.add_const(Value::InternString(kwarg.key.name_id))?;
+                    self.code.emit_u16(Opcode::LoadConst, key_const)?;
                     // Push value
                     self.compile_expr(&kwarg.value)?;
                 }
             }
-            self.code.emit_u16(
-                Opcode::BuildDict,
-                u16::try_from(kw_count).expect("keyword count exceeds u16"),
-            );
+            let kw_count_u16 = check_collection_size_u16(kw_count, call_pos)?;
+            self.code.emit_u16(Opcode::BuildDict, kw_count_u16)?;
 
             // Merge **kwargs if present
             if let Some(var_kwargs_expr) = var_kwargs {
                 self.compile_expr(var_kwargs_expr)?;
-                self.code.emit_u16(Opcode::DictMerge, func_name_id);
+                self.code.emit_u16(Opcode::DictMerge, func_name_id)?;
             }
         }
 
         // 3. Call the function
         self.code.set_location(call_pos, None);
         let flags = u8::from(has_kwargs);
-        self.code.emit_u8(Opcode::CallFunctionExtended, flags);
+        self.code.emit_u8(Opcode::CallFunctionExtended, flags)?;
         Ok(())
     }
 
@@ -1731,10 +1844,10 @@ impl<'a> Compiler<'a> {
     /// When the callable is not a named local/global, we still try to resolve
     /// builtin functions, builtin exception constructors, and builtin types to
     /// their interned public names.
-    fn get_callable_name_id(&self, callable: &Callable) -> u16 {
+    fn get_callable_name_id(&self, callable: &Callable) -> Result<u16, CompileError> {
         match callable {
-            Callable::Name(ident) => u16::try_from(ident.name_id.index()).expect("name index exceeds u16"),
-            Callable::Builtin(builtin) => self.get_builtin_name_id(*builtin).unwrap_or(0xFFFF),
+            Callable::Name(ident) => check_name_index_u16(ident.name_id, ident.position),
+            Callable::Builtin(builtin) => Ok(self.get_builtin_name_id(*builtin).unwrap_or(0xFFFF)),
         }
     }
 
@@ -1769,37 +1882,27 @@ impl<'a> Compiler<'a> {
         args: &ArgExprs,
         call_pos: CodeRange,
     ) -> Result<(), CompileError> {
-        // Get the interned attribute name
+        // Get the interned attribute name, converted up-front so the limit check
+        // happens once per method call rather than at every emit-site below.
         let name_id = attr.string_id().expect("CallAttr requires interned attr name");
+        let name_idx = check_name_index_u16(name_id, call_pos)?;
 
         // Compile arguments based on the argument type
         match args {
             ArgExprs::Empty => {
                 self.code.set_location(call_pos, None);
-                self.code.emit_u16_u8(
-                    Opcode::CallAttr,
-                    u16::try_from(name_id.index()).expect("name index exceeds u16"),
-                    0,
-                );
+                self.code.emit_u16_u8(Opcode::CallAttr, name_idx, 0)?;
             }
             ArgExprs::One(arg) => {
                 self.compile_expr(arg)?;
                 self.code.set_location(call_pos, None);
-                self.code.emit_u16_u8(
-                    Opcode::CallAttr,
-                    u16::try_from(name_id.index()).expect("name index exceeds u16"),
-                    1,
-                );
+                self.code.emit_u16_u8(Opcode::CallAttr, name_idx, 1)?;
             }
             ArgExprs::Two(arg1, arg2) => {
                 self.compile_expr(arg1)?;
                 self.compile_expr(arg2)?;
                 self.code.set_location(call_pos, None);
-                self.code.emit_u16_u8(
-                    Opcode::CallAttr,
-                    u16::try_from(name_id.index()).expect("name index exceeds u16"),
-                    2,
-                );
+                self.code.emit_u16_u8(Opcode::CallAttr, name_idx, 2)?;
             }
             ArgExprs::Args(args) => {
                 // Check argument count limit
@@ -1814,11 +1917,7 @@ impl<'a> Compiler<'a> {
                 }
                 let arg_count = u8::try_from(args.len()).expect("argument count exceeds u8");
                 self.code.set_location(call_pos, None);
-                self.code.emit_u16_u8(
-                    Opcode::CallAttr,
-                    u16::try_from(name_id.index()).expect("name index exceeds u16"),
-                    arg_count,
-                );
+                self.code.emit_u16_u8(Opcode::CallAttr, name_idx, arg_count)?;
             }
             ArgExprs::Kwargs(kwargs) => {
                 // Keyword-only method call
@@ -1832,14 +1931,10 @@ impl<'a> Compiler<'a> {
                 let mut kwname_ids = Vec::with_capacity(kwargs.len());
                 for kwarg in kwargs {
                     self.compile_expr(&kwarg.value)?;
-                    kwname_ids.push(u16::try_from(kwarg.key.name_id.index()).expect("name index exceeds u16"));
+                    kwname_ids.push(check_name_index_u16(kwarg.key.name_id, call_pos)?);
                 }
                 self.code.set_location(call_pos, None);
-                self.code.emit_call_attr_kw(
-                    u16::try_from(name_id.index()).expect("name index exceeds u16"),
-                    0, // no positional args
-                    &kwname_ids,
-                );
+                self.code.emit_call_attr_kw(name_idx, 0, &kwname_ids)?;
             }
             ArgExprs::ArgsKargs {
                 args,
@@ -1888,55 +1983,55 @@ impl<'a> Compiler<'a> {
                 if let Some(kwargs) = kwargs {
                     for kwarg in kwargs {
                         self.compile_expr(&kwarg.value)?;
-                        kwname_ids.push(u16::try_from(kwarg.key.name_id.index()).expect("name index exceeds u16"));
+                        kwname_ids.push(check_name_index_u16(kwarg.key.name_id, call_pos)?);
                     }
                 }
 
                 self.code.set_location(call_pos, None);
                 self.code.emit_call_attr_kw(
-                    u16::try_from(name_id.index()).expect("name index exceeds u16"),
+                    name_idx,
                     u8::try_from(pos_count).expect("positional arg count exceeds u8"),
                     &kwname_ids,
-                );
+                )?;
             }
             ArgExprs::GeneralizedCall { args, kwargs } => {
                 // PEP 448: generalized unpacking on a method call.
                 // Receiver is already on the stack; build args tuple and kwargs dict,
                 // then emit CallAttrExtended.
-                let func_name_id = u16::try_from(name_id.index()).expect("name index exceeds u16");
+                let func_name_id = name_idx;
                 let has_kwargs = !kwargs.is_empty();
 
                 // 1. Build args tuple
-                self.code.emit_u16(Opcode::BuildList, 0);
+                self.code.emit_u16(Opcode::BuildList, 0)?;
                 for arg in args {
                     match arg {
                         CallArg::Value(e) => {
                             self.compile_expr(e)?;
-                            self.code.emit_u8(Opcode::ListAppend, 0);
+                            self.code.emit_u8(Opcode::ListAppend, 0)?;
                         }
                         CallArg::Unpack(e) => {
                             self.compile_expr(e)?;
-                            self.code.emit(Opcode::ListExtend);
+                            self.code.emit(Opcode::ListExtend)?;
                         }
                     }
                 }
-                self.code.emit(Opcode::ListToTuple);
+                self.code.emit(Opcode::ListToTuple)?;
 
                 // 2. Build kwargs dict (if any)
                 if has_kwargs {
-                    self.code.emit_u16(Opcode::BuildDict, 0);
+                    self.code.emit_u16(Opcode::BuildDict, 0)?;
                     for kwarg in kwargs {
                         match kwarg {
                             CallKwarg::Named(kw) => {
-                                let key_const = self.code.add_const(Value::InternString(kw.key.name_id));
-                                self.code.emit_u16(Opcode::LoadConst, key_const);
+                                let key_const = self.code.add_const(Value::InternString(kw.key.name_id))?;
+                                self.code.emit_u16(Opcode::LoadConst, key_const)?;
                                 self.compile_expr(&kw.value)?;
-                                self.code.emit_u16(Opcode::BuildDict, 1);
-                                self.code.emit_u16(Opcode::DictMerge, func_name_id);
+                                self.code.emit_u16(Opcode::BuildDict, 1)?;
+                                self.code.emit_u16(Opcode::DictMerge, func_name_id)?;
                             }
                             CallKwarg::Unpack(e) => {
                                 self.compile_expr(e)?;
-                                self.code.emit_u16(Opcode::DictMerge, func_name_id);
+                                self.code.emit_u16(Opcode::DictMerge, func_name_id)?;
                             }
                         }
                     }
@@ -1945,7 +2040,7 @@ impl<'a> Compiler<'a> {
                 // 3. Emit CallAttrExtended
                 self.code.set_location(call_pos, None);
                 let flags = u8::from(has_kwargs);
-                self.code.emit_u16_u8(Opcode::CallAttrExtended, func_name_id, flags);
+                self.code.emit_u16_u8(Opcode::CallAttrExtended, func_name_id, flags)?;
             }
         }
         Ok(())
@@ -1964,6 +2059,10 @@ impl<'a> Compiler<'a> {
         var_kwargs: Option<&ExprLoc>,
         call_pos: CodeRange,
     ) -> Result<(), CompileError> {
+        // Convert the attribute name id up front so the overflow check happens
+        // once and both `DictMerge` (for error messages) and `CallAttrExtended`
+        // can reuse the converted value.
+        let name_idx = check_name_index_u16(name_id, call_pos)?;
         // 1. Build args tuple
         // Push regular positional args and build list
         let pos_count = args.map_or(0, Vec::len);
@@ -1972,19 +2071,17 @@ impl<'a> Compiler<'a> {
                 self.compile_expr(arg)?;
             }
         }
-        self.code.emit_u16(
-            Opcode::BuildList,
-            u16::try_from(pos_count).expect("positional arg count exceeds u16"),
-        );
+        let pos_count_u16 = check_collection_size_u16(pos_count, call_pos)?;
+        self.code.emit_u16(Opcode::BuildList, pos_count_u16)?;
 
         // Extend with *args if present
         if let Some(var_args_expr) = var_args {
             self.compile_expr(var_args_expr)?;
-            self.code.emit(Opcode::ListExtend);
+            self.code.emit(Opcode::ListExtend)?;
         }
 
         // Convert list to tuple
-        self.code.emit(Opcode::ListToTuple);
+        self.code.emit(Opcode::ListToTuple)?;
 
         // 2. Build kwargs dict (if we have kwargs or var_kwargs)
         let has_kwargs = kwargs.is_some() || var_kwargs.is_some();
@@ -1994,33 +2091,27 @@ impl<'a> Compiler<'a> {
             if let Some(kwargs) = kwargs {
                 for kwarg in kwargs {
                     // Push key as interned string constant
-                    let key_const = self.code.add_const(Value::InternString(kwarg.key.name_id));
-                    self.code.emit_u16(Opcode::LoadConst, key_const);
+                    let key_const = self.code.add_const(Value::InternString(kwarg.key.name_id))?;
+                    self.code.emit_u16(Opcode::LoadConst, key_const)?;
                     // Push value
                     self.compile_expr(&kwarg.value)?;
                 }
             }
-            self.code.emit_u16(
-                Opcode::BuildDict,
-                u16::try_from(kw_count).expect("keyword count exceeds u16"),
-            );
+            let kw_count_u16 = check_collection_size_u16(kw_count, call_pos)?;
+            self.code.emit_u16(Opcode::BuildDict, kw_count_u16)?;
 
             // Merge **kwargs if present
             if let Some(var_kwargs_expr) = var_kwargs {
                 self.compile_expr(var_kwargs_expr)?;
                 // Use the method name for error messages
-                self.code.emit_u16(
-                    Opcode::DictMerge,
-                    u16::try_from(name_id.index()).expect("name index exceeds u16"),
-                );
+                self.code.emit_u16(Opcode::DictMerge, name_idx)?;
             }
         }
 
         // 3. Call the method with CallAttrExtended
         self.code.set_location(call_pos, None);
-        let name_idx = u16::try_from(name_id.index()).expect("name index exceeds u16");
         let flags = u8::from(has_kwargs);
-        self.code.emit_u16_u8(Opcode::CallAttrExtended, name_idx, flags);
+        self.code.emit_u16_u8(Opcode::CallAttrExtended, name_idx, flags)?;
         Ok(())
     }
 
@@ -2045,40 +2136,40 @@ impl<'a> Compiler<'a> {
         call_pos: CodeRange,
     ) -> Result<(), CompileError> {
         // 1. Build args tuple
-        self.code.emit_u16(Opcode::BuildList, 0);
+        self.code.emit_u16(Opcode::BuildList, 0)?;
         for arg in args {
             match arg {
                 CallArg::Value(e) => {
                     self.compile_expr(e)?;
-                    self.code.emit_u8(Opcode::ListAppend, 0);
+                    self.code.emit_u8(Opcode::ListAppend, 0)?;
                 }
                 CallArg::Unpack(e) => {
                     self.compile_expr(e)?;
-                    self.code.emit(Opcode::ListExtend);
+                    self.code.emit(Opcode::ListExtend)?;
                 }
             }
         }
-        self.code.emit(Opcode::ListToTuple);
+        self.code.emit(Opcode::ListToTuple)?;
 
         // 2. Build kwargs dict (if any)
         let has_kwargs = !kwargs.is_empty();
         if has_kwargs {
             // Start with an empty dict, then merge each kwarg one at a time via DictMerge
             // so that duplicates (including Named+Unpack ordering) raise TypeError correctly.
-            self.code.emit_u16(Opcode::BuildDict, 0);
+            self.code.emit_u16(Opcode::BuildDict, 0)?;
             for kwarg in kwargs {
                 match kwarg {
                     CallKwarg::Named(kw) => {
                         // Wrap key+value in a single-item dict, then merge into kwargs dict.
-                        let key_const = self.code.add_const(Value::InternString(kw.key.name_id));
-                        self.code.emit_u16(Opcode::LoadConst, key_const);
+                        let key_const = self.code.add_const(Value::InternString(kw.key.name_id))?;
+                        self.code.emit_u16(Opcode::LoadConst, key_const)?;
                         self.compile_expr(&kw.value)?;
-                        self.code.emit_u16(Opcode::BuildDict, 1);
-                        self.code.emit_u16(Opcode::DictMerge, func_name_id);
+                        self.code.emit_u16(Opcode::BuildDict, 1)?;
+                        self.code.emit_u16(Opcode::DictMerge, func_name_id)?;
                     }
                     CallKwarg::Unpack(e) => {
                         self.compile_expr(e)?;
-                        self.code.emit_u16(Opcode::DictMerge, func_name_id);
+                        self.code.emit_u16(Opcode::DictMerge, func_name_id)?;
                     }
                 }
             }
@@ -2087,7 +2178,7 @@ impl<'a> Compiler<'a> {
         // 3. Emit the extended call
         self.code.set_location(call_pos, None);
         let flags = u8::from(has_kwargs);
-        self.code.emit_u8(Opcode::CallFunctionExtended, flags);
+        self.code.emit_u8(Opcode::CallFunctionExtended, flags)?;
         Ok(())
     }
 
@@ -2102,7 +2193,7 @@ impl<'a> Compiler<'a> {
         // Compile iterator expression
         self.compile_expr(iter)?;
         // Convert to iterator
-        self.code.emit(Opcode::GetIter);
+        self.code.emit(Opcode::GetIter)?;
 
         // Loop start
         let loop_start = self.code.current_jump_target();
@@ -2115,18 +2206,18 @@ impl<'a> Compiler<'a> {
         });
 
         // ForIter: advance iterator or jump to end
-        let end_jump = self.code.emit_jump(Opcode::ForIter);
+        let end_jump = self.code.emit_jump(Opcode::ForIter)?;
 
         // Store current value to target (handles both single identifiers and tuple unpacking)
-        self.compile_unpack_target(target);
+        self.compile_unpack_target(target)?;
 
         // Compile body
         self.compile_block(body)?;
 
         // Jump back to loop start
-        self.code.emit_jump_to(Opcode::Jump, loop_start);
+        self.code.emit_jump_to(Opcode::Jump, loop_start)?;
         // End of loop - ForIter jumps here when iterator is exhausted
-        self.code.patch_jump(end_jump);
+        self.code.patch_jump(end_jump)?;
 
         // Pop loop info before compiling else block
         let loop_info = self.loop_stack.pop().expect("loop stack underflow");
@@ -2138,7 +2229,7 @@ impl<'a> Compiler<'a> {
 
         // Patch break jumps to here - AFTER the else block so break skips else
         for break_jump in loop_info.break_jumps {
-            self.code.patch_jump(break_jump);
+            self.code.patch_jump(break_jump)?;
         }
 
         Ok(())
@@ -2178,12 +2269,12 @@ impl<'a> Compiler<'a> {
         });
 
         self.compile_expr(test)?;
-        let end_jump = self.code.emit_jump(Opcode::JumpIfFalse);
+        let end_jump = self.code.emit_jump(Opcode::JumpIfFalse)?;
 
         self.compile_block(body)?;
-        self.code.emit_jump_to(Opcode::Jump, loop_start);
+        self.code.emit_jump_to(Opcode::Jump, loop_start)?;
 
-        self.code.patch_jump(end_jump);
+        self.code.patch_jump(end_jump)?;
         let loop_info = self.loop_stack.pop().expect("loop stack underflow");
 
         if !or_else.is_empty() {
@@ -2191,7 +2282,7 @@ impl<'a> Compiler<'a> {
         }
 
         for break_jump in loop_info.break_jumps {
-            self.code.patch_jump(break_jump);
+            self.code.patch_jump(break_jump)?;
         }
 
         Ok(())
@@ -2222,13 +2313,13 @@ impl<'a> Compiler<'a> {
         // If inside except handlers, clear each enclosing exception_stack
         // entry.
         for _ in 0..self.except_handler_depth {
-            self.code.emit(Opcode::ClearException);
+            self.code.emit(Opcode::ClearException)?;
         }
 
         // Pop the iterator only for `for` loops (has iterator on stack)
         // `while` loops don't have an iterator to pop
         if self.loop_stack[target_loop_depth].has_iterator_on_stack {
-            self.code.emit(Opcode::Pop);
+            self.code.emit(Opcode::Pop)?;
         }
 
         // Check if we need to go through any finally blocks
@@ -2239,7 +2330,7 @@ impl<'a> Compiler<'a> {
         {
             // Breaking from a loop that's outside (or at the start of) this try-finally,
             // so finally must run before the break
-            let jump = self.code.emit_jump(Opcode::Jump);
+            let jump = self.code.emit_jump(Opcode::Jump)?;
             finally_target.break_jumps.push(BreakContinueThruFinally {
                 jump,
                 target_loop_depth,
@@ -2247,7 +2338,7 @@ impl<'a> Compiler<'a> {
             return Ok(());
         }
         // No finally to go through, jump directly to loop end
-        let jump = self.code.emit_jump(Opcode::Jump);
+        let jump = self.code.emit_jump(Opcode::Jump)?;
         self.loop_stack[target_loop_depth].break_jumps.push(jump);
 
         Ok(())
@@ -2268,7 +2359,7 @@ impl<'a> Compiler<'a> {
         // If inside except handlers, clear each enclosing exception_stack
         // entry.
         for _ in 0..self.except_handler_depth {
-            self.code.emit(Opcode::ClearException);
+            self.code.emit(Opcode::ClearException)?;
         }
 
         // Check if we need to go through any finally blocks
@@ -2278,7 +2369,7 @@ impl<'a> Compiler<'a> {
         {
             // Continuing a loop that's outside (or at the start of) this try-finally,
             // so finally must run before the continue
-            let jump = self.code.emit_jump(Opcode::Jump);
+            let jump = self.code.emit_jump(Opcode::Jump)?;
             finally_target.continue_jumps.push(BreakContinueThruFinally {
                 jump,
                 target_loop_depth,
@@ -2287,7 +2378,7 @@ impl<'a> Compiler<'a> {
 
         // No finally to go through, jump directly to loop start
         let loop_start = self.loop_stack[target_loop_depth].start;
-        self.code.emit_jump_to(Opcode::Jump, loop_start);
+        self.code.emit_jump_to(Opcode::Jump, loop_start)?;
 
         Ok(())
     }
@@ -2301,13 +2392,17 @@ impl<'a> Compiler<'a> {
     /// Note: All items in the list jumped to the same finally block, so they all
     /// have the same starting point. After finally runs, we need to route each
     /// to its target loop, potentially through more finally blocks.
-    fn compile_control_flow_after_finally(&mut self, items: &[BreakContinueThruFinally], is_break: bool) {
+    fn compile_control_flow_after_finally(
+        &mut self,
+        items: &[BreakContinueThruFinally],
+        is_break: bool,
+    ) -> Result<(), CompileError> {
         // All items went through the same finally, now we need to dispatch to
         // potentially different loops. For simplicity, we assume all items in
         // a single finally target the same loop (the innermost one at the time).
         // This is always true since break/continue only targets the innermost loop.
         let Some(first) = items.first() else {
-            return;
+            return Ok(());
         };
         let target_loop_depth = first.target_loop_depth;
 
@@ -2316,7 +2411,7 @@ impl<'a> Compiler<'a> {
             && target_loop_depth < finally_target.loop_depth_at_entry
         {
             // Need to go through another finally
-            let jump = self.code.emit_jump(Opcode::Jump);
+            let jump = self.code.emit_jump(Opcode::Jump)?;
             let jump_info = BreakContinueThruFinally {
                 jump,
                 target_loop_depth,
@@ -2327,18 +2422,19 @@ impl<'a> Compiler<'a> {
                 // else continue
                 finally_target.continue_jumps.push(jump_info);
             }
-            return;
+            return Ok(());
         }
 
         // No more finally blocks, jump directly to the loop target
         if is_break {
-            let jump = self.code.emit_jump(Opcode::Jump);
+            let jump = self.code.emit_jump(Opcode::Jump)?;
             self.loop_stack[target_loop_depth].break_jumps.push(jump);
         } else {
             // else continue
             let loop_start = self.loop_stack[target_loop_depth].start;
-            self.code.emit_jump_to(Opcode::Jump, loop_start);
+            self.code.emit_jump_to(Opcode::Jump, loop_start)?;
         }
+        Ok(())
     }
 
     // ========================================================================
@@ -2365,14 +2461,13 @@ impl<'a> Compiler<'a> {
     /// ```
     fn compile_list_comp(&mut self, elt: &ExprLoc, generators: &[Comprehension]) -> Result<(), CompileError> {
         // Build empty list
-        self.code.emit_u16(Opcode::BuildList, 0);
+        self.code.emit_u16(Opcode::BuildList, 0)?;
 
         // Compile the nested generators, which will eventually append to the list
-        let depth = u8::try_from(generators.len()).expect("too many generators in list comprehension");
+        let depth = check_comp_generators(generators.len(), elt.position)?;
         self.compile_comprehension_generators(generators, 0, |compiler| {
             compiler.compile_expr(elt)?;
-            compiler.code.emit_u8(Opcode::ListAppend, depth);
-            Ok(())
+            compiler.code.emit_u8(Opcode::ListAppend, depth)
         })?;
 
         Ok(())
@@ -2381,14 +2476,13 @@ impl<'a> Compiler<'a> {
     /// Compiles a set comprehension: `{elt for target in iter if cond...}`
     fn compile_set_comp(&mut self, elt: &ExprLoc, generators: &[Comprehension]) -> Result<(), CompileError> {
         // Build empty set
-        self.code.emit_u16(Opcode::BuildSet, 0);
+        self.code.emit_u16(Opcode::BuildSet, 0)?;
 
         // Compile the nested generators, which will eventually add to the set
-        let depth = u8::try_from(generators.len()).expect("too many generators in set comprehension");
+        let depth = check_comp_generators(generators.len(), elt.position)?;
         self.compile_comprehension_generators(generators, 0, |compiler| {
             compiler.compile_expr(elt)?;
-            compiler.code.emit_u8(Opcode::SetAdd, depth);
-            Ok(())
+            compiler.code.emit_u8(Opcode::SetAdd, depth)
         })?;
 
         Ok(())
@@ -2402,15 +2496,14 @@ impl<'a> Compiler<'a> {
         generators: &[Comprehension],
     ) -> Result<(), CompileError> {
         // Build empty dict
-        self.code.emit_u16(Opcode::BuildDict, 0);
+        self.code.emit_u16(Opcode::BuildDict, 0)?;
 
         // Compile the nested generators, which will eventually set items in the dict
-        let depth = u8::try_from(generators.len()).expect("too many generators in dict comprehension");
+        let depth = check_comp_generators(generators.len(), key.position)?;
         self.compile_comprehension_generators(generators, 0, |compiler| {
             compiler.compile_expr(key)?;
             compiler.compile_expr(value)?;
-            compiler.code.emit_u8(Opcode::DictSetItem, depth);
-            Ok(())
+            compiler.code.emit_u8(Opcode::DictSetItem, depth)
         })?;
 
         Ok(())
@@ -2437,22 +2530,22 @@ impl<'a> Compiler<'a> {
 
         // Compile iterator expression
         self.compile_expr(&generator.iter)?;
-        self.code.emit(Opcode::GetIter);
+        self.code.emit(Opcode::GetIter)?;
 
         // Loop start
         let loop_start = self.code.current_jump_target();
 
         // FOR_ITER: advance iterator or jump to end
-        let end_jump = self.code.emit_jump(Opcode::ForIter);
+        let end_jump = self.code.emit_jump(Opcode::ForIter)?;
 
         // Store current value to target (single variable or tuple unpacking)
-        self.compile_unpack_target(&generator.target);
+        self.compile_unpack_target(&generator.target)?;
 
         // Compile filter conditions - jump back to loop start if any fails
         for cond in &generator.ifs {
             self.compile_expr(cond)?;
             // If condition is false, skip to next iteration
-            self.code.emit_jump_to(Opcode::JumpIfFalse, loop_start);
+            self.code.emit_jump_to(Opcode::JumpIfFalse, loop_start)?;
         }
 
         // Either recurse for inner generator, or emit body
@@ -2465,8 +2558,8 @@ impl<'a> Compiler<'a> {
         }
 
         // Jump back to loop start
-        self.code.emit_jump_to(Opcode::Jump, loop_start);
-        self.code.patch_jump(end_jump);
+        self.code.emit_jump_to(Opcode::Jump, loop_start)?;
+        self.code.patch_jump(end_jump)?;
 
         Ok(())
     }
@@ -2476,16 +2569,16 @@ impl<'a> Compiler<'a> {
     /// For single identifiers: emits a simple store.
     /// For nested tuples: emits `UnpackSequence` (or `UnpackEx` with starred) and recursively
     /// handles each sub-target.
-    fn compile_unpack_target(&mut self, target: &UnpackTarget) {
+    fn compile_unpack_target(&mut self, target: &UnpackTarget) -> Result<(), CompileError> {
         match target {
             UnpackTarget::Name(ident) => {
                 // Single identifier - just store directly
-                self.compile_store(ident);
+                self.compile_store(ident)?;
             }
             UnpackTarget::Starred(ident) => {
                 // Starred target by itself (shouldn't happen at top level normally)
                 // Just store as if it were a name
-                self.compile_store(ident);
+                self.compile_store(ident)?;
             }
             UnpackTarget::Tuple { targets, position } => {
                 // Check if there's a starred target
@@ -2495,22 +2588,23 @@ impl<'a> Compiler<'a> {
 
                 if let Some(star_idx) = star_idx {
                     // Has starred target - use UnpackEx
-                    let before = u8::try_from(star_idx).expect("too many targets before star");
-                    let after = u8::try_from(targets.len() - star_idx - 1).expect("too many targets after star");
-                    self.code.emit_u8_u8(Opcode::UnpackEx, before, after);
+                    let before = check_unpack_targets(star_idx, *position)?;
+                    let after = check_unpack_targets(targets.len() - star_idx - 1, *position)?;
+                    self.code.emit_u8_u8(Opcode::UnpackEx, before, after)?;
                 } else {
                     // No starred target - use UnpackSequence
-                    let count = u8::try_from(targets.len()).expect("too many targets in nested unpack");
-                    self.code.emit_u8(Opcode::UnpackSequence, count);
+                    let count = check_unpack_targets(targets.len(), *position)?;
+                    self.code.emit_u8(Opcode::UnpackSequence, count)?;
                 }
 
                 // After UnpackSequence/UnpackEx, values are on stack with first item on top
                 // Store them in order, recursively handling further nesting
                 for target in targets {
-                    self.compile_unpack_target(target);
+                    self.compile_unpack_target(target)?;
                 }
             }
         }
+        Ok(())
     }
 
     /// Compiles a single assignment step, assuming the value to assign is on top of stack.
@@ -2522,7 +2616,7 @@ impl<'a> Compiler<'a> {
     /// chained forms.
     fn compile_assign_target(&mut self, target: &AssignTarget) -> Result<(), CompileError> {
         match target {
-            AssignTarget::Name(ident) => self.compile_store(ident),
+            AssignTarget::Name(ident) => self.compile_store(ident)?,
             AssignTarget::Subscript {
                 target,
                 index,
@@ -2536,7 +2630,7 @@ impl<'a> Compiler<'a> {
             AssignTarget::Unpack {
                 targets,
                 targets_position,
-            } => self.emit_unpack_store(targets, *targets_position),
+            } => self.emit_unpack_store(targets, *targets_position)?,
         }
         Ok(())
     }
@@ -2555,7 +2649,7 @@ impl<'a> Compiler<'a> {
         self.compile_expr(target)?;
         self.compile_expr(index)?;
         self.code.set_location(target_position, None);
-        self.code.emit(Opcode::StoreSubscr);
+        self.code.emit(Opcode::StoreSubscr)?;
         Ok(())
     }
 
@@ -2582,12 +2676,10 @@ impl<'a> Compiler<'a> {
                 target_position,
             ));
         };
+        let name_idx = check_name_index_u16(name_id, target_position)?;
         self.compile_expr(object)?;
         self.code.set_location(target_position, None);
-        self.code.emit_u16(
-            Opcode::StoreAttr,
-            u16::try_from(name_id.index()).expect("name index exceeds u16"),
-        );
+        self.code.emit_u16(Opcode::StoreAttr, name_idx)?;
         Ok(())
     }
 
@@ -2597,20 +2689,21 @@ impl<'a> Compiler<'a> {
     /// (no starred target) and `UnpackEx` (exactly one starred target), then stores the
     /// unpacked values into each sub-target — recursing through nested tuple patterns.
     /// Shared between `Node::UnpackAssign` and chained-assignment unpack steps.
-    fn emit_unpack_store(&mut self, targets: &[UnpackTarget], targets_position: CodeRange) {
+    fn emit_unpack_store(&mut self, targets: &[UnpackTarget], targets_position: CodeRange) -> Result<(), CompileError> {
         let star_idx = targets.iter().position(|t| matches!(t, UnpackTarget::Starred(_)));
         self.code.set_location(targets_position, None);
         if let Some(star_idx) = star_idx {
-            let before = u8::try_from(star_idx).expect("too many targets before star");
-            let after = u8::try_from(targets.len() - star_idx - 1).expect("too many targets after star");
-            self.code.emit_u8_u8(Opcode::UnpackEx, before, after);
+            let before = check_unpack_targets(star_idx, targets_position)?;
+            let after = check_unpack_targets(targets.len() - star_idx - 1, targets_position)?;
+            self.code.emit_u8_u8(Opcode::UnpackEx, before, after)?;
         } else {
-            let count = u8::try_from(targets.len()).expect("too many targets in unpack");
-            self.code.emit_u8(Opcode::UnpackSequence, count);
+            let count = check_unpack_targets(targets.len(), targets_position)?;
+            self.code.emit_u8(Opcode::UnpackSequence, count)?;
         }
         for t in targets {
-            self.compile_unpack_target(t);
+            self.compile_unpack_target(t)?;
         }
+        Ok(())
     }
 
     // ========================================================================
@@ -2622,25 +2715,25 @@ impl<'a> Compiler<'a> {
         // Compile test
         self.compile_expr(test)?;
         // Jump over raise if truthy
-        let skip_jump = self.code.emit_jump(Opcode::JumpIfTrue);
+        let skip_jump = self.code.emit_jump(Opcode::JumpIfTrue)?;
 
         // Raise AssertionError
         let exc_idx = self
             .code
-            .add_const(Value::Builtin(Builtins::ExcType(ExcType::AssertionError)));
-        self.code.emit_u16(Opcode::LoadConst, exc_idx);
+            .add_const(Value::Builtin(Builtins::ExcType(ExcType::AssertionError)))?;
+        self.code.emit_u16(Opcode::LoadConst, exc_idx)?;
 
         if let Some(msg_expr) = msg {
             // Call AssertionError(msg)
             self.compile_expr(msg_expr)?;
-            self.code.emit_u8(Opcode::CallFunction, 1);
+            self.code.emit_u8(Opcode::CallFunction, 1)?;
         } else {
             // Call AssertionError()
-            self.code.emit_u8(Opcode::CallFunction, 0);
+            self.code.emit_u8(Opcode::CallFunction, 0)?;
         }
 
-        self.code.emit(Opcode::Raise);
-        self.code.patch_jump(skip_jump);
+        self.code.emit(Opcode::Raise)?;
+        self.code.patch_jump(skip_jump)?;
         Ok(())
     }
 
@@ -2656,8 +2749,8 @@ impl<'a> Compiler<'a> {
             match part {
                 FStringPart::Literal(string_id) => {
                     // Push the interned string as a constant
-                    let const_idx = self.code.add_const(Value::InternString(*string_id));
-                    self.code.emit_u16(Opcode::LoadConst, const_idx);
+                    let const_idx = self.code.add_const(Value::InternString(*string_id))?;
+                    self.code.emit_u16(Opcode::LoadConst, const_idx)?;
                     count += 1;
                 }
                 FStringPart::Interpolation {
@@ -2668,8 +2761,8 @@ impl<'a> Compiler<'a> {
                 } => {
                     // If debug prefix present, push it first
                     if let Some(prefix_id) = debug_prefix {
-                        let const_idx = self.code.add_const(Value::InternString(*prefix_id));
-                        self.code.emit_u16(Opcode::LoadConst, const_idx);
+                        let const_idx = self.code.add_const(Value::InternString(*prefix_id))?;
+                        self.code.emit_u16(Opcode::LoadConst, const_idx)?;
                         count += 1;
                     }
 
@@ -2685,7 +2778,7 @@ impl<'a> Compiler<'a> {
 
                     // Emit FormatValue with appropriate flags
                     let flags = self.compile_format_value(effective_conversion, format_spec.as_ref())?;
-                    self.code.emit_u8(Opcode::FormatValue, flags);
+                    self.code.emit_u8(Opcode::FormatValue, flags)?;
                     count += 1;
                 }
             }
@@ -2720,8 +2813,8 @@ impl<'a> Compiler<'a> {
                 // Push the raw encoded form; the static-spec flag tells the
                 // VM to read it back via decode_format_spec without inspecting
                 // the Value variant.
-                let const_idx = self.code.add_const(Value::Int(*encoded));
-                self.code.emit_u16(Opcode::LoadConst, const_idx);
+                let const_idx = self.code.add_const(Value::Int(*encoded))?;
+                self.code.emit_u16(Opcode::LoadConst, const_idx)?;
                 Ok(conv_bits | FORMAT_VALUE_HAS_SPEC | FORMAT_VALUE_STATIC_SPEC)
             }
             Some(FormatSpec::Dynamic(dynamic_parts)) => {
@@ -2729,7 +2822,7 @@ impl<'a> Compiler<'a> {
                 // Then parse it at runtime
                 let part_count = self.compile_fstring_parts(dynamic_parts)?;
                 if part_count > 1 {
-                    self.code.emit_u16(Opcode::BuildFString, part_count);
+                    self.code.emit_u16(Opcode::BuildFString, part_count)?;
                 }
                 // Format spec string is now on stack
                 Ok(conv_bits | FORMAT_VALUE_HAS_SPEC)
@@ -2748,10 +2841,10 @@ impl<'a> Compiler<'a> {
         if let Some(expr) = expr {
             self.compile_expr(expr)?;
         } else {
-            self.code.emit(Opcode::LoadNone);
+            self.code.emit(Opcode::LoadNone)?;
         }
 
-        self.compile_return_routing();
+        self.compile_return_routing()?;
 
         Ok(())
     }
@@ -2779,22 +2872,24 @@ impl<'a> Compiler<'a> {
     ///
     /// The remaining handlers are cleared further out by the finally
     /// trailers in [`compile_try`] as control flows through them.
-    fn compile_return_routing(&mut self) {
+    fn compile_return_routing(&mut self) -> Result<(), CompileError> {
         let target_depth = self
             .finally_targets
             .last()
             .map_or(0, |t| t.except_handler_depth_at_entry);
 
         for _ in 0..(self.except_handler_depth - target_depth) {
-            self.code.emit(Opcode::ClearException);
+            self.code.emit(Opcode::ClearException)?;
         }
 
         if let Some(finally_target) = self.finally_targets.last_mut() {
-            let jump = self.code.emit_jump(Opcode::Jump);
+            let jump = self.code.emit_jump(Opcode::Jump)?;
             finally_target.return_jumps.push(jump);
         } else {
-            self.code.emit(Opcode::ReturnValue);
+            self.code.emit(Opcode::ReturnValue)?;
         }
+
+        Ok(())
     }
 
     /// Compiles a try/except/else/finally block.
@@ -2845,7 +2940,7 @@ impl<'a> Compiler<'a> {
         // frame's exception_stack entries that should be active inside the
         // try body. The VM uses this on unwind to drain entries left
         // behind by abandoned-but-trailer-skipped handlers.
-        let try_exc_stack_count = u16::try_from(self.except_handler_depth).expect("except_handler_depth exceeds u16");
+        let try_exc_stack_count = self.except_handler_depth;
 
         // If there's a finally block, track returns/break/continue inside try/handlers/else
         if has_finally {
@@ -2863,7 +2958,7 @@ impl<'a> Compiler<'a> {
         self.compile_block(&try_block.body)?;
 
         // Jump to else/finally if no exception (skip handlers)
-        let after_try_jump = self.code.emit_jump(Opcode::Jump);
+        let after_try_jump = self.code.emit_jump(Opcode::Jump)?;
         // End of the try-body region for the exception table. This is past
         // the `after_try_jump` if it was emitted, so an exception that fires
         // up to and including that Jump still routes to the handler.
@@ -2897,9 +2992,9 @@ impl<'a> Compiler<'a> {
             // But we can't easily save the exception, so we use a different approach:
             // The exception is already on the exception_stack from handle_exception,
             // so we can just pop from operand stack, run finally, then reraise.
-            self.code.emit(Opcode::Pop); // Pop exception from operand stack
+            self.code.emit(Opcode::Pop)?; // Pop exception from operand stack
             self.compile_block(&try_block.finally)?;
-            self.code.emit(Opcode::Reraise); // Re-raise from exception_stack
+            self.code.emit(Opcode::Reraise)?; // Re-raise from exception_stack
             Some(cleanup_start)
         } else {
             None
@@ -2916,10 +3011,10 @@ impl<'a> Compiler<'a> {
             } else {
                 let start = self.code.current_offset();
                 for jump in finally_target.return_jumps {
-                    self.code.patch_jump(jump);
+                    self.code.patch_jump(jump)?;
                 }
                 self.compile_block(&try_block.finally)?;
-                self.compile_return_routing();
+                self.compile_return_routing()?;
                 Some(start)
             };
 
@@ -2929,21 +3024,21 @@ impl<'a> Compiler<'a> {
             // - Jump directly to the loop's break target
             if !finally_target.break_jumps.is_empty() {
                 for break_info in &finally_target.break_jumps {
-                    self.code.patch_jump(break_info.jump);
+                    self.code.patch_jump(break_info.jump)?;
                 }
                 self.compile_block(&try_block.finally)?;
                 // After finally, compile the break again (handles nested finally or direct jump)
-                self.compile_control_flow_after_finally(&finally_target.break_jumps, true);
+                self.compile_control_flow_after_finally(&finally_target.break_jumps, true)?;
             }
 
             // === Finally with continue path ===
             if !finally_target.continue_jumps.is_empty() {
                 for continue_info in &finally_target.continue_jumps {
-                    self.code.patch_jump(continue_info.jump);
+                    self.code.patch_jump(continue_info.jump)?;
                 }
                 self.compile_block(&try_block.finally)?;
                 // After finally, compile the continue again (handles nested finally or direct jump)
-                self.compile_control_flow_after_finally(&finally_target.continue_jumps, false);
+                self.compile_control_flow_after_finally(&finally_target.continue_jumps, false)?;
             }
 
             return_start
@@ -2952,7 +3047,7 @@ impl<'a> Compiler<'a> {
         };
 
         // === Else block (runs if no exception) ===
-        self.code.patch_jump(after_try_jump);
+        self.code.patch_jump(after_try_jump)?;
         let else_start = self.code.current_offset();
         if has_else {
             self.compile_block(&try_block.or_else)?;
@@ -2962,7 +3057,7 @@ impl<'a> Compiler<'a> {
         // === Normal finally path (no exception pending, no return) ===
         // Patch all jumps from handlers to go here
         for jump in finally_jumps {
-            self.code.patch_jump(jump);
+            self.code.patch_jump(jump)?;
         }
 
         if has_finally {
@@ -2976,13 +3071,8 @@ impl<'a> Compiler<'a> {
         // exception_stack_count = try_exc_stack_count: entering the try body
         // adds no handler entries.
         if has_handlers || has_finally {
-            self.code.add_exception_entry(ExceptionEntry::new(
-                try_start,
-                try_end,
-                handler_start,
-                stack_depth,
-                try_exc_stack_count,
-            ));
+            self.code
+                .add_exception_entry(try_start, try_end, handler_start, stack_depth, try_exc_stack_count)?;
         }
 
         // Entry 2: Handler dispatch -> finally cleanup (only if has_finally).
@@ -2990,39 +3080,34 @@ impl<'a> Compiler<'a> {
         // exception was pushed onto exception_stack by entry 1's catch and
         // is still active throughout handler dispatch.
         if let Some(cleanup_start) = finally_cleanup_start {
-            self.code.add_exception_entry(ExceptionEntry::new(
+            self.code.add_exception_entry(
                 handler_start,
                 handler_dispatch_end,
                 cleanup_start,
                 stack_depth,
                 try_exc_stack_count + 1,
-            ));
+            )?;
         }
 
         // Entry 3: Finally with return -> finally cleanup
         // If an exception occurs while running finally (in the return path), catch it
         if let (Some(return_start), Some(cleanup_start)) = (finally_with_return_start, finally_cleanup_start) {
             // End at else_start (before else block).
-            self.code.add_exception_entry(ExceptionEntry::new(
+            self.code.add_exception_entry(
                 return_start,
                 else_start,
                 cleanup_start,
                 stack_depth,
                 try_exc_stack_count,
-            ));
+            )?;
         }
 
         // Entry 4: Else block -> finally cleanup (only if has_finally and
         // has_else). Else runs when no exception was raised, so no handler
         // pushed an entry: exception_stack_count = try_exc_stack_count.
         if has_else && let Some(cleanup_start) = finally_cleanup_start {
-            self.code.add_exception_entry(ExceptionEntry::new(
-                else_start,
-                else_end,
-                cleanup_start,
-                stack_depth,
-                try_exc_stack_count,
-            ));
+            self.code
+                .add_exception_entry(else_start, else_end, cleanup_start, stack_depth, try_exc_stack_count)?;
         }
 
         Ok(())
@@ -3055,8 +3140,8 @@ impl<'a> Compiler<'a> {
                 // exception (doesn't pop it), so [exception] stays on the
                 // stack across the check on both match and no-match paths.
                 self.compile_expr(exc_type)?;
-                self.code.emit(Opcode::CheckExcMatch);
-                Some(self.code.emit_jump(Opcode::JumpIfFalse))
+                self.code.emit(Opcode::CheckExcMatch)?;
+                Some(self.code.emit_jump(Opcode::JumpIfFalse)?)
             } else {
                 // Bare `except:` (must be the last handler per Python rules).
                 None
@@ -3065,9 +3150,9 @@ impl<'a> Compiler<'a> {
             // Match path: consume exception from the stack and store
             // to target if present.
             if let Some(name) = &handler.name {
-                self.compile_store(name);
+                self.compile_store(name)?;
             } else {
-                self.code.emit(Opcode::Pop);
+                self.code.emit(Opcode::Pop)?;
             }
 
             self.except_handler_depth += 1;
@@ -3075,21 +3160,21 @@ impl<'a> Compiler<'a> {
             self.except_handler_depth -= 1;
 
             if let Some(name) = &handler.name {
-                self.compile_delete(name);
+                self.compile_delete(name)?;
             }
 
-            self.code.emit(Opcode::ClearException);
-            finally_jumps.push(self.code.emit_jump(Opcode::Jump));
+            self.code.emit(Opcode::ClearException)?;
+            finally_jumps.push(self.code.emit_jump(Opcode::Jump)?);
 
             if let Some(no_match_jump) = no_match_jump {
                 // No-match landing: stack is [exception]. Falls through into
                 // the next handler's check (or the post-loop `Reraise`).
-                self.code.patch_jump(no_match_jump);
+                self.code.patch_jump(no_match_jump)?;
             }
         }
 
         // No handler matched - reraise the exception
-        self.code.emit(Opcode::Reraise);
+        self.code.emit(Opcode::Reraise)?;
 
         Ok(())
     }
@@ -3098,29 +3183,43 @@ impl<'a> Compiler<'a> {
     ///
     /// At module level, `Local` and `LocalUnassigned` scopes emit `DeleteGlobal`
     /// because module-level locals live in the globals array.
-    fn compile_delete(&mut self, target: &Identifier) {
-        let slot = u16::try_from(target.namespace_id().index()).expect("local slot exceeds u16");
+    ///
+    /// Function-scope `Local` deletes are limited to the first 256 slots
+    /// because the only available opcode (`DeleteLocal`) takes a `u8`
+    /// operand; a wide variant has not been added because slot-255 deletes
+    /// are essentially unreachable in real code (each `except ... as e`
+    /// implicitly emits a delete on the bound name, but functions with 256+
+    /// locals plus an `except as` are exotic enough that we surface a
+    /// `SyntaxError` rather than introduce a new opcode just for this).
+    fn compile_delete(&mut self, target: &Identifier) -> Result<(), CompileError> {
+        let slot = target.namespace_id().as_u16();
         match target.scope {
             NameScope::Local | NameScope::LocalUnassigned => {
                 if self.is_module_scope {
-                    self.code.emit_u16(Opcode::DeleteGlobal, slot);
+                    self.code.emit_u16(Opcode::DeleteGlobal, slot)?;
                 } else if let Ok(s) = u8::try_from(slot) {
-                    self.code.emit_u8(Opcode::DeleteLocal, s);
+                    self.code.emit_u8(Opcode::DeleteLocal, s)?;
                 } else {
-                    // Wide variant not implemented yet
-                    todo!("DeleteLocalW for slot > 255");
+                    return Err(CompileError::new(
+                        format!(
+                            "cannot delete local variable in function with more than {} locals (slot {slot})",
+                            u16::from(u8::MAX) + 1,
+                        ),
+                        target.position,
+                    ));
                 }
             }
             NameScope::Global => {
-                self.code.emit_u16(Opcode::DeleteGlobal, slot);
+                self.code.emit_u16(Opcode::DeleteGlobal, slot)?;
             }
             NameScope::Cell => {
                 // Delete cell not commonly needed
                 // For now, just store None
-                self.code.emit(Opcode::LoadNone);
-                self.compile_store(target);
+                self.code.emit(Opcode::LoadNone)?;
+                self.compile_store(target)?;
             }
         }
+        Ok(())
     }
 }
 
@@ -3143,7 +3242,7 @@ impl CompileError {
     /// Creates a new compile error with the given message and position.
     ///
     /// Defaults to `SyntaxError` exception type.
-    fn new(message: impl Into<Cow<'static, str>>, position: CodeRange) -> Self {
+    pub(super) fn new(message: impl Into<Cow<'static, str>>, position: CodeRange) -> Self {
         Self {
             message: message.into(),
             position,

--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -175,7 +175,7 @@ fn name_index_too_large(position: CodeRange) -> CompileError {
     CompileError::new(
         format!(
             "module has too many distinct names; the bytecode format supports up to {} interned strings",
-            u16::MAX
+            usize::from(u16::MAX) + 1,
         ),
         position,
     )

--- a/crates/monty/src/namespace.rs
+++ b/crates/monty/src/namespace.rs
@@ -3,19 +3,31 @@
 /// Used by the bytecode compiler to emit slot indices for variable access.
 /// The VM uses these indices to read/write values in the globals vector
 /// or the stack-inlined locals region.
+///
+/// Storage is `u16` because every bytecode opcode that takes a namespace
+/// slot (`LoadLocal`, `LoadGlobal`, `StoreLocal`, …) encodes the slot in
+/// 16 bits.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
-pub(crate) struct NamespaceId(u32);
+pub(crate) struct NamespaceId(u16);
 
 impl NamespaceId {
-    pub fn new(index: usize) -> Self {
-        Self(index.try_into().expect("Invalid namespace id"))
+    /// Creates a `NamespaceId` from a `usize` slot index, returning `None` if
+    /// the index doesn't fit in `u16`. Callers in the prepare phase wrap the
+    /// `None` case in a `ParseError::Syntax` so user-input-driven overflows
+    /// surface as a clean `SyntaxError` rather than a panic at emission time.
+    pub fn new(index: usize) -> Option<Self> {
+        u16::try_from(index).ok().map(Self)
     }
 
-    /// Returns the raw index value.
-    ///
-    /// Used by the bytecode compiler to emit slot indices for variable access.
+    /// Returns the slot index as the `u16` operand consumed by the bytecode.
+    #[inline]
+    pub fn as_u16(self) -> u16 {
+        self.0
+    }
+
+    /// Returns the slot as `usize` for `Vec`/array indexing in the VM.
     #[inline]
     pub fn index(self) -> usize {
-        self.0 as usize
+        self.0.into()
     }
 }

--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -1,5 +1,3 @@
-use std::collections::hash_map::Entry;
-
 use ahash::{AHashMap, AHashSet};
 
 use crate::{
@@ -15,6 +13,18 @@ use crate::{
     parse::{CodeRange, ExceptHandler, ParseError, ParseNode, ParseResult, ParsedSignature, RawFunctionDef, Try},
     signature::Signature,
 };
+
+/// Builds the `ParseError` raised when a scope's namespace would exceed
+/// `NamespaceId`'s `u16` capacity (the bytecode slot operand width).
+/// Hoisted so the cold error path stays out of inlined allocator calls.
+#[cold]
+#[inline(never)]
+fn namespace_overflow(position: CodeRange) -> ParseError {
+    ParseError::syntax(
+        format!("too many distinct names in scope; maximum is {} per scope", u16::MAX),
+        position,
+    )
+}
 
 /// Result of the prepare phase, containing everything needed to compile and execute code.
 ///
@@ -45,7 +55,7 @@ pub struct PrepareResult {
 /// At module level, the local namespace IS the global namespace.
 pub(crate) fn prepare(parse_result: ParseResult, input_names: Vec<String>) -> Result<PrepareResult, ParseError> {
     let ParseResult { nodes, interner } = parse_result;
-    let mut p = Prepare::new_module(input_names, &interner);
+    let mut p = Prepare::new_module(input_names, &interner)?;
     let mut prepared_nodes = p.prepare_nodes(nodes)?;
 
     // In the root frame, the last expression is implicitly returned
@@ -159,16 +169,35 @@ impl<'i> Prepare<'i> {
     /// At module level, all variables are global. The `global` keyword is a no-op
     /// since all variables are already in the global namespace.
     ///
+    /// Allocates the next namespace slot, incrementing `namespace_size`.
+    ///
+    /// Wraps the recurring `let id = NamespaceId::new(self.namespace_size);
+    /// self.namespace_size += 1;` pattern and surfaces a clean `ParseError`
+    /// if the scope is about to grow past `NamespaceId`'s `u16` capacity.
+    /// Anchors the error to `position` so the traceback caret lands on the
+    /// statement that triggered the overflow.
+    fn alloc_slot(&mut self, position: CodeRange) -> Result<NamespaceId, ParseError> {
+        let id = NamespaceId::new(self.namespace_size).ok_or_else(|| namespace_overflow(position))?;
+        self.namespace_size += 1;
+        Ok(id)
+    }
+
     /// # Arguments
     /// * `input_names` - Names that should be pre-registered in the namespace (e.g., input variables)
     /// * `interner` - Reference to the string interner for looking up names
-    fn new_module(input_names: Vec<String>, interner: &'i InternerBuilder) -> Self {
+    ///
+    /// Returns a `ParseError` if more than `u16::MAX + 1` input names are
+    /// supplied — bytecode slot indices are `u16` so the namespace cannot grow
+    /// past that. Practically only reachable via misuse by the embedder, since
+    /// `input_names` is supplied programmatically, not from user source.
+    fn new_module(input_names: Vec<String>, interner: &'i InternerBuilder) -> Result<Self, ParseError> {
         let mut name_map = AHashMap::with_capacity(input_names.len());
         for (index, name) in input_names.into_iter().enumerate() {
-            name_map.insert(name, NamespaceId::new(index));
+            let slot = NamespaceId::new(index).ok_or_else(|| namespace_overflow(CodeRange::default()))?;
+            name_map.insert(name, slot);
         }
         let namespace_size = name_map.len();
-        Self {
+        Ok(Self {
             interner,
             name_map,
             namespace_size,
@@ -181,7 +210,7 @@ impl<'i> Prepare<'i> {
             free_var_map: AHashMap::new(),
             cell_var_map: AHashMap::new(),
             unassigned_ref_names: AHashSet::new(),
-        }
+        })
     }
 
     /// Creates a module-scope Prepare instance from an existing global name map.
@@ -249,7 +278,8 @@ impl<'i> Prepare<'i> {
         let mut name_map = AHashMap::with_capacity(capacity);
         for (index, string_id) in params.iter().enumerate() {
             let name_str = interner.get_str(*string_id);
-            if name_map.insert(name_str.to_string(), NamespaceId::new(index)).is_some() {
+            let slot = NamespaceId::new(index).ok_or_else(|| namespace_overflow(position))?;
+            if name_map.insert(name_str.to_string(), slot).is_some() {
                 return Err(ParseError::syntax(
                     format!("duplicate argument '{name_str}' in function definition"),
                     position,
@@ -270,9 +300,9 @@ impl<'i> Prepare<'i> {
         let mut namespace_size = namespace_size;
         for name in cell_var_names {
             if !nonlocal_names.contains(&name) && !implicit_captures.contains(&name) {
-                let slot = namespace_size;
+                let slot = NamespaceId::new(namespace_size).ok_or_else(|| namespace_overflow(position))?;
                 namespace_size += 1;
-                cell_var_map.insert(name, NamespaceId::new(slot));
+                cell_var_map.insert(name, slot);
             }
         }
 
@@ -283,15 +313,15 @@ impl<'i> Prepare<'i> {
         let free_var_capacity = nonlocal_names.len() + implicit_captures.len();
         let mut free_var_map = AHashMap::with_capacity(free_var_capacity);
         for name in nonlocal_names {
-            let slot = namespace_size;
+            let slot = NamespaceId::new(namespace_size).ok_or_else(|| namespace_overflow(position))?;
             namespace_size += 1;
-            free_var_map.insert(name, NamespaceId::new(slot));
+            free_var_map.insert(name, slot);
         }
         // Implicit captures (variables accessed from enclosing scope without explicit nonlocal)
         for name in implicit_captures {
-            let slot = namespace_size;
+            let slot = NamespaceId::new(namespace_size).ok_or_else(|| namespace_overflow(position))?;
             namespace_size += 1;
-            free_var_map.insert(name, NamespaceId::new(slot));
+            free_var_map.insert(name, slot);
         }
 
         Ok(Self {
@@ -366,7 +396,7 @@ impl<'i> Prepare<'i> {
                     // Track that this name was assigned before we call get_id
                     self.names_assigned_in_order
                         .insert(self.interner.get_str(target.name_id).to_string());
-                    let (target, _) = self.get_id(target);
+                    let (target, _) = self.get_id(target)?;
                     new_nodes.push(Node::Assign { target, object });
                 }
                 Node::UnpackAssign {
@@ -379,7 +409,7 @@ impl<'i> Prepare<'i> {
                     let targets = targets
                         .into_iter()
                         .map(|target| self.prepare_unpack_target(target))
-                        .collect();
+                        .collect::<Result<_, _>>()?;
                     new_nodes.push(Node::UnpackAssign {
                         targets,
                         targets_position,
@@ -390,7 +420,7 @@ impl<'i> Prepare<'i> {
                     // Track that this name was assigned
                     self.names_assigned_in_order
                         .insert(self.interner.get_str(target.name_id).to_string());
-                    let target = self.get_id(target).0;
+                    let target = self.get_id(target)?.0;
                     let value = self.prepare_expression(value)?;
                     new_nodes.push(Node::OpAssign { target, op, value });
                 }
@@ -480,7 +510,7 @@ impl<'i> Prepare<'i> {
                     or_else,
                 } => {
                     // Prepare target with normal scoping (not comprehension isolation)
-                    let target = self.prepare_unpack_target(target);
+                    let target = self.prepare_unpack_target(target)?;
                     new_nodes.push(Node::For {
                         target,
                         iter: self.prepare_expression(iter)?,
@@ -610,14 +640,14 @@ impl<'i> Prepare<'i> {
                     // Resolve each binding identifier to get the namespace slot
                     let resolved_names = names
                         .into_iter()
-                        .map(|import_name| {
-                            let (resolved_binding, _) = self.get_id(import_name.binding);
-                            ImportName {
+                        .map(|import_name| -> Result<_, ParseError> {
+                            let (resolved_binding, _) = self.get_id(import_name.binding)?;
+                            Ok(ImportName {
                                 module_name: import_name.module_name,
                                 binding: resolved_binding,
-                            }
+                            })
                         })
-                        .collect();
+                        .collect::<Result<_, _>>()?;
                     new_nodes.push(Node::Import { names: resolved_names });
                 }
                 Node::ImportFrom {
@@ -628,11 +658,11 @@ impl<'i> Prepare<'i> {
                     // Resolve each binding identifier to get namespace slots
                     let resolved_names = names
                         .into_iter()
-                        .map(|(import_name, binding)| {
-                            let (resolved_binding, _) = self.get_id(binding);
-                            (import_name, resolved_binding)
+                        .map(|(import_name, binding)| -> Result<_, ParseError> {
+                            let (resolved_binding, _) = self.get_id(binding)?;
+                            Ok((import_name, resolved_binding))
                         })
-                        .collect();
+                        .collect::<Result<_, _>>()?;
                     new_nodes.push(Node::ImportFrom {
                         module_name,
                         names: resolved_names,
@@ -661,7 +691,7 @@ impl<'i> Prepare<'i> {
                 // Track that this name was assigned
                 self.names_assigned_in_order
                     .insert(self.interner.get_str(ident.name_id).to_string());
-                Some(self.get_id(ident).0)
+                Some(self.get_id(ident)?.0)
             }
             None => None,
         };
@@ -686,7 +716,7 @@ impl<'i> Prepare<'i> {
         let expr = match expr {
             Expr::Literal(object) => Expr::Literal(object),
             Expr::Builtin(callable) => Expr::Builtin(callable),
-            Expr::Name(name) => self.resolve_name_or_builtin(name),
+            Expr::Name(name) => self.resolve_name_or_builtin(name)?,
             Expr::Op { left, op, right } => Expr::Op {
                 left: Box::new(self.prepare_expression(*left)?),
                 op,
@@ -710,7 +740,7 @@ impl<'i> Prepare<'i> {
                 // For Name callables, resolve the identifier in the namespace
                 // Don't error here if undefined - let runtime raise NameError with proper traceback
                 let callable = match callable {
-                    Callable::Name(ident) => match self.resolve_name_or_builtin(ident) {
+                    Callable::Name(ident) => match self.resolve_name_or_builtin(ident)? {
                         Expr::Builtin(b) => Callable::Builtin(b),
                         Expr::Name(resolved) => Callable::Name(resolved),
                         _ => unreachable!("resolve_name_or_builtin returns Name or Builtin"),
@@ -834,7 +864,7 @@ impl<'i> Prepare<'i> {
                 // Register the target as assigned in this scope
                 self.names_assigned_in_order
                     .insert(self.interner.get_str(target.name_id).to_string());
-                let (resolved_target, _) = self.get_id(target);
+                let (resolved_target, _) = self.get_id(target)?;
                 Expr::Named {
                     target: resolved_target,
                     value,
@@ -881,7 +911,7 @@ impl<'i> Prepare<'i> {
     /// We check before calling `get_id` to avoid allocating unnecessary namespace slots.
     /// At module level, a slot allocated for an unassigned builtin would leak into
     /// `global_name_map` for nested functions, causing incorrect resolution.
-    fn resolve_name_or_builtin(&mut self, name: Identifier) -> Expr {
+    fn resolve_name_or_builtin(&mut self, name: Identifier) -> Result<Expr, ParseError> {
         let name_str = self.interner.get_str(name.name_id);
 
         // Check if the name is assigned in the current scope. If so, it shadows
@@ -908,11 +938,11 @@ impl<'i> Prepare<'i> {
                     || self.global_name_map.as_ref().is_some_and(|m| m.contains_key(name_str)));
 
             if !is_otherwise_bound && let Ok(builtin) = name_str.parse::<Builtins>() {
-                return Expr::Builtin(builtin);
+                return Ok(Expr::Builtin(builtin));
             }
         }
 
-        Expr::Name(self.get_id(name).0)
+        Ok(Expr::Name(self.get_id(name)?.0))
     }
 
     /// Prepares a `SequenceItem` by recursively preparing its inner expression.
@@ -964,11 +994,14 @@ impl<'i> Prepare<'i> {
                 collect_assigned_names_from_expr(cond, &mut walrus_targets, self.interner);
             }
         }
-        // Pre-allocate slots for walrus targets in the enclosing scope
+        // Pre-allocate slots for walrus targets in the enclosing scope.
+        // Anchor any namespace-overflow error to the first generator's iter,
+        // since the walrus statements themselves can be scattered through the
+        // comprehension and don't have a single load-bearing position.
+        let comp_pos = generators.first().map(|g| g.iter.position).unwrap_or_default();
         for name in &walrus_targets {
             if !self.name_map.contains_key(name) {
-                let slot = NamespaceId::new(self.namespace_size);
-                self.namespace_size += 1;
+                let slot = self.alloc_slot(comp_pos)?;
                 self.name_map.insert(name.clone(), slot);
                 self.names_assigned_in_order.insert(name.clone());
             }
@@ -994,7 +1027,7 @@ impl<'i> Prepare<'i> {
         // We allocate slots but don't mark them as "assigned" yet - this causes
         // UnboundLocalError if a later generator's iter references an earlier-declared
         // but not-yet-assigned loop variable.
-        let first_target = self.prepare_unpack_target_for_comprehension(first_gen.target);
+        let first_target = self.prepare_unpack_target_for_comprehension(first_gen.target)?;
 
         // Collect remaining generators so we can pre-shadow their targets
         let remaining_gens: Vec<Comprehension> = generators_iter.collect();
@@ -1004,7 +1037,7 @@ impl<'i> Prepare<'i> {
         // so referencing a later loop var in an earlier iter raises UnboundLocalError.
         let mut preshadowed_targets: Vec<UnpackTarget> = Vec::with_capacity(remaining_gens.len());
         for generator in &remaining_gens {
-            preshadowed_targets.push(self.prepare_unpack_target_shadow_only(generator.target.clone()));
+            preshadowed_targets.push(self.prepare_unpack_target_shadow_only(generator.target.clone())?);
         }
 
         // Prepare first generator's filters (can see first loop variable)
@@ -1069,7 +1102,7 @@ impl<'i> Prepare<'i> {
             AssignTarget::Name(ident) => {
                 self.names_assigned_in_order
                     .insert(self.interner.get_str(ident.name_id).to_string());
-                let (ident, _) = self.get_id(ident);
+                let (ident, _) = self.get_id(ident)?;
                 Ok(AssignTarget::Name(ident))
             }
             AssignTarget::Subscript {
@@ -1094,7 +1127,10 @@ impl<'i> Prepare<'i> {
                 targets,
                 targets_position,
             } => {
-                let targets = targets.into_iter().map(|t| self.prepare_unpack_target(t)).collect();
+                let targets = targets
+                    .into_iter()
+                    .map(|t| self.prepare_unpack_target(t))
+                    .collect::<Result<_, _>>()?;
                 Ok(AssignTarget::Unpack {
                     targets,
                     targets_position,
@@ -1106,27 +1142,27 @@ impl<'i> Prepare<'i> {
     /// Prepares an unpack target by resolving identifiers recursively.
     ///
     /// Handles both single identifiers and nested tuples like `(a, b), c`.
-    fn prepare_unpack_target(&mut self, target: UnpackTarget) -> UnpackTarget {
+    fn prepare_unpack_target(&mut self, target: UnpackTarget) -> Result<UnpackTarget, ParseError> {
         match target {
             UnpackTarget::Name(ident) => {
                 self.names_assigned_in_order
                     .insert(self.interner.get_str(ident.name_id).to_string());
-                UnpackTarget::Name(self.get_id(ident).0)
+                Ok(UnpackTarget::Name(self.get_id(ident)?.0))
             }
             UnpackTarget::Starred(ident) => {
                 self.names_assigned_in_order
                     .insert(self.interner.get_str(ident.name_id).to_string());
-                UnpackTarget::Starred(self.get_id(ident).0)
+                Ok(UnpackTarget::Starred(self.get_id(ident)?.0))
             }
             UnpackTarget::Tuple { targets, position } => {
-                let resolved_targets: Vec<UnpackTarget> = targets
+                let resolved_targets = targets
                     .into_iter()
                     .map(|t| self.prepare_unpack_target(t)) // Recursive call
-                    .collect();
-                UnpackTarget::Tuple {
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(UnpackTarget::Tuple {
                     targets: resolved_targets,
                     position,
-                }
+                })
             }
         }
     }
@@ -1135,47 +1171,45 @@ impl<'i> Prepare<'i> {
     ///
     /// Unlike regular unpack targets, comprehension targets need new slots to shadow
     /// any existing bindings with the same name.
-    fn prepare_unpack_target_for_comprehension(&mut self, target: UnpackTarget) -> UnpackTarget {
+    fn prepare_unpack_target_for_comprehension(&mut self, target: UnpackTarget) -> Result<UnpackTarget, ParseError> {
         match target {
             UnpackTarget::Name(ident) => {
                 let name_str = self.interner.get_str(ident.name_id).to_string();
-                let comp_var_id = NamespaceId::new(self.namespace_size);
-                self.namespace_size += 1;
+                let comp_var_id = self.alloc_slot(ident.position)?;
 
                 // Shadow any existing binding
                 self.shadow_for_comprehension(&name_str, comp_var_id);
 
-                UnpackTarget::Name(Identifier::new_with_scope(
+                Ok(UnpackTarget::Name(Identifier::new_with_scope(
                     ident.name_id,
                     ident.position,
                     comp_var_id,
                     NameScope::Local,
-                ))
+                )))
             }
             UnpackTarget::Starred(ident) => {
                 let name_str = self.interner.get_str(ident.name_id).to_string();
-                let comp_var_id = NamespaceId::new(self.namespace_size);
-                self.namespace_size += 1;
+                let comp_var_id = self.alloc_slot(ident.position)?;
 
                 // Shadow any existing binding
                 self.shadow_for_comprehension(&name_str, comp_var_id);
 
-                UnpackTarget::Starred(Identifier::new_with_scope(
+                Ok(UnpackTarget::Starred(Identifier::new_with_scope(
                     ident.name_id,
                     ident.position,
                     comp_var_id,
                     NameScope::Local,
-                ))
+                )))
             }
             UnpackTarget::Tuple { targets, position } => {
-                let resolved_targets: Vec<UnpackTarget> = targets
+                let resolved_targets = targets
                     .into_iter()
                     .map(|t| self.prepare_unpack_target_for_comprehension(t)) // Recursive call
-                    .collect();
-                UnpackTarget::Tuple {
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(UnpackTarget::Tuple {
                     targets: resolved_targets,
                     position,
-                }
+                })
             }
         }
     }
@@ -1184,12 +1218,11 @@ impl<'i> Prepare<'i> {
     ///
     /// Allocates namespace slots without marking as assigned, causing UnboundLocalError
     /// if accessed before assignment.
-    fn prepare_unpack_target_shadow_only(&mut self, target: UnpackTarget) -> UnpackTarget {
+    fn prepare_unpack_target_shadow_only(&mut self, target: UnpackTarget) -> Result<UnpackTarget, ParseError> {
         match target {
             UnpackTarget::Name(ident) => {
                 let name_str = self.interner.get_str(ident.name_id).to_string();
-                let comp_var_id = NamespaceId::new(self.namespace_size);
-                self.namespace_size += 1;
+                let comp_var_id = self.alloc_slot(ident.position)?;
 
                 // Shadow but do NOT add to names_assigned_in_order yet
                 self.name_map.insert(name_str.clone(), comp_var_id);
@@ -1199,17 +1232,16 @@ impl<'i> Prepare<'i> {
                     enclosing.remove(&name_str);
                 }
 
-                UnpackTarget::Name(Identifier::new_with_scope(
+                Ok(UnpackTarget::Name(Identifier::new_with_scope(
                     ident.name_id,
                     ident.position,
                     comp_var_id,
                     NameScope::Local,
-                ))
+                )))
             }
             UnpackTarget::Starred(ident) => {
                 let name_str = self.interner.get_str(ident.name_id).to_string();
-                let comp_var_id = NamespaceId::new(self.namespace_size);
-                self.namespace_size += 1;
+                let comp_var_id = self.alloc_slot(ident.position)?;
 
                 // Shadow but do NOT add to names_assigned_in_order yet
                 self.name_map.insert(name_str.clone(), comp_var_id);
@@ -1219,22 +1251,22 @@ impl<'i> Prepare<'i> {
                     enclosing.remove(&name_str);
                 }
 
-                UnpackTarget::Starred(Identifier::new_with_scope(
+                Ok(UnpackTarget::Starred(Identifier::new_with_scope(
                     ident.name_id,
                     ident.position,
                     comp_var_id,
                     NameScope::Local,
-                ))
+                )))
             }
             UnpackTarget::Tuple { targets, position } => {
-                let resolved_targets: Vec<UnpackTarget> = targets
+                let resolved_targets = targets
                     .into_iter()
                     .map(|t| self.prepare_unpack_target_shadow_only(t)) // Recursive call
-                    .collect();
-                UnpackTarget::Tuple {
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(UnpackTarget::Tuple {
                     targets: resolved_targets,
                     position,
-                }
+                })
             }
         }
     }
@@ -1280,7 +1312,7 @@ impl<'i> Prepare<'i> {
         is_async: bool,
     ) -> Result<PreparedNode, ParseError> {
         // Register the function name in the current scope
-        let (name, _) = self.get_id(name);
+        let (name, _) = self.get_id(name)?;
 
         // Extract param names from the parsed signature for scope analysis
         let param_names: Vec<StringId> = parsed_sig.param_names().collect();
@@ -1346,14 +1378,12 @@ impl<'i> Prepare<'i> {
             if !self.cell_var_map.contains_key(captured_name) && !self.free_var_map.contains_key(captured_name) {
                 // Only add to cell_var_map if not already a free_var (pass-through case)
                 // Allocate a namespace slot for the cell reference
-                let slot = match self.name_map.entry(captured_name.clone()) {
-                    Entry::Occupied(e) => *e.get(),
-                    Entry::Vacant(e) => {
-                        let slot = NamespaceId::new(self.namespace_size);
-                        self.namespace_size += 1;
-                        e.insert(slot);
-                        slot
-                    }
+                let slot = if let Some(existing) = self.name_map.get(captured_name) {
+                    *existing
+                } else {
+                    let slot = self.alloc_slot(name.position)?;
+                    self.name_map.insert(captured_name.clone(), slot);
+                    slot
                 };
                 self.cell_var_map.insert(captured_name.clone(), slot);
             }
@@ -1491,7 +1521,9 @@ impl<'i> Prepare<'i> {
         let lambda_name = Identifier::new_with_scope(
             lambda_name_id,
             position,
-            NamespaceId::new(0), // Placeholder, not actually used for storage
+            // Slot 0 is the trivial placeholder; the lambda name never lands
+            // in a namespace because lambdas don't have a binding name.
+            NamespaceId::new(0).expect("slot 0 fits in u16"),
             NameScope::Local,
         );
 
@@ -1557,14 +1589,12 @@ impl<'i> Prepare<'i> {
         // Mark variables that the inner function captures as our cell_vars
         for captured_name in inner_prepare.free_var_map.keys() {
             if !self.cell_var_map.contains_key(captured_name) && !self.free_var_map.contains_key(captured_name) {
-                let slot = match self.name_map.entry(captured_name.clone()) {
-                    Entry::Occupied(e) => *e.get(),
-                    Entry::Vacant(e) => {
-                        let slot = NamespaceId::new(self.namespace_size);
-                        self.namespace_size += 1;
-                        e.insert(slot);
-                        slot
-                    }
+                let slot = if let Some(existing) = self.name_map.get(captured_name) {
+                    *existing
+                } else {
+                    let slot = self.alloc_slot(position)?;
+                    self.name_map.insert(captured_name.clone(), slot);
+                    slot
                 };
                 self.cell_var_map.insert(captured_name.clone(), slot);
             }
@@ -1694,47 +1724,31 @@ impl<'i> Prepare<'i> {
     ///
     /// # Returns
     /// A tuple of (resolved Identifier with id and scope set, whether this is a new local name).
-    fn get_id(&mut self, ident: Identifier) -> (Identifier, bool) {
+    fn get_id(&mut self, ident: Identifier) -> Result<(Identifier, bool), ParseError> {
         let name_str = self.interner.get_str(ident.name_id);
+        let position = ident.position;
 
         // At module level, all names are local (which is also the global namespace).
         // The compiler emits global opcodes for these, so the VM reads/writes
         // directly from the globals array rather than the stack.
         if self.is_module_scope {
-            return match self.name_map.entry(name_str.to_string()) {
-                Entry::Occupied(e) => {
-                    // Name already exists (from prior reference or pre-registered).
-                    // Determine scope the same way as for vacant entries: if the name
-                    // has been assigned so far, it's a true local; otherwise it's an
-                    // unassigned reference that should yield NameLookup at runtime.
-                    let scope = if self.names_assigned_in_order.contains(name_str) {
-                        NameScope::Local
-                    } else {
-                        NameScope::LocalUnassigned
-                    };
-                    (
-                        Identifier::new_with_scope(ident.name_id, ident.position, *e.get(), scope),
-                        false,
-                    )
-                }
-                Entry::Vacant(e) => {
-                    let id = NamespaceId::new(self.namespace_size);
-                    self.namespace_size += 1;
-                    e.insert(id);
-                    // Determine scope: if the name is assigned somewhere (even later in the file),
-                    // it's a true local that will raise UnboundLocalError if accessed before assignment.
-                    // If the name is never assigned, it's an undefined reference that raises NameError.
-                    let scope = if self.names_assigned_in_order.contains(name_str) {
-                        NameScope::Local
-                    } else {
-                        NameScope::LocalUnassigned
-                    };
-                    (
-                        Identifier::new_with_scope(ident.name_id, ident.position, id, scope),
-                        true,
-                    )
-                }
+            // Determine scope: if the name is assigned somewhere (even later in the
+            // file), it's a true local that will raise UnboundLocalError if accessed
+            // before assignment. If the name is never assigned, it's an undefined
+            // reference that raises NameError.
+            let scope = if self.names_assigned_in_order.contains(name_str) {
+                NameScope::Local
+            } else {
+                NameScope::LocalUnassigned
             };
+            let (id, is_new) = if let Some(existing) = self.name_map.get(name_str).copied() {
+                (existing, false)
+            } else {
+                let id = self.alloc_slot(position)?;
+                self.name_map.insert(name_str.to_string(), id);
+                (id, true)
+            };
+            return Ok((Identifier::new_with_scope(ident.name_id, position, id, scope), is_new));
         }
 
         // In a function: determine scope based on global_names, nonlocal_names, assigned_names, global_name_map
@@ -1745,10 +1759,10 @@ impl<'i> Prepare<'i> {
                 && let Some(&global_id) = global_map.get(name_str)
             {
                 // Name exists in global namespace
-                return (
-                    Identifier::new_with_scope(ident.name_id, ident.position, global_id, NameScope::Global),
+                return Ok((
+                    Identifier::new_with_scope(ident.name_id, position, global_id, NameScope::Global),
                     false,
-                );
+                ));
             }
             // Declared global but doesn't exist yet - it will be created when assigned
             // For now, we still need a global index. We'll use a placeholder approach:
@@ -1757,30 +1771,28 @@ impl<'i> Prepare<'i> {
             // For our implementation, we'll resolve to global but the variable won't exist until assigned.
             // Return a "new" global - but we can't modify global_name_map here.
             // For simplicity, we'll resolve to local with Global scope - runtime will handle the lookup.
-            let (id, is_new) = match self.name_map.entry(name_str.to_string()) {
-                Entry::Occupied(e) => (*e.get(), false),
-                Entry::Vacant(e) => {
-                    let id = NamespaceId::new(self.namespace_size);
-                    self.namespace_size += 1;
-                    e.insert(id);
-                    (id, true)
-                }
+            let (id, is_new) = if let Some(existing) = self.name_map.get(name_str).copied() {
+                (existing, false)
+            } else {
+                let id = self.alloc_slot(position)?;
+                self.name_map.insert(name_str.to_string(), id);
+                (id, true)
             };
             // Mark as Global scope - runtime will need to handle this specially
-            return (
-                Identifier::new_with_scope(ident.name_id, ident.position, id, NameScope::Global),
+            return Ok((
+                Identifier::new_with_scope(ident.name_id, position, id, NameScope::Global),
                 is_new,
-            );
+            ));
         }
 
         // 2. Check if captured from enclosing scope (nonlocal declaration or implicit capture)
         // free_var_map stores namespace slot indices where the cell reference will be stored
         if let Some(&slot) = self.free_var_map.get(name_str) {
             // At runtime, the cell reference is in namespace[slot] as Value::Ref(cell_id)
-            return (
-                Identifier::new_with_scope(ident.name_id, ident.position, slot, NameScope::Cell),
+            return Ok((
+                Identifier::new_with_scope(ident.name_id, position, slot, NameScope::Cell),
                 false, // Not a new local - it's captured from enclosing scope
-            );
+            ));
         }
 
         // 3. Check if this is a cell variable (captured by nested functions)
@@ -1788,27 +1800,25 @@ impl<'i> Prepare<'i> {
         // At call time, a cell is created and stored as Value::Ref(cell_id) at this slot
         if let Some(&slot) = self.cell_var_map.get(name_str) {
             // The namespace slot was already allocated when cell_var_map was populated
-            return (
-                Identifier::new_with_scope(ident.name_id, ident.position, slot, NameScope::Cell),
+            return Ok((
+                Identifier::new_with_scope(ident.name_id, position, slot, NameScope::Cell),
                 false, // Not a "new" local - it's a cell variable
-            );
+            ));
         }
 
         // 4. Check if assigned in this function (local variable)
         if self.assigned_names.contains(name_str) {
-            let (id, is_new) = match self.name_map.entry(name_str.to_string()) {
-                Entry::Occupied(e) => (*e.get(), false),
-                Entry::Vacant(e) => {
-                    let id = NamespaceId::new(self.namespace_size);
-                    self.namespace_size += 1;
-                    e.insert(id);
-                    (id, true)
-                }
+            let (id, is_new) = if let Some(existing) = self.name_map.get(name_str).copied() {
+                (existing, false)
+            } else {
+                let id = self.alloc_slot(position)?;
+                self.name_map.insert(name_str.to_string(), id);
+                (id, true)
             };
-            return (
-                Identifier::new_with_scope(ident.name_id, ident.position, id, NameScope::Local),
+            return Ok((
+                Identifier::new_with_scope(ident.name_id, position, id, NameScope::Local),
                 is_new,
-            );
+            ));
         }
 
         // 5. Check if name was pre-populated in name_map (from function parameters)
@@ -1824,10 +1834,10 @@ impl<'i> Prepare<'i> {
         if !self.unassigned_ref_names.contains(name_str)
             && let Some(&id) = self.name_map.get(name_str)
         {
-            return (
-                Identifier::new_with_scope(ident.name_id, ident.position, id, NameScope::Local),
+            return Ok((
+                Identifier::new_with_scope(ident.name_id, position, id, NameScope::Local),
                 false, // Not new - was pre-populated from parameters
-            );
+            ));
         }
 
         // 6. Check if exists in enclosing scope (implicit closure capture)
@@ -1840,26 +1850,25 @@ impl<'i> Prepare<'i> {
                 existing_slot
             } else {
                 // Allocate a namespace slot for this free variable
-                let slot = NamespaceId::new(self.namespace_size);
-                self.namespace_size += 1;
+                let slot = self.alloc_slot(position)?;
                 self.name_map.insert(name_str.to_string(), slot);
                 self.free_var_map.insert(name_str.to_string(), slot);
                 slot
             };
-            return (
-                Identifier::new_with_scope(ident.name_id, ident.position, slot, NameScope::Cell),
+            return Ok((
+                Identifier::new_with_scope(ident.name_id, position, slot, NameScope::Cell),
                 false, // Not a new local - it's captured from enclosing scope
-            );
+            ));
         }
 
         // 7. Check if exists in global namespace (implicit global read)
         if let Some(ref global_map) = self.global_name_map
             && let Some(&global_id) = global_map.get(name_str)
         {
-            return (
-                Identifier::new_with_scope(ident.name_id, ident.position, global_id, NameScope::Global),
+            return Ok((
+                Identifier::new_with_scope(ident.name_id, position, global_id, NameScope::Global),
                 false,
-            );
+            ));
         }
 
         // 8. Name not found anywhere - allocate a local slot (will be NameError at runtime)
@@ -1869,19 +1878,17 @@ impl<'i> Prepare<'i> {
         // Track in `unassigned_ref_names` so step 6 doesn't treat subsequent references
         // as `Local` (parameters).
         self.unassigned_ref_names.insert(name_str.to_string());
-        let (id, is_new) = match self.name_map.entry(name_str.to_string()) {
-            Entry::Occupied(e) => (*e.get(), false),
-            Entry::Vacant(e) => {
-                let id = NamespaceId::new(self.namespace_size);
-                self.namespace_size += 1;
-                e.insert(id);
-                (id, true)
-            }
+        let (id, is_new) = if let Some(existing) = self.name_map.get(name_str).copied() {
+            (existing, false)
+        } else {
+            let id = self.alloc_slot(position)?;
+            self.name_map.insert(name_str.to_string(), id);
+            (id, true)
         };
-        (
-            Identifier::new_with_scope(ident.name_id, ident.position, id, NameScope::LocalUnassigned),
+        Ok((
+            Identifier::new_with_scope(ident.name_id, position, id, NameScope::LocalUnassigned),
             is_new,
-        )
+        ))
     }
 
     /// Prepares an f-string part by resolving names in interpolated expressions.

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -13,7 +13,7 @@ use crate::{
     io::PrintWriter,
     namespace::NamespaceId,
     object::MontyObject,
-    parse::{parse, parse_with_interner},
+    parse::{CodeRange, ParseError, parse, parse_with_interner},
     prepare::{prepare, prepare_with_existing_names},
     resource::{NoLimitTracker, ResourceTracker},
     run_progress::{RunProgress, build_run_progress, check_snapshot_from_converted, convert_frame_exit},
@@ -234,9 +234,10 @@ impl Executor {
         // Create interns with empty functions (functions will be set after compilation)
         let mut interns = Interns::new(prepared.interner, Vec::new());
 
-        // Compile the module to bytecode, which also compiles all nested functions
-        let namespace_size_u16 = u16::try_from(prepared.namespace_size).expect("module namespace size exceeds u16");
-        let compile_result = Compiler::compile_module(&prepared.nodes, &interns, namespace_size_u16)
+        // Compile the module to bytecode, which also compiles all nested functions.
+        // The compiler enforces the bytecode-format namespace-size limit and reports
+        // it as a `SyntaxError` rather than panicking on the `u16` cast.
+        let compile_result = Compiler::compile_module(&prepared.nodes, &interns, prepared.namespace_size)
             .map_err(|e| e.into_python_exc(script_name, &code))?;
 
         // Set the compiled functions in the interns
@@ -272,11 +273,22 @@ impl Executor {
     ) -> Result<Self, MontyException> {
         check_identifier(&input_names)?;
         // Pre-register input names so they get stable slots before preparation.
+        // Surfaced via the standard parse/prepare error path; if the embedder
+        // hands over more than `u16::MAX + 1` names the bytecode encoding
+        // can't represent them all.
         for name in &input_names {
+            if existing_name_map.contains_key(name) {
+                continue;
+            }
             let next_slot = existing_name_map.len();
-            existing_name_map
-                .entry(name.clone())
-                .or_insert_with(|| NamespaceId::new(next_slot));
+            let slot = NamespaceId::new(next_slot).ok_or_else(|| {
+                ParseError::syntax(
+                    format!("too many distinct names in scope; maximum is {} per scope", u16::MAX),
+                    CodeRange::default(),
+                )
+                .into_python_exc(script_name, &code)
+            })?;
+            existing_name_map.insert(name.clone(), slot);
         }
 
         let seeded_interner = InternerBuilder::from_interns(existing_interns, &code);
@@ -287,10 +299,13 @@ impl Executor {
 
         let existing_functions = existing_interns.functions_clone();
         let mut interns = Interns::new(prepared.interner, Vec::new());
-        let namespace_size_u16 = u16::try_from(prepared.namespace_size).expect("module namespace size exceeds u16");
-        let compile_result =
-            Compiler::compile_module_with_functions(&prepared.nodes, &interns, namespace_size_u16, existing_functions)
-                .map_err(|e| e.into_python_exc(script_name, &code))?;
+        let compile_result = Compiler::compile_module_with_functions(
+            &prepared.nodes,
+            &interns,
+            prepared.namespace_size,
+            existing_functions,
+        )
+        .map_err(|e| e.into_python_exc(script_name, &code))?;
         interns.set_functions(compile_result.functions);
 
         Ok(Self {

--- a/crates/monty/tests/parse_errors.rs
+++ b/crates/monty/tests/parse_errors.rs
@@ -706,7 +706,7 @@ fn module_with_too_many_interned_strings_returns_syntax_error() {
     assert_eq!(err.exc_type(), ExcType::SyntaxError);
     assert_eq!(
         err.message(),
-        Some("module has too many distinct names; the bytecode format supports up to 65535 interned strings"),
+        Some("module has too many distinct names; the bytecode format supports up to 65536 interned strings"),
     );
 }
 

--- a/crates/monty/tests/parse_errors.rs
+++ b/crates/monty/tests/parse_errors.rs
@@ -646,3 +646,134 @@ fn moderate_bool_op_chain_within_limit() {
     let result = MontyRun::new(code, "test.py", vec![]);
     assert!(result.is_ok(), "moderate bool-op chain should succeed: {result:?}");
 }
+
+#[test]
+fn function_with_too_many_locals_and_except_as_returns_syntax_error() {
+    let mut code = "def f():\n".to_owned();
+    for i in 0..256 {
+        writeln!(code, "    l{i} = 0").unwrap();
+    }
+    code.push_str("    try:\n        1/0\n    except Exception as e:\n        pass\n");
+    let result = MontyRun::new(code, "test.py", vec![]);
+    let err = result.expect_err("expected compile error");
+    assert_eq!(err.exc_type(), ExcType::SyntaxError);
+    assert_eq!(
+        err.message(),
+        Some("cannot delete local variable in function with more than 256 locals (slot 256)"),
+    );
+}
+
+#[test]
+fn function_with_oversized_jump_offset_returns_syntax_error() {
+    let mut code = "def f(x):\n    if x:\n".to_owned();
+    for i in 0..20_000 {
+        writeln!(code, "        a{i} = 1").unwrap();
+    }
+    code.push_str("    return 0\n");
+    let result = MontyRun::new(code, "test.py", vec![]);
+    let err = result.expect_err("expected compile error");
+    assert_eq!(err.exc_type(), ExcType::SyntaxError);
+    assert_eq!(err.message(), Some("function too large: jump offset exceeds i16 range"));
+}
+
+#[test]
+fn module_with_too_many_names_returns_syntax_error() {
+    // 70 000 distinct top-level names is enough to overflow u16 even after
+    // any future small per-module reservations.
+    let mut code = String::with_capacity(700_000);
+    for i in 0..70_000 {
+        writeln!(code, "a{i} = 1").unwrap();
+    }
+    let result = MontyRun::new(code, "test.py", vec![]);
+    let err = result.expect_err("expected compile error");
+    assert_eq!(err.exc_type(), ExcType::SyntaxError);
+    assert_eq!(
+        err.message(),
+        Some("too many distinct names in scope; maximum is 65535 per scope"),
+    );
+}
+
+#[test]
+fn module_with_too_many_interned_strings_returns_syntax_error() {
+    // 60 000 distinct attribute references push the user-intern pool past its
+    // `u16::MAX - INTERN_STRING_ID_OFFSET` cap.
+    let mut code = "x = None\n".to_owned();
+    for i in 0..60_000 {
+        writeln!(code, "x.a{i}").unwrap();
+    }
+    let result = MontyRun::new(code, "test.py", vec![]);
+    let err = result.expect_err("expected compile error");
+    assert_eq!(err.exc_type(), ExcType::SyntaxError);
+    assert_eq!(
+        err.message(),
+        Some("module has too many distinct names; the bytecode format supports up to 65535 interned strings"),
+    );
+}
+
+#[test]
+fn oversized_tuple_literal_returns_syntax_error() {
+    let mut code = "x = (".to_owned();
+    for _ in 0..70_000 {
+        code.push_str("1, ");
+    }
+    code.push_str(")\n");
+    let result = MontyRun::new(code, "test.py", vec![]);
+    let err = result.expect_err("expected compile error");
+    assert_eq!(err.exc_type(), ExcType::SyntaxError);
+    assert_eq!(
+        err.message(),
+        Some("function too large: required stack exceeds u16::MAX")
+    );
+}
+
+#[test]
+fn oversized_unpacking_call_returns_syntax_error() {
+    let mut code = "def f(*args): return 0\nxs = ()\nf(".to_owned();
+    for _ in 0..70_000 {
+        code.push_str("1, ");
+    }
+    code.push_str("*xs)\n");
+    let result = MontyRun::new(code, "test.py", vec![]);
+    let err = result.expect_err("expected compile error");
+    assert_eq!(err.exc_type(), ExcType::SyntaxError);
+    assert_eq!(
+        err.message(),
+        Some("function too large: required stack exceeds u16::MAX")
+    );
+}
+
+#[test]
+fn function_with_too_many_defaults_returns_syntax_error() {
+    let mut code = "def f(".to_owned();
+    for i in 0..256 {
+        if i > 0 {
+            code.push_str(", ");
+        }
+        write!(code, "a{i}=0").unwrap();
+    }
+    code.push_str("): pass\n");
+    let result = MontyRun::new(code, "test.py", vec![]);
+    let err = result.expect_err("expected compile error");
+    assert_eq!(err.exc_type(), ExcType::SyntaxError);
+    assert_eq!(err.message(), Some("more than 255 default parameter values (256)"));
+}
+
+#[test]
+fn function_with_too_many_closure_variables_returns_syntax_error() {
+    // Each `xN` reference in `inner` captures the enclosing local as a free
+    // variable, so 256 distinct references push `MakeClosure`'s cell-count
+    // operand past `u8`. Flat per-statement references avoid hitting the
+    // parser's nested-parens depth limit before the closure-count limit.
+    let mut code = "def outer():\n".to_owned();
+    for i in 0..256 {
+        writeln!(code, "    x{i} = 0").unwrap();
+    }
+    code.push_str("    def inner():\n");
+    for i in 0..256 {
+        writeln!(code, "        _ = x{i}").unwrap();
+    }
+    let result = MontyRun::new(code, "test.py", vec![]);
+    let err = result.expect_err("expected compile error");
+    assert_eq!(err.exc_type(), ExcType::SyntaxError);
+    assert_eq!(err.message(), Some("more than 255 closure variables (256)"));
+}


### PR DESCRIPTION
This is a lot of churn, most of it is adding `?` across compiler functions. Makes the chance of panic from bad compile input much much lower.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Convert compiler limit failures from panics to `SyntaxError`s so oversized or invalid programs fail cleanly and predictably, removing many crash paths in the compiler.

- **Refactors**
  - All `CodeBuilder` emit/jump/patch helpers now return `Result<_, CompileError>` and validate stack depth, jump ranges, constant-pool size, keyword counts, name-id width, and bytecode size; jump overflows are reported at the jump site.
  - `ExceptionEntry::new` now takes `u32` offsets; the builder converts/validates from `Offset`. `Offset::as_u32` returns `Option`.
  - `NamespaceId` is `u16`; `NamespaceId::new` returns `Option`. Prepare allocators (`alloc_slot`, `new_module`, identifier resolution) return `ParseError` on overflow; executor input-name seeding reports `SyntaxError` on overflow.
  - `Compiler::compile_module(_with_functions)` takes the namespace size directly; the compiler enforces bytecode limits internally. `Code::location_for_offset` degrades gracefully if the offset doesn’t fit `u32`.

- **Bug Fixes**
  - All size/limit violations now surface as `SyntaxError`: too-large jumps, stack overflow, constant pool full, too many keyword args, interned-name/id overflow, too many locals/defaults/closure vars, and oversized bytecode or scopes.
  - Edge cases like `except … as e` cleanup in functions with >255 locals now error cleanly.
  - Added tests covering these cases.

<sup>Written for commit 52407dad4a8668c1b7b1241c9559bc97db532db6. Summary will update on new commits. <a href="https://cubic.dev/pr/pydantic/monty/pull/449?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

