### PR TITLE
[codex] Add JS virtual filesystem mounts

### DIFF
--- a/crates/monty-js/__test__/virtual_mount.spec.ts
+++ b/crates/monty-js/__test__/virtual_mount.spec.ts
@@ -1,0 +1,168 @@
+import test from 'ava'
+
+import { Monty, MontyRepl, MontyRuntimeError, VirtualMount, VirtualMountError, runMontyAsync } from '../wrapper'
+
+function createMemoryMount(asyncBackend = false): VirtualMount {
+  const files = new Map<string, Buffer>([
+    ['/remote/hello.txt', Buffer.from('hello world')],
+    ['/remote/subdir/nested.txt', Buffer.from('nested')],
+  ])
+  const dirs = new Set(['/remote', '/remote/subdir'])
+
+  const delay = async <T>(value: T): Promise<T> => value
+  const maybe = <T>(value: T): T | Promise<T> => (asyncBackend ? delay(value) : value)
+  const requireFile = (path: string): Buffer => {
+    const file = files.get(path)
+    if (!file) {
+      throw new VirtualMountError('FileNotFoundError', `No such file or directory: '${path}'`)
+    }
+    return file
+  }
+
+  return new VirtualMount('/remote', {
+    exists: (path) => maybe(files.has(path) || dirs.has(path)),
+    isFile: (path) => maybe(files.has(path)),
+    isDir: (path) => maybe(dirs.has(path)),
+    isSymlink: () => maybe(false),
+    readText: (path) => maybe(requireFile(path).toString('utf8')),
+    readBytes: (path) => maybe(Buffer.from(requireFile(path))),
+    writeText: (path, data) => {
+      files.set(path, Buffer.from(data))
+      return maybe([...data].length)
+    },
+    writeBytes: (path, data) => {
+      files.set(path, Buffer.from(data))
+      return maybe(data.byteLength)
+    },
+    appendText: (path, data) => {
+      const current = files.get(path) ?? Buffer.alloc(0)
+      files.set(path, Buffer.concat([current, Buffer.from(data)]))
+      return maybe([...data].length)
+    },
+    appendBytes: (path, data) => {
+      const current = files.get(path) ?? Buffer.alloc(0)
+      files.set(path, Buffer.concat([current, Buffer.from(data)]))
+      return maybe(data.byteLength)
+    },
+    mkdir: (path) => {
+      dirs.add(path)
+      return maybe(undefined)
+    },
+    unlink: (path) => {
+      files.delete(path)
+      return maybe(undefined)
+    },
+    rmdir: (path) => {
+      dirs.delete(path)
+      return maybe(undefined)
+    },
+    rename: (src, dst) => {
+      const file = requireFile(src)
+      files.set(dst, file)
+      files.delete(src)
+      return maybe(undefined)
+    },
+    iterdir: (path) => {
+      const prefix = `${path}/`
+      const names = new Set<string>()
+      for (const file of files.keys()) {
+        if (file.startsWith(prefix)) {
+          names.add(file.slice(prefix.length).split('/')[0])
+        }
+      }
+      for (const dir of dirs) {
+        if (dir.startsWith(prefix)) {
+          names.add(dir.slice(prefix.length).split('/')[0])
+        }
+      }
+      return maybe([...names].filter(Boolean).sort())
+    },
+    stat: (path) => {
+      if (dirs.has(path)) {
+        return maybe({ type: 'directory' as const, size: 4096, mtime: 1 })
+      }
+      const file = requireFile(path)
+      return maybe({ type: 'file' as const, size: file.byteLength, mtime: 1 })
+    },
+  })
+}
+
+test('VirtualMount supports pathlib read write list stat and rename', (t) => {
+  const mount = createMemoryMount()
+  const code = `
+from pathlib import Path
+root = Path('/remote')
+before = root.joinpath('hello.txt').read_text()
+root.joinpath('new.txt').write_text('created')
+root.joinpath('new.txt').rename('/remote/renamed.txt')
+names = sorted([p.name for p in root.iterdir()])
+size = root.joinpath('renamed.txt').stat().st_size
+[before, names, size, root.joinpath('new.txt').exists(), root.joinpath('renamed.txt').read_text()]
+`
+
+  const result = new Monty(code).run({ mount })
+
+  t.deepEqual(result, ['hello world', ['hello.txt', 'renamed.txt', 'subdir'], 7, false, 'created'])
+})
+
+test('VirtualMount supports open read and write', (t) => {
+  const mount = createMemoryMount()
+  const code = `
+f = open('/remote/open.txt', 'w')
+written = f.write('via open')
+f.close()
+g = open('/remote/open.txt', 'r')
+content = g.read()
+g.close()
+[written, content]
+`
+
+  const result = new Monty(code).run({ mount })
+
+  t.deepEqual(result, [8, 'via open'])
+})
+
+test('VirtualMount read-only mode blocks writes', (t) => {
+  const backendMount = createMemoryMount()
+  const mount = new VirtualMount('/remote', backendMount.backend, { mode: 'read-only' })
+
+  const error = t.throws(
+    () => new Monty("from pathlib import Path; Path('/remote/nope.txt').write_text('x')").run({ mount }),
+    {
+      instanceOf: MontyRuntimeError,
+    },
+  )
+
+  t.true(error.message.includes('Read-only file system'))
+})
+
+test('runMontyAsync supports async VirtualMount backends', async (t) => {
+  const mount = createMemoryMount(true)
+  const code = "from pathlib import Path; Path('/remote/hello.txt').read_text()"
+
+  const result = await runMontyAsync(new Monty(code), { mount })
+
+  t.is(result, 'hello world')
+})
+
+test('MontyRepl feed supports VirtualMount persistence', (t) => {
+  const mount = createMemoryMount()
+  const repl = new MontyRepl()
+
+  repl.feed('from pathlib import Path', { mount })
+  repl.feed("Path('/remote/repl.txt').write_text('from repl')", { mount })
+  const result = repl.feed("Path('/remote/repl.txt').read_text()", { mount })
+
+  t.is(result, 'from repl')
+})
+
+test('MontyRepl feedAsync supports async VirtualMount backends', async (t) => {
+  const mount = createMemoryMount(true)
+  const repl = new MontyRepl()
+
+  await repl.feedAsync('from pathlib import Path', { mount })
+  await repl.feedAsync("Path('/remote/async.txt').write_text('async repl')", { mount })
+  const result = await repl.feedAsync("Path('/remote/async.txt').read_text()", { mount })
+
+  t.is(result, 'async repl')
+})

--- a/crates/monty-js/src/convert.rs
+++ b/crates/monty-js/src/convert.rs
@@ -26,12 +26,18 @@
 //! - `MontyObject::Type` → `{ __monty_type__: 'Type', value }`
 //! - `MontyObject::BuiltinFunction` → `{ __monty_type__: 'BuiltinFunction', value }`
 //! - `MontyObject::Dataclass` → `{ __monty_type__: 'Dataclass', name, fields, ... }`
+//! - JS `{ __monty_type__: 'Path', value }` → `MontyObject::Path`
+//! - JS `{ __monty_type__: 'FileHandle', path, mode, position }` → `MontyObject::FileHandle`
+//! - JS `{ __monty_type__: 'StatResult', ... }` → `MontyObject::NamedTuple`
 //! - `MontyObject::Repr` → plain `string`
 //! - `MontyObject::Cycle` → placeholder `string`
 
 use std::{collections::HashMap, ptr};
 
-use monty::{DictPairs, ExcType, MontyDate, MontyDateTime, MontyObject, MontyTimeDelta, MontyTimeZone};
+use monty::{
+    stat_result, DictPairs, ExcType, FileMode, MontyDate, MontyDateTime, MontyFileHandle, MontyObject, MontyTimeDelta,
+    MontyTimeZone,
+};
 use napi::{bindgen_prelude::*, sys::Status};
 use num_bigint::BigInt as NumBigInt;
 
@@ -632,6 +638,42 @@ fn js_marked_object_to_monty(obj: &Object, monty_type: &str, env: Env) -> Result
             offset_seconds: obj.get_named_property::<i32>("offsetSeconds")?,
             name: obj.get_named_property::<Option<String>>("name")?,
         })),
+        "Path" => {
+            let value: String = obj.get_named_property("value")?;
+            Ok(MontyObject::Path(value))
+        }
+        "FileHandle" => {
+            let path: String = obj.get_named_property("path")?;
+            let mode_str: String = obj.get_named_property("mode")?;
+            let mode: FileMode = mode_str
+                .parse()
+                .map_err(|e| Error::from_reason(format!("Invalid file mode for FileHandle: {e}")))?;
+            let position = obj.get_named_property::<Option<i64>>("position")?.unwrap_or(0);
+            if position < 0 {
+                return Err(Error::from_reason("FileHandle position cannot be negative"));
+            }
+            #[expect(clippy::cast_sign_loss, reason = "position is checked as non-negative")]
+            Ok(MontyObject::FileHandle(MontyFileHandle {
+                path,
+                mode,
+                position: position as u64,
+            }))
+        }
+        "StatResult" => {
+            let st_mode = obj.get_named_property::<Option<i64>>("stMode")?.unwrap_or(0o100_644);
+            let st_ino = obj.get_named_property::<Option<i64>>("stIno")?.unwrap_or(0);
+            let st_dev = obj.get_named_property::<Option<i64>>("stDev")?.unwrap_or(0);
+            let st_nlink = obj.get_named_property::<Option<i64>>("stNlink")?.unwrap_or(1);
+            let st_uid = obj.get_named_property::<Option<i64>>("stUid")?.unwrap_or(0);
+            let st_gid = obj.get_named_property::<Option<i64>>("stGid")?.unwrap_or(0);
+            let st_size = obj.get_named_property::<Option<i64>>("stSize")?.unwrap_or(0);
+            let st_atime = obj.get_named_property::<Option<f64>>("stAtime")?.unwrap_or(0.0);
+            let st_mtime = obj.get_named_property::<Option<f64>>("stMtime")?.unwrap_or(st_atime);
+            let st_ctime = obj.get_named_property::<Option<f64>>("stCtime")?.unwrap_or(st_mtime);
+            Ok(stat_result(
+                st_mode, st_ino, st_dev, st_nlink, st_uid, st_gid, st_size, st_atime, st_mtime, st_ctime,
+            ))
+        }
         "Type" => {
             // Type objects can't be fully round-tripped; return as Repr
             let value: String = obj.get_named_property("value")?;

--- a/crates/monty-js/src/monty_cls.rs
+++ b/crates/monty-js/src/monty_cls.rs
@@ -43,12 +43,18 @@
 //! console.log('Final result:', progress.output);
 //! ```
 
-use std::{borrow::Cow, fmt::Write, mem, ptr, result};
+use std::{
+    borrow::Cow,
+    fmt::Write,
+    mem, ptr, result,
+    sync::{Arc, Mutex},
+};
 
 use monty::{
     fs::MountTable, ExcType, ExtFunctionResult, FunctionCall, LimitedTracker, MontyException, MontyObject,
     MontyRepl as CoreMontyRepl, MontyRun, NameLookup, NameLookupResult, NoLimitTracker, OsCall, PrintWriter,
-    PrintWriterCallback, ReplProgress, ResourceTracker, RunProgress,
+    PrintWriterCallback, ReplFunctionCall, ReplNameLookup, ReplOsCall, ReplProgress, ReplStartError, ResourceTracker,
+    RunProgress,
 };
 use monty_type_checking::{type_check, SourceFile};
 use napi::{bindgen_prelude::*, sys::Status};
@@ -125,6 +131,8 @@ pub struct StartOptions<'env> {
     /// Filesystem mount(s) for the sandbox.
     /// A single `MountDir` or an array of `MountDir`.
     pub mount: Option<Object<'env>>,
+    /// Pause and return OS calls not handled by native mounts.
+    pub pause_os_calls: Option<bool>,
 }
 
 #[napi]
@@ -362,9 +370,10 @@ impl Monty {
         &self,
         env: &'env Env,
         options: Option<StartOptions<'env>>,
-    ) -> Result<Either4<MontySnapshot, MontyNameLookup, MontyComplete, JsMontyException>> {
+    ) -> Result<Either5<MontySnapshot, MontyNameLookup, MontyComplete, MontyOsCall, JsMontyException>> {
         let options = options.unwrap_or_default();
         let input_values = self.extract_input_values(options.inputs, *env)?;
+        let pause_os_calls = options.pause_os_calls.unwrap_or(false);
 
         // Build the mount handler from the mount parameter
         let os_handler = match options.mount.as_ref() {
@@ -401,20 +410,34 @@ impl Monty {
                 Ok(p) => p,
                 Err(exc) => {
                     put_back_mount_state(mount_state);
-                    return Ok(Either4::D(JsMontyException::new(exc)));
+                    return Ok(Either5::E(JsMontyException::new(exc)));
                 }
             };
-            progress_to_result_with_mounts(env, progress, print_callback_ref, self.script_name(), mount_state)
+            progress_to_result_with_mounts(
+                env,
+                progress,
+                print_callback_ref,
+                self.script_name(),
+                mount_state,
+                pause_os_calls,
+            )
         } else {
             let tracker = NoLimitTracker;
             let progress = match runner.start(input_values, tracker, print_writer) {
                 Ok(p) => p,
                 Err(exc) => {
                     put_back_mount_state(mount_state);
-                    return Ok(Either4::D(JsMontyException::new(exc)));
+                    return Ok(Either5::E(JsMontyException::new(exc)));
                 }
             };
-            progress_to_result_with_mounts(env, progress, print_callback_ref, self.script_name(), mount_state)
+            progress_to_result_with_mounts(
+                env,
+                progress,
+                print_callback_ref,
+                self.script_name(),
+                mount_state,
+                pause_os_calls,
+            )
         }
     }
 
@@ -518,6 +541,8 @@ enum EitherRepl {
     Limited(CoreMontyRepl<LimitedTracker>),
 }
 
+type SharedRepl = Arc<Mutex<Option<EitherRepl>>>;
+
 /// Options for creating a new `MontyRepl` instance.
 ///
 /// Controls the script name shown in tracebacks and optional resource limits
@@ -535,9 +560,13 @@ pub struct MontyReplOptions {
 #[napi(object)]
 #[derive(Default)]
 pub struct FeedOptions<'env> {
+    /// Optional print callback function.
+    pub print_callback: Option<JsPrintCallback<'env>>,
     /// Filesystem mount(s) for the sandbox.
     /// A single `MountDir` or an array of `MountDir`.
     pub mount: Option<Object<'env>>,
+    /// Pause and return OS calls not handled by native mounts.
+    pub pause_os_calls: Option<bool>,
 }
 
 /// Stateful no-replay REPL session.
@@ -546,7 +575,7 @@ pub struct FeedOptions<'env> {
 /// incrementally against persistent heap and namespace state.
 #[napi]
 pub struct MontyRepl {
-    repl: Option<EitherRepl>,
+    repl: SharedRepl,
     script_name: String,
 }
 
@@ -571,7 +600,7 @@ impl MontyRepl {
         };
 
         Ok(Self {
-            repl: Some(repl),
+            repl: Arc::new(Mutex::new(Some(repl))),
             script_name,
         })
     }
@@ -602,18 +631,26 @@ impl MontyRepl {
 
         // If mounts are provided, use feed_start/resume loop to handle OsCall
         if os_handler.is_some() {
-            return self.feed_with_mounts(env, code, os_handler);
+            let print_callback_ref = options.print_callback.as_ref().map(Function::create_ref).transpose()?;
+            return self.feed_with_mounts(env, code, os_handler, print_callback_ref);
         }
 
-        let repl = self
-            .repl
-            .as_mut()
-            .ok_or_else(|| Error::from_reason("REPL session is currently in use"))?;
-
-        let output = match repl {
-            EitherRepl::NoLimit(repl) => repl.feed_run(&code, vec![], PrintWriter::Stdout),
-            EitherRepl::Limited(repl) => repl.feed_run(&code, vec![], PrintWriter::Stdout),
+        let mut print_cb;
+        let print_writer = match &options.print_callback {
+            Some(func) => {
+                print_cb = CallbackStringPrint::new_js(env, func)?;
+                PrintWriter::Callback(&mut print_cb)
+            }
+            None => PrintWriter::Stdout,
         };
+
+        let mut repl = take_shared_repl(&self.repl)?;
+
+        let output = match &mut repl {
+            EitherRepl::NoLimit(repl) => repl.feed_run(&code, vec![], print_writer),
+            EitherRepl::Limited(repl) => repl.feed_run(&code, vec![], print_writer),
+        };
+        put_shared_repl(&self.repl, repl)?;
 
         match output {
             Ok(value) => Ok(Either::A(monty_to_js(&value, env)?)),
@@ -621,11 +658,71 @@ impl MontyRepl {
         }
     }
 
+    /// Starts executing one incremental snippet and returns a resumable progress object.
+    #[napi]
+    pub fn feed_start<'env>(
+        &self,
+        env: &'env Env,
+        code: String,
+        options: Option<FeedOptions<'env>>,
+    ) -> Result<Either5<MontySnapshot, MontyNameLookup, MontyComplete, MontyOsCall, JsMontyException>> {
+        let options = options.unwrap_or_default();
+        let pause_os_calls = options.pause_os_calls.unwrap_or(false);
+        let os_handler = match options.mount.as_ref() {
+            Some(obj) => OsHandler::from_extracted(extract_mounts(obj)?),
+            None => None,
+        };
+        let mount_table: Option<MountTable> = os_handler.as_ref().map(OsHandler::take).transpose()?;
+        let mount_state = os_handler.zip(mount_table);
+        let print_callback_ref = options.print_callback.as_ref().map(Function::create_ref).transpose()?;
+
+        let repl = take_shared_repl(&self.repl)?;
+        let repl_state = Arc::clone(&self.repl);
+
+        macro_rules! feed_start_impl {
+            ($repl:expr) => {{
+                let mut print_cb = match &print_callback_ref {
+                    Some(func) => Some(CallbackStringPrint::new_js_ref(env, func)?),
+                    None => None,
+                };
+                let print_writer = match &mut print_cb {
+                    Some(cb) => PrintWriter::Callback(cb),
+                    None => PrintWriter::Stdout,
+                };
+                let progress = match $repl.feed_start(&code, vec![], print_writer) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        put_shared_repl(&repl_state, EitherRepl::from_core(e.repl))?;
+                        put_back_mount_state(mount_state);
+                        return Ok(Either5::E(JsMontyException::new(e.error)));
+                    }
+                };
+                repl_progress_to_result_with_mounts(
+                    env,
+                    progress,
+                    print_callback_ref,
+                    self.script_name.clone(),
+                    mount_state,
+                    repl_state,
+                    pause_os_calls,
+                )
+            }};
+        }
+
+        match repl {
+            EitherRepl::NoLimit(repl) => feed_start_impl!(repl),
+            EitherRepl::Limited(repl) => feed_start_impl!(repl),
+        }
+    }
+
     /// Serializes this REPL session to bytes.
     #[napi]
     pub fn dump(&self) -> Result<Buffer> {
-        let repl = self
+        let repl_guard = self
             .repl
+            .lock()
+            .map_err(|_| Error::from_reason("REPL session lock is poisoned"))?;
+        let repl = repl_guard
             .as_ref()
             .ok_or_else(|| Error::from_reason("REPL session is currently in use"))?;
         let serialized = SerializedRepl {
@@ -643,7 +740,7 @@ impl MontyRepl {
         let serialized: SerializedReplOwned =
             postcard::from_bytes(&data).map_err(|e| Error::from_reason(format!("Deserialization failed: {e}")))?;
         Ok(Self {
-            repl: Some(serialized.repl),
+            repl: Arc::new(Mutex::new(Some(serialized.repl))),
             script_name: serialized.script_name,
         })
     }
@@ -666,6 +763,7 @@ impl MontyRepl {
         env: &'env Env,
         code: String,
         os_handler: Option<OsHandler>,
+        print_callback: Option<JsPrintCallbackRef>,
     ) -> Result<Either<JsMontyObject<'env>, JsMontyException>> {
         // Take mounts out of shared slots
         let mut mount_table: Option<MountTable> = os_handler.as_ref().map(OsHandler::take).transpose()?;
@@ -677,18 +775,23 @@ impl MontyRepl {
         };
 
         // Take the REPL out (feed_start consumes it)
-        let repl = self
-            .repl
-            .take()
-            .ok_or_else(|| Error::from_reason("REPL session is currently in use"))?;
+        let repl = take_shared_repl(&self.repl)?;
 
         macro_rules! feed_loop {
             ($repl:expr) => {{
-                let progress = match $repl.feed_start(&code, vec![], PrintWriter::Stdout) {
+                let mut print_cb = match &print_callback {
+                    Some(func) => Some(CallbackStringPrint::new_js_ref(env, func)?),
+                    None => None,
+                };
+                let print_writer = match &mut print_cb {
+                    Some(cb) => PrintWriter::Callback(cb),
+                    None => PrintWriter::Stdout,
+                };
+                let progress = match $repl.feed_start(&code, vec![], print_writer) {
                     Ok(p) => p,
                     Err(e) => {
                         // Restore REPL from error
-                        self.repl = Some(EitherRepl::from_core(e.repl));
+                        put_shared_repl(&self.repl, EitherRepl::from_core(e.repl))?;
                         put_back(mount_table);
                         return Ok(Either::B(JsMontyException::new(e.error)));
                     }
@@ -698,7 +801,7 @@ impl MontyRepl {
                 loop {
                     match progress {
                         ReplProgress::Complete { repl, value } => {
-                            self.repl = Some(EitherRepl::from_core(repl));
+                            put_shared_repl(&self.repl, EitherRepl::from_core(repl))?;
                             put_back(mount_table);
                             return Ok(Either::A(monty_to_js(&value, env)?));
                         }
@@ -708,10 +811,14 @@ impl MontyRepl {
                             } else {
                                 call.function_call.on_no_handler().into()
                             };
-                            progress = match call.resume(os_result, PrintWriter::Stdout) {
+                            let print_writer = match &mut print_cb {
+                                Some(cb) => PrintWriter::Callback(cb),
+                                None => PrintWriter::Stdout,
+                            };
+                            progress = match call.resume(os_result, print_writer) {
                                 Ok(p) => p,
                                 Err(e) => {
-                                    self.repl = Some(EitherRepl::from_core(e.repl));
+                                    put_shared_repl(&self.repl, EitherRepl::from_core(e.repl))?;
                                     put_back(mount_table);
                                     return Ok(Either::B(JsMontyException::new(e.error)));
                                 }
@@ -720,7 +827,7 @@ impl MontyRepl {
                         ReplProgress::FunctionCall(call) => {
                             // No external function support in feed — return error
                             let func_name = call.function_name.clone();
-                            self.repl = Some(EitherRepl::from_core(call.into_repl()));
+                            put_shared_repl(&self.repl, EitherRepl::from_core(call.into_repl()))?;
                             put_back(mount_table);
                             return Ok(Either::B(JsMontyException::new(MontyException::new(
                                 ExcType::RuntimeError,
@@ -731,17 +838,21 @@ impl MontyRepl {
                         }
                         ReplProgress::NameLookup(lookup) => {
                             // No name lookup support — let it raise NameError
-                            progress = match lookup.resume(NameLookupResult::Undefined, PrintWriter::Stdout) {
+                            let print_writer = match &mut print_cb {
+                                Some(cb) => PrintWriter::Callback(cb),
+                                None => PrintWriter::Stdout,
+                            };
+                            progress = match lookup.resume(NameLookupResult::Undefined, print_writer) {
                                 Ok(p) => p,
                                 Err(e) => {
-                                    self.repl = Some(EitherRepl::from_core(e.repl));
+                                    put_shared_repl(&self.repl, EitherRepl::from_core(e.repl))?;
                                     put_back(mount_table);
                                     return Ok(Either::B(JsMontyException::new(e.error)));
                                 }
                             };
                         }
                         ReplProgress::ResolveFutures(state) => {
-                            self.repl = Some(EitherRepl::from_core(state.into_repl()));
+                            put_shared_repl(&self.repl, EitherRepl::from_core(state.into_repl()))?;
                             put_back(mount_table);
                             return Err(Error::from_reason(
                                 "Async futures are not supported in REPL feed()",
@@ -759,16 +870,41 @@ impl MontyRepl {
     }
 }
 
+fn take_shared_repl(shared: &SharedRepl) -> Result<EitherRepl> {
+    let mut guard = shared
+        .lock()
+        .map_err(|_| Error::from_reason("REPL session lock is poisoned"))?;
+    guard
+        .take()
+        .ok_or_else(|| Error::from_reason("REPL session is currently in use"))
+}
+
+fn put_shared_repl(shared: &SharedRepl, repl: EitherRepl) -> Result<()> {
+    let mut guard = shared
+        .lock()
+        .map_err(|_| Error::from_reason("REPL session lock is poisoned"))?;
+    if guard.is_some() {
+        return Err(Error::from_reason("REPL session has already been restored"));
+    }
+    *guard = Some(repl);
+    Ok(())
+}
+
+fn restore_repl_start_error<T: ResourceTracker>(shared: &SharedRepl, err: ReplStartError<T>) -> Result<JsMontyException>
+where
+    EitherRepl: FromCoreRepl<T>,
+{
+    put_shared_repl(shared, EitherRepl::from_core(err.repl))?;
+    Ok(JsMontyException::new(err.error))
+}
+
 /// Handles an OS call from the REPL using a mount table.
 fn handle_os_call_with_table_repl<T: ResourceTracker>(
     call: &monty::ReplOsCall<T>,
     table: &mut MountTable,
 ) -> ExtFunctionResult {
-    match table.handle_os_call(&call.function_call) {
-        Some(Ok(obj)) => obj.into(),
-        Some(Err(mount_err)) => mount_err.into_exception().into(),
-        None => call.function_call.on_no_handler().into(),
-    }
+    handle_os_function_with_table(&call.function_call, table)
+        .unwrap_or_else(|| call.function_call.on_no_handler().into())
 }
 
 /// Trait to convert a typed `CoreMontyRepl<T>` back into `EitherRepl`.
@@ -864,7 +1000,18 @@ fn extract_input_values_in_order(
 enum EitherSnapshot {
     NoLimit(FunctionCall<NoLimitTracker>),
     Limited(FunctionCall<LimitedTracker>),
+    ReplNoLimit(ReplFunctionCall<NoLimitTracker>),
+    ReplLimited(ReplFunctionCall<LimitedTracker>),
     /// Sentinel indicating the snapshot has been consumed via `resume()`.
+    Done,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+enum EitherOsSnapshot {
+    NoLimit(OsCall<NoLimitTracker>),
+    Limited(OsCall<LimitedTracker>),
+    ReplNoLimit(ReplOsCall<NoLimitTracker>),
+    ReplLimited(ReplOsCall<LimitedTracker>),
     Done,
 }
 
@@ -898,6 +1045,10 @@ pub struct MontySnapshot {
     print_callback: Option<JsPrintCallbackRef>,
     /// Mount state carried from `start()` for use during `resume()`.
     mount_state: Option<MountState>,
+    /// REPL state to restore when a REPL feed-start chain completes or errors.
+    repl_state: Option<SharedRepl>,
+    /// Whether unhandled OS calls should be surfaced to JavaScript.
+    pause_os_calls: bool,
 }
 
 /// Options for resuming execution.
@@ -975,7 +1126,7 @@ impl MontySnapshot {
         &mut self,
         env: &'env Env,
         options: ResumeOptions<'env>,
-    ) -> Result<Either4<Self, MontyNameLookup, MontyComplete, JsMontyException>> {
+    ) -> Result<Either5<Self, MontyNameLookup, MontyComplete, MontyOsCall, JsMontyException>> {
         // Validate that exactly one of returnValue or exception is provided
         let external_result = match (options.return_value, options.exception) {
             (Some(value), None) => {
@@ -1016,6 +1167,8 @@ impl MontySnapshot {
 
         // Take mount state from the snapshot
         let mount_state = mem::take(&mut self.mount_state);
+        let repl_state = self.repl_state.clone();
+        let pause_os_calls = self.pause_os_calls;
 
         // Resume execution based on the snapshot type
         match snapshot {
@@ -1024,20 +1177,80 @@ impl MontySnapshot {
                     Ok(p) => p,
                     Err(exc) => {
                         put_back_mount_state(mount_state);
-                        return Ok(Either4::D(JsMontyException::new(exc)));
+                        return Ok(Either5::E(JsMontyException::new(exc)));
                     }
                 };
-                progress_to_result_with_mounts(env, progress, print_callback, self.script_name.clone(), mount_state)
+                progress_to_result_with_mounts(
+                    env,
+                    progress,
+                    print_callback,
+                    self.script_name.clone(),
+                    mount_state,
+                    pause_os_calls,
+                )
             }
             EitherSnapshot::Limited(call) => {
                 let progress = match call.resume(external_result, print_writer) {
                     Ok(p) => p,
                     Err(exc) => {
                         put_back_mount_state(mount_state);
-                        return Ok(Either4::D(JsMontyException::new(exc)));
+                        return Ok(Either5::E(JsMontyException::new(exc)));
                     }
                 };
-                progress_to_result_with_mounts(env, progress, print_callback, self.script_name.clone(), mount_state)
+                progress_to_result_with_mounts(
+                    env,
+                    progress,
+                    print_callback,
+                    self.script_name.clone(),
+                    mount_state,
+                    pause_os_calls,
+                )
+            }
+            EitherSnapshot::ReplNoLimit(call) => {
+                let Some(repl_state) = repl_state else {
+                    put_back_mount_state(mount_state);
+                    return Err(Error::from_reason("REPL snapshot is missing its REPL owner"));
+                };
+                let progress = match call.resume(external_result, print_writer) {
+                    Ok(p) => p,
+                    Err(exc) => {
+                        let exc = restore_repl_start_error(&repl_state, *exc)?;
+                        put_back_mount_state(mount_state);
+                        return Ok(Either5::E(exc));
+                    }
+                };
+                repl_progress_to_result_with_mounts(
+                    env,
+                    progress,
+                    print_callback,
+                    self.script_name.clone(),
+                    mount_state,
+                    repl_state,
+                    pause_os_calls,
+                )
+            }
+            EitherSnapshot::ReplLimited(call) => {
+                let Some(repl_state) = repl_state else {
+                    put_back_mount_state(mount_state);
+                    return Err(Error::from_reason("REPL snapshot is missing its REPL owner"));
+                };
+                let progress = match call.resume(external_result, print_writer) {
+                    Ok(p) => p,
+                    Err(exc) => {
+                        let exc = restore_repl_start_error(&repl_state, *exc)?;
+                        put_back_mount_state(mount_state);
+                        return Ok(Either5::E(exc));
+                    }
+                };
+                repl_progress_to_result_with_mounts(
+                    env,
+                    progress,
+                    print_callback,
+                    self.script_name.clone(),
+                    mount_state,
+                    repl_state,
+                    pause_os_calls,
+                )
             }
             EitherSnapshot::Done => Err(Error::from_reason("Snapshot has already been resumed")),
         }
@@ -1053,6 +1266,14 @@ impl MontySnapshot {
     pub fn dump(&self) -> Result<Buffer> {
         if matches!(self.snapshot, EitherSnapshot::Done) {
             return Err(Error::from_reason("Cannot dump snapshot that has already been resumed"));
+        }
+        if matches!(
+            self.snapshot,
+            EitherSnapshot::ReplNoLimit(_) | EitherSnapshot::ReplLimited(_)
+        ) {
+            return Err(Error::from_reason(
+                "Cannot dump REPL snapshots from the JS bindings; dump the MontyRepl after completion instead",
+            ));
         }
 
         let serialized = SerializedSnapshot {
@@ -1090,6 +1311,8 @@ impl MontySnapshot {
                 .map(Function::create_ref)
                 .transpose()?,
             mount_state: None,
+            repl_state: None,
+            pause_os_calls: false,
         })
     }
 
@@ -1098,6 +1321,242 @@ impl MontySnapshot {
     pub fn repr(&self) -> String {
         format!(
             "MontySnapshot(scriptName='{}', functionName='{}', args={:?}, kwargs={:?})",
+            self.script_name, self.function_name, self.args, self.kwargs
+        )
+    }
+}
+
+// =============================================================================
+// MontyOsCall - Paused execution at an OS call
+// =============================================================================
+
+/// Represents paused execution waiting for a host OS/filesystem operation.
+#[napi]
+pub struct MontyOsCall {
+    snapshot: EitherOsSnapshot,
+    script_name: String,
+    function_name: String,
+    args: Vec<MontyObject>,
+    kwargs: Vec<(MontyObject, MontyObject)>,
+    print_callback: Option<JsPrintCallbackRef>,
+    mount_state: Option<MountState>,
+    repl_state: Option<SharedRepl>,
+    pause_os_calls: bool,
+}
+
+#[napi]
+impl MontyOsCall {
+    /// Returns the name of the script being executed.
+    #[napi(getter)]
+    pub fn script_name(&self) -> String {
+        self.script_name.clone()
+    }
+
+    /// Returns the stable OS function name, such as `Path.read_text` or `Open`.
+    #[napi(getter)]
+    pub fn function_name(&self) -> String {
+        self.function_name.clone()
+    }
+
+    /// Returns the positional arguments passed to the OS operation.
+    #[napi(getter)]
+    pub fn args<'env>(&self, env: &'env Env) -> Result<Vec<JsMontyObject<'env>>> {
+        self.args.iter().map(|obj| monty_to_js(obj, env)).collect()
+    }
+
+    /// Returns the keyword arguments passed to the OS operation as an object.
+    #[napi(getter)]
+    pub fn kwargs<'env>(&self, env: &'env Env) -> Result<Object<'env>> {
+        let mut obj = Object::new(env)?;
+        for (k, v) in &self.kwargs {
+            let key = match k {
+                MontyObject::String(s) => s.clone(),
+                _ => format!("{k:?}"),
+            };
+            let js_value = monty_to_js(v, env)?;
+            obj.set_named_property(&key, js_value)?;
+        }
+        Ok(obj)
+    }
+
+    /// Resumes execution with either the OS call return value or an exception.
+    #[napi]
+    pub fn resume<'env>(
+        &mut self,
+        env: &'env Env,
+        options: ResumeOptions<'env>,
+    ) -> Result<Either5<MontySnapshot, MontyNameLookup, MontyComplete, Self, JsMontyException>> {
+        let external_result = match (options.return_value, options.exception) {
+            (Some(value), None) => {
+                let monty_value = js_to_monty(value, *env)?;
+                ExtFunctionResult::Return(monty_value)
+            }
+            (None, Some(exc)) => {
+                let monty_exc = MontyException::new(string_to_exc_type(&exc.r#type)?, Some(exc.message));
+                ExtFunctionResult::Error(monty_exc)
+            }
+            (Some(_), Some(_)) => {
+                return Err(Error::from_reason(
+                    "resume() accepts either returnValue or exception, not both",
+                ));
+            }
+            (None, None) => {
+                return Err(Error::from_reason("resume() requires either returnValue or exception"));
+            }
+        };
+
+        let snapshot = mem::replace(&mut self.snapshot, EitherOsSnapshot::Done);
+        let print_callback = mem::take(&mut self.print_callback);
+        let mut print_cb;
+        let print_writer = match &print_callback {
+            Some(func) => {
+                print_cb = CallbackStringPrint::new_js_ref(env, func)?;
+                PrintWriter::Callback(&mut print_cb)
+            }
+            None => PrintWriter::Stdout,
+        };
+        let mount_state = mem::take(&mut self.mount_state);
+        let repl_state = self.repl_state.clone();
+        let pause_os_calls = self.pause_os_calls;
+
+        match snapshot {
+            EitherOsSnapshot::NoLimit(call) => {
+                let progress = match call.resume(external_result, print_writer) {
+                    Ok(p) => p,
+                    Err(exc) => {
+                        put_back_mount_state(mount_state);
+                        return Ok(Either5::E(JsMontyException::new(exc)));
+                    }
+                };
+                progress_to_result_with_mounts(
+                    env,
+                    progress,
+                    print_callback,
+                    self.script_name.clone(),
+                    mount_state,
+                    pause_os_calls,
+                )
+            }
+            EitherOsSnapshot::Limited(call) => {
+                let progress = match call.resume(external_result, print_writer) {
+                    Ok(p) => p,
+                    Err(exc) => {
+                        put_back_mount_state(mount_state);
+                        return Ok(Either5::E(JsMontyException::new(exc)));
+                    }
+                };
+                progress_to_result_with_mounts(
+                    env,
+                    progress,
+                    print_callback,
+                    self.script_name.clone(),
+                    mount_state,
+                    pause_os_calls,
+                )
+            }
+            EitherOsSnapshot::ReplNoLimit(call) => {
+                let Some(repl_state) = repl_state else {
+                    put_back_mount_state(mount_state);
+                    return Err(Error::from_reason("REPL OS call is missing its REPL owner"));
+                };
+                let progress = match call.resume(external_result, print_writer) {
+                    Ok(p) => p,
+                    Err(exc) => {
+                        let exc = restore_repl_start_error(&repl_state, *exc)?;
+                        put_back_mount_state(mount_state);
+                        return Ok(Either5::E(exc));
+                    }
+                };
+                repl_progress_to_result_with_mounts(
+                    env,
+                    progress,
+                    print_callback,
+                    self.script_name.clone(),
+                    mount_state,
+                    repl_state,
+                    pause_os_calls,
+                )
+            }
+            EitherOsSnapshot::ReplLimited(call) => {
+                let Some(repl_state) = repl_state else {
+                    put_back_mount_state(mount_state);
+                    return Err(Error::from_reason("REPL OS call is missing its REPL owner"));
+                };
+                let progress = match call.resume(external_result, print_writer) {
+                    Ok(p) => p,
+                    Err(exc) => {
+                        let exc = restore_repl_start_error(&repl_state, *exc)?;
+                        put_back_mount_state(mount_state);
+                        return Ok(Either5::E(exc));
+                    }
+                };
+                repl_progress_to_result_with_mounts(
+                    env,
+                    progress,
+                    print_callback,
+                    self.script_name.clone(),
+                    mount_state,
+                    repl_state,
+                    pause_os_calls,
+                )
+            }
+            EitherOsSnapshot::Done => Err(Error::from_reason("OS call has already been resumed")),
+        }
+    }
+
+    /// Serializes this OS call snapshot. REPL OS calls cannot be dumped.
+    #[napi]
+    pub fn dump(&self) -> Result<Buffer> {
+        if matches!(self.snapshot, EitherOsSnapshot::Done) {
+            return Err(Error::from_reason("Cannot dump OS call that has already been resumed"));
+        }
+        if matches!(
+            self.snapshot,
+            EitherOsSnapshot::ReplNoLimit(_) | EitherOsSnapshot::ReplLimited(_)
+        ) {
+            return Err(Error::from_reason(
+                "Cannot dump REPL OS calls from the JS bindings; dump the MontyRepl after completion instead",
+            ));
+        }
+        let serialized = SerializedOsCall {
+            snapshot: &self.snapshot,
+            script_name: &self.script_name,
+            function_name: &self.function_name,
+            args: &self.args,
+            kwargs: &self.kwargs,
+        };
+        let bytes =
+            postcard::to_allocvec(&serialized).map_err(|e| Error::from_reason(format!("Serialization failed: {e}")))?;
+        Ok(Buffer::from(bytes))
+    }
+
+    /// Deserializes an OS call snapshot.
+    #[napi(factory)]
+    pub fn load(data: Buffer, options: Option<SnapshotLoadOptions>) -> Result<Self> {
+        let serialized: SerializedOsCallOwned =
+            postcard::from_bytes(&data).map_err(|e| Error::from_reason(format!("Deserialization failed: {e}")))?;
+        Ok(Self {
+            snapshot: serialized.snapshot,
+            script_name: serialized.script_name,
+            function_name: serialized.function_name,
+            args: serialized.args,
+            kwargs: serialized.kwargs,
+            print_callback: options
+                .as_ref()
+                .and_then(|t| t.print_callback.as_ref())
+                .map(Function::create_ref)
+                .transpose()?,
+            mount_state: None,
+            repl_state: None,
+            pause_os_calls: false,
+        })
+    }
+
+    /// Returns a string representation of this OS call.
+    #[napi]
+    pub fn repr(&self) -> String {
+        format!(
+            "MontyOsCall(scriptName='{}', functionName='{}', args={:?}, kwargs={:?})",
             self.script_name, self.function_name, self.args, self.kwargs
         )
     }
@@ -1144,6 +1603,8 @@ impl MontyComplete {
 enum EitherLookupSnapshot {
     NoLimit(NameLookup<NoLimitTracker>),
     Limited(NameLookup<LimitedTracker>),
+    ReplNoLimit(ReplNameLookup<NoLimitTracker>),
+    ReplLimited(ReplNameLookup<LimitedTracker>),
     /// Sentinel indicating the snapshot has been consumed via `resume()`.
     Done,
 }
@@ -1163,6 +1624,22 @@ impl FromLookupSnapshot<NoLimitTracker> for EitherLookupSnapshot {
 impl FromLookupSnapshot<LimitedTracker> for EitherLookupSnapshot {
     fn from_lookup(lookup: NameLookup<LimitedTracker>) -> Self {
         Self::Limited(lookup)
+    }
+}
+
+trait FromReplLookupSnapshot<T: ResourceTracker> {
+    fn from_repl_lookup(lookup: ReplNameLookup<T>) -> Self;
+}
+
+impl FromReplLookupSnapshot<NoLimitTracker> for EitherLookupSnapshot {
+    fn from_repl_lookup(lookup: ReplNameLookup<NoLimitTracker>) -> Self {
+        Self::ReplNoLimit(lookup)
+    }
+}
+
+impl FromReplLookupSnapshot<LimitedTracker> for EitherLookupSnapshot {
+    fn from_repl_lookup(lookup: ReplNameLookup<LimitedTracker>) -> Self {
+        Self::ReplLimited(lookup)
     }
 }
 
@@ -1187,6 +1664,10 @@ pub struct MontyNameLookup {
     print_callback: Option<JsPrintCallbackRef>,
     /// Mount state carried from `start()` for use during `resume()`.
     mount_state: Option<MountState>,
+    /// REPL state to restore when a REPL feed-start chain completes or errors.
+    repl_state: Option<SharedRepl>,
+    /// Whether unhandled OS calls should be surfaced to JavaScript.
+    pause_os_calls: bool,
 }
 
 /// Options for resuming execution from a name lookup.
@@ -1233,7 +1714,7 @@ impl MontyNameLookup {
         &mut self,
         env: &'env Env,
         options: Option<NameLookupResumeOptions<'env>>,
-    ) -> Result<Either4<MontySnapshot, Self, MontyComplete, JsMontyException>> {
+    ) -> Result<Either5<MontySnapshot, Self, MontyComplete, MontyOsCall, JsMontyException>> {
         let lookup_result = match options.and_then(|opts| opts.value) {
             Some(value) => {
                 let monty_value = js_to_monty(value, *env)?;
@@ -1260,6 +1741,8 @@ impl MontyNameLookup {
 
         // Take mount state from the snapshot
         let mount_state = mem::take(&mut self.mount_state);
+        let repl_state = self.repl_state.clone();
+        let pause_os_calls = self.pause_os_calls;
 
         match snapshot {
             EitherLookupSnapshot::NoLimit(lookup) => {
@@ -1267,20 +1750,80 @@ impl MontyNameLookup {
                     Ok(p) => p,
                     Err(exc) => {
                         put_back_mount_state(mount_state);
-                        return Ok(Either4::D(JsMontyException::new(exc)));
+                        return Ok(Either5::E(JsMontyException::new(exc)));
                     }
                 };
-                progress_to_result_with_mounts(env, progress, print_callback, self.script_name.clone(), mount_state)
+                progress_to_result_with_mounts(
+                    env,
+                    progress,
+                    print_callback,
+                    self.script_name.clone(),
+                    mount_state,
+                    pause_os_calls,
+                )
             }
             EitherLookupSnapshot::Limited(lookup) => {
                 let progress = match lookup.resume(lookup_result, print_writer) {
                     Ok(p) => p,
                     Err(exc) => {
                         put_back_mount_state(mount_state);
-                        return Ok(Either4::D(JsMontyException::new(exc)));
+                        return Ok(Either5::E(JsMontyException::new(exc)));
                     }
                 };
-                progress_to_result_with_mounts(env, progress, print_callback, self.script_name.clone(), mount_state)
+                progress_to_result_with_mounts(
+                    env,
+                    progress,
+                    print_callback,
+                    self.script_name.clone(),
+                    mount_state,
+                    pause_os_calls,
+                )
+            }
+            EitherLookupSnapshot::ReplNoLimit(lookup) => {
+                let Some(repl_state) = repl_state else {
+                    put_back_mount_state(mount_state);
+                    return Err(Error::from_reason("REPL name lookup is missing its REPL owner"));
+                };
+                let progress = match lookup.resume(lookup_result, print_writer) {
+                    Ok(p) => p,
+                    Err(exc) => {
+                        let exc = restore_repl_start_error(&repl_state, *exc)?;
+                        put_back_mount_state(mount_state);
+                        return Ok(Either5::E(exc));
+                    }
+                };
+                repl_progress_to_result_with_mounts(
+                    env,
+                    progress,
+                    print_callback,
+                    self.script_name.clone(),
+                    mount_state,
+                    repl_state,
+                    pause_os_calls,
+                )
+            }
+            EitherLookupSnapshot::ReplLimited(lookup) => {
+                let Some(repl_state) = repl_state else {
+                    put_back_mount_state(mount_state);
+                    return Err(Error::from_reason("REPL name lookup is missing its REPL owner"));
+                };
+                let progress = match lookup.resume(lookup_result, print_writer) {
+                    Ok(p) => p,
+                    Err(exc) => {
+                        let exc = restore_repl_start_error(&repl_state, *exc)?;
+                        put_back_mount_state(mount_state);
+                        return Ok(Either5::E(exc));
+                    }
+                };
+                repl_progress_to_result_with_mounts(
+                    env,
+                    progress,
+                    print_callback,
+                    self.script_name.clone(),
+                    mount_state,
+                    repl_state,
+                    pause_os_calls,
+                )
             }
             EitherLookupSnapshot::Done => Err(Error::from_reason("Name lookup has already been resumed")),
         }
@@ -1296,6 +1839,14 @@ impl MontyNameLookup {
         if matches!(self.snapshot, EitherLookupSnapshot::Done) {
             return Err(Error::from_reason(
                 "Cannot dump name lookup that has already been resumed",
+            ));
+        }
+        if matches!(
+            self.snapshot,
+            EitherLookupSnapshot::ReplNoLimit(_) | EitherLookupSnapshot::ReplLimited(_)
+        ) {
+            return Err(Error::from_reason(
+                "Cannot dump REPL name lookups from the JS bindings; dump the MontyRepl after completion instead",
             ));
         }
 
@@ -1330,6 +1881,8 @@ impl MontyNameLookup {
                 .map(Function::create_ref)
                 .transpose()?,
             mount_state: None,
+            repl_state: None,
+            pause_os_calls: false,
         })
     }
 
@@ -1398,11 +1951,13 @@ fn progress_to_result_with_mounts<T>(
     print_callback: Option<JsPrintCallbackRef>,
     script_name: String,
     mut mount_state: Option<MountState>,
-) -> Result<Either4<MontySnapshot, MontyNameLookup, MontyComplete, JsMontyException>>
+    pause_os_calls: bool,
+) -> Result<Either5<MontySnapshot, MontyNameLookup, MontyComplete, MontyOsCall, JsMontyException>>
 where
     T: ResourceTracker + serde::Serialize + DeserializeOwned,
     EitherSnapshot: FromSnapshot<T>,
     EitherLookupSnapshot: FromLookupSnapshot<T>,
+    EitherOsSnapshot: FromOsSnapshot<T>,
 {
     // Build a reusable print callback so OsCall resumes use the JS callback
     // instead of falling back to stdout.
@@ -1416,13 +1971,13 @@ where
         match progress {
             RunProgress::Complete(result) => {
                 put_back_mount_state(mount_state);
-                return Ok(Either4::C(MontyComplete { output_value: result }));
+                return Ok(Either5::C(MontyComplete { output_value: result }));
             }
             RunProgress::FunctionCall(call) => {
                 let function_name = call.function_name.clone();
                 let args = call.args.clone();
                 let kwargs = call.kwargs.clone();
-                return Ok(Either4::A(MontySnapshot {
+                return Ok(Either5::A(MontySnapshot {
                     snapshot: EitherSnapshot::from_snapshot(call),
                     script_name,
                     function_name,
@@ -1430,32 +1985,62 @@ where
                     kwargs,
                     print_callback,
                     mount_state,
+                    repl_state: None,
+                    pause_os_calls,
                 }));
             }
             RunProgress::NameLookup(lookup) => {
                 let variable_name = lookup.name.clone();
-                return Ok(Either4::B(MontyNameLookup {
+                return Ok(Either5::B(MontyNameLookup {
                     snapshot: EitherLookupSnapshot::from_lookup(lookup),
                     script_name,
                     variable_name,
                     print_callback,
                     mount_state,
+                    repl_state: None,
+                    pause_os_calls,
                 }));
             }
             RunProgress::ResolveFutures(_) => {
                 put_back_mount_state(mount_state);
-                return Ok(Either4::D(JsMontyException::new(MontyException::new(
+                return Ok(Either5::E(JsMontyException::new(MontyException::new(
                     ExcType::NotImplementedError,
                     Some("Async futures (ResolveFutures) are not yet supported in the JS bindings".to_owned()),
                 ))));
             }
             RunProgress::OsCall(call) => {
-                let os_result = if let Some((_, ref mut table)) = mount_state {
-                    handle_os_call_with_table(&call, table)
-                } else {
-                    // No mounts configured — use on_no_handler for appropriate error
-                    call.function_call.on_no_handler().into()
-                };
+                if let Some((_, ref mut table)) = mount_state {
+                    if let Some(os_result) = handle_os_call_with_table(&call, table) {
+                        let print_writer = match &mut print_cb {
+                            Some(cb) => PrintWriter::Callback(cb),
+                            None => PrintWriter::Stdout,
+                        };
+                        progress = match call.resume(os_result, print_writer) {
+                            Ok(p) => p,
+                            Err(exc) => {
+                                put_back_mount_state(mount_state);
+                                return Ok(Either5::E(JsMontyException::new(exc)));
+                            }
+                        };
+                        continue;
+                    }
+                }
+                if pause_os_calls {
+                    let function_name = call.function_call.name().to_owned();
+                    let (args, kwargs) = call.function_call.clone().to_args();
+                    return Ok(Either5::D(MontyOsCall {
+                        snapshot: EitherOsSnapshot::from_os_snapshot(call),
+                        script_name,
+                        function_name,
+                        args,
+                        kwargs,
+                        print_callback,
+                        mount_state,
+                        repl_state: None,
+                        pause_os_calls,
+                    }));
+                }
+                let os_result: ExtFunctionResult = call.function_call.on_no_handler().into();
                 let print_writer = match &mut print_cb {
                     Some(cb) => PrintWriter::Callback(cb),
                     None => PrintWriter::Stdout,
@@ -1464,7 +2049,7 @@ where
                     Ok(p) => p,
                     Err(exc) => {
                         put_back_mount_state(mount_state);
-                        return Ok(Either4::D(JsMontyException::new(exc)));
+                        return Ok(Either5::E(JsMontyException::new(exc)));
                     }
                 };
             }
@@ -1479,24 +2064,153 @@ fn put_back_mount_state(mount_state: Option<MountState>) {
     }
 }
 
+fn repl_progress_to_result_with_mounts<T>(
+    env: &Env,
+    mut progress: ReplProgress<T>,
+    print_callback: Option<JsPrintCallbackRef>,
+    script_name: String,
+    mut mount_state: Option<MountState>,
+    repl_state: SharedRepl,
+    pause_os_calls: bool,
+) -> Result<Either5<MontySnapshot, MontyNameLookup, MontyComplete, MontyOsCall, JsMontyException>>
+where
+    T: ResourceTracker,
+    EitherRepl: FromCoreRepl<T>,
+    EitherSnapshot: FromReplSnapshot<T>,
+    EitherLookupSnapshot: FromReplLookupSnapshot<T>,
+    EitherOsSnapshot: FromReplOsSnapshot<T>,
+{
+    let mut print_cb = match &print_callback {
+        Some(func) => Some(CallbackStringPrint::new_js_ref(env, func)?),
+        None => None,
+    };
+
+    loop {
+        match progress {
+            ReplProgress::Complete { repl, value } => {
+                put_shared_repl(&repl_state, EitherRepl::from_core(repl))?;
+                put_back_mount_state(mount_state);
+                return Ok(Either5::C(MontyComplete { output_value: value }));
+            }
+            ReplProgress::FunctionCall(call) => {
+                let function_name = call.function_name.clone();
+                let args = call.args.clone();
+                let kwargs = call.kwargs.clone();
+                return Ok(Either5::A(MontySnapshot {
+                    snapshot: EitherSnapshot::from_repl_snapshot(call),
+                    script_name,
+                    function_name,
+                    args,
+                    kwargs,
+                    print_callback,
+                    mount_state,
+                    repl_state: Some(repl_state),
+                    pause_os_calls,
+                }));
+            }
+            ReplProgress::NameLookup(lookup) => {
+                let variable_name = lookup.name.clone();
+                return Ok(Either5::B(MontyNameLookup {
+                    snapshot: EitherLookupSnapshot::from_repl_lookup(lookup),
+                    script_name,
+                    variable_name,
+                    print_callback,
+                    mount_state,
+                    repl_state: Some(repl_state),
+                    pause_os_calls,
+                }));
+            }
+            ReplProgress::ResolveFutures(state) => {
+                put_shared_repl(&repl_state, EitherRepl::from_core(state.into_repl()))?;
+                put_back_mount_state(mount_state);
+                return Ok(Either5::E(JsMontyException::new(MontyException::new(
+                    ExcType::NotImplementedError,
+                    Some("Async futures (ResolveFutures) are not yet supported in the JS REPL bindings".to_owned()),
+                ))));
+            }
+            ReplProgress::OsCall(call) => {
+                if let Some((_, ref mut table)) = mount_state {
+                    if let Some(os_result) = handle_repl_os_call_with_table(&call, table) {
+                        let print_writer = match &mut print_cb {
+                            Some(cb) => PrintWriter::Callback(cb),
+                            None => PrintWriter::Stdout,
+                        };
+                        progress = match call.resume(os_result, print_writer) {
+                            Ok(p) => p,
+                            Err(exc) => {
+                                let exc = restore_repl_start_error(&repl_state, *exc)?;
+                                put_back_mount_state(mount_state);
+                                return Ok(Either5::E(exc));
+                            }
+                        };
+                        continue;
+                    }
+                }
+                if pause_os_calls {
+                    let function_name = call.function_call.name().to_owned();
+                    let (args, kwargs) = call.function_call.clone().to_args();
+                    return Ok(Either5::D(MontyOsCall {
+                        snapshot: EitherOsSnapshot::from_repl_os_snapshot(call),
+                        script_name,
+                        function_name,
+                        args,
+                        kwargs,
+                        print_callback,
+                        mount_state,
+                        repl_state: Some(repl_state),
+                        pause_os_calls,
+                    }));
+                }
+                let os_result: ExtFunctionResult = call.function_call.on_no_handler().into();
+                let print_writer = match &mut print_cb {
+                    Some(cb) => PrintWriter::Callback(cb),
+                    None => PrintWriter::Stdout,
+                };
+                progress = match call.resume(os_result, print_writer) {
+                    Ok(p) => p,
+                    Err(exc) => {
+                        let exc = restore_repl_start_error(&repl_state, *exc)?;
+                        put_back_mount_state(mount_state);
+                        return Ok(Either5::E(exc));
+                    }
+                };
+            }
+        }
+    }
+}
+
 /// Handles an OS call by dispatching to the mount table.
 ///
 /// Returns the result from the mount table if it handles the call,
 /// or falls back to [`OsFunctionCall::on_no_handler`] for unhandled calls.
 fn handle_os_call<T: ResourceTracker>(call: &OsCall<T>, mount_table: &mut Option<MountTable>) -> ExtFunctionResult {
     if let Some(table) = mount_table {
-        handle_os_call_with_table(call, table)
+        handle_os_call_with_table(call, table).unwrap_or_else(|| call.function_call.on_no_handler().into())
     } else {
         call.function_call.on_no_handler().into()
     }
 }
 
 /// Handles an OS call using a specific mount table.
-fn handle_os_call_with_table<T: ResourceTracker>(call: &OsCall<T>, table: &mut MountTable) -> ExtFunctionResult {
-    match table.handle_os_call(&call.function_call) {
-        Some(Ok(obj)) => obj.into(),
-        Some(Err(mount_err)) => mount_err.into_exception().into(),
-        None => call.function_call.on_no_handler().into(),
+fn handle_os_call_with_table<T: ResourceTracker>(
+    call: &OsCall<T>,
+    table: &mut MountTable,
+) -> Option<ExtFunctionResult> {
+    handle_os_function_with_table(&call.function_call, table)
+}
+
+fn handle_repl_os_call_with_table<T: ResourceTracker>(
+    call: &ReplOsCall<T>,
+    table: &mut MountTable,
+) -> Option<ExtFunctionResult> {
+    handle_os_function_with_table(&call.function_call, table)
+}
+
+fn handle_os_function_with_table(call: &monty::OsFunctionCall, table: &mut MountTable) -> Option<ExtFunctionResult> {
+    match table.handle_os_call(call) {
+        Some(Ok(obj)) => Some(obj.into()),
+        Some(Err(mount_err)) => Some(mount_err.into_exception().into()),
+        None => None,
     }
 }
 
@@ -1515,6 +2229,54 @@ impl FromSnapshot<NoLimitTracker> for EitherSnapshot {
 impl FromSnapshot<LimitedTracker> for EitherSnapshot {
     fn from_snapshot(call: FunctionCall<LimitedTracker>) -> Self {
         Self::Limited(call)
+    }
+}
+
+trait FromReplSnapshot<T: ResourceTracker> {
+    fn from_repl_snapshot(call: ReplFunctionCall<T>) -> Self;
+}
+
+impl FromReplSnapshot<NoLimitTracker> for EitherSnapshot {
+    fn from_repl_snapshot(call: ReplFunctionCall<NoLimitTracker>) -> Self {
+        Self::ReplNoLimit(call)
+    }
+}
+
+impl FromReplSnapshot<LimitedTracker> for EitherSnapshot {
+    fn from_repl_snapshot(call: ReplFunctionCall<LimitedTracker>) -> Self {
+        Self::ReplLimited(call)
+    }
+}
+
+trait FromOsSnapshot<T: ResourceTracker> {
+    fn from_os_snapshot(call: OsCall<T>) -> Self;
+}
+
+impl FromOsSnapshot<NoLimitTracker> for EitherOsSnapshot {
+    fn from_os_snapshot(call: OsCall<NoLimitTracker>) -> Self {
+        Self::NoLimit(call)
+    }
+}
+
+impl FromOsSnapshot<LimitedTracker> for EitherOsSnapshot {
+    fn from_os_snapshot(call: OsCall<LimitedTracker>) -> Self {
+        Self::Limited(call)
+    }
+}
+
+trait FromReplOsSnapshot<T: ResourceTracker> {
+    fn from_repl_os_snapshot(call: ReplOsCall<T>) -> Self;
+}
+
+impl FromReplOsSnapshot<NoLimitTracker> for EitherOsSnapshot {
+    fn from_repl_os_snapshot(call: ReplOsCall<NoLimitTracker>) -> Self {
+        Self::ReplNoLimit(call)
+    }
+}
+
+impl FromReplOsSnapshot<LimitedTracker> for EitherOsSnapshot {
+    fn from_repl_os_snapshot(call: ReplOsCall<LimitedTracker>) -> Self {
+        Self::ReplLimited(call)
     }
 }
 
@@ -1565,6 +2327,26 @@ struct SerializedSnapshot<'a> {
 #[derive(serde::Deserialize)]
 struct SerializedSnapshotOwned {
     snapshot: EitherSnapshot,
+    script_name: String,
+    function_name: String,
+    args: Vec<MontyObject>,
+    kwargs: Vec<(MontyObject, MontyObject)>,
+}
+
+/// Serialization wrapper for `MontyOsCall` using borrowed references.
+#[derive(serde::Serialize)]
+struct SerializedOsCall<'a> {
+    snapshot: &'a EitherOsSnapshot,
+    script_name: &'a str,
+    function_name: &'a str,
+    args: &'a [MontyObject],
+    kwargs: &'a [(MontyObject, MontyObject)],
+}
+
+/// Owned version of `SerializedOsCall` for deserialization.
+#[derive(serde::Deserialize)]
+struct SerializedOsCallOwned {
+    snapshot: EitherOsSnapshot,
     script_name: String,
     function_name: String,
     args: Vec<MontyObject>,

--- a/crates/monty-js/wrapper.ts
+++ b/crates/monty-js/wrapper.ts
@@ -23,6 +23,7 @@ import {
   MountDir,
   MontyRepl as NativeMontyRepl,
   MontySnapshot as NativeMontySnapshot,
+  MontyOsCall as NativeMontyOsCall,
   MontyNameLookup as NativeMontyNameLookup,
   MontyComplete as NativeMontyComplete,
   MontyException as NativeMontyException,
@@ -46,22 +47,178 @@ export type {
 /** Options for running code. */
 export interface RunOptions extends Omit<NativeRunOptions, 'mount'> {
   /** Filesystem mount(s) for the sandbox. */
-  mount?: MountDir | MountDir[]
+  mount?: MountLike | MountLike[]
 }
 
 /** Options for starting execution. */
 export interface StartOptions extends Omit<NativeStartOptions, 'mount'> {
   /** Filesystem mount(s) for the sandbox. */
-  mount?: MountDir | MountDir[]
+  mount?: MountLike | MountLike[]
 }
 
 /** Options for REPL feed(). */
 export interface FeedOptions extends Omit<NativeFeedOptions, 'mount'> {
+  /** Callback invoked on each print() call. */
+  printCallback?: (stream: string, text: string) => void
   /** Filesystem mount(s) for the sandbox. */
-  mount?: MountDir | MountDir[]
+  mount?: MountLike | MountLike[]
 }
 
 export { MountDir }
+
+type MaybePromise<T> = T | Promise<T>
+
+export type MountLike = MountDir | VirtualMount
+
+export type VirtualMountMode = 'read-only' | 'read-write'
+
+export interface VirtualMountOptions {
+  /** Access mode. Default: 'read-write'. */
+  mode?: VirtualMountMode
+  /** Optional cumulative write limit, counted in bytes. */
+  writeBytesLimit?: number
+}
+
+export interface VirtualMountStat {
+  type?: 'file' | 'directory' | 'symlink'
+  mode?: number
+  size?: number
+  mtime?: number
+  atime?: number
+  ctime?: number
+  ino?: number
+  dev?: number
+  nlink?: number
+  uid?: number
+  gid?: number
+}
+
+export interface VirtualMountBackend {
+  exists?(path: string): MaybePromise<boolean>
+  isFile?(path: string): MaybePromise<boolean>
+  isDir?(path: string): MaybePromise<boolean>
+  isSymlink?(path: string): MaybePromise<boolean>
+  readText?(path: string): MaybePromise<string>
+  readBytes?(path: string): MaybePromise<Uint8Array | Buffer>
+  writeText?(path: string, data: string): MaybePromise<number | void>
+  writeBytes?(path: string, data: Uint8Array | Buffer): MaybePromise<number | void>
+  appendText?(path: string, data: string): MaybePromise<number | void>
+  appendBytes?(path: string, data: Uint8Array | Buffer): MaybePromise<number | void>
+  mkdir?(path: string, options: { parents: boolean; existOk: boolean }): MaybePromise<void>
+  unlink?(path: string): MaybePromise<void>
+  rmdir?(path: string): MaybePromise<void>
+  rename?(src: string, dst: string): MaybePromise<void>
+  iterdir?(path: string): MaybePromise<Array<string | { name?: string; path?: string }>>
+  stat?(path: string): MaybePromise<VirtualMountStat | ReturnType<typeof statResult>>
+  resolve?(path: string): MaybePromise<string>
+  absolute?(path: string): MaybePromise<string>
+  open?(path: string, mode: string): MaybePromise<ReturnType<typeof fileHandle> | void>
+}
+
+export class VirtualMountError extends Error {
+  readonly typeName: string
+
+  constructor(typeName: string, message: string) {
+    super(message)
+    this.name = typeName
+    this.typeName = typeName
+  }
+}
+
+export class VirtualMount {
+  readonly virtualPath: string
+  readonly backend: VirtualMountBackend
+  readonly mode: VirtualMountMode
+  readonly writeBytesLimit: number | null
+  private _writeBytesUsed = 0
+
+  constructor(virtualPath: string, backend: VirtualMountBackend, options: VirtualMountOptions = {}) {
+    if (!backend || typeof backend !== 'object') {
+      throw new TypeError('VirtualMount backend must be an object')
+    }
+    this.virtualPath = normalizeVirtualPath(virtualPath)
+    this.backend = backend
+    this.mode = options.mode ?? 'read-write'
+    if (this.mode !== 'read-only' && this.mode !== 'read-write') {
+      throw new TypeError("VirtualMount mode must be 'read-only' or 'read-write'")
+    }
+    if (options.writeBytesLimit != null && options.writeBytesLimit < 0) {
+      throw new TypeError('writeBytesLimit must be non-negative')
+    }
+    this.writeBytesLimit = options.writeBytesLimit ?? null
+  }
+
+  get writeBytesUsed(): number {
+    return this._writeBytesUsed
+  }
+
+  matches(path: string): boolean {
+    return pathMatchesMount(normalizeVirtualPath(path), this.virtualPath)
+  }
+
+  assertWritable(path: string): void {
+    if (this.mode === 'read-only') {
+      throw new VirtualMountError('PermissionError', `Read-only file system: '${path}'`)
+    }
+  }
+
+  chargeWrite(bytes: number): void {
+    if (this.writeBytesLimit == null) {
+      return
+    }
+    if (this._writeBytesUsed + bytes > this.writeBytesLimit) {
+      throw new VirtualMountError('OSError', `write limit exceeded: ${this.writeBytesLimit} bytes`)
+    }
+    this._writeBytesUsed += bytes
+  }
+
+  repr(): string {
+    return `VirtualMount('${this.virtualPath}', '${this.mode}')`
+  }
+}
+
+export function montyPath(value: string): { __monty_type__: 'Path'; value: string } {
+  return { __monty_type__: 'Path', value: normalizeVirtualPath(value) }
+}
+
+export function fileHandle(
+  path: string,
+  mode: string,
+  position = 0,
+): { __monty_type__: 'FileHandle'; path: string; mode: string; position: number } {
+  return { __monty_type__: 'FileHandle', path: normalizeVirtualPath(path), mode, position }
+}
+
+export function statResult(stat: VirtualMountStat): {
+  __monty_type__: 'StatResult'
+  stMode: number
+  stIno: number
+  stDev: number
+  stNlink: number
+  stUid: number
+  stGid: number
+  stSize: number
+  stAtime: number
+  stMtime: number
+  stCtime: number
+} {
+  const kind = stat.type ?? 'file'
+  const defaultMode = kind === 'directory' ? 0o040755 : kind === 'symlink' ? 0o120777 : 0o100644
+  const mtime = stat.mtime ?? 0
+  return {
+    __monty_type__: 'StatResult',
+    stMode: stat.mode ?? defaultMode,
+    stIno: stat.ino ?? 0,
+    stDev: stat.dev ?? 0,
+    stNlink: stat.nlink ?? (kind === 'directory' ? 2 : 1),
+    stUid: stat.uid ?? 0,
+    stGid: stat.gid ?? 0,
+    stSize: stat.size ?? (kind === 'directory' ? 4096 : 0),
+    stAtime: stat.atime ?? mtime,
+    stMtime: mtime,
+    stCtime: stat.ctime ?? mtime,
+  }
+}
 
 /**
  * Alias for ResourceLimits (deprecated name).
@@ -322,7 +479,12 @@ export class Monty {
    * @throws {MontyRuntimeError} If the code raises an exception
    */
   run(options?: RunOptions): JsMontyObject {
-    const result = this._native.run(options)
+    const split = splitMounts(options?.mount)
+    if (split.virtualMounts.length > 0) {
+      return runMontySync(this, { ...options, splitMounts: split })
+    }
+    const nativeOptions = options ? { ...options, mount: split.nativeMount } : undefined
+    const result = this._native.run(nativeOptions)
     if (result instanceof NativeMontyException) {
       throw new MontyRuntimeError(result)
     }
@@ -337,9 +499,23 @@ export class Monty {
    *   name lookup, MontyComplete if done
    * @throws {MontyRuntimeError} If the code raises an exception
    */
-  start(options?: StartOptions): MontySnapshot | MontyNameLookup | MontyComplete {
-    const result = this._native.start(options)
-    return wrapStartResult(result)
+  start(options?: StartOptions): MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall {
+    const split = splitMounts(options?.mount)
+    const context = createDispatchContext(split)
+    return advanceSync(this._startNative(options, split, context), context)
+  }
+
+  _startNative(
+    options: StartOptions | undefined,
+    split: SplitMounts,
+    context: DispatchContext,
+  ): MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall {
+    const result = this._native.start({
+      ...options,
+      mount: split.nativeMount,
+      pauseOsCalls: options?.pauseOsCalls || split.virtualMounts.length > 0,
+    })
+    return wrapStartResult(result, context)
   }
 
   /**
@@ -414,11 +590,84 @@ export class MontyRepl {
    * @throws {MontyRuntimeError} If execution raises an exception
    */
   feed(code: string, options?: FeedOptions): JsMontyObject {
-    const result = this._native.feed(code, options)
+    const split = splitMounts(options?.mount)
+    if (split.virtualMounts.length > 0) {
+      let progress = this.feedStart(code, options)
+      while (!(progress instanceof MontyComplete)) {
+        if (progress instanceof MontyNameLookup) {
+          progress = progress.resume()
+          continue
+        }
+        if (progress instanceof MontyOsCall) {
+          progress = advanceSync(progress, progress.context)
+          continue
+        }
+        progress = progress.resume({
+          exception: {
+            type: 'RuntimeError',
+            message: `External function '${progress.functionName}' called but REPL feed() does not support external functions`,
+          },
+        })
+      }
+      return progress.output
+    }
+    const nativeOptions = options ? { ...options, mount: split.nativeMount } : undefined
+    const result = this._native.feed(code, nativeOptions)
     if (result instanceof NativeMontyException) {
       throw new MontyRuntimeError(result)
     }
     return result
+  }
+
+  /**
+   * Starts one incremental snippet and returns a resumable progress object.
+   *
+   * @param code - Snippet code to execute
+   * @param options - Optional feed options (mount, printCallback)
+   * @returns MontySnapshot if paused at function call, MontyNameLookup if
+   *   paused at name lookup, MontyOsCall if paused at OS call, MontyComplete if done
+   * @throws {MontyRuntimeError} If execution raises an exception
+   */
+  feedStart(code: string, options?: FeedOptions): MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall {
+    const split = splitMounts(options?.mount)
+    const context = createDispatchContext(split)
+    const result = this._native.feedStart(code, {
+      ...options,
+      mount: split.nativeMount,
+      pauseOsCalls: options?.pauseOsCalls || split.virtualMounts.length > 0,
+    })
+    return advanceSync(wrapStartResult(result, context), context)
+  }
+
+  /** Executes one incremental snippet with async virtual mount support. */
+  async feedAsync(code: string, options?: FeedOptions): Promise<JsMontyObject> {
+    const split = splitMounts(options?.mount)
+    const context = createDispatchContext(split)
+    let progress = wrapStartResult(
+      this._native.feedStart(code, {
+        ...options,
+        mount: split.nativeMount,
+        pauseOsCalls: options?.pauseOsCalls || split.virtualMounts.length > 0,
+      }),
+      context,
+    )
+    progress = await advanceAsync(progress, context)
+    while (!(progress instanceof MontyComplete)) {
+      if (progress instanceof MontyNameLookup) {
+        progress = await progress.resumeAsync()
+      } else if (progress instanceof MontyOsCall) {
+        progress = await advanceAsync(progress, context)
+      } else {
+        progress = await progress.resumeAsync({
+          exception: {
+            type: 'RuntimeError',
+            message: `External function '${progress.functionName}' called but REPL feedAsync() does not support external functions`,
+          },
+        })
+      }
+      progress = await advanceAsync(progress, context)
+    }
+    return progress.output
   }
 
   /** Serializes the REPL session to bytes. */
@@ -444,18 +693,22 @@ export class MontyRepl {
  * Helper to wrap native start/resume results, throwing errors as needed.
  */
 function wrapStartResult(
-  result: NativeMontySnapshot | NativeMontyNameLookup | NativeMontyComplete | NativeMontyException,
-): MontySnapshot | MontyNameLookup | MontyComplete {
+  result: NativeMontySnapshot | NativeMontyNameLookup | NativeMontyComplete | NativeMontyOsCall | NativeMontyException,
+  context?: DispatchContext,
+): MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall {
   if (result instanceof NativeMontyException) {
     throw new MontyRuntimeError(result)
   }
   // Check MontyNameLookup before MontySnapshot — napi `Either4` may cause
   // false positives with `instanceof` if checked in the wrong order.
   if (result instanceof NativeMontyNameLookup) {
-    return new MontyNameLookup(result)
+    return new MontyNameLookup(result, context)
   }
   if (result instanceof NativeMontySnapshot) {
-    return new MontySnapshot(result)
+    return new MontySnapshot(result, context)
+  }
+  if (result instanceof NativeMontyOsCall) {
+    return new MontyOsCall(result, context)
   }
   if (result instanceof NativeMontyComplete) {
     return new MontyComplete(result)
@@ -471,9 +724,11 @@ function wrapStartResult(
  */
 export class MontySnapshot {
   private _native: NativeMontySnapshot
+  private _context?: DispatchContext
 
-  constructor(nativeSnapshot: NativeMontySnapshot) {
+  constructor(nativeSnapshot: NativeMontySnapshot, context?: DispatchContext) {
     this._native = nativeSnapshot
+    this._context = context
   }
 
   /** Returns the name of the script being executed. */
@@ -504,9 +759,17 @@ export class MontySnapshot {
    *   name lookup, MontyComplete if done
    * @throws {MontyRuntimeError} If the code raises an exception
    */
-  resume(options: ResumeOptions): MontySnapshot | MontyNameLookup | MontyComplete {
+  resume(options: ResumeOptions): MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall {
+    return advanceSync(this._resumeNative(options), this._context)
+  }
+
+  async resumeAsync(options: ResumeOptions): Promise<MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall> {
+    return advanceAsync(this._resumeNative(options), this._context)
+  }
+
+  _resumeNative(options: ResumeOptions): MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall {
     const result = this._native.resume(options)
-    return wrapStartResult(result)
+    return wrapStartResult(result, this._context)
   }
 
   /**
@@ -539,9 +802,11 @@ export class MontySnapshot {
  */
 export class MontyNameLookup {
   private _native: NativeMontyNameLookup
+  private _context?: DispatchContext
 
-  constructor(nativeNameLookup: NativeMontyNameLookup) {
+  constructor(nativeNameLookup: NativeMontyNameLookup, context?: DispatchContext) {
     this._native = nativeNameLookup
+    this._context = context
   }
 
   /** Returns the name of the script being executed. */
@@ -565,9 +830,19 @@ export class MontyNameLookup {
    *   another name lookup, MontyComplete if done
    * @throws {MontyRuntimeError} If the code raises an exception
    */
-  resume(options?: NameLookupResumeOptions): MontySnapshot | MontyNameLookup | MontyComplete {
+  resume(options?: NameLookupResumeOptions): MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall {
+    return advanceSync(this._resumeNative(options), this._context)
+  }
+
+  async resumeAsync(
+    options?: NameLookupResumeOptions,
+  ): Promise<MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall> {
+    return advanceAsync(this._resumeNative(options), this._context)
+  }
+
+  _resumeNative(options?: NameLookupResumeOptions): MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall {
     const result = this._native.resume(options)
-    return wrapStartResult(result)
+    return wrapStartResult(result, this._context)
   }
 
   /**
@@ -586,6 +861,73 @@ export class MontyNameLookup {
   }
 
   /** Returns a string representation of the MontyNameLookup. */
+  repr(): string {
+    return this._native.repr()
+  }
+}
+
+/**
+ * Represents paused execution waiting for an OS or filesystem operation.
+ */
+export class MontyOsCall {
+  private _native: NativeMontyOsCall
+  private _context?: DispatchContext
+
+  constructor(nativeOsCall: NativeMontyOsCall, context?: DispatchContext) {
+    this._native = nativeOsCall
+    this._context = context
+  }
+
+  get context(): DispatchContext | undefined {
+    return this._context
+  }
+
+  /** Returns the name of the script being executed. */
+  get scriptName(): string {
+    return this._native.scriptName
+  }
+
+  /** Returns the OS function name, such as `Path.read_text` or `Open`. */
+  get functionName(): string {
+    return this._native.functionName
+  }
+
+  /** Returns the positional arguments passed to the OS function. */
+  get args(): JsMontyObject[] {
+    return this._native.args
+  }
+
+  /** Returns the keyword arguments passed to the OS function as an object. */
+  get kwargs(): Record<string, JsMontyObject> {
+    return this._native.kwargs as Record<string, JsMontyObject>
+  }
+
+  /** Resumes execution with either an OS return value or an exception. */
+  resume(options: ResumeOptions): MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall {
+    return advanceSync(this._resumeNative(options), this._context)
+  }
+
+  async resumeAsync(options: ResumeOptions): Promise<MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall> {
+    return advanceAsync(this._resumeNative(options), this._context)
+  }
+
+  _resumeNative(options: ResumeOptions): MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall {
+    const result = this._native.resume(options)
+    return wrapStartResult(result, this._context)
+  }
+
+  /** Serializes the OS-call snapshot to a binary format. */
+  dump(): Buffer {
+    return this._native.dump()
+  }
+
+  /** Deserializes a MontyOsCall from binary format. */
+  static load(data: Buffer, options?: SnapshotLoadOptions): MontyOsCall {
+    const nativeOsCall = NativeMontyOsCall.load(data, options)
+    return new MontyOsCall(nativeOsCall)
+  }
+
+  /** Returns a string representation of the MontyOsCall. */
   repr(): string {
     return this._native.repr()
   }
@@ -612,6 +954,411 @@ export class MontyComplete {
   }
 }
 
+interface SplitMounts {
+  nativeMount?: MountDir | MountDir[]
+  virtualMounts: VirtualMount[]
+}
+
+interface DispatchContext extends SplitMounts {
+  externalFunctions?: Record<string, (...args: unknown[]) => unknown>
+}
+
+function createDispatchContext(
+  split: SplitMounts,
+  externalFunctions?: Record<string, (...args: unknown[]) => unknown>,
+): DispatchContext {
+  return { ...split, externalFunctions }
+}
+
+function splitMounts(mount?: MountLike | MountLike[] | SplitMounts): SplitMounts {
+  if (isSplitMounts(mount)) {
+    return mount
+  }
+  const native: MountDir[] = []
+  const virtualMounts: VirtualMount[] = []
+  const mounts = mount == null ? [] : Array.isArray(mount) ? mount : [mount]
+  for (const item of mounts) {
+    if (item instanceof MountDir) {
+      native.push(item)
+    } else if (item instanceof VirtualMount) {
+      virtualMounts.push(item)
+    } else {
+      throw new TypeError('mount must be a MountDir, VirtualMount, or an array of mounts')
+    }
+  }
+  virtualMounts.sort((a, b) => b.virtualPath.length - a.virtualPath.length)
+  return {
+    nativeMount: native.length === 0 ? undefined : native.length === 1 ? native[0] : native,
+    virtualMounts,
+  }
+}
+
+function isSplitMounts(value: unknown): value is SplitMounts {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    'virtualMounts' in value &&
+    Array.isArray((value as SplitMounts).virtualMounts)
+  )
+}
+
+function runMontySync(montyRunner: Monty, options: RunOptions & { splitMounts: SplitMounts }): JsMontyObject {
+  const context = createDispatchContext(
+    options.splitMounts,
+    options.externalFunctions as Record<string, (...args: unknown[]) => unknown> | undefined,
+  )
+  let progress: MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall = montyRunner.start({
+    inputs: options.inputs,
+    limits: options.limits,
+    printCallback: options.printCallback,
+    mount: options.splitMounts as unknown as MountLike,
+    pauseOsCalls: true,
+  })
+
+  while (!(progress instanceof MontyComplete)) {
+    progress = advanceSync(progress, context)
+    if (progress instanceof MontyComplete) {
+      break
+    }
+    if (progress instanceof MontyNameLookup) {
+      const extFunction = context.externalFunctions?.[progress.variableName]
+      progress = extFunction ? progress.resume({ value: extFunction }) : progress.resume()
+      continue
+    }
+    if (progress instanceof MontyOsCall) {
+      continue
+    }
+    if (!(progress instanceof MontySnapshot)) {
+      continue
+    }
+    const snapshot = progress
+    const extFunction = context.externalFunctions?.[snapshot.functionName]
+    if (!extFunction) {
+      progress = snapshot.resume({
+        exception: {
+          type: 'NameError',
+          message: `name '${snapshot.functionName}' is not defined`,
+        },
+      })
+      continue
+    }
+    try {
+      const result = extFunction(...snapshot.args, snapshot.kwargs)
+      if (isPromiseLike(result)) {
+        throw new TypeError('Monty.run() cannot await async external functions or virtual mount operations')
+      }
+      progress = snapshot.resume({ returnValue: result })
+    } catch (error) {
+      progress = snapshot.resume({ exception: exceptionFromError(error, 'RuntimeError') })
+    }
+  }
+
+  return progress.output
+}
+
+function advanceSync(
+  progress: MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall,
+  context?: DispatchContext,
+): MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall {
+  if (!context || context.virtualMounts.length === 0) {
+    return progress
+  }
+  let current = progress
+  while (current instanceof MontyOsCall) {
+    const osCall = current
+    try {
+      const result = dispatchVirtualMount(osCall, context)
+      if (isPromiseLike(result)) {
+        throw new TypeError('Use runMontyAsync() or MontyRepl.feedAsync() for async virtual mount operations')
+      }
+      current = osCall._resumeNative({ returnValue: result })
+    } catch (error) {
+      current = osCall._resumeNative({ exception: exceptionFromError(error, 'PermissionError') })
+    }
+  }
+  return current
+}
+
+async function advanceAsync(
+  progress: MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall,
+  context?: DispatchContext,
+): Promise<MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall> {
+  if (!context || context.virtualMounts.length === 0) {
+    return progress
+  }
+  let current = progress
+  while (current instanceof MontyOsCall) {
+    const osCall = current
+    try {
+      const result = await dispatchVirtualMount(osCall, context)
+      current = osCall._resumeNative({ returnValue: result })
+    } catch (error) {
+      current = osCall._resumeNative({ exception: exceptionFromError(error, 'PermissionError') })
+    }
+  }
+  return current
+}
+
+function dispatchVirtualMount(call: MontyOsCall, context: DispatchContext): MaybePromise<JsMontyObject> {
+  const primaryPath = getPrimaryPath(call)
+  const mount = context.virtualMounts.find((m) => m.matches(primaryPath))
+  if (!mount) {
+    throw new VirtualMountError('PermissionError', `Permission denied: '${primaryPath}'`)
+  }
+  const normalizedPath = normalizeVirtualPath(primaryPath)
+  const backend = mount.backend
+
+  switch (call.functionName) {
+    case 'Path.exists':
+      return callRequired(backend.exists, 'exists', normalizedPath)
+    case 'Path.is_file':
+      return callRequired(backend.isFile, 'isFile', normalizedPath)
+    case 'Path.is_dir':
+      return callRequired(backend.isDir, 'isDir', normalizedPath)
+    case 'Path.is_symlink':
+      return callRequired(backend.isSymlink, 'isSymlink', normalizedPath)
+    case 'Path.read_text':
+      return callRequired(backend.readText, 'readText', normalizedPath)
+    case 'Path.read_bytes':
+      return callRequired(backend.readBytes, 'readBytes', normalizedPath)
+    case 'Path.write_text': {
+      mount.assertWritable(normalizedPath)
+      const data = getStringArg(call, 1, 'Path.write_text data')
+      const bytes = Buffer.byteLength(data)
+      mount.chargeWrite(bytes)
+      return normalizeWriteResult(callRequired(backend.writeText, 'writeText', normalizedPath, data), [...data].length)
+    }
+    case 'Path.write_bytes': {
+      mount.assertWritable(normalizedPath)
+      const data = getBytesArg(call, 1, 'Path.write_bytes data')
+      mount.chargeWrite(data.byteLength)
+      return normalizeWriteResult(callRequired(backend.writeBytes, 'writeBytes', normalizedPath, data), data.byteLength)
+    }
+    case 'Path.append_text': {
+      mount.assertWritable(normalizedPath)
+      const data = getStringArg(call, 1, 'Path.append_text data')
+      const bytes = Buffer.byteLength(data)
+      mount.chargeWrite(bytes)
+      return normalizeWriteResult(
+        callRequired(backend.appendText, 'appendText', normalizedPath, data),
+        [...data].length,
+      )
+    }
+    case 'Path.append_bytes': {
+      mount.assertWritable(normalizedPath)
+      const data = getBytesArg(call, 1, 'Path.append_bytes data')
+      mount.chargeWrite(data.byteLength)
+      return normalizeWriteResult(
+        callRequired(backend.appendBytes, 'appendBytes', normalizedPath, data),
+        data.byteLength,
+      )
+    }
+    case 'Path.mkdir':
+      mount.assertWritable(normalizedPath)
+      return normalizeNoneResult(
+        callRequired(backend.mkdir, 'mkdir', normalizedPath, {
+          parents: Boolean(call.kwargs.parents),
+          existOk: Boolean(call.kwargs.exist_ok),
+        }),
+      )
+    case 'Path.unlink':
+      mount.assertWritable(normalizedPath)
+      return normalizeNoneResult(callRequired(backend.unlink, 'unlink', normalizedPath))
+    case 'Path.rmdir':
+      mount.assertWritable(normalizedPath)
+      return normalizeNoneResult(callRequired(backend.rmdir, 'rmdir', normalizedPath))
+    case 'Path.rename': {
+      mount.assertWritable(normalizedPath)
+      const dst = normalizeVirtualPath(String(call.args[1]))
+      if (!mount.matches(dst)) {
+        throw new VirtualMountError('OSError', `Invalid cross-mount rename from '${normalizedPath}' to '${dst}'`)
+      }
+      return normalizeNoneResult(callRequired(backend.rename, 'rename', normalizedPath, dst))
+    }
+    case 'Path.iterdir':
+      return normalizeIterdir(callRequired(backend.iterdir, 'iterdir', normalizedPath), normalizedPath)
+    case 'Path.stat':
+      return normalizeStatResult(callRequired(backend.stat, 'stat', normalizedPath))
+    case 'Path.resolve':
+      return normalizePathResult(callOptional(backend.resolve, normalizedPath), normalizedPath)
+    case 'Path.absolute':
+      return normalizePathResult(callOptional(backend.absolute, normalizedPath), normalizedPath)
+    case 'Open':
+      return handleVirtualOpen(mount, normalizedPath, getStringArg(call, 1, 'open mode'))
+    default:
+      throw new VirtualMountError('RuntimeError', `'${call.functionName}' is not supported by VirtualMount`)
+  }
+}
+
+function callRequired<TArgs extends unknown[], TResult>(
+  fn: ((...args: TArgs) => MaybePromise<TResult>) | undefined,
+  name: string,
+  ...args: TArgs
+): MaybePromise<TResult> {
+  if (!fn) {
+    throw new VirtualMountError('NotImplementedError', `VirtualMount backend does not implement ${name}()`)
+  }
+  return fn(...args)
+}
+
+function callOptional<T>(
+  fn: ((path: string) => MaybePromise<T>) | undefined,
+  path: string,
+): MaybePromise<T | undefined> {
+  return fn?.(path)
+}
+
+function normalizeWriteResult(result: MaybePromise<number | void>, fallback: number): MaybePromise<number> {
+  if (isPromiseLike(result)) {
+    return result.then((value) => value ?? fallback)
+  }
+  return result ?? fallback
+}
+
+function normalizeNoneResult(result: MaybePromise<void>): MaybePromise<null> {
+  return isPromiseLike(result) ? result.then(() => null) : null
+}
+
+function normalizeIterdir(
+  result: MaybePromise<Array<string | { name?: string; path?: string }>>,
+  parentPath: string,
+): MaybePromise<Array<ReturnType<typeof montyPath>>> {
+  const convert = (entries: Array<string | { name?: string; path?: string }>) =>
+    entries.map((entry) => {
+      const raw = typeof entry === 'string' ? entry : (entry.path ?? entry.name)
+      if (!raw) {
+        throw new VirtualMountError('RuntimeError', 'VirtualMount iterdir() entries must include a name or path')
+      }
+      return montyPath(raw.startsWith('/') ? raw : joinVirtualPath(parentPath, raw))
+    })
+  return isPromiseLike(result) ? result.then(convert) : convert(result)
+}
+
+function normalizeStatResult(
+  result: MaybePromise<VirtualMountStat | ReturnType<typeof statResult>>,
+): MaybePromise<ReturnType<typeof statResult>> {
+  const convert = (value: VirtualMountStat | ReturnType<typeof statResult>) =>
+    '__monty_type__' in value ? value : statResult(value)
+  return isPromiseLike(result) ? result.then(convert) : convert(result)
+}
+
+function normalizePathResult(
+  result: MaybePromise<string | undefined>,
+  fallback: string,
+): MaybePromise<ReturnType<typeof montyPath>> {
+  const convert = (value: string | undefined) => montyPath(value ?? fallback)
+  return isPromiseLike(result) ? result.then(convert) : convert(result)
+}
+
+function handleVirtualOpen(
+  mount: VirtualMount,
+  path: string,
+  mode: string,
+): MaybePromise<ReturnType<typeof fileHandle>> {
+  if (mode.startsWith('w') || mode.startsWith('a')) {
+    mount.assertWritable(path)
+  }
+  const custom = mount.backend.open?.(path, mode)
+  if (custom !== undefined) {
+    const normalize = (value: ReturnType<typeof fileHandle> | void) => value ?? fileHandle(path, mode)
+    return isPromiseLike(custom) ? custom.then(normalize) : normalize(custom)
+  }
+  const binary = mode.includes('b')
+  if (mode.startsWith('r')) {
+    const exists = mount.backend.exists?.(path)
+    const validate = (value: boolean | undefined) => {
+      if (value === false) {
+        throw new VirtualMountError('FileNotFoundError', `No such file or directory: '${path}'`)
+      }
+      return fileHandle(path, mode)
+    }
+    return isPromiseLike(exists) ? exists.then(validate) : validate(exists)
+  }
+  if (mode.startsWith('w')) {
+    mount.chargeWrite(0)
+    const result = binary
+      ? callRequired(mount.backend.writeBytes, 'writeBytes', path, Buffer.alloc(0))
+      : callRequired(mount.backend.writeText, 'writeText', path, '')
+    return isPromiseLike(result) ? result.then(() => fileHandle(path, mode)) : fileHandle(path, mode)
+  }
+  if (mode.startsWith('a')) {
+    const result = binary
+      ? callRequired(mount.backend.appendBytes, 'appendBytes', path, Buffer.alloc(0))
+      : callRequired(mount.backend.appendText, 'appendText', path, '')
+    return isPromiseLike(result) ? result.then(() => fileHandle(path, mode)) : fileHandle(path, mode)
+  }
+  throw new VirtualMountError('ValueError', `invalid mode: '${mode}'`)
+}
+
+function getPrimaryPath(call: MontyOsCall): string {
+  const path = call.args[0]
+  if (typeof path !== 'string') {
+    throw new VirtualMountError('RuntimeError', `${call.functionName} did not provide a path argument`)
+  }
+  return path
+}
+
+function getStringArg(call: MontyOsCall, index: number, label: string): string {
+  const value = call.args[index]
+  if (typeof value !== 'string') {
+    throw new VirtualMountError('TypeError', `${label} must be a string`)
+  }
+  return value
+}
+
+function getBytesArg(call: MontyOsCall, index: number, label: string): Buffer {
+  const value = call.args[index]
+  if (Buffer.isBuffer(value)) {
+    return value
+  }
+  if (value instanceof Uint8Array) {
+    return Buffer.from(value)
+  }
+  throw new VirtualMountError('TypeError', `${label} must be bytes`)
+}
+
+function exceptionFromError(error: unknown, fallbackType: string): ExceptionInput {
+  const err = error as Error & { typeName?: string }
+  return {
+    type: err.typeName || err.name || fallbackType,
+    message: err.message || String(error),
+  }
+}
+
+function isPromiseLike(value: unknown): value is Promise<unknown> {
+  return (
+    !!value &&
+    (typeof value === 'object' || typeof value === 'function') &&
+    typeof (value as Promise<unknown>).then === 'function'
+  )
+}
+
+function normalizeVirtualPath(path: string): string {
+  if (!path.startsWith('/')) {
+    throw new TypeError(`virtual path must be absolute: '${path}'`)
+  }
+  const out: string[] = []
+  for (const part of path.split('/')) {
+    if (!part || part === '.') {
+      continue
+    }
+    if (part === '..') {
+      out.pop()
+    } else {
+      out.push(part)
+    }
+  }
+  return `/${out.join('/')}`
+}
+
+function pathMatchesMount(path: string, mountPath: string): boolean {
+  return path === mountPath || (mountPath === '/' ? path.startsWith('/') : path.startsWith(`${mountPath}/`))
+}
+
+function joinVirtualPath(parent: string, child: string): string {
+  return normalizeVirtualPath(`${parent.replace(/\/+$/, '')}/${child.replace(/^\/+/, '')}`)
+}
+
 /**
  * Options for `runMontyAsync`.
  */
@@ -625,7 +1372,7 @@ export interface RunMontyAsyncOptions {
   /** Callback invoked on each print() call. The first argument is the stream name (always "stdout"), the second is the printed text. */
   printCallback?: (stream: string, text: string) => void
   /** Filesystem mount(s) for the sandbox. */
-  mount?: MountDir | MountDir[]
+  mount?: MountLike | MountLike[]
 }
 
 /**
@@ -658,26 +1405,39 @@ export interface RunMontyAsyncOptions {
  */
 export async function runMontyAsync(montyRunner: Monty, options: RunMontyAsyncOptions = {}): Promise<JsMontyObject> {
   const { inputs, externalFunctions = {}, limits, printCallback, mount } = options
+  const split = splitMounts(mount)
+  const context = createDispatchContext(split, externalFunctions)
 
-  let progress: MontySnapshot | MontyNameLookup | MontyComplete = montyRunner.start({
-    inputs,
-    limits,
-    printCallback,
-    mount,
-  })
+  let progress: MontySnapshot | MontyNameLookup | MontyComplete | MontyOsCall = montyRunner._startNative(
+    {
+      inputs,
+      limits,
+      printCallback,
+      mount: split as unknown as MountLike,
+      pauseOsCalls: split.virtualMounts.length > 0,
+    },
+    split,
+    context,
+  )
+  progress = await advanceAsync(progress, context)
 
   while (!(progress instanceof MontyComplete)) {
+    if (progress instanceof MontyOsCall) {
+      progress = await advanceAsync(progress, context)
+      continue
+    }
     if (progress instanceof MontyNameLookup) {
       // Name lookup — check if the name is a known external function
       const name = progress.variableName
       const extFunction = externalFunctions[name]
       if (extFunction) {
         // Resolve the name as a function value
-        progress = progress.resume({ value: extFunction })
+        progress = await progress.resumeAsync({ value: extFunction })
       } else {
         // Unknown name — resume with no value to raise NameError
-        progress = progress.resume()
+        progress = await progress.resumeAsync()
       }
+      progress = await advanceAsync(progress, context)
       continue
     }
 
@@ -689,12 +1449,13 @@ export async function runMontyAsync(montyRunner: Monty, options: RunMontyAsyncOp
     if (!extFunction) {
       // Function not found — this shouldn't normally happen since NameLookup
       // would have raised NameError, but handle it defensively
-      progress = snapshot.resume({
+      progress = await snapshot.resumeAsync({
         exception: {
           type: 'NameError',
           message: `name '${funcName}' is not defined`,
         },
       })
+      progress = await advanceAsync(progress, context)
       continue
     }
 
@@ -708,19 +1469,20 @@ export async function runMontyAsync(montyRunner: Monty, options: RunMontyAsyncOp
       }
 
       // Resume with the return value
-      progress = snapshot.resume({ returnValue: result })
+      progress = await snapshot.resumeAsync({ returnValue: result })
     } catch (error) {
       // External function threw an exception - convert to Monty exception
       const err = error as Error
       const excType = err.name || 'RuntimeError'
       const excMessage = err.message || String(error)
-      progress = snapshot.resume({
+      progress = await snapshot.resumeAsync({
         exception: {
           type: excType,
           message: excMessage,
         },
       })
     }
+    progress = await advanceAsync(progress, context)
   }
 
   return progress.output


### PR DESCRIPTION
## Summary

Adds first-class JavaScript virtual filesystem mounts for Monty, independent of the external-function support path.

- adds a native paused OS-call surface so unsupported filesystem calls can be handled by JS and resumed
- keeps native `MountDir` handling as the fast path and falls back to paused OS calls only when needed
- adds `VirtualMount` support in the JS wrapper with sync and async backends, read-only/read-write modes, write limits, and path routing
- extends REPL execution with `feedStart`, sync `feed`, and async `feedAsync` support for paused filesystem calls
- adds marker conversions for Monty path, file handle, and stat result values returned from JS

## Validation

- `cargo fmt`
- `cargo check -p monty-js`
- `npm run build:debug`
- `npm test -- __test__/virtual_mount.spec.ts`
- `npm test -- __test__/mount.spec.ts __test__/start.spec.ts __test__/repl.spec.ts __test__/async.spec.ts __test__/virtual_mount.spec.ts`
- `npm run lint`
- `cargo test -p monty-js`
- `git diff --check`
- `npm test`