### PR TITLE
apply `INT_MAX_STR_DIGITS` guard to natural JSON BigInt path

### DIFF
--- a/crates/monty/src/object_json.rs
+++ b/crates/monty/src/object_json.rs
@@ -45,7 +45,7 @@ use serde::{
 
 use crate::{
     object::{DictPairs, MontyFileHandle, MontyObject},
-    types::Type,
+    types::{Type, long_int::check_bigint_str_digits_limit},
 };
 
 /// Serialize-only wrapper around [`MontyObject`] that produces natural JSON.
@@ -82,6 +82,14 @@ impl Serialize for JsonMontyObject<'_> {
                 } else if let Ok(u) = u64::try_from(bi) {
                     serializer.serialize_u64(u)
                 } else {
+                    // Apply the same `INT_MAX_STR_DIGITS` guard that
+                    // `json.dumps` uses before converting to a decimal string.
+                    // Without this, attacker-controlled BigInts could trigger
+                    // O(n^2) base-10 conversion on the host outside Monty's
+                    // VM resource tracker.
+                    check_bigint_str_digits_limit(bi).map_err(|_| {
+                        S::Error::custom("bigint exceeds the limit (4300 digits) for integer string conversion")
+                    })?;
                     let n: serde_json::Number = bi
                         .to_string()
                         .parse()

--- a/crates/monty/tests/json_output.rs
+++ b/crates/monty/tests/json_output.rs
@@ -238,6 +238,18 @@ fn json_output_bigint_raw_number() {
 }
 
 #[test]
+fn json_output_bigint_respects_digit_limit() {
+    // The natural JSON serializer must apply the same decimal conversion
+    // guard as `json.dumps` to avoid expensive bigint-to-decimal DoS paths
+    // on the host outside Monty's VM resource tracker.
+    let err = serde_json::to_string(&JsonMontyObject(&eval("10 ** 4300"))).unwrap_err();
+    assert_snapshot!(
+        err.to_string(),
+        @"bigint exceeds the limit (4300 digits) for integer string conversion"
+    );
+}
+
+#[test]
 fn json_output_type_tagged() {
     // `type(int)` evaluates to the `type` metaclass itself, which maps to
     // `MontyObject::Type(Type::Type)` and serializes as `{"$type": "type"}`.


### PR DESCRIPTION
The natural JSON serializer used by output_json/args_json/kwargs_json converted large BigInts to decimal via bi.to_string() without the INT_MAX_STR_DIGITS guard that json.dumps already applies, leaving an O(n^2) decimal-conversion DoS reachable from attacker-controlled Monty values outside the VM resource tracker.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `INT_MAX_STR_DIGITS` guard to natural JSON BigInt serialization. Matches `json.dumps` and prevents an O(n^2) decimal-conversion DoS reachable from attacker-controlled Monty values outside the VM resource tracker.

- **Bug Fixes**
  - Validate BigInt digits via `long_int::check_bigint_str_digits_limit` before `to_string()`.
  - Return "bigint exceeds the limit (4300 digits) for integer string conversion" when over the limit.
  - Add test `json_output_bigint_respects_digit_limit` to ensure the guard is enforced.

<sup>Written for commit d5ee3a7ca9458704e8bdb03061b0184063ea46db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/475?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

