### PR TITLE
Fix wasm CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -986,8 +986,7 @@ jobs:
   build-wasm:
     name: build wasm
     runs-on: ubuntu-latest
-    # only run on push to main, on tags, or if 'Full Build' label is present
-    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'Full Build') || (github.event_name == 'workflow_dispatch' && inputs.run_release)
+    # used by test-wasm so always run this
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1077,7 +1077,7 @@ jobs:
       - name: Test bindings
         run: npx ava "__test__/wasm_*.spec.ts"
         env:
-          NAPI_RS_FORCE_WASI: 1
+          NAPI_RS_FORCE_WASI: true
         working-directory: crates/monty-js
 
   release-js:

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ build-wasm: install-js ## Build the wasm artifacts (requires the wasm32-wasip1-t
 
 .PHONY: test-wasm
 test-wasm: ## Test the in-process API against the wasm build (requires a prior build-wasm)
-	cd crates/monty-js && NAPI_RS_FORCE_WASI=1 npx ava "__test__/wasm_*.spec.ts"
+	cd crates/monty-js && NAPI_RS_FORCE_WASI=true npx ava "__test__/wasm_*.spec.ts"
 
 # OCI image for the monty-cpython sandbox worker. Override to retag/push, e.g.
 # `make build-cpython-image MONTY_CPYTHON_IMAGE=ghcr.io/pydantic/monty-cpython`.

--- a/crates/monty-js/__test__/external.spec.ts
+++ b/crates/monty-js/__test__/external.spec.ts
@@ -438,7 +438,20 @@ test('calling a stale proxy whose entry is now non-callable raises TypeError', a
 
 test('stale proxy TypeError names tuple-marked and __monty_type__ values', async (t) => {
   // The type in the message follows the js->monty conversion, honoring the
-  // `__tuple__` array marker and `__monty_type__` object markers.
+  // `__tuple__` array marker and `__monty_type__` object markers. The marked
+  // payload must be a *valid* value for that type (a bare `{ __monty_type__:
+  // 'DateTime' }` fails conversion and would name `'object'` instead), so the
+  // datetime carries all the fields `js_to_monty` requires.
+  const datetime = {
+    __monty_type__: 'DateTime',
+    year: 2020,
+    month: 1,
+    day: 2,
+    hour: 3,
+    minute: 4,
+    second: 5,
+    microsecond: 6,
+  }
   const session = await pool().checkout()
   try {
     await session.feedRun('f = fn', { externalLookup: { fn: () => 1 } })
@@ -447,11 +460,33 @@ test('stale proxy TypeError names tuple-marked and __monty_type__ values', async
       { instanceOf: MontyRuntimeError },
     )
     t.is(tupleError.message, "TypeError: 'tuple' object is not callable")
-    const markedError = await t.throwsAsync(
-      () => session.feedRun('f()', { externalLookup: { fn: { __monty_type__: 'DateTime' } } }),
-      { instanceOf: MontyRuntimeError },
-    )
+    const markedError = await t.throwsAsync(() => session.feedRun('f()', { externalLookup: { fn: datetime } }), {
+      instanceOf: MontyRuntimeError,
+    })
     t.is(markedError.message, "TypeError: 'datetime' object is not callable")
+  } finally {
+    await session.close()
+  }
+})
+
+test('stale proxy TypeError survives a throwing getter on the entry', async (t) => {
+  // Naming the type reads `__monty_type__`/`__tuple__` off the entry *while
+  // formatting the error*; a host value whose getter (or Proxy trap) throws must
+  // still yield a clean sandbox TypeError, not escalate into a broken session.
+  const hostile = Object.defineProperty({}, '__monty_type__', {
+    get() {
+      throw new Error('boom')
+    },
+  })
+  const session = await pool().checkout()
+  try {
+    await session.feedRun('f = fn', { externalLookup: { fn: () => 1 } })
+    const error = await t.throwsAsync(() => session.feedRun('f()', { externalLookup: { fn: hostile } }), {
+      instanceOf: MontyRuntimeError,
+    })
+    t.is(error.message, "TypeError: 'dict' object is not callable")
+    // The session is still usable — the throwing getter did not poison it.
+    t.is(await session.feedRun('1 + 1'), 2)
   } finally {
     await session.close()
   }

--- a/crates/monty-js/__test__/external.spec.ts
+++ b/crates/monty-js/__test__/external.spec.ts
@@ -436,6 +436,27 @@ test('calling a stale proxy whose entry is now non-callable raises TypeError', a
   }
 })
 
+test('stale proxy TypeError names tuple-marked and __monty_type__ values', async (t) => {
+  // The type in the message follows the js->monty conversion, honoring the
+  // `__tuple__` array marker and `__monty_type__` object markers.
+  const session = await pool().checkout()
+  try {
+    await session.feedRun('f = fn', { externalLookup: { fn: () => 1 } })
+    const tupleError = await t.throwsAsync(
+      () => session.feedRun('f()', { externalLookup: { fn: Object.assign([1, 2], { __tuple__: true }) } }),
+      { instanceOf: MontyRuntimeError },
+    )
+    t.is(tupleError.message, "TypeError: 'tuple' object is not callable")
+    const markedError = await t.throwsAsync(
+      () => session.feedRun('f()', { externalLookup: { fn: { __monty_type__: 'DateTime' } } }),
+      { instanceOf: MontyRuntimeError },
+    )
+    t.is(markedError.message, "TypeError: 'datetime' object is not callable")
+  } finally {
+    await session.close()
+  }
+})
+
 test('externalLookup unconvertible value rejects the turn', async (t) => {
   // a non-callable value that cannot cross the wire surfaces as a conversion
   // error (not a misleading NameError); the worker never observed the name

--- a/crates/monty-js/__test__/wasm_external.spec.ts
+++ b/crates/monty-js/__test__/wasm_external.spec.ts
@@ -401,6 +401,40 @@ test('calling a proxy whose entry is now non-callable raises TypeError', (t) => 
   t.is(error.message, "TypeError: 'int' object is not callable")
 })
 
+test('non-callable TypeError names tuple-marked and __monty_type__ values', (t) => {
+  // The in-process path converts the entry (js_to_monty) and names the type of
+  // the result, so it must agree with the pool path's `pyTypeName`. A valid
+  // datetime (all fields present) names `'datetime'`; a bare `{ __monty_type__:
+  // 'DateTime' }` would fail conversion and name `'object'` instead.
+  const datetime = {
+    __monty_type__: 'DateTime',
+    year: 2020,
+    month: 1,
+    day: 2,
+    hour: 3,
+    minute: 4,
+    second: 5,
+    microsecond: 6,
+  }
+  const tupleLookup: Record<string, unknown> = {
+    f: () => {
+      tupleLookup.f = Object.assign([1, 2], { __tuple__: true })
+      return 1
+    },
+  }
+  const tupleError = t.throws(() => new Monty('f()\nf()').run({ externalLookup: tupleLookup }), isRuntimeError)
+  t.is(tupleError.message, "TypeError: 'tuple' object is not callable")
+
+  const dateLookup: Record<string, unknown> = {
+    f: () => {
+      dateLookup.f = datetime
+      return 1
+    },
+  }
+  const dateError = t.throws(() => new Monty('f()\nf()').run({ externalLookup: dateLookup }), isRuntimeError)
+  t.is(dateError.message, "TypeError: 'datetime' object is not callable")
+})
+
 test('externalLookup mixes a function and a value', (t) => {
   const m = new Monty('double(n)')
   const double = (x: number) => x * 2

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -12,6 +12,7 @@
         "@emnapi/core": "^1.5.0",
         "@emnapi/runtime": "^1.5.0",
         "@napi-rs/cli": "^3.2.0",
+        "@napi-rs/wasm-runtime": "^1.1.5",
         "@oxc-node/core": "^0.0.35",
         "@tybys/wasm-util": "^0.10.0",
         "@types/node": "^25.0.9",
@@ -1282,8 +1283,8 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
       "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.2"
       },

--- a/crates/monty-js/package.json
+++ b/crates/monty-js/package.json
@@ -67,6 +67,7 @@
     "@emnapi/core": "^1.5.0",
     "@emnapi/runtime": "^1.5.0",
     "@napi-rs/cli": "^3.2.0",
+    "@napi-rs/wasm-runtime": "^1.1.5",
     "@oxc-node/core": "^0.0.35",
     "@tybys/wasm-util": "^0.10.0",
     "@types/node": "^25.0.9",

--- a/crates/monty-js/ts/errors.ts
+++ b/crates/monty-js/ts/errors.ts
@@ -290,13 +290,29 @@ function pyTypeName(value: unknown): string {
       if (value instanceof Map) return 'dict'
       if (value instanceof Set) return 'set'
       if (Array.isArray(value)) {
-        return (value as { __tuple__?: boolean }).__tuple__ ? 'tuple' : 'list'
+        return readMarker(value, '__tuple__') ? 'tuple' : 'list'
       }
-      const marker = (value as { __monty_type__?: unknown }).__monty_type__
+      const marker = readMarker(value, '__monty_type__')
       return typeof marker === 'string' ? (MARKED_TYPE_NAMES[marker] ?? 'dict') : 'dict'
     }
     default:
       // symbols and other exotic values have no Monty equivalent
       return 'object'
+  }
+}
+
+/**
+ * Reads a marker property off a host-provided value without letting a throwing
+ * getter or `Proxy` trap escape. `pyTypeName` runs *while formatting a
+ * TypeError message*, and the drive loop treats any throw from a call handler as
+ * fatal (it marks the session broken), so an exotic `externalLookup` entry must
+ * still degrade to a plain type rather than poison the turn — mirroring the Rust
+ * `js_to_monty`, which falls back to `object`/`dict` on any conversion failure.
+ */
+function readMarker(value: object, key: '__tuple__' | '__monty_type__'): unknown {
+  try {
+    return (value as Record<string, unknown>)[key]
+  } catch {
+    return undefined
   }
 }

--- a/crates/monty-js/ts/errors.ts
+++ b/crates/monty-js/ts/errors.ts
@@ -252,6 +252,23 @@ export function notCallableMessage(value: unknown): string {
   return `'${pyTypeName(value)}' object is not callable`
 }
 
+/**
+ * `__monty_type__` marker → the Python type its conversion produces. `Type`
+ * and `BuiltinFunction` cannot round-trip and convert to reprs; an unknown
+ * marker converts as a plain dict.
+ */
+const MARKED_TYPE_NAMES: Readonly<Record<string, string>> = {
+  Ellipsis: 'ellipsis',
+  Exception: 'Exception',
+  Date: 'date',
+  DateTime: 'datetime',
+  TimeDelta: 'timedelta',
+  TimeZone: 'timezone',
+  Type: 'repr',
+  BuiltinFunction: 'repr',
+  Dataclass: 'dataclass',
+}
+
 /** Python type name the JS value converts to (mirrors the Rust `js_to_monty`). */
 function pyTypeName(value: unknown): string {
   if (value === null || value === undefined) {
@@ -266,12 +283,18 @@ function pyTypeName(value: unknown): string {
       return 'int'
     case 'string':
       return 'str'
-    case 'object':
+    case 'function':
+      return 'function'
+    case 'object': {
       if (value instanceof Uint8Array) return 'bytes'
       if (value instanceof Map) return 'dict'
       if (value instanceof Set) return 'set'
-      if (Array.isArray(value)) return 'list'
-      return 'dict'
+      if (Array.isArray(value)) {
+        return (value as { __tuple__?: boolean }).__tuple__ ? 'tuple' : 'list'
+      }
+      const marker = (value as { __monty_type__?: unknown }).__monty_type__
+      return typeof marker === 'string' ? (MARKED_TYPE_NAMES[marker] ?? 'dict') : 'dict'
+    }
     default:
       // symbols and other exotic values have no Monty equivalent
       return 'object'


### PR DESCRIPTION
Follow up to #520 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes wasm CI by forcing WASI, always building wasm, and installing the wasm runtime so tests run against the fresh artifact. Also fixes and hardens not-callable TypeErrors to name `tuple`/`__monty_type__` values and avoid session breakage from hostile lookups.

- Bug Fixes
  - Ensure wasm tests use the built wasm: always run build-wasm, force WASI with NAPI_RS_FORCE_WASI=true, and add `@napi-rs/wasm-runtime` so the wasi loader resolves; "1" was loading native `@pydantic/monty-linux-x64-gnu`.
  - Align and harden not-callable TypeErrors: mirror js→monty for `__tuple__` and `__monty_type__` (e.g., 'tuple', 'datetime'); read markers safely to tolerate throwing getters/Proxies and keep sessions intact; add matching in-process and wasm tests for consistency.

<sup>Written for commit 4bf02ff572d6e9b165551648a33cb186ab5b0b7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

