### PR TITLE
Deny unmounted filesystem paths when mounts are configured

### DIFF
--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -169,10 +169,13 @@ class Monty:
             print_callback: `None` (write to stdout/stderr), a callable `(stream, text) -> None`,
                 `CollectStreams()`, or `CollectString()`.
             mount: Optional filesystem mount(s) to expose inside the sandbox.
-            os: Optional callback for OS calls.
-                Called with (function_name, args) where function_name is like 'Path.exists'
-                and args is a tuple of arguments. Must return the appropriate value for the
-                OS function (e.g., bool for exists(), stat_result for stat()).
+                When supplied, filesystem calls are handled only by the mount table;
+                unmounted filesystem paths use Monty's default unhandled filesystem
+                error and do not call `os`.
+            os: Optional callback for OS calls. Called with (function_name, args, kwargs)
+                and must return the appropriate value for the OS function. When `mount`
+                is supplied, this callback is used for non-filesystem OS calls only.
+                Without `mount`, it can handle filesystem calls as well.
 
         Returns:
             The result of the last expression in the code.
@@ -198,8 +201,8 @@ class Monty:
         The GIL is released allowing parallel execution.
 
         When `mount` or `os` is provided, OS calls are resolved automatically using
-        the same logic as `run()` (mount table first, then the `os` callback),
-        this method only returns a snapshot when a non-OS event is reached
+        the same mount/OS boundary as `run()`, and this method only returns a snapshot
+        when a non-OS event is reached
         (external function, name lookup, future, or completion).
 
         Auto-dispatch does NOT persist across subsequent `snapshot.resume()` calls —
@@ -211,9 +214,12 @@ class Monty:
             limits: Optional resource limits configuration
             print_callback: Optional callback for print output
             mount: Optional filesystem mount(s) to expose inside the sandbox.
+                When supplied, filesystem calls are handled only by the mount table;
+                unmounted filesystem paths do not call `os`.
             os: Optional callback for OS calls. Called with (function_name, args, kwargs)
-                and must return the appropriate value for the OS function. Return
-                `NOT_HANDLED` to fall back to Monty's default unhandled behavior.
+                and must return the appropriate value for the OS function. With
+                `mount`, this handles non-filesystem OS calls. Return `NOT_HANDLED`
+                to fall back to Monty's default unhandled behavior.
 
         Returns:
             FunctionSnapshot if an external function call is pending,
@@ -395,8 +401,12 @@ class MontyRepl:
                 dispatched to the provided callables — matching the behavior
                 of `Monty.run(external_functions=...)`.
             print_callback: Optional callback for print output
-            mount: Optional filesystem mount(s) to expose inside the sandbox
-            os: Optional OS access handler for filesystem operations
+            mount: Optional filesystem mount(s) to expose inside the sandbox.
+                When supplied, filesystem calls are handled only by the mount table;
+                unmounted filesystem paths do not call `os`.
+            os: Optional OS access callback. With `mount`, this handles
+                non-filesystem OS calls. Without `mount`, it can handle filesystem
+                calls as well.
             skip_type_check: When `True`, static type checking is bypassed for
                 this snippet AND the snippet is NOT appended to the accumulated
                 type-check context, so later type-checked snippets will not see
@@ -462,8 +472,8 @@ class MontyRepl:
         including support for async external functions via `FutureSnapshot`.
 
         When `mount` or `os` is provided, OS calls are resolved automatically using
-        the same logic as `feed_run()`, and this method only returns a snapshot when
-        a non-OS event is reached. Auto-dispatch does NOT persist across subsequent
+        the same mount/OS boundary as `feed_run()`, and this method only returns a
+        snapshot when a non-OS event is reached. Auto-dispatch does NOT persist across subsequent
         `snapshot.resume()` calls — OS calls produced after the first resume surface
         as a `FunctionSnapshot` with `is_os_function=True`, as before.
 
@@ -475,9 +485,12 @@ class MontyRepl:
                 before executing the snippet
             print_callback: Optional callback for print output
             mount: Optional filesystem mount(s) to expose inside the sandbox.
+                When supplied, filesystem calls are handled only by the mount table;
+                unmounted filesystem paths do not call `os`.
             os: Optional callback for OS calls. Called with (function_name, args, kwargs)
-                and must return the appropriate value for the OS function. Return
-                `NOT_HANDLED` to fall back to Monty's default unhandled behavior.
+                and must return the appropriate value for the OS function. With
+                `mount`, this handles non-filesystem OS calls. Return `NOT_HANDLED`
+                to fall back to Monty's default unhandled behavior.
             skip_type_check: When `True`, static type checking is bypassed for
                 this snippet AND the snippet is NOT appended to the accumulated
                 type-check context, so later type-checked snippets will not see
@@ -583,8 +596,11 @@ class FunctionSnapshot:
         Arguments:
             result: A typeddict representing the return value, exception, or pending future.
             mount: Optional filesystem mount(s) to expose inside the sandbox.
-            os: Optional callback for OS calls. Return `NOT_HANDLED` to fall back
-                to Monty's default unhandled behavior.
+                When supplied, filesystem calls are handled only by the mount table;
+                unmounted filesystem paths do not call `os`.
+            os: Optional callback for OS calls. With `mount`, this handles
+                non-filesystem OS calls. Return `NOT_HANDLED` to fall back to
+                Monty's default unhandled behavior.
 
         Returns:
             FunctionSnapshot if another external function call is pending,
@@ -611,6 +627,7 @@ class FunctionSnapshot:
 
         When `mount` or `os` is provided, OS calls produced by the resumed
         execution are auto-dispatched until a non-OS event is reached.
+        With `mount`, unmounted filesystem paths do not call `os`.
         """
 
     def dump(self) -> bytes:
@@ -672,8 +689,11 @@ class NameLookupSnapshot:
         Arguments:
             value: The value from the name lookup, if any.
             mount: Optional filesystem mount(s) to expose inside the sandbox.
-            os: Optional callback for OS calls. Return `NOT_HANDLED` to fall back
-                to Monty's default unhandled behavior.
+                When supplied, filesystem calls are handled only by the mount table;
+                unmounted filesystem paths do not call `os`.
+            os: Optional callback for OS calls. With `mount`, this handles
+                non-filesystem OS calls. Return `NOT_HANDLED` to fall back to
+                Monty's default unhandled behavior.
 
         Returns:
             FunctionSnapshot if an external function call is pending,
@@ -748,8 +768,11 @@ class FutureSnapshot:
             results: Dict mapping call_id to result dict. Each result dict must have
                 either 'return_value' or 'exception' key (not both).
             mount: Optional filesystem mount(s) to expose inside the sandbox.
-            os: Optional callback for OS calls. Return `NOT_HANDLED` to fall back
-                to Monty's default unhandled behavior.
+                When supplied, filesystem calls are handled only by the mount table;
+                unmounted filesystem paths do not call `os`.
+            os: Optional callback for OS calls. With `mount`, this handles
+                non-filesystem OS calls. Return `NOT_HANDLED` to fall back to
+                Monty's default unhandled behavior.
 
         Returns:
             FunctionSnapshot if an external function call is pending,

--- a/crates/monty-python/src/monty_cls.rs
+++ b/crates/monty-python/src/monty_cls.rs
@@ -221,9 +221,9 @@ impl PyMonty {
     /// Starts code execution, returning a progress snapshot or the final result.
     ///
     /// When `mount` or `os` is provided, OS calls are resolved automatically via
-    /// the same logic as [`Monty::run`] (mount table first, then the Python
-    /// callback), and the method only returns a snapshot when a non-OS event is
-    /// reached (external function, name lookup, future, or completion).
+    /// the same mount/OS boundary as [`Monty::run`], and the method only returns
+    /// a snapshot when a non-OS event is reached (external function, name lookup,
+    /// future, or completion).
     ///
     /// The auto-dispatch does **not** persist across subsequent `snapshot.resume()`
     /// calls — once a snapshot is returned, any OS call produced by a later resume
@@ -628,11 +628,12 @@ impl PyMonty {
                 }
                 RunProgress::OsCall(call) => {
                     let fallback = os_handler.as_ref().and_then(|h| h.fallback.as_ref());
+                    let filesystem_boundary = os_handler.as_ref().is_some_and(|h| h.filesystem_boundary);
                     // `handle_mount_os_call` can fail during Python⇄Monty conversion;
                     // put mounts back before propagating so the `MountDir` slot doesn't
                     // get permanently stuck in the "in use" state.
                     let result: ExtFunctionResult = if let Some(table) = &mut mount_table {
-                        match handle_mount_os_call(py, &call, table, fallback, &self.dc_registry) {
+                        match handle_mount_os_call(py, &call, table, filesystem_boundary, fallback, &self.dc_registry) {
                             Ok(r) => r,
                             Err(e) => {
                                 put_back(mount_table);
@@ -2081,6 +2082,7 @@ pub(crate) fn drive_run_progress_through_os_calls<T: ResourceTracker + Send>(
 ) -> PyResult<RunProgress<T>> {
     let mut mount_table: Option<MountTable> = None;
     let fallback = handler.fallback.as_ref();
+    let filesystem_boundary = handler.filesystem_boundary;
     let put_back = |mount_table: &mut Option<MountTable>| {
         if let Some(table) = mount_table.take() {
             handler.put_back(table);
@@ -2095,7 +2097,7 @@ pub(crate) fn drive_run_progress_through_os_calls<T: ResourceTracker + Send>(
                     let table = handler.take()?;
                     mount_table.insert(table)
                 };
-                let result = match handle_mount_os_call(py, &call, table, fallback, dc_registry) {
+                let result = match handle_mount_os_call(py, &call, table, filesystem_boundary, fallback, dc_registry) {
                     Ok(r) => r,
                     Err(e) => {
                         put_back(&mut mount_table);
@@ -2119,16 +2121,16 @@ pub(crate) fn drive_run_progress_through_os_calls<T: ResourceTracker + Send>(
 }
 
 /// Handles an OS call via a Rust [`MountTable`], falling through to the
-/// `fallback` callable for unhandled operations.
+/// `fallback` callable only when the mount table is not the filesystem boundary.
 ///
-/// The mount table returns `None` for non-filesystem ops and for paths that
-/// don't match any mount. In both cases we try the fallback, or fall back to
-/// [`OsFunction::on_no_handler`] which returns `PermissionError` for filesystem
-/// ops and `RuntimeError` for non-filesystem ops.
+/// When `mount=` is supplied, filesystem paths outside the configured mounts are
+/// denied via [`OsFunction::on_no_handler`]. Non-filesystem ops still fall through
+/// to `fallback`, and `os=`-only callers keep filesystem fallback compatibility.
 pub(crate) fn handle_mount_os_call<T: ResourceTracker>(
     py: Python<'_>,
     call: &OsCall<T>,
     table: &mut MountTable,
+    filesystem_boundary: bool,
     fallback: Option<&Py<PyAny>>,
     dc_registry: &DcRegistry,
 ) -> PyResult<ExtFunctionResult> {
@@ -2136,8 +2138,9 @@ pub(crate) fn handle_mount_os_call<T: ResourceTracker>(
         Some(Ok(obj)) => Ok(obj.into()),
         Some(Err(mount_err)) => Ok(mount_err.into_exception().into()),
         None => {
-            // Intentional: unmounted paths fall through to `os=`.
-            if let Some(fb) = fallback {
+            if filesystem_boundary && call.function_call.is_filesystem() {
+                Ok(call.function_call.on_no_handler().into())
+            } else if let Some(fb) = fallback {
                 call_os_callback(py, call, fb.bind(py), dc_registry)
             } else {
                 Ok(call.function_call.on_no_handler().into())

--- a/crates/monty-python/src/mount.rs
+++ b/crates/monty-python/src/mount.rs
@@ -141,6 +141,8 @@ pub(crate) struct OsHandler {
     /// Shared references to each mount's storage. The mounts are **taken** out
     /// at the start of a run and **put back** when the run completes.
     mounts: Vec<SharedMount>,
+    /// Whether `mount=` was supplied, making the mount table the filesystem boundary.
+    pub(crate) filesystem_boundary: bool,
     /// Optional Python callable for non-filesystem OS operations.
     pub(crate) fallback: Option<Py<PyAny>>,
 }
@@ -158,6 +160,7 @@ impl OsHandler {
         mount: Option<&Bound<'_, PyAny>>,
         os: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Option<Self>> {
+        let filesystem_boundary = mount.is_some();
         let mounts = match mount {
             Some(arg) => extract_mounts(arg)?,
             None => vec![],
@@ -176,13 +179,17 @@ impl OsHandler {
             None => None,
         };
 
-        if mounts.is_empty() && fallback.is_none() {
+        if !filesystem_boundary && fallback.is_none() {
             return Ok(None);
         }
 
         // For backwards compatibility: if only `os` is provided (no mounts),
         // the callable handles all OS operations including filesystem ops.
-        Ok(Some(Self { mounts, fallback }))
+        Ok(Some(Self {
+            mounts,
+            filesystem_boundary,
+            fallback,
+        }))
     }
 
     /// Takes all mounts out of their shared slots and assembles a [`MountTable`].

--- a/crates/monty-python/src/repl.rs
+++ b/crates/monty-python/src/repl.rs
@@ -868,6 +868,7 @@ impl PyMontyRepl {
         // Take mounts out of shared slots for zero-overhead execution.
         let mut mount_table: Option<MountTable> = os_handler.map(OsHandler::take).transpose()?;
         let fallback = os_handler.and_then(|h| h.fallback.as_ref());
+        let filesystem_boundary = os_handler.is_some_and(|h| h.filesystem_boundary);
 
         // Helper: put mounts back into shared slots.
         let put_back = |table: Option<MountTable>| {
@@ -938,15 +939,21 @@ impl PyMontyRepl {
                     // `handle_repl_os_call` can fail during Python⇄Monty conversion of
                     // args/results. The OS call still owns the REPL handle — extract
                     // it via `into_repl` and put mounts back so neither leaks.
-                    let result: ExtFunctionResult =
-                        match handle_repl_os_call(py, &call, mount_table.as_mut(), fallback, &self.dc_registry) {
-                            Ok(r) => r,
-                            Err(e) => {
-                                put_back(mount_table);
-                                self.put_repl_after_rollback(EitherRepl::from_core(call.into_repl()));
-                                return Err(e);
-                            }
-                        };
+                    let result: ExtFunctionResult = match handle_repl_os_call(
+                        py,
+                        &call,
+                        mount_table.as_mut(),
+                        filesystem_boundary,
+                        fallback,
+                        &self.dc_registry,
+                    ) {
+                        Ok(r) => r,
+                        Err(e) => {
+                            put_back(mount_table);
+                            self.put_repl_after_rollback(EitherRepl::from_core(call.into_repl()));
+                            return Err(e);
+                        }
+                    };
 
                     progress = match py.detach(|| print_target.with_writer(|w| call.resume(result, w))) {
                         Ok(p) => p,
@@ -1065,6 +1072,7 @@ where
 {
     let mut mount_table: Option<MountTable> = None;
     let fallback = handler.fallback.as_ref();
+    let filesystem_boundary = handler.filesystem_boundary;
     let put_back = |mount_table: &mut Option<MountTable>| {
         if let Some(table) = mount_table.take() {
             handler.put_back(table);
@@ -1085,7 +1093,7 @@ where
                     };
                     Some(mount_table.insert(table))
                 };
-                let result = match handle_repl_os_call(py, &call, table, fallback, dc_registry) {
+                let result = match handle_repl_os_call(py, &call, table, filesystem_boundary, fallback, dc_registry) {
                     Ok(r) => r,
                     Err(e) => {
                         put_back(&mut mount_table);
@@ -1122,10 +1130,14 @@ where
 /// mount is configured. This matches [`handle_mount_os_call`] (which always has
 /// a mount table) while remaining ergonomic from the `Option<MountTable>`-holding
 /// loops in `feed_start_loop` and `drive_repl_progress_through_os_calls`.
+///
+/// When `mount=` is supplied, filesystem paths outside the mounts are denied
+/// before the fallback callback. `os=`-only callers still get filesystem fallback.
 fn handle_repl_os_call<T: ResourceTracker>(
     py: Python<'_>,
     call: &monty::ReplOsCall<T>,
     mount_table: Option<&mut MountTable>,
+    filesystem_boundary: bool,
     fallback: Option<&Py<PyAny>>,
     dc_registry: &DcRegistry,
 ) -> PyResult<ExtFunctionResult> {
@@ -1133,8 +1145,12 @@ fn handle_repl_os_call<T: ResourceTracker>(
         match table.handle_os_call(&call.function_call) {
             Some(Ok(obj)) => return Ok(obj.into()),
             Some(Err(mount_err)) => return Ok(mount_err.into_exception().into()),
-            None => {} // Intentional: unmounted paths fall through to `os=`.
+            None => {}
         }
+    }
+
+    if filesystem_boundary && call.function_call.is_filesystem() {
+        return Ok(call.function_call.on_no_handler().into());
     }
 
     if let Some(fb) = fallback {

--- a/crates/monty-python/tests/test_mount_table.py
+++ b/crates/monty-python/tests/test_mount_table.py
@@ -295,6 +295,54 @@ def test_unmounted_path_denied(test_dir: Path):
     assert 'Permission denied' in str(exc_info.value)
 
 
+def test_unmounted_path_denied_before_os_fallback(test_dir: Path):
+    md = MountDir('/data', str(test_dir), mode='read-only')
+    calls: list[str] = []
+
+    def fallback(function_name: str, args: tuple[object, ...], kwargs: dict[str, object]) -> object:
+        calls.append(function_name)
+        return True
+
+    with pytest.raises(MontyRuntimeError) as exc_info:
+        Monty("from pathlib import Path; Path('/other/file.txt').exists()").run(mount=md, os=fallback)
+    assert isinstance(exc_info.value.exception(), PermissionError)
+    assert calls == []
+    assert_mount_reusable(md)
+
+
+def test_unmounted_open_denied_before_os_fallback(test_dir: Path):
+    md = MountDir('/data', str(test_dir), mode='read-only')
+    calls: list[str] = []
+
+    def fallback(function_name: str, args: tuple[object, ...], kwargs: dict[str, object]) -> object:
+        calls.append(function_name)
+        return 'fallback'
+
+    with pytest.raises(MontyRuntimeError) as exc_info:
+        Monty("open('/outside.txt')").run(mount=md, os=fallback)
+    assert isinstance(exc_info.value.exception(), PermissionError)
+    assert calls == []
+    assert_mount_reusable(md)
+
+
+def test_repl_feed_run_unmounted_path_denied_before_os_fallback(test_dir: Path):
+    md = MountDir('/data', str(test_dir), mode='read-only')
+    repl = MontyRepl()
+    repl.feed_run('x = 42')
+    calls: list[str] = []
+
+    def fallback(function_name: str, args: tuple[object, ...], kwargs: dict[str, object]) -> object:
+        calls.append(function_name)
+        return True
+
+    with pytest.raises(MontyRuntimeError) as exc_info:
+        repl.feed_run("from pathlib import Path; Path('/outside').exists()", mount=md, os=fallback)
+    assert isinstance(exc_info.value.exception(), PermissionError)
+    assert calls == []
+    assert repl.feed_run('x') == snapshot(42)
+    assert_mount_reusable(md)
+
+
 # =============================================================================
 # Fallback via os= for non-filesystem ops
 # =============================================================================
@@ -316,6 +364,30 @@ def test_no_fallback_not_implemented(test_dir: Path):
     with pytest.raises(MontyRuntimeError) as exc_info:
         Monty("import os; os.getenv('PATH')").run(mount=md)
     assert 'is not supported in this environment' in str(exc_info.value)
+
+
+def test_empty_mount_list_denies_filesystem_but_keeps_non_fs_fallback():
+    calls: list[str] = []
+
+    def fallback(function_name: str, args: tuple[object, ...], kwargs: dict[str, object]) -> object:
+        calls.append(function_name)
+        return 'my_value' if function_name == 'os.getenv' else True
+
+    result = Monty("import os; os.getenv('MY_VAR')").run(mount=[], os=fallback)
+    assert result == snapshot('my_value')
+    assert calls == snapshot(['os.getenv'])
+
+    calls.clear()
+    with pytest.raises(MontyRuntimeError) as exc_info:
+        Monty("from pathlib import Path; Path('/other/file.txt').exists()").run(mount=[], os=fallback)
+    assert isinstance(exc_info.value.exception(), PermissionError)
+    assert calls == []
+
+
+def test_empty_mount_list_without_os_denies_filesystem():
+    with pytest.raises(MontyRuntimeError) as exc_info:
+        Monty("from pathlib import Path; Path('/other/file.txt').exists()").run(mount=[])
+    assert isinstance(exc_info.value.exception(), PermissionError)
 
 
 # =============================================================================
@@ -494,8 +566,7 @@ def test_run_mount_released_after_callback_marshalling_error(test_dir: Path):
     def os_cb(func: object, args: tuple[object, ...], kwargs: dict[str, object]) -> object:
         return object()  # unconvertible — surfaces inside Monty as TypeError
 
-    # Path is outside the mount so it falls through to the os= fallback.
-    code = "from pathlib import Path; Path('/outside/path.txt').exists()"
+    code = "import os; os.getenv('MY_VAR')"
     with pytest.raises(MontyRuntimeError) as exc_info:
         Monty(code).run(mount=md, os=os_cb)
     assert isinstance(exc_info.value.exception(), TypeError)
@@ -513,9 +584,9 @@ def test_os_callback_lone_surrogate_return_surfaces_inside_monty(test_dir: Path)
     # Catching inside Monty proves the error arrives as an in-VM exception rather
     # than propagating out as a raw PyErr.
     code = (
-        'from pathlib import Path\n'
+        'import os\n'
         'try:\n'
-        "    Path('/outside/path.txt').read_text()\n"
+        "    os.getenv('MY_VAR')\n"
         "    result = 'no error'\n"
         'except ValueError as e:\n'
         "    result = 'caught'\n"
@@ -538,7 +609,7 @@ def test_repl_feed_run_mount_and_repl_released_after_callback_marshalling_error(
     def os_cb(func: object, args: tuple[object, ...], kwargs: dict[str, object]) -> object:
         return object()  # unconvertible — surfaces inside Monty as TypeError
 
-    code = "from pathlib import Path; Path('/outside/path.txt').exists()"
+    code = "import os; os.getenv('MY_VAR')"
     with pytest.raises(MontyRuntimeError) as exc_info:
         repl.feed_run(code, mount=md, os=os_cb)
     assert isinstance(exc_info.value.exception(), TypeError)

--- a/crates/monty-python/tests/test_repl.py
+++ b/crates/monty-python/tests/test_repl.py
@@ -1024,6 +1024,23 @@ def test_feed_start_os_not_handled_falls_through():
     assert repl.feed_run('1 + 1') == snapshot(2)
 
 
+def test_feed_start_mount_denies_unmounted_path_before_os_callback(test_dir: Path):
+    md = MountDir('/data', str(test_dir), mode='read-only')
+    calls: list[str] = []
+
+    def os_cb(func: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> bool:
+        calls.append(func)
+        return True
+
+    repl = pydantic_monty.MontyRepl()
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        repl.feed_start("from pathlib import Path; Path('/outside').exists()", mount=md, os=os_cb)
+    assert isinstance(exc_info.value.exception(), PermissionError)
+    assert calls == []
+    assert repl.feed_run('1 + 1') == snapshot(2)
+    assert_mount_reusable(md)
+
+
 def test_feed_start_mount_released_after_completion(test_dir: Path):
     """After feed_start auto-dispatches, the mount is put back and usable again."""
     md = MountDir('/data', str(test_dir), mode='read-only')
@@ -1047,7 +1064,7 @@ def test_feed_start_mount_contention_on_os_call_restores_repl_state(test_dir: Pa
             repl.feed_start("from pathlib import Path; Path('/data/hello.txt').read_text()", mount=md)
         return False
 
-    outer = pydantic_monty.Monty("from pathlib import Path; Path('/outside').exists()")
+    outer = pydantic_monty.Monty("import os; os.getenv('MY_VAR')")
     result = outer.start(mount=md, os=os_cb)
     assert isinstance(result, pydantic_monty.MontyComplete)
     assert result.output is False
@@ -1105,6 +1122,31 @@ result = (x, exists)
     assert isinstance(p1, pydantic_monty.FunctionSnapshot)
     p1.resume({'return_value': 'fetched'}, os=os_cb)
     assert repl.feed_run('result') == snapshot(('fetched', True))
+
+
+def test_repl_function_snapshot_resume_mount_denies_unmounted_path_before_os_callback(test_dir: Path):
+    md = MountDir('/data', str(test_dir), mode='read-only')
+    calls: list[str] = []
+    repl = pydantic_monty.MontyRepl()
+    code = """
+from pathlib import Path
+value = fetch()
+Path('/outside').exists()
+result = value
+"""
+    progress = repl.feed_start(code)
+    assert isinstance(progress, pydantic_monty.FunctionSnapshot)
+
+    def os_cb(func: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> bool:
+        calls.append(func)
+        return True
+
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        progress.resume({'return_value': 'fetched'}, mount=md, os=os_cb)
+    assert isinstance(exc_info.value.exception(), PermissionError)
+    assert calls == []
+    assert repl.feed_run('1 + 1') == snapshot(2)
+    assert_mount_reusable(md)
 
 
 def test_repl_function_snapshot_resume_yields_next_external(test_dir: Path):
@@ -1322,7 +1364,7 @@ result = (value, content)
             pending.resume({'return_value': 'fetched'}, mount=md)
         return False
 
-    outer = pydantic_monty.Monty("from pathlib import Path; Path('/outside').exists()")
+    outer = pydantic_monty.Monty("import os; os.getenv('MY_VAR')")
     result = outer.start(mount=md, os=os_cb)
     assert isinstance(result, pydantic_monty.MontyComplete)
     assert result.output is False

--- a/crates/monty-python/tests/test_start.py
+++ b/crates/monty-python/tests/test_start.py
@@ -710,6 +710,37 @@ def test_start_with_os_callback_not_handled():
     assert isinstance(inner, PermissionError)
 
 
+def test_start_mount_denies_unmounted_path_before_os_callback(test_dir: Path):
+    md = MountDir('/data', str(test_dir), mode='read-only')
+    calls: list[str] = []
+
+    def os_cb(func: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> bool:
+        calls.append(func)
+        return True
+
+    m = Monty("from pathlib import Path; Path('/outside').exists()")
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        m.start(mount=md, os=os_cb)
+    assert isinstance(exc_info.value.exception(), PermissionError)
+    assert calls == []
+    assert_mount_reusable(md)
+
+
+def test_start_mount_keeps_non_filesystem_os_callback(test_dir: Path):
+    md = MountDir('/data', str(test_dir), mode='read-only')
+    calls: list[str] = []
+
+    def os_cb(func: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> object:
+        calls.append(func)
+        return 'my_value'
+
+    result = Monty("import os; os.getenv('MY_VAR')").start(mount=md, os=os_cb)
+    assert isinstance(result, pydantic_monty.MontyComplete)
+    assert result.output == snapshot('my_value')
+    assert calls == snapshot(['os.getenv'])
+    assert_mount_reusable(md)
+
+
 def test_start_mount_then_external_function(test_dir: Path):
     """OS calls are auto-dispatched, then start() returns the external FunctionSnapshot."""
     md = MountDir('/data', str(test_dir), mode='read-only')
@@ -862,7 +893,7 @@ def test_start_mount_ignored_when_progress_never_reaches_os_call(test_dir: Path)
         assert inner.output == snapshot(2)
         return False
 
-    outer = Monty("from pathlib import Path; Path('/outside').exists()")
+    outer = Monty("import os; os.getenv('MY_VAR')")
     result = outer.start(mount=md, os=os_cb)
     assert isinstance(result, pydantic_monty.MontyComplete)
     assert result.output is False
@@ -911,6 +942,29 @@ exists = Path('/tmp/some.txt').exists()
     result = p1.resume({'return_value': 'fetched'}, os=os_cb)
     assert isinstance(result, pydantic_monty.MontyComplete)
     assert result.output == snapshot(('fetched', True))
+
+
+def test_function_snapshot_resume_mount_denies_unmounted_path_before_os_callback(test_dir: Path):
+    md = MountDir('/data', str(test_dir), mode='read-only')
+    calls: list[str] = []
+    code = """
+from pathlib import Path
+value = fetch()
+Path('/outside').exists()
+value
+"""
+    progress = Monty(code).start()
+    assert isinstance(progress, pydantic_monty.FunctionSnapshot)
+
+    def os_cb(func: str, args: tuple[Any, ...], kwargs: dict[str, Any]) -> bool:
+        calls.append(func)
+        return True
+
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        progress.resume({'return_value': 'fetched'}, mount=md, os=os_cb)
+    assert isinstance(exc_info.value.exception(), PermissionError)
+    assert calls == []
+    assert_mount_reusable(md)
 
 
 def test_function_snapshot_resume_with_mount_yields_next_external(test_dir: Path):
@@ -1164,7 +1218,7 @@ def test_resume_mount_ignored_when_progress_never_reaches_os_call(test_dir: Path
         assert inner.output == snapshot(1)
         return False
 
-    outer = Monty("from pathlib import Path; Path('/outside').exists()")
+    outer = Monty("import os; os.getenv('MY_VAR')")
     result = outer.start(mount=md, os=os_cb)
     assert isinstance(result, pydantic_monty.MontyComplete)
     assert result.output is False

--- a/crates/monty/src/os.rs
+++ b/crates/monty/src/os.rs
@@ -719,3 +719,77 @@ const STAT_RESULT_TYPE_NAME: &str = "StatResult";
 const STAT_RESULT_FIELDS: &[&str] = &[
     "st_mode", "st_ino", "st_dev", "st_nlink", "st_uid", "st_gid", "st_size", "st_atime", "st_mtime", "st_ctime",
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn path() -> MontyPath {
+        MontyPath::new("/path".to_owned())
+    }
+
+    #[test]
+    fn filesystem_classification_covers_real_os_calls() {
+        let filesystem_calls = vec![
+            OsFunctionCall::Exists(path()),
+            OsFunctionCall::IsFile(path()),
+            OsFunctionCall::IsDir(path()),
+            OsFunctionCall::IsSymlink(path()),
+            OsFunctionCall::ReadText(path()),
+            OsFunctionCall::ReadBytes(path()),
+            OsFunctionCall::Stat(path()),
+            OsFunctionCall::Iterdir(path()),
+            OsFunctionCall::Resolve(path()),
+            OsFunctionCall::Absolute(path()),
+            OsFunctionCall::WriteText(PathStringDataArgs {
+                path: path(),
+                data: "text".to_owned(),
+            }),
+            OsFunctionCall::AppendText(PathStringDataArgs {
+                path: path(),
+                data: "text".to_owned(),
+            }),
+            OsFunctionCall::WriteBytes(PathBytesDataArgs {
+                path: path(),
+                data: b"bytes".to_vec(),
+            }),
+            OsFunctionCall::AppendBytes(PathBytesDataArgs {
+                path: path(),
+                data: b"bytes".to_vec(),
+            }),
+            OsFunctionCall::Open(OpenCallArgs {
+                path: path(),
+                mode: FileMode::Read(false),
+            }),
+            OsFunctionCall::Mkdir(MkdirCallArgs {
+                path: path(),
+                parents: false,
+                exist_ok: false,
+            }),
+            OsFunctionCall::Unlink(path()),
+            OsFunctionCall::Rmdir(path()),
+            OsFunctionCall::Rename(RenameCallArgs {
+                src: path(),
+                dst: MontyPath::new("/dst".to_owned()),
+            }),
+        ];
+
+        for call in filesystem_calls {
+            assert!(call.is_filesystem(), "{} should be filesystem", call.name());
+        }
+
+        let non_filesystem_calls = vec![
+            OsFunctionCall::Getenv(GetenvArgs {
+                key: "KEY".to_owned(),
+                default: MontyObject::None,
+            }),
+            OsFunctionCall::GetEnviron,
+            OsFunctionCall::DateToday,
+            OsFunctionCall::DateTimeNow(MontyObject::None),
+        ];
+
+        for call in non_filesystem_calls {
+            assert!(!call.is_filesystem(), "{} should not be filesystem", call.name());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

When `mount=` and `os=` are both configured, filesystem operations outside the mounted paths now fail closed instead of falling through to the `os=` callback.

This keeps the mount table as the filesystem boundary once mounts are supplied. The `os=` callback still handles non-filesystem operations such as environment and clock lookups, and `os=`-only usage keeps the existing behavior for callers that intentionally provide their own filesystem handler.

Fixes #350.

## Changes

- deny unmounted filesystem calls before invoking the fallback callback
- apply the same rule to `Monty.run/start`, `MontyRepl.feed_*`, and snapshot resume auto-dispatch
- update comments, public stubs, and tests to describe the new contract
- keep `os=`-only filesystem dispatch compatible

## Validation

- `uv sync --all-packages --only-dev`
- `RUSTUP_TOOLCHAIN=1.95 uv run maturin develop --uv -m crates/monty-python/Cargo.toml`
- `RUSTUP_TOOLCHAIN=1.95 uv run --package pydantic-monty --only-dev pytest crates/monty-python/tests/test_mount_table.py crates/monty-python/tests/test_start.py crates/monty-python/tests/test_repl.py crates/monty-python/tests/test_os_calls.py`
- `RUSTUP_TOOLCHAIN=1.95 cargo test --workspace`
- `RUSTUP_TOOLCHAIN=1.95 make lint-py`
- `cargo +nightly fmt --all --check`
- `git diff --check`