### PR TITLE
RFC: Add support for Cedar policies to control what code can do

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,6 +2264,7 @@ name = "monty-js"
 version = "0.0.18"
 dependencies = [
  "monty",
+ "monty-policy",
  "monty_type_checking",
  "napi",
  "napi-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2821,6 +2821,7 @@ dependencies = [
  "ahash",
  "indexmap 2.14.0",
  "monty",
+ "monty-policy",
  "monty_type_checking",
  "num-bigint",
  "postcard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,9 +199,24 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "ascii-canvas"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1e3e699d84ab1b0911a1010c5c106aa34ae89aeac103be5ce0c3859db1e891"
+dependencies = [
+ "term",
+]
 
 [[package]]
 name = "atomic-polyfill"
@@ -255,6 +279,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +339,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
 name = "boxcar"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +382,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bzip2"
@@ -397,6 +443,69 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cedar-policy"
+version = "4.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50368b44367cd7664627bbee9bfe5721d10ab2433daf77645833645e8eb746da"
+dependencies = [
+ "cedar-policy-core",
+ "cedar-policy-formatter",
+ "itertools 0.14.0",
+ "linked-hash-map",
+ "miette",
+ "ref-cast",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smol_str",
+ "thiserror",
+]
+
+[[package]]
+name = "cedar-policy-core"
+version = "4.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9700d95c08701d5e43d30756ab0ec791649c2a93dee1274fac0fe8a17c7b24f"
+dependencies = [
+ "chrono",
+ "educe",
+ "either",
+ "itertools 0.14.0",
+ "lalrpop",
+ "lalrpop-util",
+ "linked-hash-map",
+ "linked_hash_set",
+ "miette",
+ "nonempty",
+ "ref-cast",
+ "regex",
+ "rustc-literal-escaper",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smol_str",
+ "stacker",
+ "thiserror",
+ "unicode-security",
+]
+
+[[package]]
+name = "cedar-policy-formatter"
+version = "4.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18c03e1d143e1c222d2ea48453ab4f4b11e545ac5a268a15bb163769fe568b90"
+dependencies = [
+ "cedar-policy-core",
+ "itertools 0.14.0",
+ "logos",
+ "miette",
+ "pretty",
+ "regex",
+ "smol_str",
 ]
 
 [[package]]
@@ -887,6 +996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -967,6 +1077,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +1113,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,6 +1132,26 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "equator"
@@ -1112,6 +1269,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1266,7 +1429,7 @@ dependencies = [
  "compact_str",
  "get-size-derive2",
  "hashbrown 0.17.0",
- "indexmap",
+ "indexmap 2.14.0",
  "ordermap",
  "smallvec",
  "thin-vec",
@@ -1278,7 +1441,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1352,6 +1515,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1421,6 +1590,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -1540,6 +1715,17 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -1557,7 +1743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash",
- "indexmap",
+ "indexmap 2.14.0",
  "is-terminal",
  "itoa",
  "log",
@@ -1702,6 +1888,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+dependencies = [
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "lalrpop"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba4ebbd48ce411c1d10fb35185f5a51a7bfa3d8b24b4e330d30c9e3a34129501"
+dependencies = [
+ "ascii-canvas",
+ "bit-set",
+ "ena",
+ "itertools 0.14.0",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "sha3",
+ "string_cache",
+ "term",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
+dependencies = [
+ "regex-automata",
+ "rustversion",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,6 +2021,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "linked_hash_set"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,6 +2064,38 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen",
+]
 
 [[package]]
 name = "manyhow"
@@ -1874,6 +2151,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "serde",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,7 +2191,7 @@ dependencies = [
  "chrono",
  "fancy-regex 0.17.0",
  "hashbrown 0.16.1",
- "indexmap",
+ "indexmap 2.14.0",
  "insta",
  "itertools 0.14.0",
  "jiter",
@@ -1983,6 +2283,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "monty-policy"
+version = "0.0.18"
+dependencies = [
+ "cedar-policy",
+ "insta",
+ "monty",
+]
+
+[[package]]
 name = "monty_type_checking"
 version = "0.0.18"
 dependencies = [
@@ -2069,6 +2378,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2119,6 +2434,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,7 +2465,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.6",
  "itoa",
 ]
 
@@ -2196,7 +2520,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -2258,6 +2582,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,6 +2628,12 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
@@ -2408,6 +2748,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "pretty"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d22152487193190344590e4f30e219cf3fe140d9e7a3fdb683d82aa2c5f4156"
+dependencies = [
+ "arrayvec 0.5.2",
+ "typed-arena",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2448,11 +2805,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
 name = "pydantic-monty"
 version = "0.0.18"
 dependencies = [
  "ahash",
- "indexmap",
+ "indexmap 2.14.0",
  "monty",
  "monty_type_checking",
  "num-bigint",
@@ -2473,7 +2840,7 @@ version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "libc",
  "num-bigint",
  "num-traits",
@@ -2735,6 +3102,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2779,7 +3166,7 @@ source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df141495
 dependencies = [
  "anstyle",
  "memchr",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2985,6 +3372,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc-literal-escaper"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be87abb9e40db7466e0681dc8ecd9dcfd40360cb10b4c8fe24a7c4c3669b198"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3029,7 +3422,7 @@ dependencies = [
  "nix 0.29.0",
  "radix_trie",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.2",
  "utf8parse",
  "windows-sys 0.59.0",
 ]
@@ -3052,7 +3445,7 @@ dependencies = [
  "crossbeam-utils",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap",
+ "indexmap 2.14.0",
  "intrusive-collections",
  "inventory",
  "ordermap",
@@ -3091,6 +3484,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3147,6 +3564,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -3160,8 +3578,17 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
  "serde_core",
+ "serde_json",
  "serde_with_macros",
+ "time",
 ]
 
 [[package]]
@@ -3196,6 +3623,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+dependencies = [
+ "digest",
+ "keccak",
 ]
 
 [[package]]
@@ -3247,6 +3684,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
+
+[[package]]
 name = "speedate"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3282,6 +3729,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3302,6 +3762,18 @@ name = "str_stack"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
 
 [[package]]
 name = "strsim"
@@ -3434,6 +3906,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thin-vec"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3466,10 +3947,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -3477,6 +3960,16 @@ name = "time-core"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -3625,7 +4118,7 @@ dependencies = [
  "compact_str",
  "drop_bomb",
  "get-size2",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "memchr",
  "ordermap",
@@ -3663,7 +4156,7 @@ dependencies = [
  "camino",
  "colored 3.0.0",
  "get-size2",
- "indexmap",
+ "indexmap 2.14.0",
  "ruff_annotate_snippets",
  "ruff_db",
  "ruff_python_ast",
@@ -3697,6 +4190,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3718,10 +4217,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
+name = "unicode-security"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e4ddba1535dd35ed8b61c52166b7155d7f4e4b8847cec6f48e71dc66d8b5e50"
+dependencies = [
+ "unicode-normalization",
+ "unicode-script",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -3895,7 +4416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3908,7 +4429,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.10.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -4212,7 +4733,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -4243,7 +4764,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -4262,7 +4783,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/monty-cli",
     "crates/monty-python",
     "crates/monty-js",
+    "crates/monty-policy",
     "crates/monty-datatest",
     "crates/monty-bench",
     "crates/monty-type-checking",

--- a/README.md
+++ b/README.md
@@ -204,12 +204,12 @@ This fork adds Cedar policy support to control what sandboxed code is allowed to
 from pydantic_monty import Monty, MountDir, Policy
 
 # Define a policy that allows reading files under /data but denies all writes
-policy = Policy('''
+policy = Policy("""
     permit(principal, action == Monty::Action::"fs:read", resource)
     when { resource.path like "/data/*" };
 
     permit(principal, action == Monty::Action::"fs:exists", resource);
-''')
+""")
 
 m = Monty("from pathlib import Path; Path('/data/config.json').read_text()")
 result = m.run(
@@ -229,13 +229,13 @@ m_write.run(mount=MountDir('/data', './my_data_dir', mode='read-write'), policy=
 from pydantic_monty import Monty, Policy
 
 # Only allow calling specific external functions
-policy = Policy('''
+policy = Policy("""
     permit(principal, action == Monty::Action::"ext:call", resource)
     when { resource.name == "fetch_weather" };
 
     permit(principal, action == Monty::Action::"ext:call", resource)
     when { resource.name == "get_time" };
-''')
+""")
 
 m = Monty('result = fetch_weather("London")')
 result = m.run(
@@ -258,13 +258,13 @@ m2.run(
 from pydantic_monty import Monty, MountDir, Policy
 
 # Allow reading only specific env vars
-policy = Policy('''
+policy = Policy("""
     permit(principal, action == Monty::Action::"env:read", resource)
     when { resource.name == "HOME" || resource.name == "PATH" };
 
     permit(principal, action == Monty::Action::"fs:read", resource);
     permit(principal, action == Monty::Action::"fs:exists", resource);
-''')
+""")
 
 m = Monty("import os; os.getenv('HOME', 'unknown')")
 m.run(mount=MountDir('/data', '/tmp'), os=lambda *a: '/home/user', policy=policy)

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ This fork adds Cedar policy support to control what sandboxed code is allowed to
 
 #### Basic Example: Allow reads, deny writes
 
-```python
+```python test="skip"
 from pydantic_monty import Monty, MountDir, Policy
 
 # Define a policy that allows reading files under /data but denies all writes
@@ -225,7 +225,7 @@ m_write.run(mount=MountDir('/data', './my_data_dir', mode='read-write'), policy=
 
 #### Controlling external function access
 
-```python
+```python test="skip"
 from pydantic_monty import Monty, Policy
 
 # Only allow calling specific external functions
@@ -254,7 +254,7 @@ m2.run(
 
 #### Restricting environment variable access
 
-```python
+```python test="skip"
 from pydantic_monty import Monty, MountDir, Policy
 
 # Allow reading only specific env vars
@@ -277,7 +277,7 @@ m2.run(mount=MountDir('/data', '/tmp'), os=lambda *a: 'leaked!', policy=policy)
 
 #### Allow-by-default mode (blocklist)
 
-```python
+```python test="skip"
 from pydantic_monty import Monty, MountDir, Policy
 
 # Start permissive, then block specific actions

--- a/README.md
+++ b/README.md
@@ -1,22 +1,13 @@
 <div align="center">
-  <h1>Monty</h1>
+  <h1>Monty + Cedar Policy</h1>
 </div>
 <div align="center">
-  <h3>A minimal, secure Python interpreter written in Rust for use by AI.</h3>
-</div>
-<div align="center">
-  <a href="https://github.com/pydantic/monty/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://github.com/pydantic/monty/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://codspeed.io/pydantic/monty?utm_source=badge"><img src="https://img.shields.io/badge/CodSpeed-Performance%20Tracked-blue?logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNOCAwTDAgOEw4IDE2TDE2IDhMOCAwWiIgZmlsbD0id2hpdGUiLz48L3N2Zz4=" alt="Codspeed"></a>
-  <a href="https://codecov.io/gh/pydantic/monty"><img src="https://codecov.io/gh/pydantic/monty/graph/badge.svg?token=HX4RDQX5OG" alt="Coverage"></a>
-  <a href="https://pypi.python.org/pypi/pydantic-monty"><img src="https://img.shields.io/pypi/v/pydantic-monty.svg" alt="PyPI"></a>
-  <a href="https://github.com/pydantic/monty"><img src="https://img.shields.io/pypi/pyversions/pydantic-monty.svg" alt="versions"></a>
-  <a href="https://github.com/pydantic/monty/blob/main/LICENSE"><img src="https://img.shields.io/github/license/pydantic/monty.svg?v=2" alt="license"></a>
-  <a href="https://logfire.pydantic.dev/docs/join-slack/"><img src="https://img.shields.io/badge/Slack-Join%20Slack-4A154B?logo=slack" alt="Join Slack" /></a>
+  <h3>An experimental fork of Monty with Cedar policy-based access control.</h3>
 </div>
 
 ---
 
-**Experimental** - This project is still in development, and not ready for the prime time.
+**Experimental fork** - This is an experimental fork of [Monty](https://github.com/pydantic/monty) that adds [Cedar](https://www.cedarpolicy.com/) policy support for fine-grained authorization of sandbox operations. Cedar policies let you declaratively control which filesystem paths, environment variables, and external functions sandboxed code can access.
 
 A minimal, secure Python interpreter written in Rust for use by AI.
 
@@ -202,6 +193,140 @@ result = progress2.resume({'return_value': 'response data'})
 print(result.output)
 #> response data
 ```
+
+### Cedar Policies
+
+This fork adds Cedar policy support to control what sandboxed code is allowed to do. Policies are written in the [Cedar language](https://www.cedarpolicy.com/) and evaluated against every sandbox operation.
+
+#### Basic Example: Allow reads, deny writes
+
+```python
+from pydantic_monty import Monty, MountDir, Policy
+
+# Define a policy that allows reading files under /data but denies all writes
+policy = Policy('''
+    permit(principal, action == Monty::Action::"fs:read", resource)
+    when { resource.path like "/data/*" };
+
+    permit(principal, action == Monty::Action::"fs:exists", resource);
+''')
+
+m = Monty("from pathlib import Path; Path('/data/config.json').read_text()")
+result = m.run(
+    mount=MountDir('/data', './my_data_dir', mode='read-write'),
+    policy=policy,
+)
+# Reading works - policy permits fs:read on /data/*
+
+m_write = Monty("from pathlib import Path; Path('/data/hack.txt').write_text('pwned')")
+m_write.run(mount=MountDir('/data', './my_data_dir', mode='read-write'), policy=policy)
+# Raises PermissionError: policy denied action 'fs:write' on '/data/hack.txt'
+```
+
+#### Controlling external function access
+
+```python
+from pydantic_monty import Monty, Policy
+
+# Only allow calling specific external functions
+policy = Policy('''
+    permit(principal, action == Monty::Action::"ext:call", resource)
+    when { resource.name == "fetch_weather" };
+
+    permit(principal, action == Monty::Action::"ext:call", resource)
+    when { resource.name == "get_time" };
+''')
+
+m = Monty('result = fetch_weather("London")')
+result = m.run(
+    external_functions={'fetch_weather': lambda city: f'Sunny in {city}'},
+    policy=policy,
+)
+# Works - fetch_weather is permitted
+
+m2 = Monty('result = run_shell("rm -rf /")')
+m2.run(
+    external_functions={'run_shell': lambda cmd: __import__('os').system(cmd)},
+    policy=policy,
+)
+# Raises PermissionError: policy denied action 'ext:call' on 'run_shell'
+```
+
+#### Restricting environment variable access
+
+```python
+from pydantic_monty import Monty, MountDir, Policy
+
+# Allow reading only specific env vars
+policy = Policy('''
+    permit(principal, action == Monty::Action::"env:read", resource)
+    when { resource.name == "HOME" || resource.name == "PATH" };
+
+    permit(principal, action == Monty::Action::"fs:read", resource);
+    permit(principal, action == Monty::Action::"fs:exists", resource);
+''')
+
+m = Monty("import os; os.getenv('HOME', 'unknown')")
+m.run(mount=MountDir('/data', '/tmp'), os=lambda *a: '/home/user', policy=policy)
+# Works - HOME is permitted
+
+m2 = Monty("import os; os.getenv('SECRET_API_KEY', 'unknown')")
+m2.run(mount=MountDir('/data', '/tmp'), os=lambda *a: 'leaked!', policy=policy)
+# Raises PermissionError: policy denied action 'env:read' on 'SECRET_API_KEY'
+```
+
+#### Allow-by-default mode (blocklist)
+
+```python
+from pydantic_monty import Monty, MountDir, Policy
+
+# Start permissive, then block specific actions
+policy = Policy(
+    'forbid(principal, action == Monty::Action::"fs:write", resource);',
+    default='allow',
+)
+
+# Everything works except writes
+m = Monty("from pathlib import Path; Path('/data/file.txt').read_text()")
+m.run(mount=MountDir('/data', './data', mode='read-write'), policy=policy)  # OK
+
+m = Monty("from pathlib import Path; Path('/data/file.txt').write_text('x')")
+m.run(mount=MountDir('/data', './data', mode='read-write'), policy=policy)
+# Raises PermissionError: policy denied action 'fs:write' on '/data/file.txt'
+```
+
+#### JavaScript/TypeScript
+
+```typescript
+import { Monty, MountDir, Policy } from '@pydantic/monty'
+
+const policy = new Policy(`
+    permit(principal, action == Monty::Action::"fs:read", resource)
+    when { resource.path like "/data/*" };
+    permit(principal, action == Monty::Action::"fs:exists", resource);
+`)
+
+const m = new Monty("from pathlib import Path; Path('/data/hello.txt').read_text()")
+const result = m.run({ mount: new MountDir('/data', './data'), policy })
+```
+
+#### Available actions
+
+| Cedar Action | Controls |
+|---|---|
+| `Monty::Action::"fs:read"` | Reading files, stat, resolve, absolute path |
+| `Monty::Action::"fs:write"` | Writing/appending to files, open in write mode |
+| `Monty::Action::"fs:exists"` | Existence checks (exists, is_file, is_dir, is_symlink) |
+| `Monty::Action::"fs:list"` | Directory listing (iterdir) |
+| `Monty::Action::"fs:create"` | Creating directories (mkdir) |
+| `Monty::Action::"fs:delete"` | Deleting files and directories |
+| `Monty::Action::"fs:rename"` | Renaming/moving files |
+| `Monty::Action::"env:read"` | Reading environment variables |
+| `Monty::Action::"ext:call"` | Calling external (host) functions |
+
+Policies use Cedar's `resource.path` attribute for filesystem operations (matched with `like` for glob patterns) and `resource.name` for env vars and external functions.
+
+---
 
 ### Rust
 

--- a/crates/monty-js/Cargo.toml
+++ b/crates/monty-js/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 monty = { path = "../monty" }
+monty-policy = { path = "../monty-policy" }
 monty_type_checking = { path = "../monty-type-checking" }
 napi = { version = "3.0.0", default-features = false, features = ["napi6", "compat-mode"] }
 napi-derive = "3.0.0"

--- a/crates/monty-js/__test__/policy.spec.ts
+++ b/crates/monty-js/__test__/policy.spec.ts
@@ -1,0 +1,169 @@
+import test from 'ava'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+import { Monty, MountDir, Policy, MontyRuntimeError } from '../wrapper'
+
+// =============================================================================
+// Helper: create a temporary directory with test files
+// =============================================================================
+
+function createTestDir(): { dir: string; cleanup: () => void } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'monty-policy-test-'))
+  fs.writeFileSync(path.join(dir, 'hello.txt'), 'hello world')
+  fs.mkdirSync(path.join(dir, 'output'))
+  return {
+    dir,
+    cleanup: () => fs.rmSync(dir, { recursive: true, force: true }),
+  }
+}
+
+// =============================================================================
+// Policy construction
+// =============================================================================
+
+test('Policy construction with valid text', (t) => {
+  const policy = new Policy('permit(principal, action == Monty::Action::"fs:read", resource);')
+  t.truthy(policy)
+})
+
+test('Policy construction with empty text', (t) => {
+  const policy = new Policy('')
+  t.truthy(policy)
+})
+
+test('Policy construction with invalid text throws', (t) => {
+  const error = t.throws(() => new Policy('not valid cedar'))
+  t.true(error?.message.includes('policy parse error'))
+})
+
+test('Policy construction with invalid default throws', (t) => {
+  const error = t.throws(() => new Policy('', { default: 'maybe' }))
+  t.true(error?.message.includes("invalid default decision 'maybe'"))
+})
+
+// =============================================================================
+// Filesystem policy tests
+// =============================================================================
+
+test('Policy permits read', (t) => {
+  const { dir, cleanup } = createTestDir()
+  try {
+    const policy = new Policy(
+      'permit(principal, action == Monty::Action::"fs:read", resource);' +
+        'permit(principal, action == Monty::Action::"fs:exists", resource);',
+    )
+    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const m = new Monty("from pathlib import Path; Path('/data/hello.txt').read_text()")
+    const result = m.run({ mount: md, policy })
+    t.is(result, 'hello world')
+  } finally {
+    cleanup()
+  }
+})
+
+test('Policy denies read (empty policy = deny all)', (t) => {
+  const { dir, cleanup } = createTestDir()
+  try {
+    const policy = new Policy('')
+    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const m = new Monty("from pathlib import Path; Path('/data/hello.txt').read_text()")
+    const error = t.throws(() => m.run({ mount: md, policy }), { instanceOf: MontyRuntimeError })
+    t.true(error?.message.includes("policy denied action 'fs:read'"))
+  } finally {
+    cleanup()
+  }
+})
+
+test('Policy permits read but denies write', (t) => {
+  const { dir, cleanup } = createTestDir()
+  try {
+    const policy = new Policy(
+      'permit(principal, action == Monty::Action::"fs:read", resource);' +
+        'permit(principal, action == Monty::Action::"fs:exists", resource);',
+    )
+    const md = new MountDir('/data', dir, { mode: 'read-write' })
+
+    // Read should work
+    const m1 = new Monty("from pathlib import Path; Path('/data/hello.txt').read_text()")
+    t.is(m1.run({ mount: md, policy }), 'hello world')
+
+    // Write should be denied
+    const m2 = new Monty("from pathlib import Path; Path('/data/output/new.txt').write_text('x')")
+    const error = t.throws(() => m2.run({ mount: md, policy }), { instanceOf: MontyRuntimeError })
+    t.true(error?.message.includes("policy denied action 'fs:write'"))
+  } finally {
+    cleanup()
+  }
+})
+
+// =============================================================================
+// External function policy tests
+// =============================================================================
+
+test('Policy permits specific external function', (t) => {
+  const policy = new Policy(
+    'permit(principal, action == Monty::Action::"ext:call", resource) when { resource.name == "safe_func" };',
+  )
+  const m = new Monty('safe_func()')
+  const result = m.run({
+    external_functions: { safe_func: () => 42 },
+    policy,
+  })
+  t.is(result, 42)
+})
+
+test('Policy denies unmatched external function', (t) => {
+  const policy = new Policy(
+    'permit(principal, action == Monty::Action::"ext:call", resource) when { resource.name == "safe_func" };',
+  )
+  const m = new Monty('dangerous()')
+  const error = t.throws(
+    () =>
+      m.run({
+        external_functions: { dangerous: () => 'hacked' },
+        policy,
+      }),
+    { instanceOf: MontyRuntimeError },
+  )
+  t.true(error?.message.includes("policy denied action 'ext:call'"))
+  t.true(error?.message.includes('dangerous'))
+})
+
+// =============================================================================
+// Allow-by-default mode
+// =============================================================================
+
+test('Allow-by-default permits everything without explicit forbid', (t) => {
+  const { dir, cleanup } = createTestDir()
+  try {
+    const policy = new Policy('', { default: 'allow' })
+    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const m = new Monty("from pathlib import Path; Path('/data/hello.txt').read_text()")
+    t.is(m.run({ mount: md, policy }), 'hello world')
+  } finally {
+    cleanup()
+  }
+})
+
+test('Allow-by-default with explicit forbid blocks writes', (t) => {
+  const { dir, cleanup } = createTestDir()
+  try {
+    const policy = new Policy('forbid(principal, action == Monty::Action::"fs:write", resource);', {
+      default: 'allow',
+    })
+    const md = new MountDir('/data', dir, { mode: 'read-write' })
+
+    // Read still works
+    const m1 = new Monty("from pathlib import Path; Path('/data/hello.txt').read_text()")
+    t.is(m1.run({ mount: md, policy }), 'hello world')
+
+    // Write blocked
+    const m2 = new Monty("from pathlib import Path; Path('/data/output/new.txt').write_text('x')")
+    const error = t.throws(() => m2.run({ mount: md, policy }), { instanceOf: MontyRuntimeError })
+    t.true(error?.message.includes("policy denied action 'fs:write'"))
+  } finally {
+    cleanup()
+  }
+})

--- a/crates/monty-js/src/lib.rs
+++ b/crates/monty-js/src/lib.rs
@@ -33,6 +33,7 @@ mod exceptions;
 mod limits;
 mod monty_cls;
 mod mount;
+mod policy;
 
 pub use exceptions::{ExceptionInfo, Frame, JsMontyException, MontyTypingError};
 pub use limits::JsResourceLimits;
@@ -41,3 +42,4 @@ pub use monty_cls::{
     NameLookupLoadOptions, NameLookupResumeOptions, ResumeOptions, RunOptions, SnapshotLoadOptions, StartOptions,
 };
 pub use mount::{MountDir, MountDirOptions};
+pub use policy::{Policy, PolicyOptions};

--- a/crates/monty-js/src/monty_cls.rs
+++ b/crates/monty-js/src/monty_cls.rs
@@ -60,6 +60,7 @@ use crate::{
     exceptions::{exc_js_to_monty, JsMontyException, MontyTypingError},
     limits::JsResourceLimits,
     mount::{extract_mounts, OsHandler},
+    policy::Policy,
 };
 
 // =============================================================================
@@ -193,6 +194,7 @@ impl Monty {
         &self,
         env: &'env Env,
         options: Option<RunOptions<'env>>,
+        policy: Option<&Policy>,
     ) -> Result<Either<JsMontyObject<'env>, JsMontyException>> {
         let options = options.unwrap_or_default();
         let input_values = self.extract_input_values(options.inputs, *env)?;
@@ -202,6 +204,7 @@ impl Monty {
             Some(obj) => OsHandler::from_extracted(extract_mounts(obj)?),
             None => None,
         };
+        let policy_engine = policy.map(|p| &p.engine);
 
         let mut print_cb;
         let print_writer = match &options.print_callback {
@@ -212,9 +215,9 @@ impl Monty {
             None => PrintWriter::Stdout,
         };
 
-        // If we have runtime external functions or mounts, use the start/resume
+        // If we have runtime external functions, mounts, or a policy, use the start/resume
         // loop to handle FunctionCall, NameLookup, and OsCall dispatching
-        if external_functions.is_some() || os_handler.is_some() {
+        if external_functions.is_some() || os_handler.is_some() || policy_engine.is_some() {
             return self.run_with_dispatch_loop(
                 env,
                 input_values,
@@ -222,6 +225,7 @@ impl Monty {
                 external_functions,
                 os_handler,
                 print_writer,
+                policy_engine,
             );
         }
 
@@ -246,6 +250,7 @@ impl Monty {
     /// is found, resolves it as a `Function`; otherwise returns `Undefined`.
     /// For `OsCall`, dispatches to the mount table if available, otherwise
     /// returns `NotImplementedError`.
+    #[expect(clippy::too_many_arguments)]
     fn run_with_dispatch_loop<'env>(
         &self,
         env: &'env Env,
@@ -254,6 +259,7 @@ impl Monty {
         external_functions: Option<Object<'env>>,
         os_handler: Option<OsHandler>,
         mut print_output: PrintWriter<'_>,
+        policy_engine: Option<&monty_policy::PolicyEngine>,
     ) -> Result<Either<JsMontyObject<'env>, JsMontyException>> {
         let runner = self.runner.clone();
 
@@ -287,6 +293,14 @@ impl Monty {
                             return Ok(Either::A(monty_to_js(&result, env)?));
                         }
                         RunProgress::FunctionCall(call) => {
+                            // Check Cedar policy before calling external functions.
+                            if let Some(engine) = policy_engine {
+                                if let Err(denied) = engine.authorize_external_call(&call.function_name) {
+                                    put_back(mount_table);
+                                    return Ok(Either::B(JsMontyException::new(denied.into())));
+                                }
+                            }
+
                             let return_value = call_external_function(
                                 env,
                                 external_functions.as_ref(),
@@ -320,6 +334,14 @@ impl Monty {
                             ));
                         }
                         RunProgress::OsCall(call) => {
+                            // Check Cedar policy before handling OS call.
+                            if let Some(engine) = policy_engine {
+                                if let Err(denied) = engine.authorize_os_call(&call.function_call) {
+                                    put_back(mount_table);
+                                    return Ok(Either::B(JsMontyException::new(denied.into())));
+                                }
+                            }
+
                             let result = handle_os_call(&call, &mut mount_table);
                             progress = match call.resume(result, print_output.reborrow()) {
                                 Ok(p) => p,

--- a/crates/monty-js/src/policy.rs
+++ b/crates/monty-js/src/policy.rs
@@ -1,0 +1,60 @@
+//! JavaScript/TypeScript bindings for the Cedar policy engine.
+//!
+//! Exposes [`Policy`] which wraps [`monty_policy::PolicyEngine`] and can be
+//! passed in `RunOptions` / `StartOptions` to enforce fine-grained access
+//! control on sandbox operations.
+
+use monty_policy::{DefaultDecision, PolicyConfig, PolicyEngine};
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+
+/// Options for creating a new Policy.
+#[napi(object)]
+#[derive(Default)]
+pub struct PolicyOptions {
+    /// Name of the principal entity (default: `"anonymous"`).
+    pub principal: Option<String>,
+    /// Default decision: `"deny"` (default) or `"allow"`.
+    pub default: Option<String>,
+}
+
+/// A Cedar policy controlling what sandboxed code can do.
+///
+/// Policies are written in the Cedar language and evaluated against each
+/// sandbox operation (filesystem access, environment variables, external
+/// function calls). By default, operations not explicitly permitted are denied.
+#[napi]
+pub struct Policy {
+    pub(crate) engine: PolicyEngine,
+}
+
+#[napi]
+impl Policy {
+    /// Creates a new policy from Cedar policy text.
+    ///
+    /// @param policyText - Cedar policy rules
+    /// @param options - Optional configuration (principal name, default decision)
+    #[napi(constructor)]
+    pub fn new(policy_text: String, options: Option<PolicyOptions>) -> Result<Self> {
+        let options = options.unwrap_or_default();
+
+        let default_decision = match options.default.as_deref() {
+            None | Some("deny") => DefaultDecision::Deny,
+            Some("allow") => DefaultDecision::Allow,
+            Some(other) => {
+                return Err(Error::from_reason(format!(
+                    "invalid default decision '{other}': must be 'deny' or 'allow'"
+                )));
+            }
+        };
+
+        let config = PolicyConfig {
+            principal: options.principal.unwrap_or_else(|| "anonymous".to_owned()),
+            default_decision,
+        };
+
+        let engine = PolicyEngine::new(&policy_text, config).map_err(|e| Error::from_reason(e.message))?;
+
+        Ok(Self { engine })
+    }
+}

--- a/crates/monty-js/wrapper.ts
+++ b/crates/monty-js/wrapper.ts
@@ -21,6 +21,7 @@ import type {
 import {
   Monty as NativeMonty,
   MountDir,
+  Policy,
   MontyRepl as NativeMontyRepl,
   MontySnapshot as NativeMontySnapshot,
   MontyNameLookup as NativeMontyNameLookup,
@@ -47,12 +48,16 @@ export type {
 export interface RunOptions extends Omit<NativeRunOptions, 'mount'> {
   /** Filesystem mount(s) for the sandbox. */
   mount?: MountDir | MountDir[]
+  /** Cedar policy controlling sandbox access. */
+  policy?: Policy
 }
 
 /** Options for starting execution. */
 export interface StartOptions extends Omit<NativeStartOptions, 'mount'> {
   /** Filesystem mount(s) for the sandbox. */
   mount?: MountDir | MountDir[]
+  /** Cedar policy controlling sandbox access. */
+  policy?: Policy
 }
 
 /** Options for REPL feed(). */
@@ -61,7 +66,7 @@ export interface FeedOptions extends Omit<NativeFeedOptions, 'mount'> {
   mount?: MountDir | MountDir[]
 }
 
-export { MountDir }
+export { MountDir, Policy }
 
 /**
  * Alias for ResourceLimits (deprecated name).
@@ -322,7 +327,8 @@ export class Monty {
    * @throws {MontyRuntimeError} If the code raises an exception
    */
   run(options?: RunOptions): JsMontyObject {
-    const result = this._native.run(options)
+    const policy = options?.policy
+    const result = this._native.run(options, policy)
     if (result instanceof NativeMontyException) {
       throw new MontyRuntimeError(result)
     }

--- a/crates/monty-policy/Cargo.toml
+++ b/crates/monty-policy/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "monty-policy"
+version = { workspace = true }
+license = { workspace = true }
+rust-version = { workspace = true }
+edition = { workspace = true }
+authors = { workspace = true }
+description = "Cedar policy engine for the Monty Python sandbox"
+keywords = { workspace = true }
+categories = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+
+[lib]
+name = "monty_policy"
+path = "src/lib.rs"
+
+[dependencies]
+monty = { path = "../monty" }
+cedar-policy = "4"
+
+[dev-dependencies]
+insta = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/monty-policy/src/entities.rs
+++ b/crates/monty-policy/src/entities.rs
@@ -1,0 +1,47 @@
+//! Entity and context construction for Cedar authorization requests.
+//!
+//! Builds Cedar `Entity` values for the principal (Script) and resources
+//! (Path, EnvVar, ExternalFunction) from Monty runtime data.
+
+use std::collections::{HashMap, HashSet};
+
+use cedar_policy::{Entity, EntityId, EntityTypeName, EntityUid, RestrictedExpression};
+
+/// Creates an `EntityUid` for a `Monty::Script` principal.
+pub fn script_uid(name: &str) -> EntityUid {
+    EntityUid::from_type_name_and_id(entity_type("Script"), EntityId::new(name))
+}
+
+/// Creates an `Entity` for a filesystem path resource.
+pub fn path_entity(path: &str) -> Entity {
+    let uid = EntityUid::from_type_name_and_id(entity_type("Path"), EntityId::new(path));
+    let attrs = HashMap::from([("path".to_owned(), RestrictedExpression::new_string(path.to_owned()))]);
+    Entity::new(uid, attrs, HashSet::new()).expect("path entity construction is infallible with known schema")
+}
+
+/// Creates an `Entity` for an environment variable resource.
+pub fn env_var_entity(name: &str) -> Entity {
+    let uid = EntityUid::from_type_name_and_id(entity_type("EnvVar"), EntityId::new(name));
+    let attrs = HashMap::from([("name".to_owned(), RestrictedExpression::new_string(name.to_owned()))]);
+    Entity::new(uid, attrs, HashSet::new()).expect("env var entity construction is infallible with known schema")
+}
+
+/// Creates an `Entity` for an external function resource.
+pub fn external_function_entity(name: &str) -> Entity {
+    let uid = EntityUid::from_type_name_and_id(entity_type("ExternalFunction"), EntityId::new(name));
+    let attrs = HashMap::from([("name".to_owned(), RestrictedExpression::new_string(name.to_owned()))]);
+    Entity::new(uid, attrs, HashSet::new())
+        .expect("external function entity construction is infallible with known schema")
+}
+
+/// Creates a `Monty::Script` entity (the principal) with no attributes.
+pub fn script_entity(name: &str) -> Entity {
+    Entity::new_no_attrs(script_uid(name), HashSet::new())
+}
+
+/// Helper to build a `Monty::<TypeName>` entity type name.
+fn entity_type(type_name: &str) -> EntityTypeName {
+    format!("Monty::{type_name}")
+        .parse()
+        .expect("known entity type names are valid")
+}

--- a/crates/monty-policy/src/entities.rs
+++ b/crates/monty-policy/src/entities.rs
@@ -6,6 +6,7 @@
 use std::collections::{HashMap, HashSet};
 
 use cedar_policy::{Entity, EntityId, EntityTypeName, EntityUid, RestrictedExpression};
+use monty::fs::normalize_virtual_path;
 
 /// Creates an `EntityUid` for a `Monty::Script` principal.
 pub fn script_uid(name: &str) -> EntityUid {
@@ -13,9 +14,15 @@ pub fn script_uid(name: &str) -> EntityUid {
 }
 
 /// Creates an `Entity` for a filesystem path resource.
+///
+/// The path is normalized (`.`/`..` collapsed, made absolute) before being used
+/// as the entity ID and `path` attribute. This ensures Cedar pattern matching
+/// sees the canonical path, preventing traversal bypasses like
+/// `/data/../secret/file` matching a `/data/*` policy.
 pub fn path_entity(path: &str) -> Entity {
-    let uid = EntityUid::from_type_name_and_id(entity_type("Path"), EntityId::new(path));
-    let attrs = HashMap::from([("path".to_owned(), RestrictedExpression::new_string(path.to_owned()))]);
+    let normalized = normalize_virtual_path(path);
+    let uid = EntityUid::from_type_name_and_id(entity_type("Path"), EntityId::new(&normalized));
+    let attrs = HashMap::from([("path".to_owned(), RestrictedExpression::new_string(normalized))]);
     Entity::new(uid, attrs, HashSet::new()).expect("path entity construction is infallible with known schema")
 }
 

--- a/crates/monty-policy/src/error.rs
+++ b/crates/monty-policy/src/error.rs
@@ -1,0 +1,50 @@
+//! Error types for policy evaluation failures.
+//!
+//! [`PolicyDenied`] is the primary error returned when Cedar denies an authorization
+//! request. It converts to a `MontyException` with `ExcType::PermissionError` so that
+//! sandboxed code sees a standard Python exception.
+
+use std::{error::Error, fmt};
+
+use monty::{ExcType, MontyException};
+
+/// Error returned when a Cedar policy denies an authorization request.
+///
+/// Contains the action and resource identifier for diagnostics, but intentionally
+/// does NOT include the policy text or policy ID to prevent policy probing.
+#[derive(Debug, Clone)]
+pub struct PolicyDenied {
+    /// The Cedar action that was attempted (e.g. "fs:read").
+    pub action: &'static str,
+    /// The resource identifier (e.g. a path or function name).
+    pub resource: String,
+}
+
+impl fmt::Display for PolicyDenied {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "policy denied action '{}' on '{}'", self.action, self.resource)
+    }
+}
+
+impl Error for PolicyDenied {}
+
+impl From<PolicyDenied> for MontyException {
+    fn from(denied: PolicyDenied) -> Self {
+        Self::new(ExcType::PermissionError, Some(denied.to_string()))
+    }
+}
+
+/// Error returned when a policy cannot be parsed or validated against the schema.
+#[derive(Debug, Clone)]
+pub struct PolicyParseError {
+    /// Human-readable description of what went wrong.
+    pub message: String,
+}
+
+impl fmt::Display for PolicyParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid Cedar policy: {}", self.message)
+    }
+}
+
+impl Error for PolicyParseError {}

--- a/crates/monty-policy/src/lib.rs
+++ b/crates/monty-policy/src/lib.rs
@@ -35,7 +35,7 @@ use std::{
     sync::{Mutex, PoisonError},
 };
 
-use cedar_policy::{Authorizer, Decision, Entities, PolicySet, Schema};
+use cedar_policy::{Authorizer, Decision, Entities, PolicySet, Schema, ValidationMode, Validator};
 use monty::OsFunctionCall;
 
 pub use crate::error::{PolicyDenied, PolicyParseError};
@@ -118,6 +118,17 @@ impl PolicyEngine {
         let policy_set = PolicySet::from_str(policy_text).map_err(|e| PolicyParseError {
             message: format!("policy parse error: {e}"),
         })?;
+
+        // Validate policies against the schema to reject references to unknown
+        // entity types or actions at construction time (not at evaluation time).
+        let validator = Validator::new(schema.clone());
+        let validation = validator.validate(&policy_set, ValidationMode::default());
+        if !validation.validation_passed() {
+            let errors: Vec<String> = validation.validation_errors().map(ToString::to_string).collect();
+            return Err(PolicyParseError {
+                message: format!("policy validation failed: {}", errors.join("; ")),
+            });
+        }
 
         Ok(Self {
             authorizer: Authorizer::new(),

--- a/crates/monty-policy/src/lib.rs
+++ b/crates/monty-policy/src/lib.rs
@@ -1,0 +1,194 @@
+//! Cedar policy engine for the Monty Python sandbox.
+//!
+//! Provides [`PolicyEngine`] which evaluates Cedar policies against Monty sandbox
+//! operations (filesystem access, environment variables, external function calls).
+//! Cedar adds fine-grained, declarative access control on top of the existing
+//! `MountTable` path security — both must allow an operation for it to proceed.
+//!
+//! # Example
+//!
+//! ```
+//! use monty_policy::{PolicyConfig, PolicyEngine};
+//!
+//! let policy_text = r#"
+//!     permit(
+//!         principal,
+//!         action == Monty::Action::"fs:read",
+//!         resource
+//!     ) when {
+//!         resource.path like "/data/*"
+//!     };
+//! "#;
+//!
+//! let engine = PolicyEngine::new(policy_text, PolicyConfig::default()).unwrap();
+//! ```
+
+mod entities;
+mod error;
+mod request;
+mod schema;
+
+use std::{fmt, str::FromStr};
+
+use cedar_policy::{Authorizer, Decision, Entities, PolicySet, Schema};
+use monty::OsFunctionCall;
+
+pub use crate::error::{PolicyDenied, PolicyParseError};
+use crate::{
+    entities::{script_entity, script_uid},
+    request::{build_entities, build_external_call_request, build_os_call_request, os_call_to_authz_request},
+    schema::SCHEMA_SRC,
+};
+
+/// Configuration for constructing a [`PolicyEngine`].
+#[derive(Debug, Clone)]
+pub struct PolicyConfig {
+    /// Name of the principal entity (the sandboxed script). Defaults to `"anonymous"`.
+    pub principal: String,
+    /// Default decision when no policy explicitly permits or forbids an action.
+    /// Defaults to `Deny` (secure by default).
+    pub default_decision: DefaultDecision,
+}
+
+impl Default for PolicyConfig {
+    fn default() -> Self {
+        Self {
+            principal: "anonymous".to_owned(),
+            default_decision: DefaultDecision::Deny,
+        }
+    }
+}
+
+/// The default authorization decision when no Cedar policy matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefaultDecision {
+    /// Deny access unless explicitly permitted. This is the secure default.
+    Deny,
+    /// Allow access unless explicitly forbidden. Use when Cedar policies are
+    /// intended only as a blocklist on top of existing mount-level controls.
+    Allow,
+}
+
+/// Cedar policy engine that authorizes Monty sandbox operations.
+///
+/// Constructed once with a Cedar policy set, then consulted on each OS call or
+/// external function call. The policy set is immutable after construction, so
+/// authorization decisions are deterministic and cacheable.
+///
+/// # Security model
+///
+/// The engine sits between the VM's `FrameExit` and the `MountTable` dispatcher.
+/// A denial here short-circuits before the mount table is consulted, preventing
+/// information leakage about mount structure. A Cedar `permit` cannot override
+/// `MountTable` denials — both layers must allow the operation.
+pub struct PolicyEngine {
+    authorizer: Authorizer,
+    policy_set: PolicySet,
+    #[expect(dead_code)]
+    schema: Schema,
+    principal_name: String,
+    default_decision: DefaultDecision,
+}
+
+impl PolicyEngine {
+    /// Creates a new policy engine by parsing Cedar policy text against the Monty schema.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PolicyParseError`] if the policy text is syntactically invalid or
+    /// references entity types/actions not defined in the Monty schema.
+    pub fn new(policy_text: &str, config: PolicyConfig) -> Result<Self, PolicyParseError> {
+        let schema = Schema::from_cedarschema_str(SCHEMA_SRC)
+            .map_err(|e| PolicyParseError {
+                message: format!("schema error: {e}"),
+            })?
+            .0;
+
+        let policy_set = PolicySet::from_str(policy_text).map_err(|e| PolicyParseError {
+            message: format!("policy parse error: {e}"),
+        })?;
+
+        Ok(Self {
+            authorizer: Authorizer::new(),
+            policy_set,
+            schema,
+            principal_name: config.principal,
+            default_decision: config.default_decision,
+        })
+    }
+
+    /// Checks whether a Cedar policy permits the given OS call.
+    ///
+    /// Returns `Ok(())` if the operation is allowed, or `Err(PolicyDenied)` if
+    /// the policy forbids it. Operations not covered by Cedar (e.g. `DateToday`)
+    /// are always allowed since they have no security implications.
+    pub fn authorize_os_call(&self, call: &OsFunctionCall) -> Result<(), PolicyDenied> {
+        let Some(authz) = os_call_to_authz_request(call) else {
+            // Not policy-gated (informational call).
+            return Ok(());
+        };
+
+        let principal_uid = script_uid(&self.principal_name);
+        let principal_entity = script_entity(&self.principal_name);
+        let entities = build_entities(&principal_entity, &authz.resource);
+        let request = build_os_call_request(&principal_uid, &authz);
+
+        self.evaluate(&request, &entities, authz.action, authz.resource.uid().id().as_ref())
+    }
+
+    /// Checks whether a Cedar policy permits calling the named external function.
+    ///
+    /// Returns `Ok(())` if the call is allowed, or `Err(PolicyDenied)` if denied.
+    pub fn authorize_external_call(&self, function_name: &str) -> Result<(), PolicyDenied> {
+        let principal_uid = script_uid(&self.principal_name);
+        let principal_entity = script_entity(&self.principal_name);
+        let (request, resource) = build_external_call_request(&principal_uid, function_name);
+        let entities = build_entities(&principal_entity, &resource);
+
+        self.evaluate(&request, &entities, "ext:call", function_name)
+    }
+
+    /// Core evaluation: runs the Cedar authorizer and interprets the decision.
+    ///
+    /// For `DefaultDecision::Deny`: uses Cedar's native semantics directly.
+    /// For `DefaultDecision::Allow`: allows unless an explicit `forbid` policy matched
+    /// (Cedar returns Deny with non-empty reasons).
+    fn evaluate(
+        &self,
+        request: &cedar_policy::Request,
+        entities: &Entities,
+        action: &'static str,
+        resource_id: &str,
+    ) -> Result<(), PolicyDenied> {
+        let response = self.authorizer.is_authorized(request, &self.policy_set, entities);
+
+        let denied = match self.default_decision {
+            // Deny-by-default: use Cedar's decision directly.
+            DefaultDecision::Deny => response.decision() == Decision::Deny,
+            // Allow-by-default: only deny if an explicit forbid policy fired.
+            // Cedar returns Deny with empty reasons when no policies matched at all;
+            // in allow-by-default mode, that should be treated as allowed.
+            DefaultDecision::Allow => {
+                response.decision() == Decision::Deny && response.diagnostics().reason().next().is_some()
+            }
+        };
+
+        if denied {
+            Err(PolicyDenied {
+                action,
+                resource: resource_id.to_owned(),
+            })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl fmt::Debug for PolicyEngine {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PolicyEngine")
+            .field("principal_name", &self.principal_name)
+            .field("default_decision", &self.default_decision)
+            .finish_non_exhaustive()
+    }
+}

--- a/crates/monty-policy/src/lib.rs
+++ b/crates/monty-policy/src/lib.rs
@@ -28,7 +28,12 @@ mod error;
 mod request;
 mod schema;
 
-use std::{fmt, str::FromStr};
+use std::{
+    collections::HashMap,
+    fmt,
+    str::FromStr,
+    sync::{Mutex, PoisonError},
+};
 
 use cedar_policy::{Authorizer, Decision, Entities, PolicySet, Schema};
 use monty::OsFunctionCall;
@@ -88,6 +93,12 @@ pub struct PolicyEngine {
     schema: Schema,
     principal_name: String,
     default_decision: DefaultDecision,
+    /// Cache of authorization decisions keyed by (action, resource_id).
+    ///
+    /// The policy set is immutable after construction, so decisions are
+    /// deterministic and safe to cache. Uses `Mutex` for thread-safe interior
+    /// mutability since the engine may be shared across thread boundaries.
+    cache: Mutex<HashMap<(&'static str, String), bool>>,
 }
 
 impl PolicyEngine {
@@ -114,6 +125,7 @@ impl PolicyEngine {
             schema,
             principal_name: config.principal,
             default_decision: config.default_decision,
+            cache: Mutex::new(HashMap::new()),
         })
     }
 
@@ -148,11 +160,12 @@ impl PolicyEngine {
         self.evaluate(&request, &entities, "ext:call", function_name)
     }
 
-    /// Core evaluation: runs the Cedar authorizer and interprets the decision.
+    /// Core evaluation: checks the cache first, then runs the Cedar authorizer.
     ///
     /// For `DefaultDecision::Deny`: uses Cedar's native semantics directly.
     /// For `DefaultDecision::Allow`: allows unless an explicit `forbid` policy matched
-    /// (Cedar returns Deny with non-empty reasons).
+    /// (Cedar returns Deny with empty reasons when no policies matched at all;
+    /// in allow-by-default mode, that should be treated as allowed).
     fn evaluate(
         &self,
         request: &cedar_policy::Request,
@@ -160,18 +173,38 @@ impl PolicyEngine {
         action: &'static str,
         resource_id: &str,
     ) -> Result<(), PolicyDenied> {
+        // Check cache first — policy set is immutable, so decisions are stable.
+        let cache_key = (action, resource_id.to_owned());
+        if let Some(&denied) = self
+            .cache
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(&cache_key)
+        {
+            return if denied {
+                Err(PolicyDenied {
+                    action,
+                    resource: cache_key.1,
+                })
+            } else {
+                Ok(())
+            };
+        }
+
         let response = self.authorizer.is_authorized(request, &self.policy_set, entities);
 
         let denied = match self.default_decision {
-            // Deny-by-default: use Cedar's decision directly.
             DefaultDecision::Deny => response.decision() == Decision::Deny,
-            // Allow-by-default: only deny if an explicit forbid policy fired.
-            // Cedar returns Deny with empty reasons when no policies matched at all;
-            // in allow-by-default mode, that should be treated as allowed.
             DefaultDecision::Allow => {
                 response.decision() == Decision::Deny && response.diagnostics().reason().next().is_some()
             }
         };
+
+        // Populate cache.
+        self.cache
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(cache_key, denied);
 
         if denied {
             Err(PolicyDenied {

--- a/crates/monty-policy/src/request.rs
+++ b/crates/monty-policy/src/request.rs
@@ -95,9 +95,12 @@ pub fn os_call_to_authz_request(call: &OsFunctionCall) -> Option<AuthzRequest> {
             action: "env:read",
             resource: env_var_entity(&a.key),
         }),
+        // GetEnviron reads the entire environment dict. We use "__all__" as
+        // a synthetic resource name (not a valid env var name on any OS) so
+        // policies can distinguish "read all env vars" from "read a specific var".
         OsFunctionCall::GetEnviron => Some(AuthzRequest {
             action: "env:read",
-            resource: env_var_entity("*"),
+            resource: env_var_entity("__all__"),
         }),
 
         // --- Not policy-gated (informational, no security implications) ---
@@ -145,9 +148,16 @@ pub fn build_entities(principal_entity: &Entity, resource: &Entity) -> Entities 
 }
 
 /// Returns `true` if the file open mode implies a write operation.
+///
+/// `ReadUpdate` (`r+`) is included because it allows writing to the file
+/// even though it also reads.
 fn open_mode_is_write(mode: FileMode) -> bool {
     matches!(
         mode,
-        FileMode::Write(_) | FileMode::WriteUpdate(_) | FileMode::Append(_) | FileMode::AppendUpdate(_)
+        FileMode::ReadUpdate(_)
+            | FileMode::Write(_)
+            | FileMode::WriteUpdate(_)
+            | FileMode::Append(_)
+            | FileMode::AppendUpdate(_)
     )
 }

--- a/crates/monty-policy/src/request.rs
+++ b/crates/monty-policy/src/request.rs
@@ -1,0 +1,153 @@
+//! Translation from Monty runtime operations to Cedar authorization requests.
+//!
+//! Maps each [`OsFunctionCall`] variant to a Cedar action name and resource entity,
+//! and provides a helper for external function call authorization.
+
+use cedar_policy::{Context, Entities, Entity, EntityUid, Request};
+use monty::{FileMode, OsFunctionCall};
+
+use crate::entities::{env_var_entity, external_function_entity, path_entity};
+
+/// The Cedar action and resource derived from a Monty operation.
+///
+/// Used internally to build a [`Request`] for the Cedar authorizer.
+pub struct AuthzRequest {
+    /// Cedar action name (e.g. "fs:read").
+    pub action: &'static str,
+    /// Resource entity for the request.
+    pub resource: Entity,
+}
+
+/// Translates an [`OsFunctionCall`] into the Cedar action name and resource entity.
+///
+/// Returns `None` for operations that are not policy-gated (e.g. `DateToday`,
+/// `DateTimeNow`) — these are considered safe informational calls.
+pub fn os_call_to_authz_request(call: &OsFunctionCall) -> Option<AuthzRequest> {
+    match call {
+        // --- fs:read ---
+        OsFunctionCall::ReadText(p)
+        | OsFunctionCall::ReadBytes(p)
+        | OsFunctionCall::Stat(p)
+        | OsFunctionCall::Resolve(p)
+        | OsFunctionCall::Absolute(p) => Some(AuthzRequest {
+            action: "fs:read",
+            resource: path_entity(p.as_str()),
+        }),
+
+        // --- fs:exists ---
+        OsFunctionCall::Exists(p)
+        | OsFunctionCall::IsFile(p)
+        | OsFunctionCall::IsDir(p)
+        | OsFunctionCall::IsSymlink(p) => Some(AuthzRequest {
+            action: "fs:exists",
+            resource: path_entity(p.as_str()),
+        }),
+
+        // --- fs:write ---
+        OsFunctionCall::WriteText(a) | OsFunctionCall::AppendText(a) => Some(AuthzRequest {
+            action: "fs:write",
+            resource: path_entity(a.path.as_str()),
+        }),
+        OsFunctionCall::WriteBytes(a) | OsFunctionCall::AppendBytes(a) => Some(AuthzRequest {
+            action: "fs:write",
+            resource: path_entity(a.path.as_str()),
+        }),
+
+        // --- fs:create ---
+        OsFunctionCall::Mkdir(a) => Some(AuthzRequest {
+            action: "fs:create",
+            resource: path_entity(a.path.as_str()),
+        }),
+
+        // --- fs:delete ---
+        OsFunctionCall::Unlink(p) | OsFunctionCall::Rmdir(p) => Some(AuthzRequest {
+            action: "fs:delete",
+            resource: path_entity(p.as_str()),
+        }),
+
+        // --- fs:list ---
+        OsFunctionCall::Iterdir(p) => Some(AuthzRequest {
+            action: "fs:list",
+            resource: path_entity(p.as_str()),
+        }),
+
+        // --- fs:rename ---
+        OsFunctionCall::Rename(a) => Some(AuthzRequest {
+            action: "fs:rename",
+            resource: path_entity(a.src.as_str()),
+        }),
+
+        // --- Open: action depends on file mode ---
+        OsFunctionCall::Open(a) => {
+            let action = if open_mode_is_write(a.mode) {
+                "fs:write"
+            } else {
+                "fs:read"
+            };
+            Some(AuthzRequest {
+                action,
+                resource: path_entity(a.path.as_str()),
+            })
+        }
+
+        // --- env:read ---
+        OsFunctionCall::Getenv(a) => Some(AuthzRequest {
+            action: "env:read",
+            resource: env_var_entity(&a.key),
+        }),
+        OsFunctionCall::GetEnviron => Some(AuthzRequest {
+            action: "env:read",
+            resource: env_var_entity("*"),
+        }),
+
+        // --- Not policy-gated (informational, no security implications) ---
+        OsFunctionCall::DateToday | OsFunctionCall::DateTimeNow(_) => None,
+
+        // Placeholder variant — never dispatched.
+        OsFunctionCall::Used => None,
+    }
+}
+
+/// Builds a Cedar [`Request`] for an OS call authorization check.
+pub fn build_os_call_request(principal: &EntityUid, authz: &AuthzRequest) -> Request {
+    let action: EntityUid = format!("Monty::Action::\"{}\"", authz.action)
+        .parse()
+        .expect("known action names are valid EntityUids");
+
+    Request::new(
+        principal.clone(),
+        action,
+        authz.resource.uid(),
+        Context::empty(),
+        None, // schema validation done at policy parse time
+    )
+    .expect("request construction with known types is infallible")
+}
+
+/// Builds a Cedar [`Request`] for an external function call authorization check.
+pub fn build_external_call_request(principal: &EntityUid, function_name: &str) -> (Request, Entity) {
+    let resource = external_function_entity(function_name);
+
+    let action: EntityUid = "Monty::Action::\"ext:call\""
+        .parse()
+        .expect("known action name is valid");
+
+    let request = Request::new(principal.clone(), action, resource.uid(), Context::empty(), None)
+        .expect("request construction with known types is infallible");
+
+    (request, resource)
+}
+
+/// Builds a Cedar [`Entities`] set containing the principal and resource entities.
+pub fn build_entities(principal_entity: &Entity, resource: &Entity) -> Entities {
+    Entities::from_entities([principal_entity.clone(), resource.clone()], None)
+        .expect("entity set construction with disjoint UIDs is infallible")
+}
+
+/// Returns `true` if the file open mode implies a write operation.
+fn open_mode_is_write(mode: FileMode) -> bool {
+    matches!(
+        mode,
+        FileMode::Write(_) | FileMode::WriteUpdate(_) | FileMode::Append(_) | FileMode::AppendUpdate(_)
+    )
+}

--- a/crates/monty-policy/src/schema.rs
+++ b/crates/monty-policy/src/schema.rs
@@ -1,0 +1,87 @@
+//! Embedded Cedar schema for the Monty sandbox policy model.
+//!
+//! The schema defines entity types (Script, Path, EnvVar, ExternalFunction, Network)
+//! and actions (fs:read, fs:write, etc.) that Cedar policies can reference. It is
+//! compiled in as a constant so users write policies against a known, fixed vocabulary
+//! — this prevents confused-deputy attacks via custom entity types.
+
+/// Cedar schema in the human-readable format.
+///
+/// Entity types:
+/// - `Script`: the sandboxed code (always the principal)
+/// - `Path`: a filesystem path (virtual, within the sandbox namespace)
+/// - `EnvVar`: an environment variable name
+/// - `ExternalFunction`: a host-registered external function
+/// - `Network`: a network endpoint (host:port or DNS name, reserved for future use)
+pub const SCHEMA_SRC: &str = r#"
+namespace Monty {
+    entity Script = {};
+
+    entity Path = {
+        "path": String,
+    };
+
+    entity EnvVar = {
+        "name": String,
+    };
+
+    entity ExternalFunction = {
+        "name": String,
+    };
+
+    entity Network = {
+        "host": String,
+        "port": __cedar::Long,
+    };
+
+    action "fs:read" appliesTo {
+        principal: [Script],
+        resource: [Path],
+    };
+
+    action "fs:write" appliesTo {
+        principal: [Script],
+        resource: [Path],
+    };
+
+    action "fs:exists" appliesTo {
+        principal: [Script],
+        resource: [Path],
+    };
+
+    action "fs:list" appliesTo {
+        principal: [Script],
+        resource: [Path],
+    };
+
+    action "fs:create" appliesTo {
+        principal: [Script],
+        resource: [Path],
+    };
+
+    action "fs:delete" appliesTo {
+        principal: [Script],
+        resource: [Path],
+    };
+
+    action "fs:rename" appliesTo {
+        principal: [Script],
+        resource: [Path],
+    };
+
+    action "env:read" appliesTo {
+        principal: [Script],
+        resource: [EnvVar],
+    };
+
+    action "ext:call" appliesTo {
+        principal: [Script],
+        resource: [ExternalFunction],
+    };
+
+    action "net:connect" appliesTo {
+        principal: [Script],
+        resource: [Network],
+    };
+}
+"#;

--- a/crates/monty-policy/tests/policy_engine.rs
+++ b/crates/monty-policy/tests/policy_engine.rs
@@ -1,0 +1,385 @@
+//! Integration tests for the Cedar policy engine.
+
+use monty::{FileMode, GetenvArgs, MkdirCallArgs, MontyObject, MontyPath, OpenCallArgs, OsFunctionCall};
+use monty_policy::{DefaultDecision, PolicyConfig, PolicyDenied, PolicyEngine};
+
+/// Helper to create a policy engine with deny-by-default and the given policy text.
+fn engine(policy_text: &str) -> PolicyEngine {
+    PolicyEngine::new(policy_text, PolicyConfig::default()).unwrap()
+}
+
+/// Helper to create a policy engine with allow-by-default (blocklist mode).
+fn engine_allow_default(policy_text: &str) -> PolicyEngine {
+    PolicyEngine::new(
+        policy_text,
+        PolicyConfig {
+            default_decision: DefaultDecision::Allow,
+            ..Default::default()
+        },
+    )
+    .unwrap()
+}
+
+// =============================================================================
+// Schema and construction tests
+// =============================================================================
+
+#[test]
+fn empty_policy_parses() {
+    let engine = PolicyEngine::new("", PolicyConfig::default()).unwrap();
+    // With deny-by-default and no policies, everything should be denied.
+    let call = OsFunctionCall::ReadText(MontyPath::new("/foo.txt".to_owned()));
+    assert!(engine.authorize_os_call(&call).is_err());
+}
+
+#[test]
+fn invalid_policy_returns_parse_error() {
+    let result = PolicyEngine::new("this is not valid cedar", PolicyConfig::default());
+    assert!(result.is_err());
+}
+
+#[test]
+fn custom_principal_name() {
+    let config = PolicyConfig {
+        principal: "my-script".to_owned(),
+        ..Default::default()
+    };
+    // Should parse without error.
+    let _engine = PolicyEngine::new(
+        r#"permit(principal == Monty::Script::"my-script", action, resource);"#,
+        config,
+    )
+    .unwrap();
+}
+
+// =============================================================================
+// Filesystem read policy tests
+// =============================================================================
+
+#[test]
+fn permit_fs_read_all_paths() {
+    let e = engine(r#"permit(principal, action == Monty::Action::"fs:read", resource);"#);
+
+    let read = OsFunctionCall::ReadText(MontyPath::new("/data/file.txt".to_owned()));
+    assert!(e.authorize_os_call(&read).is_ok());
+
+    let read_bytes = OsFunctionCall::ReadBytes(MontyPath::new("/other.bin".to_owned()));
+    assert!(e.authorize_os_call(&read_bytes).is_ok());
+}
+
+#[test]
+fn permit_fs_read_specific_path_pattern() {
+    let e = engine(
+        r#"permit(principal, action == Monty::Action::"fs:read", resource) when { resource.path like "/data/*" };"#,
+    );
+
+    let allowed = OsFunctionCall::ReadText(MontyPath::new("/data/file.txt".to_owned()));
+    assert!(e.authorize_os_call(&allowed).is_ok());
+
+    let denied = OsFunctionCall::ReadText(MontyPath::new("/secret/file.txt".to_owned()));
+    assert!(e.authorize_os_call(&denied).is_err());
+}
+
+#[test]
+fn deny_fs_read_denies_stat_and_resolve() {
+    // No permit policies = deny all (deny-by-default)
+    let e = engine("");
+
+    let stat = OsFunctionCall::Stat(MontyPath::new("/foo".to_owned()));
+    assert!(e.authorize_os_call(&stat).is_err());
+
+    let resolve = OsFunctionCall::Resolve(MontyPath::new("/foo".to_owned()));
+    assert!(e.authorize_os_call(&resolve).is_err());
+
+    let absolute = OsFunctionCall::Absolute(MontyPath::new("/foo".to_owned()));
+    assert!(e.authorize_os_call(&absolute).is_err());
+}
+
+// =============================================================================
+// Filesystem write policy tests
+// =============================================================================
+
+#[test]
+fn permit_fs_write_specific_path() {
+    let e = engine(
+        r#"permit(principal, action == Monty::Action::"fs:write", resource) when { resource.path like "/output/*" };"#,
+    );
+
+    let allowed = OsFunctionCall::WriteText(monty::PathStringDataArgs {
+        path: MontyPath::new("/output/result.txt".to_owned()),
+        data: "hello".to_owned(),
+    });
+    assert!(e.authorize_os_call(&allowed).is_ok());
+
+    let denied = OsFunctionCall::WriteText(monty::PathStringDataArgs {
+        path: MontyPath::new("/input/data.txt".to_owned()),
+        data: "hack".to_owned(),
+    });
+    assert!(e.authorize_os_call(&denied).is_err());
+}
+
+#[test]
+fn open_write_mode_uses_fs_write_action() {
+    let e = engine(r#"permit(principal, action == Monty::Action::"fs:write", resource);"#);
+
+    let open_write = OsFunctionCall::Open(OpenCallArgs {
+        path: MontyPath::new("/file.txt".to_owned()),
+        mode: FileMode::Write(false),
+    });
+    assert!(e.authorize_os_call(&open_write).is_ok());
+
+    // Read mode should NOT match fs:write permit
+    let open_read = OsFunctionCall::Open(OpenCallArgs {
+        path: MontyPath::new("/file.txt".to_owned()),
+        mode: FileMode::Read(false),
+    });
+    assert!(e.authorize_os_call(&open_read).is_err());
+}
+
+#[test]
+fn open_read_mode_uses_fs_read_action() {
+    let e = engine(r#"permit(principal, action == Monty::Action::"fs:read", resource);"#);
+
+    let open_read = OsFunctionCall::Open(OpenCallArgs {
+        path: MontyPath::new("/file.txt".to_owned()),
+        mode: FileMode::Read(false),
+    });
+    assert!(e.authorize_os_call(&open_read).is_ok());
+}
+
+// =============================================================================
+// Filesystem exists/list/create/delete/rename tests
+// =============================================================================
+
+#[test]
+fn permit_fs_exists() {
+    let e = engine(r#"permit(principal, action == Monty::Action::"fs:exists", resource);"#);
+
+    let exists = OsFunctionCall::Exists(MontyPath::new("/foo".to_owned()));
+    assert!(e.authorize_os_call(&exists).is_ok());
+
+    let is_file = OsFunctionCall::IsFile(MontyPath::new("/foo".to_owned()));
+    assert!(e.authorize_os_call(&is_file).is_ok());
+
+    let is_dir = OsFunctionCall::IsDir(MontyPath::new("/foo".to_owned()));
+    assert!(e.authorize_os_call(&is_dir).is_ok());
+
+    let is_symlink = OsFunctionCall::IsSymlink(MontyPath::new("/foo".to_owned()));
+    assert!(e.authorize_os_call(&is_symlink).is_ok());
+}
+
+#[test]
+fn permit_fs_list() {
+    let e = engine(r#"permit(principal, action == Monty::Action::"fs:list", resource);"#);
+
+    let iterdir = OsFunctionCall::Iterdir(MontyPath::new("/data".to_owned()));
+    assert!(e.authorize_os_call(&iterdir).is_ok());
+}
+
+#[test]
+fn permit_fs_create() {
+    let e = engine(r#"permit(principal, action == Monty::Action::"fs:create", resource);"#);
+
+    let mkdir = OsFunctionCall::Mkdir(MkdirCallArgs {
+        path: MontyPath::new("/new_dir".to_owned()),
+        parents: false,
+        exist_ok: false,
+    });
+    assert!(e.authorize_os_call(&mkdir).is_ok());
+}
+
+#[test]
+fn permit_fs_delete() {
+    let e = engine(r#"permit(principal, action == Monty::Action::"fs:delete", resource);"#);
+
+    let unlink = OsFunctionCall::Unlink(MontyPath::new("/file.txt".to_owned()));
+    assert!(e.authorize_os_call(&unlink).is_ok());
+
+    let rmdir = OsFunctionCall::Rmdir(MontyPath::new("/dir".to_owned()));
+    assert!(e.authorize_os_call(&rmdir).is_ok());
+}
+
+#[test]
+fn permit_fs_rename() {
+    let e = engine(r#"permit(principal, action == Monty::Action::"fs:rename", resource);"#);
+
+    let rename = OsFunctionCall::Rename(monty::RenameCallArgs {
+        src: MontyPath::new("/old.txt".to_owned()),
+        dst: MontyPath::new("/new.txt".to_owned()),
+    });
+    assert!(e.authorize_os_call(&rename).is_ok());
+}
+
+// =============================================================================
+// Environment variable policy tests
+// =============================================================================
+
+#[test]
+fn permit_env_read_specific_var() {
+    let e =
+        engine(r#"permit(principal, action == Monty::Action::"env:read", resource) when { resource.name == "HOME" };"#);
+
+    let allowed = OsFunctionCall::Getenv(GetenvArgs {
+        key: "HOME".to_owned(),
+        default: MontyObject::None,
+    });
+    assert!(e.authorize_os_call(&allowed).is_ok());
+
+    let denied = OsFunctionCall::Getenv(GetenvArgs {
+        key: "SECRET_KEY".to_owned(),
+        default: MontyObject::None,
+    });
+    assert!(e.authorize_os_call(&denied).is_err());
+}
+
+#[test]
+fn permit_env_read_all() {
+    let e = engine(r#"permit(principal, action == Monty::Action::"env:read", resource);"#);
+
+    let get_environ = OsFunctionCall::GetEnviron;
+    assert!(e.authorize_os_call(&get_environ).is_ok());
+}
+
+// =============================================================================
+// External function call policy tests
+// =============================================================================
+
+#[test]
+fn permit_ext_call_specific_function() {
+    let e = engine(
+        r#"permit(principal, action == Monty::Action::"ext:call", resource) when { resource.name == "fetch" };"#,
+    );
+
+    assert!(e.authorize_external_call("fetch").is_ok());
+    assert!(e.authorize_external_call("exec_dangerous").is_err());
+}
+
+#[test]
+fn permit_ext_call_all() {
+    let e = engine(r#"permit(principal, action == Monty::Action::"ext:call", resource);"#);
+
+    assert!(e.authorize_external_call("anything").is_ok());
+}
+
+// =============================================================================
+// Default decision behavior tests
+// =============================================================================
+
+#[test]
+fn deny_default_blocks_everything_without_explicit_permit() {
+    let e = engine("");
+
+    let read = OsFunctionCall::ReadText(MontyPath::new("/foo".to_owned()));
+    assert!(e.authorize_os_call(&read).is_err());
+    assert!(e.authorize_external_call("func").is_err());
+}
+
+#[test]
+fn allow_default_permits_everything_without_explicit_forbid() {
+    let e = engine_allow_default("");
+
+    let read = OsFunctionCall::ReadText(MontyPath::new("/foo".to_owned()));
+    assert!(e.authorize_os_call(&read).is_ok());
+    assert!(e.authorize_external_call("func").is_ok());
+}
+
+#[test]
+fn allow_default_with_forbid_blocks_specific() {
+    let e = engine_allow_default(r#"forbid(principal, action == Monty::Action::"fs:write", resource);"#);
+
+    // Reads still allowed (no forbid for read)
+    let read = OsFunctionCall::ReadText(MontyPath::new("/foo".to_owned()));
+    assert!(e.authorize_os_call(&read).is_ok());
+
+    // Writes blocked by explicit forbid
+    let write = OsFunctionCall::WriteText(monty::PathStringDataArgs {
+        path: MontyPath::new("/foo".to_owned()),
+        data: "x".to_owned(),
+    });
+    assert!(e.authorize_os_call(&write).is_err());
+}
+
+// =============================================================================
+// Non-gated operations (should always succeed)
+// =============================================================================
+
+#[test]
+fn date_operations_not_policy_gated() {
+    // Even with deny-all, date operations should pass since they're informational.
+    let e = engine("");
+
+    let today = OsFunctionCall::DateToday;
+    assert!(e.authorize_os_call(&today).is_ok());
+
+    let now = OsFunctionCall::DateTimeNow(MontyObject::None);
+    assert!(e.authorize_os_call(&now).is_ok());
+}
+
+// =============================================================================
+// Error message tests
+// =============================================================================
+
+#[test]
+fn policy_denied_error_contains_action_and_resource() {
+    let e = engine("");
+    let read = OsFunctionCall::ReadText(MontyPath::new("/secret/file.txt".to_owned()));
+    let err = e.authorize_os_call(&read).unwrap_err();
+
+    assert_eq!(err.action, "fs:read");
+    assert_eq!(err.resource, "/secret/file.txt");
+    assert!(err.to_string().contains("fs:read"));
+    assert!(err.to_string().contains("/secret/file.txt"));
+}
+
+#[test]
+fn policy_denied_converts_to_monty_exception() {
+    let denied = PolicyDenied {
+        action: "fs:write",
+        resource: "/path".to_owned(),
+    };
+    let exc: monty::MontyException = denied.into();
+    // Should be a PermissionError
+    assert!(format!("{exc}").contains("policy denied"));
+}
+
+// =============================================================================
+// Combined policy tests (multiple rules)
+// =============================================================================
+
+#[test]
+fn combined_read_write_policy() {
+    let e = engine(
+        r#"
+        permit(principal, action == Monty::Action::"fs:read", resource);
+        permit(principal, action == Monty::Action::"fs:write", resource)
+            when { resource.path like "/output/*" };
+        permit(principal, action == Monty::Action::"fs:exists", resource);
+    "#,
+    );
+
+    // Read anywhere: allowed
+    let read = OsFunctionCall::ReadText(MontyPath::new("/anywhere/file.txt".to_owned()));
+    assert!(e.authorize_os_call(&read).is_ok());
+
+    // Write to /output: allowed
+    let write_ok = OsFunctionCall::WriteText(monty::PathStringDataArgs {
+        path: MontyPath::new("/output/result.txt".to_owned()),
+        data: "ok".to_owned(),
+    });
+    assert!(e.authorize_os_call(&write_ok).is_ok());
+
+    // Write elsewhere: denied
+    let write_bad = OsFunctionCall::WriteText(monty::PathStringDataArgs {
+        path: MontyPath::new("/input/file.txt".to_owned()),
+        data: "bad".to_owned(),
+    });
+    assert!(e.authorize_os_call(&write_bad).is_err());
+
+    // Exists check: allowed
+    let exists = OsFunctionCall::Exists(MontyPath::new("/foo".to_owned()));
+    assert!(e.authorize_os_call(&exists).is_ok());
+
+    // Delete: denied (no permit for fs:delete)
+    let delete = OsFunctionCall::Unlink(MontyPath::new("/file".to_owned()));
+    assert!(e.authorize_os_call(&delete).is_err());
+}

--- a/crates/monty-python/Cargo.toml
+++ b/crates/monty-python/Cargo.toml
@@ -19,6 +19,7 @@ crate-type = ["cdylib"]
 [dependencies]
 ahash = { workspace = true }
 monty = { path = "../monty" }
+monty-policy = { path = "../monty-policy" }
 monty_type_checking = { path = "../monty-type-checking" }
 pyo3 = { version = "0.28", features = ["indexmap", "generate-import-lib", "num-bigint"] }
 num-bigint = { workspace = true }

--- a/crates/monty-python/python/pydantic_monty/__init__.py
+++ b/crates/monty-python/python/pydantic_monty/__init__.py
@@ -24,6 +24,7 @@ from ._monty import (
     MontyTypingError,
     MountDir,
     NameLookupSnapshot,
+    Policy,
     __version__,
     load_repl_snapshot,
     load_snapshot,
@@ -61,6 +62,7 @@ __all__ = (
     'MontyTypingError',
     'Frame',
     'MountDir',
+    'Policy',
     'load_snapshot',
     'load_repl_snapshot',
     # os_access

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -24,6 +24,7 @@ __all__ = [
     'MontyTypingError',
     'MontyFileHandle',
     'MountDir',
+    'Policy',
     'Frame',
     'load_snapshot',
     'load_repl_snapshot',
@@ -67,6 +68,23 @@ class MountDir:
         mode: Literal['read-only', 'read-write', 'overlay'] = 'overlay',
         write_bytes_limit: int | None = None,
     ) -> MountDir: ...
+
+@final
+class Policy:
+    """A Cedar policy controlling what sandboxed code can do.
+
+    Policies are written in the Cedar language and evaluated against each
+    sandbox operation (filesystem access, environment variables, external
+    function calls). By default, operations not explicitly permitted are denied.
+    """
+
+    def __new__(
+        cls,
+        policy_text: str,
+        *,
+        principal: str = 'anonymous',
+        default: Literal['deny', 'allow'] = 'deny',
+    ) -> Policy: ...
 
 @final
 class Monty:
@@ -156,6 +174,7 @@ class Monty:
         print_callback: Callable[[Literal['stdout'], str], None] | CollectStreams | CollectString | None = None,
         mount: MountDir | list[MountDir] | None = None,
         os: Callable[[OsFunction, tuple[Any, ...], dict[str, Any]], Any] | None = None,
+        policy: Policy | None = None,
     ) -> Any:
         """
         Execute the code and return the result.
@@ -189,6 +208,7 @@ class Monty:
         print_callback: Callable[[Literal['stdout'], str], None] | CollectStreams | CollectString | None = None,
         mount: MountDir | list[MountDir] | None = None,
         os: Callable[[OsFunction, tuple[Any, ...], dict[str, Any]], Any] | None = None,
+        policy: Policy | None = None,
     ) -> FunctionSnapshot | NameLookupSnapshot | FutureSnapshot | MontyComplete:
         """
         Start the code execution and return a progress object, or completion.

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -253,6 +253,7 @@ class Monty:
         external_functions: dict[str, Callable[..., Any]] | None = None,
         print_callback: Callable[[Literal['stdout'], str], None] | CollectStreams | CollectString | None = None,
         os: AbstractOS | None = None,
+        policy: Policy | None = None,
     ) -> Coroutine[Any, Any, Any]:
         """
         Execute the code with support for async external functions.

--- a/crates/monty-python/src/async_dispatch.rs
+++ b/crates/monty-python/src/async_dispatch.rs
@@ -8,12 +8,13 @@
 //! VM resume calls are offloaded to `spawn_blocking()` to avoid
 //! blocking the Python event loop.
 
-use std::mem::drop;
+use std::{mem::drop, sync::Arc};
 
 use monty::{
     ExcType, ExtFunctionResult, MontyException, MontyObject, MontyRepl, NameLookupResult, OsFunctionCall, ReplProgress,
     ReplStartError, ResourceTracker, RunProgress,
 };
+use monty_policy::PolicyEngine;
 use pyo3::{
     exceptions::PyRuntimeError,
     prelude::*,
@@ -28,7 +29,7 @@ use tokio::{
 use crate::{
     convert::{get_docstring, monty_to_py, py_to_monty_value},
     dataclass::DcRegistry,
-    exceptions::{MontyError, exc_py_to_monty},
+    exceptions::{MontyError, exc_monty_to_py, exc_py_to_monty},
     external::{
         CallResult, ExternalFunctionRegistry, dispatch_method_call_or_coroutine, py_err_to_ext_result,
         py_obj_to_ext_result,
@@ -131,6 +132,7 @@ pub(crate) async fn dispatch_loop_run<T: ResourceTracker + Send + 'static>(
     os: Option<Py<PyAny>>,
     dc_registry: DcRegistry,
     print_target: PrintTarget,
+    policy_engine: Option<Arc<PolicyEngine>>,
 ) -> PyResult<Py<PyAny>> {
     let mut join_set: JoinSet<(u32, ExtFunctionResult)> = JoinSet::new();
 
@@ -140,6 +142,14 @@ pub(crate) async fn dispatch_loop_run<T: ResourceTracker + Send + 'static>(
                 return Python::attach(|py| monty_to_py(py, &result, &dc_registry));
             }
             RunProgress::FunctionCall(call) => {
+                // Check Cedar policy before calling external functions.
+                if !call.method_call
+                    && let Some(ref engine) = policy_engine
+                    && let Err(denied) = engine.authorize_external_call(&call.function_name)
+                {
+                    return Err(Python::attach(|py| exc_monty_to_py(py, denied.into())));
+                }
+
                 let call_result = dispatch_function_call(
                     &call.function_name,
                     call.method_call,
@@ -165,6 +175,13 @@ pub(crate) async fn dispatch_loop_run<T: ResourceTracker + Send + 'static>(
                 }
             }
             RunProgress::OsCall(mut call) => {
+                // Check Cedar policy before handling the OS call.
+                if let Some(ref engine) = policy_engine
+                    && let Err(denied) = engine.authorize_os_call(&call.function_call)
+                {
+                    return Err(Python::attach(|py| exc_monty_to_py(py, denied.into())));
+                }
+
                 let result = dispatch_os_call_py(call.take_function_call(), os.as_ref(), &dc_registry);
                 let target = print_target.clone_handle_detached();
                 progress =

--- a/crates/monty-python/src/lib.rs
+++ b/crates/monty-python/src/lib.rs
@@ -13,6 +13,7 @@ mod external;
 mod limits;
 mod monty_cls;
 mod mount;
+mod policy;
 mod print_target;
 mod repl;
 mod serialization;
@@ -24,6 +25,7 @@ pub use convert::PyMontyFileHandle;
 pub use exceptions::{MontyError, MontyRuntimeError, MontySyntaxError, MontyTypingError, PyFrame};
 pub use monty_cls::{PyFunctionSnapshot, PyFutureSnapshot, PyMonty, PyMontyComplete, PyNameLookupSnapshot};
 pub use mount::PyMountDir;
+pub use policy::PyPolicy;
 pub use print_target::{PyCollectStreams, PyCollectString};
 use pyo3::{prelude::*, sync::PyOnceLock, types::PyAny};
 pub use repl::PyMontyRepl;
@@ -105,6 +107,8 @@ mod _monty {
     use super::PyMountDir as MountDir;
     #[pymodule_export]
     use super::PyNameLookupSnapshot as NameLookupSnapshot;
+    #[pymodule_export]
+    use super::PyPolicy as Policy;
     #[pymodule_export]
     use super::serialization::load_repl_snapshot;
     #[pymodule_export]

--- a/crates/monty-python/src/monty_cls.rs
+++ b/crates/monty-python/src/monty_cls.rs
@@ -25,10 +25,11 @@ use crate::{
     build::{ConstructInputs, extract_type_check_stubs, py_type_check},
     convert::{get_docstring, monty_to_py, py_to_monty_value},
     dataclass::DcRegistry,
-    exceptions::{MontyError, exc_py_to_monty},
+    exceptions::{MontyError, exc_monty_to_py, exc_py_to_monty},
     external::{ExternalFunctionRegistry, dispatch_method_call},
     limits::{CancellationFlag, FutureCancellationGuard, PySignalTracker, extract_limits},
     mount::OsHandler,
+    policy::PyPolicy,
     print_target::PrintTarget,
     repl::{EitherRepl, FromCoreRepl, PyMontyRepl, drive_repl_progress_through_os_calls},
     serialization,
@@ -185,7 +186,7 @@ impl PyMonty {
     /// # Raises
     /// Various Python exceptions matching what the code would raise
     #[expect(clippy::too_many_arguments)]
-    #[pyo3(signature = (*, inputs=None, limits=None, external_functions=None, print_callback=None, mount=None, os=None))]
+    #[pyo3(signature = (*, inputs=None, limits=None, external_functions=None, print_callback=None, mount=None, os=None, policy=None))]
     fn run<'py>(
         &self,
         py: Python<'py>,
@@ -195,6 +196,7 @@ impl PyMonty {
         print_callback: Option<&Bound<'_, PyAny>>,
         mount: Option<&Bound<'_, PyAny>>,
         os: Option<&Bound<'_, PyAny>>,
+        policy: Option<&PyPolicy>,
     ) -> PyResult<Bound<'py, PyAny>> {
         // Clone the Arc handle — all clones share the same underlying registry,
         // so auto-registrations during execution are visible to all users.
@@ -208,13 +210,31 @@ impl PyMonty {
         // objects keep accumulating across transitions.
         let print_target = PrintTarget::from_py(print_callback)?;
 
+        let policy_engine = policy.map(|p| &p.engine);
+
         // Run with appropriate tracker type (must branch due to different generic types)
         if let Some(limits) = limits {
             let tracker = PySignalTracker::new(LimitedTracker::new(extract_limits(limits)?));
-            self.run_impl(py, input_values, tracker, external_functions, os_handler, print_target)
+            self.run_impl(
+                py,
+                input_values,
+                tracker,
+                external_functions,
+                os_handler,
+                print_target,
+                policy_engine,
+            )
         } else {
             let tracker = PySignalTracker::new(NoLimitTracker);
-            self.run_impl(py, input_values, tracker, external_functions, os_handler, print_target)
+            self.run_impl(
+                py,
+                input_values,
+                tracker,
+                external_functions,
+                os_handler,
+                print_target,
+                policy_engine,
+            )
         }
     }
 
@@ -228,7 +248,8 @@ impl PyMonty {
     /// The auto-dispatch does **not** persist across subsequent `snapshot.resume()`
     /// calls — once a snapshot is returned, any OS call produced by a later resume
     /// surfaces as a `FunctionSnapshot` with `is_os_function=True`, as before.
-    #[pyo3(signature = (*, inputs=None, limits=None, print_callback=None, mount=None, os=None))]
+    #[expect(clippy::too_many_arguments)]
+    #[pyo3(signature = (*, inputs=None, limits=None, print_callback=None, mount=None, os=None, policy=None))]
     fn start<'py>(
         &self,
         py: Python<'py>,
@@ -237,6 +258,7 @@ impl PyMonty {
         print_callback: Option<&Bound<'_, PyAny>>,
         mount: Option<&Bound<'_, PyAny>>,
         os: Option<&Bound<'_, PyAny>>,
+        policy: Option<&PyPolicy>,
     ) -> PyResult<Bound<'py, PyAny>> {
         // Clone the Arc handle — shares the same underlying registry
         let dc_registry = self.dc_registry.clone_ref(py);
@@ -267,7 +289,8 @@ impl PyMonty {
                 // until we reach the first non-OS event. Mounts are taken inside
                 // the helper and put back on every exit path.
                 if let Some(handler) = &os_handler {
-                    drive_run_progress_through_os_calls(py, progress, handler, &print_target, &self.dc_registry)?
+                    let pe = policy.map(|p| &p.engine);
+                    drive_run_progress_through_os_calls(py, progress, handler, &print_target, &self.dc_registry, pe)?
                 } else {
                     progress
                 }
@@ -520,7 +543,7 @@ impl PyMonty {
     ///
     /// Takes explicit field references instead of `&mut self` so that `run()` can
     /// remain `&self` (required for concurrent thread access in PyO3).
-    #[expect(clippy::needless_pass_by_value)]
+    #[expect(clippy::needless_pass_by_value, clippy::too_many_arguments)]
     fn run_impl<'py>(
         &self,
         py: Python<'py>,
@@ -529,6 +552,7 @@ impl PyMonty {
         external_functions: Option<&Bound<'_, PyDict>>,
         os_handler: Option<OsHandler>,
         print_target: PrintTarget,
+        policy_engine: Option<&monty_policy::PolicyEngine>,
     ) -> PyResult<Bound<'py, PyAny>> {
         // Each VM transition builds its own `PrintWriter` via
         // `print_target.with_writer`, which only holds any collector lock for
@@ -582,15 +606,24 @@ impl PyMonty {
                     // Dataclass method calls have method_call=true and the first arg is the instance
                     let return_value = if call.method_call {
                         dispatch_method_call(py, &call.function_name, &call.args, &call.kwargs, &self.dc_registry)
-                    } else if let Some(ext_fns) = external_functions {
-                        let registry = ExternalFunctionRegistry::new(py, ext_fns, &self.dc_registry);
-                        registry.call(&call.function_name, &call.args, &call.kwargs)
                     } else {
-                        put_back(mount_table);
-                        return Err(PyRuntimeError::new_err(format!(
-                            "External function '{}' called but no external_functions provided",
-                            call.function_name
-                        )));
+                        // Check Cedar policy before calling external functions.
+                        if let Some(engine) = policy_engine
+                            && let Err(denied) = engine.authorize_external_call(&call.function_name)
+                        {
+                            put_back(mount_table);
+                            return Err(exc_monty_to_py(py, denied.into()));
+                        }
+                        if let Some(ext_fns) = external_functions {
+                            let registry = ExternalFunctionRegistry::new(py, ext_fns, &self.dc_registry);
+                            registry.call(&call.function_name, &call.args, &call.kwargs)
+                        } else {
+                            put_back(mount_table);
+                            return Err(PyRuntimeError::new_err(format!(
+                                "External function '{}' called but no external_functions provided",
+                                call.function_name
+                            )));
+                        }
                     };
 
                     progress = match py.detach(|| print_target.with_writer(|writer| call.resume(return_value, writer)))
@@ -627,6 +660,14 @@ impl PyMonty {
                     return Err(PyRuntimeError::new_err("async futures not supported with `Monty.run`"));
                 }
                 RunProgress::OsCall(call) => {
+                    // Check Cedar policy before handling the OS call.
+                    if let Some(engine) = policy_engine
+                        && let Err(denied) = engine.authorize_os_call(&call.function_call)
+                    {
+                        put_back(mount_table);
+                        return Err(exc_monty_to_py(py, denied.into()));
+                    }
+
                     let fallback = os_handler.as_ref().and_then(|h| h.fallback.as_ref());
                     // `handle_mount_os_call` can fail during Python⇄Monty conversion;
                     // put mounts back before propagating so the `MountDir` slot doesn't
@@ -692,6 +733,7 @@ impl EitherProgress {
                 handler,
                 print_target,
                 dc_registry,
+                None,
             )?)),
             Self::Limited(p) => Ok(Self::Limited(drive_run_progress_through_os_calls(
                 py,
@@ -699,6 +741,7 @@ impl EitherProgress {
                 handler,
                 print_target,
                 dc_registry,
+                None,
             )?)),
             Self::ReplNoLimit(p, owner) => {
                 let next = {
@@ -2078,6 +2121,7 @@ pub(crate) fn drive_run_progress_through_os_calls<T: ResourceTracker + Send>(
     handler: &OsHandler,
     print_target: &PrintTarget,
     dc_registry: &DcRegistry,
+    policy_engine: Option<&monty_policy::PolicyEngine>,
 ) -> PyResult<RunProgress<T>> {
     let mut mount_table: Option<MountTable> = None;
     let fallback = handler.fallback.as_ref();
@@ -2089,6 +2133,14 @@ pub(crate) fn drive_run_progress_through_os_calls<T: ResourceTracker + Send>(
     loop {
         match progress {
             RunProgress::OsCall(call) => {
+                // Check Cedar policy before dispatching the OS call.
+                if let Some(engine) = policy_engine
+                    && let Err(denied) = engine.authorize_os_call(&call.function_call)
+                {
+                    put_back(&mut mount_table);
+                    return Err(exc_monty_to_py(py, denied.into()));
+                }
+
                 let table = if let Some(table) = mount_table.as_mut() {
                     table
                 } else {

--- a/crates/monty-python/src/monty_cls.rs
+++ b/crates/monty-python/src/monty_cls.rs
@@ -210,7 +210,7 @@ impl PyMonty {
         // objects keep accumulating across transitions.
         let print_target = PrintTarget::from_py(print_callback)?;
 
-        let policy_engine = policy.map(|p| &p.engine);
+        let policy_engine = policy.map(|p| p.engine.as_ref());
 
         // Run with appropriate tracker type (must branch due to different generic types)
         if let Some(limits) = limits {
@@ -289,7 +289,7 @@ impl PyMonty {
                 // until we reach the first non-OS event. Mounts are taken inside
                 // the helper and put back on every exit path.
                 if let Some(handler) = &os_handler {
-                    let pe = policy.map(|p| &p.engine);
+                    let pe = policy.map(|p| p.engine.as_ref());
                     drive_run_progress_through_os_calls(py, progress, handler, &print_target, &self.dc_registry, pe)?
                 } else {
                     progress
@@ -320,7 +320,8 @@ impl PyMonty {
     ///
     /// # Raises
     /// Various Python exceptions matching what the code would raise.
-    #[pyo3(signature = (*, inputs=None, limits=None, external_functions=None, print_callback=None, os=None))]
+    #[expect(clippy::too_many_arguments)]
+    #[pyo3(signature = (*, inputs=None, limits=None, external_functions=None, print_callback=None, os=None, policy=None))]
     fn run_async<'py>(
         &self,
         py: Python<'py>,
@@ -329,6 +330,7 @@ impl PyMonty {
         external_functions: Option<&Bound<'_, PyDict>>,
         print_callback: Option<&Bound<'_, PyAny>>,
         os: Option<Py<PyAny>>,
+        policy: Option<&PyPolicy>,
     ) -> PyResult<Bound<'py, PyAny>> {
         if let Some(ref os_cb) = os
             && !os_cb.bind(py).is_callable()
@@ -346,6 +348,7 @@ impl PyMonty {
         let ext_fns = external_functions.map(|d| d.clone().unbind());
         let print_target = PrintTarget::from_py(print_callback)?;
         let runner = self.runner.clone();
+        let policy_engine = policy.map(|p| p.engine.clone());
         if let Some(limits) = limits {
             Self::run_async_with_tracker(
                 py,
@@ -355,6 +358,7 @@ impl PyMonty {
                 os,
                 dc_registry,
                 print_target,
+                policy_engine,
                 move |cancel_flag| PySignalTracker::new_with_cancellation(LimitedTracker::new(limits), cancel_flag),
             )
         } else {
@@ -366,6 +370,7 @@ impl PyMonty {
                 os,
                 dc_registry,
                 print_target,
+                policy_engine,
                 move |cancel_flag| PySignalTracker::new_with_cancellation(NoLimitTracker, cancel_flag),
             )
         }
@@ -452,6 +457,7 @@ impl PyMonty {
         os: Option<Py<PyAny>>,
         dc_registry: DcRegistry,
         print_target: PrintTarget,
+        policy_engine: Option<Arc<monty_policy::PolicyEngine>>,
         tracker_builder: F,
     ) -> PyResult<Bound<'_, PyAny>>
     where
@@ -473,7 +479,15 @@ impl PyMonty {
             .await?
             .map_err(|e| Python::attach(|py| MontyError::new_err(py, e)))?;
 
-            let result = dispatch_loop_run(progress, external_functions, os, dc_registry, print_target).await;
+            let result = dispatch_loop_run(
+                progress,
+                external_functions,
+                os,
+                dc_registry,
+                print_target,
+                policy_engine,
+            )
+            .await;
             cancellation_guard.disarm();
             result
         })

--- a/crates/monty-python/src/policy.rs
+++ b/crates/monty-python/src/policy.rs
@@ -4,6 +4,8 @@
 //! passed to `Monty.run()` / `Monty.start()` to enforce fine-grained access
 //! control on sandbox operations.
 
+use std::sync::Arc;
+
 use monty_policy::{DefaultDecision, PolicyConfig, PolicyEngine};
 use pyo3::{exceptions::PyValueError, prelude::*};
 
@@ -25,7 +27,7 @@ use pyo3::{exceptions::PyValueError, prelude::*};
 /// ```
 #[pyclass(name = "Policy", module = "pydantic_monty", frozen)]
 pub struct PyPolicy {
-    pub(crate) engine: PolicyEngine,
+    pub(crate) engine: Arc<PolicyEngine>,
 }
 
 #[pymethods]
@@ -59,6 +61,8 @@ impl PyPolicy {
 
         let engine = PolicyEngine::new(policy_text, config).map_err(|e| PyValueError::new_err(e.message))?;
 
-        Ok(Self { engine })
+        Ok(Self {
+            engine: Arc::new(engine),
+        })
     }
 }

--- a/crates/monty-python/src/policy.rs
+++ b/crates/monty-python/src/policy.rs
@@ -1,0 +1,64 @@
+//! Python bindings for the Cedar policy engine.
+//!
+//! Exposes [`PyPolicy`] which wraps [`monty_policy::PolicyEngine`] and can be
+//! passed to `Monty.run()` / `Monty.start()` to enforce fine-grained access
+//! control on sandbox operations.
+
+use monty_policy::{DefaultDecision, PolicyConfig, PolicyEngine};
+use pyo3::{exceptions::PyValueError, prelude::*};
+
+/// A Cedar policy that controls what sandboxed code is allowed to do.
+///
+/// Policies are written in the Cedar language and evaluated against each
+/// sandbox operation (filesystem access, environment variables, external
+/// function calls). Operations not explicitly permitted are denied by default.
+///
+/// # Example
+///
+/// ```python
+/// from pydantic_monty import Policy
+///
+/// policy = Policy('''
+///     permit(principal, action == Monty::Action::"fs:read", resource)
+///     when { resource.path like "/data/*" };
+/// ''')
+/// ```
+#[pyclass(name = "Policy", module = "pydantic_monty", frozen)]
+pub struct PyPolicy {
+    pub(crate) engine: PolicyEngine,
+}
+
+#[pymethods]
+impl PyPolicy {
+    /// Creates a new policy from Cedar policy text.
+    ///
+    /// # Arguments
+    /// * `policy_text` — Cedar policy rules
+    /// * `principal` — name of the principal entity (default: `"anonymous"`)
+    /// * `default` — default decision: `"deny"` (default) or `"allow"`
+    ///
+    /// # Raises
+    /// `ValueError` if the policy text is invalid or `default` is not recognized.
+    #[new]
+    #[pyo3(signature = (policy_text, *, principal = "anonymous", default = "deny"))]
+    fn new(policy_text: &str, principal: &str, default: &str) -> PyResult<Self> {
+        let default_decision = match default {
+            "deny" => DefaultDecision::Deny,
+            "allow" => DefaultDecision::Allow,
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "invalid default decision '{other}': must be 'deny' or 'allow'"
+                )));
+            }
+        };
+
+        let config = PolicyConfig {
+            principal: principal.to_owned(),
+            default_decision,
+        };
+
+        let engine = PolicyEngine::new(policy_text, config).map_err(|e| PyValueError::new_err(e.message))?;
+
+        Ok(Self { engine })
+    }
+}

--- a/crates/monty-python/tests/test_policy.py
+++ b/crates/monty-python/tests/test_policy.py
@@ -108,8 +108,7 @@ def test_policy_path_pattern(test_dir: Path):
 
 def test_policy_permits_external_function():
     policy = Policy(
-        'permit(principal, action == Monty::Action::"ext:call", resource)'
-        '  when { resource.name == "safe_func" };'
+        'permit(principal, action == Monty::Action::"ext:call", resource)  when { resource.name == "safe_func" };'
     )
     m = Monty('safe_func()')
     result = m.run(
@@ -121,8 +120,7 @@ def test_policy_permits_external_function():
 
 def test_policy_denies_external_function():
     policy = Policy(
-        'permit(principal, action == Monty::Action::"ext:call", resource)'
-        '  when { resource.name == "safe_func" };'
+        'permit(principal, action == Monty::Action::"ext:call", resource)  when { resource.name == "safe_func" };'
     )
     m = Monty('dangerous()')
     with pytest.raises(Exception) as exc_info:
@@ -140,9 +138,7 @@ def test_policy_denies_external_function():
 
 
 def test_policy_permits_env_read(test_dir: Path):
-    policy = Policy(
-        'permit(principal, action == Monty::Action::"env:read", resource);'
-    )
+    policy = Policy('permit(principal, action == Monty::Action::"env:read", resource);')
     md = MountDir('/data', str(test_dir), mode='read-only')
     m = Monty("import os; os.getenv('HOME', 'default')")
     # With env:read permitted, the OS call should proceed (may need OS handler)
@@ -157,9 +153,7 @@ def test_policy_permits_env_read(test_dir: Path):
 
 def test_policy_denies_env_read(test_dir: Path):
     # Only permit filesystem, not env
-    policy = Policy(
-        'permit(principal, action == Monty::Action::"fs:read", resource);'
-    )
+    policy = Policy('permit(principal, action == Monty::Action::"fs:read", resource);')
     md = MountDir('/data', str(test_dir), mode='read-only')
     m = Monty("import os; os.getenv('SECRET', 'fallback')")
     with pytest.raises(Exception) as exc_info:

--- a/crates/monty-python/tests/test_policy.py
+++ b/crates/monty-python/tests/test_policy.py
@@ -1,0 +1,218 @@
+"""Tests for Cedar policy enforcement via the Policy class."""
+
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+from inline_snapshot import snapshot
+
+from pydantic_monty import Monty, MountDir, Policy
+
+
+@pytest.fixture
+def test_dir() -> Generator[Path, None, None]:
+    """Creates a temporary directory with test files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        p = Path(tmpdir)
+        (p / 'hello.txt').write_text('hello world')
+        (p / 'output').mkdir()
+        yield p
+
+
+# =============================================================================
+# Policy construction
+# =============================================================================
+
+
+def test_policy_invalid_text():
+    with pytest.raises(ValueError) as exc_info:
+        Policy('not valid cedar')
+    assert 'policy parse error' in str(exc_info.value)
+
+
+def test_policy_invalid_default():
+    with pytest.raises(ValueError) as exc_info:
+        Policy('', default='maybe')  # pyright: ignore[reportArgumentType]
+    assert str(exc_info.value) == snapshot("invalid default decision 'maybe': must be 'deny' or 'allow'")
+
+
+def test_policy_empty_deny_default():
+    # Empty policy with deny default should block everything.
+    Policy('', default='deny')
+
+
+# =============================================================================
+# Filesystem policy tests
+# =============================================================================
+
+
+def test_policy_permits_read(test_dir: Path):
+    policy = Policy(
+        'permit(principal, action == Monty::Action::"fs:read", resource);'
+        'permit(principal, action == Monty::Action::"fs:exists", resource);'
+    )
+    md = MountDir('/data', str(test_dir), mode='read-only')
+    m = Monty("from pathlib import Path; Path('/data/hello.txt').read_text()")
+    result = m.run(mount=md, policy=policy)
+    assert result == snapshot('hello world')
+
+
+def test_policy_denies_read(test_dir: Path):
+    # Empty policy = deny all
+    policy = Policy('')
+    md = MountDir('/data', str(test_dir), mode='read-only')
+    m = Monty("from pathlib import Path; Path('/data/hello.txt').read_text()")
+    with pytest.raises(Exception) as exc_info:
+        m.run(mount=md, policy=policy)
+    assert "policy denied action 'fs:read'" in str(exc_info.value)
+
+
+def test_policy_permits_read_denies_write(test_dir: Path):
+    policy = Policy(
+        'permit(principal, action == Monty::Action::"fs:read", resource);'
+        'permit(principal, action == Monty::Action::"fs:exists", resource);'
+    )
+    md = MountDir('/data', str(test_dir), mode='read-write')
+    # Read should work
+    m_read = Monty("from pathlib import Path; Path('/data/hello.txt').read_text()")
+    assert m_read.run(mount=md, policy=policy) == snapshot('hello world')
+
+    # Write should be denied by policy
+    m_write = Monty("from pathlib import Path; Path('/data/output/new.txt').write_text('x')")
+    with pytest.raises(Exception) as exc_info:
+        m_write.run(mount=md, policy=policy)
+    assert "policy denied action 'fs:write'" in str(exc_info.value)
+
+
+def test_policy_path_pattern(test_dir: Path):
+    policy = Policy(
+        'permit(principal, action == Monty::Action::"fs:read", resource)'
+        '  when { resource.path like "/data/output/*" };'
+        'permit(principal, action == Monty::Action::"fs:exists", resource);'
+    )
+    md = MountDir('/data', str(test_dir), mode='read-only')
+
+    # Read from /data/output/* is not testable with read-only since there's nothing there,
+    # but read from /data/hello.txt should be denied since it doesn't match /data/output/*
+    m = Monty("from pathlib import Path; Path('/data/hello.txt').read_text()")
+    with pytest.raises(Exception) as exc_info:
+        m.run(mount=md, policy=policy)
+    assert "policy denied action 'fs:read'" in str(exc_info.value)
+
+
+# =============================================================================
+# External function policy tests
+# =============================================================================
+
+
+def test_policy_permits_external_function():
+    policy = Policy(
+        'permit(principal, action == Monty::Action::"ext:call", resource)'
+        '  when { resource.name == "safe_func" };'
+    )
+    m = Monty('safe_func()')
+    result = m.run(
+        external_functions={'safe_func': lambda: 42},
+        policy=policy,
+    )
+    assert result == snapshot(42)
+
+
+def test_policy_denies_external_function():
+    policy = Policy(
+        'permit(principal, action == Monty::Action::"ext:call", resource)'
+        '  when { resource.name == "safe_func" };'
+    )
+    m = Monty('dangerous()')
+    with pytest.raises(Exception) as exc_info:
+        m.run(
+            external_functions={'dangerous': lambda: 'hacked'},
+            policy=policy,
+        )
+    assert "policy denied action 'ext:call'" in str(exc_info.value)
+    assert 'dangerous' in str(exc_info.value)
+
+
+# =============================================================================
+# Environment variable policy tests
+# =============================================================================
+
+
+def test_policy_permits_env_read(test_dir: Path):
+    policy = Policy(
+        'permit(principal, action == Monty::Action::"env:read", resource);'
+    )
+    md = MountDir('/data', str(test_dir), mode='read-only')
+    m = Monty("import os; os.getenv('HOME', 'default')")
+    # With env:read permitted, the OS call should proceed (may need OS handler)
+    # Using os= callback to provide the env
+    result = m.run(
+        mount=md,
+        os=lambda name, args, kwargs: 'test_home',
+        policy=policy,
+    )
+    assert result == snapshot('test_home')
+
+
+def test_policy_denies_env_read(test_dir: Path):
+    # Only permit filesystem, not env
+    policy = Policy(
+        'permit(principal, action == Monty::Action::"fs:read", resource);'
+    )
+    md = MountDir('/data', str(test_dir), mode='read-only')
+    m = Monty("import os; os.getenv('SECRET', 'fallback')")
+    with pytest.raises(Exception) as exc_info:
+        m.run(
+            mount=md,
+            os=lambda name, args, kwargs: 'should_not_reach',
+            policy=policy,
+        )
+    assert "policy denied action 'env:read'" in str(exc_info.value)
+
+
+# =============================================================================
+# Allow-by-default mode (blocklist)
+# =============================================================================
+
+
+def test_allow_default_permits_everything(test_dir: Path):
+    policy = Policy('', default='allow')
+    md = MountDir('/data', str(test_dir), mode='read-only')
+    m = Monty("from pathlib import Path; Path('/data/hello.txt').read_text()")
+    result = m.run(mount=md, policy=policy)
+    assert result == snapshot('hello world')
+
+
+def test_allow_default_with_forbid(test_dir: Path):
+    policy = Policy(
+        'forbid(principal, action == Monty::Action::"fs:write", resource);',
+        default='allow',
+    )
+    md = MountDir('/data', str(test_dir), mode='read-write')
+    # Read should still work
+    m_read = Monty("from pathlib import Path; Path('/data/hello.txt').read_text()")
+    assert m_read.run(mount=md, policy=policy) == snapshot('hello world')
+
+    # Write should be denied by explicit forbid
+    m_write = Monty("from pathlib import Path; Path('/data/output/new.txt').write_text('x')")
+    with pytest.raises(Exception) as exc_info:
+        m_write.run(mount=md, policy=policy)
+    assert "policy denied action 'fs:write'" in str(exc_info.value)
+
+
+# =============================================================================
+# Policy with start() method
+# =============================================================================
+
+
+def test_policy_with_start(test_dir: Path):
+    policy = Policy(
+        'permit(principal, action == Monty::Action::"fs:read", resource);'
+        'permit(principal, action == Monty::Action::"fs:exists", resource);'
+    )
+    md = MountDir('/data', str(test_dir), mode='read-only')
+    m = Monty("from pathlib import Path; Path('/data/hello.txt').read_text()")
+    result = m.start(mount=md, policy=policy)
+    # Should complete successfully (start auto-dispatches OS calls when mount is provided)
+    assert result.output == snapshot('hello world')

--- a/crates/monty-python/tests/test_policy.py
+++ b/crates/monty-python/tests/test_policy.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 from inline_snapshot import snapshot
 
-from pydantic_monty import Monty, MountDir, Policy
+from pydantic_monty import Monty, MontyComplete, MountDir, Policy
 
 
 @pytest.fixture
@@ -215,4 +215,5 @@ def test_policy_with_start(test_dir: Path):
     m = Monty("from pathlib import Path; Path('/data/hello.txt').read_text()")
     result = m.start(mount=md, policy=policy)
     # Should complete successfully (start auto-dispatches OS calls when mount is provided)
+    assert isinstance(result, MontyComplete)
     assert result.output == snapshot('hello world')

--- a/crates/monty/src/fs/mod.rs
+++ b/crates/monty/src/fs/mod.rs
@@ -23,6 +23,7 @@ pub use error::MountError;
 pub use mount_mode::MountMode;
 pub use mount_table::{Mount, MountTable};
 pub use overlay_state::OverlayState;
+pub use path_security::normalize_virtual_path;
 
 mod common;
 mod direct;

--- a/crates/monty/src/fs/path_security.rs
+++ b/crates/monty/src/fs/path_security.rs
@@ -71,7 +71,7 @@ pub(super) fn resolve_path(
 /// The result is always absolute. Excess `..` components at the root collapse
 /// to `/` instead of escaping the sandbox namespace.
 #[must_use]
-pub(super) fn normalize_virtual_path(path: &str) -> String {
+pub fn normalize_virtual_path(path: &str) -> String {
     if is_already_normalized_absolute_path(path) {
         return path.to_owned();
     }

--- a/policy-examples/01_read_only.py
+++ b/policy-examples/01_read_only.py
@@ -1,0 +1,43 @@
+"""Example: Allow filesystem reads, deny everything else.
+
+This is the most common pattern — sandboxed code can read data
+but cannot modify the host filesystem.
+"""
+
+import tempfile
+from pathlib import Path
+
+from pydantic_monty import Monty, MountDir, Policy
+
+# Create a temp directory with some files to read
+tmpdir = tempfile.mkdtemp()
+Path(tmpdir, 'config.json').write_text('{"key": "value", "count": 42}')
+Path(tmpdir, 'data.txt').write_text('hello from the sandbox')
+
+# Policy: allow reads and existence checks, deny everything else
+policy = Policy('''
+    permit(principal, action == Monty::Action::"fs:read", resource);
+    permit(principal, action == Monty::Action::"fs:exists", resource);
+''')
+
+mount = MountDir('/data', tmpdir, mode='read-write')
+
+# Reading works
+m = Monty("from pathlib import Path; Path('/data/config.json').read_text()")
+result = m.run(mount=mount, policy=policy)
+print(f'Read config.json: {result}')
+
+# Existence check works
+m = Monty("from pathlib import Path; Path('/data/data.txt').exists()")
+result = m.run(mount=mount, policy=policy)
+print(f'data.txt exists: {result}')
+
+# Writing is denied by policy (even though mount is read-write)
+m = Monty("from pathlib import Path; Path('/data/hack.txt').write_text('pwned')")
+try:
+    m.run(mount=mount, policy=policy)
+    print('ERROR: write should have been denied!')
+except Exception as e:
+    print(f'Write denied: {e}')
+
+print('\nDone! Policy allowed reads but blocked writes.')

--- a/policy-examples/02_write_restricted.py
+++ b/policy-examples/02_write_restricted.py
@@ -1,0 +1,48 @@
+"""Example: Allow writes only to a specific output directory.
+
+Sandboxed code can read from anywhere but can only write to /data/output/*.
+This is useful when you want code to produce results in a controlled location.
+"""
+
+import tempfile
+from pathlib import Path
+
+from pydantic_monty import Monty, MountDir, Policy
+
+# Create a temp directory with an output subdirectory
+tmpdir = tempfile.mkdtemp()
+Path(tmpdir, 'input.txt').write_text('source data')
+Path(tmpdir, 'output').mkdir()
+
+# Policy: read anywhere, write only to /data/output/*
+policy = Policy('''
+    permit(principal, action == Monty::Action::"fs:read", resource);
+    permit(principal, action == Monty::Action::"fs:exists", resource);
+    permit(principal, action == Monty::Action::"fs:list", resource);
+    permit(principal, action == Monty::Action::"fs:create", resource)
+    when { resource.path like "/data/output/*" };
+    permit(principal, action == Monty::Action::"fs:write", resource)
+    when { resource.path like "/data/output/*" };
+''')
+
+mount = MountDir('/data', tmpdir, mode='read-write')
+
+# Read from input — allowed
+m = Monty("from pathlib import Path; Path('/data/input.txt').read_text()")
+result = m.run(mount=mount, policy=policy)
+print(f'Read input.txt: {result}')
+
+# Write to output directory — allowed
+m = Monty("from pathlib import Path; Path('/data/output/result.txt').write_text('processed')")
+m.run(mount=mount, policy=policy)
+print(f'Wrote to output/result.txt: {Path(tmpdir, "output", "result.txt").read_text()}')
+
+# Write to root — denied
+m = Monty("from pathlib import Path; Path('/data/input.txt').write_text('overwritten!')")
+try:
+    m.run(mount=mount, policy=policy)
+    print('ERROR: write to root should have been denied!')
+except Exception as e:
+    print(f'Write to root denied: {e}')
+
+print('\nDone! Writes restricted to /data/output/* only.')

--- a/policy-examples/03_external_functions.py
+++ b/policy-examples/03_external_functions.py
@@ -1,0 +1,56 @@
+"""Example: Allowlist specific external function calls.
+
+Only the functions explicitly named in the policy can be called by
+sandboxed code. This prevents an LLM from calling dangerous functions
+even if they are registered.
+"""
+
+from pydantic_monty import Monty, Policy
+
+# Policy: only allow fetch_weather and get_time
+policy = Policy('''
+    permit(principal, action == Monty::Action::"ext:call", resource)
+    when { resource.name == "fetch_weather" };
+
+    permit(principal, action == Monty::Action::"ext:call", resource)
+    when { resource.name == "get_time" };
+''')
+
+
+# Define some external functions
+def fetch_weather(city):
+    return f'Sunny, 22C in {city}'
+
+
+def get_time():
+    return '2026-06-02T10:30:00Z'
+
+
+def delete_database():
+    return 'DATABASE DELETED!'  # This should never be callable
+
+
+all_functions = {
+    'fetch_weather': fetch_weather,
+    'get_time': get_time,
+    'delete_database': delete_database,
+}
+
+# Calling allowed functions works
+m = Monty('fetch_weather("London")')
+result = m.run(external_functions=all_functions, policy=policy)
+print(f'fetch_weather: {result}')
+
+m = Monty('get_time()')
+result = m.run(external_functions=all_functions, policy=policy)
+print(f'get_time: {result}')
+
+# Calling a disallowed function is blocked
+m = Monty('delete_database()')
+try:
+    m.run(external_functions=all_functions, policy=policy)
+    print('ERROR: delete_database should have been denied!')
+except Exception as e:
+    print(f'delete_database denied: {e}')
+
+print('\nDone! Only allowlisted functions are callable.')

--- a/policy-examples/04_env_vars.py
+++ b/policy-examples/04_env_vars.py
@@ -1,0 +1,70 @@
+"""Example: Restrict which environment variables are readable.
+
+Sandboxed code can only access explicitly permitted env vars.
+Secrets like API keys remain hidden even if the code tries to read them.
+"""
+
+from pydantic_monty import Monty, MountDir, Policy
+
+import tempfile
+from pathlib import Path
+
+tmpdir = tempfile.mkdtemp()
+Path(tmpdir, 'dummy').write_text('')
+
+# Policy: only allow reading HOME and LANG env vars
+policy = Policy('''
+    permit(principal, action == Monty::Action::"env:read", resource)
+    when { resource.name == "HOME" };
+
+    permit(principal, action == Monty::Action::"env:read", resource)
+    when { resource.name == "LANG" };
+
+    permit(principal, action == Monty::Action::"fs:read", resource);
+    permit(principal, action == Monty::Action::"fs:exists", resource);
+''')
+
+mount = MountDir('/data', tmpdir, mode='read-only')
+
+
+# Simulate an OS callback that provides env vars
+def os_callback(name, args, kwargs):
+    env_vars = {
+        'HOME': '/home/user',
+        'LANG': 'en_US.UTF-8',
+        'SECRET_API_KEY': 'sk-12345-NEVER-EXPOSE-THIS',
+        'DATABASE_URL': 'postgres://admin:password@prod-db:5432/main',
+    }
+    if name == 'os.getenv':
+        key = args[0]
+        return env_vars.get(key)
+    return None
+
+
+# Reading HOME — allowed
+m = Monty("import os; os.getenv('HOME', 'unknown')")
+result = m.run(mount=mount, os=os_callback, policy=policy)
+print(f"HOME = {result}")
+
+# Reading LANG — allowed
+m = Monty("import os; os.getenv('LANG', 'unknown')")
+result = m.run(mount=mount, os=os_callback, policy=policy)
+print(f"LANG = {result}")
+
+# Reading SECRET_API_KEY — denied by policy
+m = Monty("import os; os.getenv('SECRET_API_KEY', 'unknown')")
+try:
+    m.run(mount=mount, os=os_callback, policy=policy)
+    print('ERROR: SECRET_API_KEY read should have been denied!')
+except Exception as e:
+    print(f'SECRET_API_KEY denied: {e}')
+
+# Reading DATABASE_URL — denied by policy
+m = Monty("import os; os.getenv('DATABASE_URL', 'unknown')")
+try:
+    m.run(mount=mount, os=os_callback, policy=policy)
+    print('ERROR: DATABASE_URL read should have been denied!')
+except Exception as e:
+    print(f'DATABASE_URL denied: {e}')
+
+print('\nDone! Only HOME and LANG are accessible to sandboxed code.')

--- a/policy-examples/05_blocklist_mode.py
+++ b/policy-examples/05_blocklist_mode.py
@@ -1,0 +1,60 @@
+"""Example: Allow-by-default with explicit forbid rules (blocklist mode).
+
+Instead of denying everything and allowlisting specific actions,
+this mode starts permissive and blocks only the dangerous operations.
+Useful when you trust the code mostly but want guardrails.
+"""
+
+import tempfile
+from pathlib import Path
+
+from pydantic_monty import Monty, MountDir, Policy
+
+tmpdir = tempfile.mkdtemp()
+Path(tmpdir, 'readme.txt').write_text('project notes')
+Path(tmpdir, 'output').mkdir()
+
+# Policy: allow everything EXCEPT writes and deletes
+policy = Policy(
+    '''
+    forbid(principal, action == Monty::Action::"fs:write", resource);
+    forbid(principal, action == Monty::Action::"fs:delete", resource);
+    forbid(principal, action == Monty::Action::"fs:rename", resource);
+    ''',
+    default='allow',
+)
+
+mount = MountDir('/data', tmpdir, mode='read-write')
+
+# Reading — allowed (no forbid rule)
+m = Monty("from pathlib import Path; Path('/data/readme.txt').read_text()")
+result = m.run(mount=mount, policy=policy)
+print(f'Read: {result}')
+
+# Listing — allowed (no forbid rule)
+m = Monty("from pathlib import Path; list(p.name for p in Path('/data').iterdir())")
+result = m.run(mount=mount, policy=policy)
+print(f'Listed: {result}')
+
+# Existence check — allowed (no forbid rule)
+m = Monty("from pathlib import Path; Path('/data/readme.txt').exists()")
+result = m.run(mount=mount, policy=policy)
+print(f'Exists: {result}')
+
+# Writing — blocked by explicit forbid
+m = Monty("from pathlib import Path; Path('/data/output/file.txt').write_text('data')")
+try:
+    m.run(mount=mount, policy=policy)
+    print('ERROR: write should have been denied!')
+except Exception as e:
+    print(f'Write denied: {e}')
+
+# Delete — blocked by explicit forbid
+m = Monty("from pathlib import Path; Path('/data/readme.txt').unlink()")
+try:
+    m.run(mount=mount, policy=policy)
+    print('ERROR: delete should have been denied!')
+except Exception as e:
+    print(f'Delete denied: {e}')
+
+print('\nDone! Blocklist mode: everything works except writes/deletes/renames.')

--- a/policy-examples/06_combined_policy.py
+++ b/policy-examples/06_combined_policy.py
@@ -1,0 +1,136 @@
+"""Example: A realistic combined policy for an AI agent sandbox.
+
+This shows a production-like policy where an AI agent can:
+- Read input data from /workspace/input/*
+- Write results to /workspace/output/*
+- Call approved external functions (fetch_url, store_result)
+- Read the WORKSPACE_ID env var
+- But cannot access secrets, write to input, or call unapproved functions
+"""
+
+import tempfile
+from pathlib import Path
+
+from pydantic_monty import Monty, MountDir, Policy
+
+# Set up a workspace
+workspace = tempfile.mkdtemp()
+Path(workspace, 'input').mkdir()
+Path(workspace, 'output').mkdir()
+Path(workspace, 'input', 'task.json').write_text('{"task": "summarize", "doc_id": "abc123"}')
+Path(workspace, 'input', 'document.txt').write_text(
+    'This is a long document that needs summarization. '
+    'It contains important findings about climate change.'
+)
+
+# A realistic agent sandbox policy
+policy = Policy('''
+    // Allow reading from anywhere in the workspace
+    permit(principal, action == Monty::Action::"fs:read", resource)
+    when { resource.path like "/workspace/*" };
+
+    // Allow existence checks anywhere
+    permit(principal, action == Monty::Action::"fs:exists", resource)
+    when { resource.path like "/workspace/*" };
+
+    // Allow listing directories
+    permit(principal, action == Monty::Action::"fs:list", resource)
+    when { resource.path like "/workspace/*" };
+
+    // Allow writing ONLY to the output directory
+    permit(principal, action == Monty::Action::"fs:write", resource)
+    when { resource.path like "/workspace/output/*" };
+
+    // Allow creating directories in output
+    permit(principal, action == Monty::Action::"fs:create", resource)
+    when { resource.path like "/workspace/output/*" };
+
+    // Allow specific external functions
+    permit(principal, action == Monty::Action::"ext:call", resource)
+    when { resource.name == "fetch_url" };
+
+    permit(principal, action == Monty::Action::"ext:call", resource)
+    when { resource.name == "store_result" };
+
+    // Allow reading workspace metadata env var
+    permit(principal, action == Monty::Action::"env:read", resource)
+    when { resource.name == "WORKSPACE_ID" };
+''')
+
+mount = MountDir('/workspace', workspace, mode='read-write')
+
+
+# Simulated external functions
+def fetch_url(url):
+    return f'<content from {url}>'
+
+
+def store_result(key, value):
+    return f'stored {key}'
+
+
+def send_email(to, body):
+    return f'email sent to {to}'  # Should be blocked
+
+
+external_functions = {
+    'fetch_url': fetch_url,
+    'store_result': store_result,
+    'send_email': send_email,
+}
+
+print('=== Agent Sandbox: Combined Policy Demo ===\n')
+
+# 1. Agent reads its task
+code = "from pathlib import Path; Path('/workspace/input/task.json').read_text()"
+m = Monty(code)
+result = m.run(mount=mount, policy=policy)
+print(f'1. Read task: {result}')
+
+# 2. Agent reads the document
+code = "from pathlib import Path; Path('/workspace/input/document.txt').read_text()"
+m = Monty(code)
+result = m.run(mount=mount, policy=policy)
+print(f'2. Read document: {result[:50]}...')
+
+# 3. Agent calls an approved function
+code = 'fetch_url("https://api.example.com/context")'
+m = Monty(code)
+result = m.run(external_functions=external_functions, policy=policy)
+print(f'3. fetch_url: {result}')
+
+# 4. Agent writes output
+code = "from pathlib import Path; Path('/workspace/output/summary.txt').write_text('Summary: climate findings')"
+m = Monty(code)
+m.run(mount=mount, policy=policy)
+actual = Path(workspace, 'output', 'summary.txt').read_text()
+print(f'4. Wrote output: {actual}')
+
+# 5. Agent tries to write to input — DENIED
+code = "from pathlib import Path; Path('/workspace/input/task.json').write_text('hacked')"
+m = Monty(code)
+try:
+    m.run(mount=mount, policy=policy)
+    print('ERROR: should have been denied!')
+except Exception as e:
+    print(f'5. Write to input denied: {e}')
+
+# 6. Agent tries to call unapproved function — DENIED
+code = 'send_email("admin@corp.com", "pwned")'
+m = Monty(code)
+try:
+    m.run(external_functions=external_functions, policy=policy)
+    print('ERROR: should have been denied!')
+except Exception as e:
+    print(f'6. send_email denied: {e}')
+
+# 7. Agent tries to read a secret env var — DENIED
+code = "import os; os.getenv('DATABASE_URL')"
+m = Monty(code)
+try:
+    m.run(mount=mount, os=lambda *a: 'secret', policy=policy)
+    print('ERROR: should have been denied!')
+except Exception as e:
+    print(f'7. SECRET env var denied: {e}')
+
+print('\n=== All checks passed! Policy enforced correctly. ===')

--- a/policy-examples/06_combined_policy.py
+++ b/policy-examples/06_combined_policy.py
@@ -1,11 +1,11 @@
 """Example: A realistic combined policy for an AI agent sandbox.
 
 This shows a production-like policy where an AI agent can:
-- Read input data from /workspace/input/*
-- Write results to /workspace/output/*
+- Read from anywhere in /workspace/* (input, output, etc.)
+- Write results ONLY to /workspace/output/*
 - Call approved external functions (fetch_url, store_result)
 - Read the WORKSPACE_ID env var
-- But cannot access secrets, write to input, or call unapproved functions
+- But cannot write to input, read secret env vars, or call unapproved functions
 """
 
 import tempfile
@@ -111,8 +111,9 @@ code = "from pathlib import Path; Path('/workspace/input/task.json').write_text(
 m = Monty(code)
 try:
     m.run(mount=mount, policy=policy)
-    print('ERROR: should have been denied!')
+    assert False, 'should have been denied!'
 except Exception as e:
+    assert 'policy denied' in str(e), f'Unexpected error: {e}'
     print(f'5. Write to input denied: {e}')
 
 # 6. Agent tries to call unapproved function — DENIED
@@ -120,8 +121,9 @@ code = 'send_email("admin@corp.com", "pwned")'
 m = Monty(code)
 try:
     m.run(external_functions=external_functions, policy=policy)
-    print('ERROR: should have been denied!')
+    assert False, 'should have been denied!'
 except Exception as e:
+    assert 'policy denied' in str(e), f'Unexpected error: {e}'
     print(f'6. send_email denied: {e}')
 
 # 7. Agent tries to read a secret env var — DENIED
@@ -129,8 +131,9 @@ code = "import os; os.getenv('DATABASE_URL')"
 m = Monty(code)
 try:
     m.run(mount=mount, os=lambda *a: 'secret', policy=policy)
-    print('ERROR: should have been denied!')
+    assert False, 'should have been denied!'
 except Exception as e:
+    assert 'policy denied' in str(e), f'Unexpected error: {e}'
     print(f'7. SECRET env var denied: {e}')
 
 print('\n=== All checks passed! Policy enforced correctly. ===')

--- a/policy-examples/README.md
+++ b/policy-examples/README.md
@@ -1,0 +1,57 @@
+# Cedar Policy Examples
+
+These examples demonstrate how to use Cedar policies to control what sandboxed Python code can do in Monty.
+
+## Setup
+
+Install the package:
+
+```bash
+uv add pydantic-monty
+```
+
+Or from this repo (development):
+
+```bash
+make dev-py
+```
+
+## Running
+
+Each example is a standalone Python script:
+
+```bash
+python policy-examples/01_read_only.py
+python policy-examples/02_write_restricted.py
+python policy-examples/03_external_functions.py
+python policy-examples/04_env_vars.py
+python policy-examples/05_blocklist_mode.py
+python policy-examples/06_combined_policy.py
+```
+
+## Overview
+
+| Example | Demonstrates |
+|---------|-------------|
+| `01_read_only.py` | Allow filesystem reads, deny writes |
+| `02_write_restricted.py` | Allow writes only to specific paths |
+| `03_external_functions.py` | Allowlist specific external function calls |
+| `04_env_vars.py` | Restrict which environment variables are readable |
+| `05_blocklist_mode.py` | Allow-by-default with explicit forbid rules |
+| `06_combined_policy.py` | A realistic policy combining multiple rules |
+
+## Cedar Action Reference
+
+| Action | Controls |
+|--------|----------|
+| `Monty::Action::"fs:read"` | Reading files, stat, resolve |
+| `Monty::Action::"fs:write"` | Writing/appending files |
+| `Monty::Action::"fs:exists"` | Existence checks |
+| `Monty::Action::"fs:list"` | Directory listing |
+| `Monty::Action::"fs:create"` | Creating directories |
+| `Monty::Action::"fs:delete"` | Deleting files/directories |
+| `Monty::Action::"fs:rename"` | Renaming/moving |
+| `Monty::Action::"env:read"` | Environment variable access |
+| `Monty::Action::"ext:call"` | External function calls |
+
+Policies match resources using `resource.path` (filesystem) or `resource.name` (env vars, functions). Use Cedar's `like` operator for glob patterns (e.g. `resource.path like "/data/*"`).

--- a/uv.lock
+++ b/uv.lock
@@ -1,14 +1,10 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15'",
     "python_full_version < '3.15'",
 ]
-
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
 
 [manifest]
 members = [
@@ -27,7 +23,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.103.1"
+version = "0.105.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -39,9 +35,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/57/0b758b08cf4606c94d63a997d67a0063f7438efbaf81cfedd0d7c0c69d67/anthropic-0.103.1.tar.gz", hash = "sha256:21c12f4fc0fdd87a2e80d58479cd0af640062b3cfb82bbfa01c7977acd4defeb", size = 848877, upload-time = "2026-05-19T15:43:27.698Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/46/47581b8c689c743ceabf6a0f9ff48472160900ce802d26c0fb50423997b3/anthropic-0.105.2.tar.gz", hash = "sha256:0e26b90841c2dced7cc6e98d21d5517d0be33f1876b8e779f478202e28bcaa07", size = 853789, upload-time = "2026-05-29T00:21:14.104Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/ec/cf357cf571377a39552c1530390a9b79bbdb6ea463f48fbe4e3624141e3b/anthropic-0.103.1-py3-none-any.whl", hash = "sha256:b9a523fac34e64caf6ee55fdbda213950e6a744b906fce100d34909aad2cd8f4", size = 832551, upload-time = "2026-05-19T15:43:29.663Z" },
+    { url = "https://files.pythonhosted.org/packages/83/75/be0c357e33a5a56c8f9db5b4212f886138d2bf59c0952d858f6b75d710ef/anthropic-0.105.2-py3-none-any.whl", hash = "sha256:e53ed5f6bf36fb1ecb9b25d8634cfd30e02fab9fb3374a0c2d5c585874757230", size = 837507, upload-time = "2026-05-29T00:21:15.528Z" },
 ]
 
 [[package]]
@@ -112,14 +108,14 @@ wheels = [
 
 [[package]]
 name = "basedpyright"
-version = "1.39.5"
+version = "1.39.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodejs-wheel-binaries" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/5d/68e9bd8a408011f820e74fdad1684cad553fce0acfd83fce0a1ec4e01d97/basedpyright-1.39.5.tar.gz", hash = "sha256:373e6999b9dc450c4af077cb76a758f5959eedf8d03f0aac144bc59227f47d33", size = 25508568, upload-time = "2026-05-17T10:56:08.126Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/1a/48296b4479ccc9051eb9617a6507a69a68f5b68693fb6a118cfe08199270/basedpyright-1.39.6.tar.gz", hash = "sha256:d00ec5f8ba4e1a67dfc2fa3a9474229c89f61f207d14c02d320db78f57aa16ef", size = 25504244, upload-time = "2026-05-24T07:44:41.864Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/d1/fce034d7b840470bef067543deab51a28d87d1b866a1a4e88752047ef846/basedpyright-1.39.5-py3-none-any.whl", hash = "sha256:dda95954607e3a5e409b5a3083607b69976353cd56c05fdd77e32f6be27c9898", size = 12420680, upload-time = "2026-05-17T10:56:12.685Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/07/6d1b3192715d42e8c9887876684a941eff28ec5d79c23a0f3758377e2182/basedpyright-1.39.6-py3-none-any.whl", hash = "sha256:5e0b9befbae6b26d0fbcc6645ac26923725e749d1224539e24f05ab07f9365ad", size = 13182122, upload-time = "2026-05-24T07:44:47.086Z" },
 ]
 
 [[package]]
@@ -295,14 +291,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.4.0"
+version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/e4/796662cd90cf80e3a363c99db2b88e0e394b988a575f60a17e16440cd011/click-8.4.0.tar.gz", hash = "sha256:638f1338fe1235c8f4e008e4a8a254fb5c5fbdcbb40ece3c9142ebb78e792973", size = 350843, upload-time = "2026-05-17T00:47:58.425Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl", hash = "sha256:40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81", size = 116147, upload-time = "2026-05-17T00:47:56.842Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2", size = 116639, upload-time = "2026-05-22T04:08:35.26Z" },
 ]
 
 [[package]]
@@ -420,15 +416,15 @@ wheels = [
 
 [[package]]
 name = "genai-prices"
-version = "0.0.61"
+version = "0.0.62"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/71/0c76010eec75f4b3623d521044785c0977c14adabe1cac72b004349567fb/genai_prices-0.0.61.tar.gz", hash = "sha256:4b3bcfd49f174c05831b09f9ee36557d3648569e2f594af6c24b72031b3f0e52", size = 67806, upload-time = "2026-05-19T17:01:36.902Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/8e/ed322d1f22b57fd455749bdbe2f285d310e1c1ebe921cb3d5c0b920de648/genai_prices-0.0.62.tar.gz", hash = "sha256:baf1ffa64be0d15577878216464d6a2d04244db5fbdf78d56bde43809e7aef44", size = 67611, upload-time = "2026-05-25T18:47:16.306Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/ec/b08dc2e834ca00fd8dfedcb17ae2e920667adaad617b45e32b7a3b146f24/genai_prices-0.0.61-py3-none-any.whl", hash = "sha256:d77142f61c13e69909ac19c8e44fd315fd65f3afd714e8d55e914fab0eaf47a2", size = 70853, upload-time = "2026-05-19T17:01:37.858Z" },
+    { url = "https://files.pythonhosted.org/packages/81/35/ce64112dcc6f406b3e290dcf57a97acfa2b7d3d0391979219cb9d4a9db6d/genai_prices-0.0.62-py3-none-any.whl", hash = "sha256:5d9ab0d9e5d81e035f88bf591fb6a8dde527922786acf1ee2737358f7bbe0167", size = 70333, upload-time = "2026-05-25T18:47:17.642Z" },
 ]
 
 [[package]]
@@ -561,6 +557,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/34/18f1c596e677962f040284246f393b10a1f8ce440b3a7e69c637d0f1c7ad/httpcore2-2.3.0.tar.gz", hash = "sha256:07327e251560960eea8e969d92d4c6a325feb13cca39e25340731336c3baf924", size = 64300, upload-time = "2026-06-01T13:15:02.998Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/dd/3357218c69360d1cecc196c230c9a1d5c9afd5dba362056e23e60a5e64e5/httpcore2-2.3.0-py3-none-any.whl", hash = "sha256:477e9e334f74e5240dcac002e890580f36a57d40ff0fb14cc9655731d23b8415", size = 80024, upload-time = "2026-06-01T13:15:00.001Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -576,24 +585,27 @@ wheels = [
 ]
 
 [[package]]
-name = "idna"
-version = "3.15"
+name = "httpx2"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/9a/cca0b9145f13d8ae34b885ae28d403a1469a433abc78e0f94f4ce94e650b/httpx2-2.3.0.tar.gz", hash = "sha256:227e7c41d95a76d4077a52640564132777215fc3394e07b66a3116c33d668fa9", size = 81115, upload-time = "2026-06-01T13:15:04.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ce/ae2911859847f9ba1d6b23027e53481cbeb50b93234f355a968d300ca2cb/httpx2-2.3.0-py3-none-any.whl", hash = "sha256:6f393663bdf6dbe7fe90118e3eb5b2bd024a675cae0390ac08cec9198812d8b7", size = 74538, upload-time = "2026-06-01T13:15:01.566Z" },
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "8.7.1"
+name = "idna"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -607,7 +619,7 @@ wheels = [
 
 [[package]]
 name = "inline-snapshot"
-version = "0.33.0"
+version = "0.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asttokens" },
@@ -617,9 +629,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/64/e8/5f661ea222480a5b512c3713abe4ce080a09105ae8212549415f40021fcc/inline_snapshot-0.33.0.tar.gz", hash = "sha256:856cfc18dea755dd78ffa0fbac8c161038ca0bfb4bd0bbb5d519f4bca3dfeff4", size = 2637158, upload-time = "2026-05-12T18:39:47.923Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/6b/70c657a50e61b51d6ac81611230edf50a30aca16b019c2a2fb77efee92a1/inline_snapshot-0.34.0.tar.gz", hash = "sha256:bb814ada843aba77356516dce5e07857bb76591c4258296a087a7cbe9e0d70f7", size = 2638680, upload-time = "2026-05-29T21:01:05.087Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/2c/4b209e9dd6700cea0c0e39d7e5e70e9f494f817a374174a823bd11561d31/inline_snapshot-0.33.0-py3-none-any.whl", hash = "sha256:76b8c2c5899d27d3d464d1160eb3b8eee179ba635bb80a8e5e93220f10b60207", size = 89625, upload-time = "2026-05-12T18:39:46.43Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/cb/c279d8d0775ffabb8c10a7f9ff991cad155a9933cb931e98e81c1c2f9050/inline_snapshot-0.34.0-py3-none-any.whl", hash = "sha256:21a89c1ff18f1a20fa1a9b16567e8a29c01874458c3f2d80a0f97550f1809354", size = 90010, upload-time = "2026-05-29T21:01:03.621Z" },
 ]
 
 [[package]]
@@ -812,7 +824,7 @@ wheels = [
 
 [[package]]
 name = "logfire"
-version = "4.33.0"
+version = "4.35.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "executing" },
@@ -824,18 +836,18 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/66/716dfae86d49f5861998151d9d10a023c225c9cf553d37bf4a7eb8444475/logfire-4.33.0.tar.gz", hash = "sha256:1f0ac129b4f76fd4a61763bff5e9fcd75aff99348b89071faa2f54e1213f856a", size = 1132586, upload-time = "2026-05-13T15:14:15.588Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/20/9508c92ad4ec2ed4ad63a20d72f08427c24117273541ec97c630332855c3/logfire-4.35.0.tar.gz", hash = "sha256:6542aa4ac5e2d2369587deab57a0d1bb9cf6da49634c8cd9c5dbd7c7581f3d51", size = 1148150, upload-time = "2026-06-02T14:55:56.792Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/30/526aa2f7f08073d56e9d9d4d8dffb991225dbd02ec537a06b1c1f8f1c4e9/logfire-4.33.0-py3-none-any.whl", hash = "sha256:eb876a497f2f8cc450005541192ca2e87e0f8781dc20f88b952ab0b141a1ae76", size = 339969, upload-time = "2026-05-13T15:14:12.516Z" },
+    { url = "https://files.pythonhosted.org/packages/77/37/a3631d0b7e4fcb19df4705c7c7e17164c5446e144f034723cf6277749973/logfire-4.35.0-py3-none-any.whl", hash = "sha256:9ae5c3f2dd81144ccf1ec6dba1a5de84aff5b2e2b8dd2190e53e87e47bc63711", size = 347012, upload-time = "2026-06-02T14:55:53.244Z" },
 ]
 
 [[package]]
 name = "logfire-api"
-version = "4.33.0"
+version = "4.35.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/1a/c44eb3a02407aa739669822d19734e76e8751284b86cd99c73baca36998a/logfire_api-4.33.0.tar.gz", hash = "sha256:0a604f710e803db08a2ddc41e6152bf8d8a56b549f8856cbf82baa36bc7de2c9", size = 81483, upload-time = "2026-05-13T15:14:17.348Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/25/016b7d5e0433ae28d8a8bcb18681c48da2a0cdbf0ca8f7b2acdac2f16f4a/logfire_api-4.35.0.tar.gz", hash = "sha256:dcc073c7e337b0005f63075cf89951bacf00944b7c7420c2422b18133c8d2605", size = 83091, upload-time = "2026-06-02T14:55:58.573Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/58/dc21672e0d5294668f4d35aaba4d839d031f096b4cf6802399c4b411b5fc/logfire_api-4.33.0-py3-none-any.whl", hash = "sha256:b992727bab71412b5a00f54453eec18e559232c83d7120cf5c6a9edd33fb0c4e", size = 128896, upload-time = "2026-05-13T15:14:14.322Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/861f2040b251aa12b653b104c314b7d140cb44a6ab19cb141535aa72beb9/logfire_api-4.35.0-py3-none-any.whl", hash = "sha256:c8eb8f49c261c09b3d815b22ecba1c5224e8ba9aa9b546b0afcdb13a89fa6bfe", size = 131026, upload-time = "2026-06-02T14:55:55.252Z" },
 ]
 
 [[package]]
@@ -990,23 +1002,23 @@ wheels = [
 
 [[package]]
 name = "nodejs-wheel-binaries"
-version = "24.15.0"
+version = "24.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3f/70/a1e4f4d5986768ab90cc860b1cc3660fd2ded74ca175a900a5c29f839c7d/nodejs_wheel_binaries-24.15.0.tar.gz", hash = "sha256:b43f5c4f6e5768d8845b2ae4682eb703a19bf7aadc84187e2d903ed3a611c859", size = 8057, upload-time = "2026-04-19T15:48:16.899Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/22/2a5beb4e21417c73233d9f65cf6f3e96e891b80d2f550a8f630ebc6b88c6/nodejs_wheel_binaries-24.16.0.tar.gz", hash = "sha256:c973cb69dc5fd16e6f6dc6e579e2c3d5534e2a1f57619dddf5ba070efa7dde37", size = 8056, upload-time = "2026-05-30T16:52:09.807Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/66/54051d14853d6ab4fb85f8be9b042b530be653357fb9a19557498bc91ab7/nodejs_wheel_binaries-24.15.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:a6232fa8b754220941f52388c8ead923f7c1c7fdf0ea0d98f657523bd9a81ef4", size = 55173485, upload-time = "2026-04-19T15:47:34.561Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/5f/66acada164da5ca10a0824db021aa7394ae18396c550cd9280e839a43126/nodejs_wheel_binaries-24.15.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:001a6b62c69d9109c1738163cca00608dd2722e8663af59300054ea02610972d", size = 55348100, upload-time = "2026-04-19T15:47:40.521Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/2d/0cbd5ff40c9bb030ca1735d8f8793bd74f08a4cbd49100a1d19313ea57ab/nodejs_wheel_binaries-24.15.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:0fbc48765e60ed0ff30d43898dbf5cadbadf2e5f1e7f204afc2b01493b7ebce6", size = 59668206, upload-time = "2026-04-19T15:47:46.848Z" },
-    { url = "https://files.pythonhosted.org/packages/da/d5/91ac63951ec75927a486b83b8cafe650e360fa70ac01dc94adfb32b93b97/nodejs_wheel_binaries-24.15.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:20ee0536809795da8a4942fc1ab4cbdebbcaaf29383eab67ba8874268fb00008", size = 60206736, upload-time = "2026-04-19T15:47:52.668Z" },
-    { url = "https://files.pythonhosted.org/packages/db/72/dc22776974d928869c0c30d23ee98ed7df254243c2df68f09f5963e8e8b8/nodejs_wheel_binaries-24.15.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1fade6c214285e72472ca40a631e98ff36559671cd5eefc8bf009471d67f04b4", size = 61720456, upload-time = "2026-04-19T15:47:58.325Z" },
-    { url = "https://files.pythonhosted.org/packages/01/0a/34461b9050cb45ee371dccdefc622aef6351506ea2691b08fc761ca67150/nodejs_wheel_binaries-24.15.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3984cb8d87766567aee67a49743227ab40ede6f47734ec990ff90e50b74e7740", size = 62326172, upload-time = "2026-04-19T15:48:04.094Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/17/09252bf35672dba926649d59dfe51443a0f6955ad13784e91131d5ec82a2/nodejs_wheel_binaries-24.15.0-py2.py3-none-win_amd64.whl", hash = "sha256:a437601956b532dcb3082046e6978e622733f90edc0932cbb9adb3bb97a16501", size = 41543461, upload-time = "2026-04-19T15:48:09.332Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/7e/b649777d148e1e0c2ce349156603cdb12f7ed99921b95d93717393650193/nodejs_wheel_binaries-24.15.0-py2.py3-none-win_arm64.whl", hash = "sha256:bdf4a431e08321a32efc604111c6f23941f87055d796a537e8c4110daecad23f", size = 39233248, upload-time = "2026-04-19T15:48:13.326Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d1/68b43b53cd0fa83ae6fd406705023ca988d9e0ca41c724d82e66fbeb2ef6/nodejs_wheel_binaries-24.16.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:d9f8f677dcf30e37ac244f07869726abe043f01eb0f45722b1df31cc2af7093c", size = 55666374, upload-time = "2026-05-30T16:51:39.588Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/b2/40a989159599080da485de966c4c2d207e852ac7aa7864702626d96c8bf5/nodejs_wheel_binaries-24.16.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:3d0370fe7120ce9697a4f60d40480d2bd8808d9f30131458d5afc0040d4e5a51", size = 55838487, upload-time = "2026-05-30T16:51:43.383Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a7/cd42174fb5ff6faff7fa8d326a18914d8f232098ab5de055b57c16fa13ca/nodejs_wheel_binaries-24.16.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:85dc92bbb79c851569c5925dcc2a4c915a034efab375f99e4e7e6bbe9cca8342", size = 60179540, upload-time = "2026-05-30T16:51:47.036Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/c8a1f9ae140aa28df8744d984d01d4b3af7cdd6555af12127f40ceb45a7d/nodejs_wheel_binaries-24.16.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:2f3036292811514ba847b3708492644764f88a833ac425c5f55007014308ddfd", size = 60716262, upload-time = "2026-05-30T16:51:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/7c35b3737f59e36d0249c265397b7bff570519b95301d6e16ea361e904ad/nodejs_wheel_binaries-24.16.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:db8a8a76ebd2b28ecbfc9ad464baa3707241b9e050a30e2efdf6f60c0f886502", size = 62230592, upload-time = "2026-05-30T16:51:55Z" },
+    { url = "https://files.pythonhosted.org/packages/04/96/d931255cf9d11a84d6b54d882dba7434646467d568ccf070ea3418638df3/nodejs_wheel_binaries-24.16.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f1a3d8f7b4491cbbd023ba3fc4e901fcca2d9fb80d57f24ba3890de8b1dbac03", size = 62841759, upload-time = "2026-05-30T16:51:59.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/7b/8b7a3f41bc255411be30b6d7d288aab8ffd9ea2055db8555ced3548007b9/nodejs_wheel_binaries-24.16.0-py2.py3-none-win_amd64.whl", hash = "sha256:bb136be9944f0662dcf1120f45193a6b75b13fac378971a95cc42c9f879a81aa", size = 42027734, upload-time = "2026-05-30T16:52:03.348Z" },
+    { url = "https://files.pythonhosted.org/packages/17/66/1ed71f1f529b8ca727d42c7ceb9db0bef145ce4a13dfc86fb50aa44f3be6/nodejs_wheel_binaries-24.16.0-py2.py3-none-win_arm64.whl", hash = "sha256:8308940b5edd0a50dc5267ea36ba21c9f668e83fe0d9f293937174d3a7e31c36", size = 39714528, upload-time = "2026-05-30T16:52:06.421Z" },
 ]
 
 [[package]]
 name = "openai"
-version = "2.37.0"
+version = "2.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1018,39 +1030,38 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/50/5901f01ef14e6c27788beb91e54fef5d6204fb5fb9e97402fc8a14de2e32/openai-2.37.0.tar.gz", hash = "sha256:f4bc562cc5f3a43d40d678105572d9d44765f6e0f50c125f63055419b72f4bd9", size = 754706, upload-time = "2026-05-15T22:30:35.428Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/9f/136562ec6c3b1a50fe06eb0bb34ed21f0d7426ec0140e5cc43ac785b69a5/openai-2.40.0.tar.gz", hash = "sha256:9a756f91f274a24ad6026cbcb2042fd356c8d4a10e8f347b08d34465e585f7a2", size = 781177, upload-time = "2026-06-01T21:48:23.878Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ed/4c/bce61680d0699a78a405fd9a67989b175ba020590428831aab2ab1d2be7c/openai-2.37.0-py3-none-any.whl", hash = "sha256:814633888b8f3b1ffd6615697c6e4ef93632d08b7c2e28c8c5ef3556e5a10107", size = 1303238, upload-time = "2026-05-15T22:30:32.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/46/180e14be801a75bc13f234cb1b594b232adeb9c84e60a9ab1832e8333591/openai-2.40.0-py3-none-any.whl", hash = "sha256:2b205637ff214477f9ce9ab035e9f494db0e3fa8f1e599008953735fbf6ff1ff", size = 1350935, upload-time = "2026-06-01T21:48:21.462Z" },
 ]
 
 [[package]]
 name = "opentelemetry-api"
-version = "1.41.1"
+version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/59/3e7118ed140f76b0982ba4321bdaed1997a0473f9720de2d10788a577033/opentelemetry_api-1.41.1-py3-none-any.whl", hash = "sha256:a22df900e75c76dc08440710e51f52f1aa6b451b429298896023e60db5b3139f", size = 69007, upload-time = "2026-04-24T13:15:15.662Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl", hash = "sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714", size = 61311, upload-time = "2026-05-21T16:32:28.822Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-common"
-version = "1.41.1"
+version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-proto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/fa/f9e3bd3c4d692b3ce9a2880a167d1f79681a1bea11f00d5bf76adc03e6ea/opentelemetry_exporter_otlp_proto_common-1.41.1.tar.gz", hash = "sha256:0e253156ea9c36b0bd3d2440c5c9ba7dd1f3fb64ba7a08fc85fbac536b56e1fb", size = 20409, upload-time = "2026-04-24T13:15:40.924Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0e/9c/216acfeaedadf2e1937f4373929b20f73197c5c4a2546d4f584b7fa63813/opentelemetry_exporter_otlp_proto_common-1.42.1.tar.gz", hash = "sha256:04f1f01fb597c4249dfcd7f8b861c902c2102369d376d9d346ff38de4469a2ee", size = 21433, upload-time = "2026-05-21T16:32:55.526Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/48/bce76d3ea772b609757e9bc844e02ab408a6446609bf74fb562062ba6b71/opentelemetry_exporter_otlp_proto_common-1.41.1-py3-none-any.whl", hash = "sha256:10da74dad6a49344b9b7b21b6182e3060373a235fde1528616d5f01f92e66aa9", size = 18366, upload-time = "2026-04-24T13:15:18.917Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/2375e7612e1121a4518c17603b6e0b03ad94f565aafad53f464dc5be2bf6/opentelemetry_exporter_otlp_proto_common-1.42.1-py3-none-any.whl", hash = "sha256:f48d395ab815b444da118868977e9798ea354c25737d5cf39578ae894011c140", size = 17327, upload-time = "2026-05-21T16:32:33.387Z" },
 ]
 
 [[package]]
 name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.41.1"
+version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
@@ -1061,14 +1072,14 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/5b/9d3c7f70cca10136ba82a81e738dee626c8e7fc61c6887ea9a58bf34c606/opentelemetry_exporter_otlp_proto_http-1.41.1.tar.gz", hash = "sha256:4747a9604c8550ab38c6fd6180e2fcb80de3267060bef2c306bad3cb443302bc", size = 24139, upload-time = "2026-04-24T13:15:42.977Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/32/826bfa1d80ecea24f47808de03cd4a0d13c17ecc07712f45123f0f61e4ac/opentelemetry_exporter_otlp_proto_http-1.42.1.tar.gz", hash = "sha256:bf142a21035d7571ac3a09cb2e5639f49886f243972883cfe777ed3bf02b734d", size = 25406, upload-time = "2026-05-21T16:32:56.807Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/4d/ef07ff2fc630849f2080ae0ae73a61f67257905b7ac79066640bfa0c5739/opentelemetry_exporter_otlp_proto_http-1.41.1-py3-none-any.whl", hash = "sha256:1a21e8f49c7a946d935551e90947d6c3eb39236723c6624401da0f33d68edcb4", size = 22673, upload-time = "2026-04-24T13:15:21.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/96/82cb223a1502f0787d4bbff12907f5f8d870a50731febcd5818d93ef9555/opentelemetry_exporter_otlp_proto_http-1.42.1-py3-none-any.whl", hash = "sha256:00a16da1b312a1d6c7233d600d557c91df71125af73020f3b9a7765bd699d59d", size = 21793, upload-time = "2026-05-21T16:32:35.277Z" },
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation"
-version = "0.62b1"
+version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
@@ -1076,48 +1087,48 @@ dependencies = [
     { name = "packaging" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/cb/0523b92c112a6cc70be43724343dc45225d3af134419844d7879a07755d4/opentelemetry_instrumentation-0.62b1.tar.gz", hash = "sha256:90e92a905ba4f84db06ac3aec96701df6c079b2d66e9379f8739f0a1bdcc7f45", size = 34043, upload-time = "2026-04-24T13:22:31.997Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/6d/4de72d97ff54db1ed270c7a59c9b904b917c0ac7af429c086c388b824ddb/opentelemetry_instrumentation-0.63b1.tar.gz", hash = "sha256:32368d6ae52c8de20aa790a6ad86b10a76f09956092337ae37d675773990e541", size = 41081, upload-time = "2026-05-21T16:36:14.206Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/0f/45adbaea1f81b847cffdcee4f4b5f89297e42facf7fac78c7aaac4c38e75/opentelemetry_instrumentation-0.62b1-py3-none-any.whl", hash = "sha256:976fc6e640f2006599e97429c949e622c108d0c17c2059347d1e6c93c707f257", size = 34163, upload-time = "2026-04-24T13:21:31.722Z" },
+    { url = "https://files.pythonhosted.org/packages/35/a1/9314e621c143e4d82a5bf7a43c2ff7a745d31023506336857607c8c543cc/opentelemetry_instrumentation-0.63b1-py3-none-any.whl", hash = "sha256:f1986716d52cc316ea5f60189098726a9071d8ecc0eee96c9ed110be08bade9c", size = 35577, upload-time = "2026-05-21T16:34:56.818Z" },
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "1.41.1"
+version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/99/e8/633c6d8a9c8840338b105907e55c32d3da1983abab5e52f899f72a82c3d1/opentelemetry_proto-1.41.1.tar.gz", hash = "sha256:4b9d2eb631237ea43b80e16c073af438554e32bc7e9e3f8ca4a9582f900020e5", size = 45670, upload-time = "2026-04-24T13:15:49.768Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/55/63eac3e1089b768ba014091fdd2ae8a9a440c821ef5e2b786909c94c8836/opentelemetry_proto-1.42.1.tar.gz", hash = "sha256:c6a51e6b4f05ae63565f3a113217f3d2bfaec68f78c02d7a6c85f9010d1cfca6", size = 45839, upload-time = "2026-05-21T16:33:03.937Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/1e/5cd77035e3e82070e2265a63a760f715aacd3cb16dddc7efee913f297fcc/opentelemetry_proto-1.41.1-py3-none-any.whl", hash = "sha256:0496713b804d127a4147e32849fbaf5683fac8ee98550e8e7679cd706c289720", size = 72076, upload-time = "2026-04-24T13:15:32.542Z" },
+    { url = "https://files.pythonhosted.org/packages/41/9d/171c02c84a76940b7e601805b3bb536985aded9168fbcc9ba52f0a730fa2/opentelemetry_proto-1.42.1-py3-none-any.whl", hash = "sha256:dedb74cba2886c59c7789b227a7a670613025a07489040050aedff6e5c0fb43c", size = 71782, upload-time = "2026-05-21T16:32:44.867Z" },
 ]
 
 [[package]]
 name = "opentelemetry-sdk"
-version = "1.41.1"
+version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-semantic-conventions" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/d0/54ee30dab82fb0acda23d144502771ff76ef8728459c83c3e89ef9fb1825/opentelemetry_sdk-1.41.1.tar.gz", hash = "sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6", size = 230180, upload-time = "2026-04-24T13:15:50.991Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/f7/b390bd9bfd703bf98a68fea1f27786c6872331fd617164a54b8a59bdc008/opentelemetry_sdk-1.42.1.tar.gz", hash = "sha256:8c834e8f8c9ba4171d4ec843d0cb8a67e4c7394d3f9e9297e582cbd9456ddbf7", size = 239262, upload-time = "2026-05-21T16:33:04.641Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/e7/a1420b698aad018e1cf60fdbaaccbe49021fb415e2a0d81c242f4c518f54/opentelemetry_sdk-1.41.1-py3-none-any.whl", hash = "sha256:edee379c126c1bce952b0c812b48fe8ff35b30df0eecf17e98afa4d598b7d85d", size = 180213, upload-time = "2026-04-24T13:15:33.767Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/6b/4287766cfbde577ae2272e8884abac325aeaac0d64f41c61d5b8cc595105/opentelemetry_sdk-1.42.1-py3-none-any.whl", hash = "sha256:083cd4bbfaa5aa7b5a9e552430d9951219967cfb27aa61feb13a77aba1fc839d", size = 170907, upload-time = "2026-05-21T16:32:45.894Z" },
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.62b1"
+version = "0.63b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-api" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/de/911ac9e309052aca1b20b2d5549d3db45d1011e1a610e552c6ccdd1b64f8/opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802", size = 145750, upload-time = "2026-04-24T13:15:52.236Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/99/4d7dd6df64795951413ce6e815f8cf1eb191daf7196ae86574589643d5f3/opentelemetry_semantic_conventions-0.63b1.tar.gz", hash = "sha256:3daf963611334b365e98a57438183eb012d3bfb40b2d931a9af613476b8701a9", size = 148340, upload-time = "2026-05-21T16:33:05.455Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/a6/83dc2ab6fa397ee66fba04fe2e74bdf7be3b3870005359ceb7689103c058/opentelemetry_semantic_conventions-0.62b1-py3-none-any.whl", hash = "sha256:cf506938103d331fbb78eded0d9788095f7fd59016f2bda813c3324e5a74a93c", size = 231620, upload-time = "2026-04-24T13:15:35.454Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7a/7fe66f5f3682b1dd47d88cc4e11f1c6c0966b737de2d16671146e23c39a5/opentelemetry_semantic_conventions-0.63b1-py3-none-any.whl", hash = "sha256:dfe5ef4dee82586b746f522b818ceb298d00b3d59f660042bd79404bff8d0682", size = 203713, upload-time = "2026-05-21T16:32:47.016Z" },
 ]
 
 [[package]]
@@ -1140,11 +1151,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.6"
+version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
@@ -1207,7 +1218,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-ai-slim"
-version = "1.100.0"
+version = "1.105.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
@@ -1219,9 +1230,9 @@ dependencies = [
     { name = "pydantic-graph" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/db/3eb296369e3001f82d7552060c3811307809954b7c7ec30499f383d3c87a/pydantic_ai_slim-1.100.0.tar.gz", hash = "sha256:cc755c7970b2e041764b9d2f74d50cbad3cf7989b14cdbf62d356f25eb2a1222", size = 726289, upload-time = "2026-05-21T04:04:59.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/ae/1b0370f9b9f1ca7ccf2e6b51ec5a8d11da11d9dd621e5eb015c6420c5e9b/pydantic_ai_slim-1.105.0.tar.gz", hash = "sha256:8b4ad8034b40ab3bde8e0c6285082a204ecd203007150a47943f192b474e06e9", size = 772048, upload-time = "2026-06-02T06:20:01.522Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/a6/164b070c59f7c69e81cb5fd38225da24c4587a8fe629af49c72709182ffc/pydantic_ai_slim-1.100.0-py3-none-any.whl", hash = "sha256:422a721b7a7157daff749a6eec9a4ba2e3e7efc28ae5a2bdfe468529eaf81aaf", size = 901788, upload-time = "2026-05-21T04:04:49.147Z" },
+    { url = "https://files.pythonhosted.org/packages/12/6e/8afdff693d21c0743ee71d792ce90afc27d4ddbaf7270d969a84452cfd0d/pydantic_ai_slim-1.105.0-py3-none-any.whl", hash = "sha256:1e65561ba9a58a9d8fc3a63b550c3c2b2c4017da275dea78291e526aa06298d8", size = 956108, upload-time = "2026-06-02T06:19:52.821Z" },
 ]
 
 [package.optional-dependencies]
@@ -1351,7 +1362,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-graph"
-version = "1.100.0"
+version = "1.105.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1359,9 +1370,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/8b/eee672fa01eec3ea34e7d8962d54aa16d658ad0723466122a7ba2828caa1/pydantic_graph-1.100.0.tar.gz", hash = "sha256:7651fa6ccce9d88a35b1d2cfe79d5d1dbb2415457503009195014bf31f6075bd", size = 62559, upload-time = "2026-05-21T04:05:01.682Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/98/0361e1eb28f8d107e4e12dcd2d14eabef55f4a8ca18b1a6f185df74934c0/pydantic_graph-1.105.0.tar.gz", hash = "sha256:3f5cf97d544b900098d3cc2dbd6a8cdd79ea59dac610d7651f86c9228d33c0b9", size = 62570, upload-time = "2026-06-02T06:20:05.158Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/12/21d6a68743229553c8ba9ca19da73c2d7e18dc6f8fbfd56c8c12c5587cb6/pydantic_graph-1.100.0-py3-none-any.whl", hash = "sha256:ba0b0a70bfd320b58b7012614b857f4b12dbb95b233da7127a6ff973c03d24e7", size = 80101, upload-time = "2026-05-21T04:04:53.635Z" },
+    { url = "https://files.pythonhosted.org/packages/be/1b/13882fd4d70299dc2995bee20f21599cb8d453b27f44e239f82384d4ea3f/pydantic_graph-1.105.0-py3-none-any.whl", hash = "sha256:ba76d77ad21a13f2961fbda9d988f3d5a3d9ffc1817ee912e0ea59b0b5a9e825", size = 80099, upload-time = "2026-06-02T06:19:57.098Z" },
 ]
 
 [[package]]
@@ -1652,27 +1663,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.13"
+version = "0.15.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/21/a7d5c126d5b557715ef81098f3db2fe20f622a039ff2e626af28d674ab80/ruff-0.15.13.tar.gz", hash = "sha256:f9d89f17f7ba7fb2ed42921f0df75da797a9a5d71bc39049e2c687cf2baf44b7", size = 4678180, upload-time = "2026-05-14T13:44:37.869Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/61/11d458dc6ac22504fd8e237b29dfd40504c7fbbcc8930402cfe51a8e63ed/ruff-0.15.13-py3-none-linux_armv6l.whl", hash = "sha256:444b580fc72fd6887e650acd3e575e18cdc79dbcf42fb4030b491057921f61f8", size = 10738279, upload-time = "2026-05-14T13:44:18.7Z" },
-    { url = "https://files.pythonhosted.org/packages/86/ca/caa871ee7be718c45256fada4e16a218ee3e33f0c4a46b729a60a24912e6/ruff-0.15.13-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6590d009e7cb7ebf36f83dbdd44a3fa48a0994ff6f1cdc1b08006abe58f98dc7", size = 11124798, upload-time = "2026-05-14T13:44:06.427Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/19/43f5f2e568dddde567fc41f8471f9432c09563e19d3e617a48cfa52f8f0a/ruff-0.15.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1c26d2f66163deeb6e08d8b39fbbe983ce3c71cea06a6d7591cfd1421793c629", size = 10460761, upload-time = "2026-05-14T13:44:04.375Z" },
-    { url = "https://files.pythonhosted.org/packages/99/df/cf938cd6de3003178f03ad7c1ea2a6c099468c03a35037985070b37e76be/ruff-0.15.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9dbd6f94b434f896308e4d57fb7bfde0d02b99f7a64b3bdab0fdfa6a864203a5", size = 10804451, upload-time = "2026-05-14T13:44:25.221Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/7d/5d0973129b154ded2225729169d7068f26b467760b146493fde138415f23/ruff-0.15.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3259f3be4d181bda591da5db2571aed6853c6a048157756448020bc6c5cd22", size = 10534285, upload-time = "2026-05-14T13:44:08.888Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/e3/6b999bbc66cd51e5f073842bc2a3995e99c5e0e72e16b15e7261f7abf57a/ruff-0.15.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae9c17e5eb4430c154e76abc25d79a318190f5a997f38fb6b114416c5319ffc9", size = 11312063, upload-time = "2026-05-14T13:44:11.274Z" },
-    { url = "https://files.pythonhosted.org/packages/af/5a/642639e9f5db04f1e97fbd6e091c6fd20725bdf072fb114d00eefb9e6eb8/ruff-0.15.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e2e39bff6c341f4b577a21b801326fab0b11847f48fcaa83f00a113c9b3cb55", size = 12183079, upload-time = "2026-05-14T13:44:01.634Z" },
-    { url = "https://files.pythonhosted.org/packages/19/4c/7585735f6b53b0f12de13618b2f7d250a844f018822efc899df2e7b8295f/ruff-0.15.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e8d9a8e08013542e94d3220bc5b62cc3e5ef87c5f74bff367d3fac14fab013e6", size = 11440833, upload-time = "2026-05-14T13:43:59.043Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/31/bf1a0803d077e679cfeee5f2f67290a0fa79c7385b5d9a8c17b9db2c48f0/ruff-0.15.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc411dfebe5eebe55ce041c6ae080eb7668955e866daa2fbb16692a784f1c4ca", size = 11434486, upload-time = "2026-05-14T13:44:27.761Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/4e/62c9b999875d4f14db80f277c030578f5e249c9852d65b7ac7ad0b43c041/ruff-0.15.13-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:768494eb08b9cee54e2fd27969966f74db5a57f6eaa7a90fcb3306af34dfc4bd", size = 11385189, upload-time = "2026-05-14T13:44:13.704Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/89/7e959047a104df3eb12863447c110140191fc5b6c4f379ea2e803fcdb0e4/ruff-0.15.13-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fb75f9a3a7e42ffe117d734494e6c5e5cb3565d66e12612cb63d0e572a41a5b6", size = 10781380, upload-time = "2026-05-14T13:43:56.734Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/52/5fd18f3b88cab63e88aa11516b3b4e1e5f720e5c330f8dbe5c26210f41f8/ruff-0.15.13-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8cb74dd33bb2f6613faf7fc03b660053b5ac4f80e706d5788c6335e2a8048d51", size = 10540605, upload-time = "2026-05-14T13:44:20.748Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/e0/9e35f338990d3e41a82875ff7053ffe97541dae81c9d02143177f381d572/ruff-0.15.13-py3-none-musllinux_1_2_i686.whl", hash = "sha256:7ef823f817fcd191dc934e984be9cf4094f808effa16f2542ad8e821ba02bbf2", size = 11036554, upload-time = "2026-05-14T13:44:16.256Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/13/070fb048c24080fba188f66371e2a92785be257ad02242066dc7255ac6e9/ruff-0.15.13-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f345a13937bd7f09f6f5d19fa0721b0c103e00e7f62bc67089a8e5e037719e0b", size = 11528133, upload-time = "2026-05-14T13:44:22.808Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/8c/b1e1666aef7fc6555094d73ae6cd981701781ae85b97ceefc0eebd0b4668/ruff-0.15.13-py3-none-win32.whl", hash = "sha256:4044f94208b3b05ba0fc4a4abd0558cf4d6459bd18325eead7fd8cc66f909b41", size = 10721455, upload-time = "2026-05-14T13:44:35.697Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/a6/870a3e8a50590bb92be184ad928c2922f088b00d9dc5c5ec7b924ee08c22/ruff-0.15.13-py3-none-win_amd64.whl", hash = "sha256:7064884d442b7d477b4e7473d12da7f08851d2b1982763c5d3f388a19468a1a4", size = 11900409, upload-time = "2026-05-14T13:44:30.389Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/36/9c015cd052fca743dae8cb2aeb16b551444787467db42ceab0fc968865af/ruff-0.15.13-py3-none-win_arm64.whl", hash = "sha256:2471da9bd1068c8c064b5fd9c0c4b6dddffd6369cb1cd68b29993b1709ff1b21", size = 11179336, upload-time = "2026-05-14T13:44:33.026Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
+    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
+    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
 ]
 
 [[package]]
@@ -1695,11 +1706,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]
@@ -1830,6 +1841,15 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1861,95 +1881,86 @@ wheels = [
 
 [[package]]
 name = "wrapt"
-version = "2.2.0"
+version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e2/f0/5e969d268d59e6035f2f1960da9e82fe6db24a7b8abe8e36a78c27cb3e2b/wrapt-2.2.0.tar.gz", hash = "sha256:b70a0b75b0a5a58d04aad06b3f167d49e729381d3417413656220c0cd7617847", size = 125173, upload-time = "2026-05-21T04:51:39.218Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620, upload-time = "2026-05-22T14:49:43.056Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/c6/17263421accbbc27bc4c8535eb9215a18a914d15eab4829a59e93f5ad29d/wrapt-2.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2b3946f0ff079623dc4f117363040433be390bfebce3719de50dfecbf31efdf0", size = 80088, upload-time = "2026-05-21T04:49:10.381Z" },
-    { url = "https://files.pythonhosted.org/packages/40/0d/81230469d6a7c6878e0763b7d84ebab6da3625ce62e8fd83086c982b8726/wrapt-2.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a50822bbbefb90b132a780c17356062a2452cd5525bfa4b5b596fd6474cceaa6", size = 81177, upload-time = "2026-05-21T04:49:12.589Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/5a/a09c8346f270ab1328ba9e6594d73d86450de22bc4d29a23167ff82d7ec1/wrapt-2.2.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:29c0b2c075f8854b3345be584ab3d84f8968c45605d1914be1c94939cef5d702", size = 152069, upload-time = "2026-05-21T04:49:14.346Z" },
-    { url = "https://files.pythonhosted.org/packages/40/5e/79b6d6295733b9fa1bee096120a556366951e3c0140234310080ede40e42/wrapt-2.2.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2f0d4a79d9af893d80caa5b709e024dd2d387f3f047008286036143f118d7010", size = 154319, upload-time = "2026-05-21T04:49:16.097Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/4d/a72b95e9389a4f350150d9a3ce9b263bad16f476551004a12de167ae7d0b/wrapt-2.2.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10e8f78948d13369b770fc17bf72272aac98b4b92d49a38f479abf718f6b615b", size = 148874, upload-time = "2026-05-21T04:49:17.751Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/56/ffec9a08beb6fcfc30b259c6b8b36741675c58de69f1c035746f06fa4a07/wrapt-2.2.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a4482d1d4108052827b354850bd6e3d1ed56262cbe4b0e8051876c298fb99280", size = 153250, upload-time = "2026-05-21T04:49:19.413Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/c5/7ab2e23d594f28b2fc00bd19e82163bce2f77e2bc916e9dc247e0f886a41/wrapt-2.2.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:43c36019a690b2cb089665eab01a50c92d814553c6e57ff03d2c68e63ce8f00b", size = 147902, upload-time = "2026-05-21T04:49:20.749Z" },
-    { url = "https://files.pythonhosted.org/packages/74/61/565965b9613dccf20286880e314cc41b20a85b2f4a7fe275786bb08b330e/wrapt-2.2.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cb9336f2dc99de00c9e58487cae5541ee4d79e859377b6312d98973d4661c584", size = 151334, upload-time = "2026-05-21T04:49:22.695Z" },
-    { url = "https://files.pythonhosted.org/packages/32/0e/1890765d97cc3016ba444f8158856a35f8944785660eb88ff73b2d1e2b9b/wrapt-2.2.0-cp310-cp310-win32.whl", hash = "sha256:63a09b40bba3b2482983e2aeba6e45e20e1f567821ac89c8922229ecc1de7f65", size = 77405, upload-time = "2026-05-21T04:49:24.43Z" },
-    { url = "https://files.pythonhosted.org/packages/02/02/a943f4d0f9084a354a722468ff2899e9177449f03f4bff8ef234792f27ad/wrapt-2.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:2ff803b3607cd76cb9b853b03d15279c7ffc8ba69e69f76304cd23d2722f2b65", size = 80353, upload-time = "2026-05-21T04:49:25.87Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/c2/2c7838cf368c04aebaef93f756f5b76e0eb12bb710c2926111dc96e5aaf9/wrapt-2.2.0-cp310-cp310-win_arm64.whl", hash = "sha256:af17d3ce1e2cc5d22ae8fe8921d7801c980ea3f5d6da4ecbd0f85c4f9e030181", size = 79121, upload-time = "2026-05-21T04:49:27.778Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/2e/a3eb4a1ef48fc743c4107e82d5b1144287ef8353b0f6844fee1add28d663/wrapt-2.2.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b93e1ccddbdf59cec4f7683dc84bc56eb61628eb01b22bdefc15f04cd09f8fae", size = 80324, upload-time = "2026-05-21T04:49:29.402Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/23/03248de44165f9c06dc23da981f3d58889ee2600004289c7afd12ef316b1/wrapt-2.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:97fbe7a0df35afe37e7e2f053dee6300a3eed00055cfd907fa51161e22c40236", size = 81201, upload-time = "2026-05-21T04:49:30.691Z" },
-    { url = "https://files.pythonhosted.org/packages/39/99/ed8c0f9f0d3c9631259bf5c5d776ec7a70d6d888ce060ad4758f00a29683/wrapt-2.2.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d8f6cf451ec4aab0cdbad128d9be1219e95ceaa9940566d71570b2d820ee50b3", size = 158770, upload-time = "2026-05-21T04:49:32.299Z" },
-    { url = "https://files.pythonhosted.org/packages/25/fc/6eed4204b30562f113e40151b94ec1ee565c040d90623a4223742cf5aa68/wrapt-2.2.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f1dc1d1a2f0b081d8c1eef2203e61717b537a1bcb0d8e4d1405aeb15aa85c34", size = 160322, upload-time = "2026-05-21T04:49:33.959Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/3d/cb9d33c140cce69e025d946deac44c636ce16a079cd4410722b552aecb5e/wrapt-2.2.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:952ec99e71d584a0e451795dbd468909c8794727ecddd9ebb4fe9803e2803f1e", size = 153088, upload-time = "2026-05-21T04:49:35.715Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/fd/e452de05a75c008acef9055dd9a58fc6a4d08a5e42747394a91030f83169/wrapt-2.2.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:33ff34dc349320dc16ebe0cdf70dddf5ae9328f4a448823a00f37976d0cc2234", size = 159258, upload-time = "2026-05-21T04:49:38.249Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/03/c06ee1605a5b11da535b64e26c9f2330de7a8e3a2253afc533f37a5a682f/wrapt-2.2.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:d23ea5a8e4ae99640d027d2fd05c9d03f8d24d561fc26c0462e96affa31bf408", size = 152155, upload-time = "2026-05-21T04:49:39.69Z" },
-    { url = "https://files.pythonhosted.org/packages/47/f8/d7cb1d184afe5a1db15515f86758fd08fa795a650f2af18ff221758921d7/wrapt-2.2.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9c95f72d212e1f178f9619b77fd7ee3533e82ded6a5ad119dd88134e185ee3b0", size = 157920, upload-time = "2026-05-21T04:49:41.225Z" },
-    { url = "https://files.pythonhosted.org/packages/92/80/5bbdade010313edbb14afbdd916a054c74c99c2f04b0f8358086c728815a/wrapt-2.2.0-cp311-cp311-win32.whl", hash = "sha256:db93eebcf951f9ee41d75dc0423378fa918fc6706db59bc20c02f6563b6b210d", size = 77572, upload-time = "2026-05-21T04:49:42.913Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/32/9df5dd381c2d4d9f14d8d442de4efd8ef8fda3df8b25a384e7060a6d91a8/wrapt-2.2.0-cp311-cp311-win_amd64.whl", hash = "sha256:22c7ee3a3737d9656ddf2c9cc1f1548ec963d966251e899561da142697d33a9d", size = 80624, upload-time = "2026-05-21T04:49:44.411Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/5c/3c441a01c9e1f072f0a9c062a3aa709b3fe488af649ecb0b74206e5a9754/wrapt-2.2.0-cp311-cp311-win_arm64.whl", hash = "sha256:7e291fa9129d9998ed5035390d4bb9cf429c489f40e5ddaa06a1e83ed52048a7", size = 79003, upload-time = "2026-05-21T04:49:45.687Z" },
-    { url = "https://files.pythonhosted.org/packages/83/ac/0d40f7f625b78d698dd8fcaf2df31585d2185dd0c261b82f7cc334c53168/wrapt-2.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8a76b27fe0d600f8a34313e1a528309aa807a16aa3a72000619bc56339020125", size = 80992, upload-time = "2026-05-21T04:49:47.024Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/56/bec7ac3b1c40bee400aecf0db3abee9d3461fd8f02eb42fb02693092b3d9/wrapt-2.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:778aa2f59615973f2637d9025a708b69196c4814f38d905647fa1a56d7ff6b79", size = 81648, upload-time = "2026-05-21T04:49:48.382Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/a9/6ecf97645bde3fc5faa980516f7007ece0b38d3219e5add54042d3ae8b4e/wrapt-2.2.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5b7f10aa09d1f5abfe3ccd022dec566a5010465b98b3755cc0705a762547101f", size = 168683, upload-time = "2026-05-21T04:49:49.703Z" },
-    { url = "https://files.pythonhosted.org/packages/10/69/de03c995ade9b215f2c019be6442fc206b05ddcbec9d2f81bf94157aef47/wrapt-2.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d98bf0078736df226e36875aa58a78f9d3b0888bcf585144fb30edbbf7145238", size = 170982, upload-time = "2026-05-21T04:49:51.167Z" },
-    { url = "https://files.pythonhosted.org/packages/19/f8/6255eb9827dbd137569de68554b1e9535c3ac79cdbc377af3da415891807/wrapt-2.2.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b62f40eb24ccf05246d203461c8920889fd38dce76978df16fe28e6f0128447d", size = 160002, upload-time = "2026-05-21T04:49:53.598Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/dd/962a9281d9c35e21c5a662c7d05c2af0108a3c833d2d6ab2eb546e520f7e/wrapt-2.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a8ce59cad2ee5a4d58ee647c4ed4d9adc4282ffdc31e98cba7f831536776a0f9", size = 168827, upload-time = "2026-05-21T04:49:55.082Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/ef/6a10e1200b2238be6da767d1814ab298f20e533a6c210f9ae6423ee3139c/wrapt-2.2.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:bb7c060c3faa78fe066b6b1c65de285d8d61fb6e01ee8195625b9636c3cd9775", size = 158164, upload-time = "2026-05-21T04:49:56.587Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/b2/4f5f4c722aa730eb2c0723ee8f32d0d7315d07173cdac0d08b7b92bbab39/wrapt-2.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4297b7338cfa48b5cfefc7416d2ae52b0aad89e9b24da479ec010717b987c07f", size = 167111, upload-time = "2026-05-21T04:49:57.996Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/b7/93fabbf2b505b610d019ec537c9dfa785a96920dcfc2ff8f57727aa54625/wrapt-2.2.0-cp312-cp312-win32.whl", hash = "sha256:9b58e2cdbcfe2278a031a12a7d73836d66bc1e9e65f97c63ea0a022f2f9f351b", size = 77867, upload-time = "2026-05-21T04:49:59.339Z" },
-    { url = "https://files.pythonhosted.org/packages/70/51/1564bcd9863dbf2cca3a687f53a6eeaaa08850e331948f1c4c7818401e88/wrapt-2.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:199abadf7dcceab4bdc5bfe356275a56b1cb429296e283da2fe90c20b09f8d07", size = 80827, upload-time = "2026-05-21T04:50:01.212Z" },
-    { url = "https://files.pythonhosted.org/packages/67/04/354d2fd146936dccf55aced66a606f6e1665435e3119765acb00a8753eb3/wrapt-2.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:8d40f1fb34d600b3eaf812941d6bcf313075728868cad1dafb7021e6a4e77983", size = 79094, upload-time = "2026-05-21T04:50:02.869Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/bc/00d23a39b5f002dfa20f7441721bb44198e7c7b4a6b3f3d7b4ff88fe2dc6/wrapt-2.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:49c7ad697d6b13f322a1c3bb22a1c66827d5c0d303a4479e327210ee4d4ad179", size = 80816, upload-time = "2026-05-21T04:50:04.563Z" },
-    { url = "https://files.pythonhosted.org/packages/14/ce/d0c5ecb47818be6d1717ea51eec1285f8d53777994fe44deaf9d7299f65c/wrapt-2.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:07dd562ebb774cad070eeedb93c7a29647979e30f0cfd1f5c9b9f803f687b6f4", size = 81346, upload-time = "2026-05-21T04:50:05.882Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/19/a68afc8f7b085bc34fa6e17a120a10b2a9e27579369c79fb40f31ba95d69/wrapt-2.2.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5b865e611c186d15366964e3d9500af504920ce7b92a211d61a83d2d3c42a508", size = 166769, upload-time = "2026-05-21T04:50:07.604Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/67/b3dadb67dd612223615438ce080be6bd1fee6de12ee16b2ff9725b3169b1/wrapt-2.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12331011cbf76b782d0beec7c7ed880f51454c127ab12012cfaecf56de01a80c", size = 166825, upload-time = "2026-05-21T04:50:09.129Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/b3/9cb0277fb0f5c853aa6a91f384784e73db4c3db8ff0f405bc3f71d93daae/wrapt-2.2.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8ae3f4b50a3befa56da0f09d2b71a192454ce48e8887823dbc9228cdbb610f3", size = 157882, upload-time = "2026-05-21T04:50:10.954Z" },
-    { url = "https://files.pythonhosted.org/packages/83/f6/e4295b9dadfd73d1db30fced3cdf1d083787d77857257998c5b9dda8b3d9/wrapt-2.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:370b2c36e8fee503c275e39b4588d74412cd0a7792f7f3a7b54c44c4d33d4884", size = 165791, upload-time = "2026-05-21T04:50:12.698Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/33/e66764a3aefb45a3a60ac76ea6878417a13f98e67f046f8e78b0a9ca6063/wrapt-2.2.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9040b15216e07ed68762e44ff231a460036e4bf3543f83988f669e7078847b2c", size = 156574, upload-time = "2026-05-21T04:50:14.28Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/90/e3355e82cc765a411283ff4335ab41034d4eab9f5226b3e5840bebcaaf96/wrapt-2.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8062689c0e6faf0c2532f566a492fb48ba60923c2cd6effda7cac9639dbdc1f3", size = 165943, upload-time = "2026-05-21T04:50:16.373Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/86/eda5a79813cd9ee86cd7275b9eac5338166886a5ffc9dcf881a3068d03a3/wrapt-2.2.0-cp313-cp313-win32.whl", hash = "sha256:a3848854af260eb4cc33602c685524fff7c8816f033325f750c7fc75c6deccf9", size = 77824, upload-time = "2026-05-21T04:50:18.241Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/de/1eadc4caa3797a33d231572435eed9116d24f56dc6c909c43b59092fbb37/wrapt-2.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:76b8111f8f5b8553c066caa26193921dea4185efecf1f9b38473054205137800", size = 80737, upload-time = "2026-05-21T04:50:20.038Z" },
-    { url = "https://files.pythonhosted.org/packages/11/34/aeda6d757664a569a19d3e88e89f1c52134bbaa59b053bb316c69c71c459/wrapt-2.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:195db5b92deba6feb818732694ad478abb8a529d97a113cc256e5e49ee2dd80d", size = 79094, upload-time = "2026-05-21T04:50:21.784Z" },
-    { url = "https://files.pythonhosted.org/packages/92/c7/3bfdcddd4c0281d104305e473953f1402bcae1898089656b6a9567a1e5cd/wrapt-2.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:cf93c441b11c1f3ae2ccf1e8d876939b301b3234ec19f311ab0e7543a9d4427e", size = 82751, upload-time = "2026-05-21T04:50:23.694Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/96/37cc2bf299cfbf21f6bb7dfd0ba590e2d29f9e1fe6aa334a97395f4406dc/wrapt-2.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b208a5dd6f9da3d4b17aa2e4f8ca9c5dc6b9a2ed571fdef9ed465102487b445c", size = 83315, upload-time = "2026-05-21T04:50:25.085Z" },
-    { url = "https://files.pythonhosted.org/packages/18/b0/bd4b4c51243a38009cc1c96f0503a535a7d8044636626bc7c545e766e73d/wrapt-2.2.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5248171d3cd33f12c144e7aa1222983cb6ab42651e985ce51fec400a876afbfd", size = 203752, upload-time = "2026-05-21T04:50:26.862Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/b6/aee7c4fd7f19026d464ca7fd8a83efa5f3168ed33897ca0d1ec83bd15de4/wrapt-2.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f663528d6ea1804d279462671b2bf98a4c0d8a4a8dd319bb3ee0629b743387f", size = 209665, upload-time = "2026-05-21T04:50:28.45Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/91/be1181e580cd20a2584260285aa25fa9eb64a27a5921a431008910ea5d70/wrapt-2.2.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fb240700f3b597c1d40d0932bfed2f4130fec2f02b8c2cb0bcdae45d321cb691", size = 194678, upload-time = "2026-05-21T04:50:30.307Z" },
-    { url = "https://files.pythonhosted.org/packages/63/f6/cae7b5f26bf1385f562b7904db23b686e66a4f4f4b3496675531b1d0d968/wrapt-2.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:1bf3ea62734b24c0241442d8b7684ef53a8de6cad0c2eba1e99fd2297b4a92e4", size = 205364, upload-time = "2026-05-21T04:50:31.899Z" },
-    { url = "https://files.pythonhosted.org/packages/81/d4/647312c3fcef95e6c65fd4c11efe4575cd021ac0074f3000cb066fc67c9e/wrapt-2.2.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ec257eedd8c3988cf76e351e949e3a56a61d90f4bb4e060de2ebfa6603df2a42", size = 192139, upload-time = "2026-05-21T04:50:33.588Z" },
-    { url = "https://files.pythonhosted.org/packages/db/c4/b40d8d176979b9397a4cfcc9eaafdd20697fc6e62293d70b1951d422b988/wrapt-2.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f58e1aa46c204171a2faa49b1ef2953edebb3913d270bb3bae7e970f254c9293", size = 199221, upload-time = "2026-05-21T04:50:36.591Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/cf/71f00a6a0e9f5244c0bcc4e445d1087467d1c80e788637929bea0a1ea637/wrapt-2.2.0-cp313-cp313t-win32.whl", hash = "sha256:615be1d2b21450748e759bed7bf9ba8bc28307e91cb96b6e968f54f39e938ee5", size = 79438, upload-time = "2026-05-21T04:50:38.531Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/01/8219ee5e1491fdd880564af04a809eb8866481faff5cce6105174202667d/wrapt-2.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:0680304db389599691bac06a2f9fb3f0ed06af59f132d35801a38cf6c321ab59", size = 83024, upload-time = "2026-05-21T04:50:39.892Z" },
-    { url = "https://files.pythonhosted.org/packages/56/c5/ec61c19ea596299b0f0fca9f5ff82418a5152d933772bac90c61a4b06c30/wrapt-2.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:60bef9dc4348a76e9c2981ec4b06b779bac02556af4479030e6f62b18545b3cc", size = 80282, upload-time = "2026-05-21T04:50:41.318Z" },
-    { url = "https://files.pythonhosted.org/packages/11/b7/dd4278d51621fd5054f840744be1c830b37e9d7b9b22b5590eb69c5039a3/wrapt-2.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5c17982ccfece323bb297a195c9602ef407819199d8dbf99b8041770513fd68f", size = 80861, upload-time = "2026-05-21T04:50:42.755Z" },
-    { url = "https://files.pythonhosted.org/packages/65/ec/06efd37278eaee793521aee41091cb29fe20603dc5bd2f5cdc4e73fe9ce8/wrapt-2.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d2aab40474b6adae53d14d1f6a7785f4346a93c072adf1e69ca11a1b6afc789e", size = 81436, upload-time = "2026-05-21T04:50:44.212Z" },
-    { url = "https://files.pythonhosted.org/packages/21/95/46922f9415f109506f8bdfd903138dbde8a507a70ca02904b8dcffaac171/wrapt-2.2.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:db48e2623a8aca63dfcfa7e574a5f3a9f760be1c464ee23f6387f70cc9112aa2", size = 166655, upload-time = "2026-05-21T04:50:45.951Z" },
-    { url = "https://files.pythonhosted.org/packages/95/57/601af72054c2166e11781a30b0fd6f7d500e9186351e73f8ff5d923afcee/wrapt-2.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f990f1b5c8ee4ff980bdef3f73f50728fd911b9ab8de8c43144e8019dcd845ff", size = 166257, upload-time = "2026-05-21T04:50:47.644Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/a0/b2e96a62cd572f186eb94be906d4854dd301b20a3b30b648c8ddab11a2fb/wrapt-2.2.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c990d58100f9ebb8e7a20bd2e7bd3c60838be38c5bbccdd35041bc9f36dc0cea", size = 157694, upload-time = "2026-05-21T04:50:49.215Z" },
-    { url = "https://files.pythonhosted.org/packages/72/f8/77fa31bda9344ca76d6a8eb6f5bd274aea1a7e24d6279b21fc2349d41fbe/wrapt-2.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:686f1798727bf4a708df015ca782b20abe99b3664e1ee9786b7712b0e2310586", size = 166036, upload-time = "2026-05-21T04:50:50.857Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/73/118d00ad41f270128aa94a80b8150c5b720c18e06dc1a2291795c33839ec/wrapt-2.2.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5b9733ef187cf05e774484ed2f703992a44429050f1cfea2e94dac543da78292", size = 156437, upload-time = "2026-05-21T04:50:52.415Z" },
-    { url = "https://files.pythonhosted.org/packages/24/43/16017c26a1eeccbbf8f79f5172095bf9b0cb7183ac9bfc4a3c2c9fc37675/wrapt-2.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:231e2728ba04536821d2327ad2b3cb2c20cc79197fe5c30ddf71b12d95febe10", size = 165492, upload-time = "2026-05-21T04:50:54.16Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/bd/d5d59f0a074e192f1cdafdeafca3d1aca25c3dd9172e0418fd04a912b864/wrapt-2.2.0-cp314-cp314-win32.whl", hash = "sha256:319720847afa6c58c32f84f9743bdcf34448ae56908c00f409764c627ff2c1fe", size = 78343, upload-time = "2026-05-21T04:50:56.028Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/f5/c7fbbcbd8285f1999666115a793890a38e8b88744b8c3630059a0efa88bb/wrapt-2.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:628fbd908649611c8b9293e2e050231f1e230be152e7d38140e3b818ec6aade0", size = 81144, upload-time = "2026-05-21T04:50:57.538Z" },
-    { url = "https://files.pythonhosted.org/packages/93/aa/152902a4b85cb55daad6e383a91ca5e23fd8d56132a4aa44987b7154f5e3/wrapt-2.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b4ce4240a3f095e77cfcc5aed6001bd63af13ea53c35ef496af1a5a972e7eaa9", size = 79573, upload-time = "2026-05-21T04:50:59.307Z" },
-    { url = "https://files.pythonhosted.org/packages/af/fe/a25c3eee98417de1caf541c1b234bbc3a8b0ce4817b0c8934ca57bfe3e89/wrapt-2.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f0318a47d23c9407f4f94c06824662499e889ab8c192c1162e4f542a118fd700", size = 82844, upload-time = "2026-05-21T04:51:00.767Z" },
-    { url = "https://files.pythonhosted.org/packages/71/bf/31060eb2f475b7798926f46c1779ec93329a48730cbeb8f9c0855162f97b/wrapt-2.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8a094508b7cd6e583378f3cf50f125814961660225bad88f4ecaa691e30b09e1", size = 83321, upload-time = "2026-05-21T04:51:02.253Z" },
-    { url = "https://files.pythonhosted.org/packages/54/b9/62702f8bdaf509e444ec38bf142122db8c5ebbdfe6e2ca8e1dd7d43fb574/wrapt-2.2.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:115ff1501c11ac0e267c4afd6f6b3dd24b48afcc77b029e6062f71b12bce1d79", size = 203740, upload-time = "2026-05-21T04:51:03.8Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/c6/c9ea3537ea759edcc856a32fc2d16abee41d7474f853bf00089058c0a33e/wrapt-2.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45d4156fd35d0bdab58eac4a6854fbd053a59544fc57eb66e977b3c13c087a1c", size = 209671, upload-time = "2026-05-21T04:51:05.56Z" },
-    { url = "https://files.pythonhosted.org/packages/79/c8/5925232cf614c23969b2267d954976e288993ef9e94a74eba4f26ad41232/wrapt-2.2.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4b0aa81f4a3d0203ae8450eae5e794540afbf00a97dd0b81accbe5b4a5362cbb", size = 194717, upload-time = "2026-05-21T04:51:07.227Z" },
-    { url = "https://files.pythonhosted.org/packages/10/95/b824ac1e5900f39f80d0d4e97cf59389b078d0fed3551f471911f9b46281/wrapt-2.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74b7949da2ffcd79869ac1e90946c14ce61a714269403a879ea9ed85a993c81f", size = 205335, upload-time = "2026-05-21T04:51:08.868Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/58/623708a153bb1a519260bf61086c5f381196a7d505ac729f7979b0d1a957/wrapt-2.2.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c7af243871699358ebf34a770205bf2b61ccb17a0b003e8726d2028cc36ce364", size = 192170, upload-time = "2026-05-21T04:51:10.52Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/4e/d771a75386676fe08086affe57b0f7cffafe528642ae5ebf95200811248e/wrapt-2.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eb9d0c3f416e2c7c37498d1716fe323379da8b4e860da3d3818a6ec8fff7b7e5", size = 199200, upload-time = "2026-05-21T04:51:12.269Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/42/afd8991950e38f32c73008a3f2cd834cab32e338cc1997b7a39272a22cbc/wrapt-2.2.0-cp314-cp314t-win32.whl", hash = "sha256:4d5b485a6f617825fa7449f5025ebcdad9355acb328cb6d198ba225762219bc0", size = 80206, upload-time = "2026-05-21T04:51:13.837Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/34/d10901fb7686ec642e22d75d260f07ba6e05d28d5c83cb1efdc8d5c03e07/wrapt-2.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:cccce5c70a209eb385c82d063f332ed97fc02d1cf7bffb95b2e6995b5a9b8388", size = 83830, upload-time = "2026-05-21T04:51:15.341Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/11/d41fd5f17432703783f996fddc475d40baf20fe76f2c6dc217c2dd219b4c/wrapt-2.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9ad894d5dc5960ebd546a87a78160a8c645b99899e7e45a538436919bc9be5a6", size = 80711, upload-time = "2026-05-21T04:51:16.859Z" },
-    { url = "https://files.pythonhosted.org/packages/33/19/713f33fcd8f7b0aa87c9d068b590dc1e86c51d5e329bf83dd91ee47fe872/wrapt-2.2.0-py3-none-any.whl", hash = "sha256:03b77d3ecab6c38e5da7a5709cee6899083d08fc1bcd648b4fa78b346fc66282", size = 60994, upload-time = "2026-05-21T04:51:37.606Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/8b/84bc1ea68b620fe0e2696a8cff07e82f4b962d952ab14efee8955997bb70/wrapt-2.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0f68f478004475d97906686e702ddbddeaf717c0b68ad2794384308f2dc713ae", size = 80093, upload-time = "2026-05-22T14:47:27.074Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8f/64ec81194a0bc708d9720174c998c8a32116e82b5b32c04e20a7fe01176c/wrapt-2.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e422b2d647a65d6b080cad5accd09055d3809bdff00c76fba8dca00ca935572a", size = 81183, upload-time = "2026-05-22T14:47:29.062Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/3d186944aae923631d1def58f4c4ff8f0b6309906afc0b6978de3e69b3e0/wrapt-2.2.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:036dfb40128819a751c6f451c6b9c10172c49e4c401aebcdb8ecf2aec1683598", size = 152494, upload-time = "2026-05-22T14:47:30.583Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d1/6b3d0ea995b867d2862aad5619bd5e17de09a9d64a821f46832dcd272d40/wrapt-2.2.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09ac16c081bebfd15d8e4dfa5bdc805990bbd52249ecff22530da7a129d6120b", size = 154310, upload-time = "2026-05-22T14:47:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/4b/37ecb90a8c3753e580327fb40731a984b754e3df65d2ef932bf359fe4adc/wrapt-2.2.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07be671fa8875971222b0ba9059ed8b4dc738631122feba17c93aa36b4213e9a", size = 149002, upload-time = "2026-05-22T14:47:34.021Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/d0/918884d9dfa84d0d135b42a51c00910f5c5447fe7a5e211a8e16ac324dd4/wrapt-2.2.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:93fc2bf40cd7f4a0256010dce073d44eeb4a351b9bca94d0477ce2b6e62532b3", size = 153185, upload-time = "2026-05-22T14:47:35.722Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/00/382299d8ced610b29b59b099a89eda821e8c489aa152b7183748ac83f32a/wrapt-2.2.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ba519b2d765df9871a25879e6f7fa78948ea59a2a31f9c1a257e34b651994afc", size = 148040, upload-time = "2026-05-22T14:47:37.052Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/46/62a79b79e35bbebb1207ca5d15b81192f37f20cc5659cf4e3ce955b7fcc8/wrapt-2.2.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9011395be8db1827d106c6449b4bb6dd17e331ff6ec521f227e4588f1c78e46f", size = 151773, upload-time = "2026-05-22T14:47:38.713Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/db/95c152151d206d4b430516c89725306e92484072f38e65492afde63f6d19/wrapt-2.2.1-cp310-cp310-win32.whl", hash = "sha256:a8f7176b83664af44567e9cc06e0d3827823fcc1a5e52307ebb8ac3aa95860b9", size = 77393, upload-time = "2026-05-22T14:47:40.061Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/882d50452c6fbd13f24fe5d2644b97cdad2565a7e1522cbb6312de8a52cf/wrapt-2.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:d7f513d3185e6fec82d0c3518f2e6365d8b4e49f5f45f29640d5162d56a23b54", size = 80350, upload-time = "2026-05-22T14:47:41.194Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0f/148376523b4e370692286a9ba14d5715cf3c5b86da3bd3630926367b6b73/wrapt-2.2.1-cp310-cp310-win_arm64.whl", hash = "sha256:44255c84bc57554fed822e83e70036b51afa9edb56fc7ca56c54410ece7898c9", size = 79149, upload-time = "2026-05-22T14:47:42.835Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ac/4370bde262c0e633e6c4f0e56d55095710024cf9a5cecc20c59a10de483c/wrapt-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:dd57607acc85678925940bd5df0385ff8332083a32fa8d7a43f8767f4997263c", size = 80321, upload-time = "2026-05-22T14:47:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/79/b8ff3a61e71babf58a8cf4c0d63358e8bad383e15bf7f35e62d2f6b6e4a4/wrapt-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1ae574d65c9fa8e86f64f6a7c2668f9fcd507b183e0e577619f504b883cb0a6c", size = 81216, upload-time = "2026-05-22T14:47:45.243Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fd/c0cac1f77c9c4f6fe58a920ca632ce379bb8be928720e11e8d73de28a5e9/wrapt-2.2.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9a04c28c10ba7fd12842b109d2edb0678872a2fe65277ca4ff06a0d61edee245", size = 159208, upload-time = "2026-05-22T14:47:47.176Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4f/744132a7b2fbefa6b81118ec5942eca5fc2e9a129f9055a0c5e46885a549/wrapt-2.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e2f02472a1cbbf3884b365714a810b5947134a95ad6952b554cb8cce9d492b0", size = 160322, upload-time = "2026-05-22T14:47:49.04Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/95/b7cd9a22a06cf93e6482904ee6afc956248983553593fd1009296d1b3b31/wrapt-2.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac2745950b2bff80219c15ebf2fa9d8427eba7e249739f97e55c9d169e47e9e1", size = 153243, upload-time = "2026-05-22T14:47:50.386Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4a/eb79423192015f46f0db2872e7e04a3dde8d359b83411e8959e7c9287eaa/wrapt-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67a97e5b6c457f0cd3cfc19ebb2d84463e60c3ece754cc831e4281a3ca29bb18", size = 159231, upload-time = "2026-05-22T14:47:51.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/dc/435015b58ce33c6fc4104158fa91ddb0e809ab03a5751fb7465d1d461456/wrapt-2.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:c803a3d331796255af51ba2c79ed0ac8275865b516c09e61f248d1e7aff31ce9", size = 152351, upload-time = "2026-05-22T14:47:53.214Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ac/5d203f98df8fd136b95c5227139aea02d34505e18baf812d0c005df61963/wrapt-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9b984d1eb252145d6302c1dbd5e87fc6d404d45531447c84eadec04bf1fcb027", size = 158347, upload-time = "2026-05-22T14:47:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2f/a92427dbdc74e54c1674abbed27e61b2cb5e7a94441b8c1270c70671d928/wrapt-2.2.1-cp311-cp311-win32.whl", hash = "sha256:8a983a603a18c8708f024f7f6991b2e66159219abbf894634c5056243c55f3cd", size = 77562, upload-time = "2026-05-22T14:47:56.275Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/56/987b9c13b3e1c1a3c6de71284076f996b79caec90e75a87c044a40c23db9/wrapt-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:9c210a6994b21aa9b29e81c8d11560e8fdab54c117e9cff37870d0a27bde1343", size = 80616, upload-time = "2026-05-22T14:47:57.854Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/25/d01f560888d99d94a959c85533de349ce68d71ace3f2591d6ea8f632cfed/wrapt-2.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:401229e9d63ca09f9b8891ecf83798d26c11bbb445d11ed9f1836b6d4585b38a", size = 79025, upload-time = "2026-05-22T14:47:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/89/0c/bfae7b9401583b6d05938cd16dedc43857d96da2f8a3d50d78cc515bf6ff/wrapt-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ffad790d9d11d8ecf9f17c4bb671a5b4089e4d8b575c46c5129597f41f836b0", size = 81021, upload-time = "2026-05-22T14:48:00.313Z" },
+    { url = "https://files.pythonhosted.org/packages/26/58/80f6a6599f933f4caecc1cb3ee88a04faf81e8b9bddbd6109c688dd63e0f/wrapt-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:628f5220c7a904d5fc78f7075c8d7871433eb6d035c94728a22fdf85f193d2a8", size = 81692, upload-time = "2026-05-22T14:48:01.49Z" },
+    { url = "https://files.pythonhosted.org/packages/17/93/fb357cc7847c58a8ae790be718903afa81a28d23e642c843dc4129e8a0b2/wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:61acce4257a9883669703c525447c5b4c392edf0f987ae77ec32668440158f0e", size = 169364, upload-time = "2026-05-22T14:48:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0b/76b601ee309a8bd556af0eecb184394c20b3c49aa9c8e085aa1ffacc2568/wrapt-2.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:727ab4244622cd6ad2390f322642090c877d2e83a608d2653a7643ae5368d926", size = 171079, upload-time = "2026-05-22T14:48:04.22Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/87/ee3f32d5658e3e26d3e0e457922b47a36dd3bfbdfee7f97bb3e802344a66/wrapt-2.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03df9ebed4c73ab93fa8c07e3d41d818dfca1852b15731a3de59457b27814624", size = 160205, upload-time = "2026-05-22T14:48:05.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d0/ae2fd64277a67f5d7bffcf2d05eea1e476263fb2a072baf0b0129ab85984/wrapt-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0d9ff006f420b2ec8296aa56ade43ea7da3e997e85769f0aafc5e0661aacb710", size = 168922, upload-time = "2026-05-22T14:48:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f3/2d541a060c5bbafb9400bca4917e4d78bfd1f239f404782c86831a8f6b29/wrapt-2.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:844c858fc3bb7eacc0ba8efa904935d16aac6a4470948ad1e7e55c9f5a2a665f", size = 158388, upload-time = "2026-05-22T14:48:08.629Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/68/8d92c8800c57e93cb116ae9e9d6cbafc34fade5ee9f9107b6f203fb4dc35/wrapt-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87bacdaf225117a342a20d9c03438d701c02112f6e3f351ce9b7f32354f14797", size = 167682, upload-time = "2026-05-22T14:48:10.042Z" },
+    { url = "https://files.pythonhosted.org/packages/30/72/83ea3790ea352439442349388e29ff07b76e0686265f9088bbb505d1608d/wrapt-2.2.1-cp312-cp312-win32.whl", hash = "sha256:2f8c90c8afde51969487be4e1343ae049b268854877d415c2510baf833775052", size = 77857, upload-time = "2026-05-22T14:48:11.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/cb/99450668dd3502d62a54a1c8aa56e44f34cb8c1261b381cfe2e7926c3b75/wrapt-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ce32763ac31ce94fe9aada947e479b1975012bff166da409b4b9e4e376cf7e5", size = 80825, upload-time = "2026-05-22T14:48:13.046Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/87512881be64e743f9ee4c66f4cbe8e884974bef2a5989af71f999653ac7/wrapt-2.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d1b4d0e0c2119587a31f5c029abd547e0c81d93b89d394566fe1588659eb579", size = 79087, upload-time = "2026-05-22T14:48:14.323Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/a1b08f8f4fac8cbb156fa51cf64ee2c7f7f74f9875ba3cf70b3c58368694/wrapt-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d2beb1c7cab10603aecdc42f8edd6ff013f9a32e4543474e38e6b77ce9975aeb", size = 80831, upload-time = "2026-05-22T14:48:15.598Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ce/57890814991446a845e09b3445ce8b694f27eb0577004f2c2a36a9772ed4/wrapt-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0cb7e4dd71f4c32e5e84843cd3c4cd65dda034314004bbe1d7f99af2426ab80", size = 81375, upload-time = "2026-05-22T14:48:17.071Z" },
+    { url = "https://files.pythonhosted.org/packages/38/65/08d7a6c76ac4493bdb668205ee9c1de1bd5daca61717c3e9aa49b4c01499/wrapt-2.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95821352042722cd9f1108874579a47989d0a7e12a37d87d2fc4af20fd99ab8a", size = 167417, upload-time = "2026-05-22T14:48:18.303Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ce/f1ccbee7a1bfe5cdc6b3da6bab4b45713d628b9294da32a39f563d648140/wrapt-2.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abd621552ede77c4c69be7fac44ba911225b0c812b6ba604e5964cf98085b474", size = 166948, upload-time = "2026-05-22T14:48:19.768Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2a/f85d48d1cd4869aee6704028d257d740a47c1c467b457ce396b4b5b55d07/wrapt-2.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e3677c7146ce694874941ba82b57092cc4875445aadf29d72807351023105143", size = 158148, upload-time = "2026-05-22T14:48:21.96Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5c/93939ad11d4a12358ab1aab219a2ef5efa5612e0db6b9fc65af8af1a891b/wrapt-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9a5934eaea872e17936b5f45501eba5ab0bce9a74122e172b663d7c28c459c4a", size = 165905, upload-time = "2026-05-22T14:48:23.373Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/b8c2aa89862ff58605934d7abf4b70e6a5a1c33df96656f49035ccdf1c8a/wrapt-2.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f5b9daf6b629fce418e0cc3dd0436eac045188fa35deadb7a7f3941d5b8203f9", size = 156712, upload-time = "2026-05-22T14:48:24.767Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/bf00a7b02239c12bb02ddcc3c0b971bfcc36e578c5a44f1ccfef5b458545/wrapt-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f53ac9f3ef573326d009ed809beff4efcac6451931c2b8132586da4b9e53ff31", size = 166560, upload-time = "2026-05-22T14:48:26.83Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/93/6390ca9c5b787683cef588d04f57c8d41b9a2323b5597a65f18638c90ef2/wrapt-2.2.1-cp313-cp313-win32.whl", hash = "sha256:1ffa9cfd4bdb581539951b14ae661ff20ed0c3599b3e911a131ee0ec5ac11337", size = 77817, upload-time = "2026-05-22T14:48:28.221Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/ce10f0e71c0cfaa1a65faadb8efd4852028b3bb9ba28932b8889df769d38/wrapt-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:368eac1e20fd0bb03dd3cc42bf9887154c3861b60989389ccb5fac032617d215", size = 80736, upload-time = "2026-05-22T14:48:30.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/4c/89f4a6818fafbbd840330e4fa3873073e1bfc166133a64cac7f8fde7a5e3/wrapt-2.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:c754dafdf5aaf0b401b644a90a30046929a0dd1a536e0ff0ec959a59155d9c7f", size = 79099, upload-time = "2026-05-22T14:48:31.405Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f2/9a8741c46f8c208ac0a45b25ba170bcb4fb72a2781d5fb97dbd7b6be73cb/wrapt-2.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ed928d0fda15fc0adc8d13305c8b3c0f2fba5b0669950c9e6d019d9162a3b3e8", size = 82802, upload-time = "2026-05-22T14:48:33.307Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0d/e9c855716a3705eef1416456bdf062b60620726fdc59428ff670fc3c60dc/wrapt-2.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fafb4e739e43544d12cb4abd1605fd4683b6ca6a9ad682b7fd8f4d21973eafa8", size = 83329, upload-time = "2026-05-22T14:48:34.593Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d6/a88f1c13112b7831adac75cea65d8310e0d696d570c8961844c90a57b865/wrapt-2.2.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:74d6a0c31472fe5d814917266b9f46495d7c61ed890af08b468acea92fb89a8d", size = 202937, upload-time = "2026-05-22T14:48:35.859Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/e29d54aef06a4d898a5b8a25589a0b3769bde454f922fad8f6f89fbfb650/wrapt-2.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab5be648d5a0b86b7438864f8df3c705a65cef35a2fd3e5561e3e203167e0f27", size = 209997, upload-time = "2026-05-22T14:48:38.153Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/91/e4454263516cf0e12640912fbca9a83654e424f0a6ddb79f5cd7ce14bf33/wrapt-2.2.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d8f204c8e3a8bf9ece17e0a83d137fd807440977f8a5e762d59306795011440", size = 194856, upload-time = "2026-05-22T14:48:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d0/fe0ee202286afdf4a7f77dd29f195703145764d572aec209c5086e57d924/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d047f6498c973874ba08ac3f97c69a2c4b2211c8de6f4c205f75cb1c9522596e", size = 205654, upload-time = "2026-05-22T14:48:43.456Z" },
+    { url = "https://files.pythonhosted.org/packages/23/b6/87d860dfc6460c246af70b1fd5c8b76df77571b42a493459423ded94fd7d/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:7a4fdb9326aab4a5a477a1640e5ad786a8495901009d7e7b038371edd23a9d2b", size = 192206, upload-time = "2026-05-22T14:48:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/df/46/3eea8cde077d985f239a38c0257087b8064fd9ee9b1a99e282d2c86da4ef/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c8cc5094b08abeae52da9c73c8a32003623be691a5193df2f4e3eac3d557c394", size = 198428, upload-time = "2026-05-22T14:48:46.319Z" },
+    { url = "https://files.pythonhosted.org/packages/18/dc/b927ee9c7fc67adc3a5658f246a0d275425eb840ba36e7b702e70f18bde8/wrapt-2.2.1-cp313-cp313t-win32.whl", hash = "sha256:9907a4402ab6db12b7077a0ea5d7a4d028ecb22c8eee2b53527080d347cd1562", size = 79448, upload-time = "2026-05-22T14:48:47.901Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b3/fd30b473fe498c70e6b9a5f328b8d3fbaf1b8c3c481465f59724bba8eb70/wrapt-2.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:5590d63f5243251641cf543009b4c9314a79d0598fdb8a8e4cfc918494536c53", size = 83021, upload-time = "2026-05-22T14:48:49.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/96c39153a8737a6e9aa85adef254ac4195bea3f2d24efc60472ccc3c9e2e/wrapt-2.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:c318a64b53d97b841d7b5e637517e50a27be64bc695128422953d4b21710954e", size = 80295, upload-time = "2026-05-22T14:48:50.479Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a3/11d7f34ebbf3231bc907a3e6d5ee051b14d034c1bc7b65a97d5cc00516df/wrapt-2.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f56a647e4eaf5f0ca40330fb070f566bdf9f7b0db89a1af20d71c28dcd7a0ab", size = 80879, upload-time = "2026-05-22T14:48:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3c/b74cfd984cef560b900fb1a727af20352d89e1f06bf2e1114dd3f00f5f5a/wrapt-2.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:64b7deeda4b70408e382328d8bbe52a256fe9bc63ae3db86d804608367e5422c", size = 81462, upload-time = "2026-05-22T14:48:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a3/7c8f704b8dc07dfe0a5d01c2edbfd88317aa8e5e3fa7c743eb7a085ae767/wrapt-2.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9cf53ba90717db2e292401de290776c498d4bbfb0d4a559ca2895db8b9dcb5c", size = 167251, upload-time = "2026-05-22T14:48:54.562Z" },
+    { url = "https://files.pythonhosted.org/packages/80/85/a34d1888d97247da6c2ff6118c3a721c73ed8cc4dd198c00208bb73b6f80/wrapt-2.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf3638274ab9d9b724c9baa0b4c04e132cd6faefb78b4dd3dd1a02a4bdaad41e", size = 166316, upload-time = "2026-05-22T14:48:56.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d7/72ffaeb01eebc704afe3fb99e840480f4bda45f0fa66e3381b6a39251c8f/wrapt-2.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aed9658797d0b45d6c49adcfc6b41f66e6f2d0c6de3ec79e16cf4b1855df240f", size = 157952, upload-time = "2026-05-22T14:48:57.924Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5b/36f5d6b024e4edfdd90b140742d11ebcf7836daf5c9daf326c55c24db412/wrapt-2.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1d676ee388bc42a04d56dd7deb5605244dac2e35cc2fadbb43c9fa25bbd93508", size = 166130, upload-time = "2026-05-22T14:48:59.384Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/9296d9e97bfdef5483dfcc859d57b095b257144b2bc5300ab521e06f4bc7/wrapt-2.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e395f7bc31851ef9b612050368cb446e9bc14cd7454b025018980349caf25ae5", size = 156604, upload-time = "2026-05-22T14:49:00.921Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/16953929ed6776175720e58fc966e779926d8d71e2c7b2273230590ca71f/wrapt-2.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f1845c2a8cc1180ccccfa45785dd06f562730d19ef75be180334254012b6283", size = 166007, upload-time = "2026-05-22T14:49:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/73/20ee58c0612dae7c31131a7095345812ed2c7b389019e175f68cde34e5b4/wrapt-2.2.1-cp314-cp314-win32.whl", hash = "sha256:436addbc4bb4fc0a88c702577f51195d7d73683a7f3e0e5b253d8404d7847243", size = 78327, upload-time = "2026-05-22T14:49:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b3/ef7c3295d02e0448a71c639a36a057f46d524d057c9486291a7a3039e65c/wrapt-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:50972a1d974ea07725a7f6b1cec5f8759008afd030a0024843ebe7d52de47f2b", size = 81144, upload-time = "2026-05-22T14:49:05.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dc/7bdf336953f99f4ceb0a584bb8870e42c8f26f93ea10c87834dad62f1668/wrapt-2.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:1c9934ea5d92957e3cd0adbc0845539dccfd62710ebe16195a8c66c53954db36", size = 79569, upload-time = "2026-05-22T14:49:06.413Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6d/6dfae80150ff1919c356d1dd528f049bcdfaae29b4d284bc957e022caef4/wrapt-2.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17de18fc12cea55b8a9587314cb830573e37fb33b247a7515696350863714188", size = 82892, upload-time = "2026-05-22T14:49:07.925Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7b/4e34766a7d7804ffce9e71befe47e9b3225dc350c49c94493c4ab39fd3a5/wrapt-2.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9dec1aca52dddde7df94818310fa2fe79739c8f385b2014c4cb1035f5508199", size = 83333, upload-time = "2026-05-22T14:49:09.257Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/57/0b34db3e8de44ccfece62d7b337abd1631dd810f5adc5f3db571727836b5/wrapt-2.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69f2e9244542cb34dd59c7f073445b9e54ad9f3fce8d93606c368a1b499fc413", size = 202899, upload-time = "2026-05-22T14:49:10.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/ac0c459f154b99d92789a6cba7ca727185b83513b986f8ec7fe2aacddcbf/wrapt-2.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d83966dc7f4f45e8b97b5933685ac2e6e67fc0e19246ea314bceb9a8970c956", size = 209986, upload-time = "2026-05-22T14:49:12.229Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/77e37ff33ad018fa81ade52c25fa327b80b56f81d734279a63614fcb4cbc/wrapt-2.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78b0aa6bfb7be8deed0ab23e7aa028cc5210c29bc2d32a04d52b50e517a7307e", size = 194893, upload-time = "2026-05-22T14:49:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9d/7ea651d1ab032fc5fa222fbec91d0f8a1397f6ae04ebb93fa7219aa921d7/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:05d5cb74d1b232ec8cfa130a8f900708699ff2491d97b8f85a4cdc5996294b85", size = 205636, upload-time = "2026-05-22T14:49:15.714Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8e88031a701275b9085c54e64bc88c0b1cd55c77eadd400691c371cd76c4/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f6518b94edb9150452e9aba08027d4cc293433753ec1fbefb4629a21cbc74181", size = 192267, upload-time = "2026-05-22T14:49:17.283Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a8/e657ca876b06710194f243d81c4b0896ade646e244bdbec2d87c8c56a8bd/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed55af48b3eb28f43228ca2306788892bcb629eb2b5c4876e2a3659872c2f17a", size = 198378, upload-time = "2026-05-22T14:49:18.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/822efe4ea722a3961331bfa35b7d90937790d2c20f0616de1997ccc3aebd/wrapt-2.2.1-cp314-cp314t-win32.whl", hash = "sha256:2e08688ab16525897da6589d56d0aebaf417bbe91c2d8e3b96203b1efa596e85", size = 80226, upload-time = "2026-05-22T14:49:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/2a7dc5f6abb2fca0b6e1610e120419f603650aceb4f1d3ac4cae0354e162/wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50", size = 83835, upload-time = "2026-05-22T14:49:21.634Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c0/782b86e28d1ceebeb74cccea12d2cd3d2ba0bd68e3dec20b1bc5873f6127/wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00", size = 80722, upload-time = "2026-05-22T14:49:23.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000, upload-time = "2026-05-22T14:49:41.593Z" },
 ]


### PR DESCRIPTION
This is more a request for comment than a complete change (although it does work end-to-end, with some tests).

This patch adds support for expressing policy about what programs can do in the Cedar policy language (https://cedarpolicy.com/en). Cedar is a formally specified, analyzable, policy language well suited for use with modern autoformalization techniques (e.g. using LLMs and other models to do reliable natural language to policy conversions).