### PR TITLE
Add 'Part of the Pydantic Stack' footer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,3 +416,11 @@ Running Python directly via `exec()` (~0.1ms) or subprocess (~30ms).
 - **Setup complexity**: None
 - **File mounting**: Direct filesystem access (that's the problem)
 - **Snapshotting**: Possible with durable execution solutions like Temporal
+
+## Part of the Pydantic Stack
+
+The Pydantic Stack is everything you need to ship production-grade AI agents:
+
+- [Pydantic AI](https://pydantic.dev/pydantic-ai?utm_source=github&utm_medium=readme&utm_campaign=monty) - Type-safe agent framework
+- [Pydantic Logfire](https://pydantic.dev/logfire?utm_source=github&utm_medium=readme&utm_campaign=monty) - AI-first, full-stack observability
+- [Logfire AI Gateway](https://pydantic.dev/ai-gateway?utm_source=github&utm_medium=readme&utm_campaign=monty) - Unified LLM proxy


### PR DESCRIPTION
Adds a short "Part of the Pydantic Stack" footer to the README so readers can discover the other products in one place.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "Part of the Pydantic Stack" footer to the README with links to Pydantic AI, Pydantic Logfire, and Logfire AI Gateway. Links include UTM parameters for attribution to this repo.

<sup>Written for commit d317398ac8b5951112d5fcd2b2c5fa02aea0ff9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

