### PR TITLE
fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,7 +550,14 @@ jobs:
           manylinux: ${{ matrix.manylinux || 'auto' }}
           args: --release --out dist -i 3.10 3.11 3.12 3.13 3.14
           rust-toolchain: stable
-          docker-options: -e CI
+          # The rustls `ring` backend ships ARMv8 `.S` assembly that `#error`s
+          # unless `__ARM_ARCH` is predefined; the old GCC in the
+          # `manylinux2014-cross:aarch64` image (used by `aarch64 - auto`) does
+          # not predefine it, so we supply it ourselves. The variable is
+          # target-triple-scoped, so it is a no-op for every other matrix entry
+          # (incl. `aarch64 - musllinux`, which is `...-linux-musl`).
+          # See https://github.com/briansmith/ring/issues/1728.
+          docker-options: -e CI -e CFLAGS_aarch64_unknown_linux_gnu=-D__ARM_ARCH=8
           working-directory: crates/monty-python
 
       # the pydantic-monty-cli wheel ships the `monty` worker binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,28 +240,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,15 +532,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1160,12 +1129,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -3299,9 +3262,8 @@ version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
- "aws-lc-rs",
- "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3323,7 +3285,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,16 +101,12 @@ clap = { version = "4", features = ["derive"] }
 tungstenite = { version = "0.27", features = ["rustls-tls-webpki-roots"] }
 # Unique, exclusively-created temp dirs (monty-cpython install dirs; pool tests).
 tempfile = "3"
-# Pulled in only to install a process-level rustls `CryptoProvider` before the
-# first `wss://` dial: rustls 0.23 panics on first TLS use when it can't pick a
-# provider automatically (both `aws-lc-rs` and `ring`, or neither, in the dep
-# tree), so naming `ring` explicitly removes the ambiguity. We use `ring` rather
-# than the default `aws-lc-rs` because aws-lc-rs's vendored C/asm fails to
-# cross-compile in our manylinux wheel containers (missing `stdatomic.h`,
-# unsupported `-march` flags). `ring` builds cleanly on every wheel target; the
-# one exception, the `aarch64 - auto` manylinux2014 cross image, is handled by a
-# `CFLAGS_aarch64_unknown_linux_gnu=-D__ARM_ARCH=8` in `.github/workflows/ci.yml`.
-rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+# Used to install a `CryptoProvider` before the first `wss://` dial (rustls 0.23
+# panics otherwise). We pick `ring` over the default `aws_lc_rs` because the
+# latter's C/asm does not cross-compile in our manylinux wheel containers.
+# `default-features = false` drops `aws_lc_rs` but also `tls12`, which we must
+# re-add or rustls negotiates TLS 1.3 only and TLS-1.2-only `wss://` servers fail.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
 
 [workspace.lints.rust]
 # codspeed cfg is set by codspeed-criterion-compat when running in CodSpeed environment

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,9 +105,11 @@ tempfile = "3"
 # first `wss://` dial: rustls 0.23 panics on first TLS use when it can't pick a
 # provider automatically (both `aws-lc-rs` and `ring`, or neither, in the dep
 # tree), so naming `ring` explicitly removes the ambiguity. We use `ring` rather
-# than the default `aws-lc-rs` because the latter compiles vendored C/asm that
-# fails to cross-compile in the manylinux aarch64/i686 wheel-build containers;
-# `ring` builds cleanly across all our targets.
+# than the default `aws-lc-rs` because aws-lc-rs's vendored C/asm fails to
+# cross-compile in our manylinux wheel containers (missing `stdatomic.h`,
+# unsupported `-march` flags). `ring` builds cleanly on every wheel target; the
+# one exception, the `aarch64 - auto` manylinux2014 cross image, is handled by a
+# `CFLAGS_aarch64_unknown_linux_gnu=-D__ARM_ARCH=8` in `.github/workflows/ci.yml`.
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,8 +104,11 @@ tempfile = "3"
 # Pulled in only to install a process-level rustls `CryptoProvider` before the
 # first `wss://` dial: rustls 0.23 panics on first TLS use when it can't pick a
 # provider automatically (both `aws-lc-rs` and `ring`, or neither, in the dep
-# tree), so naming `aws_lc_rs` explicitly removes the ambiguity.
-rustls = { version = "0.23", features = ["aws_lc_rs"] }
+# tree), so naming `ring` explicitly removes the ambiguity. We use `ring` rather
+# than the default `aws-lc-rs` because the latter compiles vendored C/asm that
+# fails to cross-compile in the manylinux aarch64/i686 wheel-build containers;
+# `ring` builds cleanly across all our targets.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 
 [workspace.lints.rust]
 # codspeed cfg is set by codspeed-criterion-compat when running in CodSpeed environment

--- a/crates/monty-cpython/src/main.rs
+++ b/crates/monty-cpython/src/main.rs
@@ -3,7 +3,7 @@
 
 use std::process::ExitCode;
 
-use rustls::crypto::aws_lc_rs::default_provider;
+use rustls::crypto::ring::default_provider;
 
 fn main() -> ExitCode {
     // rustls 0.23 panics on first TLS use if it can't pick a `CryptoProvider`
@@ -12,7 +12,7 @@ fn main() -> ExitCode {
     // any tungstenite `wss://` dial in the `websocket` subcommand.
     default_provider()
         .install_default()
-        .expect("install rustls aws_lc_rs CryptoProvider");
+        .expect("install rustls ring CryptoProvider");
 
     monty_cpython::run()
 }

--- a/crates/monty-pool/src/worker.rs
+++ b/crates/monty-pool/src/worker.rs
@@ -22,7 +22,7 @@ use std::{
 };
 
 use monty_proto::{FrameError, FrameReader, MAX_FRAME_LEN, decode_frame, encode_to_capped_vec, pb, write_frame};
-use rustls::crypto::aws_lc_rs::default_provider;
+use rustls::crypto::ring::default_provider;
 use tungstenite::{
     Error as WsError, Message, WebSocket,
     client::{IntoClientRequest, uri_mode},
@@ -384,7 +384,7 @@ fn underlying_tcp(stream: &MaybeTlsStream<TcpStream>) -> Option<&TcpStream> {
 /// Installs the process-level rustls `CryptoProvider` exactly once before the
 /// first `wss://` dial. rustls 0.23 panics on first TLS use when it can't pick a
 /// provider automatically (both `aws-lc-rs` and `ring`, or neither, compiled
-/// in), so we name `aws_lc_rs` explicitly. Idempotent via `Once`, and the
+/// in), so we name `ring` explicitly. Idempotent via `Once`, and the
 /// install error is ignored: another part of the process (e.g. a host embedding
 /// the pool) may have already installed a provider, which is fine.
 fn install_crypto_provider() {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch `rustls` to the `ring` crypto backend and install it at startup to stop TLS panics and fix manylinux aarch64 cross-builds. Re-enable TLS 1.2 to maintain `wss://` compatibility.

- **Bug Fixes**
  - Install `rustls::crypto::ring::default_provider()` in `monty-cpython` and `monty-pool` before first TLS use.
  - Set `rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }` and remove `aws-lc-rs` and C/ASM deps.
  - In CI, pass `CFLAGS_aarch64_unknown_linux_gnu=-D__ARM_ARCH=8` for the `manylinux2014-cross:aarch64` wheel build.

<sup>Written for commit a71335320f8212bc571a1ec0ef592a49a31e9984. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

