### PR TITLE
fix(asyncio): raise RuntimeError on cross-gather coroutine reuse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -757,10 +757,12 @@ wasm toolchain (`make build-wasm`).
 
 Every pull request that adds, changes, or removes user-visible behavior MUST
 land (or update) a markdown document under `./limitations/` describing how
-the feature diverges from CPython and what subset of the CPython surface
+the feature DIVERGES from CPython and what subset of the CPython surface
 area Monty actually implements. The directory is the single source of truth
 for "what does Monty *not* do that CPython does" — module-level docstrings
 and inline comments are not sufficient on their own.
+
+**NOTE**: `./limitations/` SHOULD **ONLY** INCLUDE INFORMATION ABOUT BEHAVIOR DIVERGENCES FROM CPython, not points that describe behavior that matches CPython's behavior.
 
 One file per feature, named after the builtin / module / construct it
 covers (e.g. `limitations/open.md`, `limitations/asyncio.md`,
@@ -771,7 +773,7 @@ Keep entries concise but comprehensive — list every known divergence,
 including ones that "feel obvious". A divergence that is not written down
 is one that future readers (and future Claude) will assume does not exist.
 Reviewers should reject PRs that change behavior without updating
-`./limitations/`.
+`./limitations/` if necessary.
 
 Structure each file around what a Python user would actually try:
 

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -1093,7 +1093,10 @@ fn drop_committed_children(
                 // Terminal or never-committed nested gathers have no active
                 // children left for this parent to tear down.
             }
-            _ => panic!("gather pending_children key is not a Coroutine, ExternalFuture, or GatherFuture"),
+            // `gather()` rejects anything other than these three types at
+            // construction (see `modules/asyncio.rs`), and heap entries don't
+            // change type — so keys here are always one of the above.
+            _ => unreachable!("gather pending_children key is not a Coroutine, ExternalFuture, or GatherFuture"),
         }
     }
 }

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -141,12 +141,9 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         let mut results_guard = HeapGuard::new(results, this);
         let (results, this) = results_guard.as_parts_mut();
 
-        // Commit each item, spawning tasks / installing sub-awaiters / recursing
-        // into nested gathers. On any mid-commit error we roll back already-
-        // committed siblings via `drop_committed_children` before propagating
-        // — otherwise they would survive as orphans pointing at the still-
-        // `Pending` outer gather and later trip
-        // `expect("...non-Awaited gather")` at teardown.
+        // Roll back already-committed siblings if a later child fails during
+        // this commit pass; otherwise spawned tasks or awaiters can outlive a
+        // gather that never reached `Awaited`.
         if let Err(err) = this.commit_gather_items(gather_id, &gather, &mut pending_children, results) {
             gather.get_mut(this.heap).state = GatherState::Failed(err.clone());
             drop_committed_children(pending_children, &mut this.scheduler, this.heap, &err);
@@ -176,22 +173,12 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         Ok(Poll::Pending)
     }
 
-    /// Walks `gather`'s items left-to-right, committing each by spawning a
-    /// task (coroutine), installing a sub-awaiter (external future), or
-    /// recursing into the child's own commit (nested gather). Synchronously-
-    /// resolved items land in `results[idx]`; everything else gets a slot in
-    /// `pending_children` keyed by the item's `HeapId`.
+    /// Commits `gather`'s items left-to-right into result slots or pending children.
     ///
-    /// Returns `Err` as soon as any item raises — cross-gather coroutine
-    /// reuse (`Scheduler::spawn` returns `None`), an already-`Failed` nested
-    /// gather, a `Pending { awaiter: Some(_) }` external, an outer
-    /// `Failed`/`Awaited` re-await, etc. The caller is responsible for
-    /// rolling back whatever's accumulated in `pending_children` via
-    /// [`drop_committed_children`].
-    ///
-    /// Split out of [`Self::await_gather_future`] so the rollback site stays
-    /// a single `if let Err(...)` instead of a `'commit: { … }` labeled
-    /// block; lets `?` propagate sub-call errors naturally.
+    /// Spawns coroutine children, installs awaiters on external futures, and
+    /// recursively awaits nested gathers. Any error leaves already-committed
+    /// entries in `pending_children`; the caller must pass them to
+    /// [`drop_committed_children`] before propagating the error.
     fn commit_gather_items(
         &mut self,
         gather_id: HeapId,
@@ -213,13 +200,13 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             };
 
             let poll = match self.heap.read(item_id) {
-                HeapReadOutput::Coroutine(_) => {
-                    // `Scheduler::spawn` returns `None` if `item_id` is already
-                    // driving another task — typically the same coroutine reached
-                    // through a second `asyncio.gather` call. Raise the canonical
-                    // `RuntimeError` and let rollback clean up the siblings we
-                    // already committed in this gather's pending_children.
-                    if self.scheduler.spawn(self.heap, item_id, Some(gather_id)).is_none() {
+                HeapReadOutput::Coroutine(coro) => {
+                    // Reject reuse up-front: either the coroutine is no longer
+                    // `New`, or another gather already spawned it (`spawn`
+                    // returns `None`).
+                    if coro.get(self.heap).state != CoroutineState::New
+                        || self.scheduler.spawn(self.heap, item_id, Some(gather_id)).is_none()
+                    {
                         return Err(ExcType::cannot_reuse_already_awaited_coroutine());
                     }
                     Poll::Pending
@@ -1064,45 +1051,20 @@ impl<'h> HeapRead<'h, GatherFuture> {
         // Drop fanned-out result Values that won't reach the waiter.
         results.drop_with_heap(heap);
 
-        // Tear down every committed child. Skips nested gathers that are
-        // already `Failed` — that case arises when failure propagated up via
-        // [`VM::deliver_awaiter_failure`] from a nested child that *itself*
-        // failed first; revisiting its `pending_children` entry without the
-        // state check would re-call `nested.fail(...)` and panic.
+        // Skip nested gathers that already failed while propagating this same
+        // error up the awaiter chain.
         drop_committed_children(pending_children, scheduler, heap, error);
 
         waiter
     }
 }
 
-/// Tears down children of a partially- or fully-committed gather, releasing
-/// their refcounts on the parent gather and the host's pending-external map.
+/// Tears down children of a failed gather commit.
 ///
-/// Shared by:
-///
-/// * the commit-time rollback path in [`VM::await_gather_future`], when an
-///   error propagates after some siblings already committed and the gather
-///   itself is still in `Pending` (transitioned to `Failed` by the caller),
-///   and
-/// * [`HeapRead::<GatherFuture>::fail`] when a sibling's failure tears down
-///   an `Awaited` gather.
-///
-/// Handling per child kind:
-///
-/// * **Coroutine** — its spawned task (if any) is cancelled via
-///   [`Scheduler::cancel_task`]. The cancel releases the task's inc_refs on
-///   the coroutine and the (outer) gather.
-/// * **ExternalFuture** — clears the awaiter slot we installed. The dropped
-///   awaiter's `drop_with_heap` releases the inc_ref it held on the (outer)
-///   gather. The future itself stays in `pending_externals` and a later
-///   host resolution simply caches the value (it has no awaiter to fan to).
-/// * **GatherFuture (nested)** — recursively `fail`ed *only if still
-///   `Awaited`*. The state check matters because this helper also runs from
-///   the awaiter-chain failure path: when a child gather fails first and
-///   walks up to its parent via `deliver_awaiter_failure`, that very child
-///   is still in the parent's `pending_children` map but is already
-///   `Failed`. Without the check the parent would call `nested.fail(...)` a
-///   second time and trip `expect("fail called on non-Awaited gather")`.
+/// Coroutine children are cancelled through the scheduler, external futures
+/// have their gather awaiter removed, and nested gathers are failed
+/// recursively while they are still `Awaited`. Nested gathers already in a
+/// terminal state were cleaned up by the error path that reached them first.
 fn drop_committed_children(
     pending_children: AHashMap<HeapId, SmallVec<[usize; 1]>>,
     scheduler: &mut Scheduler,
@@ -1128,10 +1090,8 @@ fn drop_committed_children(
                     let nested_awaiter = nested.fail(scheduler, heap, error);
                     nested_awaiter.drop_with_heap(heap);
                 }
-                // Else: nested is already `Failed`/`Completed`/`Pending` —
-                // its resources are already cleaned up (or were never
-                // committed) and dropping the `pending_children` key
-                // (via `into_keys`) is the only bookkeeping left.
+                // Terminal or never-committed nested gathers have no active
+                // children left for this parent to tear down.
             }
             _ => panic!("gather pending_children key is not a Coroutine, ExternalFuture, or GatherFuture"),
         }

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -8,7 +8,7 @@
 
 use std::{collections::hash_map::Entry, mem, task::Poll};
 
-use ahash::AHashMap;
+use ahash::{AHashMap, AHashSet};
 use smallvec::{SmallVec, smallvec};
 
 use super::{AwaitResult, CallFrame, FrameExit, VM};
@@ -77,9 +77,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
     fn await_coroutine(&mut self, mut coro: HeapRead<'h, Coroutine>) -> Result<AwaitResult, RunError> {
         // Check if coroutine can be awaited (must be New)
         if coro.get(self.heap).state != CoroutineState::New {
-            return Err(
-                SimpleException::new_msg(ExcType::RuntimeError, "cannot reuse already awaited coroutine").into(),
-            );
+            return Err(ExcType::cannot_reuse_already_awaited_coroutine());
         }
 
         // Extract coroutine data before mutating
@@ -136,6 +134,19 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             return Ok(Poll::Ready(Value::Ref(list_id)));
         }
 
+        // Pre-flight pass: descend through this gather's items (recursively into
+        // any nested `Pending` gathers) and ensure no coroutine is reachable
+        // through more than one would-be spawn or is already driving another
+        // task. Raising here keeps every gather in the tree in `Pending`, so
+        // the failure path needs no rollback — sibling commits below have not
+        // happened yet. Without this, two gathers sharing a coroutine would
+        // each commit and orphan a child task whose teardown later panics with
+        // `fail called on non-Awaited gather`.
+        {
+            let mut seen: AHashSet<HeapId> = AHashSet::new();
+            preflight_gather_no_double_spawn(&gather.get(this.heap).items, &mut seen, &this.scheduler, this.heap)?;
+        }
+
         // Await all items, storing already resolved state and tracking the rest in `pending_children`.
 
         let mut pending_children: AHashMap<HeapId, SmallVec<[usize; 1]>> = AHashMap::new();
@@ -158,7 +169,15 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
 
             let poll = match this.heap.read(item_id) {
                 HeapReadOutput::Coroutine(_) => {
-                    this.scheduler.spawn(this.heap, item_id, Some(gather_id));
+                    // `Scheduler::spawn` returns `None` if `item_id` is already
+                    // driving another task — typically the same coroutine reached
+                    // through a second `asyncio.gather` call. Raise the same
+                    // `RuntimeError` CPython does instead of clobbering the
+                    // `coroutine_to_task` mapping (which previously panicked at
+                    // gather teardown: `fail called on non-Awaited gather`).
+                    if this.scheduler.spawn(this.heap, item_id, Some(gather_id)).is_none() {
+                        return Err(ExcType::cannot_reuse_already_awaited_coroutine());
+                    }
                     Poll::Pending
                 }
                 HeapReadOutput::ExternalFuture(mut fut) => {
@@ -557,9 +576,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             if coro.get(self.heap).state == CoroutineState::New {
                 self.init_task_from_coroutine(coro_id)?;
             } else {
-                let error: RunError =
-                    SimpleException::new_msg(ExcType::RuntimeError, "cannot reuse already awaited coroutine").into();
-                return self.handle_task_failure(error);
+                return self.handle_task_failure(ExcType::cannot_reuse_already_awaited_coroutine());
             }
         } else {
             // This shouldn't happen - task with no frames and no coroutine
@@ -584,9 +601,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
 
         // Check state
         if coro.get(self.heap).state != CoroutineState::New {
-            return Err(
-                SimpleException::new_msg(ExcType::RuntimeError, "cannot reuse already awaited coroutine").into(),
-            );
+            return Err(ExcType::cannot_reuse_already_awaited_coroutine());
         }
 
         // Extract coroutine data
@@ -1067,4 +1082,70 @@ impl<'h> HeapRead<'h, GatherFuture> {
 
         waiter
     }
+}
+
+/// Validates that no coroutine reachable through this gather's items would be
+/// spawned more than once or reused after a previous await.
+///
+/// Walks `items` and recursively descends into any `Pending` nested
+/// `GatherFuture`. Raises [`ExcType::cannot_reuse_already_awaited_coroutine`]
+/// when it spots a coroutine that:
+///
+/// * is no longer in `CoroutineState::New` (already directly awaited, running,
+///   or completed),
+/// * already has an entry in the scheduler's `coroutine_to_task` map (already
+///   driving a task from a prior gather), or
+/// * appears at two distinct positions in the same outer-gather tree (the
+///   cross-gather double-spawn shape `g1 = gather(c); g2 = gather(c);
+///   await gather(g1, g2)` — both gathers would otherwise call
+///   `Scheduler::spawn` and clobber the inverse mapping).
+///
+/// Crucially, **within a single gather** duplicates dedup rather than raise
+/// (CPython allows `gather(c, c)` and the existing in-gather dedup pass in
+/// [`VM::await_gather_future`] handles them). That is enforced via the
+/// per-gather `local_dedup` set below — only the first occurrence at each
+/// level is checked against the tree-wide `seen` set.
+///
+/// Running this *before* any commit work (spawn / awaiter installation / state
+/// transition) means the failure path requires no rollback: the gather and
+/// every nested gather stay in `GatherState::Pending` and can be re-awaited
+/// later if the caller catches the `RuntimeError`.
+fn preflight_gather_no_double_spawn(
+    items: &[HeapId],
+    seen: &mut AHashSet<HeapId>,
+    scheduler: &Scheduler,
+    heap: &HeapReader<'_, impl ResourceTracker>,
+) -> Result<(), RunError> {
+    let mut local_dedup: AHashSet<HeapId> = AHashSet::new();
+    for &item_id in items {
+        if !local_dedup.insert(item_id) {
+            // Same item already validated at this level — `await_gather_future`
+            // dedups via `pending_children`; matching that here keeps
+            // `gather(c, c)` legal.
+            continue;
+        }
+        match heap.read(item_id) {
+            HeapReadOutput::Coroutine(coro) => {
+                if coro.get(heap).state != CoroutineState::New
+                    || scheduler.task_for_coroutine(item_id).is_some()
+                    || !seen.insert(item_id)
+                {
+                    return Err(ExcType::cannot_reuse_already_awaited_coroutine());
+                }
+            }
+            HeapReadOutput::GatherFuture(child) => {
+                if matches!(child.get(heap).state, GatherState::Pending) {
+                    // The borrow on `child` lives across the recursive call —
+                    // safe because `preflight` only ever reads (no `get_mut`,
+                    // no `allocate`), and multiple `HeapRead` handles can
+                    // coexist for reads.
+                    preflight_gather_no_double_spawn(&child.get(heap).items, seen, scheduler, heap)?;
+                }
+            }
+            // ExternalFuture and already-Resolved/Failed gathers can't
+            // contribute a duplicate coroutine spawn — they're skipped.
+            _ => {}
+        }
+    }
+    Ok(())
 }

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -8,7 +8,7 @@
 
 use std::{collections::hash_map::Entry, mem, task::Poll};
 
-use ahash::{AHashMap, AHashSet};
+use ahash::AHashMap;
 use smallvec::{SmallVec, smallvec};
 
 use super::{AwaitResult, CallFrame, FrameExit, VM};
@@ -134,19 +134,6 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             return Ok(Poll::Ready(Value::Ref(list_id)));
         }
 
-        // Pre-flight pass: descend through this gather's items (recursively into
-        // any nested `Pending` gathers) and ensure no coroutine is reachable
-        // through more than one would-be spawn or is already driving another
-        // task. Raising here keeps every gather in the tree in `Pending`, so
-        // the failure path needs no rollback — sibling commits below have not
-        // happened yet. Without this, two gathers sharing a coroutine would
-        // each commit and orphan a child task whose teardown later panics with
-        // `fail called on non-Awaited gather`.
-        {
-            let mut seen: AHashSet<HeapId> = AHashSet::new();
-            preflight_gather_no_double_spawn(&gather.get(this.heap).items, &mut seen, &this.scheduler, this.heap)?;
-        }
-
         // Await all items, storing already resolved state and tracking the rest in `pending_children`.
 
         let mut pending_children: AHashMap<HeapId, SmallVec<[usize; 1]>> = AHashMap::new();
@@ -154,59 +141,16 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         let mut results_guard = HeapGuard::new(results, this);
         let (results, this) = results_guard.as_parts_mut();
 
-        for (idx, result) in results.iter_mut().enumerate() {
-            let item_id = gather.get(this.heap).items[idx];
-            let vacant_entry = match pending_children.entry(item_id) {
-                Entry::Occupied(occ) => {
-                    // Dedup: We've already registered this item in this commit pass —
-                    // this is a duplicate item (e.g. `gather(coro, coro)`). Just
-                    // append the new slot index to the existing entry.
-                    occ.into_mut().push(idx);
-                    continue;
-                }
-                Entry::Vacant(vacant) => vacant,
-            };
-
-            let poll = match this.heap.read(item_id) {
-                HeapReadOutput::Coroutine(_) => {
-                    // `Scheduler::spawn` returns `None` if `item_id` is already
-                    // driving another task — typically the same coroutine reached
-                    // through a second `asyncio.gather` call. Raise the same
-                    // `RuntimeError` CPython does instead of clobbering the
-                    // `coroutine_to_task` mapping (which previously panicked at
-                    // gather teardown: `fail called on non-Awaited gather`).
-                    if this.scheduler.spawn(this.heap, item_id, Some(gather_id)).is_none() {
-                        return Err(ExcType::cannot_reuse_already_awaited_coroutine());
-                    }
-                    Poll::Pending
-                }
-                HeapReadOutput::ExternalFuture(mut fut) => {
-                    this.heap.inc_ref(gather_id);
-                    let sub_awaiter = Awaiter::GatherSlot {
-                        gather: gather_id,
-                        source: item_id,
-                    };
-                    this.await_external_future(&mut fut, sub_awaiter)?
-                }
-                HeapReadOutput::GatherFuture(child_gather) => {
-                    this.heap.inc_ref(gather_id);
-                    let sub_awaiter = Awaiter::GatherSlot {
-                        gather: gather_id,
-                        source: item_id,
-                    };
-                    this.await_gather_future(item_id, child_gather, sub_awaiter)?
-                }
-                _ => panic!("gather item is not a Coroutine, ExternalFuture, or GatherFuture"),
-            };
-
-            match poll {
-                Poll::Ready(value) => {
-                    *result = Some(value);
-                }
-                Poll::Pending => {
-                    vacant_entry.insert(smallvec![idx]);
-                }
-            }
+        // Commit each item, spawning tasks / installing sub-awaiters / recursing
+        // into nested gathers. On any mid-commit error we roll back already-
+        // committed siblings via `drop_committed_children` before propagating
+        // — otherwise they would survive as orphans pointing at the still-
+        // `Pending` outer gather and later trip
+        // `expect("...non-Awaited gather")` at teardown.
+        if let Err(err) = this.commit_gather_items(gather_id, &gather, &mut pending_children, results) {
+            gather.get_mut(this.heap).state = GatherState::Failed(err.clone());
+            drop_committed_children(pending_children, &mut this.scheduler, this.heap, &err);
+            return Err(err);
         }
 
         if pending_children.is_empty() {
@@ -230,6 +174,85 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         });
 
         Ok(Poll::Pending)
+    }
+
+    /// Walks `gather`'s items left-to-right, committing each by spawning a
+    /// task (coroutine), installing a sub-awaiter (external future), or
+    /// recursing into the child's own commit (nested gather). Synchronously-
+    /// resolved items land in `results[idx]`; everything else gets a slot in
+    /// `pending_children` keyed by the item's `HeapId`.
+    ///
+    /// Returns `Err` as soon as any item raises — cross-gather coroutine
+    /// reuse (`Scheduler::spawn` returns `None`), an already-`Failed` nested
+    /// gather, a `Pending { awaiter: Some(_) }` external, an outer
+    /// `Failed`/`Awaited` re-await, etc. The caller is responsible for
+    /// rolling back whatever's accumulated in `pending_children` via
+    /// [`drop_committed_children`].
+    ///
+    /// Split out of [`Self::await_gather_future`] so the rollback site stays
+    /// a single `if let Err(...)` instead of a `'commit: { … }` labeled
+    /// block; lets `?` propagate sub-call errors naturally.
+    fn commit_gather_items(
+        &mut self,
+        gather_id: HeapId,
+        gather: &HeapRead<'h, GatherFuture>,
+        pending_children: &mut AHashMap<HeapId, SmallVec<[usize; 1]>>,
+        results: &mut [Option<Value>],
+    ) -> Result<(), RunError> {
+        for (idx, result) in results.iter_mut().enumerate() {
+            let item_id = gather.get(self.heap).items[idx];
+            let vacant_entry = match pending_children.entry(item_id) {
+                Entry::Occupied(occ) => {
+                    // Dedup: We've already registered this item in this commit pass —
+                    // this is a duplicate item (e.g. `gather(coro, coro)`). Just
+                    // append the new slot index to the existing entry.
+                    occ.into_mut().push(idx);
+                    continue;
+                }
+                Entry::Vacant(vacant) => vacant,
+            };
+
+            let poll = match self.heap.read(item_id) {
+                HeapReadOutput::Coroutine(_) => {
+                    // `Scheduler::spawn` returns `None` if `item_id` is already
+                    // driving another task — typically the same coroutine reached
+                    // through a second `asyncio.gather` call. Raise the canonical
+                    // `RuntimeError` and let rollback clean up the siblings we
+                    // already committed in this gather's pending_children.
+                    if self.scheduler.spawn(self.heap, item_id, Some(gather_id)).is_none() {
+                        return Err(ExcType::cannot_reuse_already_awaited_coroutine());
+                    }
+                    Poll::Pending
+                }
+                HeapReadOutput::ExternalFuture(mut fut) => {
+                    self.heap.inc_ref(gather_id);
+                    let sub_awaiter = Awaiter::GatherSlot {
+                        gather: gather_id,
+                        source: item_id,
+                    };
+                    self.await_external_future(&mut fut, sub_awaiter)?
+                }
+                HeapReadOutput::GatherFuture(child_gather) => {
+                    self.heap.inc_ref(gather_id);
+                    let sub_awaiter = Awaiter::GatherSlot {
+                        gather: gather_id,
+                        source: item_id,
+                    };
+                    self.await_gather_future(item_id, child_gather, sub_awaiter)?
+                }
+                _ => panic!("gather item is not a Coroutine, ExternalFuture, or GatherFuture"),
+            };
+
+            match poll {
+                Poll::Ready(value) => {
+                    *result = Some(value);
+                }
+                Poll::Pending => {
+                    vacant_entry.insert(smallvec![idx]);
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Awaits an external future by inspecting its heap state.
@@ -1041,111 +1064,76 @@ impl<'h> HeapRead<'h, GatherFuture> {
         // Drop fanned-out result Values that won't reach the waiter.
         results.drop_with_heap(heap);
 
-        // Walk every child the gather was waiting on and clean it up
-        // appropriately. `heap.read(id)` recovers the kind:
-        // - Coroutine: find its driving task via the scheduler's
-        //   `task_for_coroutine` index and cancel it, releasing the task's
-        //   inc_refs on the gather and coroutine.
-        // - ExternalFuture: clear the awaiter slot so a late host resolution
-        //   doesn't fan into the now-failed gather. The future stays in
-        //   `pending_externals` and a `Pending { awaiter: None }` resolution
-        //   simply caches the value (and a re-await replays it).
-        // - GatherFuture (nested): recurse — tear it down with the same
-        //   error so its own tasks/externals/gathers are cleaned up too.
-        for child_id in pending_children.into_keys() {
-            match heap.read(child_id) {
-                HeapReadOutput::Coroutine(_) => {
-                    if let Some(tid) = scheduler.task_for_coroutine(child_id) {
-                        scheduler.cancel_task(tid, heap);
-                    }
-                }
-                HeapReadOutput::ExternalFuture(mut fut) => {
-                    // Take the awaiter out so the inc_ref it holds on this
-                    // (failing) gather is released.
-                    if let ExternalFutureState::Pending { awaiter } = &mut fut.get_mut(heap).state
-                        && let Some(old) = awaiter.take()
-                    {
-                        old.drop_with_heap(heap);
-                    }
-                }
-                HeapReadOutput::GatherFuture(mut nested) => {
-                    // The nested gather's waiter is `Awaiter::GatherSlot {
-                    // gather: self, .. }` — we own its routing and are now
-                    // gone, so drop the returned awaiter (releasing its
-                    // inc_ref back on us) rather than forwarding the chain.
-                    let nested_awaiter = nested.fail(scheduler, heap, error);
-                    nested_awaiter.drop_with_heap(heap);
-                }
-                _ => panic!("gather pending_children key is not a Coroutine, ExternalFuture, or GatherFuture"),
-            }
-        }
+        // Tear down every committed child. Skips nested gathers that are
+        // already `Failed` — that case arises when failure propagated up via
+        // [`VM::deliver_awaiter_failure`] from a nested child that *itself*
+        // failed first; revisiting its `pending_children` entry without the
+        // state check would re-call `nested.fail(...)` and panic.
+        drop_committed_children(pending_children, scheduler, heap, error);
 
         waiter
     }
 }
 
-/// Validates that no coroutine reachable through this gather's items would be
-/// spawned more than once or reused after a previous await.
+/// Tears down children of a partially- or fully-committed gather, releasing
+/// their refcounts on the parent gather and the host's pending-external map.
 ///
-/// Walks `items` and recursively descends into any `Pending` nested
-/// `GatherFuture`. Raises [`ExcType::cannot_reuse_already_awaited_coroutine`]
-/// when it spots a coroutine that:
+/// Shared by:
 ///
-/// * is no longer in `CoroutineState::New` (already directly awaited, running,
-///   or completed),
-/// * already has an entry in the scheduler's `coroutine_to_task` map (already
-///   driving a task from a prior gather), or
-/// * appears at two distinct positions in the same outer-gather tree (the
-///   cross-gather double-spawn shape `g1 = gather(c); g2 = gather(c);
-///   await gather(g1, g2)` — both gathers would otherwise call
-///   `Scheduler::spawn` and clobber the inverse mapping).
+/// * the commit-time rollback path in [`VM::await_gather_future`], when an
+///   error propagates after some siblings already committed and the gather
+///   itself is still in `Pending` (transitioned to `Failed` by the caller),
+///   and
+/// * [`HeapRead::<GatherFuture>::fail`] when a sibling's failure tears down
+///   an `Awaited` gather.
 ///
-/// Crucially, **within a single gather** duplicates dedup rather than raise
-/// (CPython allows `gather(c, c)` and the existing in-gather dedup pass in
-/// [`VM::await_gather_future`] handles them). That is enforced via the
-/// per-gather `local_dedup` set below — only the first occurrence at each
-/// level is checked against the tree-wide `seen` set.
+/// Handling per child kind:
 ///
-/// Running this *before* any commit work (spawn / awaiter installation / state
-/// transition) means the failure path requires no rollback: the gather and
-/// every nested gather stay in `GatherState::Pending` and can be re-awaited
-/// later if the caller catches the `RuntimeError`.
-fn preflight_gather_no_double_spawn(
-    items: &[HeapId],
-    seen: &mut AHashSet<HeapId>,
-    scheduler: &Scheduler,
-    heap: &HeapReader<'_, impl ResourceTracker>,
-) -> Result<(), RunError> {
-    let mut local_dedup: AHashSet<HeapId> = AHashSet::new();
-    for &item_id in items {
-        if !local_dedup.insert(item_id) {
-            // Same item already validated at this level — `await_gather_future`
-            // dedups via `pending_children`; matching that here keeps
-            // `gather(c, c)` legal.
-            continue;
-        }
-        match heap.read(item_id) {
-            HeapReadOutput::Coroutine(coro) => {
-                if coro.get(heap).state != CoroutineState::New
-                    || scheduler.task_for_coroutine(item_id).is_some()
-                    || !seen.insert(item_id)
+/// * **Coroutine** — its spawned task (if any) is cancelled via
+///   [`Scheduler::cancel_task`]. The cancel releases the task's inc_refs on
+///   the coroutine and the (outer) gather.
+/// * **ExternalFuture** — clears the awaiter slot we installed. The dropped
+///   awaiter's `drop_with_heap` releases the inc_ref it held on the (outer)
+///   gather. The future itself stays in `pending_externals` and a later
+///   host resolution simply caches the value (it has no awaiter to fan to).
+/// * **GatherFuture (nested)** — recursively `fail`ed *only if still
+///   `Awaited`*. The state check matters because this helper also runs from
+///   the awaiter-chain failure path: when a child gather fails first and
+///   walks up to its parent via `deliver_awaiter_failure`, that very child
+///   is still in the parent's `pending_children` map but is already
+///   `Failed`. Without the check the parent would call `nested.fail(...)` a
+///   second time and trip `expect("fail called on non-Awaited gather")`.
+fn drop_committed_children(
+    pending_children: AHashMap<HeapId, SmallVec<[usize; 1]>>,
+    scheduler: &mut Scheduler,
+    heap: &mut HeapReader<'_, impl ResourceTracker>,
+    error: &RunError,
+) {
+    for child_id in pending_children.into_keys() {
+        match heap.read(child_id) {
+            HeapReadOutput::Coroutine(_) => {
+                if let Some(tid) = scheduler.task_for_coroutine(child_id) {
+                    scheduler.cancel_task(tid, heap);
+                }
+            }
+            HeapReadOutput::ExternalFuture(mut fut) => {
+                if let ExternalFutureState::Pending { awaiter } = &mut fut.get_mut(heap).state
+                    && let Some(old) = awaiter.take()
                 {
-                    return Err(ExcType::cannot_reuse_already_awaited_coroutine());
+                    old.drop_with_heap(heap);
                 }
             }
-            HeapReadOutput::GatherFuture(child) => {
-                if matches!(child.get(heap).state, GatherState::Pending) {
-                    // The borrow on `child` lives across the recursive call —
-                    // safe because `preflight` only ever reads (no `get_mut`,
-                    // no `allocate`), and multiple `HeapRead` handles can
-                    // coexist for reads.
-                    preflight_gather_no_double_spawn(&child.get(heap).items, seen, scheduler, heap)?;
+            HeapReadOutput::GatherFuture(mut nested) => {
+                if matches!(nested.get(heap).state, GatherState::Awaited(_)) {
+                    let nested_awaiter = nested.fail(scheduler, heap, error);
+                    nested_awaiter.drop_with_heap(heap);
                 }
+                // Else: nested is already `Failed`/`Completed`/`Pending` —
+                // its resources are already cleaned up (or were never
+                // committed) and dropping the `pending_children` key
+                // (via `into_keys`) is the only bookkeeping left.
             }
-            // ExternalFuture and already-Resolved/Failed gathers can't
-            // contribute a duplicate coroutine spawn — they're skipped.
-            _ => {}
+            _ => panic!("gather pending_children key is not a Coroutine, ExternalFuture, or GatherFuture"),
         }
     }
-    Ok(())
 }

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -298,14 +298,19 @@ impl Scheduler {
         self.ready_queue.retain(|&id| id != task_id);
     }
 
-    /// Spawns a new task from a coroutine.
+    /// Spawns a new task from a coroutine, enforcing one-task-per-coroutine.
     ///
-    /// Creates a new task that will execute the given coroutine when scheduled.
-    /// The task is added to the ready queue.
+    /// Returns `None` if `coroutine_id` is already driving a task — the
+    /// "each spawned task owns exactly one coroutine for its lifetime"
+    /// invariant is enforced at this chokepoint rather than at the (currently
+    /// single) caller. Without this guard, a second `spawn` for the same
+    /// coroutine would overwrite `coroutine_to_task`, leaving the first
+    /// gather's child task unreachable and panicking at gather teardown
+    /// (`fail called on non-Awaited gather` etc.).
     ///
     /// Both `coroutine_id` and `gather_id` (when present) become **owning**
     /// references held by the new task — `inc_ref` is called on each before
-    /// storing. The matching `dec_ref` happens in [`Scheduler::remove_task`]
+    /// storing. The matching `dec_ref` happens in [`Scheduler::cancel_task`]
     /// when the task is eventually removed (typically at gather finalization).
     ///
     /// # Arguments
@@ -314,13 +319,25 @@ impl Scheduler {
     /// * `gather_id` - Optional HeapId of the GatherFuture this task belongs to
     ///
     /// # Returns
-    /// The TaskId of the newly created task.
+    /// `Some(task_id)` of the newly created task, or `None` if `coroutine_id`
+    /// is already driving a task. Callers translate `None` into the canonical
+    /// `RuntimeError: cannot reuse already awaited coroutine`.
+    #[must_use]
     pub fn spawn(
         &mut self,
         heap: &Heap<impl ResourceTracker>,
         coroutine_id: HeapId,
         gather_id: Option<HeapId>,
-    ) -> TaskId {
+    ) -> Option<TaskId> {
+        // Single-shot invariant: one task per coroutine. The direct-await
+        // paths check `CoroutineState::New` to enforce this, but the spawn
+        // path through `await_gather_future` can hit two gathers committing
+        // before either child task runs — both coroutines are still `New`,
+        // so only this scheduler-level check catches the cross-gather case.
+        if self.coroutine_to_task.contains_key(&coroutine_id) {
+            return None;
+        }
+
         let task_id = TaskId::new(self.next_task_id);
         self.next_task_id += 1;
 
@@ -336,7 +353,7 @@ impl Scheduler {
         self.coroutine_to_task.insert(coroutine_id, task_id);
         self.ready_queue.push_back(task_id);
 
-        task_id
+        Some(task_id)
     }
 
     /// Returns the task driving `coroutine_id`, if any.

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -300,28 +300,15 @@ impl Scheduler {
 
     /// Spawns a new task from a coroutine, enforcing one-task-per-coroutine.
     ///
-    /// Returns `None` if `coroutine_id` is already driving a task — the
-    /// "each spawned task owns exactly one coroutine for its lifetime"
-    /// invariant is enforced at this chokepoint rather than at the (currently
-    /// single) caller. Without this guard, a second `spawn` for the same
-    /// coroutine would overwrite `coroutine_to_task`, leaving the first
-    /// gather's child task unreachable and panicking at gather teardown
-    /// (`fail called on non-Awaited gather` etc.).
+    /// Returns `None` if `coroutine_id` is already driving a task — caught
+    /// here because cross-gather reuse can hit two spawns while both
+    /// coroutine states are still `New`, so the state check in
+    /// `await_coroutine` doesn't catch it. Callers translate `None` into a
+    /// `RuntimeError: cannot reuse already awaited coroutine`.
     ///
     /// Both `coroutine_id` and `gather_id` (when present) become **owning**
-    /// references held by the new task — `inc_ref` is called on each before
-    /// storing. The matching `dec_ref` happens in [`Scheduler::cancel_task`]
-    /// when the task is eventually removed (typically at gather finalization).
-    ///
-    /// # Arguments
-    /// * `heap` - Heap to increment reference counts in
-    /// * `coroutine_id` - HeapId of the coroutine to execute
-    /// * `gather_id` - Optional HeapId of the GatherFuture this task belongs to
-    ///
-    /// # Returns
-    /// `Some(task_id)` of the newly created task, or `None` if `coroutine_id`
-    /// is already driving a task. Callers translate `None` into the canonical
-    /// `RuntimeError: cannot reuse already awaited coroutine`.
+    /// references held by the new task; the matching `dec_ref` happens in
+    /// [`Scheduler::cancel_task`].
     #[must_use]
     pub fn spawn(
         &mut self,
@@ -329,11 +316,6 @@ impl Scheduler {
         coroutine_id: HeapId,
         gather_id: Option<HeapId>,
     ) -> Option<TaskId> {
-        // Single-shot invariant: one task per coroutine. The direct-await
-        // paths check `CoroutineState::New` to enforce this, but the spawn
-        // path through `await_gather_future` can hit two gathers committing
-        // before either child task runs — both coroutines are still `New`,
-        // so only this scheduler-level check catches the cross-gather case.
         if self.coroutine_to_task.contains_key(&coroutine_id) {
             return None;
         }

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -294,14 +294,8 @@ impl ExcType {
         SimpleException::new_msg(Self::TypeError, format!("'{type_}' object can't be awaited")).into()
     }
 
-    /// Creates the canonical `RuntimeError: cannot reuse already awaited coroutine`.
-    ///
-    /// Raised whenever an already-driven coroutine is awaited again — either
-    /// directly (`await c; await c`) or through a second `asyncio.gather`
-    /// call (`g1 = gather(c); g2 = gather(c)`). The four reuse sites in
-    /// `async_exec.rs` all funnel through this helper so the message stays in
-    /// one place and the gather/spawn path raises the same error CPython does
-    /// instead of panicking the worker.
+    /// Creates the canonical `RuntimeError: cannot reuse already awaited coroutine`,
+    /// raised on direct re-await and on cross-gather coroutine reuse.
     #[must_use]
     pub(crate) fn cannot_reuse_already_awaited_coroutine() -> RunError {
         SimpleException::new_msg(Self::RuntimeError, "cannot reuse already awaited coroutine").into()

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -294,6 +294,19 @@ impl ExcType {
         SimpleException::new_msg(Self::TypeError, format!("'{type_}' object can't be awaited")).into()
     }
 
+    /// Creates the canonical `RuntimeError: cannot reuse already awaited coroutine`.
+    ///
+    /// Raised whenever an already-driven coroutine is awaited again — either
+    /// directly (`await c; await c`) or through a second `asyncio.gather`
+    /// call (`g1 = gather(c); g2 = gather(c)`). The four reuse sites in
+    /// `async_exec.rs` all funnel through this helper so the message stays in
+    /// one place and the gather/spawn path raises the same error CPython does
+    /// instead of panicking the worker.
+    #[must_use]
+    pub(crate) fn cannot_reuse_already_awaited_coroutine() -> RunError {
+        SimpleException::new_msg(Self::RuntimeError, "cannot reuse already awaited coroutine").into()
+    }
+
     /// Creates a TypeError for item assignment on types that don't support it.
     ///
     /// Matches CPython's format: `TypeError: '{type}' object does not support item assignment`

--- a/crates/monty/test_cases/async__gather_commit_rollback.py
+++ b/crates/monty/test_cases/async__gather_commit_rollback.py
@@ -1,33 +1,12 @@
 # run-async
-"""Mid-commit errors in `asyncio.gather` must roll back already-committed
-siblings, and failure propagation must not re-fail an already-Failed nested
-gather.
-
-Two distinct topologies historically reached the same
-`expect("...non-Awaited gather")` panics at `async_exec.rs:957` /
-`async_exec.rs:1030`:
-
-1. **Commit-time orphan.** An earlier item in the outer gather successfully
-   commits (spawn / sub-awaiter install / nested-gather Awaited), then a
-   *later* item raises synchronously (already-`Failed` nested gather, etc.).
-   The outer gather never reaches `Awaited`, but the earlier sibling's
-   task/awaiter survives in the scheduler, points back at the still-`Pending`
-   outer, and panics on next pickup. Rollback cancels the sibling.
-2. **Double-fail on nested gather.** A child coroutine of `g_inner` raises;
-   propagation walks `g_inner → g_outer` via `Awaiter::GatherSlot`. `g_outer`
-   then iterates its own `pending_children`, which still contains the
-   already-`Failed` `g_inner`, and previously called `g_inner.fail(...)` a
-   second time. The teardown helper now skips nested children that aren't
-   `Awaited`.
-"""
+"""Gather failure must clean up committed siblings and nested failures."""
 
 import asyncio
 
 
 # === Commit-time orphan: Failed nested gather is the second item ===
-# Smallest published repro of the orphan. Outer spawns slow() first, then hits
-# `g_failed` which raises synchronously. Rollback must cancel slow()'s task;
-# the post-error gather then runs cleanly.
+# Outer spawns slow() first, then hits `g_failed` which raises synchronously.
+# Rollback must cancel slow()'s task.
 async def boom_orphan():
     raise ValueError('boom')
 
@@ -49,17 +28,14 @@ try:
 except ValueError as e:
     assert str(e) == 'boom', f'second await: {e}'
 
-# If `slow_orphan`'s task was orphaned, scheduling another await would let it
-# complete and trip `resolve_child` on a `Pending` gather (the panic at
-# `async_exec.rs:957`).
+# If `slow_orphan`'s task was orphaned, this later gather would trip stale
+# scheduler state.
 result_after_orphan = await asyncio.gather(slow_orphan())  # pyright: ignore
 assert result_after_orphan == ['slow ok'], f'post-orphan gather: {result_after_orphan}'
 
 
 # === Double-fail: nested gather whose only child raises ===
-# `gather(gather(b()))` previously triggered `expect("fail called on
-# non-Awaited gather")` because the outer's failure walk re-failed the
-# already-Failed inner.
+# The outer failure walk must not re-fail an inner gather that already failed.
 async def boom_double_fail():
     raise ValueError('double-fail err')
 
@@ -76,8 +52,8 @@ except ValueError as e:
 
 
 # === Three-deep nested gather with the deepest child raising ===
-# Failure walks up two GatherSlot links; both ancestors must skip the
-# already-Failed entry in their own pending_children.
+# Failure walks up two GatherSlot links; both ancestors must skip the inner
+# gather that already failed.
 async def boom_triple():
     raise ValueError('triple')
 
@@ -94,10 +70,8 @@ except ValueError as e:
 
 
 # === Sibling-failure-with-orphan: outer has nested-gather + coroutine ===
-# `gather(gather(boom_a(), boom_b()), ext_c())` — inner gather has two
-# children; one raises and propagates upward, leaving outer's other coroutine
-# (ext_c) committed. The fail-walk on outer must (a) cancel ext_c, (b) skip
-# the already-Failed inner.
+# One inner child raises and propagates upward while the outer sibling has
+# already committed. Teardown must cancel that sibling and skip the failed inner.
 async def boom_a():
     raise NotImplementedError('a')
 
@@ -117,9 +91,7 @@ async def sibling_main():
         await outer
         assert False, 'sibling_main should have raised'
     except NotImplementedError as e:
-        # The first child of inner to be scheduled raises and is the one
-        # whose error wins; both 'a' and 'b' are valid depending on schedule
-        # order. Same for ext_c('c').
+        # Any committed sibling may win before teardown reaches the rest.
         assert str(e) in ('a', 'b', 'c'), f'sibling error: {e}'
 
 
@@ -127,9 +99,7 @@ await sibling_main()  # pyright: ignore
 
 
 # === Rolled-back gather caches the error: re-await replays it ===
-# After rollback transitions the outer gather to `Failed`, a second `await`
-# on the same instance must replay the cached error rather than retry the
-# (still-broken) commit.
+# Re-awaiting a rolled-back gather must replay the cached error.
 async def boom_replay():
     raise ValueError('replay')
 
@@ -160,10 +130,8 @@ except ValueError as e:
 
 
 # === Cross-gather double-spawn rollback works mid-tree ===
-# Cross-gather coroutine reuse no longer panics — but it now also has to
-# roll back: in `await gather(g1, g2)`, g1 commits (spawns c), then g2 hits
-# spawn-None for the same c. The rollback must cancel c's task spawned by g1
-# so a subsequent gather over a fresh coroutine completes cleanly.
+# Cross-gather coroutine reuse must also roll back siblings committed before
+# the duplicate spawn is detected.
 async def make_payload():
     return 'payload'
 

--- a/crates/monty/test_cases/async__gather_commit_rollback.py
+++ b/crates/monty/test_cases/async__gather_commit_rollback.py
@@ -1,0 +1,182 @@
+# run-async
+"""Mid-commit errors in `asyncio.gather` must roll back already-committed
+siblings, and failure propagation must not re-fail an already-Failed nested
+gather.
+
+Two distinct topologies historically reached the same
+`expect("...non-Awaited gather")` panics at `async_exec.rs:957` /
+`async_exec.rs:1030`:
+
+1. **Commit-time orphan.** An earlier item in the outer gather successfully
+   commits (spawn / sub-awaiter install / nested-gather Awaited), then a
+   *later* item raises synchronously (already-`Failed` nested gather, etc.).
+   The outer gather never reaches `Awaited`, but the earlier sibling's
+   task/awaiter survives in the scheduler, points back at the still-`Pending`
+   outer, and panics on next pickup. Rollback cancels the sibling.
+2. **Double-fail on nested gather.** A child coroutine of `g_inner` raises;
+   propagation walks `g_inner → g_outer` via `Awaiter::GatherSlot`. `g_outer`
+   then iterates its own `pending_children`, which still contains the
+   already-`Failed` `g_inner`, and previously called `g_inner.fail(...)` a
+   second time. The teardown helper now skips nested children that aren't
+   `Awaited`.
+"""
+
+import asyncio
+
+
+# === Commit-time orphan: Failed nested gather is the second item ===
+# Smallest published repro of the orphan. Outer spawns slow() first, then hits
+# `g_failed` which raises synchronously. Rollback must cancel slow()'s task;
+# the post-error gather then runs cleanly.
+async def boom_orphan():
+    raise ValueError('boom')
+
+
+async def slow_orphan():
+    return 'slow ok'
+
+
+g_failed = asyncio.gather(boom_orphan())
+try:
+    await g_failed  # pyright: ignore
+    assert False, 'g_failed should have raised'
+except ValueError as e:
+    assert str(e) == 'boom', f'first await: {e}'
+
+try:
+    await asyncio.gather(slow_orphan(), g_failed)  # pyright: ignore
+    assert False, 'reuse of failed gather should raise'
+except ValueError as e:
+    assert str(e) == 'boom', f'second await: {e}'
+
+# If `slow_orphan`'s task was orphaned, scheduling another await would let it
+# complete and trip `resolve_child` on a `Pending` gather (the panic at
+# `async_exec.rs:957`).
+result_after_orphan = await asyncio.gather(slow_orphan())  # pyright: ignore
+assert result_after_orphan == ['slow ok'], f'post-orphan gather: {result_after_orphan}'
+
+
+# === Double-fail: nested gather whose only child raises ===
+# `gather(gather(b()))` previously triggered `expect("fail called on
+# non-Awaited gather")` because the outer's failure walk re-failed the
+# already-Failed inner.
+async def boom_double_fail():
+    raise ValueError('double-fail err')
+
+
+async def double_fail_main():
+    await asyncio.gather(asyncio.gather(boom_double_fail()))
+
+
+try:
+    await double_fail_main()  # pyright: ignore
+    assert False, 'double_fail_main should have raised'
+except ValueError as e:
+    assert str(e) == 'double-fail err', f'double-fail error: {e}'
+
+
+# === Three-deep nested gather with the deepest child raising ===
+# Failure walks up two GatherSlot links; both ancestors must skip the
+# already-Failed entry in their own pending_children.
+async def boom_triple():
+    raise ValueError('triple')
+
+
+async def triple_main():
+    await asyncio.gather(asyncio.gather(asyncio.gather(boom_triple())))
+
+
+try:
+    await triple_main()  # pyright: ignore
+    assert False, 'triple_main should have raised'
+except ValueError as e:
+    assert str(e) == 'triple', f'triple-nested error: {e}'
+
+
+# === Sibling-failure-with-orphan: outer has nested-gather + coroutine ===
+# `gather(gather(boom_a(), boom_b()), ext_c())` — inner gather has two
+# children; one raises and propagates upward, leaving outer's other coroutine
+# (ext_c) committed. The fail-walk on outer must (a) cancel ext_c, (b) skip
+# the already-Failed inner.
+async def boom_a():
+    raise NotImplementedError('a')
+
+
+async def boom_b():
+    raise NotImplementedError('b')
+
+
+async def ext_c():
+    raise NotImplementedError('c')
+
+
+async def sibling_main():
+    inner = asyncio.gather(boom_a(), boom_b())
+    outer = asyncio.gather(inner, ext_c())
+    try:
+        await outer
+        assert False, 'sibling_main should have raised'
+    except NotImplementedError as e:
+        # The first child of inner to be scheduled raises and is the one
+        # whose error wins; both 'a' and 'b' are valid depending on schedule
+        # order. Same for ext_c('c').
+        assert str(e) in ('a', 'b', 'c'), f'sibling error: {e}'
+
+
+await sibling_main()  # pyright: ignore
+
+
+# === Rolled-back gather caches the error: re-await replays it ===
+# After rollback transitions the outer gather to `Failed`, a second `await`
+# on the same instance must replay the cached error rather than retry the
+# (still-broken) commit.
+async def boom_replay():
+    raise ValueError('replay')
+
+
+async def slow_replay():
+    return 1
+
+
+g_replay = asyncio.gather(boom_replay())
+try:
+    await g_replay  # pyright: ignore
+except ValueError:
+    pass
+
+outer_replay = asyncio.gather(slow_replay(), g_replay)
+try:
+    await outer_replay  # pyright: ignore
+    assert False, 'first outer_replay should raise'
+except ValueError as e:
+    assert str(e) == 'replay', f'first outer_replay: {e}'
+
+# Second await on the same outer gather instance — must replay, not retry.
+try:
+    await outer_replay  # pyright: ignore
+    assert False, 'second outer_replay should raise'
+except ValueError as e:
+    assert str(e) == 'replay', f'second outer_replay: {e}'
+
+
+# === Cross-gather double-spawn rollback works mid-tree ===
+# Cross-gather coroutine reuse no longer panics — but it now also has to
+# roll back: in `await gather(g1, g2)`, g1 commits (spawns c), then g2 hits
+# spawn-None for the same c. The rollback must cancel c's task spawned by g1
+# so a subsequent gather over a fresh coroutine completes cleanly.
+async def make_payload():
+    return 'payload'
+
+
+c_shared = make_payload()
+g_share_1 = asyncio.gather(c_shared)
+g_share_2 = asyncio.gather(c_shared)
+try:
+    await asyncio.gather(g_share_1, g_share_2)  # pyright: ignore
+    assert False, 'shared-coroutine outer gather should raise'
+except RuntimeError as e:
+    assert str(e) == 'cannot reuse already awaited coroutine', f'cross-gather: {e}'
+
+# Heap/scheduler still usable.
+final = await asyncio.gather(make_payload(), make_payload())  # pyright: ignore
+assert final == ['payload', 'payload'], f'final gather: {final}'

--- a/crates/monty/test_cases/async__gather_double_spawn.py
+++ b/crates/monty/test_cases/async__gather_double_spawn.py
@@ -1,0 +1,134 @@
+# run-async
+"""Cross-gather coroutine reuse must raise `RuntimeError`, not panic the VM.
+
+Awaiting the same coroutine through two separate `asyncio.gather` calls
+spawns it twice in monty's scheduler. Without a single-shot guard at
+`Scheduler::spawn`, the second spawn clobbers `coroutine_to_task`, which
+later trips `as_awaited_mut().expect("...")` panics in `GatherFuture::fail`
+and `GatherFuture::resolve_child`. CPython catches the reuse with
+`RuntimeError: cannot reuse already awaited coroutine`; these tests pin
+that behavior down for every cross-gather shape we have seen in the wild.
+"""
+
+import asyncio
+
+
+# === Canonical: g1 = gather(c); g2 = gather(c); await gather(g1, g2) ===
+# The minimal reachable-from-live-server repro from `01-gather-double-spawn.md`.
+async def foo_canonical():
+    return [1, 2, 3]
+
+
+async def main_canonical():
+    c = foo_canonical()
+    g1 = asyncio.gather(c)
+    g2 = asyncio.gather(c)
+    try:
+        await asyncio.gather(g1, g2)
+        assert False, 'cross-gather reuse should have raised RuntimeError'
+    except RuntimeError as e:
+        assert str(e) == 'cannot reuse already awaited coroutine', f'canonical: unexpected error: {e}'
+
+
+await main_canonical()  # pyright: ignore
+
+
+# === Nested: gather(gather(c), gather(c)) ===
+# Same shape, simpler driver — no `main()` wrapper, no intermediate references.
+async def foo_nested():
+    return 1
+
+
+c_nested = foo_nested()
+try:
+    await asyncio.gather(asyncio.gather(c_nested), asyncio.gather(c_nested))  # pyright: ignore
+    assert False, 'nested cross-gather reuse should have raised RuntimeError'
+except RuntimeError as e:
+    assert str(e) == 'cannot reuse already awaited coroutine', f'nested: unexpected error: {e}'
+
+
+# === Sequential: g1 = gather(c); g2 = gather(c); await g1; await g2 ===
+# CPython: `await g1` resolves successfully with `[[result]]`; `await g2` raises
+# because the coroutine was already driven by g1.
+async def foo_seq():
+    return 42
+
+
+c_seq = foo_seq()
+g1_seq = asyncio.gather(c_seq)
+g2_seq = asyncio.gather(c_seq)
+r1_seq = await g1_seq  # pyright: ignore
+assert r1_seq == [42], f'sequential g1 should resolve to [42], got {r1_seq}'
+try:
+    await g2_seq  # pyright: ignore
+    assert False, 'sequential g2 should have raised RuntimeError'
+except RuntimeError as e:
+    assert str(e) == 'cannot reuse already awaited coroutine', f'sequential g2: unexpected error: {e}'
+
+
+# === Three separate gathers sharing one coroutine ===
+async def foo_three():
+    return 'x'
+
+
+c_three = foo_three()
+try:
+    await asyncio.gather(asyncio.gather(c_three), asyncio.gather(c_three), asyncio.gather(c_three))  # pyright: ignore
+    assert False, 'three-way cross-gather reuse should have raised RuntimeError'
+except RuntimeError as e:
+    assert str(e) == 'cannot reuse already awaited coroutine', f'three-way: unexpected error: {e}'
+
+
+# === Direct await then gather: await c; await gather(c) ===
+# Already covered by the existing state-check guard at `await_coroutine`,
+# but kept here so the full matrix lives in one place.
+async def foo_direct_first():
+    return 9
+
+
+c_direct_first = foo_direct_first()
+r_direct = await c_direct_first  # pyright: ignore
+assert r_direct == 9, f'direct await should return 9, got {r_direct}'
+try:
+    await asyncio.gather(c_direct_first)  # pyright: ignore
+    assert False, 'gather after direct await should have raised'
+except RuntimeError as e:
+    assert str(e) == 'cannot reuse already awaited coroutine', f'direct→gather: unexpected error: {e}'
+
+
+# === Gather then direct await: g = gather(c); await g; await c ===
+async def foo_gather_first():
+    return 11
+
+
+c_gather_first = foo_gather_first()
+g_first = asyncio.gather(c_gather_first)
+r_g = await g_first  # pyright: ignore
+assert r_g == [11], f'gather should resolve to [11], got {r_g}'
+try:
+    await c_gather_first  # pyright: ignore
+    assert False, 'direct await after gather should have raised'
+except RuntimeError as e:
+    assert str(e) == 'cannot reuse already awaited coroutine', f'gather→direct: unexpected error: {e}'
+
+
+# === Cleanup smoke test: scheduler/heap still usable after the error path ===
+# Proves the error path doesn't leak refs that wedge subsequent gathers.
+async def foo_cleanup_doomed():
+    return 1
+
+
+async def foo_cleanup_ok():
+    return 'ok'
+
+
+c_doomed = foo_cleanup_doomed()
+try:
+    await asyncio.gather(asyncio.gather(c_doomed), asyncio.gather(c_doomed))  # pyright: ignore
+    assert False, 'cleanup doomed gather should have raised'
+except RuntimeError:
+    pass
+
+# Fresh coroutines should still drive a fresh gather to completion.
+clean_result = await asyncio.gather(foo_cleanup_ok(), foo_cleanup_ok())  # pyright: ignore
+assert clean_result == ['ok', 'ok'], f'post-error gather should still work, got {clean_result}'

--- a/crates/monty/test_cases/async__gather_double_spawn.py
+++ b/crates/monty/test_cases/async__gather_double_spawn.py
@@ -1,20 +1,10 @@
 # run-async
-"""Cross-gather coroutine reuse must raise `RuntimeError`, not panic the VM.
-
-Awaiting the same coroutine through two separate `asyncio.gather` calls
-spawns it twice in monty's scheduler. Without a single-shot guard at
-`Scheduler::spawn`, the second spawn clobbers `coroutine_to_task`, which
-later trips `as_awaited_mut().expect("...")` panics in `GatherFuture::fail`
-and `GatherFuture::resolve_child`. CPython catches the reuse with
-`RuntimeError: cannot reuse already awaited coroutine`; these tests pin
-that behavior down for every cross-gather shape we have seen in the wild.
-"""
+"""Cross-gather coroutine reuse must raise `RuntimeError`, not panic."""
 
 import asyncio
 
 
 # === Canonical: g1 = gather(c); g2 = gather(c); await gather(g1, g2) ===
-# The minimal reachable-from-live-server repro from `01-gather-double-spawn.md`.
 async def foo_canonical():
     return [1, 2, 3]
 
@@ -48,7 +38,7 @@ except RuntimeError as e:
 
 
 # === Sequential: g1 = gather(c); g2 = gather(c); await g1; await g2 ===
-# CPython: `await g1` resolves successfully with `[[result]]`; `await g2` raises
+# CPython: `await g1` resolves successfully with `[result]`; `await g2` raises
 # because the coroutine was already driven by g1.
 async def foo_seq():
     return 42
@@ -80,8 +70,7 @@ except RuntimeError as e:
 
 
 # === Direct await then gather: await c; await gather(c) ===
-# Already covered by the existing state-check guard at `await_coroutine`,
-# but kept here so the full matrix lives in one place.
+# Covered by the direct await state check; kept with the gather reuse matrix.
 async def foo_direct_first():
     return 9
 
@@ -113,7 +102,7 @@ except RuntimeError as e:
 
 
 # === Cleanup smoke test: scheduler/heap still usable after the error path ===
-# Proves the error path doesn't leak refs that wedge subsequent gathers.
+# The scheduler and heap should still be usable after the error path.
 async def foo_cleanup_doomed():
     return 1
 

--- a/crates/monty/test_cases/async__gather_double_spawn_traceback.py
+++ b/crates/monty/test_cases/async__gather_double_spawn_traceback.py
@@ -1,0 +1,24 @@
+# run-async
+"""Locks in the exception type, message, and frame layout for the canonical
+cross-gather coroutine reuse case (the reachable-on-live-server repro from
+`01-gather-double-spawn.md`)."""
+
+import asyncio
+
+
+async def foo():
+    return [1, 2, 3]
+
+
+c = foo()
+g1 = asyncio.gather(c)
+g2 = asyncio.gather(c)
+await asyncio.gather(g1, g2)  # pyright: ignore
+"""
+TRACEBACK:
+Traceback (most recent call last):
+  File "async__gather_double_spawn_traceback.py", line 16, in <module>
+    await asyncio.gather(g1, g2)  # pyright: ignore
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+RuntimeError: cannot reuse already awaited coroutine
+"""

--- a/scripts/run_nasty_code.py
+++ b/scripts/run_nasty_code.py
@@ -1,0 +1,150 @@
+"""Run code snippets from `all_code.jsonl` concurrently via `AsyncMonty`.
+
+The input is a JSONL file with one `{"code": "..."}` object per line. For
+every snippet we spawn an asyncio task; a semaphore caps in-flight work at
+the pool size, so each `checkout()` finds an idle worker immediately and we
+keep every CPU busy without queueing inside the pool. Results are discarded
+— we only track status counts and throughput.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+from typing import IO
+
+import jiter
+
+from pydantic_monty import AsyncMonty, CollectString, MontyCrashedError, MontyError, ResourceLimits
+
+DEFAULT_LIMITS: ResourceLimits = {
+    'max_duration_secs': 1.0,
+    'max_memory': 64 * 1024 * 1024,
+    'max_allocations': 1_000_000,
+    'max_recursion_depth': 500,
+}
+
+
+async def run_one(
+    pool: AsyncMonty,
+    sem: asyncio.Semaphore,
+    index: int,
+    code: str,
+    request_timeout: float,
+    panic_log: IO[str] | None,
+) -> str:
+    """Execute a single snippet and return a short status tag."""
+    async with sem:
+        try:
+            async with pool.checkout(
+                script_name=f'snippet_{index}.py',
+                limits=DEFAULT_LIMITS,
+            ) as session:
+                await asyncio.wait_for(
+                    session.feed_run(code, print_callback=CollectString()),
+                    timeout=request_timeout,
+                )
+            return 'completed'
+        except asyncio.TimeoutError:
+            return 'timeout'
+        except MontyCrashedError as exc:
+            # `timed_out=True` is the watchdog killing a slow worker, not a real panic.
+            if exc.timed_out:
+                return 'MontyCrashedError:timeout'
+            if panic_log is not None:
+                panic_log.write(
+                    json.dumps(
+                        {
+                            'index': index,
+                            'exit_status': exc.exit_status,
+                            'message': str(exc),
+                            'code': code,
+                        }
+                    )
+                    + '\n'
+                )
+                panic_log.flush()
+            print(f'[snippet {index}] PANIC exit={exc.exit_status}: {exc}', flush=True)
+            return 'MontyCrashedError:panic'
+        except MontyError as exc:
+            return type(exc).__name__
+        except Exception as exc:
+            print(f'[snippet {index}] {type(exc).__name__}: {exc}', flush=True)
+            return f'runner_error:{type(exc).__name__}'
+
+
+async def main(snippets: list[str], max_processes: int, request_timeout: float, panic_log_path: Path | None) -> None:
+    sem = asyncio.Semaphore(max_processes)
+    counts: Counter[str] = Counter()
+    total = len(snippets)
+    started = time.monotonic()
+    done = 0
+
+    panic_log = panic_log_path.open('w', encoding='utf-8') if panic_log_path is not None else None
+
+    try:
+        async with AsyncMonty(max_processes=max_processes, request_timeout=request_timeout) as pool:
+
+            async def task(i: int, code: str) -> None:
+                nonlocal done
+                status = await run_one(pool, sem, i, code, request_timeout, panic_log)
+                counts[status] += 1
+                done += 1
+                if done % 1000 == 0 or done == total:
+                    rate = done / (time.monotonic() - started)
+                    print(f'{done}/{total} ({rate:.1f}/s)', flush=True)
+
+            await asyncio.gather(*(task(i, c) for i, c in enumerate(snippets)))
+    finally:
+        if panic_log is not None:
+            panic_log.close()
+
+    print(f'\nfinished in {time.monotonic() - started:.1f}s')
+    for status, n in counts.most_common():
+        print(f'  {status}: {n}')
+
+
+def cli() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--input',
+        default='all_code.jsonl',
+        help='Path to JSONL file with one {"code": "..."} object per line.',
+    )
+    parser.add_argument(
+        '--max-processes',
+        type=int,
+        default=os.cpu_count() or 1,
+        help='Pool size; defaults to host CPU count.',
+    )
+    parser.add_argument('--request-timeout', type=float, default=5.0)
+    parser.add_argument(
+        '--panic-log',
+        default='subprocess_panic_cases.jsonl',
+        help='Write panic-causing snippets to this JSONL file (empty string disables).',
+    )
+    args = parser.parse_args()
+
+    snippets: list[str] = []
+    with Path(args.input).open('rb') as f:
+        for line in f:
+            if not line.strip():
+                continue
+            code = jiter.from_json(line)['code']
+            if isinstance(code, str) and code.strip():
+                snippets.append(code)
+    print(f'running {len(snippets)} snippets across {args.max_processes} workers', flush=True)
+
+    panic_log_path = Path(args.panic_log) if args.panic_log else None
+    asyncio.run(main(snippets, args.max_processes, args.request_timeout, panic_log_path))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(cli())

--- a/scripts/run_nasty_code.py
+++ b/scripts/run_nasty_code.py
@@ -1,10 +1,8 @@
-"""Run code snippets from `all_code.jsonl` concurrently via `AsyncMonty`.
+"""Run JSONL code snippets concurrently via `AsyncMonty`.
 
-The input is a JSONL file with one `{"code": "..."}` object per line. For
-every snippet we spawn an asyncio task; a semaphore caps in-flight work at
-the pool size, so each `checkout()` finds an idle worker immediately and we
-keep every CPU busy without queueing inside the pool. Results are discarded
-— we only track status counts and throughput.
+Each non-empty input line must be a JSON object with a string `code` field.
+The runner records status counts and optionally logs snippets that crash a
+worker.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Awaiting the same coroutine through two separate `asyncio.gather` calls (`g1 = gather(c); g2 = gather(c); await gather(g1, g2)`, `gather(gather(c), gather(c))`, etc.) clobbered `Scheduler::spawn`'s `coroutine_to_task` mapping and later panicked at gather teardown with `fail called on non-Awaited gather` (async_exec.rs:1015) or `resolve_child called on non-Awaited gather` (:942). Accounts for 28 of the 40 Rust-level panics surfaced by `scripts/run_nasty_code.py` across ~122k snippets.

`Scheduler::spawn` now returns `Option<TaskId>`, rejecting with `None` when the coroutine is already driving a task — enforcing the one-task-per-coroutine invariant at the chokepoint. `await_gather_future` runs a tree-wide pre-flight pass that descends into Pending nested gathers and raises the canonical `RuntimeError: cannot reuse already awaited coroutine` before any sibling has committed, so the failure path needs no rollback (matching CPython). The four reuse-error sites share an
`ExcType::cannot_reuse_already_awaited_coroutine` helper.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise RuntimeError: cannot reuse already awaited coroutine on cross-gather coroutine reuse and add commit-time rollback for partial `asyncio.gather` commits to eliminate “non-Awaited gather” panics.

- **Bug Fixes**
  - Enforce one-task-per-coroutine in `Scheduler::spawn` by returning `Option<TaskId>`; translate `None` to `ExcType::cannot_reuse_already_awaited_coroutine()` across direct-await and gather paths; per-gather dedup still permits `gather(c, c)`.
  - Replace preflight with commit-time rollback in `await_gather_future`: factor `commit_gather_items`; on error mark `Failed` and `drop_committed_children` to cancel spawned tasks, clear external awaiters, and fail Awaited nested gathers; skip already-`Failed` nested children to avoid double-fail panics.
  - Add tests for orphan rollback, nested double-fail, three-deep nesting, sibling-with-orphan, replay-after-rollback, and cross-gather reuse; include a stress runner in `scripts/run_nasty_code.py`; minor cleanups (simplified comments, replace a defensive panic with `unreachable!`).

<sup>Written for commit 2ecff3bedd45747e187e1b444cd2d25b174dd0ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

