### PR TITLE
avoid unbounded recursion in `monty_to_py`

### DIFF
--- a/crates/monty-python/src/convert.rs
+++ b/crates/monty-python/src/convert.rs
@@ -182,6 +182,26 @@ pub fn py_to_monty(obj: &Bound<'_, PyAny>, dc_registry: &DcRegistry, mut depth: 
 /// an instance of the original Python type is created (so `isinstance()` works).
 /// Otherwise, falls back to `PyMontyDataclass`.
 pub fn monty_to_py(py: Python<'_>, obj: &MontyObject, dc_registry: &DcRegistry) -> PyResult<Py<PyAny>> {
+    monty_to_py_inner(py, obj, dc_registry, 0)
+}
+
+/// Recursive worker for [`monty_to_py`] that threads a native-stack depth counter.
+///
+/// `depth` is the current nesting level on entry; the function bumps it before
+/// processing and raises `RuntimeError` once it exceeds [`MAX_DEPTH`]. This
+/// prevents adversarial input — e.g. deeply nested tuples built in a `for`
+/// loop that never push a Python call frame — from overflowing the Rust call
+/// stack and aborting the host process.
+pub(crate) fn monty_to_py_inner(
+    py: Python<'_>,
+    obj: &MontyObject,
+    dc_registry: &DcRegistry,
+    mut depth: u8,
+) -> PyResult<Py<PyAny>> {
+    depth += 1;
+    if depth > MAX_DEPTH {
+        return Err(PyRuntimeError::new_err("Max output depth exceeded"));
+    }
     match obj {
         MontyObject::None => Ok(py.None()),
         MontyObject::Ellipsis => Ok(py.Ellipsis()),
@@ -192,13 +212,17 @@ pub fn monty_to_py(py: Python<'_>, obj: &MontyObject, dc_registry: &DcRegistry) 
         MontyObject::String(s) => Ok(PyString::new(py, s).into_any().unbind()),
         MontyObject::Bytes(b) => Ok(PyBytes::new(py, b).into_any().unbind()),
         MontyObject::List(items) => {
-            let py_items: PyResult<Vec<Py<PyAny>>> =
-                items.iter().map(|item| monty_to_py(py, item, dc_registry)).collect();
+            let py_items: PyResult<Vec<Py<PyAny>>> = items
+                .iter()
+                .map(|item| monty_to_py_inner(py, item, dc_registry, depth))
+                .collect();
             Ok(PyList::new(py, py_items?)?.into_any().unbind())
         }
         MontyObject::Tuple(items) => {
-            let py_items: PyResult<Vec<Py<PyAny>>> =
-                items.iter().map(|item| monty_to_py(py, item, dc_registry)).collect();
+            let py_items: PyResult<Vec<Py<PyAny>>> = items
+                .iter()
+                .map(|item| monty_to_py_inner(py, item, dc_registry, depth))
+                .collect();
             Ok(PyTuple::new(py, py_items?)?.into_any().unbind())
         }
         // NamedTuple - create a proper Python namedtuple using collections.namedtuple
@@ -230,28 +254,35 @@ pub fn monty_to_py(py: Python<'_>, obj: &MontyObject, dc_registry: &DcRegistry) 
             // Convert values and instantiate using _make() which accepts an iterable
             // note `_make` might start with an underscore, but it's a public documented method
             // https://docs.python.org/3/library/collections.html#collections.somenamedtuple._make
-            let py_values: PyResult<Vec<Py<PyAny>>> =
-                values.iter().map(|item| monty_to_py(py, item, dc_registry)).collect();
+            let py_values: PyResult<Vec<Py<PyAny>>> = values
+                .iter()
+                .map(|item| monty_to_py_inner(py, item, dc_registry, depth))
+                .collect();
             let instance = nt_type.call_method1("_make", (py_values?,))?;
             Ok(instance.into_any().unbind())
         }
         MontyObject::Dict(map) => {
             let dict = PyDict::new(py);
             for (k, v) in map {
-                dict.set_item(monty_to_py(py, k, dc_registry)?, monty_to_py(py, v, dc_registry)?)?;
+                dict.set_item(
+                    monty_to_py_inner(py, k, dc_registry, depth)?,
+                    monty_to_py_inner(py, v, dc_registry, depth)?,
+                )?;
             }
             Ok(dict.into_any().unbind())
         }
         MontyObject::Set(items) => {
             let set = PySet::empty(py)?;
             for item in items {
-                set.add(monty_to_py(py, item, dc_registry)?)?;
+                set.add(monty_to_py_inner(py, item, dc_registry, depth)?)?;
             }
             Ok(set.into_any().unbind())
         }
         MontyObject::FrozenSet(items) => {
-            let py_items: PyResult<Vec<Py<PyAny>>> =
-                items.iter().map(|item| monty_to_py(py, item, dc_registry)).collect();
+            let py_items: PyResult<Vec<Py<PyAny>>> = items
+                .iter()
+                .map(|item| monty_to_py_inner(py, item, dc_registry, depth))
+                .collect();
             Ok(PyFrozenSet::new(py, &py_items?)?.into_any().unbind())
         }
         // Return the exception instance as a value (not raised)
@@ -277,7 +308,7 @@ pub fn monty_to_py(py: Python<'_>, obj: &MontyObject, dc_registry: &DcRegistry) 
             field_names,
             attrs,
             frozen,
-        } => dataclass_to_py(py, name, *type_id, field_names, attrs, *frozen, dc_registry),
+        } => dataclass_to_py(py, name, *type_id, field_names, attrs, *frozen, dc_registry, depth),
         // Path - convert to Python pathlib.Path
         MontyObject::Path(p) => {
             let pure_posix_path = get_pure_posix_path(py)?;

--- a/crates/monty-python/src/dataclass.rs
+++ b/crates/monty-python/src/dataclass.rs
@@ -20,7 +20,7 @@ use pyo3::{
     types::{PyDict, PyList, PyString, PyType},
 };
 
-use crate::convert::{monty_to_py, py_to_monty};
+use crate::convert::{monty_to_py_inner, py_to_monty};
 
 /// Checks if a Python object is a dataclass instance (not a type).
 ///
@@ -95,6 +95,11 @@ pub fn dataclass_to_monty(value: &Bound<'_, PyAny>, dc_registry: &DcRegistry, de
 /// If the `type_id` is found in the dc_registry, creates an instance of the original
 /// Python dataclass type (so `isinstance(result, OriginalClass)` works).
 /// Otherwise, falls back to creating a `PyUnknownDataclass`.
+///
+/// `depth` is the caller's current recursion depth; it is forwarded to
+/// `monty_to_py_inner` so nested dataclass fields continue to respect the
+/// output-depth limit and cannot trigger a native stack overflow.
+#[expect(clippy::too_many_arguments)]
 pub fn dataclass_to_py(
     py: Python<'_>,
     name: &str,
@@ -103,6 +108,7 @@ pub fn dataclass_to_py(
     attrs: &DictPairs,
     frozen: bool,
     dc_registry: &DcRegistry,
+    depth: u8,
 ) -> PyResult<Py<PyAny>> {
     // Try to use the original type from the dc_registry (keyed by type_id)
     if let Some(original_type_py) = dc_registry.get(py, type_id)? {
@@ -115,7 +121,7 @@ pub fn dataclass_to_py(
                 // Only include declared fields in constructor kwargs
                 let key_str = s.as_str();
                 if field_names.iter().any(|f| f.as_str() == key_str) {
-                    kwargs.set_item(key_str, monty_to_py(py, value, dc_registry)?)?;
+                    kwargs.set_item(key_str, monty_to_py_inner(py, value, dc_registry, depth)?)?;
                 }
             }
         }
@@ -124,7 +130,15 @@ pub fn dataclass_to_py(
         original_type.call((), Some(&kwargs)).map(Bound::unbind)
     } else {
         // Fall back to PyUnknownDataclass
-        let dc = PyUnknownDataclass::new(py, name.to_string(), field_names.to_vec(), attrs, frozen, dc_registry)?;
+        let dc = PyUnknownDataclass::new(
+            py,
+            name.to_string(),
+            field_names.to_vec(),
+            attrs,
+            frozen,
+            dc_registry,
+            depth,
+        )?;
         Ok(Py::new(py, dc)?.into_any())
     }
 }
@@ -401,6 +415,9 @@ impl PyUnknownDataclass {
 
 impl PyUnknownDataclass {
     /// Creates a new `PyUnknownDataclass` from `MontyObject` fields.
+    ///
+    /// `depth` is the caller's current recursion depth and is forwarded to
+    /// `monty_to_py_inner` so field conversion respects the output-depth limit.
     pub fn new<'a>(
         py: Python<'_>,
         name: String,
@@ -408,10 +425,14 @@ impl PyUnknownDataclass {
         attrs: impl IntoIterator<Item = &'a (MontyObject, MontyObject)>,
         frozen: bool,
         dc_registry: &DcRegistry,
+        depth: u8,
     ) -> PyResult<Self> {
         let dict = PyDict::new(py);
         for (k, v) in attrs {
-            dict.set_item(monty_to_py(py, k, dc_registry)?, monty_to_py(py, v, dc_registry)?)?;
+            dict.set_item(
+                monty_to_py_inner(py, k, dc_registry, depth)?,
+                monty_to_py_inner(py, v, dc_registry, depth)?,
+            )?;
         }
         Ok(Self {
             name,

--- a/crates/monty-python/tests/test_inputs.py
+++ b/crates/monty-python/tests/test_inputs.py
@@ -147,6 +147,23 @@ def test_input_deep():
     assert str(exc_info.value) == snapshot('RuntimeError: Max input depth exceeded')
 
 
+def test_output_deep():
+    # Sandbox code that iteratively builds a deeply nested list bypasses the
+    # Python-level recursion limit (the `for` loop never pushes a call frame),
+    # so monty_to_py needs its own depth guard to avoid overflowing the host's
+    # native stack when converting the result back.
+    code = """
+x = [1]
+for _ in range(300):
+    x = [x]
+x
+"""
+    m = pydantic_monty.Monty(code)
+    with pytest.raises(RuntimeError) as exc_info:
+        m.run()
+    assert str(exc_info.value) == snapshot('Max output depth exceeded')
+
+
 def test_empty_inputs():
     m = pydantic_monty.Monty('1 + 1', inputs=[])
     assert m.run(inputs={}) == snapshot(2)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a depth guard to `monty_to_py` to prevent native stack overflows when converting deeply nested outputs. All recursive conversions now respect a shared `MAX_DEPTH`, and a test covers the new failure mode.

- **Bug Fixes**
  - Introduced `monty_to_py_inner` with a depth counter; raises `RuntimeError("Max output depth exceeded")`.
  - Switched recursive calls for lists, tuples, sets, frozensets, dicts, and namedtuples to use `monty_to_py_inner`.
  - Threaded depth through dataclass path: `dataclass_to_py` and `PyUnknownDataclass::new` accept `depth` and forward it to field conversions.
  - Added `test_output_deep` to verify deeply nested results created in a loop trigger the depth guard.

<sup>Written for commit e6a5021351966a73028929d993a9d8a3e77a616a. Summary will update on new commits. <a href="https://cubic.dev/pr/pydantic/monty/pull/453?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

