### PR TITLE
move recursion count from heap to VM

### DIFF
--- a/crates/monty/src/builtins/isinstance.rs
+++ b/crates/monty/src/builtins/isinstance.rs
@@ -51,8 +51,8 @@ fn isinstance_check_tuple<'h>(
     vm: &mut VM<'h, impl ResourceTracker>,
 ) -> RunResult<bool> {
     let len = tuple.get(vm.heap).as_slice().len();
-    let token = vm.heap.incr_recursion_depth()?;
-    defer_drop!(token, vm);
+    let mut guard = vm.recursion_guard()?;
+    let vm = &mut *guard;
     for i in 0..len {
         match &tuple.get(vm.heap).as_slice()[i] {
             Value::Builtin(Builtins::Type(t)) => {

--- a/crates/monty/src/bytecode/mod.rs
+++ b/crates/monty/src/bytecode/mod.rs
@@ -20,7 +20,7 @@ mod vm;
 
 pub use code::Code;
 pub use compiler::Compiler;
-pub(crate) use vm::CallResult;
+pub(crate) use vm::{CallResult, ContainsVM, DropWithVM, RecursionToken, VmGuard};
 pub use vm::{FrameExit, VM, VMSnapshot};
 
 /// Module-level dunder names Monty exposes with fixed values for CPython

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -553,8 +553,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         // Count this task's recursion depth contribution and subtract it from
         // the global counter so the next task gets a clean budget.
         let task_depth = frames.len().saturating_sub(1); // root frame doesn't contribute to recursion depth
-        let global_depth = self.heap.get_recursion_depth();
-        self.heap.set_recursion_depth(global_depth - task_depth);
+        self.recursion_depth -= task_depth;
 
         // Save VM state into the task
         let task = self.scheduler.get_task_mut(task_id);
@@ -591,8 +590,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
 
         // Restore this task's recursion depth contribution to the global counter
         let task_depth = frames.len().saturating_sub(1); // root frame doesn't contribute to recursion depth
-        let global_depth = self.heap.get_recursion_depth();
-        self.heap.set_recursion_depth(global_depth + task_depth);
+        self.recursion_depth += task_depth;
 
         self.heap.track_shrink(saved_size);
 

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -12,11 +12,13 @@ mod compare;
 mod context_manager;
 mod exceptions;
 mod format;
+mod recursion;
 mod scheduler;
 
 use std::{cmp::Ordering, mem};
 
 pub(crate) use call::CallResult;
+pub(crate) use recursion::{ContainsVM, DropWithVM, RecursionToken, VmGuard};
 use scheduler::Scheduler;
 
 use crate::{
@@ -692,6 +694,14 @@ pub struct VM<'h, T: ResourceTracker> {
     /// single `Option` is sufficient even with async tasks (which interleave
     /// between OS calls, not within one).
     pub(crate) pending_file_effect: Option<PendingFileEffect>,
+
+    /// Current recursion depth — charged by function-call frames and by nested
+    /// data-structure traversals (`repr`/`eq`/`cmp`/`hash`, json, ...).
+    ///
+    /// See [`recursion`](self::recursion) for the guard/token primitives that
+    /// maintain it. Not serialized: it is reconstructed from the active frame
+    /// count on `restore` and rebalanced per-task across async switches.
+    recursion_depth: usize,
 }
 
 impl<'h, T: ResourceTracker> VM<'h, T> {
@@ -716,6 +726,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             module_code: None,
             json_string_cache: JsonStringCache::default(),
             pending_file_effect: None,
+            recursion_depth: 0,
         }
     }
 
@@ -761,10 +772,9 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             .collect();
 
         // Restore recursion depth to match the number of active function frames.
-        // During serialization, recursion_depth is transient (defaults to 0),
-        // but cleanup paths call decr_recursion_depth for each non-root frame.
-        let current_frame_depth = frames.len().saturating_sub(1); // Subtract 1 for root frame which doesn't contribute to depth
-        heap.set_recursion_depth(current_frame_depth);
+        // recursion_depth is not serialized; cleanup paths decrement it for each
+        // non-root frame, so it must start matching the restored frame count.
+        let current_frame_depth = frames.len().saturating_sub(1); // root frame doesn't contribute to depth
 
         Self {
             stack: snapshot.stack,
@@ -780,6 +790,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             ext_function_load_ip: None,
             json_string_cache: JsonStringCache::default(),
             pending_file_effect: snapshot.pending_file_effect,
+            recursion_depth: current_frame_depth,
         }
     }
 
@@ -1860,7 +1871,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
     pub(super) fn push_frame(&mut self, frame: CallFrame<'h>) -> RunResult<()> {
         // root frame doesn't count towards recursion depth, so only check if there's already a frame on the stack
         if !self.frames.is_empty()
-            && let Err(e) = self.heap.incr_recursion_depth()
+            && let Err(e) = self.charge_recursion()
         {
             self.cleanup_frame_state(&frame);
             return Err(e.into());
@@ -1887,7 +1898,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         }
         // Decrement recursion depth if this wasn't the root frame
         if !self.frames.is_empty() {
-            self.heap.decr_recursion_depth();
+            self.decr_recursion();
         }
         frame.should_return
     }

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -1871,7 +1871,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
     pub(super) fn push_frame(&mut self, frame: CallFrame<'h>) -> RunResult<()> {
         // root frame doesn't count towards recursion depth, so only check if there's already a frame on the stack
         if !self.frames.is_empty()
-            && let Err(e) = self.charge_recursion()
+            && let Err(e) = self.incr_recursion()
         {
             self.cleanup_frame_state(&frame);
             return Err(e.into());

--- a/crates/monty/src/bytecode/vm/recursion.rs
+++ b/crates/monty/src/bytecode/vm/recursion.rs
@@ -146,16 +146,11 @@ impl<'h, T: ResourceTracker> ContainsVM<'h> for VM<'h, T> {
 /// borrow the brand outlives. Callers discharge it from the implied bound on
 /// [`VmGuard`]'s `&mut VM<'h, _>` phantom (`'h: 'a`), so it never surfaces.
 pub(crate) trait DropWithVM<'h>: Sized {
-    fn drop_with_vm<'c>(self, container: &'c mut impl ContainsVM<'h>)
-    where
-        'h: 'c;
+    fn drop_with_vm(self, container: &mut impl ContainsVM<'h>);
 }
 
 impl<'h> DropWithVM<'h> for RecursionToken {
-    fn drop_with_vm<'c>(self, container: &'c mut impl ContainsVM<'h>)
-    where
-        'h: 'c,
-    {
+    fn drop_with_vm(self, container: &mut impl ContainsVM<'h>) {
         container.vm().decr_recursion();
     }
 }

--- a/crates/monty/src/bytecode/vm/recursion.rs
+++ b/crates/monty/src/bytecode/vm/recursion.rs
@@ -138,11 +138,6 @@ impl<'h, T: ResourceTracker> ContainsVM<'h> for VM<'h, T> {
 /// There is deliberately no blanket impl over `DropWithHeap` (it would overlap
 /// the `RecursionToken` impl under coherence) — implementers drop their plain
 /// heap fields via `drop_with_heap(container)` directly (`ContainsVM: ContainsHeap`).
-///
-/// The `'h: 'c` bound is what lets [`ContainsVM::vm`] hand back a `&mut VM<'h, _>`:
-/// the returned borrow lives for `'c`, and `VM<'h, _>` is only well-formed for a
-/// borrow the brand outlives. Callers discharge it from the implied bound on
-/// [`VmGuard`]'s `&mut VM<'h, _>` phantom (`'h: 'a`), so it never surfaces.
 pub(crate) trait DropWithVM<'h>: Sized {
     fn drop_with_vm(self, container: &mut impl ContainsVM<'h>);
 }

--- a/crates/monty/src/bytecode/vm/recursion.rs
+++ b/crates/monty/src/bytecode/vm/recursion.rs
@@ -41,7 +41,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
     ///
     /// Returns `Err(ResourceError::Recursion)` if the limit would be exceeded.
     pub(crate) fn recursion_guard(&mut self) -> Result<RecursionGuard<'_, 'h, T>, ResourceError> {
-        self.charge_recursion()?;
+        self.incr_recursion()?;
         Ok(RecursionGuard { vm: self })
     }
 
@@ -50,18 +50,16 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
     ///
     /// Unlike [`recursion_guard`](Self::recursion_guard), the token does not
     /// borrow the VM, so it can be stored (e.g. inside a container iterator) and
-    /// released later with `defer_drop_vm!`. Keeping the bound inside the iterator
-    /// means callers iterating nested structures cannot forget to charge depth.
-    pub(crate) fn incr_recursion(&mut self) -> Result<RecursionToken, ResourceError> {
-        self.charge_recursion()?;
+    /// released later with `defer_drop_vm!`.
+    pub(crate) fn recursion_token(&mut self) -> Result<RecursionToken, ResourceError> {
+        self.incr_recursion()?;
         Ok(RecursionToken(()))
     }
 
     /// Checks the recursion limit against the heap's tracker and increments the
-    /// depth counter. The shared entry point behind both recursion primitives and
-    /// `push_frame`.
+    /// depth counter.
     #[inline]
-    pub(crate) fn charge_recursion(&mut self) -> Result<(), ResourceError> {
+    pub(crate) fn incr_recursion(&mut self) -> Result<(), ResourceError> {
         self.heap.tracker().check_recursion_depth(self.recursion_depth)?;
         self.recursion_depth += 1;
         Ok(())

--- a/crates/monty/src/bytecode/vm/recursion.rs
+++ b/crates/monty/src/bytecode/vm/recursion.rs
@@ -1,0 +1,234 @@
+//! Recursion-depth tracking for the [`VM`].
+//!
+//! The recursion counter lives on the `VM` (not the heap) because every site
+//! that charges depth — function-call frames, container `repr`/`eq`/`cmp`/`hash`,
+//! `isinstance`, json encoding — has a `&mut VM` in scope. Two primitives charge
+//! a level:
+//!
+//! - [`VM::recursion_guard`] for lexically-scoped recursion: an RAII guard that
+//!   derefs to the VM and releases the level on drop (every path, incl. `?`).
+//! - [`VM::incr_recursion`] for reservations that must outlive a lexical scope —
+//!   notably the container iterators, which store the [`RecursionToken`] so the
+//!   bound is owned by the iterator and a caller cannot forget to charge it.
+//!
+//! A stored token can't be released through [`DropWithHeap`](crate::heap::DropWithHeap)
+//! (the heap has no path back to the VM counter), so it uses the parallel
+//! [`DropWithVM`] / [`ContainsVM`] machinery and the `defer_drop_vm!` macros.
+
+use std::{
+    marker::PhantomData,
+    mem::ManuallyDrop,
+    ops::{Deref, DerefMut},
+};
+
+use super::VM;
+use crate::{
+    heap::ContainsHeap,
+    resource::{ResourceError, ResourceTracker},
+};
+
+impl<'h, T: ResourceTracker> VM<'h, T> {
+    /// Enters a lexically-scoped recursive operation, returning a guard that
+    /// releases the depth level when dropped.
+    ///
+    /// The guard derefs to the VM, so recursive calls run through `&mut *guard`:
+    ///
+    /// ```ignore
+    /// let mut guard = vm.recursion_guard()?;
+    /// let vm = &mut *guard;
+    /// // ... recurse through `vm`; the level is released when `guard` drops ...
+    /// ```
+    ///
+    /// Returns `Err(ResourceError::Recursion)` if the limit would be exceeded.
+    pub(crate) fn recursion_guard(&mut self) -> Result<RecursionGuard<'_, 'h, T>, ResourceError> {
+        self.charge_recursion()?;
+        Ok(RecursionGuard { vm: self })
+    }
+
+    /// Reserves one recursion level as a standalone [`RecursionToken`], released
+    /// via [`DropWithVM`] rather than tied to a lexical scope.
+    ///
+    /// Unlike [`recursion_guard`](Self::recursion_guard), the token does not
+    /// borrow the VM, so it can be stored (e.g. inside a container iterator) and
+    /// released later with `defer_drop_vm!`. Keeping the bound inside the iterator
+    /// means callers iterating nested structures cannot forget to charge depth.
+    pub(crate) fn incr_recursion(&mut self) -> Result<RecursionToken, ResourceError> {
+        self.charge_recursion()?;
+        Ok(RecursionToken(()))
+    }
+
+    /// Checks the recursion limit against the heap's tracker and increments the
+    /// depth counter. The shared entry point behind both recursion primitives and
+    /// `push_frame`.
+    #[inline]
+    pub(crate) fn charge_recursion(&mut self) -> Result<(), ResourceError> {
+        self.heap.tracker().check_recursion_depth(self.recursion_depth)?;
+        self.recursion_depth += 1;
+        Ok(())
+    }
+
+    /// Releases one recursion level. Paired with [`charge_recursion`](Self::charge_recursion);
+    /// called by the guard/token cleanup and by `pop_frame`.
+    #[inline]
+    pub(crate) fn decr_recursion(&mut self) {
+        debug_assert!(self.recursion_depth > 0, "decr_recursion called when depth is 0");
+        self.recursion_depth -= 1;
+    }
+}
+
+/// RAII guard for a lexically-scoped recursion level (see [`VM::recursion_guard`]).
+///
+/// Derefs to the [`VM`] so recursive operations run through the guard; the
+/// reserved level is released when the guard is dropped on any code path.
+pub(crate) struct RecursionGuard<'a, 'h, T: ResourceTracker> {
+    vm: &'a mut VM<'h, T>,
+}
+
+impl<'h, T: ResourceTracker> Deref for RecursionGuard<'_, 'h, T> {
+    type Target = VM<'h, T>;
+    fn deref(&self) -> &Self::Target {
+        self.vm
+    }
+}
+
+impl<T: ResourceTracker> DerefMut for RecursionGuard<'_, '_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.vm
+    }
+}
+
+impl<T: ResourceTracker> Drop for RecursionGuard<'_, '_, T> {
+    fn drop(&mut self) {
+        self.vm.decr_recursion();
+    }
+}
+
+/// Zero-size reservation of one recursion level, returned by [`VM::incr_recursion`].
+///
+/// Released via [`DropWithVM`] (it cannot reach the VM counter through the heap).
+/// Stored by container iterators so the depth bound is owned by the iterator and
+/// released on every exit path via `defer_drop_vm!`.
+pub(crate) struct RecursionToken(());
+
+/// Types that can release a recursion level — the VM analogue of
+/// [`ContainsHeap`](crate::heap::ContainsHeap), which it extends so that a
+/// [`DropWithVM`] value can drop its plain heap fields through the same handle.
+///
+/// Implemented by the [`VM`] itself and by wrappers that own a `&mut VM` (the
+/// json `Encoder`), so a token released through such a wrapper still reaches the
+/// counter while the wrapper stays borrowable.
+pub(crate) trait ContainsVM<'h>: ContainsHeap {
+    // `+ 'h` because `VM<'h, T>` is only well-formed when its tracker outlives the
+    // brand; making it part of the associated-type bound means callers of `vm()`
+    // get `Self::Tracker: 'h` for free instead of having to prove it.
+    type Tracker: ResourceTracker + 'h;
+    fn vm(&mut self) -> &mut VM<'h, Self::Tracker>;
+}
+
+impl<'h, T: ResourceTracker> ContainsVM<'h> for VM<'h, T> {
+    type Tracker = T;
+    fn vm(&mut self) -> &mut VM<'h, Self::Tracker> {
+        self
+    }
+}
+
+/// Cleanup for values holding a VM-side reservation that can't be released
+/// through the heap alone (a [`RecursionToken`], or an iterator holding one).
+///
+/// The VM analogue of [`DropWithHeap`](crate::heap::DropWithHeap); use
+/// `defer_drop_vm!` / `defer_drop_vm_mut!` to guarantee cleanup on every path.
+/// There is deliberately no blanket impl over `DropWithHeap` (it would overlap
+/// the `RecursionToken` impl under coherence) — implementers drop their plain
+/// heap fields via `drop_with_heap(container)` directly (`ContainsVM: ContainsHeap`).
+///
+/// The `'h: 'c` bound is what lets [`ContainsVM::vm`] hand back a `&mut VM<'h, _>`:
+/// the returned borrow lives for `'c`, and `VM<'h, _>` is only well-formed for a
+/// borrow the brand outlives. Callers discharge it from the implied bound on
+/// [`VmGuard`]'s `&mut VM<'h, _>` phantom (`'h: 'a`), so it never surfaces.
+pub(crate) trait DropWithVM<'h>: Sized {
+    fn drop_with_vm<'c>(self, container: &'c mut impl ContainsVM<'h>)
+    where
+        'h: 'c;
+}
+
+impl<'h> DropWithVM<'h> for RecursionToken {
+    fn drop_with_vm<'c>(self, container: &'c mut impl ContainsVM<'h>)
+    where
+        'h: 'c,
+    {
+        container.vm().decr_recursion();
+    }
+}
+
+/// RAII guard ensuring a [`DropWithVM`] value is released on every code path —
+/// the VM analogue of [`HeapGuard`](crate::heap::HeapGuard).
+///
+/// Prefer the `defer_drop_vm!` / `defer_drop_vm_mut!` macros; use the guard
+/// directly only when you need to reclaim the value via [`as_parts_mut`](Self::as_parts_mut).
+pub(crate) struct VmGuard<'a, 'h, C: ContainsVM<'h>, V: DropWithVM<'h>> {
+    value: ManuallyDrop<V>,
+    container: &'a mut C,
+    phantom: PhantomData<&'a mut VM<'h, C::Tracker>>,
+}
+
+impl<'a, 'h, C: ContainsVM<'h>, V: DropWithVM<'h>> VmGuard<'a, 'h, C, V> {
+    #[inline]
+    pub(crate) fn new(value: V, container: &'a mut C) -> Self {
+        Self {
+            value: ManuallyDrop::new(value),
+            container,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Borrows the value (immutably) and container (mutably) — backs `defer_drop_vm!`.
+    #[inline]
+    pub(crate) fn as_parts(&mut self) -> (&V, &mut C) {
+        (&self.value, self.container)
+    }
+
+    /// Borrows the value (mutably) and container (mutably) — backs `defer_drop_vm_mut!`.
+    #[inline]
+    pub(crate) fn as_parts_mut(&mut self) -> (&mut V, &mut C) {
+        (&mut self.value, self.container)
+    }
+}
+
+impl<'h, C: ContainsVM<'h>, V: DropWithVM<'h>> Drop for VmGuard<'_, 'h, C, V> {
+    fn drop(&mut self) {
+        // SAFETY: `value` is wrapped in `ManuallyDrop` and never otherwise taken
+        // before this point, so this is the unique move-out.
+        unsafe { ManuallyDrop::take(&mut self.value) }.drop_with_vm(self.container);
+    }
+}
+
+/// Like [`defer_drop!`](crate::defer_drop), but for [`DropWithVM`] values released
+/// through a [`ContainsVM`] (e.g. a [`RecursionToken`] held alongside a json
+/// `Encoder`). Rebinds `$value` as `&V` and `$container` as `&mut C`.
+#[macro_export]
+macro_rules! defer_drop_vm {
+    ($value:ident, $container:ident) => {
+        let mut _vm_guard = $crate::bytecode::VmGuard::new($value, $container);
+        #[allow(
+            clippy::allow_attributes,
+            reason = "the reborrowed parts may not both be used in every case, so allow unused vars to avoid warnings"
+        )]
+        #[allow(unused_variables)]
+        let ($value, $container) = _vm_guard.as_parts();
+    };
+}
+
+/// Like [`defer_drop_vm!`], but rebinds `$value` as `&mut V` — for iterators that
+/// store a [`RecursionToken`] and are advanced in place (`next`/`next_with_index`).
+#[macro_export]
+macro_rules! defer_drop_vm_mut {
+    ($value:ident, $container:ident) => {
+        let mut _vm_guard = $crate::bytecode::VmGuard::new($value, $container);
+        #[allow(
+            clippy::allow_attributes,
+            reason = "the reborrowed parts may not both be used in every case, so allow unused vars to avoid warnings"
+        )]
+        #[allow(unused_variables)]
+        let ($value, $container) = _vm_guard.as_parts_mut();
+    };
+}

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -718,21 +718,6 @@ impl<'de> serde::Deserialize<'de> for UnsafeHeapData {
     }
 }
 
-/// Zero-size token returned by [`Heap::incr_recursion_depth`].
-///
-/// Represents one level of recursion depth that must be released when the
-/// recursive operation completes. Released via [`DropWithHeap`] — compatible
-/// with [`defer_drop!`] and [`HeapGuard`] for automatic cleanup on all code paths.
-#[derive(Debug)]
-pub(crate) struct RecursionToken(());
-
-impl DropWithHeap for RecursionToken {
-    #[inline]
-    fn drop_with_heap<H: ContainsHeap>(self, heap: &mut H) {
-        heap.heap().decr_recursion_depth();
-    }
-}
-
 /// Reference-counted arena that backs all heap-only runtime values.
 ///
 /// Uses a free list to reuse slots from freed values, keeping memory usage
@@ -786,11 +771,6 @@ pub(crate) struct Heap<T: ResourceTracker> {
     /// calls still run.
     #[cfg(feature = "test-hooks")]
     gc_disabled: bool,
-    /// Current recursion depth — incremented on function calls and data structure traversals.
-    ///
-    /// Uses `Cell` for interior mutability so that methods with only `&Heap`
-    /// (like `py_repr_fmt`) can still increment/decrement the depth counter.
-    recursion_depth: Cell<usize>,
     /// Cached HeapId for the `datetime.timezone.utc` singleton.
     ///
     /// Lazily allocated on first access to `timezone.utc`. Once created, the refcount
@@ -831,7 +811,6 @@ impl<'de, T: ResourceTracker + serde::Deserialize<'de>> serde::Deserialize<'de> 
             allocations_since_gc: Cell::new(fields.allocations_since_gc),
             #[cfg(feature = "test-hooks")]
             gc_disabled: false,
-            recursion_depth: Cell::new(0),
             timezone_utc: fields.timezone_utc,
         })
     }
@@ -864,7 +843,6 @@ impl<T: ResourceTracker> Heap<T> {
             allocations_since_gc: Cell::new(0),
             #[cfg(feature = "test-hooks")]
             gc_disabled: false,
-            recursion_depth: Cell::new(0),
             timezone_utc: None,
         };
 
@@ -931,50 +909,6 @@ impl<T: ResourceTracker> Heap<T> {
     #[inline]
     pub fn track_shrink(&self, bytes: usize) {
         self.tracker.on_free(|| bytes);
-    }
-
-    /// Increments the recursion depth and checks the limit via the `ResourceTracker`.
-    ///
-    /// Returns `Ok(RecursionToken)` if within limits. The caller must ensure the
-    /// token is released on all code paths — typically via `defer_drop!` or `HeapGuard`,
-    /// which call [`DropWithHeap::drop_with_heap`] on the token.
-    ///
-    /// Returns `Err(ResourceError::Recursion)` if the limit would be exceeded.
-    #[inline]
-    pub fn incr_recursion_depth(&self) -> Result<RecursionToken, ResourceError> {
-        let depth = self.recursion_depth.get();
-        self.tracker.check_recursion_depth(depth)?;
-        self.recursion_depth.set(depth + 1);
-        Ok(RecursionToken(()))
-    }
-
-    /// Decrements the recursion depth.
-    ///
-    /// Called internally by `RecursionToken` — prefer releasing the token
-    /// rather than calling this directly.
-    #[inline]
-    pub(crate) fn decr_recursion_depth(&self) {
-        let depth = self.recursion_depth.get();
-        debug_assert!(depth > 0, "decr_recursion_depth called when depth is 0");
-        self.recursion_depth.set(depth - 1);
-    }
-
-    /// Returns the current recursion depth.
-    ///
-    /// Used during async task switching to compute a task's depth contribution
-    /// before adjusting the global counter.
-    pub(crate) fn get_recursion_depth(&self) -> usize {
-        self.recursion_depth.get()
-    }
-
-    /// Sets the recursion depth to an explicit value.
-    ///
-    /// Used after deserialization to restore the recursion depth to match
-    /// the number of active (non-global) namespace frames that were serialized.
-    /// Also used during async task switching to subtract/add a task's depth
-    /// contribution when switching away from/to that task.
-    pub(crate) fn set_recursion_depth(&self, depth: usize) {
-        self.recursion_depth.set(depth);
     }
 
     /// Number of entries in the heap (including freed slots).

--- a/crates/monty/src/modules/json/dump.rs
+++ b/crates/monty/src/modules/json/dump.rs
@@ -10,8 +10,8 @@ use std::{
 
 use crate::{
     args::{ArgValues, FromArgs},
-    bytecode::VM,
-    defer_drop, defer_drop_mut,
+    bytecode::{ContainsVM, VM},
+    defer_drop_mut, defer_drop_vm, defer_drop_vm_mut,
     exception_private::{ExcType, RunResult},
     heap::{ContainsHeap, Heap, HeapData, HeapGuard, HeapId, HeapRead, HeapReadOutput},
     resource::ResourceTracker,
@@ -364,6 +364,17 @@ impl<R: ResourceTracker> ContainsHeap for Encoder<'_, '_, R> {
     }
 }
 
+/// Lets a [`RecursionToken`] (and the container iterators that hold one) be
+/// released through the encoder via `defer_drop_vm!`, reaching the VM-side
+/// recursion counter while the encoder itself stays borrowable.
+impl<'h, R: ResourceTracker> ContainsVM<'h> for Encoder<'_, 'h, R> {
+    type Tracker = R;
+
+    fn vm(&mut self) -> &mut VM<'h, Self::Tracker> {
+        self.vm
+    }
+}
+
 impl<'h, R: ResourceTracker> Encoder<'_, 'h, R> {
     /// Serializes a Monty value into JSON text.
     ///
@@ -414,7 +425,7 @@ impl<'h, R: ResourceTracker> Encoder<'_, 'h, R> {
                 }
                 HeapReadOutput::List(list) => self.with_entered_container(*heap_id, |enc| {
                     let iter = list.iter(enc.vm)?;
-                    defer_drop_mut!(iter, enc);
+                    defer_drop_vm_mut!(iter, enc);
                     enc.serialize_array(depth, |enc, depth| {
                         if let Some(item) = iter.next(enc.vm)? {
                             enc.serialize_value(item, depth)?;
@@ -426,7 +437,7 @@ impl<'h, R: ResourceTracker> Encoder<'_, 'h, R> {
                 }),
                 HeapReadOutput::Tuple(tuple) => self.with_entered_container(*heap_id, |enc| {
                     let iter = tuple.iter(enc.vm)?;
-                    defer_drop_mut!(iter, enc);
+                    defer_drop_vm_mut!(iter, enc);
                     enc.serialize_array(depth, |enc, depth| {
                         if let Some(item) = iter.next(enc.vm)? {
                             enc.serialize_value(item, depth)?;
@@ -445,8 +456,8 @@ impl<'h, R: ResourceTracker> Encoder<'_, 'h, R> {
                     defer_drop_mut!(entries, this);
                     // Need to explicitly acquire a recursion token for the dict as we don't go
                     // via the default dict iterator.
-                    let token = this.vm.heap.incr_recursion_depth()?;
-                    defer_drop!(token, this);
+                    let token = this.vm.incr_recursion()?;
+                    defer_drop_vm!(token, this);
                     this.with_entered_container(*heap_id, |enc| enc.serialize_dict(entries, depth))
                 }
                 _ => Err(ExcType::json_not_serializable_error(value.py_type(self.vm))),

--- a/crates/monty/src/modules/json/dump.rs
+++ b/crates/monty/src/modules/json/dump.rs
@@ -456,7 +456,7 @@ impl<'h, R: ResourceTracker> Encoder<'_, 'h, R> {
                     defer_drop_mut!(entries, this);
                     // Need to explicitly acquire a recursion token for the dict as we don't go
                     // via the default dict iterator.
-                    let token = this.vm.incr_recursion()?;
+                    let token = this.vm.recursion_token()?;
                     defer_drop_vm!(token, this);
                     this.with_entered_container(*heap_id, |enc| enc.serialize_dict(entries, depth))
                 }

--- a/crates/monty/src/modules/json/dump.rs
+++ b/crates/monty/src/modules/json/dump.rs
@@ -364,9 +364,9 @@ impl<R: ResourceTracker> ContainsHeap for Encoder<'_, '_, R> {
     }
 }
 
-/// Lets a [`RecursionToken`] (and the container iterators that hold one) be
-/// released through the encoder via `defer_drop_vm!`, reaching the VM-side
-/// recursion counter while the encoder itself stays borrowable.
+/// Lets a [`RecursionToken`](crate::bytecode::RecursionToken) (and the container
+/// iterators that hold one) be released through the encoder via `defer_drop_vm!`,
+/// reaching the VM-side recursion counter while the encoder itself stays borrowable.
 impl<'h, R: ResourceTracker> ContainsVM<'h> for Encoder<'_, 'h, R> {
     type Tracker = R;
 

--- a/crates/monty/src/object.rs
+++ b/crates/monty/src/object.rs
@@ -596,10 +596,10 @@ impl MontyObject {
     /// container during the recursive call without freeing the value mid-format.
     fn from_value_inner(object: &Value, vm: &mut VM<'_, impl ResourceTracker>, visited: &mut AHashSet<HeapId>) -> Self {
         // Check depth limit before processing
-        let Ok(token) = vm.heap.incr_recursion_depth() else {
+        let Ok(mut guard) = vm.recursion_guard() else {
             return Self::Repr("<deeply nested>".to_owned());
         };
-        defer_drop!(token, vm);
+        let vm = &mut *guard;
 
         let interns = vm.interns;
         match object {

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -184,8 +184,8 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
         if !self.get(vm.heap).frozen {
             return Ok(None);
         }
-        let token = vm.heap.incr_recursion_depth()?;
-        crate::defer_drop!(token, vm);
+        let mut guard = vm.recursion_guard()?;
+        let vm = &mut *guard;
         let mut hasher = DefaultHasher::new();
         // Hash the class name
         self.get(vm.heap).name.hash(&mut hasher);
@@ -218,10 +218,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         // Check depth limit before recursing
-        let Ok(token) = vm.heap.incr_recursion_depth() else {
+        let Ok(mut guard) = vm.recursion_guard() else {
             return Ok(f.write_str("...")?);
         };
-        defer_drop!(token, vm);
+        let vm = &mut *guard;
 
         // Format: ClassName(field1=value1, field2=value2, ...)
         // Only declared fields are shown, not dynamically added attributes

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -13,13 +13,10 @@ use smallvec::{SmallVec, smallvec};
 use super::{DictItemsView, DictKeysView, DictValuesView, MontyIter, PyTrait, allocate_tuple};
 use crate::{
     args::{ArgValues, FromArgs, KwargsValues},
-    bytecode::{CallResult, VM},
-    defer_drop, defer_drop_mut,
+    bytecode::{CallResult, ContainsVM, DropWithVM, RecursionToken, VM},
+    defer_drop, defer_drop_mut, defer_drop_vm_mut,
     exception_private::{ExcType, RunResult},
-    heap::{
-        ContainsHeap, DropWithHeap, Heap, HeapData, HeapGuard, HeapId, HeapItem, HeapRead, HeapReadOutput,
-        RecursionToken,
-    },
+    heap::{ContainsHeap, DropWithHeap, Heap, HeapData, HeapGuard, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     resource::ResourceTracker,
     types::Type,
@@ -236,7 +233,7 @@ impl<'h> HeapRead<'h, Dict> {
             return Ok(false);
         }
         let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
+        defer_drop_vm_mut!(iter, vm);
         while let Some((key, value)) = iter.next(vm)? {
             let Some(other_value) = other.dict_get(key, vm)? else {
                 return Ok(false);
@@ -542,7 +539,7 @@ impl<'h> HeapRead<'h, Dict> {
             let src_id = *id;
             if let HeapReadOutput::Dict(src) = vm.heap.read(src_id) {
                 let iter = src.iter(vm)?;
-                defer_drop_mut!(iter, vm);
+                defer_drop_vm_mut!(iter, vm);
                 while let Some((key, value)) = iter.next_owned(vm)? {
                     let old_value = self.set(key, value, vm)?;
                     old_value.drop_with_heap(vm);
@@ -715,7 +712,7 @@ pub(crate) struct DictIter<'a, 'h> {
 impl<'a, 'h> DictIter<'a, 'h> {
     fn new<R: ResourceTracker>(dict: &'a HeapRead<'h, Dict>, vm: &mut VM<'h, R>) -> RunResult<Self> {
         let expected_len = dict.get(vm.heap).entries.len();
-        let token = vm.heap.incr_recursion_depth()?;
+        let token = vm.incr_recursion()?;
         Ok(Self {
             dict,
             index: 0,
@@ -788,11 +785,14 @@ impl<'a, 'h> DictIter<'a, 'h> {
     }
 }
 
-impl DropWithHeap for DictIter<'_, '_> {
-    fn drop_with_heap<H: ContainsHeap>(self, heap: &mut H) {
-        self.current_key.drop_with_heap(heap);
-        self.current_value.drop_with_heap(heap);
-        self.token.drop_with_heap(heap);
+impl<'h> DropWithVM<'h> for DictIter<'_, 'h> {
+    fn drop_with_vm<'c>(self, container: &'c mut impl ContainsVM<'h>)
+    where
+        'h: 'c,
+    {
+        self.current_key.drop_with_heap(container);
+        self.current_value.drop_with_heap(container);
+        self.token.drop_with_vm(container);
     }
 }
 
@@ -832,10 +832,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
         }
 
         // Check depth limit before recursing
-        let Ok(token) = vm.heap.incr_recursion_depth() else {
+        let Ok(mut guard) = vm.recursion_guard() else {
             return Ok(f.write_str("{...}")?);
         };
-        defer_drop!(token, vm);
+        let vm = &mut *guard;
 
         f.write_char('{')?;
         let len = self.get(vm.heap).len();

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -712,7 +712,7 @@ pub(crate) struct DictIter<'a, 'h> {
 impl<'a, 'h> DictIter<'a, 'h> {
     fn new<R: ResourceTracker>(dict: &'a HeapRead<'h, Dict>, vm: &mut VM<'h, R>) -> RunResult<Self> {
         let expected_len = dict.get(vm.heap).entries.len();
-        let token = vm.incr_recursion()?;
+        let token = vm.recursion_token()?;
         Ok(Self {
             dict,
             index: 0,

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -686,8 +686,8 @@ impl IntoIterator for Dict {
 /// held before doing its work.
 ///
 /// **Recursion guard.** Acquires a [`RecursionToken`] at construction and
-/// releases it via [`DropWithHeap`]. The iterator MUST be wrapped in
-/// [`defer_drop_mut!`] so the token (and any in-flight pair) is released on
+/// releases it via [`DropWithVM`]. The iterator MUST be wrapped in
+/// [`defer_drop_vm_mut!`] so the token (and any in-flight pair) is released on
 /// every exit path — dict iteration almost always calls back into
 /// `py_eq` / `py_hash` (membership lookups, comparison) which recurse on
 /// cyclic structures.
@@ -786,10 +786,7 @@ impl<'a, 'h> DictIter<'a, 'h> {
 }
 
 impl<'h> DropWithVM<'h> for DictIter<'_, 'h> {
-    fn drop_with_vm<'c>(self, container: &'c mut impl ContainsVM<'h>)
-    where
-        'h: 'c,
-    {
+    fn drop_with_vm(self, container: &mut impl ContainsVM<'h>) {
         self.current_key.drop_with_heap(container);
         self.current_value.drop_with_heap(container);
         self.token.drop_with_vm(container);

--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -6,7 +6,7 @@ use smallvec::smallvec;
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, VM},
-    defer_drop, defer_drop_mut,
+    defer_drop, defer_drop_mut, defer_drop_vm_mut,
     exception_private::{ExcType, RunError, RunResult},
     heap::{Heap, HeapData, HeapGuard, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
@@ -99,7 +99,7 @@ impl<'h> HeapRead<'h, DictKeysView> {
         let dict = self.dict(vm);
         let mut result = Set::with_capacity(dict.get(vm.heap).len());
         let iter = dict.iter(vm)?;
-        defer_drop_mut!(iter, vm);
+        defer_drop_vm_mut!(iter, vm);
         while let Some((key, value)) = iter.next_owned(vm)? {
             value.drop_with_heap(vm);
             result.add(key, vm)?;
@@ -261,7 +261,7 @@ impl<'h> HeapRead<'h, DictItemsView> {
         let dict = self.dict(vm);
         let mut result = Set::with_capacity(dict.get(vm.heap).len());
         let iter = dict.iter(vm)?;
-        defer_drop_mut!(iter, vm);
+        defer_drop_vm_mut!(iter, vm);
         while let Some((key, value)) = iter.next_owned(vm)? {
             let item = allocate_tuple(smallvec![key, value], vm.heap)?;
             result.add(item, vm)?;
@@ -439,8 +439,8 @@ fn dict_keys_eq_set_like<'h, T: ResourceTracker>(
         return Ok(false);
     }
 
-    let token = vm.heap.incr_recursion_depth()?;
-    defer_drop!(token, vm);
+    let mut guard = vm.recursion_guard()?;
+    let vm = &mut *guard;
     let len = dict.get(vm.heap).len();
     for i in 0..len {
         vm.heap.check_time()?;
@@ -464,8 +464,8 @@ fn dict_items_eq_set_like<'h, T: ResourceTracker>(
         return Ok(false);
     }
 
-    let token = vm.heap.incr_recursion_depth()?;
-    defer_drop!(token, vm);
+    let mut guard = vm.recursion_guard()?;
+    let vm = &mut *guard;
     let len = dict.get(vm.heap).len();
     for i in 0..len {
         vm.heap.check_time()?;
@@ -487,7 +487,7 @@ fn write_dict_keys_contents<'h>(
     heap_ids: &mut AHashSet<HeapId>,
 ) -> RunResult<()> {
     let iter = dict.iter(vm)?;
-    defer_drop_mut!(iter, vm);
+    defer_drop_vm_mut!(iter, vm);
     let mut first = true;
     while let Some((key, _value)) = iter.next(vm)? {
         if !first {
@@ -507,7 +507,7 @@ fn write_dict_items_contents<'h>(
     heap_ids: &mut AHashSet<HeapId>,
 ) -> RunResult<()> {
     let iter = dict.iter(vm)?;
-    defer_drop_mut!(iter, vm);
+    defer_drop_vm_mut!(iter, vm);
     let mut first = true;
     while let Some((key, value)) = iter.next(vm)? {
         if !first {
@@ -531,7 +531,7 @@ fn write_dict_values_contents<'h>(
     heap_ids: &mut AHashSet<HeapId>,
 ) -> RunResult<()> {
     let iter = dict.iter(vm)?;
-    defer_drop_mut!(iter, vm);
+    defer_drop_vm_mut!(iter, vm);
     let mut first = true;
     while let Some((_key, value)) = iter.next(vm)? {
         if !first {

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -6,13 +6,10 @@ use smallvec::SmallVec;
 use super::{MontyIter, PyTrait};
 use crate::{
     args::ArgValues,
-    bytecode::{CallResult, VM},
-    defer_drop, defer_drop_mut,
+    bytecode::{CallResult, ContainsVM, DropWithVM, RecursionToken, VM},
+    defer_drop, defer_drop_mut, defer_drop_vm_mut,
     exception_private::{ExcType, RunError, RunResult, SimpleException},
-    heap::{
-        ContainsHeap, DropWithHeap, Heap, HeapData, HeapGuard, HeapId, HeapItem, HeapRead, HeapReadOutput, HeapReader,
-        RecursionToken,
-    },
+    heap::{DropWithHeap, Heap, HeapData, HeapGuard, HeapId, HeapItem, HeapRead, HeapReadOutput, HeapReader},
     intern::StaticStrings,
     resource::{ResourceError, ResourceTracker},
     sorting::parse_and_sort,
@@ -273,7 +270,7 @@ pub(crate) struct ListIter<'a, 'h> {
 
 impl<'a, 'h> ListIter<'a, 'h> {
     fn new<R: ResourceTracker>(list: &'a HeapRead<'h, List>, vm: &mut VM<'h, R>) -> RunResult<Self> {
-        let token = vm.heap.incr_recursion_depth()?;
+        let token = vm.incr_recursion()?;
         Ok(Self {
             list,
             index: 0,
@@ -321,10 +318,13 @@ impl<'a, 'h> ListIter<'a, 'h> {
     }
 }
 
-impl DropWithHeap for ListIter<'_, '_> {
-    fn drop_with_heap<H: ContainsHeap>(self, heap: &mut H) {
-        self.current.drop_with_heap(heap);
-        self.token.drop_with_heap(heap);
+impl<'h> DropWithVM<'h> for ListIter<'_, 'h> {
+    fn drop_with_vm<'c>(self, container: &'c mut impl ContainsVM<'h>)
+    where
+        'h: 'c,
+    {
+        self.current.drop_with_heap(container);
+        self.token.drop_with_vm(container);
     }
 }
 
@@ -424,7 +424,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
             return Ok(Some(false));
         }
         let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
+        defer_drop_vm_mut!(iter, vm);
         while let Some((i, a)) = iter.next_with_index(vm)? {
             let b = other.clone_item(i, vm);
             defer_drop!(b, vm);
@@ -669,7 +669,7 @@ fn list_remove<'h>(
     let mut found_idx = None;
     {
         let iter = list.iter(vm)?;
-        defer_drop_mut!(iter, vm);
+        defer_drop_vm_mut!(iter, vm);
         while let Some((i, item)) = iter.next_with_index(vm)? {
             if value.py_eq(item, vm)? {
                 found_idx = Some(i);
@@ -758,7 +758,7 @@ fn list_index<'h>(
 
     // Search for the value in the specified range
     let iter = list.iter(vm)?;
-    defer_drop_mut!(iter, vm);
+    defer_drop_vm_mut!(iter, vm);
     while let Some((idx, item)) = iter.next_with_index(vm)? {
         if idx >= end {
             // No further matches possible inside [start, end).
@@ -785,7 +785,7 @@ fn list_count<'h>(
 
     let mut count: usize = 0;
     let iter = list.iter(vm)?;
-    defer_drop_mut!(iter, vm);
+    defer_drop_vm_mut!(iter, vm);
     while let Some(item) = iter.next(vm)? {
         if value.py_eq(item, vm)? {
             count += 1;
@@ -860,10 +860,10 @@ pub(crate) fn repr_sequence_fmt<'h, T: ResourceTracker>(
     heap_ids: &mut AHashSet<HeapId>,
 ) -> RunResult<()> {
     // Check depth limit before recursing
-    let Ok(token) = vm.heap.incr_recursion_depth() else {
+    let Ok(mut guard) = vm.recursion_guard() else {
         return Ok(f.write_str("...")?);
     };
-    defer_drop!(token, vm);
+    let vm = &mut *guard;
 
     f.write_char(start)?;
     for i in 0..len {

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -270,7 +270,7 @@ pub(crate) struct ListIter<'a, 'h> {
 
 impl<'a, 'h> ListIter<'a, 'h> {
     fn new<R: ResourceTracker>(list: &'a HeapRead<'h, List>, vm: &mut VM<'h, R>) -> RunResult<Self> {
-        let token = vm.incr_recursion()?;
+        let token = vm.recursion_token()?;
         Ok(Self {
             list,
             index: 0,

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -243,12 +243,12 @@ impl<'h> HeapRead<'h, List> {
 /// item in its `current` slot (using [`Value::Undefined`] as the empty
 /// sentinel) and drops the previous item at the start of each `next` call.
 /// The held item is also dropped when the iterator itself is released via
-/// [`DropWithHeap`]. This means call sites do **not** need a per-item
+/// [`DropWithVM`]. This means call sites do **not** need a per-item
 /// `defer_drop!`; the iter manages every item it hands out.
 ///
 /// **Recursion guard.** Acquires a [`RecursionToken`] at construction and
-/// releases it via [`DropWithHeap`]. The iterator MUST be wrapped in
-/// [`defer_drop_mut!`] so the token (and any in-flight item) is released on
+/// releases it via [`DropWithVM`]. The iterator MUST be wrapped in
+/// [`defer_drop_vm_mut!`] so the token (and any in-flight item) is released on
 /// every exit path (success, early `return`, error via `?`). The token is
 /// intentionally non-optional — every iteration of a Python container can
 /// transitively trigger `py_eq` / `py_hash` / `py_repr` / `py_cmp` /
@@ -319,10 +319,7 @@ impl<'a, 'h> ListIter<'a, 'h> {
 }
 
 impl<'h> DropWithVM<'h> for ListIter<'_, 'h> {
-    fn drop_with_vm<'c>(self, container: &'c mut impl ContainsVM<'h>)
-    where
-        'h: 'c,
-    {
+    fn drop_with_vm(self, container: &mut impl ContainsVM<'h>) {
         self.current.drop_with_heap(container);
         self.token.drop_with_vm(container);
     }

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -221,7 +221,7 @@ pub(crate) struct NamedTupleIter<'a, 'h> {
 
 impl<'a, 'h> NamedTupleIter<'a, 'h> {
     fn new<R: ResourceTracker>(tuple: &'a HeapRead<'h, NamedTuple>, vm: &mut VM<'h, R>) -> RunResult<Self> {
-        let token = vm.incr_recursion()?;
+        let token = vm.recursion_token()?;
         Ok(Self {
             tuple,
             index: 0,

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -27,11 +27,11 @@ use ahash::AHashSet;
 
 use super::PyTrait;
 use crate::{
-    bytecode::{CallResult, VM},
-    defer_drop, defer_drop_mut,
+    bytecode::{CallResult, ContainsVM, DropWithVM, RecursionToken, VM},
+    defer_drop, defer_drop_vm_mut,
     exception_private::{ExcType, RunResult},
     hash::HashValue,
-    heap::{ContainsHeap, DropWithHeap, HeapId, HeapItem, HeapRead, HeapReadOutput, RecursionToken},
+    heap::{HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StringId},
     resource::ResourceTracker,
     types::Type,
@@ -186,7 +186,7 @@ impl<'h> HeapRead<'h, NamedTuple> {
             return Ok(false);
         }
         let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
+        defer_drop_vm_mut!(iter, vm);
         while let Some((i, a)) = iter.next_with_index(vm)? {
             let b = other.clone_item(i, vm);
             defer_drop!(b, vm);
@@ -221,7 +221,7 @@ pub(crate) struct NamedTupleIter<'a, 'h> {
 
 impl<'a, 'h> NamedTupleIter<'a, 'h> {
     fn new<R: ResourceTracker>(tuple: &'a HeapRead<'h, NamedTuple>, vm: &mut VM<'h, R>) -> RunResult<Self> {
-        let token = vm.heap.incr_recursion_depth()?;
+        let token = vm.incr_recursion()?;
         Ok(Self {
             tuple,
             index: 0,
@@ -263,10 +263,13 @@ impl<'a, 'h> NamedTupleIter<'a, 'h> {
     }
 }
 
-impl DropWithHeap for NamedTupleIter<'_, '_> {
-    fn drop_with_heap<H: ContainsHeap>(self, heap: &mut H) {
-        self.current.drop_with_heap(heap);
-        self.token.drop_with_heap(heap);
+impl<'h> DropWithVM<'h> for NamedTupleIter<'_, 'h> {
+    fn drop_with_vm<'c>(self, container: &'c mut impl ContainsVM<'h>)
+    where
+        'h: 'c,
+    {
+        self.current.drop_with_heap(container);
+        self.token.drop_with_vm(container);
     }
 }
 
@@ -306,7 +309,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
                     return Ok(Some(false));
                 }
                 let iter = self.iter(vm)?;
-                defer_drop_mut!(iter, vm);
+                defer_drop_vm_mut!(iter, vm);
                 while let Some((i, a)) = iter.next_with_index(vm)? {
                     let b = other.clone_item(i, vm);
                     defer_drop!(b, vm);
@@ -331,7 +334,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
         }
         let mut hasher = DefaultHasher::new();
         let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
+        defer_drop_vm_mut!(iter, vm);
         while let Some(item) = iter.next(vm)? {
             match item.py_hash(vm)? {
                 Some(h) => h.hash(&mut hasher),
@@ -354,10 +357,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
         heap_ids: &mut AHashSet<HeapId>,
     ) -> RunResult<()> {
         // Check depth limit before recursing
-        let Ok(token) = vm.heap.incr_recursion_depth() else {
+        let Ok(mut guard) = vm.recursion_guard() else {
             return Ok(f.write_str("...")?);
         };
-        defer_drop!(token, vm);
+        let vm = &mut *guard;
 
         write!(f, "{}(", self.get(vm.heap).name.as_str(vm.interns))?;
 

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -203,7 +203,7 @@ impl<'h> HeapRead<'h, NamedTuple> {
 /// Same shape as [`TupleIter`](super::tuple::TupleIter): yields each item by
 /// reference, owns the most-recently-yielded item in a `Value::Undefined`
 /// sentinel slot, and holds a [`RecursionToken`] for its lifetime. MUST be
-/// wrapped in [`defer_drop_mut!`] so the token and the in-flight item are
+/// wrapped in [`defer_drop_vm_mut!`] so the token and the in-flight item are
 /// released on every exit path.
 ///
 /// `NamedTuple` is immutable, so there is no size-change detection — only
@@ -264,10 +264,7 @@ impl<'a, 'h> NamedTupleIter<'a, 'h> {
 }
 
 impl<'h> DropWithVM<'h> for NamedTupleIter<'_, 'h> {
-    fn drop_with_vm<'c>(self, container: &'c mut impl ContainsVM<'h>)
-    where
-        'h: 'c,
-    {
+    fn drop_with_vm(self, container: &mut impl ContainsVM<'h>) {
         self.current.drop_with_heap(container);
         self.token.drop_with_vm(container);
     }

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -102,8 +102,8 @@ pub trait PyTrait<'h> {
     /// the recursion limit is exceeded while hashing nested containers.`
     ///
     /// Container implementations should track recursion depth via
-    /// `heap.incr_recursion_depth()` and recurse through `Value::py_hash` for
-    /// nested values.
+    /// `vm.recursion_guard()` (or `vm.incr_recursion()` when iterating) and
+    /// recurse through `Value::py_hash` for nested values.
     ///
     /// `self_id` is the heap ID of this value; it is required for types like
     /// `Cell` that hash by identity. Most implementations ignore it.
@@ -130,7 +130,7 @@ pub trait PyTrait<'h> {
     /// heap to resolve nested references; `&mut VM` allows lazy hash computation
     /// for dict key lookups and access to interned string content.
     ///
-    /// Recursion depth is tracked via `heap.incr_recursion_depth()`; returns
+    /// Recursion depth is tracked via `vm.recursion_guard()`; returns
     /// `Err(ResourceError::Recursion)` if maximum depth is exceeded.
     fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<bool>>;
 
@@ -140,7 +140,7 @@ pub trait PyTrait<'h> {
     /// to resolve nested references. Takes `&mut VM` to allow lazy hash
     /// computation for dict key lookups and access to interned string content.
     ///
-    /// Recursion depth is tracked via `heap.incr_recursion_depth()`.
+    /// Recursion depth is tracked via `vm.recursion_guard()`.
     ///
     /// Returns `Ok(Some(Ordering))` for comparable values, `Ok(None)` if not comparable,
     /// or `Err(ResourceError::Recursion)` if maximum depth is exceeded.
@@ -161,7 +161,7 @@ pub trait PyTrait<'h> {
     /// visited heap IDs. When a cycle is detected (ID already in `heap_ids`), implementations
     /// should write an ellipsis (e.g., `[...]` for lists, `{...}` for dicts).
     ///
-    /// Recursion depth is tracked via `heap.incr_recursion_depth()`.
+    /// Recursion depth is tracked via `vm.recursion_guard()`.
     ///
     /// # Arguments
     /// * `f` - The formatter to write to

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -7,13 +7,13 @@ use smallvec::SmallVec;
 use super::{MontyIter, PyTrait};
 use crate::{
     args::ArgValues,
-    bytecode::{CallResult, VM},
-    defer_drop, defer_drop_mut,
+    bytecode::{CallResult, ContainsVM, DropWithVM, RecursionToken, VM},
+    defer_drop, defer_drop_mut, defer_drop_vm_mut,
     exception_private::{ExcType, RunResult},
     hash::HashValue,
     heap::{
         BorrowedHeapRead, BorrowedHeapReadMut, ContainsHeap, DropWithHeap, HeapData, HeapGuard, HeapId, HeapItem,
-        HeapRead, HeapReadOutput, RecursionToken, heap_read_ref_as_field, heap_read_ref_as_field_mut,
+        HeapRead, HeapReadOutput, heap_read_ref_as_field, heap_read_ref_as_field_mut,
     },
     intern::StaticStrings,
     resource::ResourceTracker,
@@ -281,7 +281,7 @@ impl<'h> HeapRead<'h, SetStorage> {
             return Ok(false);
         }
         let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
+        defer_drop_vm_mut!(iter, vm);
         while let Some(elem) = iter.next(vm)? {
             if !other.contains(elem, vm)? {
                 return Ok(false);
@@ -339,7 +339,7 @@ pub(crate) struct SetIter<'a, 'h> {
 impl<'a, 'h> SetIter<'a, 'h> {
     fn new<R: ResourceTracker>(storage: &'a HeapRead<'h, SetStorage>, vm: &mut VM<'h, R>) -> RunResult<Self> {
         let expected_len = storage.get(vm.heap).entries.len();
-        let token = vm.heap.incr_recursion_depth()?;
+        let token = vm.incr_recursion()?;
         Ok(Self {
             storage,
             index: 0,
@@ -372,10 +372,13 @@ impl<'a, 'h> SetIter<'a, 'h> {
     }
 }
 
-impl DropWithHeap for SetIter<'_, '_> {
-    fn drop_with_heap<H: ContainsHeap>(self, heap: &mut H) {
-        self.current.drop_with_heap(heap);
-        self.token.drop_with_heap(heap);
+impl<'h> DropWithVM<'h> for SetIter<'_, 'h> {
+    fn drop_with_vm<'c>(self, container: &'c mut impl ContainsVM<'h>)
+    where
+        'h: 'c,
+    {
+        self.current.drop_with_heap(container);
+        self.token.drop_with_vm(container);
     }
 }
 
@@ -515,10 +518,10 @@ impl<'h> HeapRead<'h, SetStorage> {
         }
 
         // Check depth limit before recursing
-        let Ok(token) = vm.heap.incr_recursion_depth() else {
+        let Ok(mut guard) = vm.recursion_guard() else {
             return Ok(f.write_str("{...}")?);
         };
-        defer_drop!(token, vm);
+        let vm = &mut *guard;
 
         // frozenset needs type prefix: frozenset({...}), but set doesn't: {...}
         let needs_prefix = type_name != "set";
@@ -1279,7 +1282,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
         let mut hash: u64 = 0;
         let storage = self.storage();
         let iter = storage.iter(vm)?;
-        defer_drop_mut!(iter, vm);
+        defer_drop_vm_mut!(iter, vm);
         while let Some(item) = iter.next(vm)? {
             hash ^= set_element_hash(item, vm)?;
         }

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -315,8 +315,8 @@ impl<'h> HeapRead<'h, SetStorage> {
 /// a per-item `defer_drop!`.
 ///
 /// **Recursion guard.** Acquires a [`RecursionToken`] at construction and
-/// releases it via [`DropWithHeap`]. The iterator MUST be wrapped in
-/// [`defer_drop_mut!`] so the token (and any in-flight element) is released
+/// releases it via [`DropWithVM`]. The iterator MUST be wrapped in
+/// [`defer_drop_vm_mut!`] so the token (and any in-flight element) is released
 /// on every exit path — set iteration usually feeds into `py_eq` /
 /// `py_hash` / membership checks which recurse on cyclic structures (e.g.
 /// frozensets of frozensets).
@@ -373,10 +373,7 @@ impl<'a, 'h> SetIter<'a, 'h> {
 }
 
 impl<'h> DropWithVM<'h> for SetIter<'_, 'h> {
-    fn drop_with_vm<'c>(self, container: &'c mut impl ContainsVM<'h>)
-    where
-        'h: 'c,
-    {
+    fn drop_with_vm(self, container: &mut impl ContainsVM<'h>) {
         self.current.drop_with_heap(container);
         self.token.drop_with_vm(container);
     }

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -339,7 +339,7 @@ pub(crate) struct SetIter<'a, 'h> {
 impl<'a, 'h> SetIter<'a, 'h> {
     fn new<R: ResourceTracker>(storage: &'a HeapRead<'h, SetStorage>, vm: &mut VM<'h, R>) -> RunResult<Self> {
         let expected_len = storage.get(vm.heap).entries.len();
-        let token = vm.incr_recursion()?;
+        let token = vm.recursion_token()?;
         Ok(Self {
             storage,
             index: 0,

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -212,11 +212,11 @@ impl<'h> HeapRead<'h, Tuple> {
 /// slot (using [`Value::Undefined`] as the empty sentinel) and drops the
 /// previous item at the start of each `next` call, so call sites do **not**
 /// need a per-item `defer_drop!`. The held item is also dropped when the
-/// iterator is released via [`DropWithHeap`].
+/// iterator is released via [`DropWithVM`].
 ///
 /// **Recursion guard.** Acquires a [`RecursionToken`] at construction and
-/// releases it via [`DropWithHeap`]. The iterator MUST be wrapped in
-/// [`defer_drop_mut!`] so the token (and any in-flight item) is released
+/// releases it via [`DropWithVM`]. The iterator MUST be wrapped in
+/// [`defer_drop_vm_mut!`] so the token (and any in-flight item) is released
 /// on every exit path. Unlike list / dict / set iteration, tuples are
 /// immutable so size never changes during iteration, but the token still
 /// belongs here — tuple iteration almost always feeds into operations that
@@ -280,10 +280,7 @@ impl<'a, 'h> TupleIter<'a, 'h> {
 }
 
 impl<'h> DropWithVM<'h> for TupleIter<'_, 'h> {
-    fn drop_with_vm<'c>(self, container: &'c mut impl ContainsVM<'h>)
-    where
-        'h: 'c,
-    {
+    fn drop_with_vm(self, container: &mut impl ContainsVM<'h>) {
         self.current.drop_with_heap(container);
         self.token.drop_with_vm(container);
     }

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -234,7 +234,7 @@ pub(crate) struct TupleIter<'a, 'h> {
 
 impl<'a, 'h> TupleIter<'a, 'h> {
     fn new<R: ResourceTracker>(tuple: &'a HeapRead<'h, Tuple>, vm: &mut VM<'h, R>) -> RunResult<Self> {
-        let token = vm.incr_recursion()?;
+        let token = vm.recursion_token()?;
         Ok(Self {
             tuple,
             index: 0,

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -29,11 +29,11 @@ use smallvec::SmallVec;
 use super::{MontyIter, PyTrait};
 use crate::{
     args::ArgValues,
-    bytecode::{CallResult, VM},
-    defer_drop, defer_drop_mut,
+    bytecode::{CallResult, ContainsVM, DropWithVM, RecursionToken, VM},
+    defer_drop, defer_drop_vm_mut,
     exception_private::{ExcType, RunResult},
     hash::HashValue,
-    heap::{ContainsHeap, DropWithHeap, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput, RecursionToken},
+    heap::{DropWithHeap, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     resource::{ResourceError, ResourceTracker},
     types::{
@@ -234,7 +234,7 @@ pub(crate) struct TupleIter<'a, 'h> {
 
 impl<'a, 'h> TupleIter<'a, 'h> {
     fn new<R: ResourceTracker>(tuple: &'a HeapRead<'h, Tuple>, vm: &mut VM<'h, R>) -> RunResult<Self> {
-        let token = vm.heap.incr_recursion_depth()?;
+        let token = vm.incr_recursion()?;
         Ok(Self {
             tuple,
             index: 0,
@@ -279,10 +279,13 @@ impl<'a, 'h> TupleIter<'a, 'h> {
     }
 }
 
-impl DropWithHeap for TupleIter<'_, '_> {
-    fn drop_with_heap<H: ContainsHeap>(self, heap: &mut H) {
-        self.current.drop_with_heap(heap);
-        self.token.drop_with_heap(heap);
+impl<'h> DropWithVM<'h> for TupleIter<'_, 'h> {
+    fn drop_with_vm<'c>(self, container: &'c mut impl ContainsVM<'h>)
+    where
+        'h: 'c,
+    {
+        self.current.drop_with_heap(container);
+        self.token.drop_with_vm(container);
     }
 }
 
@@ -329,7 +332,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
             return Ok(Some(false));
         }
         let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
+        defer_drop_vm_mut!(iter, vm);
         while let Some((i, a)) = iter.next_with_index(vm)? {
             let b = other.clone_item(i, vm);
             defer_drop!(b, vm);
@@ -355,7 +358,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         }
         let mut hasher = DefaultHasher::new();
         let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
+        defer_drop_vm_mut!(iter, vm);
         while let Some(item) = iter.next(vm)? {
             match item.py_hash(vm)? {
                 Some(h) => h.hash(&mut hasher),
@@ -380,7 +383,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         let b_len = other.get(vm.heap).items.len();
         let min_len = a_len.min(b_len);
         let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
+        defer_drop_vm_mut!(iter, vm);
         while let Some((i, av)) = iter.next_with_index(vm)? {
             if i >= min_len {
                 // `self` was longer than `other`; remaining items don't
@@ -446,10 +449,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
             //
             // Match `repr_sequence_fmt`'s depth handling so nested one-element
             // tuples can't bypass `max_recursion_depth` and overflow the stack.
-            let Ok(token) = vm.heap.incr_recursion_depth() else {
+            let Ok(mut guard) = vm.recursion_guard() else {
                 return Ok(f.write_str("...")?);
             };
-            defer_drop!(token, vm);
+            let vm = &mut *guard;
             write!(f, "(")?;
             let item = self.clone_item(0, vm);
             defer_drop!(item, vm);
@@ -515,7 +518,7 @@ fn tuple_index<'h>(
     };
 
     let iter = tuple.iter(vm)?;
-    defer_drop_mut!(iter, vm);
+    defer_drop_vm_mut!(iter, vm);
     while let Some((idx, item)) = iter.next_with_index(vm)? {
         if idx >= end {
             // No further matches possible inside [start, end).
@@ -543,7 +546,7 @@ fn tuple_count<'h>(
 
     let mut count = 0usize;
     let iter = tuple.iter(vm)?;
-    defer_drop_mut!(iter, vm);
+    defer_drop_vm_mut!(iter, vm);
     while let Some(item) = iter.next(vm)? {
         if value.py_eq(item, vm)? {
             count += 1;


### PR DESCRIPTION
This field should exist in VM (and heap is a safety boundary, should be as simple as possible).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved recursion depth tracking from the heap to the VM to keep limits accurate across frames, iterators, and async tasks. Adds VM-side guard/token APIs for automatic cleanup and simplifies the heap.

- **Refactors**
  - Added `recursion_depth` to `VM` and a new `vm::recursion` module.
  - Introduced `VM::recursion_guard()`, `VM::recursion_token()`, and `VM::incr_recursion()`; replaced all `heap.incr_recursion_depth()` calls.
  - Added `ContainsVM`, `DropWithVM`, `VmGuard`, and `defer_drop_vm!`/`defer_drop_vm_mut!`; re-exported from `bytecode`.
  - Removed heap recursion token and all heap recursion depth APIs.
  - Updated iterators (`ListIter`, `TupleIter`, `DictIter`, `SetIter`, `NamedTupleIter`) to hold a VM `RecursionToken` and drop via `DropWithVM`.
  - Made JSON `Encoder` implement `ContainsVM` and switched to `defer_drop_vm!` macros.
  - VM now restores depth from frame count on snapshot restore and rebalances it on async task switches.
  - Switched `repr`/`eq`/`cmp`/`hash`/`isinstance` paths to `recursion_guard()`.

- **Migration**
  - Replace `heap.incr_recursion_depth()` with `vm.recursion_guard()` (lexical) or `vm.recursion_token()` (stored token).
  - Replace `defer_drop!`/`defer_drop_mut!` on recursion tokens/iterators with `defer_drop_vm!`/`defer_drop_vm_mut!`.

<sup>Written for commit 36263ef41d14a7b53f91d845f027c3671004724c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

