### PR TITLE
fix: name-based identity and equality for external function values

### DIFF
--- a/crates/monty-python/tests/test_external_function_identity.py
+++ b/crates/monty-python/tests/test_external_function_identity.py
@@ -1,0 +1,78 @@
+"""Identity and equality semantics for external function inputs (#347, #345).
+
+Monty represents external function inputs in two ways depending on whether the
+function's `__name__` was interned during parsing:
+
+- inline `Value::ExtFunction(StringId)` when the name appears in source
+- heap `HeapData::ExtFunction(String)` otherwise
+
+Both representations refer to the same logical callable and must therefore be
+`is`-, `==`-, `id()`-, and `hash()`-identical based on the name string. The same
+callable passed twice as input must satisfy these invariants regardless of
+which path the conversion takes.
+"""
+
+from inline_snapshot import snapshot
+
+import pydantic_monty
+
+
+def foo():
+    pass
+
+
+def bar():
+    pass
+
+
+def test_same_callable_identical_when_name_not_in_source():
+    m = pydantic_monty.Monty('(a is b, a == b)', inputs=['a', 'b'])
+    assert m.run(inputs={'a': foo, 'b': foo}) == snapshot((True, True))
+
+
+def test_same_callable_identical_when_name_in_source():
+    # `foo = None` interns the string "foo" during parsing, so the input
+    # conversion takes the inline `Value::ExtFunction(StringId)` path.
+    m = pydantic_monty.Monty('foo = None\n(a is b, a == b)', inputs=['a', 'b'])
+    assert m.run(inputs={'a': foo, 'b': foo}) == snapshot((True, True))
+
+
+def test_id_matches_is_for_same_callable():
+    m = pydantic_monty.Monty('id(a) == id(b)', inputs=['a', 'b'])
+    assert m.run(inputs={'a': foo, 'b': foo}) == snapshot(True)
+
+
+def test_hash_matches_equality_for_same_callable():
+    m = pydantic_monty.Monty('hash(a) == hash(b)', inputs=['a', 'b'])
+    assert m.run(inputs={'a': foo, 'b': foo}) == snapshot(True)
+
+
+def test_callable_as_dict_key_round_trips():
+    # Inserting under one binding and reading under the other relies on
+    # consistent hash + equality across the inputs.
+    m = pydantic_monty.Monty('d = {a: 42}\nd[b]', inputs=['a', 'b'])
+    assert m.run(inputs={'a': foo, 'b': foo}) == snapshot(42)
+
+
+def test_distinct_named_callables_remain_distinct():
+    # Different __name__ values must not collapse: the most we collapse on is
+    # the function name, and these have different names.
+    m = pydantic_monty.Monty('(a is b, a == b)', inputs=['a', 'b'])
+    assert m.run(inputs={'a': foo, 'b': bar}) == snapshot((False, False))
+
+
+def test_inline_callable_exports_as_function_object():
+    # Round-trip through the inline path (the bug from #345): when the
+    # function name is interned in source, the inline `Value::ExtFunction`
+    # used to fall through to `repr_or_error` and export as the repr string
+    # `<function 'foo' external>` rather than the name `foo`.
+    m = pydantic_monty.Monty('foo = None\nx', inputs=['x'])
+    assert m.run(inputs={'x': foo}) == snapshot('foo')
+
+
+def test_callable_export_stable_across_source_mention():
+    # Same callable, two source variants. The exported value must be the same
+    # representation regardless of whether the name was interned.
+    m1 = pydantic_monty.Monty('x', inputs=['x'])
+    m2 = pydantic_monty.Monty('foo = None\nx', inputs=['x'])
+    assert m1.run(inputs={'x': foo}) == m2.run(inputs={'x': foo})

--- a/crates/monty/src/builtins/id.rs
+++ b/crates/monty/src/builtins/id.rs
@@ -11,7 +11,7 @@ pub fn builtin_id(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> Run
     let value = args.get_one_arg("id", vm.heap)?;
     defer_drop!(value, vm);
 
-    let id = value.id();
+    let id = value.id(vm);
 
     // Python's id() returns a signed integer; reinterpret bits for large values
     // On 64-bit: large addresses wrap to negative; on 32-bit: always fits positive

--- a/crates/monty/src/bytecode/vm/compare.rs
+++ b/crates/monty/src/bytecode/vm/compare.rs
@@ -58,14 +58,6 @@ impl<T: ResourceTracker> VM<'_, T> {
     }
 
     /// Identity comparison (is/is not).
-    ///
-    /// Compares identity using `Value::is()` which compares IDs.
-    ///
-    /// Identity is determined by `Value::id()` which uses:
-    /// - Fixed IDs for singletons (None, True, False, Ellipsis)
-    /// - Interned string/bytes index for InternString/InternBytes
-    /// - HeapId for heap-allocated values (Ref)
-    /// - Value-based hashing for immediate types (Int, Float, Function, etc.)
     pub(super) fn compare_is(&mut self, negate: bool) {
         let this = self;
 
@@ -74,7 +66,7 @@ impl<T: ResourceTracker> VM<'_, T> {
         let lhs = this.pop();
         defer_drop!(lhs, this);
 
-        let result = lhs.is(rhs);
+        let result = lhs.is(rhs, this);
         this.push(Value::Bool(if negate { !result } else { result }));
     }
 

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -16,7 +16,7 @@ use crate::{
     asyncio::{Awaiter, Coroutine, ExternalFuture, ExternalFutureState, GatherFuture, GatherState},
     bytecode::{CallResult, VM},
     exception_private::{RunError, RunResult, SimpleException},
-    hash::HashValue,
+    hash::{HashValue, hash_python_str},
     heap::{DropWithHeap, HeapId, HeapItem, HeapReadOutput},
     intern::FunctionId,
     types::{
@@ -635,6 +635,10 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
             (HeapReadOutput::DateTime(a), HeapReadOutput::DateTime(b)) => a.py_eq(b, vm),
             (HeapReadOutput::TimeDelta(a), HeapReadOutput::TimeDelta(b)) => a.py_eq(b, vm),
             (HeapReadOutput::TimeZone(a), HeapReadOutput::TimeZone(b)) => a.py_eq(b, vm),
+            // External functions compare equal iff their names match — the
+            // same name-based identity used by `Value::py_eq`'s ExtFunction
+            // arms and `py_hash` via `hash_python_str`. (#347)
+            (HeapReadOutput::ExtFunction(a), HeapReadOutput::ExtFunction(b)) => Ok(a.get(vm.heap) == b.get(vm.heap)),
             // Identity-only types (handled by HeapId comparison above)
             (HeapReadOutput::ReMatch(_), HeapReadOutput::ReMatch(_))
             | (HeapReadOutput::Cell(_), HeapReadOutput::Cell(_))
@@ -691,11 +695,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
             // LongInt's hash matches `Value::InternLongInt`'s, since they are
             // both Python `int` values and must hash equally when equal.
             Self::LongInt(li) => Ok(Some(li.get(vm.heap).hash())),
-            Self::ExtFunction(name) => {
-                let mut hasher = DefaultHasher::new();
-                name.get(vm.heap).hash(&mut hasher);
-                Ok(Some(HashValue::new(hasher.finish())))
-            }
+            Self::ExtFunction(name) => Ok(Some(hash_python_str(name.get(vm.heap)))),
             // Unhashable: List, Dict, Set, the dict views, Iter, Module,
             // Exception, Coroutine, GatherFuture, RePattern, ReMatch.
             _ => Ok(None),

--- a/crates/monty/src/object.rs
+++ b/crates/monty/src/object.rs
@@ -805,6 +805,14 @@ impl MontyObject {
             Value::Builtin(Builtins::Type(t)) => Self::Type(*t),
             Value::Builtin(Builtins::ExcType(e)) => Self::Type(Type::Exception(*e)),
             Value::Builtin(Builtins::Function(f)) => Self::BuiltinFunction(*f),
+            // Inline external function: export under the same shape as the heap
+            // path's `HeapReadOutput::ExtFunction` arm above, so an interned
+            // function name round-trips through Monty as `MontyObject::Function`
+            // regardless of which representation it took (issue #345).
+            Value::ExtFunction(name_id) => Self::Function {
+                name: vm.interns.get_str(*name_id).to_owned(),
+                docstring: None,
+            },
             #[cfg(feature = "memory-model-checks")]
             Value::Dereferenced => panic!("Dereferenced found while converting to MontyObject"),
             _ => repr_or_error(object, vm),

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -18,7 +18,7 @@ use crate::{
     builtins::Builtins,
     bytecode::{CallResult, VM},
     exception_private::{ExcType, RunError, RunResult, SimpleException},
-    hash::HashValue,
+    hash::{HashValue, hash_python_str},
     heap::{ContainsHeap, DropWithHeap, Heap, HeapData, HeapGuard, HeapId, HeapReadOutput},
     intern::{BytesId, FunctionId, Interns, LongIntId, StaticStrings, StringId},
     modules::ModuleFunctions,
@@ -215,6 +215,19 @@ impl PyTrait<'_> for Value {
             // Module functions equality
             (Self::ModuleFunction(mf1), Self::ModuleFunction(mf2)) => Ok(mf1 == mf2),
             (Self::DefFunction(f1), Self::DefFunction(f2)) => Ok(f1 == f2),
+            // External function equality is name-based: two ExtFunction values
+            // (any combination of inline `Value::ExtFunction(StringId)` and heap
+            // `HeapData::ExtFunction(String)`) compare equal iff they reference
+            // the same function name. Interned StringIds are deduped, so equal
+            // StringId ⇔ equal string; the cross-representation arms read the
+            // heap string directly. (#347)
+            (Self::ExtFunction(s1), Self::ExtFunction(s2)) => Ok(s1 == s2),
+            (Self::ExtFunction(s), Self::Ref(id)) if let HeapData::ExtFunction(n) = vm.heap.get(*id) => {
+                Ok(interns.get_str(*s) == n.as_str())
+            }
+            (Self::Ref(id), Self::ExtFunction(s)) if let HeapData::ExtFunction(n) = vm.heap.get(*id) => {
+                Ok(n.as_str() == interns.get_str(*s))
+            }
             // Markers compare equal if they're the same variant
             (Self::Marker(m1), Self::Marker(m2)) => Ok(m1 == m2),
             // Properties compare equal if they're the same variant
@@ -329,8 +342,8 @@ impl PyTrait<'_> for Value {
                 }
             }
             Self::Builtin(b) => Ok(b.py_repr_fmt(f)?),
-            Self::ModuleFunction(mf) => Ok(mf.py_repr_fmt(f, self.id())?),
-            Self::DefFunction(f_id) => Ok(interns.get_function(*f_id).py_repr_fmt(f, interns, self.id())?),
+            Self::ModuleFunction(mf) => Ok(mf.py_repr_fmt(f, self.id(vm))?),
+            Self::DefFunction(f_id) => Ok(interns.get_function(*f_id).py_repr_fmt(f, interns, self.id(vm))?),
             Self::ExtFunction(name_id) => Ok(write!(f, "<function '{}' external>", interns.get_str(*name_id))?),
             Self::InternString(string_id) => Ok(string_repr_fmt(interns.get_str(*string_id), f)?),
             Self::InternBytes(bytes_id) => Ok(bytes_repr_fmt(interns.get_bytes(*bytes_id), f)?),
@@ -1406,9 +1419,14 @@ impl Value {
         }
     }
 
-    /// Returns a stable, unique identifier for this value.
+    /// Returns the Python-visible `id()` for this value.
     ///
-    /// Should match Python's `id()` function conceptually.
+    /// `ExtFunction` values (inline `Value::ExtFunction` or heap
+    /// `HeapData::ExtFunction`) get a name-derived id so that two external
+    /// function values with the same name always satisfy CPython's invariant
+    /// `a is b ⇒ id(a) == id(b)` — needed because `MontyObject::Function`
+    /// conversion has discarded host object identity. All other variants use
+    /// a representation-based id.
     ///
     /// For immediate values (Int, Float, Builtins), this computes a deterministic ID
     /// based on the value's hash, avoiding heap allocation. This means `id(5) == id(5)` will
@@ -1416,9 +1434,16 @@ impl Value {
     ///
     /// Singletons (None, True, False, etc.) return IDs from a dedicated tagged range.
     /// Interned strings/bytes use their interner index for stable identity.
-    /// Heap-allocated values (Ref) reuse their `HeapId` inside the heap-tagged range.
-    pub fn id(&self) -> usize {
+    /// Heap-allocated values (Ref) reuse their `HeapId` inside the heap-tagged range,
+    /// except for heap `ExtFunction` which uses the name-derived id described above.
+    pub fn id(&self, vm: &VM<'_, impl ResourceTracker>) -> usize {
         match self {
+            // ExtFunction id is name-derived so the inline and heap representations
+            // agree; this also keeps `is(a, b) ⇒ id(a) == id(b)`. The guarded `Ref`
+            // arm must precede the bare `Ref` arm below — match evaluation is
+            // top-to-bottom.
+            Self::ExtFunction(name_id) => ext_function_value_id(vm.interns.get_str(*name_id)),
+            Self::Ref(id) if let HeapData::ExtFunction(name) = vm.heap.get(*id) => ext_function_value_id(name.as_str()),
             // Singletons have fixed tagged IDs
             Self::Undefined => singleton_id(SingletonSlot::Undefined),
             Self::Ellipsis => singleton_id(SingletonSlot::Ellipsis),
@@ -1444,7 +1469,6 @@ impl Value {
             Self::Builtin(c) => builtin_value_id(*c),
             Self::ModuleFunction(mf) => module_function_value_id(*mf),
             Self::DefFunction(f_id) => function_value_id(*f_id),
-            Self::ExtFunction(name_id) => ext_function_value_id(*name_id),
             // Markers get deterministic IDs based on discriminant
             Self::Marker(m) => marker_value_id(*m),
             // Properties get deterministic IDs based on discriminant
@@ -1475,11 +1499,11 @@ impl Value {
         }
     }
 
-    /// Equivalent of Python's `is` operator.
-    ///
-    /// Compares value identity by comparing their IDs.
-    pub fn is(&self, other: &Self) -> bool {
-        self.id() == other.id()
+    /// Python-visible `is` operator. Identity is name-based for `ExtFunction`
+    /// values via [`Value::id`], so two callables with the same `__name__`
+    /// compare identical regardless of representation.
+    pub fn is(&self, other: &Self, vm: &VM<'_, impl ResourceTracker>) -> bool {
+        self.id(vm) == other.id(vm)
     }
 
     /// Computes the hash value for this value, used for dict keys.
@@ -1523,7 +1547,11 @@ impl Value {
             Self::ModuleFunction(mf) => mf.hash(&mut hasher),
             // Hash functions based on function ID
             Self::DefFunction(f_id) => f_id.hash(&mut hasher),
-            Self::ExtFunction(name_id) => name_id.hash(&mut hasher),
+            // Hash the function name's string contents so the inline path
+            // agrees with the heap `HeapData::ExtFunction` arm in `heap_data.rs`.
+            // Required so cross-representation equality (added in the same fix
+            // series) preserves the dict invariant `a == b ⇒ hash(a) == hash(b)`.
+            Self::ExtFunction(name_id) => return Ok(Some(hash_python_str(vm.interns.get_str(*name_id)))),
             // Markers are hashable based on their discriminant (already included above)
             Self::Marker(m) => m.hash(&mut hasher),
             // Properties are hashable based on their OS function discriminant
@@ -2297,10 +2325,21 @@ fn function_value_id(f_id: FunctionId) -> usize {
     FUNCTION_ID_TAG | (f_id.index() & FUNCTION_ID_MASK)
 }
 
-/// Computes a deterministic ID for an external function based on its interned name.
+/// Computes a deterministic ID for an external function from its name string.
+///
+/// Used by [`Value::id`] so that inline `Value::ExtFunction` and heap
+/// `HeapData::ExtFunction` values referring to the same function name share
+/// the same Python-visible `id()` — required by CPython's
+/// `a is b ⇒ id(a) == id(b)` invariant. Collisions across distinct names are
+/// possible (the masked hash space is finite) but acceptable: Python's `id()`
+/// is allowed to collide across distinct objects.
 #[inline]
-fn ext_function_value_id(name_id: StringId) -> usize {
-    EXTFUNCTION_ID_TAG | (name_id.index() & EXTFUNCTION_ID_MASK)
+fn ext_function_value_id(name: &str) -> usize {
+    let hash_u64 = hash_python_str(name).raw();
+    // Mask to usize range before conversion to handle 32-bit platforms.
+    let masked = hash_u64 & (usize::MAX as u64);
+    let hash_usize = usize::try_from(masked).expect("masked value fits in usize");
+    EXTFUNCTION_ID_TAG | (hash_usize & EXTFUNCTION_ID_MASK)
 }
 
 /// Computes a deterministic ID for a marker value based on its discriminant.

--- a/crates/monty/tests/external_function_identity.rs
+++ b/crates/monty/tests/external_function_identity.rs
@@ -1,0 +1,218 @@
+//! Identity, equality, and export semantics for external function inputs (#347, #345).
+//!
+//! Monty represents external function inputs in two ways depending on whether the
+//! function's `__name__` was interned during parsing:
+//!
+//! - inline `Value::ExtFunction(StringId)` when the name appears in source
+//! - heap `HeapData::ExtFunction(String)` otherwise
+//!
+//! Both refer to the same logical callable: `is`/`==`/`id()`/`hash()` and export
+//! conversion must agree on a single answer based on the name string, regardless
+//! of which path the conversion took.
+
+use monty::{MontyObject, MontyRepl, MontyRun, NameLookupResult, NoLimitTracker, PrintWriter};
+
+/// Builds two `MontyObject::Function` inputs with the same `__name__` ("foo")
+/// and runs `code` against them as inputs `a` and `b`.
+fn run_with_same_callable_inputs(code: &str) -> MontyObject {
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec!["a".to_owned(), "b".to_owned()]).unwrap();
+    runner
+        .run_no_limits(vec![
+            MontyObject::Function {
+                name: "foo".to_owned(),
+                docstring: None,
+            },
+            MontyObject::Function {
+                name: "foo".to_owned(),
+                docstring: None,
+            },
+        ])
+        .unwrap()
+}
+
+/// Source does not mention `foo`, so the function name is not interned and the
+/// conversion takes the heap path. Two separate `to_value` calls allocate two
+/// distinct `HeapId`s, but they refer to the same logical callable.
+#[test]
+fn same_callable_is_and_eq_via_heap_path() {
+    let result = run_with_same_callable_inputs("(a is b, a == b)");
+    assert_eq!(
+        result,
+        MontyObject::Tuple(vec![MontyObject::Bool(true), MontyObject::Bool(true)]),
+    );
+}
+
+/// Source mentions `foo`, so the function name is interned and the conversion
+/// takes the inline `Value::ExtFunction(StringId)` path. Same logical callable,
+/// different representation — identity must agree.
+#[test]
+fn same_callable_is_and_eq_via_inline_path() {
+    let result = run_with_same_callable_inputs("foo = None\n(a is b, a == b)");
+    assert_eq!(
+        result,
+        MontyObject::Tuple(vec![MontyObject::Bool(true), MontyObject::Bool(true)]),
+    );
+}
+
+/// `id()` must agree with `is`: equal-by-name → equal-by-id.
+#[test]
+fn same_callable_id_matches() {
+    let result = run_with_same_callable_inputs("id(a) == id(b)");
+    assert_eq!(result, MontyObject::Bool(true));
+}
+
+/// `hash()` must agree with `==`: equal callables hash equally, regardless of
+/// representation. This invariant is required for the dict-key contract.
+#[test]
+fn same_callable_hash_matches() {
+    let result = run_with_same_callable_inputs("hash(a) == hash(b)");
+    assert_eq!(result, MontyObject::Bool(true));
+}
+
+/// Using one binding as a dict key and looking up via the other exercises the
+/// full hash + eq pipeline.
+#[test]
+fn same_callable_round_trips_through_dict() {
+    let result = run_with_same_callable_inputs("d = {a: 42}\nd[b]");
+    assert_eq!(result, MontyObject::Int(42));
+}
+
+/// Two callables with different `__name__` values must remain distinct — Monty
+/// distinguishes external functions by name (the most identity it has after
+/// `MontyObject::Function` conversion has discarded host object identity).
+#[test]
+fn different_named_callables_remain_distinct() {
+    let runner = MontyRun::new(
+        "(a is b, a == b)".to_owned(),
+        "test.py",
+        vec!["a".to_owned(), "b".to_owned()],
+    )
+    .unwrap();
+    let result = runner
+        .run_no_limits(vec![
+            MontyObject::Function {
+                name: "foo".to_owned(),
+                docstring: None,
+            },
+            MontyObject::Function {
+                name: "bar".to_owned(),
+                docstring: None,
+            },
+        ])
+        .unwrap();
+    assert_eq!(
+        result,
+        MontyObject::Tuple(vec![MontyObject::Bool(false), MontyObject::Bool(false)]),
+    );
+}
+
+/// Round-trip export through the inline path (the #345 bug): when the function
+/// name is interned in source, `Value::ExtFunction` previously fell through to
+/// `repr_or_error` and exported as a string rather than `MontyObject::Function`.
+/// After the fix the export representation must be the same as the heap path.
+#[test]
+fn inline_callable_exports_as_function_object() {
+    let runner = MontyRun::new("foo = None\nx".to_owned(), "test.py", vec!["x".to_owned()]).unwrap();
+    let result = runner
+        .run_no_limits(vec![MontyObject::Function {
+            name: "foo".to_owned(),
+            docstring: None,
+        }])
+        .unwrap();
+    assert_eq!(
+        result,
+        MontyObject::Function {
+            name: "foo".to_owned(),
+            docstring: None,
+        },
+    );
+}
+
+/// Same callable, same export, regardless of source mention.
+#[test]
+fn callable_export_stable_across_source_mention() {
+    let func_input = || {
+        vec![MontyObject::Function {
+            name: "foo".to_owned(),
+            docstring: None,
+        }]
+    };
+    let r1 = MontyRun::new("x".to_owned(), "test.py", vec!["x".to_owned()])
+        .unwrap()
+        .run_no_limits(func_input())
+        .unwrap();
+    let r2 = MontyRun::new("foo = None\nx".to_owned(), "test.py", vec!["x".to_owned()])
+        .unwrap()
+        .run_no_limits(func_input())
+        .unwrap();
+    assert_eq!(r1, r2);
+}
+
+/// REPL-driven cross-representation scenario.
+///
+/// `MontyRepl` accumulates interned strings across feeds (see `repl.rs:252`
+/// where the executor's interns commit back to the session). This makes a
+/// mixed inline/heap `ExtFunction` state reachable: a host-supplied function
+/// name that the first feed didn't intern becomes interned by a later feed,
+/// so a subsequent resolution to the same callable takes the inline path
+/// while the first feed's binding is still the heap `Ref`.
+///
+/// This exercises the cross-representation arms in `Value::is`, `Value::id`,
+/// `Value::py_eq`, and the hash alignment — the production path the
+/// unit-input tests above cannot reach.
+#[test]
+fn repl_cross_representation_extfunction_identity() {
+    let repl = MontyRepl::new("session.py", NoLimitTracker);
+
+    // Feed 1: `x = foobar` triggers NameLookup for "foobar"; host returns a
+    // `Function` whose `__name__` ("ext_fn") does not appear in feed 1's
+    // source, so it is not interned and the conversion takes the heap path.
+    let progress = repl.feed_start("x = foobar", vec![], PrintWriter::Stdout).unwrap();
+    let lookup = progress.into_name_lookup().expect("expected NameLookup for 'foobar'");
+    assert_eq!(lookup.name, "foobar");
+    let progress = lookup
+        .resume(
+            NameLookupResult::Value(MontyObject::Function {
+                name: "ext_fn".to_owned(),
+                docstring: None,
+            }),
+            PrintWriter::Stdout,
+        )
+        .unwrap();
+    let (repl, _) = progress.into_complete().expect("feed 1 should complete");
+
+    // Feed 2: source mentions `ext_fn` as a name (interning it), then resolves
+    // a second NameLookup ("barbaz") to the same `Function(name="ext_fn")`.
+    // That conversion now finds "ext_fn" interned and takes the inline path —
+    // creating the inline-vs-heap mix between `y` and `x`.
+    let progress = repl
+        .feed_start(
+            "ext_fn = 1\ny = barbaz\n(x is y, x == y, id(x) == id(y), hash(x) == hash(y))",
+            vec![],
+            PrintWriter::Stdout,
+        )
+        .unwrap();
+    let lookup = progress.into_name_lookup().expect("expected NameLookup for 'barbaz'");
+    assert_eq!(lookup.name, "barbaz");
+    let progress = lookup
+        .resume(
+            NameLookupResult::Value(MontyObject::Function {
+                name: "ext_fn".to_owned(),
+                docstring: None,
+            }),
+            PrintWriter::Stdout,
+        )
+        .unwrap();
+    let (_repl, result) = progress.into_complete().expect("feed 2 should complete");
+
+    // All four cross-representation checks must agree:
+    assert_eq!(
+        result,
+        MontyObject::Tuple(vec![
+            MontyObject::Bool(true),
+            MontyObject::Bool(true),
+            MontyObject::Bool(true),
+            MontyObject::Bool(true),
+        ]),
+    );
+}


### PR DESCRIPTION
Fixes #347 (external function identity). Fixes #345 (inline ExtFunction export).

## What changed

`Value::is` and `Value::id` are now name-aware for `ExtFunction` values across both inline (`Value::ExtFunction`) and heap (`HeapData::ExtFunction`) representations. Same-named external functions now satisfy CPython's `a is b ⇒ id(a) == id(b)` invariant regardless of how each side was constructed. Both methods now take `&VM` (shared, read-only — matching the `PyTrait::py_type` precedent) so the heap is reachable for the cross-representation arms.

`Value::py_eq` and `HeapData::py_eq` gained matching cross-representation arms, and ExtFunction hashing is aligned via `hash_python_str` on both sides so the equality/hash contract holds (required for dict keys, set membership, and \`in\` checks).

\`object.rs::from_value_inner\` now has the missing \`Value::ExtFunction → MontyObject::Function\` arm — that was #345 in one line.

## Design note

An earlier iteration of this branch introduced parallel \`Value::py_is\` and \`Value::py_id\` methods alongside the existing identity-only \`is\`/\`id\`. After review discussion, we collapsed that to modify-in-place: \`is\` and \`id\` themselves now carry the name-aware semantics, with the display-only callers in \`py_repr_fmt\` updated to pass \`vm\`. One method per concept, no parallel surface to keep in sync.

## Coverage

Cross-representation \`ExtFunction\` state is reachable via the REPL (interns accumulate across feed_run calls — see \`repl.rs:252\`), and \`tests/external_function_identity.rs::repl_cross_representation_extfunction_identity\` exercises that scenario directly. \`Value::is\` is now a one-liner delegating to \`Value::id\`, which itself handles the cross-representation case, so the explicit per-case arms only remain where the id fallback wouldn't apply (\`Value::py_eq\` and \`HeapReadOutput::py_eq\`).

## Commit shape

History was rewritten via force-push to a single commit (squashed from 6 incremental commits) reflecting the final modify-in-place design. The squash is based on the latest \`origin/main\`.

## Test plan

- [x] \`cargo test -p monty external_function_identity\` (9 Rust integration cases, including REPL cross-rep)
- [x] \`pytest crates/monty-python/tests/test_external_function_identity.py\` (8 cases)
- [x] \`make test-memory-model-checks\`
- [x] Full datatest sweep (946 cases) green
- [x] \`make lint-rs\`, \`make lint-py\` clean
- [x] Existing \`tests/name_lookup.rs::resolve_function_with_non_interned_name\` passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)