### PR TITLE
Match monty's floating point modulo behavior to cpython

### DIFF
--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -519,21 +519,21 @@ impl PyTrait<'_> for Value {
                 if *v2 == 0.0 {
                     Err(ExcType::zero_division().into())
                 } else {
-                    Ok(Some(Self::Float(v1 % v2)))
+                    Ok(Some(Self::Float(py_float_mod(*v1, *v2))))
                 }
             }
             (Self::Float(v1), Self::Int(v2)) => {
                 if *v2 == 0 {
                     Err(ExcType::zero_division().into())
                 } else {
-                    Ok(Some(Self::Float(v1 % (*v2 as f64))))
+                    Ok(Some(Self::Float(py_float_mod(*v1, *v2 as f64))))
                 }
             }
             (Self::Int(v1), Self::Float(v2)) => {
                 if *v2 == 0.0 {
                     Err(ExcType::zero_division().into())
                 } else {
-                    Ok(Some(Self::Float((*v1 as f64) % v2)))
+                    Ok(Some(Self::Float(py_float_mod(*v1 as f64, *v2))))
                 }
             }
             _ => Ok(None),
@@ -2301,6 +2301,16 @@ pub(crate) fn floor_divmod(a: i64, b: i64) -> Option<(i64, i64)> {
     } else {
         Some((quot, rem))
     }
+}
+
+/// Python-style floored float modulo: result has the same sign as the divisor.
+///
+/// Rust's `%` operator uses truncated division (C `fmod`), which gives the remainder
+/// the sign of the dividend. Python's `%` uses floored division, matching `a - b * floor(a/b)`.
+fn py_float_mod(a: f64, b: f64) -> f64 {
+    let r = a % b;
+    // Adjust when remainder and divisor have different signs
+    if r != 0.0 && ((r < 0.0) != (b < 0.0)) { r + b } else { r }
 }
 
 /// Converts a heap `HeapId` into its tagged `id()` value, ensuring it never collides with other spaces.

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -552,9 +552,9 @@ impl PyTrait<'_> for Value {
                     (*v2 != 0).then_some(0 == right_value)
                 }
             }
-            (Self::Float(v1), Self::Float(v2)) => Some(v1 % v2 == right_value as f64),
-            (Self::Float(v1), Self::Int(v2)) => Some(v1 % (*v2 as f64) == right_value as f64),
-            (Self::Int(v1), Self::Float(v2)) => Some((*v1 as f64) % v2 == right_value as f64),
+            (Self::Float(v1), Self::Float(v2)) => Some(py_float_mod(*v1, *v2) == right_value as f64),
+            (Self::Float(v1), Self::Int(v2)) => Some(py_float_mod(*v1, *v2 as f64) == right_value as f64),
+            (Self::Int(v1), Self::Float(v2)) => Some(py_float_mod(*v1 as f64, *v2) == right_value as f64),
             _ => None,
         }
     }

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -2309,8 +2309,13 @@ pub(crate) fn floor_divmod(a: i64, b: i64) -> Option<(i64, i64)> {
 /// the sign of the dividend. Python's `%` uses floored division, matching `a - b * floor(a/b)`.
 fn py_float_mod(a: f64, b: f64) -> f64 {
     let r = a % b;
-    // Adjust when remainder and divisor have different signs
-    if r != 0.0 && ((r < 0.0) != (b < 0.0)) { r + b } else { r }
+    if r != 0.0 && ((r < 0.0) != (b < 0.0)) {
+        r + b
+    } else {
+        // Normalize sign of zero: CPython ensures 0.0 carries the divisor's sign,
+        // so e.g. `-0.47 % 1.0` yields `0.0` not `-0.0`.
+        f64::copysign(r, b)
+    }
 }
 
 /// Converts a heap `HeapId` into its tagged `id()` value, ensuring it never collides with other spaces.

--- a/crates/monty/test_cases/arith__float_mod.py
+++ b/crates/monty/test_cases/arith__float_mod.py
@@ -21,17 +21,20 @@ assert -7 % 3.0 == 2.0, 'negative int % positive float'
 assert 7.0 % -3 == -2.0, 'positive float % negative int'
 assert -1 % 10.0 == 9.0, 'negative int % positive float large'
 
-# === Edge cases ===
-assert 0.0 % 5.0 == 0.0, 'zero % positive'
-assert 0.0 % -5.0 == 0.0, 'zero % negative'
-assert -0.0 % 5.0 == 0.0, 'negative zero % positive'
-
-# === Sign of zero: CPython ensures zero result carries the divisor's sign ===
+# === Edge cases: sign of zero must match divisor (CPython semantics) ===
 import math
+
+r = 0.0 % 5.0
+assert r == 0.0 and math.copysign(1.0, r) > 0, 'zero % positive must be +0.0'
+
+r = 0.0 % -5.0
+assert r == 0.0 and math.copysign(1.0, r) < 0, 'zero % negative must be -0.0'
+
+r = -0.0 % 5.0
+assert r == 0.0 and math.copysign(1.0, r) > 0, 'negative zero % positive must be +0.0'
+
 r = -1.0 % 1.0
-assert r == 0.0, 'exact zero from negative % positive'
-assert math.copysign(1.0, r) > 0, '-1.0 % 1.0 must be +0.0 not -0.0'
+assert r == 0.0 and math.copysign(1.0, r) > 0, '-1.0 % 1.0 must be +0.0 not -0.0'
 
 r = 1.0 % -1.0
-assert r == 0.0, 'exact zero from positive % negative'
-assert math.copysign(1.0, r) < 0, '1.0 % -1.0 must be -0.0'
+assert r == 0.0 and math.copysign(1.0, r) < 0, '1.0 % -1.0 must be -0.0'

--- a/crates/monty/test_cases/arith__float_mod.py
+++ b/crates/monty/test_cases/arith__float_mod.py
@@ -23,5 +23,15 @@ assert -1 % 10.0 == 9.0, 'negative int % positive float large'
 
 # === Edge cases ===
 assert 0.0 % 5.0 == 0.0, 'zero % positive'
-assert 0.0 % -5.0 == 0.0, 'zero % negative (should not be -0.0 per CPython)'
+assert 0.0 % -5.0 == 0.0, 'zero % negative'
 assert -0.0 % 5.0 == 0.0, 'negative zero % positive'
+
+# === Sign of zero: CPython ensures zero result carries the divisor's sign ===
+import math
+r = -1.0 % 1.0
+assert r == 0.0, 'exact zero from negative % positive'
+assert math.copysign(1.0, r) > 0, '-1.0 % 1.0 must be +0.0 not -0.0'
+
+r = 1.0 % -1.0
+assert r == 0.0, 'exact zero from positive % negative'
+assert math.copysign(1.0, r) < 0, '1.0 % -1.0 must be -0.0'

--- a/crates/monty/test_cases/arith__float_mod.py
+++ b/crates/monty/test_cases/arith__float_mod.py
@@ -1,0 +1,27 @@
+# === Float modulo: Python uses floored division (result sign matches divisor) ===
+
+# Positive dividend, positive divisor
+assert 7.5 % 2.0 == 1.5, 'positive % positive'
+assert 10.0 % 3.0 == 1.0, 'positive % positive integer result'
+
+# Negative dividend, positive divisor — result must be positive
+assert -7.0 % 3.0 == 2.0, 'negative % positive'
+assert -1.0 % 10.0 == 9.0, 'negative % large positive'
+assert -0.5 % 1.0 == 0.5, 'small negative % positive'
+
+# Positive dividend, negative divisor — result must be negative
+assert 7.0 % -3.0 == -2.0, 'positive % negative'
+assert 1.0 % -10.0 == -9.0, 'positive % large negative'
+
+# Negative dividend, negative divisor — result must be negative
+assert -7.0 % -3.0 == -1.0, 'negative % negative'
+
+# === Mixed int/float operands ===
+assert -7 % 3.0 == 2.0, 'negative int % positive float'
+assert 7.0 % -3 == -2.0, 'positive float % negative int'
+assert -1 % 10.0 == 9.0, 'negative int % positive float large'
+
+# === Edge cases ===
+assert 0.0 % 5.0 == 0.0, 'zero % positive'
+assert 0.0 % -5.0 == 0.0, 'zero % negative (should not be -0.0 per CPython)'
+assert -0.0 % 5.0 == 0.0, 'negative zero % positive'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Match float modulo to CPython: use floored semantics, normalize zero sign, and align `py_mod_eq` fast path to fix wrong results with negative operands and -0.0/+0.0 anomalies.

- **Bug Fixes**
  - Implemented Python-style modulo via `py_float_mod` for float%float, float%int, and int%float (remainder takes the divisor’s sign).
  - Fixed `py_mod_eq` fast path to use `py_float_mod` for float cases to keep compare-mod-equals consistent.
  - Normalized exact-zero results with `f64::copysign` so 0.0 matches the divisor’s sign; strengthened zero-sign tests with `math.copysign`.

<sup>Written for commit 75d71ef6341f9520e5a25c6c24f9e7a4ac496418. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

