### PR TITLE
Prototype type checking w/ pyrefly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocative"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8cf9afc79c83d514444b55df3935d317da54b1ce3b17a133c646889cc260de8"
+dependencies = [
+ "allocative_derive",
+ "ctor 1.0.7",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "allocative_derive"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614043c56c1173b800acb007b81fd0cbc0a0d7d717b71ba705fc2230d0760a23"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -163,9 +185,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "append-only-vec"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114736faba96bcd79595c700d03183f61357b9fbce14852515e59f3bee4ed4a"
 
 [[package]]
 name = "approx"
@@ -174,6 +202,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
+dependencies = [
+ "object 0.39.1",
 ]
 
 [[package]]
@@ -187,12 +224,28 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.8.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "argfile"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99489a733dea0d2930bfa59c243146a8513ce7b0991b9d006647687cc61f53e7"
+dependencies = [
+ "fs-err",
+ "os_str_bytes",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -202,14 +255,20 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
+
+[[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
 
 [[package]]
 name = "atomic-polyfill"
@@ -237,7 +296,7 @@ dependencies = [
  "manyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -253,7 +312,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "quote-use",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -264,9 +323,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -274,14 +333,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -294,7 +354,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.37.3",
  "rustc-demangle",
  "windows-link",
 ]
@@ -340,9 +400,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
@@ -357,6 +417,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ae7bad254120e9e4c63bafc385310756f90c484eac0e36b8317cf09cb92a77"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq 0.4.2",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+ "memmap2",
+ "rayon-core",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,10 +443,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "boxcar"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "bstr"
@@ -405,6 +500,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bzip2"
@@ -437,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -455,14 +553,23 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+checksum = "c1ec78e242cfa2cfe276807ac2ecc00315a6c97786977414bcd1c3963b6c91b8"
 dependencies = [
  "cap-primitives",
  "io-extras",
  "io-lifetimes 3.0.1",
  "rustix",
+]
+
+[[package]]
+name = "capnp"
+version = "0.25.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4777a3bc19b8f8e5fb2d0196c6b5dfcbbcc8b2fe08ae57f873f2f35f15cfc210"
+dependencies = [
+ "embedded-io 0.7.1",
 ]
 
 [[package]]
@@ -523,8 +630,9 @@ checksum = "576ba56f6ca18ebb069d0d07260407171712aff4dfe15ee3f8982dc16a455bcf"
 dependencies = [
  "castaway",
  "get-size2",
- "itoa",
- "ryu",
+ "itoa 1.0.17",
+ "ryu 1.0.22",
+ "serde_core",
 ]
 
 [[package]]
@@ -574,15 +682,15 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -590,33 +698,36 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
- "anstream 0.6.21",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
+ "unicase",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clipboard-win"
@@ -637,12 +748,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -673,7 +790,7 @@ dependencies = [
  "codspeed",
  "codspeed-criterion-compat-walltime",
  "colored 2.2.0",
- "futures",
+ "futures 0.3.31",
  "regex",
  "tokio",
 ]
@@ -690,7 +807,7 @@ dependencies = [
  "clap",
  "codspeed",
  "criterion-plot",
- "futures",
+ "futures 0.3.31",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
@@ -731,18 +848,18 @@ dependencies = [
 
 [[package]]
 name = "colored"
-version = "3.1.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -756,19 +873,30 @@ checksum = "79fcda08c33bb58b97008b2cdada6622500e949e060f5913361763121abd2416"
 dependencies = [
  "castaway",
  "cfg-if",
- "itoa",
+ "itoa 1.0.17",
+ "serde",
  "static_assertions",
  "zmij",
 ]
 
 [[package]]
-name = "console"
-version = "0.16.3"
+name = "configparser"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "b46dec724fd22199ebde05033a0cbae453bc3b1ecff11eb6a6bb3eec4b90c6a4"
+dependencies = [
+ "indexmap",
+]
+
+[[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -779,10 +907,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1af709f1f33454bf52eadfc8c78b3b9ef9cb26fb54d16dc9cd9a7299f899fd1b"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -850,7 +993,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "futures",
+ "futures 0.3.31",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
@@ -882,6 +1025,15 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98b0cc327b5bc766e7fda9c9260cc0fa81b43a8e240440422dff70788e3f9ef1"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "crossbeam-deque"
@@ -934,6 +1086,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctor"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,16 +1105,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
+]
+
+[[package]]
 name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
-name = "dashmap"
-version = "6.1.0"
+name = "ctutils"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -961,13 +1175,15 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+ "rayon",
+ "serde",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "datatest-stable"
@@ -991,12 +1207,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "deranged"
-version = "0.5.5"
+name = "defmt"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
 dependencies = [
- "powerfmt",
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1007,7 +1262,7 @@ checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1018,7 +1273,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1033,20 +1288,31 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.6"
+name = "digest"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1077,6 +1343,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dupe"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed2bc011db9c93fbc2b6cdb341a53737a55bafb46dbb74cf6764fc33a2fbf9c"
+dependencies = [
+ "dupe_derive",
+]
+
+[[package]]
+name = "dupe_derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e195b4945e88836d826124af44fdcb262ec01ef94d44f14f4fb5103f19892a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1381,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "embedded-io"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1397,26 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "enum-iterator"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "env_filter"
@@ -1133,7 +1445,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1149,7 +1461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1172,7 +1484,7 @@ checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
 dependencies = [
  "bit-set",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -1183,8 +1495,14 @@ checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.11",
 ]
+
+[[package]]
+name = "faster-hex"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e2ce894d53b295cf97b05685aa077950ff3e8541af83217fc720a6437169f8"
 
 [[package]]
 name = "fastrand"
@@ -1277,6 +1595,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "fs-set-times"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,10 +1621,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
 
 [[package]]
 name = "futures"
@@ -1355,7 +1697,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1376,6 +1718,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures 0.1.31",
  "futures-channel",
  "futures-core",
  "futures-io",
@@ -1386,6 +1729,24 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1406,7 +1767,7 @@ checksum = "c736d226c32e496b8377813b52269e11ad3a48d8373b68862d0364f04fd1229d"
 dependencies = [
  "attribute-derive",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1417,7 +1778,7 @@ checksum = "b411f34418305908ab15a82ff78958c2a9aee9a272b2a2e663836b20a4e4b9d3"
 dependencies = [
  "compact_str",
  "get-size-derive2",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap",
  "ordermap",
  "smallvec",
@@ -1460,15 +1821,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
  "wasm-bindgen",
 ]
 
@@ -1480,9 +1843,22 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax 0.8.11",
+]
 
 [[package]]
 name = "half"
@@ -1532,9 +1908,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1543,11 +1919,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
 dependencies = [
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1560,7 +1936,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin 0.9.9",
+ "spin 0.9.8",
  "stable_deref_trait",
 ]
 
@@ -1577,12 +1953,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1596,12 +1978,12 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
- "itoa",
+ "itoa 1.0.17",
 ]
 
 [[package]]
@@ -1616,9 +1998,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1634,10 +2016,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "hyper"
-version = "1.11.0"
+name = "human_bytes"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "91f255a4535024abf7640cb288260811fc14794f62b063652ed349f9a6c2348e"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1646,7 +2043,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
- "itoa",
+ "itoa 1.0.17",
  "pin-project-lite",
  "smallvec",
  "tokio",
@@ -1804,6 +2201,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,15 +2228,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
+name = "index_vec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44faf5bb8861a9c72e20d3fb0fdbd59233e43056e2b80475ab0aacdc2e781355"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
+dependencies = [
+ "console",
+ "futures-core",
+ "portable-atomic",
+ "rayon",
+ "tokio",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+ "unit-prefix",
+ "web-time",
 ]
 
 [[package]]
@@ -1845,13 +2287,33 @@ dependencies = [
  "ahash",
  "indexmap",
  "is-terminal",
- "itoa",
+ "itoa 1.0.17",
  "log",
  "num-format",
  "once_cell",
  "quick-xml",
  "rgb",
  "str_stack",
+]
+
+[[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags 2.13.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1883,12 +2345,9 @@ checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
 name = "intrusive-collections"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b719c59241cfaac1042a6d26787e28ed7ee4a4e21a5a907786f54222d1b0062"
-dependencies = [
- "memoffset",
-]
+checksum = "4275b20e6057cd7733fd8df8a5a31701e4fe44497dad0f3fa0e1c4fb971506be"
 
 [[package]]
 name = "inventory"
@@ -1906,7 +2365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1936,7 +2395,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1947,7 +2406,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1985,9 +2444,50 @@ dependencies = [
 
 [[package]]
 name = "itoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "jiter"
@@ -1998,7 +2498,7 @@ dependencies = [
  "ahash",
  "bitvec",
  "lexical-parse-float",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "pyo3",
  "smallvec",
@@ -2016,7 +2516,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -2031,7 +2531,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2050,7 +2550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2071,6 +2571,26 @@ checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
 ]
 
 [[package]]
@@ -2143,12 +2663,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "libc",
  "redox_syscall 0.7.0",
 ]
@@ -2166,10 +2695,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.11.0"
+name = "link-section"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "c2b1dd6fe32e55c0fc0ea9493aa57459ca3cf4ff3c857c7d0302290150da6e4f"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2184,6 +2725,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
+]
+
+[[package]]
+name = "lock_free_hashtable"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf3631712f5b790675292ff827af269f5d9f920c920b77dc41d0485e3719612"
+dependencies = [
+ "atomic",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2208,7 +2759,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "rand 0.10.1",
- "thiserror",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
@@ -2250,9 +2801,9 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "regex-syntax",
+ "regex-syntax 0.8.11",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2265,8 +2816,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-automata",
- "regex-syntax",
- "syn 2.0.114",
+ "regex-syntax 0.8.11",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2294,6 +2845,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lsp-server"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee25a31f2e571e426eef2896179450cafc7e2f5be00d8a93b1c2d21c0ff7656"
+dependencies = [
+ "crossbeam-channel",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "lsp-types"
+version = "0.95.2"
+source = "git+https://github.com/yangdanny97/lsp-types?rev=395d6bfcd6c3696a64cfe9cd93b86f981fb85112#395d6bfcd6c3696a64cfe9cd93b86f981fb85112"
+dependencies = [
+ "bitflags 1.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "url",
+]
+
+[[package]]
 name = "manyhow"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2302,7 +2878,7 @@ dependencies = [
  "manyhow-macros",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2315,6 +2891,12 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matchers"
@@ -2353,12 +2935,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
+name = "memory-stats"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+checksum = "c73f5c649995a115e1a0220b35e4df0a1294500477f97a91d0660fb5abeb574a"
 dependencies = [
- "autocfg",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2380,7 +2963,16 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -2395,11 +2987,12 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -2416,22 +3009,22 @@ dependencies = [
  "indexmap",
  "insta",
  "itertools 0.14.0",
- "itoa",
+ "itoa 1.0.17",
  "jiter",
  "libm",
  "memchr",
  "monty-macros",
  "monty-types",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
  "postcard",
- "ruff_python_ast",
+ "ruff_python_ast 0.0.9",
  "ruff_python_codegen",
- "ruff_python_parser",
+ "ruff_python_parser 0.0.9",
  "ruff_python_stdlib",
- "ruff_source_file",
- "ruff_text_size",
+ "ruff_source_file 0.0.9",
+ "ruff_text_size 0.0.9",
  "serde",
  "serde_json",
  "smallvec",
@@ -2535,7 +3128,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "num-bigint",
+ "num-bigint 0.4.6",
  "opentelemetry",
  "opentelemetry_sdk",
  "postcard",
@@ -2551,7 +3144,7 @@ dependencies = [
  "insta",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2588,7 +3181,7 @@ dependencies = [
  "monty",
  "monty-type-checking",
  "monty-types",
- "num-bigint",
+ "num-bigint 0.4.6",
  "prost",
  "prost-build",
  "protox",
@@ -2627,9 +3220,10 @@ dependencies = [
  "monty-typeshed",
  "pprof",
  "pretty_assertions",
+ "pyrefly",
  "ruff_db",
- "ruff_python_ast",
- "ruff_text_size",
+ "ruff_python_ast 0.0.9",
+ "ruff_text_size 0.0.9",
  "salsa",
  "ty_module_resolver",
  "ty_python_core",
@@ -2642,7 +3236,7 @@ version = "0.0.23"
 dependencies = [
  "chrono",
  "monty-macros",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "postcard",
  "serde",
@@ -2669,7 +3263,7 @@ dependencies = [
  "monty-alloc",
  "monty-proto",
  "monty-types",
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
 ]
 
 [[package]]
@@ -2684,9 +3278,9 @@ version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "909805cbad4d569e69b80e101290fe72e92b9742ba9e333b0c1e83b22fb7447b"
 dependencies = [
- "bitflags 2.13.1",
- "ctor",
- "futures",
+ "bitflags 2.13.0",
+ "ctor 0.6.3",
+ "futures 0.3.31",
  "napi-build",
  "napi-sys",
  "nohash-hasher",
@@ -2706,12 +3300,12 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04ba21bbdf40b33496b4ee6eadfc64d17a6a6cde57cd31549117b0882d1fef86"
 dependencies = [
- "convert_case",
- "ctor",
+ "convert_case 0.10.0",
+ "ctor 0.6.3",
  "napi-derive-backend",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2720,11 +3314,11 @@ version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9a63791e230572c3218a7acd86ca0a0529fc64294bcbea567cf906d7b04e077"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "semver",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2762,7 +3356,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2774,7 +3368,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2787,12 +3381,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.13.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2807,10 +3428,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-conv"
-version = "0.1.0"
+name = "num-bigint"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand 0.10.1",
+ "rand_core 0.10.1",
+ "serde",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-format"
@@ -2819,7 +3453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
  "arrayvec",
- "itoa",
+ "itoa 1.0.17",
 ]
 
 [[package]]
@@ -2850,10 +3484,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
+name = "object"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2883,7 +3526,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -2913,7 +3556,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2939,8 +3582,8 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "portable-atomic",
- "rand 0.9.4",
- "thiserror",
+ "rand 0.9.2",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
 ]
@@ -2952,6 +3595,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1"
 dependencies = [
  "indexmap",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89284d0c2af7b0eb5e814798aa07265413c8fd72009f7fc82ea25a81fb287ce9"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2978,6 +3630,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-display"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6509d08722b53e8dafe97f2027b22ccbe3a5db83cb352931e9716b0aa44bc5c"
+dependencies = [
+ "once_cell",
+ "parse-display-derive",
+ "regex",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68517892c8daf78da08c0db777fcc17e07f2f63ef70041718f8a7630ad84f341"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax 0.7.5",
+ "structmeta",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "password-hash"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2986,6 +3664,30 @@ dependencies = [
  "base64ct",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "path-absolutize"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -3006,7 +3708,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
  "password-hash",
  "sha2",
@@ -3120,6 +3822,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3164,10 +3875,10 @@ dependencies = [
  "nix 0.26.4",
  "once_cell",
  "smallvec",
- "spin 0.10.1",
+ "spin 0.10.0",
  "symbolic-demangle",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3196,7 +3907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3212,9 +3923,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3236,7 +3947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -3244,7 +3955,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.114",
+ "syn 2.0.118",
  "tempfile",
 ]
 
@@ -3255,17 +3966,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "prost-reflect"
-version = "0.16.4"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590aa145fee8f7a26b5a6055365e7c5e89a5c1caae9869de76ec0ee73181a2f9"
+checksum = "01b80ea363c31af2de2b92e3c07ed1156628f7838c4afb4df75ee78a37fedbd1"
 dependencies = [
  "logos 0.16.1",
  "miette",
@@ -3294,7 +4005,7 @@ dependencies = [
  "prost-reflect",
  "prost-types",
  "protox-parse",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3306,7 +4017,17 @@ dependencies = [
  "logos 0.15.1",
  "miette",
  "prost-types",
- "thiserror",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd034599e63b970727f70d79e02d62390a4a84f7c6b827c27c46d5ac3fa622"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -3318,7 +4039,7 @@ dependencies = [
  "monty-pool",
  "monty-proto",
  "monty-types",
- "num-bigint",
+ "num-bigint 0.4.6",
  "opentelemetry",
  "opentelemetry_sdk",
  "pyo3",
@@ -3335,7 +4056,7 @@ checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
  "indexmap",
  "libc",
- "num-bigint",
+ "num-bigint 0.4.6",
  "num-traits",
  "once_cell",
  "portable-atomic",
@@ -3386,7 +4107,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3398,7 +4119,261 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "pyrefly"
+version = "1.3.0-dev.4"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+dependencies = [
+ "anstream 0.6.21",
+ "anyhow",
+ "append-only-vec",
+ "arc-swap",
+ "blake3",
+ "capnp",
+ "clap",
+ "crossbeam-channel",
+ "dashmap",
+ "dupe",
+ "enum-iterator",
+ "faster-hex",
+ "fuzzy-matcher",
+ "fxhash",
+ "indicatif",
+ "itertools 0.15.0",
+ "lsp-server",
+ "lsp-types",
+ "mimalloc",
+ "num-traits",
+ "parse-display",
+ "paste",
+ "percent-encoding",
+ "pyrefly_build",
+ "pyrefly_bundled",
+ "pyrefly_config",
+ "pyrefly_derive",
+ "pyrefly_glean_schema",
+ "pyrefly_graph",
+ "pyrefly_python",
+ "pyrefly_types",
+ "pyrefly_util",
+ "rayon",
+ "regex",
+ "ruff_annotate_snippets 0.0.11",
+ "ruff_notebook 0.0.11",
+ "ruff_python_ast 0.0.11",
+ "ruff_python_parser 0.0.11",
+ "ruff_source_file 0.0.11",
+ "ruff_text_size 0.0.11",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "starlark_map",
+ "static_assertions",
+ "tempfile",
+ "thin-vec",
+ "tikv-jemallocator",
+ "tokio",
+ "toml",
+ "tracing",
+ "tsp_types",
+ "uuid",
+ "vec1",
+ "web-time",
+ "xxhash-rust",
+ "yansi",
+]
+
+[[package]]
+name = "pyrefly_build"
+version = "1.3.0-dev.4"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+dependencies = [
+ "anyhow",
+ "dupe",
+ "itertools 0.15.0",
+ "pyrefly_python",
+ "pyrefly_util",
+ "regex",
+ "serde",
+ "serde_json",
+ "starlark_map",
+ "static_interner",
+ "tempfile",
+ "tracing",
+ "vec1",
+ "which",
+]
+
+[[package]]
+name = "pyrefly_bundled"
+version = "1.3.0-dev.4"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+dependencies = [
+ "anyhow",
+ "sha2",
+ "starlark_map",
+ "tar",
+ "zstd 0.13.3",
+]
+
+[[package]]
+name = "pyrefly_config"
+version = "1.3.0-dev.4"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+dependencies = [
+ "anyhow",
+ "clap",
+ "configparser",
+ "convert_case 0.12.0",
+ "derivative",
+ "dupe",
+ "enum-iterator",
+ "itertools 0.15.0",
+ "parse-display",
+ "pyrefly_build",
+ "pyrefly_python",
+ "pyrefly_util",
+ "regex",
+ "regex-syntax 0.7.5",
+ "serde",
+ "serde_json",
+ "serde_jsonrc",
+ "serde_with",
+ "starlark_map",
+ "thiserror 2.0.20",
+ "toml",
+ "toml_edit",
+ "tracing",
+ "uv-pep440",
+ "which",
+ "yansi",
+]
+
+[[package]]
+name = "pyrefly_derive"
+version = "1.3.0-dev.4"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
+]
+
+[[package]]
+name = "pyrefly_glean_schema"
+version = "1.3.0-dev.4"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
+name = "pyrefly_graph"
+version = "1.3.0-dev.4"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+dependencies = [
+ "dupe",
+ "pyrefly_util",
+ "starlark_map",
+]
+
+[[package]]
+name = "pyrefly_python"
+version = "1.3.0-dev.4"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+dependencies = [
+ "anyhow",
+ "clap",
+ "dupe",
+ "enum-iterator",
+ "equivalent",
+ "itertools 0.15.0",
+ "lsp-types",
+ "pathdiff",
+ "pyrefly_util",
+ "regex",
+ "ruff_notebook 0.0.11",
+ "ruff_python_ast 0.0.11",
+ "ruff_python_parser 0.0.11",
+ "ruff_text_size 0.0.11",
+ "serde",
+ "starlark_map",
+ "static_interner",
+ "thin-vec",
+ "thiserror 2.0.20",
+ "unicode-ident",
+ "vec1",
+]
+
+[[package]]
+name = "pyrefly_types"
+version = "1.3.0-dev.4"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+dependencies = [
+ "compact_str",
+ "dupe",
+ "itertools 0.15.0",
+ "num-bigint 0.5.1",
+ "num-traits",
+ "parse-display",
+ "pyrefly_derive",
+ "pyrefly_python",
+ "pyrefly_util",
+ "ruff_python_ast 0.0.11",
+ "ruff_text_size 0.0.11",
+ "starlark_map",
+ "static_assertions",
+ "vec1",
+]
+
+[[package]]
+name = "pyrefly_util"
+version = "1.3.0-dev.4"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+dependencies = [
+ "anstream 0.6.21",
+ "anyhow",
+ "append-only-vec",
+ "argfile",
+ "compact_str",
+ "dupe",
+ "equivalent",
+ "fxhash",
+ "glob",
+ "hashbrown 0.17.1",
+ "human_bytes",
+ "ignore",
+ "index_vec",
+ "itertools 0.15.0",
+ "lock_free_hashtable",
+ "lsp-types",
+ "memory-stats",
+ "notify",
+ "parse-display",
+ "path-absolutize",
+ "pathdiff",
+ "rayon",
+ "ruff_notebook 0.0.11",
+ "ruff_python_ast 0.0.11",
+ "ruff_source_file 0.0.11",
+ "ruff_text_size 0.0.11",
+ "serde",
+ "serde_json",
+ "starlark_map",
+ "static_interner",
+ "thin-vec",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+ "vec1",
+ "watchman_client",
+ "web-time",
+ "yansi",
 ]
 
 [[package]]
@@ -3424,7 +4399,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -3432,13 +4407,13 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.4.3",
+ "getrandom 0.4.2",
  "lru-slab",
  "rand 0.10.1",
  "rand_pcg",
@@ -3447,7 +4422,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3464,14 +4439,14 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3495,7 +4470,7 @@ dependencies = [
  "proc-macro-utils",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3539,12 +4514,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3554,7 +4529,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.3",
+ "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
 
@@ -3575,7 +4550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3589,9 +4564,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
@@ -3637,7 +4612,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3646,37 +4621,63 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -3748,6 +4749,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruff_annotate_snippets"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518575159aaf69108409cdbbf1caacc7c8e5fc0a9a818c0479949de0bd6ed420"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "ruff_cache"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06b8055982244edaceae3c72477dad22df058b673864018bdde42c32571e2d1e"
+dependencies = [
+ "char_str",
+ "filetime",
+ "glob",
+ "globset",
+ "itertools 0.15.0",
+ "regex",
+ "seahash",
+]
+
+[[package]]
 name = "ruff_db"
 version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3764,22 +4791,22 @@ dependencies = [
  "matchit",
  "path-slash",
  "pathdiff",
- "ruff_annotate_snippets",
- "ruff_diagnostics",
+ "ruff_annotate_snippets 0.0.9",
+ "ruff_diagnostics 0.0.9",
  "ruff_memory_usage",
- "ruff_notebook",
- "ruff_python_ast",
- "ruff_python_parser",
- "ruff_python_trivia",
- "ruff_source_file",
- "ruff_text_size",
+ "ruff_notebook 0.0.9",
+ "ruff_python_ast 0.0.9",
+ "ruff_python_parser 0.0.9",
+ "ruff_python_trivia 0.0.9",
+ "ruff_source_file 0.0.9",
+ "ruff_text_size 0.0.9",
  "rustc-hash",
  "salsa",
  "serde",
  "serde_json",
  "similar 3.1.0",
  "supports-hyperlinks",
- "thiserror",
+ "thiserror 2.0.20",
  "tracing",
  "ty_static",
  "web-time",
@@ -3794,8 +4821,19 @@ checksum = "296101978cdad972760596fa12a8583632d1cc50d7919a75dcff454500aae25e"
 dependencies = [
  "get-size2",
  "is-macro",
- "ruff_text_size",
+ "ruff_text_size 0.0.9",
  "serde",
+]
+
+[[package]]
+name = "ruff_diagnostics"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e2bd47e1c17a9310f5d1a30c1a0dacde3f253ed4c1778dc9b74d7774d46c3c"
+dependencies = [
+ "get-size2",
+ "is-macro",
+ "ruff_text_size 0.0.11",
 ]
 
 [[package]]
@@ -3820,8 +4858,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "ruff_python_trivia",
- "syn 3.0.3",
+ "ruff_python_trivia 0.0.9",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -3841,12 +4879,29 @@ checksum = "3a49c68b7f7ee1383fb155ee4c72efc2df6fff95578d49d8485ad96567f65a71"
 dependencies = [
  "anyhow",
  "rand 0.10.1",
- "ruff_diagnostics",
- "ruff_source_file",
- "ruff_text_size",
+ "ruff_diagnostics 0.0.9",
+ "ruff_source_file 0.0.9",
+ "ruff_text_size 0.0.9",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
+ "uuid",
+]
+
+[[package]]
+name = "ruff_notebook"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c65f3d852063448cfd29dd3249b9fef8286b3b8a2b61738bb21016bbfb7158f"
+dependencies = [
+ "anyhow",
+ "rand 0.10.1",
+ "ruff_diagnostics 0.0.11",
+ "ruff_source_file 0.0.11",
+ "ruff_text_size 0.0.11",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
  "uuid",
 ]
 
@@ -3858,19 +4913,43 @@ checksum = "2ca96e1ff7a76b0235df556968ae10e5f8a00a0efa3061f247ad18365f769c2d"
 dependencies = [
  "aho-corasick",
  "arrayvec",
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "char_str",
  "compact_str",
  "get-size2",
  "is-macro",
  "memchr",
- "ruff_python_trivia",
- "ruff_source_file",
- "ruff_text_size",
+ "ruff_python_trivia 0.0.9",
+ "ruff_source_file 0.0.9",
+ "ruff_text_size 0.0.9",
  "rustc-hash",
  "salsa",
  "thin-vec",
- "thiserror",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "ruff_python_ast"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b71594172c232139cdc90e2122adb3d66b45269152f39f3ae4b530543882f"
+dependencies = [
+ "aho-corasick",
+ "arrayvec",
+ "bitflags 2.13.0",
+ "char_str",
+ "compact_str",
+ "get-size2",
+ "is-macro",
+ "memchr",
+ "ruff_cache",
+ "ruff_python_trivia 0.0.11",
+ "ruff_source_file 0.0.11",
+ "ruff_text_size 0.0.11",
+ "rustc-hash",
+ "serde",
+ "thin-vec",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3879,11 +4958,11 @@ version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d160278f35f69e31610f068ecac420baaee14be8b1defadc4ea464b5c5523b78"
 dependencies = [
- "ruff_python_ast",
+ "ruff_python_ast 0.0.9",
  "ruff_python_literal",
- "ruff_python_parser",
- "ruff_source_file",
- "ruff_text_size",
+ "ruff_python_parser 0.0.9",
+ "ruff_source_file 0.0.9",
+ "ruff_text_size 0.0.9",
 ]
 
 [[package]]
@@ -3892,10 +4971,10 @@ version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66ef25a922a0345c97a9eda5896a8bc9313b937b828596c4c65016e206285663"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "icu_properties",
  "itertools 0.15.0",
- "ruff_python_ast",
+ "ruff_python_ast 0.0.9",
 ]
 
 [[package]]
@@ -3904,15 +4983,38 @@ version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cf63608d433331007574be9d7fa17f3d99fc4b9305abcd9cf47a8033690628d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "bstr",
  "drop_bomb",
  "get-size2",
  "memchr",
- "ruff_python_ast",
- "ruff_python_trivia",
- "ruff_text_size",
+ "ruff_python_ast 0.0.9",
+ "ruff_python_trivia 0.0.9",
+ "ruff_text_size 0.0.9",
  "rustc-hash",
+ "static_assertions",
+ "thin-vec",
+ "unicode-ident",
+ "unicode-normalization",
+ "unicode_names2",
+]
+
+[[package]]
+name = "ruff_python_parser"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c594645c2b92e988ea74dd8b90f9156b93e37212f2e01151990590b406d2b34"
+dependencies = [
+ "bitflags 2.13.0",
+ "bstr",
+ "drop_bomb",
+ "get-size2",
+ "memchr",
+ "ruff_python_ast 0.0.11",
+ "ruff_python_trivia 0.0.11",
+ "ruff_text_size 0.0.11",
+ "rustc-hash",
+ "stacker",
  "static_assertions",
  "thin-vec",
  "unicode-ident",
@@ -3926,7 +5028,7 @@ version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd1e8d8e6d805f5a39a38ae2c7db3e885ef598fabeea36443f2a35c07f555bc"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "unicode-ident",
 ]
 
@@ -3937,8 +5039,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb21454ef368d9f4f55cc3d42cf262fa61cd4109e3f1c8aeb138d696b74d563d"
 dependencies = [
  "itertools 0.15.0",
- "ruff_source_file",
- "ruff_text_size",
+ "ruff_source_file 0.0.9",
+ "ruff_text_size 0.0.9",
+ "rustc-hash",
+ "unicode-ident",
+]
+
+[[package]]
+name = "ruff_python_trivia"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02da0941bb4529c5a4f393f1d7e04421f582ae2d9992df4d9ccb05f6dba820b5"
+dependencies = [
+ "itertools 0.15.0",
+ "ruff_source_file 0.0.11",
+ "ruff_text_size 0.0.11",
  "rustc-hash",
  "unicode-ident",
 ]
@@ -3950,7 +5065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06376959ad4718b79e86abde905910ec6a4ccb9bfc3b0e3508a374810aa4740f"
 dependencies = [
  "ruff_db",
- "ruff_text_size",
+ "ruff_text_size 0.0.9",
  "serde",
  "toml",
 ]
@@ -3963,7 +5078,18 @@ checksum = "9d7b074f9b29744b641588c521c6943534ca6e7c161b2b1299c01d1cc1b860f3"
 dependencies = [
  "get-size2",
  "memchr",
- "ruff_text_size",
+ "ruff_text_size 0.0.9",
+ "serde",
+]
+
+[[package]]
+name = "ruff_source_file"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8908271a26103a142c97f752662458c54554782f74f23d9e123b5a46f555c73d"
+dependencies = [
+ "memchr",
+ "ruff_text_size 0.0.11",
  "serde",
 ]
 
@@ -3972,6 +5098,16 @@ name = "ruff_text_size"
 version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0944e5527042c3e1ef3e79bfed2655fe3ae66433f0112fa38d702e078f549d49"
+dependencies = [
+ "get-size2",
+ "serde",
+]
+
+[[package]]
+name = "ruff_text_size"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c87ba4fa867d5a413a6282f5cdaa89d2c347c57b8f01db658440c82866c4bb"
 dependencies = [
  "get-size2",
  "serde",
@@ -4010,15 +5146,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4033,9 +5169,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4060,9 +5196,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4086,7 +5222,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4097,9 +5233,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4119,7 +5255,7 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1e066dc922e513bda599c6ccb5f3bb2b0ea5870a579448f2622993f0a9a2f"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -4137,6 +5273,12 @@ dependencies = [
 
 [[package]]
 name = "ryu"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
+
+[[package]]
+name = "ryu"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
@@ -4151,7 +5293,7 @@ dependencies = [
  "compact_str",
  "crossbeam-queue",
  "crossbeam-utils",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "hashlink",
  "indexmap",
  "intrusive-collections",
@@ -4182,7 +5324,7 @@ checksum = "445be2bfbb2f67cb663225ecd7bc5a25370c0250fca30f9d8cbad9a913650370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4210,12 +5352,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4240,45 +5388,91 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_core"
-version = "1.0.228"
+name = "serde_bser"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "a56b4bcc15e42e5b5ae16c6f75582bef80d36c6ffe2c03b1b5317754b38f8717"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "bytes",
+ "serde",
+ "serde_bytes",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
- "itoa",
+ "itoa 1.0.17",
  "memchr",
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_jsonrc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b591e90bcce7185aa4f8c775c504456586ae0f7df49a4087a1ee4179d402b8a8"
+dependencies = [
+ "itoa 0.4.8",
+ "ryu 0.2.8",
+ "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -4291,6 +5485,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "jiff",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4298,7 +5521,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4309,7 +5532,7 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4397,9 +5620,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.5"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4418,18 +5641,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.9"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "lock_api",
 ]
@@ -4441,10 +5664,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stacker"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707f49d46706bacf8a2b00d51dace3f9de527c13eec3778f570c411f89e69967"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "starlark_map"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234877898fd216af93b2f5798b08cbbdc1a2e8f16a622a258b1db23a61a1c4ba"
+dependencies = [
+ "allocative",
+ "dupe",
+ "equivalent",
+ "fxhash",
+ "hashbrown 0.16.1",
+ "serde",
+ "strong_hash",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "static_interner"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a72d2480db611b8ee9287b4a2e0adc63c4d7fdd647d2a1a65d529fc234fd16"
+dependencies = [
+ "dupe",
+ "equivalent",
+ "lock_free_hashtable",
+]
 
 [[package]]
 name = "statrs"
@@ -4463,10 +5725,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
 
 [[package]]
+name = "strong_hash"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0831334aea34390b6b6ec7af0a27f9ee6324ad3a69463e6b240d83d6b7bce9c9"
+dependencies = [
+ "ref-cast",
+ "strong_hash_derive",
+]
+
+[[package]]
+name = "strong_hash_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace6b48b7c4383a39bd3b966cca41bc999003aab9f690a2f355525c924296928"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structmeta"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ad9e09554f0456d67a69c1584c9798ba733a5b50349a6c0d0948710523922d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a60bcaff7397072dca0017d1db428e30d5002e00b6847703e2e42005c95fbe00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "strum"
@@ -4495,7 +5800,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4507,7 +5812,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4547,9 +5852,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4558,9 +5863,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4584,7 +5900,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4594,6 +5910,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4601,70 +5928,123 @@ checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "thin-vec"
-version = "0.2.14"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144f754d318415ac792f9d69fc87abbbfc043ce2ef041c60f16ad828f638717d"
+checksum = "79def32ffcd477db1ff26f76dab9e3a91f0bd42a85ca96577089b24623056f9d"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.10"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
-name = "time"
-version = "0.3.44"
+name = "tikv-jemalloc-sys"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "time"
+version = "0.3.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tinystr"
@@ -4703,13 +6083,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -4719,20 +6100,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -4766,10 +6147,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "1.1.2+spec-1.1.0"
+name = "tokio-util"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -4790,19 +6187,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -4825,7 +6237,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -4868,7 +6280,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4933,6 +6345,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tsp_types"
+version = "1.3.0-dev.4"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+dependencies = [
+ "lsp-server",
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4943,11 +6366,11 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.2",
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror",
+ "thiserror 2.0.20",
  "utf-8",
  "webpki-roots 0.26.11",
 ]
@@ -4960,7 +6383,7 @@ checksum = "ef03cc4aefc301d1bacf6ed24d6ee9f9df3b274ace8651d425521faaf0edae57"
 dependencies = [
  "ordermap",
  "ruff_db",
- "ruff_python_ast",
+ "ruff_python_ast 0.0.9",
  "ruff_ranged_value",
 ]
 
@@ -4976,16 +6399,16 @@ dependencies = [
  "get-size2",
  "ordermap",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.8.11",
  "ruff_db",
  "ruff_memory_usage",
- "ruff_python_ast",
+ "ruff_python_ast 0.0.9",
  "ruff_python_stdlib",
  "rustc-hash",
  "salsa",
  "strum 0.28.0",
  "strum_macros 0.28.0",
- "thiserror",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -4995,18 +6418,18 @@ version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375e7f851f3c84a258f7159dcf47abe6310d1061686da1c04d4b9d28de12923d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "bitvec",
  "char_str",
  "get-size2",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "itertools 0.15.0",
  "ruff_db",
  "ruff_index",
  "ruff_memory_usage",
- "ruff_python_ast",
- "ruff_python_parser",
- "ruff_text_size",
+ "ruff_python_ast 0.0.9",
+ "ruff_python_parser 0.0.9",
+ "ruff_text_size 0.0.9",
  "rustc-hash",
  "salsa",
  "smallvec",
@@ -5025,7 +6448,7 @@ version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ff4dc61accc4c1b470fc2fe6a9ed7e1bfbe875a9f79b94faba0bc1baeae90d7"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "char_str",
  "compact_str",
  "drop_bomb",
@@ -5036,24 +6459,24 @@ dependencies = [
  "ordermap",
  "rayon",
  "ruff_db",
- "ruff_diagnostics",
+ "ruff_diagnostics 0.0.9",
  "ruff_index",
  "ruff_macros",
  "ruff_memory_usage",
- "ruff_python_ast",
+ "ruff_python_ast 0.0.9",
  "ruff_python_literal",
- "ruff_python_parser",
+ "ruff_python_parser 0.0.9",
  "ruff_python_stdlib",
- "ruff_python_trivia",
- "ruff_source_file",
- "ruff_text_size",
+ "ruff_python_trivia 0.0.9",
+ "ruff_source_file 0.0.9",
+ "ruff_text_size 0.0.9",
  "rustc-hash",
  "salsa",
  "smallvec",
  "static_assertions",
  "strum 0.28.0",
  "strum_macros 0.28.0",
- "thiserror",
+ "thiserror 2.0.20",
  "tracing",
  "ty_module_resolver",
  "ty_python_core",
@@ -5068,15 +6491,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00af3d6c6a391755092fe30f7e8fde4907f0221210c99486b6aa8f1cce80212e"
 dependencies = [
  "camino",
- "colored 3.1.1",
+ "colored 3.0.0",
  "get-size2",
  "indexmap",
- "ruff_annotate_snippets",
+ "ruff_annotate_snippets 0.0.9",
  "ruff_db",
- "ruff_python_ast",
- "ruff_python_trivia",
- "ruff_source_file",
- "ruff_text_size",
+ "ruff_python_ast 0.0.9",
+ "ruff_python_trivia 0.0.9",
+ "ruff_source_file 0.0.9",
+ "ruff_text_size 0.0.9",
  "strum 0.28.0",
  "strum_macros 0.28.0",
  "tracing",
@@ -5124,6 +6547,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5131,9 +6560,9 @@ checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -5191,6 +6620,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unscanny"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9df2af067a7953e9c3831320f35c1cc0600c30d44d9f7a12b01db1cd88d6b47"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5206,6 +6647,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -5228,12 +6670,61 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
+ "uuid-rng-internal",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-rng-internal"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee9ad27c58031a66157ac3b5c93e65068357eeeaceaa658a6163d4e5befb4a06"
+dependencies = [
+ "getrandom 0.4.2",
+]
+
+[[package]]
+name = "uv-cache-key"
+version = "0.0.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd72020959ceea23b28bc39736163bd293bd55217cb8f983a719fc30e992d6d"
+dependencies = [
+ "hex",
+ "memchr",
+ "percent-encoding",
+ "seahash",
+ "url",
+ "uv-redacted",
+]
+
+[[package]]
+name = "uv-pep440"
+version = "0.0.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "946f97ff8f936ba2afd46b908cd64428b54387bf9a413000919159795ad5c8a1"
+dependencies = [
+ "serde",
+ "unicode-width 0.2.2",
+ "unscanny",
+ "uv-cache-key",
+]
+
+[[package]]
+name = "uv-redacted"
+version = "0.0.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8735c21e882e605f108b9c8b9a6d2f00732147e86754f7137c4a08acdeecbe2"
+dependencies = [
+ "ref-cast",
+ "serde",
+ "thiserror 2.0.20",
+ "url",
 ]
 
 [[package]]
@@ -5241,6 +6732,15 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vec1"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab68b56840f69efb0fefbe3ab6661499217ffdc58e2eef7c3f6f69835386322"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "version_check"
@@ -5279,7 +6779,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -5327,7 +6836,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -5347,7 +6856,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be00faa2b4950c76fe618c409d2c3ea5a3c9422013e079482d78544bb2d184c"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.239.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -5358,8 +6877,20 @@ checksum = "20b3ec880a9ac69ccd92fbdbcf46ee833071cf09f82bb005b2327c7ae6025ae2"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.239.0",
+ "wasmparser 0.239.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -5368,10 +6899,40 @@ version = "0.239.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "watchman_client"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88bc4c9bb443a7aae10d4fa7807bffc397805315e2305288c90c80e2f66cfb52"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "futures 0.3.31",
+ "maplit",
+ "serde",
+ "serde_bser",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "winapi",
 ]
 
 [[package]]
@@ -5409,16 +6970,25 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.8",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "8.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -5443,7 +7013,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5473,7 +7043,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5484,7 +7054,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5681,6 +7251,9 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winx"
@@ -5688,7 +7261,7 @@ version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
 dependencies = [
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "windows-sys 0.59.0",
 ]
 
@@ -5698,10 +7271,19 @@ version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 dependencies = [
- "bitflags 2.13.1",
- "futures",
+ "bitflags 2.13.0",
+ "futures 0.3.31",
  "once_cell",
- "wit-bindgen-rust-macro",
+ "wit-bindgen-rust-macro 0.46.0",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro 0.51.0",
 ]
 
 [[package]]
@@ -5712,7 +7294,18 @@ checksum = "cabd629f94da277abc739c71353397046401518efb2c707669f805205f0b9890"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser",
+ "wit-parser 0.239.0",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -5725,10 +7318,26 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.114",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
+ "syn 2.0.118",
+ "wasm-metadata 0.239.0",
+ "wit-bindgen-core 0.46.0",
+ "wit-component 0.239.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.118",
+ "wasm-metadata 0.244.0",
+ "wit-bindgen-core 0.51.0",
+ "wit-component 0.244.0",
 ]
 
 [[package]]
@@ -5741,9 +7350,24 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
- "wit-bindgen-core",
- "wit-bindgen-rust",
+ "syn 2.0.118",
+ "wit-bindgen-core 0.46.0",
+ "wit-bindgen-rust 0.46.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "wit-bindgen-core 0.51.0",
+ "wit-bindgen-rust 0.51.0",
 ]
 
 [[package]]
@@ -5753,16 +7377,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a866b19dba2c94d706ec58c92a4c62ab63e482b4c935d2a085ac94caecb136"
 dependencies = [
  "anyhow",
- "bitflags 2.13.1",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
+ "wasm-encoder 0.239.0",
+ "wasm-metadata 0.239.0",
+ "wasmparser 0.239.0",
+ "wit-parser 0.239.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.13.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.244.0",
+ "wasm-metadata 0.244.0",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -5780,7 +7423,25 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.239.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -5799,6 +7460,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5806,9 +7483,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5823,7 +7500,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -5844,14 +7521,14 @@ checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.8"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -5864,7 +7541,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -5904,7 +7581,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5916,7 +7593,7 @@ dependencies = [
  "aes",
  "byteorder",
  "bzip2",
- "constant_time_eq",
+ "constant_time_eq 0.1.5",
  "crc32fast",
  "crossbeam-utils",
  "flate2",
@@ -5924,7 +7601,7 @@ dependencies = [
  "pbkdf2",
  "sha1",
  "time",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -5951,7 +7628,16 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe 7.2.4",
 ]
 
 [[package]]
@@ -5961,6 +7647,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
  "zstd-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,7 +1461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2365,7 +2365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
 dependencies = [
  "io-lifetimes 3.0.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2406,7 +2406,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3413,7 +3413,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4125,7 +4125,7 @@ dependencies = [
 [[package]]
 name = "pyrefly"
 version = "1.3.0-dev.4"
-source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=04e9e8ee345495e90b52b9ba9bb41a3c642f0020#04e9e8ee345495e90b52b9ba9bb41a3c642f0020"
 dependencies = [
  "anstream 0.6.21",
  "anyhow",
@@ -4189,7 +4189,7 @@ dependencies = [
 [[package]]
 name = "pyrefly_build"
 version = "1.3.0-dev.4"
-source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=04e9e8ee345495e90b52b9ba9bb41a3c642f0020#04e9e8ee345495e90b52b9ba9bb41a3c642f0020"
 dependencies = [
  "anyhow",
  "dupe",
@@ -4210,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "pyrefly_bundled"
 version = "1.3.0-dev.4"
-source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=04e9e8ee345495e90b52b9ba9bb41a3c642f0020#04e9e8ee345495e90b52b9ba9bb41a3c642f0020"
 dependencies = [
  "anyhow",
  "sha2",
@@ -4222,7 +4222,7 @@ dependencies = [
 [[package]]
 name = "pyrefly_config"
 version = "1.3.0-dev.4"
-source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=04e9e8ee345495e90b52b9ba9bb41a3c642f0020#04e9e8ee345495e90b52b9ba9bb41a3c642f0020"
 dependencies = [
  "anyhow",
  "clap",
@@ -4255,7 +4255,7 @@ dependencies = [
 [[package]]
 name = "pyrefly_derive"
 version = "1.3.0-dev.4"
-source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=04e9e8ee345495e90b52b9ba9bb41a3c642f0020#04e9e8ee345495e90b52b9ba9bb41a3c642f0020"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4265,7 +4265,7 @@ dependencies = [
 [[package]]
 name = "pyrefly_glean_schema"
 version = "1.3.0-dev.4"
-source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=04e9e8ee345495e90b52b9ba9bb41a3c642f0020#04e9e8ee345495e90b52b9ba9bb41a3c642f0020"
 dependencies = [
  "serde",
  "serde_json",
@@ -4275,7 +4275,7 @@ dependencies = [
 [[package]]
 name = "pyrefly_graph"
 version = "1.3.0-dev.4"
-source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=04e9e8ee345495e90b52b9ba9bb41a3c642f0020#04e9e8ee345495e90b52b9ba9bb41a3c642f0020"
 dependencies = [
  "dupe",
  "pyrefly_util",
@@ -4285,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "pyrefly_python"
 version = "1.3.0-dev.4"
-source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=04e9e8ee345495e90b52b9ba9bb41a3c642f0020#04e9e8ee345495e90b52b9ba9bb41a3c642f0020"
 dependencies = [
  "anyhow",
  "clap",
@@ -4313,7 +4313,7 @@ dependencies = [
 [[package]]
 name = "pyrefly_types"
 version = "1.3.0-dev.4"
-source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=04e9e8ee345495e90b52b9ba9bb41a3c642f0020#04e9e8ee345495e90b52b9ba9bb41a3c642f0020"
 dependencies = [
  "compact_str",
  "dupe",
@@ -4334,7 +4334,7 @@ dependencies = [
 [[package]]
 name = "pyrefly_util"
 version = "1.3.0-dev.4"
-source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=04e9e8ee345495e90b52b9ba9bb41a3c642f0020#04e9e8ee345495e90b52b9ba9bb41a3c642f0020"
 dependencies = [
  "anstream 0.6.21",
  "anyhow",
@@ -4439,7 +4439,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5154,7 +5154,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5222,7 +5222,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5936,7 +5936,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5946,7 +5946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6347,7 +6347,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "tsp_types"
 version = "1.3.0-dev.4"
-source = "git+https://github.com/yangdanny97/pyrefly?rev=a155e04163d8bda6f7e30b897f7591531dcaf8b1#a155e04163d8bda6f7e30b897f7591531dcaf8b1"
+source = "git+https://github.com/yangdanny97/pyrefly?rev=04e9e8ee345495e90b52b9ba9bb41a3c642f0020#04e9e8ee345495e90b52b9ba9bb41a3c642f0020"
 dependencies = [
  "lsp-server",
  "serde",
@@ -7013,7 +7013,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ monty-fs = { path = "crates/monty-fs", version = "0.0.23" }
 monty-macros = { path = "crates/monty-macros", version = "0.0.23" }
 monty-proto = { path = "crates/monty-proto", version = "0.0.23" }
 monty-pool = { path = "crates/monty-pool", version = "0.0.23" }
-monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.23" }
+monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.23", default-features = false }
 monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.23" }
 # ruff, ty and related crates
 ruff_python_parser = "0.0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ monty-fs = { path = "crates/monty-fs", version = "0.0.23" }
 monty-macros = { path = "crates/monty-macros", version = "0.0.23" }
 monty-proto = { path = "crates/monty-proto", version = "0.0.23" }
 monty-pool = { path = "crates/monty-pool", version = "0.0.23" }
-monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.23", default-features = false }
+monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.23" }
 monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.23" }
 # ruff, ty and related crates
 ruff_python_parser = "0.0.9"

--- a/crates/monty-proto/Cargo.toml
+++ b/crates/monty-proto/Cargo.toml
@@ -45,6 +45,8 @@ python = ["dep:pyo3"]
 # the interpreter. Off by default so host-side consumers (monty-pool, the
 # bindings) never link the interpreter itself.
 worker = ["dep:monty", "dep:monty-type-checking"]
+type-check-ty = ["monty-type-checking?/ty"]
+type-check-pyrefly = ["monty-type-checking?/pyrefly"]
 
 [[bin]]
 name = "generate-proto"

--- a/crates/monty-proto/Cargo.toml
+++ b/crates/monty-proto/Cargo.toml
@@ -45,8 +45,7 @@ python = ["dep:pyo3"]
 # the interpreter. Off by default so host-side consumers (monty-pool, the
 # bindings) never link the interpreter itself.
 worker = ["dep:monty", "dep:monty-type-checking"]
-type-check-ty = ["monty-type-checking?/ty"]
-type-check-pyrefly = ["monty-type-checking?/pyrefly"]
+pyrefly = ["monty-type-checking?/pyrefly"]
 
 [[bin]]
 name = "generate-proto"

--- a/crates/monty-runtime/Cargo.toml
+++ b/crates/monty-runtime/Cargo.toml
@@ -19,7 +19,10 @@ name = "monty"
 path = "src/main.rs"
 
 [features]
-default = ["standalone"]
+default = ["standalone", "ty"]
+# The type-check backend, forwarded to monty-type-checking and the worker.
+ty = ["monty-type-checking/ty", "monty-proto/type-check-ty"]
+pyrefly = ["monty-type-checking/pyrefly", "monty-proto/type-check-pyrefly"]
 # The standalone CLI (`run.rs`) and its terminal stack. Drop it to build the
 # worker `monty subprocess` alone, which is all a pool ever spawns.
 standalone = ["dep:anstream", "dep:anstyle", "dep:rustyline"]

--- a/crates/monty-runtime/Cargo.toml
+++ b/crates/monty-runtime/Cargo.toml
@@ -19,10 +19,9 @@ name = "monty"
 path = "src/main.rs"
 
 [features]
-default = ["standalone", "ty"]
-# The type-check backend, forwarded to monty-type-checking and the worker.
-ty = ["monty-type-checking/ty", "monty-proto/type-check-ty"]
-pyrefly = ["monty-type-checking/pyrefly", "monty-proto/type-check-pyrefly"]
+default = ["standalone"]
+# Swaps the ty backend for pyrefly; ty is used when unset.
+pyrefly = ["monty-type-checking/pyrefly", "monty-proto/pyrefly"]
 # The standalone CLI (`run.rs`) and its terminal stack. Drop it to build the
 # worker `monty subprocess` alone, which is all a pool ever spawns.
 standalone = ["dep:anstream", "dep:anstyle", "dep:rustyline"]

--- a/crates/monty-type-checking/Cargo.toml
+++ b/crates/monty-type-checking/Cargo.toml
@@ -18,14 +18,31 @@ path = "src/lib.rs"
 
 [dependencies]
 monty-types = { workspace = true }
-monty-typeshed = { workspace = true }
-ruff_python_ast = { workspace = true }
-ruff_db = { workspace = true }
-ruff_text_size = { workspace = true }
-ty_python_semantic = { workspace = true }
-ty_python_core = { workspace = true }
-ty_module_resolver = { workspace = true }
-salsa = { workspace = true }
+monty-typeshed = { workspace = true, optional = true }
+ruff_python_ast = { workspace = true, optional = true }
+ruff_db = { workspace = true, optional = true }
+ruff_text_size = { workspace = true, optional = true }
+ty_python_semantic = { workspace = true, optional = true }
+ty_python_core = { workspace = true, optional = true }
+ty_module_resolver = { workspace = true, optional = true }
+salsa = { workspace = true, optional = true }
+# `default-features = false` drops pyrefly's bundled third-party stubs (~2.6 MB),
+# which nothing in the sandbox can import.
+pyrefly = { git = "https://github.com/yangdanny97/pyrefly", rev = "a155e04163d8bda6f7e30b897f7591531dcaf8b1", optional = true, default-features = false }
+
+[features]
+default = ["ty"]
+ty = [
+    "dep:monty-typeshed",
+    "dep:ruff_python_ast",
+    "dep:ruff_db",
+    "dep:ruff_text_size",
+    "dep:ty_python_semantic",
+    "dep:ty_python_core",
+    "dep:ty_module_resolver",
+    "dep:salsa",
+]
+pyrefly = ["dep:pyrefly"]
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/monty-type-checking/Cargo.toml
+++ b/crates/monty-type-checking/Cargo.toml
@@ -26,8 +26,8 @@ ty_python_semantic = { workspace = true, optional = true }
 ty_python_core = { workspace = true, optional = true }
 ty_module_resolver = { workspace = true, optional = true }
 salsa = { workspace = true, optional = true }
-# `default-features = false` drops pyrefly's bundled third-party stubs (~2.6 MB),
-# which nothing in the sandbox can import.
+# `default-features = false` drops pyrefly's bundled third-party stubs, which
+# nothing in the sandbox can import.
 pyrefly = { git = "https://github.com/yangdanny97/pyrefly", rev = "a155e04163d8bda6f7e30b897f7591531dcaf8b1", optional = true, default-features = false }
 
 [features]

--- a/crates/monty-type-checking/Cargo.toml
+++ b/crates/monty-type-checking/Cargo.toml
@@ -28,7 +28,7 @@ ty_module_resolver = { workspace = true }
 salsa = { workspace = true }
 # `default-features = false` drops pyrefly's bundled third-party stubs, which
 # nothing in the sandbox can import.
-pyrefly = { git = "https://github.com/yangdanny97/pyrefly", rev = "a155e04163d8bda6f7e30b897f7591531dcaf8b1", optional = true, default-features = false }
+pyrefly = { git = "https://github.com/yangdanny97/pyrefly", rev = "04e9e8ee345495e90b52b9ba9bb41a3c642f0020", optional = true, default-features = false }
 
 [features]
 # Swaps the ty backend for pyrefly; ty is used when unset.

--- a/crates/monty-type-checking/Cargo.toml
+++ b/crates/monty-type-checking/Cargo.toml
@@ -18,30 +18,20 @@ path = "src/lib.rs"
 
 [dependencies]
 monty-types = { workspace = true }
-monty-typeshed = { workspace = true, optional = true }
-ruff_python_ast = { workspace = true, optional = true }
-ruff_db = { workspace = true, optional = true }
-ruff_text_size = { workspace = true, optional = true }
-ty_python_semantic = { workspace = true, optional = true }
-ty_python_core = { workspace = true, optional = true }
-ty_module_resolver = { workspace = true, optional = true }
-salsa = { workspace = true, optional = true }
+monty-typeshed = { workspace = true }
+ruff_python_ast = { workspace = true }
+ruff_db = { workspace = true }
+ruff_text_size = { workspace = true }
+ty_python_semantic = { workspace = true }
+ty_python_core = { workspace = true }
+ty_module_resolver = { workspace = true }
+salsa = { workspace = true }
 # `default-features = false` drops pyrefly's bundled third-party stubs, which
 # nothing in the sandbox can import.
 pyrefly = { git = "https://github.com/yangdanny97/pyrefly", rev = "a155e04163d8bda6f7e30b897f7591531dcaf8b1", optional = true, default-features = false }
 
 [features]
-default = ["ty"]
-ty = [
-    "dep:monty-typeshed",
-    "dep:ruff_python_ast",
-    "dep:ruff_db",
-    "dep:ruff_text_size",
-    "dep:ty_python_semantic",
-    "dep:ty_python_core",
-    "dep:ty_module_resolver",
-    "dep:salsa",
-]
+# Swaps the ty backend for pyrefly; ty is used when unset.
 pyrefly = ["dep:pyrefly"]
 
 [dev-dependencies]

--- a/crates/monty-type-checking/README.md
+++ b/crates/monty-type-checking/README.md
@@ -11,6 +11,9 @@ typeshed describing the stdlib subset Monty actually implements. Code that
 uses unsupported stdlib surface is therefore flagged *before* it runs rather
 than failing at runtime.
 
+The `pyrefly` cargo feature swaps ty for an experimental
+[Pyrefly](https://github.com/facebook/pyrefly) backend; ty is used when it is unset.
+
 It backs `monty --type-check` in the CLI and the `type_check` option on
 sessions in the [`pydantic-monty`](https://pypi.org/project/pydantic-monty/)
 and [`@pydantic/monty`](https://www.npmjs.com/package/@pydantic/monty)

--- a/crates/monty-type-checking/benches/type_check.rs
+++ b/crates/monty-type-checking/benches/type_check.rs
@@ -19,6 +19,17 @@ fn prewarmed() -> TypeChecker {
     checker
 }
 
+const fn backend_label() -> &'static str {
+    #[cfg(feature = "ty")]
+    {
+        "ty"
+    }
+    #[cfg(feature = "pyrefly")]
+    {
+        "pyrefly"
+    }
+}
+
 /// Diagnostics are rendered by the checker, so the format is part of what the
 /// benchmarks measure; `Full` is the default a session gets.
 const CONFIG: TypeCheckingConfig = TypeCheckingConfig {
@@ -29,9 +40,9 @@ const CONFIG: TypeCheckingConfig = TypeCheckingConfig {
 /// Steady-state cost of type-checking a trivial snippet. This is the headline metric —
 /// it isolates per-call overhead (write one file, run `check_types`) from the
 /// one-time cost of building the database.
-fn bench_warm_trivial(c: &mut Criterion) {
+fn bench_warm_trivial(c: &mut Criterion, label: &str) {
     let mut checker = prewarmed();
-    c.bench_function("type_check__warm_trivial", |b| {
+    c.bench_function(&format!("type_check__{label}__warm_trivial"), |b| {
         b.iter(|| {
             let out = checker.run(&SourceFile::new("x = 1", "main.py"), None, CONFIG).unwrap();
             black_box(out);
@@ -41,9 +52,9 @@ fn bench_warm_trivial(c: &mut Criterion) {
 
 /// Steady-state cost of type-checking a snippet that exercises a builtin (`int.__add__`).
 /// Slightly heavier than `warm_trivial` because it actually resolves a type.
-fn bench_warm_builtin(c: &mut Criterion) {
+fn bench_warm_builtin(c: &mut Criterion, label: &str) {
     let mut checker = prewarmed();
-    c.bench_function("type_check__warm_builtin", |b| {
+    c.bench_function(&format!("type_check__{label}__warm_builtin"), |b| {
         b.iter(|| {
             let out = checker
                 .run(&SourceFile::new("x = 1 + 2", "main.py"), None, CONFIG)
@@ -56,9 +67,9 @@ fn bench_warm_builtin(c: &mut Criterion) {
 /// Realistic REPL-like pattern: each iteration type-checks a growing accumulated-stubs
 /// context plus a new "current" snippet. Mirrors how the REPL would call `type_check`
 /// per feed_run.
-fn bench_repl_sequence(c: &mut Criterion) {
+fn bench_repl_sequence(c: &mut Criterion, label: &str) {
     let mut checker = prewarmed();
-    c.bench_function("type_check__repl_sequence", |b| {
+    c.bench_function(&format!("type_check__{label}__repl_sequence"), |b| {
         b.iter(|| {
             let mut stubs = String::new();
             for (i, snippet) in [
@@ -90,9 +101,10 @@ fn bench_repl_sequence(c: &mut Criterion) {
 
 /// Configures the type-checking benchmarks.
 fn criterion_benchmark(c: &mut Criterion) {
-    bench_warm_trivial(c);
-    bench_warm_builtin(c);
-    bench_repl_sequence(c);
+    let label = backend_label();
+    bench_warm_trivial(c, label);
+    bench_warm_builtin(c, label);
+    bench_repl_sequence(c, label);
 }
 
 // Use pprof flamegraph profiler when running locally on Unix (not on CodSpeed or Windows)

--- a/crates/monty-type-checking/benches/type_check.rs
+++ b/crates/monty-type-checking/benches/type_check.rs
@@ -20,14 +20,7 @@ fn prewarmed() -> TypeChecker {
 }
 
 const fn backend_label() -> &'static str {
-    #[cfg(feature = "ty")]
-    {
-        "ty"
-    }
-    #[cfg(feature = "pyrefly")]
-    {
-        "pyrefly"
-    }
+    if cfg!(feature = "pyrefly") { "pyrefly" } else { "ty" }
 }
 
 /// Diagnostics are rendered by the checker, so the format is part of what the

--- a/crates/monty-type-checking/benches/type_check.rs
+++ b/crates/monty-type-checking/benches/type_check.rs
@@ -92,12 +92,40 @@ fn bench_repl_sequence(c: &mut Criterion, label: &str) {
     });
 }
 
+fn bench_repl_sequence_200(c: &mut Criterion, label: &str) {
+    let snippets: Vec<String> = (0..200).map(|i| format!("v{i}: int = {i}")).collect();
+    let mut checker = prewarmed();
+    let mut group = c.benchmark_group("type_check");
+    group.sample_size(10);
+    group.bench_function(format!("{label}__repl_sequence_200"), |b| {
+        b.iter(|| {
+            let mut stubs = String::new();
+            for (i, snippet) in snippets.iter().enumerate() {
+                let path = format!("step_{i}.py");
+                let out = checker
+                    .run(
+                        &SourceFile::new(snippet, &path),
+                        Some(&SourceFile::new(&stubs, "type_stubs.pyi")),
+                        CONFIG,
+                    )
+                    .expect("repl-sequence benchmark should not hit internal type-check failures");
+                assert!(out.is_none(), "snippet should type-check cleanly: {snippet}");
+                black_box(out);
+                stubs.push_str(snippet);
+                stubs.push('\n');
+            }
+        });
+    });
+    group.finish();
+}
+
 /// Configures the type-checking benchmarks.
 fn criterion_benchmark(c: &mut Criterion) {
     let label = backend_label();
     bench_warm_trivial(c, label);
     bench_warm_builtin(c, label);
     bench_repl_sequence(c, label);
+    bench_repl_sequence_200(c, label);
 }
 
 // Use pprof flamegraph profiler when running locally on Unix (not on CodSpeed or Windows)

--- a/crates/monty-type-checking/benches/type_check.rs
+++ b/crates/monty-type-checking/benches/type_check.rs
@@ -95,9 +95,7 @@ fn bench_repl_sequence(c: &mut Criterion, label: &str) {
 fn bench_repl_sequence_200(c: &mut Criterion, label: &str) {
     let snippets: Vec<String> = (0..200).map(|i| format!("v{i}: int = {i}")).collect();
     let mut checker = prewarmed();
-    let mut group = c.benchmark_group("type_check");
-    group.sample_size(10);
-    group.bench_function(format!("{label}__repl_sequence_200"), |b| {
+    c.bench_function(&format!("type_check__{label}__repl_sequence_200"), |b| {
         b.iter(|| {
             let mut stubs = String::new();
             for (i, snippet) in snippets.iter().enumerate() {
@@ -116,7 +114,6 @@ fn bench_repl_sequence_200(c: &mut Criterion, label: &str) {
             }
         });
     });
-    group.finish();
 }
 
 /// Configures the type-checking benchmarks.

--- a/crates/monty-type-checking/src/lib.rs
+++ b/crates/monty-type-checking/src/lib.rs
@@ -1,6 +1,21 @@
 #![doc = include_str!("../README.md")]
 
+#[cfg(all(feature = "ty", feature = "pyrefly"))]
+compile_error!("the `ty` and `pyrefly` features are mutually exclusive.");
+
+#[cfg(not(any(feature = "ty", feature = "pyrefly")))]
+compile_error!("monty-type-checking needs exactly one backend: enable either the `ty` or `pyrefly` feature.");
+
+#[cfg(feature = "ty")]
 mod db;
+#[cfg(feature = "pyrefly")]
+mod pyrefly_check;
+mod source_file;
+#[cfg(feature = "ty")]
 mod type_check;
 
-pub use crate::type_check::{SourceFile, TypeChecker, TypeCheckingDiagnostics};
+#[cfg(feature = "pyrefly")]
+pub use crate::pyrefly_check::{PyreflyChecker as TypeChecker, PyreflyDiagnostics as TypeCheckingDiagnostics};
+pub use crate::source_file::SourceFile;
+#[cfg(feature = "ty")]
+pub use crate::type_check::{TypeChecker, TypeCheckingDiagnostics};

--- a/crates/monty-type-checking/src/lib.rs
+++ b/crates/monty-type-checking/src/lib.rs
@@ -1,21 +1,15 @@
 #![doc = include_str!("../README.md")]
 
-#[cfg(all(feature = "ty", feature = "pyrefly"))]
-compile_error!("the `ty` and `pyrefly` features are mutually exclusive.");
-
-#[cfg(not(any(feature = "ty", feature = "pyrefly")))]
-compile_error!("monty-type-checking needs exactly one backend: enable either the `ty` or `pyrefly` feature.");
-
-#[cfg(feature = "ty")]
+#[cfg(not(feature = "pyrefly"))]
 mod db;
 #[cfg(feature = "pyrefly")]
 mod pyrefly_check;
 mod source_file;
-#[cfg(feature = "ty")]
+#[cfg(not(feature = "pyrefly"))]
 mod type_check;
 
 #[cfg(feature = "pyrefly")]
 pub use crate::pyrefly_check::{PyreflyChecker as TypeChecker, PyreflyDiagnostics as TypeCheckingDiagnostics};
 pub use crate::source_file::SourceFile;
-#[cfg(feature = "ty")]
+#[cfg(not(feature = "pyrefly"))]
 pub use crate::type_check::{TypeChecker, TypeCheckingDiagnostics};

--- a/crates/monty-type-checking/src/pyrefly_check.rs
+++ b/crates/monty-type-checking/src/pyrefly_check.rs
@@ -3,7 +3,7 @@
 //! Pyrefly needs its module set declared up front, so a run gets exactly two:
 //! the snippet and its stubs. Arbitrary module paths are not importable here.
 
-use std::{fmt, marker::PhantomData};
+use std::fmt;
 
 use monty_types::{TypeCheckingConfig, TypeCheckingFormat};
 use pyrefly::embed::{Checker, Diagnostic, Severity};
@@ -11,9 +11,7 @@ use pyrefly::embed::{Checker, Diagnostic, Severity};
 use crate::source_file::SourceFile;
 
 const PYTHON_VERSION: &str = "3.14";
-
 const MAIN_MODULE: &str = "__monty_main__";
-
 const STUB_MODULE: &str = "__monty_stubs__";
 
 /// A reusable Pyrefly checker. Built lazily: constructing one loads the typeshed.
@@ -22,24 +20,20 @@ pub struct PyreflyChecker {
     checker: Option<Checker>,
 }
 
-impl fmt::Debug for PyreflyChecker {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("PyreflyChecker")
-            .field("warm", &self.checker.is_some())
-            .finish()
-    }
-}
-
 impl PyreflyChecker {
     /// Type check `python_source`, with `stubs_file` (if any) importable from it.
     /// `Ok(None)` means it checks clean.
-    pub fn run<'a>(
-        &'a mut self,
+    pub fn run(
+        &mut self,
         python_source: &SourceFile<'_>,
         stubs_file: Option<&SourceFile<'_>>,
         config: TypeCheckingConfig,
-    ) -> Result<Option<PyreflyDiagnostics<'a>>, String> {
-        let format = supported_format(config.format)?;
+    ) -> Result<Option<PyreflyDiagnostics>, String> {
+        // Only the two renderers below are implemented; anything else would be
+        // silently wrong for a host that parses it.
+        if !matches!(config.format, TypeCheckingFormat::Full | TypeCheckingFormat::Concise) {
+            return Err(format!("the pyrefly backend cannot render '{}'", config.format));
+        }
 
         // The injected import shifts reported lines down by one; `line_offset`
         // undoes that when rendering.
@@ -49,101 +43,67 @@ impl PyreflyChecker {
         };
         let stub_source = stubs_file.map_or("", |stubs| stubs.source_code);
 
-        let diagnostics = self
-            .checker()?
-            .check(MAIN_MODULE, &[(STUB_MODULE, stub_source), (MAIN_MODULE, &main_source)]);
+        if self.checker.is_none() {
+            self.checker = Some(Checker::new(Some(PYTHON_VERSION), &[MAIN_MODULE, STUB_MODULE])?);
+        }
+        let Some(checker) = &self.checker else {
+            return Err("pyrefly checker was not initialised".to_owned());
+        };
 
-        let diagnostics: Vec<Diagnostic> = diagnostics
+        let diagnostics: Vec<Diagnostic> = checker
+            .check(MAIN_MODULE, &[(STUB_MODULE, stub_source), (MAIN_MODULE, &main_source)])
             .into_iter()
             .filter(|d| matches!(d.severity, Severity::Error | Severity::Warn))
             .collect();
 
-        if diagnostics.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(PyreflyDiagnostics {
-                diagnostics,
-                path: python_source.path.to_owned(),
-                line_offset,
-                format,
-                checker: PhantomData,
-            }))
-        }
+        Ok((!diagnostics.is_empty()).then(|| PyreflyDiagnostics {
+            diagnostics,
+            path: python_source.path.to_owned(),
+            line_offset,
+            full: config.format == TypeCheckingFormat::Full,
+        }))
     }
 
     /// Blank both modules so the checker can be reused for unrelated code.
     ///
     /// Security-critical: a checker reset and handed to another session without a
-    /// run in between must not still hold the previous session's source. The warm
-    /// typeshed is kept — it carries no session state.
+    /// run in between must not still hold the previous session's source.
     pub fn reset(&mut self) -> Result<(), String> {
         if let Some(checker) = &self.checker {
             checker.check(MAIN_MODULE, &[(STUB_MODULE, ""), (MAIN_MODULE, "")]);
         }
         Ok(())
     }
-
-    fn checker(&mut self) -> Result<&Checker, String> {
-        if self.checker.is_none() {
-            self.checker = Some(Checker::new(Some(PYTHON_VERSION), &[MAIN_MODULE, STUB_MODULE])?);
-        }
-        Ok(self.checker.as_ref().expect("checker built above"))
-    }
-}
-
-/// Pyrefly returns structured diagnostics rather than driving ruff's renderer, so
-/// the machine-readable formats are rejected rather than silently downgraded.
-/// `TypeCheckingConfig::color` is ignored throughout.
-fn supported_format(format: TypeCheckingFormat) -> Result<TypeCheckingFormat, String> {
-    match format {
-        TypeCheckingFormat::Full | TypeCheckingFormat::Concise => Ok(format),
-        other => Err(format!(
-            "the pyrefly type-check backend renders only 'full' and 'concise', not '{other}'"
-        )),
-    }
 }
 
 /// The diagnostics of one failed Pyrefly check.
-#[derive(Debug, Clone)]
-pub struct PyreflyDiagnostics<'a> {
+pub struct PyreflyDiagnostics {
     diagnostics: Vec<Diagnostic>,
     /// The caller's path, reported instead of `__monty_main__`.
     path: String,
     line_offset: u32,
-    format: TypeCheckingFormat,
-    /// Borrows nothing; the lifetime only matches the ty backend's signature.
-    checker: PhantomData<&'a ()>,
+    full: bool,
 }
 
-impl fmt::Display for PyreflyDiagnostics<'_> {
+impl fmt::Display for PyreflyDiagnostics {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for diagnostic in &self.diagnostics {
+        for d in &self.diagnostics {
             // Clamped at 1: the injected import line would underflow to 0.
-            let line = diagnostic.start_line.saturating_sub(self.line_offset).max(1);
+            let line = d.start_line.saturating_sub(self.line_offset).max(1);
+            let severity = if d.severity == Severity::Error {
+                "error"
+            } else {
+                "warning"
+            };
             writeln!(
                 f,
-                "{}:{}:{}: {}[{}] {}",
-                self.path,
-                line,
-                diagnostic.start_col,
-                severity_label(diagnostic.severity),
-                diagnostic.kind,
-                diagnostic.message,
+                "{}:{line}:{}: {severity}[{}] {}",
+                self.path, d.start_col, d.kind, d.message
             )?;
-            if self.format == TypeCheckingFormat::Full && !diagnostic.details.is_empty() {
-                writeln!(f, "{}", diagnostic.details)?;
+            if self.full && !d.details.is_empty() {
+                writeln!(f, "{}", d.details)?;
             }
         }
         Ok(())
-    }
-}
-
-/// `ty`-style label, so both backends' output reads the same way.
-fn severity_label(severity: Severity) -> &'static str {
-    match severity {
-        Severity::Error => "error",
-        Severity::Warn => "warning",
-        // Filtered out by `run`; matched so a new severity is a compile error.
-        Severity::Info | Severity::Ignore => "info",
     }
 }

--- a/crates/monty-type-checking/src/pyrefly_check.rs
+++ b/crates/monty-type-checking/src/pyrefly_check.rs
@@ -1,0 +1,149 @@
+//! Experimental Pyrefly type-checking backend.
+//!
+//! Pyrefly needs its module set declared up front, so a run gets exactly two:
+//! the snippet and its stubs. Arbitrary module paths are not importable here.
+
+use std::{fmt, marker::PhantomData};
+
+use monty_types::{TypeCheckingConfig, TypeCheckingFormat};
+use pyrefly::embed::{Checker, Diagnostic, Severity};
+
+use crate::source_file::SourceFile;
+
+const PYTHON_VERSION: &str = "3.14";
+
+const MAIN_MODULE: &str = "__monty_main__";
+
+const STUB_MODULE: &str = "__monty_stubs__";
+
+/// A reusable Pyrefly checker. Built lazily: constructing one loads the typeshed.
+#[derive(Default)]
+pub struct PyreflyChecker {
+    checker: Option<Checker>,
+}
+
+impl fmt::Debug for PyreflyChecker {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PyreflyChecker")
+            .field("warm", &self.checker.is_some())
+            .finish()
+    }
+}
+
+impl PyreflyChecker {
+    /// Type check `python_source`, with `stubs_file` (if any) importable from it.
+    /// `Ok(None)` means it checks clean.
+    pub fn run<'a>(
+        &'a mut self,
+        python_source: &SourceFile<'_>,
+        stubs_file: Option<&SourceFile<'_>>,
+        config: TypeCheckingConfig,
+    ) -> Result<Option<PyreflyDiagnostics<'a>>, String> {
+        let format = supported_format(config.format)?;
+
+        // The injected import shifts reported lines down by one; `line_offset`
+        // undoes that when rendering.
+        let (main_source, line_offset) = match stubs_file {
+            Some(_) => (format!("from {STUB_MODULE} import *\n{}", python_source.source_code), 1),
+            None => (python_source.source_code.to_owned(), 0),
+        };
+        let stub_source = stubs_file.map_or("", |stubs| stubs.source_code);
+
+        let diagnostics = self
+            .checker()?
+            .check(MAIN_MODULE, &[(STUB_MODULE, stub_source), (MAIN_MODULE, &main_source)]);
+
+        let diagnostics: Vec<Diagnostic> = diagnostics
+            .into_iter()
+            .filter(|d| matches!(d.severity, Severity::Error | Severity::Warn))
+            .collect();
+
+        if diagnostics.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(PyreflyDiagnostics {
+                diagnostics,
+                path: python_source.path.to_owned(),
+                line_offset,
+                format,
+                checker: PhantomData,
+            }))
+        }
+    }
+
+    /// Blank both modules so the checker can be reused for unrelated code.
+    ///
+    /// Security-critical: a checker reset and handed to another session without a
+    /// run in between must not still hold the previous session's source. The warm
+    /// typeshed is kept — it carries no session state.
+    pub fn reset(&mut self) -> Result<(), String> {
+        if let Some(checker) = &self.checker {
+            checker.check(MAIN_MODULE, &[(STUB_MODULE, ""), (MAIN_MODULE, "")]);
+        }
+        Ok(())
+    }
+
+    fn checker(&mut self) -> Result<&Checker, String> {
+        if self.checker.is_none() {
+            self.checker = Some(Checker::new(Some(PYTHON_VERSION), &[MAIN_MODULE, STUB_MODULE])?);
+        }
+        Ok(self.checker.as_ref().expect("checker built above"))
+    }
+}
+
+/// Pyrefly returns structured diagnostics rather than driving ruff's renderer, so
+/// the machine-readable formats are rejected rather than silently downgraded.
+/// `TypeCheckingConfig::color` is ignored throughout.
+fn supported_format(format: TypeCheckingFormat) -> Result<TypeCheckingFormat, String> {
+    match format {
+        TypeCheckingFormat::Full | TypeCheckingFormat::Concise => Ok(format),
+        other => Err(format!(
+            "the pyrefly type-check backend renders only 'full' and 'concise', not '{other}'"
+        )),
+    }
+}
+
+/// The diagnostics of one failed Pyrefly check.
+#[derive(Debug, Clone)]
+pub struct PyreflyDiagnostics<'a> {
+    diagnostics: Vec<Diagnostic>,
+    /// The caller's path, reported instead of `__monty_main__`.
+    path: String,
+    line_offset: u32,
+    format: TypeCheckingFormat,
+    /// Borrows nothing; the lifetime only matches the ty backend's signature.
+    checker: PhantomData<&'a ()>,
+}
+
+impl fmt::Display for PyreflyDiagnostics<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for diagnostic in &self.diagnostics {
+            // Clamped at 1: the injected import line would underflow to 0.
+            let line = diagnostic.start_line.saturating_sub(self.line_offset).max(1);
+            writeln!(
+                f,
+                "{}:{}:{}: {}[{}] {}",
+                self.path,
+                line,
+                diagnostic.start_col,
+                severity_label(diagnostic.severity),
+                diagnostic.kind,
+                diagnostic.message,
+            )?;
+            if self.format == TypeCheckingFormat::Full && !diagnostic.details.is_empty() {
+                writeln!(f, "{}", diagnostic.details)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// `ty`-style label, so both backends' output reads the same way.
+fn severity_label(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Error => "error",
+        Severity::Warn => "warning",
+        // Filtered out by `run`; matched so a new severity is a compile error.
+        Severity::Info | Severity::Ignore => "info",
+    }
+}

--- a/crates/monty-type-checking/src/pyrefly_check.rs
+++ b/crates/monty-type-checking/src/pyrefly_check.rs
@@ -44,7 +44,7 @@ impl PyreflyChecker {
         let stub_source = stubs_file.map_or("", |stubs| stubs.source_code);
 
         if self.checker.is_none() {
-            self.checker = Some(Checker::new(Some(PYTHON_VERSION), &[MAIN_MODULE, STUB_MODULE])?);
+            self.checker = Some(Checker::new(Some(PYTHON_VERSION))?);
         }
         let Some(checker) = &self.checker else {
             return Err("pyrefly checker was not initialised".to_owned());

--- a/crates/monty-type-checking/src/pyrefly_check.rs
+++ b/crates/monty-type-checking/src/pyrefly_check.rs
@@ -64,10 +64,10 @@ impl PyreflyChecker {
         }))
     }
 
-    /// Blank both modules so the checker can be reused for unrelated code.
+    /// Blank both modules, for parity with the ty backend's `reset`.
     ///
-    /// Security-critical: a checker reset and handed to another session without a
-    /// run in between must not still hold the previous session's source.
+    /// Has no observable effect today: [`Self::run`] re-supplies both modules on
+    /// every call, so nothing survives into the next run anyway.
     pub fn reset(&mut self) -> Result<(), String> {
         if let Some(checker) = &self.checker {
             checker.check(MAIN_MODULE, &[(STUB_MODULE, ""), (MAIN_MODULE, "")]);

--- a/crates/monty-type-checking/src/source_file.rs
+++ b/crates/monty-type-checking/src/source_file.rs
@@ -1,0 +1,15 @@
+/// Definition of a source file handed to a type checker.
+pub struct SourceFile<'a> {
+    /// source code
+    pub source_code: &'a str,
+    /// file path
+    pub path: &'a str,
+}
+
+impl<'a> SourceFile<'a> {
+    /// Create a new source file.
+    #[must_use]
+    pub fn new(source_code: &'a str, path: &'a str) -> Self {
+        Self { source_code, path }
+    }
+}

--- a/crates/monty-type-checking/src/type_check.rs
+++ b/crates/monty-type-checking/src/type_check.rs
@@ -15,23 +15,10 @@ use ruff_text_size::{TextRange, TextSize};
 use salsa::Setter as _;
 use ty_python_semantic::{Db as _, check_file_unwrap};
 
-use crate::db::{MemoryDb, SRC_ROOT};
-
-/// Definition of a source file.
-pub struct SourceFile<'a> {
-    /// source code
-    pub source_code: &'a str,
-    /// file path
-    pub path: &'a str,
-}
-
-impl<'a> SourceFile<'a> {
-    /// Create a new source file.
-    #[must_use]
-    pub fn new(source_code: &'a str, path: &'a str) -> Self {
-        Self { source_code, path }
-    }
-}
+use crate::{
+    db::{MemoryDb, SRC_ROOT},
+    source_file::SourceFile,
+};
 
 #[derive(Debug, Default)]
 pub struct TypeChecker {

--- a/crates/monty-type-checking/tests/main.rs
+++ b/crates/monty-type-checking/tests/main.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "ty")]
+
 use std::thread;
 
 use insta::assert_snapshot;

--- a/crates/monty-type-checking/tests/main.rs
+++ b/crates/monty-type-checking/tests/main.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "ty")]
+#![cfg(not(feature = "pyrefly"))]
 
 use std::thread;
 

--- a/crates/monty-type-checking/tests/pyrefly.rs
+++ b/crates/monty-type-checking/tests/pyrefly.rs
@@ -1,131 +1,31 @@
-//! Tests for the experimental Pyrefly backend.
-
 #![cfg(feature = "pyrefly")]
 
-use insta::assert_snapshot;
 use monty_type_checking::{SourceFile, TypeChecker};
-use monty_types::{TypeCheckingConfig, TypeCheckingFormat};
+use monty_types::TypeCheckingConfig;
 
-fn pyrefly() -> TypeChecker {
-    TypeChecker::default()
-}
-
-fn concise() -> TypeCheckingConfig {
-    TypeCheckingConfig {
-        format: TypeCheckingFormat::Concise,
-        color: false,
-    }
-}
-
-fn render(checker: &mut TypeChecker, code: &str, path: &str) -> Option<String> {
+fn check(checker: &mut TypeChecker, code: &str, stubs: Option<&str>) -> Option<String> {
+    let stubs = stubs.map(|s| SourceFile::new(s, "type_stubs.pyi"));
     checker
-        .run(&SourceFile::new(code, path), None, concise())
-        .expect("type check should not fail internally")
+        .run(
+            &SourceFile::new(code, "main.py"),
+            stubs.as_ref(),
+            TypeCheckingConfig::default(),
+        )
+        .unwrap()
         .map(|d| d.to_string())
 }
 
 #[test]
-fn clean_snippet_has_no_diagnostics() {
-    let code = "\
-def add(x: int, y: int) -> int:
-    return x + y
-
-result = add(1, 2)
-";
-    let result = render(&mut pyrefly(), code, "main.py");
-    assert!(result.is_none(), "expected no type errors, got: {result:#?}");
-}
-
-/// The same snippet `main.rs` checks under ty, for comparing wording.
-#[test]
-fn argument_type_error_is_reported() {
-    let code = "\
-def add(x: int, y: int) -> int:
-    return x + y
-
-result = add(1, '2')
-";
-    assert_snapshot!(
-        render(&mut pyrefly(), code, "main.py").expect("expected type errors"),
-        @"main.py:4:17: error[bad-argument-type] Argument `Literal['2']` is not assignable to parameter `y` with type `int` in function `add`"
-    );
-}
-
-/// The injected stub import must not shift the reported line.
-#[test]
-fn stub_import_line_offset_is_removed() {
-    let stubs = "\
-class Widget:
-    x: int
-";
-    let code = "\
-w = Widget()
-w.x = 'not an int'
-";
-    let mut checker = pyrefly();
-    let diagnostics = checker
-        .run(
-            &SourceFile::new(code, "main.py"),
-            Some(&SourceFile::new(stubs, "type_stubs.pyi")),
-            concise(),
-        )
-        .unwrap()
-        .expect("expected type errors")
-        .to_string();
-    assert_snapshot!(
-        diagnostics,
-        @"main.py:2:7: error[bad-assignment] `Literal['not an int']` is not assignable to attribute `x` with type `int`"
-    );
+fn single_snippet() {
+    let mut checker = TypeChecker::default();
+    assert!(check(&mut checker, "x: int = 1\n", None).is_none());
+    assert!(check(&mut checker, "x: int = 'nope'\n", None).is_some());
 }
 
 #[test]
-fn machine_readable_formats_are_rejected() {
-    let mut checker = pyrefly();
-    let result = checker.run(
-        &SourceFile::new("x = 1\n", "main.py"),
-        None,
-        TypeCheckingConfig {
-            format: TypeCheckingFormat::Json,
-            color: false,
-        },
-    );
-    match result {
-        Err(err) => assert_snapshot!(
-            err,
-            @"the pyrefly type-check backend renders only 'full' and 'concise', not 'json'"
-        ),
-        Ok(_) => panic!("json must be rejected by the pyrefly backend"),
-    }
-}
-
-/// Security-critical: a reused checker must not resolve a name from a prior run.
-#[test]
-fn rerun_does_not_see_previous_source() {
-    let mut checker = pyrefly();
-    let first = render(&mut checker, "GOOD: int = 1\nresult = GOOD + 1\n", "main.py");
-    assert!(first.is_none(), "first run should succeed: {first:#?}");
-
-    let second = render(&mut checker, "x: int = GOOD\n", "main.py")
-        .expect("second run must error — `GOOD` was only defined in the first run");
-    assert_snapshot!(second, @"main.py:1:10: error[unknown-name] Could not find name `GOOD`");
-}
-
-/// Security-critical: `reset` must scrub the stubs a session supplied.
-#[test]
-fn reset_removes_stubs() {
-    let mut checker = pyrefly();
-    let first = checker
-        .run(
-            &SourceFile::new("from __monty_stubs__ import Widget\nw: Widget\n", "main.py"),
-            Some(&SourceFile::new("class Widget:\n    x: int\n", "type_stubs.pyi")),
-            concise(),
-        )
-        .unwrap()
-        .map(|d| d.to_string());
-    assert!(first.is_none(), "first run with stubs should succeed: {first:#?}");
-    checker.reset().expect("reset");
-
-    let second = render(&mut checker, "from __monty_stubs__ import Widget\n", "main.py")
-        .expect("second run must error — the stubs were scrubbed by reset");
-    assert_snapshot!(second, @"main.py:1:29: error[missing-module-attribute] Could not import `Widget` from `__monty_stubs__`");
+fn repl_sequence() {
+    let mut checker = TypeChecker::default();
+    let stubs = "x = 1\n";
+    assert!(check(&mut checker, "y = x + 2\n", Some(stubs)).is_none());
+    assert!(check(&mut checker, "y = undefined\n", Some(stubs)).is_some());
 }

--- a/crates/monty-type-checking/tests/pyrefly.rs
+++ b/crates/monty-type-checking/tests/pyrefly.rs
@@ -1,0 +1,131 @@
+//! Tests for the experimental Pyrefly backend.
+
+#![cfg(feature = "pyrefly")]
+
+use insta::assert_snapshot;
+use monty_type_checking::{SourceFile, TypeChecker};
+use monty_types::{TypeCheckingConfig, TypeCheckingFormat};
+
+fn pyrefly() -> TypeChecker {
+    TypeChecker::default()
+}
+
+fn concise() -> TypeCheckingConfig {
+    TypeCheckingConfig {
+        format: TypeCheckingFormat::Concise,
+        color: false,
+    }
+}
+
+fn render(checker: &mut TypeChecker, code: &str, path: &str) -> Option<String> {
+    checker
+        .run(&SourceFile::new(code, path), None, concise())
+        .expect("type check should not fail internally")
+        .map(|d| d.to_string())
+}
+
+#[test]
+fn clean_snippet_has_no_diagnostics() {
+    let code = "\
+def add(x: int, y: int) -> int:
+    return x + y
+
+result = add(1, 2)
+";
+    let result = render(&mut pyrefly(), code, "main.py");
+    assert!(result.is_none(), "expected no type errors, got: {result:#?}");
+}
+
+/// The same snippet `main.rs` checks under ty, for comparing wording.
+#[test]
+fn argument_type_error_is_reported() {
+    let code = "\
+def add(x: int, y: int) -> int:
+    return x + y
+
+result = add(1, '2')
+";
+    assert_snapshot!(
+        render(&mut pyrefly(), code, "main.py").expect("expected type errors"),
+        @"main.py:4:17: error[bad-argument-type] Argument `Literal['2']` is not assignable to parameter `y` with type `int` in function `add`"
+    );
+}
+
+/// The injected stub import must not shift the reported line.
+#[test]
+fn stub_import_line_offset_is_removed() {
+    let stubs = "\
+class Widget:
+    x: int
+";
+    let code = "\
+w = Widget()
+w.x = 'not an int'
+";
+    let mut checker = pyrefly();
+    let diagnostics = checker
+        .run(
+            &SourceFile::new(code, "main.py"),
+            Some(&SourceFile::new(stubs, "type_stubs.pyi")),
+            concise(),
+        )
+        .unwrap()
+        .expect("expected type errors")
+        .to_string();
+    assert_snapshot!(
+        diagnostics,
+        @"main.py:2:7: error[bad-assignment] `Literal['not an int']` is not assignable to attribute `x` with type `int`"
+    );
+}
+
+#[test]
+fn machine_readable_formats_are_rejected() {
+    let mut checker = pyrefly();
+    let result = checker.run(
+        &SourceFile::new("x = 1\n", "main.py"),
+        None,
+        TypeCheckingConfig {
+            format: TypeCheckingFormat::Json,
+            color: false,
+        },
+    );
+    match result {
+        Err(err) => assert_snapshot!(
+            err,
+            @"the pyrefly type-check backend renders only 'full' and 'concise', not 'json'"
+        ),
+        Ok(_) => panic!("json must be rejected by the pyrefly backend"),
+    }
+}
+
+/// Security-critical: a reused checker must not resolve a name from a prior run.
+#[test]
+fn rerun_does_not_see_previous_source() {
+    let mut checker = pyrefly();
+    let first = render(&mut checker, "GOOD: int = 1\nresult = GOOD + 1\n", "main.py");
+    assert!(first.is_none(), "first run should succeed: {first:#?}");
+
+    let second = render(&mut checker, "x: int = GOOD\n", "main.py")
+        .expect("second run must error — `GOOD` was only defined in the first run");
+    assert_snapshot!(second, @"main.py:1:10: error[unknown-name] Could not find name `GOOD`");
+}
+
+/// Security-critical: `reset` must scrub the stubs a session supplied.
+#[test]
+fn reset_removes_stubs() {
+    let mut checker = pyrefly();
+    let first = checker
+        .run(
+            &SourceFile::new("from __monty_stubs__ import Widget\nw: Widget\n", "main.py"),
+            Some(&SourceFile::new("class Widget:\n    x: int\n", "type_stubs.pyi")),
+            concise(),
+        )
+        .unwrap()
+        .map(|d| d.to_string());
+    assert!(first.is_none(), "first run with stubs should succeed: {first:#?}");
+    checker.reset().expect("reset");
+
+    let second = render(&mut checker, "from __monty_stubs__ import Widget\n", "main.py")
+        .expect("second run must error — the stubs were scrubbed by reset");
+    assert_snapshot!(second, @"main.py:1:29: error[missing-module-attribute] Could not import `Widget` from `__monty_stubs__`");
+}

--- a/crates/monty-type-checking/tests/pyrefly.rs
+++ b/crates/monty-type-checking/tests/pyrefly.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "pyrefly")]
 
+use insta::assert_snapshot;
 use monty_type_checking::{SourceFile, TypeChecker};
 use monty_types::TypeCheckingConfig;
 
@@ -28,4 +29,21 @@ fn repl_sequence() {
     let stubs = "x = 1\n";
     assert!(check(&mut checker, "y = x + 2\n", Some(stubs)).is_none());
     assert!(check(&mut checker, "y = undefined\n", Some(stubs)).is_some());
+}
+
+#[test]
+fn error_output() {
+    let mut checker = TypeChecker::default();
+    let code = "def add(x: int, y: int) -> int:\n    return x + y\n\nr = add(1, '2')\n";
+    assert_snapshot!(check(&mut checker, code, None).unwrap(), @"main.py:4:12: error[bad-argument-type] Argument `Literal['2']` is not assignable to parameter `y` with type `int` in function `add`");
+}
+
+/// The injected stub import must not shift the reported line: the error is on
+/// line 2 of the snippet below.
+#[test]
+fn error_output_with_stubs() {
+    let mut checker = TypeChecker::default();
+    let code = "w = Widget()\nw.x = 'not an int'\n";
+    let stubs = "class Widget:\n    x: int\n";
+    assert_snapshot!(check(&mut checker, code, Some(stubs)).unwrap(), @"main.py:2:7: error[bad-assignment] `Literal['not an int']` is not assignable to attribute `x` with type `int`");
 }

--- a/crates/monty-type-checking/tests/pyrefly.rs
+++ b/crates/monty-type-checking/tests/pyrefly.rs
@@ -47,14 +47,3 @@ fn error_output_with_stubs() {
     let stubs = "class Widget:\n    x: int\n";
     assert_snapshot!(check(&mut checker, code, Some(stubs)).unwrap(), @"main.py:2:7: error[bad-assignment] `Literal['not an int']` is not assignable to attribute `x` with type `int`");
 }
-
-/// Security-critical: `reset` must scrub the stubs a session supplied.
-#[test]
-fn reset_removes_stubs() {
-    let mut checker = TypeChecker::default();
-    let code = "from __monty_stubs__ import Widget\n";
-    assert!(check(&mut checker, code, Some("class Widget:\n    x: int\n")).is_none());
-
-    checker.reset().unwrap();
-    assert!(check(&mut checker, code, None).is_some());
-}

--- a/crates/monty-type-checking/tests/pyrefly.rs
+++ b/crates/monty-type-checking/tests/pyrefly.rs
@@ -47,3 +47,14 @@ fn error_output_with_stubs() {
     let stubs = "class Widget:\n    x: int\n";
     assert_snapshot!(check(&mut checker, code, Some(stubs)).unwrap(), @"main.py:2:7: error[bad-assignment] `Literal['not an int']` is not assignable to attribute `x` with type `int`");
 }
+
+/// Security-critical: `reset` must scrub the stubs a session supplied.
+#[test]
+fn reset_removes_stubs() {
+    let mut checker = TypeChecker::default();
+    let code = "from __monty_stubs__ import Widget\n";
+    assert!(check(&mut checker, code, Some("class Widget:\n    x: int\n")).is_none());
+
+    checker.reset().unwrap();
+    assert!(check(&mut checker, code, None).is_some());
+}


### PR DESCRIPTION
This PR prototypes the ability to swap between using ty and Pyrefly as the type checker for Monty, via the `MONTY_TYPE_CHECKER` env var right now.

The actual diff is small - Pyrefly exposes a minimal API that is easy to call, most of the remaining logic is refactoring to support 2 separate backends. There's just a lot of Cargo.lock churn from pulling in Pyrefly as a dependency.

For context, I believe @samuelcolvin spoke with @migeed-z at PyCon about this, and was open to us experimenting in this direction

It can't be merged in this state, because:
- This points at my own fork of Pyrefly, which prototypes the new API that Monty uses. I will upstream it once we're on the same page.
- Monty depends on a fork of ruff, while Pyrefly depends on a different version of ruff, so right now we're pulling in 2 copies of ruff, and we'll need to decide on a way to reconcile the versions and handle upgrades.
- Needs some profiling and optimization: ATM bench_warm_trivial/bench_warm_builtin are pretty close to ty's performance, but repl-based benchmarks are 3-5x slower (tho admittedly I didn't do much optimization)

I'm putting this PR up just to get some early feedback. Let me know what you guys think!
