### PR TITLE
collect cell vars from `for` / `while` / `if` control flow expressions

### DIFF
--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -2432,7 +2432,10 @@ fn collect_cell_vars_from_node(
             }
         }
         // Recurse into control flow structures
-        Node::For { body, or_else, .. } => {
+        Node::For {
+            iter, body, or_else, ..
+        } => {
+            collect_cell_vars_from_expr(iter, our_locals, cell_vars, interner);
             for n in body {
                 collect_cell_vars_from_node(n, our_locals, cell_vars, interner);
             }
@@ -2440,7 +2443,8 @@ fn collect_cell_vars_from_node(
                 collect_cell_vars_from_node(n, our_locals, cell_vars, interner);
             }
         }
-        Node::While { body, or_else, .. } => {
+        Node::While { test, body, or_else } => {
+            collect_cell_vars_from_expr(test, our_locals, cell_vars, interner);
             for n in body {
                 collect_cell_vars_from_node(n, our_locals, cell_vars, interner);
             }
@@ -2448,7 +2452,8 @@ fn collect_cell_vars_from_node(
                 collect_cell_vars_from_node(n, our_locals, cell_vars, interner);
             }
         }
-        Node::If { body, or_else, .. } => {
+        Node::If { test, body, or_else } => {
+            collect_cell_vars_from_expr(test, our_locals, cell_vars, interner);
             for n in body {
                 collect_cell_vars_from_node(n, our_locals, cell_vars, interner);
             }

--- a/crates/monty/test_cases/lambda__all.py
+++ b/crates/monty/test_cases/lambda__all.py
@@ -143,3 +143,69 @@ def test_inner_lambda_capture():
 
 
 assert test_inner_lambda_capture() == 7, 'inner lambda captures outer lambda param'
+
+
+# === Lambda captures in control-flow test expressions ===
+# Regression: the closure pre-scan must visit the test/iter expression of
+# while/if/for, otherwise a lambda buried there is discovered after `x` has
+# already been assigned a normal local slot. The late path then reuses that
+# local slot as a cell slot, breaking the contiguous cell layout the VM
+# assumes, and `LoadCell` indexes outside the frame's cell vector.
+
+
+def while_test_capture():
+    a = 0
+    x = 1
+    while False and (lambda: x)():
+        pass
+    return x
+
+
+assert while_test_capture() == 1, 'lambda capture in while-test'
+
+
+def if_test_capture():
+    a = 0
+    x = 2
+    if False and (lambda: x)():
+        pass
+    return x
+
+
+assert if_test_capture() == 2, 'lambda capture in if-test'
+
+
+def for_iter_capture():
+    a = 0
+    x = 3
+    for _ in [(lambda: x)()]:
+        pass
+    return x
+
+
+assert for_iter_capture() == 3, 'lambda capture in for-iter'
+
+
+# Same as above, but the lambda is actually invoked and must read the cell.
+def while_test_capture_runs():
+    a = 0
+    x = 7
+    count = 0
+    while (lambda: x == 7)() and count < 2:
+        count += 1
+    return (x, count)
+
+
+assert while_test_capture_runs() == (7, 2), 'lambda in while-test reads captured cell'
+
+
+def for_iter_capture_runs():
+    a = 0
+    x = 5
+    seen = []
+    for v in [(lambda: x)()]:
+        seen.append(v)
+    return (x, seen)
+
+
+assert for_iter_capture_runs() == (5, [5]), 'lambda in for-iter reads captured cell'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Collect cell vars from `for`/`while`/`if` test/iter expressions so lambdas there are captured during pre-scan. This prevents misallocated locals that break the VM’s cell layout and cause out-of-bounds `LoadCell`.

- **Bug Fixes**
  - Pre-scan now visits `for.iter`, `while.test`, and `if.test` when computing cell vars.
  - Added regression tests for lambda captures in these positions, including invoked cases.

<sup>Written for commit 47d97345cf9988d31b744b392ee69219ab7c2825. Summary will update on new commits. <a href="https://cubic.dev/pr/pydantic/monty/pull/465?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

