### PR TITLE
ci: try newer manylinux version

### DIFF
--- a/.github/actions/build-pgo-wheel/action.yml
+++ b/.github/actions/build-pgo-wheel/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: build initial wheel (instrumented)
       uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1.50.1
       with:
-        manylinux: auto
+        manylinux: manylinux_2_28
         args: >
           --release
           --out pgo-wheel
@@ -71,7 +71,7 @@ runs:
     - name: build pgo-optimized wheel
       uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1.50.1
       with:
-        manylinux: auto
+        manylinux: manylinux_2_28
         args: >
           --release
           --out dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -547,7 +547,7 @@ jobs:
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1.50.1
         with:
           target: ${{ matrix.target }}
-          manylinux: ${{ matrix.manylinux || 'auto' }}
+          manylinux: ${{ matrix.manylinux || 'manylinux_2_28' }}
           args: --release --out dist -i 3.10 3.11 3.12 3.13 3.14
           rust-toolchain: stable
           docker-options: -e CI
@@ -561,7 +561,7 @@ jobs:
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1.50.1
         with:
           target: ${{ matrix.target }}
-          manylinux: ${{ matrix.manylinux || 'auto' }}
+          manylinux: ${{ matrix.manylinux || 'manylinux_2_28' }}
           args: --release --out dist -i 3.10 3.11 3.12 3.13 3.14
           rust-toolchain: stable
           docker-options: -e CI
@@ -632,7 +632,7 @@ jobs:
       - name: build cli wheel
         uses: PyO3/maturin-action@04ac600d27cdf7a9a280dadf7147097c42b757ad # v1.50.1
         with:
-          manylinux: auto
+          manylinux: manylinux_2_28
           args: --release --out dist -i 3.10 3.11 3.12 3.13 3.14
           rust-toolchain: stable
           docker-options: -e CI


### PR DESCRIPTION
possible alternative to #518 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CI wheel builds to `manylinux_2_28` instead of `auto` for all `PyO3/maturin-action` steps. This standardizes the Linux wheel baseline on a newer manylinux image across instrumented, PGO-optimized, and CLI builds.

<sup>Written for commit 9e6888921ad7d1567bbd72ad5e334c91f8ca843e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

