### PR TITLE
fix overlay append quota

### DIFF
--- a/crates/monty/src/fs/common.rs
+++ b/crates/monty/src/fs/common.rs
@@ -181,7 +181,7 @@ pub(super) fn iterdir_fs(host_path: &Path, vpath: &str, mount_host_path: &Path) 
 pub(super) fn check_write_limit(bytes: usize, ctx: &MountContext<'_>) -> Result<(), MountError> {
     if let Some(limit) = ctx.write_bytes_limit {
         let bytes = u64::try_from(bytes).unwrap_or(u64::MAX);
-        if *ctx.write_bytes_used + bytes > limit {
+        if (*ctx.write_bytes_used).saturating_add(bytes) > limit {
             return Err(MountError::WriteLimitExceeded(limit));
         }
     }
@@ -191,7 +191,7 @@ pub(super) fn check_write_limit(bytes: usize, ctx: &MountContext<'_>) -> Result<
 /// Records a successful write against the mount's cumulative quota counter.
 pub(super) fn commit_write_bytes(bytes: usize, ctx: &mut MountContext<'_>) {
     if ctx.write_bytes_limit.is_some() {
-        *ctx.write_bytes_used += u64::try_from(bytes).unwrap_or(u64::MAX);
+        *ctx.write_bytes_used = (*ctx.write_bytes_used).saturating_add(u64::try_from(bytes).unwrap_or(u64::MAX));
     }
 }
 

--- a/crates/monty/src/fs/overlay.rs
+++ b/crates/monty/src/fs/overlay.rs
@@ -357,10 +357,16 @@ fn append_bytes(
     data: &[u8],
     ctx: &mut MountContext<'_>,
 ) -> Result<MontyObject, MountError> {
-    check_write_limit(data.len(), ctx)?;
     let relative = relative_path(vpath, ctx)?;
     ensure_parent_exists(state, &relative, ctx, vpath)?;
     reject_directory_target(state, &relative, ctx, vpath)?;
+    let target_is_overlay_file = matches!(state.get(&relative), Some(OverlayEntry::File(_)));
+    let charged_bytes = if ctx.write_bytes_limit.is_some() && !target_is_overlay_file {
+        existing_file_len(state, &relative, ctx, vpath)?.saturating_add(data.len())
+    } else {
+        data.len()
+    };
+    check_write_limit(charged_bytes, ctx)?;
 
     if let Some(OverlayEntry::File(file)) = state.get_mut(&relative) {
         file.content.extend_from_slice(data);
@@ -377,8 +383,45 @@ fn append_bytes(
         );
     }
 
-    commit_write_bytes(data.len(), ctx);
+    commit_write_bytes(charged_bytes, ctx);
     Ok(MontyObject::Int(i64::try_from(data.len()).unwrap_or(i64::MAX)))
+}
+
+/// Returns the visible file length for append accounting without loading bytes.
+///
+/// Overlay append may need to copy a real backing file into memory before
+/// extending it. Counting that existing file size before materialization keeps
+/// `write_bytes_limit` aligned with the amount of overlay memory the operation
+/// can create.
+fn existing_file_len(
+    state: &OverlayState,
+    relative: &str,
+    ctx: &MountContext<'_>,
+    vpath: &str,
+) -> Result<usize, MountError> {
+    match state.get(relative) {
+        Some(OverlayEntry::File(file)) => Ok(file.content.len()),
+        Some(OverlayEntry::Deleted) => Ok(0),
+        Some(OverlayEntry::RealFileRef(file_ref)) => file_len(&file_ref.host_path, vpath),
+        Some(OverlayEntry::Directory { .. }) => {
+            Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
+        }
+        None => match resolve_real_path_state(vpath, ctx, ResolveMode::Existing)? {
+            RealPathState::Present(host_path) => file_len(&host_path, vpath),
+            RealPathState::Missing => Ok(0),
+        },
+    }
+}
+
+/// Returns a host file's byte length for quota checks.
+///
+/// File sizes larger than addressable memory saturate so quota comparison fails
+/// closed instead of wrapping before the overlay tries to allocate.
+fn file_len(path: &Path, vpath: &str) -> Result<usize, MountError> {
+    let len = fs::metadata(path)
+        .map_err(|error| MountError::Io(error, vpath.to_owned()))?
+        .len();
+    Ok(usize::try_from(len).unwrap_or(usize::MAX))
 }
 
 /// Loads the current visible file content for append operations.

--- a/crates/monty/tests/fs.rs
+++ b/crates/monty/tests/fs.rs
@@ -1826,6 +1826,39 @@ fn ovl_cumulative_writes_exceed_limit() {
 }
 
 #[test]
+fn ovl_append_existing_real_file_counts_existing_bytes_toward_limit() {
+    let dir = create_test_dir();
+    fs::write(dir.path().join("large.bin"), vec![0u8; 10]).unwrap();
+    let mut mt = mount_at_mnt_with_limit(&dir, MountMode::OverlayMemory(OverlayState::new()), 5);
+
+    let exc = call_write(
+        &mut mt,
+        OsFunction::AppendBytes,
+        "/mnt/large.bin",
+        MontyObject::Bytes(vec![1u8]),
+    )
+    .unwrap()
+    .expect_err("expected write limit error")
+    .into_exception();
+
+    assert_exc(&exc, ExcType::OSError, "disk write limit of 5 bytes exceeded");
+    assert_eq!(
+        call_ok(&mut mt, OsFunction::ReadBytes, "/mnt/large.bin"),
+        MontyObject::Bytes(vec![0u8; 10]),
+        "failed append should leave the real backing file visible and unchanged"
+    );
+
+    call_write(
+        &mut mt,
+        OsFunction::WriteBytes,
+        "/mnt/quota_ok.bin",
+        MontyObject::Bytes(vec![1u8; 5]),
+    )
+    .unwrap()
+    .unwrap();
+}
+
+#[test]
 fn write_limit_pretty_format_kb() {
     let dir = create_test_dir();
     let mut mt = mount_at_mnt_with_limit(&dir, MountMode::ReadWrite, 5_000);

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -26,6 +26,13 @@ Each mount is configured by the host as one of:
   directory, writes are captured in memory and never touch the host. The
   changes vanish when the VM is discarded.
 
+## Write limits
+
+Hosts can configure a cumulative `write_bytes_limit` per mount. In
+`OverlayMemory`, appending to an existing real file can materialize that
+file into the in-memory overlay, so the existing file bytes count against
+the limit along with the newly appended bytes.
+
 ## Sandbox guarantees
 
 The host enforces these invariants on every path operation:

--- a/uv.lock
+++ b/uv.lock
@@ -6,6 +6,10 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [manifest]
 members = [
     "monty-workspace",

--- a/uv.lock
+++ b/uv.lock
@@ -6,10 +6,6 @@ resolution-markers = [
     "python_full_version < '3.15'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
-
 [manifest]
 members = [
     "monty-workspace",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes write quota enforcement for overlay append operations. Appending to a real backing file now charges the existing file size plus the appended bytes, with saturating counters to prevent overflow.

- **Bug Fixes**
  - Charge existing backing file bytes on first append in `OverlayMemory` to honor `write_bytes_limit`; failed appends leave the real file unchanged.
  - Use saturating addition in quota checks and commits; add tests and docs for write limit behavior.

<sup>Written for commit 81436a8fb3b09bf47f75f9d79ec8ec44d4262318. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/472?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

