### PR TITLE
fix(file): release the buffered-file OS-call pin on all paths

### DIFF
--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -88,9 +88,10 @@ impl DropWithHeap for CallResult {
             Self::FramePushed => {}
             Self::OsCallStoreBuffer { call, file_id } => {
                 call.drop_with_heap(heap);
-                let heap = heap.heap_mut();
-                heap.dec_ref(file_id);
-                heap.dec_ref(file_id);
+                // Single pin (see `inc_ref_for_pending_oscall`): release one ref
+                // if the call is discarded before dispatch routes it to a
+                // `pending_file_effect`.
+                heap.heap_mut().dec_ref(file_id);
             }
         }
     }

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -1654,6 +1654,15 @@ fn for_each_child_id<F: FnMut(HeapId)>(data: &HeapData, mut on_child: F) {
                 on_child(tz_id);
             }
         }
+        HeapData::OpenFile(file) => {
+            // Kept in sync with `py_dec_ref_ids_for_data`: the file owns one
+            // ref on its loaded buffer. (`OpenFile` is not GC-tracked today, so
+            // this arm is not reached by the collector, but the two walkers must
+            // mirror each other per the contract above.)
+            if let Some(buffer_id) = file.buffer_id() {
+                on_child(buffer_id);
+            }
+        }
         // Leaf types with no heap references
         _ => {}
     }
@@ -1734,6 +1743,12 @@ fn py_dec_ref_ids_for_data(data: &mut HeapData, stack: &mut Vec<HeapId>) {
             if let Some(tz_id) = dt.tzinfo_ref() {
                 stack.push(tz_id);
             }
+        }
+        HeapData::OpenFile(f) => {
+            // Kept in sync with `for_each_child_id`: release the file's owned
+            // ref on its loaded buffer when the file is freed (e.g. read but
+            // never `close()`d).
+            f.py_dec_ref_ids(stack);
         }
         // other types have no nested heap references
         _ => {}

--- a/crates/monty/src/types/file.rs
+++ b/crates/monty/src/types/file.rs
@@ -486,6 +486,16 @@ impl OpenFile {
         self.position
     }
 
+    /// The heap id of the loaded full-file buffer, if any.
+    ///
+    /// The file owns one `inc_ref` on this buffer; the heap's child-traversal
+    /// (`for_each_child_id`) and free (`py_dec_ref_ids`) paths use this to keep
+    /// the buffer's refcount balanced when the file is freed.
+    #[must_use]
+    pub(crate) fn buffer_id(&self) -> Option<HeapId> {
+        self.buffer
+    }
+
     /// Returns the type represented by this file wrapper.
     #[must_use]
     pub fn file_type(&self) -> Type {
@@ -936,19 +946,17 @@ impl OpenFile {
     }
 }
 
-/// Increments `file_id`'s refcount by 2 for an OS call that pins the file
-/// across the host yield.
+/// Increments `file_id`'s refcount by 1 to pin the file across the host yield.
 ///
-/// One ref is owned by the [`ArgValues`] passed to the host (released when
-/// the host boundary converts the args to `MontyObject` and drops them); the
-/// other ref is owned by the VM's `pending_file_effect` slot and is released
-/// in [`apply_buffer_store`] / [`apply_write_position`] (or by
-/// [`VM::resume_with_exception`](crate::bytecode::VM::resume_with_exception)
-/// if the host raises). Keeping both inc_refs behind this one helper makes
-/// the matched dec_refs easier to verify by eye.
+/// The buffered read/write OS calls carry only the file's path, never a
+/// `Value::Ref` to the file object, so there is no argument ref to release at
+/// the host boundary. The single pin is owned by the VM's `pending_file_effect`
+/// slot and released by exactly one site per path: [`apply_buffer_store`] /
+/// [`apply_write_position`] (success), `resume_with_exception` (host raised),
+/// `VM::drop` (abandoned), or `CallResult`'s drop (call discarded before
+/// dispatch).
 fn inc_ref_for_pending_oscall(vm: &VM<'_, impl ResourceTracker>, file_id: HeapId) {
-    vm.heap.inc_ref(file_id); // released at the host boundary (args drop)
-    vm.heap.inc_ref(file_id); // released in apply_*_position / resume_with_exception (pin)
+    vm.heap.inc_ref(file_id);
 }
 
 /// Materialises the host-returned `result` into a heap-resident `HeapId`

--- a/crates/monty/tests/file_resource_tracking.rs
+++ b/crates/monty/tests/file_resource_tracking.rs
@@ -159,3 +159,37 @@ os.getenv('PROBE')
         "expected buffer to be released, but {mem_after_close} bytes still tracked",
     );
 }
+
+// ---------------------------------------------------------------------------
+// A file read but never `close()`d must still release its buffer once the
+// `OpenFile` becomes unreachable (`f = 0`). Regression for two coupled refcount
+// bugs in the buffered-read path: the OS-call pin over-counted the file so it
+// was never freed on `f = 0`, and the free walker (`py_dec_ref_ids_for_data`)
+// had no `OpenFile` arm, so even once freed the buffer was not released. Both
+// must be fixed for `current_memory()` to drop back to baseline here.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dropping_unclosed_file_releases_buffer() {
+    let code = r"
+import os
+f = open('/data.txt')
+f.read(5)
+f = 0            # OpenFile becomes unreachable WITHOUT close(); refcount -> 0
+os.getenv('PROBE')
+";
+    let body = "abcdefghijklmnopqrstuvwxyz".repeat(100); // 2600 bytes
+    let limits = ResourceLimits::new().max_memory(1_000_000);
+    let (mem, _) = open_then_read(
+        code,
+        "Path.read_text",
+        file_handle("/data.txt", "r"),
+        MontyObject::String(body),
+        limits,
+    )
+    .expect("should succeed");
+    assert!(
+        mem < 1500,
+        "OpenFile buffer leaked: {mem} bytes still tracked after the unclosed file was freed",
+    );
+}


### PR DESCRIPTION
AI disclaimer - this bug was found and fixed with claude code. The changes seem sensible to me, but I'm far from an expert. If the review or verification burden for this change is high, feel free to disregard / I'll happily close.

## What

Fixes two coupled reference-count leaks in the buffered file (`open()`) path.

1. **Pin double-count (read + write).** `inc_ref_for_pending_oscall` inc_ref'd the OpenFile twice, on the assumption that one ref rides in the OS-call args and is dropped at the host boundary. But the buffered OS calls (`OsFunctionCall::ReadText`/`ReadBytes`/`WriteText`/…) carry only a `MontyPath`, never a `Value::Ref` to the file, so that ref is never released. Every buffered `read()`/`write()` leaked one ref on the OpenFile, so the file object was never freed (even with an explicit `close()`). Fixed by pinning with a single `inc_ref` so each release site — the success pin in `apply_buffer_store`/`apply_write_position`, the `dec_ref` in `resume_with_exception`, `VM::drop`, and `CallResult`'s drop — balances exactly one ref.

2. **Buffer leak on free.** `py_dec_ref_ids_for_data` had no `HeapData::OpenFile` arm, so a file read but never `close()`d leaked its full-file buffer (`Str`/`Bytes`) when the OpenFile was freed. Added the arm, plus the matching `for_each_child_id` arm which the in-file comment requires to stay in sync.

## Tests

`crates/monty/tests/file_resource_tracking.rs::dropping_unclosed_file_releases_buffer`: a file read but not closed releases its buffer once the OpenFile is freed (`current_memory()` returns to baseline). This requires both fixes — the OpenFile must be freed (1) and the free path must release the buffer (2).

The pin fix lives in the shared `inc_ref_for_pending_oscall` helper, so it applies identically to writes (same helper + the symmetric single-pin release in `apply_write_position`). The write/append paths in `file_error_paths` and the snapshot/resume round-trips in `binary_serde` pass under `memory-model-checks` (no over-release on either path). A buffered write loads no buffer, so its leak was the small `OpenFile` handle alone, which isn't cleanly isolatable via `current_memory()` — hence the regression test targets the read path, where the leaked buffer makes both fixes observable.

## How this was found

Surfaced while auditing Monty's reference-counting discipline for use-after-free conditions as part of Hack Monty. This one is an over-retention *leak* (memory-safe, not an escape), caught and confirmed with the repo's own `memory-model-checks` + `ref-count-return` tooling.
