### PR TITLE
fix(file): do not serialize OpenFile buffer_meta cache across snapshots

### DIFF
--- a/crates/monty-python/tests/test_serialize.py
+++ b/crates/monty-python/tests/test_serialize.py
@@ -468,3 +468,63 @@ except ValueError as e:
     result = progress2.resume({'return_value': None})
     assert isinstance(result, pydantic_monty.MontyComplete)
     assert result.output == snapshot(('hello', 'I/O operation on closed file.'))
+
+
+def test_snapshot_rebuilds_buffer_meta_after_load_for_each_op():
+    """Security regression — `OpenFile.buffer_meta` (cached byte offset
+    into a UTF-8 buffer + cached char count) must not be serialised
+    across the snapshot trust boundary.
+
+    Pre-fix it was, so a crafted snapshot with `byte_position` past
+    `buffer.len()` or in the middle of a UTF-8 code point made
+    `compute_slice_text` panic on `&buffer[byte_position..]` (only a
+    `debug_assert!` guarded it). An embedder accepting client-supplied
+    snapshots could be DoS-ed.
+
+    The fix tags `buffer_meta` `#[serde(skip)]`; on every reload the
+    cache is rebuilt from the trusted heap buffer + `position` on the
+    first read. This test stresses the rebuild path by snapshotting
+    repeatedly between sized reads, seeks, and `tell()`s on a UTF-8
+    multi-byte file. Each post-load read forces a fresh
+    `populate_buffer_meta` walk, and any misalignment between the
+    rebuilt `byte_position` and the user-visible `position` would
+    desync `tell()` or produce mojibake from the next `read()`.
+    """
+    fs = OSAccess([MemoryFile('/greek.txt', content='αβγδε')])
+    code = """
+f = open('/greek.txt')
+a = f.read(1)
+checkpoint(('a', a, f.tell()))
+b = f.read(2)
+checkpoint(('b', b, f.tell()))
+f.seek(1)
+c = f.read(3)
+checkpoint(('c', c, f.tell()))
+f.seek(0)
+d = f.read()
+(a, b, c, d)
+"""
+    # Dump and reload at each checkpoint, so every subsequent
+    # `read` / `seek` / `tell` runs against a freshly rebuilt
+    # `buffer_meta` rather than a cached one carried in-memory.
+    progress1 = pydantic_monty.Monty(code).start(os=fs)
+    assert isinstance(progress1, pydantic_monty.FunctionSnapshot)
+    assert progress1.args == snapshot((('a', 'α', 1),))
+
+    progress2 = pydantic_monty.load_snapshot(progress1.dump())
+    assert isinstance(progress2, pydantic_monty.FunctionSnapshot)
+    progress3 = progress2.resume({'return_value': None})
+    assert isinstance(progress3, pydantic_monty.FunctionSnapshot)
+    assert progress3.args == snapshot((('b', 'βγ', 3),))
+
+    progress4 = pydantic_monty.load_snapshot(progress3.dump())
+    assert isinstance(progress4, pydantic_monty.FunctionSnapshot)
+    progress5 = progress4.resume({'return_value': None})
+    assert isinstance(progress5, pydantic_monty.FunctionSnapshot)
+    assert progress5.args == snapshot((('c', 'βγδ', 4),))
+
+    progress6 = pydantic_monty.load_snapshot(progress5.dump())
+    assert isinstance(progress6, pydantic_monty.FunctionSnapshot)
+    result = progress6.resume({'return_value': None})
+    assert isinstance(result, pydantic_monty.MontyComplete)
+    assert result.output == snapshot(('α', 'βγ', 'βγδ', 'αβγδε'))

--- a/crates/monty-python/tests/test_serialize.py
+++ b/crates/monty-python/tests/test_serialize.py
@@ -510,6 +510,20 @@ d = f.read()
     progress1 = pydantic_monty.Monty(code).start(os=fs)
     assert isinstance(progress1, pydantic_monty.FunctionSnapshot)
     assert progress1.args == snapshot((('a', 'α', 1),))
+    # Direct assertion on the serialised payload: pin its length so
+    # that re-introducing `Serialize` (or removing `#[serde(skip)]`)
+    # on `OpenFile::buffer_meta` shifts the size and fails the test.
+    # A healthy roundtrip alone is not enough — `populate_buffer_meta`
+    # would rebuild the same values on load, so a re-serialised cache
+    # would still pass the equality checks below.
+    #
+    # At this checkpoint `buffer_meta` would have been
+    # `Some(BufferMeta { byte_position: 2, buffer_total: 5 })`
+    # (one 2-byte Greek letter consumed, five chars in buffer). Postcard
+    # would encode that as `1u8` (Some tag) + varint(2) + varint(5)
+    # = 3 extra bytes on top of the current payload.
+    pinned_dump_len = len(progress1.dump())
+    assert pinned_dump_len == snapshot(1056)
 
     progress2 = pydantic_monty.load_snapshot(progress1.dump())
     assert isinstance(progress2, pydantic_monty.FunctionSnapshot)

--- a/crates/monty/src/types/file.rs
+++ b/crates/monty/src/types/file.rs
@@ -382,6 +382,17 @@ pub(crate) struct OpenFile {
     /// buffer from char 0 on every call (so a 10k-`readline()` loop on a
     /// 1MB UTF-8 file is O(n²)). See [`BufferMeta`] for field semantics.
     /// `None` while `buffer` is `None`; otherwise always `Some`.
+    ///
+    /// **Not serialized.** This is a pure cache derived from `buffer` +
+    /// `position`, and trusting it across a snapshot boundary would let a
+    /// crafted snapshot (with `byte_position` past `buffer.len()` or in the
+    /// middle of a UTF-8 code point, or a `buffer_total` larger than the
+    /// real buffer) drive `compute_slice_text` / `compute_slice_binary`
+    /// into a panicking `&buffer[..]` slice. By skipping serde, the field
+    /// is always `None` after deserialization; the next `compute_slice`
+    /// call sees `Some(buffer) + None(buffer_meta)` and rebuilds it via
+    /// [`populate_buffer_meta`] from the trusted heap buffer.
+    #[serde(skip)]
     buffer_meta: Option<BufferMeta>,
     /// Set between emitting the OS-call-with-store hook and the resume firing.
     /// Tells the resume path which slice to compute once the buffer is
@@ -408,7 +419,11 @@ pub(crate) struct OpenFile {
 /// `buffer_total == buffer.len()` — the cache is mostly redundant there, but
 /// kept identical to the text-mode layout so the surrounding code does not
 /// need to branch on mode.
-#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+/// **Not (de)serialized** — see the security note on
+/// [`OpenFile::buffer_meta`]. Without `serde` derives, the cache cannot be
+/// driven by attacker-controlled snapshot bytes; it is rebuilt by
+/// [`populate_buffer_meta`] from the trusted heap buffer after a restore.
+#[derive(Debug, Clone, Copy)]
 struct BufferMeta {
     /// Byte offset into the buffer that matches `position`, clamped to
     /// `buffer.len()`. For text mode this caches the

--- a/uv.lock
+++ b/uv.lock
@@ -6,10 +6,6 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
-
 [manifest]
 members = [
     "monty-workspace",


### PR DESCRIPTION
The cached `OpenFile::buffer_meta` (byte offset into a UTF-8 buffer + cached char count) used to be carried in the snapshot payload, so a crafted snapshot with `byte_position` past `buffer.len()` or inside a UTF-8 code point made `compute_slice_text` panic on `&buffer[byte_position..]` (only a `debug_assert!` guarded it). An embedder accepting client-supplied snapshots could be DoS-ed.

The cache is fully derivable from `buffer` + `position`, so marking the field `#[serde(skip)]` is sufficient: the existing recovery branch in `compute_slice` rebuilds it via `populate_buffer_meta` from the trusted heap buffer on the next read after restore.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop serializing the `OpenFile` read cache across snapshots to prevent panics and a potential DoS. The cache is rebuilt from the trusted buffer after restore.

- **Bug Fixes**
  - Marked `OpenFile::buffer_meta` with `#[serde(skip)]` and removed `Serialize`/`Deserialize` from `BufferMeta` to block crafted offsets that crash `compute_slice_*`.
  - Added a regression test that reloads between UTF-8 reads/seeks/tells and pins the snapshot dump length to catch any re-serialization of `buffer_meta`.
  - Removed stale options from `uv.lock`.

<sup>Written for commit df194537248373ce63d5ff6c9ad9e9b90984f187. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/471?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

