### PR TITLE
fix type-object marshalling across the sandbox boundary

### DIFF
--- a/crates/monty-python/src/convert.rs
+++ b/crates/monty-python/src/convert.rs
@@ -166,10 +166,10 @@ pub fn py_to_monty(obj: &Bound<'_, PyAny>, dc_registry: &DcRegistry, mut depth: 
         // result of an `Open` OS callback) back into `MontyObject::FileHandle`.
         Ok(MontyObject::FileHandle(handle.borrow().0.clone()))
     } else if let Ok(ty) = obj.cast::<PyType>() {
-        // A class is callable, so it would otherwise fall into the generic
-        // callable branch below. Preserve types Monty models as type objects
-        // (so they round-trip and `isinstance` works inside the sandbox); host
-        // classes Monty has no `Type` for still degrade to a callable function.
+        // A class is callable, so it would otherwise fall into the generic callable
+        // branch below. Classes Monty models are preserved as type objects (so they
+        // round-trip and `isinstance` works in the sandbox); any other host class has
+        // no Monty `Type`, so it falls back to the callable representation.
         match py_type_object_to_monty(ty)? {
             Some(t) => Ok(MontyObject::Type(t)),
             None => Ok(callable_to_monty_function(obj)),

--- a/crates/monty-python/src/convert.rs
+++ b/crates/monty-python/src/convert.rs
@@ -191,30 +191,62 @@ pub fn py_to_monty(obj: &Bound<'_, PyAny>, dc_registry: &DcRegistry, mut depth: 
 
 /// Inverse of [`type_object_to_py`]: maps a host class passed *into* the sandbox
 /// to the Monty [`Type`] it represents, so it round-trips instead of degrading to
-/// a callable. Matches on `(__module__, __name__)` to tolerate aliasing (`io` vs
-/// `_io`). Every `pathlib` path class collapses to [`Type::Path`] (re-emerges as
-/// `PurePosixPath`). Returns `None` for classes Monty does not model, which the
+/// a callable. Matches by type-object **identity**, not `__module__`/`__name__` —
+/// the latter is spoofable and churns across Python versions (e.g. `pathlib` paths
+/// report `pathlib._local` on 3.13). Every `pathlib` path class collapses to
+/// [`Type::Path`]. Returns `None` for classes Monty does not model, which the
 /// caller then represents as a [`MontyObject::Function`].
 fn py_type_object_to_monty(ty: &Bound<'_, PyType>) -> PyResult<Option<Type>> {
-    let name = ty.name()?.to_string();
-    let module: String = ty.getattr(intern!(ty.py(), "__module__"))?.extract()?;
-    Ok(match (module.as_str(), name.as_str()) {
-        ("builtins", name) => Type::from_builtin_name(name),
-        ("datetime", "date") => Some(Type::Date),
-        ("datetime", "datetime") => Some(Type::DateTime),
-        ("datetime", "timedelta") => Some(Type::TimeDelta),
-        ("datetime", "timezone") => Some(Type::TimeZone),
-        ("pathlib", "PurePath" | "PurePosixPath" | "PureWindowsPath" | "Path" | "PosixPath" | "WindowsPath") => {
-            Some(Type::Path)
+    let py = ty.py();
+    for (obj, t) in round_trip_type_table(py)? {
+        if ty.is(obj) {
+            return Ok(Some(*t));
         }
-        ("re", "Pattern") => Some(Type::RePattern),
-        ("re", "Match") => Some(Type::ReMatch),
-        ("io" | "_io", "TextIOWrapper") => Some(Type::TextIOWrapper),
-        ("io" | "_io", "BufferedReader") => Some(Type::BufferedReader),
-        ("io" | "_io", "BufferedWriter") => Some(Type::BufferedWriter),
-        ("io" | "_io", "BufferedRandom") => Some(Type::BufferedRandom),
-        ("typing", "_SpecialForm") => Some(Type::SpecialForm),
-        _ => None,
+    }
+    // pathlib's concrete path classes (PurePath, PosixPath, …) all subclass
+    // PurePath and collapse to one Monty path type.
+    Ok(ty.is_subclass(get_pure_path(py)?)?.then_some(Type::Path))
+}
+
+/// Host type objects that round-trip into the sandbox, each paired with its Monty
+/// [`Type`]. Built once and cached. Identities are taken from [`type_object_to_py`]
+/// so the two directions stay in lock-step. [`Type::Path`] is handled separately
+/// (by subclass check) since pathlib exposes several concrete path classes.
+fn round_trip_type_table(py: Python<'_>) -> PyResult<&'static Vec<(Py<PyAny>, Type)>> {
+    static TABLE: PyOnceLock<Vec<(Py<PyAny>, Type)>> = PyOnceLock::new();
+    TABLE.get_or_try_init(py, || {
+        [
+            Type::NoneType,
+            Type::Ellipsis,
+            Type::Bool,
+            Type::Int,
+            Type::Float,
+            Type::Str,
+            Type::Bytes,
+            Type::List,
+            Type::Tuple,
+            Type::Dict,
+            Type::Set,
+            Type::FrozenSet,
+            Type::Range,
+            Type::Slice,
+            Type::Type,
+            Type::Property,
+            Type::Date,
+            Type::DateTime,
+            Type::TimeDelta,
+            Type::TimeZone,
+            Type::RePattern,
+            Type::ReMatch,
+            Type::TextIOWrapper,
+            Type::BufferedReader,
+            Type::BufferedWriter,
+            Type::BufferedRandom,
+            Type::SpecialForm,
+        ]
+        .into_iter()
+        .map(|t| Ok((type_object_to_py(py, t)?, t)))
+        .collect()
     })
 }
 
@@ -419,6 +451,10 @@ fn type_object_to_py(py: Python<'_>, t: Type) -> PyResult<Py<PyAny>> {
         Type::BufferedWriter => cached!("io", "BufferedWriter"),
         Type::BufferedRandom => cached!("io", "BufferedRandom"),
         Type::SpecialForm => cached!("typing", "_SpecialForm"),
+        // `NoneType` and `ellipsis` aren't `builtins` attributes; take them from
+        // the singletons (`type(None)` / `type(...)`).
+        Type::NoneType => Ok(py.None().bind(py).get_type().into_any().unbind()),
+        Type::Ellipsis => Ok(py.Ellipsis().bind(py).get_type().into_any().unbind()),
         _ => import_builtins(py)?.getattr(py, t.to_string()),
     }
 }
@@ -616,6 +652,14 @@ fn get_pure_posix_path(py: Python<'_>) -> PyResult<&Bound<'_, PyAny>> {
     static PUREPOSIX: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
 
     PUREPOSIX.import(py, "pathlib", "PurePosixPath")
+}
+
+/// Cached import of `pathlib.PurePath` — the common base of every path class,
+/// used to recognise any path type passed into the sandbox.
+fn get_pure_path(py: Python<'_>) -> PyResult<&Bound<'_, PyAny>> {
+    static PUREPATH: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+
+    PUREPATH.import(py, "pathlib", "PurePath")
 }
 
 /// Host-side mirror of [`MontyObject::FileHandle`].

--- a/crates/monty-python/src/convert.rs
+++ b/crates/monty-python/src/convert.rs
@@ -6,7 +6,7 @@
 
 use std::borrow::Cow;
 
-use ::monty::{FileMode, MontyDate, MontyDateTime, MontyFileHandle, MontyObject, MontyTimeDelta, MontyTimeZone};
+use ::monty::{FileMode, MontyDate, MontyDateTime, MontyFileHandle, MontyObject, MontyTimeDelta, MontyTimeZone, Type};
 use monty::{MontyException, StringRepr};
 use num_bigint::BigInt;
 use pyo3::{
@@ -16,7 +16,7 @@ use pyo3::{
     sync::PyOnceLock,
     types::{
         PyBool, PyBytes, PyDate, PyDateAccess, PyDateTime, PyDelta, PyDeltaAccess, PyDict, PyFloat, PyFrozenSet, PyInt,
-        PyList, PyModule, PySet, PyString, PyTimeAccess, PyTuple, PyTzInfo, PyTzInfoAccess,
+        PyList, PyModule, PySet, PyString, PyTimeAccess, PyTuple, PyType, PyTzInfo, PyTzInfoAccess,
     },
 };
 
@@ -165,12 +165,19 @@ pub fn py_to_monty(obj: &Bound<'_, PyAny>, dc_registry: &DcRegistry, mut depth: 
         // Round-trip a `MontyFileHandle` returned from Python (e.g. as the
         // result of an `Open` OS callback) back into `MontyObject::FileHandle`.
         Ok(MontyObject::FileHandle(handle.borrow().0.clone()))
+    } else if let Ok(ty) = obj.cast::<PyType>() {
+        // A class is callable, so it would otherwise fall into the generic
+        // callable branch below. Preserve types Monty models as type objects
+        // (so they round-trip and `isinstance` works inside the sandbox); host
+        // classes Monty has no `Type` for still degrade to a callable function.
+        match py_type_object_to_monty(ty)? {
+            Some(t) => Ok(MontyObject::Type(t)),
+            None => Ok(callable_to_monty_function(obj)),
+        }
     } else if obj.is_callable() {
         // Callable check is last since many Python types (classes, etc.) are technically callable,
         // and we want to match more specific types first (e.g. dataclasses).
-        let name = get_name(obj);
-        let docstring = get_docstring(obj);
-        Ok(MontyObject::Function { name, docstring })
+        Ok(callable_to_monty_function(obj))
     } else if let Ok(name) = obj.get_type().qualname() {
         let msg = match obj.get_type().module() {
             Ok(module) => format!("Cannot convert {module}.{name} to Monty value"),
@@ -179,6 +186,45 @@ pub fn py_to_monty(obj: &Bound<'_, PyAny>, dc_registry: &DcRegistry, mut depth: 
         Err(PyTypeError::new_err(msg))
     } else {
         Err(PyTypeError::new_err("Cannot convert unknown type to Monty value"))
+    }
+}
+
+/// Inverse of [`type_object_to_py`]: maps a host class passed *into* the sandbox
+/// to the Monty [`Type`] it represents, so it round-trips instead of degrading to
+/// a callable. Matches on `(__module__, __name__)` to tolerate aliasing (`io` vs
+/// `_io`). Every `pathlib` path class collapses to [`Type::Path`] (re-emerges as
+/// `PurePosixPath`). Returns `None` for classes Monty does not model, which the
+/// caller then represents as a [`MontyObject::Function`].
+fn py_type_object_to_monty(ty: &Bound<'_, PyType>) -> PyResult<Option<Type>> {
+    let name = ty.name()?.to_string();
+    let module: String = ty.getattr(intern!(ty.py(), "__module__"))?.extract()?;
+    Ok(match (module.as_str(), name.as_str()) {
+        ("builtins", name) => Type::from_builtin_name(name),
+        ("datetime", "date") => Some(Type::Date),
+        ("datetime", "datetime") => Some(Type::DateTime),
+        ("datetime", "timedelta") => Some(Type::TimeDelta),
+        ("datetime", "timezone") => Some(Type::TimeZone),
+        ("pathlib", "PurePath" | "PurePosixPath" | "PureWindowsPath" | "Path" | "PosixPath" | "WindowsPath") => {
+            Some(Type::Path)
+        }
+        ("re", "Pattern") => Some(Type::RePattern),
+        ("re", "Match") => Some(Type::ReMatch),
+        ("io" | "_io", "TextIOWrapper") => Some(Type::TextIOWrapper),
+        ("io" | "_io", "BufferedReader") => Some(Type::BufferedReader),
+        ("io" | "_io", "BufferedWriter") => Some(Type::BufferedWriter),
+        ("io" | "_io", "BufferedRandom") => Some(Type::BufferedRandom),
+        ("typing", "_SpecialForm") => Some(Type::SpecialForm),
+        _ => None,
+    })
+}
+
+/// Represents a host callable with no richer Monty mapping as a
+/// [`MontyObject::Function`], carrying its `__name__` and docstring. Used for
+/// plain callables and for host classes Monty does not model.
+fn callable_to_monty_function(obj: &Bound<'_, PyAny>) -> MontyObject {
+    MontyObject::Function {
+        name: get_name(obj),
+        docstring: get_docstring(obj),
     }
 }
 
@@ -304,8 +350,8 @@ pub(crate) fn monty_to_py_inner(
             .map(Bound::into_any)
             .map(Bound::unbind),
         MontyObject::TimeZone(timezone) => monty_timezone_to_py(py, timezone),
-        // Return Python's built-in type object
-        MontyObject::Type(t) => import_builtins(py)?.getattr(py, t.to_string()),
+        // Return the host Python type object the sandbox type maps to.
+        MontyObject::Type(t) => type_object_to_py(py, *t),
         MontyObject::BuiltinFunction(f) => import_builtins(py)?.getattr(py, f.to_string()),
         // Dataclass - use registry to reconstruct original type if available
         MontyObject::Dataclass {
@@ -339,6 +385,42 @@ pub fn import_builtins(py: Python<'_>) -> PyResult<&Py<PyModule>> {
     static BUILTINS: PyOnceLock<Py<PyModule>> = PyOnceLock::new();
 
     BUILTINS.get_or_try_init(py, || py.import("builtins").map(Bound::unbind))
+}
+
+/// Reconstructs the host Python *type object* for a Monty [`Type`] crossing the
+/// boundary as a value (e.g. sandbox code passing `type(Path('/x'))` to a host call).
+///
+/// Genuine builtins resolve from `builtins`; modeled stdlib types resolve from their
+/// real defining module (the `Path` class maps to `PurePosixPath`, like its instances).
+/// The import path can differ from [`Type`]'s `Display` (io types show `_io.*` but live
+/// in `io`). Unmodeled types fall through to `builtins` and raise `AttributeError`.
+/// Each modeled type's host class is cached in its own `PyOnceLock` (imported once).
+fn type_object_to_py(py: Python<'_>, t: Type) -> PyResult<Py<PyAny>> {
+    // Each expansion gets a distinct hygienic `LOCK` static, so every arm caches
+    // its own resolved type object. `PyOnceLock::import` imports + getattrs once.
+    macro_rules! cached {
+        ($module:literal, $name:literal) => {{
+            static LOCK: PyOnceLock<Py<PyAny>> = PyOnceLock::new();
+            LOCK.import(py, $module, $name).map(|b| b.clone().unbind())
+        }};
+    }
+    match t {
+        Type::Date => cached!("datetime", "date"),
+        Type::DateTime => cached!("datetime", "datetime"),
+        Type::TimeDelta => cached!("datetime", "timedelta"),
+        Type::TimeZone => cached!("datetime", "timezone"),
+        // Consistent with the Path *instance* arm, which marshals as PurePosixPath
+        // and is instantiable on every host OS (unlike PosixPath on Windows).
+        Type::Path => get_pure_posix_path(py).map(|b| b.clone().unbind()),
+        Type::RePattern => cached!("re", "Pattern"),
+        Type::ReMatch => cached!("re", "Match"),
+        Type::TextIOWrapper => cached!("io", "TextIOWrapper"),
+        Type::BufferedReader => cached!("io", "BufferedReader"),
+        Type::BufferedWriter => cached!("io", "BufferedWriter"),
+        Type::BufferedRandom => cached!("io", "BufferedRandom"),
+        Type::SpecialForm => cached!("typing", "_SpecialForm"),
+        _ => import_builtins(py)?.getattr(py, t.to_string()),
+    }
 }
 
 /// Converts a native Python `datetime.timedelta` to Monty's carrier representation.

--- a/crates/monty-python/tests/test_external.py
+++ b/crates/monty-python/tests/test_external.py
@@ -1,4 +1,7 @@
+import datetime
 import io
+import pathlib
+import re
 from typing import Any
 
 import pytest
@@ -60,6 +63,99 @@ def test_external_function_complex_types():
         return 'ok'
 
     assert m.run(external_functions={'func': func}) == snapshot('ok')
+
+
+def test_external_function_type_objects():
+    """A type object passed as an external-call argument reconstructs as the matching
+    host type; modeled stdlib types resolve from their real module (`Path` → `PurePosixPath`)."""
+    code = """
+import datetime
+import re
+from pathlib import Path
+func(
+    type(1),
+    type('x'),
+    type(int),
+    type(Path('/x')),
+    Path,
+    datetime.datetime,
+    datetime.date,
+    datetime.timedelta,
+    type(re.compile('a')),
+    type(re.match('a', 'a')),
+)
+"""
+    m = pydantic_monty.Monty(code)
+
+    def func(*args: Any, **kwargs: Any) -> str:
+        assert args == (
+            int,
+            str,
+            type,
+            pathlib.PurePosixPath,
+            pathlib.PurePosixPath,
+            datetime.datetime,
+            datetime.date,
+            datetime.timedelta,
+            re.Pattern,
+            re.Match,
+        )
+        assert kwargs == {}
+        return 'ok'
+
+    assert m.run(external_functions={'func': func}) == snapshot('ok')
+
+
+def test_external_function_returns_instances():
+    """A host callback returning an instance of a modeled stdlib type marshals back
+    into the sandbox (datetime family and `pathlib` paths round-trip)."""
+    code = """
+results = []
+for v in (get_dt(), get_dt_tz(), get_date(), get_delta(), get_tz(), get_path()):
+    results.append((type(v).__name__, repr(v)))
+results
+"""
+    fns: dict[str, Any] = {
+        'get_dt': lambda: datetime.datetime(2021, 1, 2, 3, 4, 5),
+        'get_dt_tz': lambda: datetime.datetime(2021, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc),
+        'get_date': lambda: datetime.date(2021, 1, 2),
+        'get_delta': lambda: datetime.timedelta(days=1, seconds=2),
+        'get_tz': lambda: datetime.timezone(datetime.timedelta(hours=5)),
+        'get_path': lambda: pathlib.PurePosixPath('/a/b'),
+    }
+    assert pydantic_monty.Monty(code).run(external_functions=fns) == snapshot(
+        [
+            ('datetime.datetime', 'datetime.datetime(2021, 1, 2, 3, 4, 5)'),
+            ('datetime.datetime', 'datetime.datetime(2021, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)'),
+            ('date', 'datetime.date(2021, 1, 2)'),
+            ('timedelta', 'datetime.timedelta(days=1, seconds=2)'),
+            ('timezone', 'datetime.timezone(datetime.timedelta(seconds=18000))'),
+            ('PosixPath', "PosixPath('/a/b')"),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    'factory, message',
+    [
+        (lambda: re.compile('a'), snapshot('Cannot convert re.Pattern to Monty value')),
+        (lambda: re.match('a', 'a'), snapshot('Cannot convert re.Match to Monty value')),
+        (lambda: io.StringIO('x'), snapshot('Cannot convert _io.StringIO to Monty value')),
+    ],
+)
+def test_external_function_returns_unconvertible_instance(factory: Any, message: str):
+    """Instances of types Monty does not model (`re.Pattern`, `re.Match`, host
+    file objects, …) cannot cross back into the sandbox; the return-value
+    conversion fails as a `TypeError` that is catchable inside Monty."""
+    code = """
+try:
+    get_thing()
+    result = 'no error'
+except TypeError as e:
+    result = str(e)
+result
+"""
+    assert pydantic_monty.Monty(code).run(external_functions={'get_thing': factory}) == message
 
 
 def test_external_function_returns_none():

--- a/crates/monty-python/tests/test_types.py
+++ b/crates/monty-python/tests/test_types.py
@@ -144,6 +144,74 @@ def test_set_output():
     assert m.run() == snapshot({1, 2, 3})
 
 
+def test_type_object_output():
+    """A type object returned from the sandbox reconstructs as the matching host
+    class; modeled stdlib types resolve from their real module (`Path` → `PurePosixPath`)."""
+    code = """
+import datetime, re
+from pathlib import Path
+[
+    int, str, type,
+    type(Path('/x')), Path,
+    datetime.datetime, datetime.date, datetime.timedelta, datetime.timezone,
+    type(re.compile('a')), type(re.match('a', 'a')),
+]
+"""
+    # Type objects have no `__eq__` override, so `==` compares them by identity.
+    assert pydantic_monty.Monty(code).run() == [
+        int,
+        str,
+        type,
+        pathlib.PurePosixPath,
+        pathlib.PurePosixPath,
+        datetime.datetime,
+        datetime.date,
+        datetime.timedelta,
+        datetime.timezone,
+        re.Pattern,
+        re.Match,
+    ]
+
+
+def test_type_object_input_roundtrip():
+    """A type object passed in as an input is preserved as a type (not degraded to
+    a callable) and round-trips back out by identity."""
+    types = [
+        int,
+        str,
+        type,
+        bool,
+        datetime.datetime,
+        datetime.date,
+        datetime.timedelta,
+        datetime.timezone,
+        pathlib.PurePosixPath,
+        re.Pattern,
+        re.Match,
+    ]
+    m = pydantic_monty.Monty('x', inputs=['x'])
+    for ty in types:
+        assert m.run(inputs={'x': ty}) is ty
+
+
+def test_type_object_input_isinstance():
+    """A type object passed in is usable as the second argument to `isinstance`
+    inside the sandbox."""
+    m = pydantic_monty.Monty('(isinstance(5, t), isinstance("a", t))', inputs=['t'])
+    assert m.run(inputs={'t': int}) == snapshot((True, False))
+
+
+def test_unmodeled_class_input_becomes_callable():
+    """A host class Monty has no `Type` for still degrades to a callable
+    function at the boundary (unchanged behavior)."""
+
+    class Foo:
+        pass
+
+    m = pydantic_monty.Monty('(type(x).__name__, repr(x))', inputs=['x'])
+    assert m.run(inputs={'x': Foo}) == snapshot(('function', "<function 'Foo' external>"))
+
+
 def test_date_input_roundtrip():
     m = pydantic_monty.Monty('x', inputs=['x'])
     result = m.run(inputs={'x': datetime.date(2024, 1, 15)})

--- a/crates/monty-python/tests/test_types.py
+++ b/crates/monty-python/tests/test_types.py
@@ -151,7 +151,7 @@ def test_type_object_output():
 import datetime, re
 from pathlib import Path
 [
-    int, str, type,
+    int, str, type, type(None), type(...),
     type(Path('/x')), Path,
     datetime.datetime, datetime.date, datetime.timedelta, datetime.timezone,
     type(re.compile('a')), type(re.match('a', 'a')),
@@ -162,6 +162,8 @@ from pathlib import Path
         int,
         str,
         type,
+        type(None),
+        type(...),
         pathlib.PurePosixPath,
         pathlib.PurePosixPath,
         datetime.datetime,
@@ -176,22 +178,29 @@ from pathlib import Path
 def test_type_object_input_roundtrip():
     """A type object passed in as an input is preserved as a type (not degraded to
     a callable) and round-trips back out by identity."""
-    types = [
+    types: list[type[object]] = [
         int,
         str,
         type,
         bool,
+        type(None),
+        type(...),
         datetime.datetime,
         datetime.date,
         datetime.timedelta,
         datetime.timezone,
         pathlib.PurePosixPath,
+        pathlib.PurePath,
+        pathlib.PosixPath,
         re.Pattern,
         re.Match,
     ]
     m = pydantic_monty.Monty('x', inputs=['x'])
     for ty in types:
-        assert m.run(inputs={'x': ty}) is ty
+        # The pathlib family all collapses to a single Monty path type, which
+        # re-emerges as PurePosixPath; everything else round-trips by identity.
+        expected: type[object] = pathlib.PurePosixPath if issubclass(ty, pathlib.PurePath) else ty
+        assert m.run(inputs={'x': ty}) is expected
 
 
 def test_type_object_input_isinstance():
@@ -210,6 +219,22 @@ def test_unmodeled_class_input_becomes_callable():
 
     m = pydantic_monty.Monty('(type(x).__name__, repr(x))', inputs=['x'])
     assert m.run(inputs={'x': Foo}) == snapshot(('function', "<function 'Foo' external>"))
+
+
+def test_spoofed_builtin_type_not_recognized():
+    """Type detection is by identity, not name/module strings: a class that
+    forges `__name__`/`__module__` to impersonate `int` is not treated as the
+    builtin and degrades to a callable."""
+
+    class FakeInt:
+        pass
+
+    FakeInt.__name__ = 'int'
+    FakeInt.__qualname__ = 'int'
+    FakeInt.__module__ = 'builtins'
+
+    m = pydantic_monty.Monty('type(x).__name__', inputs=['x'])
+    assert m.run(inputs={'x': FakeInt}) == snapshot('function')
 
 
 def test_date_input_roundtrip():

--- a/crates/monty/src/lib.rs
+++ b/crates/monty/src/lib.rs
@@ -59,5 +59,5 @@ pub use crate::{
     run_progress::{
         ExtFunctionResult, FunctionCall, NameLookup, NameLookupResult, OsCall, ResolveFutures, RunProgress,
     },
-    types::{file::FileMode, str::StringRepr},
+    types::{file::FileMode, str::StringRepr, r#type::Type},
 };

--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -25,7 +25,6 @@ use crate::{
 /// while others are internal types only available through imports or introspection
 /// (e.g., `TextIOWrapper`, `PosixPath`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[expect(clippy::enum_variant_names)]
 pub enum Type {
     Ellipsis,
     Type,

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -66,3 +66,22 @@ mechanism beyond dataclass field inheritance.
   its name was interned in source. This applies only to external functions
   — `def`-defined functions inside the sandbox retain per-definition
   identity.
+- **Type objects across the host boundary** — a `type` object (a class, not an
+  instance) round-trips in both directions.
+  - *Sandbox → host* (external/OS-call argument, or a `.run()` return value): the
+    type is reconstructed as the corresponding host class. Genuine builtins
+    (`int`, `str`, `type`, `bytes`, `list`, `dict`, `property`, …) resolve to the
+    real builtin; Monty's modeled stdlib types map to their host stdlib class:
+    `datetime`/`date`/`timedelta`/`timezone` → `datetime.*`,
+    `re.Pattern`/`re.Match` → `re.*`, the binary/text file types → `io.*`. The
+    `pathlib.Path` class maps to `pathlib.PurePosixPath` (consistent with how Path
+    *instances* round-trip, and instantiable on every host OS). A type with no
+    faithful host class (e.g. an internal function or cell type) cannot be
+    reconstructed and surfaces as an `AttributeError` from the host call.
+  - *Host → sandbox* (input, or an external-call return value): the same recognized
+    builtins and modeled stdlib types are preserved as type objects, so
+    `isinstance(x, the_type)` works inside the sandbox. Every `pathlib` path class
+    collapses to `PurePosixPath` (it re-emerges as `PurePosixPath`). A host class
+    Monty does **not** model (e.g. a user-defined class) is not preserved as a
+    type — it degrades to a callable, appearing inside the sandbox as a `function`
+    rather than a `type`.

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -80,8 +80,10 @@ mechanism beyond dataclass field inheritance.
     reconstructed and surfaces as an `AttributeError` from the host call.
   - *Host → sandbox* (input, or an external-call return value): the same recognized
     builtins and modeled stdlib types are preserved as type objects, so
-    `isinstance(x, the_type)` works inside the sandbox. Every `pathlib` path class
-    collapses to `PurePosixPath` (it re-emerges as `PurePosixPath`). A host class
-    Monty does **not** model (e.g. a user-defined class) is not preserved as a
-    type — it degrades to a callable, appearing inside the sandbox as a `function`
-    rather than a `type`.
+    `isinstance(x, the_type)` works inside the sandbox. Recognition is by
+    type-object **identity**, not class name/module, so a class that forges
+    `__name__`/`__module__` to impersonate a builtin is *not* treated as one. Every
+    `pathlib` path class collapses to `PurePosixPath` (it re-emerges as
+    `PurePosixPath`). A host class Monty does **not** model (e.g. a user-defined
+    class) is not preserved as a type — it degrades to a callable, appearing inside
+    the sandbox as a `function` rather than a `type`.


### PR DESCRIPTION
Modeled stdlib type objects (PosixPath, datetime.*, re.*, io.*, …) were reconstructed host-side via getattr(builtins, name), raising AttributeError since they don't live in builtins. They now resolve from their real defining module, each cached in its own PyOnceLock. The Path class maps to PurePosixPath, consistent with how Path instances round-trip.

Also fix the inverse direction: a type object passed into the sandbox (input or external-call return) previously degraded to a callable; recognized builtins and modeled stdlib types are now preserved as MontyObject::Type so they round-trip and isinstance works inside the sandbox.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes type-object marshalling across the sandbox boundary so modeled stdlib types resolve from their real modules and incoming host types are preserved by identity. `pathlib.Path` maps to `pathlib.PurePosixPath` for consistency.

- **Bug Fixes**
  - Sandbox → host: resolve modeled stdlib types from `datetime`, `re`, `io`, `typing` (not `builtins`); map `pathlib.Path` → `pathlib.PurePosixPath`; cache each resolved class in its own `PyOnceLock`.
  - Host → sandbox: preserve recognized builtins and modeled stdlib classes as type objects (`MontyObject::Type`), matching by identity; match all `pathlib` via `issubclass(PurePath)`; also preserve `NoneType` and `ellipsis`; unmodeled classes still degrade to callables.
  - Added tests for type-object args/returns, identity round-trips, `isinstance`, and unconvertible-instance errors; updated limitations docs; exported `Type` from the crate root.

<sup>Written for commit b0d574dede20baa149c6c8fa946d1d80f9a31265. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

