### PR TITLE
fix CI since subprocesses

### DIFF
--- a/.github/actions/build-pgo-wheel/action.yml
+++ b/.github/actions/build-pgo-wheel/action.yml
@@ -35,9 +35,25 @@ runs:
       env:
         RUSTFLAGS: '-Cprofile-generate=${{ github.workspace }}/profdata'
 
+    # `exercise.py` drives `pydantic_monty.Monty()` which spawns the `monty`
+    # worker subprocess — build an instrumented worker so PGO data covers
+    # both the parent (FFI/pool/proto in pydantic-monty) and the worker
+    # (bytecode interpreter in monty-cli).
+    - name: build instrumented monty binary
+      shell: bash
+      run: cargo build --release -p monty-cli
+      env:
+        RUSTFLAGS: '-Cprofile-generate=${{ github.workspace }}/profdata'
+
     - name: generate pgo data
       run: |
         export RUST_HOST=$(rustc --print host-tuple)
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          MONTY_BIN="$GITHUB_WORKSPACE/target/release/monty.exe"
+        else
+          MONTY_BIN="$GITHUB_WORKSPACE/target/release/monty"
+        fi
+        export MONTY_BIN
         pip install typing_extensions
         pip install pydantic-monty --no-index --no-deps --find-links pgo-wheel --force-reinstall
         python exercise.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -541,13 +541,15 @@ jobs:
           working-directory: crates/monty-python
 
       # the pydantic-monty-cli wheel ships the `monty` worker binary
-      # (bin bindings, one py3-none wheel per platform)
+      # (bin bindings, one py3-none wheel per platform). `-i` is required so
+      # maturin can find a Python to read pyproject.toml — the produced wheel
+      # is `py3-none-<plat>` and doesn't depend on a specific Python version.
       - name: build cli wheel
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1.50.1
         with:
           target: ${{ matrix.target }}
           manylinux: ${{ matrix.manylinux || 'auto' }}
-          args: --release --out dist
+          args: --release --out dist -i 3.10 3.11 3.12 3.13 3.14
           rust-toolchain: stable
           docker-options: -e CI
           working-directory: crates/monty-cli
@@ -608,15 +610,22 @@ jobs:
           interpreter: ${{ matrix.interpreter }}
           rust-toolchain: stable
 
-      # the cli wheel for the main platforms (no PGO — it's a plain binary)
+      # the PGO-optimized cli wheel for the main platforms — reuses the
+      # merged profile data from the build-pgo-wheel action above (which
+      # exercised an instrumented monty binary via `exercise.py`).
+      # `-i` is required so maturin can find a Python to read pyproject.toml
+      # inside the manylinux docker container; the produced wheel is
+      # `py3-none-<plat>` and doesn't depend on a specific Python version.
       - name: build cli wheel
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1.50.1
         with:
           manylinux: auto
-          args: --release --out dist
+          args: --release --out dist -i 3.10 3.11 3.12 3.13 3.14
           rust-toolchain: stable
           docker-options: -e CI
           working-directory: crates/monty-cli
+        env:
+          RUSTFLAGS: '-Cprofile-use=${{ github.workspace }}/merged.profdata'
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:


### PR DESCRIPTION
since #500

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI by collecting PGO data from the `monty` worker subprocess and using it to build the CLI wheel. Also ensure `maturin` finds a Python to read `pyproject.toml` for `py3-none-<plat>` wheels.

- **Bug Fixes**
  - Build an instrumented `monty` binary (`monty-cli`) so `exercise.py` profiles both parent and worker.
  - Export `MONTY_BIN` with OS-specific path (Windows/non-Windows) for the profiling run.
  - Add `-i 3.10 3.11 3.12 3.13 3.14` to `PyO3/maturin-action` invocations so `maturin` can read `pyproject.toml`.
  - Use `RUSTFLAGS=-Cprofile-use=${{ github.workspace }}/merged.profdata` to build the PGO-optimized CLI wheel.

<sup>Written for commit 6f3f8045969ae637a050ccee6988388fa57baa2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

