### PR TITLE
Fstring precision limits

### DIFF
--- a/crates/monty/src/fstring.rs
+++ b/crates/monty/src/fstring.rs
@@ -478,6 +478,31 @@ pub fn format_with_spec(
     // already use. The check is free below `LARGE_RESULT_THRESHOLD`.
     check_repeat_size(spec.fill.len_utf8(), spec.width, vm.heap.tracker())?;
 
+    // `spec.precision` on `f`/`e`/`%` float formats is rendered as that many
+    // decimal digits. `fmt_float_fixed` / `fmt_float_exp` synthesise the digits
+    // beyond `MAX_FMT_PRECISION` by appending raw `'0'` chars to an untracked
+    // Rust `String`, so an attacker-chosen precision (`f"{v:.{p}f}"`, `p` a
+    // runtime value) would allocate gigabytes before `allocate_string` accounts
+    // for the result. Precision is parsed as an unrestricted `usize`; bound it
+    // by the active resource tracker the same way the width check above does.
+    // Skip for non-finite floats since the helpers ignore precision in that
+    // case. `g`/`G` already cap precision internally.
+    if let Some(precision) = spec.precision
+        && matches!(
+            spec.type_char,
+            Some(TypeChar::F | TypeChar::FUpper | TypeChar::E | TypeChar::EUpper | TypeChar::Percent)
+        )
+    {
+        let numeric_finite = match value {
+            Value::Int(_) => true,
+            Value::Float(f) => f.is_finite(),
+            _ => false,
+        };
+        if numeric_finite {
+            check_repeat_size(precision, 1, vm.heap.tracker())?;
+        }
+    }
+
     match (value, spec.type_char) {
         // Integer formatting
         (Value::Int(n), None | Some(TypeChar::D)) => Ok(format_int(*n, spec)),

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -356,10 +356,15 @@ fn fstring_dynamic_precision_memory_bounded() {
         "p = 999_999_999\nf'{1.0:.{p}f}'",
         "p = 999_999_999\nf'{1.0:.{p}e}'",
         "p = 999_999_999\nf'{1.0:.{p}E}'",
+        "p = 999_999_999\nf'{1.0:.{p}F}'",
         "p = 999_999_999\nf'{1.0:.{p}%}'",
         // Int coerced to float via the F/E/% type chars must also be bounded.
         "p = 999_999_999\nf'{1:.{p}f}'",
+        "p = 999_999_999\nf'{1:.{p}F}'",
         "p = 999_999_999\nf'{1:.{p}e}'",
+        // Literal precisions above the compact bytecode encoding capacity are
+        // emitted as dynamic specs and must still be checked at runtime.
+        "f'{1.0:.999999999f}'",
     ] {
         let ex = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
         let limits = ResourceLimits::new()

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -340,6 +340,49 @@ fn fstring_dynamic_width_memory_bounded() {
     );
 }
 
+/// Regression: an f-string with a large *dynamic* precision on a float
+/// format (`f`/`e`/`%`) must be rejected by the memory limit before the
+/// digit-padding string is materialized.
+///
+/// `fmt_float_fixed` / `fmt_float_exp` cap Rust's native precision at
+/// `MAX_FMT_PRECISION` and synthesise the remaining digits by extending the
+/// result `String` with `'0'` chars. Without the precision guard alongside
+/// the width guard, `p = 10**9` would allocate ~1 GB of zeros before
+/// `allocate_string` could account for the result. Mirrors the width-bounded
+/// test above; covers both float values and int-coerced-to-float values.
+#[test]
+fn fstring_dynamic_precision_memory_bounded() {
+    for code in [
+        "p = 999_999_999\nf'{1.0:.{p}f}'",
+        "p = 999_999_999\nf'{1.0:.{p}e}'",
+        "p = 999_999_999\nf'{1.0:.{p}E}'",
+        "p = 999_999_999\nf'{1.0:.{p}%}'",
+        // Int coerced to float via the F/E/% type chars must also be bounded.
+        "p = 999_999_999\nf'{1:.{p}f}'",
+        "p = 999_999_999\nf'{1:.{p}e}'",
+    ] {
+        let ex = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+        let limits = ResourceLimits::new()
+            .max_memory(1_048_576)
+            .max_duration(Duration::from_secs(30));
+        let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+        let exc = result
+            .err()
+            .unwrap_or_else(|| panic!("{code:?}: should exceed the memory limit"));
+        assert_eq!(exc.exc_type(), ExcType::MemoryError, "{code:?}: wrong exc type");
+    }
+
+    // A small dynamic precision is unaffected and still formats correctly.
+    let ex = MontyRun::new("p = 3\nf'{1.5:.{p}f}'".to_owned(), "test.py", vec![]).unwrap();
+    let limits = ResourceLimits::new().max_memory(1_048_576);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+    assert_eq!(
+        result.expect("small dynamic precision should succeed"),
+        MontyObject::String("1.500".to_owned())
+    );
+}
+
 #[test]
 fn memory_limit_zero() {
     let code = "x = 1 + 2\nx";

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -12,9 +12,11 @@ inside the sandbox).
 - Operations whose result is bounded by simple arithmetic on input sizes
   are **pre-checked** before allocating: integer multiplication, left
   shift, integer power, sequence repeat (`'x' * n`), padding (`str.ljust`,
-  `str.center`, `str.zfill`, `bytes.ljust`, …). The pre-check threshold is
-  100 KB — anything that would estimate above that is rejected with
-  `ResourceError` rather than attempting the allocation.
+  `str.center`, `str.zfill`, `bytes.ljust`, …), and f-string formatting
+  (both dynamic width `f"{v:>{w}}"` and dynamic precision on float
+  formats `f"{v:.{p}f}"` / `e` / `%`). The pre-check threshold is 100 KB —
+  anything that would estimate above that is rejected with `ResourceError`
+  rather than attempting the allocation.
 - `bigint.pow(base, exp)` estimates result size as `bits(base) * exp` with
   a 4× safety multiplier to cover repeated-squaring intermediate values.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a precision guard for f-string float formats to enforce memory limits and prevent huge allocations from attacker-controlled precisions. Also adds tests and updates the resource limits docs.

- **Bug Fixes**
  - Pre-check dynamic precision for `f`/`F`/`e`/`E`/`%` using the resource tracker; skip non-finite floats; `g`/`G` unchanged.
  - Add tests that reject very large dynamic precisions and confirm small precisions still format correctly.
  - Document f-string width and precision pre-checks in the resource limits guide.

<sup>Written for commit f01b67c6a73a18e0e5f33b116174be75dab2dc74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/474?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

