### PR TITLE
reintroduce `feed_start` API to both python & JS

### DIFF
--- a/crates/monty-cli/src/subprocess.rs
+++ b/crates/monty-cli/src/subprocess.rs
@@ -505,7 +505,7 @@ impl Child {
             Ok(table) => table,
             Err(err) => return violation(&format!("invalid mounts: {err}")),
         };
-        let event = match tag {
+        let mut event = match tag {
             0 => match MontyRepl::load(payload) {
                 Ok(repl) => {
                     self.state = SessionState::Ready(Box::new(repl));
@@ -537,10 +537,12 @@ impl Child {
         }
         // adopt the restored metadata only once the payload actually loaded
         // (state is now Ready/Suspended) — a failed load leaves the child in
-        // its prior un-started state, re-loadable
+        // its prior un-started state, re-loadable. Surface the adopted script
+        // name so the parent can report it without parsing the opaque dump.
         if matches!(self.state, SessionState::Ready(_) | SessionState::Suspended(_)) {
             self.script_name = script_name;
             self.type_check = type_check;
+            event.restored_script_name = Some(self.script_name.clone());
         }
         event
     }

--- a/crates/monty-cli/src/subprocess.rs
+++ b/crates/monty-cli/src/subprocess.rs
@@ -35,16 +35,22 @@ type Tracker = LimitedTracker;
 /// Wire layout: `[DUMP_VERSION u16 LE][tag u8][session meta][postcard
 /// payload]` where tag 0 is a `MontyRepl` (idle session) and tag 1 a
 /// `ReplProgress` (suspended). The session meta carries the child-side state
-/// that lives *outside* the repl — script name and accumulated type-check
-/// stubs — so a `Load`ed session keeps type-check enforcement instead of
-/// silently dropping it:
+/// that lives *outside* the repl — script name, accumulated type-check stubs,
+/// and the in-flight feed's mount requirements — so a `Load`ed session keeps
+/// type-check enforcement and can validate its mounts instead of silently
+/// dropping them:
 ///
-/// `[script_name str][type_check u8]` and, when `type_check` is 1,
-/// `[committed_stubs str][has_pending u8][pending_snippet str?]`, where each
-/// `str` is a `u32 LE` byte length followed by UTF-8 bytes. The payload is
-/// monty's postcard format — only a monty child of the same version can
-/// restore it.
-const DUMP_VERSION: u16 = 1;
+/// - `[script_name str][type_check u8]` and, when `type_check` is 1,
+///   `[committed_stubs str][has_pending u8][pending_snippet str?]`, where each
+///   `str` is a `u32 LE` byte length followed by UTF-8 bytes.
+/// - mount requirements: `[count u32 LE]` then per entry `[virtual_path
+///   str][mode i32 LE][has_limit u8][write_bytes_limit u64 LE?]`, recording the
+///   feed's mounts *without* host paths so `Load` can verify the re-supply. The
+///   count is 0 for an idle dump.
+///
+/// The payload is monty's postcard format — only a monty child of the same
+/// version can restore it.
+const DUMP_VERSION: u16 = 2;
 
 /// Runs the subprocess child loop until EOF, `Shutdown`, or a fatal error.
 pub(crate) fn run() -> ExitCode {
@@ -89,9 +95,11 @@ pub(crate) fn run() -> ExitCode {
 
 /// REPL session state of the child.
 enum SessionState {
-    /// No session; only `ReplCreate` / `Load` / `Reset` / `Shutdown` are
-    /// valid.
-    Idle,
+    /// No repl materialized yet. `Some` once `Configure` has stored the config
+    /// (the repl is built lazily on the first `ReplFeed` / `Dump`); `None` on a
+    /// freshly spawned or just-`Reset` worker, before `Configure`. `Load` is
+    /// valid only from here — it cannot clobber a started session.
+    Configured(Option<Box<pb::Configure>>),
     /// Session ready for the next `ReplFeed`.
     Ready(Box<MontyRepl<Tracker>>),
     /// Mid-feed, waiting for a resume request. Never holds
@@ -109,6 +117,39 @@ struct TypeCheckState {
     pending_snippet: Option<String>,
 }
 
+/// The child-side session state that lives *outside* the repl/progress payload
+/// and so must travel in the dump envelope explicitly: the script name, the
+/// type-check state, and the in-flight feed's mount requirements. Serialized by
+/// [`push_session_meta`] and parsed by [`take_session_meta`].
+struct SessionMeta {
+    script_name: String,
+    type_check: Option<TypeCheckState>,
+    mount_requirements: Vec<MountRequirement>,
+}
+
+/// The host-independent shape of one mount: everything in a `pb::Mount`
+/// except the machine-specific `host_path`. Recorded in a suspended feed's
+/// dump so `Load` can verify the parent re-supplied the *same* mounts (by
+/// virtual path, mode, and write cap) before resuming — host paths are never
+/// dumped, so a malicious dump cannot inject a mount of an arbitrary host
+/// directory.
+#[derive(Clone, PartialEq)]
+struct MountRequirement {
+    virtual_path: String,
+    mode: i32,
+    write_bytes_limit: Option<u64>,
+}
+
+impl MountRequirement {
+    fn of(mount: &pb::Mount) -> Self {
+        Self {
+            virtual_path: mount.virtual_path.clone(),
+            mode: mount.mode,
+            write_bytes_limit: mount.write_bytes_limit,
+        }
+    }
+}
+
 /// All child state.
 struct Child {
     state: SessionState,
@@ -116,9 +157,15 @@ struct Child {
     /// diagnostics).
     script_name: String,
     /// Mount table for the in-flight feed; rebuilt per feed, dropped when the
-    /// feed completes. Not part of dumps — a `Load`ed suspended feed has no
-    /// mounts, so its remaining OS calls all bubble to the parent.
+    /// feed completes. Not part of dumps (mounts are host configuration, not
+    /// sandbox state) — instead a `Load` resuming a suspended feed carries the
+    /// mounts the parent re-supplies, and `handle_load` rebuilds the table from
+    /// them after checking they match `mount_requirements`.
     mounts: Option<MountTable>,
+    /// Host-independent shape of the in-flight feed's mounts, dumped alongside
+    /// a suspended session so `Load` can validate the re-supplied mounts.
+    /// Empty between feeds and for idle sessions.
+    mount_requirements: Vec<MountRequirement>,
     /// `Some` when the session was created with `type_check: true`.
     type_check: Option<TypeCheckState>,
 }
@@ -126,11 +173,20 @@ struct Child {
 impl Child {
     fn new() -> Self {
         Self {
-            state: SessionState::Idle,
+            state: SessionState::Configured(None),
             script_name: String::new(),
             mounts: None,
+            mount_requirements: Vec::new(),
             type_check: None,
         }
+    }
+
+    /// Drops the in-flight feed's mount table and its recorded requirements.
+    /// Called when a feed ends (completion, error, reset) so a later idle dump
+    /// records no mount requirements.
+    fn clear_feed_mounts(&mut self) {
+        self.mounts = None;
+        self.mount_requirements.clear();
     }
 
     /// Handles one request: emits exactly one turn-ending event and returns
@@ -142,13 +198,13 @@ impl Child {
         };
 
         let mut event = match kind {
-            pb::parent_request::Kind::ReplCreate(create) => self.handle_repl_create(create),
+            pb::parent_request::Kind::Configure(configure) => self.handle_configure(configure),
             pb::parent_request::Kind::ReplFeed(feed) => self.handle_repl_feed(feed),
             pb::parent_request::Kind::ResumeCall(resume) => self.handle_resume_call(resume),
             pb::parent_request::Kind::ResumeNameLookup(resume) => self.handle_resume_name_lookup(resume),
             pb::parent_request::Kind::ResumeFutures(resume) => self.handle_resume_futures(resume),
             pb::parent_request::Kind::Dump(_) => self.handle_dump(),
-            pb::parent_request::Kind::Load(load) => self.handle_load(&load),
+            pb::parent_request::Kind::Load(load) => self.handle_load(load),
             pb::parent_request::Kind::Reset(_) => {
                 self.reset();
                 ok_event()
@@ -199,7 +255,8 @@ impl Child {
         let tracker = match &self.state {
             SessionState::Ready(repl) => repl.tracker(),
             SessionState::Suspended(progress) => progress.tracker(),
-            SessionState::Idle => return,
+            // no repl materialized yet → no tracker to report
+            SessionState::Configured(_) => return,
         };
         event.total_execution_micros = u64::try_from(tracker.elapsed().as_micros()).unwrap_or(u64::MAX);
         event.max_duration_micros = tracker
@@ -207,24 +264,55 @@ impl Child {
             .map(|max| u64::try_from(max.as_micros()).unwrap_or(u64::MAX));
     }
 
-    fn handle_repl_create(&mut self, create: pb::ReplCreate) -> pb::ChildEvent {
-        if !matches!(self.state, SessionState::Idle) {
-            return violation("ReplCreate while a session already exists");
+    /// Stores the session config; the repl is built lazily by [`ensure_repl`]
+    /// on the first feed/dump (or restored by `Load` instead). Valid only on a
+    /// not-yet-configured worker.
+    fn handle_configure(&mut self, configure: pb::Configure) -> pb::ChildEvent {
+        if !matches!(self.state, SessionState::Configured(None)) {
+            return violation("Configure while a session already exists");
         }
-        let limits = create.limits.unwrap_or_default().into();
-        self.script_name = create.script_name;
-        self.type_check = create.type_check.then(|| TypeCheckState {
-            committed_stubs: create.type_check_stubs.unwrap_or_default(),
-            pending_snippet: None,
-        });
-        self.state = SessionState::Ready(Box::new(MontyRepl::new(&self.script_name, LimitedTracker::new(limits))));
+        self.state = SessionState::Configured(Some(Box::new(configure)));
         ok_event()
     }
 
-    fn handle_repl_feed(&mut self, feed: pb::ReplFeed) -> pb::ChildEvent {
-        let SessionState::Ready(_) = &self.state else {
-            return violation("ReplFeed without a session ready for input");
+    /// Materializes the repl from the stored config the first time the session
+    /// runs (feed/dump), applying the config's script name, limits, and
+    /// type-check setup. A no-op once the repl exists; errors only if the
+    /// worker was never configured (which the pool's `Configure`-first checkout
+    /// prevents in normal operation).
+    fn ensure_repl(&mut self) -> Result<(), Box<pb::ChildEvent>> {
+        let config = match &mut self.state {
+            SessionState::Configured(config) => config.take(),
+            // already materialized (or mid-feed) — nothing to do here
+            SessionState::Ready(_) | SessionState::Suspended(_) => return Ok(()),
         };
+        let Some(config) = config else {
+            return Err(Box::new(violation("session has not been configured")));
+        };
+        let pb::Configure {
+            script_name,
+            limits,
+            type_check,
+            type_check_stubs,
+        } = *config;
+        let limits = limits.unwrap_or_default().into();
+        self.script_name = script_name;
+        self.type_check = type_check.then(|| TypeCheckState {
+            committed_stubs: type_check_stubs.unwrap_or_default(),
+            pending_snippet: None,
+        });
+        self.state = SessionState::Ready(Box::new(MontyRepl::new(&self.script_name, LimitedTracker::new(limits))));
+        Ok(())
+    }
+
+    fn handle_repl_feed(&mut self, feed: pb::ReplFeed) -> pb::ChildEvent {
+        if let Err(event) = self.ensure_repl() {
+            return *event;
+        }
+        if !matches!(self.state, SessionState::Ready(_)) {
+            // ensure_repl left it un-Ready only when mid-suspension
+            return violation("ReplFeed without a session ready for input");
+        }
         if !feed.skip_type_check
             && let Some(event) = self.type_check_feed(&feed.code)
         {
@@ -234,12 +322,16 @@ impl Child {
             Ok(inputs) => inputs,
             Err(event) => return *event,
         };
+        // record the host-independent mount shape before consuming the specs,
+        // so a dump taken mid-feed can make `Load` validate the re-supply
+        let requirements = feed.mounts.iter().map(MountRequirement::of).collect();
         self.mounts = match build_mount_table(feed.mounts) {
             Ok(mounts) => mounts,
             Err(err) => return violation(&format!("invalid mounts: {err}")),
         };
-        let SessionState::Ready(repl) = mem::replace(&mut self.state, SessionState::Idle) else {
-            unreachable!("checked above");
+        self.mount_requirements = requirements;
+        let SessionState::Ready(repl) = mem::replace(&mut self.state, SessionState::Configured(None)) else {
+            unreachable!("checked Ready above");
         };
         // snippets fed with skip_type_check never become type-check context:
         // the caller explicitly excluded them from checking, so later snippets
@@ -281,7 +373,7 @@ impl Child {
             },
             None => return violation("ResumeCall has no result"),
         };
-        let SessionState::Suspended(progress) = mem::replace(&mut self.state, SessionState::Idle) else {
+        let SessionState::Suspended(progress) = mem::replace(&mut self.state, SessionState::Configured(None)) else {
             unreachable!("checked above");
         };
         let mut print = ProtoPrint::new();
@@ -306,7 +398,7 @@ impl Child {
             Ok(result) => result,
             Err(err) => return violation(&format!("invalid result: {err}")),
         };
-        let SessionState::Suspended(progress) = mem::replace(&mut self.state, SessionState::Idle) else {
+        let SessionState::Suspended(progress) = mem::replace(&mut self.state, SessionState::Configured(None)) else {
             unreachable!("checked above");
         };
         let ReplProgress::NameLookup(lookup) = *progress else {
@@ -330,7 +422,7 @@ impl Child {
             Ok(results) => results,
             Err(err) => return violation(&format!("invalid results: {err}")),
         };
-        let SessionState::Suspended(progress) = mem::replace(&mut self.state, SessionState::Idle) else {
+        let SessionState::Suspended(progress) = mem::replace(&mut self.state, SessionState::Configured(None)) else {
             unreachable!("checked above");
         };
         let ReplProgress::ResolveFutures(state) = *progress else {
@@ -346,31 +438,27 @@ impl Child {
     /// Serializes the current session into the opaque dump envelope. The
     /// session stays live — dumping is read-only.
     fn handle_dump(&mut self) -> pb::ChildEvent {
+        // a never-fed session is materialized into an empty repl so it can be
+        // dumped; a never-configured worker has nothing to dump
+        if let Err(event) = self.ensure_repl() {
+            return *event;
+        }
         let dumped = match &self.state {
             SessionState::Ready(repl) => repl.dump().map(|bytes| (0u8, bytes)),
             SessionState::Suspended(progress) => progress.dump().map(|bytes| (1u8, bytes)),
-            SessionState::Idle => return violation("Dump without a session"),
+            SessionState::Configured(_) => unreachable!("ensure_repl materialized the repl or errored"),
         };
         match dumped {
             Ok((tag, payload)) => {
                 let mut state = Vec::with_capacity(payload.len() + 64);
                 state.extend_from_slice(&DUMP_VERSION.to_le_bytes());
                 state.push(tag);
-                push_str_field(&mut state, &self.script_name);
-                match &self.type_check {
-                    Some(tc) => {
-                        state.push(1);
-                        push_str_field(&mut state, &tc.committed_stubs);
-                        match &tc.pending_snippet {
-                            Some(snippet) => {
-                                state.push(1);
-                                push_str_field(&mut state, snippet);
-                            }
-                            None => state.push(0),
-                        }
-                    }
-                    None => state.push(0),
-                }
+                push_session_meta(
+                    &mut state,
+                    &self.script_name,
+                    self.type_check.as_ref(),
+                    &self.mount_requirements,
+                );
                 state.extend_from_slice(&payload);
                 event(pb::child_event::Kind::DumpResult(pb::DumpResult { state }))
             }
@@ -378,14 +466,21 @@ impl Child {
         }
     }
 
-    /// Restores a dump produced by [`Self::handle_dump`] into this (idle)
-    /// child. A restored suspension re-emits its suspension event so the
-    /// parent learns the resume point.
-    fn handle_load(&mut self, load: &pb::Load) -> pb::ChildEvent {
-        if !matches!(self.state, SessionState::Idle) {
-            return violation("Load while a session already exists");
+    /// Restores a dump produced by [`Self::handle_dump`] into this child. A
+    /// restored suspension re-emits its suspension event so the parent learns
+    /// the resume point.
+    ///
+    /// `Load` is valid only when no repl has been materialized yet — a freshly
+    /// checked-out (`Configure`d, unfed) worker — so it initializes the session
+    /// instead of feeding. Once a feed has run (or a prior `Load` restored a
+    /// session), the repl exists and `Load` is rejected rather than silently
+    /// discarding it.
+    fn handle_load(&mut self, load: pb::Load) -> pb::ChildEvent {
+        if !matches!(self.state, SessionState::Configured(_)) {
+            return violation("Load requires a session that has not started (a feed has already run)");
         }
-        let Some((version_bytes, rest)) = load.state.split_at_checked(2) else {
+        let pb::Load { state, mounts } = load;
+        let Some((version_bytes, rest)) = state.split_at_checked(2) else {
             return violation("dump state too short");
         };
         let version = u16::from_le_bytes([version_bytes[0], version_bytes[1]]);
@@ -395,8 +490,20 @@ impl Child {
         let Some((&tag, rest)) = rest.split_first() else {
             return violation("dump state too short");
         };
-        let Some((script_name, type_check, payload)) = take_session_meta(rest) else {
+        let Some((meta, payload)) = take_session_meta(rest) else {
             return violation("malformed dump session metadata");
+        };
+        let SessionMeta {
+            script_name,
+            type_check,
+            mount_requirements: requirements,
+        } = meta;
+        if let Err(message) = validate_supplied_mounts(&requirements, &mounts) {
+            return error_event(ExcType::RuntimeError, &message);
+        }
+        let mount_table = match build_mount_table(mounts) {
+            Ok(table) => table,
+            Err(err) => return violation(&format!("invalid mounts: {err}")),
         };
         let event = match tag {
             0 => match MontyRepl::load(payload) {
@@ -422,9 +529,16 @@ impl Child {
             },
             other => violation(&format!("unknown dump tag {other}")),
         };
-        // adopt the restored metadata only once the payload actually loaded —
-        // a failed load must leave the child fully idle
-        if !matches!(self.state, SessionState::Idle) {
+        // a resumed feed re-establishes the mounts the parent re-supplied; an
+        // idle restore leaves `self.mounts` untouched (the next feed sets it)
+        if matches!(self.state, SessionState::Suspended(_)) {
+            self.mounts = mount_table;
+            self.mount_requirements = requirements;
+        }
+        // adopt the restored metadata only once the payload actually loaded
+        // (state is now Ready/Suspended) — a failed load leaves the child in
+        // its prior un-started state, re-loadable
+        if matches!(self.state, SessionState::Ready(_) | SessionState::Suspended(_)) {
             self.script_name = script_name;
             self.type_check = type_check;
         }
@@ -442,7 +556,7 @@ impl Child {
             match result {
                 Ok(ReplProgress::Complete { repl, value }) => {
                     self.state = SessionState::Ready(Box::new(repl));
-                    self.mounts = None;
+                    self.clear_feed_mounts();
                     if let Some(state) = &mut self.type_check
                         && let Some(snippet) = state.pending_snippet.take()
                     {
@@ -532,7 +646,7 @@ impl Child {
                 Err(err) => {
                     // Python-level failure: the session always survives
                     self.state = SessionState::Ready(Box::new(err.repl));
-                    self.mounts = None;
+                    self.clear_feed_mounts();
                     if let Some(state) = &mut self.type_check {
                         state.pending_snippet = None;
                     }
@@ -547,7 +661,7 @@ impl Child {
     /// Ends the current feed with a runtime error while keeping the REPL usable.
     fn abort_feed_with_runtime_error(&mut self, repl: MontyRepl<Tracker>, message: &str) -> pb::ChildEvent {
         self.state = SessionState::Ready(Box::new(repl));
-        self.mounts = None;
+        self.clear_feed_mounts();
         if let Some(state) = &mut self.type_check {
             state.pending_snippet = None;
         }
@@ -570,10 +684,11 @@ impl Child {
         }
     }
 
-    /// Drops all session state, returning to `Idle`.
+    /// Drops all session state, returning to the unconfigured state ready for
+    /// the next `Configure` (or `Load`).
     fn reset(&mut self) {
-        self.state = SessionState::Idle;
-        self.mounts = None;
+        self.state = SessionState::Configured(None);
+        self.clear_feed_mounts();
         self.type_check = None;
         self.script_name = String::new();
     }
@@ -718,15 +833,40 @@ fn push_str_field(buf: &mut Vec<u8>, s: &str) {
     buf.extend_from_slice(s.as_bytes());
 }
 
-/// Splits the session metadata (script name + type-check state, see
-/// [`DUMP_VERSION`]) off the front of a dump envelope, returning it together
-/// with the remaining postcard payload. `None` means the envelope is
+/// Appends the session metadata (script name + type-check state + mount
+/// requirements, see [`DUMP_VERSION`]) to a dump envelope.
+fn push_session_meta(
+    buf: &mut Vec<u8>,
+    script_name: &str,
+    type_check: Option<&TypeCheckState>,
+    mount_requirements: &[MountRequirement],
+) {
+    push_str_field(buf, script_name);
+    match type_check {
+        Some(tc) => {
+            buf.push(1);
+            push_str_field(buf, &tc.committed_stubs);
+            match &tc.pending_snippet {
+                Some(snippet) => {
+                    buf.push(1);
+                    push_str_field(buf, snippet);
+                }
+                None => buf.push(0),
+            }
+        }
+        None => buf.push(0),
+    }
+    push_mount_requirements(buf, mount_requirements);
+}
+
+/// Splits the [`SessionMeta`] off the front of a dump envelope, returning it
+/// together with the remaining postcard payload. `None` means the envelope is
 /// malformed.
-fn take_session_meta(bytes: &[u8]) -> Option<(String, Option<TypeCheckState>, &[u8])> {
+fn take_session_meta(bytes: &[u8]) -> Option<(SessionMeta, &[u8])> {
     let (script_name, rest) = take_str_field(bytes)?;
     let (&type_check_flag, rest) = rest.split_first()?;
-    match type_check_flag {
-        0 => Some((script_name, None, rest)),
+    let (type_check, rest) = match type_check_flag {
+        0 => (None, rest),
         1 => {
             let (committed_stubs, rest) = take_str_field(rest)?;
             let (&pending_flag, rest) = rest.split_first()?;
@@ -735,17 +875,25 @@ fn take_session_meta(bytes: &[u8]) -> Option<(String, Option<TypeCheckState>, &[
                 1 => take_str_field(rest).map(|(snippet, rest)| (Some(snippet), rest))?,
                 _ => return None,
             };
-            Some((
-                script_name,
+            (
                 Some(TypeCheckState {
                     committed_stubs,
                     pending_snippet,
                 }),
                 rest,
-            ))
+            )
         }
-        _ => None,
-    }
+        _ => return None,
+    };
+    let (mount_requirements, rest) = take_mount_requirements(rest)?;
+    Some((
+        SessionMeta {
+            script_name,
+            type_check,
+            mount_requirements,
+        },
+        rest,
+    ))
 }
 
 /// Splits a `u32 LE`-length-prefixed string field off the front of a dump
@@ -755,6 +903,90 @@ fn take_str_field(bytes: &[u8]) -> Option<(String, &[u8])> {
     let len = u32::from_le_bytes(len_bytes.try_into().ok()?) as usize;
     let (field, rest) = rest.split_at_checked(len)?;
     Some((String::from_utf8(field.to_vec()).ok()?, rest))
+}
+
+/// Appends the in-flight feed's mount requirements to a dump envelope (see
+/// [`DUMP_VERSION`]). Host paths are deliberately excluded.
+fn push_mount_requirements(buf: &mut Vec<u8>, requirements: &[MountRequirement]) {
+    let count = u32::try_from(requirements.len()).expect("mount count exceeds u32::MAX");
+    buf.extend_from_slice(&count.to_le_bytes());
+    for req in requirements {
+        push_str_field(buf, &req.virtual_path);
+        buf.extend_from_slice(&req.mode.to_le_bytes());
+        match req.write_bytes_limit {
+            Some(limit) => {
+                buf.push(1);
+                buf.extend_from_slice(&limit.to_le_bytes());
+            }
+            None => buf.push(0),
+        }
+    }
+}
+
+/// Splits the mount requirements off the front of a dump envelope, returning
+/// them with the remaining postcard payload. `None` means the envelope is
+/// malformed. The count comes from untrusted bytes, so entries are pushed
+/// without pre-reserving capacity (a bogus count simply runs out of bytes).
+fn take_mount_requirements(bytes: &[u8]) -> Option<(Vec<MountRequirement>, &[u8])> {
+    let (count_bytes, mut rest) = bytes.split_at_checked(4)?;
+    let count = u32::from_le_bytes(count_bytes.try_into().ok()?);
+    let mut requirements = Vec::new();
+    for _ in 0..count {
+        let (virtual_path, after_path) = take_str_field(rest)?;
+        let (mode_bytes, after_mode) = after_path.split_at_checked(4)?;
+        let mode = i32::from_le_bytes(mode_bytes.try_into().ok()?);
+        let (&has_limit, after_flag) = after_mode.split_first()?;
+        let (write_bytes_limit, after_limit) = match has_limit {
+            0 => (None, after_flag),
+            1 => {
+                let (limit_bytes, after) = after_flag.split_at_checked(8)?;
+                (Some(u64::from_le_bytes(limit_bytes.try_into().ok()?)), after)
+            }
+            _ => return None,
+        };
+        requirements.push(MountRequirement {
+            virtual_path,
+            mode,
+            write_bytes_limit,
+        });
+        rest = after_limit;
+    }
+    Some((requirements, rest))
+}
+
+/// Checks that the mounts the parent re-supplied to `Load` match the suspended
+/// feed's recorded requirements exactly (by virtual path, mode, and write cap;
+/// host paths may differ). Returns a human-readable error describing the first
+/// discrepancy — a missing, extra, or altered mount — so a forgotten re-supply
+/// fails loudly instead of silently dropping the feed's mounts.
+fn validate_supplied_mounts(required: &[MountRequirement], supplied: &[pb::Mount]) -> Result<(), String> {
+    for req in required {
+        match supplied.iter().find(|m| m.virtual_path == req.virtual_path) {
+            None => {
+                return Err(format!(
+                    "the dump was suspended with a mount at {:?} that was not re-supplied to load; \
+                     pass the same mounts the original feed used",
+                    req.virtual_path
+                ));
+            }
+            Some(m) if m.mode != req.mode || m.write_bytes_limit != req.write_bytes_limit => {
+                return Err(format!(
+                    "the re-supplied mount at {:?} does not match the dump (mount mode or write limit differs)",
+                    req.virtual_path
+                ));
+            }
+            Some(_) => {}
+        }
+    }
+    for mount in supplied {
+        if !required.iter().any(|req| req.virtual_path == mount.virtual_path) {
+            return Err(format!(
+                "a mount at {:?} was supplied to load but the dump's feed had no such mount",
+                mount.virtual_path
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Converts wire named inputs into `(name, value)` pairs for `feed_start`.

--- a/crates/monty-cli/tests/subprocess.rs
+++ b/crates/monty-cli/tests/subprocess.rs
@@ -60,7 +60,7 @@ impl ChildProc {
     }
 
     fn create_repl(&mut self) {
-        self.create_repl_with(pb::ReplCreate {
+        self.create_repl_with(pb::Configure {
             script_name: "main.py".to_owned(),
             limits: None,
             type_check: false,
@@ -68,11 +68,11 @@ impl ChildProc {
         });
     }
 
-    fn create_repl_with(&mut self, create: pb::ReplCreate) {
-        self.send(pb::parent_request::Kind::ReplCreate(create));
+    fn create_repl_with(&mut self, create: pb::Configure) {
+        self.send(pb::parent_request::Kind::Configure(create));
         match self.recv() {
             pb::child_event::Kind::Ok(_) => {}
-            other => panic!("expected Ok for ReplCreate, got {other:?}"),
+            other => panic!("expected Ok for Configure, got {other:?}"),
         }
     }
 
@@ -402,7 +402,7 @@ fn overlay_mount_discards_writes_at_feed_end() {
 #[test]
 fn child_enforces_time_limit() {
     let mut child = ChildProc::spawn();
-    child.create_repl_with(pb::ReplCreate {
+    child.create_repl_with(pb::Configure {
         script_name: "main.py".to_owned(),
         limits: Some(pb::ResourceLimits {
             max_duration_micros: Some(100_000), // 100ms
@@ -415,7 +415,7 @@ fn child_enforces_time_limit() {
     let error = expect_error(event);
     assert_eq!(error.exc_type, "TimeoutError");
     // resource exhaustion is terminal for the SESSION (the tracker stays
-    // exhausted) but not for the child process: Reset + ReplCreate reuses it
+    // exhausted) but not for the child process: Reset + Configure reuses it
     let (_, event) = child.feed("1 + 1");
     assert_eq!(expect_error(event).exc_type, "TimeoutError");
     child.send(pb::parent_request::Kind::Reset(pb::Reset {}));
@@ -434,7 +434,7 @@ fn child_enforces_time_limit() {
 #[test]
 fn type_checked_session_rejects_bad_snippets_and_remembers_good_ones() {
     let mut child = ChildProc::spawn();
-    child.create_repl_with(pb::ReplCreate {
+    child.create_repl_with(pb::Configure {
         script_name: "main.py".to_owned(),
         limits: None,
         type_check: true,
@@ -490,7 +490,10 @@ fn dump_then_load_into_fresh_child_resumes() {
 
     // a fresh child restores the dump and re-announces the suspension
     let mut fresh = ChildProc::spawn();
-    fresh.send(pb::parent_request::Kind::Load(pb::Load { state: dump.state }));
+    fresh.send(pb::parent_request::Kind::Load(pb::Load {
+        state: dump.state,
+        mounts: vec![],
+    }));
     let (_, event) = fresh.recv_turn();
     let pb::child_event::Kind::FunctionCall(restored) = event else {
         panic!("expected re-emitted FunctionCall after Load, got {event:?}");
@@ -511,7 +514,7 @@ fn dump_then_load_into_fresh_child_resumes() {
 #[test]
 fn type_check_state_survives_dump_and_load() {
     let mut child = ChildProc::spawn();
-    child.create_repl_with(pb::ReplCreate {
+    child.create_repl_with(pb::Configure {
         script_name: "main.py".to_owned(),
         limits: None,
         type_check: true,
@@ -526,7 +529,10 @@ fn type_check_state_survives_dump_and_load() {
     drop(child);
 
     let mut fresh = ChildProc::spawn();
-    fresh.send(pb::parent_request::Kind::Load(pb::Load { state: dump.state }));
+    fresh.send(pb::parent_request::Kind::Load(pb::Load {
+        state: dump.state,
+        mounts: vec![],
+    }));
     let pb::child_event::Kind::Ok(_) = fresh.recv() else {
         panic!("expected Ok for Load");
     };
@@ -558,7 +564,7 @@ fn protocol_violations_keep_the_child_alive() {
     child.create_repl();
 
     // double create
-    child.send(pb::parent_request::Kind::ReplCreate(pb::ReplCreate {
+    child.send(pb::parent_request::Kind::Configure(pb::Configure {
         script_name: "again.py".to_owned(),
         limits: None,
         type_check: false,

--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -77,6 +77,37 @@ Keyword arguments arrive as a trailing object; thrown errors cross into the
 sandbox as Python exceptions (the error's `name` is used when it matches a
 Python exception type, e.g. `TypeError`, otherwise `RuntimeError`).
 
+## Snapshots: pausing and resuming
+
+`feedStart` is the suspendable counterpart of `feedRun`: instead of driving a
+snippet to completion, it returns a snapshot at each external call, OS call, or
+name lookup. Answer it with `snapshot.resume(...)`, which resolves to the next
+snapshot or a `MontyComplete`.
+
+```ts
+import { FunctionSnapshot, MontyComplete } from '@pydantic/monty'
+
+const snap = await session.feedStart('greet(name) + "!"', { inputs: { name: 'Ada' } })
+if (snap instanceof FunctionSnapshot) {
+  // snap.functionName === 'greet', snap.args === ['Ada']
+  const done = await snap.resume('hello Ada')
+  if (done instanceof MontyComplete) console.log(done.output) // 'hello Ada!'
+}
+```
+
+`snapshot.dump()` (or `session.dump()`) serializes the paused worker to bytes;
+a fresh session's `loadSnapshot` restores it and returns the snapshot to resume
+(`loadSnapshot` is valid only before any feed, and resolves to `null` for a
+dump taken between feeds). Re-supply the same `mount`s the paused feed used —
+their host paths are not stored in the dump.
+
+```ts
+const blob = await snap.dump()
+// ...later, in a fresh session:
+const restored = await session.loadSnapshot(blob)
+if (restored instanceof FunctionSnapshot) await restored.resume('value')
+```
+
 ## Print Output
 
 ```ts

--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -95,11 +95,10 @@ if (snap instanceof FunctionSnapshot) {
 }
 ```
 
-`snapshot.dump()` (or `session.dump()`) serializes the paused worker to bytes;
-a fresh session's `loadSnapshot` restores it and returns the snapshot to resume
-(`loadSnapshot` is valid only before any feed, and resolves to `null` for a
-dump taken between feeds). Re-supply the same `mount`s the paused feed used —
-their host paths are not stored in the dump.
+`snapshot.dump()` serializes the paused worker to bytes; a fresh session's
+`loadSnapshot` restores it and returns the snapshot to resume. Re-supply the
+same `mount`s the paused feed used — their host paths are not stored in the
+dump.
 
 ```ts
 const blob = await snap.dump()
@@ -107,6 +106,11 @@ const blob = await snap.dump()
 const restored = await session.loadSnapshot(blob)
 if (restored instanceof FunctionSnapshot) await restored.resume('value')
 ```
+
+`session.dump()` between feeds serializes an idle session instead; restore it
+with `await session.load(blob)` (which resolves to `void`) and keep feeding.
+Both `load` and `loadSnapshot` are valid only on a fresh session, before any
+feed; using the wrong one for a dump's kind throws.
 
 ## Print Output
 

--- a/crates/monty-js/__test__/feed_start.spec.ts
+++ b/crates/monty-js/__test__/feed_start.spec.ts
@@ -106,7 +106,7 @@ test('dump at a suspension, then loadSnapshot and resume', async (t) => {
   }
 })
 
-test('loadSnapshot of an idle dump returns null', async (t) => {
+test('load restores an idle session', async (t) => {
   let blob: Buffer
   {
     const session = await pool().checkout()
@@ -116,20 +116,54 @@ test('loadSnapshot of an idle dump returns null', async (t) => {
   }
   const session = await pool().checkout()
   try {
-    t.is(await session.loadSnapshot(blob), null)
+    await session.load(blob)
     t.is(await session.feedRun('kept + 1'), 8)
   } finally {
     await session.close()
   }
 })
 
-test('loadSnapshot after a feed is rejected', async (t) => {
+test('load and loadSnapshot reject the wrong dump kind', async (t) => {
+  let idle: Buffer
+  let suspended: Buffer
+  {
+    const session = await pool().checkout()
+    idle = await session.dump()
+    await session.close()
+  }
+  {
+    const session = await pool().checkout()
+    await session.feedStart('f()')
+    suspended = await session.dump()
+    await session.close()
+  }
+  {
+    const session = await pool().checkout()
+    await t.throwsAsync(() => session.loadSnapshot(idle), {
+      message: 'this dump is an idle session — use load() to restore it',
+    })
+    // the failed load poisons the session — it is not retryable
+    await t.throwsAsync(() => session.feedRun('1 + 1'))
+    await session.close()
+  }
+  {
+    const session = await pool().checkout()
+    await t.throwsAsync(() => session.load(suspended), {
+      message: 'this dump is a suspended snapshot — use loadSnapshot() to resume it',
+    })
+    await t.throwsAsync(() => session.feedRun('1 + 1'))
+    await session.close()
+  }
+})
+
+test('load after a feed is rejected', async (t) => {
   const session = await pool().checkout()
   try {
     const blob = await session.dump()
     await session.feedRun('x = 1')
     await t.throwsAsync(() => session.loadSnapshot(blob), {
-      message: 'loadSnapshot is only valid on a fresh session, before any feedRun / feedStart / loadSnapshot',
+      message:
+        'load / loadSnapshot is only valid on a fresh session, before any feedRun / feedStart / load / loadSnapshot',
     })
   } finally {
     await session.close()
@@ -159,10 +193,11 @@ test('mounts are re-supplied to loadSnapshot and validated', async (t) => {
     await session.close()
   }
 
-  // omitted: validation rejects the load
+  // omitted: validation rejects the load and poisons the session
   {
     const session = await pool().checkout()
     await t.throwsAsync(() => session.loadSnapshot(blob), { instanceOf: MontyRuntimeError })
+    await t.throwsAsync(() => session.feedRun('1 + 1'))
     await session.close()
   }
 })

--- a/crates/monty-js/__test__/feed_start.spec.ts
+++ b/crates/monty-js/__test__/feed_start.spec.ts
@@ -1,0 +1,168 @@
+import test from 'ava'
+
+import {
+  FunctionSnapshot,
+  FutureSnapshot,
+  MontyComplete,
+  NameLookupSnapshot,
+  MontyRuntimeError,
+  MountDir,
+} from '../ts/index.js'
+import { setupPool } from './helpers.js'
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const { pool } = setupPool(test)
+
+test('feedStart suspends at a function call, then completes', async (t) => {
+  const session = await pool().checkout()
+  try {
+    const snap = await session.feedStart('x = add(2, 3)\nx * 10')
+    t.true(snap instanceof FunctionSnapshot)
+    const call = snap as FunctionSnapshot
+    t.is(call.functionName, 'add')
+    t.deepEqual(call.args, [2, 3])
+    t.false(call.isOsFunction)
+    const done = await call.resume(5)
+    t.true(done instanceof MontyComplete)
+    t.is((done as MontyComplete).output, 50)
+  } finally {
+    await session.close()
+  }
+})
+
+test('feedStart surfaces a name lookup', async (t) => {
+  const session = await pool().checkout()
+  try {
+    const snap = await session.feedStart('missing + 1')
+    t.true(snap instanceof NameLookupSnapshot)
+    t.is((snap as NameLookupSnapshot).variableName, 'missing')
+  } finally {
+    await session.close()
+  }
+})
+
+test('a snapshot resumes at most once', async (t) => {
+  const session = await pool().checkout()
+  try {
+    const snap = (await session.feedStart('f()')) as FunctionSnapshot
+    await snap.resume(1)
+    t.throws(() => snap.resume(2), { message: 'snapshot has already been resumed' })
+  } finally {
+    await session.close()
+  }
+})
+
+test('os handler is auto-dispatched between snapshots', async (t) => {
+  const session = await pool().checkout()
+  try {
+    const snap = await session.feedStart("from pathlib import Path\nPath('/data/x').read_text()", {
+      os: (name) => {
+        t.is(name, 'Path.read_text')
+        return 'file body'
+      },
+    })
+    t.true(snap instanceof MontyComplete)
+    t.is((snap as MontyComplete).output, 'file body')
+  } finally {
+    await session.close()
+  }
+})
+
+test('the sandbox future mechanism is caller-driven', async (t) => {
+  const session = await pool().checkout()
+  try {
+    const code = 'import asyncio\nasync def main():\n    return await go()\nasyncio.run(main())'
+    const call = (await session.feedStart(code)) as FunctionSnapshot
+    t.is(call.functionName, 'go')
+    const futures = (await call.resumeFuture()) as FutureSnapshot
+    t.true(futures instanceof FutureSnapshot)
+    t.deepEqual(futures.pendingCallIds, [call.callId])
+    const done = (await futures.resume([{ callId: call.callId, value: 99 }])) as MontyComplete
+    t.true(done instanceof MontyComplete)
+    t.is(done.output, 99)
+  } finally {
+    await session.close()
+  }
+})
+
+test('dump at a suspension, then loadSnapshot and resume', async (t) => {
+  let blob: Buffer
+  {
+    const session = await pool().checkout()
+    const snap = (await session.feedStart('y = fetch()\ny + 1')) as FunctionSnapshot
+    blob = await snap.dump()
+    await session.close()
+  }
+  const session = await pool().checkout()
+  try {
+    const snap = await session.loadSnapshot(blob)
+    t.true(snap instanceof FunctionSnapshot)
+    const done = (await (snap as FunctionSnapshot).resume(41)) as MontyComplete
+    t.is(done.output, 42)
+  } finally {
+    await session.close()
+  }
+})
+
+test('loadSnapshot of an idle dump returns null', async (t) => {
+  let blob: Buffer
+  {
+    const session = await pool().checkout()
+    await session.feedRun('kept = 7')
+    blob = await session.dump()
+    await session.close()
+  }
+  const session = await pool().checkout()
+  try {
+    t.is(await session.loadSnapshot(blob), null)
+    t.is(await session.feedRun('kept + 1'), 8)
+  } finally {
+    await session.close()
+  }
+})
+
+test('loadSnapshot after a feed is rejected', async (t) => {
+  const session = await pool().checkout()
+  try {
+    const blob = await session.dump()
+    await session.feedRun('x = 1')
+    await t.throwsAsync(() => session.loadSnapshot(blob), {
+      message: 'loadSnapshot is only valid on a fresh session, before any feedRun / feedStart / loadSnapshot',
+    })
+  } finally {
+    await session.close()
+  }
+})
+
+test('mounts are re-supplied to loadSnapshot and validated', async (t) => {
+  const dir = await mkdtemp(join(tmpdir(), 'monty-js-snap-'))
+  await writeFile(join(dir, 'hello.txt'), 'hi')
+  const mount = new MountDir('/data', dir, { mode: 'read-only' })
+  const code = "f()\nfrom pathlib import Path\nPath('/data/hello.txt').read_text()"
+
+  let blob: Buffer
+  {
+    const session = await pool().checkout()
+    const snap = (await session.feedStart(code, { mount })) as FunctionSnapshot
+    blob = await snap.dump()
+    await session.close()
+  }
+
+  // re-supplied: the mounted read is served and execution completes
+  {
+    const session = await pool().checkout()
+    const snap = (await session.loadSnapshot(blob, { mount })) as FunctionSnapshot
+    const done = (await snap.resume(null)) as MontyComplete
+    t.is(done.output, 'hi')
+    await session.close()
+  }
+
+  // omitted: validation rejects the load
+  {
+    const session = await pool().checkout()
+    await t.throwsAsync(() => session.loadSnapshot(blob), { instanceOf: MontyRuntimeError })
+    await session.close()
+  }
+})

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -372,6 +372,32 @@ impl NativeSession {
         })
     }
 
+    /// Restores a dump into this session's worker in place of starting it
+    /// fresh, replacing the worker's (non-suspended) session. Resolves to a
+    /// turn object: a suspension when the dump was mid-feed, or `loaded` for an
+    /// idle dump. The TypeScript layer enforces "fresh session only".
+    #[napi]
+    pub fn load<'env>(
+        &self,
+        env: &'env Env,
+        state: Buffer,
+        mounts: Vec<NativeMount>,
+        on_print: PrintCallback<'env>,
+    ) -> Result<PromiseRaw<'env, Object<'env>>> {
+        let mounts = mounts
+            .into_iter()
+            .map(MountSpec::try_from)
+            .collect::<Result<Vec<_>>>()?;
+        let state = state.to_vec();
+        self.run_outcome(env, on_print, move |checkout, on_print| {
+            match checkout.load_snapshot(state, mounts, on_print) {
+                Ok(Some(event)) => TurnOutcome::Event(event),
+                Ok(None) => TurnOutcome::LoadedIdle,
+                Err(err) => TurnOutcome::from(Err(err)),
+            }
+        })
+    }
+
     /// Serializes the worker's session state (idle or suspended) into opaque
     /// bytes via monty's dump format. The session stays usable.
     #[napi]
@@ -431,6 +457,22 @@ impl NativeSession {
         on_print: PrintCallback<'env>,
         turn: impl FnOnce(&mut Checkout, OnPrint<'_>) -> StdResult<TurnEvent, PoolError> + Send + 'static,
     ) -> Result<PromiseRaw<'env, Object<'env>>> {
+        self.run_outcome(env, on_print, move |checkout, on_print| {
+            TurnOutcome::from(turn(checkout, on_print))
+        })
+    }
+
+    /// The shared turn machinery behind [`run_turn`](Self::run_turn): locks the
+    /// checkout off the event loop, streams prints, and resolves the computed
+    /// [`TurnOutcome`] to a JS turn object. `compute` returns the outcome
+    /// directly so the `load` turn (which yields `Option<TurnEvent>`) can map
+    /// its idle case to [`TurnOutcome::LoadedIdle`].
+    fn run_outcome<'env>(
+        &self,
+        env: &'env Env,
+        on_print: PrintCallback<'env>,
+        compute: impl FnOnce(&mut Checkout, OnPrint<'_>) -> TurnOutcome + Send + 'static,
+    ) -> Result<PromiseRaw<'env, Object<'env>>> {
         let tsfn = on_print.build_threadsafe_function().build()?;
         let slot = Arc::clone(&self.checkout);
         let pending_not_handled = Arc::clone(&self.pending_not_handled);
@@ -454,7 +496,7 @@ impl NativeSession {
                         };
                         let _ = block_on(tsfn.call_async(FnArgs::from((stream.to_owned(), text.to_owned()))));
                     };
-                    let outcome = TurnOutcome::from(turn(checkout, &mut on_print));
+                    let outcome = compute(checkout, &mut on_print);
                     if let TurnOutcome::Event(TurnEvent::OsCall { not_handled_error, .. }) = &outcome {
                         lock(&pending_not_handled).clone_from(not_handled_error);
                     }
@@ -485,6 +527,9 @@ enum TurnOutcome {
     },
     /// The worker (or caller) violated the protocol; the session is lost.
     Protocol(String),
+    /// A `load` restored an idle (between-feeds) session — there is no
+    /// suspension to resume. Only produced by [`NativeSession::load`].
+    LoadedIdle,
 }
 
 impl From<StdResult<TurnEvent, PoolError>> for TurnOutcome {
@@ -580,6 +625,9 @@ fn turn_to_js(env: &Env, outcome: TurnOutcome) -> Result<Object<'_>> {
         TurnOutcome::Protocol(message) => {
             obj.set("kind", "protocol")?;
             obj.set("message", message)?;
+        }
+        TurnOutcome::LoadedIdle => {
+            obj.set("kind", "loaded")?;
         }
     }
     Ok(obj)

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -372,12 +372,12 @@ impl NativeSession {
         })
     }
 
-    /// Restores a dump into this session's worker in place of starting it
-    /// fresh, replacing the worker's (non-suspended) session. Resolves to a
-    /// turn object: a suspension when the dump was mid-feed, or `loaded` for an
-    /// idle dump. The TypeScript layer enforces "fresh session only".
+    /// Restores a dump into this session's freshly configured worker. Resolves
+    /// to a turn object: a suspension when the dump was mid-feed, or `loaded`
+    /// for an idle dump. The TypeScript `load` / `loadSnapshot` split inspects
+    /// the kind and enforces "fresh session only".
     #[napi]
-    pub fn load<'env>(
+    pub fn restore<'env>(
         &self,
         env: &'env Env,
         state: Buffer,
@@ -390,7 +390,7 @@ impl NativeSession {
             .collect::<Result<Vec<_>>>()?;
         let state = state.to_vec();
         self.run_outcome(env, on_print, move |checkout, on_print| {
-            match checkout.load_snapshot(state, mounts, on_print) {
+            match checkout.restore(state, mounts, on_print) {
                 Ok(Some(event)) => TurnOutcome::Event(event),
                 Ok(None) => TurnOutcome::LoadedIdle,
                 Err(err) => TurnOutcome::from(Err(err)),

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -390,9 +390,10 @@ impl NativeSession {
             .collect::<Result<Vec<_>>>()?;
         let state = state.to_vec();
         self.run_outcome(env, on_print, move |checkout, on_print| {
+            // JS snapshots expose no script name, so the restored name is unused
             match checkout.restore(state, mounts, on_print) {
-                Ok(Some(event)) => TurnOutcome::Event(event),
-                Ok(None) => TurnOutcome::LoadedIdle,
+                Ok((Some(event), _)) => TurnOutcome::Event(event),
+                Ok((None, _)) => TurnOutcome::LoadedIdle,
                 Err(err) => TurnOutcome::from(Err(err)),
             }
         })

--- a/crates/monty-js/ts/index.ts
+++ b/crates/monty-js/ts/index.ts
@@ -10,12 +10,20 @@
 
 export { Monty, type CheckoutOptions, type MontyOptions, type ResourceLimits } from './pool.js'
 export {
+  FunctionSnapshot,
+  FutureSnapshot,
+  MontyComplete,
   MontySession,
+  NameLookupSnapshot,
   NOT_HANDLED,
   type ExternalFunction,
   type FeedOptions,
+  type FeedStartOptions,
+  type FutureResolution,
+  type LoadSnapshotOptions,
   type OsCallback,
   type PrintCallback,
+  type Snapshot,
 } from './session.js'
 export { MountDir, type MountDirMode, type MountDirOptions } from './mount.js'
 export {

--- a/crates/monty-js/ts/native.ts
+++ b/crates/monty-js/ts/native.ts
@@ -102,6 +102,12 @@ export interface ProtocolTurn {
   message: string
 }
 
+/** A `load` restored an idle (between-feeds) session — no suspension to
+ *  resume. Only produced by `NativeSession.load`. */
+export interface LoadedTurn {
+  kind: 'loaded'
+}
+
 /** Everything one protocol turn can resolve to. */
 export type NativeTurn =
   | CompleteTurn

--- a/crates/monty-js/ts/session.ts
+++ b/crates/monty-js/ts/session.ts
@@ -193,30 +193,86 @@ export class MontySession {
   }
 
   /**
-   * Restores a dump (from `session.dump()` / `snapshot.dump()`) into this
-   * session instead of starting it fresh, resolving to the re-announced
-   * snapshot to resume — or `null` when the dump was taken between feeds.
+   * Restores a dumped **idle** session — bytes from `session.dump()` taken
+   * between feeds — so you can keep feeding it. Use [`loadSnapshot`] for a dump
+   * taken mid-execution.
    *
-   * Valid only on a fresh session, before any `feedRun` / `feedStart` /
-   * `loadSnapshot` (it replaces the whole session); throws otherwise. The dump
-   * restores its own resource limits and type-check state. Re-supply the same
-   * `mount`s the paused feed used (their host paths are not in the dump);
-   * a missing, extra, or altered mount throws.
+   * Valid only on a fresh session, before any feed or load (it replaces the
+   * whole session); throws otherwise. The dump restores its own resource limits
+   * and type-check state. Throws if the dump is actually a suspended snapshot.
    */
-  async loadSnapshot(state: Uint8Array, options: LoadSnapshotOptions = {}): Promise<Snapshot | null> {
-    this.ensureUsable()
-    if (this.driven) {
-      throw new Error('loadSnapshot is only valid on a fresh session, before any feedRun / feedStart / loadSnapshot')
+  async load(state: Uint8Array): Promise<void> {
+    this.claimFresh()
+    const printTarget = new PrintTarget(undefined)
+    const turn = (await this.native.restore(Buffer.from(state), [], printTarget.write.bind(printTarget))) as
+      | NativeTurn
+      | LoadedTurn
+    switch (turn.kind) {
+      case 'loaded':
+        return
+      case 'crashed':
+        throw await this.failedLoad(new MontyCrashedError(turn.message, turn))
+      case 'protocol':
+        throw await this.failedLoad(new ProtocolError(turn.message))
+      case 'error':
+        throw await this.failedLoad(montyErrorFromNative(turn.exception))
+      default:
+        throw await this.failedLoad(new Error('this dump is a suspended snapshot — use loadSnapshot() to resume it'))
     }
-    this.driven = true
+  }
+
+  /**
+   * Restores a dumped **suspended** snapshot — bytes from `feedStart` +
+   * `snapshot.dump()` — and resolves to the snapshot to resume. Use [`load`]
+   * for a dump taken between feeds.
+   *
+   * Valid only on a fresh session, before any feed or load; throws otherwise.
+   * Re-supply the same `mount`s the paused feed used (their host paths are not
+   * in the dump); a missing, extra, or altered mount throws. Throws if the dump
+   * is actually an idle session.
+   */
+  async loadSnapshot(state: Uint8Array, options: LoadSnapshotOptions = {}): Promise<Snapshot> {
+    this.claimFresh()
     const driver = this.newDriver(options)
-    const turn = (await this.native.load(Buffer.from(state), mountsToNative(options.mount), driver.onPrint)) as
+    const turn = (await this.native.restore(Buffer.from(state), mountsToNative(options.mount), driver.onPrint)) as
       | NativeTurn
       | LoadedTurn
     if (turn.kind === 'loaded') {
-      return null
+      throw await this.failedLoad(new Error('this dump is an idle session — use load() to restore it'))
     }
-    return driver.advance(turn)
+    try {
+      return await driver.advance(turn)
+    } catch (err) {
+      // any failure restoring the snapshot (bad mount, crash, protocol desync)
+      // leaves the session unusable — poison it and release the worker
+      throw await this.failedLoad(err instanceof Error ? err : new Error(String(err)))
+    }
+  }
+
+  /** Claims a fresh session for a load (rejecting a reused one). */
+  private claimFresh(): void {
+    this.ensureUsable()
+    if (this.driven) {
+      throw new Error(
+        'load / loadSnapshot is only valid on a fresh session, before any feedRun / feedStart / load / loadSnapshot',
+      )
+    }
+    this.driven = true
+  }
+
+  /**
+   * Poisons the session and releases its worker after a failed load, so any
+   * later op fails like a crashed session — a failed load is not retryable.
+   * Returns the error to throw.
+   */
+  private async failedLoad(err: Error): Promise<Error> {
+    this.poison(err)
+    try {
+      await this.native.finish()
+    } catch {
+      // the worker was already discarded (e.g. it crashed) — nothing to release
+    }
+    return err
   }
 
   /** Builds the per-feed snapshot driver (print target, os handler, poison). */

--- a/crates/monty-js/ts/session.ts
+++ b/crates/monty-js/ts/session.ts
@@ -13,7 +13,15 @@ import type { NativeSession } from '../index.js'
 import { MontyCrashedError, MontyError, montyErrorFromNative, MontyTypingError, ProtocolError } from './errors.js'
 import { PYTHON_EXC_NAMES } from './errors.js'
 import { mountsToNative, type MountDir } from './mount.js'
-import type { FunctionCallTurn, NativeFutureResult, NativeTurn, OsCallTurn, ResolveFuturesTurn } from './native.js'
+import type {
+  FunctionCallTurn,
+  LoadedTurn,
+  NameLookupTurn,
+  NativeFutureResult,
+  NativeTurn,
+  OsCallTurn,
+  ResolveFuturesTurn,
+} from './native.js'
 
 /**
  * Sentinel an `os` callback returns to decline a call: the sandbox then
@@ -50,6 +58,42 @@ export interface FeedOptions {
   skipTypeCheck?: boolean
 }
 
+/**
+ * Options for [`MontySession.feedStart`]. Like [`FeedOptions`] without
+ * `externalFunctions` — `feedStart` surfaces external calls as snapshots
+ * instead of dispatching them.
+ */
+export interface FeedStartOptions {
+  /** Values bound as globals before the snippet runs. */
+  inputs?: Record<string, unknown>
+  /** Receives `print()` output; defaults to the host process stdout/stderr. */
+  printCallback?: PrintCallback
+  /** Host directories mounted into the sandbox for this feed. */
+  mount?: MountDir | MountDir[]
+  /** Handler for OS calls not covered by mounts; auto-dispatched between
+   *  snapshots. Omit to surface OS calls as snapshots instead. */
+  os?: OsCallback
+  /** Skip type checking for this feed even when the session enables it. */
+  skipTypeCheck?: boolean
+}
+
+/** Options for [`MontySession.loadSnapshot`]. */
+export interface LoadSnapshotOptions {
+  /** Receives `print()` output from the resumed feed. */
+  printCallback?: PrintCallback
+  /** The mounts the paused feed used (re-established by value; host paths are
+   *  not stored in the dump). Validated against the dump's requirements. */
+  mount?: MountDir | MountDir[]
+  /** Handler for OS calls, auto-dispatched as in `feedStart`. */
+  os?: OsCallback
+}
+
+/** What [`MontySession.feedStart`] / `resume` / `loadSnapshot` yield. */
+export type Snapshot = FunctionSnapshot | NameLookupSnapshot | FutureSnapshot | MontyComplete
+
+/** A settled future outcome passed to [`FutureSnapshot.resume`]. */
+export type FutureResolution = { callId: number; value: unknown } | { callId: number; error: unknown }
+
 /** A promise-returning external call registered as a sandbox future. */
 interface PendingFuture {
   readonly callId: number
@@ -70,6 +114,9 @@ export class MontySession {
   /** Set once the session is unusable: crashed worker or protocol error. */
   private broken: Error | null = null
   private closed = false
+  /** Set once the session has been fed or restored; `loadSnapshot` is valid
+   *  only while unset (a fresh session). */
+  private driven = false
   /** Pending async external calls, by call id. */
   private readonly futures = new Map<number, PendingFuture>()
 
@@ -85,6 +132,7 @@ export class MontySession {
    */
   async feedRun(code: string, options: FeedOptions = {}): Promise<unknown> {
     this.ensureUsable()
+    this.driven = true
     const printTarget = new PrintTarget(options.printCallback)
     const onPrint = printTarget.write.bind(printTarget)
     try {
@@ -118,6 +166,63 @@ export class MontySession {
       // promises the worker will never ask about again accumulate
       this.futures.clear()
     }
+  }
+
+  /**
+   * Starts a snippet but, instead of driving it to completion, returns a
+   * snapshot at each external call, OS call, name lookup, or future
+   * resolution. Answer it with `snapshot.resume(...)`, which resolves to the
+   * next snapshot or a `MontyComplete`. Unlike `feedRun` there is no
+   * `externalFunctions` option — surfacing those calls is the point — but an
+   * `os` handler still auto-dispatches uncovered OS calls until the next
+   * non-OS event. Use `snapshot.dump()` to checkpoint the worker and
+   * `loadSnapshot` to restore it.
+   */
+  async feedStart(code: string, options: FeedStartOptions = {}): Promise<Snapshot> {
+    this.ensureUsable()
+    this.driven = true
+    const driver = this.newDriver(options)
+    const turn = (await this.native.feed(
+      code,
+      options.inputs ?? null,
+      mountsToNative(options.mount),
+      options.skipTypeCheck ?? false,
+      driver.onPrint,
+    )) as NativeTurn
+    return driver.advance(turn)
+  }
+
+  /**
+   * Restores a dump (from `session.dump()` / `snapshot.dump()`) into this
+   * session instead of starting it fresh, resolving to the re-announced
+   * snapshot to resume — or `null` when the dump was taken between feeds.
+   *
+   * Valid only on a fresh session, before any `feedRun` / `feedStart` /
+   * `loadSnapshot` (it replaces the whole session); throws otherwise. The dump
+   * restores its own resource limits and type-check state. Re-supply the same
+   * `mount`s the paused feed used (their host paths are not in the dump);
+   * a missing, extra, or altered mount throws.
+   */
+  async loadSnapshot(state: Uint8Array, options: LoadSnapshotOptions = {}): Promise<Snapshot | null> {
+    this.ensureUsable()
+    if (this.driven) {
+      throw new Error('loadSnapshot is only valid on a fresh session, before any feedRun / feedStart / loadSnapshot')
+    }
+    this.driven = true
+    const driver = this.newDriver(options)
+    const turn = (await this.native.load(Buffer.from(state), mountsToNative(options.mount), driver.onPrint)) as
+      | NativeTurn
+      | LoadedTurn
+    if (turn.kind === 'loaded') {
+      return null
+    }
+    return driver.advance(turn)
+  }
+
+  /** Builds the per-feed snapshot driver (print target, os handler, poison). */
+  private newDriver(options: FeedStartOptions): SnapshotDriver {
+    const printTarget = new PrintTarget(options.printCallback)
+    return new SnapshotDriver(this.native, printTarget, options.os, (err) => this.poison(err))
   }
 
   /**
@@ -342,6 +447,258 @@ class PrintTarget {
       throw this.failure
     }
   }
+}
+
+/**
+ * Drives a `feedStart` / `loadSnapshot` chain: runs each protocol turn,
+ * auto-dispatches OS calls through the `os` handler (until a non-OS event),
+ * and turns the result into the next [`Snapshot`]. One driver is shared across
+ * a snapshot and every snapshot its `resume` produces, so they all answer the
+ * same worker with the same print sink.
+ */
+class SnapshotDriver {
+  /** Exposed so the session's first turn can stream prints through it. */
+  readonly onPrint: PrintCallback
+
+  constructor(
+    private readonly native: NativeSession,
+    private readonly printTarget: PrintTarget,
+    private readonly os: OsCallback | undefined,
+    private readonly poison: (err: Error) => Error,
+  ) {
+    this.onPrint = printTarget.write.bind(printTarget)
+  }
+
+  /** Resolves a turn (after auto-dispatching OS calls) to the next snapshot. */
+  async advance(turn: NativeTurn): Promise<Snapshot> {
+    for (;;) {
+      switch (turn.kind) {
+        case 'complete':
+          this.printTarget.throwIfFailed()
+          return new MontyComplete(turn.value)
+        case 'error':
+          this.printTarget.throwIfFailed()
+          throw montyErrorFromNative(turn.exception)
+        case 'typingError':
+          this.printTarget.throwIfFailed()
+          throw new MontyTypingError(turn.diagnostics)
+        case 'crashed':
+          throw this.poison(new MontyCrashedError(turn.message, turn))
+        case 'protocol':
+          throw this.poison(new ProtocolError(turn.message))
+        case 'osCall':
+          if (this.os === undefined) {
+            return new FunctionSnapshot(this, turn, true)
+          }
+          turn = await this.dispatchOs(turn)
+          continue
+        case 'functionCall':
+          return new FunctionSnapshot(this, turn, false)
+        case 'nameLookup':
+          return new NameLookupSnapshot(this, turn)
+        case 'resolveFutures':
+          return new FutureSnapshot(this, turn)
+        default:
+          throw this.poison(new ProtocolError(`unexpected turn kind: ${(turn as { kind: string }).kind}`))
+      }
+    }
+  }
+
+  /** Handles one OS call via the `os` callback (defined here), then resumes. */
+  private async dispatchOs(call: OsCallTurn): Promise<NativeTurn> {
+    let returned: unknown
+    try {
+      returned = this.os!(call.functionName, call.args, kwargsToRecord(call.kwargs))
+      if (isThenable(returned)) {
+        returned = await returned
+      }
+    } catch (err) {
+      const { excType, message } = jsErrorParts(err)
+      return (await this.native.resumeError(excType, message, this.onPrint)) as NativeTurn
+    }
+    if (returned === NOT_HANDLED) {
+      return (await this.native.resumeNotHandled(this.onPrint)) as NativeTurn
+    }
+    return (await this.native.resumeReturn(returned, this.onPrint)) as NativeTurn
+  }
+
+  // resume primitives — each runs one turn, then advances to the next snapshot
+
+  async resumeReturn(value: unknown): Promise<Snapshot> {
+    return this.advance((await this.native.resumeReturn(value, this.onPrint)) as NativeTurn)
+  }
+
+  async resumeError(err: unknown): Promise<Snapshot> {
+    const { excType, message } = jsErrorParts(err)
+    return this.advance((await this.native.resumeError(excType, message, this.onPrint)) as NativeTurn)
+  }
+
+  async resumeNotFound(): Promise<Snapshot> {
+    return this.advance((await this.native.resumeNotFound(this.onPrint)) as NativeTurn)
+  }
+
+  async resumeNotHandled(): Promise<Snapshot> {
+    return this.advance((await this.native.resumeNotHandled(this.onPrint)) as NativeTurn)
+  }
+
+  async resumeFuture(): Promise<Snapshot> {
+    return this.advance((await this.native.resumeFuture(this.onPrint)) as NativeTurn)
+  }
+
+  async resumeNameLookup(functionName: string | null): Promise<Snapshot> {
+    return this.advance((await this.native.resumeNameLookup(functionName, this.onPrint)) as NativeTurn)
+  }
+
+  async resolveFutures(results: NativeFutureResult[]): Promise<Snapshot> {
+    return this.advance((await this.native.resolveFutures(results, this.onPrint)) as NativeTurn)
+  }
+
+  async dump(): Promise<Buffer> {
+    return Buffer.from(await this.native.dump())
+  }
+}
+
+/** Marks a snapshot single-use: each may be resumed at most once. */
+class SingleUse {
+  private used = false
+  protected claim(): void {
+    if (this.used) {
+      throw new Error('snapshot has already been resumed')
+    }
+    this.used = true
+  }
+}
+
+/**
+ * A paused execution waiting for an external function or OS call result. For
+ * OS calls `isOsFunction` is `true`; resume with a value, an error, or
+ * `resumeNotHandled()`.
+ */
+export class FunctionSnapshot extends SingleUse {
+  readonly functionName: string
+  /** Positional arguments, already converted to JS values. */
+  readonly args: unknown[]
+  /** Keyword arguments (null-prototype record; string keys only). */
+  readonly kwargs: Record<string, unknown>
+  readonly callId: number
+  readonly isOsFunction: boolean
+  readonly isMethodCall: boolean
+
+  /** @internal */
+  constructor(
+    private readonly driver: SnapshotDriver,
+    turn: FunctionCallTurn | OsCallTurn,
+    isOsFunction: boolean,
+  ) {
+    super()
+    this.functionName = turn.functionName
+    this.args = turn.args
+    this.kwargs = kwargsToRecord(turn.kwargs)
+    this.callId = turn.callId
+    this.isOsFunction = isOsFunction
+    this.isMethodCall = 'methodCall' in turn ? turn.methodCall : false
+  }
+
+  /** Resumes with the call's return value. */
+  resume(value: unknown): Promise<Snapshot> {
+    this.claim()
+    return this.driver.resumeReturn(value)
+  }
+
+  /** Resumes by raising the given error inside the sandbox. */
+  resumeError(error: unknown): Promise<Snapshot> {
+    this.claim()
+    return this.driver.resumeError(error)
+  }
+
+  /** Resumes as "no such function": the sandbox raises `NameError`. */
+  resumeNotFound(): Promise<Snapshot> {
+    this.claim()
+    return this.driver.resumeNotFound()
+  }
+
+  /** Registers the call as a pending future; other sandbox tasks keep
+   *  running and surface later as a [`FutureSnapshot`]. */
+  resumeFuture(): Promise<Snapshot> {
+    this.claim()
+    return this.driver.resumeFuture()
+  }
+
+  /** Resumes an OS call with monty's default unhandled behaviour. */
+  resumeNotHandled(): Promise<Snapshot> {
+    if (!this.isOsFunction) {
+      throw new Error('resumeNotHandled is only valid for OS-call snapshots')
+    }
+    this.claim()
+    return this.driver.resumeNotHandled()
+  }
+
+  /** Serializes the paused worker; restore with `session.loadSnapshot`. */
+  dump(): Promise<Buffer> {
+    return this.driver.dump()
+  }
+}
+
+/** A paused execution waiting for the value of an undefined name. */
+export class NameLookupSnapshot extends SingleUse {
+  readonly variableName: string
+
+  /** @internal */
+  constructor(
+    private readonly driver: SnapshotDriver,
+    turn: NameLookupTurn,
+  ) {
+    super()
+    this.variableName = turn.name
+  }
+
+  /** Resolves the name to an external function by name, or — with no argument
+   *  — lets the sandbox raise `NameError`. */
+  resume(functionName?: string): Promise<Snapshot> {
+    this.claim()
+    return this.driver.resumeNameLookup(functionName ?? null)
+  }
+
+  dump(): Promise<Buffer> {
+    return this.driver.dump()
+  }
+}
+
+/** A paused execution where every sandbox task is blocked on external futures. */
+export class FutureSnapshot extends SingleUse {
+  readonly pendingCallIds: number[]
+
+  /** @internal */
+  constructor(
+    private readonly driver: SnapshotDriver,
+    turn: ResolveFuturesTurn,
+  ) {
+    super()
+    this.pendingCallIds = turn.pendingCallIds
+  }
+
+  /** Delivers settled outcomes for one or more pending futures, by call id. */
+  resume(results: FutureResolution[]): Promise<Snapshot> {
+    this.claim()
+    const native: NativeFutureResult[] = results.map((result) => {
+      if ('error' in result) {
+        const { excType, message } = jsErrorParts(result.error)
+        return { callId: result.callId, ok: false, excType, message }
+      }
+      return { callId: result.callId, ok: true, value: result.value }
+    })
+    return this.driver.resolveFutures(native)
+  }
+
+  dump(): Promise<Buffer> {
+    return this.driver.dump()
+  }
+}
+
+/** The result of a completed `feedStart` execution. */
+export class MontyComplete {
+  /** @internal */
+  constructor(readonly output: unknown) {}
 }
 
 /** Positional args, with kwargs appended as an object when present. */

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -127,9 +127,9 @@ pub struct Checkout {
     /// The suspension awaiting an answer, when mid-feed.
     pending: Option<Pending>,
     /// The session's `max_duration` budget for the parent-side backstop, when
-    /// configured. Set from the config on `create`; for `checkout_load`
-    /// restores it is adopted from the timing fields on the worker's first
-    /// reply (the limits travel inside the opaque dump).
+    /// configured. Set from the config on `create`; for `restore`d sessions it
+    /// is adopted from the timing fields on the worker's first reply (the limits
+    /// travel inside the opaque dump).
     duration_budget: Option<Duration>,
     /// Cumulative sandbox execution time as last reported by the worker —
     /// the child's clock is the single source of truth (it runs only while
@@ -140,6 +140,11 @@ pub struct Checkout {
     /// The deadline armed for the most recent turn, surfaced by
     /// [`PoolError::Timeout`] when the watchdog fires.
     armed_deadline: Option<Duration>,
+    /// The script name a `restore` adopted, captured from the worker's `Load`
+    /// reply (the name travels inside the opaque dump, so the parent learns it
+    /// only by the worker echoing it). Reset at the start of each `restore` and
+    /// taken by `restore` to return; unset for non-restore turns.
+    restored_script_name: Option<String>,
 }
 
 /// Which kind of suspension is awaiting an answer.
@@ -165,6 +170,7 @@ impl Checkout {
             duration_budget: repl.limits.as_ref().and_then(|limits| limits.max_duration),
             reported_execution: Duration::ZERO,
             armed_deadline: None,
+            restored_script_name: None,
         };
         let request = pb::ParentRequest {
             kind: Some(pb::parent_request::Kind::Configure(pb::Configure {
@@ -195,30 +201,36 @@ impl Checkout {
     /// empty `Vec` for an idle dump. The session's resource budget is taken
     /// from the dump, so the prior `Configure` limits are dropped here and
     /// re-adopted from the worker's reply.
+    ///
+    /// Returns the re-announced suspension (`Some` — a suspended dump) or `None`
+    /// (an idle dump), paired with the worker's adopted script name (the dump's,
+    /// not the `Configure` one), which the parent surfaces in restored snapshots.
     pub fn restore(
         &mut self,
         state: Vec<u8>,
         mounts: Vec<MountSpec>,
         on_print: OnPrint<'_>,
-    ) -> Result<Option<TurnEvent>, PoolError> {
-        // the dump carries its own limits/consumed time — forget what the
-        // worker's Configure established and re-adopt from the reply
+    ) -> Result<(Option<TurnEvent>, Option<String>), PoolError> {
+        // the dump carries its own limits/consumed time/script name — forget
+        // what the worker's Configure established and re-adopt from the reply
         self.pending = None;
         self.duration_budget = None;
         self.reported_execution = Duration::ZERO;
+        self.restored_script_name = None;
         let request = pb::ParentRequest {
             kind: Some(pb::parent_request::Kind::Load(pb::Load {
                 state,
                 mounts: mounts.into_iter().map(mount_to_proto).collect::<Result<Vec<_>, _>>()?,
             })),
         };
-        match self.request_turn(&request, self.pool.config.request_timeout, on_print)? {
-            ControlEvent::Ok => Ok(None),
-            ControlEvent::Turn(event) => Ok(Some(event)),
+        let event = match self.request_turn(&request, self.pool.config.request_timeout, on_print)? {
+            ControlEvent::Ok => None,
+            ControlEvent::Turn(event) => Some(event),
             other @ ControlEvent::Dump(_) => {
-                Err(self.protocol_violation(&format!("unexpected reply to Load: {other:?}")))
+                return Err(self.protocol_violation(&format!("unexpected reply to Load: {other:?}")));
             }
-        }
+        };
+        Ok((event, self.restored_script_name.take()))
     }
 
     /// Executes one snippet against the session. Inputs become sandbox
@@ -478,6 +490,11 @@ impl Checkout {
             // Print events carry no timing (the fields are zero), so this is
             // a no-op for them thanks to the monotonic-max ratchet.
             self.note_reported_time(&event);
+            // Only a `Load` reply carries this; it lets `restore` report the
+            // dump's script name without parsing the opaque dump bytes.
+            if let Some(name) = &event.restored_script_name {
+                self.restored_script_name = Some(name.clone());
+            }
             match event.kind {
                 Some(pb::child_event::Kind::Print(print)) => {
                     let stream = match print.stream() {

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -180,30 +180,29 @@ impl Checkout {
         }
     }
 
-    /// Restores a dumped session into this checkout's worker, replacing its
-    /// current (non-suspended) session, and returns the re-announced suspension
-    /// event when the dump was taken mid-feed (`None` for an idle dump).
+    /// Restores a dumped session into this checkout's freshly configured (but
+    /// not-yet-fed) worker, returning the re-announced suspension event when the
+    /// dump was taken mid-feed (`None` for an idle, between-feeds dump).
     ///
-    /// Intended to initialize a freshly created checkout by loading instead of
-    /// feeding: the worker is `Ready` with an empty session, and `Load`
-    /// overwrites it (no `Reset` round-trip). It is the caller's job to only do
-    /// this on a checkout that has not been fed (a suspended worker rejects
-    /// `Load`).
+    /// This is the low-level restore both `session.load` (idle dumps) and
+    /// `session.load_snapshot` (suspended dumps) drive: the caller inspects the
+    /// returned `Option` to tell which kind of dump it was and reject a
+    /// mismatch. Only valid before the worker has been fed (the child rejects a
+    /// `Load` once a repl exists).
     ///
-    /// `mounts` re-establish the suspended feed's mounts (which are never part
-    /// of the dump). They must match the mounts the original feed used; pass an
-    /// empty `Vec` for an idle dump or to deliberately resume without mounts
-    /// (its mount-covered OS calls then bubble up). The session's resource
-    /// budget is taken from the dump, so the prior `Configure` limits are
-    /// dropped here and re-adopted from the worker's reply.
-    pub fn load_snapshot(
+    /// `mounts` re-establish a suspended feed's mounts (which are never part of
+    /// the dump). They must match the mounts the original feed used; pass an
+    /// empty `Vec` for an idle dump. The session's resource budget is taken
+    /// from the dump, so the prior `Configure` limits are dropped here and
+    /// re-adopted from the worker's reply.
+    pub fn restore(
         &mut self,
         state: Vec<u8>,
         mounts: Vec<MountSpec>,
         on_print: OnPrint<'_>,
     ) -> Result<Option<TurnEvent>, PoolError> {
         // the dump carries its own limits/consumed time — forget what the
-        // replaced session.s Configure established and re-adopt from the reply
+        // worker's Configure established and re-adopt from the reply
         self.pending = None;
         self.duration_budget = None;
         self.reported_execution = Duration::ZERO;

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -155,7 +155,8 @@ enum Pending {
 }
 
 impl Checkout {
-    /// Sends `ReplCreate` on a fresh worker.
+    /// Sends `Configure` on a fresh worker (the worker materializes the repl
+    /// lazily on the first feed, or restores one via `load_snapshot` instead).
     pub(crate) fn create(worker: Worker, pool: Arc<PoolInner>, repl: &ReplConfig) -> Result<Self, PoolError> {
         let mut this = Self {
             worker: Some(worker),
@@ -166,7 +167,7 @@ impl Checkout {
             armed_deadline: None,
         };
         let request = pb::ParentRequest {
-            kind: Some(pb::parent_request::Kind::ReplCreate(pb::ReplCreate {
+            kind: Some(pb::parent_request::Kind::Configure(pb::Configure {
                 script_name: repl.script_name.clone(),
                 limits: repl.limits.as_ref().map(Into::into),
                 type_check: repl.type_check,
@@ -175,33 +176,48 @@ impl Checkout {
         };
         match this.request_turn(&request, this.pool.config.request_timeout, &mut |_, _| {})? {
             ControlEvent::Ok => Ok(this),
-            other => Err(this.protocol_violation(&format!("unexpected reply to ReplCreate: {other:?}"))),
+            other => Err(this.protocol_violation(&format!("unexpected reply to Configure: {other:?}"))),
         }
     }
 
-    /// Restores a dumped session on a fresh worker; returns the re-announced
-    /// suspension event when the dump was taken mid-feed.
-    pub(crate) fn load(
-        worker: Worker,
-        pool: Arc<PoolInner>,
+    /// Restores a dumped session into this checkout's worker, replacing its
+    /// current (non-suspended) session, and returns the re-announced suspension
+    /// event when the dump was taken mid-feed (`None` for an idle dump).
+    ///
+    /// Intended to initialize a freshly created checkout by loading instead of
+    /// feeding: the worker is `Ready` with an empty session, and `Load`
+    /// overwrites it (no `Reset` round-trip). It is the caller's job to only do
+    /// this on a checkout that has not been fed (a suspended worker rejects
+    /// `Load`).
+    ///
+    /// `mounts` re-establish the suspended feed's mounts (which are never part
+    /// of the dump). They must match the mounts the original feed used; pass an
+    /// empty `Vec` for an idle dump or to deliberately resume without mounts
+    /// (its mount-covered OS calls then bubble up). The session's resource
+    /// budget is taken from the dump, so the prior `Configure` limits are
+    /// dropped here and re-adopted from the worker's reply.
+    pub fn load_snapshot(
+        &mut self,
         state: Vec<u8>,
-    ) -> Result<(Self, Option<TurnEvent>), PoolError> {
-        let mut this = Self {
-            worker: Some(worker),
-            pool,
-            pending: None,
-            duration_budget: None,
-            reported_execution: Duration::ZERO,
-            armed_deadline: None,
-        };
+        mounts: Vec<MountSpec>,
+        on_print: OnPrint<'_>,
+    ) -> Result<Option<TurnEvent>, PoolError> {
+        // the dump carries its own limits/consumed time — forget what the
+        // replaced session.s Configure established and re-adopt from the reply
+        self.pending = None;
+        self.duration_budget = None;
+        self.reported_execution = Duration::ZERO;
         let request = pb::ParentRequest {
-            kind: Some(pb::parent_request::Kind::Load(pb::Load { state })),
+            kind: Some(pb::parent_request::Kind::Load(pb::Load {
+                state,
+                mounts: mounts.into_iter().map(mount_to_proto).collect::<Result<Vec<_>, _>>()?,
+            })),
         };
-        match this.request_turn(&request, this.pool.config.request_timeout, &mut |_, _| {})? {
-            ControlEvent::Ok => Ok((this, None)),
-            ControlEvent::Turn(event) => Ok((this, Some(event))),
+        match self.request_turn(&request, self.pool.config.request_timeout, on_print)? {
+            ControlEvent::Ok => Ok(None),
+            ControlEvent::Turn(event) => Ok(Some(event)),
             other @ ControlEvent::Dump(_) => {
-                Err(this.protocol_violation(&format!("unexpected reply to Load: {other:?}")))
+                Err(self.protocol_violation(&format!("unexpected reply to Load: {other:?}")))
             }
         }
     }

--- a/crates/monty-pool/src/pool.rs
+++ b/crates/monty-pool/src/pool.rs
@@ -80,16 +80,6 @@ impl Pool {
         Checkout::create(worker, Arc::clone(&self.inner), repl)
     }
 
-    /// Like [`Pool::checkout`], but restores a session previously serialized
-    /// with [`Checkout::dump`] instead of creating a fresh one.
-    ///
-    /// Returns the checkout plus the re-announced suspension event when the
-    /// dump was taken mid-feed (`None` for an idle session).
-    pub fn checkout_load(&self, state: Vec<u8>) -> Result<(Checkout, Option<crate::TurnEvent>), PoolError> {
-        let worker = self.inner.acquire_worker()?;
-        Checkout::load(worker, Arc::clone(&self.inner), state)
-    }
-
     /// Number of idle workers right now (diagnostics/tests only — the value
     /// is stale the moment it is returned).
     #[must_use]

--- a/crates/monty-pool/src/worker.rs
+++ b/crates/monty-pool/src/worker.rs
@@ -38,7 +38,7 @@ impl Worker {
     ///
     /// There is no spawn-time handshake: a wrong or broken binary surfaces as
     /// an error on the first request the worker serves (typically the
-    /// `ReplCreate` of its first checkout).
+    /// `Configure` of its first checkout).
     pub(crate) fn spawn(config: &PoolConfig) -> Result<Self, PoolError> {
         let mut command = Command::new(&config.binary_path);
         command

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -532,7 +532,7 @@ fn suspension_time_does_not_consume_the_duration_budget() {
 fn loaded_session_keeps_its_duration_budget_for_the_backstop() {
     // The `max_duration` budget and consumed execution time travel inside the
     // dump, and the worker stamps them onto its replies — so a session
-    // restored via `load_snapshot` regains the parent-side backstop without
+    // restored via `restore` regains the parent-side backstop without
     // the parent ever having seen the original `ReplConfig`.
     let dir = tempfile::tempdir().unwrap();
     let status = Command::new("mkfifo").arg(dir.path().join("pipe")).status().unwrap();
@@ -551,7 +551,7 @@ fn loaded_session_keeps_its_duration_budget_for_the_backstop() {
     drop(session);
 
     let mut restored = pool.checkout(&ReplConfig::default()).unwrap();
-    let event = restored.load_snapshot(state, vec![], &mut no_print).unwrap();
+    let event = restored.restore(state, vec![], &mut no_print).unwrap();
     assert!(event.is_none(), "idle dump should restore without a suspension");
     let err = restored
         .feed(
@@ -712,7 +712,7 @@ fn dump_survives_worker_death_and_loads_elsewhere() {
 
     // restore into a fresh worker by loading over its empty session
     let mut restored = pool.checkout(&ReplConfig::default()).unwrap();
-    let event = restored.load_snapshot(state, vec![], &mut no_print).unwrap();
+    let event = restored.restore(state, vec![], &mut no_print).unwrap();
     let Some(TurnEvent::FunctionCall { ref function_name, .. }) = event else {
         panic!("expected re-announced FunctionCall, got {event:?}");
     };

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -551,7 +551,7 @@ fn loaded_session_keeps_its_duration_budget_for_the_backstop() {
     drop(session);
 
     let mut restored = pool.checkout(&ReplConfig::default()).unwrap();
-    let event = restored.restore(state, vec![], &mut no_print).unwrap();
+    let (event, _script_name) = restored.restore(state, vec![], &mut no_print).unwrap();
     assert!(event.is_none(), "idle dump should restore without a suspension");
     let err = restored
         .feed(
@@ -712,7 +712,9 @@ fn dump_survives_worker_death_and_loads_elsewhere() {
 
     // restore into a fresh worker by loading over its empty session
     let mut restored = pool.checkout(&ReplConfig::default()).unwrap();
-    let event = restored.restore(state, vec![], &mut no_print).unwrap();
+    let (event, script_name) = restored.restore(state, vec![], &mut no_print).unwrap();
+    // the worker echoes the dump's adopted script name back to the parent
+    assert_eq!(script_name.as_deref(), Some("main.py"));
     let Some(TurnEvent::FunctionCall { ref function_name, .. }) = event else {
         panic!("expected re-announced FunctionCall, got {event:?}");
     };

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -532,7 +532,7 @@ fn suspension_time_does_not_consume_the_duration_budget() {
 fn loaded_session_keeps_its_duration_budget_for_the_backstop() {
     // The `max_duration` budget and consumed execution time travel inside the
     // dump, and the worker stamps them onto its replies — so a session
-    // restored via `checkout_load` regains the parent-side backstop without
+    // restored via `load_snapshot` regains the parent-side backstop without
     // the parent ever having seen the original `ReplConfig`.
     let dir = tempfile::tempdir().unwrap();
     let status = Command::new("mkfifo").arg(dir.path().join("pipe")).status().unwrap();
@@ -550,7 +550,8 @@ fn loaded_session_keeps_its_duration_budget_for_the_backstop() {
     let state = session.dump().unwrap();
     drop(session);
 
-    let (mut restored, event) = pool.checkout_load(state).unwrap();
+    let mut restored = pool.checkout(&ReplConfig::default()).unwrap();
+    let event = restored.load_snapshot(state, vec![], &mut no_print).unwrap();
     assert!(event.is_none(), "idle dump should restore without a suspension");
     let err = restored
         .feed(
@@ -709,7 +710,9 @@ fn dump_survives_worker_death_and_loads_elsewhere() {
     let state = session.dump().unwrap();
     drop(session); // kill the original worker outright
 
-    let (mut restored, event) = pool.checkout_load(state).unwrap();
+    // restore into a fresh worker by loading over its empty session
+    let mut restored = pool.checkout(&ReplConfig::default()).unwrap();
+    let event = restored.load_snapshot(state, vec![], &mut no_print).unwrap();
     let Some(TurnEvent::FunctionCall { ref function_name, .. }) = event else {
         panic!("expected re-announced FunctionCall, got {event:?}");
     };

--- a/crates/monty-proto/proto/monty/v1/monty.proto
+++ b/crates/monty-proto/proto/monty/v1/monty.proto
@@ -362,8 +362,7 @@ message ResumeFutures {
 // be restored by a monty child of the same version via `Load`.
 message Dump {}
 
-// Restores state produced by `Dump`, replacing any current non-suspended
-// session (valid from no session or a between-feeds one, but not mid-feed). If
+// Restores state produced by `Dump`. Valid only from no session. If
 // the restored state was suspended, the child re-emits the suspension event so
 // the parent learns the resume point; otherwise it replies `Ok`.
 message Load {
@@ -372,7 +371,7 @@ message Load {
   // host configuration, not sandbox state, so they are never part of the dump
   // — the parent re-supplies the same mounts it used for the original feed.
   // Without them a restored feed has no mounts and its OS calls all bubble up.
-  // Ignored when the restored state is idle (the next feed supplies its own).
+  // When the restored state is idle this must be empty.
   repeated Mount mounts = 2;
 }
 

--- a/crates/monty-proto/proto/monty/v1/monty.proto
+++ b/crates/monty-proto/proto/monty/v1/monty.proto
@@ -296,7 +296,7 @@ message NamedValue {
 
 message ParentRequest {
   oneof kind {
-    ReplCreate repl_create = 1;
+    Configure configure = 1;
     ReplFeed repl_feed = 2;
     ResumeCall resume_call = 3;
     ResumeNameLookup resume_name_lookup = 4;
@@ -308,9 +308,12 @@ message ParentRequest {
   }
 }
 
-// Creates the REPL session this child will serve until `Reset`. Valid only
-// when the child has no session.
-message ReplCreate {
+// Configures the REPL session this child will serve until `Reset`, sent once
+// when the worker is checked out. The session's repl is materialized lazily on
+// the first `ReplFeed` (or restored by `Load`), so a checked-out-but-unfed
+// worker can still be initialized by `Load` instead. Valid only when the
+// worker has no session yet.
+message Configure {
   string script_name = 1;
   ResourceLimits limits = 2;
   // Type-check each fed snippet before executing it.
@@ -359,15 +362,22 @@ message ResumeFutures {
 // be restored by a monty child of the same version via `Load`.
 message Dump {}
 
-// Restores state produced by `Dump` into a fresh child (no session). If the
-// restored state was suspended, the child re-emits the suspension event so
+// Restores state produced by `Dump`, replacing any current non-suspended
+// session (valid from no session or a between-feeds one, but not mid-feed). If
+// the restored state was suspended, the child re-emits the suspension event so
 // the parent learns the resume point; otherwise it replies `Ok`.
 message Load {
   bytes state = 1;
+  // Mounts to re-establish for a suspended feed being resumed. Mounts are
+  // host configuration, not sandbox state, so they are never part of the dump
+  // — the parent re-supplies the same mounts it used for the original feed.
+  // Without them a restored feed has no mounts and its OS calls all bubble up.
+  // Ignored when the restored state is idle (the next feed supplies its own).
+  repeated Mount mounts = 2;
 }
 
 // Ends the checkout: the child drops all session state and returns to the
-// no-session state, ready for the next `ReplCreate` or `Load`.
+// no-session state, ready for the next `Configure` or `Load`.
 message Reset {}
 
 // The child replies `Ok` and exits cleanly.
@@ -489,7 +499,7 @@ message DumpResult {
   bytes state = 1;
 }
 
-// Generic acknowledgement for ReplCreate / Load (idle) / Reset / Shutdown.
+// Generic acknowledgement for Configure / Load (idle) / Reset / Shutdown.
 message Ok {}
 
 // The child hit an unrecoverable error (frame desync, panic, unsupported

--- a/crates/monty-proto/proto/monty/v1/monty.proto
+++ b/crates/monty-proto/proto/monty/v1/monty.proto
@@ -415,6 +415,12 @@ message ChildEvent {
   // restored a session via `Load` (where the limits travel inside the opaque
   // state bytes) still learns the budget.
   optional uint64 max_duration_micros = 13;
+
+  // The session's script name, surfaced on a `Load` reply so a parent that
+  // restored a session (whose script name, like the limits above, travels
+  // inside the opaque dump bytes) learns it without parsing the dump. Set only
+  // on a successful `Load` reply; unset on all other events.
+  optional string restored_script_name = 14;
 }
 
 enum PrintStream {

--- a/crates/monty-proto/src/generated/monty.v1.rs
+++ b/crates/monty-proto/src/generated/monty.v1.rs
@@ -283,7 +283,7 @@ pub mod parent_request {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Kind {
         #[prost(message, tag = "1")]
-        ReplCreate(super::ReplCreate),
+        Configure(super::Configure),
         #[prost(message, tag = "2")]
         ReplFeed(super::ReplFeed),
         #[prost(message, tag = "3")]
@@ -302,10 +302,13 @@ pub mod parent_request {
         Shutdown(super::Shutdown),
     }
 }
-/// Creates the REPL session this child will serve until `Reset`. Valid only
-/// when the child has no session.
+/// Configures the REPL session this child will serve until `Reset`, sent once
+/// when the worker is checked out. The session's repl is materialized lazily on
+/// the first `ReplFeed` (or restored by `Load`), so a checked-out-but-unfed
+/// worker can still be initialized by `Load` instead. Valid only when the
+/// worker has no session yet.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct ReplCreate {
+pub struct Configure {
     #[prost(string, tag = "1")]
     pub script_name: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "2")]
@@ -372,16 +375,24 @@ pub struct ResumeFutures {
 /// be restored by a monty child of the same version via `Load`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Dump {}
-/// Restores state produced by `Dump` into a fresh child (no session). If the
-/// restored state was suspended, the child re-emits the suspension event so
+/// Restores state produced by `Dump`, replacing any current non-suspended
+/// session (valid from no session or a between-feeds one, but not mid-feed). If
+/// the restored state was suspended, the child re-emits the suspension event so
 /// the parent learns the resume point; otherwise it replies `Ok`.
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Load {
     #[prost(bytes = "vec", tag = "1")]
     pub state: ::prost::alloc::vec::Vec<u8>,
+    /// Mounts to re-establish for a suspended feed being resumed. Mounts are
+    /// host configuration, not sandbox state, so they are never part of the dump
+    /// — the parent re-supplies the same mounts it used for the original feed.
+    /// Without them a restored feed has no mounts and its OS calls all bubble up.
+    /// Ignored when the restored state is idle (the next feed supplies its own).
+    #[prost(message, repeated, tag = "2")]
+    pub mounts: ::prost::alloc::vec::Vec<Mount>,
 }
 /// Ends the checkout: the child drops all session state and returns to the
-/// no-session state, ready for the next `ReplCreate` or `Load`.
+/// no-session state, ready for the next `Configure` or `Load`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Reset {}
 /// The child replies `Ok` and exits cleanly.
@@ -487,7 +498,7 @@ pub struct DumpResult {
     #[prost(bytes = "vec", tag = "1")]
     pub state: ::prost::alloc::vec::Vec<u8>,
 }
-/// Generic acknowledgement for ReplCreate / Load (idle) / Reset / Shutdown.
+/// Generic acknowledgement for Configure / Load (idle) / Reset / Shutdown.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Ok {}
 /// The child hit an unrecoverable error (frame desync, panic, unsupported

--- a/crates/monty-proto/src/generated/monty.v1.rs
+++ b/crates/monty-proto/src/generated/monty.v1.rs
@@ -375,8 +375,7 @@ pub struct ResumeFutures {
 /// be restored by a monty child of the same version via `Load`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Dump {}
-/// Restores state produced by `Dump`, replacing any current non-suspended
-/// session (valid from no session or a between-feeds one, but not mid-feed). If
+/// Restores state produced by `Dump`. Valid only from no session. If
 /// the restored state was suspended, the child re-emits the suspension event so
 /// the parent learns the resume point; otherwise it replies `Ok`.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -387,7 +386,7 @@ pub struct Load {
     /// host configuration, not sandbox state, so they are never part of the dump
     /// — the parent re-supplies the same mounts it used for the original feed.
     /// Without them a restored feed has no mounts and its OS calls all bubble up.
-    /// Ignored when the restored state is idle (the next feed supplies its own).
+    /// When the restored state is idle this must be empty.
     #[prost(message, repeated, tag = "2")]
     pub mounts: ::prost::alloc::vec::Vec<Mount>,
 }
@@ -415,6 +414,12 @@ pub struct ChildEvent {
     /// state bytes) still learns the budget.
     #[prost(uint64, optional, tag = "13")]
     pub max_duration_micros: ::core::option::Option<u64>,
+    /// The session's script name, surfaced on a `Load` reply so a parent that
+    /// restored a session (whose script name, like the limits above, travels
+    /// inside the opaque dump bytes) learns it without parsing the dump. Set only
+    /// on a successful `Load` reply; unset on all other events.
+    #[prost(string, optional, tag = "14")]
+    pub restored_script_name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(oneof = "child_event::Kind", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11")]
     pub kind: ::core::option::Option<child_event::Kind>,
 }

--- a/crates/monty-proto/tests/oracle/monty.v1.rs
+++ b/crates/monty-proto/tests/oracle/monty.v1.rs
@@ -465,8 +465,7 @@ pub struct ResumeFutures {
 /// be restored by a monty child of the same version via `Load`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Dump {}
-/// Restores state produced by `Dump`, replacing any current non-suspended
-/// session (valid from no session or a between-feeds one, but not mid-feed). If
+/// Restores state produced by `Dump`. Valid only from no session. If
 /// the restored state was suspended, the child re-emits the suspension event so
 /// the parent learns the resume point; otherwise it replies `Ok`.
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -477,7 +476,7 @@ pub struct Load {
     /// host configuration, not sandbox state, so they are never part of the dump
     /// — the parent re-supplies the same mounts it used for the original feed.
     /// Without them a restored feed has no mounts and its OS calls all bubble up.
-    /// Ignored when the restored state is idle (the next feed supplies its own).
+    /// When the restored state is idle this must be empty.
     #[prost(message, repeated, tag = "2")]
     pub mounts: ::prost::alloc::vec::Vec<Mount>,
 }
@@ -505,6 +504,12 @@ pub struct ChildEvent {
     /// state bytes) still learns the budget.
     #[prost(uint64, optional, tag = "13")]
     pub max_duration_micros: ::core::option::Option<u64>,
+    /// The session's script name, surfaced on a `Load` reply so a parent that
+    /// restored a session (whose script name, like the limits above, travels
+    /// inside the opaque dump bytes) learns it without parsing the dump. Set only
+    /// on a successful `Load` reply; unset on all other events.
+    #[prost(string, optional, tag = "14")]
+    pub restored_script_name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(oneof = "child_event::Kind", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11")]
     pub kind: ::core::option::Option<child_event::Kind>,
 }

--- a/crates/monty-proto/tests/oracle/monty.v1.rs
+++ b/crates/monty-proto/tests/oracle/monty.v1.rs
@@ -373,7 +373,7 @@ pub mod parent_request {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Kind {
         #[prost(message, tag = "1")]
-        ReplCreate(super::ReplCreate),
+        Configure(super::Configure),
         #[prost(message, tag = "2")]
         ReplFeed(super::ReplFeed),
         #[prost(message, tag = "3")]
@@ -392,10 +392,13 @@ pub mod parent_request {
         Shutdown(super::Shutdown),
     }
 }
-/// Creates the REPL session this child will serve until `Reset`. Valid only
-/// when the child has no session.
+/// Configures the REPL session this child will serve until `Reset`, sent once
+/// when the worker is checked out. The session's repl is materialized lazily on
+/// the first `ReplFeed` (or restored by `Load`), so a checked-out-but-unfed
+/// worker can still be initialized by `Load` instead. Valid only when the
+/// worker has no session yet.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
-pub struct ReplCreate {
+pub struct Configure {
     #[prost(string, tag = "1")]
     pub script_name: ::prost::alloc::string::String,
     #[prost(message, optional, tag = "2")]
@@ -462,16 +465,24 @@ pub struct ResumeFutures {
 /// be restored by a monty child of the same version via `Load`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Dump {}
-/// Restores state produced by `Dump` into a fresh child (no session). If the
-/// restored state was suspended, the child re-emits the suspension event so
+/// Restores state produced by `Dump`, replacing any current non-suspended
+/// session (valid from no session or a between-feeds one, but not mid-feed). If
+/// the restored state was suspended, the child re-emits the suspension event so
 /// the parent learns the resume point; otherwise it replies `Ok`.
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Load {
     #[prost(bytes = "vec", tag = "1")]
     pub state: ::prost::alloc::vec::Vec<u8>,
+    /// Mounts to re-establish for a suspended feed being resumed. Mounts are
+    /// host configuration, not sandbox state, so they are never part of the dump
+    /// — the parent re-supplies the same mounts it used for the original feed.
+    /// Without them a restored feed has no mounts and its OS calls all bubble up.
+    /// Ignored when the restored state is idle (the next feed supplies its own).
+    #[prost(message, repeated, tag = "2")]
+    pub mounts: ::prost::alloc::vec::Vec<Mount>,
 }
 /// Ends the checkout: the child drops all session state and returns to the
-/// no-session state, ready for the next `ReplCreate` or `Load`.
+/// no-session state, ready for the next `Configure` or `Load`.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Reset {}
 /// The child replies `Ok` and exits cleanly.
@@ -618,7 +629,7 @@ pub struct DumpResult {
     #[prost(bytes = "vec", tag = "1")]
     pub state: ::prost::alloc::vec::Vec<u8>,
 }
-/// Generic acknowledgement for ReplCreate / Load (idle) / Reset / Shutdown.
+/// Generic acknowledgement for Configure / Load (idle) / Reset / Shutdown.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct Ok {}
 /// The child hit an unrecoverable error (frame desync, panic, unsupported

--- a/crates/monty-python/README.md
+++ b/crates/monty-python/README.md
@@ -113,9 +113,8 @@ with Monty() as pool:
 ```
 
 `snapshot.dump()` serializes the paused worker to bytes; a fresh session's
-`load_snapshot` restores it and returns the snapshot to resume (`load_snapshot`
-is valid only on a fresh session, before any feed). This lets you checkpoint
-execution and continue it later, even in a different process:
+`load_snapshot` restores it and returns the snapshot to resume. This lets you
+checkpoint execution and continue it later, even in a different process:
 
 ```python
 from pydantic_monty import FunctionSnapshot, Monty, MontyComplete
@@ -139,8 +138,12 @@ with Monty() as pool:
 
 If the paused feed used filesystem `mount`s, re-supply the same ones to
 `load_snapshot(blob, mount=...)` — their host paths are not stored in the dump.
-`AsyncMonty` sessions expose the same `feed_start` / `load_snapshot`, with
-awaitable `resume(...)`.
+
+`session.dump()` between feeds serializes an idle session instead; restore it
+with `session.load(blob)` (which returns `None`) and keep feeding. Both `load`
+and `load_snapshot` are valid only on a fresh session, before any feed; using
+the wrong one for a dump's kind raises. `AsyncMonty` sessions expose the same
+`feed_start` / `load` / `load_snapshot`, with awaitable `resume(...)`.
 
 ### Resource limits
 

--- a/crates/monty-python/README.md
+++ b/crates/monty-python/README.md
@@ -90,6 +90,58 @@ with Monty() as pool:
     #> 11
 ```
 
+### Snapshots: pausing and resuming execution
+
+`feed_start` is the suspendable counterpart of `feed_run`: instead of driving a
+snippet to completion, it hands control back at each external call, OS call,
+name lookup, or future resolution as a *snapshot*. You answer with
+`snapshot.resume(...)`, which returns the next snapshot or a `MontyComplete`.
+
+```python
+from pydantic_monty import FunctionSnapshot, Monty, MontyComplete
+
+with Monty() as pool:
+    with pool.checkout() as session:
+        snapshot = session.feed_start('greet(name) + "!"', inputs={'name': 'Ada'})
+        assert isinstance(snapshot, FunctionSnapshot)
+        print(snapshot.function_name, snapshot.args)
+        #> greet ('Ada',)
+        result = snapshot.resume({'return_value': 'hello Ada'})
+        assert isinstance(result, MontyComplete)
+        print(result.output)
+        #> hello Ada!
+```
+
+`snapshot.dump()` serializes the paused worker to bytes; a fresh session's
+`load_snapshot` restores it and returns the snapshot to resume (`load_snapshot`
+is valid only on a fresh session, before any feed). This lets you checkpoint
+execution and continue it later, even in a different process:
+
+```python
+from pydantic_monty import FunctionSnapshot, Monty, MontyComplete
+
+with Monty() as pool:
+    with pool.checkout() as session:
+        snapshot = session.feed_start(
+            'fetch(url)', inputs={'url': 'https://example.com'}
+        )
+        blob = snapshot.dump()
+
+    # later — restore into a fresh session and resume
+    with pool.checkout() as session:
+        snapshot = session.load_snapshot(blob)
+        assert isinstance(snapshot, FunctionSnapshot)
+        result = snapshot.resume({'return_value': 'page contents'})
+        assert isinstance(result, MontyComplete)
+        print(result.output)
+        #> page contents
+```
+
+If the paused feed used filesystem `mount`s, re-supply the same ones to
+`load_snapshot(blob, mount=...)` — their host paths are not stored in the dump.
+`AsyncMonty` sessions expose the same `feed_start` / `load_snapshot`, with
+awaitable `resume(...)`.
+
 ### Resource limits
 
 Limits are enforced inside the worker; the pool's `request_timeout` is a

--- a/crates/monty-python/python/pydantic_monty/__init__.py
+++ b/crates/monty-python/python/pydantic_monty/__init__.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
-from typing_extensions import TypedDict
+from types import EllipsisType
+from typing import Any, Callable, Literal
+
+from typing_extensions import NotRequired, TypeAlias, TypedDict
 
 from ._monty import (
     NOT_HANDLED,
+    AsyncFunctionSnapshot,
+    AsyncFutureSnapshot,
     AsyncMonty,
     AsyncMontySession,
+    AsyncNameLookupSnapshot,
     CollectStreams,
     CollectString,
     Frame,
+    FunctionSnapshot,
+    FutureSnapshot,
     Monty,
+    MontyComplete,
     MontyCrashedError,
     MontyError,
     MontyFileHandle,
@@ -18,6 +27,7 @@ from ._monty import (
     MontySyntaxError,
     MontyTypingError,
     MountDir,
+    NameLookupSnapshot,
     __version__,
 )
 from .os_access import (
@@ -33,6 +43,16 @@ from .os_access import (
 __all__ = (
     # this file
     'ResourceLimits',
+    'ExternalResult',
+    'ExternalReturnValue',
+    'ExternalException',
+    'ExternalExceptionData',
+    'ExternalFuture',
+    'ExcType',
+    'PrintCallback',
+    'OsHandler',
+    'SyncSnapshot',
+    'AsyncSnapshot',
     # _monty
     '__version__',
     'AsyncMonty',
@@ -49,6 +69,14 @@ __all__ = (
     'MontyRuntimeError',
     'MontyTypingError',
     'MountDir',
+    # feed_start snapshots
+    'MontyComplete',
+    'FunctionSnapshot',
+    'NameLookupSnapshot',
+    'FutureSnapshot',
+    'AsyncFunctionSnapshot',
+    'AsyncNameLookupSnapshot',
+    'AsyncFutureSnapshot',
     # os_access
     'StatResult',
     'OsFunction',
@@ -83,3 +111,99 @@ class ResourceLimits(TypedDict, total=False):
 
     max_recursion_depth: int | None
     """Maximum function call stack depth (default: 1000)."""
+
+
+class ExternalReturnValue(TypedDict):
+    """Represents the return value of an external function call."""
+
+    return_value: Any
+
+
+class ExternalException(TypedDict):
+    """Represents an exception raised during an external function call."""
+
+    exception: Exception
+
+
+ExcType = Literal[
+    'Exception',
+    'BaseException',
+    'SystemExit',
+    'KeyboardInterrupt',
+    'ArithmeticError',
+    'OverflowError',
+    'ZeroDivisionError',
+    'LookupError',
+    'IndexError',
+    'KeyError',
+    'RuntimeError',
+    'NotImplementedError',
+    'RecursionError',
+    'AttributeError',
+    'FrozenInstanceError',
+    'NameError',
+    'UnboundLocalError',
+    'ValueError',
+    'UnicodeDecodeError',
+    'json.JSONDecodeError',
+    'ImportError',
+    'ModuleNotFoundError',
+    'OSError',
+    'FileNotFoundError',
+    'FileExistsError',
+    'IsADirectoryError',
+    'NotADirectoryError',
+    'PermissionError',
+    'io.UnsupportedOperation',
+    'AssertionError',
+    'MemoryError',
+    'StopIteration',
+    'SyntaxError',
+    'TimeoutError',
+    'TypeError',
+    're.PatternError',
+]
+"""String names of Python exception types that Monty understands.
+
+Used by `ExternalExceptionData` to identify an exception by name rather than
+passing a concrete Python exception instance. Names match Python's built-in
+exception classes, except for `json.JSONDecodeError` and `re.PatternError`
+which are dotted to disambiguate from their `ValueError` / `Exception`
+parents.
+"""
+
+
+class ExternalExceptionData(TypedDict):
+    """Represents an exception raised during an external function call by its type and optional message.
+
+    Prefer this variant over `ExternalException` when the caller does not have
+    (or does not want to construct) a concrete Python exception instance —
+    e.g. when resuming a snapshot whose original exception type is not
+    available, or when resuming from another language.
+    """
+
+    exc_type: ExcType
+    message: NotRequired[str]
+
+
+class ExternalFuture(TypedDict):
+    """Represents a pending future returned from an external function call."""
+
+    future: EllipsisType
+
+
+ExternalResult = ExternalReturnValue | ExternalException | ExternalExceptionData | ExternalFuture
+"""A caller's answer to a `FunctionSnapshot` / `FutureSnapshot`: a return value,
+an exception (by instance or by type name), or a pending `future`."""
+
+PrintCallback: TypeAlias = Callable[[Literal['stdout', 'stderr'], str], None] | CollectStreams | CollectString
+"""Print sink accepted by `feed_run` / `feed_start` / `load_snapshot`."""
+
+OsHandler: TypeAlias = Callable[[OsFunction, tuple[Any, ...], dict[str, Any]], Any] | AbstractOS
+"""OS-call handler shared by `feed_run` / `feed_start`."""
+
+SyncSnapshot: TypeAlias = FunctionSnapshot | NameLookupSnapshot | FutureSnapshot | MontyComplete
+"""What `MontySession.feed_start` (and each sync `resume`) yields."""
+
+AsyncSnapshot: TypeAlias = AsyncFunctionSnapshot | AsyncNameLookupSnapshot | AsyncFutureSnapshot | MontyComplete
+"""What `AsyncMontySession.feed_start` (and each async `resume`) yields."""

--- a/crates/monty-python/python/pydantic_monty/__init__.py
+++ b/crates/monty-python/python/pydantic_monty/__init__.py
@@ -44,6 +44,7 @@ __all__ = (
     # this file
     'ResourceLimits',
     'ExternalResult',
+    'ExternalSettledResult',
     'ExternalReturnValue',
     'ExternalException',
     'ExternalExceptionData',
@@ -122,7 +123,7 @@ class ExternalReturnValue(TypedDict):
 class ExternalException(TypedDict):
     """Represents an exception raised during an external function call."""
 
-    exception: Exception
+    exception: BaseException
 
 
 ExcType = Literal[
@@ -192,9 +193,14 @@ class ExternalFuture(TypedDict):
     future: EllipsisType
 
 
-ExternalResult = ExternalReturnValue | ExternalException | ExternalExceptionData | ExternalFuture
-"""A caller's answer to a `FunctionSnapshot` / `FutureSnapshot`: a return value,
-an exception (by instance or by type name), or a pending `future`."""
+ExternalSettledResult = ExternalReturnValue | ExternalException | ExternalExceptionData
+"""A *settled* answer — a return value or an exception, but never a pending
+`future`. Resolving a `FutureSnapshot` requires settled results: a future
+cannot resolve to another future."""
+
+ExternalResult = ExternalSettledResult | ExternalFuture
+"""A caller's answer to a `FunctionSnapshot`: a return value, an exception (by
+instance or by type name), or a pending `future`."""
 
 PrintCallback: TypeAlias = Callable[[Literal['stdout', 'stderr'], str], None] | CollectStreams | CollectString
 """Print sink accepted by `feed_run` / `feed_start` / `load_snapshot`."""

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -3,7 +3,7 @@ from typing import Any, Callable, Literal, final
 
 from typing_extensions import Self
 
-from . import ResourceLimits
+from . import AsyncSnapshot, ExternalResult, OsHandler, PrintCallback, ResourceLimits, SyncSnapshot
 from .os_access import AbstractOS, OsFunction
 
 __all__ = [
@@ -23,6 +23,13 @@ __all__ = [
     'MontyRuntimeError',
     'MontyTypingError',
     'MountDir',
+    'MontyComplete',
+    'FunctionSnapshot',
+    'NameLookupSnapshot',
+    'FutureSnapshot',
+    'AsyncFunctionSnapshot',
+    'AsyncNameLookupSnapshot',
+    'AsyncFutureSnapshot',
 ]
 __version__: str
 
@@ -359,6 +366,59 @@ class MontySession:
                 the session is lost but the pool replaces the worker.
         """
 
+    def feed_start(
+        self,
+        code: str,
+        *,
+        inputs: dict[str, Any] | None = None,
+        print_callback: PrintCallback | None = None,
+        mount: MountDir | list[MountDir] | None = None,
+        os: OsHandler | None = None,
+        skip_type_check: bool = False,
+    ) -> SyncSnapshot:
+        """
+        Start a snippet and return a snapshot at each external call, OS call,
+        name lookup, or future resolution instead of driving to completion.
+
+        Answer the snapshot with `snapshot.resume(...)`, which returns the next
+        snapshot or a `MontyComplete`. Unlike `feed_run` there is no
+        `external_functions` argument — surfacing those calls is the point. An
+        `os=` handler still auto-dispatches uncovered OS calls until the next
+        non-OS event. Mounts are fixed for the whole feed (there is no `mount=`
+        on `resume`).
+
+        Use `snapshot.dump()` to checkpoint the worker mid-execution and
+        `load_snapshot` to restore it.
+        """
+
+    def load_snapshot(
+        self,
+        state: bytes,
+        *,
+        mount: MountDir | list[MountDir] | None = None,
+        print_callback: PrintCallback | None = None,
+    ) -> SyncSnapshot | None:
+        """
+        Restore a dump (from `session.dump()` / `snapshot.dump()`) into this
+        session instead of starting it fresh, returning the re-announced
+        snapshot to resume — or `None` when the dump was taken between feeds.
+
+        Valid only on a fresh session, before any `feed_run` / `feed_start` /
+        `load_snapshot` (it replaces the whole session, so it would otherwise
+        silently discard work); raises `RuntimeError` otherwise.
+
+        The dump restores its own `script_name` / limits / type-check state, so
+        the `checkout()` config for those is not applied; the dataclass registry
+        from `checkout()` is reused. `mount` re-establishes the suspended feed's
+        mounts (whose host paths are not in the dump) and is validated against
+        the dump's recorded requirements — a missing, extra, or altered mount
+        raises. An idle dump takes no `mount`. `'overlay'` writes made before
+        the dump are not preserved (the restored overlay starts empty).
+
+        A re-announced OS-call snapshot carries only its `not_handled_error`,
+        not the original `args`/`kwargs` (those were consumed before the dump).
+        """
+
     def dump(self) -> bytes:
         """
         Serialize the worker's session state (idle or suspended) to opaque
@@ -457,6 +517,34 @@ class AsyncMontySession:
         shared semantics (mounts, error types).
         """
 
+    async def feed_start(
+        self,
+        code: str,
+        *,
+        inputs: dict[str, Any] | None = None,
+        print_callback: PrintCallback | None = None,
+        mount: MountDir | list[MountDir] | None = None,
+        os: OsHandler | None = None,
+        skip_type_check: bool = False,
+    ) -> AsyncSnapshot:
+        """
+        Async counterpart of `MontySession.feed_start`: resolves to a snapshot
+        (whose `resume(...)` is awaitable) or a `MontyComplete`.
+        """
+
+    async def load_snapshot(
+        self,
+        state: bytes,
+        *,
+        mount: MountDir | list[MountDir] | None = None,
+        print_callback: PrintCallback | None = None,
+    ) -> AsyncSnapshot | None:
+        """
+        Async counterpart of `MontySession.load_snapshot`: resolves to the
+        re-announced snapshot (whose `resume(...)` is awaitable) or `None` for a
+        between-feeds dump. Valid only on a fresh session.
+        """
+
     async def dump(self) -> bytes:
         """
         Serialize the worker's session state (idle or suspended) to opaque
@@ -470,3 +558,163 @@ class AsyncMontySession:
         `None` when no worker is attached or a turn is currently in flight
         on another thread (the getter never blocks on a running turn).
         """
+
+@final
+class MontyComplete:
+    """The result of a completed `feed_start` execution."""
+
+    @property
+    def output(self) -> Any:
+        """The final value, converted to a Python object on each access."""
+
+    def __repr__(self) -> str: ...
+
+@final
+class FunctionSnapshot:
+    """A paused execution waiting for an external function or OS call result.
+
+    For OS calls `is_os_function` is `True` and `function_name` is the
+    `OsFunction` name; resume with a value, an exception, or
+    `resume_not_handled()`.
+    """
+
+    @property
+    def script_name(self) -> str: ...
+    @property
+    def is_os_function(self) -> bool: ...
+    @property
+    def is_method_call(self) -> bool:
+        """Whether this is a dataclass method call (the instance is `args[0]`)."""
+
+    @property
+    def function_name(self) -> str | OsFunction: ...
+    @property
+    def call_id(self) -> int: ...
+    @property
+    def args(self) -> tuple[Any, ...]: ...
+    @property
+    def kwargs(self) -> dict[str, Any]: ...
+    def resume(
+        self,
+        result: ExternalResult,
+        *,
+        os: OsHandler | None = None,
+    ) -> SyncSnapshot:
+        """Resume with the call's result; resumes at most once.
+
+        Mounts are fixed when the feed starts, so there is no `mount=` here. An
+        `os=` handler auto-dispatches OS calls produced by the continuation
+        until the next non-OS event.
+        """
+
+    def resume_not_handled(self, *, os: OsHandler | None = None) -> SyncSnapshot:
+        """Resume an OS-call snapshot with monty's default unhandled behaviour."""
+
+    def dump(self) -> bytes:
+        """Serialize the suspended worker; restore via `Monty.load_snapshot`."""
+
+    def __repr__(self) -> str: ...
+
+@final
+class NameLookupSnapshot:
+    """A paused execution waiting for the value of an undefined name."""
+
+    @property
+    def script_name(self) -> str: ...
+    @property
+    def variable_name(self) -> str: ...
+    def resume(
+        self,
+        *,
+        value: Any | None = None,
+        os: OsHandler | None = None,
+    ) -> SyncSnapshot:
+        """Resume with `value` to define the name, or nothing to raise `NameError`."""
+
+    def dump(self) -> bytes:
+        """Serialize the suspended worker; restore via `Monty.load_snapshot`."""
+
+    def __repr__(self) -> str: ...
+
+@final
+class FutureSnapshot:
+    """A paused execution where every sandbox task is blocked on external futures."""
+
+    @property
+    def script_name(self) -> str: ...
+    @property
+    def pending_call_ids(self) -> list[int]: ...
+    def resume(
+        self,
+        results: dict[int, ExternalResult],
+        *,
+        os: OsHandler | None = None,
+    ) -> SyncSnapshot:
+        """Resume with results for one or more pending futures (by `call_id`)."""
+
+    def dump(self) -> bytes:
+        """Serialize the suspended worker; restore via `Monty.load_snapshot`."""
+
+    def __repr__(self) -> str: ...
+
+@final
+class AsyncFunctionSnapshot:
+    """Async sibling of `FunctionSnapshot`; `resume`/`resume_not_handled` are awaitable."""
+
+    @property
+    def script_name(self) -> str: ...
+    @property
+    def is_os_function(self) -> bool: ...
+    @property
+    def is_method_call(self) -> bool: ...
+    @property
+    def function_name(self) -> str | OsFunction: ...
+    @property
+    def call_id(self) -> int: ...
+    @property
+    def args(self) -> tuple[Any, ...]: ...
+    @property
+    def kwargs(self) -> dict[str, Any]: ...
+    async def resume(
+        self,
+        result: ExternalResult,
+        *,
+        os: OsHandler | None = None,
+    ) -> AsyncSnapshot: ...
+    async def resume_not_handled(self, *, os: OsHandler | None = None) -> AsyncSnapshot: ...
+    def dump(self) -> bytes: ...
+    def __repr__(self) -> str: ...
+
+@final
+class AsyncNameLookupSnapshot:
+    """Async sibling of `NameLookupSnapshot`."""
+
+    @property
+    def script_name(self) -> str: ...
+    @property
+    def variable_name(self) -> str: ...
+    async def resume(
+        self,
+        *,
+        value: Any | None = None,
+        os: OsHandler | None = None,
+    ) -> AsyncSnapshot: ...
+    def dump(self) -> bytes: ...
+    def __repr__(self) -> str: ...
+
+@final
+class AsyncFutureSnapshot:
+    """Async sibling of `FutureSnapshot`."""
+
+    @property
+    def script_name(self) -> str: ...
+    @property
+    def pending_call_ids(self) -> list[int]: ...
+    async def resume(
+        self,
+        results: dict[int, ExternalResult],
+        *,
+        os: OsHandler | None = None,
+    ) -> AsyncSnapshot: ...
+    def dump(self) -> bytes: ...
+    def __repr__(self) -> str: ...

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -3,7 +3,15 @@ from typing import Any, Callable, Literal, final
 
 from typing_extensions import Self
 
-from . import AsyncSnapshot, ExternalResult, OsHandler, PrintCallback, ResourceLimits, SyncSnapshot
+from . import (
+    AsyncSnapshot,
+    ExternalResult,
+    ExternalSettledResult,
+    OsHandler,
+    PrintCallback,
+    ResourceLimits,
+    SyncSnapshot,
+)
 from .os_access import AbstractOS, OsFunction
 
 __all__ = [
@@ -645,10 +653,11 @@ class NameLookupSnapshot:
     def resume(
         self,
         *,
-        value: Any | None = None,
+        value: Any = ...,
         os: OsHandler | None = None,
     ) -> SyncSnapshot:
-        """Resume with `value` to define the name, or nothing to raise `NameError`."""
+        """Resume by binding the name to `value` (any value, including `None`), or
+        omit `value` to leave the name undefined and raise `NameError`."""
 
     def dump(self) -> bytes:
         """Serialize the suspended worker; restore via `MontySession.load_snapshot`."""
@@ -665,11 +674,12 @@ class FutureSnapshot:
     def pending_call_ids(self) -> list[int]: ...
     def resume(
         self,
-        results: dict[int, ExternalResult],
+        results: dict[int, ExternalSettledResult],
         *,
         os: OsHandler | None = None,
     ) -> SyncSnapshot:
-        """Resume with results for one or more pending futures (by `call_id`)."""
+        """Resume with settled results for one or more pending futures (by
+        `call_id`); a future cannot resolve to another `future`."""
 
     def dump(self) -> bytes:
         """Serialize the suspended worker; restore via `MontySession.load_snapshot`."""
@@ -715,7 +725,7 @@ class AsyncNameLookupSnapshot:
     async def resume(
         self,
         *,
-        value: Any | None = None,
+        value: Any = ...,
         os: OsHandler | None = None,
     ) -> AsyncSnapshot: ...
     def dump(self) -> bytes: ...
@@ -731,7 +741,7 @@ class AsyncFutureSnapshot:
     def pending_call_ids(self) -> list[int]: ...
     async def resume(
         self,
-        results: dict[int, ExternalResult],
+        results: dict[int, ExternalSettledResult],
         *,
         os: OsHandler | None = None,
     ) -> AsyncSnapshot: ...

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -391,29 +391,40 @@ class MontySession:
         `load_snapshot` to restore it.
         """
 
+    def load(self, state: bytes) -> None:
+        """
+        Restore a dumped **idle** session — bytes from `session.dump()` taken
+        between feeds — so you can keep feeding it. Use `load_snapshot` for a
+        dump taken mid-execution.
+
+        Valid only on a fresh session, before any feed or load; raises
+        `RuntimeError` otherwise. The dump restores its own `script_name` /
+        limits / type-check state (the `checkout()` config for those is not
+        applied); the dataclass registry from `checkout()` is reused. Raises if
+        the dump is actually a suspended snapshot.
+        """
+
     def load_snapshot(
         self,
         state: bytes,
         *,
         mount: MountDir | list[MountDir] | None = None,
         print_callback: PrintCallback | None = None,
-    ) -> SyncSnapshot | None:
+    ) -> SyncSnapshot:
         """
-        Restore a dump (from `session.dump()` / `snapshot.dump()`) into this
-        session instead of starting it fresh, returning the re-announced
-        snapshot to resume — or `None` when the dump was taken between feeds.
+        Restore a dumped **suspended** snapshot — bytes from `feed_start` +
+        `snapshot.dump()` — and return the re-announced snapshot to resume. Use
+        `load` for a dump taken between feeds.
 
-        Valid only on a fresh session, before any `feed_run` / `feed_start` /
-        `load_snapshot` (it replaces the whole session, so it would otherwise
-        silently discard work); raises `RuntimeError` otherwise.
-
-        The dump restores its own `script_name` / limits / type-check state, so
-        the `checkout()` config for those is not applied; the dataclass registry
-        from `checkout()` is reused. `mount` re-establishes the suspended feed's
-        mounts (whose host paths are not in the dump) and is validated against
-        the dump's recorded requirements — a missing, extra, or altered mount
-        raises. An idle dump takes no `mount`. `'overlay'` writes made before
-        the dump are not preserved (the restored overlay starts empty).
+        Valid only on a fresh session, before any feed or load; raises
+        `RuntimeError` otherwise. The dump restores its own `script_name` /
+        limits / type-check state (the `checkout()` config for those is not
+        applied); the dataclass registry from `checkout()` is reused. `mount`
+        re-establishes the suspended feed's mounts (whose host paths are not in
+        the dump), validated against the dump's recorded requirements — a
+        missing, extra, or altered mount raises. `'overlay'` writes made before
+        the dump are not preserved (the restored overlay starts empty). Raises
+        if the dump is actually an idle session.
 
         A re-announced OS-call snapshot carries only its `not_handled_error`,
         not the original `args`/`kwargs` (those were consumed before the dump).
@@ -532,17 +543,25 @@ class AsyncMontySession:
         (whose `resume(...)` is awaitable) or a `MontyComplete`.
         """
 
+    async def load(self, state: bytes) -> None:
+        """
+        Async counterpart of `MontySession.load`: restores a dumped idle
+        session. Valid only on a fresh session; raises if the dump is actually a
+        suspended snapshot.
+        """
+
     async def load_snapshot(
         self,
         state: bytes,
         *,
         mount: MountDir | list[MountDir] | None = None,
         print_callback: PrintCallback | None = None,
-    ) -> AsyncSnapshot | None:
+    ) -> AsyncSnapshot:
         """
-        Async counterpart of `MontySession.load_snapshot`: resolves to the
-        re-announced snapshot (whose `resume(...)` is awaitable) or `None` for a
-        between-feeds dump. Valid only on a fresh session.
+        Async counterpart of `MontySession.load_snapshot`: restores a dumped
+        suspended snapshot and resolves to it (whose `resume(...)` is
+        awaitable). Valid only on a fresh session; raises if the dump is
+        actually an idle session.
         """
 
     async def dump(self) -> bytes:
@@ -611,7 +630,7 @@ class FunctionSnapshot:
         """Resume an OS-call snapshot with monty's default unhandled behaviour."""
 
     def dump(self) -> bytes:
-        """Serialize the suspended worker; restore via `Monty.load_snapshot`."""
+        """Serialize the suspended worker; restore via `MontySession.load_snapshot`."""
 
     def __repr__(self) -> str: ...
 
@@ -632,7 +651,7 @@ class NameLookupSnapshot:
         """Resume with `value` to define the name, or nothing to raise `NameError`."""
 
     def dump(self) -> bytes:
-        """Serialize the suspended worker; restore via `Monty.load_snapshot`."""
+        """Serialize the suspended worker; restore via `MontySession.load_snapshot`."""
 
     def __repr__(self) -> str: ...
 
@@ -653,7 +672,7 @@ class FutureSnapshot:
         """Resume with results for one or more pending futures (by `call_id`)."""
 
     def dump(self) -> bytes:
-        """Serialize the suspended worker; restore via `Monty.load_snapshot`."""
+        """Serialize the suspended worker; restore via `MontySession.load_snapshot`."""
 
     def __repr__(self) -> str: ...
 

--- a/crates/monty-python/src/lib.rs
+++ b/crates/monty-python/src/lib.rs
@@ -17,6 +17,7 @@ mod limits;
 mod mount;
 mod pool;
 mod print_target;
+mod snapshot;
 
 use std::sync::OnceLock;
 
@@ -27,6 +28,10 @@ pub use mount::PyMountDir;
 pub use pool::{PyAsyncMonty, PyAsyncMontySession, PyMonty, PyMontySession};
 pub use print_target::{PyCollectStreams, PyCollectString};
 use pyo3::{prelude::*, sync::PyOnceLock, types::PyAny};
+pub use snapshot::{
+    MontyComplete, PyAsyncFunctionSnapshot, PyAsyncFutureSnapshot, PyAsyncNameLookupSnapshot, PyFunctionSnapshot,
+    PyFutureSnapshot, PyNameLookupSnapshot,
+};
 
 /// Copied from `get_pydantic_core_version` in pydantic
 fn get_version() -> &'static str {
@@ -76,6 +81,8 @@ mod _monty {
     use pyo3::prelude::*;
 
     #[pymodule_export]
+    use super::MontyComplete;
+    #[pymodule_export]
     use super::MontyCrashedError;
     #[pymodule_export]
     use super::MontyError;
@@ -86,15 +93,25 @@ mod _monty {
     #[pymodule_export]
     use super::MontyTypingError;
     #[pymodule_export]
+    use super::PyAsyncFunctionSnapshot as AsyncFunctionSnapshot;
+    #[pymodule_export]
+    use super::PyAsyncFutureSnapshot as AsyncFutureSnapshot;
+    #[pymodule_export]
     use super::PyAsyncMonty as AsyncMonty;
     #[pymodule_export]
     use super::PyAsyncMontySession as AsyncMontySession;
+    #[pymodule_export]
+    use super::PyAsyncNameLookupSnapshot as AsyncNameLookupSnapshot;
     #[pymodule_export]
     use super::PyCollectStreams as CollectStreams;
     #[pymodule_export]
     use super::PyCollectString as CollectString;
     #[pymodule_export]
     use super::PyFrame as Frame;
+    #[pymodule_export]
+    use super::PyFunctionSnapshot as FunctionSnapshot;
+    #[pymodule_export]
+    use super::PyFutureSnapshot as FutureSnapshot;
     #[pymodule_export]
     use super::PyMonty as Monty;
     #[pymodule_export]
@@ -103,6 +120,8 @@ mod _monty {
     use super::PyMontySession as MontySession;
     #[pymodule_export]
     use super::PyMountDir as MountDir;
+    #[pymodule_export]
+    use super::PyNameLookupSnapshot as NameLookupSnapshot;
     use super::{get_not_handled, get_version};
 
     #[pymodule_init]

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -26,7 +26,10 @@
 
 use std::{
     path::PathBuf,
-    sync::{Arc, Mutex, MutexGuard, PoisonError, TryLockError},
+    sync::{
+        Arc, Mutex, MutexGuard, PoisonError, TryLockError,
+        atomic::{AtomicBool, Ordering},
+    },
     time::Duration,
 };
 
@@ -51,14 +54,15 @@ use crate::{
     limits::extract_limits,
     mount::PyMountDir,
     print_target::PrintTarget,
+    snapshot::{DriveContext, build_snapshot, feed_start_async, feed_start_sync},
 };
 
 /// The pool handle shared between a pool object and its sessions. `None`
 /// until the context manager is entered and again after it exits.
-type SharedPool = Arc<Mutex<Option<Arc<Pool>>>>;
+pub(crate) type SharedPool = Arc<Mutex<Option<Arc<Pool>>>>;
 /// The worker handle of one session. `None` before the session is entered,
 /// after it exits, and after the worker is discarded on a crash.
-type SharedCheckout = Arc<Mutex<Option<Checkout>>>;
+pub(crate) type SharedCheckout = Arc<Mutex<Option<Checkout>>>;
 
 // =============================================================================
 // Sync API: Monty / MontySession
@@ -147,6 +151,7 @@ impl PyMonty {
             repl_config: parse_repl_config(py, script_name, limits, type_check, type_check_stubs)?,
             dc_registry: DcRegistry::from_list(py, dataclass_registry)?,
             checkout: Arc::new(Mutex::new(None)),
+            used: AtomicBool::new(false),
         })
     }
 }
@@ -159,6 +164,9 @@ pub struct PyMontySession {
     repl_config: ReplConfig,
     dc_registry: DcRegistry,
     checkout: SharedCheckout,
+    /// Set once the session has been fed or restored. `load_snapshot` is valid
+    /// only while this is unset (a fresh, undriven session).
+    used: AtomicBool,
 }
 
 #[pymethods]
@@ -215,6 +223,7 @@ impl PyMontySession {
         os: Option<Py<PyAny>>,
         skip_type_check: bool,
     ) -> PyResult<Py<PyAny>> {
+        self.used.store(true, Ordering::Relaxed);
         let args = FeedArgs::extract(
             py,
             &self.checkout,
@@ -227,6 +236,93 @@ impl PyMontySession {
             skip_type_check,
         )?;
         drive_sync(py, args, external_functions)
+    }
+
+    /// Starts a snippet but, instead of driving it to completion, returns a
+    /// snapshot at each external call, OS call, name lookup, or future
+    /// resolution. The caller answers with `snapshot.resume(...)` and may
+    /// `snapshot.dump()` to checkpoint the worker mid-execution.
+    ///
+    /// Unlike [`feed_run`](Self::feed_run) there is no `external_functions`
+    /// argument — surfacing those calls is the point. An `os=` handler still
+    /// auto-dispatches uncovered OS calls until the next non-OS event.
+    #[pyo3(signature = (code, *, inputs=None, print_callback=None, mount=None, os=None, skip_type_check=false))]
+    #[expect(clippy::too_many_arguments)]
+    fn feed_start(
+        &self,
+        py: Python<'_>,
+        code: &Bound<'_, PyString>,
+        inputs: Option<&Bound<'_, PyDict>>,
+        print_callback: Option<&Bound<'_, PyAny>>,
+        mount: Option<&Bound<'_, PyAny>>,
+        os: Option<Py<PyAny>>,
+        skip_type_check: bool,
+    ) -> PyResult<Py<PyAny>> {
+        self.used.store(true, Ordering::Relaxed);
+        let args = FeedArgs::extract(
+            py,
+            &self.checkout,
+            &self.dc_registry,
+            code,
+            inputs,
+            print_callback,
+            mount,
+            os,
+            skip_type_check,
+        )?;
+        feed_start_sync(py, args, self.repl_config.script_name.clone())
+    }
+
+    /// Restores a dump (from `session.dump()` / `snapshot.dump()`) into this
+    /// session instead of starting it fresh, returning the re-announced
+    /// snapshot to resume — or `None` when the dump was taken between feeds.
+    ///
+    /// Valid only on a fresh session, before any `feed_run` / `feed_start` /
+    /// `load_snapshot` (it replaces the whole session, so it would otherwise
+    /// silently discard work); raises `RuntimeError` otherwise.
+    ///
+    /// The dump restores its own `script_name` / limits / type-check state —
+    /// the `checkout()` config for those is not applied. `mount` re-establishes
+    /// the suspended feed's mounts (whose host paths are not in the dump) and
+    /// is validated against the dump's recorded mount requirements; the
+    /// session's dataclass registry from `checkout()` is reused.
+    #[pyo3(signature = (state, *, mount=None, print_callback=None))]
+    fn load_snapshot(
+        &self,
+        py: Python<'_>,
+        state: Vec<u8>,
+        mount: Option<&Bound<'_, PyAny>>,
+        print_callback: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<Option<Py<PyAny>>> {
+        // extract args before committing the session, so a bad-args error
+        // leaves it loadable; then claim it (a failed load is not retryable on
+        // the same session — checkout a fresh one), matching the async path.
+        let mounts = extract_mount_specs(mount)?;
+        let print_target = PrintTarget::from_py(print_callback)?;
+        if self.used.swap(true, Ordering::Relaxed) {
+            return Err(load_snapshot_used_err());
+        }
+        let checkout = Arc::clone(&self.checkout);
+        let event = py
+            .detach(|| {
+                let mut guard = lock(&checkout);
+                guard
+                    .as_mut()
+                    .ok_or(PoolError::Finished)?
+                    .load_snapshot(state, mounts, &mut |_, _| {})
+            })
+            .map_err(|e| pool_err_to_py(py, e))?;
+        event
+            .map(|event| {
+                let ctx = DriveContext::new(
+                    checkout,
+                    self.dc_registry.clone_ref(py),
+                    print_target,
+                    self.repl_config.script_name.clone(),
+                );
+                build_snapshot(py, ctx, event, false)
+            })
+            .transpose()
     }
 
     /// Serializes the worker's session state (idle or suspended) into opaque
@@ -345,6 +441,7 @@ impl PyAsyncMonty {
             repl_config: parse_repl_config(py, script_name, limits, type_check, type_check_stubs)?,
             dc_registry: DcRegistry::from_list(py, dataclass_registry)?,
             checkout: Arc::new(Mutex::new(None)),
+            used: AtomicBool::new(false),
         })
     }
 }
@@ -357,6 +454,9 @@ pub struct PyAsyncMontySession {
     repl_config: ReplConfig,
     dc_registry: DcRegistry,
     checkout: SharedCheckout,
+    /// Set once the session has been fed or restored; `load_snapshot` is valid
+    /// only while unset. See [`PyMontySession::load_snapshot`].
+    used: AtomicBool,
 }
 
 #[pymethods]
@@ -421,6 +521,7 @@ impl PyAsyncMontySession {
         os: Option<Py<PyAny>>,
         skip_type_check: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
+        self.used.store(true, Ordering::Relaxed);
         let args = FeedArgs::extract(
             py,
             &self.checkout,
@@ -434,6 +535,82 @@ impl PyAsyncMontySession {
         )?;
         let ext_fns = external_functions.map(|d| d.clone().unbind());
         future_into_py(py, async move { drive_async(args, ext_fns).await })
+    }
+
+    /// Async counterpart of [`PyMontySession::feed_start`]: the returned
+    /// coroutine resolves to a snapshot (whose `resume(...)` is awaitable) or a
+    /// `MontyComplete`. See that method for the snapshot-driven protocol.
+    #[pyo3(signature = (code, *, inputs=None, print_callback=None, mount=None, os=None, skip_type_check=false))]
+    #[expect(clippy::too_many_arguments)]
+    fn feed_start<'py>(
+        &self,
+        py: Python<'py>,
+        code: &Bound<'_, PyString>,
+        inputs: Option<&Bound<'_, PyDict>>,
+        print_callback: Option<&Bound<'_, PyAny>>,
+        mount: Option<&Bound<'_, PyAny>>,
+        os: Option<Py<PyAny>>,
+        skip_type_check: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        self.used.store(true, Ordering::Relaxed);
+        let args = FeedArgs::extract(
+            py,
+            &self.checkout,
+            &self.dc_registry,
+            code,
+            inputs,
+            print_callback,
+            mount,
+            os,
+            skip_type_check,
+        )?;
+        feed_start_async(py, args, self.repl_config.script_name.clone())
+    }
+
+    /// Async counterpart of [`PyMontySession::load_snapshot`]: the coroutine
+    /// resolves to the re-announced snapshot (whose `resume(...)` is awaitable)
+    /// or `None` for a between-feeds dump. Valid only on a fresh session.
+    #[pyo3(signature = (state, *, mount=None, print_callback=None))]
+    fn load_snapshot<'py>(
+        &self,
+        py: Python<'py>,
+        state: Vec<u8>,
+        mount: Option<&Bound<'_, PyAny>>,
+        print_callback: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        // extract args before committing the session, then claim it in the
+        // synchronous prologue (which runs to completion before the future):
+        // a second concurrent call sees `used` set and is rejected at call
+        // time, and the off-thread load can't race onto a fresh session.
+        let mounts = extract_mount_specs(mount)?;
+        let print_target = PrintTarget::from_py(print_callback)?;
+        if self.used.swap(true, Ordering::Relaxed) {
+            return Err(load_snapshot_used_err());
+        }
+        let checkout = Arc::clone(&self.checkout);
+        let dc_registry = self.dc_registry.clone_ref(py);
+        let script_name = self.repl_config.script_name.clone();
+        future_into_py(py, async move {
+            let load_checkout = Arc::clone(&checkout);
+            let event = spawn_blocking(move || {
+                let mut guard = lock(&load_checkout);
+                guard
+                    .as_mut()
+                    .ok_or(PoolError::Finished)?
+                    .load_snapshot(state, mounts, &mut |_, _| {})
+            })
+            .await
+            .map_err(join_error_to_py)?
+            .map_err(|e| Python::attach(|py| pool_err_to_py(py, e)))?;
+            Python::attach(|py| {
+                event
+                    .map(|event| {
+                        let ctx = DriveContext::new(checkout, dc_registry, print_target, script_name);
+                        build_snapshot(py, ctx, event, true)
+                    })
+                    .transpose()
+            })
+        })
     }
 
     /// Serializes the worker's session state (idle or suspended) into opaque
@@ -493,9 +670,17 @@ fn parse_pool_config(
     Ok(config)
 }
 
+/// The error raised when `load_snapshot` is called on a session that has
+/// already been fed or restored (it would otherwise silently discard work).
+fn load_snapshot_used_err() -> PyErr {
+    PyRuntimeError::new_err(
+        "load_snapshot is only valid on a fresh session, before any feed_run / feed_start / load_snapshot",
+    )
+}
+
 /// Builds the worker-side REPL session config from the (shared) `checkout`
 /// arguments.
-fn parse_repl_config(
+pub(crate) fn parse_repl_config(
     py: Python<'_>,
     script_name: &str,
     limits: Option<&Bound<'_, PyDict>>,
@@ -512,7 +697,7 @@ fn parse_repl_config(
 
 /// Clones the live pool handle out of a shared slot, erroring when the
 /// context manager has not been entered (or already exited).
-fn active_pool(pool: &SharedPool) -> PyResult<Arc<Pool>> {
+pub(crate) fn active_pool(pool: &SharedPool) -> PyResult<Arc<Pool>> {
     lock(pool).as_ref().map(Arc::clone).ok_or_else(|| {
         PyRuntimeError::new_err("the pool is not active — enter the Monty / AsyncMonty context manager first")
     })
@@ -527,20 +712,20 @@ fn dump_checkout(checkout: &SharedCheckout) -> Result<Vec<u8>, PoolError> {
 
 /// Everything a feed needs, extracted from Python arguments up front so the
 /// sync and async drive loops share one validation path.
-struct FeedArgs {
-    code: String,
-    inputs: Vec<(String, MontyObject)>,
-    mounts: Vec<MountSpec>,
-    skip_type_check: bool,
-    os: Option<Py<PyAny>>,
-    print_target: PrintTarget,
-    checkout: SharedCheckout,
-    dc_registry: DcRegistry,
+pub(crate) struct FeedArgs {
+    pub(crate) code: String,
+    pub(crate) inputs: Vec<(String, MontyObject)>,
+    pub(crate) mounts: Vec<MountSpec>,
+    pub(crate) skip_type_check: bool,
+    pub(crate) os: Option<Py<PyAny>>,
+    pub(crate) print_target: PrintTarget,
+    pub(crate) checkout: SharedCheckout,
+    pub(crate) dc_registry: DcRegistry,
 }
 
 impl FeedArgs {
     #[expect(clippy::too_many_arguments)]
-    fn extract(
+    pub(crate) fn extract(
         py: Python<'_>,
         checkout: &SharedCheckout,
         dc_registry: &DcRegistry,
@@ -746,7 +931,7 @@ enum TurnAnswer {
 
 /// Runs one protocol turn against the (locked) checkout, streaming prints to
 /// `print_target` and capturing the first print-callback failure.
-fn run_turn_blocking(
+pub(crate) fn run_turn_blocking(
     checkout: &SharedCheckout,
     print_target: &PrintTarget,
     turn: impl FnOnce(&mut Checkout, monty_pool::OnPrint<'_>) -> Result<TurnEvent, PoolError>,
@@ -785,7 +970,7 @@ fn run_turn_blocking(
 }
 
 /// `spawn_blocking` wrapper around [`run_turn_blocking`] for the async loop.
-async fn run_turn_async(
+pub(crate) async fn run_turn_async(
     checkout: &SharedCheckout,
     print_target: &PrintTarget,
     turn: impl FnOnce(&mut Checkout, monty_pool::OnPrint<'_>) -> Result<TurnEvent, PoolError> + Send + 'static,
@@ -800,7 +985,7 @@ async fn run_turn_async(
 
 /// Converts a turn outcome into the next event, surfacing print-callback
 /// failures (which take precedence — they are host-side errors).
-fn finalize_turn(
+pub(crate) fn finalize_turn(
     py: Python<'_>,
     result: Result<TurnEvent, PoolError>,
     print_err: Option<MontyException>,
@@ -817,7 +1002,7 @@ fn finalize_turn(
 
 /// Maps an `ExtFunctionResult` from callback dispatch onto the pool's resume
 /// payload.
-fn ext_to_resume(result: ExtFunctionResult) -> PyResult<ResumeValue> {
+pub(crate) fn ext_to_resume(result: ExtFunctionResult) -> PyResult<ResumeValue> {
     match result {
         ExtFunctionResult::Return(value) => Ok(ResumeValue::Return(value)),
         ExtFunctionResult::Error(exc) => Ok(ResumeValue::Error(exc)),
@@ -830,7 +1015,7 @@ fn ext_to_resume(result: ExtFunctionResult) -> PyResult<ResumeValue> {
 /// Calls the Python `os=` fallback for a bubbled OS call. With no callback —
 /// or when it returns `NOT_HANDLED` — answers with the child-provided
 /// `not_handled_error`, preserving monty's per-call no-handler semantics.
-fn dispatch_os_parts(
+pub(crate) fn dispatch_os_parts(
     py: Python<'_>,
     function_name: &str,
     args: &[MontyObject],
@@ -873,7 +1058,10 @@ fn dispatch_os_parts(
 }
 
 /// Resolves a bare-name lookup against the external functions dict.
-fn resolve_pool_name_lookup(name: &str, external_functions: Option<&Bound<'_, PyDict>>) -> Option<MontyObject> {
+pub(crate) fn resolve_pool_name_lookup(
+    name: &str,
+    external_functions: Option<&Bound<'_, PyDict>>,
+) -> Option<MontyObject> {
     let value = external_functions?.get_item(name).ok().flatten()?;
     Some(MontyObject::Function {
         name: name.to_owned(),
@@ -922,7 +1110,7 @@ fn mount_spec(dir: &PyRef<'_, PyMountDir>) -> PyResult<MountSpec> {
 }
 
 /// Maps a pool failure onto the Python exception hierarchy.
-fn pool_err_to_py(py: Python<'_>, err: PoolError) -> PyErr {
+pub(crate) fn pool_err_to_py(py: Python<'_>, err: PoolError) -> PyErr {
     let message = err.to_string();
     match err {
         PoolError::Runtime(exc) => MontyError::new_err(py, exc),
@@ -945,7 +1133,7 @@ fn duration_from_secs(secs: f64) -> PyResult<Duration> {
 /// checkout lock for its whole duration and attaches for print callbacks, so
 /// a GIL-holding waiter deadlocks both threads — detach first, or use
 /// [`try_lock`].
-fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+pub(crate) fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
     mutex.lock().unwrap_or_else(PoisonError::into_inner)
 }
 

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -273,19 +273,35 @@ impl PyMontySession {
         feed_start_sync(py, args, self.repl_config.script_name.clone())
     }
 
-    /// Restores a dump (from `session.dump()` / `snapshot.dump()`) into this
-    /// session instead of starting it fresh, returning the re-announced
-    /// snapshot to resume — or `None` when the dump was taken between feeds.
+    /// Restores a dumped **idle** session — bytes from `session.dump()` taken
+    /// between feeds — so you can keep feeding it. Use
+    /// [`load_snapshot`](Self::load_snapshot) for a dump taken mid-execution.
     ///
-    /// Valid only on a fresh session, before any `feed_run` / `feed_start` /
-    /// `load_snapshot` (it replaces the whole session, so it would otherwise
-    /// silently discard work); raises `RuntimeError` otherwise.
+    /// Valid only on a fresh session, before any feed or load; raises
+    /// `RuntimeError` otherwise. The dump restores its own `script_name` /
+    /// limits / type-check state (the `checkout()` config for those is not
+    /// applied); the dataclass registry from `checkout()` is reused. Raises if
+    /// the dump is actually a suspended snapshot.
+    fn load(&self, py: Python<'_>, state: Vec<u8>) -> PyResult<()> {
+        if self.restore_turn(py, state, Vec::new())?.is_some() {
+            py.detach(|| discard_checkout(&self.checkout));
+            return Err(PyRuntimeError::new_err(
+                "this dump is a suspended snapshot — use load_snapshot() to resume it",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Restores a dumped **suspended** snapshot — bytes from `feed_start` +
+    /// `snapshot.dump()` — and returns the re-announced snapshot to resume. Use
+    /// [`load`](Self::load) for a dump taken between feeds.
     ///
-    /// The dump restores its own `script_name` / limits / type-check state —
-    /// the `checkout()` config for those is not applied. `mount` re-establishes
-    /// the suspended feed's mounts (whose host paths are not in the dump) and
-    /// is validated against the dump's recorded mount requirements; the
-    /// session's dataclass registry from `checkout()` is reused.
+    /// Valid only on a fresh session, before any feed or load; raises
+    /// `RuntimeError` otherwise. `mount` re-establishes the suspended feed's
+    /// mounts (whose host paths are not in the dump), validated against the
+    /// dump's recorded requirements. The dump restores its own config; the
+    /// dataclass registry from `checkout()` is reused. Raises if the dump is
+    /// actually an idle session.
     #[pyo3(signature = (state, *, mount=None, print_callback=None))]
     fn load_snapshot(
         &self,
@@ -293,36 +309,25 @@ impl PyMontySession {
         state: Vec<u8>,
         mount: Option<&Bound<'_, PyAny>>,
         print_callback: Option<&Bound<'_, PyAny>>,
-    ) -> PyResult<Option<Py<PyAny>>> {
+    ) -> PyResult<Py<PyAny>> {
         // extract args before committing the session, so a bad-args error
-        // leaves it loadable; then claim it (a failed load is not retryable on
-        // the same session — checkout a fresh one), matching the async path.
+        // leaves it loadable (a failed load is not retryable — checkout a fresh
+        // session — matching the async path)
         let mounts = extract_mount_specs(mount)?;
         let print_target = PrintTarget::from_py(print_callback)?;
-        if self.used.swap(true, Ordering::Relaxed) {
-            return Err(load_snapshot_used_err());
-        }
-        let checkout = Arc::clone(&self.checkout);
-        let event = py
-            .detach(|| {
-                let mut guard = lock(&checkout);
-                guard
-                    .as_mut()
-                    .ok_or(PoolError::Finished)?
-                    .load_snapshot(state, mounts, &mut |_, _| {})
-            })
-            .map_err(|e| pool_err_to_py(py, e))?;
-        event
-            .map(|event| {
-                let ctx = DriveContext::new(
-                    checkout,
-                    self.dc_registry.clone_ref(py),
-                    print_target,
-                    self.repl_config.script_name.clone(),
-                );
-                build_snapshot(py, ctx, event, false)
-            })
-            .transpose()
+        let Some(event) = self.restore_turn(py, state, mounts)? else {
+            py.detach(|| discard_checkout(&self.checkout));
+            return Err(PyRuntimeError::new_err(
+                "this dump is an idle session — use load() to restore it",
+            ));
+        };
+        let ctx = DriveContext::new(
+            Arc::clone(&self.checkout),
+            self.dc_registry.clone_ref(py),
+            print_target,
+            self.repl_config.script_name.clone(),
+        );
+        build_snapshot(py, ctx, event, false)
     }
 
     /// Serializes the worker's session state (idle or suspended) into opaque
@@ -343,6 +348,35 @@ impl PyMontySession {
     #[getter]
     fn worker_pid(&self) -> Option<u32> {
         try_lock(&self.checkout)?.as_ref().and_then(Checkout::pid)
+    }
+}
+
+impl PyMontySession {
+    /// Claims the fresh session (rejecting a reused one) and runs the low-level
+    /// restore off the GIL, returning the re-announced suspension (`Some`) or
+    /// `None` for an idle dump. The restore turn runs no sandbox code, so it
+    /// needs no print sink. Shared by [`load`](Self::load) and
+    /// [`load_snapshot`](Self::load_snapshot).
+    fn restore_turn(&self, py: Python<'_>, state: Vec<u8>, mounts: Vec<MountSpec>) -> PyResult<Option<TurnEvent>> {
+        if self.used.swap(true, Ordering::Relaxed) {
+            // non-destructive: an already-running session keeps its worker
+            return Err(session_used_err());
+        }
+        let checkout = Arc::clone(&self.checkout);
+        let result = py.detach(|| {
+            let mut guard = lock(&checkout);
+            guard
+                .as_mut()
+                .ok_or(PoolError::Finished)?
+                .restore(state, mounts, &mut |_, _| {})
+        });
+        // a failed restore (bad mount, protocol desync, ...) leaves the worker
+        // in an untrusted state: discard it so a later feed fails fast rather
+        // than running on a half-restored session
+        if result.is_err() {
+            py.detach(|| discard_checkout(&checkout));
+        }
+        result.map_err(|e| pool_err_to_py(py, e))
     }
 }
 
@@ -567,9 +601,37 @@ impl PyAsyncMontySession {
         feed_start_async(py, args, self.repl_config.script_name.clone())
     }
 
+    /// Async counterpart of [`PyMontySession::load`]: the coroutine restores a
+    /// dumped idle session, resolving to `None`. Valid only on a fresh session;
+    /// raises if the dump is actually a suspended snapshot.
+    fn load<'py>(&self, py: Python<'py>, state: Vec<u8>) -> PyResult<Bound<'py, PyAny>> {
+        // claim the session in the synchronous prologue (which completes before
+        // the future), so a concurrent call is rejected at call time and the
+        // off-thread restore can't race onto a fresh session
+        if self.used.swap(true, Ordering::Relaxed) {
+            return Err(session_used_err());
+        }
+        let checkout = Arc::clone(&self.checkout);
+        future_into_py(py, async move {
+            if restore_turn_async(Arc::clone(&checkout), state, Vec::new())
+                .await?
+                .is_some()
+            {
+                spawn_blocking(move || discard_checkout(&checkout))
+                    .await
+                    .map_err(join_error_to_py)?;
+                return Err(PyRuntimeError::new_err(
+                    "this dump is a suspended snapshot — use load_snapshot() to resume it",
+                ));
+            }
+            Ok(())
+        })
+    }
+
     /// Async counterpart of [`PyMontySession::load_snapshot`]: the coroutine
-    /// resolves to the re-announced snapshot (whose `resume(...)` is awaitable)
-    /// or `None` for a between-feeds dump. Valid only on a fresh session.
+    /// restores a dumped suspended snapshot and resolves to it (whose
+    /// `resume(...)` is awaitable). Valid only on a fresh session; raises if the
+    /// dump is actually an idle session.
     #[pyo3(signature = (state, *, mount=None, print_callback=None))]
     fn load_snapshot<'py>(
         &self,
@@ -578,37 +640,28 @@ impl PyAsyncMontySession {
         mount: Option<&Bound<'_, PyAny>>,
         print_callback: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        // extract args before committing the session, then claim it in the
-        // synchronous prologue (which runs to completion before the future):
-        // a second concurrent call sees `used` set and is rejected at call
-        // time, and the off-thread load can't race onto a fresh session.
+        // extract args before committing the session (a bad-args error leaves
+        // it loadable), then claim it in the synchronous prologue
         let mounts = extract_mount_specs(mount)?;
         let print_target = PrintTarget::from_py(print_callback)?;
         if self.used.swap(true, Ordering::Relaxed) {
-            return Err(load_snapshot_used_err());
+            return Err(session_used_err());
         }
         let checkout = Arc::clone(&self.checkout);
         let dc_registry = self.dc_registry.clone_ref(py);
         let script_name = self.repl_config.script_name.clone();
         future_into_py(py, async move {
-            let load_checkout = Arc::clone(&checkout);
-            let event = spawn_blocking(move || {
-                let mut guard = lock(&load_checkout);
-                guard
-                    .as_mut()
-                    .ok_or(PoolError::Finished)?
-                    .load_snapshot(state, mounts, &mut |_, _| {})
-            })
-            .await
-            .map_err(join_error_to_py)?
-            .map_err(|e| Python::attach(|py| pool_err_to_py(py, e)))?;
+            let Some(event) = restore_turn_async(Arc::clone(&checkout), state, mounts).await? else {
+                spawn_blocking(move || discard_checkout(&checkout))
+                    .await
+                    .map_err(join_error_to_py)?;
+                return Err(PyRuntimeError::new_err(
+                    "this dump is an idle session — use load() to restore it",
+                ));
+            };
             Python::attach(|py| {
-                event
-                    .map(|event| {
-                        let ctx = DriveContext::new(checkout, dc_registry, print_target, script_name);
-                        build_snapshot(py, ctx, event, true)
-                    })
-                    .transpose()
+                let ctx = DriveContext::new(checkout, dc_registry, print_target, script_name);
+                build_snapshot(py, ctx, event, true)
             })
         })
     }
@@ -670,12 +723,52 @@ fn parse_pool_config(
     Ok(config)
 }
 
-/// The error raised when `load_snapshot` is called on a session that has
-/// already been fed or restored (it would otherwise silently discard work).
-fn load_snapshot_used_err() -> PyErr {
+/// The error raised when `load` / `load_snapshot` is called on a session that
+/// has already been fed or restored (it would otherwise silently discard work).
+fn session_used_err() -> PyErr {
     PyRuntimeError::new_err(
-        "load_snapshot is only valid on a fresh session, before any feed_run / feed_start / load_snapshot",
+        "load / load_snapshot is only valid on a fresh session, before any feed_run / feed_start / load / load_snapshot",
     )
+}
+
+/// Runs the low-level restore off the event loop (via `spawn_blocking`),
+/// returning the re-announced suspension (`Some`) or `None` for an idle dump.
+/// The restore turn runs no sandbox code, so it needs no print sink. Shared by
+/// the async [`PyAsyncMontySession::load`] / `load_snapshot`.
+async fn restore_turn_async(
+    checkout: SharedCheckout,
+    state: Vec<u8>,
+    mounts: Vec<MountSpec>,
+) -> PyResult<Option<TurnEvent>> {
+    spawn_blocking(move || {
+        let result = {
+            let mut guard = lock(&checkout);
+            guard
+                .as_mut()
+                .ok_or(PoolError::Finished)
+                .and_then(|checkout| checkout.restore(state, mounts, &mut |_, _| {}))
+        };
+        // discard the worker on failure (the lock is released above) so a later
+        // feed fails fast — a failed load is not retryable
+        if result.is_err() {
+            discard_checkout(&checkout);
+        }
+        result
+    })
+    .await
+    .map_err(join_error_to_py)?
+    .map_err(|e| Python::attach(|py| pool_err_to_py(py, e)))
+}
+
+/// Kills the session's worker and empties its checkout slot after a failed
+/// load. Any subsequent feed then fails with [`PoolError::Finished`] — like a
+/// crashed session — enforcing that a failed load is not retryable (callers
+/// must check out a fresh session). Does no protocol I/O, so it never blocks.
+fn discard_checkout(checkout: &SharedCheckout) {
+    // take in its own statement so the lock is released before the worker is
+    // dropped (its `Drop` kills the process)
+    let taken = lock(checkout).take();
+    drop(taken);
 }
 
 /// Builds the worker-side REPL session config from the (shared) `checkout`

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -283,7 +283,8 @@ impl PyMontySession {
     /// applied); the dataclass registry from `checkout()` is reused. Raises if
     /// the dump is actually a suspended snapshot.
     fn load(&self, py: Python<'_>, state: Vec<u8>) -> PyResult<()> {
-        if self.restore_turn(py, state, Vec::new())?.is_some() {
+        // an idle session has no snapshot, so the restored script name is unused
+        if self.restore_turn(py, state, Vec::new())?.0.is_some() {
             py.detach(|| discard_checkout(&self.checkout));
             return Err(PyRuntimeError::new_err(
                 "this dump is a suspended snapshot — use load_snapshot() to resume it",
@@ -315,7 +316,8 @@ impl PyMontySession {
         // session — matching the async path)
         let mounts = extract_mount_specs(mount)?;
         let print_target = PrintTarget::from_py(print_callback)?;
-        let Some(event) = self.restore_turn(py, state, mounts)? else {
+        let (event, script_name) = self.restore_turn(py, state, mounts)?;
+        let Some(event) = event else {
             py.detach(|| discard_checkout(&self.checkout));
             return Err(PyRuntimeError::new_err(
                 "this dump is an idle session — use load() to restore it",
@@ -325,7 +327,9 @@ impl PyMontySession {
             Arc::clone(&self.checkout),
             self.dc_registry.clone_ref(py),
             print_target,
-            self.repl_config.script_name.clone(),
+            // the dump's own script name, falling back to the session config
+            // only if the worker did not report one (e.g. an older child)
+            script_name.unwrap_or_else(|| self.repl_config.script_name.clone()),
         );
         build_snapshot(py, ctx, event, false)
     }
@@ -354,10 +358,16 @@ impl PyMontySession {
 impl PyMontySession {
     /// Claims the fresh session (rejecting a reused one) and runs the low-level
     /// restore off the GIL, returning the re-announced suspension (`Some`) or
-    /// `None` for an idle dump. The restore turn runs no sandbox code, so it
-    /// needs no print sink. Shared by [`load`](Self::load) and
+    /// `None` for an idle dump, paired with the dump's adopted script name (for
+    /// restored snapshots' `script_name`). The restore turn runs no sandbox
+    /// code, so it needs no print sink. Shared by [`load`](Self::load) and
     /// [`load_snapshot`](Self::load_snapshot).
-    fn restore_turn(&self, py: Python<'_>, state: Vec<u8>, mounts: Vec<MountSpec>) -> PyResult<Option<TurnEvent>> {
+    fn restore_turn(
+        &self,
+        py: Python<'_>,
+        state: Vec<u8>,
+        mounts: Vec<MountSpec>,
+    ) -> PyResult<(Option<TurnEvent>, Option<String>)> {
         if self.used.swap(true, Ordering::Relaxed) {
             // non-destructive: an already-running session keeps its worker
             return Err(session_used_err());
@@ -613,8 +623,10 @@ impl PyAsyncMontySession {
         }
         let checkout = Arc::clone(&self.checkout);
         future_into_py(py, async move {
+            // an idle session has no snapshot, so the restored name is unused
             if restore_turn_async(Arc::clone(&checkout), state, Vec::new())
                 .await?
+                .0
                 .is_some()
             {
                 spawn_blocking(move || discard_checkout(&checkout))
@@ -649,9 +661,10 @@ impl PyAsyncMontySession {
         }
         let checkout = Arc::clone(&self.checkout);
         let dc_registry = self.dc_registry.clone_ref(py);
-        let script_name = self.repl_config.script_name.clone();
+        let config_script_name = self.repl_config.script_name.clone();
         future_into_py(py, async move {
-            let Some(event) = restore_turn_async(Arc::clone(&checkout), state, mounts).await? else {
+            let (event, restored_script_name) = restore_turn_async(Arc::clone(&checkout), state, mounts).await?;
+            let Some(event) = event else {
                 spawn_blocking(move || discard_checkout(&checkout))
                     .await
                     .map_err(join_error_to_py)?;
@@ -659,6 +672,9 @@ impl PyAsyncMontySession {
                     "this dump is an idle session — use load() to restore it",
                 ));
             };
+            // the dump's own script name, falling back to the session config
+            // only if the worker did not report one (e.g. an older child)
+            let script_name = restored_script_name.unwrap_or(config_script_name);
             Python::attach(|py| {
                 let ctx = DriveContext::new(checkout, dc_registry, print_target, script_name);
                 build_snapshot(py, ctx, event, true)
@@ -732,14 +748,15 @@ fn session_used_err() -> PyErr {
 }
 
 /// Runs the low-level restore off the event loop (via `spawn_blocking`),
-/// returning the re-announced suspension (`Some`) or `None` for an idle dump.
-/// The restore turn runs no sandbox code, so it needs no print sink. Shared by
-/// the async [`PyAsyncMontySession::load`] / `load_snapshot`.
+/// returning the re-announced suspension (`Some`) or `None` for an idle dump,
+/// paired with the dump's adopted script name. The restore turn runs no sandbox
+/// code, so it needs no print sink. Shared by the async
+/// [`PyAsyncMontySession::load`] / `load_snapshot`.
 async fn restore_turn_async(
     checkout: SharedCheckout,
     state: Vec<u8>,
     mounts: Vec<MountSpec>,
-) -> PyResult<Option<TurnEvent>> {
+) -> PyResult<(Option<TurnEvent>, Option<String>)> {
     spawn_blocking(move || {
         let result = {
             let mut guard = lock(&checkout);

--- a/crates/monty-python/src/snapshot.rs
+++ b/crates/monty-python/src/snapshot.rs
@@ -18,16 +18,21 @@
 //! When a caller supplies an `os=` handler, OS calls the mounts don't cover are
 //! auto-dispatched through it (reusing the `feed_run` path) until the next
 //! non-OS event, matching the old behaviour. Mounts are fixed for the whole
-//! feed (passed to `feed_start`), so `resume` takes no `mount=`: a normal feed
-//! already has its mounts live in the worker, and a `load_snapshot`-restored
-//! feed has none (they are not part of the dump) — its mount-covered OS calls
-//! bubble up to be answered via `os=` / `resume`.
+//! feed (passed to `feed_start`), so `resume` takes no `mount=`. Restoring a
+//! suspended feed with `load_snapshot` re-establishes those mounts — the caller
+//! re-supplies them (their host paths are not in the dump) and they are
+//! validated against the dump's recorded requirements — so the restored feed's
+//! mount-covered file access is served in-worker exactly as before the dump.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::{
+    convert::Infallible,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use ::monty::{ExtFunctionResult, MontyException, MontyObject};
 use monty_pool::{Checkout, OnPrint, PoolError, ResumeValue, TurnEvent};
 use pyo3::{
+    Borrowed,
     exceptions::{PyBaseException, PyRuntimeError, PyTypeError},
     intern,
     prelude::*,
@@ -648,11 +653,39 @@ struct NameLookupSnapshot {
     name: String,
 }
 
+/// The argument to `NameLookupSnapshot.resume`, distinguishing an omitted value
+/// (`Unset` — raise `NameError`) from an explicitly supplied one (`Set`,
+/// including `None`).
+///
+/// A bare `Option<Bound<PyAny>>` cannot express this: PyO3 extracts Python
+/// `None` to Rust `None`, collapsing an explicit `None` binding into the
+/// "omitted" case. Capturing the object here keeps `None` a real value, while
+/// the unit `Unset` default — which needs no `py` token, unlike any Python
+/// object — marks omission.
+enum MaybeValue<'py> {
+    Unset,
+    Set(Bound<'py, PyAny>),
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for MaybeValue<'py> {
+    type Error = Infallible;
+
+    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> Result<Self, Self::Error> {
+        Ok(MaybeValue::Set(obj.to_owned()))
+    }
+}
+
 impl NameLookupSnapshot {
-    fn resume_value(&self, py: Python<'_>, value: Option<&Bound<'_, PyAny>>) -> PyResult<Option<MontyObject>> {
-        value
-            .map(|v| py_to_monty_value(v, &self.snapshot.ctx.dc_registry).map_err(|e| MontyError::new_err(py, e)))
-            .transpose()
+    /// Converts the `resume` argument into the name's binding: an omitted value
+    /// (`Unset`) leaves the name undefined so the sandbox raises `NameError`,
+    /// while a supplied value — **including `None`** — binds the name to it.
+    fn resume_value(&self, py: Python<'_>, value: MaybeValue<'_>) -> PyResult<Option<MontyObject>> {
+        match value {
+            MaybeValue::Unset => Ok(None),
+            MaybeValue::Set(value) => py_to_monty_value(&value, &self.snapshot.ctx.dc_registry)
+                .map(Some)
+                .map_err(|e| MontyError::new_err(py, e)),
+        }
     }
 }
 
@@ -673,8 +706,8 @@ impl PyNameLookupSnapshot {
         &self.0.name
     }
 
-    #[pyo3(signature = (*, value=None, os=None))]
-    fn resume(&self, py: Python<'_>, value: Option<&Bound<'_, PyAny>>, os: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
+    #[pyo3(signature = (*, value=MaybeValue::Unset, os=None))]
+    fn resume(&self, py: Python<'_>, value: MaybeValue<'_>, os: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
         let value = self.0.resume_value(py, value)?;
         let ctx = self.0.snapshot.claim(py)?;
         drive_sync(py, ctx, os, move |c, p| c.resume_name_lookup(value, p))
@@ -705,11 +738,11 @@ impl PyAsyncNameLookupSnapshot {
         &self.0.name
     }
 
-    #[pyo3(signature = (*, value=None, os=None))]
+    #[pyo3(signature = (*, value=MaybeValue::Unset, os=None))]
     fn resume<'py>(
         &self,
         py: Python<'py>,
-        value: Option<&Bound<'_, PyAny>>,
+        value: MaybeValue<'_>,
         os: Option<Py<PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let value = self.0.resume_value(py, value)?;

--- a/crates/monty-python/src/snapshot.rs
+++ b/crates/monty-python/src/snapshot.rs
@@ -1,0 +1,854 @@
+//! Suspendable `feed_start` execution surface for the subprocess pool.
+//!
+//! `feed_run` drives a snippet to completion, answering every external call
+//! from host callbacks before it returns. `feed_start` instead hands control
+//! back to the caller at each suspension as a *snapshot* object — a
+//! [`PyFunctionSnapshot`] for an external/OS call, a [`PyNameLookupSnapshot`]
+//! for an undefined name, or a [`PyFutureSnapshot`] when every sandbox task is
+//! blocked on external futures — so the caller can inspect the call, snapshot
+//! the worker with [`PyFunctionSnapshot::dump`] (etc.), and resume when ready.
+//! Completion yields a [`MontyComplete`].
+//!
+//! This reinstates the pre-subprocess `feed_start` API shape, mapped onto the
+//! `monty-pool` [`Checkout`] turn primitives. The execution state lives in the
+//! worker, so a snapshot is a *cursor* on a live suspended session rather than
+//! owned, freely-copyable state: only one suspension is live per session, each
+//! snapshot resumes at most once, and `resume` advances that worker forward.
+//!
+//! When a caller supplies an `os=` handler, OS calls the mounts don't cover are
+//! auto-dispatched through it (reusing the `feed_run` path) until the next
+//! non-OS event, matching the old behaviour. Mounts are fixed for the whole
+//! feed (passed to `feed_start`), so `resume` takes no `mount=`: a normal feed
+//! already has its mounts live in the worker, and a `load_snapshot`-restored
+//! feed has none (they are not part of the dump) — its mount-covered OS calls
+//! bubble up to be answered via `os=` / `resume`.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use ::monty::{ExtFunctionResult, MontyException, MontyObject};
+use monty_pool::{Checkout, OnPrint, PoolError, ResumeValue, TurnEvent};
+use pyo3::{
+    exceptions::{PyBaseException, PyRuntimeError, PyTypeError},
+    intern,
+    prelude::*,
+    types::{PyBytes, PyDict, PyTuple},
+};
+use pyo3_async_runtimes::tokio::future_into_py;
+
+use crate::{
+    convert::{monty_to_py, py_to_monty_value},
+    dataclass::DcRegistry,
+    exceptions::{MontyError, exc_py_to_monty},
+    pool::{
+        FeedArgs, SharedCheckout, dispatch_os_parts, finalize_turn, lock, pool_err_to_py, run_turn_async,
+        run_turn_blocking,
+    },
+    print_target::PrintTarget,
+};
+
+/// Shared context threaded across a `feed_start` drive so each `resume` can
+/// keep dispatching against the same worker, conversion registry, and print
+/// sink. Cloning bumps the shared handles (the checkout `Arc`, the dataclass
+/// registry dict, the print collector buffer) — every clone drives the **same**
+/// underlying session.
+pub(crate) struct DriveContext {
+    checkout: SharedCheckout,
+    dc_registry: DcRegistry,
+    print_target: PrintTarget,
+    script_name: String,
+}
+
+impl DriveContext {
+    pub(crate) fn new(
+        checkout: SharedCheckout,
+        dc_registry: DcRegistry,
+        print_target: PrintTarget,
+        script_name: String,
+    ) -> Self {
+        Self {
+            checkout,
+            dc_registry,
+            print_target,
+            script_name,
+        }
+    }
+
+    fn clone_ref(&self, py: Python<'_>) -> Self {
+        Self {
+            checkout: SharedCheckout::clone(&self.checkout),
+            dc_registry: self.dc_registry.clone_ref(py),
+            print_target: self.print_target.clone_handle(py),
+            script_name: self.script_name.clone(),
+        }
+    }
+}
+
+// =============================================================================
+// feed_start entry points (called from the session pymethods)
+// =============================================================================
+
+/// Runs the first feed turn synchronously and returns the resulting snapshot
+/// (or [`MontyComplete`]).
+pub(crate) fn feed_start_sync(py: Python<'_>, args: FeedArgs, script_name: String) -> PyResult<Py<PyAny>> {
+    let FeedArgs {
+        code,
+        inputs,
+        mounts,
+        skip_type_check,
+        os,
+        print_target,
+        checkout,
+        dc_registry,
+    } = args;
+    let ctx = DriveContext::new(checkout, dc_registry, print_target, script_name);
+    drive_sync(py, ctx, os, move |c, p| {
+        c.feed(&code, inputs, mounts, skip_type_check, p)
+    })
+}
+
+/// Async counterpart of [`feed_start_sync`]: the returned coroutine runs the
+/// first feed turn off the event loop and resolves to the snapshot (or
+/// [`MontyComplete`]).
+pub(crate) fn feed_start_async(py: Python<'_>, args: FeedArgs, script_name: String) -> PyResult<Bound<'_, PyAny>> {
+    let FeedArgs {
+        code,
+        inputs,
+        mounts,
+        skip_type_check,
+        os,
+        print_target,
+        checkout,
+        dc_registry,
+    } = args;
+    let ctx = DriveContext::new(checkout, dc_registry, print_target, script_name);
+    future_into_py(py, async move {
+        drive_async(ctx, os, move |c, p| c.feed(&code, inputs, mounts, skip_type_check, p)).await
+    })
+}
+
+// =============================================================================
+// Drive loops: run one turn, auto-dispatch OS calls, then build the snapshot
+// =============================================================================
+
+/// Runs `initial` (a feed or resume turn) and any OS auto-dispatch turns it
+/// produces — with the GIL released for each worker round-trip — until a
+/// caller-visible event is reached, then builds the matching Python object.
+///
+/// Takes `os` by value (rather than by reference) so the pyclass `resume`
+/// methods, which receive it by value from pyo3, can hand it straight through
+/// without a `needless_pass_by_value` lint at every call site.
+#[expect(clippy::needless_pass_by_value)]
+fn drive_sync(
+    py: Python<'_>,
+    ctx: DriveContext,
+    os: Option<Py<PyAny>>,
+    initial: impl FnOnce(&mut Checkout, OnPrint<'_>) -> Result<TurnEvent, PoolError> + Send,
+) -> PyResult<Py<PyAny>> {
+    let (result, print_err) = py.detach(|| run_turn_blocking(&ctx.checkout, &ctx.print_target, initial));
+    let mut event = finalize_turn(py, result, print_err)?;
+    loop {
+        match event {
+            TurnEvent::OsCall {
+                function_name,
+                args,
+                kwargs,
+                not_handled_error,
+                ..
+            } if os.is_some() => {
+                let result = dispatch_os_parts(
+                    py,
+                    &function_name,
+                    &args,
+                    &kwargs,
+                    not_handled_error.as_ref(),
+                    os.as_ref(),
+                    &ctx.dc_registry,
+                );
+                let resume = ext_result_to_resume(result);
+                let (result, print_err) =
+                    py.detach(|| run_turn_blocking(&ctx.checkout, &ctx.print_target, move |c, p| c.resume(resume, p)));
+                event = finalize_turn(py, result, print_err)?;
+            }
+            other => break build_snapshot(py, ctx, other, false),
+        }
+    }
+}
+
+/// Async counterpart of [`drive_sync`]: worker turns run via `spawn_blocking`
+/// and OS auto-dispatch re-attaches the GIL for the callback.
+async fn drive_async(
+    ctx: DriveContext,
+    os: Option<Py<PyAny>>,
+    initial: impl FnOnce(&mut Checkout, OnPrint<'_>) -> Result<TurnEvent, PoolError> + Send + 'static,
+) -> PyResult<Py<PyAny>> {
+    let mut event = run_turn_async(&ctx.checkout, &ctx.print_target, initial).await?;
+    loop {
+        match event {
+            TurnEvent::OsCall {
+                function_name,
+                args,
+                kwargs,
+                not_handled_error,
+                ..
+            } if os.is_some() => {
+                let resume = Python::attach(|py| {
+                    let result = dispatch_os_parts(
+                        py,
+                        &function_name,
+                        &args,
+                        &kwargs,
+                        not_handled_error.as_ref(),
+                        os.as_ref(),
+                        &ctx.dc_registry,
+                    );
+                    ext_result_to_resume(result)
+                });
+                event = run_turn_async(&ctx.checkout, &ctx.print_target, move |c, p| c.resume(resume, p)).await?;
+            }
+            other => return Python::attach(|py| build_snapshot(py, ctx, other, true)),
+        }
+    }
+}
+
+/// Builds the Python object for a caller-visible turn event: a snapshot for a
+/// suspension or [`MontyComplete`] for completion. `is_async` selects the sync
+/// or async snapshot classes (the latter expose awaitable `resume`).
+pub(crate) fn build_snapshot(
+    py: Python<'_>,
+    ctx: DriveContext,
+    event: TurnEvent,
+    is_async: bool,
+) -> PyResult<Py<PyAny>> {
+    match event {
+        TurnEvent::Complete(value) => Py::new(
+            py,
+            MontyComplete {
+                value,
+                dc_registry: ctx.dc_registry,
+            },
+        )
+        .map(Py::into_any),
+        TurnEvent::FunctionCall {
+            function_name,
+            args,
+            kwargs,
+            call_id,
+            method_call,
+        } => {
+            let call = FunctionCallData {
+                function_name,
+                args,
+                kwargs,
+                call_id,
+                is_os_function: false,
+                is_method_call: method_call,
+                not_handled_error: None,
+            };
+            function_snapshot_py(py, ctx, call, is_async)
+        }
+        TurnEvent::OsCall {
+            function_name,
+            args,
+            kwargs,
+            call_id,
+            not_handled_error,
+        } => {
+            let call = FunctionCallData {
+                function_name,
+                args,
+                kwargs,
+                call_id,
+                is_os_function: true,
+                is_method_call: false,
+                not_handled_error,
+            };
+            function_snapshot_py(py, ctx, call, is_async)
+        }
+        TurnEvent::NameLookup { name } => {
+            let snapshot = SnapshotState::new(ctx);
+            if is_async {
+                Py::new(py, PyAsyncNameLookupSnapshot(NameLookupSnapshot { snapshot, name })).map(Py::into_any)
+            } else {
+                Py::new(py, PyNameLookupSnapshot(NameLookupSnapshot { snapshot, name })).map(Py::into_any)
+            }
+        }
+        TurnEvent::ResolveFutures { pending_call_ids } => {
+            let snapshot = SnapshotState::new(ctx);
+            if is_async {
+                Py::new(
+                    py,
+                    PyAsyncFutureSnapshot(FutureSnapshot {
+                        snapshot,
+                        pending_call_ids,
+                    }),
+                )
+                .map(Py::into_any)
+            } else {
+                Py::new(
+                    py,
+                    PyFutureSnapshot(FutureSnapshot {
+                        snapshot,
+                        pending_call_ids,
+                    }),
+                )
+                .map(Py::into_any)
+            }
+        }
+    }
+}
+
+fn function_snapshot_py(
+    py: Python<'_>,
+    ctx: DriveContext,
+    call: FunctionCallData,
+    is_async: bool,
+) -> PyResult<Py<PyAny>> {
+    let snapshot = SnapshotState::new(ctx);
+    if is_async {
+        Py::new(py, PyAsyncFunctionSnapshot(FunctionSnapshot { snapshot, call })).map(Py::into_any)
+    } else {
+        Py::new(py, PyFunctionSnapshot(FunctionSnapshot { snapshot, call })).map(Py::into_any)
+    }
+}
+
+// =============================================================================
+// Shared snapshot state and resume plumbing
+// =============================================================================
+
+/// The live-cursor state every snapshot carries: the drive context plus a
+/// single-use latch enforcing "resume at most once".
+struct SnapshotState {
+    ctx: DriveContext,
+    resumed: AtomicBool,
+}
+
+impl SnapshotState {
+    fn new(ctx: DriveContext) -> Self {
+        Self {
+            ctx,
+            resumed: AtomicBool::new(false),
+        }
+    }
+
+    /// Claims the single resume for this snapshot, returning a fresh
+    /// [`DriveContext`] for the continuation. Errors if already resumed.
+    fn claim(&self, py: Python<'_>) -> PyResult<DriveContext> {
+        if self.resumed.swap(true, Ordering::SeqCst) {
+            Err(PyRuntimeError::new_err("snapshot has already been resumed"))
+        } else {
+            Ok(self.ctx.clone_ref(py))
+        }
+    }
+
+    fn dump(&self, py: Python<'_>) -> PyResult<Py<PyBytes>> {
+        let checkout = SharedCheckout::clone(&self.ctx.checkout);
+        let state = py
+            .detach(|| {
+                let mut guard = lock(&checkout);
+                guard.as_mut().ok_or(PoolError::Finished).and_then(Checkout::dump)
+            })
+            .map_err(|e| pool_err_to_py(py, e))?;
+        Ok(PyBytes::new(py, &state).unbind())
+    }
+}
+
+/// Maps an `ExtFunctionResult` onto a pool `ResumeValue`, preserving the
+/// `future` answer (which the sandbox uses to register an external future and
+/// keep running other tasks — valid in both sync and async drives).
+fn ext_result_to_resume(result: ExtFunctionResult) -> ResumeValue {
+    match result {
+        ExtFunctionResult::Return(value) => ResumeValue::Return(value),
+        ExtFunctionResult::Error(exc) => ResumeValue::Error(exc),
+        ExtFunctionResult::Future(_) => ResumeValue::Future,
+        ExtFunctionResult::NotFound(name) => {
+            // Preserve the name so the worker raises the right NameError; the
+            // pool fills it from the pending call when resuming.
+            let _ = name;
+            ResumeValue::NotFound
+        }
+    }
+}
+
+/// Parses an `ExternalResult` TypedDict — one of `{'return_value': obj}`,
+/// `{'exception': exc}`, `{'exc_type': str, 'message'?: str}`, or
+/// `{'future': ...}` — into a [`ResumeValue`]. `call_id` is unused by the pool
+/// (the worker tracks it) but kept for parity with the documented shape.
+fn parse_external_result(
+    py: Python<'_>,
+    result: &Bound<'_, PyDict>,
+    dc_registry: &DcRegistry,
+) -> PyResult<ResumeValue> {
+    const ARGS_ERROR: &str = "ExternalResult must be a dict with one of: 'return_value', 'exception', 'exc_type' (with optional 'message'), or 'future'";
+
+    if let Some(exc_type_val) = result.get_item(intern!(py, "exc_type"))? {
+        let message_val = result.get_item(intern!(py, "message"))?;
+        let expected_len = if message_val.is_some() { 2 } else { 1 };
+        if result.len() != expected_len {
+            return Err(PyTypeError::new_err(ARGS_ERROR));
+        }
+        let exc_type_str: String = exc_type_val
+            .extract()
+            .map_err(|_| PyTypeError::new_err("'exc_type' must be a string"))?;
+        let exc_type = exc_type_str
+            .parse()
+            .map_err(|_| PyTypeError::new_err(format!("Unknown exception type: '{exc_type_str}'")))?;
+        let message = message_val
+            .map(|m| {
+                m.extract::<String>()
+                    .map_err(|_| PyTypeError::new_err("'message' must be a string"))
+            })
+            .transpose()?;
+        return Ok(ResumeValue::Error(MontyException::new(exc_type, message)));
+    }
+
+    if result.len() != 1 {
+        Err(PyTypeError::new_err(ARGS_ERROR))
+    } else if let Some(rv) = result.get_item(intern!(py, "return_value"))? {
+        let value = py_to_monty_value(&rv, dc_registry).map_err(|e| MontyError::new_err(py, e))?;
+        Ok(ResumeValue::Return(value))
+    } else if let Some(exc) = result.get_item(intern!(py, "exception"))? {
+        if exc.is_instance_of::<PyBaseException>() {
+            let py_err = PyErr::from_value(exc);
+            Ok(ResumeValue::Error(exc_py_to_monty(py, &py_err)))
+        } else {
+            Err(PyTypeError::new_err("'exception' must be a BaseException instance"))
+        }
+    } else if let Some(fut) = result.get_item(intern!(py, "future"))? {
+        if fut.is(py.Ellipsis()) {
+            Ok(ResumeValue::Future)
+        } else {
+            Err(PyTypeError::new_err(
+                "value for the 'future' key must be Ellipsis (...)",
+            ))
+        }
+    } else {
+        Err(PyTypeError::new_err(ARGS_ERROR))
+    }
+}
+
+fn args_to_py<'py>(py: Python<'py>, args: &[MontyObject], dc_registry: &DcRegistry) -> PyResult<Bound<'py, PyTuple>> {
+    let items = args
+        .iter()
+        .map(|arg| monty_to_py(py, arg, dc_registry))
+        .collect::<PyResult<Vec<_>>>()?;
+    PyTuple::new(py, items)
+}
+
+fn kwargs_to_py<'py>(
+    py: Python<'py>,
+    kwargs: &[(MontyObject, MontyObject)],
+    dc_registry: &DcRegistry,
+) -> PyResult<Bound<'py, PyDict>> {
+    let dict = PyDict::new(py);
+    for (key, value) in kwargs {
+        dict.set_item(monty_to_py(py, key, dc_registry)?, monty_to_py(py, value, dc_registry)?)?;
+    }
+    Ok(dict)
+}
+
+// =============================================================================
+// FunctionSnapshot (external / OS call) — sync and async
+// =============================================================================
+
+/// The pending-call payload shared by the sync and async function snapshots.
+struct FunctionCallData {
+    function_name: String,
+    args: Vec<MontyObject>,
+    kwargs: Vec<(MontyObject, MontyObject)>,
+    call_id: u32,
+    is_os_function: bool,
+    is_method_call: bool,
+    /// The exception the sandbox would raise with no handler — present only for
+    /// OS calls, and consumed by `resume_not_handled`.
+    not_handled_error: Option<MontyException>,
+}
+
+struct FunctionSnapshot {
+    snapshot: SnapshotState,
+    call: FunctionCallData,
+}
+
+impl FunctionSnapshot {
+    fn resume_value(&self, py: Python<'_>, result: &Bound<'_, PyDict>) -> PyResult<ResumeValue> {
+        parse_external_result(py, result, &self.snapshot.ctx.dc_registry)
+    }
+
+    fn not_handled_value(&self) -> PyResult<ResumeValue> {
+        if !self.call.is_os_function {
+            return Err(PyRuntimeError::new_err(
+                "resume_not_handled() is only valid for OS function snapshots",
+            ));
+        }
+        let exc = self
+            .call
+            .not_handled_error
+            .clone()
+            .ok_or_else(|| PyRuntimeError::new_err("OS snapshot has no default unhandled error"))?;
+        Ok(ResumeValue::Error(exc))
+    }
+}
+
+/// A paused execution waiting for an external function or OS call result.
+/// Resume with [`Self::resume`] (or [`Self::resume_not_handled`] for OS calls).
+#[pyclass(name = "FunctionSnapshot", module = "pydantic_monty", frozen)]
+pub struct PyFunctionSnapshot(FunctionSnapshot);
+
+#[pymethods]
+impl PyFunctionSnapshot {
+    #[getter]
+    fn script_name(&self) -> &str {
+        &self.0.snapshot.ctx.script_name
+    }
+
+    #[getter]
+    fn is_os_function(&self) -> bool {
+        self.0.call.is_os_function
+    }
+
+    #[getter]
+    fn is_method_call(&self) -> bool {
+        self.0.call.is_method_call
+    }
+
+    #[getter]
+    fn function_name(&self) -> &str {
+        &self.0.call.function_name
+    }
+
+    #[getter]
+    fn call_id(&self) -> u32 {
+        self.0.call.call_id
+    }
+
+    #[getter]
+    fn args<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyTuple>> {
+        args_to_py(py, &self.0.call.args, &self.0.snapshot.ctx.dc_registry)
+    }
+
+    #[getter]
+    fn kwargs<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        kwargs_to_py(py, &self.0.call.kwargs, &self.0.snapshot.ctx.dc_registry)
+    }
+
+    /// Resumes execution with an `ExternalResult` (return value, exception, or
+    /// future). Resumes once; OS calls produced by the continuation are
+    /// auto-dispatched through `os=` until the next non-OS event.
+    #[pyo3(signature = (result, *, os=None))]
+    fn resume(&self, py: Python<'_>, result: &Bound<'_, PyDict>, os: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
+        let value = self.0.resume_value(py, result)?;
+        let ctx = self.0.snapshot.claim(py)?;
+        drive_sync(py, ctx, os, move |c, p| c.resume(value, p))
+    }
+
+    /// Resumes an OS-call snapshot with monty's default unhandled-OS behaviour.
+    #[pyo3(signature = (*, os=None))]
+    fn resume_not_handled(&self, py: Python<'_>, os: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
+        let value = self.0.not_handled_value()?;
+        let ctx = self.0.snapshot.claim(py)?;
+        drive_sync(py, ctx, os, move |c, p| c.resume(value, p))
+    }
+
+    fn dump(&self, py: Python<'_>) -> PyResult<Py<PyBytes>> {
+        self.0.snapshot.dump(py)
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "FunctionSnapshot(function_name={:?}, is_os_function={})",
+            self.0.call.function_name, self.0.call.is_os_function
+        )
+    }
+}
+
+/// Async sibling of [`PyFunctionSnapshot`]: `resume` / `resume_not_handled`
+/// return awaitables driven off the event loop.
+#[pyclass(name = "AsyncFunctionSnapshot", module = "pydantic_monty", frozen)]
+pub struct PyAsyncFunctionSnapshot(FunctionSnapshot);
+
+#[pymethods]
+impl PyAsyncFunctionSnapshot {
+    #[getter]
+    fn script_name(&self) -> &str {
+        &self.0.snapshot.ctx.script_name
+    }
+
+    #[getter]
+    fn is_os_function(&self) -> bool {
+        self.0.call.is_os_function
+    }
+
+    #[getter]
+    fn is_method_call(&self) -> bool {
+        self.0.call.is_method_call
+    }
+
+    #[getter]
+    fn function_name(&self) -> &str {
+        &self.0.call.function_name
+    }
+
+    #[getter]
+    fn call_id(&self) -> u32 {
+        self.0.call.call_id
+    }
+
+    #[getter]
+    fn args<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyTuple>> {
+        args_to_py(py, &self.0.call.args, &self.0.snapshot.ctx.dc_registry)
+    }
+
+    #[getter]
+    fn kwargs<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        kwargs_to_py(py, &self.0.call.kwargs, &self.0.snapshot.ctx.dc_registry)
+    }
+
+    #[pyo3(signature = (result, *, os=None))]
+    fn resume<'py>(
+        &self,
+        py: Python<'py>,
+        result: &Bound<'_, PyDict>,
+        os: Option<Py<PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let value = self.0.resume_value(py, result)?;
+        let ctx = self.0.snapshot.claim(py)?;
+        future_into_py(
+            py,
+            async move { drive_async(ctx, os, move |c, p| c.resume(value, p)).await },
+        )
+    }
+
+    #[pyo3(signature = (*, os=None))]
+    fn resume_not_handled<'py>(&self, py: Python<'py>, os: Option<Py<PyAny>>) -> PyResult<Bound<'py, PyAny>> {
+        let value = self.0.not_handled_value()?;
+        let ctx = self.0.snapshot.claim(py)?;
+        future_into_py(
+            py,
+            async move { drive_async(ctx, os, move |c, p| c.resume(value, p)).await },
+        )
+    }
+
+    fn dump(&self, py: Python<'_>) -> PyResult<Py<PyBytes>> {
+        self.0.snapshot.dump(py)
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "AsyncFunctionSnapshot(function_name={:?}, is_os_function={})",
+            self.0.call.function_name, self.0.call.is_os_function
+        )
+    }
+}
+
+// =============================================================================
+// NameLookupSnapshot — sync and async
+// =============================================================================
+
+struct NameLookupSnapshot {
+    snapshot: SnapshotState,
+    name: String,
+}
+
+impl NameLookupSnapshot {
+    fn resume_value(&self, py: Python<'_>, value: Option<&Bound<'_, PyAny>>) -> PyResult<Option<MontyObject>> {
+        value
+            .map(|v| py_to_monty_value(v, &self.snapshot.ctx.dc_registry).map_err(|e| MontyError::new_err(py, e)))
+            .transpose()
+    }
+}
+
+/// A paused execution waiting for the value of an undefined name. Resume with a
+/// `value` to define it, or with nothing to let the sandbox raise `NameError`.
+#[pyclass(name = "NameLookupSnapshot", module = "pydantic_monty", frozen)]
+pub struct PyNameLookupSnapshot(NameLookupSnapshot);
+
+#[pymethods]
+impl PyNameLookupSnapshot {
+    #[getter]
+    fn script_name(&self) -> &str {
+        &self.0.snapshot.ctx.script_name
+    }
+
+    #[getter]
+    fn variable_name(&self) -> &str {
+        &self.0.name
+    }
+
+    #[pyo3(signature = (*, value=None, os=None))]
+    fn resume(&self, py: Python<'_>, value: Option<&Bound<'_, PyAny>>, os: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
+        let value = self.0.resume_value(py, value)?;
+        let ctx = self.0.snapshot.claim(py)?;
+        drive_sync(py, ctx, os, move |c, p| c.resume_name_lookup(value, p))
+    }
+
+    fn dump(&self, py: Python<'_>) -> PyResult<Py<PyBytes>> {
+        self.0.snapshot.dump(py)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("NameLookupSnapshot(variable_name={:?})", self.0.name)
+    }
+}
+
+/// Async sibling of [`PyNameLookupSnapshot`].
+#[pyclass(name = "AsyncNameLookupSnapshot", module = "pydantic_monty", frozen)]
+pub struct PyAsyncNameLookupSnapshot(NameLookupSnapshot);
+
+#[pymethods]
+impl PyAsyncNameLookupSnapshot {
+    #[getter]
+    fn script_name(&self) -> &str {
+        &self.0.snapshot.ctx.script_name
+    }
+
+    #[getter]
+    fn variable_name(&self) -> &str {
+        &self.0.name
+    }
+
+    #[pyo3(signature = (*, value=None, os=None))]
+    fn resume<'py>(
+        &self,
+        py: Python<'py>,
+        value: Option<&Bound<'_, PyAny>>,
+        os: Option<Py<PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let value = self.0.resume_value(py, value)?;
+        let ctx = self.0.snapshot.claim(py)?;
+        future_into_py(py, async move {
+            drive_async(ctx, os, move |c, p| c.resume_name_lookup(value, p)).await
+        })
+    }
+
+    fn dump(&self, py: Python<'_>) -> PyResult<Py<PyBytes>> {
+        self.0.snapshot.dump(py)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("AsyncNameLookupSnapshot(variable_name={:?})", self.0.name)
+    }
+}
+
+// =============================================================================
+// FutureSnapshot — sync and async
+// =============================================================================
+
+struct FutureSnapshot {
+    snapshot: SnapshotState,
+    pending_call_ids: Vec<u32>,
+}
+
+impl FutureSnapshot {
+    fn resume_values(&self, py: Python<'_>, results: &Bound<'_, PyDict>) -> PyResult<Vec<(u32, ResumeValue)>> {
+        let mut resolved = Vec::with_capacity(results.len());
+        for (key, value) in results {
+            let call_id: u32 = key
+                .extract()
+                .map_err(|_| PyTypeError::new_err("future result keys must be int call ids"))?;
+            let dict = value
+                .cast_into::<PyDict>()
+                .map_err(|_| PyTypeError::new_err("future result values must be ExternalResult dicts"))?;
+            resolved.push((
+                call_id,
+                parse_external_result(py, &dict, &self.snapshot.ctx.dc_registry)?,
+            ));
+        }
+        Ok(resolved)
+    }
+}
+
+/// A paused execution where every sandbox task is blocked on external futures.
+/// Resume with a `{call_id: ExternalResult}` mapping for one or more futures.
+#[pyclass(name = "FutureSnapshot", module = "pydantic_monty", frozen)]
+pub struct PyFutureSnapshot(FutureSnapshot);
+
+#[pymethods]
+impl PyFutureSnapshot {
+    #[getter]
+    fn script_name(&self) -> &str {
+        &self.0.snapshot.ctx.script_name
+    }
+
+    #[getter]
+    fn pending_call_ids(&self) -> Vec<u32> {
+        self.0.pending_call_ids.clone()
+    }
+
+    #[pyo3(signature = (results, *, os=None))]
+    fn resume(&self, py: Python<'_>, results: &Bound<'_, PyDict>, os: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
+        let resolved = self.0.resume_values(py, results)?;
+        let ctx = self.0.snapshot.claim(py)?;
+        drive_sync(py, ctx, os, move |c, p| c.resume_futures(resolved, p))
+    }
+
+    fn dump(&self, py: Python<'_>) -> PyResult<Py<PyBytes>> {
+        self.0.snapshot.dump(py)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("FutureSnapshot(pending_call_ids={:?})", self.0.pending_call_ids)
+    }
+}
+
+/// Async sibling of [`PyFutureSnapshot`].
+#[pyclass(name = "AsyncFutureSnapshot", module = "pydantic_monty", frozen)]
+pub struct PyAsyncFutureSnapshot(FutureSnapshot);
+
+#[pymethods]
+impl PyAsyncFutureSnapshot {
+    #[getter]
+    fn script_name(&self) -> &str {
+        &self.0.snapshot.ctx.script_name
+    }
+
+    #[getter]
+    fn pending_call_ids(&self) -> Vec<u32> {
+        self.0.pending_call_ids.clone()
+    }
+
+    #[pyo3(signature = (results, *, os=None))]
+    fn resume<'py>(
+        &self,
+        py: Python<'py>,
+        results: &Bound<'_, PyDict>,
+        os: Option<Py<PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let resolved = self.0.resume_values(py, results)?;
+        let ctx = self.0.snapshot.claim(py)?;
+        future_into_py(py, async move {
+            drive_async(ctx, os, move |c, p| c.resume_futures(resolved, p)).await
+        })
+    }
+
+    fn dump(&self, py: Python<'_>) -> PyResult<Py<PyBytes>> {
+        self.0.snapshot.dump(py)
+    }
+
+    fn __repr__(&self) -> String {
+        format!("AsyncFutureSnapshot(pending_call_ids={:?})", self.0.pending_call_ids)
+    }
+}
+
+// =============================================================================
+// MontyComplete — terminal value (shared by sync and async)
+// =============================================================================
+
+/// The result of a completed `feed_start` execution. `output` converts the
+/// final value from monty's representation to a Python object on each access.
+#[pyclass(name = "MontyComplete", module = "pydantic_monty", frozen)]
+pub struct MontyComplete {
+    value: MontyObject,
+    dc_registry: DcRegistry,
+}
+
+#[pymethods]
+impl MontyComplete {
+    #[getter]
+    fn output(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        monty_to_py(py, &self.value, &self.dc_registry)
+    }
+
+    fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
+        let output = self.output(py)?;
+        Ok(format!("MontyComplete(output={})", output.bind(py).repr()?))
+    }
+}

--- a/crates/monty-python/src/snapshot.rs
+++ b/crates/monty-python/src/snapshot.rs
@@ -346,22 +346,28 @@ impl SnapshotState {
     }
 
     fn dump(&self, py: Python<'_>) -> PyResult<Py<PyBytes>> {
-        // a resumed snapshot is a spent cursor: the worker has advanced past
-        // this suspension, so dumping now would serialize the *current* session
-        // state mislabeled as this snapshot. Reject it, matching `claim`.
-        if self.resumed.load(Ordering::SeqCst) {
-            return Err(PyRuntimeError::new_err(
-                "cannot dump a snapshot that has already been resumed",
-            ));
-        }
+        // Check resumed only under the checkout lock
         let checkout = SharedCheckout::clone(&self.ctx.checkout);
+        let resumed = &self.resumed;
         let state = py
             .detach(|| {
                 let mut guard = lock(&checkout);
-                guard.as_mut().ok_or(PoolError::Finished).and_then(Checkout::dump)
+                if resumed.load(Ordering::SeqCst) {
+                    return Ok(None);
+                }
+                guard
+                    .as_mut()
+                    .ok_or(PoolError::Finished)
+                    .and_then(Checkout::dump)
+                    .map(Some)
             })
             .map_err(|e| pool_err_to_py(py, e))?;
-        Ok(PyBytes::new(py, &state).unbind())
+        match state {
+            Some(state) => Ok(PyBytes::new(py, &state).unbind()),
+            None => Err(PyRuntimeError::new_err(
+                "cannot dump a snapshot that has already been resumed",
+            )),
+        }
     }
 }
 

--- a/crates/monty-python/src/snapshot.rs
+++ b/crates/monty-python/src/snapshot.rs
@@ -346,6 +346,14 @@ impl SnapshotState {
     }
 
     fn dump(&self, py: Python<'_>) -> PyResult<Py<PyBytes>> {
+        // a resumed snapshot is a spent cursor: the worker has advanced past
+        // this suspension, so dumping now would serialize the *current* session
+        // state mislabeled as this snapshot. Reject it, matching `claim`.
+        if self.resumed.load(Ordering::SeqCst) {
+            return Err(PyRuntimeError::new_err(
+                "cannot dump a snapshot that has already been resumed",
+            ));
+        }
         let checkout = SharedCheckout::clone(&self.ctx.checkout);
         let state = py
             .detach(|| {
@@ -771,6 +779,11 @@ struct FutureSnapshot {
 }
 
 impl FutureSnapshot {
+    /// Parses the `{call_id: result}` mapping into `ResumeValue`s, rejecting a
+    /// pending `future` answer up front: a future must settle to a return value
+    /// or exception, not to another future. Validating here — before `resume`
+    /// calls `claim()` — means an invalid resolution fails with a `PyTypeError`
+    /// without consuming the (single-use) snapshot or stranding the worker.
     fn resume_values(&self, py: Python<'_>, results: &Bound<'_, PyDict>) -> PyResult<Vec<(u32, ResumeValue)>> {
         let mut resolved = Vec::with_capacity(results.len());
         for (key, value) in results {
@@ -780,10 +793,13 @@ impl FutureSnapshot {
             let dict = value
                 .cast_into::<PyDict>()
                 .map_err(|_| PyTypeError::new_err("future result values must be ExternalResult dicts"))?;
-            resolved.push((
-                call_id,
-                parse_external_result(py, &dict, &self.snapshot.ctx.dc_registry)?,
-            ));
+            let resume = parse_external_result(py, &dict, &self.snapshot.ctx.dc_registry)?;
+            if matches!(resume, ResumeValue::Future) {
+                return Err(PyTypeError::new_err(format!(
+                    "future {call_id} cannot resolve to another future; provide a return value or exception"
+                )));
+            }
+            resolved.push((call_id, resume));
         }
         Ok(resolved)
     }

--- a/crates/monty-python/tests/test_feed_start.py
+++ b/crates/monty-python/tests/test_feed_start.py
@@ -1,0 +1,270 @@
+"""Tests for the suspendable `feed_start` surface and `load_snapshot`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from inline_snapshot import snapshot
+
+from pydantic_monty import (
+    AsyncFunctionSnapshot,
+    AsyncFutureSnapshot,
+    AsyncMonty,
+    FunctionSnapshot,
+    FutureSnapshot,
+    Monty,
+    MontyComplete,
+    MontyRuntimeError,
+    MontySession,
+    MountDir,
+    NameLookupSnapshot,
+    OsFunction,
+)
+
+
+def test_function_call_suspends_then_completes(session: MontySession):
+    snap = session.feed_start('x = add(2, 3)\nx * 10')
+    assert isinstance(snap, FunctionSnapshot)
+    assert snap.function_name == snapshot('add')
+    assert snap.args == snapshot((2, 3))
+    assert snap.kwargs == snapshot({})
+    assert snap.is_os_function == snapshot(False)
+    assert snap.is_method_call == snapshot(False)
+    done = snap.resume({'return_value': 5})
+    assert isinstance(done, MontyComplete)
+    assert done.output == snapshot(50)
+
+
+def test_kwargs_surface(session: MontySession):
+    snap = session.feed_start('greet(name="ada", times=2)')
+    assert isinstance(snap, FunctionSnapshot)
+    assert snap.kwargs == snapshot({'name': 'ada', 'times': 2})
+
+
+def test_resume_with_exception_instance(session: MontySession):
+    snap = session.feed_start('r = None\ntry:\n    boom()\nexcept ValueError as e:\n    r = str(e)\nr')
+    assert isinstance(snap, FunctionSnapshot)
+    done = snap.resume({'exception': ValueError('nope')})
+    assert isinstance(done, MontyComplete)
+    assert done.output == snapshot('nope')
+
+
+def test_resume_with_exc_type(session: MontySession):
+    snap = session.feed_start('r = None\ntry:\n    boom()\nexcept ValueError as e:\n    r = str(e)\nr')
+    assert isinstance(snap, FunctionSnapshot)
+    done = snap.resume({'exc_type': 'ValueError', 'message': 'bad'})
+    assert isinstance(done, MontyComplete)
+    assert done.output == snapshot('bad')
+
+
+def test_name_lookup_resume_with_value(session: MontySession):
+    snap = session.feed_start('missing + 1')
+    assert isinstance(snap, NameLookupSnapshot)
+    assert snap.variable_name == snapshot('missing')
+    done = snap.resume(value=41)
+    assert isinstance(done, MontyComplete)
+    assert done.output == snapshot(42)
+
+
+def test_name_lookup_resume_without_value_raises_name_error(session: MontySession):
+    snap = session.feed_start('missing + 1')
+    assert isinstance(snap, NameLookupSnapshot)
+    with pytest.raises(MontyRuntimeError) as exc_info:
+        snap.resume()
+    assert exc_info.value.display(format='msg') == snapshot("name 'missing' is not defined")
+
+
+def test_double_resume_raises(session: MontySession):
+    snap = session.feed_start('f()')
+    assert isinstance(snap, FunctionSnapshot)
+    snap.resume({'return_value': 1})
+    with pytest.raises(RuntimeError) as exc_info:
+        snap.resume({'return_value': 2})
+    assert str(exc_info.value) == snapshot('snapshot has already been resumed')
+
+
+def test_feed_while_suspended_raises(session: MontySession):
+    session.feed_start('f()')
+    with pytest.raises(RuntimeError):
+        session.feed_run('1 + 1')
+
+
+def test_resume_has_no_mount_arg(session: MontySession):
+    # mounts are fixed for the feed: resume takes no mount=, so passing one is
+    # a plain unexpected-keyword TypeError (go through Any to bypass the stub).
+    snap = session.feed_start('f()')
+    assert isinstance(snap, FunctionSnapshot)
+    untyped_snap: Any = snap
+    with pytest.raises(TypeError):
+        untyped_snap.resume({'return_value': 1}, mount=[])
+    # the rejected call did not consume the snapshot — it can still be answered
+    done = snap.resume({'return_value': 1})
+    assert isinstance(done, MontyComplete)
+
+
+def test_os_call_surfaces_without_handler(session: MontySession):
+    snap = session.feed_start("from pathlib import Path\nPath('/etc/x').read_text()")
+    assert isinstance(snap, FunctionSnapshot)
+    assert snap.is_os_function == snapshot(True)
+    assert snap.function_name == snapshot('Path.read_text')
+
+
+def test_os_handler_auto_dispatched(session: MontySession):
+    def handle_os(name: OsFunction, args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
+        assert name == 'Path.read_text'
+        return 'file body'
+
+    snap = session.feed_start(
+        "from pathlib import Path\nPath('/data/x').read_text()",
+        os=handle_os,
+    )
+    assert isinstance(snap, MontyComplete)
+    assert snap.output == snapshot('file body')
+
+
+def test_future_mechanism_sync(session: MontySession):
+    code = 'import asyncio\nasync def main():\n    return await go()\nasyncio.run(main())'
+    snap = session.feed_start(code)
+    assert isinstance(snap, FunctionSnapshot)
+    assert snap.function_name == snapshot('go')
+    call_id = snap.call_id
+    nxt = snap.resume({'future': ...})
+    assert isinstance(nxt, FutureSnapshot)
+    assert nxt.pending_call_ids == [call_id]
+    done = nxt.resume({call_id: {'return_value': 99}})
+    assert isinstance(done, MontyComplete)
+    assert done.output == snapshot(99)
+
+
+def test_dump_at_suspension_then_load_and_resume(pool: Monty):
+    with pool.checkout() as session:
+        snap = session.feed_start('y = fetch()\ny + 1')
+        assert isinstance(snap, FunctionSnapshot)
+        blob = snap.dump()
+
+    with pool.checkout() as session:
+        loaded_snap = session.load_snapshot(blob)
+        assert isinstance(loaded_snap, FunctionSnapshot)
+        assert loaded_snap.function_name == snapshot('fetch')
+        done = loaded_snap.resume({'return_value': 41})
+        assert isinstance(done, MontyComplete)
+        assert done.output == snapshot(42)
+
+
+def test_mounts_restored_on_load_when_resupplied(pool: Monty, tmp_path: Path):
+    # Re-supplying the feed's mounts to load_snapshot rebuilds the mount table,
+    # so the mounted read after resume is served in-worker and never surfaces.
+    (tmp_path / 'hello.txt').write_text('hi')
+    mount = MountDir('/data', str(tmp_path), mode='read-only')
+    code = "f()\nfrom pathlib import Path\nPath('/data/hello.txt').read_text()"
+    with pool.checkout() as session:
+        snap = session.feed_start(code, mount=mount)
+        assert isinstance(snap, FunctionSnapshot)
+        assert snap.function_name == snapshot('f')
+        blob = snap.dump()
+
+    with pool.checkout() as session:
+        loaded_snap = session.load_snapshot(blob, mount=mount)
+        assert isinstance(loaded_snap, FunctionSnapshot)
+        done = loaded_snap.resume({'return_value': None})
+        assert isinstance(done, MontyComplete)
+        assert done.output == snapshot('hi')
+
+
+def test_load_errors_when_required_mount_not_resupplied(pool: Monty, tmp_path: Path):
+    # Omitting a mount the suspended feed had is a loud error, not a silent
+    # drop — load validates the dump's recorded mount requirements.
+    (tmp_path / 'hello.txt').write_text('hi')
+    mount = MountDir('/data', str(tmp_path), mode='read-only')
+    code = "f()\nfrom pathlib import Path\nPath('/data/hello.txt').read_text()"
+    with pool.checkout() as session:
+        snap = session.feed_start(code, mount=mount)
+        assert isinstance(snap, FunctionSnapshot)
+        blob = snap.dump()
+
+    with pool.checkout() as session:
+        with pytest.raises(MontyRuntimeError) as exc_info:
+            session.load_snapshot(blob)
+    assert exc_info.value.display(format='msg') == snapshot(
+        'the dump was suspended with a mount at "/data" that was not re-supplied to load; pass the same mounts the original feed used'
+    )
+
+
+def test_load_errors_when_mount_supplied_to_idle_dump(pool: Monty, tmp_path: Path):
+    # An idle dump has no mount requirements, so supplying one is rejected.
+    with pool.checkout() as session:
+        session.feed_run('kept = 1')
+        blob = session.dump()
+
+    mount = MountDir('/data', str(tmp_path), mode='read-only')
+    with pool.checkout() as session:
+        with pytest.raises(MontyRuntimeError) as exc_info:
+            session.load_snapshot(blob, mount=mount)
+    assert exc_info.value.display(format='msg') == snapshot(
+        'a mount at "/data" was supplied to load but the dump\'s feed had no such mount'
+    )
+
+
+def test_load_idle_session_has_no_snapshot(pool: Monty):
+    with pool.checkout() as session:
+        session.feed_run('kept = 7')
+        blob = session.dump()
+
+    with pool.checkout() as session:
+        assert session.load_snapshot(blob) is None
+        assert session.feed_run('kept + 1') == snapshot(8)
+
+
+def test_load_snapshot_after_feed_raises(pool: Monty):
+    # load_snapshot is only valid on a fresh, undriven session.
+    with pool.checkout() as session:
+        blob = session.dump()
+    with pool.checkout() as session:
+        session.feed_run('x = 1')
+        with pytest.raises(RuntimeError) as exc_info:
+            session.load_snapshot(blob)
+        assert str(exc_info.value) == snapshot(
+            'load_snapshot is only valid on a fresh session, before any feed_run / feed_start / load_snapshot'
+        )
+
+
+async def test_async_function_call_suspends_then_completes():
+    async with AsyncMonty() as pool:
+        async with pool.checkout() as session:
+            snap = await session.feed_start('x = add(2, 3)\nx * 10')
+            assert isinstance(snap, AsyncFunctionSnapshot)
+            assert snap.function_name == snapshot('add')
+            done = await snap.resume({'return_value': 5})
+            assert isinstance(done, MontyComplete)
+            assert done.output == snapshot(50)
+
+
+async def test_async_future_mechanism():
+    async with AsyncMonty() as pool:
+        async with pool.checkout() as session:
+            code = 'import asyncio\nasync def main():\n    return await go()\nasyncio.run(main())'
+            snap = await session.feed_start(code)
+            assert isinstance(snap, AsyncFunctionSnapshot)
+            call_id = snap.call_id
+            nxt = await snap.resume({'future': ...})
+            assert isinstance(nxt, AsyncFutureSnapshot)
+            assert nxt.pending_call_ids == [call_id]
+            done = await nxt.resume({call_id: {'return_value': 99}})
+            assert isinstance(done, MontyComplete)
+            assert done.output == snapshot(99)
+
+
+async def test_async_dump_load_round_trip():
+    async with AsyncMonty() as pool:
+        async with pool.checkout() as session:
+            await session.feed_start('y = fetch()\ny + 1')
+            blob = await session.dump()
+
+        async with pool.checkout() as session:
+            loaded_snap = await session.load_snapshot(blob)
+            assert isinstance(loaded_snap, AsyncFunctionSnapshot)
+            done = await loaded_snap.resume({'return_value': 41})
+            assert isinstance(done, MontyComplete)
+            assert done.output == snapshot(42)

--- a/crates/monty-python/tests/test_feed_start.py
+++ b/crates/monty-python/tests/test_feed_start.py
@@ -187,6 +187,9 @@ def test_load_errors_when_required_mount_not_resupplied(pool: Monty, tmp_path: P
     with pool.checkout() as session:
         with pytest.raises(MontyRuntimeError) as exc_info:
             session.load_snapshot(blob)
+        # a failed load (here a validation error) poisons the session
+        with pytest.raises(RuntimeError):
+            session.feed_run('1 + 1')
     assert exc_info.value.display(format='msg') == snapshot(
         'the dump was suspended with a mount at "/data" that was not re-supplied to load; pass the same mounts the original feed used'
     )
@@ -207,18 +210,48 @@ def test_load_errors_when_mount_supplied_to_idle_dump(pool: Monty, tmp_path: Pat
     )
 
 
-def test_load_idle_session_has_no_snapshot(pool: Monty):
+def test_load_restores_idle_session(pool: Monty):
     with pool.checkout() as session:
         session.feed_run('kept = 7')
         blob = session.dump()
 
     with pool.checkout() as session:
-        assert session.load_snapshot(blob) is None
+        assert session.load(blob) is None
         assert session.feed_run('kept + 1') == snapshot(8)
 
 
-def test_load_snapshot_after_feed_raises(pool: Monty):
-    # load_snapshot is only valid on a fresh, undriven session.
+def test_load_snapshot_on_idle_dump_raises(pool: Monty):
+    with pool.checkout() as session:
+        session.feed_run('kept = 1')
+        blob = session.dump()
+
+    with pool.checkout() as session:
+        with pytest.raises(RuntimeError) as exc_info:
+            session.load_snapshot(blob)
+        assert str(exc_info.value) == snapshot('this dump is an idle session — use load() to restore it')
+        # the failed load poisons the session — it is not retryable
+        with pytest.raises(RuntimeError):
+            session.feed_run('1 + 1')
+
+
+def test_load_idle_dump_after_a_suspended_dump_path(pool: Monty):
+    # the converse mismatch: load() on a suspended snapshot raises
+    with pool.checkout() as session:
+        snap = session.feed_start('f()')
+        assert isinstance(snap, FunctionSnapshot)
+        blob = snap.dump()
+
+    with pool.checkout() as session:
+        with pytest.raises(RuntimeError) as exc_info:
+            session.load(blob)
+        assert str(exc_info.value) == snapshot('this dump is a suspended snapshot — use load_snapshot() to resume it')
+        # the failed load poisons the session — it is not retryable
+        with pytest.raises(RuntimeError):
+            session.feed_run('1 + 1')
+
+
+def test_load_after_feed_raises(pool: Monty):
+    # load / load_snapshot are only valid on a fresh, undriven session.
     with pool.checkout() as session:
         blob = session.dump()
     with pool.checkout() as session:
@@ -226,7 +259,7 @@ def test_load_snapshot_after_feed_raises(pool: Monty):
         with pytest.raises(RuntimeError) as exc_info:
             session.load_snapshot(blob)
         assert str(exc_info.value) == snapshot(
-            'load_snapshot is only valid on a fresh session, before any feed_run / feed_start / load_snapshot'
+            'load / load_snapshot is only valid on a fresh session, before any feed_run / feed_start / load / load_snapshot'
         )
 
 

--- a/crates/monty-python/tests/test_feed_start.py
+++ b/crates/monty-python/tests/test_feed_start.py
@@ -68,6 +68,16 @@ def test_name_lookup_resume_with_value(session: MontySession):
     assert done.output == snapshot(42)
 
 
+def test_name_lookup_resume_with_none_value(session: MontySession):
+    # an explicit None binds the name to None — distinct from omitting value,
+    # which raises NameError
+    snap = session.feed_start('x = missing\nx is None')
+    assert isinstance(snap, NameLookupSnapshot)
+    done = snap.resume(value=None)
+    assert isinstance(done, MontyComplete)
+    assert done.output == snapshot(True)
+
+
 def test_name_lookup_resume_without_value_raises_name_error(session: MontySession):
     snap = session.feed_start('missing + 1')
     assert isinstance(snap, NameLookupSnapshot)

--- a/crates/monty-python/tests/test_feed_start.py
+++ b/crates/monty-python/tests/test_feed_start.py
@@ -95,10 +95,25 @@ def test_double_resume_raises(session: MontySession):
     assert str(exc_info.value) == snapshot('snapshot has already been resumed')
 
 
+def test_dump_after_resume_raises(session: MontySession):
+    # a resumed snapshot is a spent cursor — dumping it would serialize the
+    # advanced session state, not this suspension, so it is rejected
+    snap = session.feed_start('f()')
+    assert isinstance(snap, FunctionSnapshot)
+    snap.dump()  # dumping a live (un-resumed) snapshot is fine
+    snap.resume({'return_value': 1})
+    with pytest.raises(RuntimeError) as exc_info:
+        snap.dump()
+    assert str(exc_info.value) == snapshot('cannot dump a snapshot that has already been resumed')
+
+
 def test_feed_while_suspended_raises(session: MontySession):
     session.feed_start('f()')
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError) as exc_info:
         session.feed_run('1 + 1')
+    assert exc_info.value.args[0] == snapshot(
+        'monty worker protocol error: feed called while a suspension is awaiting an answer'
+    )
 
 
 def test_resume_has_no_mount_arg(session: MontySession):
@@ -107,8 +122,9 @@ def test_resume_has_no_mount_arg(session: MontySession):
     snap = session.feed_start('f()')
     assert isinstance(snap, FunctionSnapshot)
     untyped_snap: Any = snap
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as exc_info:
         untyped_snap.resume({'return_value': 1}, mount=[])
+    assert exc_info.value.args[0] == snapshot("FunctionSnapshot.resume() got an unexpected keyword argument 'mount'")
     # the rejected call did not consume the snapshot — it can still be answered
     done = snap.resume({'return_value': 1})
     assert isinstance(done, MontyComplete)
@@ -148,6 +164,31 @@ def test_future_mechanism_sync(session: MontySession):
     assert done.output == snapshot(99)
 
 
+def test_future_cannot_resolve_to_future(session: MontySession):
+    # a future must settle to a value/exception; resolving with another future
+    # is rejected up front, without consuming the (single-use) snapshot
+    code = 'import asyncio\nasync def main():\n    return await go()\nasyncio.run(main())'
+    snap = session.feed_start(code)
+    assert isinstance(snap, FunctionSnapshot)
+    call_id = snap.call_id
+    nxt = snap.resume({'future': ...})
+    assert isinstance(nxt, FutureSnapshot)
+    # a future result is not a settled result, so the stub rejects it too —
+    # go through Any to exercise the runtime guard
+    untyped_nxt: Any = nxt
+    with pytest.raises(TypeError) as exc_info:
+        untyped_nxt.resume({call_id: {'future': ...}})
+    # message embeds the runtime call id, so compare directly rather than snapshot
+    assert (
+        exc_info.value.args[0]
+        == f'future {call_id} cannot resolve to another future; provide a return value or exception'
+    )
+    # the rejected resolution did not consume the snapshot — it still resolves
+    done = nxt.resume({call_id: {'return_value': 7}})
+    assert isinstance(done, MontyComplete)
+    assert done.output == snapshot(7)
+
+
 def test_dump_at_suspension_then_load_and_resume(pool: Monty):
     with pool.checkout() as session:
         snap = session.feed_start('y = fetch()\ny + 1')
@@ -161,6 +202,21 @@ def test_dump_at_suspension_then_load_and_resume(pool: Monty):
         done = loaded_snap.resume({'return_value': 41})
         assert isinstance(done, MontyComplete)
         assert done.output == snapshot(42)
+
+
+def test_loaded_snapshot_reports_the_dumps_script_name(pool: Monty):
+    # script_name travels inside the dump; the restored snapshot reports the
+    # dump's name, not the (differently-configured) restoring session's
+    with pool.checkout(script_name='original.py') as session:
+        snap = session.feed_start('fetch()')
+        assert isinstance(snap, FunctionSnapshot)
+        assert snap.script_name == snapshot('original.py')
+        blob = snap.dump()
+
+    with pool.checkout(script_name='different.py') as session:
+        loaded_snap = session.load_snapshot(blob)
+        assert isinstance(loaded_snap, FunctionSnapshot)
+        assert loaded_snap.script_name == snapshot('original.py')
 
 
 def test_mounts_restored_on_load_when_resupplied(pool: Monty, tmp_path: Path):

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -15,10 +15,11 @@ the *host API* surface.
 
 - The protocol (and `pydantic_monty`) is **REPL-only**: a pool checkout is a
   REPL session in a dedicated worker, and a one-shot run is a checkout plus a
-  single feed. There are no manual suspension snapshots in Python; external
-  function calls, OS callbacks, and print callbacks are driven automatically
-  by `feed_run` (sync or awaited). (The Rust `monty-pool::Checkout` API does
-  expose manual suspension driving and `Pool::checkout_load`.)
+  single feed. `feed_run` drives external function calls, OS callbacks, and
+  print callbacks automatically. `feed_start` instead returns a *snapshot* at
+  each suspension (`FunctionSnapshot` / `NameLookupSnapshot` / `FutureSnapshot`,
+  or `MontyComplete`) for the caller to inspect, `dump()`, and `resume(...)`;
+  see the snapshot divergences below.
 - A session whose worker crashed is lost: subsequent calls raise
   `MontyCrashedError`. The pool itself recovers by replacing the worker.
 - Resource exhaustion (e.g. `max_duration_secs`) is terminal for the
@@ -131,12 +132,48 @@ the *host API* surface.
   filesystem calls are handled inside the worker and never reach the
   callback.
 - **`dump()`** bytes use a subprocess-specific envelope and can only be
-  restored into another subprocess worker (Rust `Pool::checkout_load`); there
-  is currently no Python API to restore them.
+  restored into another subprocess worker of the same version, via
+  `session.load_snapshot` (Rust `Checkout::load_in_place`).
+- **`feed_start` snapshots are live cursors, not owned state.** The execution
+  state lives in the worker, so only one suspension is live per session, each
+  snapshot may be resumed at most once (a second resume raises
+  `RuntimeError`), and feeding while suspended raises. This differs from the
+  pre-subprocess in-process API, where a snapshot owned freely-copyable state.
+- **`load_snapshot` is a session method, valid only on a fresh session.** The
+  old module-level `load_snapshot` / `load_repl_snapshot` are replaced by
+  `session.load_snapshot(state) -> snapshot | None` (the snapshot is `None` for
+  a dump taken between feeds). It restores a dump *into* a freshly checked-out
+  session in place of starting it fresh, so it is rejected (`RuntimeError`)
+  after any `feed_run` / `feed_start` / `load_snapshot` — it would otherwise
+  silently discard work. The dump restores its own `script_name` / limits /
+  type-check state (the `checkout()` config for those is not applied); the
+  dataclass registry from `checkout()` is reused.
+- **`resume` takes no `mount=`.** Mounts are fixed for the whole feed (passed
+  to `feed_start`), so there is no per-`resume` mount argument.
+- **Mounts are re-supplied to `load_snapshot`, not stored in the dump.** Mounts
+  are host configuration, not sandbox state, so their **host paths** never enter
+  the (opaque, possibly-transmitted) dump bytes — a dump that carried host paths
+  could otherwise be crafted to mount an arbitrary host directory on load. To
+  resume a suspended feed with its mounts, pass the same `mount=` the original
+  `feed_start` used to `load_snapshot`; the worker rebuilds the mount table.
+- **`load_snapshot` validates the re-supplied mounts.** The dump records the
+  suspended feed's mount *requirements* (virtual path + mode + write limit, no
+  host path). `load_snapshot` must supply mounts that match them exactly (host
+  paths may differ); a missing, extra, or altered mount raises rather than
+  silently dropping the feed's mounts. An idle dump records no requirements, so
+  it takes no `mount=` (supplying one raises).
+- **`'overlay'` writes are not preserved across a dump.** A restored overlay
+  mount starts empty; `read-only` / `read-write` mounts hold no in-worker state
+  and restore fully.
+- **A re-announced OS-call snapshot after `load_snapshot` carries only its
+  `not_handled_error`** — its `args`/`kwargs` were consumed before the dump, so
+  they come back empty.
 - **Natural-JSON host serialization was removed.** Results now cross the
   subprocess boundary as structured protocol values; the old
   `MontyComplete.output_json()` / `FunctionSnapshot.args_json()` /
-  `kwargs_json()` helper format is not part of the pool API.
+  `kwargs_json()` helper format is not part of the pool API. (`feed_start`
+  snapshots and `MontyComplete` expose `args` / `kwargs` / `output` as
+  converted Python objects only.)
 
 ## JavaScript client (`@pydantic/monty`)
 
@@ -158,7 +195,17 @@ binaries shipped in platform npm packages. Everything above applies, plus:
   Return values that cannot be converted at all (e.g. a `Symbol`, or a
   malformed `__monty_type__` marker object) likewise raise a catchable
   in-sandbox `TypeError` instead of failing host-side.
-- **`dump()`** returns the opaque bytes; there is no JS restore API.
+- **Snapshots mirror `pydantic_monty`.** `session.feedStart(code, opts)`
+  returns a `FunctionSnapshot` / `NameLookupSnapshot` / `FutureSnapshot` (or a
+  `MontyComplete`); `session.dump()` / `snapshot.dump()` serialize the worker,
+  and `session.loadSnapshot(bytes, opts)` restores it (fresh-session-only,
+  returning the re-announced snapshot or `null`). Differences from Python: a
+  name lookup resolves only to an external *function* (`resume(functionName?)`,
+  matching `resumeNameLookup`), not an arbitrary value; resume verbs are
+  methods (`resume`, `resumeError`, `resumeNotFound`, `resumeFuture`,
+  `resumeNotHandled`) rather than a result dict; and the sandbox-future
+  mechanism is fully caller-driven (`resumeFuture()` then
+  `FutureSnapshot.resume([{callId, value}|{callId, error}])`).
 - Sessions and pools support `await using` (async disposal) in addition to
   explicit `close()`.
 

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -133,21 +133,27 @@ the *host API* surface.
   callback.
 - **`dump()`** bytes use a subprocess-specific envelope and can only be
   restored into another subprocess worker of the same version, via
-  `session.load_snapshot` (Rust `Checkout::load_in_place`).
+  `session.load` / `session.load_snapshot` (Rust `Checkout::restore`).
 - **`feed_start` snapshots are live cursors, not owned state.** The execution
   state lives in the worker, so only one suspension is live per session, each
   snapshot may be resumed at most once (a second resume raises
   `RuntimeError`), and feeding while suspended raises. This differs from the
   pre-subprocess in-process API, where a snapshot owned freely-copyable state.
-- **`load_snapshot` is a session method, valid only on a fresh session.** The
-  old module-level `load_snapshot` / `load_repl_snapshot` are replaced by
-  `session.load_snapshot(state) -> snapshot | None` (the snapshot is `None` for
-  a dump taken between feeds). It restores a dump *into* a freshly checked-out
-  session in place of starting it fresh, so it is rejected (`RuntimeError`)
-  after any `feed_run` / `feed_start` / `load_snapshot` — it would otherwise
-  silently discard work. The dump restores its own `script_name` / limits /
-  type-check state (the `checkout()` config for those is not applied); the
-  dataclass registry from `checkout()` is reused.
+- **Restoring a dump is a session method, split by dump kind.** The old
+  module-level `load_snapshot` / `load_repl_snapshot` are replaced by two
+  fresh-session-only methods: `session.load(state)` restores a dump taken
+  between feeds (an idle session) so you can keep feeding it, and
+  `session.load_snapshot(state, *, mount=…)` restores a dump taken mid-feed and
+  returns the re-announced snapshot to resume. The caller knows which kind it
+  dumped (`session.dump()` between feeds vs `snapshot.dump()`); using the wrong
+  method raises. Both restore *into* a freshly checked-out worker, so they are
+  rejected (`RuntimeError`) after any `feed_run` / `feed_start` / `load` /
+  `load_snapshot` — restoring would otherwise discard work. The dump restores
+  its own `script_name` / limits / type-check state (the `checkout()` config
+  for those is not applied); the dataclass registry from `checkout()` is reused.
+  A *failed* load (wrong dump kind, or a restore error such as a missing mount)
+  poisons the session — its worker is discarded, so every later feed fails too;
+  the load is not retryable and the caller must check out a fresh session.
 - **`resume` takes no `mount=`.** Mounts are fixed for the whole feed (passed
   to `feed_start`), so there is no per-`resume` mount argument.
 - **Mounts are re-supplied to `load_snapshot`, not stored in the dump.** Mounts
@@ -156,12 +162,13 @@ the *host API* surface.
   could otherwise be crafted to mount an arbitrary host directory on load. To
   resume a suspended feed with its mounts, pass the same `mount=` the original
   `feed_start` used to `load_snapshot`; the worker rebuilds the mount table.
+  (`load` takes no `mount` — an idle session has no in-flight feed; the next
+  feed supplies its own.)
 - **`load_snapshot` validates the re-supplied mounts.** The dump records the
   suspended feed's mount *requirements* (virtual path + mode + write limit, no
   host path). `load_snapshot` must supply mounts that match them exactly (host
   paths may differ); a missing, extra, or altered mount raises rather than
-  silently dropping the feed's mounts. An idle dump records no requirements, so
-  it takes no `mount=` (supplying one raises).
+  silently dropping the feed's mounts.
 - **`'overlay'` writes are not preserved across a dump.** A restored overlay
   mount starts empty; `read-only` / `read-write` mounts hold no in-worker state
   and restore fully.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Brings back suspendable execution to both SDKs: `feed_start`/`feedStart` return snapshots you can resume, with dump/restore for idle and mid-feed, lazy session configuration, and mount-validated loads. Also fixes a race that could resume a snapshot twice.

- New Features
  - Python (`pydantic_monty`)
    - `MontySession.feed_start(...)` returns `FunctionSnapshot` / `NameLookupSnapshot` / `FutureSnapshot` or `MontyComplete`.
    - `snapshot.resume(...)`, `snapshot.dump()`, plus `session.dump()` and `session.load_snapshot(...)`. Async variants, types, docs, and tests.
  - JS (`@pydantic/monty`)
    - `MontySession.feedStart(...)` returning `FunctionSnapshot` / `NameLookupSnapshot` / `FutureSnapshot` or `MontyComplete`.
    - `session.dump()`, `session.load(...)` (idle dumps), and `session.loadSnapshot(...)` (mid-feed). `NativeSession.restore(...)` now takes mounts and returns a suspension or a `'loaded'` turn. Types, docs, and tests added.
  - Dumps include type-check state and in-flight mount requirements; loading validates mounts.

- Migration
  - `monty-proto`: `ReplCreate` renamed to `Configure` (sent once per checkout). The REPL is created on first `ReplFeed` or via `Load`.
  - `monty-pool`: removed `Pool::checkout_load`; use `Checkout::restore(state, mounts, ...)`.
  - TypeScript: `NativeSession.restore` replaces `load`; use `MontySession.load` and `MontySession.loadSnapshot` and only restore into a fresh session. Handle the `'loaded'` turn from `NativeSession.restore`.

<sup>Written for commit 52ba4cf832a89dcf476ea4133d80d77d07a96221. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

