### PR TITLE
clean up unsupported results in `evaluate_function`

### DIFF
--- a/crates/monty/src/builtins/getattr.rs
+++ b/crates/monty/src/builtins/getattr.rs
@@ -6,6 +6,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{RunError, RunResult, SimpleException},
+    heap::DropWithHeap,
     resource::ResourceTracker,
     types::PyTrait,
     value::Value,
@@ -47,7 +48,8 @@ pub fn builtin_getattr(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -
 
     match object.py_getattr(&attr, vm) {
         Ok(CallResult::Value(value)) => Ok(value),
-        Ok(_) => {
+        Ok(other) => {
+            other.drop_with_heap(vm);
             // getattr() only retrieves attribute values — OS calls, external calls,
             // method calls, and awaits are not supported here
             //

--- a/crates/monty/src/builtins/hasattr.rs
+++ b/crates/monty/src/builtins/hasattr.rs
@@ -6,6 +6,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{RunError, RunResult, SimpleException},
+    heap::DropWithHeap,
     resource::ResourceTracker,
     types::PyTrait,
     value::Value,
@@ -50,7 +51,8 @@ pub fn builtin_hasattr(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -
             value.drop_with_heap(vm);
             true
         }
-        Ok(_) => {
+        Ok(other) => {
+            other.drop_with_heap(vm);
             // hasattr() only tests attribute values — OS calls, external calls,
             // method calls, and awaits are not supported here
             //

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -14,7 +14,7 @@ use crate::{
     bytecode::FrameExit,
     defer_drop,
     exception_private::{ExcType, RunError},
-    heap::{DropWithHeap, HeapData, HeapGuard, HeapId},
+    heap::{ContainsHeap, DropWithHeap, HeapData, HeapGuard, HeapId},
     heap_data::CellValue,
     intern::{FunctionId, StringId},
     os::OsFunction,
@@ -56,6 +56,18 @@ pub(crate) enum CallResult {
     /// Used by `asyncio.run()` to execute a coroutine without an explicit `await`.
     /// The VM will push the value onto the stack and execute `exec_get_awaitable`.
     AwaitValue(Value),
+}
+
+impl DropWithHeap for CallResult {
+    fn drop_with_heap<H: ContainsHeap>(self, heap: &mut H) {
+        match self {
+            Self::Value(value) | Self::AwaitValue(value) => value.drop_with_heap(heap),
+            Self::External(_, args) | Self::OsCall(_, args) | Self::MethodCall(_, args) => {
+                args.drop_with_heap(heap);
+            }
+            Self::FramePushed => {}
+        }
+    }
 }
 
 impl<T: ResourceTracker> VM<'_, T> {
@@ -319,11 +331,8 @@ impl<T: ResourceTracker> VM<'_, T> {
                 self.current_frame_mut().should_return = true;
                 match self.run()? {
                     FrameExit::Return(v) => return Ok(v),
-                    FrameExit::ResolveFutures(_)
-                    | FrameExit::ExternalCall { .. }
-                    | FrameExit::OsCall { .. }
-                    | FrameExit::MethodCall { .. }
-                    | FrameExit::NameLookup { .. } => {
+                    exit => {
+                        exit.drop_with_heap(self);
                         // Pop frames off the stack from this failed evaluation
                         // (including the one just pushed)
                         while self.frames.len() >= stack_depth {
@@ -332,10 +341,7 @@ impl<T: ResourceTracker> VM<'_, T> {
                     }
                 }
             }
-            CallResult::External(_, _)
-            | CallResult::OsCall(_, _)
-            | CallResult::MethodCall(_, _)
-            | CallResult::AwaitValue(_) => {}
+            other => other.drop_with_heap(self),
         }
 
         Err(ExcType::not_implemented(format!(

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -285,6 +285,18 @@ pub enum FrameExit {
     },
 }
 
+impl DropWithHeap for FrameExit {
+    fn drop_with_heap<H: ContainsHeap>(self, heap: &mut H) {
+        match self {
+            Self::Return(value) => value.drop_with_heap(heap),
+            Self::ExternalCall { args, .. } | Self::OsCall { args, .. } | Self::MethodCall { args, .. } => {
+                args.drop_with_heap(heap);
+            }
+            Self::ResolveFutures(_) | Self::NameLookup { .. } => {}
+        }
+    }
+}
+
 /// A single function activation record.
 ///
 /// Each frame represents one level in the call stack and owns its own

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -394,11 +394,9 @@ impl Executor {
                     let err = ExcType::name_error(name);
                     frame_exit_result = vm.resume_with_exception(err.into());
                 }
-                _ => break,
+                other => return frame_exit_to_object(other, vm),
             }
         }
-
-        frame_exit_to_object(frame_exit_result, vm)
     }
 
     /// Executes the code and returns both the result and reference count data, used for testing only.


### PR DESCRIPTION
closes #359 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents heap refcount leaks when `evaluate_function`, `getattr`, or `hasattr` encounter unsupported results by explicitly releasing their heap-backed payloads. Also forwards non-return VM exits to the host instead of silently holding on to them.

- **Bug Fixes**
  - Implemented `DropWithHeap` for `CallResult` and `FrameExit` to release `Value`/`ArgValues` payloads.
  - Updated `getattr`/`hasattr` to call `.drop_with_heap(vm)` for non-value results before returning errors/booleans.
  - In the VM call path, drops payloads for unsupported `CallResult`/`FrameExit`, unwinds frames, then returns a clear error.
  - In `Executor::evaluate_function`, immediately returns any non-name-lookup `FrameExit` via `frame_exit_to_object` to hand unsupported exits back to the host.

<sup>Written for commit cf56a00af00e4453d74578f0db91dffc4b35e24f. Summary will update on new commits. <a href="https://cubic.dev/pr/pydantic/monty/pull/463?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

