### PR TITLE
monty-cpython: rich sandbox tracebacks with source previews and carets

### DIFF
--- a/crates/monty-cpython/README.md
+++ b/crates/monty-cpython/README.md
@@ -165,17 +165,21 @@ its `ResumeCall` arrives, so only one external call is outstanding at a time.
   `max_duration_micros` on events are always zero.
 - **Type checking** (`Configure.type_check`, `Feed.skip_type_check`) is
   ignored — snippets are always executed, never type-checked.
-- **`Configure.script_name`** is the filename snippets compile under, so CPython
-  tracebacks (and `SyntaxError`s) report it. It is also how user frames are told
-  apart from the internal `runner.py` driver frames when rebuilding the traceback.
+- **`Configure.script_name`** is the filename reported for every sandbox frame
+  in a traceback. Internally each feed compiles under a unique `<input-N>` name
+  (with its source registered in `linecache`, so previews resolve even for a
+  frame from a function defined in an earlier feed); `script_name` is substituted
+  in when the traceback is rebuilt.
 - **Error tracebacks** are reconstructed from the CPython traceback and sent in
-  `RaisedException.traceback`, but only at reduced fidelity: one frame per *user*
-  frame (the `runner.py` driver frames — `run`/`drive_async`/`eval` — are filtered
-  out), each carrying the `script_name` filename, the line number, and the
-  function name (`<module>` for top-level code). Column ranges, source-line
-  previews, and caret markers are **not** reconstructed, so a frame's rendered
-  traceback line has no `~~~` underline. This is unlike both native Monty (which
-  attaches previews and carets) and CPython's own rich traceback output.
+  `RaisedException.traceback`: one frame per *user* frame (the `runner.py` driver
+  frames — `run`/`drive_async`/`eval` — are filtered out), each with the
+  `script_name` filename, line number, function name (`<module>` for top-level
+  code), source-line preview, and caret span. The caret column span and the
+  show/hide decision are taken from CPython's own renderer (so `raise` shows no
+  caret, whole-line calls do), but rendered in Monty's uniform `~~~` style rather
+  than CPython's two-tone `~~~^^^`. `SyntaxError`s raise during compilation, so
+  their frames are runner-internal and filtered out — only the type and message
+  survive.
 - **Mounts** (`Feed.mounts`) are ignored; the child performs no virtual
   filesystem mapping. Real filesystem access goes straight to the host FS
   (see the security note above).

--- a/crates/monty-cpython/README.md
+++ b/crates/monty-cpython/README.md
@@ -174,12 +174,15 @@ its `ResumeCall` arrives, so only one external call is outstanding at a time.
   `RaisedException.traceback`: one frame per *user* frame (the `runner.py` driver
   frames — `run`/`drive_async`/`eval` — are filtered out), each with the
   `script_name` filename, line number, function name (`<module>` for top-level
-  code), source-line preview, and caret span. The caret column span and the
-  show/hide decision are taken from CPython's own renderer (so `raise` shows no
-  caret, whole-line calls do), but rendered in Monty's uniform `~~~` style rather
-  than CPython's two-tone `~~~^^^`. `SyntaxError`s raise during compilation, so
-  their frames are runner-internal and filtered out — only the type and message
-  survive.
+  code), source-line preview, and caret span. The caret column span comes from
+  CPython's reported offsets, rendered in Monty's uniform `~~~` style rather than
+  CPython's two-tone `~~~^^^`. Caret *visibility*, however, is a rough heuristic,
+  not CPython's exact anchor-aware decision: a caret line is drawn for every frame
+  except `raise` statements. So CPython's other no-caret cases — attribute access,
+  a bare-name lookup on its own line, and full-line `x = f()` / `return f()` calls
+  — get a whole-line underline here where CPython draws none. `SyntaxError`s raise
+  during compilation, so their frames are runner-internal and filtered out — only
+  the type and message survive.
 - **Mounts** (`Feed.mounts`) are ignored; the child performs no virtual
   filesystem mapping. Real filesystem access goes straight to the host FS
   (see the security note above).

--- a/crates/monty-cpython/src/pyexec.rs
+++ b/crates/monty-cpython/src/pyexec.rs
@@ -9,7 +9,7 @@
 //! converted and returned directly, and an **unknown** name raises `NameError`.
 //! All the real work — name resolution, value conversion, the transport round
 //! trips — happens in Rust on [`SandboxGlobals`]; the Python glue is intentionally
-//! tiny (just the REPL runner `run`).
+//! tiny (the REPL runner plus traceback extraction).
 //!
 //! SECURITY: this runs untrusted code in *full CPython*, which is not itself a
 //! sandbox (the code can `import os` and do anything this process can). Isolation
@@ -40,9 +40,9 @@ use crate::{
     transport::{Incoming, SendError, SharedTransport},
 };
 
-/// Python glue, executed once per process. Defines just the REPL runner (`run`);
-/// everything else — the namespace, name resolution, host calls — lives in Rust
-/// on [`SandboxGlobals`].
+/// Python glue, executed once per process. Defines the REPL runner (`run`) and
+/// traceback extractor; everything else — the namespace, name resolution, host
+/// calls — lives in Rust on [`SandboxGlobals`].
 ///
 /// The source lives in `runner.py` (so it reads/edits/lints as real Python) and
 /// is inlined here at compile time as a `&CStr` — `include_str!` embeds the file,
@@ -73,14 +73,16 @@ impl Runner {
     /// Runs `code` in `namespace`, returning the trailing expression's value.
     /// The snippet compiles under an internal `<input-N>` filename (see
     /// `runner.py`'s `run`); the parent-visible name is applied when a traceback
-    /// is rebuilt via [`Runner::traceback_extractor`].
+    /// is rebuilt via [`Runner::extract_traceback`], or directly on syntax
+    /// errors because they have no user traceback frame to rewrite.
     pub fn run<'py>(
         &self,
         py: Python<'py>,
         code: String,
         namespace: &Bound<'py, SandboxGlobals>,
+        script_name: &str,
     ) -> PyResult<Bound<'py, PyAny>> {
-        self.run.bind(py).call1((code, namespace))
+        self.run.bind(py).call1((code, namespace, script_name))
     }
 
     /// Extracts a structured traceback from the given `traceback` object, using

--- a/crates/monty-cpython/src/pyexec.rs
+++ b/crates/monty-cpython/src/pyexec.rs
@@ -53,28 +53,45 @@ const RUNNER: &CStr = match CStr::from_bytes_with_nul(concat!(include_str!("runn
     Err(_) => panic!("runner.py must not contain a NUL byte"),
 };
 
-pub struct Runner(Py<PyAny>);
+/// The compiled `RUNNER` module, providing the REPL runner (`run`) and the
+/// traceback rebuilder (`extract_traceback`) the session calls.
+pub struct Runner {
+    run: Py<PyAny>,
+    extract_traceback: Py<PyAny>,
+}
 
 impl Runner {
-    /// Compiles [`RUNNER`] into a module whose `run` the session uses to execute
-    /// feeds.
+    /// Compiles [`RUNNER`] into the module the session drives feeds through.
     pub fn new(py: Python<'_>) -> PyResult<Self> {
         let module = PyModule::from_code(py, RUNNER, c"runner.py", c"runner")?;
-        let run_function = module.getattr("run")?;
-        Ok(Self(run_function.unbind()))
+        Ok(Self {
+            run: module.getattr("run")?.unbind(),
+            extract_traceback: module.getattr("extract_traceback")?.unbind(),
+        })
     }
 
-    /// Runs `code` in `namespace`, compiling it under `script_name` so CPython
-    /// tracebacks report the session's filename (see `runner.py`'s `run`).
+    /// Runs `code` in `namespace`, returning the trailing expression's value.
+    /// The snippet compiles under an internal `<input-N>` filename (see
+    /// `runner.py`'s `run`); the parent-visible name is applied when a traceback
+    /// is rebuilt via [`Runner::traceback_extractor`].
     pub fn run<'py>(
         &self,
         py: Python<'py>,
         code: String,
         namespace: &Bound<'py, SandboxGlobals>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        self.run.bind(py).call1((code, namespace))
+    }
+
+    /// Extracts a structured traceback from the given `traceback` object, using
+    /// `script_name` as the filename for the traceback's frames.
+    pub fn extract_traceback<'py>(
+        &self,
+        py: Python<'py>,
+        traceback: &Bound<'py, PyAny>,
         script_name: &str,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let run_function = self.0.bind(py);
-        run_function.call1((code, namespace, script_name))
+        self.extract_traceback.bind(py).call1((traceback, script_name))
     }
 }
 

--- a/crates/monty-cpython/src/runner.py
+++ b/crates/monty-cpython/src/runner.py
@@ -18,35 +18,30 @@ TOP_LEVEL_AWAIT = ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
 # every feed shares one session, but their line numbers would otherwise collide.
 # Mirrors monty's own REPL (`MontyRepl.sources` keyed by `<python-input-N>`).
 # Process-global is fine: a worker serves exactly one session.
-_input_counter = 0
-_input_files: set[str] = set()
+input_counter = 0
+input_files: set[str] = set()
 
 
 def run(code: str, ns: dict[str, Any], script_name: str) -> Any:
     """Execute `code` REPL-style: a trailing expression becomes the value.
 
-    Mirrors how IPython/the stdlib REPL split a cell — run the body in `exec`
-    mode, then evaluate a trailing *expression* statement separately so its value
-    can be returned. The split node keeps its original location, so a traceback
-    from the trailing expression still points at the right line.
+    Like IPython/the stdlib REPL, the body runs in `exec` mode and a trailing
+    expression is evaluated separately so its value can be returned; the split
+    node keeps its location so tracebacks still point at the right line.
 
-    The snippet is compiled under a unique internal `<input-N>` filename and its
-    source is registered in `linecache`, so a later `extract_traceback` can
-    recover each frame's source line (and CPython's caret anchors) — even for
-    frames from functions defined in earlier feeds. Runtime traceback frames get
-    their parent-visible filename substituted in `extract_traceback`; syntax
-    errors have no user frame to rewrite, so their filename is rewritten here.
+    Each snippet compiles under a unique `<input-N>` filename, registered in
+    `linecache` so `extract_traceback` can recover source lines — even for frames
+    from functions defined in earlier feeds. Runtime frames get `script_name`
+    substituted there; syntax errors have no user frame, so they are rewritten here.
 
-    Top-level `await` is supported: both halves are compiled with
-    `PyCF_ALLOW_TOP_LEVEL_AWAIT`. If *either* half is a coroutine, both are driven
-    in a single `asyncio.run` event loop (see `drive_async`) so async objects the
-    body creates keep their loop affinity in the trailing expression. Purely
-    synchronous snippets never touch asyncio.
+    Top-level `await` is supported: if either half is a coroutine, both run in one
+    `asyncio.run` loop (see `drive_async`) to keep async objects' loop affinity.
+    Purely synchronous snippets never touch asyncio.
     """
-    global _input_counter
-    filename = f'<input-{_input_counter}>'
-    _input_counter += 1
-    _input_files.add(filename)
+    global input_counter
+    filename = f'<input-{input_counter}>'
+    input_counter += 1
+    input_files.add(filename)
     # `mtime=None` marks a non-file cache entry that `linecache.checkcache`
     # leaves in place (it would otherwise try to `stat` the fake filename).
     linecache.cache[filename] = (len(code), None, code.splitlines(keepends=True), filename)
@@ -89,10 +84,9 @@ async def drive_async(
 ) -> Any:
     """Run a cell's body then its trailing expression in one event loop.
 
-    Either half may be a top-level-await coroutine (`*_async`); the other is a
-    plain `eval`. Driving both on the same loop preserves loop affinity for any
-    async object the body hands to the trailing expression. Returns the trailing
-    expression's value (or `None` when there is none).
+    Either half may be a top-level-await coroutine (`*_async`); driving both on
+    the same loop preserves loop affinity for any async object the body hands to
+    the expression. Returns the expression's value (or `None`).
     """
     result = eval(body_code, ns)
     if body_async:
@@ -111,38 +105,32 @@ Frame = tuple[str, int, int, int, int, str | None, str | None, bool, bool]
 
 
 def extract_traceback(tb: Any, script_name: str) -> list[Frame]:
-    """Rebuild the sandbox traceback as structured frames for the Rust side.
+    """Rebuild the sandbox traceback as `Frame` tuples for the Rust side.
 
-    Keeps only frames from fed code (the `<input-N>` files this module registered
-    in `linecache`) so the runner's own driver frames are dropped. Returns one
-    `Frame` tuple per frame, outermost first. `script_name` is reported as every
-    frame's filename, so a multi-feed session shows the session's name rather
-    than the internal per-feed keys.
-
-    The rich path uses CPython's `traceback`/`linecache` machinery for source
-    previews and caret spans. The sandbox is full CPython, though, so user code
-    can monkey-patch those modules; if anything in the rich path fails, fall back
-    to a stdlib-free walk so a hostile (or merely buggy) sandbox still gets
-    frames — degraded to filename/line/function — rather than an empty traceback
-    that would erase the original exception's stack.
+    Keeps only frames from fed code (the `<input-N>` files registered in
+    `linecache`), dropping the runner's driver frames, and reports each under
+    `script_name`, outermost first. Best-effort: any failure (e.g. a sandbox that
+    monkey-patched `traceback`) yields an empty list rather than masking the
+    original exception, whose type and message are carried separately.
     """
     try:
-        return _extract_rich(tb, script_name)
+        return _extract_traceback(tb, script_name)
     except Exception:
-        return _extract_basic(tb, script_name)
+        return []
 
 
-def _extract_rich(tb: Any, script_name: str) -> list[Frame]:
-    """Full-fidelity extraction: source previews and caret spans.
+def _extract_traceback(tb: Any, script_name: str) -> list[Frame]:
+    """Walk `tb` into `Frame` tuples with source previews and caret spans.
 
     `extract_tb` is imported at call time so a sandbox that monkey-patched
-    `traceback` is observed and the rich path falls back (see `extract_traceback`).
+    `traceback` makes this raise (handled by `extract_traceback`) rather than
+    silently driving off a patched module.
     """
     from traceback import extract_tb
 
     frames: list[Frame] = []
     for fs in extract_tb(tb):
-        if fs.filename not in _input_files:
+        if fs.filename not in input_files:
             continue
         # The *unstripped* source line (minus its line terminator): monty's
         # `StackFrame` stores the full line and trims it at render time, and
@@ -161,38 +149,21 @@ def _extract_rich(tb: Any, script_name: str) -> list[Frame]:
             # character columns.
             start_col = byte_to_char(preview, fs.colno) + 1
             end_col = byte_to_char(preview, fs.end_colno) + 1
-            hide_caret = _is_raise_statement(preview)
+            hide_caret = is_raise_statement(preview)
         frames.append((script_name, lineno, start_col, lineno, end_col, frame_name, preview, hide_caret, False))
     return frames
 
 
-def _is_raise_statement(preview: str) -> bool:
-    """Whether `preview`'s first token is the `raise` keyword.
+def is_raise_statement(preview: str) -> bool:
+    """Whether `preview`'s first token is `raise`, the caret-visibility heuristic.
 
-    A rough caret-visibility heuristic: CPython hides carets for `raise` and shows
-    them otherwise. We mirror only that case, so CPython's other no-caret cases
-    (attribute access, bare-name lookups, full-line `x = f()` calls) over-draw a
-    whole-line underline here — cosmetic, and it keeps us off `traceback` internals.
+    CPython hides carets for `raise` and shows them otherwise; we mirror only that
+    case. Its other no-caret cases (attribute access, bare names, full-line
+    `x = f()` calls) over-draw a whole-line underline — cosmetic, and it keeps us
+    off `traceback` internals.
     """
     head = preview.split(maxsplit=1)
     return bool(head) and head[0] == 'raise'
-
-
-def _extract_basic(tb: Any, script_name: str) -> list[Frame]:
-    """Fallback extraction using only traceback/frame/code object attributes.
-
-    Touches no stdlib module, so a sandbox that monkey-patched `traceback` or
-    `linecache` cannot make it fail. Yields filename/line/function only — no
-    source preview or caret span.
-    """
-    frames: list[Frame] = []
-    while tb is not None:
-        code = tb.tb_frame.f_code
-        if code.co_filename in _input_files:
-            frame_name = None if code.co_name == '<module>' else code.co_name
-            frames.append((script_name, tb.tb_lineno, 0, tb.tb_lineno, 0, frame_name, None, True, False))
-        tb = tb.tb_next
-    return frames
 
 
 def byte_to_char(line: str, byte_offset: int) -> int:

--- a/crates/monty-cpython/src/runner.py
+++ b/crates/monty-cpython/src/runner.py
@@ -27,7 +27,7 @@ _input_counter = 0
 _input_files: set[str] = set()
 
 
-def run(code: str, ns: dict[str, Any]) -> Any:
+def run(code: str, ns: dict[str, Any], script_name: str) -> Any:
     """Execute `code` REPL-style: a trailing expression becomes the value.
 
     Mirrors how IPython/the stdlib REPL split a cell — run the body in `exec`
@@ -38,8 +38,9 @@ def run(code: str, ns: dict[str, Any]) -> Any:
     The snippet is compiled under a unique internal `<input-N>` filename and its
     source is registered in `linecache`, so a later `extract_traceback` can
     recover each frame's source line (and CPython's caret anchors) — even for
-    frames from functions defined in earlier feeds. The parent-visible filename
-    is substituted in `extract_traceback`, not here.
+    frames from functions defined in earlier feeds. Runtime traceback frames get
+    their parent-visible filename substituted in `extract_traceback`; syntax
+    errors have no user frame to rewrite, so their filename is rewritten here.
 
     Top-level `await` is supported: both halves are compiled with
     `PyCF_ALLOW_TOP_LEVEL_AWAIT`. If *either* half is a coroutine, both are driven
@@ -54,16 +55,23 @@ def run(code: str, ns: dict[str, Any]) -> Any:
     # `mtime=None` marks a non-file cache entry that `linecache.checkcache`
     # leaves in place (it would otherwise try to `stat` the fake filename).
     linecache.cache[filename] = (len(code), None, code.splitlines(keepends=True), filename)
-    module = ast.parse(code, filename, 'exec')
-    trailing_expr = None
-    if module.body and isinstance(module.body[-1], ast.Expr):
-        trailing_expr = cast(ast.Expr, module.body.pop()).value
-    body_code = compile(module, filename, 'exec', flags=TOP_LEVEL_AWAIT)
-    expr_code = (
-        None
-        if trailing_expr is None
-        else compile(ast.Expression(trailing_expr), filename, 'eval', flags=TOP_LEVEL_AWAIT)
-    )
+    try:
+        module = ast.parse(code, filename, 'exec')
+        trailing_expr = None
+        if module.body and isinstance(module.body[-1], ast.Expr):
+            trailing_expr = cast(ast.Expr, module.body.pop()).value
+        body_code = compile(module, filename, 'exec', flags=TOP_LEVEL_AWAIT)
+        expr_code = (
+            None
+            if trailing_expr is None
+            else compile(ast.Expression(trailing_expr), filename, 'eval', flags=TOP_LEVEL_AWAIT)
+        )
+    except SyntaxError as exc:
+        exc.filename = script_name
+        if len(exc.args) >= 2 and isinstance(exc.args[1], tuple) and exc.args[1]:
+            location = cast(tuple[Any, ...], exc.args[1])
+            exc.args = (exc.args[0], (script_name, *location[1:]), *exc.args[2:])
+        raise
     body_async = bool(body_code.co_flags & CO_COROUTINE)
     expr_async = expr_code is not None and bool(expr_code.co_flags & CO_COROUTINE)
     if body_async or expr_async:

--- a/crates/monty-cpython/src/runner.py
+++ b/crates/monty-cpython/src/runner.py
@@ -1,6 +1,7 @@
-import ast as _ast
-import asyncio as _asyncio
-import typing as _typing
+import ast
+import asyncio
+import linecache
+from typing import Any, cast
 
 # inspect.CO_COROUTINE — set on a code object the compiler turned into a coroutine
 # because it contains a top-level `await`. A bare expression that merely *evaluates*
@@ -9,10 +10,24 @@ import typing as _typing
 CO_COROUTINE = 0x80
 # Allow `await`/`async for`/`async with` at module level (the flag the asyncio
 # REPL and IPython use); the compiled unit then needs driving to completion.
-TOP_LEVEL_AWAIT = _ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
+TOP_LEVEL_AWAIT = ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
+
+# Characters that make up a caret-marker line in CPython's rendered traceback
+# (spaces plus the primary `~` / secondary `^` anchors). Used to detect whether
+# CPython chose to draw carets for a frame — see `extract_traceback`.
+_CARET_CHARS = frozenset(' ~^')
+
+# Monotonic counter and registry for the per-feed filenames fed code compiles
+# under. Each feed gets a unique `<input-N>` name so a traceback can resolve the
+# right source even for a frame from a function defined in an *earlier* feed —
+# every feed shares one session, but their line numbers would otherwise collide.
+# Mirrors monty's own REPL (`MontyRepl.sources` keyed by `<python-input-N>`).
+# Process-global is fine: a worker serves exactly one session.
+_input_counter = 0
+_input_files: set[str] = set()
 
 
-def run(code: str, ns: dict[str, _typing.Any], script_name: str) -> _typing.Any:
+def run(code: str, ns: dict[str, Any]) -> Any:
     """Execute `code` REPL-style: a trailing expression becomes the value.
 
     Mirrors how IPython/the stdlib REPL split a cell — run the body in `exec`
@@ -20,10 +35,11 @@ def run(code: str, ns: dict[str, _typing.Any], script_name: str) -> _typing.Any:
     can be returned. The split node keeps its original location, so a traceback
     from the trailing expression still points at the right line.
 
-    `script_name` is the filename the code is compiled under (the session's
-    `Configure.script_name`), so CPython tracebacks and `SyntaxError`s report it
-    rather than an internal placeholder. It is also how the Rust side tells user
-    frames apart from this module's driver frames when rebuilding the traceback.
+    The snippet is compiled under a unique internal `<input-N>` filename and its
+    source is registered in `linecache`, so a later `extract_traceback` can
+    recover each frame's source line (and CPython's caret anchors) — even for
+    frames from functions defined in earlier feeds. The parent-visible filename
+    is substituted in `extract_traceback`, not here.
 
     Top-level `await` is supported: both halves are compiled with
     `PyCF_ALLOW_TOP_LEVEL_AWAIT`. If *either* half is a coroutine, both are driven
@@ -31,15 +47,22 @@ def run(code: str, ns: dict[str, _typing.Any], script_name: str) -> _typing.Any:
     body creates keep their loop affinity in the trailing expression. Purely
     synchronous snippets never touch asyncio.
     """
-    module = _ast.parse(code, script_name, 'exec')
+    global _input_counter
+    filename = f'<input-{_input_counter}>'
+    _input_counter += 1
+    _input_files.add(filename)
+    # `mtime=None` marks a non-file cache entry that `linecache.checkcache`
+    # leaves in place (it would otherwise try to `stat` the fake filename).
+    linecache.cache[filename] = (len(code), None, code.splitlines(keepends=True), filename)
+    module = ast.parse(code, filename, 'exec')
     trailing_expr = None
-    if module.body and isinstance(module.body[-1], _ast.Expr):
-        trailing_expr = _typing.cast(_ast.Expr, module.body.pop()).value
-    body_code = compile(module, script_name, 'exec', flags=TOP_LEVEL_AWAIT)
+    if module.body and isinstance(module.body[-1], ast.Expr):
+        trailing_expr = cast(ast.Expr, module.body.pop()).value
+    body_code = compile(module, filename, 'exec', flags=TOP_LEVEL_AWAIT)
     expr_code = (
         None
         if trailing_expr is None
-        else compile(_ast.Expression(trailing_expr), script_name, 'eval', flags=TOP_LEVEL_AWAIT)
+        else compile(ast.Expression(trailing_expr), filename, 'eval', flags=TOP_LEVEL_AWAIT)
     )
     body_async = bool(body_code.co_flags & CO_COROUTINE)
     expr_async = expr_code is not None and bool(expr_code.co_flags & CO_COROUTINE)
@@ -48,19 +71,19 @@ def run(code: str, ns: dict[str, _typing.Any], script_name: str) -> _typing.Any:
         # across two `asyncio.run` calls would give each its own loop, so an
         # object created in the body (a `Lock`, `Queue`, task, future, ...) would
         # be bound to a loop already closed by the time the expression awaits it.
-        return _asyncio.run(drive_async(body_code, body_async, expr_code, expr_async, ns))
+        return asyncio.run(drive_async(body_code, body_async, expr_code, expr_async, ns))
     else:
         eval(body_code, ns)
         return None if expr_code is None else eval(expr_code, ns)
 
 
 async def drive_async(
-    body_code: _typing.Any,
+    body_code: Any,
     body_async: bool,
-    expr_code: _typing.Any,
+    expr_code: Any,
     expr_async: bool,
-    ns: dict[str, _typing.Any],
-) -> _typing.Any:
+    ns: dict[str, Any],
+) -> Any:
     """Run a cell's body then its trailing expression in one event loop.
 
     Either half may be a top-level-await coroutine (`*_async`); the other is a
@@ -75,3 +98,59 @@ async def drive_async(
         return None
     result = eval(expr_code, ns)
     return (await result) if expr_async else result
+
+
+# One structured frame, shaped to map directly onto monty's `StackFrame`:
+# (filename, start_line, start_col, end_line, end_col, frame_name, preview_line,
+#  hide_caret, hide_frame_name). Lines and columns are 1-based; columns count
+# characters (not bytes). `frame_name` is `None` for module-level code.
+Frame = tuple[str, int, int, int, int, str | None, str | None, bool, bool]
+
+
+def extract_traceback(tb: Any, script_name: str) -> list[Frame]:
+    """Rebuild the sandbox traceback as structured frames for the Rust side.
+
+    Walks `tb`, keeping only frames from fed code (the `<input-N>` files this
+    module registered in `linecache`) so the runner's own driver frames are
+    dropped. Returns one `Frame` tuple per frame, outermost first.
+
+    `script_name` is reported as every frame's filename, so a multi-feed session
+    shows the session's name rather than the internal per-feed keys. Whether to
+    draw caret markers — and the exact anchored span — is taken from CPython's
+    own machinery, so `raise`/whole-line cases match CPython (and monty) exactly.
+    """
+    from traceback import StackSummary, extract_tb
+
+    frames: list[Frame] = []
+    for fs in extract_tb(tb):
+        if fs.filename not in _input_files:
+            continue
+        # The *unstripped* source line: monty's `StackFrame` stores the full line
+        # and trims it at render time, and CPython's byte columns index into it.
+        lineno = cast(int, fs.lineno)
+        line = linecache.getline(fs.filename, lineno)
+        preview = line.rstrip('\n') if line else None
+        frame_name = None if fs.name == '<module>' else fs.name
+        start_col = 0
+        end_col = 0
+        hide_caret = True
+        # Carets need a same-line anchored span and a preview to render against.
+        if preview is not None and fs.colno is not None and fs.end_colno is not None and fs.end_lineno == lineno:
+            # CPython reports columns as UTF-8 byte offsets; monty wants 1-based
+            # character columns.
+            start_col = byte_to_char(preview, fs.colno) + 1
+            end_col = byte_to_char(preview, fs.end_colno) + 1
+            # Defer the show/hide decision to CPython so `raise` (no caret) and
+            # whole-line calls/binops (caret) match its renderer. The caret is
+            # hidden when CPython renders *no* marker line for the frame.
+            rendered = ''.join(StackSummary.from_list([fs]).format())
+            hide_caret = not any(
+                set(part) <= _CARET_CHARS and ('~' in part or '^' in part) for part in rendered.splitlines()
+            )
+        frames.append((script_name, lineno, start_col, lineno, end_col, frame_name, preview, hide_caret, False))
+    return frames
+
+
+def byte_to_char(line: str, byte_offset: int) -> int:
+    """Convert a 0-based UTF-8 byte offset into `line` to a 0-based char offset."""
+    return len(line.encode('utf-8')[:byte_offset].decode('utf-8', 'replace'))

--- a/crates/monty-cpython/src/runner.py
+++ b/crates/monty-cpython/src/runner.py
@@ -12,11 +12,6 @@ CO_COROUTINE = 0x80
 # REPL and IPython use); the compiled unit then needs driving to completion.
 TOP_LEVEL_AWAIT = ast.PyCF_ALLOW_TOP_LEVEL_AWAIT
 
-# Characters that make up a caret-marker line in CPython's rendered traceback
-# (spaces plus the primary `~` / secondary `^` anchors). Used to detect whether
-# CPython chose to draw carets for a frame — see `extract_traceback`.
-_CARET_CHARS = frozenset(' ~^')
-
 # Monotonic counter and registry for the per-feed filenames fed code compiles
 # under. Each feed gets a unique `<input-N>` name so a traceback can resolve the
 # right source even for a frame from a function defined in an *earlier* feed —
@@ -138,8 +133,12 @@ def extract_traceback(tb: Any, script_name: str) -> list[Frame]:
 
 
 def _extract_rich(tb: Any, script_name: str) -> list[Frame]:
-    """Full-fidelity extraction: source previews and CPython-decided carets."""
-    from traceback import StackSummary, extract_tb
+    """Full-fidelity extraction: source previews and caret spans.
+
+    `extract_tb` is imported at call time so a sandbox that monkey-patched
+    `traceback` is observed and the rich path falls back (see `extract_traceback`).
+    """
+    from traceback import extract_tb
 
     frames: list[Frame] = []
     for fs in extract_tb(tb):
@@ -156,21 +155,27 @@ def _extract_rich(tb: Any, script_name: str) -> list[Frame]:
         start_col = 0
         end_col = 0
         hide_caret = True
-        # Carets need a same-line anchored span and a preview to render against.
+        # Carets need a same-line span and a preview to render against.
         if preview is not None and fs.colno is not None and fs.end_colno is not None and fs.end_lineno == lineno:
             # CPython reports columns as UTF-8 byte offsets; monty wants 1-based
             # character columns.
             start_col = byte_to_char(preview, fs.colno) + 1
             end_col = byte_to_char(preview, fs.end_colno) + 1
-            # Defer the show/hide decision to CPython so `raise` (no caret) and
-            # whole-line calls/binops (caret) match its renderer. The caret is
-            # hidden when CPython renders *no* marker line for the frame.
-            rendered = ''.join(StackSummary.from_list([fs]).format())
-            hide_caret = not any(
-                set(part) <= _CARET_CHARS and ('~' in part or '^' in part) for part in rendered.splitlines()
-            )
+            hide_caret = _is_raise_statement(preview)
         frames.append((script_name, lineno, start_col, lineno, end_col, frame_name, preview, hide_caret, False))
     return frames
+
+
+def _is_raise_statement(preview: str) -> bool:
+    """Whether `preview`'s first token is the `raise` keyword.
+
+    A rough caret-visibility heuristic: CPython hides carets for `raise` and shows
+    them otherwise. We mirror only that case, so CPython's other no-caret cases
+    (attribute access, bare-name lookups, full-line `x = f()` calls) over-draw a
+    whole-line underline here — cosmetic, and it keeps us off `traceback` internals.
+    """
+    head = preview.split(maxsplit=1)
+    return bool(head) and head[0] == 'raise'
 
 
 def _extract_basic(tb: Any, script_name: str) -> list[Frame]:

--- a/crates/monty-cpython/src/runner.py
+++ b/crates/monty-cpython/src/runner.py
@@ -118,26 +118,40 @@ Frame = tuple[str, int, int, int, int, str | None, str | None, bool, bool]
 def extract_traceback(tb: Any, script_name: str) -> list[Frame]:
     """Rebuild the sandbox traceback as structured frames for the Rust side.
 
-    Walks `tb`, keeping only frames from fed code (the `<input-N>` files this
-    module registered in `linecache`) so the runner's own driver frames are
-    dropped. Returns one `Frame` tuple per frame, outermost first.
+    Keeps only frames from fed code (the `<input-N>` files this module registered
+    in `linecache`) so the runner's own driver frames are dropped. Returns one
+    `Frame` tuple per frame, outermost first. `script_name` is reported as every
+    frame's filename, so a multi-feed session shows the session's name rather
+    than the internal per-feed keys.
 
-    `script_name` is reported as every frame's filename, so a multi-feed session
-    shows the session's name rather than the internal per-feed keys. Whether to
-    draw caret markers — and the exact anchored span — is taken from CPython's
-    own machinery, so `raise`/whole-line cases match CPython (and monty) exactly.
+    The rich path uses CPython's `traceback`/`linecache` machinery for source
+    previews and caret spans. The sandbox is full CPython, though, so user code
+    can monkey-patch those modules; if anything in the rich path fails, fall back
+    to a stdlib-free walk so a hostile (or merely buggy) sandbox still gets
+    frames — degraded to filename/line/function — rather than an empty traceback
+    that would erase the original exception's stack.
     """
+    try:
+        return _extract_rich(tb, script_name)
+    except Exception:
+        return _extract_basic(tb, script_name)
+
+
+def _extract_rich(tb: Any, script_name: str) -> list[Frame]:
+    """Full-fidelity extraction: source previews and CPython-decided carets."""
     from traceback import StackSummary, extract_tb
 
     frames: list[Frame] = []
     for fs in extract_tb(tb):
         if fs.filename not in _input_files:
             continue
-        # The *unstripped* source line: monty's `StackFrame` stores the full line
-        # and trims it at render time, and CPython's byte columns index into it.
+        # The *unstripped* source line (minus its line terminator): monty's
+        # `StackFrame` stores the full line and trims it at render time, and
+        # CPython's byte columns index into it. Strip `\r` as well as `\n` so a
+        # CRLF-fed snippet does not leave a stray carriage return in the preview.
         lineno = cast(int, fs.lineno)
         line = linecache.getline(fs.filename, lineno)
-        preview = line.rstrip('\n') if line else None
+        preview = line.rstrip('\r\n') if line else None
         frame_name = None if fs.name == '<module>' else fs.name
         start_col = 0
         end_col = 0
@@ -156,6 +170,23 @@ def extract_traceback(tb: Any, script_name: str) -> list[Frame]:
                 set(part) <= _CARET_CHARS and ('~' in part or '^' in part) for part in rendered.splitlines()
             )
         frames.append((script_name, lineno, start_col, lineno, end_col, frame_name, preview, hide_caret, False))
+    return frames
+
+
+def _extract_basic(tb: Any, script_name: str) -> list[Frame]:
+    """Fallback extraction using only traceback/frame/code object attributes.
+
+    Touches no stdlib module, so a sandbox that monkey-patched `traceback` or
+    `linecache` cannot make it fail. Yields filename/line/function only — no
+    source preview or caret span.
+    """
+    frames: list[Frame] = []
+    while tb is not None:
+        code = tb.tb_frame.f_code
+        if code.co_filename in _input_files:
+            frame_name = None if code.co_name == '<module>' else code.co_name
+            frames.append((script_name, tb.tb_lineno, 0, tb.tb_lineno, 0, frame_name, None, True, False))
+        tb = tb.tb_next
     return frames
 
 

--- a/crates/monty-cpython/src/session.rs
+++ b/crates/monty-cpython/src/session.rs
@@ -51,11 +51,12 @@ enum State {
     /// host). `sys.stdout`/`sys.stderr` are separate `Stdio` sinks kept alive by
     /// the interpreter, so they need no Rust-side handle here. `install` holds the
     /// session's `uv` install dir, created lazily on the first `InstallDependencies`.
-    /// `script_name` is the `Configure.script_name` snippets compile under, so
-    /// CPython tracebacks report the parent's filename.
+    /// `script_name` is the parent-visible filename used for tracebacks and syntax
+    /// errors.
     Ready {
         namespace: Py<SandboxGlobals>,
         install: Option<InstallEnv>,
+        /// Parent-visible filename reported in tracebacks and syntax errors.
         script_name: String,
     },
 }
@@ -300,7 +301,7 @@ impl Session {
             return event;
         }
 
-        match self.runner.run(py, feed.code, &namespace) {
+        match self.runner.run(py, feed.code, &namespace, &script_name) {
             Ok(value) => match py_to_monty_value(&value, &dc) {
                 Ok(value) if exceeds_max_value_depth(&value) => error_event(
                     ExcType::RuntimeError,

--- a/crates/monty-cpython/src/session.rs
+++ b/crates/monty-cpython/src/session.rs
@@ -300,7 +300,7 @@ impl Session {
             return event;
         }
 
-        match self.runner.run(py, feed.code, &namespace, &script_name) {
+        match self.runner.run(py, feed.code, &namespace) {
             Ok(value) => match py_to_monty_value(&value, &dc) {
                 Ok(value) if exceeds_max_value_depth(&value) => error_event(
                     ExcType::RuntimeError,
@@ -310,12 +310,12 @@ impl Session {
                 Err(exc) => error_from_exception(&exc),
             },
             Err(err) => {
-                // The sandbox raised: convert the type/message, then walk the
-                // CPython traceback to attach the user frames (those compiled
-                // under `script_name`) so the parent gets a real stack rather
-                // than a bare `Type: message`.
+                // The sandbox raised: convert the type/message, then rebuild the
+                // CPython traceback into structured frames (reported under
+                // `script_name`) so the parent gets a real stack with source
+                // previews and carets rather than a bare `Type: message`.
                 let mut exc = exc_py_to_monty(py, &err);
-                exc.add_traceback(py_traceback_frames(py, &err, &script_name));
+                exc.add_traceback(py_traceback_frames(py, &self.runner, &err, &script_name));
                 error_from_exception(&exc)
             }
         }

--- a/crates/monty-cpython/src/traceback.rs
+++ b/crates/monty-cpython/src/traceback.rs
@@ -12,7 +12,7 @@
 //! (so `raise` and whole-line cases match exactly). This Rust side just hands it
 //! the traceback object and maps the returned tuples onto [`StackFrame`].
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use monty::{CodeLoc, StackFrame};
 use pyo3::prelude::*;
@@ -28,8 +28,12 @@ type FrameTuple = (String, u32, u32, u32, u32, Option<String>, Option<String>, b
 /// Rebuilds `err`'s traceback into Monty stack frames, outermost first, with
 /// `script_name` as every frame's reported filename.
 ///
-/// Best-effort: any failure talking to the Python extractor yields an empty
-/// traceback rather than masking the original exception.
+/// Best-effort: a failure talking to the Python extractor yields an empty
+/// traceback rather than masking the original exception. This is only a true
+/// last resort — `extract_traceback` itself already falls back to a stdlib-free
+/// walk when the rich path fails (e.g. the sandbox monkey-patched
+/// `traceback`/`linecache`), so it still returns frames rather than erasing
+/// them.
 pub fn py_traceback_frames(py: Python<'_>, runner: &Runner, err: &PyErr, script_name: &str) -> Vec<StackFrame> {
     extract(py, runner, err, script_name).unwrap_or_default()
 }
@@ -41,9 +45,19 @@ fn extract(py: Python<'_>, runner: &Runner, err: &PyErr, script_name: &str) -> P
     };
     let result = runner.extract_traceback(py, &traceback, script_name)?;
     let mut frames = Vec::new();
+    // Share one `Arc` per distinct preview line, the same sharing `StackFrame`
+    // relies on: a deep recursion on a long line would otherwise clone the whole
+    // line into every frame and amplify memory by the call depth.
+    let mut previews: HashMap<String, Arc<str>> = HashMap::new();
     for item in result.try_iter()? {
         let (filename, start_line, start_col, end_line, end_col, frame_name, preview_line, hide_caret, hide_frame_name): FrameTuple =
             item?.extract()?;
+        let preview_line = preview_line.map(|line| {
+            previews
+                .entry(line)
+                .or_insert_with_key(|line| Arc::from(line.as_str()))
+                .clone()
+        });
         frames.push(StackFrame {
             filename,
             start: CodeLoc {
@@ -55,7 +69,7 @@ fn extract(py: Python<'_>, runner: &Runner, err: &PyErr, script_name: &str) -> P
                 column: end_col,
             },
             frame_name,
-            preview_line: preview_line.map(Arc::from),
+            preview_line,
             hide_caret,
             hide_frame_name,
         });

--- a/crates/monty-cpython/src/traceback.rs
+++ b/crates/monty-cpython/src/traceback.rs
@@ -1,84 +1,64 @@
-//! Rebuilding a Monty traceback from an embedded-CPython `PyErr`.
+//! Rebuilding a Monty traceback from an embedded-CPython exception.
 //!
 //! The wire protocol carries a full `RaisedException.traceback`, and
 //! `error_from_exception` serializes whatever frames a `MontyException` holds —
 //! but a `MontyException` converted from a `PyErr` via `exc_py_to_monty` arrives
-//! with none. This module walks the CPython traceback object and rebuilds the
-//! sandbox frames so the parent sees a real stack, not just `Type: message`.
+//! with none. This module fills them in.
 //!
-//! Only frames whose filename is the session's `script_name` (the name fed code
-//! compiles under — see `runner.py`'s `run`) are kept; the driver frames inside
-//! `runner.py` (`run`, `drive_async`, the `eval` calls) are dropped so the
-//! traceback shows only the user's code.
-//!
-//! This is "tier 1" fidelity: filename, line, and function name only. CPython
-//! column ranges and source-line previews are not reconstructed, so frames
-//! carry no caret markers (`hide_caret: true`).
+//! The heavy lifting lives in `runner.py`'s `extract_traceback`, which walks the
+//! CPython traceback using CPython's own machinery: it keeps only user frames,
+//! recovers each frame's source line from `linecache`, and takes the anchored
+//! column span and caret-visibility decision straight from CPython's renderer
+//! (so `raise` and whole-line cases match exactly). This Rust side just hands it
+//! the traceback object and maps the returned tuples onto [`StackFrame`].
+
+use std::sync::Arc;
 
 use monty::{CodeLoc, StackFrame};
 use pyo3::prelude::*;
 
-/// CPython's `co_name` for module-level code, which Monty renders as `<module>`
-/// from a `None` frame name.
-const MODULE_FRAME_NAME: &str = "<module>";
+use crate::pyexec::Runner;
 
-/// Walks `err`'s CPython traceback into Monty stack frames, outermost first.
+/// One frame as returned by `runner.py`'s `extract_traceback`, in declaration
+/// order: `(filename, start_line, start_col, end_line, end_col, frame_name,
+/// preview_line, hide_caret, hide_frame_name)`. Lines/columns are 1-based and
+/// columns count characters.
+type FrameTuple = (String, u32, u32, u32, u32, Option<String>, Option<String>, bool, bool);
+
+/// Rebuilds `err`'s traceback into Monty stack frames, outermost first, with
+/// `script_name` as every frame's reported filename.
 ///
-/// `script_name` is the filename fed code was compiled under; only frames from
-/// that file are kept (driver frames live in `runner.py`).
-///
-/// Best-effort: any failure to read a traceback attribute stops the walk and
-/// returns the frames gathered so far, so a malformed traceback degrades to a
-/// shorter (or empty) one rather than masking the original exception.
-pub fn py_traceback_frames(py: Python<'_>, err: &PyErr, script_name: &str) -> Vec<StackFrame> {
-    let mut frames = Vec::new();
-    let Some(tb) = err.traceback(py) else {
-        return frames;
-    };
-    let mut current = tb.into_any();
-    loop {
-        match frame_from_tb(&current, script_name) {
-            Ok(Some(frame)) => frames.push(frame),
-            Ok(None) => {}   // a runner/internal frame, skipped
-            Err(_) => break, // malformed traceback: keep what we have
-        }
-        current = match current.getattr("tb_next") {
-            Ok(next) if !next.is_none() => next,
-            _ => break,
-        };
-    }
-    frames
+/// Best-effort: any failure talking to the Python extractor yields an empty
+/// traceback rather than masking the original exception.
+pub fn py_traceback_frames(py: Python<'_>, runner: &Runner, err: &PyErr, script_name: &str) -> Vec<StackFrame> {
+    extract(py, runner, err, script_name).unwrap_or_default()
 }
 
-/// Builds a `StackFrame` for one CPython traceback node, or `None` if the node
-/// belongs to another file (a `runner.py` driver frame to be dropped).
-fn frame_from_tb(tb: &Bound<'_, PyAny>, script_name: &str) -> PyResult<Option<StackFrame>> {
-    let frame = tb.getattr("tb_frame")?;
-    let code = frame.getattr("f_code")?;
-    let filename: String = code.getattr("co_filename")?.extract()?;
-    if filename != script_name {
-        return Ok(None);
-    }
-    let lineno: u32 = tb.getattr("tb_lineno")?.extract()?;
-    let name: String = code.getattr("co_name")?.extract()?;
-    // CPython names module-level code `<module>`; Monty renders that from a
-    // `None` frame name, so map it back rather than carrying the literal.
-    let frame_name = (name != MODULE_FRAME_NAME).then_some(name);
-    // Tier 1: line only. No column range or source preview is reconstructed, so
-    // the start/end positions are a bare line and carets are suppressed. The
-    // wire decoder only validates columns when a preview line is present, so a
-    // zero column here roundtrips cleanly.
-    let position = CodeLoc {
-        line: lineno,
-        column: 0,
+/// The fallible core: invokes `extract_traceback` and converts its result.
+fn extract(py: Python<'_>, runner: &Runner, err: &PyErr, script_name: &str) -> PyResult<Vec<StackFrame>> {
+    let Some(traceback) = err.traceback(py) else {
+        return Ok(Vec::new());
     };
-    Ok(Some(StackFrame {
-        filename,
-        start: position,
-        end: position,
-        frame_name,
-        preview_line: None,
-        hide_caret: true,
-        hide_frame_name: false,
-    }))
+    let result = runner.extract_traceback(py, &traceback, script_name)?;
+    let mut frames = Vec::new();
+    for item in result.try_iter()? {
+        let (filename, start_line, start_col, end_line, end_col, frame_name, preview_line, hide_caret, hide_frame_name): FrameTuple =
+            item?.extract()?;
+        frames.push(StackFrame {
+            filename,
+            start: CodeLoc {
+                line: start_line,
+                column: start_col,
+            },
+            end: CodeLoc {
+                line: end_line,
+                column: end_col,
+            },
+            frame_name,
+            preview_line: preview_line.map(Arc::from),
+            hide_caret,
+            hide_frame_name,
+        });
+    }
+    Ok(frames)
 }

--- a/crates/monty-cpython/tests/stdio_session.rs
+++ b/crates/monty-cpython/tests/stdio_session.rs
@@ -419,11 +419,12 @@ fn traceback_preview_strips_carriage_returns() {
 }
 
 /// The sandbox is full CPython, so user code can monkey-patch the `traceback`
-/// module. The runner binds the helpers it needs at import time, so a patch must
-/// not erase the reconstructed frames of an unrelated exception. A second feed
-/// restores the module — the embedded interpreter is shared across tests.
+/// module. A patch that breaks traceback extraction must degrade gracefully: the
+/// exception's type and message still reach the parent, only the traceback drops
+/// to empty (extraction is best-effort). A second feed restores the module — the
+/// embedded interpreter is shared across tests.
 #[test]
-fn traceback_survives_sandbox_patching_traceback_module() {
+fn error_survives_sandbox_patching_traceback_module() {
     let events = Rc::new(RefCell::new(Vec::new()));
     let parent = ScriptedParent {
         script: VecDeque::from([
@@ -456,22 +457,11 @@ fn traceback_survives_sandbox_patching_traceback_module() {
         })
         .expect("an Error event");
 
+    // The exception still propagates intact; only the traceback is lost, since
+    // extraction calls the patched (broken) `traceback.extract_tb` and bails.
     assert_eq!(error.exc_type, "ValueError");
     assert_eq!(error.message.as_deref(), Some("real"));
-    // Frames survive via the stdlib-free fallback: the `raise` is on line 5, and
-    // the absent preview confirms the rich path was bypassed (it would set one).
-    let frames: Vec<(u32, Option<&str>, Option<&str>)> = error
-        .traceback
-        .iter()
-        .map(|f| {
-            (
-                f.start.as_ref().unwrap().line,
-                f.frame_name.as_deref(),
-                f.preview_line.as_deref(),
-            )
-        })
-        .collect();
-    assert_eq!(frames, vec![(5, None, None)]);
+    assert!(error.traceback.is_empty());
 }
 
 /// `sys.stdout` and `sys.stderr` are separate sinks: each `print()` chunk streams

--- a/crates/monty-cpython/tests/stdio_session.rs
+++ b/crates/monty-cpython/tests/stdio_session.rs
@@ -388,6 +388,92 @@ fn syntax_error_reports_configured_script_name() {
     assert!(error.traceback.is_empty());
 }
 
+/// A CRLF-fed snippet must not leave a carriage return in the preview line — a
+/// stray `\r` would move the cursor and misrender the caret line.
+#[test]
+fn traceback_preview_strips_carriage_returns() {
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let parent = ScriptedParent {
+        // CRLF line endings; the ZeroDivisionError is on line 2.
+        script: VecDeque::from([configure(), feed("a = 1\r\nb = a / 0"), shutdown()]),
+        pending_resume: None,
+        name_values: HashMap::new(),
+        externals: HashMap::new(),
+        events: events.clone(),
+    };
+
+    drive(parent);
+
+    let events = events.borrow();
+    let error = events
+        .iter()
+        .filter_map(|e| e.kind.as_ref())
+        .find_map(|k| match k {
+            pb::child_event::Kind::Error(e) => e.exception.as_ref(),
+            _ => None,
+        })
+        .expect("an Error event");
+
+    let frame = error.traceback.last().expect("a frame");
+    assert_eq!(frame.preview_line.as_deref(), Some("b = a / 0"));
+}
+
+/// The sandbox is full CPython, so user code can monkey-patch the `traceback`
+/// module. The runner binds the helpers it needs at import time, so a patch must
+/// not erase the reconstructed frames of an unrelated exception. A second feed
+/// restores the module — the embedded interpreter is shared across tests.
+#[test]
+fn traceback_survives_sandbox_patching_traceback_module() {
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let parent = ScriptedParent {
+        script: VecDeque::from([
+            configure(),
+            feed(
+                "import traceback\n\
+                 _oe, _os = traceback.extract_tb, traceback.StackSummary\n\
+                 traceback.extract_tb = None\n\
+                 traceback.StackSummary = None\n\
+                 raise ValueError('real')",
+            ),
+            feed("import traceback\ntraceback.extract_tb, traceback.StackSummary = _oe, _os"),
+            shutdown(),
+        ]),
+        pending_resume: None,
+        name_values: HashMap::new(),
+        externals: HashMap::new(),
+        events: events.clone(),
+    };
+
+    drive(parent);
+
+    let events = events.borrow();
+    let error = events
+        .iter()
+        .filter_map(|e| e.kind.as_ref())
+        .find_map(|k| match k {
+            pb::child_event::Kind::Error(e) => e.exception.as_ref(),
+            _ => None,
+        })
+        .expect("an Error event");
+
+    assert_eq!(error.exc_type, "ValueError");
+    assert_eq!(error.message.as_deref(), Some("real"));
+    // Frames survive via the stdlib-free fallback: the `raise` is on line 5, and
+    // the absent preview confirms the rich path was bypassed (it would set one).
+    let frames: Vec<(u32, Option<&str>, Option<&str>)> = error
+        .traceback
+        .iter()
+        .map(|f| {
+            (
+                f.start.as_ref().unwrap().line,
+                f.frame_name.as_deref(),
+                f.preview_line.as_deref(),
+            )
+        })
+        .collect();
+    assert_eq!(frames, vec![(5, None, None)]);
+}
+
 /// `sys.stdout` and `sys.stderr` are separate sinks: each `print()` chunk streams
 /// as a `Print` event tagged with its stream, so the parent can tell them apart.
 #[test]

--- a/crates/monty-cpython/tests/stdio_session.rs
+++ b/crates/monty-cpython/tests/stdio_session.rs
@@ -358,6 +358,36 @@ fn traceback_preview_resolves_across_feeds() {
     );
 }
 
+/// Syntax errors are raised before a user traceback frame exists, so the runner
+/// rewrites the compile-time `<input-N>` filename directly on the `SyntaxError`.
+#[test]
+fn syntax_error_reports_configured_script_name() {
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let parent = ScriptedParent {
+        script: VecDeque::from([configure(), feed("1 +"), shutdown()]),
+        pending_resume: None,
+        name_values: HashMap::new(),
+        externals: HashMap::new(),
+        events: events.clone(),
+    };
+
+    drive(parent);
+
+    let events = events.borrow();
+    let error = events
+        .iter()
+        .filter_map(|e| e.kind.as_ref())
+        .find_map(|k| match k {
+            pb::child_event::Kind::Error(e) => e.exception.as_ref(),
+            _ => None,
+        })
+        .expect("an Error event");
+
+    assert_eq!(error.exc_type, "SyntaxError");
+    assert_eq!(error.message.as_deref(), Some("invalid syntax (main.py, line 1)"));
+    assert!(error.traceback.is_empty());
+}
+
 /// `sys.stdout` and `sys.stderr` are separate sinks: each `print()` chunk streams
 /// as a `Print` event tagged with its stream, so the parent can tell them apart.
 #[test]
@@ -827,7 +857,7 @@ fn feed_installs_pep723_dependencies() {
 fn configure() -> pb::ParentRequest {
     request(pb::parent_request::Kind::Configure(pb::Configure {
         monty_version: env!("CARGO_PKG_VERSION").to_string(),
-        // Fed code compiles under this filename, so it appears in tracebacks.
+        // Parent-visible filename reported in tracebacks and syntax errors.
         script_name: "main.py".to_string(),
         ..Default::default()
     }))

--- a/crates/monty-cpython/tests/stdio_session.rs
+++ b/crates/monty-cpython/tests/stdio_session.rs
@@ -21,7 +21,7 @@ use std::{
     sync::{Mutex, PoisonError},
 };
 
-use monty::{ExtFunctionResult, MontyObject, NameLookupResult};
+use monty::{ExtFunctionResult, MontyException, MontyObject, NameLookupResult};
 use monty_cpython::{
     run_with_transport,
     transport::{Incoming, SendError, Transport},
@@ -198,27 +198,27 @@ fn drives_a_full_session() {
         })
         .expect("an Error event");
     assert_eq!(error.exc_type, "ZeroDivisionError");
-    // The error carries the sandbox traceback: a single module-level frame for
-    // the trailing `1 / 0` expression on line 1, compiled under the configured
-    // `script_name` (driver frames are filtered).
-    let frames: Vec<(&str, u32, Option<&str>)> = error
-        .traceback
-        .iter()
-        .map(|f| {
-            (
-                f.filename.as_str(),
-                f.start.as_ref().unwrap().line,
-                f.frame_name.as_deref(),
-            )
-        })
-        .collect();
-    assert_eq!(frames, vec![("main.py", 1, None)]);
+    // The error carries the full sandbox traceback: a single module-level frame
+    // for the trailing `1 / 0` expression on line 1 (reported under the
+    // configured `script_name`, driver frames filtered), with a source preview
+    // and carets under the failing span.
+    let rendered = MontyException::try_from(error.clone())
+        .expect("valid exception")
+        .to_string();
+    assert_eq!(
+        rendered,
+        "Traceback (most recent call last):\n  \
+         File \"main.py\", line 1, in <module>\n    \
+         1 / 0\n    ~~~~~\n\
+         ZeroDivisionError: division by zero"
+    );
 }
 
 /// A sandbox exception raised through nested user frames carries a multi-frame
-/// CPython traceback back to the parent: one `StackFrame` per user frame,
-/// outermost first, with the configured `script_name` filename, line numbers,
-/// and function names. The `runner.py` driver frames are filtered out.
+/// CPython traceback back to the parent: one frame per user frame, outermost
+/// first, under the configured `script_name`, each with a source preview. Carets
+/// follow CPython — shown under the `f()` call, hidden for the `raise` — and the
+/// `runner.py` driver frames are filtered out.
 #[test]
 fn error_carries_multi_frame_traceback() {
     let events = Rc::new(RefCell::new(Vec::new()));
@@ -250,20 +250,112 @@ fn error_carries_multi_frame_traceback() {
     assert_eq!(error.exc_type, "ValueError");
     assert_eq!(error.message.as_deref(), Some("boom"));
 
-    // Outermost first: the module-level `f()` call on line 4, then the `raise`
-    // inside `f` on line 2.
-    let frames: Vec<(&str, u32, Option<&str>)> = error
-        .traceback
+    // Outermost first: the module-level `f()` call on line 4 (carets shown),
+    // then the `raise` inside `f` on line 2 (carets hidden, matching CPython).
+    let rendered = MontyException::try_from(error.clone())
+        .expect("valid exception")
+        .to_string();
+    assert_eq!(
+        rendered,
+        "Traceback (most recent call last):\n  \
+         File \"main.py\", line 4, in <module>\n    \
+         f()\n    ~~~\n  \
+         File \"main.py\", line 2, in f\n    \
+         raise ValueError('boom')\n\
+         ValueError: boom"
+    );
+}
+
+/// Caret columns are character offsets, not bytes: a non-ASCII preview line
+/// still underlines the right span. CPython reports the failing span as UTF-8
+/// byte offsets (end byte 12 for the 11-character `'héllo' + 1`); the rebuilt
+/// frame converts them to characters so the carets span all 11 characters.
+#[test]
+fn traceback_carets_are_character_aligned() {
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let parent = ScriptedParent {
+        script: VecDeque::from([configure(), feed("'héllo' + 1"), shutdown()]),
+        pending_resume: None,
+        name_values: HashMap::new(),
+        externals: HashMap::new(),
+        events: events.clone(),
+    };
+
+    drive(parent);
+
+    let events = events.borrow();
+    let error = events
         .iter()
-        .map(|f| {
-            (
-                f.filename.as_str(),
-                f.start.as_ref().unwrap().line,
-                f.frame_name.as_deref(),
-            )
+        .filter_map(|e| e.kind.as_ref())
+        .find_map(|k| match k {
+            pb::child_event::Kind::Error(e) => e.exception.as_ref(),
+            _ => None,
         })
-        .collect();
-    assert_eq!(frames, vec![("main.py", 4, None), ("main.py", 2, Some("f"))]);
+        .expect("an Error event");
+
+    assert_eq!(error.exc_type, "TypeError");
+    let rendered = MontyException::try_from(error.clone())
+        .expect("valid exception")
+        .to_string();
+    assert_eq!(
+        rendered,
+        "Traceback (most recent call last):\n  \
+         File \"main.py\", line 1, in <module>\n    \
+         'héllo' + 1\n    ~~~~~~~~~~~\n\
+         TypeError: can only concatenate str (not \"int\") to str"
+    );
+}
+
+/// Source previews resolve across feeds: a function defined in one feed and
+/// called from a later one still renders its own source line. This is why each
+/// feed compiles under a unique internal filename with its source registered in
+/// `linecache` — a single shared filename would collide on line numbers and show
+/// the wrong (or no) preview for the earlier feed's frame.
+#[test]
+fn traceback_preview_resolves_across_feeds() {
+    let events = Rc::new(RefCell::new(Vec::new()));
+    let parent = ScriptedParent {
+        script: VecDeque::from([
+            configure(),
+            // Feed 1 defines `boom` (the `return` is on line 2) and completes.
+            feed("def boom():\n    return undefined_xyz"),
+            // Feed 2 calls it; the NameError unwinds through feed 1's line 2.
+            feed("boom()"),
+            shutdown(),
+        ]),
+        pending_resume: None,
+        name_values: HashMap::new(),
+        externals: HashMap::new(),
+        events: events.clone(),
+    };
+
+    drive(parent);
+
+    let events = events.borrow();
+    let error = events
+        .iter()
+        .filter_map(|e| e.kind.as_ref())
+        .find_map(|k| match k {
+            pb::child_event::Kind::Error(e) => e.exception.as_ref(),
+            _ => None,
+        })
+        .expect("an Error event");
+
+    assert_eq!(error.exc_type, "NameError");
+    // The `boom` frame's preview is feed 1's `return undefined_xyz`, even though
+    // the error surfaced in feed 2 (whose source has no line 2).
+    let rendered = MontyException::try_from(error.clone())
+        .expect("valid exception")
+        .to_string();
+    assert_eq!(
+        rendered,
+        "Traceback (most recent call last):\n  \
+         File \"main.py\", line 1, in <module>\n    \
+         boom()\n    ~~~~~~\n  \
+         File \"main.py\", line 2, in boom\n    \
+         return undefined_xyz\n           ~~~~~~~~~~~~~\n\
+         NameError: name 'undefined_xyz' is not defined"
+    );
 }
 
 /// `sys.stdout` and `sys.stderr` are separate sinks: each `print()` chunk streams


### PR DESCRIPTION
Upgrade the reconstructed traceback from filename/line/function only to full fidelity: each frame now carries its source-line preview and caret span.

Each feed compiles under a unique internal `<input-N>` filename with its source registered in `linecache`, so previews resolve correctly even for a frame from a function defined in an earlier feed (mirrors native Monty's per-feed sources). A new `extract_traceback` walks the CPython traceback via `traceback.extract_tb`, recovers each source line, converts CPython's UTF-8 byte columns to character columns, and defers the caret show/hide decision to CPython's own renderer (so `raise` shows no caret, whole-line calls do) — rendered in Monty's uniform `~~~` style. The parent-visible filename is `Configure.script_name`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt sandbox tracebacks to full fidelity with source previews and caret spans, matching CPython’s column offsets. Caret visibility is simplified (hidden only for `raise`), and extraction now returns an empty traceback if it fails.

- **New Features**
  - Compile each feed under a unique `<input-N>` and register its source in `linecache`, so previews resolve across feeds.
  - Added `runner.py` `extract_traceback` using `traceback.extract_tb`; converts byte columns to character columns and renders carets as `~~~` (shown for all frames except `raise`).
  - Rust `Runner` exposes `extract_traceback`; `session` attaches structured frames with previews/carets, strips `\r` from previews, and shares one `Arc` per distinct preview line.
  - SyntaxErrors are rewritten at compile time to report `Configure.script_name` (no user frames).
  - On extraction failure (e.g. patched stdlib), the traceback is empty rather than partially rebuilt; tests cover CRLF stripping, non-ASCII alignment, cross-feed previews, `SyntaxError` filename, and patched-stdlib behavior; README notes the caret limitations.

<sup>Written for commit cb37e8ce3f833b5c154071112e36d4edd8639b76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

