### PR TITLE
Async memory limits

### DIFF
--- a/crates/monty/src/asyncio.rs
+++ b/crates/monty/src/asyncio.rs
@@ -4,6 +4,8 @@
 //! and task identifiers. The host acts as the event loop - external function
 //! calls return `ExternalFuture` objects that can be awaited.
 
+use std::mem;
+
 use ahash::AHashMap;
 use smallvec::SmallVec;
 
@@ -13,6 +15,29 @@ use crate::{
     intern::FunctionId,
     value::Value,
 };
+
+/// Rough byte cost of the dynamically-allocated `Awaited` bookkeeping for a
+/// gather with the given pending children and result slots. Authoritative
+/// for the tracker charge taken at `Pending → Awaited` *and* for
+/// `GatherFuture::py_estimate_size`; keeping the formula in one place
+/// prevents the charge and the eventual shrink from silently drifting apart.
+///
+/// Per-entry sizing matches conventions elsewhere in the codebase: the
+/// HashMap's bucket overhead is elided, and only `SmallVec` entries spilled
+/// beyond the inline buffer (size 1) are counted.
+pub(crate) fn awaited_state_size(
+    pending_children: &AHashMap<HeapId, SmallVec<[usize; 1]>>,
+    results: &[Option<Value>],
+) -> usize {
+    let pending_size: usize = pending_children
+        .values()
+        .map(|slots| {
+            let spilled = slots.len().saturating_sub(1);
+            mem::size_of::<HeapId>() + spilled * mem::size_of::<usize>()
+        })
+        .sum();
+    mem::size_of_val(results) + pending_size
+}
 
 /// Unique identifier for external function calls.
 ///

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -164,12 +164,10 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
 
         let results = results_guard.into_inner();
         let (awaiter, this) = awaiter_guard.into_parts();
-        // Charge the per-await bookkeeping (`pending_children` map +
-        // `results` slot vector) against the tracker. `Pending` reports
-        // 0 state-size, so the delta equals the new `Awaited` state-size.
-        // A budget-overshoot error is surfaced; the gather is left in
-        // `Awaited` and the eventual heap-entry free / `Awaited → …`
-        // transition will undo the partial accounting.
+        // `Pending` reports 0 state-size, so the delta covers the new
+        // `Awaited` bookkeeping. On a budget overshoot we leave the
+        // state as `Awaited` and let the eventual transition out (or
+        // entry free) undo the partial accounting.
         let old_size = gather.get(this.heap).py_estimate_size();
         gather.get_mut(this.heap).state = GatherState::Awaited(AwaitedGather {
             awaiter,
@@ -212,10 +210,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
                 HeapReadOutput::Coroutine(coro) => {
                     // Reject reuse up-front: either the coroutine is no longer
                     // `New`, or another gather already spawned it (`spawn`
-                    // returns `Ok(None)`). `spawn` may also return
-                    // `Err(ResourceError)` when the per-task scheduler
-                    // overhead would push past the memory limit; that
-                    // propagates via `?` as a normal `MemoryError`.
+                    // returns `Ok(None)`).
                     if coro.get(self.heap).state != CoroutineState::New
                         || self.scheduler.spawn(self.heap, item_id, Some(gather_id))?.is_none()
                     {
@@ -505,24 +500,13 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
     ///
     /// Serializes frames, moves stack/exception_stack, stores instruction_ip,
     /// adjusts the global recursion depth counter, and charges the saved
-    /// state's size against the tracker — the matching `track_shrink`
-    /// runs in [`Self::load_or_init_task`] (when the context is moved
-    /// back into the VM) or in [`Scheduler::cancel_task`] (when the
-    /// suspended task is torn down).
+    /// state's size against the tracker — released by `load_or_init_task`
+    /// when the context is moved back, or by `cancel_task` if the task
+    /// is torn down while suspended.
     ///
-    /// Returns `Err(ResourceError)` when the tracker rejects the
-    /// charge. Charging happens *before* the VM state is moved into
-    /// the task, so on the error path the VM still holds its current
-    /// frame and the regular `handle_exception` path can attach a
-    /// traceback — without this ordering, the exception unwinder
-    /// would find `self.frames` already drained and panic in
-    /// `current_frame_name`.
+    /// Charging happens *before* draining VM state so a budget rejection
+    /// leaves `self.frames` intact for the exception unwinder to walk.
     fn save_task_context(&mut self, task_id: TaskId) -> Result<(), RunError> {
-        // Pre-charge the tracker so a budget rejection leaves the VM
-        // intact (see method docstring). Size is computed from the
-        // current frame count + stack lengths; the actual
-        // `SerializedTaskFrame` values are built only after the charge
-        // succeeds.
         let saved_size = self.frames.len() * mem::size_of::<SerializedTaskFrame>()
             + mem::size_of_val(self.stack.as_slice())
             + mem::size_of_val(self.exception_stack.as_slice());
@@ -579,11 +563,9 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         let global_depth = self.heap.get_recursion_depth();
         self.heap.set_recursion_depth(global_depth + task_depth);
 
-        // Release the tracker charge made by `save_task_context` — the
-        // saved context now lives in VM-local Vecs again, which are
-        // treated as untracked the same way the rest of the stack
-        // accounting is. For a fresh task with no saved context this
-        // is a no-op (all three slices are empty).
+        // Release the charge from `save_task_context`. VM-local Vecs are
+        // untracked (matching the rest of the stack accounting); a fresh
+        // task with no saved context makes this a no-op.
         self.heap
             .track_shrink(saved_task_context_size(&frames, &stack, &exception_stack));
 
@@ -979,12 +961,9 @@ impl<'h> HeapRead<'h, GatherFuture> {
     /// (empty gather, all externals already resolved); on the async path the
     /// transition happens inside [`Self::resolve_child`].
     pub(crate) fn cache_result(&mut self, heap: &mut HeapReader<'h, impl ResourceTracker>, list_id: HeapId) {
-        // Release any Awaited-state bookkeeping charged by
-        // `await_gather_future`. `py_estimate_size` for Pending /
-        // Completed reports 0 state-size, so on the synchronous-completion
-        // paths (gather constructed and immediately resolved without
-        // crossing through Awaited) the delta is zero and this is a
-        // no-op.
+        // Pending and Completed both report 0 state-size, so this is a
+        // no-op on the synchronous-completion path and a real shrink
+        // when transitioning out of `Awaited`.
         let old_size = self.get(heap).py_estimate_size();
         heap.inc_ref(list_id);
         self.get_mut(heap).state = GatherState::Completed(Value::Ref(list_id));
@@ -1082,9 +1061,8 @@ impl<'h> HeapRead<'h, GatherFuture> {
         heap: &mut HeapReader<'h, impl ResourceTracker>,
         error: &RunError,
     ) -> Awaiter {
-        // Capture the Awaited state-size before any draining so the
-        // tracker decrement below balances the `track_growth` charged at
-        // the Pending → Awaited transition.
+        // Captured before draining so the decrement below balances the
+        // `track_growth` from the Pending → Awaited transition.
         let old_size = self.get(heap).py_estimate_size();
 
         // Take the Awaited bookkeeping. The state stays `Awaited` (with

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -18,10 +18,10 @@ use crate::{
         AwaitedGather, Awaiter, CallId, Coroutine, CoroutineState, ExternalFuture, ExternalFutureState, GatherFuture,
         GatherState, TaskId,
     },
-    bytecode::vm::scheduler::{Scheduler, SerializedTaskFrame, TaskState},
+    bytecode::vm::scheduler::{Scheduler, SerializedTaskFrame, TaskState, saved_task_context_size},
     defer_drop,
     exception_private::{ExcType, RunError, RunResult, SimpleException},
-    heap::{DropWithHeap, HeapData, HeapGuard, HeapId, HeapRead, HeapReadOutput, HeapReader},
+    heap::{DropWithHeap, HeapData, HeapGuard, HeapId, HeapItem, HeapRead, HeapReadOutput, HeapReader},
     intern::FunctionId,
     resource::ResourceTracker,
     run_progress::ExtFunctionResult,
@@ -164,11 +164,20 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
 
         let results = results_guard.into_inner();
         let (awaiter, this) = awaiter_guard.into_parts();
+        // Charge the per-await bookkeeping (`pending_children` map +
+        // `results` slot vector) against the tracker. `Pending` reports
+        // 0 state-size, so the delta equals the new `Awaited` state-size.
+        // A budget-overshoot error is surfaced; the gather is left in
+        // `Awaited` and the eventual heap-entry free / `Awaited → …`
+        // transition will undo the partial accounting.
+        let old_size = gather.get(this.heap).py_estimate_size();
         gather.get_mut(this.heap).state = GatherState::Awaited(AwaitedGather {
             awaiter,
             pending_children,
             results,
         });
+        let new_size = gather.get(this.heap).py_estimate_size();
+        this.heap.track_growth(new_size.saturating_sub(old_size))?;
 
         Ok(Poll::Pending)
     }
@@ -203,9 +212,12 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
                 HeapReadOutput::Coroutine(coro) => {
                     // Reject reuse up-front: either the coroutine is no longer
                     // `New`, or another gather already spawned it (`spawn`
-                    // returns `None`).
+                    // returns `Ok(None)`). `spawn` may also return
+                    // `Err(ResourceError)` when the per-task scheduler
+                    // overhead would push past the memory limit; that
+                    // propagates via `?` as a normal `MemoryError`.
                     if coro.get(self.heap).state != CoroutineState::New
-                        || self.scheduler.spawn(self.heap, item_id, Some(gather_id)).is_none()
+                        || self.scheduler.spawn(self.heap, item_id, Some(gather_id))?.is_none()
                     {
                         return Err(ExcType::cannot_reuse_already_awaited_coroutine());
                     }
@@ -324,7 +336,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             // This is critical: if we're about to yield (no ready tasks), the main task's
             // frames must stay in the VM so they're included in the snapshot.
             if let Some(current_task_id) = self.scheduler.current_task_id() {
-                self.save_task_context(current_task_id);
+                self.save_task_context(current_task_id)?;
             }
 
             self.scheduler.set_current_task(Some(next_task_id));
@@ -492,8 +504,19 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
     /// Saves the current VM context into the given task in the scheduler.
     ///
     /// Serializes frames, moves stack/exception_stack, stores instruction_ip,
-    /// and adjusts the global recursion depth counter.
-    fn save_task_context(&mut self, task_id: TaskId) {
+    /// adjusts the global recursion depth counter, and charges the saved
+    /// state's size against the tracker — the matching `track_shrink`
+    /// runs in [`Self::load_or_init_task`] (when the context is moved
+    /// back into the VM) or in [`Scheduler::cancel_task`] (when the
+    /// suspended task is torn down).
+    ///
+    /// Returns `Err(ResourceError)` when the tracker rejects the
+    /// charge. The VM state has already been moved into the task at
+    /// that point — the caller propagates the error up to the run
+    /// loop, which tears the run down through the normal `RunError`
+    /// path; pending tasks (including this one) are freed by
+    /// `Scheduler::clear` on heap drop.
+    fn save_task_context(&mut self, task_id: TaskId) -> Result<(), RunError> {
         let frames: Vec<SerializedTaskFrame> = self
             .frames
             .drain(..)
@@ -513,12 +536,19 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         let global_depth = self.heap.get_recursion_depth();
         self.heap.set_recursion_depth(global_depth - task_depth);
 
+        // Charge the about-to-be-saved context against the tracker.
+        // Symmetric with `load_or_init_task` / `cancel_task` shrinks.
+        let saved_size = saved_task_context_size(&frames, &self.stack, &self.exception_stack);
+        self.heap.track_growth(saved_size)?;
+
         // Save VM state into the task
         let task = self.scheduler.get_task_mut(task_id);
         task.frames = frames;
         task.stack = mem::take(&mut self.stack);
         task.exception_stack = mem::take(&mut self.exception_stack);
         task.instruction_ip = self.instruction_ip;
+
+        Ok(())
     }
 
     /// Loads an existing task's context or initializes a new task from its coroutine.
@@ -542,6 +572,14 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         let task_depth = frames.len().saturating_sub(1); // root frame doesn't contribute to recursion depth
         let global_depth = self.heap.get_recursion_depth();
         self.heap.set_recursion_depth(global_depth + task_depth);
+
+        // Release the tracker charge made by `save_task_context` — the
+        // saved context now lives in VM-local Vecs again, which are
+        // treated as untracked the same way the rest of the stack
+        // accounting is. For a fresh task with no saved context this
+        // is a no-op (all three slices are empty).
+        self.heap
+            .track_shrink(saved_task_context_size(&frames, &stack, &exception_stack));
 
         if !frames.is_empty() {
             // Task has existing context - restore it
@@ -897,7 +935,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         // progress
         if let Some(next_task_id) = self.scheduler.next_ready_task() {
             if let Some(current_task_id) = self.scheduler.current_task_id() {
-                self.save_task_context(current_task_id);
+                self.save_task_context(current_task_id)?;
             }
             self.scheduler.set_current_task(Some(next_task_id));
             self.load_or_init_task(next_task_id)?;
@@ -935,8 +973,17 @@ impl<'h> HeapRead<'h, GatherFuture> {
     /// (empty gather, all externals already resolved); on the async path the
     /// transition happens inside [`Self::resolve_child`].
     pub(crate) fn cache_result(&mut self, heap: &mut HeapReader<'h, impl ResourceTracker>, list_id: HeapId) {
+        // Release any Awaited-state bookkeeping charged by
+        // `await_gather_future`. `py_estimate_size` for Pending /
+        // Completed reports 0 state-size, so on the synchronous-completion
+        // paths (gather constructed and immediately resolved without
+        // crossing through Awaited) the delta is zero and this is a
+        // no-op.
+        let old_size = self.get(heap).py_estimate_size();
         heap.inc_ref(list_id);
         self.get_mut(heap).state = GatherState::Completed(Value::Ref(list_id));
+        let new_size = self.get(heap).py_estimate_size();
+        heap.track_shrink(old_size.saturating_sub(new_size));
     }
 
     /// Records one child's resolution on this gather and, if everything has
@@ -1029,6 +1076,11 @@ impl<'h> HeapRead<'h, GatherFuture> {
         heap: &mut HeapReader<'h, impl ResourceTracker>,
         error: &RunError,
     ) -> Awaiter {
+        // Capture the Awaited state-size before any draining so the
+        // tracker decrement below balances the `track_growth` charged at
+        // the Pending → Awaited transition.
+        let old_size = self.get(heap).py_estimate_size();
+
         // Take the Awaited bookkeeping. The state stays `Awaited` (with
         // placeholder fields) until the state replace below commits the
         // transition. The extracted `awaiter` is transferred to the caller
@@ -1047,6 +1099,8 @@ impl<'h> HeapRead<'h, GatherFuture> {
 
         // Cache a clone so re-awaits replay the same exception.
         self.get_mut(heap).state = GatherState::Failed(error.clone());
+        let new_size = self.get(heap).py_estimate_size();
+        heap.track_shrink(old_size.saturating_sub(new_size));
 
         // Drop fanned-out result Values that won't reach the waiter.
         results.drop_with_heap(heap);

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -16,9 +16,9 @@ use crate::{
     MontyException,
     asyncio::{
         AwaitedGather, Awaiter, CallId, Coroutine, CoroutineState, ExternalFuture, ExternalFutureState, GatherFuture,
-        GatherState, TaskId,
+        GatherState, TaskId, awaited_state_size,
     },
-    bytecode::vm::scheduler::{Scheduler, SerializedTaskFrame, TaskState, saved_task_context_size},
+    bytecode::vm::scheduler::{Scheduler, SerializedTaskFrame, TaskState},
     defer_drop,
     exception_private::{ExcType, RunError, RunResult, SimpleException},
     heap::{DropWithHeap, HeapData, HeapGuard, HeapId, HeapItem, HeapRead, HeapReadOutput, HeapReader},
@@ -169,16 +169,10 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         // committing the state: a rejected charge that landed after the
         // mutation would leave bytes that were never added, then `fail`
         // would shrink them and drift the tracker counter downward.
-        // Mirrors the per-entry sizing in `GatherFuture::py_estimate_size`.
-        let awaited_state_size: usize = pending_children
-            .values()
-            .map(|slots| {
-                let spilled = slots.len().saturating_sub(1);
-                mem::size_of::<HeapId>() + spilled * mem::size_of::<usize>()
-            })
-            .sum::<usize>()
-            + results.len() * mem::size_of::<Option<Value>>();
-        if let Err(err) = this.heap.track_growth(awaited_state_size) {
+        // Reuse the same formula `GatherFuture::py_estimate_size` uses so
+        // the eventual shrink matches the charge exactly.
+        let delta = awaited_state_size(&pending_children, &results);
+        if let Err(err) = this.heap.track_growth(delta) {
             let err = RunError::from(err);
             // Roll back: gather is still `Pending`, so the locals (awaiter,
             // results) and the committed children own resources that need
@@ -348,16 +342,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             // Save current task context ONLY when switching to another task.
             // This is critical: if we're about to yield (no ready tasks), the main task's
             // frames must stay in the VM so they're included in the snapshot.
-            if let Some(current_task_id) = self.scheduler.current_task_id()
-                && let Err(err) = self.save_task_context(current_task_id)
-            {
-                // Save failed (e.g. tracker rejected the growth charge):
-                // put `next_task_id` back at the head of the queue so a
-                // recoverable error path can still schedule it later.
-                self.scheduler.requeue_ready_front(next_task_id);
-                return Err(err);
-            }
-
+            self.save_current_context_or_requeue(next_task_id)?;
             self.scheduler.set_current_task(Some(next_task_id));
 
             // Load or initialize the next task's context
@@ -370,6 +355,22 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             // Don't save the main task's context - frames stay in VM for the snapshot.
             Ok(AwaitResult::Yield(self.scheduler.pending_call_ids()))
         }
+    }
+
+    /// Saves the current task's context before switching to `next_task_id`.
+    ///
+    /// If the save fails (typically a tracker growth rejection) the dequeued
+    /// `next_task_id` is restored to the head of the ready queue so a
+    /// recoverable error path can still schedule it later. No-op when there
+    /// is no current task to save.
+    fn save_current_context_or_requeue(&mut self, next_task_id: TaskId) -> Result<(), RunError> {
+        if let Some(current_task_id) = self.scheduler.current_task_id()
+            && let Err(err) = self.save_task_context(current_task_id)
+        {
+            self.scheduler.requeue_ready_front(next_task_id);
+            return Err(err);
+        }
+        Ok(())
     }
 
     /// Handles completion of a spawned task.
@@ -576,6 +577,12 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
     /// (balances the subtraction in `save_task_context`).
     fn load_or_init_task(&mut self, task_id: TaskId) -> Result<(), RunError> {
         let task = self.scheduler.get_task_mut(task_id);
+        // Snapshot the charge to release *before* draining the Vecs out of
+        // `task`; the released bytes mirror what `save_task_context`
+        // charged. VM-local Vecs are untracked (matching the rest of the
+        // stack accounting); a fresh task with no saved context makes
+        // this a no-op.
+        let saved_size = task.saved_context_size();
         let frames = mem::take(&mut task.frames);
         let stack = mem::take(&mut task.stack);
         let exception_stack = mem::take(&mut task.exception_stack);
@@ -587,11 +594,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         let global_depth = self.heap.get_recursion_depth();
         self.heap.set_recursion_depth(global_depth + task_depth);
 
-        // Release the charge from `save_task_context`. VM-local Vecs are
-        // untracked (matching the rest of the stack accounting); a fresh
-        // task with no saved context makes this a no-op.
-        self.heap
-            .track_shrink(saved_task_context_size(&frames, &stack, &exception_stack));
+        self.heap.track_shrink(saved_size);
 
         if !frames.is_empty() {
             // Task has existing context - restore it
@@ -957,14 +960,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         // Current task was not able to resume, but there might be other ready tasks which can make
         // progress
         if let Some(next_task_id) = self.scheduler.next_ready_task() {
-            if let Some(current_task_id) = self.scheduler.current_task_id()
-                && let Err(err) = self.save_task_context(current_task_id)
-            {
-                // Restore the dequeued task on a save failure (see
-                // `switch_or_yield` for the same handling).
-                self.scheduler.requeue_ready_front(next_task_id);
-                return Err(err);
-            }
+            self.save_current_context_or_requeue(next_task_id)?;
             self.scheduler.set_current_task(Some(next_task_id));
             self.load_or_init_task(next_task_id)?;
             return self.run_external();

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -511,12 +511,23 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
     /// suspended task is torn down).
     ///
     /// Returns `Err(ResourceError)` when the tracker rejects the
-    /// charge. The VM state has already been moved into the task at
-    /// that point — the caller propagates the error up to the run
-    /// loop, which tears the run down through the normal `RunError`
-    /// path; pending tasks (including this one) are freed by
-    /// `Scheduler::clear` on heap drop.
+    /// charge. Charging happens *before* the VM state is moved into
+    /// the task, so on the error path the VM still holds its current
+    /// frame and the regular `handle_exception` path can attach a
+    /// traceback — without this ordering, the exception unwinder
+    /// would find `self.frames` already drained and panic in
+    /// `current_frame_name`.
     fn save_task_context(&mut self, task_id: TaskId) -> Result<(), RunError> {
+        // Pre-charge the tracker so a budget rejection leaves the VM
+        // intact (see method docstring). Size is computed from the
+        // current frame count + stack lengths; the actual
+        // `SerializedTaskFrame` values are built only after the charge
+        // succeeds.
+        let saved_size = self.frames.len() * mem::size_of::<SerializedTaskFrame>()
+            + mem::size_of_val(self.stack.as_slice())
+            + mem::size_of_val(self.exception_stack.as_slice());
+        self.heap.track_growth(saved_size)?;
+
         let frames: Vec<SerializedTaskFrame> = self
             .frames
             .drain(..)
@@ -535,11 +546,6 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         let task_depth = frames.len().saturating_sub(1); // root frame doesn't contribute to recursion depth
         let global_depth = self.heap.get_recursion_depth();
         self.heap.set_recursion_depth(global_depth - task_depth);
-
-        // Charge the about-to-be-saved context against the tracker.
-        // Symmetric with `load_or_init_task` / `cancel_task` shrinks.
-        let saved_size = saved_task_context_size(&frames, &self.stack, &self.exception_stack);
-        self.heap.track_growth(saved_size)?;
 
         // Save VM state into the task
         let task = self.scheduler.get_task_mut(task_id);

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -164,18 +164,36 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
 
         let results = results_guard.into_inner();
         let (awaiter, this) = awaiter_guard.into_parts();
-        // `Pending` reports 0 state-size, so the delta covers the new
-        // `Awaited` bookkeeping. On a budget overshoot we leave the
-        // state as `Awaited` and let the eventual transition out (or
-        // entry free) undo the partial accounting.
-        let old_size = gather.get(this.heap).py_estimate_size();
+        // `Pending` reports 0 state-size, so the new `Awaited` bookkeeping
+        // *is* the delta. Pre-charge from the still-owned locals before
+        // committing the state: a rejected charge that landed after the
+        // mutation would leave bytes that were never added, then `fail`
+        // would shrink them and drift the tracker counter downward.
+        // Mirrors the per-entry sizing in `GatherFuture::py_estimate_size`.
+        let awaited_state_size: usize = pending_children
+            .values()
+            .map(|slots| {
+                let spilled = slots.len().saturating_sub(1);
+                mem::size_of::<HeapId>() + spilled * mem::size_of::<usize>()
+            })
+            .sum::<usize>()
+            + results.len() * mem::size_of::<Option<Value>>();
+        if let Err(err) = this.heap.track_growth(awaited_state_size) {
+            let err = RunError::from(err);
+            // Roll back: gather is still `Pending`, so the locals (awaiter,
+            // results) and the committed children own resources that need
+            // releasing. Cache the failure so a re-await replays it.
+            gather.get_mut(this.heap).state = GatherState::Failed(err.clone());
+            awaiter.drop_with_heap(this.heap);
+            results.drop_with_heap(this.heap);
+            drop_committed_children(pending_children, &mut this.scheduler, this.heap, &err);
+            return Err(err);
+        }
         gather.get_mut(this.heap).state = GatherState::Awaited(AwaitedGather {
             awaiter,
             pending_children,
             results,
         });
-        let new_size = gather.get(this.heap).py_estimate_size();
-        this.heap.track_growth(new_size.saturating_sub(old_size))?;
 
         Ok(Poll::Pending)
     }
@@ -330,8 +348,14 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             // Save current task context ONLY when switching to another task.
             // This is critical: if we're about to yield (no ready tasks), the main task's
             // frames must stay in the VM so they're included in the snapshot.
-            if let Some(current_task_id) = self.scheduler.current_task_id() {
-                self.save_task_context(current_task_id)?;
+            if let Some(current_task_id) = self.scheduler.current_task_id()
+                && let Err(err) = self.save_task_context(current_task_id)
+            {
+                // Save failed (e.g. tracker rejected the growth charge):
+                // put `next_task_id` back at the head of the queue so a
+                // recoverable error path can still schedule it later.
+                self.scheduler.requeue_ready_front(next_task_id);
+                return Err(err);
             }
 
             self.scheduler.set_current_task(Some(next_task_id));
@@ -726,19 +750,30 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
     /// has already been cancelled (no longer in the scheduler) or failed,
     /// drops `value` instead — the resolution still gets cached on the future,
     /// but the (now-gone) awaiter doesn't receive it.
-    fn deliver_value_to_task(&mut self, task_id: TaskId, value: Value) {
+    ///
+    /// Pushing onto a parked task's `task.stack` grows the saved-context size
+    /// that `load_or_init_task` will later shrink by — so this path pre-charges
+    /// one `Value` slot against the tracker. The current-task branch pushes
+    /// onto the VM's untracked stack, matching the rest of the stack
+    /// accounting.
+    fn deliver_value_to_task(&mut self, task_id: TaskId, value: Value) -> RunResult<()> {
         if !self.scheduler.has_task(task_id) || self.scheduler.is_task_failed(task_id) {
             value.drop_with_heap(self);
-            return;
+            return Ok(());
         }
 
         let task_is_current = self.scheduler.current_task_id() == Some(task_id) && !self.frames.is_empty();
         if task_is_current {
             self.stack.push(value);
         } else {
+            if let Err(err) = self.heap.track_growth(mem::size_of::<Value>()) {
+                value.drop_with_heap(self);
+                return Err(err.into());
+            }
             self.scheduler.get_task_mut(task_id).stack.push(value);
         }
         self.scheduler.make_ready(task_id, self.heap);
+        Ok(())
     }
 
     /// Delivers `value` along the awaiter chain starting at `awaiter`.
@@ -763,7 +798,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         loop {
             match awaiter {
                 Awaiter::Task(t) => {
-                    this.deliver_value_to_task(t, value);
+                    this.deliver_value_to_task(t, value)?;
                     return Ok(Some(t));
                 }
                 Awaiter::GatherSlot { gather, source } => {
@@ -922,8 +957,13 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         // Current task was not able to resume, but there might be other ready tasks which can make
         // progress
         if let Some(next_task_id) = self.scheduler.next_ready_task() {
-            if let Some(current_task_id) = self.scheduler.current_task_id() {
-                self.save_task_context(current_task_id)?;
+            if let Some(current_task_id) = self.scheduler.current_task_id()
+                && let Err(err) = self.save_task_context(current_task_id)
+            {
+                // Restore the dequeued task on a save failure (see
+                // `switch_or_yield` for the same handling).
+                self.scheduler.requeue_ready_front(next_task_id);
+                return Err(err);
             }
             self.scheduler.set_current_task(Some(next_task_id));
             self.load_or_init_task(next_task_id)?;

--- a/crates/monty/src/bytecode/vm/exceptions.rs
+++ b/crates/monty/src/bytecode/vm/exceptions.rs
@@ -13,14 +13,10 @@ use crate::{
 };
 
 impl<T: ResourceTracker> VM<'_, T> {
-    /// Returns the current frame's name for traceback generation.
-    ///
-    /// Returns the function name for user-defined functions, or `<module>` for
-    /// module-level code. When the frame stack is empty (rare — an error
-    /// raised between `save_task_context` draining the VM and
-    /// `load_or_init_task` populating the next task's frames), falls back
-    /// to the `<module>` sentinel so the exception machinery can still
-    /// attach a frame and unwind cleanly rather than panicking.
+    /// Returns the current frame's name for traceback generation: the
+    /// function name for user-defined functions, or `<module>` for
+    /// module-level code. Falls back to `<module>` when the frame stack
+    /// is empty so transitional async error paths still unwind cleanly.
     fn current_frame_name(&self) -> StringId {
         match self.frames.last() {
             Some(frame) => match frame.function_id {

--- a/crates/monty/src/bytecode/vm/exceptions.rs
+++ b/crates/monty/src/bytecode/vm/exceptions.rs
@@ -15,8 +15,11 @@ use crate::{
 impl<T: ResourceTracker> VM<'_, T> {
     /// Returns the current frame's name for traceback generation: the
     /// function name for user-defined functions, or `<module>` for
-    /// module-level code. Falls back to `<module>` when the frame stack
-    /// is empty so transitional async error paths still unwind cleanly.
+    /// module-level code. The empty-frames branch is defensive — async
+    /// error paths now charge their tracker growth *before* draining
+    /// `self.frames`, so any caller reaching this with an empty stack
+    /// indicates a bug elsewhere; the `<module>` fallback keeps
+    /// traceback generation total rather than panicking.
     fn current_frame_name(&self) -> StringId {
         match self.frames.last() {
             Some(frame) => match frame.function_id {

--- a/crates/monty/src/bytecode/vm/exceptions.rs
+++ b/crates/monty/src/bytecode/vm/exceptions.rs
@@ -16,14 +16,17 @@ impl<T: ResourceTracker> VM<'_, T> {
     /// Returns the current frame's name for traceback generation.
     ///
     /// Returns the function name for user-defined functions, or `<module>` for
-    /// module-level code. The frame stack must be non-empty: callers in the
-    /// async path that may run with no active frame (e.g. just before a spawned
-    /// task's first frame is pushed) are expected to route errors through
-    /// `handle_task_failure` rather than the regular exception machinery.
+    /// module-level code. When the frame stack is empty (rare — an error
+    /// raised between `save_task_context` draining the VM and
+    /// `load_or_init_task` populating the next task's frames), falls back
+    /// to the `<module>` sentinel so the exception machinery can still
+    /// attach a frame and unwind cleanly rather than panicking.
     fn current_frame_name(&self) -> StringId {
-        let frame = self.current_frame();
-        match frame.function_id {
-            Some(func_id) => self.interns.get_function(func_id).name.name_id,
+        match self.frames.last() {
+            Some(frame) => match frame.function_id {
+                Some(func_id) => self.interns.get_function(func_id).name.name_id,
+                None => StaticStrings::Module.into(),
+            },
             None => StaticStrings::Module.into(),
         }
     }

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -23,11 +23,10 @@ use crate::{
 /// Per-spawn scheduler overhead charged against the tracker so memory
 /// budgets bound recursive gathers. The exact value isn't load-bearing
 /// — it just needs to be non-zero. HashMap bucket overhead is elided to
-/// match `py_estimate_size` conventions elsewhere.
-pub(crate) const SCHEDULER_TASK_OVERHEAD: usize = mem::size_of::<Task>()
-    + mem::size_of::<(TaskId, Task)>()
-    + mem::size_of::<(HeapId, TaskId)>()
-    + mem::size_of::<TaskId>();
+/// match `py_estimate_size` conventions elsewhere; the `(TaskId, Task)`
+/// entry covers the `Task` value, so it isn't summed in separately.
+pub(crate) const SCHEDULER_TASK_OVERHEAD: usize =
+    mem::size_of::<(TaskId, Task)>() + mem::size_of::<(HeapId, TaskId)>() + mem::size_of::<TaskId>();
 
 /// Task execution state for async scheduling.
 ///
@@ -367,6 +366,17 @@ impl Scheduler {
     /// Returns `None` if no tasks are ready.
     pub fn next_ready_task(&mut self) -> Option<TaskId> {
         self.ready_queue.pop_front()
+    }
+
+    /// Pushes `task_id` back onto the front of the ready queue.
+    ///
+    /// Used by error-recovery paths that popped a task via
+    /// [`Scheduler::next_ready_task`] and then hit a fallible step
+    /// (e.g. `save_task_context`'s growth charge) — re-queueing at the
+    /// front keeps the original scheduling order intact instead of
+    /// sending the task to the back.
+    pub fn requeue_ready_front(&mut self, task_id: TaskId) {
+        self.ready_queue.push_front(task_id);
     }
 
     /// Replaces a task's state, properly releasing any heap references owned

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -20,19 +20,10 @@ use crate::{
     value::Value,
 };
 
-/// Fixed per-spawn scheduler overhead charged against `ResourceTracker`
-/// every time [`Scheduler::spawn`] inserts a new task into `self.tasks`,
-/// `self.coroutine_to_task`, and the ready queue.
-///
-/// HashMap bucket overhead is intentionally elided to match the rest of
-/// the codebase's `py_estimate_size` conventions; this constant captures
-/// the `Task` itself plus one entry in each of the two indexing maps and
-/// a slot on the ready queue, which is what scales O(N) per recursive
-/// gather-spawn. The exact value isn't load-bearing — what matters is
-/// that scheduler growth becomes visible to `max_memory` so unbounded
-/// `async def f(): await asyncio.gather(f())` can no longer drive the
-/// host process to allocator abort. See
-/// `security-reports/subprocess_panics.md` (group 4).
+/// Per-spawn scheduler overhead charged against the tracker so memory
+/// budgets bound recursive gathers. The exact value isn't load-bearing
+/// — it just needs to be non-zero. HashMap bucket overhead is elided to
+/// match `py_estimate_size` conventions elsewhere.
 pub(crate) const SCHEDULER_TASK_OVERHEAD: usize = mem::size_of::<Task>()
     + mem::size_of::<(TaskId, Task)>()
     + mem::size_of::<(HeapId, TaskId)>()
@@ -323,13 +314,8 @@ impl Scheduler {
     /// both coroutine states are still `New`, so the state check in
     /// `await_coroutine` doesn't catch it. Callers translate `None`
     /// into a `RuntimeError: cannot reuse already awaited coroutine`.
-    ///
-    /// Returns `Err(ResourceError)` when charging
-    /// [`SCHEDULER_TASK_OVERHEAD`] against the tracker would exceed the
-    /// memory limit. Without this charge the per-spawn cost is
-    /// invisible to `max_memory`, and unbounded async recursion such as
-    /// `async def f(): await asyncio.gather(f())` drives the worker to
-    /// allocator abort instead of a graceful `MemoryError`.
+    /// Returns `Err(ResourceError)` if charging
+    /// [`SCHEDULER_TASK_OVERHEAD`] would exceed the memory limit.
     ///
     /// Both `coroutine_id` and `gather_id` (when present) become **owning**
     /// references held by the new task; the matching `dec_ref` happens in
@@ -435,17 +421,9 @@ impl Scheduler {
             return;
         };
 
-        // Symmetric release of the per-spawn overhead charged by
-        // [`Scheduler::spawn`], plus any saved task-context bytes still
-        // sitting in `task.{frames,stack,exception_stack}`. The latter is
-        // a no-op for an actively-running task (whose context lives in
-        // the VM, not the Task struct) and a real shrink for a suspended
-        // task whose context was moved here by `save_task_context`.
-        //
-        // The main task (task 0, pre-created in [`Scheduler::new`] and
-        // therefore never charged via `spawn`) is excluded from the
-        // per-spawn decrement so cleanup doesn't drift the tracker
-        // counter on every VM drop.
+        // The main task is pre-created in `Scheduler::new`, not via `spawn`,
+        // so it was never charged for `SCHEDULER_TASK_OVERHEAD`; skipping
+        // its decrement keeps cleanup balanced across VM drops.
         if task_id != TaskId::default() {
             heap.heap_mut().track_shrink(SCHEDULER_TASK_OVERHEAD);
         }
@@ -608,12 +586,9 @@ impl Default for Scheduler {
     }
 }
 
-/// Estimated bytes occupied by a suspended task's saved VM context — the
-/// frames vector, the operand stack, and the exception stack. Used by
-/// `save_task_context` (charge) and `load_or_init_task` / `cancel_task`
-/// (release) so the per-suspension memory cost is visible to
-/// `ResourceTracker::on_grow`. The Vec capacity overhead is elided to
-/// stay consistent with `py_estimate_size`'s len-based estimates.
+/// Estimated bytes occupied by a suspended task's saved VM context.
+/// Vec capacity overhead is elided to match `py_estimate_size`'s
+/// len-based estimates elsewhere.
 pub(crate) fn saved_task_context_size(
     frames: &[SerializedTaskFrame],
     stack: &[Value],

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -16,9 +16,27 @@ use crate::{
     heap::{ContainsHeap, DropWithHeap, Heap, HeapId, HeapReadOutput, HeapReader},
     intern::FunctionId,
     parse::CodeRange,
-    resource::ResourceTracker,
+    resource::{ResourceError, ResourceTracker},
     value::Value,
 };
+
+/// Fixed per-spawn scheduler overhead charged against `ResourceTracker`
+/// every time [`Scheduler::spawn`] inserts a new task into `self.tasks`,
+/// `self.coroutine_to_task`, and the ready queue.
+///
+/// HashMap bucket overhead is intentionally elided to match the rest of
+/// the codebase's `py_estimate_size` conventions; this constant captures
+/// the `Task` itself plus one entry in each of the two indexing maps and
+/// a slot on the ready queue, which is what scales O(N) per recursive
+/// gather-spawn. The exact value isn't load-bearing — what matters is
+/// that scheduler growth becomes visible to `max_memory` so unbounded
+/// `async def f(): await asyncio.gather(f())` can no longer drive the
+/// host process to allocator abort. See
+/// `security-reports/subprocess_panics.md` (group 4).
+pub(crate) const SCHEDULER_TASK_OVERHEAD: usize = mem::size_of::<Task>()
+    + mem::size_of::<(TaskId, Task)>()
+    + mem::size_of::<(HeapId, TaskId)>()
+    + mem::size_of::<TaskId>();
 
 /// Task execution state for async scheduling.
 ///
@@ -300,25 +318,36 @@ impl Scheduler {
 
     /// Spawns a new task from a coroutine, enforcing one-task-per-coroutine.
     ///
-    /// Returns `None` if `coroutine_id` is already driving a task — caught
-    /// here because cross-gather reuse can hit two spawns while both
-    /// coroutine states are still `New`, so the state check in
-    /// `await_coroutine` doesn't catch it. Callers translate `None` into a
-    /// `RuntimeError: cannot reuse already awaited coroutine`.
+    /// Returns `Ok(None)` if `coroutine_id` is already driving a task —
+    /// caught here because cross-gather reuse can hit two spawns while
+    /// both coroutine states are still `New`, so the state check in
+    /// `await_coroutine` doesn't catch it. Callers translate `None`
+    /// into a `RuntimeError: cannot reuse already awaited coroutine`.
+    ///
+    /// Returns `Err(ResourceError)` when charging
+    /// [`SCHEDULER_TASK_OVERHEAD`] against the tracker would exceed the
+    /// memory limit. Without this charge the per-spawn cost is
+    /// invisible to `max_memory`, and unbounded async recursion such as
+    /// `async def f(): await asyncio.gather(f())` drives the worker to
+    /// allocator abort instead of a graceful `MemoryError`.
     ///
     /// Both `coroutine_id` and `gather_id` (when present) become **owning**
     /// references held by the new task; the matching `dec_ref` happens in
     /// [`Scheduler::cancel_task`].
-    #[must_use]
     pub fn spawn(
         &mut self,
         heap: &Heap<impl ResourceTracker>,
         coroutine_id: HeapId,
         gather_id: Option<HeapId>,
-    ) -> Option<TaskId> {
+    ) -> Result<Option<TaskId>, ResourceError> {
         if self.coroutine_to_task.contains_key(&coroutine_id) {
-            return None;
+            return Ok(None);
         }
+
+        // Charge the per-spawn scheduler overhead *before* mutating any
+        // state, so an over-budget spawn leaves the scheduler untouched
+        // and the caller's error path doesn't have to undo half a spawn.
+        heap.track_growth(SCHEDULER_TASK_OVERHEAD)?;
 
         let task_id = TaskId::new(self.next_task_id);
         self.next_task_id += 1;
@@ -335,7 +364,7 @@ impl Scheduler {
         self.coroutine_to_task.insert(coroutine_id, task_id);
         self.ready_queue.push_back(task_id);
 
-        Some(task_id)
+        Ok(Some(task_id))
     }
 
     /// Returns the task driving `coroutine_id`, if any.
@@ -405,6 +434,26 @@ impl Scheduler {
         let Some(task) = self.tasks.remove(&task_id) else {
             return;
         };
+
+        // Symmetric release of the per-spawn overhead charged by
+        // [`Scheduler::spawn`], plus any saved task-context bytes still
+        // sitting in `task.{frames,stack,exception_stack}`. The latter is
+        // a no-op for an actively-running task (whose context lives in
+        // the VM, not the Task struct) and a real shrink for a suspended
+        // task whose context was moved here by `save_task_context`.
+        //
+        // The main task (task 0, pre-created in [`Scheduler::new`] and
+        // therefore never charged via `spawn`) is excluded from the
+        // per-spawn decrement so cleanup doesn't drift the tracker
+        // counter on every VM drop.
+        if task_id != TaskId::default() {
+            heap.heap_mut().track_shrink(SCHEDULER_TASK_OVERHEAD);
+        }
+        heap.heap_mut().track_shrink(saved_task_context_size(
+            &task.frames,
+            &task.stack,
+            &task.exception_stack,
+        ));
 
         // If we're cancelling the current task, clear `current_task` so callers
         // don't try to look up a task that's about to be dropped (e.g.
@@ -557,4 +606,18 @@ impl Default for Scheduler {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Estimated bytes occupied by a suspended task's saved VM context — the
+/// frames vector, the operand stack, and the exception stack. Used by
+/// `save_task_context` (charge) and `load_or_init_task` / `cancel_task`
+/// (release) so the per-suspension memory cost is visible to
+/// `ResourceTracker::on_grow`. The Vec capacity overhead is elided to
+/// stay consistent with `py_estimate_size`'s len-based estimates.
+pub(crate) fn saved_task_context_size(
+    frames: &[SerializedTaskFrame],
+    stack: &[Value],
+    exception_stack: &[Value],
+) -> usize {
+    mem::size_of_val(frames) + mem::size_of_val(stack) + mem::size_of_val(exception_stack)
 }

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -160,6 +160,16 @@ impl Task {
     pub fn is_finished(&self) -> bool {
         matches!(self.state, TaskState::Completed(_) | TaskState::Failed(_))
     }
+
+    /// Estimated bytes occupied by this task's saved VM context — the
+    /// charge `save_task_context` takes and `load_or_init_task` /
+    /// `cancel_task` release. Vec capacity overhead is elided to match
+    /// `py_estimate_size`'s len-based estimates elsewhere.
+    pub(crate) fn saved_context_size(&self) -> usize {
+        mem::size_of_val(self.frames.as_slice())
+            + mem::size_of_val(self.stack.as_slice())
+            + mem::size_of_val(self.exception_stack.as_slice())
+    }
 }
 
 /// Scheduler for managing call IDs, async tasks, and external call tracking.
@@ -437,11 +447,7 @@ impl Scheduler {
         if task_id != TaskId::default() {
             heap.heap_mut().track_shrink(SCHEDULER_TASK_OVERHEAD);
         }
-        heap.heap_mut().track_shrink(saved_task_context_size(
-            &task.frames,
-            &task.stack,
-            &task.exception_stack,
-        ));
+        heap.heap_mut().track_shrink(task.saved_context_size());
 
         // If we're cancelling the current task, clear `current_task` so callers
         // don't try to look up a task that's about to be dropped (e.g.
@@ -594,15 +600,4 @@ impl Default for Scheduler {
     fn default() -> Self {
         Self::new()
     }
-}
-
-/// Estimated bytes occupied by a suspended task's saved VM context.
-/// Vec capacity overhead is elided to match `py_estimate_size`'s
-/// len-based estimates elsewhere.
-pub(crate) fn saved_task_context_size(
-    frames: &[SerializedTaskFrame],
-    stack: &[Value],
-    exception_stack: &[Value],
-) -> usize {
-    mem::size_of_val(frames) + mem::size_of_val(stack) + mem::size_of_val(exception_stack)
 }

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -922,6 +922,22 @@ impl<T: ResourceTracker> Heap<T> {
         self.tracker.on_grow(additional_bytes)
     }
 
+    /// Mirror of [`track_growth`](Self::track_growth) for in-place shrinks:
+    /// subtracts `bytes` from the tracker's `current_memory` counter.
+    ///
+    /// Use at state transitions that release dynamically-allocated bookkeeping
+    /// *without* freeing the enclosing heap entry — e.g. `GatherFuture`'s
+    /// `Awaited → Completed` / `Failed` transitions release the
+    /// `pending_children` map and `results` slot vector while the entry
+    /// itself lives on. Without a matching shrink, the bytes charged at
+    /// `track_growth` time would leak into the tracker counter forever
+    /// (`on_free` at heap-entry release only ever subtracts the *current*
+    /// `py_estimate_size`).
+    #[inline]
+    pub fn track_shrink(&self, bytes: usize) {
+        self.tracker.on_free(|| bytes);
+    }
+
     /// Increments the recursion depth and checks the limit via the `ResourceTracker`.
     ///
     /// Returns `Ok(RecursionToken)` if within limits. The caller must ensure the

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -922,17 +922,12 @@ impl<T: ResourceTracker> Heap<T> {
         self.tracker.on_grow(additional_bytes)
     }
 
-    /// Mirror of [`track_growth`](Self::track_growth) for in-place shrinks:
-    /// subtracts `bytes` from the tracker's `current_memory` counter.
+    /// Mirror of [`track_growth`](Self::track_growth) for in-place shrinks.
     ///
-    /// Use at state transitions that release dynamically-allocated bookkeeping
-    /// *without* freeing the enclosing heap entry — e.g. `GatherFuture`'s
-    /// `Awaited → Completed` / `Failed` transitions release the
-    /// `pending_children` map and `results` slot vector while the entry
-    /// itself lives on. Without a matching shrink, the bytes charged at
-    /// `track_growth` time would leak into the tracker counter forever
-    /// (`on_free` at heap-entry release only ever subtracts the *current*
-    /// `py_estimate_size`).
+    /// Needed when a heap entry's `py_estimate_size` decreases without the
+    /// entry itself being freed: `on_free` at entry release reads the
+    /// *current* size, so growth charged earlier would otherwise leak in
+    /// the tracker counter.
     #[inline]
     pub fn track_shrink(&self, bytes: usize) {
         self.tracker.on_free(|| bytes);

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -17,7 +17,7 @@ use crate::types::TestContextManager;
 use crate::{
     ExcType, ResourceTracker,
     args::ArgValues,
-    asyncio::{Awaiter, Coroutine, ExternalFuture, ExternalFutureState, GatherFuture, GatherState},
+    asyncio::{Awaiter, Coroutine, ExternalFuture, ExternalFutureState, GatherFuture, GatherState, awaited_state_size},
     bytecode::{CallResult, VM},
     exception_private::{RunError, RunResult, SimpleException},
     hash::{HashValue, hash_python_str},
@@ -396,22 +396,7 @@ impl HeapItem for Coroutine {
 impl HeapItem for GatherFuture {
     fn py_estimate_size(&self) -> usize {
         let state_size = match &self.state {
-            GatherState::Awaited(awaited) => {
-                // Rough sizing — per-entry storage in `pending_children` plus
-                // the result-slot vector. The map's bucket overhead and the
-                // SmallVec inline buffer are elided; we only estimate
-                // dynamically-allocated content tied to user code.
-                let pending_size: usize = awaited
-                    .pending_children
-                    .values()
-                    .map(|slots| {
-                        // Spilled SmallVec entries (beyond the inline 1) are heap-allocated.
-                        let spilled = slots.len().saturating_sub(1);
-                        mem::size_of::<HeapId>() + spilled * mem::size_of::<usize>()
-                    })
-                    .sum::<usize>();
-                awaited.results.len() * mem::size_of::<Option<Value>>() + pending_size
-            }
+            GatherState::Awaited(awaited) => awaited_state_size(&awaited.pending_children, &awaited.results),
             GatherState::Pending | GatherState::Completed(_) | GatherState::Failed(_) => 0,
         };
         mem::size_of::<Self>() + self.items.len() * mem::size_of::<HeapId>() + state_size

--- a/crates/monty/tests/async_memory_limits.rs
+++ b/crates/monty/tests/async_memory_limits.rs
@@ -1,0 +1,254 @@
+//! Tests that the async runtime accounts its dynamically-allocated state
+//! against `ResourceTracker`.
+//!
+//! Two memory-bypass classes are covered here. Both let untrusted Monty code
+//! grow live memory inside the worker without `LimitedTracker::max_memory`
+//! ever seeing it, which in the worst case drives the host process to
+//! allocator abort (SIGABRT) — see `security-reports/async-memory.md` and
+//! the SIGABRT group in `security-reports/subprocess_panics.md`.
+//!
+//! 1. **Gather `Pending → Awaited` bookkeeping.** `GatherFuture` is created
+//!    in `GatherState::Pending`, whose `py_estimate_size` charges no
+//!    state-side bytes. On first await, `await_gather_future` allocates
+//!    `pending_children` and `results` slot storage and stores them as
+//!    `GatherState::Awaited(...)`. That growth must be charged against
+//!    the tracker; otherwise an `await asyncio.gather(...)` over many
+//!    unresolved externals keeps O(N) untracked bytes live.
+//!
+//! 2. **Scheduler task overhead.** `Scheduler::spawn` and
+//!    `VM::save_task_context` allocate a `Task` (plus map entries and
+//!    a saved frames/stack/exception_stack) on every coroutine spawn and
+//!    suspension. None of that is charged today, so deeply recursive
+//!    `await asyncio.gather(f())` consumes host memory unbounded.
+
+use std::{mem, rc::Rc, time::Duration};
+
+use monty::{
+    ExcType, ExtFunctionResult, LimitedTracker, MontyException, MontyObject, MontyRun, NameLookupResult, PrintWriter,
+    ResourceError, ResourceLimits, ResourceTracker, RunProgress,
+};
+
+/// Wraps `LimitedTracker` in `Rc` so a test can hold its own handle for
+/// probing `current_memory()` while the VM owns one for accounting.
+#[derive(Debug, Clone)]
+struct SharedTracker(Rc<LimitedTracker>);
+
+impl SharedTracker {
+    fn new(limits: ResourceLimits) -> Self {
+        Self(Rc::new(LimitedTracker::new(limits)))
+    }
+
+    fn current_memory(&self) -> usize {
+        self.0.current_memory()
+    }
+}
+
+impl ResourceTracker for SharedTracker {
+    fn on_allocate(&self, get_size: impl FnOnce() -> usize) -> Result<(), ResourceError> {
+        self.0.on_allocate(get_size)
+    }
+
+    fn on_free(&self, get_size: impl FnOnce() -> usize) {
+        self.0.on_free(get_size);
+    }
+
+    fn check_time(&self) -> Result<(), ResourceError> {
+        self.0.check_time()
+    }
+
+    fn check_recursion_depth(&self, current_depth: usize) -> Result<(), ResourceError> {
+        self.0.check_recursion_depth(current_depth)
+    }
+
+    fn check_large_result(&self, estimated_bytes: usize) -> Result<(), ResourceError> {
+        self.0.check_large_result(estimated_bytes)
+    }
+
+    fn on_grow(&self, additional_bytes: usize) -> Result<(), ResourceError> {
+        self.0.on_grow(additional_bytes)
+    }
+
+    fn gc_interval(&self) -> Option<usize> {
+        self.0.gc_interval()
+    }
+
+    fn on_execution_start(&self) {
+        self.0.on_execution_start();
+    }
+
+    fn on_execution_stop(&self) {
+        self.0.on_execution_stop();
+    }
+}
+
+/// Drives `RunProgress` past every `NameLookup` and every `FunctionCall`
+/// (treating each external call as still pending — the host never
+/// resolves them). Returns whatever non-name/non-call state the VM
+/// settles into, or the exception it raises along the way.
+///
+/// Used by the gather bookkeeping witness, which expects the run to
+/// raise `MemoryError` inside the gather await *before* it would
+/// otherwise settle at `ResolveFutures`.
+fn drive_until_settled<T: monty::ResourceTracker>(
+    mut progress: RunProgress<T>,
+) -> Result<RunProgress<T>, monty::MontyException> {
+    loop {
+        match progress {
+            RunProgress::NameLookup(lookup) => {
+                let name = lookup.name.clone();
+                progress = lookup.resume(
+                    NameLookupResult::Value(MontyObject::Function { name, docstring: None }),
+                    PrintWriter::Stdout,
+                )?;
+            }
+            RunProgress::FunctionCall(call) => {
+                progress = call.resume_pending(PrintWriter::Stdout)?;
+            }
+            other => return Ok(other),
+        }
+    }
+}
+
+/// Builds top-level code that awaits `asyncio.gather(*pendings)` over a
+/// list of `n` unresolved external futures. Splatting through `*args`
+/// dodges the 255-argument literal limit Monty inherits from CPython
+/// while still producing the same Pending → Awaited transition with
+/// `n` slots in `results` and `n` entries in `pending_children`.
+fn gather_n_pending_runner(n: usize) -> MontyRun {
+    let code = format!(
+        r"
+import asyncio
+
+async def main():
+    pendings = [pending() for _ in range({n})]
+    await asyncio.gather(*pendings)
+
+await main()
+"
+    );
+    MontyRun::new(code, "test.py", vec![]).unwrap()
+}
+
+// ============================================================================
+// Bug A — gather Pending → Awaited bookkeeping is charged against the tracker.
+// ============================================================================
+
+/// Witness for the bypass reported in `security-reports/async-memory.md`.
+///
+/// With `n` unresolved externals the Awaited-state bookkeeping is on the
+/// order of `n * (sizeof::<Option<Value>>() + sizeof::<HeapId>())` bytes
+/// (`results` slot vector + `pending_children` map entries — see
+/// `heap_data.rs::py_estimate_size for GatherFuture`). The chosen budget
+/// covers the bare GatherFuture, the `n` `ExternalFuture` heap entries,
+/// the coroutine frame, and module bookkeeping, but leaves no headroom
+/// for the per-await bookkeeping. Post-fix the `Pending → Awaited`
+/// transition raises `MemoryError`; pre-fix the run quietly settles into
+/// `ResolveFutures` with the Awaited bookkeeping off-the-books.
+#[test]
+fn gather_awaited_state_charged_against_tracker() {
+    // Run with a generous budget so the gather drives all the way to
+    // `ResolveFutures`. Once there, tracker `current_memory()` must
+    // include the bookkeeping that `await_gather_future` just stored
+    // (`pending_children` map + `results` slot vector). Pre-fix the
+    // transition didn't call `track_growth`, so the tracker counter
+    // was about 1.12 MiB at this point; post-fix it is about
+    // 1.36 MiB — the ~240 KiB Awaited state-size for N = 10_000.
+    //
+    // A budget-based witness is unreliable because the run has
+    // transient allocation spikes between the list comprehension and
+    // the gather construction that exceed any threshold sitting
+    // close to the bookkeeping delta. Observing the post-await
+    // tracker counter directly is the cleanest signal.
+    let n = 10_000;
+    let runner = gather_n_pending_runner(n);
+
+    let limits = ResourceLimits::new()
+        .max_memory(10 * 1024 * 1024)
+        .max_duration(Duration::from_secs(30));
+    let tracker = SharedTracker::new(limits);
+    let handle = tracker.clone();
+    let progress = runner.start(vec![], tracker, PrintWriter::Stdout).unwrap();
+    let settled = drive_until_settled(progress).expect("run must reach ResolveFutures without raising");
+    let resolve = match settled {
+        RunProgress::ResolveFutures(state) => state,
+        other => panic!(
+            "expected the run to suspend at ResolveFutures after building the gather (got {:?})",
+            mem::discriminant(&other),
+        ),
+    };
+
+    let memory = handle.current_memory();
+    // Pre-fix measured: ~1_120_448 bytes (no charge for `pending_children`
+    // or `results`). Post-fix: ~1_360_448 bytes. The threshold sits
+    // safely between, so it only holds when the per-await bookkeeping
+    // is accounted.
+    let post_fix_threshold = 1_250_000;
+    let threshold_failure = (memory < post_fix_threshold).then_some(memory);
+
+    // Resume with an error on the first pending external so the gather
+    // tears down and the snapshot is consumed cleanly. Dropping a
+    // `ResolveFutures` directly would leave `Value::Ref` entries inside
+    // `VMSnapshot.stack` to be auto-dropped, which `memory-model-checks`
+    // (correctly) treats as a refcounting bug.
+    let first_call = resolve.pending_call_ids()[0];
+    let error = MontyException::new(ExcType::ValueError, Some("test-shutdown".to_string()));
+    let outcome = resolve.resume(vec![(first_call, ExtFunctionResult::Error(error))], PrintWriter::Stdout);
+    // The gather propagates the error; either form is acceptable —
+    // what matters is that the heap is consumed and freed cleanly.
+    let _ = outcome;
+
+    if let Some(memory) = threshold_failure {
+        panic!(
+            "Gather Pending → Awaited bookkeeping is not charged against \
+             the tracker: tracker memory = {memory} bytes; expected at \
+             least {post_fix_threshold} (pre-fix is ~1.12 MiB, post-fix \
+             ~1.36 MiB for N = {n}).",
+        );
+    }
+}
+
+// ============================================================================
+// Bug B — Scheduler task overhead must not SIGABRT under a memory cap.
+// ============================================================================
+
+/// Regression for the SIGABRT case from
+/// `security-reports/subprocess_panics.md` (group 4, snippet 51165).
+///
+/// `async def f(): return await asyncio.gather(f())` creates one new
+/// scheduler task per recursion level. Without tracker accounting on
+/// `Scheduler::spawn` and `VM::save_task_context`, the worker grows
+/// linearly per level and is eventually killed by the system
+/// allocator. With *any* memory cap configured, this run MUST exit
+/// gracefully with `MemoryError` rather than running the host out of
+/// memory — the tracked Coroutine + GatherFuture allocations alone
+/// are enough to trip the budget today, but the test also pins that
+/// the additional scheduler-task accounting (added by Bug B's fix)
+/// cannot regress the worker into the SIGABRT path.
+#[test]
+fn recursive_gather_hits_memory_limit_not_sigabrt() {
+    let code = r"
+import asyncio
+
+async def f():
+    return await asyncio.gather(f())
+
+asyncio.run(f())
+";
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+
+    let limits = ResourceLimits::new()
+        .max_memory(128 * 1024)
+        .max_allocations(50_000)
+        .max_duration(Duration::from_secs(30));
+    let tracker = LimitedTracker::new(limits);
+    let result = runner.run(vec![], tracker, PrintWriter::Stdout);
+
+    let exc = result.expect_err("recursive gather must be bounded by the memory limit");
+    assert_eq!(exc.exc_type(), ExcType::MemoryError);
+    let msg = exc.message().expect("memory error carries a message");
+    assert!(
+        msg.starts_with("memory limit exceeded:"),
+        "expected memory-limit error from scheduler task accounting, \
+         not the allocation-count safety net: {msg}"
+    );
+}

--- a/crates/monty/tests/async_memory_limits.rs
+++ b/crates/monty/tests/async_memory_limits.rs
@@ -224,6 +224,54 @@ fn gather_awaited_state_charged_against_tracker() {
 /// are enough to trip the budget today, but the test also pins that
 /// the additional scheduler-task accounting (added by Bug B's fix)
 /// cannot regress the worker into the SIGABRT path.
+/// Regression for the second SIGABRT reproducer (snippet 108681).
+///
+/// `async def deep(n): r = await asyncio.gather(deep(n - 1)); return r[0]`
+/// returns the gather result back through every level. When the
+/// memory budget trips mid-recursion, the `MemoryError` originates
+/// inside `save_task_context` *after* it has drained `self.frames`,
+/// which used to leave the exception unwinder calling
+/// `current_frame()` on an empty frame stack and aborting with
+/// "no active frame".
+///
+/// Two changes guard this:
+///   * `save_task_context` charges the tracker *before* draining
+///     frames, so a rejected charge leaves the VM intact.
+///   * `current_frame_name` falls back to `<module>` when frames is
+///     empty, so any future transitional-error path can still attach
+///     a traceback frame instead of panicking.
+#[test]
+fn recursive_gather_with_return_value_hits_memory_limit_not_panic() {
+    let code = r"
+import asyncio
+
+async def deep(n):
+    if n <= 0:
+        return None
+    r = await asyncio.gather(deep(n - 1))
+    return r[0]
+
+asyncio.run(deep(20000))
+";
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+
+    let limits = ResourceLimits::new()
+        .max_memory(128 * 1024)
+        .max_allocations(200_000)
+        .max_duration(Duration::from_secs(30));
+    let tracker = LimitedTracker::new(limits);
+    let result = runner.run(vec![], tracker, PrintWriter::Stdout);
+
+    let exc = result.expect_err("deep recursive gather must be bounded by the memory limit");
+    assert_eq!(exc.exc_type(), ExcType::MemoryError);
+    let msg = exc.message().expect("memory error carries a message");
+    assert!(
+        msg.starts_with("memory limit exceeded:"),
+        "expected memory-limit error from scheduler task accounting, \
+         not the allocation-count safety net: {msg}"
+    );
+}
+
 #[test]
 fn recursive_gather_hits_memory_limit_not_sigabrt() {
     let code = r"

--- a/crates/monty/tests/async_memory_limits.rs
+++ b/crates/monty/tests/async_memory_limits.rs
@@ -1,25 +1,7 @@
 //! Tests that the async runtime accounts its dynamically-allocated state
-//! against `ResourceTracker`.
-//!
-//! Two memory-bypass classes are covered here. Both let untrusted Monty code
-//! grow live memory inside the worker without `LimitedTracker::max_memory`
-//! ever seeing it, which in the worst case drives the host process to
-//! allocator abort (SIGABRT) — see `security-reports/async-memory.md` and
-//! the SIGABRT group in `security-reports/subprocess_panics.md`.
-//!
-//! 1. **Gather `Pending → Awaited` bookkeeping.** `GatherFuture` is created
-//!    in `GatherState::Pending`, whose `py_estimate_size` charges no
-//!    state-side bytes. On first await, `await_gather_future` allocates
-//!    `pending_children` and `results` slot storage and stores them as
-//!    `GatherState::Awaited(...)`. That growth must be charged against
-//!    the tracker; otherwise an `await asyncio.gather(...)` over many
-//!    unresolved externals keeps O(N) untracked bytes live.
-//!
-//! 2. **Scheduler task overhead.** `Scheduler::spawn` and
-//!    `VM::save_task_context` allocate a `Task` (plus map entries and
-//!    a saved frames/stack/exception_stack) on every coroutine spawn and
-//!    suspension. None of that is charged today, so deeply recursive
-//!    `await asyncio.gather(f())` consumes host memory unbounded.
+//! against `ResourceTracker`, so a configured `max_memory` actually
+//! bounds gathers over many unresolved externals and unbounded async
+//! recursion via `gather`.
 
 use std::{mem, rc::Rc, time::Duration};
 
@@ -129,36 +111,19 @@ await main()
     MontyRun::new(code, "test.py", vec![]).unwrap()
 }
 
-// ============================================================================
-// Bug A — gather Pending → Awaited bookkeeping is charged against the tracker.
-// ============================================================================
-
-/// Witness for the bypass reported in `security-reports/async-memory.md`.
+/// `await_gather_future` must charge its per-await bookkeeping
+/// (`pending_children` + `results`) against the tracker.
 ///
-/// With `n` unresolved externals the Awaited-state bookkeeping is on the
-/// order of `n * (sizeof::<Option<Value>>() + sizeof::<HeapId>())` bytes
-/// (`results` slot vector + `pending_children` map entries — see
-/// `heap_data.rs::py_estimate_size for GatherFuture`). The chosen budget
-/// covers the bare GatherFuture, the `n` `ExternalFuture` heap entries,
-/// the coroutine frame, and module bookkeeping, but leaves no headroom
-/// for the per-await bookkeeping. Post-fix the `Pending → Awaited`
-/// transition raises `MemoryError`; pre-fix the run quietly settles into
-/// `ResolveFutures` with the Awaited bookkeeping off-the-books.
+/// Run with a generous budget so the gather drives to `ResolveFutures`
+/// without raising; then assert `current_memory()` includes the
+/// bookkeeping. A budget-based witness is unreliable: transient
+/// allocations between list construction and gather construction
+/// exceed any threshold sitting close to the bookkeeping delta. For
+/// N = 10_000 unresolved externals the threshold (1.25 MiB) sits
+/// between the pre-fix counter (~1.12 MiB) and the post-fix counter
+/// (~1.36 MiB).
 #[test]
 fn gather_awaited_state_charged_against_tracker() {
-    // Run with a generous budget so the gather drives all the way to
-    // `ResolveFutures`. Once there, tracker `current_memory()` must
-    // include the bookkeeping that `await_gather_future` just stored
-    // (`pending_children` map + `results` slot vector). Pre-fix the
-    // transition didn't call `track_growth`, so the tracker counter
-    // was about 1.12 MiB at this point; post-fix it is about
-    // 1.36 MiB — the ~240 KiB Awaited state-size for N = 10_000.
-    //
-    // A budget-based witness is unreliable because the run has
-    // transient allocation spikes between the list comprehension and
-    // the gather construction that exceed any threshold sitting
-    // close to the bookkeeping delta. Observing the post-await
-    // tracker counter directly is the cleanest signal.
     let n = 10_000;
     let runner = gather_n_pending_runner(n);
 
@@ -178,68 +143,30 @@ fn gather_awaited_state_charged_against_tracker() {
     };
 
     let memory = handle.current_memory();
-    // Pre-fix measured: ~1_120_448 bytes (no charge for `pending_children`
-    // or `results`). Post-fix: ~1_360_448 bytes. The threshold sits
-    // safely between, so it only holds when the per-await bookkeeping
-    // is accounted.
     let post_fix_threshold = 1_250_000;
     let threshold_failure = (memory < post_fix_threshold).then_some(memory);
 
-    // Resume with an error on the first pending external so the gather
-    // tears down and the snapshot is consumed cleanly. Dropping a
-    // `ResolveFutures` directly would leave `Value::Ref` entries inside
-    // `VMSnapshot.stack` to be auto-dropped, which `memory-model-checks`
-    // (correctly) treats as a refcounting bug.
+    // Tear the gather down before dropping the snapshot. Dropping
+    // `ResolveFutures` directly auto-drops `Value::Ref`s on the saved
+    // VM stack, which `memory-model-checks` treats as a refcounting bug.
     let first_call = resolve.pending_call_ids()[0];
     let error = MontyException::new(ExcType::ValueError, Some("test-shutdown".to_string()));
-    let outcome = resolve.resume(vec![(first_call, ExtFunctionResult::Error(error))], PrintWriter::Stdout);
-    // The gather propagates the error; either form is acceptable —
-    // what matters is that the heap is consumed and freed cleanly.
-    let _ = outcome;
+    let _ = resolve.resume(vec![(first_call, ExtFunctionResult::Error(error))], PrintWriter::Stdout);
 
     if let Some(memory) = threshold_failure {
         panic!(
-            "Gather Pending → Awaited bookkeeping is not charged against \
-             the tracker: tracker memory = {memory} bytes; expected at \
-             least {post_fix_threshold} (pre-fix is ~1.12 MiB, post-fix \
-             ~1.36 MiB for N = {n}).",
+            "Awaited bookkeeping not charged: tracker memory = {memory} bytes; \
+             expected at least {post_fix_threshold} for N = {n}.",
         );
     }
 }
 
-// ============================================================================
-// Bug B — Scheduler task overhead must not SIGABRT under a memory cap.
-// ============================================================================
-
-/// Regression for the SIGABRT case from
-/// `security-reports/subprocess_panics.md` (group 4, snippet 51165).
-///
-/// `async def f(): return await asyncio.gather(f())` creates one new
-/// scheduler task per recursion level. Without tracker accounting on
-/// `Scheduler::spawn` and `VM::save_task_context`, the worker grows
-/// linearly per level and is eventually killed by the system
-/// allocator. With *any* memory cap configured, this run MUST exit
-/// gracefully with `MemoryError` rather than running the host out of
-/// memory — the tracked Coroutine + GatherFuture allocations alone
-/// are enough to trip the budget today, but the test also pins that
-/// the additional scheduler-task accounting (added by Bug B's fix)
-/// cannot regress the worker into the SIGABRT path.
-/// Regression for the second SIGABRT reproducer (snippet 108681).
-///
-/// `async def deep(n): r = await asyncio.gather(deep(n - 1)); return r[0]`
-/// returns the gather result back through every level. When the
-/// memory budget trips mid-recursion, the `MemoryError` originates
-/// inside `save_task_context` *after* it has drained `self.frames`,
-/// which used to leave the exception unwinder calling
-/// `current_frame()` on an empty frame stack and aborting with
-/// "no active frame".
-///
-/// Two changes guard this:
-///   * `save_task_context` charges the tracker *before* draining
-///     frames, so a rejected charge leaves the VM intact.
-///   * `current_frame_name` falls back to `<module>` when frames is
-///     empty, so any future transitional-error path can still attach
-///     a traceback frame instead of panicking.
+/// `deep(n)` that returns the gather result back through every level
+/// used to trip a "no active frame" panic when the memory budget fired
+/// mid-recursion inside `save_task_context` after it had already
+/// drained `self.frames`. Charging the tracker before the drain — plus
+/// a `current_frame_name` fallback when frames is empty — turns this
+/// back into a graceful `MemoryError`.
 #[test]
 fn recursive_gather_with_return_value_hits_memory_limit_not_panic() {
     let code = r"
@@ -272,6 +199,9 @@ asyncio.run(deep(20000))
     );
 }
 
+/// Unbounded `async def f(): await asyncio.gather(f())` must terminate
+/// under any configured `max_memory` instead of growing the worker
+/// until the system allocator aborts.
 #[test]
 fn recursive_gather_hits_memory_limit_not_sigabrt() {
     let code = r"

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -9,6 +9,12 @@ inside the sandbox).
 
 - Allocation tracking is global; the host sets the bytes budget when
   constructing the VM.
+- The byte count is **approximate**: per-object sizing uses `py_estimate_size`,
+  which elides bookkeeping overhead (HashMap bucket padding, `Vec` capacity
+  slack, `SmallVec` inline buffers, scheduler queue allocations) and rounds
+  per-spawn task overhead to a fixed conservative constant. The configured
+  `max_memory` is a budget on user-visible data, not a hard ceiling on
+  process RSS.
 - Operations whose result is bounded by simple arithmetic on input sizes
   are **pre-checked** before allocating: integer multiplication, left
   shift, integer power, sequence repeat (`'x' * n`), padding (`str.ljust`,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds memory accounting to the async runtime so gather bookkeeping, per-task scheduler overhead, and saved task context are charged to `ResourceTracker`, preventing OOM/SIGABRT and raising `MemoryError` instead. Docs now clarify that memory accounting is approximate.

- **Bug Fixes**
  - Charge `GatherFuture` Pending→Awaited bookkeeping from locals; on rejection, mark `Failed`, drop awaiter/results, and tear down committed children; shrink on Completed/Failed via `Heap::track_shrink` using `py_estimate_size` deltas.
  - Make `Scheduler::spawn` fallible and charge `SCHEDULER_TASK_OVERHEAD` (remove redundant `size_of::<Task>`); release in `cancel_task` (skip main task). Add `requeue_ready_front` and re-queue if `save_task_context` fails after dequeuing.
  - Pre-charge in `save_task_context` before draining VM state; release in `load_or_init_task` via saved-context size. Keeps frames intact on errors; `current_frame_name` falls back to `<module>` when empty.
  - Pre-charge one `Value` when delivering to a parked task’s saved stack; shrink on resume to prevent tracker drift.
  - Tests cover: (1) gather Awaited bookkeeping counted at `ResolveFutures`, (2) recursive `asyncio.gather` cases hit the memory cap with `MemoryError` (no SIGABRT or frame panics).

- **Refactors**
  - Centralized size calculations: added `awaited_state_size` for gather Awaited bookkeeping and `Task::saved_context_size` for suspended VM state.
  - Consolidated save-and-requeue logic into `save_current_context_or_requeue` and used it in both switching paths.
  - Clarified `current_frame_name` fallback and trimmed comments/docstrings.
  - Docs: note that memory accounting is approximate in `limitations/resource_limits.md`.

<sup>Written for commit 42233a033782e7c20ee80580b547d2ee546243e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

