### PR TITLE
add more limitations

### DIFF
--- a/limitations/asyncio.md
+++ b/limitations/asyncio.md
@@ -1,0 +1,45 @@
+# `asyncio` module and `async` / `await`
+
+Monty's async support is a thin layer that lets `async def` functions
+suspend on `await` and lets the host drive long-running external calls.
+There is no event loop *inside* the sandbox — the host is the loop.
+
+## Module surface
+
+The `asyncio` module exposes exactly two functions:
+
+- `asyncio.run(coro)` — runs a coroutine to completion. Returns the value
+  the coroutine `return`s, or re-raises an exception from it.
+- `asyncio.gather(*awaitables)` — runs awaitables concurrently and returns
+  a list of results. Always behaves as `return_exceptions=False`.
+
+Not implemented (raise `AttributeError`):
+
+`create_task`, `sleep`, `wait`, `wait_for`, `shield`, `to_thread`,
+`new_event_loop`, `get_event_loop`, `get_running_loop`, `Queue`, `Lock`,
+`Semaphore`, `Event`, `Future`, `Task`, `TaskGroup`,
+`as_completed`, `iscoroutine`, `ensure_future`, the whole `asyncio.subprocess`
+/ `asyncio.streams` / `asyncio.protocols` surface.
+
+## `async def` / `await`
+
+- `async def` functions and `await` work; coroutines can call each other.
+- **Coroutines are single-shot.** Awaiting the same coroutine object twice
+  raises `RuntimeError`. Store the *result*, not the coroutine, if you need
+  it again.
+- `await` on a non-awaitable raises `TypeError`.
+- `async for` and `async with` are **rejected at parse time** (see
+  [language.md](language.md)). Async iteration / context-manager protocols
+  do not exist.
+- Async comprehensions (`[x async for x in ...]`) are rejected at parse
+  time.
+- There is no `__await__` protocol — awaitables are only the things Monty
+  knows internally (coroutines from `async def`, gather futures, external
+  function call futures returned by host bindings).
+
+## Concurrency model
+
+Concurrency is cooperative and host-driven. `gather` suspends Monty
+whenever every branch is blocked on an external call, hands the pending
+calls to the host, and resumes when the host returns results. There is no
+preemption, no threads, and no in-sandbox scheduler.

--- a/limitations/asyncio.md
+++ b/limitations/asyncio.md
@@ -17,9 +17,14 @@ Not implemented (raise `AttributeError`):
 
 `create_task`, `sleep`, `wait`, `wait_for`, `shield`, `to_thread`,
 `new_event_loop`, `get_event_loop`, `get_running_loop`, `Queue`, `Lock`,
-`Semaphore`, `Event`, `Future`, `Task`, `TaskGroup`,
-`as_completed`, `iscoroutine`, `ensure_future`, the whole `asyncio.subprocess`
-/ `asyncio.streams` / `asyncio.protocols` surface.
+`Semaphore`, `Event`, `Future`, `Task`, `TaskGroup`, `timeout`,
+`timeout_at`, `Timeout`, `as_completed`, `iscoroutine`, `ensure_future`,
+the whole `asyncio.subprocess` / `asyncio.streams` / `asyncio.protocols`
+surface.
+
+`asyncio.timeout()` / `asyncio.timeout_at()` would in any case be
+unreachable: they are async context managers, and `async with` is rejected
+at parse time (see [language.md](language.md)).
 
 ## `async def` / `await`
 

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -1,0 +1,58 @@
+# Built-in functions
+
+Monty implements a deliberate subset of CPython's builtins. Referencing any
+name not listed here raises `NameError` at runtime — there is no fallback to
+a host Python.
+
+## Implemented builtin functions
+
+`abs`, `all`, `any`, `bin`, `chr`, `divmod`, `enumerate`, `filter`,
+`getattr`, `hasattr`, `hash`, `hex`, `id`, `isinstance`, `len`, `map`,
+`max`, `min`, `next`, `oct`, `open`, `ord`, `pow`, `print`, `repr`,
+`reversed`, `round`, `setattr`, `sorted`, `sum`, `type`, `zip`.
+
+## Implemented type constructors (also builtins)
+
+`bool`, `bytes`, `bytearray`-style construction is **not** available;
+`dict`, `float`, `frozenset`, `int`, `list`, `range`, `set`, `slice`-style
+construction is **not** available, `str`, `tuple`. Exception classes
+(`ValueError`, `TypeError`, etc.) are also names in the builtin namespace.
+
+## Builtins that are NOT implemented
+
+These raise `NameError`:
+
+- **Code execution**: `eval`, `exec`, `compile`, `__import__`. Deliberate —
+  sandboxed code must not be able to compile new code at runtime.
+- **Namespace introspection**: `globals`, `locals`, `vars`, `dir`.
+- **Interactive**: `input`, `breakpoint`, `help`.
+- **Decorators / descriptors**: `classmethod`, `staticmethod`, `property`,
+  `super`. (`@property` on functions is not recognized; use a method.)
+- **Construction / coercion**: `bytearray`, `complex`, `memoryview`,
+  `object`, `frozenset()`, `slice()`, `iter`, `format`, `ascii`.
+- **Other**: `callable`, `delattr`, `issubclass`, `aiter`, `anext`.
+
+`super()` is the biggest practical omission — combined with the lack of
+`class` statements (see [language.md](language.md)) there is no inheritance
+mechanism beyond dataclass field inheritance.
+
+## Behavioural divergences
+
+- **`getattr(obj, name)`** — if the resolved attribute would be an async
+  coroutine, external function, or OS call, raises `TypeError:
+  "getattr(): attribute is not a simple value"` rather than returning a
+  bound method object. Use direct attribute access (`obj.name(...)`) for
+  these.
+- **`isinstance(obj, T)`** — `T` must be a built-in type (`int`, `str`,
+  `list`, ...), a built-in exception class, or a tuple of those. Passing a
+  user-defined dataclass / namedtuple as the second argument raises
+  `TypeError`.
+- **`pow(base, exp, mod)`** — three-argument form requires all integers and
+  rejects negative exponents with `ValueError`. Exponents greater than
+  `u32::MAX` raise `OverflowError` (see [resource_limits.md](resource_limits.md)).
+- **`sorted(iterable, *, key=None, reverse=False)`** — `key` and `reverse`
+  must be passed by keyword; positional forms raise `TypeError`.
+- **`round(x, n)`** — `n` must be an integer; CPython accepts and truncates
+  floats.
+- **`print`** — writes via the host print callback. `file=`, `flush=` are
+  not honoured; `sep=` and `end=` are.

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -13,10 +13,9 @@ a host Python.
 
 ## Implemented type constructors (also builtins)
 
-`bool`, `bytes`, `bytearray`-style construction is **not** available;
-`dict`, `float`, `frozenset`, `int`, `list`, `range`, `set`, `slice`-style
-construction is **not** available, `str`, `tuple`. Exception classes
-(`ValueError`, `TypeError`, etc.) are also names in the builtin namespace.
+`bool`, `bytes`, `dict`, `float`, `frozenset`, `int`, `list`, `range`,
+`set`, `slice`, `str`, `tuple`. Exception classes (`ValueError`,
+`TypeError`, etc.) are also names in the builtin namespace.
 
 ## Builtins that are NOT implemented
 
@@ -29,7 +28,7 @@ These raise `NameError`:
 - **Decorators / descriptors**: `classmethod`, `staticmethod`, `property`,
   `super`. (`@property` on functions is not recognized; use a method.)
 - **Construction / coercion**: `bytearray`, `complex`, `memoryview`,
-  `object`, `frozenset()`, `slice()`, `iter`, `format`, `ascii`.
+  `object`, `iter`, `format`, `ascii`.
 - **Other**: `callable`, `delattr`, `issubclass`, `aiter`, `anext`.
 
 `super()` is the biggest practical omission — combined with the lack of

--- a/limitations/classes.md
+++ b/limitations/classes.md
@@ -1,0 +1,41 @@
+# Classes
+
+Sandboxed Python code in Monty cannot define new classes. The `class`
+statement is rejected at parse time (see [language.md](language.md)),
+and `type()`, `@dataclass`, `collections.namedtuple`, and `typing.NamedTuple`
+are all unavailable as class factories *inside* the sandbox.
+
+The host can construct dataclass and namedtuple values (using the
+`MontyObject` API) and pass them in. Sandboxed code can then read fields,
+call methods, mutate (if not frozen), and round-trip them through the
+host. Methods defined on a host-supplied dataclass DO work — see
+`test_cases/dataclass__basic.py`.
+
+## What does NOT exist for user code
+
+- `class Foo: ...` — rejected at parse time.
+- `class Foo(Bar): ...` — there is no inheritance, no MRO, no `super()`.
+- Metaclasses, `__init_subclass__`, `__set_name__`.
+- `__slots__`, descriptors (`__get__` / `__set__` / `__delete__`).
+- Abstract base classes (`abc.ABC`, `@abstractmethod`).
+- `@classmethod`, `@staticmethod`, `@property` decorators.
+- Dunder protocols on user-side types: `__init__`, `__new__`, `__call__`,
+  `__iter__`, `__next__`, `__getitem__`, `__setitem__`, `__contains__`,
+  `__enter__`, `__exit__`, `__add__`, `__eq__`, `__hash__`, `__repr__`,
+  `__str__`, `__bool__`, etc. None of these are dispatched for any value
+  the sandbox itself constructs — they are only consulted on host-supplied
+  dataclasses (and only for the methods the host attached).
+- Multiple inheritance, mixins, diamond MRO.
+
+## `FrozenInstanceError`
+
+Raised when assigning to a field of a frozen host-supplied dataclass.
+Subclass of `AttributeError` — `except AttributeError:` catches it, as in
+CPython's `dataclasses` module.
+
+## Practical consequence
+
+Code that depends on user-defined dunders — custom iterators, custom
+context managers, custom hashable wrappers, most ORM models, anything
+using `__init_subclass__` for registration — will not run on Monty.
+Define such types on the host side and pass them in.

--- a/limitations/datetime.md
+++ b/limitations/datetime.md
@@ -1,0 +1,65 @@
+# `datetime` module
+
+Provides four classes: `date`, `datetime`, `timedelta`, `timezone`. The
+module-level `time`, `tzinfo`, and `MINYEAR` / `MAXYEAR` symbols are not
+exposed.
+
+## `date`
+
+Constructor: `date(year, month, day)`.
+Attributes: `year`, `month`, `day`.
+Methods: `isoformat`, `strftime`, `replace`, `weekday`, `isoweekday`.
+
+Class methods `today()`, `fromisoformat()`, `fromtimestamp()`,
+`fromordinal()` are not implemented. `today()` is missing because the
+sandbox has no access to the host clock.
+
+## `datetime`
+
+Constructor: `datetime(year, month, day, hour=0, minute=0, second=0,
+microsecond=0, tzinfo=None)`.
+Attributes: `year`, `month`, `day`, `hour`, `minute`, `second`,
+`microsecond`, `tzinfo`.
+Methods: `isoformat`, `strftime`, `replace`, `weekday`, `isoweekday`,
+`date`, `timestamp`.
+
+Class methods supported: `now(tz=None)`, `strptime(date_string, format)`,
+`fromisoformat(date_string)`.
+
+- `now()` reaches the host for the current time (the only "live" datetime
+  call); it yields an external call.
+- `utcnow()` and `today()` (the deprecated class method) are not
+  implemented.
+- `combine()`, `fromtimestamp()`, `fromordinal()`, `utcfromtimestamp()`
+  are not implemented.
+
+Subclassing `datetime` is not possible (no `class` statement; see
+[language.md](language.md)).
+
+## `timedelta`
+
+Constructor: `timedelta(days=0, seconds=0, microseconds=0, minutes=0,
+hours=0)`. The CPython `milliseconds` and `weeks` parameters are not
+supported.
+Attributes: `days`, `seconds`, `microseconds`.
+No methods (`.total_seconds()` is **not** implemented).
+
+Arithmetic (`+`, `-`, `*`, comparisons) works between `timedelta`s and
+between `datetime`/`date` and `timedelta`. Division and floor-division of
+two `timedelta`s is not implemented.
+
+## `timezone`
+
+Constructor: `timezone(offset, name=None)` where `offset` is a
+`timedelta`.
+Attributes: `offset`, `name`.
+
+`timezone.utc` and `timezone.min` / `timezone.max` class constants are not
+defined. The abstract `tzinfo` base class is not exposed.
+
+## Formatting
+
+`strftime` supports the directives that map onto Rust's `chrono`
+formatting; locale-specific directives (`%c`, `%x`, `%X`, `%p`) follow
+Rust's defaults rather than the C locale and may differ from CPython.
+`%Z` always emits an empty string for naive datetimes.

--- a/limitations/datetime.md
+++ b/limitations/datetime.md
@@ -10,9 +10,9 @@ Constructor: `date(year, month, day)`.
 Attributes: `year`, `month`, `day`.
 Methods: `isoformat`, `strftime`, `replace`, `weekday`, `isoweekday`.
 
-Class methods `today()`, `fromisoformat()`, `fromtimestamp()`,
-`fromordinal()` are not implemented. `today()` is missing because the
-sandbox has no access to the host clock.
+Class methods `today()`, `fromisoformat()`, `fromisocalendar()`,
+`fromtimestamp()`, `fromordinal()` are not implemented. `today()` is
+missing because the sandbox has no access to the host clock.
 
 ## `datetime`
 
@@ -28,7 +28,7 @@ Class methods supported: `now(tz=None)`, `strptime(date_string, format)`,
 
 - `now()` reaches the host for the current time (the only "live" datetime
   call); it yields an external call.
-- `utcnow()` and `today()` (the deprecated class method) are not
+- `utcnow()` (the deprecated class method) and `today()` are not
   implemented.
 - `combine()`, `fromtimestamp()`, `fromordinal()`, `utcfromtimestamp()`
   are not implemented.

--- a/limitations/exceptions.md
+++ b/limitations/exceptions.md
@@ -1,0 +1,67 @@
+# Exceptions
+
+Monty implements a fixed set of exception classes, listed below. Sandboxed
+code **cannot define new exception classes** (no `class` statement; see
+[language.md](language.md)) — `raise` must use one of these built-ins.
+
+## Implemented exception classes
+
+`BaseException`, `Exception`, `SystemExit`, `KeyboardInterrupt`,
+`ArithmeticError`, `OverflowError`, `ZeroDivisionError`, `LookupError`,
+`IndexError`, `KeyError`, `RuntimeError`, `NotImplementedError`,
+`RecursionError`, `AttributeError`, `FrozenInstanceError`, `NameError`,
+`UnboundLocalError`, `ValueError`, `UnicodeDecodeError`, `ImportError`,
+`ModuleNotFoundError`, `OSError`, `FileNotFoundError`, `FileExistsError`,
+`IsADirectoryError`, `NotADirectoryError`, `PermissionError`,
+`AssertionError`, `MemoryError`, `StopIteration`, `SyntaxError`,
+`TimeoutError`, `TypeError`.
+
+Module-specific: `json.JSONDecodeError` (subclass of `ValueError`),
+`re.PatternError` / `re.error`, `io.UnsupportedOperation` (catchable as
+both `OSError` and `ValueError`, matching CPython's dual parentage).
+
+## Exception classes NOT implemented
+
+`Warning` and all its subclasses (`DeprecationWarning`, etc.),
+`BufferError`, `EOFError`, `FloatingPointError`, `GeneratorExit`,
+`ConnectionError` and subclasses (`ConnectionAbortedError`,
+`ConnectionRefusedError`, `ConnectionResetError`,
+`BrokenPipeError`), `BlockingIOError`, `ChildProcessError`,
+`InterruptedError`, `ProcessLookupError`, `ReferenceError`,
+`StopAsyncIteration`, `SystemError`, `TabError`, `IndentationError`,
+`UnicodeError` (parent), `UnicodeEncodeError`, `UnicodeTranslateError`,
+`EncodingWarning`, `EnvironmentError` / `IOError` aliases,
+`ExceptionGroup` / `BaseExceptionGroup` (see [language.md](language.md)).
+
+## Constructor signature
+
+All exception constructors accept **zero or one string argument** only.
+Multi-argument forms used in CPython (e.g. `OSError(errno, strerror,
+filename)`, `UnicodeDecodeError(encoding, obj, start, end, reason)`) are
+not supported — passing more than one argument raises an internal error.
+
+## Attributes
+
+- `exc.args` — a tuple with 0 or 1 elements. Always a `tuple`, even when
+  empty.
+- `str(exc)` — returns the single message string, or `""` if none.
+- `repr(exc)` — `ClassName('message')` matching CPython.
+
+**Not implemented:** `__cause__`, `__context__`, `__suppress_context__`,
+`__traceback__`, `__notes__`, `add_note()`. The `raise X from Y` syntax
+parses, but the `from Y` cause is **silently dropped** — chained
+tracebacks are not preserved across `raise from`.
+
+## Custom subclasses
+
+Because user `class` definitions are rejected at parse time, there is no
+way to create a new exception class inside the sandbox. Define custom
+exception types on the host side if needed, or use the built-in subclass
+that best fits.
+
+## Traceback behaviour
+
+Tracebacks are formatted to match CPython, including the
+`File "...", line N, in <function>` lines and `~` caret markers (Monty
+uses `~` where CPython uses `^`; the test harness normalizes between
+them). Frame names use `<module>` for top-level code.

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -1,0 +1,49 @@
+# Filesystem and sandbox boundary
+
+The sandbox has no default filesystem access. The host explicitly mounts
+real directories at virtual paths through Monty's `MountTable`; everything
+outside a mount is invisible. Without any mounts, [`open()`](open.md) and
+all of [pathlib](pathlib.md)'s I/O methods raise `FileNotFoundError` for
+every path.
+
+## Virtual paths are always POSIX
+
+Inside the sandbox, paths use forward slashes regardless of host OS.
+`Path("C:/Users/foo")` is not a Windows path — it is the literal POSIX
+path `C:/Users/foo`. Path repr is always `PosixPath(...)`.
+
+Bytes paths are accepted but decoded as strict UTF-8 (no `surrogateescape`
+/ PEP 383 round-tripping). See [open.md](open.md) for the full rationale.
+
+## Mount modes
+
+Each mount is configured by the host as one of:
+
+- **`ReadOnly`** — reads allowed; any write (open with `w`/`a`, `mkdir`,
+  `unlink`, `write_text`, ...) raises `PermissionError`.
+- **`ReadWrite`** — full read/write into the underlying host directory.
+- **`OverlayMemory`** — copy-on-write: reads fall through to the host
+  directory, writes are captured in memory and never touch the host. The
+  changes vanish when the VM is discarded.
+
+## Sandbox guarantees
+
+The host enforces these invariants on every path operation:
+
+- Canonicalization happens *after* mapping virtual → host paths.
+- The canonical path must remain inside the mount; `..` traversal cannot
+  escape (raises `PermissionError`).
+- Symlinks pointing outside the mount are rejected on resolution.
+- Null bytes in any path component are rejected (`ValueError`).
+- Resolved paths returned to the sandbox (e.g. via `Path.resolve()`) are
+  virtual paths, never host paths.
+
+`/tmp`, `/etc`, `/proc`, `/dev`, `~`, and the host current working
+directory are **not** available unless the host explicitly mounts them.
+
+## No live host descriptors
+
+`open()` and pathlib I/O do not keep an OS handle alive between calls —
+each `read`/`write` is a separate one-shot host operation. This is what
+makes [snapshotting](#) safe, and it means external processes can observe
+partial state between writes. See the design note in [open.md](open.md).

--- a/limitations/json.md
+++ b/limitations/json.md
@@ -21,7 +21,8 @@ are not implemented (no file-object protocol).
 - Nesting depth is capped at 200 levels; deeper inputs raise
   `json.JSONDecodeError`.
 - JSON integers that would exceed Monty's BigInt digit limit are rejected
-  with `JSONDecodeError` rather than being parsed and then erroring.
+  with `ValueError` (matching CPython's `int_max_str_digits` behaviour)
+  rather than `JSONDecodeError`.
 
 ## `json.dumps(obj, **kwargs)`
 

--- a/limitations/json.md
+++ b/limitations/json.md
@@ -1,0 +1,42 @@
+# `json` module
+
+Monty's `json` provides `loads`, `dumps`, and the `JSONDecodeError`
+exception. Parsing is backed by `jiter`; serialization is a hand-written
+encoder matching CPython byte-for-byte for the supported keyword set.
+
+## What's NOT in the module
+
+`json.JSONEncoder` and `json.JSONDecoder` classes are not implemented —
+the `cls=` keyword is rejected. `json.load(fp)` and `json.dump(obj, fp)`
+are not implemented (no file-object protocol).
+
+## `json.loads(s, **kwargs)`
+
+- Accepts `str` or `bytes` as input.
+- **No keyword arguments are accepted.** Passing any of `cls`,
+  `object_hook`, `parse_float`, `parse_int`, `parse_constant`, or
+  `object_pairs_hook` raises `TypeError: ... unexpected keyword argument`.
+- `NaN`, `Infinity`, `-Infinity` are *always* accepted (CPython requires
+  `parse_constant` or accepts them by default — same result, no toggle).
+- Nesting depth is capped at 200 levels; deeper inputs raise
+  `json.JSONDecodeError`.
+- JSON integers that would exceed Monty's BigInt digit limit are rejected
+  with `JSONDecodeError` rather than being parsed and then erroring.
+
+## `json.dumps(obj, **kwargs)`
+
+Supported kwargs: `indent`, `sort_keys`, `ensure_ascii`, `allow_nan`,
+`separators`, `skipkeys` — matching CPython semantics.
+
+Rejected with `TypeError` if passed:
+
+- `cls` — custom encoder classes are not supported.
+- `default` — fallback encoder callback is not supported. Non-serializable
+  values raise `TypeError` instead of routing through a callback.
+- `check_circular` — circular reference detection is always on.
+
+## `JSONDecodeError`
+
+Inherits from `ValueError` (catchable as `except ValueError:`). The class
+qualified name is `json.JSONDecodeError`; `__name__` matches CPython.
+Error messages use the same `line N column M (char K)` suffix as CPython.

--- a/limitations/language.md
+++ b/limitations/language.md
@@ -7,9 +7,12 @@ any code runs.
 
 ## Statements rejected at parse time
 
-- **`class` definitions** — bare `class Foo: ...` is not supported. Use
-  `@dataclass`, `collections.namedtuple`, or a plain function instead. See
-  [classes.md](classes.md).
+- **`class` definitions** — bare `class Foo: ...` is not supported. There
+  is no in-sandbox class factory: `@dataclass`, `typing.NamedTuple`, and
+  `collections.namedtuple` are all unavailable inside the sandbox (and
+  `collections` is not importable). Host-supplied dataclass / namedtuple
+  values can be passed in and used; use a plain function or a host-defined
+  type for new structured data. See [classes.md](classes.md).
 - **`with` / `async with` statements** — no context manager protocol. This
   means no `with open(...) as f:` (call `f.close()` explicitly). See
   [open.md](open.md).

--- a/limitations/language.md
+++ b/limitations/language.md
@@ -1,0 +1,56 @@
+# Python language / parser
+
+Monty parses Python source with Ruff's parser but rejects several constructs
+at parse time. Anything listed below raises `NotImplementedError` (prefixed
+with "The monty syntax parser does not yet support ") at compile time, before
+any code runs.
+
+## Statements rejected at parse time
+
+- **`class` definitions** — bare `class Foo: ...` is not supported. Use
+  `@dataclass`, `collections.namedtuple`, or a plain function instead. See
+  [classes.md](classes.md).
+- **`with` / `async with` statements** — no context manager protocol. This
+  means no `with open(...) as f:` (call `f.close()` explicitly). See
+  [open.md](open.md).
+- **`yield` / `yield from` expressions** — no generator functions. Generator
+  *expressions* (`(x for x in ...)`) parse but currently materialize to a
+  `list` rather than a lazy iterator (this is a known temporary divergence;
+  see `iter__generator_expr_type.py`).
+- **`match` statements** — structural pattern matching is not supported.
+- **`del` statements** — neither `del x` nor `del d[k]` parse.
+- **`try*` / `except*` exception groups** — PEP 654 syntax rejected.
+- **`type` aliases** (PEP 695 `type Foo = int`).
+- **`async for` loops** and **async comprehensions**.
+- **Wildcard imports** (`from m import *`) — raises `ImportError:
+  "Wildcard imports (\`from ... import *\`) are not supported"`.
+
+## Expressions rejected at parse time
+
+- **Starred expressions** in expression position (e.g. `[*xs, *ys]`,
+  `f(*args)`). Function calls with `*args` unpacking are not supported.
+- **Multiple `**kwargs` unpacking** in a single call (`f(**a, **b)`).
+- **Complex number literals** (`1j`, `2+3j`).
+- **Template strings (t-strings)** — PEP 750.
+- **Walrus operator** (`:=`) — also rejected.
+
+## Imports
+
+- Only the bundled stdlib modules listed in [modules.md](modules.md) can be
+  imported. Importing anything else raises `ModuleNotFoundError`.
+- Relative imports (`from . import x`) raise `ImportError: "attempted
+  relative import with no known parent package"` — there is no package
+  system.
+- `__import__` is not defined.
+
+## What *does* work
+
+- Functions (`def`, `async def`), nested functions, closures, decorators.
+- List / dict / set comprehensions (generator comprehensions degrade to
+  lists — see above).
+- `try` / `except` / `else` / `finally`, `raise ... from ...`.
+- `for` / `while` / `if` / `elif` / `else`, `break`, `continue`, `pass`,
+  `assert`, `global`, `nonlocal`, `return`.
+- `import x`, `import x.y`, `from x import y, z as w`.
+- f-strings including `=` debug specifier, `!r`/`!s`/`!a` conversions, and
+  format specs.

--- a/limitations/math.md
+++ b/limitations/math.md
@@ -1,0 +1,36 @@
+# `math` module
+
+Wide coverage; behaviour matches CPython 3.14 for the implemented set.
+
+## Implemented
+
+**Rounding**: `floor`, `ceil`, `trunc`.
+**Roots / powers**: `sqrt`, `isqrt`, `cbrt`, `pow`, `exp`, `exp2`, `expm1`.
+**Logarithms**: `log`, `log2`, `log10`, `log1p`.
+**Trig**: `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2`.
+**Hyperbolic**: `sinh`, `cosh`, `tanh`, `asinh`, `acosh`, `atanh`.
+**Angles**: `degrees`, `radians`.
+**Float properties**: `fabs`, `isnan`, `isinf`, `isfinite`, `copysign`,
+`isclose`, `nextafter`, `ulp`.
+**Integer math**: `factorial`, `gcd`, `lcm`, `comb`, `perm`.
+**Modular**: `fmod`, `remainder`, `modf`, `frexp`, `ldexp`.
+**Special**: `gamma`, `lgamma`, `erf`, `erfc`.
+
+**Constants**: `pi`, `e`, `tau`, `inf`, `nan`.
+
+## Not implemented
+
+`fsum`, `prod`, `hypot` (multi-arg), `dist`, `sumprod`, `degrees`-aware
+trig, `isqrt` for negative inputs (raises `ValueError` matching CPython
+— this is *not* a divergence), `nan` from arbitrary payloads.
+
+## Behavioural notes
+
+- `math.asin` / `math.acos` reject inputs outside `[-1, 1]` with
+  `ValueError: "expected a number in range from -1 up to 1, got <x>"`.
+  CPython uses `"math domain error"` — Monty's message is more specific.
+- Domain errors (e.g. `log(-1)`) raise `ValueError: "math domain error"`
+  matching CPython.
+- Overflow (finite input → infinite result) raises `OverflowError: "math
+  range error"` matching CPython.
+- `math.gamma` rejects non-positive integers (poles) with `ValueError`.

--- a/limitations/math.md
+++ b/limitations/math.md
@@ -20,9 +20,8 @@ Wide coverage; behaviour matches CPython 3.14 for the implemented set.
 
 ## Not implemented
 
-`fsum`, `prod`, `hypot` (multi-arg), `dist`, `sumprod`, `degrees`-aware
-trig, `isqrt` for negative inputs (raises `ValueError` matching CPython
-— this is *not* a divergence), `nan` from arbitrary payloads.
+`fsum`, `prod`, `hypot`, `dist`, `sumprod`, `nan` from arbitrary
+payloads.
 
 ## Behavioural notes
 

--- a/limitations/modules.md
+++ b/limitations/modules.md
@@ -10,7 +10,6 @@ and no way for sandboxed code to load additional modules.
 | ---------- | ------------------------------------ |
 | `asyncio`  | [asyncio.md](asyncio.md)             |
 | `datetime` | [datetime.md](datetime.md)           |
-| `gc`       | stub only; `gc.collect()` is a no-op |
 | `json`     | [json.md](json.md)                   |
 | `math`     | [math.md](math.md)                   |
 | `os`       | [os.md](os.md)                       |
@@ -18,6 +17,10 @@ and no way for sandboxed code to load additional modules.
 | `re`       | [re.md](re.md)                       |
 | `sys`      | [sys.md](sys.md)                     |
 | `typing`   | [typing.md](typing.md)               |
+
+A `gc` module exposing `collect()` / `enable()` / `disable()` is compiled
+in only under the `test-hooks` Cargo feature for use by Monty's own test
+suite; production sandboxes never see it.
 
 ## Notable modules NOT available
 

--- a/limitations/modules.md
+++ b/limitations/modules.md
@@ -1,0 +1,39 @@
+# Standard library modules
+
+Monty ships a fixed set of built-in stdlib modules. `import` of anything
+else raises `ModuleNotFoundError` — there is no `sys.path`, no site-packages,
+and no way for sandboxed code to load additional modules.
+
+## Modules available
+
+| Module     | See                                  |
+| ---------- | ------------------------------------ |
+| `asyncio`  | [asyncio.md](asyncio.md)             |
+| `datetime` | [datetime.md](datetime.md)           |
+| `gc`       | stub only; `gc.collect()` is a no-op |
+| `json`     | [json.md](json.md)                   |
+| `math`     | [math.md](math.md)                   |
+| `os`       | [os.md](os.md)                       |
+| `pathlib`  | [pathlib.md](pathlib.md)             |
+| `re`       | [re.md](re.md)                       |
+| `sys`      | [sys.md](sys.md)                     |
+| `typing`   | [typing.md](typing.md)               |
+
+## Notable modules NOT available
+
+Common modules that are *not* importable in Monty (non-exhaustive):
+`abc`, `argparse`, `array`, `base64`, `bisect`, `collections` (no
+`defaultdict`, `Counter`, `OrderedDict`, `deque`; `namedtuple` is exposed
+as a builtin, not via `collections`), `contextlib`, `copy`, `csv`,
+`ctypes`, `dataclasses` (the `@dataclass` decorator is built in; the
+module is not importable), `decimal`, `enum`, `fractions`, `functools`,
+`hashlib`, `heapq`, `hmac`, `http`, `inspect`, `io`, `itertools`,
+`logging`, `multiprocessing`, `operator`, `pickle`, `queue`, `random`,
+`socket`, `string`, `struct`, `subprocess`, `tempfile`, `threading`,
+`time`, `traceback`, `unittest`, `urllib`, `uuid`, `warnings`, `weakref`,
+`zipfile`, `zlib`.
+
+Many of these are deliberately excluded (`socket`, `subprocess`,
+`multiprocessing`, `threading`, `ctypes`) because they would breach the
+sandbox. Others (`itertools`, `functools`, `collections`, `enum`) are
+simply unimplemented; they may appear over time.

--- a/limitations/namedtuple.md
+++ b/limitations/namedtuple.md
@@ -1,0 +1,38 @@
+# Named tuples
+
+Named tuples exist as a heap type but cannot be **constructed** by
+sandboxed Python code:
+
+- `collections.namedtuple` — `collections` is not importable.
+- `typing.NamedTuple` — exists as a marker only; subscripting / `class`
+  inheritance does not produce a type (no `class` statement; see
+  [language.md](language.md)).
+- There is no builtin `namedtuple` factory.
+
+Named tuples enter the sandbox in two ways: as `sys.version_info`, and
+as values passed in from the host via the `MontyObject` API.
+
+## Supported operations
+
+- Indexing by integer: `nt[0]`. `IndexError` on out-of-range.
+- Field access by name as an attribute: `nt.major`. `AttributeError` on
+  unknown names.
+- `len(nt)`, iteration (`for x in nt`).
+- Equality: `nt == nt2` and `nt == (a, b, c)` — a named tuple equals a
+  plain tuple with the same elements (matches CPython).
+- Hashing: same hash as a plain tuple with the same elements; usable as
+  a dict key or set element.
+- `repr(nt)` — `Name(field1=v1, field2=v2, ...)` matching CPython.
+- `bool(nt)` — `True` if non-empty, `False` if empty (tuple semantics).
+
+## NOT supported
+
+- Slicing: `nt[1:3]` raises — `__getitem__` only accepts integer keys.
+  (CPython returns a plain tuple for slices.)
+- Lookup by string key: `nt["major"]` raises `TypeError: ... indices must
+  be integers`. Use attribute access instead.
+- Named-tuple methods from CPython: `._replace(**kw)`, `._asdict()`,
+  `._make(iterable)`, `._fields`, `._field_defaults`, `._source`.
+- Concatenation / multiplication: `nt + nt2`, `nt * 3` are not
+  implemented (plain tuples support these; named tuples in Monty do not).
+- Subclassing.

--- a/limitations/os.md
+++ b/limitations/os.md
@@ -1,0 +1,29 @@
+# `os` module
+
+The sandbox deliberately exposes almost nothing from `os`. Filesystem
+work goes via [pathlib](pathlib.md) and [open](open.md), which route
+through the host's mount table.
+
+## Implemented
+
+- `os.getenv(key, default=None)` — yields to the host; the host decides
+  which environment variables are visible (typically a curated subset, not
+  the full host environment).
+- `os.environ` — property that yields to the host and returns a `dict` of
+  the same curated environment. It is a plain dict, not an `os._Environ`
+  object: mutating it does **not** propagate back to the host.
+
+## Not implemented
+
+Everything else, including but not limited to: `os.path.*` (use
+`pathlib.Path` instead), `os.getcwd`, `os.chdir`, `os.listdir`,
+`os.walk`, `os.scandir`, `os.mkdir`, `os.makedirs`, `os.remove`,
+`os.unlink`, `os.rmdir`, `os.rename`, `os.replace`, `os.stat`, `os.lstat`,
+`os.access`, `os.symlink`, `os.readlink`, `os.chmod`, `os.chown`,
+`os.umask`, `os.system`, `os.popen`, `os.fork`, `os.exec*`, `os.spawn*`,
+`os.kill`, `os.pipe`, `os.read`, `os.write`, `os.open`, `os.close`,
+`os.dup`, `os.fsync`, `os.urandom`, `os.cpu_count`, `os.getpid`,
+`os.getuid`, `os.getgid`, `os.uname`.
+
+`subprocess`, `signal`, `socket`, `threading`, `multiprocessing` are not
+importable either (see [modules.md](modules.md)).

--- a/limitations/pathlib.md
+++ b/limitations/pathlib.md
@@ -1,0 +1,52 @@
+# `pathlib` module
+
+Only one class is exported: `pathlib.Path`. It always represents a virtual
+POSIX path inside the sandbox — `/mnt/data/foo.txt`, never a Windows path
+even when the host is Windows. `PurePath`, `PurePosixPath`, `PureWindowsPath`,
+`PosixPath`, `WindowsPath` are not separately exposed (the printed `repr`
+of a `Path` is `PosixPath(...)` for compatibility).
+
+## Construction
+
+`Path(*segments)` works. Each segment may be a `str` or another `Path`.
+Bytes paths are rejected with `TypeError`.
+
+`Path.cwd()` and `Path.home()` are **not** implemented — there is no
+notion of "current directory" or "home" inside the sandbox.
+
+## Pure (no I/O) methods and attributes
+
+Implemented: `name`, `parent`, `stem`, `suffix`, `suffixes`, `parts`,
+`is_absolute()`, `joinpath(*other)`, `with_name(name)`, `with_stem(stem)`,
+`with_suffix(suffix)`, `as_posix()`, `__fspath__()`.
+
+The `/` operator works (`Path("a") / "b"` → `Path("a/b")`).
+
+Not implemented: `anchor`, `drive`, `root`, `relative_to`, `is_reserved`,
+`match`, `full_match`, `__truediv__` with a `Path` on the *left* of a str
+(but right-side str is fine), `with_segments`.
+
+## I/O methods (yield to host)
+
+These yield an `OsCall` for the host to resolve:
+
+- `exists()`, `is_file()`, `is_dir()`, `is_symlink()`
+- `read_text()`, `read_bytes()`
+- `write_text(data)`, `write_bytes(data)`
+- `mkdir()`, `unlink()`, `rmdir()`
+- `iterdir()`, `stat()`, `rename(target)`
+- `resolve()`, `absolute()`
+
+The `mode`, `parents`, `exist_ok`, `missing_ok`, `target_is_directory`
+keyword arguments accepted by the corresponding CPython methods are NOT
+parsed — pass only the positional arguments documented above.
+
+Not implemented: `glob`, `rglob`, `touch`, `chmod`, `lchmod`, `owner`,
+`group`, `symlink_to`, `hardlink_to`, `link_to`, `readlink`, `lstat`,
+`samefile`, `walk`, `open` (use the builtin `open()` instead),
+`replace`, `expanduser`.
+
+## Path normalization and the sandbox
+
+Every I/O call routes through the host's mount table; paths are resolved
+strictly within mounted roots. See [filesystem.md](filesystem.md).

--- a/limitations/print.md
+++ b/limitations/print.md
@@ -1,0 +1,29 @@
+# `print()`
+
+Output always goes to the host via a print callback (`vm.print_writer`).
+The host decides where it ends up — there is no real `sys.stdout`
+underneath (see [sys.md](sys.md)).
+
+## Supported keyword arguments
+
+- `sep=...` — separator between arguments. `None` falls back to a single
+  space. Must be a `str` or `None`; otherwise `TypeError`.
+- `end=...` — appended after the last argument. `None` falls back to `"\n"`.
+  Must be a `str` or `None`; otherwise `TypeError`.
+
+## Rejected / ignored
+
+- `file=...` — explicitly rejected with `TypeError: "print() 'file'
+  argument is not supported"`. Code that does `print(..., file=sys.stderr)`
+  will not work; `sys.stderr` is an opaque marker (see [sys.md](sys.md)).
+- `flush=...` — silently accepted but ignored. Monty does not buffer print
+  output; the host receives each call immediately.
+- Any other keyword raises `TypeError: ... unexpected keyword argument`.
+
+## Behaviour
+
+- Each positional argument is converted via `py_str` (equivalent to
+  `str(x)`) before being written.
+- The host callback receives the formatted string for each chunk; there
+  is no atomicity guarantee across multiple `print()` calls if the host
+  interleaves with other output.

--- a/limitations/re.md
+++ b/limitations/re.md
@@ -1,0 +1,53 @@
+# `re` module
+
+Monty's `re` module is backed by the Rust `fancy-regex` crate, not
+CPython's regex engine. Most patterns behave identically, but the
+underlying engine differs in syntax extensions and error reporting.
+
+## Module functions
+
+Implemented: `compile`, `search`, `match`, `fullmatch`, `findall`, `sub`,
+`split`, `finditer`, `escape`.
+
+Not implemented: `subn`, `purge`, `template`. The pre-compiled `re._compile`
+internal is not exposed.
+
+## Flags
+
+Supported: `NOFLAG`, `IGNORECASE` / `I`, `MULTILINE` / `M`, `DOTALL` / `S`,
+`ASCII` / `A`.
+
+Not implemented: `VERBOSE` / `X`, `LOCALE` / `L`, `DEBUG`, `UNICODE` / `U`
+(Unicode is always on). Passing an unknown flag bit is silently accepted.
+
+## `re.Pattern` objects
+
+Attributes: `pattern`, `flags`.
+Methods: `search`, `match`, `fullmatch`, `findall`, `sub`, `split`,
+`finditer`.
+
+Not implemented: `subn`, `groups` (count), `groupindex` (named-group
+mapping), `scanner`. The `pos` / `endpos` arguments accepted by
+`Pattern.search(string, pos, endpos)` etc. in CPython are **not** supported.
+
+## `re.Match` objects
+
+Attributes: `re`, `string`.
+Methods: `group`, `groups`, `groupdict`, `start`, `end`, `span`.
+
+Not implemented: `lastindex`, `lastgroup`, `expand`, `pos`, `endpos`,
+`regs`. Indexing (`m[0]`, `m["name"]`) is not supported — use `.group()`.
+
+## `re.PatternError` / `re.error`
+
+Raised for invalid regex patterns. Unlike CPython, `pattern`, `pos`,
+`lineno`, and `colno` attributes are not populated — `fancy-regex`'s error
+representation does not carry them.
+
+## Engine-level differences
+
+- Unsupported regex features (some Unicode property escapes, some
+  CPython-specific extensions) raise `re.PatternError` at compile time.
+- Backreference syntax `\10` and higher is not recognized; only `\1`–`\9`.
+- Error messages for invalid patterns come from `fancy-regex` and do not
+  match CPython's wording.

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -1,0 +1,54 @@
+# Resource limits
+
+Monty enforces hard limits on memory, time, allocations, and recursion to
+keep untrusted code bounded. When a limit is exceeded, execution
+terminates with a `ResourceError` (visible to the *host*, not catchable
+inside the sandbox).
+
+## Memory / size limits
+
+- Allocation tracking is global; the host sets the bytes budget when
+  constructing the VM.
+- Operations whose result is bounded by simple arithmetic on input sizes
+  are **pre-checked** before allocating: integer multiplication, left
+  shift, integer power, sequence repeat (`'x' * n`), padding (`str.ljust`,
+  `str.center`, `str.zfill`, `bytes.ljust`, …). The pre-check threshold is
+  100 KB — anything that would estimate above that is rejected with
+  `ResourceError` rather than attempting the allocation.
+- `bigint.pow(base, exp)` estimates result size as `bits(base) * exp` with
+  a 4× safety multiplier to cover repeated-squaring intermediate values.
+
+## Integer-specific caps
+
+- `pow(base, exp)` / `base ** exp` with an exponent larger than `u32::MAX`
+  (≈ 4.3 × 10⁹) raises `OverflowError: "exponent too large"`.
+- `pow(base, exp, mod)` requires all integer arguments and rejects negative
+  exponents (`ValueError`).
+- `int(str)` for very long decimal strings is rejected before the O(n²)
+  BigInt parse runs; the cut-off matches CPython's `sys.int_info.str_digits_check_threshold`.
+
+## Recursion
+
+- Python-level call depth is hardcoded at **1000 frames**. The 1001st
+  nested call raises `RecursionError`.
+- There is no `sys.getrecursionlimit()` / `setrecursionlimit()` — the
+  limit cannot be changed by sandboxed code.
+- Async stacks count toward the limit but each `await` boundary is treated
+  as one frame, so `await`-chains do not amplify depth.
+
+## Time
+
+- The host can set a wall-clock budget; if exceeded the VM stops on the
+  next bytecode boundary with `ResourceError`.
+- There is no in-sandbox way to observe the budget or remaining time.
+
+## JSON
+
+- `json.loads` rejects input nested deeper than 200 levels with
+  `json.JSONDecodeError` (independent of the Python recursion limit).
+
+## After a ResourceError
+
+When a resource limit fires, **no guarantees are made about heap state or
+reference counts**. The host should discard the VM rather than try to
+recover and continue running code in it.

--- a/limitations/sys.md
+++ b/limitations/sys.md
@@ -1,0 +1,26 @@
+# `sys` module
+
+Minimal. The module exposes only the attributes listed below; every other
+`sys.*` access raises `AttributeError`.
+
+## Attributes
+
+- `sys.version` — the string `"3.14.0 (Monty)"`.
+- `sys.version_info` — named tuple `(major=3, minor=14, micro=0,
+  releaselevel='final', serial=0)`.
+- `sys.platform` — the string `"monty"` (not `"linux"` / `"darwin"` /
+  `"win32"`). Code that branches on the host OS will not work; the
+  sandbox deliberately hides it.
+- `sys.stdout` / `sys.stderr` — opaque marker objects with no methods.
+  They cannot be written to via `.write()`; printing always goes through
+  the host print callback regardless.
+
+## Not implemented
+
+`argv`, `path`, `modules`, `prefix`, `executable`, `byteorder`,
+`maxsize`, `maxunicode`, `flags`, `float_info`, `int_info`, `hash_info`,
+`exit`, `exc_info`, `getrecursionlimit`, `setrecursionlimit`,
+`getsizeof`, `getrefcount`, `intern`, `displayhook`, `excepthook`,
+`settrace`, `setprofile`, `stdin`, `__stdout__`, `_getframe`, `audit`.
+
+The recursion limit is hardcoded; see [resource_limits.md](resource_limits.md).

--- a/limitations/typing.md
+++ b/limitations/typing.md
@@ -1,0 +1,29 @@
+# `typing` module
+
+`typing` exists purely so type-annotated code can `import` it without
+`ModuleNotFoundError`. **No runtime type checking happens.** The forms are
+inert marker objects; subscripting them (`list[int]`, `Optional[str]`,
+`Union[int, str]`) returns a placeholder value but does not validate
+anything.
+
+## Names defined
+
+`Any`, `Optional`, `Union`, `List`, `Dict`, `Tuple`, `Set`, `FrozenSet`,
+`Callable`, `Type`, `Sequence`, `Mapping`, `Iterable`, `Iterator`,
+`Generator`, `ClassVar`, `Final`, `Literal`, `TypeVar`, `Generic`,
+`Protocol`, `Annotated`, `Self`, `Never`, `NoReturn`, `TYPE_CHECKING`.
+
+`TYPE_CHECKING` is `False` (as in CPython at runtime).
+
+## Not implemented
+
+- `get_type_hints`, `get_args`, `get_origin`, `cast`, `assert_type`,
+  `assert_never`, `overload`, `final`, `runtime_checkable`, `NewType`,
+  `NamedTuple`, `TypedDict`, `dataclass_transform`, `ParamSpec`,
+  `Concatenate`, `Unpack`, `TypeAlias`, `TypeAliasType`, `LiteralString`.
+- Any introspection of annotations: `__annotations__` is not populated on
+  functions or modules, so libraries that read it (Pydantic, attrs,
+  inspect-based code) cannot run.
+
+If you need real type validation, do it on the *host* side around the
+sandbox boundary.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a comprehensive “limitations” section documenting Monty’s sandbox behavior across language features, stdlib modules, I/O, and resource limits. Clearly states what’s supported, what’s omitted, and key divergences from `CPython`.

- **New Features**
  - Language/parser rules: rejected constructs, import constraints, async model with host-driven `await`, `asyncio.run`/`asyncio.gather` only.
  - Builtins/types/exceptions: implemented vs missing builtins, no user-defined classes, host dataclass/namedtuple behavior, fixed exception set and one-arg ctor rule.
  - Filesystem/OS: virtual POSIX paths, mount modes (ReadOnly/ReadWrite/Overlay), no live descriptors, `pathlib.Path` I/O surface, `os.getenv`/`os.environ` only.
  - Modules: documented surfaces for `asyncio`, `datetime`, `json`, `math`, `os`, `pathlib`, `re`, `sys`, `typing`; others not importable.
  - Resource limits: memory/time/recursion caps, BigInt and `pow()` bounds, JSON depth, guidance after a limit trip.
  - Misc: `print()` semantics and kwargs; namedtuple operations and limits.

<sup>Written for commit 5b077cd5292a42db79faed2bd63a8afdace3f59b. Summary will update on new commits. <a href="https://cubic.dev/pr/pydantic/monty/pull/460?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

