### PR TITLE
Publish all library crates to crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
       - run: cargo llvm-cov --no-report -p monty --features ref-count-return
       - run: cargo llvm-cov run --no-report -p monty-datatest --features ref-count-return
       # coverage for `make test-type-checking`
-      - run: cargo llvm-cov --no-report -p monty_type_checking -p monty_typeshed
+      - run: cargo llvm-cov --no-report -p monty-type-checking -p monty-typeshed
       # subprocess protocol + child mode + worker pool. The pool tests spawn a
       # real `monty` binary: build it plainly first (outside the llvm-cov
       # target dir) and point the tests at it explicitly.
@@ -815,6 +815,43 @@ jobs:
 
       - name: Publish to PyPI
         run: 'uv publish --trusted-publishing always dist/*'
+
+  release-crates:
+    name: release to crates.io
+    needs: [check]
+    if: success() && (startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.run_release))
+    runs-on: ubuntu-latest
+
+    environment:
+      name: release-crates
+      url: https://crates.io/crates/monty
+
+    # trusted publishing to crates.io via OIDC, no long-lived token required
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # no release versioning, see https://github.com/dtolnay/rust-toolchain/issues/180
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        with:
+          toolchain: stable
+
+      # exchanges the GitHub OIDC token for a short-lived crates.io token,
+      # exported as CARGO_REGISTRY_TOKEN for the publish step
+      - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+        id: auth
+
+      # Publishes every workspace member that is not `publish = false` (i.e. all
+      # the library/bin crates, but not the `pydantic-monty`/`monty-js` bindings,
+      # which ship to PyPI/npm). `--workspace` publishes in dependency order and
+      # waits for each crate to land in the index before publishing dependents.
+      - run: cargo publish --workspace
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   test-js:
     name: test JS on ${{ matrix.os }} - node@${{ matrix.node }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,7 +287,7 @@ make test-no-features     Run rust tests without any features enabled
 make test-memory-model-checks Run rust tests with memory-model-checks enabled - THIS IS EXTREMELY SLOW, SHOULD MOSTLY BE RUN IN CI OR IF ABSOLUTELY NECESSARY
 make test-ref-count-return Run rust tests with ref-count-return enabled
 make test-cases           Run tests cases only
-make test-type-checking   Run rust tests on monty_type_checking
+make test-type-checking   Run rust tests on monty-type-checking
 make pytest               Run Python tests with pytest
 make test-py              Build the python package (debug profile) and run tests
 make test-docs            Test docs examples only

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1982,7 +1982,7 @@ dependencies = [
  "clap",
  "monty",
  "monty-proto",
- "monty_type_checking",
+ "monty-type-checking",
  "prost",
  "rustyline",
  "tempfile",
@@ -2017,7 +2017,7 @@ version = "0.0.18"
 dependencies = [
  "monty",
  "monty-pool",
- "monty_type_checking",
+ "monty-type-checking",
  "napi",
  "napi-build",
  "napi-derive",
@@ -2056,13 +2056,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "monty_type_checking"
+name = "monty-type-checking"
 version = "0.0.18"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
  "insta",
- "monty_typeshed",
+ "monty-typeshed",
  "pprof",
  "pretty_assertions",
  "ruff_db",
@@ -2075,7 +2075,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "monty_typeshed"
+name = "monty-typeshed"
 version = "0.0.18"
 dependencies = [
  "path-slash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,6 @@ members = [
     "crates/fuzz"
 ]
 default-members = ["crates/monty-cli"]
-# `squat/` is a separate throwaway workspace of 0.0.0 placeholder crates used to
-# reserve crate names on crates.io; it must not be part of the real workspace.
-exclude = ["squat"]
 
 [workspace.package]
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,9 @@ members = [
     "crates/fuzz"
 ]
 default-members = ["crates/monty-cli"]
+# `squat/` is a separate throwaway workspace of 0.0.0 placeholder crates used to
+# reserve crate names on crates.io; it must not be part of the real workspace.
+exclude = ["squat"]
 
 [workspace.package]
 edition = "2024"
@@ -41,6 +44,17 @@ strip = false
 lto = false
 
 [workspace.dependencies]
+# Internal crates. The `path` is used for local/workspace builds; the `version`
+# is required so the crates can be published to crates.io (`cargo publish`
+# rejects path-only dependencies). These versions MUST be kept in lockstep with
+# `workspace.package.version` above and bumped together on each release — see
+# RELEASING.md.
+monty = { path = "crates/monty", version = "0.0.18" }
+monty-macros = { path = "crates/monty-macros", version = "0.0.18" }
+monty-proto = { path = "crates/monty-proto", version = "0.0.18" }
+monty-pool = { path = "crates/monty-pool", version = "0.0.18" }
+monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.18" }
+monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.18" }
 # ruff, ty and related crates
 ruff_python_parser = "0.0.3"
 ruff_python_stdlib = "0.0.3"

--- a/Makefile
+++ b/Makefile
@@ -151,8 +151,8 @@ miri-test-cases: ## Run library inline tests under miri (particularly relevant f
 	MIRIFLAGS=-Zmiri-disable-isolation cargo +nightly miri run -p monty-datatest -- run_test_cases_monty
 
 .PHONY: test-type-checking
-test-type-checking: ## Run rust tests on monty_type_checking
-	cargo test -p monty_type_checking -p monty_typeshed
+test-type-checking: ## Run rust tests on monty-type-checking
+	cargo test -p monty-type-checking -p monty-typeshed
 
 .PHONY: test-subprocess
 test-subprocess: ## Run subprocess protocol, child-mode, and worker-pool tests
@@ -188,7 +188,7 @@ testcov: ## Run Rust tests with coverage, print table, and generate HTML report
 	cargo llvm-cov --no-report -p monty --features ref-count-return
 	cargo llvm-cov run --no-report -p monty-datatest --features ref-count-return
 	echo "coverage for `make test-type-checking`"
-	cargo llvm-cov --no-report -p monty_type_checking -p monty_typeshed
+	cargo llvm-cov --no-report -p monty-type-checking -p monty-typeshed
 	echo "Generating reports:"
 	cargo llvm-cov report --ignore-filename-regex '(tests/|test_cases/|/tests\.rs$$)'
 	cargo llvm-cov report --html --ignore-filename-regex '(tests/|test_cases/|/tests\.rs$$)'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,10 @@
 Update version in both files:
 
 ```bash
-# Edit Cargo.toml - update workspace.package.version
+# Edit Cargo.toml - update workspace.package.version AND the internal crate
+#   versions in [workspace.dependencies] (monty, monty-macros, monty-proto,
+#   monty-pool, monty-type-checking, monty-typeshed). These must all equal
+#   workspace.package.version or `cargo publish` will fail.
 # Edit crates/monty-js/package.json - update version AND the optionalDependencies
 #   versions (they must all equal the package version; CI's
 #   create-platform-packages fails if they drift)
@@ -39,6 +42,7 @@ Once the tag is pushed, CI will:
 - Build wheels for all platforms
 - Publish to PyPI (`pydantic-monty`)
 - Publish to NPM (`@pydantic/monty` + the platform packages carrying the napi library, the `monty` binary, and the wasm build)
+- Publish the Rust crates to crates.io (`monty`, `monty-cli`, `monty-macros`, `monty-proto`, `monty-pool`, `monty-type-checking`, `monty-typeshed`) via `cargo publish --workspace`
 
 Monitor the workflow at https://github.com/pydantic/monty/actions
 

--- a/crates/fuzz/Cargo.toml
+++ b/crates/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 [dependencies]
 arbitrary = { version = "1", features = ["derive"] }
 libfuzzer-sys = "0.4"
-monty = { path = "../monty" }
+monty = { workspace = true }
 
 [[bin]]
 name = "string_input_panic"

--- a/crates/monty-bench/Cargo.toml
+++ b/crates/monty-bench/Cargo.toml
@@ -9,8 +9,8 @@ description = "Benchmarks for the Monty interpreter — compares Monty vs CPytho
 publish = false
 
 [dependencies]
-monty = { path = "../monty", features = ["test-hooks"] }
-monty-pool = { path = "../monty-pool" }
+monty = { workspace = true, features = ["test-hooks"] }
+monty-pool = { workspace = true }
 pyo3 = { version = "0.28", features = ["auto-initialize"] }
 codspeed-criterion-compat = "4.2.1"
 criterion = "0.5"

--- a/crates/monty-cli/Cargo.toml
+++ b/crates/monty-cli/Cargo.toml
@@ -17,9 +17,9 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-monty = { path = "../monty" }
-monty-proto = { path = "../monty-proto" }
-monty_type_checking = { path = "../monty-type-checking" }
+monty = { workspace = true }
+monty-proto = { workspace = true }
+monty-type-checking = { workspace = true }
 prost = { workspace = true }
 rustyline = "15"
 

--- a/crates/monty-datatest/Cargo.toml
+++ b/crates/monty-datatest/Cargo.toml
@@ -9,7 +9,7 @@ description = "Datatest harness for Monty — runs test cases against both Monty
 publish = false
 
 [dependencies]
-monty = { path = "../monty", features = ["test-hooks"] }
+monty = { workspace = true, features = ["test-hooks"] }
 pyo3 = { version = "0.28", features = ["auto-initialize"] }
 ahash = { workspace = true }
 chrono = "0.4"

--- a/crates/monty-js/Cargo.toml
+++ b/crates/monty-js/Cargo.toml
@@ -2,6 +2,8 @@
 name = "monty-js"
 description = "Node.js/TypeScript bindings for the Monty sandboxed Python interpreter"
 readme = "README.md"
+# Distributed as a napi-rs native addon on npm, not as a crate on crates.io.
+publish = false
 version = { workspace = true }
 rust-version = { workspace = true }
 # napi-derive's generated code is not yet edition-2024 clean
@@ -17,8 +19,8 @@ repository = { workspace = true }
 crate-type = ["cdylib"]
 
 [dependencies]
-monty = { path = "../monty" }
-monty_type_checking = { path = "../monty-type-checking" }
+monty = { workspace = true }
+monty-type-checking = { workspace = true }
 napi = { version = "3.8", default-features = false, features = ["napi6", "compat-mode", "tokio_rt"] }
 napi-derive = "3.0.0"
 num-bigint = { workspace = true }
@@ -28,7 +30,7 @@ postcard = { workspace = true }
 # the subprocess pool spawns workers — impossible on wasm, where only the
 # in-process API is exposed
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-monty-pool = { path = "../monty-pool" }
+monty-pool = { workspace = true }
 
 [build-dependencies]
 napi-build = "2"

--- a/crates/monty-pool/Cargo.toml
+++ b/crates/monty-pool/Cargo.toml
@@ -15,8 +15,8 @@ repository = { workspace = true }
 name = "monty_pool"
 
 [dependencies]
-monty = { path = "../monty" }
-monty-proto = { path = "../monty-proto" }
+monty = { workspace = true }
+monty-proto = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/monty-proto/Cargo.toml
+++ b/crates/monty-proto/Cargo.toml
@@ -15,7 +15,7 @@ repository = { workspace = true }
 name = "monty_proto"
 
 [dependencies]
-monty = { path = "../monty" }
+monty = { workspace = true }
 num-bigint = { workspace = true }
 prost = { workspace = true }
 # generation-only dependencies (see src/bin/generate.rs); exact pins so the

--- a/crates/monty-python/Cargo.toml
+++ b/crates/monty-python/Cargo.toml
@@ -2,6 +2,8 @@
 name = "pydantic-monty"
 description = "Python bindings for the Monty sandboxed Python interpreter"
 readme = "README.md"
+# Distributed as a PyO3 extension wheel on PyPI, not as a crate on crates.io.
+publish = false
 version = { workspace = true }
 rust-version = { workspace = true }
 edition = { workspace = true }
@@ -18,8 +20,8 @@ crate-type = ["cdylib"]
 
 [dependencies]
 ahash = { workspace = true }
-monty-pool = { path = "../monty-pool" }
-monty = { path = "../monty" }
+monty-pool = { workspace = true }
+monty = { workspace = true }
 pyo3 = { version = "0.28", features = ["indexmap", "generate-import-lib", "num-bigint"] }
 num-bigint = { workspace = true }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }

--- a/crates/monty-type-checking/Cargo.toml
+++ b/crates/monty-type-checking/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "monty_type_checking"
+name = "monty-type-checking"
 readme = "../../README.md"
 version = { workspace = true }
 rust-version = { workspace = true }
@@ -17,7 +17,7 @@ name = "monty_type_checking"
 path = "src/lib.rs"
 
 [dependencies]
-monty_typeshed = { path = "../monty-typeshed" }
+monty-typeshed = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_db = { workspace = true }
 ruff_text_size = { workspace = true }

--- a/crates/monty-typeshed/Cargo.toml
+++ b/crates/monty-typeshed/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "monty_typeshed"
+name = "monty-typeshed"
 readme = "README.md"
 version = { workspace = true }
 rust-version = { workspace = true }
@@ -11,6 +11,12 @@ keywords = { workspace = true }
 categories = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
+
+# Explicit lib name keeps the Rust import path `monty_typeshed` even though the
+# crates.io package name uses hyphens.
+[lib]
+name = "monty_typeshed"
+path = "src/lib.rs"
 
 [dependencies]
 ruff_db = { workspace = true }

--- a/crates/monty/Cargo.toml
+++ b/crates/monty/Cargo.toml
@@ -38,7 +38,7 @@ chrono = { version = "0.4", features = ["serde"] }
 speedate = "0.17.0"
 itertools = "0.14.0"
 jiter = { version = "0.15.0", features = ["num-bigint"] }
-monty-macros = { path = "../monty-macros" }
+monty-macros = { workspace = true }
 
 [features]
 # ref-count-return changes behavior to return information on reference counts to check they're correct


### PR DESCRIPTION
fix #148.

Add a tag-triggered `release-crates` CI job that runs `cargo publish --workspace` to publish the Rust crates (monty, monty-cli, monty-macros, monty-proto, monty-pool, monty-type-checking, monty-typeshed), authenticating via crates.io trusted publishing (OIDC).

To make this work:
- Centralize internal crate deps in [workspace.dependencies] with both `path` (local builds) and `version` (required by `cargo publish`).
- Mark the pydantic-monty and monty-js bindings `publish = false` since they ship to PyPI/npm, so `--workspace` selects exactly the right set.
- Rename the two underscore packages to hyphens for consistency (monty_type_checking -> monty-type-checking, monty_typeshed -> monty-typeshed); Rust import paths stay underscored via explicit [lib] name.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tag-triggered CI job to publish our Rust library crates to crates.io and standardizes workspace deps and crate names so `cargo publish --workspace` works reliably.

- **New Features**
  - Added `release-crates` job that uses OIDC (`rust-lang/crates-io-auth-action`) to run `cargo publish --workspace` for `monty`, `monty-cli`, `monty-macros`, `monty-proto`, `monty-pool`, `monty-type-checking`, `monty-typeshed`.
  - Centralized internal deps in `[workspace.dependencies]` with both `path` and `version`.
  - Excluded bindings from crates.io: `pydantic-monty` and `monty-js` now `publish = false`.
  - Renamed crates to hyphens on crates.io: `monty_type_checking` → `monty-type-checking`, `monty_typeshed` → `monty-typeshed` (Rust import paths stay underscored via `[lib]`).
  - Updated CI, Makefile, and docs to use the new crate names.

- **Migration**
  - If depending from crates.io, use `monty-type-checking` and `monty-typeshed` in `Cargo.toml`; keep `use monty_type_checking` / `use monty_typeshed` in code.
  - For releases, bump `workspace.package.version` and the internal crate versions in `[workspace.dependencies]`; pushing a tag publishes the crates.

<sup>Written for commit ec3ebd093312a8876a4ee1cb60648de8fd25fecf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

