### PR TITLE
prep v0.0.18 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1885,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "monty"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "ahash",
  "chrono",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "monty-bench"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "monty-cli"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "clap",
  "monty",
@@ -1938,7 +1938,7 @@ dependencies = [
 
 [[package]]
 name = "monty-datatest"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "ahash",
  "chrono",
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "monty-fuzz"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -1961,7 +1961,7 @@ dependencies = [
 
 [[package]]
 name = "monty-js"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "monty",
  "monty_type_checking",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "monty-macros"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "monty_type_checking"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "monty_typeshed"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "path-slash",
  "ruff_db",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-monty"
-version = "0.0.17"
+version = "0.0.18"
 dependencies = [
  "ahash",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ default-members = ["crates/monty-cli"]
 
 [workspace.package]
 edition = "2024"
-version = "0.0.17"
+version = "0.0.18"
 rust-version = "1.95"
 license = "MIT"
 authors = ["Samuel Colvin <samuel@pydantic.dev>"]

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pydantic/monty",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "license": "MIT",
       "devDependencies": {
         "@emnapi/core": "^1.5.0",

--- a/crates/monty-js/package.json
+++ b/crates/monty-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "type": "module",
   "description": "Sandboxed Python interpreter for JavaScript/TypeScript",
   "main": "wrapper.js",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepare v0.0.18 release by bumping versions across the Rust workspace and the `@pydantic/monty` package. No functional changes.

- **Dependencies**
  - Set workspace and crate versions to 0.0.18 in Cargo files.
  - Updated `@pydantic/monty` to 0.0.18 in package.json and package-lock.json.

<sup>Written for commit 809e1d5f28bff0b9930718423f595847e43b5d65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/476?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

