### PR TITLE
fix: accept subscript and attribute targets in unpacking, for-loop, and comprehension contexts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /TODO.md
 /monty
 /.claude/settings.local.json
+/CLAUDE.local.md
 /scratch/
 /worktrees/
 /flame/

--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -118,12 +118,15 @@ fn check_comp_generators(count: usize, position: CodeRange) -> Result<(), Compil
 /// Returns a position that locates `target` in source for error reporting.
 ///
 /// `Name` / `Starred` carry the identifier's position; `Tuple` carries its
-/// own. Used by comp-target unpacking when the per-leaf position isn't
-/// available at the error point.
+/// own; `Subscript`/`Attribute` carry `target_position`. Used by comp-target
+/// unpacking when the per-leaf position isn't available at the error point.
 fn target_position(target: &UnpackTarget) -> CodeRange {
     match target {
         UnpackTarget::Name(ident) | UnpackTarget::Starred(ident) => ident.position,
         UnpackTarget::Tuple { position, .. } => *position,
+        UnpackTarget::Subscript { target_position, .. } | UnpackTarget::Attribute { target_position, .. } => {
+            *target_position
+        }
     }
 }
 
@@ -2880,6 +2883,22 @@ impl<'a> Compiler<'a> {
             UnpackTarget::Name(ident) | UnpackTarget::Starred(ident) => {
                 sim.push(SimItem::Leaf(ident.namespace_id().as_u16()));
             }
+            UnpackTarget::Subscript {
+                target,
+                index,
+                target_position,
+            } => {
+                // Consumes value off TOS; net −1 matches `Name`/`Starred`, so the
+                // sim ↔ operand-stack 1:1 invariant survives without pushing back.
+                self.emit_subscript_store(target, index, *target_position)?;
+            }
+            UnpackTarget::Attribute {
+                object,
+                attr,
+                target_position,
+            } => {
+                self.emit_attr_store(object, attr, *target_position)?;
+            }
             UnpackTarget::Tuple { targets, position } => {
                 // Pick UNPACK_EX vs UNPACK_SEQUENCE based on whether a starred
                 // sub-target is present (same logic as the regular assignment
@@ -2928,11 +2947,12 @@ impl<'a> Compiler<'a> {
         Ok(())
     }
 
-    /// Compiles storage of an unpack target - either a single identifier, nested tuple, or starred.
+    /// Compiles storage of an unpack target, assuming the value is on TOS.
     ///
-    /// For single identifiers: emits a simple store.
-    /// For nested tuples: emits `UnpackSequence` (or `UnpackEx` with starred) and recursively
-    /// handles each sub-target.
+    /// Each variant's net stack effect is −1, so the per-target loops in
+    /// `Tuple` and `emit_unpack_store` work uniformly. Subscript/attribute
+    /// delegate to `emit_subscript_store`/`emit_attr_store` (sub-expressions
+    /// evaluated at store time, matching CPython).
     fn compile_unpack_target(&mut self, target: &UnpackTarget) -> Result<(), CompileError> {
         match target {
             UnpackTarget::Name(ident) => {
@@ -2943,6 +2963,20 @@ impl<'a> Compiler<'a> {
                 // Starred target by itself (shouldn't happen at top level normally)
                 // Just store as if it were a name
                 self.compile_store(ident)?;
+            }
+            UnpackTarget::Subscript {
+                target,
+                index,
+                target_position,
+            } => {
+                self.emit_subscript_store(target, index, *target_position)?;
+            }
+            UnpackTarget::Attribute {
+                object,
+                attr,
+                target_position,
+            } => {
+                self.emit_attr_store(object, attr, *target_position)?;
             }
             UnpackTarget::Tuple { targets, position } => {
                 // Check if there's a starred target

--- a/crates/monty/src/expressions.rs
+++ b/crates/monty/src/expressions.rs
@@ -357,26 +357,35 @@ pub enum Expr {
     },
 }
 
-/// Target for tuple unpacking - can be a single name, nested tuple, or starred target.
+/// Target for tuple unpacking. Used in assignment LHS, `for`-loop, and
+/// comprehension `for` clauses.
 ///
-/// Supports recursive structures like `(a, b), c` or `a, (b, c)`.
-/// Also supports starred targets like `first, *rest = [1, 2, 3, 4]`.
-/// Used in assignment statements, for loop targets, and comprehension targets.
+/// `Name`/`Starred` introduce bindings; `Subscript`/`Attribute` mutate existing
+/// state and bind nothing (scope analysis must skip them as binding sites but
+/// still walk their sub-expressions for walrus targets). The matching leaves
+/// on `AssignTarget` carry identical shapes.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum UnpackTarget {
-    /// Single identifier: `a`
     Name(Identifier),
-    /// Nested tuple: `(a, b)` - can contain further nested tuples
+    /// Nested tuple — can recurse via `targets`.
     Tuple {
-        /// The targets to unpack into (can be names or nested tuples)
         targets: Vec<Self>,
-        /// Source position covering all targets (for error caret placement)
         position: CodeRange,
     },
-    /// Starred target: `*rest` - captures remaining values into a list.
-    ///
-    /// Only one starred target is allowed per unpacking level.
+    /// `*rest`. At most one per unpacking level.
     Starred(Identifier),
+    /// `container[index]`. Sub-expressions evaluated at store time.
+    Subscript {
+        target: ExprLoc,
+        index: ExprLoc,
+        target_position: CodeRange,
+    },
+    /// `obj.attr`. Sub-expression evaluated at store time.
+    Attribute {
+        object: ExprLoc,
+        attr: EitherStr,
+        target_position: CodeRange,
+    },
 }
 
 /// Target of a single assignment step within a chained assignment.

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -1454,6 +1454,18 @@ impl<'a> Parser<'a> {
                 }
                 Ok(UnpackTarget::Tuple { targets, position })
             }
+            AstExpr::Subscript(ast::ExprSubscript {
+                value, slice, range, ..
+            }) => Ok(UnpackTarget::Subscript {
+                target: self.parse_expression(*value)?,
+                index: self.parse_expression(*slice)?,
+                target_position: self.convert_range(range),
+            }),
+            AstExpr::Attribute(ast::ExprAttribute { value, attr, range, .. }) => Ok(UnpackTarget::Attribute {
+                object: self.parse_expression(*value)?,
+                attr: EitherStr::Interned(self.interner.intern(attr.id())),
+                target_position: self.convert_range(range),
+            }),
             other => Err(ParseError::syntax(
                 format!("invalid unpacking target: {}", describe_expr_kind(&other)),
                 self.convert_range(other.range()),

--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -1210,6 +1210,24 @@ impl<'i> Prepare<'i> {
                     position,
                 })
             }
+            UnpackTarget::Subscript {
+                target: container,
+                index,
+                target_position,
+            } => Ok(UnpackTarget::Subscript {
+                target: self.prepare_expression(container)?,
+                index: self.prepare_expression(index)?,
+                target_position,
+            }),
+            UnpackTarget::Attribute {
+                object,
+                attr,
+                target_position,
+            } => Ok(UnpackTarget::Attribute {
+                object: self.prepare_expression(object)?,
+                attr,
+                target_position,
+            }),
         }
     }
 
@@ -1260,6 +1278,26 @@ impl<'i> Prepare<'i> {
                     position,
                 })
             }
+            // Subscript/attribute leaves mutate, they don't bind, so no comp-var
+            // slot. Their sub-expressions resolve against the surrounding scope.
+            UnpackTarget::Subscript {
+                target: container,
+                index,
+                target_position,
+            } => Ok(UnpackTarget::Subscript {
+                target: self.prepare_expression(container)?,
+                index: self.prepare_expression(index)?,
+                target_position,
+            }),
+            UnpackTarget::Attribute {
+                object,
+                attr,
+                target_position,
+            } => Ok(UnpackTarget::Attribute {
+                object: self.prepare_expression(object)?,
+                attr,
+                target_position,
+            }),
         }
     }
 
@@ -2480,8 +2518,14 @@ fn collect_cell_vars_from_node(
         }
         // Recurse into control flow structures
         Node::For {
-            iter, body, or_else, ..
+            target,
+            iter,
+            body,
+            or_else,
+            ..
         } => {
+            // Subscript/attribute targets carry sub-expressions that may capture.
+            collect_cell_vars_from_unpack_target(target, our_locals, cell_vars, interner);
             collect_cell_vars_from_expr(iter, our_locals, cell_vars, interner);
             for n in body {
                 collect_cell_vars_from_node(n, our_locals, cell_vars, interner);
@@ -2529,8 +2573,14 @@ fn collect_cell_vars_from_node(
                 collect_cell_vars_from_node(n, our_locals, cell_vars, interner);
             }
         }
-        Node::With { context, body, .. } => {
+        Node::With {
+            context, target, body, ..
+        } => {
             collect_cell_vars_from_expr(context, our_locals, cell_vars, interner);
+            // `with f() as x[i]:` — same target-walk rationale as `For` above.
+            if let Some(target) = target {
+                collect_cell_vars_from_unpack_target(target, our_locals, cell_vars, interner);
+            }
             for n in body {
                 collect_cell_vars_from_node(n, our_locals, cell_vars, interner);
             }
@@ -2854,8 +2904,14 @@ fn collect_referenced_names_from_node(node: &ParseNode, referenced: &mut AHashSe
             collect_referenced_names_from_expr(object, referenced, interner);
         }
         Node::For {
-            iter, body, or_else, ..
+            target,
+            iter,
+            body,
+            or_else,
+            ..
         } => {
+            // Subscript/attribute targets read from surrounding state at store time.
+            collect_referenced_names_from_unpack_target(target, referenced, interner);
             collect_referenced_names_from_expr(iter, referenced, interner);
             for n in body {
                 collect_referenced_names_from_node(n, referenced, interner);
@@ -2910,8 +2966,13 @@ fn collect_referenced_names_from_node(node: &ParseNode, referenced: &mut AHashSe
                 collect_referenced_names_from_node(n, referenced, interner);
             }
         }
-        Node::With { context, body, .. } => {
+        Node::With {
+            context, target, body, ..
+        } => {
             collect_referenced_names_from_expr(context, referenced, interner);
+            if let Some(target) = target {
+                collect_referenced_names_from_unpack_target(target, referenced, interner);
+            }
             for n in body {
                 collect_referenced_names_from_node(n, referenced, interner);
             }
@@ -3199,9 +3260,9 @@ fn collect_referenced_names_from_fstring_parts(
     }
 }
 
-/// Collects all names from an unpack target into the given set.
-///
-/// Recursively traverses nested tuples to find all identifier names.
+/// Collects names bound by an unpack target, plus walrus targets found inside
+/// subscript/attribute sub-expressions (those leaves bind nothing themselves).
+/// Mirrors `collect_assigned_names_from_assign_target`.
 fn collect_names_from_unpack_target(target: &UnpackTarget, names: &mut AHashSet<String>, interner: &InternerBuilder) {
     match target {
         UnpackTarget::Name(ident) | UnpackTarget::Starred(ident) => {
@@ -3211,6 +3272,64 @@ fn collect_names_from_unpack_target(target: &UnpackTarget, names: &mut AHashSet<
             for t in targets {
                 collect_names_from_unpack_target(t, names, interner);
             }
+        }
+        UnpackTarget::Subscript { target, index, .. } => {
+            collect_assigned_names_from_expr(target, names, interner);
+            collect_assigned_names_from_expr(index, names, interner);
+        }
+        UnpackTarget::Attribute { object, .. } => {
+            collect_assigned_names_from_expr(object, names, interner);
+        }
+    }
+}
+
+/// Cell-var walk for the sub-expressions inside `Subscript`/`Attribute` leaves.
+/// `Name`/`Starred` contribute nothing. Mirrors
+/// `collect_cell_vars_from_assign_target`.
+fn collect_cell_vars_from_unpack_target(
+    target: &UnpackTarget,
+    our_locals: &AHashSet<String>,
+    cell_vars: &mut AHashSet<String>,
+    interner: &InternerBuilder,
+) {
+    match target {
+        UnpackTarget::Name(_) | UnpackTarget::Starred(_) => {}
+        UnpackTarget::Tuple { targets, .. } => {
+            for t in targets {
+                collect_cell_vars_from_unpack_target(t, our_locals, cell_vars, interner);
+            }
+        }
+        UnpackTarget::Subscript { target, index, .. } => {
+            collect_cell_vars_from_expr(target, our_locals, cell_vars, interner);
+            collect_cell_vars_from_expr(index, our_locals, cell_vars, interner);
+        }
+        UnpackTarget::Attribute { object, .. } => {
+            collect_cell_vars_from_expr(object, our_locals, cell_vars, interner);
+        }
+    }
+}
+
+/// Read-side name walk for the sub-expressions inside `Subscript`/`Attribute`
+/// leaves. `Name`/`Starred` contribute nothing. Mirrors
+/// `collect_referenced_names_from_assign_target`.
+fn collect_referenced_names_from_unpack_target(
+    target: &UnpackTarget,
+    referenced: &mut AHashSet<String>,
+    interner: &InternerBuilder,
+) {
+    match target {
+        UnpackTarget::Name(_) | UnpackTarget::Starred(_) => {}
+        UnpackTarget::Tuple { targets, .. } => {
+            for t in targets {
+                collect_referenced_names_from_unpack_target(t, referenced, interner);
+            }
+        }
+        UnpackTarget::Subscript { target, index, .. } => {
+            collect_referenced_names_from_expr(target, referenced, interner);
+            collect_referenced_names_from_expr(index, referenced, interner);
+        }
+        UnpackTarget::Attribute { object, .. } => {
+            collect_referenced_names_from_expr(object, referenced, interner);
         }
     }
 }

--- a/crates/monty/test_cases/comprehension__all.py
+++ b/crates/monty/test_cases/comprehension__all.py
@@ -206,3 +206,25 @@ for s in ['hello']:
         [int(c) for c in s]
     except ValueError:
         pass
+
+# === Subscript target as comprehension `for` variable (issue #408) ===
+# CPython allows `for x[i] in iter:` inside comprehensions. The store leaks
+# out of the comprehension's transient scope into the surrounding container
+# (subscript targets mutate, they don't allocate a fresh comp-var).
+box = [None]
+result = [box[0] for box[0] in (1, 2, 3)]
+assert result == [1, 2, 3], 'comp subscript target visible inside body'
+assert box[0] == 3, 'comp subscript target final write persists'
+
+# Generator with subscript target — each emitted value passes through the
+# subscript store; the slot holds the last write after exhaustion.
+a = [0, 0]
+i = 0
+list(a[i] for a[i] in (5, 6, 7))
+assert a == [7, 0], 'generator subscript target stores final value'
+
+# Subscript target inside nested tuple in a comprehension
+a = [0]
+out = [(a[0], y) for a[0], y in [(1, 'x'), (2, 'y')]]
+assert out == [(1, 'x'), (2, 'y')], 'comp nested subscript target reads-through'
+assert a == [2], 'comp nested subscript target final write persists'

--- a/crates/monty/test_cases/iter__for_loop_unpacking.py
+++ b/crates/monty/test_cases/iter__for_loop_unpacking.py
@@ -64,3 +64,35 @@ for k, v in d.items():
     vals.append(v)
 assert sorted(keys) == ['x', 'y'], 'dict items unpacking keys'
 assert sorted(vals) == [1, 2], 'dict items unpacking values'
+
+# === Subscript target as for-loop variable (issue #408) ===
+# Subscript target stores into the existing container on each iteration; the
+# final iteration's value persists after the loop.
+box = [None]
+for box[0] in (1, 2, 3):
+    pass
+assert box[0] == 3, 'for-loop subscript target retains last value'
+
+# Subscript target with computed index — index is re-evaluated each iteration.
+# If `i` were cached at loop entry both stores would target a[0], yielding
+# [20, 0]; re-evaluation lets the body's mutation of `i` shift the second store
+# to a[1].
+a = [0, 0]
+i = 0
+for a[i] in (10, 20):
+    i = 1
+assert a == [10, 20], 'for-loop subscript target re-evaluates index each iteration'
+
+# Subscript target combined with body that reads from the same container
+trace = []
+a = [0]
+for a[0] in (1, 2, 3):
+    trace.append(a[0])
+assert trace == [1, 2, 3], 'for-loop subscript target visible inside body'
+
+# Subscript target inside a nested tuple target
+a = [0]
+for a[0], b in [(1, 'x'), (2, 'y')]:
+    pass
+assert a == [2], 'for-loop nested: subscript updated'
+assert b == 'y', 'for-loop nested: name bound'

--- a/crates/monty/test_cases/unpack__attr.py
+++ b/crates/monty/test_cases/unpack__attr.py
@@ -1,0 +1,67 @@
+# call-external
+# Attribute targets in unpacking, for-loop, and comprehension contexts (issue #408).
+#
+# CPython allows the assignment LHS / for-loop target / comprehension `for`
+# target to be an attribute access on an existing object — these mutate the
+# attribute, they do not bind a new name. Requires a mutable object from the
+# host; mutable dataclasses are the only sandbox-available shape with settable
+# attributes today, so all sections use `make_mutable_point()`.
+
+# === Two-target attribute unpack ===
+p = make_mutable_point()
+p.x, p.y = 11, 22
+assert p.x == 11, 'attr unpack: first'
+assert p.y == 22, 'attr unpack: second'
+
+# === Attribute swap (RHS evaluated before stores) ===
+p = make_mutable_point()
+p.x = 1
+p.y = 2
+p.x, p.y = p.y, p.x
+assert p.x == 2, 'attr swap: first'
+assert p.y == 1, 'attr swap: second'
+
+# === Attribute target with name siblings ===
+p = make_mutable_point()
+p.x, b = (100, 200)
+assert p.x == 100, 'attr + name: attr set'
+assert b == 200, 'attr + name: name bound'
+
+# === Attribute target nested inside a tuple target ===
+p = make_mutable_point()
+(p.x, (p.y, c)) = (1, (2, 3))
+assert p.x == 1, 'nested attr: first'
+assert p.y == 2, 'nested attr: second'
+assert c == 3, 'nested attr: name bound'
+
+# === Starred middle with attribute targets at the edges ===
+p = make_mutable_point()
+p.x, *mid, p.y = [10, 20, 30, 40]
+assert p.x == 10, 'starred middle: attr first'
+assert p.y == 40, 'starred middle: attr last'
+assert mid == [20, 30], 'starred middle: rest captures middle'
+
+# === Attribute target as for-loop variable ===
+p = make_mutable_point()
+for p.x in (1, 2, 3):
+    pass
+assert p.x == 3, 'for-loop attr target retains last value'
+
+# Attribute target as for-loop variable, visible inside body
+p = make_mutable_point()
+trace = []
+for p.x in ('a', 'b', 'c'):
+    trace.append(p.x)
+assert trace == ['a', 'b', 'c'], 'for-loop attr target visible inside body'
+
+# === Attribute target as comprehension `for` variable ===
+p = make_mutable_point()
+result = [p.x for p.x in (1, 2, 3)]
+assert result == [1, 2, 3], 'comp attr target reads-through'
+assert p.x == 3, 'comp attr target final write persists'
+
+# Attribute target nested inside tuple in a comprehension
+p = make_mutable_point()
+out = [(p.x, y) for p.x, y in [(1, 'a'), (2, 'b')]]
+assert out == [(1, 'a'), (2, 'b')], 'comp nested attr target reads-through'
+assert p.x == 2, 'comp nested attr target final write persists'

--- a/crates/monty/test_cases/unpack__ops.py
+++ b/crates/monty/test_cases/unpack__ops.py
@@ -205,3 +205,31 @@ a = [0]
 (a[idx()],) = (7,)
 assert a == [7], 'side-effecting index produces correct store'
 assert calls == ['idx'], 'index expression evaluated exactly once at store time'
+
+
+# Lambda inside a `for`-loop subscript-target index — exercises the scope
+# walker that must promote captured outer locals to cell-vars when the only
+# reference to them lives inside the loop target's sub-expressions.
+def _for_target_lambda():
+    x = 1
+    y = [0, 0]
+    for y[(lambda: x)()] in (10, 20):
+        pass
+    return y
+
+
+assert _for_target_lambda() == [0, 20], 'lambda capturing local from inside for-target subscript index'
+
+
+# Same pattern wrapped in a nested tuple target — exercises the Tuple
+# recursion arm in the cell-var / referenced-name unpack-target walkers.
+def _for_target_tuple_lambda():
+    x = 1
+    y = [0, 0]
+    z = ''
+    for y[(lambda: x)()], z in [(10, 'a'), (20, 'b')]:
+        pass
+    return y, z
+
+
+assert _for_target_tuple_lambda() == ([0, 20], 'b'), 'tuple target with lambda-in-subscript-index'

--- a/crates/monty/test_cases/unpack__ops.py
+++ b/crates/monty/test_cases/unpack__ops.py
@@ -151,3 +151,57 @@ assert tail == [], 'single item: tail is empty'
 assert a == 1, 'bracket syntax: a'
 assert b == [2, 3], 'bracket syntax: b'
 assert c == 4, 'bracket syntax: c'
+
+# === Subscript targets in unpack assignment (issue #408) ===
+# Single subscript target in a 1-tuple LHS
+x = [0]
+(x[0],) = (5,)
+assert x[0] == 5, 'single subscript target unpack'
+
+# Two subscript targets
+a = [0, 0]
+a[0], a[1] = 1, 2
+assert a == [1, 2], 'two subscript targets'
+
+# Swap two elements via subscript targets (CPython evaluates RHS before stores)
+a = [1, 2]
+a[0], a[1] = a[1], a[0]
+assert a == [2, 1], 'subscript swap'
+
+# Subscript target nested inside a tuple target
+a = [0, 0]
+(a[0], (a[1], b)) = (1, (2, 3))
+assert a == [1, 2], 'nested: subscripts updated'
+assert b == 3, 'nested: name bound'
+
+# Subscript target with name siblings
+a = [0]
+a[0], b = (10, 20)
+assert a == [10], 'subscript + name: subscript updated'
+assert b == 20, 'subscript + name: name bound'
+
+# Starred middle with subscript targets at the edges
+a = [0, 0]
+a[0], *rest, a[1] = [10, 20, 30, 40]
+assert a == [10, 40], 'starred middle: subscript edges'
+assert rest == [20, 30], 'starred middle: rest captures middle'
+
+# Walrus inside subscript index — bind survives the unpack
+a = [0, 0]
+(a[(i := 1)],) = (5,)
+assert a == [0, 5], 'walrus in subscript index'
+assert i == 1, 'walrus binding survives unpack'
+
+# Side-effecting index expression evaluates at store time, not before
+calls = []
+
+
+def idx():
+    calls.append('idx')
+    return 0
+
+
+a = [0]
+(a[idx()],) = (7,)
+assert a == [7], 'side-effecting index produces correct store'
+assert calls == ['idx'], 'index expression evaluated exactly once at store time'

--- a/crates/monty/tests/parse_errors.rs
+++ b/crates/monty/tests/parse_errors.rs
@@ -556,15 +556,24 @@ fn starred_subscript_target_has_clean_message() {
 }
 
 #[test]
-fn for_loop_attribute_target_has_clean_message() {
-    // `for x.y in [1]: pass`: attribute as a for-loop target. CPython
-    // accepts this; Monty currently rejects at `parse_unpack_target_impl`.
-    // That rejection of valid Python is a separate issue; this test locks
-    // only that the error message does not leak `ExprAttribute` Debug.
-    let result = MontyRun::new("for x.y in [1]: pass".to_owned(), "test.py", vec![]);
+fn unpack_target_constant_rejected() {
+    // `1, 2 = 3, 4`: ruff's parser rejects a numeric-literal LHS before it
+    // ever reaches Monty's `parse_unpack_target_impl`. Snapshot here so any
+    // future plumbing change that lets it through surfaces loudly.
+    let result = MontyRun::new("1, 2 = 3, 4".to_owned(), "test.py", vec![]);
     let exc = result.expect_err("expected parse error");
     assert_eq!(exc.exc_type(), ExcType::SyntaxError);
-    assert_snapshot!(exc.message().expect("has message"), @"invalid unpacking target: attribute");
+    assert_snapshot!(exc.message().expect("has message"), @"Invalid assignment target");
+}
+
+#[test]
+fn unpack_target_call_rejected() {
+    // `f(), = (1,)`: a function call as an unpack target. Same upstream
+    // rejection as `unpack_target_constant_rejected` — locks the message.
+    let result = MontyRun::new("f(), = (1,)".to_owned(), "test.py", vec![]);
+    let exc = result.expect_err("expected parse error");
+    assert_eq!(exc.exc_type(), ExcType::SyntaxError);
+    assert_snapshot!(exc.message().expect("has message"), @"Invalid assignment target");
 }
 
 #[test]


### PR DESCRIPTION
Closes #408.

## Summary

CPython allows subscript (`x[i]`) and attribute (`o.a`) expressions as targets inside tuple unpacking, `for`-loop variables, and comprehension `for` clauses. Monty's `parse_unpack_target_impl` only accepted `Name`/`Tuple`/`Starred`/`List` and rejected everything else with `SyntaxError: invalid unpacking target: <kind>`. That breaks:

- `x[0], x[1] = x[1], x[0]` (the reported case)
- `x[0], = (1,)`
- `o.a, o.b = 1, 2` (attribute targets — same parse arm, wider than the issue title)
- `for box[0] in iter:` / `for o.a in iter:`
- `[... for box[0] in iter]` and the same shape in comprehensions

This PR fixes all five contexts in a single parse-site change plus the matching prepare/compile wiring.

## Design

`UnpackTarget` gains two new leaf variants `Subscript { target, index, target_position }` and `Attribute { object, attr, target_position }`, mirroring `AssignTarget::Subscript`/`Attr` exactly. The two-enum split between `AssignTarget` (top-level assignment LHS) and `UnpackTarget` (inside-an-unpack pattern) is intentional grammar typing — `Starred` is only valid inside unpack, `Unpack` is only valid at the top — and the fix preserves that. The leaves themselves are duplicated between the two enums (matching how `Name` is duplicated today); a follow-up could extract a shared `LeafAssignTarget` if a third enum ever needs the same leaves, but YAGNI for now.

## Implementation notes

- **Compiler stack invariant**: `compile_unpack_target` and `process_unpack_sim` delegate to `emit_subscript_store`/`emit_attr_store`. Each variant's net operand-stack effect is −1, identical to `Name`/`Starred`, so the existing per-target loop and `compile_comp_target_unpack`'s leaf enumeration work unchanged. In the comprehension simulator the sim ↔ operand-stack 1:1 invariant is preserved by shrinking sim in lock-step (the `Pending` is popped and nothing pushed back — no sentinel needed). Traced through `Tuple { sub_0=Subscript, sub_1, sub_2 }` cases to confirm.

- **CPython evaluation order**: RHS unpacks first, then each target's sub-expressions evaluate at store time. Locked in by the `side-effecting index` test in `unpack__ops.py`.

- **Silent-correctness fix**: `collect_cell_vars_from_node` and `collect_referenced_names_from_node` previously ignored `Node::For`/`Node::With` targets — correct then, since `UnpackTarget` had no sub-expressions. After this change the targets can carry expressions that reference enclosing variables, so two new helpers `collect_{cell_vars,referenced_names}_from_unpack_target` are wired into both `For` and `With` arms.

- **Comp-var slot allocation**: `prepare_unpack_target_for_comprehension`'s new arms intentionally do NOT allocate comp-var slots. Subscript/attribute targets mutate existing state, they don't introduce a binding — their sub-expressions resolve against the surrounding scope via the normal `prepare_expression` path.

- **Walrus inside subscript index**: a walrus `(i := 0)` inside the index expression of a subscript target correctly binds in the outer scope — `collect_names_from_unpack_target` walks the sub-expressions via `collect_assigned_names_from_expr` to pick it up. Locked in by the `walrus in subscript index` test.

## Test plan

- [x] `cargo test -p monty --features memory-model-checks` (all rust tests pass, 968 cases)
- [x] `cargo test -p monty --test parse_errors --features memory-model-checks` (63 cases, including new negative snapshots)
- [x] `cargo run -p monty-datatest --features memory-model-checks unpack__` / `iter__for_loop` / `comprehension__` (all green)
- [x] `make test-py` (1091 Python binding tests pass)
- [x] CPython parity confirmed for every new test case
- [x] `make format-rs && make lint-rs && make lint-py` clean
- [x] Pre-commit hooks pass

## Tests added

| File | Coverage |
|---|---|
| `crates/monty/test_cases/unpack__ops.py` | subscript-target assignment unpack: single, two, swap, nested in tuple, name siblings, starred middle, walrus in index, side-effecting index |
| `crates/monty/test_cases/iter__for_loop_unpacking.py` | `for x[i] in iter:` last-value, computed index re-evaluated each iteration, body visibility, nested tuple |
| `crates/monty/test_cases/comprehension__all.py` | comp `for` clause with subscript targets, nested tuple subscript, leak-out semantics |
| `crates/monty/test_cases/unpack__attr.py` (new) | attribute targets across assignment / swap / nested / starred / for-loop / comprehension via `make_mutable_point()` |
| `crates/monty/tests/parse_errors.rs` | replaced `for_loop_attribute_target_has_clean_message` (the snapshot that locked the now-fixed rejection) with `unpack_target_constant_rejected` / `unpack_target_call_rejected` to lock the upstream ruff rejection for genuinely-invalid LHS shapes |

## Out of scope

- Refactoring the leaf overlap between `AssignTarget` and `UnpackTarget` into a shared `LeafAssignTarget` — preserved the existing architecture; happy to split that out if reviewers prefer.
- Augmented assignment (`x[0] += 1`) — separate code path via `AugAssign`, unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow subscript (`x[i]`) and attribute (`obj.a`) targets in unpacking, for-loops, and comprehensions, matching CPython. Fixes #408 and unblocks swaps, nested patterns, and comprehension targets.

- **Bug Fixes**
  - Parser/AST: Add `UnpackTarget::Subscript` and `UnpackTarget::Attribute` (with `target_position`); parse arms mirror assign-target shapes.
  - Compiler: Delegate stores to `emit_subscript_store`/`emit_attr_store`; net stack effect −1; preserve CPython eval order; comprehension sim shrinks in lock-step.
  - Prepare/Scope: Recurse into sub-expressions; no comp-var slots for these leaves; walk `For`/`With` targets for cell-var and referenced-name analysis; walrus inside indices binds in outer scope.
  - Tests: Cover assignment, for-loops, and comprehensions (subs/attrs: swaps, nested, starred, side effects, leak-out); add lambda-in-subscript-index cases to exercise closure capture in `for` targets and nested tuple targets; update parse-error snapshots to lock upstream rejections for constant/call LHS shapes.

<sup>Written for commit 51a2d41042cbe20bfbeff1950f54ed590b53867a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/473?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

