### PR TITLE
uprev ruff and ty crates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 /.zed/
 /scripts/json_files/
 .DS_Store
+/.codex/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "colored"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -942,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1138,6 +1138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -1266,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "get-size-derive2"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f8ab1b98a1284961d722ce994d9a0f3018ab1917618d4113824a72b9f71bc9"
+checksum = "1da24fbda09ec01bca7cfa1797c0e520e75123bccb01dcdf9041f8aa65183bc2"
 dependencies = [
  "attribute-derive",
  "quote",
@@ -1277,9 +1278,9 @@ dependencies = [
 
 [[package]]
 name = "get-size2"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0cd0777a1057362cab35a779e0d79dacecb8d73e2c733eaafeb7ea917b08f03"
+checksum = "823645bc6404ae2915707777061a47d3a031a9ee0bff51b34ec973df3d8d2990"
 dependencies = [
  "compact_str",
  "get-size-derive2",
@@ -1380,8 +1381,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1402,16 +1401,18 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
+ "allocator-api2",
  "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -1615,9 +1616,9 @@ checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
 name = "intrusive-collections"
-version = "0.9.7"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
+checksum = "4b719c59241cfaac1042a6d26787e28ed7ee4a4e21a5a907786f54222d1b0062"
 dependencies = [
  "memoffset",
 ]
@@ -1809,6 +1810,15 @@ dependencies = [
  "anstyle",
  "clap",
  "escape8259",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c10501e7805cee23da17c7790e59df2870c0d4043ec6d03f67d31e2b53e77415"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2139,7 +2149,7 @@ dependencies = [
  "path-slash",
  "ruff_db",
  "walkdir",
- "zip",
+ "zip 0.6.6",
 ]
 
 [[package]]
@@ -2613,7 +2623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -2632,7 +2642,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -3007,8 +3017,8 @@ dependencies = [
 
 [[package]]
 name = "ruff_annotate_snippets"
-version = "0.1.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "anstyle",
  "memchr",
@@ -3017,12 +3027,13 @@ dependencies = [
 
 [[package]]
 name = "ruff_db"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "anstyle",
  "arc-swap",
  "camino",
+ "compact_str",
  "dashmap",
  "dunce",
  "filetime",
@@ -3049,13 +3060,13 @@ dependencies = [
  "tracing",
  "ty_static",
  "web-time",
- "zip",
+ "zip 8.6.0",
 ]
 
 [[package]]
 name = "ruff_diagnostics"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "get-size2",
  "is-macro",
@@ -3065,8 +3076,8 @@ dependencies = [
 
 [[package]]
 name = "ruff_index"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "get-size2",
  "ruff_macros",
@@ -3075,8 +3086,8 @@ dependencies = [
 
 [[package]]
 name = "ruff_macros"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "heck",
  "itertools 0.14.0",
@@ -3089,16 +3100,16 @@ dependencies = [
 
 [[package]]
 name = "ruff_memory_usage"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "get-size2",
 ]
 
 [[package]]
 name = "ruff_notebook"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -3115,10 +3126,11 @@ dependencies = [
 
 [[package]]
 name = "ruff_python_ast"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "aho-corasick",
+ "arrayvec",
  "bitflags 2.10.0",
  "compact_str",
  "get-size2",
@@ -3135,8 +3147,8 @@ dependencies = [
 
 [[package]]
 name = "ruff_python_literal"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "bitflags 2.10.0",
  "icu_properties",
@@ -3146,8 +3158,8 @@ dependencies = [
 
 [[package]]
 name = "ruff_python_parser"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "bitflags 2.10.0",
  "bstr",
@@ -3167,8 +3179,8 @@ dependencies = [
 
 [[package]]
 name = "ruff_python_stdlib"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "bitflags 2.10.0",
  "unicode-ident",
@@ -3176,8 +3188,8 @@ dependencies = [
 
 [[package]]
 name = "ruff_python_trivia"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "itertools 0.14.0",
  "ruff_source_file",
@@ -3187,8 +3199,8 @@ dependencies = [
 
 [[package]]
 name = "ruff_source_file"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "get-size2",
  "memchr",
@@ -3198,8 +3210,8 @@ dependencies = [
 
 [[package]]
 name = "ruff_text_size"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "get-size2",
  "serde",
@@ -3275,15 +3287,15 @@ checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "salsa"
-version = "0.26.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07bc2a7df3f8e2306434a172a694d44d14fda738d08aad5f2f7f747d2f06fdc"
+checksum = "0b903173b7867d2b5837bad8fe38cb08928b6ec11a27641ff0d9c3f97d2d3860"
 dependencies = [
  "boxcar",
  "compact_str",
  "crossbeam-queue",
  "crossbeam-utils",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.0",
  "hashlink",
  "indexmap",
  "intrusive-collections",
@@ -3297,19 +3309,20 @@ dependencies = [
  "smallvec",
  "thin-vec",
  "tracing",
+ "typeid",
 ]
 
 [[package]]
 name = "salsa-macro-rules"
-version = "0.26.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec256ece77895f4a8d624cecc133dd798c7961a861439740b1c7410a613ee7ba"
+checksum = "536f8ea9f7cbcf2e58872bae5a78c95839021facafdab8462324337f89f6d1eb"
 
 [[package]]
 name = "salsa-macros"
-version = "0.26.1"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978e5d5c9533ce19b6a58ad91024e1d136f6eec83c4ba98b5ce94c87986c41d8"
+checksum = "5c49f4d53ec8fa201e74a27dd9eb8320146b0e45ad2b11ae503437109a502965"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3783,7 +3796,7 @@ dependencies = [
 [[package]]
 name = "ty_combine"
 version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "ordermap",
  "ruff_db",
@@ -3792,8 +3805,8 @@ dependencies = [
 
 [[package]]
 name = "ty_module_resolver"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "anyhow",
  "camino",
@@ -3816,7 +3829,7 @@ dependencies = [
 [[package]]
 name = "ty_python_core"
 version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "bitflags 2.10.0",
  "bitvec",
@@ -3825,7 +3838,6 @@ dependencies = [
  "itertools 0.14.0",
  "ruff_db",
  "ruff_index",
- "ruff_macros",
  "ruff_memory_usage",
  "ruff_python_ast",
  "ruff_python_parser",
@@ -3833,9 +3845,9 @@ dependencies = [
  "ruff_text_size",
  "rustc-hash",
  "salsa",
- "serde",
  "smallvec",
  "static_assertions",
+ "thin-vec",
  "tracing",
  "ty_combine",
  "ty_module_resolver",
@@ -3846,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "ty_python_semantic"
 version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "bitflags 2.10.0",
  "compact_str",
@@ -3884,11 +3896,11 @@ dependencies = [
 
 [[package]]
 name = "ty_site_packages"
-version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "camino",
- "colored 3.0.0",
+ "colored 3.1.1",
  "get-size2",
  "indexmap",
  "ruff_annotate_snippets",
@@ -3905,8 +3917,8 @@ dependencies = [
 
 [[package]]
 name = "ty_static"
-version = "0.0.1"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+version = "0.0.2"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "ruff_macros",
 ]
@@ -3914,14 +3926,26 @@ dependencies = [
 [[package]]
 name = "ty_vendored"
 version = "0.0.0"
-source = "git+https://github.com/samuelcolvin/ruff.git?rev=6aaa91ac2b269df1414954ccd5134f0e6f5c6d30#6aaa91ac2b269df1414954ccd5134f0e6f5c6d30"
+source = "git+https://github.com/astral-sh/ruff.git?tag=0.15.19#7f0436561d013b190b2a7ccad6f6ddda749102f9"
 dependencies = [
  "path-slash",
  "ruff_db",
  "static_assertions",
  "walkdir",
- "zip",
+ "zip 8.6.0",
 ]
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -4534,9 +4558,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4577,9 +4601,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -4646,8 +4670,28 @@ dependencies = [
  "pbkdf2",
  "sha1",
  "time",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zstd 0.13.3",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
 
 [[package]]
 name = "zmij"
@@ -4661,7 +4705,16 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe 7.2.4",
 ]
 
 [[package]]
@@ -4671,6 +4724,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
  "zstd-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,17 +42,18 @@ lto = false
 
 [workspace.dependencies]
 # ruff, ty and related crates
-ruff_python_parser = { git = "https://github.com/samuelcolvin/ruff.git", package = "ruff_python_parser", rev = "6aaa91ac2b269df1414954ccd5134f0e6f5c6d30" }
-ruff_python_stdlib = { git = "https://github.com/samuelcolvin/ruff.git", package = "ruff_python_stdlib", rev = "6aaa91ac2b269df1414954ccd5134f0e6f5c6d30" }
-ruff_python_ast = { git = "https://github.com/samuelcolvin/ruff.git", package = "ruff_python_ast", rev = "6aaa91ac2b269df1414954ccd5134f0e6f5c6d30" }
-ruff_text_size = { git = "https://github.com/samuelcolvin/ruff.git", package = "ruff_text_size", rev = "6aaa91ac2b269df1414954ccd5134f0e6f5c6d30" }
-ruff_db = { git = "https://github.com/samuelcolvin/ruff.git", package = "ruff_db", rev = "6aaa91ac2b269df1414954ccd5134f0e6f5c6d30", features = ["serde"] }
-ty_python_semantic = { git = "https://github.com/samuelcolvin/ruff.git", package = "ty_python_semantic", rev = "6aaa91ac2b269df1414954ccd5134f0e6f5c6d30" }
-ty_python_core = { git = "https://github.com/samuelcolvin/ruff.git", package = "ty_python_core", rev = "6aaa91ac2b269df1414954ccd5134f0e6f5c6d30" }
-ty_module_resolver = { git = "https://github.com/samuelcolvin/ruff.git", package = "ty_module_resolver", rev = "6aaa91ac2b269df1414954ccd5134f0e6f5c6d30" }
-ty_vendored = { git = "https://github.com/samuelcolvin/ruff.git", package = "ty_vendored", rev = "6aaa91ac2b269df1414954ccd5134f0e6f5c6d30" }
-# salsa version matches current main of ruff
-salsa = { version="0.26.1", default-features = false, features = [
+# using git until all ruff and ty crates are published to crates.io
+ruff_python_parser = { git = "https://github.com/astral-sh/ruff.git", package = "ruff_python_parser", tag = "0.15.19" }
+ruff_python_stdlib = { git = "https://github.com/astral-sh/ruff.git", package = "ruff_python_stdlib", tag = "0.15.19" }
+ruff_python_ast = { git = "https://github.com/astral-sh/ruff.git", package = "ruff_python_ast", tag = "0.15.19" }
+ruff_text_size = { git = "https://github.com/astral-sh/ruff.git", package = "ruff_text_size", tag = "0.15.19" }
+ruff_db = { git = "https://github.com/astral-sh/ruff.git", package = "ruff_db", tag = "0.15.19" ,features = ["serde"] }
+ty_python_semantic = { git = "https://github.com/astral-sh/ruff.git", package = "ty_python_semantic", tag = "0.15.19" }
+ty_python_core = { git = "https://github.com/astral-sh/ruff.git", package = "ty_python_core", tag = "0.15.19" }
+ty_module_resolver = { git = "https://github.com/astral-sh/ruff.git", package = "ty_module_resolver", tag = "0.15.19" }
+ty_vendored = { git = "https://github.com/astral-sh/ruff.git", package = "ty_vendored", tag = "0.15.19" }
+# salsa version matches the version ruff uses
+salsa = { version="0.27.0", default-features = false, features = [
     "compact_str",
     "macros",
     "salsa_unstable",

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -1036,7 +1036,7 @@ impl<'a> Parser<'a> {
                 let position = self.convert_range(range);
                 let ast::Arguments { args, keywords, .. } = arguments;
                 let args_vec = args.into_vec();
-                let keywords_vec = keywords.into_vec();
+                let keywords_vec: Vec<_> = keywords.into_iter().collect();
 
                 // Detect whether we need the generalized path (PEP 448):
                 // - multiple *args unpacks, OR


### PR DESCRIPTION
in preparation for all ruff crates being in crates.io, #148

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Ruff and Ty crates to the official `astral-sh/ruff` tag `0.15.19`, align `salsa` to 0.27, and update one parser callsite for the new AST API. This prepares the workspace for crates.io-published Ruff/Ty crates and refreshes transitive dependencies.

- **Dependencies**
  - Switch `ruff_*` and `ty_*` from `samuelcolvin/ruff` to `astral-sh/ruff` at tag `0.15.19`.
  - Bump `salsa` to `0.27.0` to match Ruff.
  - Lockfile refresh with notable bumps (`zip`, `colored`, `hashbrown`, `intrusive-collections`).
  - Add `/.codex/` to `.gitignore`.

- **Refactors**
  - Update `crates/monty/src/parse.rs` to collect `keywords` via iterator to match the new Ruff AST API.

<sup>Written for commit d8db20a737254ab8ba4d227c212ca5285308e983. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

