### PR TITLE
use stable clippy in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,17 @@ jobs:
       # no release versioning, see https://github.com/dtolnay/rust-toolchain/issues/180
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
+          toolchain: stable
+          components: clippy
+
+      # nightly is only used for `cargo +nightly fmt` (make format-rs); clippy must
+      # run on stable. Install both toolchains: the last dtolnay invocation sets the
+      # default, so stable below is what bare `cargo clippy` (make lint-rs) uses.
+      # no release versioning, see https://github.com/dtolnay/rust-toolchain/issues/180
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        with:
           toolchain: nightly
-          components: rustfmt, clippy
+          components: rustfmt
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,20 +32,24 @@ jobs:
         with:
           persist-credentials: false
 
+      # nightly is only used for `cargo +nightly fmt` (make format-rs); clippy must
+      # run on stable. Install both toolchains, then explicitly set stable as the
+      # default so bare `cargo clippy` (make lint-rs) resolves to stable — dtolnay's
+      # install order alone does not reliably control which toolchain is the default.
+      # no release versioning, see https://github.com/dtolnay/rust-toolchain/issues/180
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        with:
+          toolchain: nightly
+          components: rustfmt
+
       # no release versioning, see https://github.com/dtolnay/rust-toolchain/issues/180
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
           toolchain: stable
           components: clippy
 
-      # nightly is only used for `cargo +nightly fmt` (make format-rs); clippy must
-      # run on stable. Install both toolchains: the last dtolnay invocation sets the
-      # default, so stable below is what bare `cargo clippy` (make lint-rs) uses.
-      # no release versioning, see https://github.com/dtolnay/rust-toolchain/issues/180
-      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
-        with:
-          toolchain: nightly
-          components: rustfmt
+      - name: Set stable as the default toolchain (clippy on stable; fmt pins +nightly)
+        run: rustup default stable
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Run `clippy` on the stable Rust toolchain in CI and keep nightly only for formatting.

The workflow now installs `nightly` with `rustfmt`, installs `stable` with `clippy`, and sets `stable` as the default via `rustup default stable` so bare `cargo clippy` runs on stable while `cargo +nightly fmt` still works.

<sup>Written for commit af3b4b48264912d2e73c523201988371cfa33dc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

