### PR TITLE
move `py_eq` to accept `&Value` for RHS

### DIFF
--- a/crates/monty-datatest/src/main.rs
+++ b/crates/monty-datatest/src/main.rs
@@ -470,7 +470,7 @@ fn dispatch_external_call(name: &str, args: Vec<MontyObject>) -> DispatchResult 
             DispatchResult::Sync(
                 MontyObject::Dataclass {
                     name: "Point".to_string(),
-                    type_id: 0, // Test fixture has no real Python type
+                    type_id: 1, // distinct per fixture class (real hosts pass the Python type id)
                     field_names: vec!["x".to_string(), "y".to_string()],
                     attrs: vec![
                         (MontyObject::String("x".to_string()), MontyObject::Int(1)),
@@ -489,7 +489,7 @@ fn dispatch_external_call(name: &str, args: Vec<MontyObject>) -> DispatchResult 
             DispatchResult::Sync(
                 MontyObject::Dataclass {
                     name: "MutablePoint".to_string(),
-                    type_id: 0, // Test fixture has no real Python type
+                    type_id: 2, // distinct per fixture class (real hosts pass the Python type id)
                     field_names: vec!["x".to_string(), "y".to_string()],
                     attrs: vec![
                         (MontyObject::String("x".to_string()), MontyObject::Int(1)),
@@ -509,7 +509,7 @@ fn dispatch_external_call(name: &str, args: Vec<MontyObject>) -> DispatchResult 
             DispatchResult::Sync(
                 MontyObject::Dataclass {
                     name: "User".to_string(),
-                    type_id: 0, // Test fixture has no real Python type
+                    type_id: 3, // distinct per fixture class (real hosts pass the Python type id)
                     field_names: vec!["name".to_string(), "active".to_string()],
                     attrs: vec![
                         (MontyObject::String("name".to_string()), MontyObject::String(name)),
@@ -528,7 +528,7 @@ fn dispatch_external_call(name: &str, args: Vec<MontyObject>) -> DispatchResult 
             DispatchResult::Sync(
                 MontyObject::Dataclass {
                     name: "Empty".to_string(),
-                    type_id: 0, // Test fixture has no real Python type
+                    type_id: 4, // distinct per fixture class (real hosts pass the Python type id)
                     field_names: vec![],
                     attrs: vec![].into(),
 
@@ -591,7 +591,7 @@ fn dispatch_method_call(
             let dy = i64::try_from(&args[2]).expect("dy must be int");
             MontyObject::Dataclass {
                 name: "Point".to_string(),
-                type_id: 0,
+                type_id: 1, // same class as `make_point`'s Point
                 field_names: vec!["x".to_string(), "y".to_string()],
                 attrs: vec![
                     (MontyObject::String("x".to_string()), MontyObject::Int(x + dx)),
@@ -609,7 +609,7 @@ fn dispatch_method_call(
             let factor = i64::try_from(&args[1]).expect("factor must be int");
             MontyObject::Dataclass {
                 name: "Point".to_string(),
-                type_id: 0,
+                type_id: 1, // same class as `make_point`'s Point
                 field_names: vec!["x".to_string(), "y".to_string()],
                 attrs: vec![
                     (MontyObject::String("x".to_string()), MontyObject::Int(x * factor)),

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -28,7 +28,7 @@ use crate::{
         MontyIter, NamedTuple, OpenFile, Path, PyTrait, Range, ReMatch, RePattern, Set, Slice, Str, Tuple, Type, date,
         datetime, str::allocate_string, timedelta, timezone,
     },
-    value::{EitherStr, Value},
+    value::{EitherStr, Value, eq_bigint, eq_bytes, eq_ext_function, eq_str},
 };
 
 /// HeapData captures every runtime value that must live in the arena.
@@ -637,94 +637,58 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         }
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        match (self, other) {
-            // Simple types: compare with shared borrows (no &mut VM needed)
-            (HeapReadOutput::Str(a), HeapReadOutput::Str(b)) => Ok(a.get(vm.heap).as_str() == b.get(vm.heap).as_str()),
-            (HeapReadOutput::Bytes(a), HeapReadOutput::Bytes(b)) => {
-                Ok(a.get(vm.heap).as_slice() == b.get(vm.heap).as_slice())
-            }
-            (HeapReadOutput::LongInt(a), HeapReadOutput::LongInt(b)) => Ok(a.get(vm.heap) == b.get(vm.heap)),
-            (HeapReadOutput::Closure(a), HeapReadOutput::Closure(b)) => {
-                let a = a.get(vm.heap);
-                let b = b.get(vm.heap);
-                Ok(a.func_id == b.func_id && a.cells == b.cells)
-            }
-            (HeapReadOutput::FunctionDefaults(a), HeapReadOutput::FunctionDefaults(b)) => {
-                Ok(a.get(vm.heap).func_id == b.get(vm.heap).func_id)
-            }
-            (HeapReadOutput::Range(a), HeapReadOutput::Range(b)) => {
-                // Range::py_eq is pure data comparison — inline to avoid
-                // borrow conflict with the &mut VM signature
-                let a = a.get(vm.heap);
-                let b = b.get(vm.heap);
-                let len_a = a.len();
-                if len_a != b.len() {
-                    Ok(false)
-                } else if len_a == 0 {
-                    Ok(true)
-                } else {
-                    Ok(a.start == b.start && a.step == b.step)
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        match self {
+            HeapReadOutput::Str(a) => Ok(eq_str(a.get(vm.heap).as_str(), other, vm)),
+            HeapReadOutput::Bytes(a) => Ok(eq_bytes(a.get(vm.heap).as_slice(), other, vm)),
+            HeapReadOutput::LongInt(a) => Ok(eq_bigint(a.get(vm.heap).inner(), other, vm)),
+            HeapReadOutput::ExtFunction(a) => Ok(eq_ext_function(a.get(vm.heap).as_str(), other, vm)),
+            // `Closure`/`FunctionDefaults` have no per-type `py_eq_impl`; their
+            // value-equality (by `func_id`, and captured cells for closures) is
+            // inlined here.
+            HeapReadOutput::Closure(a) => Ok(match other.read_heap(vm) {
+                Some(HeapReadOutput::Closure(b)) => {
+                    let a = a.get(vm.heap);
+                    let b = b.get(vm.heap);
+                    Some(a.func_id == b.func_id && a.cells == b.cells)
                 }
-            }
-            // Container types: use HeapRead-specific comparison methods
-            (HeapReadOutput::List(a), HeapReadOutput::List(b)) => a.py_eq(b, vm),
-            (HeapReadOutput::Tuple(a), HeapReadOutput::Tuple(b)) => a.py_eq(b, vm),
-            // Container types with HeapRead eq methods
-            (HeapReadOutput::Dict(a), HeapReadOutput::Dict(b)) => a.py_eq(b, vm),
-            (HeapReadOutput::Set(a), HeapReadOutput::Set(b)) => a.py_eq(b, vm),
-            (HeapReadOutput::FrozenSet(a), HeapReadOutput::FrozenSet(b)) => a.py_eq(b, vm),
-            // NamedTuple: element-wise comparison via HeapRead clone_item
-            (HeapReadOutput::NamedTuple(a), HeapReadOutput::NamedTuple(b)) => a.py_eq(b, vm),
-            // NamedTuple/Tuple cross-type comparison
-            (HeapReadOutput::NamedTuple(nt), HeapReadOutput::Tuple(t))
-            | (HeapReadOutput::Tuple(t), HeapReadOutput::NamedTuple(nt)) => nt.eq_tuple(t, vm),
-            // DictKeysView comparisons
-            (HeapReadOutput::DictKeysView(a), HeapReadOutput::DictKeysView(b)) => a.py_eq(b, vm),
-            (HeapReadOutput::DictKeysView(a), HeapReadOutput::Set(b)) => a.eq_set(b, vm),
-            (HeapReadOutput::Set(b), HeapReadOutput::DictKeysView(a)) => a.eq_set(b, vm),
-            (HeapReadOutput::DictKeysView(a), HeapReadOutput::FrozenSet(b)) => a.eq_frozenset(b, vm),
-            (HeapReadOutput::FrozenSet(b), HeapReadOutput::DictKeysView(a)) => a.eq_frozenset(b, vm),
-            // DictItemsView comparisons
-            (HeapReadOutput::DictItemsView(a), HeapReadOutput::DictItemsView(b)) => a.py_eq(b, vm),
-            (HeapReadOutput::DictItemsView(a), HeapReadOutput::Set(b)) => a.eq_set(b, vm),
-            (HeapReadOutput::Set(b), HeapReadOutput::DictItemsView(a)) => a.eq_set(b, vm),
-            (HeapReadOutput::DictItemsView(a), HeapReadOutput::FrozenSet(b)) => a.eq_frozenset(b, vm),
-            (HeapReadOutput::FrozenSet(b), HeapReadOutput::DictItemsView(a)) => a.eq_frozenset(b, vm),
-            (HeapReadOutput::Dataclass(a), HeapReadOutput::Dataclass(b)) => {
-                if a.get(vm.heap).name(vm.interns) != b.get(vm.heap).name(vm.interns) {
-                    return Ok(false);
-                }
-                a.attrs().py_eq(&b.attrs(), vm)
-            }
-            // Pure data comparisons (no VM needed)
-            (HeapReadOutput::Slice(a), HeapReadOutput::Slice(b)) => {
-                let a = a.get(vm.heap);
-                let b = b.get(vm.heap);
-                Ok(a.start == b.start && a.stop == b.stop && a.step == b.step)
-            }
-            (HeapReadOutput::Path(a), HeapReadOutput::Path(b)) => Ok(a.get(vm.heap) == b.get(vm.heap)),
-            (HeapReadOutput::RePattern(a), HeapReadOutput::RePattern(b)) => Ok(a.get(vm.heap) == b.get(vm.heap)),
-            // Datetime types
-            (HeapReadOutput::Date(a), HeapReadOutput::Date(b)) => a.py_eq(b, vm),
-            (HeapReadOutput::DateTime(a), HeapReadOutput::DateTime(b)) => a.py_eq(b, vm),
-            (HeapReadOutput::TimeDelta(a), HeapReadOutput::TimeDelta(b)) => a.py_eq(b, vm),
-            (HeapReadOutput::TimeZone(a), HeapReadOutput::TimeZone(b)) => a.py_eq(b, vm),
-            // External functions compare equal iff their names match — the
-            // same name-based identity used by `Value::py_eq`'s ExtFunction
-            // arms and `py_hash` via `hash_python_str`. (#347)
-            (HeapReadOutput::ExtFunction(a), HeapReadOutput::ExtFunction(b)) => Ok(a.get(vm.heap) == b.get(vm.heap)),
-            // Identity-only types (handled by HeapId comparison above)
-            (HeapReadOutput::ReMatch(_), HeapReadOutput::ReMatch(_))
-            | (HeapReadOutput::Cell(_), HeapReadOutput::Cell(_))
-            | (HeapReadOutput::Exception(_), HeapReadOutput::Exception(_))
-            | (HeapReadOutput::Iter(_), HeapReadOutput::Iter(_))
-            | (HeapReadOutput::Module(_), HeapReadOutput::Module(_))
-            | (HeapReadOutput::Coroutine(_), HeapReadOutput::Coroutine(_))
-            | (HeapReadOutput::GatherFuture(_), HeapReadOutput::GatherFuture(_))
-            | (HeapReadOutput::DictValuesView(_), HeapReadOutput::DictValuesView(_)) => Ok(false),
-            // Different types are never equal
-            _ => Ok(false),
+                _ => None,
+            }),
+            HeapReadOutput::FunctionDefaults(a) => Ok(match other.read_heap(vm) {
+                Some(HeapReadOutput::FunctionDefaults(b)) => Some(a.get(vm.heap).func_id == b.get(vm.heap).func_id),
+                _ => None,
+            }),
+            HeapReadOutput::List(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::Tuple(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::NamedTuple(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::Dict(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::Set(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::FrozenSet(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::DictKeysView(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::DictItemsView(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::DictValuesView(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::Range(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::Slice(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::Dataclass(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::Path(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::RePattern(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::ReMatch(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::OpenFile(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::Date(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::DateTime(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::TimeDelta(a) => a.py_eq_impl(other, vm),
+            HeapReadOutput::TimeZone(a) => a.py_eq_impl(other, vm),
+            // Identity-only types: equality is pure identity (handled before the
+            // heap read in `Value::py_eq_impl`), so they never define `==` themselves.
+            HeapReadOutput::Cell(_)
+            | HeapReadOutput::Exception(_)
+            | HeapReadOutput::Iter(_)
+            | HeapReadOutput::Module(_)
+            | HeapReadOutput::Coroutine(_)
+            | HeapReadOutput::GatherFuture(_)
+            | HeapReadOutput::ExternalFuture(_) => Ok(None),
+            #[cfg(feature = "test-hooks")]
+            HeapReadOutput::TestContextManager(a) => a.py_eq_impl(other, vm),
         }
     }
 

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -90,7 +90,7 @@ use crate::{
         List,
         slice::{normalize_sequence_index, slice_collect_iterator},
     },
-    value::{EitherStr, Value},
+    value::{EitherStr, Value, eq_bytes},
 };
 
 // =============================================================================
@@ -265,8 +265,9 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Bytes> {
         Ok(Value::Int(i64::from(byte)))
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        Ok(self.get(vm.heap).0 == other.get(vm.heap).0)
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        // Heap bytes equal interned or heap bytes with the same content.
+        Ok(eq_bytes(self.get(vm.heap).as_slice(), other, vm))
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -169,8 +169,8 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
         let Some(HeapReadOutput::Dataclass(other)) = other.read_heap(vm) else {
             return Ok(None);
         };
-        // Dataclasses are equal if they have the same class name and equal attrs.
-        if self.get(vm.heap).name(vm.interns) != other.get(vm.heap).name(vm.interns) {
+        // Dataclasses are equal only if they are the same class and have equal attrs.
+        if self.get(vm.heap).type_id() != other.get(vm.heap).type_id() {
             return Ok(Some(false));
         }
         Ok(Some(self.attrs().eq_dict(&other.attrs(), vm)?))

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -15,7 +15,7 @@ use crate::{
     exception_private::{ExcType, RunResult, SimpleException},
     hash::HashValue,
     heap::{
-        BorrowedHeapRead, BorrowedHeapReadMut, HeapId, HeapItem, HeapRead, heap_read_ref_as_field,
+        BorrowedHeapRead, BorrowedHeapReadMut, HeapId, HeapItem, HeapRead, HeapReadOutput, heap_read_ref_as_field,
         heap_read_ref_as_field_mut,
     },
     intern::Interns,
@@ -165,9 +165,15 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
         None
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        // Dataclasses are equal if they have the same name and equal attrs
-        Ok(self.get(vm.heap).name == other.get(vm.heap).name && self.attrs().py_eq(&other.attrs(), vm)?)
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        let Some(HeapReadOutput::Dataclass(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
+        // Dataclasses are equal if they have the same class name and equal attrs.
+        if self.get(vm.heap).name(vm.interns) != other.get(vm.heap).name(vm.interns) {
+            return Ok(Some(false));
+        }
+        Ok(Some(self.attrs().eq_dict(&other.attrs(), vm)?))
     }
 
     /// Hashes a frozen dataclass by its class name and the values of declared fields.

--- a/crates/monty/src/types/date.rs
+++ b/crates/monty/src/types/date.rs
@@ -20,7 +20,7 @@ use crate::{
     bytecode::{CallResult, VM},
     exception_private::{ExcType, RunError, RunResult, SimpleException},
     hash::HashValue,
-    heap::{Heap, HeapData, HeapId, HeapItem, HeapRead},
+    heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     os::OsFunctionCall,
     resource::{ResourceError, ResourceTracker},
@@ -210,8 +210,11 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Date> {
         None
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        Ok(*self.get(vm.heap) == *other.get(vm.heap))
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        let Some(HeapReadOutput::Date(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
+        Ok(Some(*self.get(vm.heap) == *other.get(vm.heap)))
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -23,7 +23,7 @@ use crate::{
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult, SimpleException},
     hash::HashValue,
-    heap::{DropWithHeap, Heap, HeapData, HeapId, HeapItem, HeapRead},
+    heap::{DropWithHeap, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     object::MontyObject,
     os::OsFunctionCall,
@@ -896,16 +896,19 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
         None
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        let Some(HeapReadOutput::DateTime(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
         let a = self.get(vm.heap);
         let b = other.get(vm.heap);
-        if is_aware(a) != is_aware(b) {
-            return Ok(false);
-        }
-        if is_aware(a) {
-            return Ok(utc_micros(a) == utc_micros(b));
-        }
-        Ok(local_micros(a) == local_micros(b))
+        Ok(Some(if is_aware(a) != is_aware(b) {
+            false
+        } else if is_aware(a) {
+            utc_micros(a) == utc_micros(b)
+        } else {
+            local_micros(a) == local_micros(b)
+        }))
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -238,7 +238,7 @@ impl<'h> HeapRead<'h, Dict> {
         let iter = self.iter(vm)?;
         defer_drop_mut!(iter, vm);
         while let Some((key, value)) = iter.next(vm)? {
-            let Ok(Some(other_value)) = other.dict_get(key, vm) else {
+            let Some(other_value) = other.dict_get(key, vm)? else {
                 return Ok(false);
             };
             defer_drop!(other_value, vm);

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -227,6 +227,28 @@ fn json_key_equals_str(key: &Value, expected: &str, heap: &Heap<impl ResourceTra
 }
 
 impl<'h> HeapRead<'h, Dict> {
+    /// Element-wise equality against another dict (matching keys and values).
+    ///
+    /// Shared by `Dict::py_eq_impl` and `Dataclass::py_eq_impl` (which compares
+    /// the dataclasses' attribute dicts).
+    pub(crate) fn eq_dict(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
+        if self.get(vm.heap).len() != other.get(vm.heap).len() {
+            return Ok(false);
+        }
+        let iter = self.iter(vm)?;
+        defer_drop_mut!(iter, vm);
+        while let Some((key, value)) = iter.next(vm)? {
+            let Ok(Some(other_value)) = other.dict_get(key, vm) else {
+                return Ok(false);
+            };
+            defer_drop!(other_value, vm);
+            if !value.py_eq(other_value, vm)? {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
     /// Gets a value from the dict by key.
     ///
     /// Returns Ok(Some(value)) if key exists, Ok(None) if key doesn't exist.
@@ -788,22 +810,11 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
         Some(self.get(vm.heap).len())
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        if self.get(vm.heap).len() != other.get(vm.heap).len() {
-            return Ok(false);
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        match other.read_heap(vm) {
+            Some(HeapReadOutput::Dict(other)) => Ok(Some(self.eq_dict(&other, vm)?)),
+            _ => Ok(None),
         }
-        let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
-        while let Some((key, value)) = iter.next(vm)? {
-            let Ok(Some(other_value)) = other.dict_get(key, vm) else {
-                return Ok(false);
-            };
-            defer_drop!(other_value, vm);
-            if !value.py_eq(other_value, vm)? {
-                return Ok(false);
-            }
-        }
-        Ok(true)
     }
 
     fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {

--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -136,19 +136,26 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictKeysView> {
         Some(self.get(vm.heap).dict(vm.heap).len())
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        if self.get(vm.heap).dict_id == other.get(vm.heap).dict_id {
-            return Ok(true);
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        match other.read_heap(vm) {
+            Some(HeapReadOutput::DictKeysView(other)) => {
+                if self.get(vm.heap).dict_id == other.get(vm.heap).dict_id {
+                    return Ok(Some(true));
+                }
+                let left = self.dict(vm);
+                let right = other.dict(vm);
+                dict_keys_eq_set_like(
+                    &left,
+                    right.get(vm.heap).len(),
+                    |key, vm| right.contains_key(key, vm),
+                    vm,
+                )
+                .map(Some)
+            }
+            Some(HeapReadOutput::Set(other)) => Ok(Some(self.eq_set(&other, vm)?)),
+            Some(HeapReadOutput::FrozenSet(other)) => Ok(Some(self.eq_frozenset(&other, vm)?)),
+            _ => Ok(None),
         }
-
-        let left = self.dict(vm);
-        let right = other.dict(vm);
-        dict_keys_eq_set_like(
-            &left,
-            right.get(vm.heap).len(),
-            |key, vm| right.contains_key(key, vm),
-            vm,
-        )
     }
 
     fn py_repr_fmt(
@@ -291,14 +298,20 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictItemsView> {
         Some(self.get(vm.heap).dict(vm.heap).len())
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        if self.get(vm.heap).dict_id == other.get(vm.heap).dict_id {
-            return Ok(true);
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        match other.read_heap(vm) {
+            Some(HeapReadOutput::DictItemsView(other)) => {
+                if self.get(vm.heap).dict_id == other.get(vm.heap).dict_id {
+                    return Ok(Some(true));
+                }
+                let left = self.dict(vm);
+                let right = other.dict(vm);
+                Ok(Some(left.eq_dict(&right, vm)?))
+            }
+            Some(HeapReadOutput::Set(other)) => Ok(Some(self.eq_set(&other, vm)?)),
+            Some(HeapReadOutput::FrozenSet(other)) => Ok(Some(self.eq_frozenset(&other, vm)?)),
+            _ => Ok(None),
         }
-
-        let left = self.dict(vm);
-        let right = other.dict(vm);
-        left.py_eq(&right, vm)
     }
 
     fn py_repr_fmt(
@@ -388,8 +401,9 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictValuesView> {
         Some(self.get(vm.heap).dict(vm.heap).len())
     }
 
-    fn py_eq(&self, _other: &Self, _vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        Ok(false)
+    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        // `dict_values` views use identity equality (handled before the heap read).
+        Ok(None)
     }
 
     fn py_repr_fmt(

--- a/crates/monty/src/types/file.rs
+++ b/crates/monty/src/types/file.rs
@@ -526,8 +526,9 @@ impl<'h> PyTrait<'h> for HeapRead<'h, OpenFile> {
         None
     }
 
-    fn py_eq(&self, _other: &Self, _vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        Ok(false)
+    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        // File objects use identity equality (handled before the heap read).
+        Ok(None)
     }
 
     fn py_bool(&self, _vm: &mut VM<'h, impl ResourceTracker>) -> bool {

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -416,9 +416,12 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
         Ok(())
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        let Some(HeapReadOutput::List(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
         if self.get(vm.heap).items.len() != other.get(vm.heap).items.len() {
-            return Ok(false);
+            return Ok(Some(false));
         }
         let iter = self.iter(vm)?;
         defer_drop_mut!(iter, vm);
@@ -426,10 +429,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
             let b = other.clone_item(i, vm);
             defer_drop!(b, vm);
             if !a.py_eq(b, vm)? {
-                return Ok(false);
+                return Ok(Some(false));
             }
         }
-        Ok(true)
+        Ok(Some(true))
     }
 
     fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {

--- a/crates/monty/src/types/long_int.rs
+++ b/crates/monty/src/types/long_int.rs
@@ -9,6 +9,7 @@
 //! having freestanding functions scattered across the codebase.
 
 use std::{
+    cmp::Ordering,
     fmt::{self, Display},
     mem,
     ops::{Add, Mul, Neg, Sub},
@@ -16,7 +17,7 @@ use std::{
 };
 
 use num_bigint::BigInt;
-use num_traits::{Signed, ToPrimitive, Zero};
+use num_traits::{FromPrimitive, Signed, ToPrimitive, Zero};
 
 use crate::{
     exception_private::{ExcType, RunResult},
@@ -133,6 +134,14 @@ impl LongInt {
         self.0.to_f64()
     }
 
+    /// Compares this integer against an `f64` *exactly* (no precision loss).
+    ///
+    /// Thin wrapper around [`bigint_cmp_f64`]; see it for the semantics. The
+    /// result is the ordering of `self` relative to `f`.
+    pub fn partial_cmp_f64(&self, f: f64) -> Option<Ordering> {
+        bigint_cmp_f64(&self.0, f)
+    }
+
     /// Tries to convert to u32.
     ///
     /// Returns `Some(u32)` if the value fits, `None` otherwise.
@@ -169,6 +178,60 @@ impl LongInt {
     /// 4301-digit values reliably raise the same error as CPython.
     pub fn check_str_digits_limit(&self) -> RunResult<()> {
         check_bigint_str_digits_limit(&self.0)
+    }
+}
+
+/// Compares a `BigInt` against an `f64` *exactly*, matching CPython's mixed
+/// `int`/`float` comparison with no precision loss in either direction
+/// (neither operand is rounded to the other's type).
+///
+/// The result is the ordering of `b` relative to `f` (e.g. `Some(Ordering::Less)`
+/// means `b < f`). Returns `None` only when `f` is NaN (unordered); an infinite
+/// `f` yields a definite ordering. Equality is `== Some(Ordering::Equal)`.
+pub fn bigint_cmp_f64(b: &BigInt, f: f64) -> Option<Ordering> {
+    if f.is_nan() {
+        None
+    } else if f.is_infinite() {
+        // +inf is greater than any finite integer, -inf is less.
+        Some(if f > 0.0 { Ordering::Less } else { Ordering::Greater })
+    } else {
+        // `f` is finite. Split it into its integer part `trunc` and the
+        // fractional remainder `f - trunc` in (-1, 1). `trunc` is integral and
+        // finite, so it converts to `BigInt` without loss.
+        let trunc = f.trunc();
+        let f_int = BigInt::from_f64(trunc).expect("finite f64 converts to BigInt");
+        match b.cmp(&f_int) {
+            // Integer parts match: the sign of `f`'s fractional part breaks the
+            // tie. A positive fraction makes `f` larger, so `b < f`.
+            Ordering::Equal => (f - trunc).partial_cmp(&0.0).map(Ordering::reverse),
+            ord => Some(ord),
+        }
+    }
+}
+
+/// Compares an `i64` against an `f64` *exactly* (no precision loss), matching
+/// CPython's mixed `int`/`float` comparison.
+///
+/// Equivalent to [`bigint_cmp_f64`] but avoids a `BigInt` allocation for the
+/// common machine-integer case. The result is the ordering of `a` relative to
+/// `f`; `None` only for NaN.
+pub fn i64_cmp_f64(a: i64, f: f64) -> Option<Ordering> {
+    // 2^63 as f64 (exactly representable): the first power of two past i64::MAX.
+    const TWO_POW_63: f64 = 9_223_372_036_854_775_808.0;
+    if f.is_nan() {
+        None
+    } else if f >= TWO_POW_63 {
+        Some(Ordering::Less) // f (incl. +inf) exceeds i64::MAX ≥ a
+    } else if f < -TWO_POW_63 {
+        Some(Ordering::Greater) // f (incl. -inf) is below i64::MIN ≤ a
+    } else {
+        // -2^63 ≤ f < 2^63 and finite, so `trunc` fits in i64 exactly.
+        let trunc = f.trunc();
+        #[expect(clippy::cast_possible_truncation, reason = "bounds-checked: -2^63 ≤ trunc < 2^63")]
+        match a.cmp(&(trunc as i64)) {
+            Ordering::Equal => (f - trunc).partial_cmp(&0.0).map(Ordering::reverse),
+            ord => Some(ord),
+        }
     }
 }
 

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -31,7 +31,7 @@ use crate::{
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult},
     hash::HashValue,
-    heap::{ContainsHeap, DropWithHeap, HeapId, HeapItem, HeapRead, RecursionToken},
+    heap::{ContainsHeap, DropWithHeap, HeapId, HeapItem, HeapRead, HeapReadOutput, RecursionToken},
     intern::{Interns, StringId},
     resource::ResourceTracker,
     types::Type,
@@ -295,20 +295,30 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
         }
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        if self.get(vm.heap).len() != other.get(vm.heap).len() {
-            return Ok(false);
-        }
-        let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
-        while let Some((i, a)) = iter.next_with_index(vm)? {
-            let b = other.clone_item(i, vm);
-            defer_drop!(b, vm);
-            if !a.py_eq(b, vm)? {
-                return Ok(false);
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        // A namedtuple equals another namedtuple element-wise, and also equals a
+        // plain tuple with the same elements (class name is ignored). Both
+        // directions of the tuple case are covered here, so `Tuple::py_eq_impl`
+        // need not know about namedtuples.
+        match other.read_heap(vm) {
+            Some(HeapReadOutput::NamedTuple(other)) => {
+                if self.get(vm.heap).len() != other.get(vm.heap).len() {
+                    return Ok(Some(false));
+                }
+                let iter = self.iter(vm)?;
+                defer_drop_mut!(iter, vm);
+                while let Some((i, a)) = iter.next_with_index(vm)? {
+                    let b = other.clone_item(i, vm);
+                    defer_drop!(b, vm);
+                    if !a.py_eq(b, vm)? {
+                        return Ok(Some(false));
+                    }
+                }
+                Ok(Some(true))
             }
+            Some(HeapReadOutput::Tuple(other)) => Ok(Some(self.eq_tuple(&other, vm)?)),
+            _ => Ok(None),
         }
-        Ok(true)
     }
 
     /// Hashes by element only (not by class name), matching `Tuple::py_hash`

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -22,7 +22,7 @@ use crate::{
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
     hash::HashValue,
-    heap::{DropWithHeap, Heap, HeapData, HeapId, HeapItem, HeapRead},
+    heap::{DropWithHeap, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     os::{MontyPath, build_path_os_call, is_path_os_method},
     resource::ResourceTracker,
@@ -470,8 +470,11 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Path> {
         None
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        Ok(self.get(vm.heap).path == other.get(vm.heap).path)
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        let Some(HeapReadOutput::Path(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
+        Ok(Some(self.get(vm.heap).path == other.get(vm.heap).path))
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -113,17 +113,26 @@ pub trait PyTrait<'h> {
         Ok(None)
     }
 
-    /// Python equality comparison (`==`).
+    /// One-sided Python equality comparison (`self == other` from `self`'s side).
     ///
-    /// For containers, this performs element-wise comparison using the heap
-    /// to resolve nested references. Takes `&mut VM` to allow lazy hash
-    /// computation for dict key lookups and access to interned string content.
+    /// Mirrors CPython's `__eq__`/`tp_richcompare` protocol: returns
+    /// `Ok(Some(bool))` when `self`'s type knows how to compare itself against
+    /// `other`, or `Ok(None)` for `NotImplemented` — i.e. `self`'s type does not
+    /// recognise `other`, so the caller should try the reflected `other == self`.
+    /// The reflection and the final "unequal" fallback are driven by
+    /// [`Value::py_eq`]; implementations only handle their own side and must
+    /// not attempt reflection themselves. This is the same convention as
+    /// [`py_cmp`](Self::py_cmp)'s `Option<Ordering>` (`None` = NotImplemented).
     ///
-    /// Recursion depth is tracked via `heap.incr_recursion_depth()`.
+    /// Cross-type equality (e.g. `int`/`float`, `namedtuple`/`tuple`,
+    /// `dict_keys`/`set`) is handled here in-situ: each type inspects `other`
+    /// directly. For containers this performs element-wise comparison using the
+    /// heap to resolve nested references; `&mut VM` allows lazy hash computation
+    /// for dict key lookups and access to interned string content.
     ///
-    /// Returns `Ok(true)` if equal, `Ok(false)` if not equal, or
+    /// Recursion depth is tracked via `heap.incr_recursion_depth()`; returns
     /// `Err(ResourceError::Recursion)` if maximum depth is exceeded.
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool>;
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>>;
 
     /// Python comparison (`<`, `>`, etc.).
     ///

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -19,7 +19,7 @@ use crate::{
     defer_drop,
     exception_private::{ExcType, RunResult},
     hash::HashValue,
-    heap::{Heap, HeapData, HeapId, HeapItem, HeapRead},
+    heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     resource::ResourceTracker,
     types::{PyTrait, Type},
     value::Value,
@@ -234,21 +234,24 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Range> {
         Ok(Value::Int(offset_i64))
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        let Some(HeapReadOutput::Range(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
         let a = self.get(vm.heap);
         let b = other.get(vm.heap);
         // Compare ranges by their actual sequences, not parameters.
         // Two ranges are equal if they produce the same elements.
         let len1 = a.len();
         let len2 = b.len();
-        if len1 != len2 {
-            return Ok(false);
-        }
-        // Same length - compare first element and step (if non-empty)
-        if len1 == 0 {
-            return Ok(true); // Both empty
-        }
-        Ok(a.start == b.start && a.step == b.step)
+        Ok(Some(if len1 != len2 {
+            false
+        } else if len1 == 0 {
+            true // Both empty
+        } else {
+            // Same length - compare first element and step
+            a.start == b.start && a.step == b.step
+        }))
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -248,15 +248,32 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Range> {
             false
         } else if len1 == 0 {
             true // Both empty
+        } else if len1 == 1 {
+            // Single-element ranges are equal when their one element matches,
+            // regardless of step (e.g. range(0, 1, 1) == range(0, 2, 2)).
+            a.start == b.start
         } else {
-            // Same length - compare first element and step
+            // Same length (>1) - compare first element and step.
             a.start == b.start && a.step == b.step
         }))
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {
+        // Ranges are equal by the sequence they produce, so the hash must depend
+        // only on what equality compares: length, then start (if non-empty), then
+        // step (only if length > 1). Hashing the raw `start`/`stop`/`step` fields
+        // would break `hash(a) == hash(b)` for equal ranges like `range(0, 1, 1)`
+        // and `range(0, 2, 2)`.
+        let r = self.get(vm.heap);
+        let len = r.len();
         let mut hasher = DefaultHasher::new();
-        self.get(vm.heap).hash(&mut hasher);
+        len.hash(&mut hasher);
+        if len > 0 {
+            r.start.hash(&mut hasher);
+            if len > 1 {
+                r.step.hash(&mut hasher);
+            }
+        }
         Ok(Some(HashValue::new(hasher.finish())))
     }
 

--- a/crates/monty/src/types/re_match.rs
+++ b/crates/monty/src/types/re_match.rs
@@ -284,9 +284,9 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
         None
     }
 
-    fn py_eq(&self, _other: &Self, _vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        // Match objects are not comparable
-        Ok(false)
+    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        // Match objects use identity equality (handled before the heap read).
+        Ok(None)
     }
 
     fn py_bool(&self, _vm: &mut VM<'h, impl ResourceTracker>) -> bool {

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -21,7 +21,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{ExcType, RunResult},
-    heap::{Heap, HeapData, HeapId, HeapItem, HeapRead},
+    heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     modules::re::{ASCII, DOTALL, IGNORECASE, MULTILINE},
     resource::{ResourceTracker, check_estimated_size},
@@ -274,8 +274,11 @@ impl<'h> PyTrait<'h> for HeapRead<'h, RePattern> {
         None
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        Ok(self.get(vm.heap) == other.get(vm.heap))
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        let Some(HeapReadOutput::RePattern(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
+        Ok(Some(self.get(vm.heap) == other.get(vm.heap)))
     }
 
     fn py_bool(&self, _vm: &mut VM<'h, impl ResourceTracker>) -> bool {

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -986,8 +986,15 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Set> {
         Some(self.get(vm.heap).len())
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        self.storage().eq(&other.storage(), vm)
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        // `set` and `frozenset` compare equal by their members, regardless of
+        // mutability. `set == dict_keys`/`dict_items` is handled by the reflected
+        // pass via the dict-view impls.
+        match other.read_heap(vm) {
+            Some(HeapReadOutput::Set(other)) => Ok(Some(self.storage().eq(&other.storage(), vm)?)),
+            Some(HeapReadOutput::FrozenSet(other)) => Ok(Some(self.storage().eq(&other.storage(), vm)?)),
+            _ => Ok(None),
+        }
     }
 
     fn py_bool(&self, vm: &mut VM<'h, impl ResourceTracker>) -> bool {
@@ -1249,8 +1256,15 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
         Some(self.get(vm.heap).len())
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        self.storage().eq(&other.storage(), vm)
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        // `frozenset` and `set` compare equal by their members, regardless of
+        // mutability. `frozenset == dict_keys`/`dict_items` is handled by the
+        // reflected pass via the dict-view impls.
+        match other.read_heap(vm) {
+            Some(HeapReadOutput::FrozenSet(other)) => Ok(Some(self.storage().eq(&other.storage(), vm)?)),
+            Some(HeapReadOutput::Set(other)) => Ok(Some(self.storage().eq(&other.storage(), vm)?)),
+            _ => Ok(None),
+        }
     }
 
     /// Hashes the frozenset by XORing all element hashes.

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -19,7 +19,7 @@ use crate::{
     defer_drop,
     exception_private::{ExcType, RunResult},
     hash::HashValue,
-    heap::{HeapData, HeapId, HeapItem, HeapRead},
+    heap::{HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     resource::ResourceTracker,
     types::{PyTrait, Type},
@@ -170,10 +170,13 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Slice> {
         None
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        let Some(HeapReadOutput::Slice(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
         let a = self.get(vm.heap);
         let b = other.get(vm.heap);
-        Ok(a.start == b.start && a.stop == b.stop && a.step == b.step)
+        Ok(Some(a.start == b.start && a.stop == b.stop && a.step == b.step))
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -23,7 +23,7 @@ use crate::{
         Type,
         slice::{normalize_sequence_index, slice_collect_iterator},
     },
-    value::{EitherStr, Value},
+    value::{EitherStr, Value, eq_str},
 };
 
 /// Python string value stored on the heap.
@@ -211,8 +211,9 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
         Ok(allocate_char(c, vm.heap)?)
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        Ok(self.get(vm.heap).0 == other.get(vm.heap).0)
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        // A heap string equals an interned or heap string with the same content.
+        Ok(eq_str(self.get(vm.heap).as_str(), other, vm))
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {

--- a/crates/monty/src/types/test_cm.rs
+++ b/crates/monty/src/types/test_cm.rs
@@ -110,8 +110,9 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TestContextManager> {
         None
     }
 
-    fn py_eq(&self, _other: &Self, _vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        Ok(false)
+    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        // Test context managers use identity equality.
+        Ok(None)
     }
 
     fn py_bool(&self, _vm: &mut VM<'h, impl ResourceTracker>) -> bool {

--- a/crates/monty/src/types/timedelta.rs
+++ b/crates/monty/src/types/timedelta.rs
@@ -21,7 +21,7 @@ use crate::{
     bytecode::{CallResult, VM},
     exception_private::{ExcType, RunResult, SimpleException},
     hash::HashValue,
-    heap::{HeapData, HeapId, HeapItem, HeapRead},
+    heap::{HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     resource::ResourceTracker,
     types::{PyTrait, Type},
@@ -283,8 +283,13 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeDelta> {
         None
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        Ok(total_microseconds(self.get(vm.heap)) == total_microseconds(other.get(vm.heap)))
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        let Some(HeapReadOutput::TimeDelta(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
+        Ok(Some(
+            total_microseconds(self.get(vm.heap)) == total_microseconds(other.get(vm.heap)),
+        ))
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {

--- a/crates/monty/src/types/timezone.rs
+++ b/crates/monty/src/types/timezone.rs
@@ -18,7 +18,7 @@ use crate::{
     defer_drop,
     exception_private::{ExcType, RunError, RunResult, SimpleException},
     hash::HashValue,
-    heap::{Heap, HeapData, HeapId, HeapItem, HeapRead},
+    heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::Interns,
     resource::ResourceTracker,
     types::{
@@ -234,8 +234,13 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeZone> {
         None
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
-        Ok(self.get(vm.heap).offset_seconds == other.get(vm.heap).offset_seconds)
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        let Some(HeapReadOutput::TimeZone(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
+        Ok(Some(
+            self.get(vm.heap).offset_seconds == other.get(vm.heap).offset_seconds,
+        ))
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<HashValue>> {

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -33,7 +33,7 @@ use crate::{
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult},
     hash::HashValue,
-    heap::{ContainsHeap, DropWithHeap, Heap, HeapData, HeapId, HeapItem, HeapRead, RecursionToken},
+    heap::{ContainsHeap, DropWithHeap, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput, RecursionToken},
     intern::StaticStrings,
     resource::{ResourceError, ResourceTracker},
     types::{
@@ -319,9 +319,14 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         Ok(self.clone_item(idx, vm))
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<bool> {
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        // A tuple equals another tuple; `tuple == namedtuple` is handled by the
+        // reflected pass via `NamedTuple::py_eq_impl`.
+        let Some(HeapReadOutput::Tuple(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
         if self.get(vm.heap).items.len() != other.get(vm.heap).items.len() {
-            return Ok(false);
+            return Ok(Some(false));
         }
         let iter = self.iter(vm)?;
         defer_drop_mut!(iter, vm);
@@ -329,10 +334,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
             let b = other.clone_item(i, vm);
             defer_drop!(b, vm);
             if !a.py_eq(b, vm)? {
-                return Ok(false);
+                return Ok(Some(false));
             }
         }
-        Ok(true)
+        Ok(Some(true))
     }
 
     /// Hashes the tuple as the combined hash of its elements.

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -11,7 +11,7 @@ use std::{
 use ahash::AHashSet;
 use num_bigint::BigInt;
 use num_integer::Integer;
-use num_traits::{ToPrimitive, Zero};
+use num_traits::{FromPrimitive, ToPrimitive, Zero};
 use smallvec::SmallVec;
 
 use crate::{
@@ -19,7 +19,7 @@ use crate::{
     bytecode::{CallResult, VM},
     exception_private::{ExcType, RunError, RunResult, SimpleException},
     fstring::FormatFloat,
-    hash::{HashValue, hash_python_str},
+    hash::{HashValue, hash_python_long_int, hash_python_str},
     heap::{ContainsHeap, DropWithHeap, Heap, HeapData, HeapGuard, HeapId, HeapReadOutput},
     intern::{BytesId, FunctionId, Interns, LongIntId, StaticStrings, StringId},
     modules::ModuleFunctions,
@@ -30,7 +30,7 @@ use crate::{
     types::{
         Bytes, List, LongInt, Property, PyTrait, Type, allocate_tuple,
         bytes::{bytes_repr_fmt, get_byte_at_index},
-        long_int::check_bits_str_digits_limit,
+        long_int::{bigint_cmp_f64, check_bits_str_digits_limit, i64_cmp_f64},
         path,
         slice::slice_collect_iterator,
         str::{allocate_char, allocate_string, get_char_at_index, string_repr_fmt},
@@ -154,87 +154,51 @@ impl PyTrait<'_> for Value {
         }
     }
 
-    fn py_eq(&self, other: &Self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<bool> {
-        let interns = vm.interns;
-        match (self, other) {
-            (Self::Undefined, _) => Ok(false),
-            (_, Self::Undefined) => Ok(false),
-            (Self::Int(v1), Self::Int(v2)) => Ok(v1 == v2),
-            (Self::Bool(v1), Self::Bool(v2)) => Ok(v1 == v2),
-            (Self::Bool(v1), Self::Int(v2)) => Ok(i64::from(*v1) == *v2),
-            (Self::Int(v1), Self::Bool(v2)) => Ok(*v1 == i64::from(*v2)),
-            (Self::Float(v1), Self::Float(v2)) => Ok(v1 == v2),
-            (Self::Int(v1), Self::Float(v2)) => Ok((*v1 as f64) == *v2),
-            (Self::Float(v1), Self::Int(v2)) => Ok(*v1 == (*v2 as f64)),
-            (Self::Bool(v1), Self::Float(v2)) => Ok((i64::from(*v1) as f64) == *v2),
-            (Self::Float(v1), Self::Bool(v2)) => Ok(*v1 == (i64::from(*v2) as f64)),
-            (Self::None, Self::None) => Ok(true),
-
-            // Int == LongInt comparison
-            (Self::Int(a), Self::Ref(id)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
-                Ok(BigInt::from(*a) == *li.inner())
-            }
-            // LongInt == Int comparison
-            (Self::Ref(id), Self::Int(b)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
-                Ok(*li.inner() == BigInt::from(*b))
-            }
-
-            // For interned interns, compare by StringId first (fast path for same interned string)
-            (Self::InternString(s1), Self::InternString(s2)) => Ok(s1 == s2),
-            // for strings we need to account for the fact they might be either interned or not
-            (Self::InternString(string_id), Self::Ref(id2)) if let HeapData::Str(s2) = vm.heap.get(*id2) => {
-                Ok(interns.get_str(*string_id) == s2.as_str())
-            }
-            (Self::Ref(id1), Self::InternString(string_id)) if let HeapData::Str(s1) = vm.heap.get(*id1) => {
-                Ok(s1.as_str() == interns.get_str(*string_id))
-            }
-
-            // For interned bytes, compare by content (bytes are not deduplicated unlike interns)
-            (Self::InternBytes(b1), Self::InternBytes(b2)) => {
-                // Fast path: same BytesId means same content
-                Ok(b1 == b2 || interns.get_bytes(*b1) == interns.get_bytes(*b2))
-            }
-            // same for bytes
-            (Self::InternBytes(bytes_id), Self::Ref(id2)) if let HeapData::Bytes(b2) = vm.heap.get(*id2) => {
-                Ok(interns.get_bytes(*bytes_id) == b2.as_slice())
-            }
-            (Self::Ref(id1), Self::InternBytes(bytes_id)) if let HeapData::Bytes(b1) = vm.heap.get(*id1) => {
-                Ok(b1.as_slice() == interns.get_bytes(*bytes_id))
-            }
-
-            (Self::Ref(id1), Self::Ref(id2)) => {
-                if *id1 == *id2 {
-                    return Ok(true);
+    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Option<bool>> {
+        match self {
+            // `Undefined` is a sentinel and is never equal to anything.
+            Self::Undefined => Ok(Some(false)),
+            Self::None => Ok(Some(matches!(other, Self::None))),
+            Self::Ellipsis => Ok(Some(matches!(other, Self::Ellipsis))),
+            Self::Bool(b) => Ok(eq_i64(i64::from(*b), other, vm)),
+            Self::Int(a) => Ok(eq_i64(*a, other, vm)),
+            Self::Float(f) => Ok(eq_f64(*f, other, vm)),
+            // `InternLongInt` is normally materialised to a heap `LongInt` before
+            // it can be compared, but handle it directly so equality never
+            // silently diverges if one reaches here.
+            Self::InternLongInt(id) => Ok(eq_bigint(vm.interns.get_long_int(*id), other, vm)),
+            Self::InternString(id) => Ok(match other {
+                // Interned strings are deduplicated, so equal ids ⇔ equal content.
+                Self::InternString(o) => Some(id == o),
+                _ => eq_str(vm.interns.get_str(*id), other, vm),
+            }),
+            Self::InternBytes(id) => Ok(match other {
+                // Fast path for the same interned bytes; otherwise compare content
+                // (interned bytes are not deduplicated, unlike strings).
+                Self::InternBytes(o) if id == o => Some(true),
+                _ => eq_bytes(vm.interns.get_bytes(*id), other, vm),
+            }),
+            Self::Builtin(b) => Ok(Some(matches!(other, Self::Builtin(o) if b == o))),
+            Self::ModuleFunction(mf) => Ok(Some(matches!(other, Self::ModuleFunction(o) if mf == o))),
+            Self::DefFunction(f) => Ok(Some(matches!(other, Self::DefFunction(o) if f == o))),
+            // External function equality is name-based across both the inline
+            // `Value::ExtFunction(StringId)` and heap `HeapData::ExtFunction(String)`
+            // representations. (#347)
+            Self::ExtFunction(name_id) => Ok(eq_ext_function(vm.interns.get_str(*name_id), other, vm)),
+            Self::Marker(m) => Ok(Some(matches!(other, Self::Marker(o) if m == o))),
+            Self::Property(p) => Ok(Some(matches!(other, Self::Property(o) if p == o))),
+            Self::Ref(id) => {
+                // Identity short-circuit: a heap object always equals itself.
+                if let Self::Ref(other_id) = other
+                    && id == other_id
+                {
+                    Ok(Some(true))
+                } else {
+                    vm.heap.read(*id).py_eq_impl(other, vm)
                 }
-                let left = vm.heap.read(*id1);
-                let right = vm.heap.read(*id2);
-                left.py_eq(&right, vm)
             }
-
-            // Builtins equality - just check the enums are equal
-            (Self::Builtin(b1), Self::Builtin(b2)) => Ok(b1 == b2),
-            // Module functions equality
-            (Self::ModuleFunction(mf1), Self::ModuleFunction(mf2)) => Ok(mf1 == mf2),
-            (Self::DefFunction(f1), Self::DefFunction(f2)) => Ok(f1 == f2),
-            // External function equality is name-based: two ExtFunction values
-            // (any combination of inline `Value::ExtFunction(StringId)` and heap
-            // `HeapData::ExtFunction(String)`) compare equal iff they reference
-            // the same function name. Interned StringIds are deduped, so equal
-            // StringId ⇔ equal string; the cross-representation arms read the
-            // heap string directly. (#347)
-            (Self::ExtFunction(s1), Self::ExtFunction(s2)) => Ok(s1 == s2),
-            (Self::ExtFunction(s), Self::Ref(id)) if let HeapData::ExtFunction(n) = vm.heap.get(*id) => {
-                Ok(interns.get_str(*s) == n.as_str())
-            }
-            (Self::Ref(id), Self::ExtFunction(s)) if let HeapData::ExtFunction(n) = vm.heap.get(*id) => {
-                Ok(n.as_str() == interns.get_str(*s))
-            }
-            // Markers compare equal if they're the same variant
-            (Self::Marker(m1), Self::Marker(m2)) => Ok(m1 == m2),
-            // Properties compare equal if they're the same variant
-            (Self::Property(p1), Self::Property(p2)) => Ok(p1 == p2),
-
-            _ => Ok(false),
+            #[cfg(feature = "memory-model-checks")]
+            Self::Dereferenced => panic!("Cannot access Dereferenced object"),
         }
     }
 
@@ -245,8 +209,9 @@ impl PyTrait<'_> for Value {
         match (self, other) {
             (Self::Int(s), Self::Int(o)) => Ok(s.partial_cmp(o)),
             (Self::Float(s), Self::Float(o)) => Ok(s.partial_cmp(o)),
-            (Self::Int(s), Self::Float(o)) => Ok((*s as f64).partial_cmp(o)),
-            (Self::Float(s), Self::Int(o)) => Ok(s.partial_cmp(&(*o as f64))),
+            // Int/float ordering is exact (no rounding of either operand).
+            (Self::Int(s), Self::Float(o)) => Ok(i64_cmp_f64(*s, *o)),
+            (Self::Float(s), Self::Int(o)) => Ok(i64_cmp_f64(*o, *s).map(Ordering::reverse)),
             // Bool promotion: convert to Int and re-dispatch. Recursion is bounded
             // to at most 2 levels (Bool→Int, then Int matches directly above).
             (Self::Bool(s), _) => Self::Int(i64::from(*s)).py_cmp(other, vm),
@@ -258,6 +223,14 @@ impl PyTrait<'_> for Value {
             // LongInt vs Int comparison
             (Self::Ref(id), Self::Int(b)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
                 Ok(li.inner().partial_cmp(&BigInt::from(*b)))
+            }
+            // Float vs LongInt comparison (exact, no precision loss)
+            (Self::Float(s), Self::Ref(id)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
+                Ok(bigint_cmp_f64(li.inner(), *s).map(Ordering::reverse))
+            }
+            // LongInt vs Float comparison (exact, no precision loss)
+            (Self::Ref(id), Self::Float(o)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
+                Ok(li.partial_cmp_f64(*o))
             }
             // Ref vs Ref comparison: handles LongInt, Str, and Tuple
             (Self::Ref(id1), Self::Ref(id2)) => match (vm.heap.read(*id1), vm.heap.read(*id2)) {
@@ -1515,6 +1488,36 @@ impl Value {
         self.id(vm) == other.id(vm)
     }
 
+    /// Python `==`, resolved to a definite boolean.
+    ///
+    /// Implements CPython's reflected comparison protocol on top of the
+    /// one-sided [`PyTrait::py_eq_impl`]: tries `self == other`, and if that is
+    /// `NotImplemented` (`None`) tries the reflected `other == self`. If neither
+    /// operand's type recognises the other, the values are unequal. This is the
+    /// entry point the VM `==`/`!=`/`in` operators and all container element
+    /// comparisons use; per-type `py_eq_impl` impls never drive reflection themselves.
+    pub fn py_eq(&self, other: &Self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<bool> {
+        if let Some(result) = self.py_eq_impl(other, vm)? {
+            Ok(result)
+        } else if let Some(result) = other.py_eq_impl(self, vm)? {
+            Ok(result)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Reads the heap entry this value references, or `None` if it is not a
+    /// heap reference.
+    ///
+    /// Used by per-type [`PyTrait::py_eq_impl`] impls to resolve the other operand
+    /// to a heap object of their own type, returning `NotImplemented` otherwise.
+    pub(crate) fn read_heap<'a>(&self, vm: &VM<'a, impl ResourceTracker>) -> Option<HeapReadOutput<'a>> {
+        match self {
+            Self::Ref(id) => Some(vm.heap.read(*id)),
+            _ => None,
+        }
+    }
+
     /// Computes the hash value for this value, used for dict keys.
     ///
     /// Returns `Ok(Some(hash))` for hashable types (immediate values and immutable heap types).
@@ -1534,15 +1537,23 @@ impl Value {
             Self::Bool(b) => return Ok(Some(HashValue::new((*b).into()))),
             Self::Int(i) => return Ok(Some(HashValue::new(i.cast_unsigned()))),
             Self::Float(f) => {
-                return {
-                    if f.fract() == 0.0 && *f >= (i64::MIN as f64) && *f <= (i64::MAX as f64) {
-                        // Hash floats that are mathematically integers the same as Ints (e.g., 1.0 hashes the same as 1)
-                        #[expect(clippy::cast_possible_truncation)]
-                        Ok(Some(HashValue::new((*f as i64).cast_unsigned())))
-                    } else {
-                        // Hash the bit representation of the float
-                        Ok(Some(HashValue::new(f.to_bits())))
-                    }
+                // 2^63, the first power of two past i64::MAX (exactly representable).
+                const TWO_POW_63: f64 = 9_223_372_036_854_775_808.0;
+                return if f.fract() != 0.0 || !f.is_finite() {
+                    // Non-integral or non-finite: hash the bit representation.
+                    Ok(Some(HashValue::new(f.to_bits())))
+                } else if *f >= -TWO_POW_63 && *f < TWO_POW_63 {
+                    // Integral float in i64 range hashes as the equivalent int
+                    // (e.g. `1.0` hashes the same as `1`).
+                    #[expect(clippy::cast_possible_truncation)]
+                    Ok(Some(HashValue::new((*f as i64).cast_unsigned())))
+                } else {
+                    // Integral float outside i64 range hashes as the equivalent
+                    // big int, so an exactly-equal `float`/`int` pair (e.g.
+                    // `2.0**100 == 2**100`) preserves `hash(a) == hash(b)`.
+                    Ok(Some(hash_python_long_int(
+                        &BigInt::from_f64(*f).expect("finite f64 converts to BigInt"),
+                    )))
                 };
             }
             // For heap-allocated values, dispatch to the per-type `py_hash`
@@ -2062,6 +2073,83 @@ impl Value {
         i32::try_from(int_value).map_err(|_| {
             SimpleException::new_msg(ExcType::OverflowError, "signed integer is greater than maximum").into()
         })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared one-sided equality helpers
+//
+// Each compares a primitive operand (extracted from either an inline `Value`
+// or a heap object) against an arbitrary `other: &Value`, resolving `other`'s
+// representation as needed. They return `None` (NotImplemented) when `other`
+// is not a compatible Python type, so the reflected comparison can run. These
+// are shared by `Value::py_eq_impl` (inline operands) and
+// `HeapReadOutput::py_eq_impl` (heap operands) so the interned-vs-heap and
+// numeric-tower logic lives once.
+// ---------------------------------------------------------------------------
+
+/// `a == other` over Python's numeric tower (`int`/`bool`/`float`/big `int`).
+pub(crate) fn eq_i64(a: i64, other: &Value, vm: &VM<'_, impl ResourceTracker>) -> Option<bool> {
+    match other {
+        Value::Int(b) => Some(a == *b),
+        Value::Bool(b) => Some(a == i64::from(*b)),
+        Value::Float(f) => Some(i64_cmp_f64(a, *f) == Some(Ordering::Equal)),
+        Value::Ref(id) if let HeapData::LongInt(li) = vm.heap.get(*id) => Some(*li.inner() == BigInt::from(a)),
+        _ => None,
+    }
+}
+
+/// `f == other`, comparing against ints/bools/big ints *exactly* (no rounding).
+pub(crate) fn eq_f64(f: f64, other: &Value, vm: &VM<'_, impl ResourceTracker>) -> Option<bool> {
+    match other {
+        Value::Float(o) => Some(f == *o),
+        Value::Int(o) => Some(i64_cmp_f64(*o, f) == Some(Ordering::Equal)),
+        Value::Bool(o) => Some(i64_cmp_f64(i64::from(*o), f) == Some(Ordering::Equal)),
+        Value::Ref(id) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
+            Some(li.partial_cmp_f64(f) == Some(Ordering::Equal))
+        }
+        _ => None,
+    }
+}
+
+/// `b == other` over the numeric tower, for heap `LongInt` / interned long-int
+/// operands. A heap `LongInt` is always outside i64 range, so it never equals
+/// an `Int`/`Bool` — but comparing exactly keeps the logic uniform.
+pub(crate) fn eq_bigint(b: &BigInt, other: &Value, vm: &VM<'_, impl ResourceTracker>) -> Option<bool> {
+    match other {
+        Value::Int(o) => Some(*b == BigInt::from(*o)),
+        Value::Bool(o) => Some(*b == BigInt::from(i64::from(*o))),
+        Value::Float(f) => Some(bigint_cmp_f64(b, *f) == Some(Ordering::Equal)),
+        Value::Ref(id) if let HeapData::LongInt(li) = vm.heap.get(*id) => Some(b == li.inner()),
+        _ => None,
+    }
+}
+
+/// `s == other`, resolving the other operand from an interned or heap string.
+pub(crate) fn eq_str(s: &str, other: &Value, vm: &VM<'_, impl ResourceTracker>) -> Option<bool> {
+    match other {
+        Value::InternString(id) => Some(s == vm.interns.get_str(*id)),
+        Value::Ref(id) if let HeapData::Str(o) = vm.heap.get(*id) => Some(s == o.as_str()),
+        _ => None,
+    }
+}
+
+/// `b == other`, resolving the other operand from interned or heap bytes.
+pub(crate) fn eq_bytes(b: &[u8], other: &Value, vm: &VM<'_, impl ResourceTracker>) -> Option<bool> {
+    match other {
+        Value::InternBytes(id) => Some(b == vm.interns.get_bytes(*id)),
+        Value::Ref(id) if let HeapData::Bytes(o) = vm.heap.get(*id) => Some(b == o.as_slice()),
+        _ => None,
+    }
+}
+
+/// External functions compare equal iff their names match — used by both the
+/// inline `Value::ExtFunction` and heap `HeapData::ExtFunction` representations. (#347)
+pub(crate) fn eq_ext_function(name: &str, other: &Value, vm: &VM<'_, impl ResourceTracker>) -> Option<bool> {
+    match other {
+        Value::ExtFunction(id) => Some(name == vm.interns.get_str(*id)),
+        Value::Ref(id) if let HeapData::ExtFunction(o) = vm.heap.get(*id) => Some(name == o.as_str()),
+        _ => None,
     }
 }
 

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -158,8 +158,9 @@ impl PyTrait<'_> for Value {
         match self {
             // `Undefined` is a sentinel and is never equal to anything.
             Self::Undefined => Ok(Some(false)),
-            Self::None => Ok(Some(matches!(other, Self::None))),
-            Self::Ellipsis => Ok(Some(matches!(other, Self::Ellipsis))),
+
+            Self::None => Ok(matches!(other, Self::None).then_some(true)),
+            Self::Ellipsis => Ok(matches!(other, Self::Ellipsis).then_some(true)),
             Self::Bool(b) => Ok(eq_i64(i64::from(*b), other, vm)),
             Self::Int(a) => Ok(eq_i64(*a, other, vm)),
             Self::Float(f) => Ok(eq_f64(*f, other, vm)),
@@ -178,15 +179,30 @@ impl PyTrait<'_> for Value {
                 Self::InternBytes(o) if id == o => Some(true),
                 _ => eq_bytes(vm.interns.get_bytes(*id), other, vm),
             }),
-            Self::Builtin(b) => Ok(Some(matches!(other, Self::Builtin(o) if b == o))),
-            Self::ModuleFunction(mf) => Ok(Some(matches!(other, Self::ModuleFunction(o) if mf == o))),
-            Self::DefFunction(f) => Ok(Some(matches!(other, Self::DefFunction(o) if f == o))),
+            Self::Builtin(b) => Ok(match other {
+                Self::Builtin(o) => Some(b == o),
+                _ => None,
+            }),
+            Self::ModuleFunction(mf) => Ok(match other {
+                Self::ModuleFunction(o) => Some(mf == o),
+                _ => None,
+            }),
+            Self::DefFunction(f) => Ok(match other {
+                Self::DefFunction(o) => Some(f == o),
+                _ => None,
+            }),
             // External function equality is name-based across both the inline
             // `Value::ExtFunction(StringId)` and heap `HeapData::ExtFunction(String)`
             // representations. (#347)
             Self::ExtFunction(name_id) => Ok(eq_ext_function(vm.interns.get_str(*name_id), other, vm)),
-            Self::Marker(m) => Ok(Some(matches!(other, Self::Marker(o) if m == o))),
-            Self::Property(p) => Ok(Some(matches!(other, Self::Property(o) if p == o))),
+            Self::Marker(m) => Ok(match other {
+                Self::Marker(o) => Some(m == o),
+                _ => None,
+            }),
+            Self::Property(p) => Ok(match other {
+                Self::Property(o) => Some(p == o),
+                _ => None,
+            }),
             Self::Ref(id) => {
                 // Identity short-circuit: a heap object always equals itself.
                 if let Self::Ref(other_id) = other

--- a/crates/monty/test_cases/compare__mixed_types.py
+++ b/crates/monty/test_cases/compare__mixed_types.py
@@ -66,6 +66,37 @@ assert small_big < large_big, 'LongInt < LongInt'
 assert large_big > small_big, 'LongInt > LongInt'
 assert big != 'hello', 'LongInt != str'
 
+# === Float vs LongInt comparisons (exact, no precision loss) ===
+# Powers of two are exactly representable as f64, so these are exactly equal
+assert 2.0**100 == 2**100, 'float == LongInt (exact power of two)'
+assert 2**100 == 2.0**100, 'LongInt == float (exact power of two)'
+assert 2.0**100 != 2**100 + 1, 'float != LongInt off by one'
+assert 2**100 + 1 != 2.0**100, 'LongInt off by one != float'
+# Non-power-of-two big ints are not exactly representable; comparison is still exact
+assert 1e30 != 10**30, 'float != LongInt (inexact, not equal)'
+assert 10**30 != 1e30, 'LongInt != float (inexact, not equal)'
+# Non-integral float is never equal to any int
+assert 2.5 != 2**100, 'non-integral float != LongInt'
+assert 2**100 != 2.5, 'LongInt != non-integral float'
+# Ordering across float and LongInt
+assert 2.0**100 < 2**101, 'float < LongInt'
+assert 2**101 > 2.0**100, 'LongInt > float'
+assert 1e308 < 10**400, 'float < huge LongInt beyond f64 range'
+assert 10**400 > 1e308, 'huge LongInt > float'
+assert 2.5 < 2**100, 'non-integral float < LongInt'
+assert 2**100 > 2.5, 'LongInt > non-integral float'
+# Infinities compare against LongInt without overflow
+assert float('inf') > 10**400, 'inf > huge LongInt'
+assert 10**400 < float('inf'), 'huge LongInt < inf'
+assert float('-inf') < 10**400, '-inf < huge LongInt'
+assert 10**400 > float('-inf'), 'huge LongInt > -inf'
+
+# Equal float/LongInt pairs must hash equally and be interchangeable dict keys
+assert hash(2.0**100) == hash(2**100), 'equal float/LongInt hash the same'
+assert {2**100: 'a'}[2.0**100] == 'a', 'float finds LongInt dict key'
+assert {2.0**100: 'b'}[2**100] == 'b', 'LongInt finds float dict key'
+assert 2.0**100 in {2**100, 3}, 'float in LongInt set'
+
 # === Bytes ordering ===
 assert b'abc' < b'abd', 'bytes lt'
 assert b'abc' <= b'abc', 'bytes le'

--- a/crates/monty/test_cases/dataclass__basic.py
+++ b/crates/monty/test_cases/dataclass__basic.py
@@ -39,9 +39,21 @@ alice = make_user('Alice')
 bob = make_user('Bob')
 assert hash(alice) != hash(bob), 'different field values have different hash'
 
+# === Equality ===
+assert point == point2, 'equal frozen dataclasses compare equal'
+assert alice != bob, 'dataclasses with different field values not equal'
+assert point != alice, 'dataclasses of different types not equal'
+# A dataclass is never equal to a non-dataclass, even with matching fields
+assert point != (1, 2), 'dataclass not equal to tuple'
+assert point != {'x': 1, 'y': 2}, 'dataclass not equal to dict'
+
 # === Mutable dataclass ===
 mut_point = make_mutable_point()
 assert repr(mut_point) == 'MutablePoint(x=1, y=2)', f'mutable point repr {mut_point=!r}'
+# Distinct classes are not equal even with identical field names and values
+# (Point and MutablePoint are both (x=1, y=2)).
+assert point != mut_point, 'different dataclass types with same fields not equal'
+assert mut_point != point, 'reflected: different dataclass types not equal'
 
 # === Dataclass with string argument ===
 alice = make_user('Alice')

--- a/crates/monty/test_cases/frozenset__ops.py
+++ b/crates/monty/test_cases/frozenset__ops.py
@@ -185,13 +185,3 @@ assert {1, 2, 3} != frozenset({1, 2}), 'set != frozenset differing members'
 assert frozenset() == set(), 'empty frozenset == empty set'
 assert set() == frozenset(), 'empty set == empty frozenset'
 assert {1: 'a', 2: 'b'}.keys() == frozenset({1, 2}), 'dict_keys == frozenset'
-
-# === set <-> frozenset cross-type equality (compare by members) ===
-assert frozenset({1, 2, 3}) == {1, 2, 3}, 'frozenset == set with same members'
-assert {1, 2, 3} == frozenset({1, 2, 3}), 'set == frozenset with same members'
-assert frozenset({1, 2}) != {1, 2, 3}, 'frozenset != set differing members'
-assert {1, 2, 3} != frozenset({1, 2}), 'set != frozenset differing members'
-assert frozenset() == set(), 'empty frozenset == empty set'
-assert set() == frozenset(), 'empty set == empty frozenset'
-# A frozenset is also equal to a set when used as a dict-view comparison target
-assert {1: 'a', 2: 'b'}.keys() == frozenset({1, 2}), 'dict_keys == frozenset'

--- a/crates/monty/test_cases/frozenset__ops.py
+++ b/crates/monty/test_cases/frozenset__ops.py
@@ -176,3 +176,22 @@ assert frozenset({1, 2}) in s, 'frozenset element lookup'
 # Duplicate frozenset should dedup
 s2 = {frozenset({1}), frozenset({1})}
 assert len(s2) == 1, 'duplicate frozensets dedup in set'
+
+# === set <-> frozenset cross-type equality (compare by members) ===
+assert frozenset({1, 2, 3}) == {1, 2, 3}, 'frozenset == set with same members'
+assert {1, 2, 3} == frozenset({1, 2, 3}), 'set == frozenset with same members'
+assert frozenset({1, 2}) != {1, 2, 3}, 'frozenset != set differing members'
+assert {1, 2, 3} != frozenset({1, 2}), 'set != frozenset differing members'
+assert frozenset() == set(), 'empty frozenset == empty set'
+assert set() == frozenset(), 'empty set == empty frozenset'
+assert {1: 'a', 2: 'b'}.keys() == frozenset({1, 2}), 'dict_keys == frozenset'
+
+# === set <-> frozenset cross-type equality (compare by members) ===
+assert frozenset({1, 2, 3}) == {1, 2, 3}, 'frozenset == set with same members'
+assert {1, 2, 3} == frozenset({1, 2, 3}), 'set == frozenset with same members'
+assert frozenset({1, 2}) != {1, 2, 3}, 'frozenset != set differing members'
+assert {1, 2, 3} != frozenset({1, 2}), 'set != frozenset differing members'
+assert frozenset() == set(), 'empty frozenset == empty set'
+assert set() == frozenset(), 'empty set == empty frozenset'
+# A frozenset is also equal to a set when used as a dict-view comparison target
+assert {1: 'a', 2: 'b'}.keys() == frozenset({1, 2}), 'dict_keys == frozenset'

--- a/crates/monty/test_cases/range__ops.py
+++ b/crates/monty/test_cases/range__ops.py
@@ -254,3 +254,23 @@ assert (2**63 - 1) not in range(-(2**63), 2**63 - 1, 1), 'stop excluded from ran
 assert -1 in range(2**63 - 1, -(2**63), -1), '-1 in backward span'
 assert (2**63 - 1) in range(2**63 - 1, -(2**63), -1), 'start in backward span'
 assert -(2**63) not in range(2**63 - 1, -(2**63), -1), 'stop excluded from backward span'
+
+# === Equality: ranges compare by the sequence they produce ===
+assert range(0, 3) == range(0, 3), 'identical ranges equal'
+assert range(0, 3) != range(0, 4), 'different length ranges not equal'
+# Empty ranges are equal regardless of start/stop/step
+assert range(0, 0) == range(5, 5), 'empty ranges equal regardless of bounds'
+assert range(0, 0, 1) == range(10, 5, 3), 'empty ranges equal regardless of step'
+# Single-element ranges are equal when their one element matches, regardless of step
+assert range(0, 1, 1) == range(0, 2, 2), 'singleton ranges equal regardless of step'
+assert range(5, 6) == range(5, 7, 100), 'singleton ranges equal with different step'
+assert range(0, 1) != range(1, 2), 'singleton ranges with different element not equal'
+# Multi-element ranges must match start and step (stop may differ if sequence matches)
+assert range(0, 4, 2) == range(0, 3, 2), 'equal multi-element ranges (same sequence [0, 2])'
+assert range(0, 4, 2) != range(0, 4, 1), 'different step multi-element ranges not equal'
+
+# === Hash consistency: equal ranges must hash equally (dict-key invariant) ===
+assert hash(range(0, 1, 1)) == hash(range(0, 2, 2)), 'equal singleton ranges hash the same'
+assert hash(range(0, 0)) == hash(range(5, 5)), 'equal empty ranges hash the same'
+assert hash(range(0, 4, 2)) == hash(range(0, 3, 2)), 'equal multi-element ranges hash the same'
+assert {range(0, 1, 1): 'a'}[range(0, 2, 2)] == 'a', 'equal ranges interchangeable as dict keys'

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -1425,7 +1425,7 @@ fn timeout_in_tuple_repetition() {
 
 /// Test that comparing two large equal lists respects the time limit.
 ///
-/// `List::py_eq()` iterates element-wise comparing pairs. With large equal lists,
+/// `List::py_eq_impl()` iterates element-wise comparing pairs. With large equal lists,
 /// it must compare every element before returning True.
 #[test]
 fn timeout_in_list_equality() {
@@ -1439,7 +1439,7 @@ a == b
 
 /// Test that comparing two large equal dicts respects the time limit.
 ///
-/// `Dict::py_eq()` iterates all entries checking keys and values. With large equal
+/// `Dict::py_eq_impl()` iterates all entries checking keys and values. With large equal
 /// dicts, it must check every entry before returning True.
 #[test]
 fn timeout_in_dict_equality() {


### PR DESCRIPTION
This solves the problem of types not being able to implement cross-type equality in their `PyType` implementation. The existing large match in `Value::py_eq` was extremely hard to reason about.

I will probably do similar to other binary trait methods 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored equality to a one-sided `py_eq_impl(&self, other: &Value)` with reflection in `Value::py_eq`, enabling precise cross-type comparisons and fixing mixed-number hashing. Also aligned `range` and dataclass equality with Python semantics.

- **New Features**
  - Exact `int`/`bool`/`float`/`LongInt` comparisons; infinities handled; NaN unordered. Equal `float`/`LongInt` pairs now hash the same (e.g., `2.0**100` and `2**100`).
  - Cross-type equality: `set` ↔ `frozenset`; `dict_keys`/`dict_items` equal to `set`/`frozenset`; `namedtuple` equals `tuple`; heap vs interned `str`/`bytes` by content; external functions by name across inline/heap.
  - Dataclass equality: same Python class (type id) and equal attrs.
  - Range equality and hashing: compare by produced sequence (empty ranges always equal; singleton ranges step-insensitive); equal ranges hash the same.

- **Refactors**
  - Replaced `PyTrait::py_eq(&Self)` with `py_eq_impl(&Value) -> Option<bool>`; reflection handled centrally in `Value::py_eq`.
  - Added shared helpers: `eq_i64`, `eq_f64`, `eq_bigint`, `eq_str`, `eq_bytes`, `eq_ext_function`; and precise comparators `i64_cmp_f64`, `bigint_cmp_f64`.
  - Moved per-type equality logic into each type; identity-only types return `NotImplemented`.
  - Updated float hashing to use `hash_python_long_int` for integral floats outside `i64` range.

<sup>Written for commit 2a254265e25a2453ab04f8ca3d47bbd4eac8fb0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

