### PR TITLE
fix: return error instead of panicking in `ForIter` heap read

### DIFF
--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -1342,7 +1342,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
                         return Err(RunError::internal("ForIter: expected iterator ref on stack"));
                     };
                     let HeapReadOutput::Iter(mut iter) = self.heap.read(heap_id) else {
-                        panic!("ForIter: expected iterator ref on stack");
+                        return Err(RunError::internal("ForIter: expected iterator ref on stack"));
                     };
 
                     match iter.advance(self) {


### PR DESCRIPTION
The `ForIter` opcode already returns `RunError::internal` when TOS is not a `Value::Ref`, but the second check on `heap.read` was a `panic!` instead.

This crashes the host process when the heap entry is unexpectedly not an iterator, rather than propagating the error through the normal exception path.