### PR TITLE
rename and change behaviour of `external_lookup`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -712,7 +712,7 @@ await using session = await pool.checkout({ typeCheck: false })
 await session.feedRun('x = 21') // session state persists across feeds
 const result = await session.feedRun('x * 2', {
   inputs: { y: 1 },
-  externalFunctions: { fetch: async (url: string) => '...' }, // sync or async
+  externalLookup: { fetch: async (url: string) => '...' }, // sync or async
   printCallback: (stream, text) => {},
 })
 ```

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ async def main():
             output = await session.feed_run(
                 code,
                 inputs={'prompt': 'testing'},
-                external_functions={'call_llm': call_llm},
+                external_lookup={'call_llm': call_llm},
             )
     print(output)
     #> example output, message count 2
@@ -179,7 +179,7 @@ console.log(await session.feedRun('x * 2')) // 42
 
 // external functions may be async
 const result = await session.feedRun('await fetch_data()', {
-  externalFunctions: { fetch_data: async () => 'data' },
+  externalLookup: { fetch_data: async () => 'data' },
 })
 ```
 

--- a/crates/monty-cpython/README.md
+++ b/crates/monty-cpython/README.md
@@ -80,7 +80,9 @@ unbound global that is **not a builtin and not a dunder** through the host: it
 emits a `NameLookup` and branches on the parent's `ResumeNameLookup` answer:
 
 - a host **value** → the converted Python value, returned directly (re-read live
-  on every reference — host values are not cached);
+  on every reference — host values are not cached). A parent reaches this branch
+  in practice via a non-callable `external_lookup` entry (not only the eager
+  `inputs`);
 - a host **function** → an `ExternalFunction` proxy whose call emits a
   `FunctionCall` (cached per session, so repeated references/calls skip the
   lookup);
@@ -94,6 +96,11 @@ Consequences that differ from CPython:
   value and the turn ends with an `Error`.
 - A `FunctionCall` the parent answers with `not_found` raises `NameError`
   (matching CPython for a genuinely undefined *call*).
+- This child does **not** cache resolved host *values*, so each reference
+  re-fires a `NameLookup` and re-reads live. The Monty sandbox worker instead
+  caches a resolved value in the namespace slot (a second reference skips the
+  lookup), so the two workers diverge on repeated references to an
+  `external_lookup` value — see `limitations/pool-architecture.md`.
 
 ## Installing dependencies (`InstallDependencies`)
 

--- a/crates/monty-cpython/README.md
+++ b/crates/monty-cpython/README.md
@@ -81,8 +81,8 @@ emits a `NameLookup` and branches on the parent's `ResumeNameLookup` answer:
 
 - a host **value** → the converted Python value, returned directly (re-read live
   on every reference — host values are not cached). A parent reaches this branch
-  in practice via a non-callable `external_lookup` entry (not only the eager
-  `inputs`);
+  in practice via a non-callable `external_lookup` entry (eager `inputs` are
+  bound directly with `set_item` and never hit `__missing__`);
 - a host **function** → an `ExternalFunction` proxy whose call emits a
   `FunctionCall` (cached per session, so repeated references/calls skip the
   lookup);
@@ -100,7 +100,7 @@ Consequences that differ from CPython:
   re-fires a `NameLookup` and re-reads live. The Monty sandbox worker instead
   caches a resolved value in the namespace slot (a second reference skips the
   lookup), so the two workers diverge on repeated references to an
-  `external_lookup` value — see `limitations/pool-architecture.md`.
+  `external_lookup` value — see `../../limitations/pool-architecture.md`.
 
 ## Installing dependencies (`InstallDependencies`)
 

--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -52,30 +52,43 @@ Pass values as globals for a feed:
 await session.feedRun('x + y', { inputs: { x: 10, y: 20 } }) // 30
 ```
 
-## External Functions
+## External Lookup
 
-The sandbox can call host functions by name — sync or async (async functions
-are awaited while other sandbox tasks keep running):
+`externalLookup` resolves names a snippet leaves undefined, lazily and on
+demand. A **function** entry becomes a host function the sandbox can call by
+name — sync or async (async functions are awaited while other sandbox tasks
+keep running). Any **other value** is converted and returned directly when the
+name is read. An absent name raises `NameError`.
 
 ```ts
 await session.feedRun('add(2, 3)', {
-  externalFunctions: { add: (a: number, b: number) => a + b },
+  externalLookup: { add: (a: number, b: number) => a + b },
 }) // 5
 
 await session.feedRun('await fetch_data(url)', {
   inputs: { url: 'https://example.com' },
-  externalFunctions: {
+  externalLookup: {
     fetch_data: async (url: string) => {
       const response = await fetch(url)
       return response.text()
     },
   },
 })
+
+await session.feedRun('greeting + name', {
+  inputs: { name: 'Ada' },
+  externalLookup: { greeting: 'hello ' },
+}) // 'hello Ada'
 ```
 
-Keyword arguments arrive as a trailing object; thrown errors cross into the
-sandbox as Python exceptions (the error's `name` is used when it matches a
-Python exception type, e.g. `TypeError`, otherwise `RuntimeError`).
+`externalLookup` is the lazy counterpart to `inputs`, which eagerly binds every
+entry as a global whether or not it is referenced; a name in both is served by
+the eager `inputs` binding.
+
+For function entries, keyword arguments arrive as a trailing object; thrown
+errors cross into the sandbox as Python exceptions (the error's `name` is used
+when it matches a Python exception type, e.g. `TypeError`, otherwise
+`RuntimeError`).
 
 ## Snapshots: pausing and resuming
 

--- a/crates/monty-js/__test__/async.spec.ts
+++ b/crates/monty-js/__test__/async.spec.ts
@@ -1,5 +1,5 @@
 // Async external functions: sync or async JS functions are passed the same
-// way via `externalFunctions`. A promise-returning function yields an
+// way via `externalLookup`. A promise-returning function yields an
 // awaitable in the sandbox (so the snippet uses `await fn()`), with the
 // promise registered as a sandbox future and delivered automatically — plain
 // `run(...)` covers everything the old in-process `runMontyAsync` helper did.
@@ -17,7 +17,7 @@ const { run } = setupPool(test)
 
 test('run with sync external function', async (t) => {
   const result = await run('get_value()', {
-    externalFunctions: {
+    externalLookup: {
       get_value: () => 42,
     },
   })
@@ -27,7 +27,7 @@ test('run with sync external function', async (t) => {
 
 test('run with async external function', async (t) => {
   const result = await run('await fetch_data()', {
-    externalFunctions: {
+    externalLookup: {
       fetch_data: async () => {
         // Simulate async operation
         await new Promise((resolve) => setTimeout(resolve, 10))
@@ -46,7 +46,7 @@ b = await fetch_b()
 a + b
 `
   const result = await run(code, {
-    externalFunctions: {
+    externalLookup: {
       fetch_a: async () => {
         await new Promise((resolve) => setTimeout(resolve, 5))
         return 10
@@ -64,7 +64,7 @@ a + b
 test('run async external function with inputs', async (t) => {
   const result = await run('await multiply(x)', {
     inputs: { x: 5 },
-    externalFunctions: {
+    externalLookup: {
       multiply: async (n: number) => n * 2,
     },
   })
@@ -74,7 +74,7 @@ test('run async external function with inputs', async (t) => {
 
 test('run async external function with args and kwargs', async (t) => {
   const result = await run('await process(1, 2, name="test")', {
-    externalFunctions: {
+    externalLookup: {
       process: async (a: number, b: number, kwargs: { name: string }) => {
         return `${kwargs.name}: ${a + b}`
       },
@@ -96,7 +96,7 @@ test('sync external function throws exception', async (t) => {
   const error = await t.throwsAsync(
     () =>
       run('fail_sync()', {
-        externalFunctions: {
+        externalLookup: {
           fail_sync: () => {
             throw new ValueError('sync error')
           },
@@ -116,7 +116,7 @@ test('async external function throws exception', async (t) => {
   const error = await t.throwsAsync(
     () =>
       run('await fail_async()', {
-        externalFunctions: {
+        externalLookup: {
           fail_async: async () => {
             await new Promise((resolve) => setTimeout(resolve, 5))
             throw new ValueError('async error')
@@ -142,7 +142,7 @@ result
   }
 
   const result = await run(code, {
-    externalFunctions: {
+    externalLookup: {
       might_fail: async () => {
         throw new ValueError('expected error')
       },
@@ -153,7 +153,7 @@ result
 })
 
 test('missing external function raises NameError', async (t) => {
-  const error = await t.throwsAsync(() => run('missing_func()', { externalFunctions: {} }), {
+  const error = await t.throwsAsync(() => run('missing_func()', { externalLookup: {} }), {
     instanceOf: MontyRuntimeError,
   })
 
@@ -168,7 +168,7 @@ except NameError:
     result = 'caught'
 result
 `
-  t.is(await run(code, { externalFunctions: {} }), 'caught')
+  t.is(await run(code, { externalLookup: {} }), 'caught')
 })
 
 // =============================================================================
@@ -177,7 +177,7 @@ result
 
 test('async external function returns complex types', async (t) => {
   const result = (await run('await get_data()', {
-    externalFunctions: {
+    externalLookup: {
       get_data: async () => {
         return [1, 2, { key: 'value' }]
       },
@@ -194,7 +194,7 @@ test('async external function returns complex types', async (t) => {
 test('async external function with list input', async (t) => {
   const result = await run('await sum_list(items)', {
     inputs: { items: [1, 2, 3, 4, 5] },
-    externalFunctions: {
+    externalLookup: {
       sum_list: async (items: number[]) => {
         return items.reduce((a, b) => a + b, 0)
       },
@@ -215,7 +215,7 @@ async_result = await async_func()
 sync_result + async_result
 `
   const result = await run(code, {
-    externalFunctions: {
+    externalLookup: {
       sync_func: () => 100,
       async_func: async () => {
         await new Promise((resolve) => setTimeout(resolve, 5))
@@ -234,7 +234,7 @@ second = await process(first)
 await finalize(second)
 `
   const result = await run(code, {
-    externalFunctions: {
+    externalLookup: {
       get_first: async () => 'hello',
       process: async (s: string) => s.toUpperCase(),
       finalize: async (s: string) => `${s}!`,
@@ -286,7 +286,7 @@ test('printCallback with external functions', async (t) => {
   const output: string[] = []
 
   const result = await run('x = get_value()\nprint(f"got {x}")\nx', {
-    externalFunctions: {
+    externalLookup: {
       get_value: () => 42,
     },
     printCallback: (stream, text) => {

--- a/crates/monty-js/__test__/external.spec.ts
+++ b/crates/monty-js/__test__/external.spec.ts
@@ -3,7 +3,7 @@ import test from 'ava'
 import { MontyRuntimeError } from '../ts/index.js'
 import { setupPool } from './helpers.js'
 
-const { run } = setupPool(test)
+const { run, pool } = setupPool(test)
 
 // =============================================================================
 // Basic external function tests
@@ -392,9 +392,24 @@ test('externalLookup mixes a function and a value', async (t) => {
 })
 
 test('externalLookup caches a resolved value within a feed', async (t) => {
-  // the monty interpreter caches a resolved name, so a second reference reads
-  // the cached value rather than re-resolving
-  t.is(await run('x + x', { externalLookup: { x: 21 } }), 42)
+  // the monty worker caches a resolved name in its namespace slot, so the
+  // second reference must not re-read the lookup — a getter observes the reads
+  let reads = 0
+  const lookup = {
+    get x() {
+      reads++
+      return 21
+    },
+  }
+  t.is(await run('x + x', { externalLookup: lookup }), 42)
+  t.is(reads, 1)
+})
+
+test('externalLookup resolves null and undefined values to None', async (t) => {
+  // null/undefined are present own keys, so they resolve to Python None
+  // rather than falling into the absent-name NameError path
+  t.is(await run('x is None', { externalLookup: { x: null } }), true)
+  t.is(await run('y is None', { externalLookup: { y: undefined } }), true)
 })
 
 test('externalLookup absent name raises name error', async (t) => {
@@ -402,6 +417,23 @@ test('externalLookup absent name raises name error', async (t) => {
     instanceOf: MontyRuntimeError,
   })
   t.is(error.message, "NameError: name 'missing' is not defined")
+})
+
+test('calling a stale proxy whose entry is now non-callable raises TypeError', async (t) => {
+  // A function proxy cached in feed 1 dispatches by name against the *current*
+  // dict on each call: with the entry replaced by a plain value, calling it
+  // raises what CPython would for calling that value (as the Python binding
+  // does by really calling the entry).
+  const session = await pool().checkout()
+  try {
+    await session.feedRun('f = double', { externalLookup: { double: (x: number) => x * 2 } })
+    const error = await t.throwsAsync(() => session.feedRun('f(2)', { externalLookup: { double: 5 } }), {
+      instanceOf: MontyRuntimeError,
+    })
+    t.is(error.message, "TypeError: 'int' object is not callable")
+  } finally {
+    await session.close()
+  }
 })
 
 test('externalLookup unconvertible value rejects the turn', async (t) => {

--- a/crates/monty-js/__test__/external.spec.ts
+++ b/crates/monty-js/__test__/external.spec.ts
@@ -15,7 +15,7 @@ test('external function no args', async (t) => {
     return 'called'
   }
 
-  t.is(await run('noop()', { externalFunctions: { noop } }), 'called')
+  t.is(await run('noop()', { externalLookup: { noop } }), 'called')
 })
 
 test('external function positional args', async (t) => {
@@ -24,7 +24,7 @@ test('external function positional args', async (t) => {
     return 'ok'
   }
 
-  t.is(await run('func(1, 2, 3)', { externalFunctions: { func } }), 'ok')
+  t.is(await run('func(1, 2, 3)', { externalLookup: { func } }), 'ok')
 })
 
 test('external function kwargs only', async (t) => {
@@ -34,7 +34,7 @@ test('external function kwargs only', async (t) => {
     return 'ok'
   }
 
-  t.is(await run('func(a=1, b="two")', { externalFunctions: { func } }), 'ok')
+  t.is(await run('func(a=1, b="two")', { externalLookup: { func } }), 'ok')
 })
 
 test('external function mixed args kwargs', async (t) => {
@@ -44,7 +44,7 @@ test('external function mixed args kwargs', async (t) => {
     return 'ok'
   }
 
-  t.is(await run('func(1, 2, x="hello", y=True)', { externalFunctions: { func } }), 'ok')
+  t.is(await run('func(1, 2, x="hello", y=True)', { externalLookup: { func } }), 'ok')
 })
 
 test('external function complex types', async (t) => {
@@ -56,7 +56,7 @@ test('external function complex types', async (t) => {
     return 'ok'
   }
 
-  t.is(await run('func([1, 2], {"key": "value"})', { externalFunctions: { func } }), 'ok')
+  t.is(await run('func([1, 2], {"key": "value"})', { externalLookup: { func } }), 'ok')
 })
 
 test('external function returns none', async (t) => {
@@ -64,7 +64,7 @@ test('external function returns none', async (t) => {
     // returns undefined which becomes None
   }
 
-  t.is(await run('do_nothing()', { externalFunctions: { do_nothing } }), null)
+  t.is(await run('do_nothing()', { externalLookup: { do_nothing } }), null)
 })
 
 test('external function returns complex type', async (t) => {
@@ -72,7 +72,7 @@ test('external function returns complex type', async (t) => {
     return { a: [1, 2, 3], b: { nested: true } }
   }
 
-  const result = (await run('get_data()', { externalFunctions: { get_data } })) as Map<string, unknown>
+  const result = (await run('get_data()', { externalLookup: { get_data } })) as Map<string, unknown>
   // Plain objects become Maps
   t.true(result instanceof Map)
   t.deepEqual(result.get('a'), [1, 2, 3])
@@ -98,7 +98,7 @@ test('multiple external functions', async (t) => {
     return a * b
   }
 
-  const result = await run('add(1, 2) + mul(3, 4)', { externalFunctions: { add, mul } })
+  const result = await run('add(1, 2) + mul(3, 4)', { externalLookup: { add, mul } })
   t.is(result, 15) // 3 + 12
 })
 
@@ -110,7 +110,7 @@ test('external function called multiple times', async (t) => {
     return callCount
   }
 
-  const result = await run('counter() + counter() + counter()', { externalFunctions: { counter } })
+  const result = await run('counter() + counter() + counter()', { externalLookup: { counter } })
   t.is(result, 6) // 1 + 2 + 3
   t.is(callCount, 3)
 })
@@ -121,7 +121,7 @@ test('external function with input', async (t) => {
     return x * 10
   }
 
-  t.is(await run('process(x)', { inputs: { x: 5 }, externalFunctions: { process } }), 50)
+  t.is(await run('process(x)', { inputs: { x: 5 }, externalLookup: { process } }), 50)
 })
 
 // =============================================================================
@@ -145,7 +145,7 @@ test('external function raises exception', async (t) => {
     throw error
   }
 
-  const error = await t.throwsAsync(() => run('fail()', { externalFunctions: { fail } }), {
+  const error = await t.throwsAsync(() => run('fail()', { externalLookup: { fail } }), {
     instanceOf: MontyRuntimeError,
   })
   t.is(error.message, 'ValueError: intentional error')
@@ -155,7 +155,7 @@ test('external function wrong name raises name error', async (t) => {
   // When 'foo' is called but only 'bar' is provided, foo is a NameError
   const bar = () => 1
 
-  const error = await t.throwsAsync(() => run('foo()', { externalFunctions: { bar } }), {
+  const error = await t.throwsAsync(() => run('foo()', { externalLookup: { bar } }), {
     instanceOf: MontyRuntimeError,
   })
   t.is(error.message, "NameError: name 'foo' is not defined")
@@ -175,7 +175,7 @@ caught
     throw error
   }
 
-  t.is(await run(code, { externalFunctions: { fail } }), true)
+  t.is(await run(code, { externalLookup: { fail } }), true)
 })
 
 test('external function exception type preserved', async (t) => {
@@ -185,7 +185,7 @@ test('external function exception type preserved', async (t) => {
     throw error
   }
 
-  const error = await t.throwsAsync(() => run('fail()', { externalFunctions: { fail } }), {
+  const error = await t.throwsAsync(() => run('fail()', { externalLookup: { fail } }), {
     instanceOf: MontyRuntimeError,
   })
   t.is(error.message, 'TypeError: type error message')
@@ -225,7 +225,7 @@ for (const [jsName, pythonType] of exceptionTypes) {
       throw error
     }
 
-    const error = await t.throwsAsync(() => run('fail()', { externalFunctions: { fail } }), {
+    const error = await t.throwsAsync(() => run('fail()', { externalLookup: { fail } }), {
       instanceOf: MontyRuntimeError,
     })
     t.is(error.exception.typeName, pythonType)
@@ -264,7 +264,7 @@ caught
     }
 
     // Child exception should be caught by parent handler (which comes first)
-    t.is(await run(code, { externalFunctions: { fail } }), 'parent')
+    t.is(await run(code, { externalLookup: { fail } }), 'parent')
   })
 }
 
@@ -279,7 +279,7 @@ test('external function exception in expression', async (t) => {
     throw error
   }
 
-  const error = await t.throwsAsync(() => run('1 + fail() + 2', { externalFunctions: { fail } }), {
+  const error = await t.throwsAsync(() => run('1 + fail() + 2', { externalLookup: { fail } }), {
     instanceOf: MontyRuntimeError,
   })
   t.is(error.message, 'RuntimeError: mid-expression error')
@@ -299,7 +299,7 @@ a + b
     throw error
   }
 
-  const error = await t.throwsAsync(() => run(code, { externalFunctions: { success, fail } }), {
+  const error = await t.throwsAsync(() => run(code, { externalLookup: { success, fail } }), {
     instanceOf: MontyRuntimeError,
   })
   t.is(error.message, 'ValueError: second call fails')
@@ -322,7 +322,7 @@ finally_ran
     throw error
   }
 
-  t.is(await run(code, { externalFunctions: { fail } }), true)
+  t.is(await run(code, { externalLookup: { fail } }), true)
 })
 
 // =============================================================================
@@ -342,14 +342,53 @@ caught
   // a Dataclass marker without its fieldNames array
   const bad = () => ({ __monty_type__: 'Dataclass', name: 'Broken' })
   t.is(
-    await run(code, { externalFunctions: { bad } }),
+    await run(code, { externalLookup: { bad } }),
     "Object property 'typeId' type mismatch. Expect value to be BigInt, but received Undefined",
   )
 })
 
 test('external function returning a symbol', async (t) => {
-  const error = await t.throwsAsync(() => run('bad()', { externalFunctions: { bad: () => Symbol('nope') } }), {
+  const error = await t.throwsAsync(() => run('bad()', { externalLookup: { bad: () => Symbol('nope') } }), {
     instanceOf: MontyRuntimeError,
   })
   t.is(error.message, 'TypeError: Cannot convert JS Symbol to Monty value')
+})
+
+// =============================================================================
+// externalLookup value resolution (non-callable entries)
+// =============================================================================
+
+test('externalLookup resolves a bare name to a value', async (t) => {
+  t.is(await run('x + 1', { externalLookup: { x: 41 } }), 42)
+})
+
+test('externalLookup resolves a container value', async (t) => {
+  const result = (await run('data', { externalLookup: { data: { a: 1, b: 2 } } })) as Map<string, unknown>
+  t.is(result.get('a'), 1)
+  t.is(result.get('b'), 2)
+})
+
+test('externalLookup mixes a function and a value', async (t) => {
+  const double = (n: number) => n * 2
+  t.is(await run('double(n)', { externalLookup: { double, n: 21 } }), 42)
+})
+
+test('externalLookup caches a resolved value within a feed', async (t) => {
+  // the monty interpreter caches a resolved name, so a second reference reads
+  // the cached value rather than re-resolving
+  t.is(await run('x + x', { externalLookup: { x: 21 } }), 42)
+})
+
+test('externalLookup absent name raises name error', async (t) => {
+  const error = await t.throwsAsync(() => run('missing', { externalLookup: { present: 1 } }), {
+    instanceOf: MontyRuntimeError,
+  })
+  t.is(error.message, "NameError: name 'missing' is not defined")
+})
+
+test('externalLookup unconvertible value rejects the turn', async (t) => {
+  // a non-callable value that cannot cross the wire surfaces as a conversion
+  // error (not a misleading NameError); the worker never observed the name
+  const error = await t.throwsAsync(() => run('x', { externalLookup: { x: Symbol('nope') } }))
+  t.is(error?.message, 'Cannot convert JS Symbol to Monty value')
 })

--- a/crates/monty-js/__test__/external.spec.ts
+++ b/crates/monty-js/__test__/external.spec.ts
@@ -138,6 +138,24 @@ test('undeclared function raises name error', async (t) => {
   t.is(error.message, "NameError: name 'unknown_func' is not defined")
 })
 
+test('inherited property name is not resolved as a host value', async (t) => {
+  // `toString` lives on Object.prototype, not as an own key, so referencing it
+  // must raise NameError rather than leaking the inherited function.
+  const error = await t.throwsAsync(() => run('toString', { externalLookup: { present: 1 } }), {
+    instanceOf: MontyRuntimeError,
+  })
+  t.is(error.message, "NameError: name 'toString' is not defined")
+})
+
+test('inherited property name is not dispatched as a host function', async (t) => {
+  // A call to an inherited callable (e.g. Object.prototype.hasOwnProperty) must
+  // be treated as "no such function" and raise NameError, not invoked.
+  const error = await t.throwsAsync(() => run('hasOwnProperty()', { externalLookup: { present: 1 } }), {
+    instanceOf: MontyRuntimeError,
+  })
+  t.is(error.message, "NameError: name 'hasOwnProperty' is not defined")
+})
+
 test('external function raises exception', async (t) => {
   const fail = () => {
     const error = new Error('intentional error')

--- a/crates/monty-js/__test__/mount.spec.ts
+++ b/crates/monty-js/__test__/mount.spec.ts
@@ -440,7 +440,7 @@ content = Path('/data/hello.txt').read_text()
 result = get_prefix()
 result + content
 `
-    const result = await run(code, { mount: md, externalFunctions: { get_prefix: () => 'PREFIX: ' } })
+    const result = await run(code, { mount: md, externalLookup: { get_prefix: () => 'PREFIX: ' } })
     t.is(result, 'PREFIX: hello world')
   } finally {
     cleanup()

--- a/crates/monty-js/__test__/pool.spec.ts
+++ b/crates/monty-js/__test__/pool.spec.ts
@@ -182,7 +182,7 @@ test('suspension time does not consume the duration budget', async (t) => {
   await using pool = await Monty.create()
   await using session = await pool.checkout({ limits: { maxDurationSecs: 0.3 } })
   const result = await session.feedRun("await fetch_data('u') + '!'", {
-    externalFunctions: {
+    externalLookup: {
       fetch_data: async () => {
         await new Promise((resolve) => setTimeout(resolve, 600))
         return 'body'

--- a/crates/monty-js/__test__/print.spec.ts
+++ b/crates/monty-js/__test__/print.spec.ts
@@ -170,7 +170,7 @@ print("hello")
 print(func())
 `
   const { output, callback } = makePrintCollector(t)
-  const result = await run(code, { printCallback: callback, externalFunctions: { func: () => 'world' } })
+  const result = await run(code, { printCallback: callback, externalLookup: { func: () => 'world' } })
   t.is(result, null)
   t.deepEqual(output, ['hello\n', 'world\n'])
 })

--- a/crates/monty-js/__test__/type_check.spec.ts
+++ b/crates/monty-js/__test__/type_check.spec.ts
@@ -100,7 +100,7 @@ test('type check stubs with external function', async (t) => {
     await run('result = fetch("https://example.com")\nresult', {
       typeCheck: true,
       typeCheckStubs: 'def fetch(url: str) -> str: ...',
-      externalFunctions: { fetch: () => 'response data' },
+      externalLookup: { fetch: () => 'response data' },
     }),
     'response data',
   )

--- a/crates/monty-js/__test__/wasm_async.spec.ts
+++ b/crates/monty-js/__test__/wasm_async.spec.ts
@@ -362,6 +362,27 @@ test('runMontyAsync resolves a falsy value', async (t) => {
   t.is(await runMontyAsync(m, { externalLookup: { n: 0 } }), 1)
 })
 
+test('runMontyAsync resolves null and undefined values to None', async (t) => {
+  t.is(await runMontyAsync(new Monty('x is None'), { externalLookup: { x: null } }), true)
+  t.is(await runMontyAsync(new Monty('y is None'), { externalLookup: { y: undefined } }), true)
+})
+
+test('runMontyAsync calling a proxy whose entry is now non-callable raises TypeError', async (t) => {
+  // Calls dispatch by name against the *current* lookup on every call: the
+  // first call replaces the entry with a plain value, so the second raises
+  // what CPython would for calling that value.
+  const lookup: Record<string, unknown> = {
+    f: () => {
+      lookup.f = 5
+      return 1
+    },
+  }
+  const error = await t.throwsAsync(runMontyAsync(new Monty('f()\nf()'), { externalLookup: lookup }), {
+    instanceOf: MontyRuntimeError,
+  })
+  t.is(error.message, "TypeError: 'int' object is not callable")
+})
+
 test('runMontyAsync mixes an async function and a value', async (t) => {
   // The host awaits the JS promise and hands the sandbox the resolved value, so
   // the sandbox calls the function directly (no `await`). `url`/`suffix` are

--- a/crates/monty-js/__test__/wasm_async.spec.ts
+++ b/crates/monty-js/__test__/wasm_async.spec.ts
@@ -10,7 +10,7 @@ test('runMontyAsync with sync external function', async (t) => {
   const m = new Monty('get_value()')
 
   const result = await runMontyAsync(m, {
-    externalFunctions: {
+    externalLookup: {
       get_value: () => 42,
     },
   })
@@ -22,7 +22,7 @@ test('runMontyAsync with async external function', async (t) => {
   const m = new Monty('fetch_data()')
 
   const result = await runMontyAsync(m, {
-    externalFunctions: {
+    externalLookup: {
       fetch_data: async () => {
         // Simulate async operation
         await new Promise((resolve) => setTimeout(resolve, 10))
@@ -45,7 +45,7 @@ a + b
   )
 
   const result = await runMontyAsync(m, {
-    externalFunctions: {
+    externalLookup: {
       fetch_a: async () => {
         await new Promise((resolve) => setTimeout(resolve, 5))
         return 10
@@ -65,7 +65,7 @@ test('runMontyAsync with inputs', async (t) => {
 
   const result = await runMontyAsync(m, {
     inputs: { x: 5 },
-    externalFunctions: {
+    externalLookup: {
       multiply: async (n: number) => n * 2,
     },
   })
@@ -77,7 +77,7 @@ test('runMontyAsync with args and kwargs', async (t) => {
   const m = new Monty('process(1, 2, name="test")')
 
   const result = await runMontyAsync(m, {
-    externalFunctions: {
+    externalLookup: {
       process: async (a: number, b: number, kwargs: { name: string }) => {
         return `${kwargs.name}: ${a + b}`
       },
@@ -100,7 +100,7 @@ test('runMontyAsync sync function throws exception', async (t) => {
 
   const error = await t.throwsAsync(
     runMontyAsync(m, {
-      externalFunctions: {
+      externalLookup: {
         fail_sync: () => {
           throw new ValueError('sync error')
         },
@@ -120,7 +120,7 @@ test('runMontyAsync async function throws exception', async (t) => {
 
   const error = await t.throwsAsync(
     runMontyAsync(m, {
-      externalFunctions: {
+      externalLookup: {
         fail_async: async () => {
           await new Promise((resolve) => setTimeout(resolve, 5))
           throw new ValueError('async error')
@@ -149,7 +149,7 @@ result
   }
 
   const result = await runMontyAsync(m, {
-    externalFunctions: {
+    externalLookup: {
       might_fail: async () => {
         throw new ValueError('expected error')
       },
@@ -162,7 +162,7 @@ result
 test('runMontyAsync missing external function raises NameError', async (t) => {
   const m = new Monty('missing_func()')
 
-  const error = await t.throwsAsync(runMontyAsync(m, { externalFunctions: {} }))
+  const error = await t.throwsAsync(runMontyAsync(m, { externalLookup: {} }))
 
   t.true(error instanceof MontyRuntimeError)
   t.true(error!.message.includes('NameError'))
@@ -179,7 +179,7 @@ result
 `,
   )
 
-  const result = await runMontyAsync(m, { externalFunctions: {} })
+  const result = await runMontyAsync(m, { externalLookup: {} })
 
   t.is(result, 'caught')
 })
@@ -192,7 +192,7 @@ test('runMontyAsync returns complex types', async (t) => {
   const m = new Monty('get_data()')
 
   const result = await runMontyAsync(m, {
-    externalFunctions: {
+    externalLookup: {
       get_data: async () => {
         return [1, 2, { key: 'value' }]
       },
@@ -211,7 +211,7 @@ test('runMontyAsync with list input', async (t) => {
 
   const result = await runMontyAsync(m, {
     inputs: { items: [1, 2, 3, 4, 5] },
-    externalFunctions: {
+    externalLookup: {
       sum_list: async (items: number[]) => {
         return items.reduce((a, b) => a + b, 0)
       },
@@ -236,7 +236,7 @@ sync_result + async_result
   )
 
   const result = await runMontyAsync(m, {
-    externalFunctions: {
+    externalLookup: {
       sync_func: () => 100,
       async_func: async () => {
         await new Promise((resolve) => setTimeout(resolve, 5))
@@ -259,7 +259,7 @@ finalize(second)
   )
 
   const result = await runMontyAsync(m, {
-    externalFunctions: {
+    externalLookup: {
       get_first: async () => 'hello',
       process: async (s: string) => s.toUpperCase(),
       finalize: async (s: string) => `${s}!`,
@@ -317,13 +317,11 @@ test('runMontyAsync with printCallback', async (t) => {
 })
 
 test('runMontyAsync printCallback with external functions', async (t) => {
-  const m = new Monty('x = get_value()\nprint(f"got {x}")\nx', {
-    externalFunctions: ['get_value'],
-  })
+  const m = new Monty('x = get_value()\nprint(f"got {x}")\nx')
   const output: string[] = []
 
   const result = await runMontyAsync(m, {
-    externalFunctions: {
+    externalLookup: {
       get_value: () => 42,
     },
     printCallback: (stream, text) => {
@@ -347,4 +345,43 @@ test('runMontyAsync printCallback with multiple prints', async (t) => {
   })
 
   t.deepEqual(output, ['a', '\n', 'b', '\n', 'c', '\n'])
+})
+
+// =============================================================================
+// externalLookup value resolution
+// =============================================================================
+
+test('runMontyAsync resolves a bare name to a value', async (t) => {
+  const m = new Monty('x + 1')
+  t.is(await runMontyAsync(m, { externalLookup: { x: 41 } }), 42)
+})
+
+test('runMontyAsync resolves a falsy value', async (t) => {
+  // 0 is falsy but a present own key, so it must resolve rather than raise.
+  const m = new Monty('n + 1')
+  t.is(await runMontyAsync(m, { externalLookup: { n: 0 } }), 1)
+})
+
+test('runMontyAsync mixes an async function and a value', async (t) => {
+  // The host awaits the JS promise and hands the sandbox the resolved value, so
+  // the sandbox calls the function directly (no `await`). `url`/`suffix` are
+  // non-callable externalLookup values resolved on bare-name reads.
+  const m = new Monty('fetch_data(url) + suffix')
+  const result = await runMontyAsync(m, {
+    externalLookup: {
+      fetch_data: async (u: string) => `<${u}>`,
+      url: 'u',
+      suffix: '!',
+    },
+  })
+  t.is(result, '<u>!')
+})
+
+test('runMontyAsync inherited property name raises name error', async (t) => {
+  // toString is inherited from Object.prototype, not an own key.
+  const m = new Monty('toString')
+  const error = await t.throwsAsync(runMontyAsync(m, { externalLookup: { present: 1 } }), {
+    instanceOf: MontyRuntimeError,
+  })
+  t.is(error.message, "NameError: name 'toString' is not defined")
 })

--- a/crates/monty-js/__test__/wasm_external.spec.ts
+++ b/crates/monty-js/__test__/wasm_external.spec.ts
@@ -381,6 +381,26 @@ test('externalLookup resolves a falsy value', (t) => {
   t.is(m.run({ externalLookup: { n: 0 } }), 1)
 })
 
+test('externalLookup resolves null and undefined values to None', (t) => {
+  t.is(new Monty('x is None').run({ externalLookup: { x: null } }), true)
+  t.is(new Monty('y is None').run({ externalLookup: { y: undefined } }), true)
+})
+
+test('calling a proxy whose entry is now non-callable raises TypeError', (t) => {
+  // Calls dispatch by name against the *current* lookup on every call: the
+  // first call replaces the entry with a plain value, so the second raises
+  // what CPython would for calling that value.
+  const lookup: Record<string, unknown> = {
+    f: () => {
+      lookup.f = 5
+      return 1
+    },
+  }
+  const m = new Monty('f()\nf()')
+  const error = t.throws(() => m.run({ externalLookup: lookup }), isRuntimeError)
+  t.is(error.message, "TypeError: 'int' object is not callable")
+})
+
 test('externalLookup mixes a function and a value', (t) => {
   const m = new Monty('double(n)')
   const double = (x: number) => x * 2

--- a/crates/monty-js/__test__/wasm_external.spec.ts
+++ b/crates/monty-js/__test__/wasm_external.spec.ts
@@ -15,7 +15,7 @@ test('external function no args', (t) => {
     return 'called'
   }
 
-  const result = m.run({ externalFunctions: { noop } })
+  const result = m.run({ externalLookup: { noop } })
   t.is(result, 'called')
 })
 
@@ -27,7 +27,7 @@ test('external function positional args', (t) => {
     return 'ok'
   }
 
-  t.is(m.run({ externalFunctions: { func } }), 'ok')
+  t.is(m.run({ externalLookup: { func } }), 'ok')
 })
 
 test('external function kwargs only', (t) => {
@@ -39,7 +39,7 @@ test('external function kwargs only', (t) => {
     return 'ok'
   }
 
-  t.is(m.run({ externalFunctions: { func } }), 'ok')
+  t.is(m.run({ externalLookup: { func } }), 'ok')
 })
 
 test('external function kwargs cannot replace prototype', (t) => {
@@ -52,7 +52,7 @@ test('external function kwargs cannot replace prototype', (t) => {
     return 'ok'
   }
 
-  t.is(m.run({ externalFunctions: { func } }), 'ok')
+  t.is(m.run({ externalLookup: { func } }), 'ok')
 })
 
 test('external function mixed args kwargs', (t) => {
@@ -64,7 +64,7 @@ test('external function mixed args kwargs', (t) => {
     return 'ok'
   }
 
-  t.is(m.run({ externalFunctions: { func } }), 'ok')
+  t.is(m.run({ externalLookup: { func } }), 'ok')
 })
 
 test('external function complex types', (t) => {
@@ -78,7 +78,7 @@ test('external function complex types', (t) => {
     return 'ok'
   }
 
-  t.is(m.run({ externalFunctions: { func } }), 'ok')
+  t.is(m.run({ externalLookup: { func } }), 'ok')
 })
 
 test('external function returns none', (t) => {
@@ -88,7 +88,7 @@ test('external function returns none', (t) => {
     // returns undefined which becomes None
   }
 
-  t.is(m.run({ externalFunctions: { do_nothing } }), null)
+  t.is(m.run({ externalLookup: { do_nothing } }), null)
 })
 
 test('external function returns complex type', (t) => {
@@ -98,7 +98,7 @@ test('external function returns complex type', (t) => {
     return { a: [1, 2, 3], b: { nested: true } }
   }
 
-  const result = m.run({ externalFunctions: { get_data } })
+  const result = m.run({ externalLookup: { get_data } })
   // Plain objects become Maps
   t.true(result instanceof Map)
   t.deepEqual(result.get('a'), [1, 2, 3])
@@ -126,7 +126,7 @@ test('multiple external functions', (t) => {
     return a * b
   }
 
-  const result = m.run({ externalFunctions: { add, mul } })
+  const result = m.run({ externalLookup: { add, mul } })
   t.is(result, 15) // 3 + 12
 })
 
@@ -140,7 +140,7 @@ test('external function called multiple times', (t) => {
     return callCount
   }
 
-  const result = m.run({ externalFunctions: { counter } })
+  const result = m.run({ externalLookup: { counter } })
   t.is(result, 6) // 1 + 2 + 3
   t.is(callCount, 3)
 })
@@ -153,7 +153,7 @@ test('external function with input', (t) => {
     return x * 10
   }
 
-  t.is(m.run({ inputs: { x: 5 }, externalFunctions: { process } }), 50)
+  t.is(m.run({ inputs: { x: 5 }, externalLookup: { process } }), 50)
 })
 
 // =============================================================================
@@ -183,19 +183,19 @@ test('external function raises exception', (t) => {
     throw error
   }
 
-  const error = t.throws(() => m.run({ externalFunctions: { fail } }), isRuntimeError)
+  const error = t.throws(() => m.run({ externalLookup: { fail } }), isRuntimeError)
   t.true(error.message.includes('ValueError'))
   t.true(error.message.includes('intentional error'))
 })
 
 test('external function wrong name raises name error', (t) => {
-  // When 'foo' is called but only 'bar' is provided at runtime, foo is a NameError
-  // because no externalFunctions are declared in the constructor
+  // When 'foo' is called but only 'bar' is provided in externalLookup, foo is a
+  // NameError since the lookup has no own 'foo' key.
   const m = new Monty('foo()')
 
   const bar = () => 1
 
-  const error = t.throws(() => m.run({ externalFunctions: { bar } }), isRuntimeError)
+  const error = t.throws(() => m.run({ externalLookup: { bar } }), isRuntimeError)
   t.is(error.message, "NameError: name 'foo' is not defined")
 })
 
@@ -215,7 +215,7 @@ caught
     throw error
   }
 
-  t.is(m.run({ externalFunctions: { fail } }), true)
+  t.is(m.run({ externalLookup: { fail } }), true)
 })
 
 test('external function exception type preserved', (t) => {
@@ -227,7 +227,7 @@ test('external function exception type preserved', (t) => {
     throw error
   }
 
-  const error = t.throws(() => m.run({ externalFunctions: { fail } }), isRuntimeError)
+  const error = t.throws(() => m.run({ externalLookup: { fail } }), isRuntimeError)
   t.true(error.message.includes('TypeError'))
   t.true(error.message.includes('type error message'))
 })
@@ -263,7 +263,7 @@ for (const exceptionType of exceptionTypes) {
       throw error
     }
 
-    const error = t.throws(() => m.run({ externalFunctions: { fail } }), isRuntimeError)
+    const error = t.throws(() => m.run({ externalLookup: { fail } }), isRuntimeError)
     t.true(error.message.includes(exceptionType))
   })
 }
@@ -301,7 +301,7 @@ caught
     }
 
     // Child exception should be caught by parent handler (which comes first)
-    t.is(m.run({ externalFunctions: { fail } }), 'parent')
+    t.is(m.run({ externalLookup: { fail } }), 'parent')
   })
 }
 
@@ -318,7 +318,7 @@ test('external function exception in expression', (t) => {
     throw error
   }
 
-  const error = t.throws(() => m.run({ externalFunctions: { fail } }), isRuntimeError)
+  const error = t.throws(() => m.run({ externalLookup: { fail } }), isRuntimeError)
   t.true(error.message.includes('RuntimeError'))
   t.true(error.message.includes('mid-expression error'))
 })
@@ -339,7 +339,7 @@ a + b
     throw error
   }
 
-  const error = t.throws(() => m.run({ externalFunctions: { success, fail } }), isRuntimeError)
+  const error = t.throws(() => m.run({ externalLookup: { success, fail } }), isRuntimeError)
   t.true(error.message.includes('ValueError'))
   t.true(error.message.includes('second call fails'))
 })
@@ -363,5 +363,40 @@ finally_ran
     throw error
   }
 
-  t.is(m.run({ externalFunctions: { fail } }), true)
+  t.is(m.run({ externalLookup: { fail } }), true)
+})
+
+// =============================================================================
+// externalLookup value resolution (non-callable entries)
+// =============================================================================
+
+test('externalLookup resolves a bare name to a value', (t) => {
+  const m = new Monty('x + 1')
+  t.is(m.run({ externalLookup: { x: 41 } }), 42)
+})
+
+test('externalLookup resolves a falsy value', (t) => {
+  // 0 is falsy but a present own key, so it must resolve rather than raise.
+  const m = new Monty('n + 1')
+  t.is(m.run({ externalLookup: { n: 0 } }), 1)
+})
+
+test('externalLookup mixes a function and a value', (t) => {
+  const m = new Monty('double(n)')
+  const double = (x: number) => x * 2
+  t.is(m.run({ externalLookup: { double, n: 21 } }), 42)
+})
+
+test('externalLookup absent name raises name error', (t) => {
+  const m = new Monty('missing')
+  const error = t.throws(() => m.run({ externalLookup: { present: 1 } }), isRuntimeError)
+  t.is(error.message, "NameError: name 'missing' is not defined")
+})
+
+test('inherited property name is not resolved as a host value', (t) => {
+  // toString lives on Object.prototype, not as an own key, so it must raise
+  // NameError rather than leaking the inherited function.
+  const m = new Monty('toString')
+  const error = t.throws(() => m.run({ externalLookup: { present: 1 } }), isRuntimeError)
+  t.is(error.message, "NameError: name 'toString' is not defined")
 })

--- a/crates/monty-js/__test__/wasm_mount.spec.ts
+++ b/crates/monty-js/__test__/wasm_mount.spec.ts
@@ -109,6 +109,24 @@ test('read_text via mount', (t) => {
   }
 })
 
+test('mount survives an externalLookup conversion error mid-run', (t) => {
+  // A name-lookup value that cannot cross into the sandbox aborts the run. The
+  // mount table taken for that run must still be restored, so the same MountDir
+  // keeps working rather than being left permanently taken from its shared slot.
+  const { dir, cleanup } = createTestDir()
+  try {
+    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    // First run references an unconvertible value (a JS Symbol) by name.
+    const error = t.throws(() => new Monty('bad').run({ mount: md, externalLookup: { bad: Symbol('nope') } }))
+    t.is(error?.message, 'Cannot convert JS Symbol to Monty value')
+    // The mount is not corrupted: a second run with the same MountDir works.
+    const result = new Monty("from pathlib import Path; Path('/data/hello.txt').read_text()").run({ mount: md })
+    t.is(result, 'hello world')
+  } finally {
+    cleanup()
+  }
+})
+
 test('read_bytes via mount', (t) => {
   const { dir, cleanup } = createTestDir()
   try {

--- a/crates/monty-js/smoke-test/test.ts
+++ b/crates/monty-js/smoke-test/test.ts
@@ -77,19 +77,19 @@ if (err !== null) {
 console.log('\n=== External Functions ===')
 
 assert(
-  (await session.feedRun('add(2, 3)', { externalFunctions: { add: (a: number, b: number) => a + b } })) === 5,
+  (await session.feedRun('add(2, 3)', { externalLookup: { add: (a: number, b: number) => a + b } })) === 5,
   'sync external function',
 )
 assert(
   (await session.feedRun('await get_data()', {
-    externalFunctions: { get_data: async () => 'async result' },
+    externalLookup: { get_data: async () => 'async result' },
   })) === 'async result',
   'async external function',
 )
 
 const callArgs: unknown[] = []
 await session.feedRun('bar(1, 2, x=3, y=4)', {
-  externalFunctions: {
+  externalLookup: {
     bar: (...args: unknown[]) => {
       callArgs.push(...args)
       return null

--- a/crates/monty-js/src/monty_cls.rs
+++ b/crates/monty-js/src/monty_cls.rs
@@ -284,13 +284,22 @@ impl Monty {
                             return Ok(Either::A(monty_to_js(&result, env)?));
                         }
                         RunProgress::FunctionCall(call) => {
-                            let return_value = call_external_function(
+                            // Dispatching the call can fail (arg/result conversion,
+                            // a callable-type check). Restore the mount table before
+                            // propagating so the shared slots are not left empty.
+                            let return_value = match call_external_function(
                                 env,
                                 external_lookup.as_ref(),
                                 &call.function_name,
                                 &call.args,
                                 &call.kwargs,
-                            )?;
+                            ) {
+                                Ok(v) => v,
+                                Err(err) => {
+                                    put_back(mount_table);
+                                    return Err(err);
+                                }
+                            };
 
                             progress = match call.resume(return_value, print_output.reborrow()) {
                                 Ok(p) => p,
@@ -301,7 +310,16 @@ impl Monty {
                             };
                         }
                         RunProgress::NameLookup(lookup) => {
-                            let result = resolve_name_lookup(env, external_lookup.as_ref(), &lookup.name)?;
+                            // Resolving the name can fail (converting a non-callable
+                            // `external_lookup` value). Restore the mount table before
+                            // propagating so the shared slots are not left empty.
+                            let result = match resolve_name_lookup(env, external_lookup.as_ref(), &lookup.name) {
+                                Ok(r) => r,
+                                Err(err) => {
+                                    put_back(mount_table);
+                                    return Err(err);
+                                }
+                            };
                             progress = match lookup.resume(result, print_output.reborrow()) {
                                 Ok(p) => p,
                                 Err(exc) => {

--- a/crates/monty-js/src/monty_cls.rs
+++ b/crates/monty-js/src/monty_cls.rs
@@ -1,9 +1,10 @@
 //! The main `Monty` class and iterative execution support for the TypeScript/JavaScript bindings.
 //!
 //! Provides a sandboxed Python interpreter that can be configured with inputs
-//! and resource limits. External functions are provided at runtime via
-//! `RunOptions` or `StartOptions`. Supports both immediate execution
-//! via `run()` and iterative execution via `start()`/`resume()`.
+//! and resource limits. Undefined names are resolved at runtime via the
+//! `externalLookup` on `RunOptions` (or, for iterative execution, by answering
+//! the name-lookup/function-call suspensions). Supports both immediate
+//! execution via `run()` and iterative execution via `start()`/`resume()`.
 //!
 //! ## Quick Start
 //!
@@ -104,9 +105,10 @@ pub struct RunOptions<'env> {
     pub limits: Option<JsResourceLimits>,
     /// Optional print callback function.
     pub print_callback: Option<JsPrintCallback<'env>>,
-    /// Dict of external function callbacks.
-    /// Keys are function names, values are callable functions.
-    pub external_functions: Option<Object<'env>>,
+    /// Lazy resolution for names the code leaves undefined. Keys are names; a
+    /// callable value resolves to a host function proxy, any other value is
+    /// converted and returned directly, and an absent name raises `NameError`.
+    pub external_lookup: Option<Object<'env>>,
     /// Filesystem mount(s) for the sandbox.
     /// A single `MountDir` or an array of `MountDir`.
     pub mount: Option<Object<'env>>,
@@ -181,11 +183,11 @@ impl Monty {
     }
 
     /// Executes the code, returning the last expression's result or a
-    /// MontyException on failure. With runtime `externalFunctions` or mounts,
+    /// MontyException on failure. With a runtime `externalLookup` or mounts,
     /// dispatches calls/lookups via the start/resume loop; otherwise runs
     /// directly.
     ///
-    /// @param options - Execution options (inputs, limits, externalFunctions)
+    /// @param options - Execution options (inputs, limits, externalLookup)
     /// @returns The result of the last expression, or a MontyException if execution fails
     #[napi]
     pub fn run<'env>(
@@ -196,7 +198,7 @@ impl Monty {
         let options = options.unwrap_or_default();
         let input_values = self.extract_input_values(options.inputs, *env)?;
 
-        let external_functions = options.external_functions;
+        let external_lookup = options.external_lookup;
         let os_handler = match options.mount.as_ref() {
             Some(obj) => OsHandler::from_extracted(extract_mounts(obj)?),
             None => None,
@@ -211,14 +213,14 @@ impl Monty {
             None => PrintWriter::Stdout,
         };
 
-        // If we have runtime external functions or mounts, use the start/resume
+        // If we have a runtime external lookup or mounts, use the start/resume
         // loop to handle FunctionCall, NameLookup, and OsCall dispatching
-        if external_functions.is_some() || os_handler.is_some() {
+        if external_lookup.is_some() || os_handler.is_some() {
             return self.run_with_dispatch_loop(
                 env,
                 input_values,
                 options.limits,
-                external_functions,
+                external_lookup,
                 os_handler,
                 print_writer,
             );
@@ -238,16 +240,16 @@ impl Monty {
         }
     }
 
-    /// Runs code with external function callbacks and/or mounts, looping over
-    /// `FunctionCall`/`NameLookup`/`OsCall`. Name lookups resolve to a
-    /// `Function` when present in the external map (else `Undefined`); OS calls
-    /// dispatch to the mount table when available.
+    /// Runs code with an external lookup and/or mounts, looping over
+    /// `FunctionCall`/`NameLookup`/`OsCall`. Name lookups resolve a callable to
+    /// a `Function` proxy and any other entry to its converted value (else
+    /// `Undefined`); OS calls dispatch to the mount table when available.
     fn run_with_dispatch_loop<'env>(
         &self,
         env: &'env Env,
         input_values: Vec<MontyObject>,
         limits: Option<JsResourceLimits>,
-        external_functions: Option<Object<'env>>,
+        external_lookup: Option<Object<'env>>,
         os_handler: Option<OsHandler>,
         mut print_output: PrintWriter<'_>,
     ) -> Result<Either<JsMontyObject<'env>, JsMontyException>> {
@@ -284,7 +286,7 @@ impl Monty {
                         RunProgress::FunctionCall(call) => {
                             let return_value = call_external_function(
                                 env,
-                                external_functions.as_ref(),
+                                external_lookup.as_ref(),
                                 &call.function_name,
                                 &call.args,
                                 &call.kwargs,
@@ -299,7 +301,7 @@ impl Monty {
                             };
                         }
                         RunProgress::NameLookup(lookup) => {
-                            let result = resolve_name_lookup(external_functions.as_ref(), &lookup.name)?;
+                            let result = resolve_name_lookup(env, external_lookup.as_ref(), &lookup.name)?;
                             progress = match lookup.resume(result, print_output.reborrow()) {
                                 Ok(p) => p,
                                 Err(exc) => {
@@ -1564,33 +1566,39 @@ struct SerializedNameLookupOwned {
 // External function support
 // =============================================================================
 
-/// Calls a JavaScript external function and returns the result.
+/// Calls a JavaScript external-lookup callable and returns the result.
 ///
-/// Converts args/kwargs from Monty format, calls the JS function,
-/// and converts the result back to Monty format (or an exception).
+/// Converts args/kwargs from Monty format, calls the JS function, and converts
+/// the result back to Monty format (or an exception). Only a callable *own*
+/// property is invocable — an absent name, an inherited member (e.g.
+/// `Object.prototype.toString`), or a non-callable value all raise `NameError`,
+/// matching how a `FunctionCall` only ever follows a callable name resolution.
 fn call_external_function(
     env: &Env,
-    external_functions: Option<&Object<'_>>,
+    external_lookup: Option<&Object<'_>>,
     function_name: &str,
     args: &[MontyObject],
     kwargs: &[(MontyObject, MontyObject)],
 ) -> Result<ExtFunctionResult> {
-    let functions = external_functions.ok_or_else(|| {
-        Error::from_reason(format!(
-            "External function '{function_name}' called but no externalFunctions provided"
-        ))
-    })?;
-
-    if !functions.has_named_property(function_name)? {
-        // NameError matches Python's behavior for undefined names.
-        let exc = MontyException::new(
+    // NameError matches Python's behavior for a name that is not a callable
+    // exposed by the lookup.
+    let name_error = || {
+        ExtFunctionResult::Error(MontyException::new(
             ExcType::NameError,
             Some(format!("name '{function_name}' is not defined")),
-        );
-        return Ok(ExtFunctionResult::Error(exc));
-    }
+        ))
+    };
 
-    let callable: Unknown = functions.get_named_property(function_name)?;
+    let Some(lookup) = external_lookup else {
+        return Ok(name_error());
+    };
+    if !lookup.has_own_property(function_name)? {
+        return Ok(name_error());
+    }
+    let callable: Unknown = lookup.get_named_property(function_name)?;
+    if callable.get_type()? != ValueType::Function {
+        return Ok(name_error());
+    }
 
     let mut js_args: Vec<sys::napi_value> = Vec::with_capacity(args.len() + 1);
     for arg in args {
@@ -1705,19 +1713,29 @@ fn extract_js_exception(exception_obj: Object<'_>) -> MontyException {
     MontyException::new(exc_type, msg)
 }
 
-/// Resolves a name lookup against the runtime external functions map.
+/// Resolves a name lookup against the runtime external lookup.
 ///
-/// If the name exists as a property on the external functions object, returns
-/// `NameLookupResult::Value` with a `Function` object. Otherwise returns
-/// `NameLookupResult::Undefined` so the VM raises `NameError`.
-fn resolve_name_lookup(external_functions: Option<&Object<'_>>, name: &str) -> Result<NameLookupResult> {
-    if let Some(functions) = external_functions {
-        if functions.has_named_property(name)? {
-            return Ok(NameLookupResult::Value(MontyObject::Function {
-                name: name.to_string(),
-                docstring: None, // TODO, can we do better?
-            }));
-        }
+/// Only *own* properties resolve, so inherited members (e.g.
+/// `Object.prototype.toString`) never satisfy a name the host did not expose. A
+/// callable becomes a host-function proxy keyed by the lookup *name* (so the
+/// follow-up `FunctionCall` dispatches against the same key); any other value is
+/// converted and returned directly. An absent name (or absent lookup) yields
+/// `Undefined`, so the VM raises `NameError`.
+fn resolve_name_lookup(env: &Env, external_lookup: Option<&Object<'_>>, name: &str) -> Result<NameLookupResult> {
+    let Some(lookup) = external_lookup else {
+        return Ok(NameLookupResult::Undefined);
+    };
+    if !lookup.has_own_property(name)? {
+        return Ok(NameLookupResult::Undefined);
     }
-    Ok(NameLookupResult::Undefined)
+    let value: Unknown = lookup.get_named_property(name)?;
+    let resolved = if value.get_type()? == ValueType::Function {
+        MontyObject::Function {
+            name: name.to_string(),
+            docstring: None, // TODO, can we do better?
+        }
+    } else {
+        js_to_monty(value, *env)?
+    };
+    Ok(NameLookupResult::Value(resolved))
 }

--- a/crates/monty-js/src/monty_cls.rs
+++ b/crates/monty-js/src/monty_cls.rs
@@ -284,9 +284,9 @@ impl Monty {
                             return Ok(Either::A(monty_to_js(&result, env)?));
                         }
                         RunProgress::FunctionCall(call) => {
-                            // Dispatching the call can fail (arg/result conversion,
-                            // a callable-type check). Restore the mount table before
-                            // propagating so the shared slots are not left empty.
+                            // Dispatching the call can fail (arg/result conversion).
+                            // Restore the mount table before propagating so the
+                            // shared slots are not left empty.
                             let return_value = match call_external_function(
                                 env,
                                 external_lookup.as_ref(),
@@ -310,9 +310,8 @@ impl Monty {
                             };
                         }
                         RunProgress::NameLookup(lookup) => {
-                            // Resolving the name can fail (converting a non-callable
-                            // `external_lookup` value). Restore the mount table before
-                            // propagating so the shared slots are not left empty.
+                            // As above: resolution can fail (converting a non-callable
+                            // value), so restore the mount table before propagating.
                             let result = match resolve_name_lookup(env, external_lookup.as_ref(), &lookup.name) {
                                 Ok(r) => r,
                                 Err(err) => {
@@ -1588,9 +1587,10 @@ struct SerializedNameLookupOwned {
 ///
 /// Converts args/kwargs from Monty format, calls the JS function, and converts
 /// the result back to Monty format (or an exception). Only a callable *own*
-/// property is invocable — an absent name, an inherited member (e.g.
-/// `Object.prototype.toString`), or a non-callable value all raise `NameError`,
-/// matching how a `FunctionCall` only ever follows a callable name resolution.
+/// property is invocable: an absent name or an inherited member (e.g.
+/// `Object.prototype.toString`) raises `NameError`, while an own non-callable
+/// entry — a cached function proxy whose entry was later replaced by a plain
+/// value — raises the `TypeError` CPython would for calling that value.
 fn call_external_function(
     env: &Env,
     external_lookup: Option<&Object<'_>>,
@@ -1598,8 +1598,7 @@ fn call_external_function(
     args: &[MontyObject],
     kwargs: &[(MontyObject, MontyObject)],
 ) -> Result<ExtFunctionResult> {
-    // NameError matches Python's behavior for a name that is not a callable
-    // exposed by the lookup.
+    // NameError matches Python's behavior for a name the lookup does not expose.
     let name_error = || {
         ExtFunctionResult::Error(MontyException::new(
             ExcType::NameError,
@@ -1615,7 +1614,13 @@ fn call_external_function(
     }
     let callable: Unknown = lookup.get_named_property(function_name)?;
     if callable.get_type()? != ValueType::Function {
-        return Ok(name_error());
+        // Converting just to name the type is fine on this cold path; values
+        // with no Monty equivalent (symbols etc.) fall back to `object`.
+        let type_name = js_to_monty(callable, *env).map_or("object", |obj| obj.type_name());
+        return Ok(ExtFunctionResult::Error(MontyException::new(
+            ExcType::TypeError,
+            Some(format!("'{type_name}' object is not callable")),
+        )));
     }
 
     let mut js_args: Vec<sys::napi_value> = Vec::with_capacity(args.len() + 1);

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -323,20 +323,26 @@ impl NativeSession {
         })
     }
 
-    /// Answers a `nameLookup` suspension. A name only ever resolves to an
-    /// external *function* (mirroring `pydantic_monty`), so the answer is
-    /// the function's display name — or absent when the name is undefined,
-    /// making the sandbox raise `NameError`.
+    /// Answers a `nameLookup` suspension against `externalLookup`. A callable
+    /// entry resolves to a host function proxy, passed here as its display name
+    /// (`function_name`); any other entry is passed as `value` and converted to
+    /// a wire value returned directly. With both absent the name is undefined
+    /// and the sandbox raises `NameError`. A `value` that cannot cross the wire
+    /// rejects the turn (the worker has not yet observed the name).
     #[napi]
     pub fn resume_name_lookup<'env>(
         &self,
         env: &'env Env,
         function_name: Option<String>,
+        value: Option<Unknown<'env>>,
         on_print: PrintCallback<'env>,
     ) -> Result<PromiseRaw<'env, Object<'env>>> {
-        let value = function_name.map(|name| MontyObject::Function { name, docstring: None });
+        let resolved = match value {
+            Some(value) => Some(name_lookup_value(env, value)?),
+            None => function_name.map(|name| MontyObject::Function { name, docstring: None }),
+        };
         self.run_turn(env, on_print, move |checkout, on_print| {
-            checkout.resume_name_lookup(value, on_print)
+            checkout.resume_name_lookup(resolved, on_print)
         })
     }
 
@@ -742,6 +748,20 @@ fn convert_inputs(env: &Env, inputs: Option<Object<'_>>) -> Result<Vec<(String, 
             }
         })
         .collect()
+}
+
+/// Converts a non-callable `externalLookup` entry into a wire value for a name
+/// lookup, rejecting values the wire cannot carry. Unlike a `resume_return`
+/// value (which becomes a catchable in-sandbox error), the worker has not yet
+/// observed the name, so a bad value fails the turn cleanly — matching the
+/// Python resolver, which surfaces a conversion error rather than `NameError`.
+fn name_lookup_value(env: &Env, value: Unknown<'_>) -> Result<MontyObject> {
+    let obj = js_to_monty(value, *env)?;
+    if exceeds_max_value_depth(&obj) {
+        Err(invalid("Max input depth exceeded"))
+    } else {
+        Ok(obj)
+    }
 }
 
 /// Reads a required field from a JS object argument.

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -35,7 +35,8 @@ use monty_pool::{
 };
 use napi::{
     bindgen_prelude::{
-        block_on, spawn_blocking, Array, Buffer, FnArgs, FromNapiValue, Function, Object, PromiseRaw, Unknown,
+        block_on, spawn_blocking, Array, Buffer, FnArgs, FromNapiValue, Function, JsObjectValue, Object, PromiseRaw,
+        Unknown,
     },
     threadsafe_function::UnknownReturnValue,
     Env, Result,
@@ -325,20 +326,24 @@ impl NativeSession {
 
     /// Answers a `nameLookup` suspension against `externalLookup`. A callable
     /// entry resolves to a host function proxy, passed here as its display name
-    /// (`function_name`); any other entry is passed as `value` and converted to
-    /// a wire value returned directly. With both absent the name is undefined
-    /// and the sandbox raises `NameError`. A `value` that cannot cross the wire
-    /// rejects the turn (the worker has not yet observed the name).
+    /// (`function_name`); any other entry is passed inside the `value` wrapper
+    /// (`{ value: ... }`) and converted to a wire value returned directly. The
+    /// wrapper exists because napi maps a bare JS `null`/`undefined` argument to
+    /// "absent" — without it, an entry whose value *is* `null` would be
+    /// indistinguishable from an undefined name. With both arguments absent the
+    /// name is undefined and the sandbox raises `NameError`. A `value` that
+    /// cannot cross the wire rejects the turn (the worker has not yet observed
+    /// the name).
     #[napi]
     pub fn resume_name_lookup<'env>(
         &self,
         env: &'env Env,
         function_name: Option<String>,
-        value: Option<Unknown<'env>>,
+        value: Option<Object<'env>>,
         on_print: PrintCallback<'env>,
     ) -> Result<PromiseRaw<'env, Object<'env>>> {
         let resolved = match value {
-            Some(value) => Some(name_lookup_value(env, value)?),
+            Some(wrapper) => Some(name_lookup_value(env, &wrapper)?),
             None => function_name.map(|name| MontyObject::Function { name, docstring: None }),
         };
         self.run_turn(env, on_print, move |checkout, on_print| {
@@ -750,12 +755,17 @@ fn convert_inputs(env: &Env, inputs: Option<Object<'_>>) -> Result<Vec<(String, 
         .collect()
 }
 
-/// Converts a non-callable `externalLookup` entry into a wire value for a name
-/// lookup, rejecting values the wire cannot carry. Unlike a `resume_return`
-/// value (which becomes a catchable in-sandbox error), the worker has not yet
+/// Converts a non-callable `externalLookup` entry — carried inside a
+/// `{ value: ... }` wrapper so JS `null`/`undefined` survive napi's
+/// null-means-absent argument mapping — into a wire value for a name lookup,
+/// rejecting values the wire cannot carry. Unlike a `resume_return` value
+/// (which becomes a catchable in-sandbox error), the worker has not yet
 /// observed the name, so a bad value fails the turn cleanly — matching the
 /// Python resolver, which surfaces a conversion error rather than `NameError`.
-fn name_lookup_value(env: &Env, value: Unknown<'_>) -> Result<MontyObject> {
+fn name_lookup_value(env: &Env, wrapper: &Object<'_>) -> Result<MontyObject> {
+    // `get_named_property` (not `get`) so an inner `undefined` still converts
+    // (to `None`) instead of collapsing back to Option::None.
+    let value: Unknown = wrapper.get_named_property("value")?;
     let obj = js_to_monty(value, *env)?;
     if exceeds_max_value_depth(&obj) {
         Err(invalid("Max input depth exceeded"))

--- a/crates/monty-js/ts/errors.ts
+++ b/crates/monty-js/ts/errors.ts
@@ -240,3 +240,39 @@ export function montyErrorFromNative(exc: NativeException): MontySyntaxError | M
   }
   return new MontyRuntimeError(exc.excType, exc.message, exc.frames, exc.traceback)
 }
+
+/**
+ * CPython-style `TypeError` message for calling a non-callable
+ * `externalLookup` entry — reachable when a cached function proxy's entry is
+ * later replaced by a plain value. Mirrors what CPython raises when calling
+ * that value, matching the Python binding (which really calls the entry).
+ */
+export function notCallableMessage(value: unknown): string {
+  return `'${pyTypeName(value)}' object is not callable`
+}
+
+/** Python type name the JS value converts to (mirrors the Rust `js_to_monty`). */
+function pyTypeName(value: unknown): string {
+  if (value === null || value === undefined) {
+    return 'NoneType'
+  }
+  switch (typeof value) {
+    case 'boolean':
+      return 'bool'
+    case 'number':
+      return Number.isInteger(value) ? 'int' : 'float'
+    case 'bigint':
+      return 'int'
+    case 'string':
+      return 'str'
+    case 'object':
+      if (value instanceof Uint8Array) return 'bytes'
+      if (value instanceof Map) return 'dict'
+      if (value instanceof Set) return 'set'
+      if (Array.isArray(value)) return 'list'
+      return 'dict'
+    default:
+      // symbols and other exotic values have no Monty equivalent
+      return 'object'
+  }
+}

--- a/crates/monty-js/ts/session.ts
+++ b/crates/monty-js/ts/session.ts
@@ -376,14 +376,19 @@ export class MontySession {
         case 'nameLookup': {
           // A callable entry resolves to a host function (by display name); any
           // other value is converted and returned directly; an absent name is
-          // left undefined so the sandbox raises NameError.
-          const v = options.externalLookup?.[turn.name]
-          if (v === undefined) {
+          // left undefined so the sandbox raises NameError. Only own keys count
+          // — an inherited member (`toString`, `constructor`, …) must never
+          // satisfy a lookup the host did not deliberately expose.
+          const lookup = options.externalLookup
+          if (lookup === undefined || !Object.prototype.hasOwnProperty.call(lookup, turn.name)) {
             next = this.native.resumeNameLookup(null, null, onPrint)
-          } else if (typeof v === 'function') {
-            next = this.native.resumeNameLookup((v as ExternalFunction).name || '<anonymous>', null, onPrint)
           } else {
-            next = this.native.resumeNameLookup(null, v, onPrint)
+            const v = lookup[turn.name]
+            if (typeof v === 'function') {
+              next = this.native.resumeNameLookup((v as ExternalFunction).name || '<anonymous>', null, onPrint)
+            } else {
+              next = this.native.resumeNameLookup(null, v, onPrint)
+            }
           }
           break
         }
@@ -417,8 +422,13 @@ export class MontySession {
       )
     }
     // Only callable entries are invocable: a non-callable can never have
-    // produced a function proxy, so treat it as "no such function".
-    const entry = externalLookup?.[call.functionName]
+    // produced a function proxy, so treat it as "no such function". Restrict to
+    // own keys so an inherited callable (e.g. `Object.prototype.toString`) can
+    // never be dispatched as a host function.
+    const entry =
+      externalLookup !== undefined && Object.prototype.hasOwnProperty.call(externalLookup, call.functionName)
+        ? externalLookup[call.functionName]
+        : undefined
     if (typeof entry !== 'function') {
       return this.native.resumeNotFound(onPrint)
     }

--- a/crates/monty-js/ts/session.ts
+++ b/crates/monty-js/ts/session.ts
@@ -10,7 +10,14 @@
 // delivered when the worker reports everything is blocked (`resolveFutures`).
 
 import type { NativeSession } from '../index.js'
-import { MontyCrashedError, MontyError, montyErrorFromNative, MontyTypingError, ProtocolError } from './errors.js'
+import {
+  MontyCrashedError,
+  MontyError,
+  montyErrorFromNative,
+  MontyTypingError,
+  notCallableMessage,
+  ProtocolError,
+} from './errors.js'
 import { PYTHON_EXC_NAMES } from './errors.js'
 import { mountsToNative, type MountDir } from './mount.js'
 import type {
@@ -378,7 +385,9 @@ export class MontySession {
           // other value is converted and returned directly; an absent name is
           // left undefined so the sandbox raises NameError. Only own keys count
           // — an inherited member (`toString`, `constructor`, …) must never
-          // satisfy a lookup the host did not deliberately expose.
+          // satisfy a lookup the host did not deliberately expose. The value is
+          // wrapped in `{ value }` so `null`/`undefined` entries resolve to
+          // `None` instead of reading as "no value" through napi.
           const lookup = options.externalLookup
           if (lookup === undefined || !Object.prototype.hasOwnProperty.call(lookup, turn.name)) {
             next = this.native.resumeNameLookup(null, null, onPrint)
@@ -387,7 +396,7 @@ export class MontySession {
             if (typeof v === 'function') {
               next = this.native.resumeNameLookup((v as ExternalFunction).name || '<anonymous>', null, onPrint)
             } else {
-              next = this.native.resumeNameLookup(null, v, onPrint)
+              next = this.native.resumeNameLookup(null, { value: v }, onPrint)
             }
           }
           break
@@ -421,16 +430,17 @@ export class MontySession {
         onPrint,
       )
     }
-    // Only callable entries are invocable: a non-callable can never have
-    // produced a function proxy, so treat it as "no such function". Restrict to
-    // own keys so an inherited callable (e.g. `Object.prototype.toString`) can
-    // never be dispatched as a host function.
-    const entry =
-      externalLookup !== undefined && Object.prototype.hasOwnProperty.call(externalLookup, call.functionName)
-        ? externalLookup[call.functionName]
-        : undefined
-    if (typeof entry !== 'function') {
+    // Own keys only, as in the nameLookup branch: an inherited callable (e.g.
+    // `Object.prototype.toString`) must never be dispatched as a host function.
+    if (externalLookup === undefined || !Object.prototype.hasOwnProperty.call(externalLookup, call.functionName)) {
       return this.native.resumeNotFound(onPrint)
+    }
+    const entry = externalLookup[call.functionName]
+    if (typeof entry !== 'function') {
+      // A cached function proxy whose entry was later replaced by a plain
+      // value: raise what CPython would for calling that value, matching the
+      // Python binding (which really calls the entry).
+      return this.native.resumeError('TypeError', notCallableMessage(entry), onPrint)
     }
     const fn = entry as ExternalFunction
     let returned: unknown

--- a/crates/monty-js/ts/session.ts
+++ b/crates/monty-js/ts/session.ts
@@ -47,8 +47,16 @@ export type PrintCallback = (stream: 'stdout' | 'stderr', text: string) => void
 export interface FeedOptions {
   /** Values bound as globals before the snippet runs. */
   inputs?: Record<string, unknown>
-  /** Host functions the sandbox may call by name. */
-  externalFunctions?: Record<string, ExternalFunction>
+  /**
+   * Host values the sandbox may reference by an otherwise-undefined name,
+   * resolved lazily on demand: a function entry becomes a host function the
+   * sandbox can call (sync or async), any other value is converted and
+   * returned directly when the name is read, and an absent name raises
+   * `NameError`. The lazy counterpart to `inputs`, which eagerly binds every
+   * entry as a global whether or not it is referenced; a name in both is
+   * served by the eager `inputs` binding.
+   */
+  externalLookup?: Record<string, unknown>
   /** Receives `print()` output; defaults to the host process stdout/stderr. */
   printCallback?: PrintCallback
   /** Host directories mounted into the sandbox for this feed. */
@@ -61,7 +69,7 @@ export interface FeedOptions {
 
 /**
  * Options for [`MontySession.feedStart`]. Like [`FeedOptions`] without
- * `externalFunctions` — `feedStart` surfaces external calls as snapshots
+ * `externalLookup` — `feedStart` surfaces external calls as snapshots
  * instead of dispatching them.
  */
 export interface FeedStartOptions {
@@ -174,7 +182,7 @@ export class MontySession {
    * snapshot at each external call, OS call, name lookup, or future
    * resolution. Answer it with `snapshot.resume(...)`, which resolves to the
    * next snapshot or a `MontyComplete`. Unlike `feedRun` there is no
-   * `externalFunctions` option — surfacing those calls is the point — but an
+   * `externalLookup` option — surfacing those calls is the point — but an
    * `os` handler still auto-dispatches uncovered OS calls until the next
    * non-OS event. Use `snapshot.dump()` to checkpoint the worker and
    * `loadSnapshot` to restore it.
@@ -360,14 +368,23 @@ export class MontySession {
     try {
       switch (turn.kind) {
         case 'functionCall':
-          next = this.answerFunctionCall(turn, options.externalFunctions, onPrint)
+          next = this.answerFunctionCall(turn, options.externalLookup, onPrint)
           break
         case 'osCall':
           next = this.answerOsCall(turn, options.os, onPrint)
           break
         case 'nameLookup': {
-          const fn = options.externalFunctions?.[turn.name]
-          next = this.native.resumeNameLookup(fn === undefined ? null : fn.name || '<anonymous>', onPrint)
+          // A callable entry resolves to a host function (by display name); any
+          // other value is converted and returned directly; an absent name is
+          // left undefined so the sandbox raises NameError.
+          const v = options.externalLookup?.[turn.name]
+          if (v === undefined) {
+            next = this.native.resumeNameLookup(null, null, onPrint)
+          } else if (typeof v === 'function') {
+            next = this.native.resumeNameLookup((v as ExternalFunction).name || '<anonymous>', null, onPrint)
+          } else {
+            next = this.native.resumeNameLookup(null, v, onPrint)
+          }
           break
         }
         case 'resolveFutures':
@@ -387,7 +404,7 @@ export class MontySession {
   /** Calls the matching external function and resumes with its result. */
   private answerFunctionCall(
     call: FunctionCallTurn,
-    externalFunctions: Record<string, ExternalFunction> | undefined,
+    externalLookup: Record<string, unknown> | undefined,
     onPrint: PrintCallback,
   ): Promise<object> {
     if (call.methodCall) {
@@ -399,10 +416,13 @@ export class MontySession {
         onPrint,
       )
     }
-    const fn = externalFunctions?.[call.functionName]
-    if (fn === undefined) {
+    // Only callable entries are invocable: a non-callable can never have
+    // produced a function proxy, so treat it as "no such function".
+    const entry = externalLookup?.[call.functionName]
+    if (typeof entry !== 'function') {
       return this.native.resumeNotFound(onPrint)
     }
+    const fn = entry as ExternalFunction
     let returned: unknown
     try {
       returned = fn(...(buildCallArgs(call) as never[]))
@@ -637,7 +657,8 @@ class SnapshotDriver {
   }
 
   async resumeNameLookup(functionName: string | null): Promise<Snapshot> {
-    return this.advance((await this.native.resumeNameLookup(functionName, this.onPrint)) as NativeTurn)
+    // feedStart name-lookup snapshots only resolve to functions (by name).
+    return this.advance((await this.native.resumeNameLookup(functionName, null, this.onPrint)) as NativeTurn)
   }
 
   async resolveFutures(results: NativeFutureResult[]): Promise<Snapshot> {

--- a/crates/monty-js/ts/wasm.ts
+++ b/crates/monty-js/ts/wasm.ts
@@ -621,8 +621,12 @@ export class MontyComplete {
 export interface RunMontyAsyncOptions {
   /** Input values for the script. */
   inputs?: Record<string, JsMontyObject>
-  /** External function implementations (sync or async). */
-  externalFunctions?: Record<string, (...args: unknown[]) => unknown>
+  /**
+   * Lazy resolution for names the code leaves undefined. A callable (sync or
+   * async) resolves to a host function; any other value is returned directly on
+   * a bare-name read; an absent name raises `NameError`.
+   */
+  externalLookup?: Record<string, unknown>
   /** Resource limits. */
   limits?: ResourceLimits
   /** Callback invoked on each print() call. The first argument is the stream name (always "stdout"), the second is the printed text. */
@@ -632,11 +636,12 @@ export interface RunMontyAsyncOptions {
 }
 
 /**
- * Runs a Monty script with async external function support.
+ * Runs a Monty script with async external-lookup support.
  *
- * This function handles both synchronous and asynchronous external functions.
- * When an external function returns a Promise, it will be awaited before
- * resuming execution.
+ * Resolves undefined names against `externalLookup`: a callable (sync or async)
+ * resolves to a host function whose call is dispatched here (a returned Promise
+ * is awaited before resuming); any other value is returned directly on a
+ * bare-name read; an absent name raises `NameError`.
  *
  * @param montyRunner - The Monty runner instance to execute
  * @param options - Execution options
@@ -651,7 +656,7 @@ export interface RunMontyAsyncOptions {
  *
  * const result = await runMontyAsync(m, {
  *   inputs: { url: 'https://example.com' },
- *   externalFunctions: {
+ *   externalLookup: {
  *     fetch_data: async (url) => {
  *       const response = await fetch(url);
  *       return response.text();
@@ -660,7 +665,11 @@ export interface RunMontyAsyncOptions {
  * });
  */
 export async function runMontyAsync(montyRunner: Monty, options: RunMontyAsyncOptions = {}): Promise<JsMontyObject> {
-  const { inputs, externalFunctions = {}, limits, printCallback, mount } = options
+  const { inputs, externalLookup = {}, limits, printCallback, mount } = options
+
+  // Only own keys resolve a name — an inherited member (`toString`,
+  // `constructor`, …) must never satisfy a lookup the host did not expose.
+  const hasOwn = (name: string): boolean => Object.prototype.hasOwnProperty.call(externalLookup, name)
 
   let progress: MontySnapshot | MontyNameLookup | MontyComplete = montyRunner.start({
     inputs,
@@ -671,12 +680,11 @@ export async function runMontyAsync(montyRunner: Monty, options: RunMontyAsyncOp
 
   while (!(progress instanceof MontyComplete)) {
     if (progress instanceof MontyNameLookup) {
-      // Name lookup — check if the name is a known external function
+      // Name lookup — a callable resolves to a host function proxy, any other
+      // own value is returned directly, and an absent name raises NameError.
       const name = progress.variableName
-      const extFunction = externalFunctions[name]
-      if (extFunction) {
-        // Resolve the name as a function value
-        progress = progress.resume({ value: extFunction })
+      if (hasOwn(name)) {
+        progress = progress.resume({ value: externalLookup[name] })
       } else {
         // Unknown name — resume with no value to raise NameError
         progress = progress.resume()
@@ -684,13 +692,14 @@ export async function runMontyAsync(montyRunner: Monty, options: RunMontyAsyncOp
       continue
     }
 
-    // MontySnapshot — external function call
+    // MontySnapshot — external function call. Only an own callable is
+    // invocable; anything else is treated as "no such function".
     const snapshot = progress
     const funcName = snapshot.functionName
-    const extFunction = externalFunctions[funcName]
+    const extFunction = hasOwn(funcName) ? externalLookup[funcName] : undefined
 
-    if (!extFunction) {
-      // Function not found — this shouldn't normally happen since NameLookup
+    if (typeof extFunction !== 'function') {
+      // Not a callable — this shouldn't normally happen since NameLookup
       // would have raised NameError, but handle it defensively
       progress = snapshot.resume({
         exception: {
@@ -703,7 +712,7 @@ export async function runMontyAsync(montyRunner: Monty, options: RunMontyAsyncOp
 
     try {
       // Call the external function
-      let result = extFunction(...snapshot.args, snapshot.kwargs)
+      let result = (extFunction as (...args: unknown[]) => unknown)(...snapshot.args, snapshot.kwargs)
 
       // If the result is a Promise, await it
       if (result && typeof (result as Promise<unknown>).then === 'function') {

--- a/crates/monty-js/ts/wasm.ts
+++ b/crates/monty-js/ts/wasm.ts
@@ -31,6 +31,7 @@ import {
   MontyException as NativeMontyException,
   MontyTypingError as NativeMontyTypingError,
 } from '../index.js'
+import { notCallableMessage } from './errors.js'
 
 export type {
   MontyOptions,
@@ -684,7 +685,10 @@ export async function runMontyAsync(montyRunner: Monty, options: RunMontyAsyncOp
       // own value is returned directly, and an absent name raises NameError.
       const name = progress.variableName
       if (hasOwn(name)) {
-        progress = progress.resume({ value: externalLookup[name] })
+        // `resume({ value: undefined })` means "unresolved" in the snapshot
+        // API, so an entry that *is* undefined crosses as null (Python None).
+        const v = externalLookup[name]
+        progress = progress.resume({ value: v === undefined ? null : v })
       } else {
         // Unknown name — resume with no value to raise NameError
         progress = progress.resume()
@@ -693,18 +697,28 @@ export async function runMontyAsync(montyRunner: Monty, options: RunMontyAsyncOp
     }
 
     // MontySnapshot — external function call. Only an own callable is
-    // invocable; anything else is treated as "no such function".
+    // invocable; these branches shouldn't normally fire (NameLookup already
+    // filtered), but the host can mutate `externalLookup` mid-run.
     const snapshot = progress
     const funcName = snapshot.functionName
-    const extFunction = hasOwn(funcName) ? externalLookup[funcName] : undefined
 
-    if (typeof extFunction !== 'function') {
-      // Not a callable — this shouldn't normally happen since NameLookup
-      // would have raised NameError, but handle it defensively
+    if (!hasOwn(funcName)) {
       progress = snapshot.resume({
         exception: {
           type: 'NameError',
           message: `name '${funcName}' is not defined`,
+        },
+      })
+      continue
+    }
+    const extFunction = externalLookup[funcName]
+    if (typeof extFunction !== 'function') {
+      // A function proxy whose entry was replaced by a plain value: raise what
+      // CPython would for calling that value.
+      progress = snapshot.resume({
+        exception: {
+          type: 'TypeError',
+          message: notCallableMessage(extFunction),
         },
       })
       continue

--- a/crates/monty-python/README.md
+++ b/crates/monty-python/README.md
@@ -65,7 +65,7 @@ async def main():
         async with pool.checkout() as session:
             result = await session.feed_run(
                 "await fetch('https://example.com')",
-                external_functions={'fetch': fetch},
+                external_lookup={'fetch': fetch},
             )
     print(result)
     #> contents of https://example.com
@@ -74,7 +74,7 @@ async def main():
 asyncio.run(main())
 ```
 
-### Input variables and external functions
+### Input variables and external lookup
 
 ```python
 from pydantic_monty import Monty
@@ -84,7 +84,7 @@ with Monty() as pool:
         result = session.feed_run(
             'double(x) + y',
             inputs={'x': 5, 'y': 1},
-            external_functions={'double': lambda x: x * 2},
+            external_lookup={'double': lambda x: x * 2},
         )
     print(result)
     #> 11

--- a/crates/monty-python/example.py
+++ b/crates/monty-python/example.py
@@ -22,7 +22,7 @@ with pydantic_monty.Monty() as pool:
         return f'Fetched: {url}'
 
     with pool.checkout() as session:
-        result = session.feed_run('fetch("https://example.com")', external_functions={'fetch': fetch})
+        result = session.feed_run('fetch("https://example.com")', external_lookup={'fetch': fetch})
         print(f'External: {result}')
 
     # Print output is forwarded to Python stdout

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -348,7 +348,7 @@ class MontySession:
         code: str,
         *,
         inputs: dict[str, Any] | None = None,
-        external_functions: dict[str, Callable[..., Any]] | None = None,
+        external_lookup: dict[str, Any] | None = None,
         print_callback: Callable[[Literal['stdout', 'stderr'], str], None]
         | CollectStreams
         | CollectString
@@ -364,6 +364,14 @@ class MontySession:
         runs; external functions, the `os` fallback, and print callbacks are
         invoked in this process. Async external functions are not supported
         here — use `AsyncMonty`.
+
+        `external_lookup` resolves names the snippet leaves undefined, lazily and
+        on demand: a callable entry becomes a host function the sandbox can call
+        (as before), any other value is converted and returned directly when the
+        name is read, and an absent name raises `NameError`. This is the lazy
+        counterpart to `inputs`, which eagerly binds every entry as a global at
+        feed start whether or not it is referenced; a name present in both is
+        served by the eager `inputs` binding.
 
         Mounts are handled inside the worker process: `'overlay'` writes live
         in the worker and are discarded when the feed ends.
@@ -391,7 +399,7 @@ class MontySession:
 
         Answer the snapshot with `snapshot.resume(...)`, which returns the next
         snapshot or a `MontyComplete`. Unlike `feed_run` there is no
-        `external_functions` argument — surfacing those calls is the point. An
+        `external_lookup` argument — surfacing those calls is the point. An
         `os=` handler still auto-dispatches uncovered OS calls until the next
         non-OS event. Mounts are fixed for the whole feed (there is no `mount=`
         on `resume`).
@@ -608,7 +616,7 @@ class AsyncMontySession:
         code: str,
         *,
         inputs: dict[str, Any] | None = None,
-        external_functions: dict[str, Callable[..., Any]] | None = None,
+        external_lookup: dict[str, Any] | None = None,
         print_callback: Callable[[Literal['stdout', 'stderr'], str], None]
         | CollectStreams
         | CollectString
@@ -620,9 +628,10 @@ class AsyncMontySession:
         """
         Execute one snippet in the worker and return its result.
 
-        Worker I/O runs off the event loop; external functions may be
-        coroutines, awaited concurrently. See `MontySession.feed_run` for the
-        shared semantics (mounts, error types).
+        Worker I/O runs off the event loop; external functions (the callable
+        entries in `external_lookup`) may be coroutines, awaited concurrently.
+        See `MontySession.feed_run` for the shared semantics (`external_lookup`,
+        mounts, error types).
         """
 
     async def feed_start(

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -365,16 +365,29 @@ class MontySession:
         invoked in this process. Async external functions are not supported
         here — use `AsyncMonty`.
 
-        `external_lookup` resolves names the snippet leaves undefined, lazily and
-        on demand: a callable entry becomes a host function the sandbox can call
-        (as before), any other value is converted and returned directly when the
-        name is read, and an absent name raises `NameError`. This is the lazy
-        counterpart to `inputs`, which eagerly binds every entry as a global at
-        feed start whether or not it is referenced; a name present in both is
-        served by the eager `inputs` binding.
-
-        Mounts are handled inside the worker process: `'overlay'` writes live
-        in the worker and are discarded when the feed ends.
+        Arguments:
+            code: The Python snippet to execute; its trailing expression value
+                (if any) is converted to a Python object and returned.
+            inputs: Values eagerly bound as globals before the snippet runs —
+                every entry is converted and bound once, whether or not it is
+                referenced.
+            external_lookup: Host values resolving names the snippet leaves
+                undefined, lazily and on demand: a callable entry becomes a host
+                function the sandbox can call, any other value is converted and
+                returned directly when the name is read, and an absent name
+                raises `NameError`. The lazy counterpart to `inputs`; a name
+                present in both is served by the eager `inputs` binding.
+            print_callback: Receives the sandbox's `print()` output as
+                `(stream, text)`, or a `CollectStreams` / `CollectString`
+                collector. Defaults to the host process stdout/stderr.
+            mount: Host directories mounted into the sandbox for this feed.
+                Handled inside the worker — `'overlay'` writes live in the
+                worker and are discarded when the feed ends.
+            os: Fallback handler for OS calls (e.g. filesystem access) not
+                covered by a mount, invoked as `(function_name, args, kwargs)`,
+                or an `AbstractOS` instance.
+            skip_type_check: Skip type checking for this feed even when the
+                session was checked out with `type_check=True`.
 
         Raises:
             MontyRuntimeError: The code raised an exception (session survives).
@@ -399,13 +412,29 @@ class MontySession:
 
         Answer the snapshot with `snapshot.resume(...)`, which returns the next
         snapshot or a `MontyComplete`. Unlike `feed_run` there is no
-        `external_lookup` argument — surfacing those calls is the point. An
-        `os=` handler still auto-dispatches uncovered OS calls until the next
-        non-OS event. Mounts are fixed for the whole feed (there is no `mount=`
-        on `resume`).
+        `external_lookup` argument — surfacing those calls is the point.
 
         Use `snapshot.dump()` to checkpoint the worker mid-execution and
         `load_snapshot` to restore it.
+
+        Arguments:
+            code: The Python snippet to execute; its trailing expression value
+                (if any) is the `MontyComplete.output` when the feed completes.
+            inputs: Values eagerly bound as globals before the snippet runs —
+                every entry is converted and bound once, whether or not it is
+                referenced.
+            print_callback: Receives the sandbox's `print()` output as
+                `(stream, text)`, or a `CollectStreams` / `CollectString`
+                collector. Defaults to the host process stdout/stderr.
+            mount: Host directories mounted into the sandbox for the whole feed
+                (there is no `mount=` on `resume`). `'overlay'` writes live in
+                the worker and are discarded when the feed ends.
+            os: Fallback handler for OS calls not covered by a mount, invoked as
+                `(function_name, args, kwargs)`, or an `AbstractOS` instance. It
+                auto-dispatches uncovered OS calls until the next non-OS event;
+                omit it to surface OS calls as snapshots instead.
+            skip_type_check: Skip type checking for this feed even when the
+                session was checked out with `type_check=True`.
         """
 
     def load(self, state: bytes) -> None:
@@ -630,8 +659,32 @@ class AsyncMontySession:
 
         Worker I/O runs off the event loop; external functions (the callable
         entries in `external_lookup`) may be coroutines, awaited concurrently.
-        See `MontySession.feed_run` for the shared semantics (`external_lookup`,
-        mounts, error types).
+        See `MontySession.feed_run` for the shared error types.
+
+        Arguments:
+            code: The Python snippet to execute; its trailing expression value
+                (if any) is converted to a Python object and returned.
+            inputs: Values eagerly bound as globals before the snippet runs —
+                every entry is converted and bound once, whether or not it is
+                referenced.
+            external_lookup: Host values resolving names the snippet leaves
+                undefined, lazily and on demand: a callable entry (sync or a
+                coroutine function) becomes a host function the sandbox can call,
+                any other value is converted and returned directly when the name
+                is read, and an absent name raises `NameError`. The lazy
+                counterpart to `inputs`; a name present in both is served by the
+                eager `inputs` binding.
+            print_callback: Receives the sandbox's `print()` output as
+                `(stream, text)`, or a `CollectStreams` / `CollectString`
+                collector. Defaults to the host process stdout/stderr.
+            mount: Host directories mounted into the sandbox for this feed.
+                Handled inside the worker — `'overlay'` writes live in the
+                worker and are discarded when the feed ends.
+            os: Fallback handler for OS calls (e.g. filesystem access) not
+                covered by a mount, invoked as `(function_name, args, kwargs)`,
+                or an `AbstractOS` instance.
+            skip_type_check: Skip type checking for this feed even when the
+                session was checked out with `type_check=True`.
         """
 
     async def feed_start(
@@ -647,6 +700,25 @@ class AsyncMontySession:
         """
         Async counterpart of `MontySession.feed_start`: resolves to a snapshot
         (whose `resume(...)` is awaitable) or a `MontyComplete`.
+
+        Arguments:
+            code: The Python snippet to execute; its trailing expression value
+                (if any) is the `MontyComplete.output` when the feed completes.
+            inputs: Values eagerly bound as globals before the snippet runs —
+                every entry is converted and bound once, whether or not it is
+                referenced.
+            print_callback: Receives the sandbox's `print()` output as
+                `(stream, text)`, or a `CollectStreams` / `CollectString`
+                collector. Defaults to the host process stdout/stderr.
+            mount: Host directories mounted into the sandbox for the whole feed
+                (there is no `mount=` on `resume`). `'overlay'` writes live in
+                the worker and are discarded when the feed ends.
+            os: Fallback handler for OS calls not covered by a mount, invoked as
+                `(function_name, args, kwargs)`, or an `AbstractOS` instance. It
+                auto-dispatches uncovered OS calls until the next non-OS event;
+                omit it to surface OS calls as snapshots instead.
+            skip_type_check: Skip type checking for this feed even when the
+                session was checked out with `type_check=True`.
         """
 
     async def load(self, state: bytes) -> None:

--- a/crates/monty-python/src/async_dispatch.rs
+++ b/crates/monty-python/src/async_dispatch.rs
@@ -13,8 +13,7 @@ use tokio::task::{JoinError, JoinSet};
 use crate::{
     dataclass::DcRegistry,
     external::{
-        CallResult, ExternalFunctionRegistry, dispatch_method_call_or_coroutine, py_err_to_ext_result,
-        py_obj_to_ext_result,
+        CallResult, ExternalLookup, dispatch_method_call_or_coroutine, py_err_to_ext_result, py_obj_to_ext_result,
     },
 };
 
@@ -32,12 +31,12 @@ pub(crate) fn dispatch_function_call(
     Python::attach(|py| {
         if method_call {
             dispatch_method_call_or_coroutine(py, function_name, args, kwargs, dc_registry)
-        } else if let Some(lookup) = external_lookup {
-            let lookup = lookup.bind(py);
-            let registry = ExternalFunctionRegistry::new(py, lookup, dc_registry);
-            registry.call_or_coroutine(function_name, args, kwargs)
         } else {
-            CallResult::Sync(ExtFunctionResult::NotFound(function_name.to_owned()))
+            ExternalLookup::new(py, external_lookup.map(|d| d.bind(py)), dc_registry).call_or_coroutine(
+                function_name,
+                args,
+                kwargs,
+            )
         }
     })
 }

--- a/crates/monty-python/src/async_dispatch.rs
+++ b/crates/monty-python/src/async_dispatch.rs
@@ -26,15 +26,15 @@ pub(crate) fn dispatch_function_call(
     method_call: bool,
     args: &[MontyObject],
     kwargs: &[(MontyObject, MontyObject)],
-    external_functions: Option<&Py<PyDict>>,
+    external_lookup: Option<&Py<PyDict>>,
     dc_registry: &DcRegistry,
 ) -> CallResult {
     Python::attach(|py| {
         if method_call {
             dispatch_method_call_or_coroutine(py, function_name, args, kwargs, dc_registry)
-        } else if let Some(ext_fns) = external_functions {
-            let ext_fns = ext_fns.bind(py);
-            let registry = ExternalFunctionRegistry::new(py, ext_fns, dc_registry);
+        } else if let Some(lookup) = external_lookup {
+            let lookup = lookup.bind(py);
+            let registry = ExternalFunctionRegistry::new(py, lookup, dc_registry);
             registry.call_or_coroutine(function_name, args, kwargs)
         } else {
             CallResult::Sync(ExtFunctionResult::NotFound(function_name.to_owned()))

--- a/crates/monty-python/src/external.rs
+++ b/crates/monty-python/src/external.rs
@@ -76,9 +76,11 @@ fn dispatch_method_call_inner(
     py_to_monty(&result, dc_registry, 0)
 }
 
-/// Maps external function names to Python callables, dispatching calls when
-/// Monty pauses at an external function. Dataclass types in return values are
-/// auto-registered into `dc_registry` transparently.
+/// Dispatches a `FunctionCall` against the session's `external_lookup` dict
+/// when Monty pauses at an external function. Only *callable* entries are ever
+/// invoked here — a name reaches a `FunctionCall` only after resolving to a
+/// function proxy, so non-callable entries never arrive. Dataclass types in
+/// return values are auto-registered into `dc_registry` transparently.
 pub struct ExternalFunctionRegistry<'a, 'py> {
     py: Python<'py>,
     functions: &'py Bound<'py, PyDict>,
@@ -86,7 +88,8 @@ pub struct ExternalFunctionRegistry<'a, 'py> {
 }
 
 impl<'a, 'py> ExternalFunctionRegistry<'a, 'py> {
-    /// Creates a new registry from a Python dict of `name -> callable`.
+    /// Creates a new registry over the `external_lookup` dict (`name -> value`);
+    /// only callable entries are invoked by [`call`](Self::call).
     pub fn new(py: Python<'py>, functions: &'py Bound<'py, PyDict>, dc_registry: &'a DcRegistry) -> Self {
         Self {
             py,

--- a/crates/monty-python/src/external.rs
+++ b/crates/monty-python/src/external.rs
@@ -15,7 +15,7 @@ use pyo3::{
 };
 
 use crate::{
-    convert::{get_docstring, monty_to_py, py_to_monty, py_to_monty_value},
+    convert::{monty_to_py, py_to_monty, py_to_monty_value},
     dataclass::DcRegistry,
     exceptions::{exc_monty_to_py, exc_py_to_monty},
 };
@@ -113,25 +113,34 @@ impl<'a, 'py> ExternalLookup<'a, 'py> {
         }
     }
 
-    /// Resolves a bare-name lookup (a `NameLookup` event): a callable entry
+    /// Resolves a bare-name lookup (a `NameLookup` event): a plain callable
     /// becomes a lazy host function proxy (`MontyObject::Function`, invoked on
-    /// the eventual `FunctionCall`), any other value is converted and returned
-    /// directly, and an absent name (or absent dict) yields `None` → the sandbox
-    /// raises `NameError`.
+    /// the eventual `FunctionCall`), any other value — including a type object
+    /// Monty models, which is technically callable but must round-trip as a
+    /// `MontyObject::Type` rather than degrade to a proxy — is converted and
+    /// returned directly, and an absent name (or absent dict) yields `None` →
+    /// the sandbox raises `NameError`.
+    ///
+    /// Conversion is delegated to [`py_to_monty_value`] so the callable-vs-type
+    /// ordering lives in one place; a resulting function proxy is renamed to the
+    /// lookup *key* (not the callable's `__name__`) so the follow-up
+    /// `FunctionCall` resolves against the same dict key in [`call`](Self::call).
     ///
     /// A non-callable value that cannot be converted surfaces as a `PyErr`
     /// rather than masquerading as `NameError`, so callers `?` it.
     pub fn resolve_name(&self, name: &str) -> PyResult<Option<MontyObject>> {
-        let Some(value) = self.lookup.and_then(|d| d.get_item(name).ok().flatten()) else {
+        let Some(lookup) = self.lookup else {
             return Ok(None);
         };
-        let obj = if value.is_callable() {
-            MontyObject::Function {
+        let Some(value) = lookup.get_item(name)? else {
+            return Ok(None);
+        };
+        let obj = match py_to_monty_value(&value, self.dc_registry).map_err(|exc| exc_monty_to_py(self.py, exc))? {
+            MontyObject::Function { docstring, .. } => MontyObject::Function {
                 name: name.to_owned(),
-                docstring: get_docstring(&value),
-            }
-        } else {
-            py_to_monty_value(&value, self.dc_registry).map_err(|exc| exc_monty_to_py(self.py, exc))?
+                docstring,
+            },
+            other => other,
         };
         Ok(Some(obj))
     }

--- a/crates/monty-python/src/external.rs
+++ b/crates/monty-python/src/external.rs
@@ -79,23 +79,15 @@ fn dispatch_method_call_inner(
     py_to_monty(&result, dc_registry, 0)
 }
 
-/// The session's `external_lookup` dict (`name -> value`) plus the machinery to
-/// resolve names against it. Bundles the `Python` token, the dict (absent when
-/// the caller passed none), and the dataclass registry — the three things every
-/// lookup needs — so both halves of the lazy-resolution protocol live together:
-///
-/// - [`resolve_name`](Self::resolve_name) answers a `NameLookup` (the first
-///   reference to an undefined name): a callable entry becomes a host function
-///   proxy, any other value is converted and returned directly, an absent name
-///   (or absent dict) yields `None` → the sandbox raises `NameError`.
-/// - [`call`](Self::call) / [`call_or_coroutine`](Self::call_or_coroutine)
-///   answer the follow-up `FunctionCall` by invoking the callable. Only
-///   callable entries ever reach here — a `FunctionCall` happens only after
-///   `resolve_name` handed back a function proxy — so a non-callable entry can
-///   never be called.
-///
-/// Dataclass types in return values are auto-registered into `dc_registry`
-/// transparently.
+/// The session's `external_lookup` dict (`name -> value`, absent when the
+/// caller passed none) plus the `Python` token and dataclass registry every
+/// resolution needs. Owns both halves of the lazy-resolution protocol:
+/// [`resolve_name`](Self::resolve_name) answers a `NameLookup`, and
+/// [`call`](Self::call) / [`call_or_coroutine`](Self::call_or_coroutine)
+/// answer the follow-up `FunctionCall` by invoking the current dict entry —
+/// which may have been replaced since it resolved, so calling a now
+/// non-callable entry raises `TypeError` exactly as CPython would. Dataclass
+/// types in return values are auto-registered into `dc_registry` transparently.
 pub struct ExternalLookup<'a, 'py> {
     py: Python<'py>,
     lookup: Option<&'py Bound<'py, PyDict>>,
@@ -114,20 +106,15 @@ impl<'a, 'py> ExternalLookup<'a, 'py> {
     }
 
     /// Resolves a bare-name lookup (a `NameLookup` event): a plain callable
-    /// becomes a lazy host function proxy (`MontyObject::Function`, invoked on
-    /// the eventual `FunctionCall`), any other value — including a type object
-    /// Monty models, which is technically callable but must round-trip as a
-    /// `MontyObject::Type` rather than degrade to a proxy — is converted and
-    /// returned directly, and an absent name (or absent dict) yields `None` →
-    /// the sandbox raises `NameError`.
+    /// becomes a host function proxy invoked on the eventual `FunctionCall`,
+    /// any other value is converted and returned directly, and an absent name
+    /// (or absent dict) yields `None` → the sandbox raises `NameError`.
     ///
-    /// Conversion is delegated to [`py_to_monty_value`] so the callable-vs-type
-    /// ordering lives in one place; a resulting function proxy is renamed to the
-    /// lookup *key* (not the callable's `__name__`) so the follow-up
-    /// `FunctionCall` resolves against the same dict key in [`call`](Self::call).
-    ///
-    /// A non-callable value that cannot be converted surfaces as a `PyErr`
-    /// rather than masquerading as `NameError`, so callers `?` it.
+    /// [`py_to_monty_value`] decides callable-vs-other (notably a type object
+    /// Monty models converts to `MontyObject::Type`, not a proxy); a function
+    /// proxy is renamed to the lookup *key* (not the callable's `__name__`) so
+    /// the `FunctionCall` hits the same dict entry. An unconvertible value
+    /// surfaces as a `PyErr` rather than masquerading as `NameError`.
     pub fn resolve_name(&self, name: &str) -> PyResult<Option<MontyObject>> {
         let Some(lookup) = self.lookup else {
             return Ok(None);

--- a/crates/monty-python/src/external.rs
+++ b/crates/monty-python/src/external.rs
@@ -1,8 +1,11 @@
-//! External function callback support.
+//! Resolving names a sandbox snippet leaves undefined against the session's
+//! `external_lookup` dict, plus dataclass method dispatch.
 //!
-//! Allows Python code running in Monty to call back to host Python functions.
-//! External functions are registered by name and called when Monty execution
-//! reaches a call to that function.
+//! [`ExternalLookup`] owns both halves of the lazy-resolution protocol — the
+//! `NameLookup` that resolves a bare name and the `FunctionCall` that invokes a
+//! resolved host function — so the callable-vs-value rule linking them lives in
+//! one place. Dataclass method calls (`dispatch_method_call*`) are a separate
+//! concern: they consult the dataclass instance, not `external_lookup`.
 
 use ::monty::{ExtFunctionResult, MontyObject};
 use pyo3::{
@@ -12,9 +15,9 @@ use pyo3::{
 };
 
 use crate::{
-    convert::{monty_to_py, py_to_monty, py_to_monty_value},
+    convert::{get_docstring, monty_to_py, py_to_monty, py_to_monty_value},
     dataclass::DcRegistry,
-    exceptions::exc_py_to_monty,
+    exceptions::{exc_monty_to_py, exc_py_to_monty},
 };
 
 /// Dispatches a dataclass method call back to the original Python object.
@@ -76,26 +79,61 @@ fn dispatch_method_call_inner(
     py_to_monty(&result, dc_registry, 0)
 }
 
-/// Dispatches a `FunctionCall` against the session's `external_lookup` dict
-/// when Monty pauses at an external function. Only *callable* entries are ever
-/// invoked here — a name reaches a `FunctionCall` only after resolving to a
-/// function proxy, so non-callable entries never arrive. Dataclass types in
-/// return values are auto-registered into `dc_registry` transparently.
-pub struct ExternalFunctionRegistry<'a, 'py> {
+/// The session's `external_lookup` dict (`name -> value`) plus the machinery to
+/// resolve names against it. Bundles the `Python` token, the dict (absent when
+/// the caller passed none), and the dataclass registry — the three things every
+/// lookup needs — so both halves of the lazy-resolution protocol live together:
+///
+/// - [`resolve_name`](Self::resolve_name) answers a `NameLookup` (the first
+///   reference to an undefined name): a callable entry becomes a host function
+///   proxy, any other value is converted and returned directly, an absent name
+///   (or absent dict) yields `None` → the sandbox raises `NameError`.
+/// - [`call`](Self::call) / [`call_or_coroutine`](Self::call_or_coroutine)
+///   answer the follow-up `FunctionCall` by invoking the callable. Only
+///   callable entries ever reach here — a `FunctionCall` happens only after
+///   `resolve_name` handed back a function proxy — so a non-callable entry can
+///   never be called.
+///
+/// Dataclass types in return values are auto-registered into `dc_registry`
+/// transparently.
+pub struct ExternalLookup<'a, 'py> {
     py: Python<'py>,
-    functions: &'py Bound<'py, PyDict>,
+    lookup: Option<&'py Bound<'py, PyDict>>,
     dc_registry: &'a DcRegistry,
 }
 
-impl<'a, 'py> ExternalFunctionRegistry<'a, 'py> {
-    /// Creates a new registry over the `external_lookup` dict (`name -> value`);
-    /// only callable entries are invoked by [`call`](Self::call).
-    pub fn new(py: Python<'py>, functions: &'py Bound<'py, PyDict>, dc_registry: &'a DcRegistry) -> Self {
+impl<'a, 'py> ExternalLookup<'a, 'py> {
+    /// Wraps the `external_lookup` dict (`None` when the caller passed none, in
+    /// which case every name resolves to `NameError` / `NotFound`).
+    pub fn new(py: Python<'py>, lookup: Option<&'py Bound<'py, PyDict>>, dc_registry: &'a DcRegistry) -> Self {
         Self {
             py,
-            functions,
+            lookup,
             dc_registry,
         }
+    }
+
+    /// Resolves a bare-name lookup (a `NameLookup` event): a callable entry
+    /// becomes a lazy host function proxy (`MontyObject::Function`, invoked on
+    /// the eventual `FunctionCall`), any other value is converted and returned
+    /// directly, and an absent name (or absent dict) yields `None` → the sandbox
+    /// raises `NameError`.
+    ///
+    /// A non-callable value that cannot be converted surfaces as a `PyErr`
+    /// rather than masquerading as `NameError`, so callers `?` it.
+    pub fn resolve_name(&self, name: &str) -> PyResult<Option<MontyObject>> {
+        let Some(value) = self.lookup.and_then(|d| d.get_item(name).ok().flatten()) else {
+            return Ok(None);
+        };
+        let obj = if value.is_callable() {
+            MontyObject::Function {
+                name: name.to_owned(),
+                docstring: get_docstring(&value),
+            }
+        } else {
+            py_to_monty_value(&value, self.dc_registry).map_err(|exc| exc_monty_to_py(self.py, exc))?
+        };
+        Ok(Some(obj))
     }
 
     /// Calls an external function by name, converting args/kwargs from Monty
@@ -115,14 +153,17 @@ impl<'a, 'py> ExternalFunctionRegistry<'a, 'py> {
     }
 
     /// `PyResult`-returning core of [`call`](Self::call); `Ok(None)` means the
-    /// function name was not found.
+    /// name was not found (an absent dict or an absent key).
     fn call_inner(
         &self,
         function_name: &str,
         args: &[MontyObject],
         kwargs: &[(MontyObject, MontyObject)],
     ) -> PyResult<Option<MontyObject>> {
-        let Some(callable) = self.functions.get_item(function_name)? else {
+        let Some(lookup) = self.lookup else {
+            return Ok(None);
+        };
+        let Some(callable) = lookup.get_item(function_name)? else {
             return Ok(None);
         };
 
@@ -174,7 +215,10 @@ impl<'a, 'py> ExternalFunctionRegistry<'a, 'py> {
     where
         'py: 'b,
     {
-        let Some(callable) = self.functions.get_item(function_name)? else {
+        let Some(lookup) = self.lookup else {
+            return Ok(None);
+        };
+        let Some(callable) = lookup.get_item(function_name)? else {
             return Ok(None);
         };
 

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -1056,12 +1056,8 @@ fn drive_sync(py: Python<'_>, args: FeedArgs, external_lookup: Option<&Bound<'_,
     };
 
     loop {
-        // `Complete` ends the loop; every other event needs an answer, and
-        // computing that answer can fail (e.g. converting an `external_lookup`
-        // value for a `NameLookup`). At that point the worker is already
-        // suspended awaiting a resume, so on failure discard the checkout rather
-        // than leave the session wedged on a dangling suspension the aborted
-        // feed will never answer.
+        // `Complete` ends the loop; on any other event a failure to compute the
+        // answer discards the checkout (see `sync_turn_answer`).
         let resume_with = match event {
             TurnEvent::Complete(value) => return monty_to_py(py, &value, &dc_registry),
             event => match sync_turn_answer(py, event, &lookup, os.as_ref(), &dc_registry) {
@@ -1155,11 +1151,10 @@ async fn drive_async(args: FeedArgs, external_lookup: Option<Py<PyDict>>) -> PyR
     .await?;
 
     loop {
-        // As in `drive_sync`, a suspension the loop cannot answer (a conversion
-        // failure, or the futures it awaits erroring) leaves the worker waiting
-        // for a resume forever, so discard the checkout on those paths rather
-        // than wedge the session. `Complete` and `ResolveFutures` stay inline —
-        // the latter must await the pending tasks.
+        // As in `drive_sync`, a failure to answer a suspension (including the
+        // futures `ResolveFutures` awaits erroring) discards the checkout.
+        // `Complete` and `ResolveFutures` stay inline — the latter must await
+        // the pending tasks.
         let answer: TurnAnswer = match event {
             TurnEvent::Complete(value) => {
                 return Python::attach(|py| monty_to_py(py, &value, &dc_registry));
@@ -1205,11 +1200,9 @@ async fn drive_async(args: FeedArgs, external_lookup: Option<Py<PyDict>>) -> PyR
     }
 }
 
-/// Computes the resume answer for an async `FunctionCall` / `OsCall` /
-/// `NameLookup` suspension. Split out of [`drive_async`]'s loop so a failure —
-/// e.g. converting an `external_lookup` value for a `NameLookup` — can discard
+/// Async counterpart of [`sync_turn_answer`] (minus `ResolveFutures`, which
+/// must await in [`drive_async`]'s loop): a failure here lets the loop discard
 /// the suspended worker instead of leaving it waiting forever for a resume.
-/// `Complete` and the awaiting `ResolveFutures` stay in the loop.
 fn async_turn_answer(
     event: TurnEvent,
     external_lookup: Option<&Py<PyDict>>,

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -46,10 +46,10 @@ use tokio::task::{JoinSet, spawn_blocking};
 use crate::{
     async_dispatch::{dispatch_function_call, join_error_to_py, spawn_coroutine_task, wait_for_futures},
     build::{extract_repl_inputs, extract_source_code, extract_type_check_stubs},
-    convert::{get_docstring, monty_to_py, py_to_monty_value},
+    convert::{monty_to_py, py_to_monty_value},
     dataclass::DcRegistry,
-    exceptions::{MontyCrashedError, MontyError, MontyTypingError, exc_monty_to_py, exc_py_to_monty},
-    external::{CallResult, ExternalFunctionRegistry, dispatch_method_call},
+    exceptions::{MontyCrashedError, MontyError, MontyTypingError, exc_py_to_monty},
+    external::{CallResult, ExternalLookup, dispatch_method_call},
     get_not_handled,
     limits::extract_limits,
     mount::PyMountDir,
@@ -1045,6 +1045,7 @@ fn drive_sync(py: Python<'_>, args: FeedArgs, external_lookup: Option<&Bound<'_,
         checkout,
         dc_registry,
     } = args;
+    let lookup = ExternalLookup::new(py, external_lookup, &dc_registry);
     let mut event = {
         let (result, print_err) = py.detach(|| {
             run_turn_blocking(&checkout, &print_target, |c, p| {
@@ -1066,10 +1067,8 @@ fn drive_sync(py: Python<'_>, args: FeedArgs, external_lookup: Option<&Bound<'_,
             } => {
                 let result = if method_call {
                     dispatch_method_call(py, &function_name, &args, &kwargs, &dc_registry)
-                } else if let Some(lookup) = external_lookup {
-                    ExternalFunctionRegistry::new(py, lookup, &dc_registry).call(&function_name, &args, &kwargs)
                 } else {
-                    ExtFunctionResult::NotFound(function_name)
+                    lookup.call(&function_name, &args, &kwargs)
                 };
                 TurnAnswer::Call(ext_to_resume(result)?)
             }
@@ -1091,9 +1090,7 @@ fn drive_sync(py: Python<'_>, args: FeedArgs, external_lookup: Option<&Bound<'_,
                 );
                 TurnAnswer::Call(ext_to_resume(result)?)
             }
-            TurnEvent::NameLookup { name } => {
-                TurnAnswer::Name(resolve_pool_name_lookup(py, &name, external_lookup, &dc_registry)?)
-            }
+            TurnEvent::NameLookup { name } => TurnAnswer::Name(lookup.resolve_name(&name)?),
             TurnEvent::ResolveFutures { .. } => {
                 return Err(PyRuntimeError::new_err("async external functions require AsyncMonty"));
             }
@@ -1177,7 +1174,7 @@ async fn drive_async(args: FeedArgs, external_lookup: Option<Py<PyDict>>) -> PyR
                 TurnAnswer::Call(ext_to_resume(result)?)
             }
             TurnEvent::NameLookup { name } => TurnAnswer::Name(Python::attach(|py| {
-                resolve_pool_name_lookup(py, &name, external_lookup.as_ref().map(|d| d.bind(py)), &dc_registry)
+                ExternalLookup::new(py, external_lookup.as_ref().map(|d| d.bind(py)), &dc_registry).resolve_name(&name)
             })?),
             TurnEvent::ResolveFutures { pending_call_ids } => {
                 let results = wait_for_futures(&mut join_set, &pending_call_ids).await?;
@@ -1330,33 +1327,6 @@ pub(crate) fn dispatch_os_parts(
         })
     };
     call().unwrap_or_else(|err| ExtFunctionResult::Error(exc_py_to_monty(py, &err)))
-}
-
-/// Resolves a bare-name lookup against the `external_lookup` dict: a callable
-/// becomes a lazy host function proxy (`MontyObject::Function`, invoked on the
-/// eventual `FunctionCall`), any other value is converted and returned directly,
-/// and an absent name yields `None` (→ the sandbox raises `NameError`).
-///
-/// A non-callable value that cannot be converted surfaces as a `PyErr` rather
-/// than masquerading as `NameError`, so callers `?` it.
-pub(crate) fn resolve_pool_name_lookup(
-    py: Python<'_>,
-    name: &str,
-    external_lookup: Option<&Bound<'_, PyDict>>,
-    dc_registry: &DcRegistry,
-) -> PyResult<Option<MontyObject>> {
-    let Some(value) = external_lookup.and_then(|d| d.get_item(name).ok().flatten()) else {
-        return Ok(None);
-    };
-    let obj = if value.is_callable() {
-        MontyObject::Function {
-            name: name.to_owned(),
-            docstring: get_docstring(&value),
-        }
-    } else {
-        py_to_monty_value(&value, dc_registry).map_err(|exc| exc_monty_to_py(py, exc))?
-    };
-    Ok(Some(obj))
 }
 
 /// Extracts `MountDir | list[MountDir] | None` into child-local mount specs.

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -1056,44 +1056,21 @@ fn drive_sync(py: Python<'_>, args: FeedArgs, external_lookup: Option<&Bound<'_,
     };
 
     loop {
-        let resume_with: TurnAnswer = match event {
+        // `Complete` ends the loop; every other event needs an answer, and
+        // computing that answer can fail (e.g. converting an `external_lookup`
+        // value for a `NameLookup`). At that point the worker is already
+        // suspended awaiting a resume, so on failure discard the checkout rather
+        // than leave the session wedged on a dangling suspension the aborted
+        // feed will never answer.
+        let resume_with = match event {
             TurnEvent::Complete(value) => return monty_to_py(py, &value, &dc_registry),
-            TurnEvent::FunctionCall {
-                function_name,
-                args,
-                kwargs,
-                method_call,
-                ..
-            } => {
-                let result = if method_call {
-                    dispatch_method_call(py, &function_name, &args, &kwargs, &dc_registry)
-                } else {
-                    lookup.call(&function_name, &args, &kwargs)
-                };
-                TurnAnswer::Call(ext_to_resume(result)?)
-            }
-            TurnEvent::OsCall {
-                function_name,
-                args,
-                kwargs,
-                not_handled_error,
-                ..
-            } => {
-                let result = dispatch_os_parts(
-                    py,
-                    &function_name,
-                    &args,
-                    &kwargs,
-                    not_handled_error.as_ref(),
-                    os.as_ref(),
-                    &dc_registry,
-                );
-                TurnAnswer::Call(ext_to_resume(result)?)
-            }
-            TurnEvent::NameLookup { name } => TurnAnswer::Name(lookup.resolve_name(&name)?),
-            TurnEvent::ResolveFutures { .. } => {
-                return Err(PyRuntimeError::new_err("async external functions require AsyncMonty"));
-            }
+            event => match sync_turn_answer(py, event, &lookup, os.as_ref(), &dc_registry) {
+                Ok(answer) => answer,
+                Err(err) => {
+                    py.detach(|| discard_checkout(&checkout));
+                    return Err(err);
+                }
+            },
         };
         let (result, print_err) = py.detach(|| {
             run_turn_blocking(&checkout, &print_target, move |c, p| match resume_with {
@@ -1102,6 +1079,57 @@ fn drive_sync(py: Python<'_>, args: FeedArgs, external_lookup: Option<&Bound<'_,
             })
         });
         event = finalize_turn(py, result, print_err)?;
+    }
+}
+
+/// Computes the resume answer for a (non-`Complete`) sync suspension. Split out
+/// of [`drive_sync`]'s loop so a failure here — e.g. converting an
+/// `external_lookup` value for a `NameLookup` — can discard the suspended worker
+/// instead of returning while it waits forever for a resume the aborted feed
+/// will never send.
+fn sync_turn_answer(
+    py: Python<'_>,
+    event: TurnEvent,
+    lookup: &ExternalLookup<'_, '_>,
+    os: Option<&Py<PyAny>>,
+    dc_registry: &DcRegistry,
+) -> PyResult<TurnAnswer> {
+    match event {
+        TurnEvent::FunctionCall {
+            function_name,
+            args,
+            kwargs,
+            method_call,
+            ..
+        } => {
+            let result = if method_call {
+                dispatch_method_call(py, &function_name, &args, &kwargs, dc_registry)
+            } else {
+                lookup.call(&function_name, &args, &kwargs)
+            };
+            Ok(TurnAnswer::Call(ext_to_resume(result)?))
+        }
+        TurnEvent::OsCall {
+            function_name,
+            args,
+            kwargs,
+            not_handled_error,
+            ..
+        } => {
+            let result = dispatch_os_parts(
+                py,
+                &function_name,
+                &args,
+                &kwargs,
+                not_handled_error.as_ref(),
+                os,
+                dc_registry,
+            );
+            Ok(TurnAnswer::Call(ext_to_resume(result)?))
+        }
+        TurnEvent::NameLookup { name } => Ok(TurnAnswer::Name(lookup.resolve_name(&name)?)),
+        TurnEvent::ResolveFutures { .. } => Err(PyRuntimeError::new_err("async external functions require AsyncMonty")),
+        TurnEvent::Complete(_) => unreachable!("Complete is handled by the drive loop"),
     }
 }
 
@@ -1127,64 +1155,47 @@ async fn drive_async(args: FeedArgs, external_lookup: Option<Py<PyDict>>) -> PyR
     .await?;
 
     loop {
+        // As in `drive_sync`, a suspension the loop cannot answer (a conversion
+        // failure, or the futures it awaits erroring) leaves the worker waiting
+        // for a resume forever, so discard the checkout on those paths rather
+        // than wedge the session. `Complete` and `ResolveFutures` stay inline —
+        // the latter must await the pending tasks.
         let answer: TurnAnswer = match event {
             TurnEvent::Complete(value) => {
                 return Python::attach(|py| monty_to_py(py, &value, &dc_registry));
             }
-            TurnEvent::FunctionCall {
-                function_name,
-                args,
-                kwargs,
-                call_id,
-                method_call,
-            } => {
-                match dispatch_function_call(
-                    &function_name,
-                    method_call,
-                    &args,
-                    &kwargs,
-                    external_lookup.as_ref(),
-                    &dc_registry,
-                ) {
-                    CallResult::Sync(result) => TurnAnswer::Call(ext_to_resume(result)?),
-                    CallResult::Coroutine(coro) => {
-                        spawn_coroutine_task(&mut join_set, call_id, coro, &dc_registry)?;
-                        TurnAnswer::Call(ResumeValue::Future)
-                    }
-                }
-            }
-            TurnEvent::OsCall {
-                function_name,
-                args,
-                kwargs,
-                not_handled_error,
-                ..
-            } => {
-                let result = Python::attach(|py| {
-                    dispatch_os_parts(
-                        py,
-                        &function_name,
-                        &args,
-                        &kwargs,
-                        not_handled_error.as_ref(),
-                        os.as_ref(),
-                        &dc_registry,
-                    )
-                });
-                TurnAnswer::Call(ext_to_resume(result)?)
-            }
-            TurnEvent::NameLookup { name } => TurnAnswer::Name(Python::attach(|py| {
-                ExternalLookup::new(py, external_lookup.as_ref().map(|d| d.bind(py)), &dc_registry).resolve_name(&name)
-            })?),
             TurnEvent::ResolveFutures { pending_call_ids } => {
-                let results = wait_for_futures(&mut join_set, &pending_call_ids).await?;
-                let results = results
-                    .into_iter()
-                    .map(|(call_id, result)| Ok((call_id, ext_to_resume(result)?)))
-                    .collect::<PyResult<Vec<_>>>()?;
+                let resolved = wait_for_futures(&mut join_set, &pending_call_ids)
+                    .await
+                    .and_then(|results| {
+                        results
+                            .into_iter()
+                            .map(|(call_id, result)| Ok((call_id, ext_to_resume(result)?)))
+                            .collect::<PyResult<Vec<_>>>()
+                    });
+                let results = match resolved {
+                    Ok(results) => results,
+                    Err(err) => {
+                        discard_checkout_async(&checkout).await;
+                        return Err(err);
+                    }
+                };
                 event = run_turn_async(&checkout, &print_target, move |c, p| c.resume_futures(results, p)).await?;
                 continue;
             }
+            event => match async_turn_answer(
+                event,
+                external_lookup.as_ref(),
+                os.as_ref(),
+                &dc_registry,
+                &mut join_set,
+            ) {
+                Ok(answer) => answer,
+                Err(err) => {
+                    discard_checkout_async(&checkout).await;
+                    return Err(err);
+                }
+            },
         };
         event = run_turn_async(&checkout, &print_target, move |c, p| match answer {
             TurnAnswer::Call(value) => c.resume(value, p),
@@ -1192,6 +1203,79 @@ async fn drive_async(args: FeedArgs, external_lookup: Option<Py<PyDict>>) -> PyR
         })
         .await?;
     }
+}
+
+/// Computes the resume answer for an async `FunctionCall` / `OsCall` /
+/// `NameLookup` suspension. Split out of [`drive_async`]'s loop so a failure —
+/// e.g. converting an `external_lookup` value for a `NameLookup` — can discard
+/// the suspended worker instead of leaving it waiting forever for a resume.
+/// `Complete` and the awaiting `ResolveFutures` stay in the loop.
+fn async_turn_answer(
+    event: TurnEvent,
+    external_lookup: Option<&Py<PyDict>>,
+    os: Option<&Py<PyAny>>,
+    dc_registry: &DcRegistry,
+    join_set: &mut JoinSet<(u32, ExtFunctionResult)>,
+) -> PyResult<TurnAnswer> {
+    match event {
+        TurnEvent::FunctionCall {
+            function_name,
+            args,
+            kwargs,
+            call_id,
+            method_call,
+        } => match dispatch_function_call(
+            &function_name,
+            method_call,
+            &args,
+            &kwargs,
+            external_lookup,
+            dc_registry,
+        ) {
+            CallResult::Sync(result) => Ok(TurnAnswer::Call(ext_to_resume(result)?)),
+            CallResult::Coroutine(coro) => {
+                spawn_coroutine_task(join_set, call_id, coro, dc_registry)?;
+                Ok(TurnAnswer::Call(ResumeValue::Future))
+            }
+        },
+        TurnEvent::OsCall {
+            function_name,
+            args,
+            kwargs,
+            not_handled_error,
+            ..
+        } => {
+            let result = Python::attach(|py| {
+                dispatch_os_parts(
+                    py,
+                    &function_name,
+                    &args,
+                    &kwargs,
+                    not_handled_error.as_ref(),
+                    os,
+                    dc_registry,
+                )
+            });
+            Ok(TurnAnswer::Call(ext_to_resume(result)?))
+        }
+        TurnEvent::NameLookup { name } => {
+            let value = Python::attach(|py| {
+                ExternalLookup::new(py, external_lookup.map(|d| d.bind(py)), dc_registry).resolve_name(&name)
+            })?;
+            Ok(TurnAnswer::Name(value))
+        }
+        TurnEvent::Complete(_) | TurnEvent::ResolveFutures { .. } => {
+            unreachable!("Complete and ResolveFutures are handled by the drive loop")
+        }
+    }
+}
+
+/// Best-effort discard of a suspended checkout from an async drive-loop error
+/// path. The caller returns the original error, so a `spawn_blocking` join
+/// failure here is deliberately ignored.
+async fn discard_checkout_async(checkout: &SharedCheckout) {
+    let checkout = Arc::clone(checkout);
+    let _ = spawn_blocking(move || discard_checkout(&checkout)).await;
 }
 
 /// The caller's answer to a suspension, paired with which resume call

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -48,7 +48,7 @@ use crate::{
     build::{extract_repl_inputs, extract_source_code, extract_type_check_stubs},
     convert::{get_docstring, monty_to_py, py_to_monty_value},
     dataclass::DcRegistry,
-    exceptions::{MontyCrashedError, MontyError, MontyTypingError, exc_py_to_monty},
+    exceptions::{MontyCrashedError, MontyError, MontyTypingError, exc_monty_to_py, exc_py_to_monty},
     external::{CallResult, ExternalFunctionRegistry, dispatch_method_call},
     get_not_handled,
     limits::extract_limits,
@@ -210,14 +210,14 @@ impl PyMontySession {
     ///
     /// Blocks the calling thread with the GIL released; async external
     /// functions are not supported here — use [`AsyncMonty`].
-    #[pyo3(signature = (code, *, inputs=None, external_functions=None, print_callback=None, mount=None, os=None, skip_type_check=false))]
+    #[pyo3(signature = (code, *, inputs=None, external_lookup=None, print_callback=None, mount=None, os=None, skip_type_check=false))]
     #[expect(clippy::too_many_arguments)]
     fn feed_run(
         &self,
         py: Python<'_>,
         code: &Bound<'_, PyString>,
         inputs: Option<&Bound<'_, PyDict>>,
-        external_functions: Option<&Bound<'_, PyDict>>,
+        external_lookup: Option<&Bound<'_, PyDict>>,
         print_callback: Option<&Bound<'_, PyAny>>,
         mount: Option<&Bound<'_, PyAny>>,
         os: Option<Py<PyAny>>,
@@ -235,7 +235,7 @@ impl PyMontySession {
             os,
             skip_type_check,
         )?;
-        drive_sync(py, args, external_functions)
+        drive_sync(py, args, external_lookup)
     }
 
     /// Starts a snippet but, instead of driving it to completion, returns a
@@ -243,7 +243,7 @@ impl PyMontySession {
     /// resolution. The caller answers with `snapshot.resume(...)` and may
     /// `snapshot.dump()` to checkpoint the worker mid-execution.
     ///
-    /// Unlike [`feed_run`](Self::feed_run) there is no `external_functions`
+    /// Unlike [`feed_run`](Self::feed_run) there is no `external_lookup`
     /// argument — surfacing those calls is the point. An `os=` handler still
     /// auto-dispatches uncovered OS calls until the next non-OS event.
     #[pyo3(signature = (code, *, inputs=None, print_callback=None, mount=None, os=None, skip_type_check=false))]
@@ -668,14 +668,14 @@ impl PyAsyncMontySession {
     /// print callbacks in this process. Session state persists across feeds.
     ///
     /// Worker I/O runs off the event loop via tokio's blocking pool.
-    #[pyo3(signature = (code, *, inputs=None, external_functions=None, print_callback=None, mount=None, os=None, skip_type_check=false))]
+    #[pyo3(signature = (code, *, inputs=None, external_lookup=None, print_callback=None, mount=None, os=None, skip_type_check=false))]
     #[expect(clippy::too_many_arguments)]
     fn feed_run<'py>(
         &self,
         py: Python<'py>,
         code: &Bound<'_, PyString>,
         inputs: Option<&Bound<'_, PyDict>>,
-        external_functions: Option<&Bound<'_, PyDict>>,
+        external_lookup: Option<&Bound<'_, PyDict>>,
         print_callback: Option<&Bound<'_, PyAny>>,
         mount: Option<&Bound<'_, PyAny>>,
         os: Option<Py<PyAny>>,
@@ -693,8 +693,8 @@ impl PyAsyncMontySession {
             os,
             skip_type_check,
         )?;
-        let ext_fns = external_functions.map(|d| d.clone().unbind());
-        future_into_py(py, async move { drive_async(args, ext_fns).await })
+        let ext = external_lookup.map(|d| d.clone().unbind());
+        future_into_py(py, async move { drive_async(args, ext).await })
     }
 
     /// Async counterpart of [`PyMontySession::feed_start`]: the returned
@@ -1034,7 +1034,7 @@ impl FeedArgs {
 
 /// Synchronous drive loop: protocol turns run with the GIL released;
 /// callbacks run between turns with the GIL held.
-fn drive_sync(py: Python<'_>, args: FeedArgs, external_functions: Option<&Bound<'_, PyDict>>) -> PyResult<Py<PyAny>> {
+fn drive_sync(py: Python<'_>, args: FeedArgs, external_lookup: Option<&Bound<'_, PyDict>>) -> PyResult<Py<PyAny>> {
     let FeedArgs {
         code,
         inputs,
@@ -1066,8 +1066,8 @@ fn drive_sync(py: Python<'_>, args: FeedArgs, external_functions: Option<&Bound<
             } => {
                 let result = if method_call {
                     dispatch_method_call(py, &function_name, &args, &kwargs, &dc_registry)
-                } else if let Some(fns) = external_functions {
-                    ExternalFunctionRegistry::new(py, fns, &dc_registry).call(&function_name, &args, &kwargs)
+                } else if let Some(lookup) = external_lookup {
+                    ExternalFunctionRegistry::new(py, lookup, &dc_registry).call(&function_name, &args, &kwargs)
                 } else {
                     ExtFunctionResult::NotFound(function_name)
                 };
@@ -1091,7 +1091,9 @@ fn drive_sync(py: Python<'_>, args: FeedArgs, external_functions: Option<&Bound<
                 );
                 TurnAnswer::Call(ext_to_resume(result)?)
             }
-            TurnEvent::NameLookup { name } => TurnAnswer::Name(resolve_pool_name_lookup(&name, external_functions)),
+            TurnEvent::NameLookup { name } => {
+                TurnAnswer::Name(resolve_pool_name_lookup(py, &name, external_lookup, &dc_registry)?)
+            }
             TurnEvent::ResolveFutures { .. } => {
                 return Err(PyRuntimeError::new_err("async external functions require AsyncMonty"));
             }
@@ -1109,7 +1111,7 @@ fn drive_sync(py: Python<'_>, args: FeedArgs, external_functions: Option<&Bound<
 /// Async drive loop: protocol turns run in `spawn_blocking`; coroutine
 /// external functions are spawned as tasks and resolved via
 /// `ResolveFutures`.
-async fn drive_async(args: FeedArgs, external_functions: Option<Py<PyDict>>) -> PyResult<Py<PyAny>> {
+async fn drive_async(args: FeedArgs, external_lookup: Option<Py<PyDict>>) -> PyResult<Py<PyAny>> {
     let FeedArgs {
         code,
         inputs,
@@ -1144,7 +1146,7 @@ async fn drive_async(args: FeedArgs, external_functions: Option<Py<PyDict>>) -> 
                     method_call,
                     &args,
                     &kwargs,
-                    external_functions.as_ref(),
+                    external_lookup.as_ref(),
                     &dc_registry,
                 ) {
                     CallResult::Sync(result) => TurnAnswer::Call(ext_to_resume(result)?),
@@ -1175,8 +1177,8 @@ async fn drive_async(args: FeedArgs, external_functions: Option<Py<PyDict>>) -> 
                 TurnAnswer::Call(ext_to_resume(result)?)
             }
             TurnEvent::NameLookup { name } => TurnAnswer::Name(Python::attach(|py| {
-                resolve_pool_name_lookup(&name, external_functions.as_ref().map(|d| d.bind(py)))
-            })),
+                resolve_pool_name_lookup(py, &name, external_lookup.as_ref().map(|d| d.bind(py)), &dc_registry)
+            })?),
             TurnEvent::ResolveFutures { pending_call_ids } => {
                 let results = wait_for_futures(&mut join_set, &pending_call_ids).await?;
                 let results = results
@@ -1330,16 +1332,31 @@ pub(crate) fn dispatch_os_parts(
     call().unwrap_or_else(|err| ExtFunctionResult::Error(exc_py_to_monty(py, &err)))
 }
 
-/// Resolves a bare-name lookup against the external functions dict.
+/// Resolves a bare-name lookup against the `external_lookup` dict: a callable
+/// becomes a lazy host function proxy (`MontyObject::Function`, invoked on the
+/// eventual `FunctionCall`), any other value is converted and returned directly,
+/// and an absent name yields `None` (→ the sandbox raises `NameError`).
+///
+/// A non-callable value that cannot be converted surfaces as a `PyErr` rather
+/// than masquerading as `NameError`, so callers `?` it.
 pub(crate) fn resolve_pool_name_lookup(
+    py: Python<'_>,
     name: &str,
-    external_functions: Option<&Bound<'_, PyDict>>,
-) -> Option<MontyObject> {
-    let value = external_functions?.get_item(name).ok().flatten()?;
-    Some(MontyObject::Function {
-        name: name.to_owned(),
-        docstring: get_docstring(&value),
-    })
+    external_lookup: Option<&Bound<'_, PyDict>>,
+    dc_registry: &DcRegistry,
+) -> PyResult<Option<MontyObject>> {
+    let Some(value) = external_lookup.and_then(|d| d.get_item(name).ok().flatten()) else {
+        return Ok(None);
+    };
+    let obj = if value.is_callable() {
+        MontyObject::Function {
+            name: name.to_owned(),
+            docstring: get_docstring(&value),
+        }
+    } else {
+        py_to_monty_value(&value, dc_registry).map_err(|exc| exc_monty_to_py(py, exc))?
+    };
+    Ok(Some(obj))
 }
 
 /// Extracts `MountDir | list[MountDir] | None` into child-local mount specs.

--- a/crates/monty-python/tests/conftest.py
+++ b/crates/monty-python/tests/conftest.py
@@ -25,7 +25,7 @@ class RunMonty(Protocol):
         code: str,
         *,
         inputs: dict[str, Any] | None = None,
-        external_functions: dict[str, Callable[..., Any]] | None = None,
+        external_lookup: dict[str, Any] | None = None,
         print_callback: Callable[[Literal['stdout', 'stderr'], str], None]
         | CollectStreams
         | CollectString
@@ -61,7 +61,7 @@ def monty_run(pool: Monty) -> RunMonty:
         code: str,
         *,
         inputs: dict[str, Any] | None = None,
-        external_functions: dict[str, Callable[..., Any]] | None = None,
+        external_lookup: dict[str, Any] | None = None,
         print_callback: Callable[[Literal['stdout', 'stderr'], str], None]
         | CollectStreams
         | CollectString
@@ -76,7 +76,7 @@ def monty_run(pool: Monty) -> RunMonty:
             return s.feed_run(
                 code,
                 inputs=inputs,
-                external_functions=external_functions,
+                external_lookup=external_lookup,
                 print_callback=print_callback,
                 mount=mount,
                 os=os,

--- a/crates/monty-python/tests/test_async.py
+++ b/crates/monty-python/tests/test_async.py
@@ -43,8 +43,19 @@ async def test_await_external_function(asession: AsyncMontySession):
     async def foobar(a: int, b: int) -> int:
         return a + b
 
-    result = await asession.feed_run('await foobar(1, 2)', external_functions={'foobar': foobar})
+    result = await asession.feed_run('await foobar(1, 2)', external_lookup={'foobar': foobar})
     assert result == snapshot(3)
+
+
+async def test_external_lookup_value(asession: AsyncMontySession):
+    """A non-callable external_lookup entry resolves the bare name to its value,
+    alongside a callable entry resolved as a function proxy."""
+
+    def double(x: int) -> int:
+        return x * 2
+
+    result = await asession.feed_run('double(n)', external_lookup={'double': double, 'n': 21})
+    assert result == snapshot(42)
 
 
 async def test_asyncio_gather(asession: AsyncMontySession):
@@ -60,7 +71,7 @@ await asyncio.gather(foo(1), bar(2))
     async def bar(x: int) -> int:
         return x + 2
 
-    result = await asession.feed_run(code, external_functions={'foo': foo, 'bar': bar})
+    result = await asession.feed_run(code, external_lookup={'foo': foo, 'bar': bar})
     assert result == snapshot([3, 4])
 
 
@@ -70,7 +81,7 @@ async def test_sync_function(asession: AsyncMontySession):
     def get_value():
         return 42
 
-    result = await asession.feed_run('get_value()', external_functions={'get_value': get_value})
+    result = await asession.feed_run('get_value()', external_lookup={'get_value': get_value})
     assert result == snapshot(42)
 
 
@@ -81,14 +92,14 @@ async def test_async_function(asession: AsyncMontySession):
         await asyncio.sleep(0.001)
         return 'async result'
 
-    result = await asession.feed_run('await fetch_data()', external_functions={'fetch_data': fetch_data})
+    result = await asession.feed_run('await fetch_data()', external_lookup={'fetch_data': fetch_data})
     assert result == snapshot('async result')
 
 
 async def test_function_not_found(asession: AsyncMontySession):
     """Missing external function raises wrapped NameError."""
     with pytest.raises(MontyRuntimeError) as exc_info:
-        await asession.feed_run('missing_func()', external_functions={})
+        await asession.feed_run('missing_func()', external_lookup={})
     inner = exc_info.value.exception()
     assert isinstance(inner, NameError)
     assert inner.args[0] == snapshot("name 'missing_func' is not defined")
@@ -101,7 +112,7 @@ async def test_sync_exception(asession: AsyncMontySession):
         raise ValueError('sync error')
 
     with pytest.raises(MontyRuntimeError) as exc_info:
-        await asession.feed_run('fail()', external_functions={'fail': fail})
+        await asession.feed_run('fail()', external_lookup={'fail': fail})
     inner = exc_info.value.exception()
     assert isinstance(inner, ValueError)
     assert inner.args[0] == snapshot('sync error')
@@ -115,7 +126,7 @@ async def test_async_exception(asession: AsyncMontySession):
         raise RuntimeError('async error')
 
     with pytest.raises(MontyRuntimeError) as exc_info:
-        await asession.feed_run('await async_fail()', external_functions={'async_fail': async_fail})
+        await asession.feed_run('await async_fail()', external_lookup={'async_fail': async_fail})
     inner = exc_info.value.exception()
     assert isinstance(inner, RuntimeError)
     assert inner.args[0] == snapshot('async error')
@@ -134,7 +145,7 @@ caught
     def fail():
         raise ValueError('caught error')
 
-    result = await asession.feed_run(code, external_functions={'fail': fail})
+    result = await asession.feed_run(code, external_lookup={'fail': fail})
     assert result == snapshot(True)
 
 
@@ -153,7 +164,7 @@ await asyncio.gather(fetch_a(), fetch_b())
         await asyncio.sleep(0.005)
         return 'b'
 
-    result = await asession.feed_run(code, external_functions={'fetch_a': fetch_a, 'fetch_b': fetch_b})
+    result = await asession.feed_run(code, external_lookup={'fetch_a': fetch_a, 'fetch_b': fetch_b})
     assert result == snapshot(['a', 'b'])
 
 
@@ -172,7 +183,7 @@ sync_val + async_val
         await asyncio.sleep(0.001)
         return 5
 
-    result = await asession.feed_run(code, external_functions={'sync_func': sync_func, 'async_func': async_func})
+    result = await asession.feed_run(code, external_lookup={'sync_func': sync_func, 'async_func': async_func})
     assert result == snapshot(15)
 
 
@@ -182,7 +193,7 @@ async def test_with_inputs(asession: AsyncMontySession):
     def process(a: int, b: int) -> int:
         return a * b
 
-    result = await asession.feed_run('process(x, y)', inputs={'x': 6, 'y': 7}, external_functions={'process': process})
+    result = await asession.feed_run('process(x, y)', inputs={'x': 6, 'y': 7}, external_lookup={'process': process})
     assert result == snapshot(42)
 
 
@@ -202,7 +213,7 @@ async def test_function_returning_none(asession: AsyncMontySession):
     def do_nothing():
         return None
 
-    result = await asession.feed_run('do_nothing()', external_functions={'do_nothing': do_nothing})
+    result = await asession.feed_run('do_nothing()', external_lookup={'do_nothing': do_nothing})
     assert result is None
 
 
@@ -225,7 +236,7 @@ Path('/test.txt').read_text()
     assert result == snapshot('hello world')
 
 
-async def test_os_with_external_functions(asession: AsyncMontySession):
+async def test_os_with_external_lookup(asession: AsyncMontySession):
     """feed_run can combine OSAccess with external functions."""
     fs = OSAccess([MemoryFile('/data.txt', content='test data')])
 
@@ -237,7 +248,7 @@ from pathlib import Path
 content = Path('/data.txt').read_text()
 await process(content)
 """
-    result = await asession.feed_run(code, external_functions={'process': process}, os=fs)
+    result = await asession.feed_run(code, external_lookup={'process': process}, os=fs)
     assert result == snapshot('TEST DATA')
 
 
@@ -278,7 +289,7 @@ p.read_text()
     assert result == snapshot('updated')
 
 
-async def test_nested_gather_with_external_functions(asession: AsyncMontySession):
+async def test_nested_gather_with_external_lookup(asession: AsyncMontySession):
     """Nested asyncio.gather with spawned tasks and external async functions.
 
     https://github.com/pydantic/monty/pull/174
@@ -335,7 +346,7 @@ await main()
 
     result = await asession.feed_run(
         code,
-        external_functions={
+        external_lookup={
             'get_lat_lng': get_lat_lng,
             'get_temp': get_temp,
             'get_weather_description': get_weather_description,
@@ -360,9 +371,9 @@ async def test_state_persists(asession: AsyncMontySession):
         return x * 2
 
     ext = {'double': double}
-    await asession.feed_run('x = 10', external_functions=ext)
-    await asession.feed_run('y = double(x)', external_functions=ext)
-    result = await asession.feed_run('y', external_functions=ext)
+    await asession.feed_run('x = 10', external_lookup=ext)
+    await asession.feed_run('y = double(x)', external_lookup=ext)
+    result = await asession.feed_run('y', external_lookup=ext)
     assert result == snapshot(20)
 
 
@@ -373,9 +384,9 @@ async def test_async_state_persists(asession: AsyncMontySession):
         return f'value_{key}'
 
     ext = {'fetch': fetch}
-    await asession.feed_run("a = await fetch('one')", external_functions=ext)
-    await asession.feed_run("b = await fetch('two')", external_functions=ext)
-    result = await asession.feed_run('a + b', external_functions=ext)
+    await asession.feed_run("a = await fetch('one')", external_lookup=ext)
+    await asession.feed_run("b = await fetch('two')", external_lookup=ext)
+    result = await asession.feed_run('a + b', external_lookup=ext)
     assert result == snapshot('value_onevalue_two')
 
 
@@ -387,7 +398,7 @@ async def test_error_preserves_state(asession: AsyncMontySession):
         raise ValueError('oops')
 
     with pytest.raises(MontyRuntimeError):
-        await asession.feed_run('fail()', external_functions={'fail': fail})
+        await asession.feed_run('fail()', external_lookup={'fail': fail})
 
     result = await asession.feed_run('x')
     assert result == snapshot(42)
@@ -402,7 +413,7 @@ async def test_async_error_preserves_state(asession: AsyncMontySession):
         raise RuntimeError('async kaboom')
 
     with pytest.raises(MontyRuntimeError):
-        await asession.feed_run('await failing_async()', external_functions={'failing_async': failing_async})
+        await asession.feed_run('await failing_async()', external_lookup={'failing_async': failing_async})
 
     result = await asession.feed_run('x')
     assert result == snapshot(100)
@@ -439,7 +450,7 @@ except ValueError:
     result = 'caught'
 result
 """
-    result = await asession.feed_run(code, external_functions={'get_str': lambda: '\ud83d'})
+    result = await asession.feed_run(code, external_lookup={'get_str': lambda: '\ud83d'})
     assert result == snapshot('caught')
 
 
@@ -451,7 +462,7 @@ async def test_async_external_return_lone_surrogate(asession: AsyncMontySession)
         return '\ud83d'
 
     with pytest.raises(MontyRuntimeError) as exc_info:
-        await asession.feed_run('await get_str()', external_functions={'get_str': get_str})
+        await asession.feed_run('await get_str()', external_lookup={'get_str': get_str})
     assert isinstance(exc_info.value.exception(), ValueError)
 
 
@@ -472,7 +483,7 @@ async def test_llm_iterative_data_collection(asession: AsyncMontySession):
     ext = {'fetch_users': fetch_users}
 
     # Snippet 1: LLM sets up accumulator
-    await asession.feed_run('all_users = []', external_functions=ext)
+    await asession.feed_run('all_users = []', external_lookup=ext)
 
     # Snippets 2-4: LLM fetches batches until one comes back empty
     batch_code = """\
@@ -480,12 +491,12 @@ batch = await fetch_users(len(all_users), 2)
 all_users = all_users + batch
 len(batch)
 """
-    assert await asession.feed_run(batch_code, external_functions=ext) == 2
-    assert await asession.feed_run(batch_code, external_functions=ext) == 1
-    assert await asession.feed_run(batch_code, external_functions=ext) == 0
+    assert await asession.feed_run(batch_code, external_lookup=ext) == 2
+    assert await asession.feed_run(batch_code, external_lookup=ext) == 1
+    assert await asession.feed_run(batch_code, external_lookup=ext) == 0
 
     # Snippet 5: LLM extracts final result
-    result = await asession.feed_run('[u["name"] for u in all_users]', external_functions=ext)
+    result = await asession.feed_run('[u["name"] for u in all_users]', external_lookup=ext)
     assert result == snapshot(['Alice', 'Bob', 'Charlie'])
 
 
@@ -504,7 +515,7 @@ async def test_llm_error_recovery_retry(asession: AsyncMontySession):
 
     # Snippet 1: LLM tries, gets error
     with pytest.raises(MontyRuntimeError):
-        await asession.feed_run("data = await flaky_api('test')", external_functions=ext)
+        await asession.feed_run("data = await flaky_api('test')", external_lookup=ext)
 
     # Snippet 2: LLM wraps in try/except and retries
     result = await asession.feed_run(
@@ -515,7 +526,7 @@ except Exception as e:
     data = 'fallback'
 data
 """,
-        external_functions=ext,
+        external_lookup=ext,
     )
     assert result == snapshot('result for test')
 
@@ -534,7 +545,7 @@ async def test_llm_redefine_helper_function(asession: AsyncMontySession):
 def parse_title(html):
     return html
 """,
-        external_functions=ext,
+        external_lookup=ext,
     )
 
     # Snippet 2: LLM uses it, gets raw html back
@@ -543,7 +554,7 @@ def parse_title(html):
 html = await fetch('example.com')
 parse_title(html)
 """,
-        external_functions=ext,
+        external_lookup=ext,
     )
     assert result == snapshot('<html>example.com</html>')
 
@@ -555,11 +566,11 @@ def parse_title(html):
     end = html.rfind('<')
     return html[start:end]
 """,
-        external_functions=ext,
+        external_lookup=ext,
     )
 
     # Snippet 4: uses improved parser on previously fetched data
-    result = await asession.feed_run('parse_title(html)', external_functions=ext)
+    result = await asession.feed_run('parse_title(html)', external_lookup=ext)
     assert result == snapshot('example.com')
 
 
@@ -588,7 +599,7 @@ for r in results:
     record(s)
 summaries
 """
-    result = await asession.feed_run(code, external_functions=ext)
+    result = await asession.feed_run(code, external_lookup=ext)
     assert result == snapshot(['summary(python async_result_1)', 'summary(python async_result_2)'])
     assert records == snapshot(['summary(python async_result_1)', 'summary(python async_result_2)'])
 
@@ -607,7 +618,7 @@ items = ['apple', 'banana', 'cherry', 'date', 'elderberry']
 prices = await asyncio.gather(*(fetch_price(item) for item in items))
 dict(zip(items, prices))
 """
-    result = await asession.feed_run(code, external_functions={'fetch_price': fetch_price})
+    result = await asession.feed_run(code, external_lookup={'fetch_price': fetch_price})
     assert result == snapshot({'apple': 1.5, 'banana': 0.75, 'cherry': 3.0, 'date': 5.0, 'elderberry': 8.0})
 
 
@@ -628,7 +639,7 @@ for key in ['good', 'bad', 'also_good']:
         results[key] = 'missing'
 results
 """
-    result = await asession.feed_run(code, external_functions={'fetch_data': fetch_data})
+    result = await asession.feed_run(code, external_lookup={'fetch_data': fetch_data})
     assert result == snapshot({'good': 'data_good', 'bad': 'missing', 'also_good': 'data_also_good'})
 
 
@@ -644,7 +655,7 @@ async def test_llm_conditional_external_call(asession: AsyncMontySession):
     ext = {'expensive_lookup': expensive_lookup}
 
     # Snippet 1: set up a cache
-    await asession.feed_run("cache = {'x': 'cached_x'}", external_functions=ext)
+    await asession.feed_run("cache = {'x': 'cached_x'}", external_lookup=ext)
 
     # Snippet 2: LLM checks cache before calling
     code = """\
@@ -658,7 +669,7 @@ for key in ['x', 'y', 'x']:
         results.append(val)
 results
 """
-    result = await asession.feed_run(code, external_functions=ext)
+    result = await asession.feed_run(code, external_lookup=ext)
     assert result == snapshot(['cached_x', 'looked up y', 'cached_x'])
     assert call_count == 1  # only 'y' triggered a call
 
@@ -682,7 +693,7 @@ for m in models:
     record_model(m['name'], m['params'], 0.01)
 len(models)
 """
-    result = await asession.feed_run(code, external_functions={'record_model': record_model, 'get_models': get_models})
+    result = await asession.feed_run(code, external_lookup={'record_model': record_model, 'get_models': get_models})
     assert result == snapshot(2)
     assert recorded == snapshot(
         [{'name': 'gpt-4', 'params': '1.7T', 'price': 0.01}, {'name': 'claude-3', 'params': '???', 'price': 0.01}]
@@ -714,11 +725,11 @@ def fetch_with_retry(url, max_retries=3):
                 raise
     raise ValueError('should not reach here')
 """,
-        external_functions=ext,
+        external_lookup=ext,
     )
 
     # Snippet 2: LLM uses the retry helper
-    result = await asession.feed_run("fetch_with_retry('example.com')", external_functions=ext)
+    result = await asession.feed_run("fetch_with_retry('example.com')", external_lookup=ext)
     assert result == snapshot('content of example.com')
     assert attempt_counts == snapshot({'example.com': 2})
 
@@ -748,7 +759,7 @@ results = await asyncio.gather(
 )
 results
 """
-    result = await asession.feed_run(code, external_functions={'get_user': get_user, 'get_posts': get_posts})
+    result = await asession.feed_run(code, external_lookup={'get_user': get_user, 'get_posts': get_posts})
     assert result == snapshot(
         [
             {'id': 1, 'name': 'user_1', 'posts': ['post_1_1', 'post_1_2']},
@@ -776,7 +787,7 @@ async def test_llm_external_returns_complex_nested_structure(asession: AsyncMont
     ext = {'get_api_response': get_api_response}
 
     # Snippet 1: fetch and store
-    await asession.feed_run('response = await get_api_response()', external_functions=ext)
+    await asession.feed_run('response = await get_api_response()', external_lookup=ext)
 
     # Snippet 2: LLM navigates nested structure
     result = await asession.feed_run(
@@ -788,7 +799,7 @@ for u in users:
     averages[u['name']] = round(avg, 1)
 averages
 """,
-        external_functions=ext,
+        external_lookup=ext,
     )
     assert result == snapshot({'Alice': 91.3, 'Bob': 84.3})
 
@@ -804,7 +815,7 @@ page1 = await search('test', limit=2, offset=0)
 page2 = await search('test', limit=2, offset=2)
 page1['results'] + page2['results']
 """
-    result = await asession.feed_run(code, external_functions={'search': search})
+    result = await asession.feed_run(code, external_lookup={'search': search})
     assert result == snapshot(['test_0', 'test_1', 'test_0', 'test_1'])
 
 
@@ -824,12 +835,12 @@ async def test_llm_os_read_then_process_with_external(asession: AsyncMontySessio
 from pathlib import Path
 raw = Path('/data.csv').read_text()
 """,
-        external_functions=ext,
+        external_lookup=ext,
         os=fs,
     )
 
     # Snippet 2: process with external
-    result = await asession.feed_run('await analyze(raw)', external_functions=ext, os=fs)
+    result = await asession.feed_run('await analyze(raw)', external_lookup=ext, os=fs)
     assert result == snapshot({'alice': 95, 'bob': 87, 'charlie': 92})
 
 
@@ -854,13 +865,13 @@ async def test_llm_long_multi_step_session(asession: AsyncMontySession):
     ext = {'query_db': query_db}
 
     # Step 1: LLM explores what's available
-    result = await asession.feed_run('await query_db("products")', external_functions=ext)
+    result = await asession.feed_run('await query_db("products")', external_lookup=ext)
     assert len(result) == 4
 
     # Step 2: LLM filters by category
     await asession.feed_run(
         "tools = await query_db('products', filters={'category': 'tools'})",
-        external_functions=ext,
+        external_lookup=ext,
     )
 
     # Step 3: LLM computes stats
@@ -870,14 +881,14 @@ total = sum(p['price'] for p in tools)
 avg = total / len(tools)
 {'count': len(tools), 'total': round(total, 2), 'average': round(avg, 2)}
 """,
-        external_functions=ext,
+        external_lookup=ext,
     )
     assert result == snapshot({'count': 2, 'total': 14.98, 'average': 7.49})
 
     # Step 4: LLM also checks electronics
     await asession.feed_run(
         "electronics = await query_db('products', filters={'category': 'electronics'})",
-        external_functions=ext,
+        external_lookup=ext,
     )
 
     # Step 5: LLM builds final summary from accumulated state
@@ -892,7 +903,7 @@ for cat, items in [('tools', tools), ('electronics', electronics)]:
     }
 summary
 """,
-        external_functions=ext,
+        external_lookup=ext,
     )
     assert result == snapshot(
         {
@@ -910,7 +921,7 @@ async def test_llm_string_manipulation_of_external_result(asession: AsyncMontySe
 
     ext = {'fetch_page': fetch_page}
 
-    await asession.feed_run("html = await fetch_page('example.com')", external_functions=ext)
+    await asession.feed_run("html = await fetch_page('example.com')", external_lookup=ext)
 
     # LLM extracts title
     result = await asession.feed_run(
@@ -920,7 +931,7 @@ end = html.find('</title>')
 title = html[start:end]
 title
 """,
-        external_functions=ext,
+        external_lookup=ext,
     )
     assert result == snapshot('Test Page')
 
@@ -936,7 +947,7 @@ while '<p>' in remaining:
     remaining = remaining[e + 4:]
 paragraphs
 """,
-        external_functions=ext,
+        external_lookup=ext,
     )
     assert result == snapshot(['Hello', 'World'])
 
@@ -950,12 +961,12 @@ async def test_llm_syntax_error_then_fix(asession: AsyncMontySession):
     ext = {'add': add}
 
     # Snippet 1: set up state
-    await asession.feed_run('x = 10', external_functions=ext)
+    await asession.feed_run('x = 10', external_lookup=ext)
 
     # Snippet 2: syntax error
     with pytest.raises(MontySyntaxError):
-        await asession.feed_run('y = add(x,', external_functions=ext)
+        await asession.feed_run('y = add(x,', external_lookup=ext)
 
     # Snippet 3: state preserved, LLM fixes the code
-    result = await asession.feed_run('y = add(x, 5)\ny', external_functions=ext)
+    result = await asession.feed_run('y = add(x, 5)\ny', external_lookup=ext)
     assert result == snapshot(15)

--- a/crates/monty-python/tests/test_dataclasses.py
+++ b/crates/monty-python/tests/test_dataclasses.py
@@ -402,7 +402,7 @@ caught
         raise FrozenInstanceError('cannot assign to field')
 
     # Monty should catch it as FrozenInstanceError specifically
-    result = monty_run(code, external_functions={'fail': fail})
+    result = monty_run(code, external_lookup={'fail': fail})
     assert result == snapshot('frozen')
 
 
@@ -413,7 +413,7 @@ def test_frozen_instance_error_from_external_function_propagates(monty_run: RunM
         raise FrozenInstanceError('test frozen error')
 
     with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
-        monty_run('fail()', external_functions={'fail': fail})
+        monty_run('fail()', external_lookup={'fail': fail})
     inner = exc_info.value.exception()
     assert isinstance(inner, FrozenInstanceError)
     assert inner.args[0] == snapshot('test frozen error')

--- a/crates/monty-python/tests/test_external.py
+++ b/crates/monty-python/tests/test_external.py
@@ -17,7 +17,7 @@ def test_external_function_no_args(monty_run: RunMonty):
         assert kwargs == snapshot({})
         return 'called'
 
-    assert monty_run('noop()', external_functions={'noop': noop}) == snapshot('called')
+    assert monty_run('noop()', external_lookup={'noop': noop}) == snapshot('called')
 
 
 def test_external_function_positional_args(monty_run: RunMonty):
@@ -26,7 +26,7 @@ def test_external_function_positional_args(monty_run: RunMonty):
         assert kwargs == snapshot({})
         return 'ok'
 
-    assert monty_run('func(1, 2, 3)', external_functions={'func': func}) == snapshot('ok')
+    assert monty_run('func(1, 2, 3)', external_lookup={'func': func}) == snapshot('ok')
 
 
 def test_external_function_kwargs_only(monty_run: RunMonty):
@@ -35,7 +35,7 @@ def test_external_function_kwargs_only(monty_run: RunMonty):
         assert kwargs == snapshot({'a': 1, 'b': 'two'})
         return 'ok'
 
-    assert monty_run('func(a=1, b="two")', external_functions={'func': func}) == snapshot('ok')
+    assert monty_run('func(a=1, b="two")', external_lookup={'func': func}) == snapshot('ok')
 
 
 def test_external_function_mixed_args_kwargs(monty_run: RunMonty):
@@ -44,7 +44,7 @@ def test_external_function_mixed_args_kwargs(monty_run: RunMonty):
         assert kwargs == snapshot({'x': 'hello', 'y': True})
         return 'ok'
 
-    assert monty_run('func(1, 2, x="hello", y=True)', external_functions={'func': func}) == snapshot('ok')
+    assert monty_run('func(1, 2, x="hello", y=True)', external_lookup={'func': func}) == snapshot('ok')
 
 
 def test_external_function_complex_types(monty_run: RunMonty):
@@ -53,7 +53,7 @@ def test_external_function_complex_types(monty_run: RunMonty):
         assert kwargs == snapshot({})
         return 'ok'
 
-    assert monty_run('func([1, 2], {"key": "value"})', external_functions={'func': func}) == snapshot('ok')
+    assert monty_run('func([1, 2], {"key": "value"})', external_lookup={'func': func}) == snapshot('ok')
 
 
 def test_external_function_type_objects(monty_run: RunMonty):
@@ -93,7 +93,7 @@ func(
         assert kwargs == {}
         return 'ok'
 
-    assert monty_run(code, external_functions={'func': func}) == snapshot('ok')
+    assert monty_run(code, external_lookup={'func': func}) == snapshot('ok')
 
 
 def test_external_function_returns_instances(monty_run: RunMonty):
@@ -113,7 +113,7 @@ results
         'get_tz': lambda: datetime.timezone(datetime.timedelta(hours=5)),
         'get_path': lambda: pathlib.PurePosixPath('/a/b'),
     }
-    assert monty_run(code, external_functions=fns) == snapshot(
+    assert monty_run(code, external_lookup=fns) == snapshot(
         [
             ('datetime.datetime', 'datetime.datetime(2021, 1, 2, 3, 4, 5)'),
             ('datetime.datetime', 'datetime.datetime(2021, 1, 2, 3, 4, 5, tzinfo=datetime.timezone.utc)'),
@@ -145,7 +145,7 @@ except TypeError as e:
     result = str(e)
 result
 """
-    assert monty_run(code, external_functions={'get_thing': factory}) == message
+    assert monty_run(code, external_lookup={'get_thing': factory}) == message
 
 
 def test_external_function_returns_none(monty_run: RunMonty):
@@ -153,18 +153,18 @@ def test_external_function_returns_none(monty_run: RunMonty):
         assert args == snapshot(())
         assert kwargs == snapshot({})
 
-    assert monty_run('do_nothing()', external_functions={'do_nothing': do_nothing}) is None
+    assert monty_run('do_nothing()', external_lookup={'do_nothing': do_nothing}) is None
 
 
 def test_external_function_returns_complex_type(monty_run: RunMonty):
     def get_data(*args: Any, **kwargs: Any) -> dict[str, Any]:
         return {'a': [1, 2, 3], 'b': {'nested': True}}
 
-    result = monty_run('get_data()', external_functions={'get_data': get_data})
+    result = monty_run('get_data()', external_lookup={'get_data': get_data})
     assert result == snapshot({'a': [1, 2, 3], 'b': {'nested': True}})
 
 
-def test_multiple_external_functions(monty_run: RunMonty):
+def test_multiple_external_lookup(monty_run: RunMonty):
     def add(*args: Any, **kwargs: Any) -> int:
         assert args == snapshot((1, 2))
         assert kwargs == snapshot({})
@@ -175,7 +175,7 @@ def test_multiple_external_functions(monty_run: RunMonty):
         assert kwargs == snapshot({})
         return args[0] * args[1]
 
-    result = monty_run('add(1, 2) + mul(3, 4)', external_functions={'add': add, 'mul': mul})
+    result = monty_run('add(1, 2) + mul(3, 4)', external_lookup={'add': add, 'mul': mul})
     assert result == snapshot(15)  # 3 + 12
 
 
@@ -189,7 +189,7 @@ def test_external_function_called_multiple_times(monty_run: RunMonty):
         call_count += 1
         return call_count
 
-    result = monty_run('counter() + counter() + counter()', external_functions={'counter': counter})
+    result = monty_run('counter() + counter() + counter()', external_lookup={'counter': counter})
     assert result == snapshot(6)  # 1 + 2 + 3
     assert call_count == snapshot(3)
 
@@ -200,11 +200,11 @@ def test_external_function_with_input(monty_run: RunMonty):
         assert kwargs == snapshot({})
         return args[0] * 10
 
-    assert monty_run('process(x)', inputs={'x': 5}, external_functions={'process': process}) == snapshot(50)
+    assert monty_run('process(x)', inputs={'x': 5}, external_lookup={'process': process}) == snapshot(50)
 
 
 def test_external_function_not_provided_raises_name_error(monty_run: RunMonty):
-    """Calling an unknown function without external_functions raises NameError."""
+    """Calling an unknown function without external_lookup raises NameError."""
     with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
         monty_run('missing()')
     inner = exc_info.value.exception()
@@ -227,20 +227,20 @@ def test_external_function_raises_exception(monty_run: RunMonty):
         raise ValueError('intentional error')
 
     with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
-        monty_run('fail()', external_functions={'fail': fail})
+        monty_run('fail()', external_lookup={'fail': fail})
     inner = exc_info.value.exception()
     assert isinstance(inner, ValueError)
     assert inner.args[0] == snapshot('intentional error')
 
 
 def test_external_function_wrong_name_raises(monty_run: RunMonty):
-    """Test that calling a function not in external_functions raises NameError."""
+    """Test that calling a function not in external_lookup raises NameError."""
 
     def bar(*args: Any, **kwargs: Any) -> int:
         return 1
 
     with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
-        monty_run('foo()', external_functions={'bar': bar})
+        monty_run('foo()', external_lookup={'bar': bar})
     inner = exc_info.value.exception()
     assert type(inner) is NameError
     assert str(inner) == snapshot("name 'foo' is not defined")
@@ -259,7 +259,7 @@ caught
     def fail(*args: Any, **kwargs: Any) -> None:
         raise ValueError('caught error')
 
-    result = monty_run(code, external_functions={'fail': fail})
+    result = monty_run(code, external_lookup={'fail': fail})
     assert result == snapshot(True)
 
 
@@ -270,7 +270,7 @@ def test_external_function_exception_type_preserved(monty_run: RunMonty):
         raise TypeError('type error message')
 
     with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
-        monty_run('fail()', external_functions={'fail': fail_type_error})
+        monty_run('fail()', external_lookup={'fail': fail_type_error})
     inner = exc_info.value.exception()
     assert isinstance(inner, TypeError)
     assert inner.args[0] == snapshot('type error message')
@@ -288,7 +288,7 @@ def test_external_function_unsupported_operation_preserves_type(monty_run: RunMo
         raise io.UnsupportedOperation('not readable')
 
     with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
-        monty_run('fail()', external_functions={'fail': fail})
+        monty_run('fail()', external_lookup={'fail': fail})
     inner = exc_info.value.exception()
     assert type(inner) is io.UnsupportedOperation
     assert isinstance(inner, io.UnsupportedOperation)
@@ -313,7 +313,7 @@ caught
     def fail(*args: Any, **kwargs: Any) -> None:
         raise io.UnsupportedOperation('boom')
 
-    assert monty_run(code, external_functions={'fail': fail}) == parent
+    assert monty_run(code, external_lookup={'fail': fail}) == parent
 
 
 @pytest.mark.parametrize(
@@ -348,7 +348,7 @@ def test_external_function_exception_hierarchy(
         raise exception_class('test message')
 
     with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
-        monty_run('fail()', external_functions={'fail': fail})
+        monty_run('fail()', external_lookup={'fail': fail})
     inner = exc_info.value.exception()
     assert isinstance(inner, exception_class)
 
@@ -388,7 +388,7 @@ caught
         raise exception_class('test')
 
     # Child exception should be caught by parent handler (which comes first)
-    result = monty_run(code, external_functions={'fail': fail})
+    result = monty_run(code, external_lookup={'fail': fail})
     assert result == 'parent'
 
 
@@ -418,7 +418,7 @@ caught
     def fail(*args: Any, **kwargs: Any) -> None:
         raise exception_class('test')
 
-    result = monty_run(code, external_functions={'fail': fail})
+    result = monty_run(code, external_lookup={'fail': fail})
     assert result == expected_result
 
 
@@ -429,7 +429,7 @@ def test_external_function_exception_in_expression(monty_run: RunMonty):
         raise RuntimeError('mid-expression error')
 
     with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
-        monty_run('1 + fail() + 2', external_functions={'fail': fail})
+        monty_run('1 + fail() + 2', external_lookup={'fail': fail})
     inner = exc_info.value.exception()
     assert isinstance(inner, RuntimeError)
     assert inner.args[0] == snapshot('mid-expression error')
@@ -450,7 +450,7 @@ a + b
         raise ValueError('second call fails')
 
     with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
-        monty_run(code, external_functions={'success': success, 'fail': fail})
+        monty_run(code, external_lookup={'success': success, 'fail': fail})
     inner = exc_info.value.exception()
     assert isinstance(inner, ValueError)
     assert inner.args[0] == snapshot('second call fails')
@@ -472,7 +472,7 @@ finally_ran
     def fail(*args: Any, **kwargs: Any) -> None:
         raise ValueError('error')
 
-    result = monty_run(code, external_functions={'fail': fail})
+    result = monty_run(code, external_lookup={'fail': fail})
     assert result == snapshot(True)
 
 
@@ -488,7 +488,7 @@ except ValueError:
     result = 'caught'
 result
 """
-    assert monty_run(code, external_functions={'get_str': lambda: '\ud83d'}) == snapshot('caught')
+    assert monty_run(code, external_lookup={'get_str': lambda: '\ud83d'}) == snapshot('caught')
 
 
 def test_external_function_return_unconvertible_catchable_inside_monty(monty_run: RunMonty):
@@ -502,4 +502,51 @@ except TypeError:
     result = 'caught'
 result
 """
-    assert monty_run(code, external_functions={'get_thing': lambda: object()}) == snapshot('caught')
+    assert monty_run(code, external_lookup={'get_thing': lambda: object()}) == snapshot('caught')
+
+
+# =============================================================================
+# external_lookup value resolution (non-callable entries)
+# =============================================================================
+
+
+def test_external_lookup_value(monty_run: RunMonty):
+    """A non-callable entry resolves the bare name to that converted value."""
+    assert monty_run('x + 1', external_lookup={'x': 41}) == snapshot(42)
+
+
+def test_external_lookup_value_container(monty_run: RunMonty):
+    """Container values convert and round-trip through a name lookup."""
+    assert monty_run('data["a"] + data["b"]', external_lookup={'data': {'a': 1, 'b': 2}}) == snapshot(3)
+
+
+def test_external_lookup_mixed_function_and_value(monty_run: RunMonty):
+    """One dict can carry both a callable (function proxy) and a plain value."""
+
+    def double(x: int) -> int:
+        return x * 2
+
+    assert monty_run('double(n)', external_lookup={'double': double, 'n': 21}) == snapshot(42)
+
+
+def test_external_lookup_value_cached(monty_run: RunMonty):
+    """The monty interpreter caches a resolved value, so referencing the same
+    name twice in one feed reads a single resolved value."""
+    assert monty_run('x + x', external_lookup={'x': 21}) == snapshot(42)
+
+
+def test_external_lookup_absent_name_raises(monty_run: RunMonty):
+    """A name absent from external_lookup raises NameError (not the value path)."""
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        monty_run('missing', external_lookup={'present': 1})
+    inner = exc_info.value.exception()
+    assert type(inner) is NameError
+    assert str(inner) == snapshot("name 'missing' is not defined")
+
+
+def test_external_lookup_value_unconvertible_surfaces_error(monty_run: RunMonty):
+    """A non-callable value of an unsupported type surfaces a conversion error,
+    not a misleading NameError."""
+    with pytest.raises(TypeError) as exc_info:
+        monty_run('x', external_lookup={'x': object()})
+    assert str(exc_info.value) == snapshot('Cannot convert builtins.object to Monty value')

--- a/crates/monty-python/tests/test_external.py
+++ b/crates/monty-python/tests/test_external.py
@@ -9,6 +9,7 @@ from conftest import RunMonty
 from inline_snapshot import snapshot
 
 import pydantic_monty
+from pydantic_monty import MontySession
 
 
 def test_external_function_no_args(monty_run: RunMonty):
@@ -550,3 +551,25 @@ def test_external_lookup_value_unconvertible_surfaces_error(monty_run: RunMonty)
     with pytest.raises(TypeError) as exc_info:
         monty_run('x', external_lookup={'x': object()})
     assert str(exc_info.value) == snapshot('Cannot convert builtins.object to Monty value')
+
+
+def test_external_lookup_type_object_round_trips(monty_run: RunMonty):
+    """A modeled type object resolves a bare name to the Monty type (so
+    `isinstance` works), rather than degrading to a host-function proxy just
+    because a type is callable."""
+    assert monty_run('isinstance(5, IntType)', external_lookup={'IntType': int}) == snapshot(True)
+    assert monty_run('isinstance(5, StrType)', external_lookup={'StrType': str}) == snapshot(False)
+
+
+def test_external_lookup_name_conversion_error_discards_session(session: MontySession):
+    """A conversion failure while resolving a bare name discards the suspended
+    worker rather than wedging it: the feed raises, and a follow-up feed on the
+    same session fails fast instead of hanging on a dangling name-lookup
+    suspension the aborted feed never answered."""
+    with pytest.raises(TypeError) as exc_info:
+        session.feed_run('x', external_lookup={'x': object()})
+    assert str(exc_info.value) == snapshot('Cannot convert builtins.object to Monty value')
+    # the worker was discarded, so the session can no longer be fed
+    with pytest.raises(RuntimeError) as exc_info2:
+        session.feed_run('1 + 1')
+    assert str(exc_info2.value) == snapshot('this checkout has already been finished')

--- a/crates/monty-python/tests/test_external.py
+++ b/crates/monty-python/tests/test_external.py
@@ -516,6 +516,12 @@ def test_external_lookup_value(monty_run: RunMonty):
     assert monty_run('x + 1', external_lookup={'x': 41}) == snapshot(42)
 
 
+def test_external_lookup_value_none(monty_run: RunMonty):
+    """A `None` entry is a present name resolving to `None`, not a `NameError`
+    (pins consistency with the JS bindings' `null`/`undefined` entries)."""
+    assert monty_run('x is None', external_lookup={'x': None}) == snapshot(True)
+
+
 def test_external_lookup_value_container(monty_run: RunMonty):
     """Container values convert and round-trip through a name lookup."""
     assert monty_run('data["a"] + data["b"]', external_lookup={'data': {'a': 1, 'b': 2}}) == snapshot(3)
@@ -530,9 +536,11 @@ def test_external_lookup_mixed_function_and_value(monty_run: RunMonty):
     assert monty_run('double(n)', external_lookup={'double': double, 'n': 21}) == snapshot(42)
 
 
-def test_external_lookup_value_cached(monty_run: RunMonty):
-    """The monty interpreter caches a resolved value, so referencing the same
-    name twice in one feed reads a single resolved value."""
+def test_external_lookup_value_repeated_reference(monty_run: RunMonty):
+    """Referencing the same lazily-resolved name twice in one feed works. The
+    worker caches the resolved value, but dict reads are not observable
+    host-side (`get_item` bypasses subclass hooks), so this only pins the
+    result; the JS test observes the single read via a getter."""
     assert monty_run('x + x', external_lookup={'x': 21}) == snapshot(42)
 
 
@@ -559,6 +567,23 @@ def test_external_lookup_type_object_round_trips(monty_run: RunMonty):
     because a type is callable."""
     assert monty_run('isinstance(5, IntType)', external_lookup={'IntType': int}) == snapshot(True)
     assert monty_run('isinstance(5, StrType)', external_lookup={'StrType': str}) == snapshot(False)
+
+
+def test_external_lookup_stale_proxy_not_callable(session: MontySession):
+    """A function proxy cached in one feed dispatches by name against the
+    *current* dict on each call: with the entry replaced by a plain value,
+    calling it raises the TypeError CPython would for calling that value (the
+    JS bindings synthesize the same error)."""
+
+    def double(x: int) -> int:
+        return x * 2
+
+    session.feed_run('f = double', external_lookup={'double': double})
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        session.feed_run('f(2)', external_lookup={'double': 5})
+    inner = exc_info.value.exception()
+    assert type(inner) is TypeError
+    assert str(inner) == snapshot("'int' object is not callable")
 
 
 def test_external_lookup_name_conversion_error_discards_session(session: MontySession):

--- a/crates/monty-python/tests/test_external_async.py
+++ b/crates/monty-python/tests/test_external_async.py
@@ -64,3 +64,18 @@ result
         return object()
 
     assert await run_async(code, external_lookup={'get_thing': get_thing}) == snapshot('caught')
+
+
+async def test_async_external_lookup_name_conversion_error_discards_session():
+    """As in the sync drive loop, a conversion failure while resolving a bare
+    name discards the suspended worker rather than wedging it: the feed raises,
+    and a follow-up feed on the same session fails fast instead of hanging."""
+    async with pydantic_monty.AsyncMonty() as pool:
+        async with pool.checkout() as session:
+            with pytest.raises(TypeError) as exc_info:
+                await session.feed_run('x', external_lookup={'x': object()})
+            assert str(exc_info.value) == snapshot('Cannot convert builtins.object to Monty value')
+            # the worker was discarded, so the session can no longer be fed
+            with pytest.raises(RuntimeError) as exc_info2:
+                await session.feed_run('1 + 1')
+            assert str(exc_info2.value) == snapshot('this checkout has already been finished')

--- a/crates/monty-python/tests/test_external_async.py
+++ b/crates/monty-python/tests/test_external_async.py
@@ -24,7 +24,7 @@ async def test_async_external_function_raises_surfaces_as_monty_runtime_error():
         raise ValueError('intentional error')
 
     with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
-        await run_async('await fail()', external_functions={'fail': fail})
+        await run_async('await fail()', external_lookup={'fail': fail})
     inner = exc_info.value.exception()
     assert isinstance(inner, ValueError)
     assert inner.args[0] == snapshot('intentional error')
@@ -45,7 +45,7 @@ result
     async def get_str():
         return '\ud83d'
 
-    assert await run_async(code, external_functions={'get_str': get_str}) == snapshot('caught')
+    assert await run_async(code, external_lookup={'get_str': get_str}) == snapshot('caught')
 
 
 async def test_async_external_function_return_unconvertible_catchable_inside_monty():
@@ -63,4 +63,4 @@ result
     async def get_thing():
         return object()
 
-    assert await run_async(code, external_functions={'get_thing': get_thing}) == snapshot('caught')
+    assert await run_async(code, external_lookup={'get_thing': get_thing}) == snapshot('caught')

--- a/crates/monty-python/tests/test_pool.py
+++ b/crates/monty-python/tests/test_pool.py
@@ -163,7 +163,7 @@ result
         raise AssertionError('the call must never reach the host')
 
     with pool.checkout() as session:
-        result = session.feed_run(code, external_functions={'f': f})
+        result = session.feed_run(code, external_lookup={'f': f})
     assert result == snapshot('Max argument depth exceeded')
 
 

--- a/crates/monty-python/tests/test_print.py
+++ b/crates/monty-python/tests/test_print.py
@@ -182,7 +182,7 @@ fetch()
     with pytest.raises(MontyRuntimeError) as exc_info:
         session.feed_run(
             code,
-            external_functions={'fetch': lambda: 42},
+            external_lookup={'fetch': lambda: 42},
             print_callback=make_error_callback(ValueError('callback boom')),
         )
     assert exc_info.value.exception().args[0] == snapshot('callback boom')
@@ -289,7 +289,7 @@ x = fetch()
 print("after", x)
 """
     collector = CollectStreams()
-    result = monty_run(code, external_functions={'fetch': lambda: 10}, print_callback=collector)
+    result = monty_run(code, external_lookup={'fetch': lambda: 10}, print_callback=collector)
 
     assert result is None
     assert collector.output == snapshot([('stdout', 'before\n'), ('stdout', 'after 10\n')])
@@ -302,7 +302,7 @@ x = fetch()
 print("after", x)
 """
     collector = CollectString()
-    result = monty_run(code, external_functions={'fetch': lambda: 10}, print_callback=collector)
+    result = monty_run(code, external_lookup={'fetch': lambda: 10}, print_callback=collector)
 
     assert result is None
     assert collector.output == snapshot('before\nafter 10\n')

--- a/crates/monty-python/tests/test_repl.py
+++ b/crates/monty-python/tests/test_repl.py
@@ -292,7 +292,7 @@ def test_external_function_basic(session: MontySession):
     def add(a: int, b: int) -> int:
         return a + b
 
-    assert session.feed_run('result = add(3, 4)', external_functions={'add': add}) == snapshot(None)
+    assert session.feed_run('result = add(3, 4)', external_lookup={'add': add}) == snapshot(None)
     assert session.feed_run('result') == snapshot(7)
 
 
@@ -300,7 +300,7 @@ def test_external_function_return_value(session: MontySession):
     def greet(name: str) -> str:
         return f'hello {name}'
 
-    assert session.feed_run('greet("world")', external_functions={'greet': greet}) == snapshot('hello world')
+    assert session.feed_run('greet("world")', external_lookup={'greet': greet}) == snapshot('hello world')
 
 
 def test_external_function_called_multiple_times(session: MontySession):
@@ -312,8 +312,8 @@ def test_external_function_called_multiple_times(session: MontySession):
         return call_count
 
     ext = {'counter': counter}
-    assert session.feed_run('counter()', external_functions=ext) == snapshot(1)
-    assert session.feed_run('counter()', external_functions=ext) == snapshot(2)
+    assert session.feed_run('counter()', external_lookup=ext) == snapshot(1)
+    assert session.feed_run('counter()', external_lookup=ext) == snapshot(2)
     assert call_count == 2
 
 
@@ -322,7 +322,7 @@ def test_external_function_persists_state_across_feeds(session: MontySession):
         return x * 2
 
     session.feed_run('x = 5')
-    assert session.feed_run('double(x)', external_functions={'double': double}) == snapshot(10)
+    assert session.feed_run('double(x)', external_lookup={'double': double}) == snapshot(10)
 
 
 def test_external_function_exception_becomes_runtime_error(session: MontySession):
@@ -330,7 +330,7 @@ def test_external_function_exception_becomes_runtime_error(session: MontySession
         raise ValueError('external failure')
 
     with pytest.raises(MontyRuntimeError) as exc_info:
-        session.feed_run('fail()', external_functions={'fail': fail})
+        session.feed_run('fail()', external_lookup={'fail': fail})
     inner = exc_info.value.exception()
     assert isinstance(inner, ValueError)
     assert str(inner) == snapshot('external failure')
@@ -342,22 +342,22 @@ def test_external_function_error_preserves_session_state(session: MontySession):
 
     session.feed_run('x = 42')
     with pytest.raises(MontyRuntimeError):
-        session.feed_run('fail()', external_functions={'fail': fail})
+        session.feed_run('fail()', external_lookup={'fail': fail})
     # session state should be preserved after error
     assert session.feed_run('x') == snapshot(42)
 
 
 def test_external_function_undefined_raises_name_error(session: MontySession):
-    """Calling a name that's not in external_functions raises NameError."""
+    """Calling a name that's not in external_lookup raises NameError."""
     with pytest.raises(MontyRuntimeError) as exc_info:
-        session.feed_run('unknown()', external_functions={'known': lambda: 1})
+        session.feed_run('unknown()', external_lookup={'known': lambda: 1})
     assert isinstance(exc_info.value.exception(), NameError)
 
 
 def test_external_function_with_print_callback(session: MontySession):
     output, callback = make_print_collector()
     ext = {'get_msg': lambda: 'from external'}
-    session.feed_run('x = get_msg()\nprint(x)', external_functions=ext, print_callback=callback)
+    session.feed_run('x = get_msg()\nprint(x)', external_lookup=ext, print_callback=callback)
     assert ''.join(output) == snapshot('from external\n')
 
 
@@ -365,9 +365,7 @@ def test_external_function_with_kwargs(session: MontySession):
     def greet(name: str, greeting: str = 'hello') -> str:
         return f'{greeting} {name}'
 
-    assert session.feed_run("greet('world', greeting='hi')", external_functions={'greet': greet}) == snapshot(
-        'hi world'
-    )
+    assert session.feed_run("greet('world', greeting='hi')", external_lookup={'greet': greet}) == snapshot('hi world')
 
 
 # === Inputs ===
@@ -391,11 +389,11 @@ def test_inputs_override_existing_variable(session: MontySession):
     assert session.feed_run('x', inputs={'x': 99}) == snapshot(99)
 
 
-def test_inputs_with_external_functions(session: MontySession):
+def test_inputs_with_external_lookup(session: MontySession):
     def double(n: int) -> int:
         return n * 2
 
-    assert session.feed_run('double(x)', inputs={'x': 5}, external_functions={'double': double}) == snapshot(10)
+    assert session.feed_run('double(x)', inputs={'x': 5}, external_lookup={'double': double}) == snapshot(10)
 
 
 def test_inputs_various_types(session: MontySession):

--- a/crates/monty-python/tests/test_threading.py
+++ b/crates/monty-python/tests/test_threading.py
@@ -117,7 +117,7 @@ x
 
         def run() -> Any:
             with pool.checkout() as session:
-                return session.feed_run(code, external_functions={'double': double})
+                return session.feed_run(code, external_lookup={'double': double})
 
         start = time.perf_counter()
         assert run() == 300_000

--- a/crates/monty-python/tests/test_type_check.py
+++ b/crates/monty-python/tests/test_type_check.py
@@ -201,7 +201,7 @@ def fetch(url: str) -> str:
     with pool.checkout(type_check=True, type_check_stubs=stubs) as session:
         result = session.feed_run(
             'result = fetch("https://example.com")',
-            external_functions={'fetch': lambda url: 'response'},  # pyright: ignore[reportUnknownLambdaType]
+            external_lookup={'fetch': lambda url: 'response'},  # pyright: ignore[reportUnknownLambdaType]
         )
         assert result == snapshot(None)
 
@@ -258,7 +258,7 @@ def test_type_check_stubs_without_trailing_newline(pool: Monty):
     with pool.checkout(type_check=True, type_check_stubs=stubs) as session:
         session.feed_run(
             "response = fetch('url')",
-            external_functions={'fetch': lambda url: 'data'},  # pyright: ignore[reportUnknownLambdaType]
+            external_lookup={'fetch': lambda url: 'data'},  # pyright: ignore[reportUnknownLambdaType]
         )
         # response must be visible in the next snippet even though stubs lacked \n
         assert session.feed_run('response.upper()') == snapshot('DATA')

--- a/crates/monty-python/tests/test_websocket.py
+++ b/crates/monty-python/tests/test_websocket.py
@@ -70,7 +70,7 @@ async def test_inputs_and_async_external_function_over_websocket(ws_url: str):
             result = await session.feed_run(
                 'await double(n) + 1',
                 inputs={'n': 20},
-                external_functions={'double': double},
+                external_lookup={'double': double},
             )
     assert result == snapshot(41)
 

--- a/examples/expense_analysis/main.py
+++ b/examples/expense_analysis/main.py
@@ -97,7 +97,7 @@ async def main():
             output = await session.feed_run(
                 code,
                 inputs={'prompt': 'testing'},
-                external_functions={
+                external_lookup={
                     'get_team_members': data.get_team_members,
                     'get_expenses': data.get_expenses,
                     'get_custom_budget': data.get_custom_budget,

--- a/examples/sql_playground/main.py
+++ b/examples/sql_playground/main.py
@@ -55,7 +55,7 @@ async def main():
         ) as session:
             results = await session.feed_run(
                 SANDBOX_CODE_PATH.read_text(),
-                external_functions={
+                external_lookup={
                     'query_csv': external_funcs.query_csv,
                     'read_json': external_funcs.read_json,
                     'analyze_sentiment': external_funcs.analyze_sentiment,

--- a/examples/web_scraper/main.py
+++ b/examples/web_scraper/main.py
@@ -122,7 +122,7 @@ Ignore any deprecated models.
                         ) as session:
                             output = await session.feed_run(
                                 extracted.code,
-                                external_functions={
+                                external_lookup={
                                     'open_page': browser.open_page,
                                     'beautiful_soup': beautiful_soup,
                                     'record_model_info': record_models.record_model_info,

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -157,6 +157,23 @@ properties that real CPython does not provide, per the caveat above.
 - **`os=` fallback** receives `(function_name, args, kwargs)`; mount-covered
   filesystem calls are handled inside the worker and never reach the
   callback.
+- **`external_lookup` resolves undefined names lazily.** `feed_run` /
+  `feedRun` take `external_lookup` (`externalLookup` in JS): a name the snippet
+  leaves undefined is resolved on first reference against this dict — a
+  *callable* entry becomes a host function proxy (invoked on the eventual call),
+  any *other value* is converted and returned directly, and an absent name
+  raises `NameError`. It is the lazy counterpart to the eager `inputs` (a name
+  present in both is served by the `inputs` binding, so no lookup fires). A
+  non-callable value that cannot be converted surfaces host-side (a conversion
+  error that rejects the turn), **not** as a misleading `NameError`. The two
+  workers diverge on *re-reading* a lazily-resolved **value**: the Monty sandbox
+  worker caches it in the namespace slot, so a second reference in the same feed
+  does not re-fire `NameLookup` (a later host mutation of the dict entry is not
+  observed), whereas the `monty-cpython` worker caches only function proxies and
+  re-fires `NameLookup` on every value reference (re-reading live). Function
+  proxies are cached by both. `feed_start` / `feedStart` take no
+  `external_lookup` — they surface name lookups as snapshots, which resolve only
+  to a function (see below).
 - **Dependency installation is only available on the embedded-CPython worker.**
   `session.install_dependencies([...])` (sync and async in `pydantic_monty`;
   `session.installDependencies([...])` in `@pydantic/monty`) makes the

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -171,7 +171,13 @@ properties that real CPython does not provide, per the caveat above.
   does not re-fire `NameLookup` (a later host mutation of the dict entry is not
   observed), whereas the `monty-cpython` worker caches only function proxies and
   re-fires `NameLookup` on every value reference (re-reading live). Function
-  proxies are cached by both. `feed_start` / `feedStart` take no
+  proxies are cached by both — but unlike a CPython function object, a proxy
+  dispatches by *name* against the dict passed to the current feed at call
+  time: replacing an entry rebinds every reference already holding the proxy,
+  and replacing it with a non-callable makes calls raise the `TypeError`
+  CPython would for calling that value (`'int' object is not callable`).
+  Because only *undefined* names fire lookups, an entry shadowing a builtin
+  (e.g. `{'len': ...}`) is silently ignored. `feed_start` / `feedStart` take no
   `external_lookup` — they surface name lookups as snapshots, which resolve only
   to a function (see below).
 - **Dependency installation is only available on the embedded-CPython worker.**


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the external function hook to external lookup and expanded it: undefined names now resolve lazily to host functions or plain values across Python, JS pool sessions, and the `@pydantic/monty/wasm` in‑process path.

- New Features
  - Added `external_lookup`/`externalLookup` for lazy name resolution: callables become host functions; other values are returned on read; absent names raise `NameError`. `inputs` wins when a name exists in both; function proxies are cached; value reads are not cached in CPython.
  - Safety/consistency: JS and WASM resolve/invoke own keys only; falsy values and `null`/`undefined` resolve; calling a cached proxy after its entry becomes non‑callable now raises a CPython‑style `TypeError`; dict access errors propagate; Python type objects round‑trip as types. WASM restores the mount table if a lookup/external call errors mid‑run.
  - API flow: `feed_start`/`feedStart` accept `external_lookup`; snapshots add `resume_auto`/`resumeAuto` to auto‑drive lookups, function calls, and futures. Conversion errors surface and end the session.

- Migration
  - Replace `external_functions` → `external_lookup` in Python (`pydantic_monty`) and `externalFunctions` → `externalLookup` in JS (`@pydantic/monty` and `@pydantic/monty/wasm`).
  - Use callables for calls; supply plain values for bare‑name reads. Missing names raise `NameError`; bad value conversions raise and end the session.

<sup>Written for commit e6bdcd070475d20912391c499dca2eba2542ae8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

