### PR TITLE
Context manager support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+DON'T COMMIT UNLESS EXPLICITLY ASKED TO DO SO BY THE USER! Previous commit requests do not matter - don't commit unless you've just been explicitly asked to do so.
+
 ## Project Overview
 
 Monty is a sandboxed Python interpreter written in Rust. It parses Python code using Ruff's `ruff_python_parser` but implements its own runtime execution model for safety and performance. This is a work-in-progress project that currently supports a subset of Python features.

--- a/crates/monty-datatest/Cargo.toml
+++ b/crates/monty-datatest/Cargo.toml
@@ -9,11 +9,6 @@ description = "Datatest harness for Monty — runs test cases against both Monty
 publish = false
 
 [dependencies]
-# `test-hooks` is enabled unconditionally because monty-datatest is a test
-# harness that exists to exercise Monty's behavior — production builds of
-# `monty` never depend on this crate, so there's no risk of leaking the
-# hooks into a user-facing sandbox. The `_test_cm()` builtin and `gc`
-# module live behind this gate; tests that consume them rely on it.
 monty = { path = "../monty", features = ["test-hooks"] }
 pyo3 = { version = "0.28", features = ["auto-initialize"] }
 ahash = "0.8.0"

--- a/crates/monty-datatest/Cargo.toml
+++ b/crates/monty-datatest/Cargo.toml
@@ -9,7 +9,12 @@ description = "Datatest harness for Monty — runs test cases against both Monty
 publish = false
 
 [dependencies]
-monty = { path = "../monty" }
+# `test-hooks` is enabled unconditionally because monty-datatest is a test
+# harness that exists to exercise Monty's behavior — production builds of
+# `monty` never depend on this crate, so there's no risk of leaking the
+# hooks into a user-facing sandbox. The `_test_cm()` builtin and `gc`
+# module live behind this gate; tests that consume them rely on it.
+monty = { path = "../monty", features = ["test-hooks"] }
 pyo3 = { version = "0.28", features = ["auto-initialize"] }
 ahash = "0.8.0"
 chrono = "0.4"

--- a/crates/monty-datatest/src/main.rs
+++ b/crates/monty-datatest/src/main.rs
@@ -322,14 +322,11 @@ fn parse_ref_counts(s: &str) -> AHashMap<String, usize> {
     counts
 }
 
-/// Python implementations of external functions for running iter mode tests in CPython.
-///
-/// These implementations mirror the behavior of `dispatch_external_call` so that
-/// iter mode tests produce identical results in both Monty and CPython.
-///
-/// This is loaded from `scripts/iter_test_methods.py` which is also imported by
-/// `scripts/run_traceback.py` to ensure consistency.
-const ITER_EXT_FUNCTIONS_PYTHON: &str = include_str!("../../../scripts/iter_test_methods.py");
+// Shared CPython-side fixtures (external function implementations for iter
+// mode tests, plus the `_test_cm` synthetic context-manager shim) live in
+// `scripts/test_fixtures.py`. The module is imported once via pyo3
+// (cached in `sys.modules`) and its `exported_globals` dict is merged into
+// each CPython test's globals — see `import_shared_test_globals`.
 
 /// Creates a temporary directory with a known structure for `# mount-fs` tests.
 ///
@@ -372,7 +369,7 @@ fn ensure_python_modules_imported() {
     static INIT: OnceLock<()> = OnceLock::new();
     INIT.get_or_init(|| {
         Python::attach(|py| {
-            // Import modules that are used by iter_test_methods.py and can cause race conditions.
+            // Import modules that are used by test_fixtures.py and can cause race conditions.
             // The order matters: import dependencies first.
             py.import("typing").expect("Failed to import typing");
             py.import("dataclasses").expect("Failed to import dataclasses");
@@ -381,11 +378,12 @@ fn ensure_python_modules_imported() {
             py.import("asyncio").expect("Failed to import asyncio");
             py.import("traceback").expect("Failed to import traceback");
 
-            // Also pre-execute the iter_test_methods code once to ensure all its
-            // module-level code (dataclass definitions, monkey-patches) is initialized
-            let ext_funcs_cstr = CString::new(ITER_EXT_FUNCTIONS_PYTHON).expect("Invalid C string");
-            py.run(&ext_funcs_cstr, None, None)
-                .expect("Failed to pre-initialize iter_test_methods");
+            // Also pre-import `test_fixtures` once so its module-level
+            // code (dataclass definitions, `os.environ` monkey-patch) runs
+            // before any test thread races on it. Per-test injection then
+            // just reads the cached `exported_globals` attribute — see
+            // `import_shared_test_globals`.
+            import_shared_test_globals(py);
         });
     });
 }
@@ -554,7 +552,7 @@ fn dispatch_external_call(name: &str, args: Vec<MontyObject>) -> DispatchResult 
 /// Dispatches a dataclass method call to the appropriate test implementation.
 ///
 /// The first argument is always the dataclass instance (`self`). Known methods
-/// are implemented to mirror the Python dataclass methods in `iter_test_methods.py`.
+/// are implemented to mirror the Python dataclass methods in `test_fixtures.py`.
 /// Unknown methods return `AttributeError`.
 fn dispatch_method_call(
     method_name: &str,
@@ -2113,6 +2111,22 @@ fn import_run_traceback(py: Python<'_>) -> Bound<'_, PyModule> {
     py.import("run_traceback").expect("Failed to import run_traceback")
 }
 
+/// Import `test_fixtures` (lazily, cached by pyo3) and return the module.
+///
+/// Every CPython test pulls the `exported_globals` dict out of this module
+/// to populate its globals. `ensure_python_modules_imported` calls this
+/// once to run the module's top-level code (dataclass definitions and the
+/// `os.environ` monkey-patch) before any test thread races on it; later
+/// calls return the cached `sys.modules` entry.
+fn import_shared_test_globals(py: Python<'_>) -> Bound<'_, PyModule> {
+    let sys = py.import("sys").expect("Failed to import sys");
+    let sys_path = sys.getattr("path").expect("Failed to get sys.path");
+    sys_path
+        .call_method1("insert", (0, SCRIPTS_DIR))
+        .expect("Failed to add scripts to sys.path");
+    py.import("test_fixtures").expect("Failed to import test_fixtures")
+}
+
 /// Result from CPython execution - either a value to compare, or an early return.
 enum CpythonResult {
     /// Value to compare against expectation
@@ -2202,19 +2216,28 @@ fn try_run_cpython_test(
         // Execute statements at module level
         let globals = PyDict::new(py);
 
+        // Inject the shared CPython-side fixtures (iter-mode external
+        // functions and `_test_cm`) into every test's globals from the
+        // single `exported_globals` dict in `test_fixtures.py`. The
+        // module is imported once and cached, so this is just an
+        // `update()` of a small dict — no re-exec per test.
+        let shared = import_shared_test_globals(py);
+        let exported = shared
+            .getattr("exported_globals")
+            .expect("test_fixtures.exported_globals missing");
+        globals
+            .call_method1("update", (exported,))
+            .expect("Failed to merge shared test globals");
+
         // For mount-fs tests, inject `root` variable pointing to real temp directory.
         if let Some(ref setup_code) = mount_root_setup {
             let setup_cstr = CString::new(setup_code.as_str()).expect("Invalid C string in mount-fs setup");
             py.run(&setup_cstr, Some(&globals), None)
                 .expect("Failed to set up mount-fs root for CPython");
         }
-
-        // For iter mode tests, inject external function implementations into globals
-        if iter_mode && !mount_fs {
-            let ext_funcs_cstr = CString::new(ITER_EXT_FUNCTIONS_PYTHON).expect("Invalid C string in ext funcs");
-            py.run(&ext_funcs_cstr, Some(&globals), None)
-                .expect("Failed to define external functions for iter mode");
-        }
+        // `iter_mode` doesn't influence CPython-side globals anymore — the
+        // shared `exported_globals` dict is installed unconditionally above.
+        let _ = iter_mode;
 
         // Run the statements
         let statements_cstr = CString::new(statements.as_str()).expect("Invalid C string in statements");

--- a/crates/monty-datatest/src/main.rs
+++ b/crates/monty-datatest/src/main.rs
@@ -2235,9 +2235,6 @@ fn try_run_cpython_test(
             py.run(&setup_cstr, Some(&globals), None)
                 .expect("Failed to set up mount-fs root for CPython");
         }
-        // `iter_mode` doesn't influence CPython-side globals anymore — the
-        // shared `exported_globals` dict is installed unconditionally above.
-        let _ = iter_mode;
 
         // Run the statements
         let statements_cstr = CString::new(statements.as_str()).expect("Invalid C string in statements");

--- a/crates/monty/src/builtins/mod.rs
+++ b/crates/monty/src/builtins/mod.rs
@@ -32,6 +32,10 @@ mod round;
 mod setattr;
 mod sorted;
 mod sum;
+/// Test-only `_test_cm` builtin — see [`test_cm`] and `types/test_cm.rs`.
+/// **REMOVE** once a real context manager covers the test paths.
+#[cfg(feature = "test-hooks")]
+mod test_cm;
 mod type_;
 mod zip;
 
@@ -211,6 +215,11 @@ pub enum BuiltinsFunctions {
     // Vars,
     Zip,
     // __import__ - not planned
+    /// Test-only synthetic context manager constructor. Only present
+    /// under the `test-hooks` feature; see `crates/monty/src/builtins/test_cm.rs`.
+    #[cfg(feature = "test-hooks")]
+    #[strum(serialize = "_test_cm")]
+    TestCm,
 }
 
 impl BuiltinsFunctions {
@@ -258,6 +267,8 @@ impl BuiltinsFunctions {
             Self::Sum => sum::builtin_sum(vm, args),
             Self::Type => type_::builtin_type(vm, args),
             Self::Zip => zip::builtin_zip(vm, args),
+            #[cfg(feature = "test-hooks")]
+            Self::TestCm => test_cm::builtin_test_cm(vm, args),
         };
         r.map(CallResult::Value)
     }

--- a/crates/monty/src/builtins/mod.rs
+++ b/crates/monty/src/builtins/mod.rs
@@ -22,7 +22,7 @@ mod map;
 mod min_max; // min and max share implementation
 mod next;
 mod oct;
-mod open;
+pub(crate) mod open;
 mod ord;
 mod pow;
 mod print;

--- a/crates/monty/src/builtins/test_cm.rs
+++ b/crates/monty/src/builtins/test_cm.rs
@@ -1,0 +1,153 @@
+//! `_test_cm()` builtin — constructs a synthetic context manager.
+//!
+//! **REMOVE THIS FILE** along with [`crate::types::test_cm`] once a real
+//! production type covers the `with` statement branches this helper exists
+//! to test. See that module's docstring for the full removal checklist.
+//!
+//! The function is intentionally not listed in CPython's builtins; it's
+//! only present under the `test-hooks` cargo feature so a production
+//! sandbox can never construct one.
+
+use crate::{
+    args::ArgValues,
+    bytecode::VM,
+    defer_drop,
+    exception_private::{ExcType, RunResult},
+    heap::HeapData,
+    resource::ResourceTracker,
+    types::{PyTrait, TestContextManager},
+    value::Value,
+};
+
+/// `_test_cm()` / `_test_cm(behavior)` / `_test_cm(behavior, payload)` —
+/// constructs a synthetic context manager configured by a behavior string
+/// and optional payload.
+///
+/// Positional API rather than kwargs to keep the implementation small (no
+/// keyword parsing) and the test sites readable. The supported behaviors
+/// are:
+///
+/// | behavior          | payload    | effect                                              |
+/// | ----------------- | ---------- | --------------------------------------------------- |
+/// | (none)            | —          | passthrough: returns self on enter, None on exit    |
+/// | `"suppress"`      | (none)     | `__exit__` returns True on the exception path       |
+/// | `"enter_value"`   | int        | `__enter__` returns the int instead of self         |
+/// | `"raise_on_enter"`| str        | `__enter__` raises `ValueError(payload)`            |
+/// | `"raise_on_exit"` | str        | `__exit__` raises `ValueError(payload)`             |
+///
+/// Each behavior pins exactly one branch of the `with` machinery, so a
+/// single test can verify that branch in isolation.
+pub fn builtin_test_cm(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let (behavior, payload) = args.get_zero_one_two_args("_test_cm", vm.heap)?;
+
+    let mut cm = TestContextManager::new();
+    if let Some(behavior_value) = behavior {
+        defer_drop!(behavior_value, vm);
+        let Some(behavior_str) = value_as_owned_str(behavior_value, vm) else {
+            if let Some(p) = payload {
+                p.drop_with_heap(vm);
+            }
+            return Err(ExcType::type_error(format!(
+                "_test_cm() behavior must be str, not {}",
+                behavior_value.py_type(vm)
+            )));
+        };
+        configure(&mut cm, &behavior_str, payload, vm)?;
+    } else if let Some(p) = payload {
+        // payload supplied with no behavior is a usage error
+        p.drop_with_heap(vm);
+        return Err(ExcType::type_error(
+            "_test_cm() payload requires a leading behavior argument".to_owned(),
+        ));
+    }
+
+    let heap_id = vm.heap.allocate(HeapData::TestContextManager(cm))?;
+    Ok(Value::Ref(heap_id))
+}
+
+/// Applies the chosen behavior to `cm`, consuming the payload (if any).
+///
+/// Caller already copied the behavior string out of the original `Value`
+/// (which is inside a `defer_drop!` guard), so we take a borrow here.
+fn configure(
+    cm: &mut TestContextManager,
+    behavior: &str,
+    payload: Option<Value>,
+    vm: &mut VM<'_, impl ResourceTracker>,
+) -> RunResult<()> {
+    match behavior {
+        "suppress" => {
+            if let Some(p) = payload {
+                p.drop_with_heap(vm);
+                return Err(ExcType::type_error("_test_cm('suppress') takes no payload".to_owned()));
+            }
+            cm.suppress = true;
+        }
+        "enter_value" => {
+            let Some(p) = payload else {
+                return Err(ExcType::type_error(
+                    "_test_cm('enter_value', n) requires an int payload".to_owned(),
+                ));
+            };
+            defer_drop!(p, vm);
+            let Value::Int(n) = p else {
+                return Err(ExcType::type_error(format!(
+                    "_test_cm('enter_value', n) requires int payload, not {}",
+                    p.py_type(vm)
+                )));
+            };
+            cm.enter_value = Some(*n);
+        }
+        "raise_on_enter" => {
+            cm.raise_on_enter = Some(extract_str_payload("raise_on_enter", payload, vm)?);
+        }
+        "raise_on_exit" => {
+            cm.raise_on_exit = Some(extract_str_payload("raise_on_exit", payload, vm)?);
+        }
+        other => {
+            if let Some(p) = payload {
+                p.drop_with_heap(vm);
+            }
+            return Err(ExcType::type_error(format!("_test_cm() unknown behavior '{other}'")));
+        }
+    }
+    Ok(())
+}
+
+/// Extracts a required string payload, surfacing CPython-style TypeErrors
+/// for missing/wrong-typed payloads.
+fn extract_str_payload(
+    behavior: &str,
+    payload: Option<Value>,
+    vm: &mut VM<'_, impl ResourceTracker>,
+) -> RunResult<String> {
+    let Some(p) = payload else {
+        return Err(ExcType::type_error(format!(
+            "_test_cm('{behavior}', msg) requires a str payload"
+        )));
+    };
+    defer_drop!(p, vm);
+    let Some(s) = value_as_owned_str(p, vm) else {
+        return Err(ExcType::type_error(format!(
+            "_test_cm('{behavior}', msg) requires str payload, not {}",
+            p.py_type(vm)
+        )));
+    };
+    Ok(s)
+}
+
+/// Reads the underlying string out of a `Value`, copying to an owned `String`.
+///
+/// Used here (rather than `Value::as_either_str`) because we need a freshly
+/// owned `String` for storage on `TestContextManager`, not a borrow tied to
+/// the heap / interns. Returns `None` for non-string `Value` variants.
+fn value_as_owned_str(value: &Value, vm: &VM<'_, impl ResourceTracker>) -> Option<String> {
+    match value {
+        Value::InternString(id) => Some(vm.interns.get_str(*id).to_owned()),
+        Value::Ref(id) => match vm.heap.get(*id) {
+            HeapData::Str(s) => Some(s.as_str().to_owned()),
+            _ => None,
+        },
+        _ => None,
+    }
+}

--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -3209,13 +3209,21 @@ impl<'a> Compiler<'a> {
         // === Body (protected region) ===
         let try_start = self.code.current_offset();
         self.compile_block(body)?;
+        // Close the protected range BEFORE `WithExit` so the normal-exit
+        // cleanup is outside the body's exception-table entry. If
+        // `__exit__` raises here, the new exception should propagate to
+        // the outer frame's exception table (matching CPython, where an
+        // `__exit__` exception replaces any prior state). Routing it
+        // back to our own handler would invoke `__exit__` a second time
+        // with the ctx already popped, blowing up the stack-depth
+        // bookkeeping in the unwinder.
+        let try_end = self.code.current_offset();
 
         // Normal exit: __exit__(None, None, None); pop the (discarded) result;
         // skip the handler.
         self.code.emit(Opcode::WithExit)?;
         self.code.emit(Opcode::Pop)?;
         let after_body_jump = self.code.emit_jump(Opcode::Jump)?;
-        let try_end = self.code.current_offset();
 
         // === Exception handler ===
         let handler_start = self.code.current_offset();

--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -3138,8 +3138,8 @@ impl<'a> Compiler<'a> {
     /// ```text
     /// <compile context expr>            ; [ctx]
     /// BEFORE_WITH                       ; [ctx, value]
-    /// <store target or POP>             ; [ctx]
     /// try_start:
+    ///   <store target or POP>           ; [ctx]
     ///   <compile body>                  ; [ctx]
     ///   WITH_EXIT                       ; []
     ///   JUMP end                        ; skip the exception handler
@@ -3160,6 +3160,13 @@ impl<'a> Compiler<'a> {
     ///  routing to the outer target>
     /// end:
     /// ```
+    ///
+    /// The `<store target or POP>` step lives *inside* the protected region so
+    /// `with f() as (a, b):` invokes `__exit__` when the unpack fails —
+    /// matching CPython, which similarly places `UNPACK_SEQUENCE` inside the
+    /// `BEFORE_WITH` exception-table entry. If the store raises, the unwinder
+    /// drops any partial unpack state down to the handler's expected depth
+    /// (`stack_depth + 1`) before pushing `exc` and entering `handler_start`.
     ///
     /// A single exception-table entry covers the body, routing exceptions to
     /// `handler_start` with stack depth `outer + 1` (the context manager). If
@@ -3186,15 +3193,9 @@ impl<'a> Compiler<'a> {
 
         let try_exc_stack_count = self.except_handler_depth;
 
-        // Evaluate context expr and invoke __enter__; bind the result to target
-        // (or discard).
+        // Evaluate context expr and invoke __enter__.
         self.compile_expr(context)?;
         self.code.emit(Opcode::BeforeWith)?;
-        if let Some(target) = target {
-            self.compile_unpack_target(target)?;
-        } else {
-            self.code.emit(Opcode::Pop)?;
-        }
 
         // Track early exits inside the body so we can call __exit__ before
         // they propagate. Mirrors the FinallyTarget push in `compile_try`.
@@ -3208,6 +3209,15 @@ impl<'a> Compiler<'a> {
 
         // === Body (protected region) ===
         let try_start = self.code.current_offset();
+        // Bind the __enter__ result to the `as` target (or discard it). This
+        // lives inside the protected region so `with f() as (a, b):` calls
+        // `__exit__` when the unpack fails — matching CPython, which similarly
+        // covers UNPACK_SEQUENCE with the with-block's exception table entry.
+        if let Some(target) = target {
+            self.compile_unpack_target(target)?;
+        } else {
+            self.code.emit(Opcode::Pop)?;
+        }
         self.compile_block(body)?;
         // Close the protected range BEFORE `WithExit` so the normal-exit
         // cleanup is outside the body's exception-table entry. If

--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -558,6 +558,9 @@ impl<'a> Compiler<'a> {
             }
             Node::FunctionDef(func_def) => self.compile_function_def(func_def)?,
             Node::Try(try_block) => self.compile_try(try_block)?,
+            Node::With {
+                context, target, body, ..
+            } => self.compile_with(context, target.as_ref(), body)?,
             Node::Import { names } => {
                 for import_name in names {
                     self.compile_import(import_name.module_name, &import_name.binding)?;
@@ -2316,30 +2319,38 @@ impl<'a> Compiler<'a> {
             self.code.emit(Opcode::ClearException)?;
         }
 
-        // Pop the iterator only for `for` loops (has iterator on stack)
-        // `while` loops don't have an iterator to pop
-        if self.loop_stack[target_loop_depth].has_iterator_on_stack {
-            self.code.emit(Opcode::Pop)?;
-        }
-
         // Check if we need to go through any finally blocks
         // We need to run finally if break crosses the try boundary, i.e., if
         // we're breaking from a loop that existed before the try started.
-        if let Some(finally_target) = self.finally_targets.last_mut()
-            && target_loop_depth < finally_target.loop_depth_at_entry
-        {
-            // Breaking from a loop that's outside (or at the start of) this try-finally,
-            // so finally must run before the break
+        let routes_through_finally = self
+            .finally_targets
+            .last()
+            .is_some_and(|ft| target_loop_depth < ft.loop_depth_at_entry);
+
+        if routes_through_finally {
+            // Routed path: leave the iterator on the stack — the chain of
+            // finally trailers may have its own per-block stack contributions
+            // (e.g. a `with` block sits on top of the iterator), and popping
+            // the iterator here would pop the wrong slot. The outermost
+            // trailer (`compile_control_flow_after_finally`) pops the
+            // iterator just before jumping to the loop's break target.
             let jump = self.code.emit_jump(Opcode::Jump)?;
-            finally_target.break_jumps.push(BreakContinueThruFinally {
-                jump,
-                target_loop_depth,
-            });
-            return Ok(());
+            self.finally_targets
+                .last_mut()
+                .expect("checked above")
+                .break_jumps
+                .push(BreakContinueThruFinally {
+                    jump,
+                    target_loop_depth,
+                });
+        } else {
+            // Direct path: pop the iterator (if any) and jump to loop end.
+            if self.loop_stack[target_loop_depth].has_iterator_on_stack {
+                self.code.emit(Opcode::Pop)?;
+            }
+            let jump = self.code.emit_jump(Opcode::Jump)?;
+            self.loop_stack[target_loop_depth].break_jumps.push(jump);
         }
-        // No finally to go through, jump directly to loop end
-        let jump = self.code.emit_jump(Opcode::Jump)?;
-        self.loop_stack[target_loop_depth].break_jumps.push(jump);
 
         Ok(())
     }
@@ -2425,8 +2436,16 @@ impl<'a> Compiler<'a> {
             return Ok(());
         }
 
-        // No more finally blocks, jump directly to the loop target
+        // No more finally blocks, jump directly to the loop target. For
+        // break paths we pop the for-loop iterator here (rather than at the
+        // break statement) so that intervening per-block stack contributions
+        // — e.g. a `with` block sitting on top of the iterator — get to clean
+        // themselves up in their own trailers first. Continue paths leave the
+        // iterator on top because the loop start (`ForIter`) expects it.
         if is_break {
+            if self.loop_stack[target_loop_depth].has_iterator_on_stack {
+                self.code.emit(Opcode::Pop)?;
+            }
             let jump = self.code.emit_jump(Opcode::Jump)?;
             self.loop_stack[target_loop_depth].break_jumps.push(jump);
         } else {
@@ -3109,6 +3128,166 @@ impl<'a> Compiler<'a> {
             self.code
                 .add_exception_entry(else_start, else_end, cleanup_start, stack_depth, try_exc_stack_count)?;
         }
+
+        Ok(())
+    }
+
+    /// Compiles a `with` statement: `with EXPR [as TARGET]: BODY`.
+    ///
+    /// The bytecode shape is:
+    /// ```text
+    /// <compile context expr>            ; [ctx]
+    /// BEFORE_WITH                       ; [ctx, value]
+    /// <store target or POP>             ; [ctx]
+    /// try_start:
+    ///   <compile body>                  ; [ctx]
+    ///   WITH_EXIT                       ; []
+    ///   JUMP end                        ; skip the exception handler
+    /// try_end:
+    /// handler_start:
+    ///   ; VM pushes the exception: stack is [ctx, exc]
+    ///   WITH_EXCEPT_START               ; [ctx, exc, suppress]
+    ///   JUMP_IF_TRUE swallow            ; pops suppress; falsy = continue
+    ///   POP                             ; [ctx]
+    ///   POP                             ; []
+    ///   RERAISE                         ; propagate
+    /// swallow:                          ; [ctx, exc]
+    ///   POP                             ; [ctx]
+    ///   POP                             ; []
+    ///   CLEAR_EXCEPTION
+    ///   JUMP end
+    /// <return / break / continue trailers, each running WITH_EXIT before
+    ///  routing to the outer target>
+    /// end:
+    /// ```
+    ///
+    /// A single exception-table entry covers the body, routing exceptions to
+    /// `handler_start` with stack depth `outer + 1` (the context manager). If
+    /// the cleanup itself (`__exit__` invocation) raises, the new exception
+    /// replaces the original one and propagates via the surrounding frame's
+    /// exception table — this matches CPython's behavior.
+    ///
+    /// `return`/`break`/`continue` inside the body are routed through this
+    /// method's trailers (analogous to `try`/`finally`) so `__exit__` is called
+    /// before propagating the early exit. The `return` trailer uses `Rot2` to
+    /// preserve the return value while invoking `WithExit` on the context
+    /// manager underneath.
+    fn compile_with(
+        &mut self,
+        context: &ExprLoc,
+        target: Option<&UnpackTarget>,
+        body: &[PreparedNode],
+    ) -> Result<(), CompileError> {
+        // Record outer stack depth for the exception-table entry. If we are in
+        // dead-code state there's nothing to emit.
+        let Some(stack_depth) = self.code.stack_depth() else {
+            return Ok(());
+        };
+
+        let try_exc_stack_count = self.except_handler_depth;
+
+        // Evaluate context expr and invoke __enter__; bind the result to target
+        // (or discard).
+        self.compile_expr(context)?;
+        self.code.emit(Opcode::BeforeWith)?;
+        if let Some(target) = target {
+            self.compile_unpack_target(target)?;
+        } else {
+            self.code.emit(Opcode::Pop)?;
+        }
+
+        // Track early exits inside the body so we can call __exit__ before
+        // they propagate. Mirrors the FinallyTarget push in `compile_try`.
+        self.finally_targets.push(FinallyTarget {
+            return_jumps: Vec::new(),
+            break_jumps: Vec::new(),
+            continue_jumps: Vec::new(),
+            loop_depth_at_entry: self.loop_stack.len(),
+            except_handler_depth_at_entry: self.except_handler_depth,
+        });
+
+        // === Body (protected region) ===
+        let try_start = self.code.current_offset();
+        self.compile_block(body)?;
+
+        // Normal exit: __exit__(None, None, None); pop the (discarded) result;
+        // skip the handler.
+        self.code.emit(Opcode::WithExit)?;
+        self.code.emit(Opcode::Pop)?;
+        let after_body_jump = self.code.emit_jump(Opcode::Jump)?;
+        let try_end = self.code.current_offset();
+
+        // === Exception handler ===
+        let handler_start = self.code.current_offset();
+        // VM unwinds to `stack_depth + 1` (the ctx) and then pushes the exception
+        // value itself, so we enter at depth `stack_depth + 2` with [ctx, exc].
+        self.code.new_code_region(stack_depth + 2);
+
+        self.code.emit(Opcode::WithExceptStart)?;
+        // Stack: [ctx, exc, suppress]
+        let swallow_jump = self.code.emit_jump(Opcode::JumpIfTrue)?;
+        // Falsy path: stack = [ctx, exc]. Drop both and re-raise.
+        self.code.emit(Opcode::Pop)?;
+        self.code.emit(Opcode::Pop)?;
+        self.code.emit(Opcode::Reraise)?;
+
+        // Swallow path: stack = [ctx, exc]. Drop both, clear current exception,
+        // jump to end.
+        self.code.patch_jump(swallow_jump)?;
+        self.code.emit(Opcode::Pop)?;
+        self.code.emit(Opcode::Pop)?;
+        self.code.emit(Opcode::ClearException)?;
+        let after_swallow_jump = self.code.emit_jump(Opcode::Jump)?;
+
+        // === Early-exit trailers (return/break/continue inside body) ===
+        let finally_target = self.finally_targets.pop().expect("finally_targets should not be empty");
+
+        // === Return path ===
+        // Stack at patch site: [ctx, return_value]. Swap so ctx is on top for
+        // WithExit, discard its result, then route the (preserved) return value.
+        if !finally_target.return_jumps.is_empty() {
+            for jump in finally_target.return_jumps {
+                self.code.patch_jump(jump)?;
+            }
+            self.code.emit(Opcode::Rot2)?;
+            self.code.emit(Opcode::WithExit)?;
+            self.code.emit(Opcode::Pop)?;
+            self.compile_return_routing()?;
+        }
+
+        // === Break path ===
+        // Stack at patch site: [ctx] (compile_break already popped any for-loop
+        // iterator). Call __exit__, discard its result, then route to the break target.
+        if !finally_target.break_jumps.is_empty() {
+            for break_info in &finally_target.break_jumps {
+                self.code.patch_jump(break_info.jump)?;
+            }
+            self.code.emit(Opcode::WithExit)?;
+            self.code.emit(Opcode::Pop)?;
+            self.compile_control_flow_after_finally(&finally_target.break_jumps, true)?;
+        }
+
+        // === Continue path ===
+        // Stack at patch site: [ctx]. Same shape as the break path.
+        if !finally_target.continue_jumps.is_empty() {
+            for continue_info in &finally_target.continue_jumps {
+                self.code.patch_jump(continue_info.jump)?;
+            }
+            self.code.emit(Opcode::WithExit)?;
+            self.code.emit(Opcode::Pop)?;
+            self.compile_control_flow_after_finally(&finally_target.continue_jumps, false)?;
+        }
+
+        // === Merge point for the normal-exit and swallowed-exception paths ===
+        self.code.patch_jump(after_body_jump)?;
+        self.code.patch_jump(after_swallow_jump)?;
+
+        // === Exception-table entry: body -> handler ===
+        // `stack_depth + 1` accounts for the ctx left on the stack; the VM
+        // pushes the exception value itself on top of that. `exception_stack_count`
+        // is unchanged because the with-block does not push to exception_stack.
+        self.code
+            .add_exception_entry(try_start, try_end, handler_start, stack_depth + 1, try_exc_stack_count)?;
 
         Ok(())
     }

--- a/crates/monty/src/bytecode/op.rs
+++ b/crates/monty/src/bytecode/op.rs
@@ -456,6 +456,43 @@ pub enum Opcode {
     /// Pops iterable (TOS), adds each item to set at stack position `len - 2 - depth`.
     /// Raises `TypeError` if iterable is not iterable.
     SetExtend,
+
+    // === Context Managers ===
+    /// Enter a context manager: call `__enter__` on TOS, push the result, keep
+    /// the context manager underneath for the eventual `__exit__` call.
+    ///
+    /// Stack: [..., ctx] -> [..., ctx, value]
+    ///
+    /// Emitted by the compiler at the head of a `with` block. The context
+    /// manager stays on the stack across the body so the matching `WithExit`
+    /// or `WithExceptStart` can find it. Calls `py_enter` on the heap object,
+    /// raising `AttributeError` for objects that don't implement the protocol.
+    /// Appended at the end to preserve the serialized byte values of all older opcodes.
+    BeforeWith,
+    /// Normal exit from a `with` block: call `__exit__(None, None, None)` on TOS,
+    /// pop the context manager, and push the result of the call.
+    ///
+    /// Stack: [..., ctx] -> [..., result]
+    ///
+    /// The compiler emits a trailing `Pop` to discard the result — splitting the
+    /// "call + discard" into two opcodes keeps the call shape compatible with
+    /// `__exit__` implementations that yield `OsCall`/`External`/`MethodCall`
+    /// (the host's resume push lands as the `result`, which `Pop` then drops).
+    /// Appended at the end to preserve the serialized byte values of all older opcodes.
+    WithExit,
+    /// Exception path of a `with` block: call `__exit__(type(exc), exc, None)`
+    /// and push the truthiness of the result so the compiler can branch on
+    /// whether to suppress the exception.
+    ///
+    /// Stack: [..., ctx, exc] -> [..., ctx, exc, suppress]
+    ///
+    /// The exception is the value pushed onto the operand stack on entry to
+    /// the with-block's exception handler region (analogous to `Try`). The
+    /// compiler-emitted control flow following this opcode pops both `ctx` and
+    /// `exc` and either swallows (via `ClearException`) or `Reraise`s based on
+    /// the `suppress` bool.
+    /// Appended at the end to preserve the serialized byte values of all older opcodes.
+    WithExceptStart,
 }
 
 impl TryFrom<u8> for Opcode {
@@ -637,6 +674,16 @@ impl Opcode {
             // `DictUpdate`/`SetExtend` also take a u8 stack-depth operand.
             (DictUpdate | SetExtend, Operand::U8(_)) => -1,
 
+            // === Fixed-effect, no operand (context managers) ===
+            // `BeforeWith` pushes the `__enter__` result on top of the existing ctx.
+            (BeforeWith, Operand::None) => 1,
+            // `WithExit` pops ctx and pushes the `__exit__` return value; compiler
+            // emits a trailing `Pop` to discard.
+            (WithExit, Operand::None) => 0,
+            // `WithExceptStart` pushes the raw `__exit__` return value above the
+            // existing [ctx, exc]; compiler uses `JumpIfTrue` to act on its truthiness.
+            (WithExceptStart, Operand::None) => 1,
+
             // === Fixed-effect, U16 operand ===
             (LoadConst, Operand::U16(_)) => 1,
             (LoadLocalW | LoadGlobal | LoadCell, Operand::U16(_)) => 1,
@@ -720,8 +767,8 @@ mod tests {
 
     #[test]
     fn test_opcode_roundtrip() {
-        // Verify that all opcodes from 0 to DeleteGlobal (last opcode) can be converted to u8 and back.
-        for byte in 0..=Opcode::DeleteGlobal as u8 {
+        // Verify that all opcodes from 0 to the last opcode can be converted to u8 and back.
+        for byte in 0..=Opcode::WithExceptStart as u8 {
             let opcode = Opcode::try_from(byte).unwrap();
             assert_eq!(opcode as u8, byte, "opcode {opcode:?} has wrong discriminant");
         }
@@ -737,12 +784,16 @@ mod tests {
         assert_eq!(Opcode::DeleteGlobal as u8, 112);
         assert_eq!(Opcode::DictUpdate as u8, 113);
         assert_eq!(Opcode::SetExtend as u8, 114);
+        // Context-manager opcodes added with the `with` statement support.
+        assert_eq!(Opcode::BeforeWith as u8, 115);
+        assert_eq!(Opcode::WithExit as u8, 116);
+        assert_eq!(Opcode::WithExceptStart as u8, 117);
     }
 
     #[test]
     fn test_invalid_opcode() {
         // Byte just after the last valid opcode should fail
-        let result = Opcode::try_from(Opcode::SetExtend as u8 + 1);
+        let result = Opcode::try_from(Opcode::WithExceptStart as u8 + 1);
         assert!(result.is_err());
         // 255 should also fail
         let result = Opcode::try_from(255u8);

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -826,13 +826,46 @@ fn dispatch_dunder<T: ResourceTracker>(
                 .and_then(|()| vm.heap.read(heap_id).py_enter(heap_id, vm))
         }
         StaticStrings::Exit => {
-            // `__exit__` accepts (typ, val, tb); we discard the values
-            // because direct invocation has no in-flight exception to
-            // forward.
             let args = args.take().expect("dispatch_dunder called with empty args slot");
-            args.drop_with_heap(vm);
-            vm.heap.read(heap_id).py_exit(heap_id, vm, None)
+            dispatch_exit(heap_id, vm, args)
         }
         _ => return None,
     })
+}
+
+/// Direct `obj.__exit__(typ, val, tb)` invocation.
+///
+/// Validates that exactly three positional arguments are passed (CPython
+/// raises `TypeError` for any other arity) and forwards `val` to
+/// [`PyTrait::py_exit`] as `Option<HeapId>`:
+///
+/// - `val is None` → `None`, treated as the "normal exit" path.
+/// - `val is a heap-allocated value` → `Some(heap_id)`. For built-in context
+///   managers this is the exception instance, matching the `with`-statement
+///   call shape.
+/// - `val is a scalar (Int, Bool, …)` → `None`. The trait abstraction can
+///   only carry `HeapId`s, so non-Ref values cannot be forwarded; in
+///   practice no supported context manager inspects a non-exception `val`,
+///   and CPython's behavior for such calls is implementation-defined per
+///   the user-provided `__exit__`.
+///
+/// `typ` and `tb` are discarded: every implementation we have re-derives the
+/// type from `val` and Monty has no traceback objects (see
+/// `limitations/with.md`).
+fn dispatch_exit<T: ResourceTracker>(
+    heap_id: HeapId,
+    vm: &mut VM<'_, T>,
+    args: ArgValues,
+) -> Result<CallResult, RunError> {
+    let positional = args.into_pos_only("__exit__", vm.heap)?;
+    defer_drop!(positional, vm);
+    let [typ, val, tb] = positional.as_slice() else {
+        return Err(ExcType::type_error_arg_count("__exit__", 3, positional.len()));
+    };
+    let _ = (typ, tb);
+    let exc = match val {
+        Value::Ref(id) => Some(*id),
+        _ => None,
+    };
+    vm.heap.read(heap_id).py_exit(heap_id, vm, exc)
 }

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -16,7 +16,7 @@ use crate::{
     exception_private::{ExcType, RunError},
     heap::{DropWithHeap, HeapData, HeapGuard, HeapId},
     heap_data::CellValue,
-    intern::{FunctionId, StringId},
+    intern::{FunctionId, StaticStrings, StringId},
     os::OsFunction,
     resource::ResourceTracker,
     types::{Dict, PyTrait, Type, bytes::call_bytes_method, str::call_str_method},
@@ -268,9 +268,32 @@ impl<T: ResourceTracker> VM<'_, T> {
     ///
     /// For interned strings (`Value::InternString`), uses the unified `call_str_method`.
     /// For interned bytes (`Value::InternBytes`), uses the unified `call_bytes_method`.
+    ///
+    /// **Dunder dispatch**: before reaching the type-specific dispatcher, this
+    /// method intercepts known dunder names (`__enter__`, `__exit__`, …) and
+    /// routes them to the corresponding [`PyTrait`] method
+    /// (`py_enter` / `py_exit` / …). The default trait impls return
+    /// `AttributeError`, so types that don't override the dunder behave
+    /// identically to a generic "no such method" lookup; types that *do*
+    /// override only need a single trait impl, not parallel `StaticStrings::Foo`
+    /// arms in their `py_call_attr` body. New dunder methods plug into the
+    /// dispatch table here without touching individual types.
     fn call_attr(&mut self, obj: Value, name_id: StringId, args: ArgValues) -> Result<CallResult, RunError> {
         let this = self;
         let attr = EitherStr::Interned(name_id);
+
+        // Centralised dunder dispatch — see `dispatch_dunder`. Wrap `args`
+        // in an `Option` so the helper can `take()` it only when it
+        // actually matches a dunder; on the fall-through path the
+        // original `args` is still owned here and goes into `py_call_attr`.
+        let mut args_slot = Some(args);
+        if let Value::Ref(heap_id) = obj
+            && let Some(result) = dispatch_dunder(name_id, heap_id, this, &mut args_slot)
+        {
+            defer_drop!(obj, this);
+            return result;
+        }
+        let args = args_slot.expect("dispatch_dunder returned None without taking args");
 
         match obj {
             Value::Ref(heap_id) => {
@@ -771,4 +794,45 @@ impl<T: ResourceTracker> VM<'_, T> {
 
         Ok(CallResult::FramePushed)
     }
+}
+
+/// Centralised dunder dispatch for `__enter__` / `__exit__` (and, when added,
+/// any other dunder that maps to a [`PyTrait`] method).
+///
+/// Returns `Some(result)` when `name_id` names a recognised dunder — `args`
+/// is taken out of the slot and consumed. Returns `None` when it isn't —
+/// `args` is left untouched in the slot so the caller can hand it off to
+/// the regular `py_call_attr` dispatch.
+///
+/// The `&mut Option<ArgValues>` shape is what keeps "all the recognition
+/// and dispatch logic in one function" honest: `args` is non-`Copy` and
+/// has a `Drop` impl that panics on stray `Ref` values, so it can only be
+/// passed by value once we know we'll consume it.
+///
+/// Adding a new dunder is just a new arm in the inner `match`; type
+/// implementations only need to override the corresponding `PyTrait`
+/// method, never a `StaticStrings::Foo` arm in their `py_call_attr`.
+fn dispatch_dunder<T: ResourceTracker>(
+    name_id: StringId,
+    heap_id: HeapId,
+    vm: &mut VM<'_, T>,
+    args: &mut Option<ArgValues>,
+) -> Option<Result<CallResult, RunError>> {
+    let static_str = StaticStrings::from_string_id(name_id)?;
+    Some(match static_str {
+        StaticStrings::Enter => {
+            let args = args.take().expect("dispatch_dunder called with empty args slot");
+            args.check_zero_args("__enter__", vm.heap)
+                .and_then(|()| vm.heap.read(heap_id).py_enter(heap_id, vm))
+        }
+        StaticStrings::Exit => {
+            // `__exit__` accepts (typ, val, tb); we discard the values
+            // because direct invocation has no in-flight exception to
+            // forward.
+            let args = args.take().expect("dispatch_dunder called with empty args slot");
+            args.drop_with_heap(vm);
+            vm.heap.read(heap_id).py_exit(heap_id, vm, None)
+        }
+        _ => return None,
+    })
 }

--- a/crates/monty/src/bytecode/vm/context_manager.rs
+++ b/crates/monty/src/bytecode/vm/context_manager.rs
@@ -1,0 +1,113 @@
+//! Context-manager opcode helpers (`BeforeWith`, `WithExit`, `WithExceptStart`).
+//!
+//! These three opcodes dispatch directly to `PyTrait::py_enter` / `PyTrait::py_exit`
+//! rather than the generic `CallAttr` machinery — explicit invocation is cheaper
+//! (no attribute lookup) and matches CPython's `BEFORE_WITH` / `WITH_EXCEPT_START`
+//! shape. Each helper returns a `CallResult` so the host can suspend during the
+//! call (e.g. `OpenFile.__exit__` issues an `OsCall` to close the file); the
+//! caller routes the result through `handle_call_result!`.
+
+use super::{CallResult, VM};
+use crate::{
+    defer_drop,
+    exception_private::{ExcType, ExceptionRaise, RunError, RunResult, SimpleException},
+    resource::ResourceTracker,
+    types::PyTrait,
+    value::Value,
+};
+
+impl<T: ResourceTracker> VM<'_, T> {
+    /// `BeforeWith`: peek the context manager at TOS, call `__enter__`, and push
+    /// the result. The context manager stays on the stack across the body so the
+    /// matching `WithExit` / `WithExceptStart` can find it.
+    ///
+    /// When the value cannot act as a context manager, CPython raises a
+    /// `TypeError` with a specific message — not the generic `AttributeError`
+    /// that `__enter__()` would yield on direct invocation. We translate the
+    /// underlying `AttributeError` (raised by `PyTrait::py_enter`'s default
+    /// impl for types that don't implement the protocol) into the expected
+    /// `TypeError` here.
+    pub(super) fn exec_before_with(&mut self) -> RunResult<CallResult> {
+        // Pattern-matching `*self.peek()` is a place expression so it doesn't
+        // move the whole Value — Rust only copies the HeapId out.
+        let Value::Ref(ctx_id) = *self.peek() else {
+            return Err(not_a_context_manager(self));
+        };
+        match self.heap.read(ctx_id).py_enter(ctx_id, self) {
+            Err(err) if is_missing_attr(&err, "__enter__") => Err(not_a_context_manager(self)),
+            other => other,
+        }
+    }
+
+    /// `WithExit`: pop the context manager, call `__exit__(None, None, None)`,
+    /// and push the result. The compiler emits a trailing `Pop` to discard the
+    /// result; splitting "call + discard" lets the call yield to the host while
+    /// the discard happens once the host has resumed with the return value.
+    pub(super) fn exec_with_exit(&mut self) -> RunResult<CallResult> {
+        let this = self;
+        let ctx = this.pop();
+        let Value::Ref(ctx_id) = ctx else {
+            // Unreachable in well-formed bytecode (BeforeWith would have rejected
+            // a non-Ref ctx), but guard rather than panic.
+            let ty = ctx.py_type(this);
+            ctx.drop_with_heap(this);
+            return Err(ExcType::attribute_error(ty, "__exit__"));
+        };
+        // Drop the ctx reference on every exit path of this function — whether
+        // py_exit returns a value, yields, or errors. This matches the ref-count
+        // balance from BeforeWith's push.
+        defer_drop!(ctx, this);
+        this.heap.read(ctx_id).py_exit(ctx_id, this, None)
+    }
+
+    /// `WithExceptStart`: peek at `[..., ctx, exc]`, call
+    /// `__exit__(type(exc), exc, None)`, and push the raw return value. The
+    /// compiler-emitted `JumpIfTrue` then branches on its truthiness to either
+    /// suppress (Pop ctx, Pop exc, ClearException) or re-raise (Pop ctx, Pop exc,
+    /// Reraise).
+    pub(super) fn exec_with_except_start(&mut self) -> RunResult<CallResult> {
+        let len = self.stack.len();
+        // Pattern-match via place expressions so neither stack slot is moved.
+        let Value::Ref(exc_id) = self.stack[len - 1] else {
+            // The exception value pushed by `handle_exception` is always a heap
+            // ref; reaching this branch means the VM is in a corrupted state.
+            return Err(RunError::internal("WithExceptStart: expected exception ref on stack"));
+        };
+        let Value::Ref(ctx_id) = self.stack[len - 2] else {
+            // BeforeWith already validated ctx as Value::Ref before pushing it
+            // onto the stack, so a non-Ref here means the VM is corrupted.
+            return Err(RunError::internal(
+                "WithExceptStart: expected context-manager ref on stack",
+            ));
+        };
+        self.heap.read(ctx_id).py_exit(ctx_id, self, Some(exc_id))
+    }
+}
+
+/// Builds the CPython-equivalent `TypeError` raised when a value used in a
+/// `with` statement does not implement the context-manager protocol.
+///
+/// CPython's message names the missing dunder (`__exit__` is what it checks
+/// for first); Monty checks `__enter__` first internally but uses the same
+/// user-visible text so traceback-equivalence tests pass.
+fn not_a_context_manager<T: ResourceTracker>(vm: &VM<'_, T>) -> RunError {
+    let ty = vm.peek().py_type(vm);
+    SimpleException::new_msg(
+        ExcType::TypeError,
+        format!("'{ty}' object does not support the context manager protocol (missed __exit__ method)"),
+    )
+    .into()
+}
+
+/// Returns true when the error is the `AttributeError` raised by `py_enter`
+/// / `py_exit`'s default impl — i.e. the type does not implement the
+/// context-manager protocol at all.
+fn is_missing_attr(err: &RunError, attr: &'static str) -> bool {
+    let RunError::Exc(ExceptionRaise { exc, .. }) = err else {
+        return false;
+    };
+    if exc.exc_type() != ExcType::AttributeError {
+        return false;
+    }
+    exc.arg().is_some_and(|m| m.contains(attr))
+}

--- a/crates/monty/src/bytecode/vm/context_manager.rs
+++ b/crates/monty/src/bytecode/vm/context_manager.rs
@@ -10,7 +10,7 @@
 use super::{CallResult, VM};
 use crate::{
     defer_drop,
-    exception_private::{ExcType, ExceptionRaise, RunError, RunResult, SimpleException},
+    exception_private::{ExcType, RunError, RunResult, SimpleException},
     resource::ResourceTracker,
     types::PyTrait,
     value::Value,
@@ -21,22 +21,21 @@ impl<T: ResourceTracker> VM<'_, T> {
     /// the result. The context manager stays on the stack across the body so the
     /// matching `WithExit` / `WithExceptStart` can find it.
     ///
-    /// When the value cannot act as a context manager, CPython raises a
-    /// `TypeError` with a specific message — not the generic `AttributeError`
-    /// that `__enter__()` would yield on direct invocation. We translate the
-    /// underlying `AttributeError` (raised by `PyTrait::py_enter`'s default
-    /// impl for types that don't implement the protocol) into the expected
-    /// `TypeError` here.
+    /// The CPython "object does not support the context manager protocol"
+    /// `TypeError` is gated on [`PyTrait::py_is_context_manager`] so we never
+    /// have to sniff exception messages — a real context manager whose
+    /// `__enter__` itself raises `AttributeError` propagates unchanged.
     pub(super) fn exec_before_with(&mut self) -> RunResult<CallResult> {
         // Pattern-matching `*self.peek()` is a place expression so it doesn't
-        // move the whole Value — Rust only copies the HeapId out.
+        // move the whole Value — Rust only copies the HeapId out. Non-Ref
+        // values (Int, Bool, None, …) never implement the protocol.
         let Value::Ref(ctx_id) = *self.peek() else {
             return Err(not_a_context_manager(self));
         };
-        match self.heap.read(ctx_id).py_enter(ctx_id, self) {
-            Err(err) if is_missing_attr(&err, "__enter__") => Err(not_a_context_manager(self)),
-            other => other,
+        if !self.heap.read(ctx_id).py_is_context_manager() {
+            return Err(not_a_context_manager(self));
         }
+        self.heap.read(ctx_id).py_enter(ctx_id, self)
     }
 
     /// `WithExit`: pop the context manager, call `__exit__(None, None, None)`,
@@ -48,10 +47,10 @@ impl<T: ResourceTracker> VM<'_, T> {
         let ctx = this.pop();
         let Value::Ref(ctx_id) = ctx else {
             // Unreachable in well-formed bytecode (BeforeWith would have rejected
-            // a non-Ref ctx), but guard rather than panic.
-            let ty = ctx.py_type(this);
+            // a non-Ref ctx), but guard rather than panic so a corrupt VM
+            // surfaces a clear internal error instead of an uncontrolled drop.
             ctx.drop_with_heap(this);
-            return Err(ExcType::attribute_error(ty, "__exit__"));
+            return Err(RunError::internal("WithExit: expected context-manager ref on stack"));
         };
         // Drop the ctx reference on every exit path of this function — whether
         // py_exit returns a value, yields, or errors. This matches the ref-count
@@ -88,8 +87,9 @@ impl<T: ResourceTracker> VM<'_, T> {
 /// `with` statement does not implement the context-manager protocol.
 ///
 /// CPython's message names the missing dunder (`__exit__` is what it checks
-/// for first); Monty checks `__enter__` first internally but uses the same
-/// user-visible text so traceback-equivalence tests pass.
+/// for first); Monty's [`PyTrait::py_is_context_manager`] gate is per-type
+/// rather than per-dunder, but the user-visible text matches CPython so
+/// traceback-equivalence tests pass.
 fn not_a_context_manager<T: ResourceTracker>(vm: &VM<'_, T>) -> RunError {
     let ty = vm.peek().py_type(vm);
     SimpleException::new_msg(
@@ -97,17 +97,4 @@ fn not_a_context_manager<T: ResourceTracker>(vm: &VM<'_, T>) -> RunError {
         format!("'{ty}' object does not support the context manager protocol (missed __exit__ method)"),
     )
     .into()
-}
-
-/// Returns true when the error is the `AttributeError` raised by `py_enter`
-/// / `py_exit`'s default impl — i.e. the type does not implement the
-/// context-manager protocol at all.
-fn is_missing_attr(err: &RunError, attr: &'static str) -> bool {
-    let RunError::Exc(ExceptionRaise { exc, .. }) = err else {
-        return false;
-    };
-    if exc.exc_type() != ExcType::AttributeError {
-        return false;
-    }
-    exc.arg().is_some_and(|m| m.contains(attr))
 }

--- a/crates/monty/src/bytecode/vm/context_manager.rs
+++ b/crates/monty/src/bytecode/vm/context_manager.rs
@@ -32,10 +32,12 @@ impl<T: ResourceTracker> VM<'_, T> {
         let Value::Ref(ctx_id) = *self.peek() else {
             return Err(not_a_context_manager(self));
         };
-        if !self.heap.read(ctx_id).py_is_context_manager() {
-            return Err(not_a_context_manager(self));
+        let mut ctx = self.heap.read(ctx_id);
+        if ctx.py_is_context_manager() {
+            ctx.py_enter(ctx_id, self)
+        } else {
+            Err(not_a_context_manager(self))
         }
-        self.heap.read(ctx_id).py_enter(ctx_id, self)
     }
 
     /// `WithExit`: pop the context manager, call `__exit__(None, None, None)`,

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -9,6 +9,7 @@ mod binary;
 mod call;
 mod collections;
 mod compare;
+mod context_manager;
 mod exceptions;
 mod format;
 mod scheduler;
@@ -1612,6 +1613,20 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
                     };
                     let error = ExcType::module_not_found_error(name_str);
                     catch_sync!(self, cached_frame, error);
+                }
+                // Context Managers
+                Opcode::BeforeWith => {
+                    // Sync IP before call (py_enter may yield to host).
+                    self.current_frame_mut().ip = cached_frame.ip;
+                    handle_call_result!(self, cached_frame, self.exec_before_with());
+                }
+                Opcode::WithExit => {
+                    self.current_frame_mut().ip = cached_frame.ip;
+                    handle_call_result!(self, cached_frame, self.exec_with_exit());
+                }
+                Opcode::WithExceptStart => {
+                    self.current_frame_mut().ip = cached_frame.ip;
+                    handle_call_result!(self, cached_frame, self.exec_with_except_start());
                 }
             }
         }

--- a/crates/monty/src/expressions.rs
+++ b/crates/monty/src/expressions.rs
@@ -667,8 +667,10 @@ pub enum Node<F> {
     /// `Name` variant since other unpack patterns are not yet exercised by
     /// any user.
     ///
-    /// Multi-item `with a() as x, b() as y:` is rejected at parse time; users
-    /// should nest `with` blocks instead. See `limitations/with.md`.
+    /// Multi-item `with a() as x, b() as y:` is desugared into nested `With`
+    /// nodes by the parser, so this variant only ever carries a single
+    /// context. See `parse.rs` for the lowering and `limitations/with.md`
+    /// for the user-facing semantics.
     With {
         context: ExprLoc,
         target: Option<UnpackTarget>,

--- a/crates/monty/src/expressions.rs
+++ b/crates/monty/src/expressions.rs
@@ -654,6 +654,27 @@ pub enum Node<F> {
     /// Executes body, catches matching exceptions with handlers, runs else if no exception,
     /// and always runs finally.
     Try(Try<Self>),
+    /// `with EXPR [as TARGET]: BODY` — runs BODY with a context manager.
+    ///
+    /// Semantics match CPython: `EXPR` is evaluated, `__enter__` is called on
+    /// the result and bound to `TARGET` (if present), then `BODY` runs. On a
+    /// normal exit `__exit__(None, None, None)` is called; on exception,
+    /// `__exit__(type, value, None)` is called (Monty has no traceback objects),
+    /// and a truthy return value suppresses the exception.
+    ///
+    /// `target` is `Option<UnpackTarget>` to permit `with foo() as (a, b):`
+    /// shapes uniformly with [`Node::For`]; today the parser only emits the
+    /// `Name` variant since other unpack patterns are not yet exercised by
+    /// any user.
+    ///
+    /// Multi-item `with a() as x, b() as y:` is rejected at parse time; users
+    /// should nest `with` blocks instead. See `limitations/with.md`.
+    With {
+        context: ExprLoc,
+        target: Option<UnpackTarget>,
+        body: Vec<Self>,
+        position: CodeRange,
+    },
     /// Import statement (e.g., `import sys`, `import sys, os`, `import sys as s`).
     ///
     /// Loads one or more modules and binds them to names in the current namespace.

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -30,6 +30,11 @@ mod free_list;
 mod stable_heap;
 use stable_heap::StableHeap;
 
+// Imported separately because `#[cfg]` cannot be applied to individual items
+// inside a brace-grouped `use`.
+#[cfg(feature = "test-hooks")]
+use crate::types::TestContextManager;
+
 /// Unique identifier for values stored inside the heap arena.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct HeapId(usize);
@@ -235,6 +240,9 @@ pub enum HeapReadOutput<'a> {
     DateTime(HeapRead<'a, datetime::DateTime>),
     TimeDelta(HeapRead<'a, timedelta::TimeDelta>),
     TimeZone(HeapRead<'a, timezone::TimeZone>),
+    /// Synthetic context manager — only present under `test-hooks`.
+    #[cfg(feature = "test-hooks")]
+    TestContextManager(HeapRead<'a, TestContextManager>),
 }
 
 pub struct HeapRead<'a, T: ?Sized> {
@@ -625,6 +633,8 @@ impl<'a> HeapPtr<'a> {
             HeapData::DateTime(d) => HeapReadOutput::DateTime(heap_read(base, d, readers)),
             HeapData::TimeDelta(d) => HeapReadOutput::TimeDelta(heap_read(base, d, readers)),
             HeapData::TimeZone(d) => HeapReadOutput::TimeZone(heap_read(base, d, readers)),
+            #[cfg(feature = "test-hooks")]
+            HeapData::TestContextManager(cm) => HeapReadOutput::TestContextManager(heap_read(base, cm, readers)),
         }
     }
 }

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -10,6 +10,10 @@ use std::{
 use ahash::AHashSet;
 use num_integer::Integer;
 
+// Imported separately because `#[cfg]` cannot be applied to individual items
+// inside a brace-grouped `use`.
+#[cfg(feature = "test-hooks")]
+use crate::types::TestContextManager;
 use crate::{
     ExcType, ResourceTracker,
     args::ArgValues,
@@ -142,6 +146,12 @@ pub(crate) enum HeapData {
     TimeDelta(timedelta::TimeDelta),
     /// A fixed-offset `datetime.timezone` value.
     TimeZone(timezone::TimeZone),
+    /// Synthetic context manager used by tests to exercise `with` statement
+    /// code paths no production type currently reaches. See
+    /// [`crate::types::test_cm`] for the full rationale and removal plan.
+    /// Only present under the `test-hooks` cargo feature.
+    #[cfg(feature = "test-hooks")]
+    TestContextManager(TestContextManager),
 }
 
 impl HeapData {
@@ -214,6 +224,8 @@ impl HeapData {
             Self::DateTime(_) => Type::DateTime,
             Self::TimeDelta(_) => Type::TimeDelta,
             Self::TimeZone(_) => Type::TimeZone,
+            #[cfg(feature = "test-hooks")]
+            Self::TestContextManager(_) => Type::TestContextManager,
         }
     }
 
@@ -252,6 +264,8 @@ impl HeapData {
             Self::DateTime(d) => d.py_estimate_size(),
             Self::TimeDelta(d) => d.py_estimate_size(),
             Self::TimeZone(d) => d.py_estimate_size(),
+            #[cfg(feature = "test-hooks")]
+            Self::TestContextManager(cm) => cm.py_estimate_size(),
         }
     }
 }
@@ -476,6 +490,8 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
             Self::RePattern(p) => p.py_bool(vm),
             Self::TimeDelta(td) => td.py_bool(vm),
             Self::Date(_) | Self::DateTime(_) | Self::TimeZone(_) => true,
+            #[cfg(feature = "test-hooks")]
+            Self::TestContextManager(cm) => cm.py_bool(vm),
         }
     }
 
@@ -506,6 +522,8 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
             HeapReadOutput::TimeDelta(td) => Ok(td.py_call_attr(self_id, vm, attr, args)?),
             HeapReadOutput::Date(d) => Ok(d.py_call_attr(self_id, vm, attr, args)?),
             HeapReadOutput::DateTime(dt) => Ok(dt.py_call_attr(self_id, vm, attr, args)?),
+            #[cfg(feature = "test-hooks")]
+            HeapReadOutput::TestContextManager(cm) => cm.py_call_attr(self_id, vm, attr, args),
             // Types without methods — return AttributeError
             _ => {
                 args.drop_with_heap(vm);
@@ -521,6 +539,8 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         // `py_call_attr` is structured.
         match self {
             HeapReadOutput::OpenFile(file) => file.py_enter(self_id, vm),
+            #[cfg(feature = "test-hooks")]
+            HeapReadOutput::TestContextManager(cm) => cm.py_enter(self_id, vm),
             _ => Err(ExcType::attribute_error(self.py_type(vm), "__enter__")),
         }
     }
@@ -533,6 +553,8 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
     ) -> RunResult<CallResult> {
         match self {
             HeapReadOutput::OpenFile(file) => file.py_exit(self_id, vm, exc),
+            #[cfg(feature = "test-hooks")]
+            HeapReadOutput::TestContextManager(cm) => cm.py_exit(self_id, vm, exc),
             _ => Err(ExcType::attribute_error(self.py_type(vm), "__exit__")),
         }
     }
@@ -568,6 +590,8 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
             Self::DateTime(d) => d.py_type(vm),
             Self::TimeDelta(d) => d.py_type(vm),
             Self::TimeZone(d) => d.py_type(vm),
+            #[cfg(feature = "test-hooks")]
+            Self::TestContextManager(cm) => cm.py_type(vm),
         }
     }
 
@@ -792,6 +816,8 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
             Self::DateTime(d) => d.py_repr_fmt(f, vm, heap_ids),
             Self::TimeDelta(d) => d.py_repr_fmt(f, vm, heap_ids),
             Self::TimeZone(d) => d.py_repr_fmt(f, vm, heap_ids),
+            #[cfg(feature = "test-hooks")]
+            Self::TestContextManager(cm) => cm.py_repr_fmt(f, vm, heap_ids),
         }
     }
 

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -515,6 +515,28 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         }
     }
 
+    fn py_enter(&mut self, self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<CallResult> {
+        // Only types that override the trait default need explicit arms; all
+        // others fall through to the catch-all `AttributeError`, matching how
+        // `py_call_attr` is structured.
+        match self {
+            HeapReadOutput::OpenFile(file) => file.py_enter(self_id, vm),
+            _ => Err(ExcType::attribute_error(self.py_type(vm), "__enter__")),
+        }
+    }
+
+    fn py_exit(
+        &mut self,
+        self_id: HeapId,
+        vm: &mut VM<'h, impl ResourceTracker>,
+        exc: Option<HeapId>,
+    ) -> RunResult<CallResult> {
+        match self {
+            HeapReadOutput::OpenFile(file) => file.py_exit(self_id, vm, exc),
+            _ => Err(ExcType::attribute_error(self.py_type(vm), "__exit__")),
+        }
+    }
+
     fn py_type(&self, vm: &VM<'h, impl ResourceTracker>) -> Type {
         match self {
             Self::Str(s) => s.py_type(vm),

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -533,6 +533,20 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         }
     }
 
+    fn py_is_context_manager(&self) -> bool {
+        // Only types that implement the protocol return true; everything else
+        // inherits the default `false`. The `with` statement gates `py_enter`
+        // / `py_exit` on this check, so a real context manager whose
+        // `__enter__` happens to raise `AttributeError` is no longer
+        // misdiagnosed as "not a context manager".
+        match self {
+            HeapReadOutput::OpenFile(file) => file.py_is_context_manager(),
+            #[cfg(feature = "test-hooks")]
+            HeapReadOutput::TestContextManager(cm) => cm.py_is_context_manager(),
+            _ => false,
+        }
+    }
+
     fn py_enter(&mut self, self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<CallResult> {
         // Only types that override the trait default need explicit arms; all
         // others fall through to the catch-all `AttributeError`, matching how

--- a/crates/monty/src/intern.rs
+++ b/crates/monty/src/intern.rs
@@ -323,6 +323,10 @@ pub enum StaticStrings {
     // Type attributes
     #[strum(serialize = "__name__")]
     DunderName,
+    #[strum(serialize = "__enter__")]
+    Enter,
+    #[strum(serialize = "__exit__")]
+    Exit,
 
     // ==========================
     // pathlib module strings

--- a/crates/monty/src/intern.rs
+++ b/crates/monty/src/intern.rs
@@ -375,6 +375,12 @@ pub enum StaticStrings {
     Rmdir,
     Rename,
 
+    // Path.open(): wraps the same `OsFunction::Open` round-trip as the
+    // `open()` builtin. Handled in `Path::py_call_attr` with custom
+    // mode/kwarg validation (so it cannot go through the generic
+    // `OsFunction::try_from(StaticStrings)` short-circuit).
+    Open,
+
     // ==========================
     // File object methods and attributes
     Read,

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -409,18 +409,63 @@ impl<'a> Parser<'a> {
                 let or_else = self.parse_elif_else_clauses(elif_else_clauses)?;
                 Ok(Node::If { test, body, or_else })
             }
-            Stmt::With(ast::StmtWith { is_async, range, .. }) => {
+            Stmt::With(ast::StmtWith {
+                is_async,
+                items,
+                body,
+                range,
+                ..
+            }) => {
                 if is_async {
-                    Err(ParseError::not_implemented(
+                    return Err(ParseError::not_implemented(
                         "async context managers (async with)",
                         self.convert_range(range),
-                    ))
-                } else {
-                    Err(ParseError::not_implemented(
-                        "context managers (with statements)",
-                        self.convert_range(range),
-                    ))
+                    ));
                 }
+                if items.is_empty() {
+                    return Err(ParseError::syntax(
+                        "with statement requires at least one context manager",
+                        self.convert_range(range),
+                    ));
+                }
+                // Multi-item `with a() as x, b() as y:` is desugared into nested
+                // `with` blocks at parse time: the outer `with` runs `a()` and
+                // wraps an inner `with` running `b()`, which wraps the user body.
+                // CPython evaluates context exprs left-to-right and exits them
+                // right-to-left, which is exactly the nested-block semantics —
+                // so the lowering is faithful and avoids needing multi-context
+                // support in the compiler / VM.
+                let position = self.convert_range(range);
+                let body = self.parse_statements(body)?;
+                let mut parsed_items: Vec<(ExprLoc, Option<UnpackTarget>)> = items
+                    .into_iter()
+                    .map(|item| -> Result<_, ParseError> {
+                        let context = self.parse_expression(item.context_expr)?;
+                        let target = match item.optional_vars {
+                            Some(expr) => Some(self.parse_unpack_target(*expr)?),
+                            None => None,
+                        };
+                        Ok((context, target))
+                    })
+                    .collect::<Result<_, _>>()?;
+                // Fold from the innermost outward: the last item wraps the user
+                // body; each outer item wraps the freshly-built inner `with`.
+                let (last_context, last_target) = parsed_items.pop().expect("checked non-empty above");
+                let mut node = Node::With {
+                    context: last_context,
+                    target: last_target,
+                    body,
+                    position,
+                };
+                while let Some((context, target)) = parsed_items.pop() {
+                    node = Node::With {
+                        context,
+                        target,
+                        body: vec![node],
+                        position,
+                    };
+                }
+                Ok(node)
             }
             Stmt::Match(m) => Err(ParseError::not_implemented(
                 "pattern matching (match statements)",

--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -636,6 +636,25 @@ impl<'i> Prepare<'i> {
                         finally,
                     }));
                 }
+                Node::With {
+                    context,
+                    target,
+                    body,
+                    position,
+                } => {
+                    let context = self.prepare_expression(context)?;
+                    let target = match target {
+                        Some(t) => Some(self.prepare_unpack_target(t)?),
+                        None => None,
+                    };
+                    let body = self.prepare_nodes(body)?;
+                    new_nodes.push(Node::With {
+                        context,
+                        target,
+                        body,
+                        position,
+                    });
+                }
                 Node::Import { names } => {
                     // Resolve each binding identifier to get the namespace slot
                     let resolved_names = names
@@ -2170,6 +2189,19 @@ fn collect_scope_info_from_node(
                 collect_scope_info_from_node(n, global_names, nonlocal_names, assigned_names, interner);
             }
         }
+        Node::With {
+            context, target, body, ..
+        } => {
+            // The `as TARGET` binds names like a for-loop target does.
+            if let Some(t) = target {
+                collect_names_from_unpack_target(t, assigned_names, interner);
+            }
+            // Scan the context expression for walrus operators.
+            collect_assigned_names_from_expr(context, assigned_names, interner);
+            for n in body {
+                collect_scope_info_from_node(n, global_names, nonlocal_names, assigned_names, interner);
+            }
+        }
         // Import creates bindings for each module name (or alias)
         Node::Import { names, .. } => {
             for import_name in names {
@@ -2474,6 +2506,12 @@ fn collect_cell_vars_from_node(
                 collect_cell_vars_from_node(n, our_locals, cell_vars, interner);
             }
             for n in finally {
+                collect_cell_vars_from_node(n, our_locals, cell_vars, interner);
+            }
+        }
+        Node::With { context, body, .. } => {
+            collect_cell_vars_from_expr(context, our_locals, cell_vars, interner);
+            for n in body {
                 collect_cell_vars_from_node(n, our_locals, cell_vars, interner);
             }
         }
@@ -2849,6 +2887,12 @@ fn collect_referenced_names_from_node(node: &ParseNode, referenced: &mut AHashSe
                 collect_referenced_names_from_node(n, referenced, interner);
             }
             for n in finally {
+                collect_referenced_names_from_node(n, referenced, interner);
+            }
+        }
+        Node::With { context, body, .. } => {
+            collect_referenced_names_from_expr(context, referenced, interner);
+            for n in body {
                 collect_referenced_names_from_node(n, referenced, interner);
             }
         }

--- a/crates/monty/src/types/file.rs
+++ b/crates/monty/src/types/file.rs
@@ -429,26 +429,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, OpenFile> {
             StaticStrings::Readable => self.readable(vm, args),
             StaticStrings::Writable => self.writable(vm, args),
             StaticStrings::Seekable => self.seekable(vm, args),
-            // Direct dunder calls dispatch to the context-manager protocol.
-            // `__enter__()` takes no args; `__exit__(typ, val, tb)` takes three
-            // (and Monty's `py_exit` ignores the passed-in typ/tb — see
-            // `limitations/with.md`). Argument arity checks happen here so
-            // CPython-style errors surface for `f.__enter__(1)` etc.
-            StaticStrings::Enter => {
-                args.check_zero_args("__enter__", vm.heap)?;
-                self.py_enter(self_id, vm)
-            }
-            StaticStrings::Exit => {
-                // `__exit__` accepts the (typ, val, tb) triple; we discard the
-                // values rather than threading them into `py_exit`, since when
-                // invoked as a normal call there is no in-flight exception. We
-                // accept any arg shape here for simplicity rather than strictly
-                // enforcing arity — direct invocation of `__exit__` is rare and
-                // CPython's TypeError message tree is not worth duplicating
-                // until a user complains.
-                args.drop_with_heap(vm);
-                self.py_exit(self_id, vm, None)
-            }
             _ => {
                 args.drop_with_heap(vm);
                 Err(ExcType::attribute_error(self.py_type(vm), attr.as_str(vm.interns)))

--- a/crates/monty/src/types/file.rs
+++ b/crates/monty/src/types/file.rs
@@ -436,6 +436,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, OpenFile> {
         }
     }
 
+    fn py_is_context_manager(&self) -> bool {
+        true
+    }
+
     fn py_enter(&mut self, self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<CallResult> {
         // Match CPython: entering on a closed file raises before the body runs.
         // (Reusing a closed file as a context manager is rare but the error

--- a/crates/monty/src/types/file.rs
+++ b/crates/monty/src/types/file.rs
@@ -20,8 +20,10 @@
 //!   are not implemented. `seekable()` reports `False` (instead of
 //!   CPython's `True` for regular files) so the
 //!   `if f.seekable(): f.seek(0)` idiom routes to the non-seekable arm.
-//! - The context-manager protocol (`with open(...) as f:`) is not yet
-//!   wired up; `__enter__` / `__exit__` raise `AttributeError`.
+//! - The context-manager protocol (`with open(...) as f:`) is supported but
+//!   `__exit__` always returns `None` — it cannot suppress an in-flight
+//!   exception. The file is closed on exit on both the success and exception
+//!   paths.
 //! - `+` update modes (`r+`, `w+`, `a+`, and their `b` variants) are
 //!   rejected at parse time because Monty has no read-position tracking;
 //!   without it a write after a read would silently truncate the file via
@@ -427,11 +429,60 @@ impl<'h> PyTrait<'h> for HeapRead<'h, OpenFile> {
             StaticStrings::Readable => self.readable(vm, args),
             StaticStrings::Writable => self.writable(vm, args),
             StaticStrings::Seekable => self.seekable(vm, args),
+            // Direct dunder calls dispatch to the context-manager protocol.
+            // `__enter__()` takes no args; `__exit__(typ, val, tb)` takes three
+            // (and Monty's `py_exit` ignores the passed-in typ/tb — see
+            // `limitations/with.md`). Argument arity checks happen here so
+            // CPython-style errors surface for `f.__enter__(1)` etc.
+            StaticStrings::Enter => {
+                args.check_zero_args("__enter__", vm.heap)?;
+                self.py_enter(self_id, vm)
+            }
+            StaticStrings::Exit => {
+                // `__exit__` accepts the (typ, val, tb) triple; we discard the
+                // values rather than threading them into `py_exit`, since when
+                // invoked as a normal call there is no in-flight exception. We
+                // accept any arg shape here for simplicity rather than strictly
+                // enforcing arity — direct invocation of `__exit__` is rare and
+                // CPython's TypeError message tree is not worth duplicating
+                // until a user complains.
+                args.drop_with_heap(vm);
+                self.py_exit(self_id, vm, None)
+            }
             _ => {
                 args.drop_with_heap(vm);
                 Err(ExcType::attribute_error(self.py_type(vm), attr.as_str(vm.interns)))
             }
         }
+    }
+
+    fn py_enter(&mut self, self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<CallResult> {
+        // Match CPython: entering on a closed file raises before the body runs.
+        // (Reusing a closed file as a context manager is rare but the error
+        // message is part of the user contract.)
+        self.get(vm.heap).ensure_open()?;
+        // Return the file itself. Bumping the refcount here gives the new
+        // Value::Ref its own count — constructing a fresh Value::Ref without
+        // an inc_ref would let the Drop impl panic when an in-flight value
+        // is later discarded without a matching drop_with_heap.
+        vm.heap.inc_ref(self_id);
+        Ok(CallResult::Value(Value::Ref(self_id)))
+    }
+
+    fn py_exit(
+        &mut self,
+        _self_id: HeapId,
+        vm: &mut VM<'h, impl ResourceTracker>,
+        _exc: Option<HeapId>,
+    ) -> RunResult<CallResult> {
+        // `with open(...) as f:` always closes the file on exit, success or
+        // failure. We don't suppress exceptions: returning `None` is falsy, so
+        // any in-flight exception propagates as it would in CPython.
+        //
+        // `close()` on an already-closed file is idempotent (a no-op), matching
+        // CPython.
+        self.get_mut(vm.heap).closed = true;
+        Ok(CallResult::Value(Value::None))
     }
 
     fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<CallResult>> {

--- a/crates/monty/src/types/mod.rs
+++ b/crates/monty/src/types/mod.rs
@@ -26,6 +26,13 @@ pub mod re_pattern;
 pub mod set;
 pub mod slice;
 pub mod str;
+/// Synthetic context manager used to exercise `with` statement codepaths that no
+/// production type currently reaches. **REMOVE** once a real context manager
+/// (suppressing or yielding from `__exit__`, returning a non-self value from
+/// `__enter__`, etc.) lands and tests can pivot to it. Gated behind `test-hooks`
+/// so it's never compiled into a production sandbox.
+#[cfg(feature = "test-hooks")]
+pub mod test_cm;
 pub mod timedelta;
 pub mod timezone;
 pub mod tuple;
@@ -50,6 +57,8 @@ pub(crate) use re_pattern::RePattern;
 pub(crate) use set::{FrozenSet, Set};
 pub(crate) use slice::Slice;
 pub(crate) use str::Str;
+#[cfg(feature = "test-hooks")]
+pub(crate) use test_cm::TestContextManager;
 pub(crate) use timedelta::TimeDelta;
 pub(crate) use timezone::TimeZone;
 pub(crate) use tuple::{Tuple, allocate_tuple};

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -17,6 +17,7 @@ use smallvec::SmallVec;
 
 use crate::{
     args::{ArgValues, KwargsValues},
+    builtins::open::builtin_open,
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
@@ -594,6 +595,20 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Path> {
             StaticStrings::AsPosix | StaticStrings::Fspath => {
                 args.check_zero_args(method.into(), vm.heap)?;
                 Ok(allocate_string(self.get(vm.heap).as_posix(), vm.heap)?)
+            }
+            StaticStrings::Open => {
+                // `Path.open(mode='r', ...)` is `open(self, mode, ...)` with
+                // `self` prepended as the implicit `file` argument. Reuses
+                // `builtin_open`'s mode/kwarg validation (including rejection
+                // of `+`/`x` modes and non-default `buffering`/`encoding`/
+                // `errors`/`newline`) so the two entry points stay in sync.
+                //
+                // The `inc_ref` is required because the prepended `Value::Ref`
+                // is dropped by `builtin_open` via `defer_drop!` once the path
+                // string has been extracted, balancing the refcount.
+                vm.heap.inc_ref(self_id);
+                let args = args.prepend(Value::Ref(self_id));
+                return builtin_open(vm, args);
             }
             _ => {
                 args.drop_with_heap(vm);

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -298,6 +298,48 @@ pub trait PyTrait<'h> {
         Err(ExcType::attribute_error(self.py_type(vm), attr.as_str(vm.interns)))
     }
 
+    /// Context-manager entry hook (`__enter__`).
+    ///
+    /// Invoked by the `BeforeWith` opcode when execution enters a `with` block
+    /// whose context expression evaluates to this object. Returns the value bound
+    /// to the `as` target (or discarded if there is none). Typically a context
+    /// manager returns itself, but it may return any value.
+    ///
+    /// Returns `CallResult` so implementations can yield to the host (OS call,
+    /// external function, etc.) before producing the entered value.
+    ///
+    /// The default implementation raises `AttributeError`, matching CPython's
+    /// behavior for objects that do not implement the context-manager protocol.
+    fn py_enter(&mut self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<CallResult> {
+        Err(ExcType::attribute_error(self.py_type(vm), "__enter__"))
+    }
+
+    /// Context-manager exit hook (`__exit__`).
+    ///
+    /// Invoked when execution leaves a `with` block. `exc` is `None` on a normal
+    /// exit and `Some(exc_id)` when an exception is propagating; on the exception
+    /// path the heap value at `exc_id` is the exception object itself, and a
+    /// truthy return value suppresses the exception.
+    ///
+    /// Monty does not have traceback objects, so the `__exit__(typ, val, tb)`
+    /// triple's traceback slot is effectively `None`. This is documented in
+    /// `limitations/with.md`.
+    ///
+    /// Returns `CallResult` so implementations can yield to the host (e.g. file
+    /// close issues an `OsCall`).
+    ///
+    /// The default implementation raises `AttributeError`. In practice a missing
+    /// `__exit__` is caught at the `BeforeWith` step (`py_enter` fails first), so
+    /// this path is reached only by direct invocation via `obj.__exit__(...)`.
+    fn py_exit(
+        &mut self,
+        _self_id: HeapId,
+        vm: &mut VM<'h, impl ResourceTracker>,
+        _exc: Option<HeapId>,
+    ) -> RunResult<CallResult> {
+        Err(ExcType::attribute_error(self.py_type(vm), "__exit__"))
+    }
+
     /// Python subscript get operation (`__getitem__`), e.g., `d[key]`.
     ///
     /// Returns the value associated with the key, or an error if the key doesn't exist

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -298,18 +298,41 @@ pub trait PyTrait<'h> {
         Err(ExcType::attribute_error(self.py_type(vm), attr.as_str(vm.interns)))
     }
 
+    /// Whether this type implements the context-manager protocol.
+    ///
+    /// The `BeforeWith` opcode calls this *before* invoking [`py_enter`] so it
+    /// can raise CPython's specific `TypeError` ("object does not support the
+    /// context manager protocol") on types that aren't context managers. We
+    /// cannot rely on translating the [`py_enter`] default's `AttributeError`,
+    /// because a real context manager whose `__enter__` itself raises
+    /// `AttributeError` would be misidentified — the distinction has to come
+    /// from a declarative check, not from sniffing exception messages.
+    ///
+    /// Default is `false`; types implementing the protocol override this
+    /// alongside [`py_enter`] / [`py_exit`].
+    ///
+    /// [`py_enter`]: PyTrait::py_enter
+    /// [`py_exit`]: PyTrait::py_exit
+    fn py_is_context_manager(&self) -> bool {
+        false
+    }
+
     /// Context-manager entry hook (`__enter__`).
     ///
-    /// Invoked by the `BeforeWith` opcode when execution enters a `with` block
-    /// whose context expression evaluates to this object. Returns the value bound
-    /// to the `as` target (or discarded if there is none). Typically a context
-    /// manager returns itself, but it may return any value.
+    /// Invoked by the `BeforeWith` opcode after [`py_is_context_manager`]
+    /// returns `true`. Returns the value bound to the `as` target (or discarded
+    /// if there is none). Typically a context manager returns itself, but it
+    /// may return any value.
     ///
     /// Returns `CallResult` so implementations can yield to the host (OS call,
     /// external function, etc.) before producing the entered value.
     ///
     /// The default implementation raises `AttributeError`, matching CPython's
-    /// behavior for objects that do not implement the context-manager protocol.
+    /// behavior for direct `obj.__enter__()` calls on objects that don't
+    /// implement the protocol. The `with` statement never reaches this default
+    /// because [`py_is_context_manager`] gates the invocation.
+    ///
+    /// [`py_is_context_manager`]: PyTrait::py_is_context_manager
     fn py_enter(&mut self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<CallResult> {
         Err(ExcType::attribute_error(self.py_type(vm), "__enter__"))
     }
@@ -328,9 +351,11 @@ pub trait PyTrait<'h> {
     /// Returns `CallResult` so implementations can yield to the host (e.g. file
     /// close issues an `OsCall`).
     ///
-    /// The default implementation raises `AttributeError`. In practice a missing
-    /// `__exit__` is caught at the `BeforeWith` step (`py_enter` fails first), so
-    /// this path is reached only by direct invocation via `obj.__exit__(...)`.
+    /// The default implementation raises `AttributeError`. In practice the
+    /// `with` statement gates this on [`py_is_context_manager`], so this path
+    /// is reached only by direct invocation via `obj.__exit__(...)`.
+    ///
+    /// [`py_is_context_manager`]: PyTrait::py_is_context_manager
     fn py_exit(
         &mut self,
         _self_id: HeapId,

--- a/crates/monty/src/types/test_cm.rs
+++ b/crates/monty/src/types/test_cm.rs
@@ -128,6 +128,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TestContextManager> {
         Ok(())
     }
 
+    fn py_is_context_manager(&self) -> bool {
+        true
+    }
+
     fn py_enter(&mut self, self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<CallResult> {
         let cfg = self.get(vm.heap);
         if let Some(msg) = cfg.raise_on_enter.clone() {

--- a/crates/monty/src/types/test_cm.rs
+++ b/crates/monty/src/types/test_cm.rs
@@ -27,12 +27,11 @@ use ahash::AHashSet;
 
 use super::{PyTrait, Type};
 use crate::{
-    args::ArgValues,
     bytecode::{CallResult, VM},
     exception_private::{ExcType, RunResult, SimpleException},
-    heap::{DropWithHeap, HeapId, HeapItem, HeapRead},
+    heap::{HeapId, HeapItem, HeapRead},
     resource::{ResourceError, ResourceTracker},
-    value::{EitherStr, Value},
+    value::Value,
 };
 
 /// Configuration for a synthetic context manager.
@@ -163,39 +162,5 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TestContextManager> {
             Value::None
         };
         Ok(CallResult::Value(value))
-    }
-
-    fn py_call_attr(
-        &mut self,
-        self_id: HeapId,
-        vm: &mut VM<'h, impl ResourceTracker>,
-        attr: &EitherStr,
-        args: ArgValues,
-    ) -> RunResult<CallResult> {
-        // Forward `obj.__enter__()` / `obj.__exit__(...)` direct calls so the
-        // synthetic manager can also exercise the attribute-access path that
-        // `OpenFile` covers in its py_call_attr.
-        use crate::intern::StaticStrings;
-        let Some(method) = attr.static_string() else {
-            args.drop_with_heap(vm);
-            return Err(ExcType::attribute_error(self.py_type(vm), attr.as_str(vm.interns)));
-        };
-        match method {
-            StaticStrings::Enter => {
-                args.check_zero_args("__enter__", vm.heap)?;
-                self.py_enter(self_id, vm)
-            }
-            StaticStrings::Exit => {
-                // Same flexibility as `OpenFile.__exit__`: accept any args
-                // and discard them; direct invocation has no in-flight
-                // exception so `py_exit` is called with `None`.
-                args.drop_with_heap(vm);
-                self.py_exit(self_id, vm, None)
-            }
-            _ => {
-                args.drop_with_heap(vm);
-                Err(ExcType::attribute_error(self.py_type(vm), attr.as_str(vm.interns)))
-            }
-        }
     }
 }

--- a/crates/monty/src/types/test_cm.rs
+++ b/crates/monty/src/types/test_cm.rs
@@ -1,0 +1,201 @@
+//! Synthetic context manager used by tests to exercise `with` statement code
+//! paths that no production type currently reaches.
+//!
+//! **REMOVE THIS FILE** (along with the `_test_cm` builtin, the `HeapData` /
+//! `HeapReadOutput` variants, and `with_test_cm.rs`) once a real context
+//! manager covers the same branches — specifically:
+//!
+//! - `__exit__` returning truthy to suppress an in-flight exception
+//!   (the swallow path emitted by `compile_with`).
+//! - `__exit__` itself raising during the exception path (replacing the
+//!   original exception).
+//! - `__enter__` returning a value other than `self`.
+//!
+//! Today only [`crate::types::OpenFile`] implements the protocol, and its
+//! `__exit__` always returns `None`, so those branches in
+//! `crates/monty/src/bytecode/compiler.rs` (`compile_with`) and
+//! `crates/monty/src/bytecode/vm/context_manager.rs` would be untested
+//! without this synthetic helper.
+//!
+//! The type is exposed to Python through the `_test_cm()` builtin defined
+//! in [`crate::builtins::test_cm`]. Both are gated behind the `test-hooks`
+//! cargo feature so a production sandbox can never construct one.
+
+use std::{fmt::Write, mem};
+
+use ahash::AHashSet;
+
+use super::{PyTrait, Type};
+use crate::{
+    args::ArgValues,
+    bytecode::{CallResult, VM},
+    exception_private::{ExcType, RunResult, SimpleException},
+    heap::{DropWithHeap, HeapId, HeapItem, HeapRead},
+    resource::{ResourceError, ResourceTracker},
+    value::{EitherStr, Value},
+};
+
+/// Configuration for a synthetic context manager.
+///
+/// All fields default to "passthrough" — the manager returns itself from
+/// `__enter__`, returns `None` from `__exit__`, and never raises. Setting a
+/// field flips one specific branch on, so a single test can pin one path at
+/// a time without touching production code.
+///
+/// `enter_value` is intentionally restricted to an integer rather than an
+/// arbitrary `Value`: a heap-allocated enter value would need refcount
+/// plumbing here (Value does not impl Clone, intentionally), and an int is
+/// sufficient to verify that `__enter__`'s return value flows to the `as`
+/// target. If a future branch needs the test manager to return a heap
+/// value, store a `HeapId` and bump its refcount on each `py_enter` call.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct TestContextManager {
+    /// Integer to return from `__enter__`. `None` means "return self".
+    pub enter_value: Option<i64>,
+    /// When `true`, `__exit__` returns `Value::Bool(true)` on the exception
+    /// path so the in-flight exception is swallowed. Has no effect on the
+    /// normal-exit path (CPython only checks the return value when an
+    /// exception is propagating).
+    pub suppress: bool,
+    /// When `Some`, `__enter__` raises `ValueError(msg)` instead of
+    /// returning `enter_value`. The body never runs.
+    pub raise_on_enter: Option<String>,
+    /// When `Some`, `__exit__` raises `ValueError(msg)`. On the normal-exit
+    /// path the new exception propagates out of the `with`; on the
+    /// exception path it replaces the in-flight exception.
+    pub raise_on_exit: Option<String>,
+}
+
+impl TestContextManager {
+    /// Builds a passthrough manager. Tests mutate the result to flip the
+    /// branches they want to exercise — keeping the constructor zero-arg
+    /// means the `_test_cm()` builtin doesn't need to know which fields
+    /// exist, only which kwargs to forward.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            enter_value: None,
+            suppress: false,
+            raise_on_enter: None,
+            raise_on_exit: None,
+        }
+    }
+}
+
+impl Default for TestContextManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HeapItem for TestContextManager {
+    fn py_estimate_size(&self) -> usize {
+        mem::size_of::<Self>()
+            + self.raise_on_enter.as_ref().map_or(0, String::len)
+            + self.raise_on_exit.as_ref().map_or(0, String::len)
+    }
+
+    fn py_dec_ref_ids(&mut self, _stack: &mut Vec<HeapId>) {
+        // The manager holds no heap references — `enter_value` is a plain
+        // i64 and the strings are owned Rust data — so cycle collection
+        // and ref-count drops have nothing to do here.
+    }
+}
+
+impl<'h> PyTrait<'h> for HeapRead<'h, TestContextManager> {
+    fn py_type(&self, _vm: &VM<'h, impl ResourceTracker>) -> Type {
+        Type::TestContextManager
+    }
+
+    fn py_len(&self, _vm: &VM<'h, impl ResourceTracker>) -> Option<usize> {
+        None
+    }
+
+    fn py_eq(&self, _other: &Self, _vm: &mut VM<'h, impl ResourceTracker>) -> Result<bool, ResourceError> {
+        Ok(false)
+    }
+
+    fn py_bool(&self, _vm: &mut VM<'h, impl ResourceTracker>) -> bool {
+        true
+    }
+
+    fn py_repr_fmt(
+        &self,
+        f: &mut impl Write,
+        _vm: &mut VM<'h, impl ResourceTracker>,
+        _heap_ids: &mut AHashSet<HeapId>,
+    ) -> RunResult<()> {
+        f.write_str("<_test_cm>")?;
+        Ok(())
+    }
+
+    fn py_enter(&mut self, self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<CallResult> {
+        let cfg = self.get(vm.heap);
+        if let Some(msg) = cfg.raise_on_enter.clone() {
+            return Err(SimpleException::new_msg(ExcType::ValueError, msg).into());
+        }
+        let value = if let Some(n) = cfg.enter_value {
+            Value::Int(n)
+        } else {
+            vm.heap.inc_ref(self_id);
+            Value::Ref(self_id)
+        };
+        Ok(CallResult::Value(value))
+    }
+
+    fn py_exit(
+        &mut self,
+        _self_id: HeapId,
+        vm: &mut VM<'h, impl ResourceTracker>,
+        exc: Option<HeapId>,
+    ) -> RunResult<CallResult> {
+        let cfg = self.get(vm.heap);
+        if let Some(msg) = cfg.raise_on_exit.clone() {
+            return Err(SimpleException::new_msg(ExcType::ValueError, msg).into());
+        }
+        // Only the exception path consults the suppress flag — on the
+        // normal-exit path CPython ignores the return value entirely, but
+        // we still return `Bool(false)` there to keep the implementation
+        // uniform and the user-visible value testable.
+        let value = if exc.is_some() && cfg.suppress {
+            Value::Bool(true)
+        } else {
+            Value::None
+        };
+        Ok(CallResult::Value(value))
+    }
+
+    fn py_call_attr(
+        &mut self,
+        self_id: HeapId,
+        vm: &mut VM<'h, impl ResourceTracker>,
+        attr: &EitherStr,
+        args: ArgValues,
+    ) -> RunResult<CallResult> {
+        // Forward `obj.__enter__()` / `obj.__exit__(...)` direct calls so the
+        // synthetic manager can also exercise the attribute-access path that
+        // `OpenFile` covers in its py_call_attr.
+        use crate::intern::StaticStrings;
+        let Some(method) = attr.static_string() else {
+            args.drop_with_heap(vm);
+            return Err(ExcType::attribute_error(self.py_type(vm), attr.as_str(vm.interns)));
+        };
+        match method {
+            StaticStrings::Enter => {
+                args.check_zero_args("__enter__", vm.heap)?;
+                self.py_enter(self_id, vm)
+            }
+            StaticStrings::Exit => {
+                // Same flexibility as `OpenFile.__exit__`: accept any args
+                // and discard them; direct invocation has no in-flight
+                // exception so `py_exit` is called with `None`.
+                args.drop_with_heap(vm);
+                self.py_exit(self_id, vm, None)
+            }
+            _ => {
+                args.drop_with_heap(vm);
+                Err(ExcType::attribute_error(self.py_type(vm), attr.as_str(vm.interns)))
+            }
+        }
+    }
+}

--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -77,6 +77,12 @@ pub enum Type {
     RePattern,
     /// A regex match result from `re.match()` / `re.search()` etc. - displays as "re.Match"
     ReMatch,
+    /// Synthetic context manager exposed via the `_test_cm` builtin. Only
+    /// reachable under the `test-hooks` cargo feature; intentionally a
+    /// distinct `Type` variant rather than one of the existing ones so a
+    /// production sandbox can't get confused with it via stale snapshots.
+    #[cfg(feature = "test-hooks")]
+    TestContextManager,
 }
 
 impl fmt::Display for Type {
@@ -122,6 +128,8 @@ impl fmt::Display for Type {
             Self::Property => f.write_str("property"),
             Self::RePattern => f.write_str("re.Pattern"),
             Self::ReMatch => f.write_str("re.Match"),
+            #[cfg(feature = "test-hooks")]
+            Self::TestContextManager => f.write_str("_test_cm"),
         }
     }
 }

--- a/crates/monty/test_cases/open__fs.py
+++ b/crates/monty/test_cases/open__fs.py
@@ -273,3 +273,68 @@ try:
     assert False, 'expected unknown mode character to fail'
 except ValueError as exc:
     assert str(exc) == "invalid mode: 'z'", f'unexpected unknown mode message: {exc}'
+
+# === Path.open() — same OsCall as builtin open() with `self` as the file ===
+# Mode/kwarg validation, open-time effects, returned wrapper types, and
+# context-manager semantics are all shared with `open()` above. The tests
+# here focus on what's specific to going through Path: that the implicit
+# `self` is used as the file argument, that positional and keyword `mode`
+# both work, and that validation still fires when called via Path.
+#
+# Each test uses its own dedicated file because earlier tests in this file
+# truncate `hello.txt` (`open(..., 'w').read()` truncates before raising).
+(root / 'path_open_text.txt').write_text('hello via Path.open\n')
+(root / 'path_open_bytes.bin').write_bytes(b'\x10\x20\x30')
+
+path_read = (root / 'path_open_text.txt').open()
+assert path_read.read() == 'hello via Path.open\n', 'Path.open() default-mode reads the file'
+path_read.close()
+
+# Positional mode reaches the same wrapper as `open(..., 'rb')`.
+binary_via_path = (root / 'path_open_bytes.bin').open('rb')
+assert str(type(binary_via_path)) == "<class '_io.BufferedReader'>", "Path.open('rb') returns BufferedReader"
+assert binary_via_path.read() == b'\x10\x20\x30', "Path.open('rb') reads bytes"
+binary_via_path.close()
+
+# Keyword-only mode works too (no positional arg).
+kw_mode = (root / 'path_open_text.txt').open(mode='r')
+assert kw_mode.read() == 'hello via Path.open\n', 'Path.open(mode=...) reads the file'
+kw_mode.close()
+
+# `encoding='utf-8'` accepted as the documented no-op (Monty always uses UTF-8).
+enc = (root / 'path_open_text.txt').open('r', encoding='utf-8')
+assert enc.read() == 'hello via Path.open\n', "Path.open('r', encoding='utf-8') accepted"
+enc.close()
+
+# Context manager works through Path.open() — closes on exit on both paths.
+with (root / 'path_open_text.txt').open() as f:
+    assert f.read() == 'hello via Path.open\n', 'Path.open() works as context manager'
+assert f.closed, 'context-manager exit closes the Path.open() file'
+
+# Write through Path.open() lands the same content as a direct open().
+(root / 'path_open_write.txt').open('w').write('written via Path.open\n')
+assert (root / 'path_open_write.txt').read_text() == 'written via Path.open\n', "Path.open('w') write committed"
+
+# Mode validation is shared — Monty rejects '+' modes; CPython would accept
+# them, so this is monty-only.
+if is_monty:
+    try:
+        (root / 'path_open_text.txt').open('r+')
+        assert False, "expected ValueError for Path.open('r+')"
+    except ValueError as exc:
+        assert str(exc) == "update modes ('+') are not yet supported", f'unexpected Path.open r+ rejection: {exc}'
+
+    try:
+        (root / 'path_open_text.txt').open(buffering=0)
+        assert False, 'expected TypeError for Path.open(buffering=0)'
+    except TypeError as exc:
+        assert str(exc) == "'buffering' argument is not yet supported", (
+            f'unexpected Path.open buffering rejection: {exc}'
+        )
+
+# Open-time existence check still fires when called via Path.open().
+try:
+    (root / 'path_open_missing.txt').open()
+    assert False, 'expected FileNotFoundError opening a missing file via Path.open'
+except FileNotFoundError as exc:
+    assert str(exc).startswith("[Errno 2] No such file or directory: '")

--- a/crates/monty/test_cases/with__all.py
+++ b/crates/monty/test_cases/with__all.py
@@ -1,0 +1,122 @@
+# mount-fs
+
+# === Basic with + open ===
+with open(root / 'open_with.txt', 'w') as f:
+    assert f.write('hello') == 5, 'write returns char count'
+    assert f.closed == False, 'file is open inside with'
+assert f.closed == True, 'file is closed after with'
+assert (root / 'open_with.txt').read_text() == 'hello', 'write committed after with'
+
+# === Read with `with` ===
+with open(root / 'hello.txt') as r:
+    assert r.read() == 'hello world\n', 'read works inside with'
+assert r.closed == True, 'reader closed after with'
+
+# === `__enter__` returns the file itself ===
+pre = open(root / 'hello.txt')
+with pre as bound:
+    assert bound is pre, '__enter__ returns the file itself'
+assert pre.closed == True, 'file closed after with even when ctx is precreated'
+
+# === Closed on exception ===
+errfile = open(root / 'hello.txt')
+caught = None
+try:
+    with errfile:
+        raise ValueError('boom')
+except ValueError as e:
+    caught = str(e)
+assert caught == 'boom', 'exception propagates out of with'
+assert errfile.closed == True, 'file closed even on exception'
+
+# === Without `as` target ===
+with open(root / 'hello.txt'):
+    pass
+
+# === Nested with ===
+with open(root / 'open_with_a.txt', 'w') as a:
+    with open(root / 'open_with_b.txt', 'w') as b:
+        a.write('A')
+        b.write('B')
+assert a.closed == True, 'outer closed after nested with'
+assert b.closed == True, 'inner closed after nested with'
+assert (root / 'open_with_a.txt').read_text() == 'A', 'outer write persisted'
+assert (root / 'open_with_b.txt').read_text() == 'B', 'inner write persisted'
+
+# === Multi-item with (desugared to nested) ===
+with open(root / 'open_with_m1.txt', 'w') as m1, open(root / 'open_with_m2.txt', 'w') as m2:
+    m1.write('M1')
+    m2.write('M2')
+assert m1.closed == True, 'first manager closed after multi-item with'
+assert m2.closed == True, 'second manager closed after multi-item with'
+assert (root / 'open_with_m1.txt').read_text() == 'M1', 'first manager write persisted'
+assert (root / 'open_with_m2.txt').read_text() == 'M2', 'second manager write persisted'
+
+# === Multi-item with: exception inside body closes both ===
+mexa = open(root / 'hello.txt')
+mexb = open(root / 'hello.txt')
+caught = None
+try:
+    with mexa as _ma, mexb as _mb:
+        raise ValueError('multi-item-boom')
+except ValueError as e:
+    caught = str(e)
+assert caught == 'multi-item-boom', 'exception in multi-item with propagates'
+assert mexa.closed == True, 'first manager closed on exception'
+assert mexb.closed == True, 'second manager closed on exception'
+
+# === Multi-item with: bare items without `as` ===
+with open(root / 'hello.txt'), open(root / 'hello.txt'):
+    pass
+
+
+# === `return` inside with calls __exit__ ===
+def write_and_return(path):
+    with open(path, 'w') as out:
+        out.write('via-return')
+        return out
+
+
+returned = write_and_return(root / 'open_with_ret.txt')
+assert returned.closed == True, 'file closed when returning from inside with'
+assert (root / 'open_with_ret.txt').read_text() == 'via-return', 'write persisted on return path'
+
+# === `break` inside with calls __exit__ ===
+break_file = None
+for _ in range(1):
+    with open(root / 'open_with_break.txt', 'w') as bf:
+        break_file = bf
+        bf.write('via-break')
+        break
+assert break_file.closed == True, 'file closed when breaking from inside with'
+assert (root / 'open_with_break.txt').read_text() == 'via-break', 'write persisted on break path'
+
+# === `continue` inside with calls __exit__ ===
+cont_files = []
+cont_paths = [root / 'open_with_cont_0.txt', root / 'open_with_cont_1.txt']
+for i in range(2):
+    with open(cont_paths[i], 'w') as cf:
+        cont_files.append(cf)
+        cf.write('iter-' + str(i))
+        continue
+assert all(f.closed for f in cont_files), 'files closed when continuing from inside with'
+assert cont_paths[0].read_text() == 'iter-0', 'first iteration persisted'
+assert cont_paths[1].read_text() == 'iter-1', 'second iteration persisted'
+
+# === Direct `__enter__()` / `__exit__()` invocation ===
+direct = open(root / 'hello.txt')
+entered = direct.__enter__()
+assert entered is direct, '__enter__ direct call returns self'
+assert direct.__exit__(None, None, None) is None, '__exit__ returns None'
+assert direct.closed == True, 'direct __exit__ closes the file'
+
+# === `__enter__` on a closed file raises ===
+closed = open(root / 'hello.txt')
+closed.close()
+err = None
+try:
+    with closed:
+        assert False, 'should not enter body when ctx is closed'
+except ValueError as e:
+    err = str(e)
+assert err == 'I/O operation on closed file.', 'closed file rejected by __enter__'

--- a/crates/monty/test_cases/with__cm_behaviors.py
+++ b/crates/monty/test_cases/with__cm_behaviors.py
@@ -77,11 +77,47 @@ cm = _test_cm()
 assert cm.__enter__() is cm, 'direct __enter__() works and returns self'
 assert cm.__exit__(None, None, None) is None, 'direct __exit__() returns None'
 
-# Suppress flag is exception-path-only — direct invocation has no
-# in-flight exception, so __exit__ returns None.
+# Suppress flag is exception-path-only — direct invocation with a None
+# value (no in-flight exception) returns None.
 assert _test_cm('suppress').__exit__(None, None, None) is None, (
     'direct __exit__(None, None, None) ignores the suppress flag'
 )
+
+# Forwarding a real exception instance to a `suppress`-configured manager
+# *should* trip the suppress branch and return True. Verifies that the
+# `val` argument of __exit__ is forwarded to py_exit, not silently dropped.
+assert _test_cm('suppress').__exit__(ValueError, ValueError('x'), None) is True, (
+    'direct __exit__ with an exception value routes to the suppress branch'
+)
+
+# Wrong arity — `__exit__` requires exactly 3 positional arguments.
+err = None
+try:
+    _test_cm().__exit__()
+except TypeError as e:
+    err = str(e)
+assert err is not None, '__exit__() with zero args should raise TypeError'
+
+err = None
+try:
+    _test_cm().__exit__(None, None, None, None)
+except TypeError as e:
+    err = str(e)
+assert err is not None, '__exit__() with four args should raise TypeError'
+
+# === Unpack failure inside the `with` body still invokes __exit__ ===
+# `TestContextManager` is not iterable, so `as (a, b):` fails during unpack.
+# The unpack lives inside the protected region, so __exit__ runs and its
+# ValueError replaces the in-flight TypeError.
+caught = None
+try:
+    with _test_cm('raise_on_exit', 'cleanup-from-unpack-fail') as (a, b):
+        pass
+except ValueError as e:
+    caught = str(e)
+except TypeError:
+    caught = 'unpack-error-uncaught'
+assert caught == 'cleanup-from-unpack-fail', '__exit__ runs when unpacking the as-target fails'
 
 # === Multi-item with: suppress on inner manager only swallows in inner scope ===
 # Outer manager sees the exception (because it's propagating after the

--- a/crates/monty/test_cases/with__cm_behaviors.py
+++ b/crates/monty/test_cases/with__cm_behaviors.py
@@ -1,0 +1,109 @@
+# Context-manager behaviors exercised via the `_test_cm()` synthetic context
+# manager. `_test_cm()` is a test-only hook injected on both sides — the
+# Monty side enables it via the `test-hooks` cargo feature, the CPython
+# side via `scripts/test_cm_shim.py`. These tests verify branches of the
+# `with` machinery that `OpenFile` (Monty's only production context
+# manager) doesn't cover today.
+
+# === Passthrough: returns self on enter, propagates exceptions ===
+cm = _test_cm()
+with cm as bound:
+    assert bound is cm, 'default __enter__ returns self'
+caught = None
+try:
+    with _test_cm():
+        raise ValueError('passthrough-prop')
+except ValueError as e:
+    caught = str(e)
+assert caught == 'passthrough-prop', 'default __exit__ does not suppress'
+
+# === Suppress: __exit__ returns True, swallows in-flight exception ===
+swallowed = False
+with _test_cm('suppress'):
+    raise ValueError('to-swallow')
+    swallowed = False  # unreachable
+swallowed = True
+assert swallowed, 'suppress branch lets control fall through to after the with'
+
+# Suppress does NOT swallow when there is no in-flight exception: a normal
+# body completes normally either way.
+with _test_cm('suppress'):
+    inside = 'ran'
+assert inside == 'ran', 'normal-exit path is unaffected by the suppress flag'
+
+# === enter_value: __enter__ returns a non-self value ===
+with _test_cm('enter_value', 42) as v:
+    assert v == 42, 'as-target gets __enter__ return value'
+
+# === raise_on_enter: body never runs ===
+ran_body = False
+caught = None
+try:
+    with _test_cm('raise_on_enter', 'no-entry'):
+        ran_body = True
+except ValueError as e:
+    caught = str(e)
+assert caught == 'no-entry', '__enter__ exception propagates'
+assert not ran_body, 'body skipped when __enter__ raises'
+
+# === raise_on_exit: on normal-exit path replaces (nonexistent) exception ===
+caught = None
+try:
+    with _test_cm('raise_on_exit', 'cleanup-failed'):
+        pass
+except ValueError as e:
+    caught = str(e)
+assert caught == 'cleanup-failed', '__exit__ exception propagates after normal body'
+
+# === raise_on_exit: on exception path REPLACES the in-flight exception ===
+# CPython semantics: an exception raised by __exit__ replaces the one
+# already propagating; the original is lost (not chained as __context__
+# in Monty, which doesn't track exception chaining yet).
+caught_type = None
+caught_msg = None
+try:
+    with _test_cm('raise_on_exit', 'cleanup-wins'):
+        raise RuntimeError('original')
+except ValueError as e:
+    caught_type = 'ValueError'
+    caught_msg = str(e)
+except RuntimeError:
+    caught_type = 'RuntimeError'
+assert caught_type == 'ValueError', '__exit__ exception replaces in-flight RuntimeError'
+assert caught_msg == 'cleanup-wins', 'replacing exception carries its own message'
+
+# === Direct __enter__() / __exit__() invocation ===
+cm = _test_cm()
+assert cm.__enter__() is cm, 'direct __enter__() works and returns self'
+assert cm.__exit__(None, None, None) is None, 'direct __exit__() returns None'
+
+# Suppress flag is exception-path-only — direct invocation has no
+# in-flight exception, so __exit__ returns None.
+assert _test_cm('suppress').__exit__(None, None, None) is None, (
+    'direct __exit__(None, None, None) ignores the suppress flag'
+)
+
+# === Multi-item with: suppress on inner manager only swallows in inner scope ===
+# Outer manager sees the exception (because it's propagating after the
+# inner one swallowed nothing, since the inner doesn't suppress here).
+outer_saw = None
+with _test_cm() as _a:
+    try:
+        with _test_cm('suppress') as _b:
+            raise ValueError('inner-swallow')
+        outer_saw = 'fell-through'
+    except ValueError:
+        outer_saw = 'propagated'
+assert outer_saw == 'fell-through', 'inner suppress prevents outer from seeing the exception'
+
+# === Nested raise_on_exit: outer __exit__ raising during exception path ===
+caught_type = None
+try:
+    with _test_cm('raise_on_exit', 'outer-fails'):
+        with _test_cm():
+            raise RuntimeError('inner-raise')
+except ValueError as e:
+    caught_type = ('ValueError', str(e))
+except RuntimeError as e:
+    caught_type = ('RuntimeError', str(e))
+assert caught_type == ('ValueError', 'outer-fails'), 'outer __exit__ raising replaces inner exception'

--- a/crates/monty/test_cases/with__cm_context_expr_raises_traceback.py
+++ b/crates/monty/test_cases/with__cm_context_expr_raises_traceback.py
@@ -1,0 +1,14 @@
+# Exception raised by the context expression itself (the `_test_cm(...)`
+# call), before `__enter__` is ever invoked. The traceback points at the
+# `with` line because that's where the call expression lives; neither
+# `BeforeWith` (Monty) nor `__enter__` (CPython) has run yet.
+with _test_cm('not-a-behavior'):
+    raise RuntimeError('body should not run')
+"""
+TRACEBACK:
+Traceback (most recent call last):
+  File "with__cm_context_expr_raises_traceback.py", line 5, in <module>
+    with _test_cm('not-a-behavior'):
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~
+TypeError: _test_cm() unknown behavior 'not-a-behavior'
+"""

--- a/crates/monty/test_cases/with__cm_enter_raises_traceback.py
+++ b/crates/monty/test_cases/with__cm_enter_raises_traceback.py
@@ -1,0 +1,16 @@
+# `__enter__` raises before the body runs. The traceback shows the `with`
+# line — Monty's `BeforeWith` opcode location, CPython's call-site frame.
+# The shim's `__enter__` frame inside `test_fixtures.py` is filtered by
+# the traceback runner (see `scripts/run_traceback.py`) so the visible
+# output matches the Monty side, which has no equivalent Python-level
+# frame for the synthetic context manager.
+with _test_cm('raise_on_enter', 'fail-enter'):
+    raise RuntimeError('body should not run')
+"""
+TRACEBACK:
+Traceback (most recent call last):
+  File "with__cm_enter_raises_traceback.py", line 7, in <module>
+    with _test_cm('raise_on_enter', 'fail-enter'):
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ValueError: fail-enter
+"""

--- a/crates/monty/test_cases/with__cm_exit_raises_normal_exit_traceback.py
+++ b/crates/monty/test_cases/with__cm_exit_raises_normal_exit_traceback.py
@@ -1,0 +1,16 @@
+# `__exit__` raises on the normal-exit path (the body completed cleanly,
+# but the cleanup itself fails). The traceback points at the `with` line:
+# Monty surfaces it from the `WithExit` opcode's location, CPython from
+# the call-site frame. The shim's `__exit__` frame inside
+# `test_fixtures.py` is filtered out, matching the Monty side which has
+# no equivalent Python-level frame.
+with _test_cm('raise_on_exit', 'fail-exit'):
+    pass
+"""
+TRACEBACK:
+Traceback (most recent call last):
+  File "with__cm_exit_raises_normal_exit_traceback.py", line 7, in <module>
+    with _test_cm('raise_on_exit', 'fail-exit'):
+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ValueError: fail-exit
+"""

--- a/crates/monty/test_cases/with__cm_nested_body_raises_traceback.py
+++ b/crates/monty/test_cases/with__cm_nested_body_raises_traceback.py
@@ -1,0 +1,15 @@
+# Nested `with` blocks with a passthrough cm at each level: an exception
+# raised in the innermost body propagates through both `__exit__` calls
+# (both return None) and surfaces with the body's frame intact. Verifies
+# that `WithExceptStart` doesn't perturb the propagating exception's
+# traceback when `__exit__` is a no-op cleanup.
+with _test_cm() as outer:
+    with _test_cm() as inner:
+        raise ValueError('from inner body')
+"""
+TRACEBACK:
+Traceback (most recent call last):
+  File "with__cm_nested_body_raises_traceback.py", line 8, in <module>
+    raise ValueError('from inner body')
+ValueError: from inner body
+"""

--- a/crates/monty/test_cases/with__cm_traceback.py
+++ b/crates/monty/test_cases/with__cm_traceback.py
@@ -1,0 +1,20 @@
+# When `__exit__` returns None (the default passthrough behavior), an
+# exception raised inside the `with` body propagates with its original
+# traceback intact — no `__exit__` frame added, no "During handling..."
+# chained context. This is the case that should match byte-for-byte
+# between Monty and CPython, because the synthetic `_test_cm` shim's
+# `__exit__` just returns and never sees the exception.
+#
+# The Monty-side `WithExceptStart` opcode call into `py_exit` is the
+# matching code path; if it ever started inadvertently rewriting the
+# in-flight exception (e.g. by clearing the original traceback) this
+# test would catch the divergence.
+with _test_cm() as cm:
+    raise ValueError('inside passthrough')
+"""
+TRACEBACK:
+Traceback (most recent call last):
+  File "with__cm_traceback.py", line 13, in <module>
+    raise ValueError('inside passthrough')
+ValueError: inside passthrough
+"""

--- a/crates/monty/test_cases/with__not_context_manager.py
+++ b/crates/monty/test_cases/with__not_context_manager.py
@@ -1,0 +1,14 @@
+# `with` on a value without `__exit__` raises CPython's specific TypeError
+# (not a generic AttributeError), even though the bytecode check itself
+# fails on `__enter__` first. We surface CPython's text so user-facing
+# diagnostics match.
+with 5:
+    assert False, 'body should never execute'
+"""
+TRACEBACK:
+Traceback (most recent call last):
+  File "with__not_context_manager.py", line 5, in <module>
+    with 5:
+         ~
+TypeError: 'int' object does not support the context manager protocol (missed __exit__ method)
+"""

--- a/crates/monty/tests/parse_errors.rs
+++ b/crates/monty/tests/parse_errors.rs
@@ -54,8 +54,14 @@ fn unknown_imports_compile_successfully_error_deferred_to_runtime() {
 }
 
 #[test]
-fn with_statement_returns_not_implemented_error() {
-    let result = MontyRun::new("with open('f') as f: pass".to_owned(), "test.py", vec![]);
+fn async_with_statement_returns_not_implemented_error() {
+    // Plain `with` is supported (see `test_cases/with__all.py`); only `async with`
+    // is still rejected at parse time.
+    let result = MontyRun::new(
+        "async def f():\n    async with open('f') as g: pass\n".to_owned(),
+        "test.py",
+        vec![],
+    );
     assert_eq!(get_exc_type(result), ExcType::NotImplementedError);
 }
 

--- a/crates/monty/tests/with_test_cm.rs
+++ b/crates/monty/tests/with_test_cm.rs
@@ -1,0 +1,230 @@
+//! Tests for the `_test_cm()` builtin and the `with` statement branches that
+//! no production type currently exercises.
+//!
+//! **REMOVE THIS FILE** once a real production context manager covers these
+//! cases. See `crates/monty/src/types/test_cm.rs` for the full removal
+//! checklist.
+//!
+//! Each test pins one specific branch:
+//!
+//! - `suppress_path_swallows_exception` exercises the swallow path
+//!   compiled by `compile_with` (the `JumpIfTrue swallow` → `Pop Pop
+//!   ClearException` sequence). `OpenFile.__exit__` always returns
+//!   `None`, so this path would otherwise be dead in tests.
+//! - `exit_raising_during_normal_exit_propagates` and
+//!   `exit_raising_during_exception_path_replaces` exercise the rule that
+//!   an exception raised by `__exit__` propagates out of the `with`
+//!   block, replacing any in-flight exception. `OpenFile.__exit__` can't
+//!   fail.
+//! - `enter_raising_skips_body` exercises the rare case where
+//!   `__enter__` fails before the body runs (currently only triggered by
+//!   `with closed_file:` in production).
+//! - `enter_value_bound_to_as_target` verifies the `as` target receives
+//!   the `__enter__` return value (not `self`), a case `OpenFile`
+//!   doesn't cover because it always returns itself.
+//! - `direct_dunder_calls` confirms `f.__enter__()` / `f.__exit__(...)`
+//!   work through the trait's default `py_call_attr` dispatch and the
+//!   manager's own override.
+#![cfg(feature = "test-hooks")]
+
+use monty::{ExcType, MontyObject, MontyRun};
+
+/// Runs a snippet and asserts it succeeds, returning the result value.
+fn run_ok(code: &str) -> MontyObject {
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![]).expect("parse");
+    runner.run_no_limits(vec![]).expect("run")
+}
+
+/// Runs a snippet and asserts it raises the given exception type with the
+/// given message.
+fn run_err(code: &str) -> (ExcType, Option<String>) {
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![]).expect("parse");
+    let err = runner.run_no_limits(vec![]).expect_err("expected exception");
+    (err.exc_type(), err.message().map(str::to_owned))
+}
+
+#[test]
+fn passthrough_test_cm_behaves_like_open_file() {
+    // Sanity check: a default `_test_cm()` runs the body, returns self on
+    // enter, and propagates any in-flight exception.
+    let result = run_ok(
+        "
+cm = _test_cm()
+with cm as bound:
+    captured = bound is cm
+captured
+",
+    );
+    assert_eq!(result, MontyObject::Bool(true));
+}
+
+#[test]
+fn suppress_path_swallows_exception() {
+    // `__exit__` returns True → exception is swallowed → control continues
+    // past the `with` block. The compiler-emitted swallow path
+    // (`Pop, Pop, ClearException`) is reachable only via this branch.
+    let result = run_ok(
+        "
+cm = _test_cm('suppress')
+try:
+    with cm:
+        raise ValueError('boom')
+    # The swallow path falls through to here, so this assignment runs.
+    outcome = 'swallowed'
+except ValueError:
+    outcome = 'propagated'
+outcome
+",
+    );
+    assert_eq!(result, MontyObject::String("swallowed".to_owned()));
+}
+
+#[test]
+fn suppress_does_not_swallow_normal_completion() {
+    // The suppress flag only matters on the exception path; a normal exit
+    // ignores `__exit__`'s return value entirely (CPython behavior).
+    let result = run_ok(
+        "
+cm = _test_cm('suppress')
+with cm:
+    inner = 'ran'
+inner
+",
+    );
+    assert_eq!(result, MontyObject::String("ran".to_owned()));
+}
+
+#[test]
+fn enter_raising_skips_body() {
+    // `__enter__` raises before the body runs — verify the body never
+    // executes and the exception type/message match.
+    let (exc_type, message) = run_err(
+        "
+cm = _test_cm('raise_on_enter', 'no entry')
+with cm:
+    raise RuntimeError('body should not run')
+",
+    );
+    assert_eq!(exc_type, ExcType::ValueError);
+    assert_eq!(message.as_deref(), Some("no entry"));
+}
+
+#[test]
+fn exit_raising_during_normal_exit_propagates() {
+    // On the normal-exit path `__exit__` raising replaces the (absent)
+    // in-flight exception with the new one.
+    let (exc_type, message) = run_err(
+        "
+cm = _test_cm('raise_on_exit', 'cleanup failed')
+with cm:
+    pass
+",
+    );
+    assert_eq!(exc_type, ExcType::ValueError);
+    assert_eq!(message.as_deref(), Some("cleanup failed"));
+}
+
+#[test]
+fn exit_raising_during_exception_path_replaces() {
+    // On the exception path, the original exception is replaced by the
+    // one raised in `__exit__` (matches CPython semantics).
+    let (exc_type, message) = run_err(
+        "
+cm = _test_cm('raise_on_exit', 'cleanup-wins')
+with cm:
+    raise RuntimeError('original')
+",
+    );
+    assert_eq!(exc_type, ExcType::ValueError);
+    assert_eq!(message.as_deref(), Some("cleanup-wins"));
+}
+
+#[test]
+fn enter_value_bound_to_as_target() {
+    // `__enter__` returns an int → the `as` target gets that int, not
+    // the context manager itself.
+    let result = run_ok(
+        "
+with _test_cm('enter_value', 42) as v:
+    captured = v
+captured
+",
+    );
+    assert_eq!(result, MontyObject::Int(42));
+}
+
+#[test]
+fn direct_enter_call_returns_self_by_default() {
+    // `f.__enter__()` should work the same as `with f:`'s entry — the
+    // `py_call_attr` dispatch is the same code path.
+    let result = run_ok(
+        "
+cm = _test_cm()
+result = cm.__enter__()
+result is cm
+",
+    );
+    assert_eq!(result, MontyObject::Bool(true));
+}
+
+#[test]
+fn direct_exit_call_returns_none_by_default() {
+    let result = run_ok(
+        "
+cm = _test_cm()
+cm.__exit__(None, None, None)
+",
+    );
+    assert_eq!(result, MontyObject::None);
+}
+
+#[test]
+fn direct_exit_call_with_suppress_returns_none_on_normal_path() {
+    // Direct invocation has no in-flight exception, so even a
+    // `suppress`-configured manager returns None (the suppress flag only
+    // affects the exception path).
+    let result = run_ok(
+        "
+cm = _test_cm('suppress')
+cm.__exit__(None, None, None)
+",
+    );
+    assert_eq!(result, MontyObject::None);
+}
+
+#[test]
+fn unknown_behavior_raises_type_error() {
+    let (exc_type, message) = run_err("_test_cm('not-a-behavior')");
+    assert_eq!(exc_type, ExcType::TypeError);
+    assert_eq!(message.as_deref(), Some("_test_cm() unknown behavior 'not-a-behavior'"));
+}
+
+#[test]
+fn non_string_behavior_raises_type_error() {
+    let (exc_type, message) = run_err("_test_cm(None, 1)");
+    assert_eq!(exc_type, ExcType::TypeError);
+    assert_eq!(
+        message.as_deref(),
+        Some("_test_cm() behavior must be str, not NoneType")
+    );
+}
+
+#[test]
+fn enter_value_requires_int_payload() {
+    let (exc_type, message) = run_err("_test_cm('enter_value', 'not-an-int')");
+    assert_eq!(exc_type, ExcType::TypeError);
+    assert_eq!(
+        message.as_deref(),
+        Some("_test_cm('enter_value', n) requires int payload, not str")
+    );
+}
+
+#[test]
+fn raise_on_enter_requires_str_payload() {
+    let (exc_type, message) = run_err("_test_cm('raise_on_enter', 7)");
+    assert_eq!(exc_type, ExcType::TypeError);
+    assert_eq!(
+        message.as_deref(),
+        Some("_test_cm('raise_on_enter', msg) requires str payload, not int")
+    );
+}

--- a/crates/monty/tests/with_test_cm.rs
+++ b/crates/monty/tests/with_test_cm.rs
@@ -193,6 +193,51 @@ cm.__exit__(None, None, None)
 }
 
 #[test]
+fn direct_exit_call_with_exception_value_routes_to_exception_path() {
+    // Forwarding a non-None val to a `suppress`-configured manager should
+    // hit the exception branch of `__exit__` and return True. This pins the
+    // "val is forwarded to py_exit" fix in `dispatch_exit`.
+    let result = run_ok(
+        "
+cm = _test_cm('suppress')
+cm.__exit__(ValueError, ValueError('x'), None)
+",
+    );
+    assert_eq!(result, MontyObject::Bool(true));
+}
+
+#[test]
+fn direct_exit_call_wrong_arity_raises_type_error() {
+    // `cm.__exit__()` and `cm.__exit__(1, 2)` are both arity errors —
+    // CPython's `__exit__` is a 3-arg function and accepts nothing else.
+    let (exc_type, _) = run_err("_test_cm().__exit__()");
+    assert_eq!(exc_type, ExcType::TypeError);
+    let (exc_type, _) = run_err("_test_cm().__exit__(None, None)");
+    assert_eq!(exc_type, ExcType::TypeError);
+    let (exc_type, _) = run_err("_test_cm().__exit__(None, None, None, None)");
+    assert_eq!(exc_type, ExcType::TypeError);
+}
+
+#[test]
+fn unpack_failure_inside_with_calls_exit() {
+    // `with cm as (a, b):` where the unpack of `__enter__`'s result fails
+    // should still invoke `__exit__` — the unpack lives inside the
+    // protected region. `_test_cm()` returns self from `__enter__`, and
+    // `TestContextManager` is not iterable, so the unpack raises
+    // `TypeError`. A `raise_on_exit` manager makes `__exit__` raise its
+    // own `ValueError` that *replaces* the in-flight `TypeError`; if
+    // `__exit__` had not been called we'd see the bare `TypeError`.
+    let (exc_type, message) = run_err(
+        "
+with _test_cm('raise_on_exit', 'cleanup-called') as (a, b):
+    pass
+",
+    );
+    assert_eq!(exc_type, ExcType::ValueError);
+    assert_eq!(message.as_deref(), Some("cleanup-called"));
+}
+
+#[test]
 fn unknown_behavior_raises_type_error() {
     let (exc_type, message) = run_err("_test_cm('not-a-behavior')");
     assert_eq!(exc_type, ExcType::TypeError);

--- a/limitations/open.md
+++ b/limitations/open.md
@@ -4,6 +4,12 @@ Monty's `open()` builtin returns a file wrapper that supports a deliberate
 subset of CPython's file API. The list below tracks every known difference
 from CPython.
 
+`pathlib.Path.open()` is wired to the same machinery — it prepends `self`
+as the `file` argument and forwards to the same internal entry point, so
+every divergence listed below applies equally whether the caller uses
+`open(path, ...)` or `path.open(...)`. The only `Path.open()`-specific
+quirks are listed in [Path.open()](#pathopen) at the bottom.
+
 ## Design note: no live host file descriptors
 
 Monty **never** keeps a native file handle alive between OS or external
@@ -129,3 +135,23 @@ These match CPython:
 - `'w'`/`'wb'` creates a missing file immediately, before any write.
 - `'a'`/`'ab'` creates a missing file immediately, preserving any existing
   content.
+
+## Path.open()
+
+`pathlib.Path.open(mode='r', ...)` forwards to the same `OsFunction::Open`
+round-trip as `open()` with `self` prepended as the `file` argument, so
+all the rules above (mode rejection, kwarg validation, returned wrapper
+types, open-time effects) apply identically. The only differences to be
+aware of:
+
+- CPython's `Path.open()` signature lists only `mode, buffering, encoding,
+  errors, newline` (no `closefd` / `opener`). Monty accepts `closefd=True`
+  and `opener=None` at their CPython `open()` defaults as documented
+  no-ops on this path too, and rejects non-default values with the same
+  `"'closefd' argument is not yet supported"` / `"'opener' argument is
+  not yet supported"` `TypeError` as `open()`. CPython would instead
+  raise `TypeError: open() got an unexpected keyword argument 'closefd'`.
+- Passing `file=...` as a keyword (which is meaningless on `Path.open()`
+  because `self` already supplies the file) raises Monty's "multiple
+  values for argument 'file'" `TypeError` rather than CPython's
+  "unexpected keyword argument 'file'". Real callers do not use this.

--- a/limitations/open.md
+++ b/limitations/open.md
@@ -75,6 +75,8 @@ methods and attributes are:
 - `read()` — full-file read (see caveats below).
 - `write(data)` — full-file or appending write.
 - `close()`, `flush()`, `readable()`, `writable()`, `seekable()`.
+- `__enter__()` / `__exit__()` — `with open(...) as f:` works; see
+  [`with.md`](with.md) for the shared protocol divergences.
 - `name`, `mode`, `closed` attributes.
 - `encoding` attribute on text files (always `"utf-8"`).
 
@@ -82,21 +84,6 @@ Everything else raises `AttributeError`, including: `read(size)`,
 `readline()`, `readlines()`, file iteration (`for line in f`), `seek()`,
 `tell()`, `truncate()`, `fileno()`, `isatty()`, `detach()`, `buffer`,
 `raw`.
-
-## Context manager
-
-`with open(...) as f:` is supported and closes the file on exit on both the
-success and exception paths. `__exit__` always returns `None`, so it cannot
-suppress an in-flight exception — any exception raised inside the body
-propagates as it would in CPython.
-
-`__enter__` raises `ValueError: I/O operation on closed file.` if the file
-was already closed (e.g. `with closed_file:` on a wrapper that already
-saw an explicit `close()`).
-
-See `limitations/with.md` for divergences shared by every context manager
-(no traceback object passed to `__exit__`, no multi-item `with`, no
-`async with`).
 
 ## Behavioural divergences
 

--- a/limitations/open.md
+++ b/limitations/open.md
@@ -81,7 +81,22 @@ methods and attributes are:
 Everything else raises `AttributeError`, including: `read(size)`,
 `readline()`, `readlines()`, file iteration (`for line in f`), `seek()`,
 `tell()`, `truncate()`, `fileno()`, `isatty()`, `detach()`, `buffer`,
-`raw`, `__enter__`/`__exit__` (no `with open(...) as f:` support yet).
+`raw`.
+
+## Context manager
+
+`with open(...) as f:` is supported and closes the file on exit on both the
+success and exception paths. `__exit__` always returns `None`, so it cannot
+suppress an in-flight exception — any exception raised inside the body
+propagates as it would in CPython.
+
+`__enter__` raises `ValueError: I/O operation on closed file.` if the file
+was already closed (e.g. `with closed_file:` on a wrapper that already
+saw an explicit `close()`).
+
+See `limitations/with.md` for divergences shared by every context manager
+(no traceback object passed to `__exit__`, no multi-item `with`, no
+`async with`).
 
 ## Behavioural divergences
 

--- a/limitations/with.md
+++ b/limitations/with.md
@@ -1,0 +1,51 @@
+# `with` statement (context managers)
+
+Monty supports the `with` statement for built-in types that implement
+`__enter__` / `__exit__` (currently just file objects produced by
+[`open()`](open.md); user-defined classes are not yet supported anywhere in
+Monty). Semantics follow CPython for the supported subset: `__enter__` runs
+before the body, `__exit__` runs on every exit path (normal completion,
+exception, `return`, `break`, `continue`), and a truthy return from
+`__exit__` suppresses an in-flight exception.
+
+## Supported but desugared
+
+- **Multiple context managers in a single `with`** (`with a() as x, b() as y:`)
+  is parsed as semantically equivalent nested `with` blocks: the leftmost
+  manager enters first and exits last. This matches CPython's left-to-right
+  enter, right-to-left exit ordering exactly. Tracebacks point at the
+  inner-most `with` line, not the original multi-item line.
+
+## Not supported
+
+- **Async `with`** (`async with EXPR:`) is rejected at parse time with
+  `SyntaxError: async context managers (async with) is not yet implemented`.
+- **User-defined classes** cannot define `__enter__` / `__exit__` because
+  `class` definitions are not yet implemented in Monty
+  (`SyntaxError: class definitions is not yet implemented`). Only built-in
+  types can be context managers.
+- **`contextlib`** (`@contextmanager`, `ExitStack`, etc.) — the module is not
+  available; only the language-level `with` statement is.
+
+## Behavioural divergences
+
+- The third argument to `__exit__` (the traceback object) is always `None`.
+  Monty has no traceback objects; the type and value arguments are passed
+  through unchanged. Code that inspects the traceback object inside `__exit__`
+  will see `None` where CPython would provide a `traceback` instance.
+- If `__exit__` itself raises during the exception path, the new exception
+  replaces the original (the original is dropped). This matches CPython's
+  behavior, but is called out here because some readers expect the original
+  to be preserved as `__context__` — Monty does not currently track exception
+  chaining.
+
+## Current implementers of the protocol
+
+| Type        | Notes                                                            |
+| ----------- | ---------------------------------------------------------------- |
+| `open()`    | Closes the file on exit; see [`open.md`](open.md) for details.   |
+
+Adding a new context-manager-capable built-in is a matter of overriding
+`PyTrait::py_enter` / `PyTrait::py_exit` on the type's `HeapRead` impl, and
+threading the `Enter`/`Exit` static-string dispatch through that type's
+`py_call_attr` if direct `obj.__enter__()` invocation should also work.

--- a/limitations/with.md
+++ b/limitations/with.md
@@ -38,6 +38,14 @@ exception, `return`, `break`, `continue`), and a truthy return from
   behavior, but is called out here because some readers expect the original
   to be preserved as `__context__` — Monty does not currently track exception
   chaining.
+- Direct `obj.__exit__(typ, val, tb)` invocation forwards `val` to the
+  type's `py_exit` only when it is `None` or a heap-allocated value
+  (matching CPython for the `None` / exception-instance cases real callers
+  use). A non-`None` *scalar* `val` (e.g. `cm.__exit__(int, 5, None)`)
+  cannot be expressed through the internal `Option<HeapId>` abstraction
+  and is treated as if `val` were `None` — every built-in context manager
+  currently shipped ignores `val`'s content beyond `is None`, so this is
+  observable only with the test-only `_test_cm('suppress')` shim.
 
 ## Current implementers of the protocol
 
@@ -45,7 +53,18 @@ exception, `return`, `break`, `continue`), and a truthy return from
 | ----------- | ---------------------------------------------------------------- |
 | `open()`    | Closes the file on exit; see [`open.md`](open.md) for details.   |
 
-Adding a new context-manager-capable built-in is a matter of overriding
-`PyTrait::py_enter` / `PyTrait::py_exit` on the type's `HeapRead` impl, and
-threading the `Enter`/`Exit` static-string dispatch through that type's
-`py_call_attr` if direct `obj.__enter__()` invocation should also work.
+Adding a new context-manager-capable built-in requires three pieces on the
+type's `HeapRead` impl:
+
+1. Override `PyTrait::py_is_context_manager` to return `true` — this is
+   what the `BeforeWith` opcode checks to raise CPython's specific
+   `TypeError` for non-CM values, *before* `py_enter` runs.
+2. Override `PyTrait::py_enter` / `PyTrait::py_exit`.
+3. Add the type's arms in `HeapReadOutput::py_is_context_manager`,
+   `py_enter`, and `py_exit` (in `heap_data.rs`) so the dispatch
+   reaches the overridden methods.
+
+Direct `obj.__enter__()` / `obj.__exit__(...)` invocation is wired
+centrally in `VM::call_attr` via `dispatch_dunder`, so no per-type
+`StaticStrings::Enter` / `StaticStrings::Exit` arms are needed in the
+type's `py_call_attr`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,9 @@ reportDeprecated = false
 reportWildcardImportFromLibrary = false
 # some test cases intentionally exercise invalid index assignment/runtime error paths
 reportIndexIssue = false
+# `break`/`return`/`continue` inside `with` tests bind through Optional outer
+# variables that pyright can't narrow.
+reportOptionalMemberAccess = false
 
 [[tool.pyright.executionEnvironments]]
 root = "crates/monty-type-checking"

--- a/scripts/run_traceback.py
+++ b/scripts/run_traceback.py
@@ -14,7 +14,7 @@ import tempfile
 import traceback
 from threading import Lock
 
-from iter_test_methods import ITER_MODE_GLOBALS
+from test_fixtures import exported_globals
 
 lock = Lock()
 
@@ -68,8 +68,13 @@ def run_file_and_get_traceback(
         if recursion_limit is not None:
             sys.setrecursionlimit(recursion_limit + 5)
 
-        # Prepare init_globals for iter mode tests
-        init_globals = dict(ITER_MODE_GLOBALS) if iter_mode else None
+        # Inject the shared CPython-side fixtures for every test. The
+        # single `exported_globals` dict in `test_fixtures.py`
+        # carries both the iter helpers and the `_test_cm` synthetic
+        # context manager; non-iter tests don't reference the iter names
+        # so installing them unconditionally has no behavioral cost.
+        # `iter_mode` is still consulted by the frame-skipping logic
+        # further down so we keep the parameter rather than deleting it.
 
         # Use delete=False so the file can be opened by runpy on Windows,
         # where NamedTemporaryFile holds an exclusive lock while open.
@@ -80,7 +85,7 @@ def run_file_and_get_traceback(
             file_path = tmp_file.name
 
             try:
-                runpy.run_path(file_path, init_globals=init_globals, run_name='__main__')
+                runpy.run_path(file_path, init_globals=exported_globals, run_name='__main__')
             except SystemExit:
                 pass  # don't error on ctrl+c
             except BaseException as e:
@@ -101,13 +106,19 @@ def run_file_and_get_traceback(
                     elif '/asyncio/' in frame or '\\asyncio\\' in frame:
                         # Skip asyncio internal frames (forward slash on Unix, backslash on Windows)
                         continue
-                    elif iter_mode:
-                        # In iter mode, skip frames from helper modules
-                        if 'iter_test_methods.py", ' in frame:
-                            continue
+                    elif 'test_fixtures.py", ' in frame:
+                        # The CPython shim file (`scripts/test_fixtures.py`)
+                        # appears in tracebacks whenever an exception passes
+                        # through one of its helpers — `_test_cm.__enter__`
+                        # / `__exit__`, the iter-mode dataclass methods,
+                        # the virtual-path overrides, etc. Monty has no
+                        # equivalent intermediate frame, so filtering these
+                        # everywhere (not just in iter mode) keeps
+                        # CPython/Monty traceback parity.
+                        continue
+                    elif iter_mode and frame.startswith('  File "<string>"'):
                         # python's doing something weird and show the file as <string> for dataclass exceptions
-                        if frame.startswith('  File "<string>"'):
-                            continue
+                        continue
 
                     # Skip until we see our test file
                     if not found_user_code and frame.startswith(f'  File "{file_path}"'):

--- a/scripts/test_fixtures.py
+++ b/scripts/test_fixtures.py
@@ -1,12 +1,21 @@
 """
-External function implementations for iter mode tests.
+Shared CPython-side fixtures for the monty-datatest harness.
 
-These implementations mirror the behavior of `dispatch_external_call` in the Rust test runner
-so that iter mode tests produce identical results in both Monty and CPython.
+Holds two unrelated bundles of helpers that are both injected into CPython
+test globals via the `exported_globals` dict at the bottom of this file:
+
+1. External-function implementations for iter mode tests (the historical
+   contents of this file), which mirror `dispatch_external_call` in the
+   Rust runner so iter-mode tests produce identical results on both sides.
+2. The `_test_cm` synthetic context manager — a CPython equivalent of
+   Monty's `test-hooks` builtin (see `crates/monty/src/types/test_cm.rs`).
+   **REMOVE** the `_TestCm` class, the `test_cm` wrapper, and the
+   `'_test_cm'` entry in `exported_globals` once a real production
+   context manager covers the same paths.
 
 This module is shared between:
 - scripts/run_traceback.py (for traceback tests)
-- crates/monty/tests/datatest_runner.rs (via include_str! for CPython execution)
+- crates/monty-datatest/src/main.rs (imported via pyo3 for CPython execution)
 """
 
 from __future__ import annotations
@@ -16,6 +25,7 @@ import os
 import stat as stat_module
 from dataclasses import dataclass
 from pathlib import Path
+from types import TracebackType
 
 
 def add_ints(a: int, b: int) -> int:
@@ -559,8 +569,114 @@ class VirtualEnviron:
 os.environ = VirtualEnviron()
 
 
-# All external functions available to iter mode tests
-ITER_MODE_GLOBALS: dict[str, object] = {
+# =============================================================================
+# Synthetic context manager — CPython mirror of Monty's `_test_cm()` test-hook
+# builtin. **Remove** alongside `crates/monty/src/types/test_cm.rs` once a
+# real production context manager covers the same paths.
+# =============================================================================
+
+
+class _TestCm:
+    """Synthetic context manager — see `crates/monty/src/types/test_cm.rs`.
+
+    Mirrors the Monty-side `TestContextManager` semantics exactly:
+
+    | behavior          | payload | effect                                              |
+    | ----------------- | ------- | --------------------------------------------------- |
+    | (none)            | —       | passthrough: returns self on enter, None on exit    |
+    | `"suppress"`      | (none)  | `__exit__` returns True on the exception path       |
+    | `"enter_value"`   | int     | `__enter__` returns the int instead of self         |
+    | `"raise_on_enter"`| str     | `__enter__` raises `ValueError(payload)`            |
+    | `"raise_on_exit"` | str     | `__exit__` raises `ValueError(payload)`             |
+
+    Type validation matches Monty's error messages so traceback-equivalence
+    tests pass on both sides.
+    """
+
+    __slots__ = ('_behavior', '_payload')
+
+    def __init__(self, behavior: object = None, payload: object = None) -> None:
+        if behavior is not None and not isinstance(behavior, str):
+            # Match the Monty-side TypeError text exactly so error-path
+            # tests pass against both interpreters.
+            raise TypeError(f'_test_cm() behavior must be str, not {type(behavior).__name__}')
+        if behavior is None:
+            if payload is not None:
+                raise TypeError('_test_cm() payload requires a leading behavior argument')
+            self._behavior: str | None = None
+            self._payload: object = None
+            return
+
+        if behavior == 'suppress':
+            if payload is not None:
+                raise TypeError("_test_cm('suppress') takes no payload")
+        elif behavior == 'enter_value':
+            if payload is None:
+                raise TypeError("_test_cm('enter_value', n) requires an int payload")
+            # bool is a subclass of int in Python — reject it to keep
+            # parity with Monty, where `Value::Bool` and `Value::Int` are
+            # distinct variants and only Int is accepted.
+            if not isinstance(payload, int) or isinstance(payload, bool):
+                raise TypeError(f"_test_cm('enter_value', n) requires int payload, not {type(payload).__name__}")
+        elif behavior in ('raise_on_enter', 'raise_on_exit'):
+            if payload is None:
+                raise TypeError(f"_test_cm('{behavior}', msg) requires a str payload")
+            if not isinstance(payload, str):
+                raise TypeError(f"_test_cm('{behavior}', msg) requires str payload, not {type(payload).__name__}")
+        else:
+            raise TypeError(f"_test_cm() unknown behavior '{behavior}'")
+
+        self._behavior = behavior
+        self._payload = payload
+
+    def __enter__(self) -> object:
+        if self._behavior == 'raise_on_enter':
+            assert isinstance(self._payload, str)
+            raise ValueError(self._payload)
+        if self._behavior == 'enter_value':
+            return self._payload
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool | None:
+        if self._behavior == 'raise_on_exit':
+            assert isinstance(self._payload, str)
+            raise ValueError(self._payload)
+        # The suppress flag only matters when an exception is propagating;
+        # CPython ignores the return value on the normal-exit path. The
+        # Monty implementation always returns Bool(False)/None on the
+        # normal path for the same reason.
+        if self._behavior == 'suppress' and exc_type is not None:
+            return True
+        return None
+
+
+def test_cm(*args: object) -> _TestCm:
+    """Mirrors the Monty `_test_cm()` builtin's positional-only signature.
+
+    Exposed in `exported_globals` under the underscore-prefixed name
+    `_test_cm` to match the Monty builtin.
+    """
+    if len(args) <= 2:
+        return _TestCm(*args)
+    raise TypeError(f'_test_cm() takes at most 2 positional arguments ({len(args)} given)')
+
+
+# =============================================================================
+# Names exported into every CPython test's globals.
+# =============================================================================
+#
+# Both the iter-mode helpers and the synthetic context manager live here.
+# The iter-mode helpers don't strictly need to be visible in non-iter-mode
+# tests, but the names are unlikely to collide and the simpler "inject one
+# dict for every test" model removes a branch in the test runner. Tests
+# that don't use these names see no behavioral difference.
+exported_globals: dict[str, object] = {
+    # Iter-mode external function implementations.
     'add_ints': add_ints,
     'concat_strings': concat_strings,
     'return_value': return_value,
@@ -572,4 +688,15 @@ ITER_MODE_GLOBALS: dict[str, object] = {
     'make_empty': make_empty,
     'async_call': async_call,
     'async_fail': async_fail,
+    # Non-function constants resolved by the Rust runner's NameLookup
+    # handler. Tests reference these by bare name, so they must be
+    # injected into the CPython test's globals to keep parity.
+    'CONST_INT': CONST_INT,
+    'CONST_STR': CONST_STR,
+    'CONST_FLOAT': CONST_FLOAT,
+    'CONST_BOOL': CONST_BOOL,
+    'CONST_LIST': CONST_LIST,
+    'CONST_NONE': CONST_NONE,
+    # Synthetic context manager — see the "REMOVE THIS" note at the top.
+    '_test_cm': test_cm,
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds `with` statement support and wires `open()` files as context managers with correct cleanup on normal and exceptional exits. Also adds `pathlib.Path.open()` that forwards to the same `open()` machinery and supports `with` the same way.

- **New Features**
  - Parse → prepare → compile `with EXPR [as TARGET]: BODY`; multi-item `with a() as x, b() as y:` desugars to nested blocks; `async with` is rejected.
  - New VM opcodes: `BeforeWith`, `WithExit`, `WithExceptStart` calling `PyTrait::py_enter`/`py_exit` directly.
  - Centralized dunder dispatch in `VM::call_attr` for `__enter__`/`__exit__` (no per-type boilerplate); clear `TypeError` for non-managers like `with 5:`.
  - `open()` implements the protocol: `__enter__` returns the file; `__exit__` closes it (never suppresses); entering a closed file raises `ValueError`.
  - `pathlib.Path.open()` forwards to `open()` (shared mode/kwarg validation, same OS call, same context-manager behavior).
  - Test-only `_test_cm()` behind `test-hooks` and a CPython shim in `scripts/test_fixtures.py` cover swallow/enter-raises/exit-raises paths; docs added (`limitations/with.md`, updated `open.md`).

- **Bug Fixes**
  - `for`-loop `break` through `finally`/`with`: defer iterator pop to the finally trailer so the context manager isn’t popped.
  - Early exits inside `with` call `__exit__` before propagating; returning preserves the value, and an exception in `__exit__` replaces the original (CPython behavior).

<sup>Written for commit 2dadcc19f6e2b793e7116a9e2f1b489835bb8328. Summary will update on new commits. <a href="https://cubic.dev/pr/pydantic/monty/pull/462?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

