### PR TITLE
small perf wins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,6 +414,8 @@ NOTE: COMMENTS AND DOCSTRINGS ARE EXTREMELY IMPORTANT TO THE LONG TERM HEALTH OF
 
 NOTE: COMMENTS AND DOCSTRINGS SHOULD BE CONCISE - EXCESSIVELY VERBOSE DOCSTRINGS MAKE THE CODE HARDER TO READ AND MAINTAIN!
 
+Comments and field docstrings should almost never be more than 3 lines, mostly 1 line. Function and struct docstrings should be concise, generally <= 5 lines.
+
 ## Tests
 
 Do **NOT** write tests within modules unless explicitly prompted to do so.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,6 +2001,7 @@ dependencies = [
  "indexmap",
  "insta",
  "itertools 0.14.0",
+ "itoa",
  "jiter",
  "libm",
  "monty-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ num-bigint = { version = "0.4", features = ["serde"] }
 num-traits = "0.2"
 num-integer = "0.1"
 # others
+itoa = "1"
 ahash = { version = "0.8.0", features = ["serde"] }
 indexmap = { version = "2.9", features = ["serde"] }
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/crates/monty/Cargo.toml
+++ b/crates/monty/Cargo.toml
@@ -22,6 +22,7 @@ ruff_python_stdlib = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_text_size = { workspace = true }
 ahash = { workspace = true }
+itoa = { workspace = true }
 indexmap = { workspace = true }
 serde = { workspace = true }
 postcard = { workspace = true }

--- a/crates/monty/src/args/bind_python.rs
+++ b/crates/monty/src/args/bind_python.rs
@@ -22,6 +22,7 @@ use crate::{
     exception_private::{ExcType, RunResult, SimpleException},
     expressions::Identifier,
     heap::{HeapData, HeapGuard},
+    heap_traits::DropWithHeap,
     intern::{Interns, StringId},
     resource::ResourceTracker,
     types::{Dict, allocate_tuple},
@@ -220,20 +221,16 @@ impl Signature {
         namespace: &mut Vec<Value>,
     ) -> RunResult<()> {
         let (pos_iter, keyword_args) = args.into_parts();
-
-        // Convert kwargs to an iterator and guard it so remaining items are cleaned up
-        // on any error path
         let n_kwargs = keyword_args.len();
-        let keyword_args = keyword_args.into_iter();
-        defer_drop_mut!(keyword_args, vm);
-
         let namespace_base = namespace.len();
 
-        // Fast path for simple signatures (no defaults, no special params) and
-        // signatures with only positional-or-keyword params and defaults.
-        // This avoids the full binding algorithm overhead for common cases.
-
-        if matches!(self.bind_mode, BindMode::Simple | BindMode::SimpleWithDefaults) && n_kwargs == 0 {
+        // Fast path for simple signatures (no special params) and signatures
+        // with only positional-or-keyword params and defaults, when no keyword
+        // arguments are passed. Handled before building the kwargs iterator +
+        // guard below, which are pure overhead in this common positional case.
+        if n_kwargs == 0 && matches!(self.bind_mode, BindMode::Simple | BindMode::SimpleWithDefaults) {
+            // No keyword arguments to bind; the empty container holds no refs.
+            keyword_args.drop_with_heap(vm);
             match pos_iter {
                 ArgPosIter::Empty => {}
                 ArgPosIter::One(a) => {
@@ -271,7 +268,12 @@ impl Signature {
             return self.wrong_arg_count_error(actual_count, vm.interns, func_name);
         }
 
-        // Full binding algorithm for complex signatures or kwargs
+        // Full binding algorithm for complex signatures or kwargs. Convert
+        // kwargs to an iterator and guard it so remaining items are cleaned up
+        // on any error path.
+        let keyword_args = keyword_args.into_iter();
+        defer_drop_mut!(keyword_args, vm);
+
         // Extract interns before guards since HeapGuard borrows the full VM mutably
         // but we only need mutable access to the heap portion.
         let mut pos_iter_guard = HeapGuard::new(pos_iter, vm);

--- a/crates/monty/src/builtins/print.rs
+++ b/crates/monty/src/builtins/print.rs
@@ -52,7 +52,11 @@ pub fn builtin_print(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> 
             vm.print_writer.stdout_push(' ')?;
         }
         let s = value.py_str(vm)?;
-        vm.print_writer.stdout_write(s)?;
+        defer_drop!(s, vm);
+        // Resolve the `str` `Value` against the heap/interns tables directly so
+        // the `&str` borrow stays disjoint from the `&mut vm.print_writer` write.
+        vm.print_writer
+            .stdout_write(s.to_str_heap(vm.heap, vm.interns)?.into())?;
     }
 
     if let Some(end) = end_str {

--- a/crates/monty/src/builtins/repr.rs
+++ b/crates/monty/src/builtins/repr.rs
@@ -1,21 +1,17 @@
 //! Implementation of the repr() builtin function.
 
 use crate::{
-    args::ArgValues,
-    bytecode::VM,
-    defer_drop,
-    exception_private::RunResult,
-    resource::ResourceTracker,
-    types::{PyTrait, str::allocate_string},
+    args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, resource::ResourceTracker, types::PyTrait,
     value::Value,
 };
 
 /// Implementation of the repr() builtin function.
 ///
 /// Returns a string containing a printable representation of an object.
+/// `py_repr` already yields a heap `str` `Value`, so it is returned as-is
+/// without an intermediate `String` round-trip.
 pub fn builtin_repr(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("repr", vm.heap)?;
     defer_drop!(value, vm);
-    let s = value.py_repr(vm)?.into_owned();
-    Ok(allocate_string(s, vm.heap)?)
+    value.py_repr(vm)
 }

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -299,7 +299,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
     /// Extends the VM stack with the coroutine's pre-bound namespace values
     /// and pushes a new frame to execute the coroutine's function body.
     fn start_coroutine_frame(&mut self, func_id: FunctionId, namespace_values: Vec<Value>) -> Result<(), RunError> {
-        let call_position = self.current_position();
+        let call_offset = self.current_offset();
         let func = self.interns.get_function(func_id);
         let locals_count = u16::try_from(namespace_values.len()).expect("coroutine namespace size exceeds u16");
 
@@ -321,7 +321,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             locals_count,
             exc_stack_base,
             func_id,
-            call_position,
+            call_offset,
         ))?;
 
         Ok(())
@@ -546,7 +546,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
                 stack_base: f.stack_base,
                 locals_count: f.locals_count,
                 exception_stack_base: f.exception_stack_base,
-                call_position: f.call_position,
+                call_offset: f.call_offset,
                 is_initializer: f.is_initializer,
             })
             .collect();
@@ -619,7 +619,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
                         locals_count: sf.locals_count,
                         exception_stack_base: sf.exception_stack_base,
                         function_id: sf.function_id,
-                        call_position: sf.call_position,
+                        call_offset: sf.call_offset,
                         should_return: false,
                         is_initializer: sf.is_initializer,
                     }

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -680,7 +680,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         coro.get_mut(self.heap).state = CoroutineState::Running;
 
         // Push locals onto stack and push frame directly (can't use start_coroutine_frame
-        // because that needs a current frame for call_position, but spawned tasks
+        // because that needs a current frame for call_offset, but spawned tasks
         // don't have a parent frame — the coroutine is the root)
         let func = self.interns.get_function(func_id);
         let locals_count = u16::try_from(namespace_values.len()).expect("coroutine namespace size exceeds u16");

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -772,17 +772,9 @@ impl<T: ResourceTracker> VM<'_, T> {
     /// Sets up the function's namespace with bound arguments, cell variables,
     /// and free variables (captured from enclosing scope for closures).
     ///
-    /// Locals are built in the reusable `namespace_scratch` buffer under a
-    /// [`HeapGuard`] (which drops the bound values with the heap on any error
-    /// path) and then drained onto the VM stack. The frame's `stack_base`
-    /// points to the start of this locals region, and operands are pushed
-    /// above it.
-    ///
-    /// The caller's call-site offset is captured cheaply via
-    /// [`current_offset`](Self::current_offset) (resolved to a source range
-    /// lazily, only if a traceback is later built); it is `None` when no frames
-    /// are on the stack (e.g. host-initiated calls via
-    /// [`MontyRepl`](crate::MontyRepl)).
+    /// Locals are built in the reusable `namespace_scratch` buffer (under a
+    /// [`HeapGuard`] for cleanup on error) and moved onto the VM stack, where
+    /// `stack_base` points to the start of the locals region.
     fn call_sync_function(
         &mut self,
         func_id: FunctionId,
@@ -804,14 +796,9 @@ impl<T: ResourceTracker> VM<'_, T> {
         let size = namespace_size * mem::size_of::<Value>();
         self.heap.tracker_mut().on_allocate(|| size)?;
 
-        // 1. Build the namespace in the reusable scratch buffer, then drain it
-        //    onto the stack below. Reusing one allocation across calls avoids a
-        //    `malloc`/`free` per call. The buffer is always empty when taken
-        //    (drained + restored at the end of the previous call), and it is
-        //    never held across user-code execution, so this is safe under
-        //    recursion. On an error path the `HeapGuard` drops the buffer
-        //    entirely (leaving `namespace_scratch` empty); the pooling simply
-        //    restarts on the next successful call.
+        // 1. Build the namespace in the reusable scratch buffer to avoid a
+        //    per-call allocation. On error `HeapGuard` drops the buffer, so the
+        //    pool just restarts empty next call.
         let mut namespace = mem::take(&mut self.namespace_scratch);
         namespace.reserve(namespace_size);
         let mut namespace_guard = HeapGuard::new(namespace, self);
@@ -833,11 +820,10 @@ impl<T: ResourceTracker> VM<'_, T> {
         let code = &func.code;
 
         // 6. Commit the guard (no rollback) and push the frame. The operand
-        // stack starts immediately above the locals region — any
-        // comprehensions emit their own push/pop bytecode at entry/exit, so
-        // no frame-level region is reserved here. Drain (rather than move) the
-        // locals onto the stack so the buffer keeps its allocation, then return
-        // it to the pool for the next call.
+        // stack starts immediately above the locals region — comprehensions
+        // emit their own push/pop bytecode, so no frame-level region is
+        // reserved here. `append` empties the buffer (keeping its allocation)
+        // so it can return to the pool.
         let (mut namespace, this) = namespace_guard.into_parts();
         this.stack.append(&mut namespace);
         this.namespace_scratch = namespace;

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -772,13 +772,17 @@ impl<T: ResourceTracker> VM<'_, T> {
     /// Sets up the function's namespace with bound arguments, cell variables,
     /// and free variables (captured from enclosing scope for closures).
     ///
-    /// Locals are built directly on the VM stack using a [`StackGuard`] that
-    /// automatically rolls back on error. The frame's `stack_base` points to
-    /// the start of this locals region, and operands are pushed above it.
+    /// Locals are built in the reusable `namespace_scratch` buffer under a
+    /// [`HeapGuard`] (which drops the bound values with the heap on any error
+    /// path) and then drained onto the VM stack. The frame's `stack_base`
+    /// points to the start of this locals region, and operands are pushed
+    /// above it.
     ///
-    /// The call position is captured from [`current_position`](Self::current_position),
-    /// which returns `None` when no frames are on the stack (e.g. host-initiated
-    /// calls via [`MontyRepl`](crate::MontyRepl)).
+    /// The caller's call-site offset is captured cheaply via
+    /// [`current_offset`](Self::current_offset) (resolved to a source range
+    /// lazily, only if a traceback is later built); it is `None` when no frames
+    /// are on the stack (e.g. host-initiated calls via
+    /// [`MontyRepl`](crate::MontyRepl)).
     fn call_sync_function(
         &mut self,
         func_id: FunctionId,
@@ -786,7 +790,7 @@ impl<T: ResourceTracker> VM<'_, T> {
         defaults: &[Value],
         args: ArgValues,
     ) -> Result<CallResult, RunError> {
-        let call_position = self.current_position();
+        let call_offset = self.current_offset();
         let stack_base = self.stack.len();
 
         let func = self.interns.get_function(func_id);
@@ -800,8 +804,16 @@ impl<T: ResourceTracker> VM<'_, T> {
         let size = namespace_size * mem::size_of::<Value>();
         self.heap.tracker_mut().on_allocate(|| size)?;
 
-        // 1. Create namespace for the frame in a temporary vec, will extend to stack later
-        let namespace = Vec::with_capacity(func.namespace_size);
+        // 1. Build the namespace in the reusable scratch buffer, then drain it
+        //    onto the stack below. Reusing one allocation across calls avoids a
+        //    `malloc`/`free` per call. The buffer is always empty when taken
+        //    (drained + restored at the end of the previous call), and it is
+        //    never held across user-code execution, so this is safe under
+        //    recursion. On an error path the `HeapGuard` drops the buffer
+        //    entirely (leaving `namespace_scratch` empty); the pooling simply
+        //    restarts on the next successful call.
+        let mut namespace = mem::take(&mut self.namespace_scratch);
+        namespace.reserve(namespace_size);
         let mut namespace_guard = HeapGuard::new(namespace, self);
         let (namespace, this) = namespace_guard.as_parts_mut();
 
@@ -823,9 +835,12 @@ impl<T: ResourceTracker> VM<'_, T> {
         // 6. Commit the guard (no rollback) and push the frame. The operand
         // stack starts immediately above the locals region — any
         // comprehensions emit their own push/pop bytecode at entry/exit, so
-        // no frame-level region is reserved here.
-        let (namespace, this) = namespace_guard.into_parts();
-        this.stack.extend(namespace);
+        // no frame-level region is reserved here. Drain (rather than move) the
+        // locals onto the stack so the buffer keeps its allocation, then return
+        // it to the pool for the next call.
+        let (mut namespace, this) = namespace_guard.into_parts();
+        this.stack.append(&mut namespace);
+        this.namespace_scratch = namespace;
 
         let exc_stack_base = this.exception_stack.len();
         this.push_frame(CallFrame::new_function(
@@ -834,7 +849,7 @@ impl<T: ResourceTracker> VM<'_, T> {
             locals_count,
             exc_stack_base,
             func_id,
-            call_position,
+            call_offset,
         ))?;
 
         Ok(CallResult::FramePushed)

--- a/crates/monty/src/bytecode/vm/exceptions.rs
+++ b/crates/monty/src/bytecode/vm/exceptions.rs
@@ -228,9 +228,9 @@ impl<T: ResourceTracker> VM<'_, T> {
                 return Some(error);
             }
 
-            // Get the call site position before popping frame
-            // This is where the caller invoked the function that's failing
-            let call_position = this.current_frame().call_position;
+            // Get the caller's call-site offset before popping frame.
+            // This is where the caller invoked the function that's failing.
+            let call_offset = this.current_frame().call_offset;
 
             // Pop this frame
             if this.pop_frame() {
@@ -239,8 +239,11 @@ impl<T: ResourceTracker> VM<'_, T> {
                 return Some(error);
             }
 
-            // Add caller frame info to traceback (if we have call position)
-            if let Some(pos) = call_position {
+            // Add caller frame info to traceback (if we have a call site).
+            // Resolve the offset now — against the caller, which is the current
+            // frame after the pop above.
+            if let Some(off) = call_offset {
+                let pos = this.resolve_offset(off);
                 let frame_name = this.current_frame_name();
                 match &mut error {
                     RunError::Exc(exc) => exc.add_caller_frame(pos, frame_name),
@@ -258,14 +261,16 @@ impl<T: ResourceTracker> VM<'_, T> {
     fn unwind_for_traceback(&mut self, mut error: RunError) -> RunError {
         // Pop frames and add caller frame info to the traceback
         while self.frames.len() > 1 {
-            // Get the call site position before popping frame
-            let call_position = self.current_frame().call_position;
+            // Get the caller's call-site offset before popping frame
+            let call_offset = self.current_frame().call_offset;
 
             // Pop this frame (cleans up namespace, etc.)
             self.pop_frame();
 
-            // Add caller frame info to traceback
-            if let Some(pos) = call_position {
+            // Add caller frame info to traceback. Resolve the offset against the
+            // caller, which is the current frame after the pop above.
+            if let Some(off) = call_offset {
+                let pos = self.resolve_offset(off);
                 let frame_name = self.current_frame_name();
                 match &mut error {
                     RunError::Exc(exc) => exc.add_caller_frame(pos, frame_name),

--- a/crates/monty/src/bytecode/vm/format.rs
+++ b/crates/monty/src/bytecode/vm/format.rs
@@ -24,7 +24,8 @@ impl<T: ResourceTracker> VM<'_, T> {
 
         for part in parts.as_slice() {
             let part_str = part.py_str(this)?;
-            result.push_str(&part_str);
+            defer_drop!(part_str, this);
+            result.push_str(part_str.to_str(this)?);
         }
 
         let value = allocate_string(result, this.heap)?;
@@ -93,10 +94,10 @@ impl<T: ResourceTracker> VM<'_, T> {
                     // type, …). Validate via the same `validate_string_spec` the
                     // `str` branch of `format_with_spec` uses, then format.
                     let s = match conversion {
-                        2 => value.py_repr(this)?.into_owned(),
-                        3 => ascii_escape(&value.py_repr(this)?),
+                        2 => str_value_into_string(value.py_repr(this)?, this)?,
+                        3 => ascii_escape(&str_value_into_string(value.py_repr(this)?, this)?),
                         // `!s` (1) and any unused bit pattern fall back to `str()`.
-                        _ => value.py_str(this)?.into_owned(),
+                        _ => str_value_into_string(value.py_str(this)?, this)?,
                     };
                     validate_string_spec(&spec)?;
                     format_string(&s, &spec)?
@@ -105,11 +106,11 @@ impl<T: ResourceTracker> VM<'_, T> {
         } else {
             // No format spec - just convert based on conversion flag
             match conversion {
-                0 => value.py_str(this)?.into_owned(),
-                1 => value.py_str(this)?.into_owned(),
-                2 => value.py_repr(this)?.into_owned(),
-                3 => ascii_escape(&value.py_repr(this)?),
-                _ => value.py_str(this)?.into_owned(),
+                0 => str_value_into_string(value.py_str(this)?, this)?,
+                1 => str_value_into_string(value.py_str(this)?, this)?,
+                2 => str_value_into_string(value.py_repr(this)?, this)?,
+                3 => ascii_escape(&str_value_into_string(value.py_repr(this)?, this)?),
+                _ => str_value_into_string(value.py_str(this)?, this)?,
             }
         };
 
@@ -127,28 +128,31 @@ impl<T: ResourceTracker> VM<'_, T> {
     /// (dynamic) spec string; an empty spec maps to `str()`, matching
     /// `datetime.__format__('')`.
     fn try_format_temporal(&mut self, value: &Value, spec_value: &Value) -> Result<Option<String>, RunError> {
+        let this = self;
         let Value::Ref(id) = value else {
             return Ok(None);
         };
         let id = *id;
         let temporal = matches!(
-            self.heap.read(id),
+            this.heap.read(id),
             HeapReadOutput::Date(_) | HeapReadOutput::DateTime(_)
         );
         if !temporal {
             return Ok(None);
         }
 
-        let spec_str = spec_value.py_str(self)?;
+        let spec_str_value = spec_value.py_str(this)?;
+        defer_drop!(spec_str_value, this);
+        let spec_str = spec_str_value.to_str(this)?;
         // An empty (dynamic) spec behaves like `str()`; strftime("") is also
         // "" but routing explicitly keeps the intent clear.
         if spec_str.is_empty() {
-            return Ok(Some(value.py_str(self)?.into_owned()));
+            return str_value_into_string(value.py_str(this)?, this).map(Some);
         }
 
-        let formatted = match self.heap.read(id) {
-            HeapReadOutput::Date(d) => format_date_strftime(*d.get(self.heap), &spec_str),
-            HeapReadOutput::DateTime(d) => format_datetime_strftime(d.get(self.heap), &spec_str),
+        let formatted = match this.heap.read(id) {
+            HeapReadOutput::Date(d) => format_date_strftime(*d.get(this.heap), spec_str),
+            HeapReadOutput::DateTime(d) => format_datetime_strftime(d.get(this.heap), spec_str),
             _ => unreachable!("temporal-ness checked above"),
         };
         formatted.map(Some)
@@ -178,14 +182,16 @@ impl<T: ResourceTracker> VM<'_, T> {
             };
             Ok(decode_format_spec(*encoded))
         } else {
-            let spec_str = spec_value.py_str(self)?;
-            spec_str.parse::<ParsedFormatSpec>().map_err(|err| {
+            let this = self;
+            let spec_str_value = spec_value.py_str(this)?;
+            defer_drop!(spec_str_value, this);
+            spec_str_value.to_str(this)?.parse::<ParsedFormatSpec>().map_err(|err| {
                 // CPython suffixes the value's type onto some spec errors
                 // (`Invalid format specifier`, `Unknown format code`) but not
                 // others (`Format specifier missing precision`, the `Cannot
                 // specify …` grouping conflicts), which are self-contained.
                 let message = if err.needs_type_suffix() {
-                    let value_type = value_for_error.py_type_name(self);
+                    let value_type = value_for_error.py_type_name(this);
                     format!("{err} for object of type '{value_type}'")
                 } else {
                     err.to_string()
@@ -194,4 +200,13 @@ impl<T: ResourceTracker> VM<'_, T> {
             })
         }
     }
+}
+
+/// Resolves a `str` `Value` (as returned by `py_str`/`py_repr`) to an owned
+/// `String`, dropping the value's heap reference on every path. Used by the
+/// f-string conversion arms, which need the text in an owned buffer to feed
+/// the mini-language formatter.
+fn str_value_into_string(value: Value, vm: &mut VM<'_, impl ResourceTracker>) -> Result<String, RunError> {
+    defer_drop!(value, vm);
+    Ok(value.to_str(vm)?.to_owned())
 }

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -356,8 +356,16 @@ pub struct CallFrame<'code> {
     /// Function ID (for tracebacks). None for module-level code.
     function_id: Option<FunctionId>,
 
-    /// Call site position (for tracebacks).
-    call_position: Option<CodeRange>,
+    /// Caller's bytecode offset at the call site, resolved to a source
+    /// [`CodeRange`] only when a traceback is actually built (see
+    /// [`current_offset`](Self::current_offset)).
+    ///
+    /// Stored raw rather than pre-resolved because resolving requires a linear
+    /// scan of the caller's location table — pure waste on the (common) path
+    /// where the call never raises. `None` for the root/module frame, which has
+    /// no caller. On unwind the offset is resolved against the *caller* frame's
+    /// `code`, which is the current frame once this frame has been popped.
+    call_offset: Option<u32>,
 
     /// When this frame returns (or exits with an exception) the VM should exit the run loop
     /// and return to the caller. Supports `evaluate_function`.
@@ -386,7 +394,7 @@ impl<'code> CallFrame<'code> {
             locals_count: 0,
             exception_stack_base,
             function_id: None,
-            call_position: None,
+            call_offset: None,
             should_return: false,
             is_initializer: false,
         }
@@ -406,7 +414,7 @@ impl<'code> CallFrame<'code> {
         locals_count: u16,
         exception_stack_base: usize,
         function_id: FunctionId,
-        call_position: Option<CodeRange>,
+        call_offset: Option<u32>,
     ) -> Self {
         Self {
             code,
@@ -415,7 +423,7 @@ impl<'code> CallFrame<'code> {
             locals_count,
             exception_stack_base,
             function_id: Some(function_id),
-            call_position,
+            call_offset,
             should_return: false,
             is_initializer: false,
         }
@@ -547,8 +555,9 @@ pub struct SerializedFrame {
     /// See `CallFrame.exception_stack_base`.
     exception_stack_base: usize,
 
-    /// Call site position (for tracebacks).
-    call_position: Option<CodeRange>,
+    /// Caller's bytecode offset at the call site (for tracebacks). See
+    /// `CallFrame.call_offset`.
+    call_offset: Option<u32>,
 
     /// Whether this frame is a class `__init__` (see `CallFrame.is_initializer`).
     ///
@@ -573,7 +582,7 @@ impl CallFrame<'_> {
             stack_base: self.stack_base,
             locals_count: self.locals_count,
             exception_stack_base: self.exception_stack_base,
-            call_position: self.call_position,
+            call_offset: self.call_offset,
             is_initializer: self.is_initializer,
         }
     }
@@ -723,6 +732,17 @@ pub struct VM<'h, T: ResourceTracker> {
     /// maintain it. Not serialized: it is reconstructed from the active frame
     /// count on `restore` and rebalanced per-task across async switches.
     recursion_depth: usize,
+
+    /// Reusable scratch buffer for building a sync call's locals region.
+    ///
+    /// `call_sync_function` binds arguments and installs cell/free-var slots
+    /// into this buffer, then drains it onto the operand stack. Reusing one
+    /// allocation across calls avoids a `malloc`/`free` per function call — a
+    /// major cost on call-heavy code (see the `fib` bench). The buffer is only
+    /// ever held transiently *within* `call_sync_function` (never across
+    /// user-code execution), so a single shared buffer is safe even under
+    /// recursion: it is always empty and back in place before the callee runs.
+    namespace_scratch: Vec<Value>,
 }
 
 impl<'h, T: ResourceTracker> VM<'h, T> {
@@ -748,6 +768,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             json_string_cache: JsonStringCache::default(),
             pending_file_effect: None,
             recursion_depth: 0,
+            namespace_scratch: Vec::new(),
         }
     }
 
@@ -786,7 +807,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
                     locals_count: sf.locals_count,
                     exception_stack_base: sf.exception_stack_base,
                     function_id: sf.function_id,
-                    call_position: sf.call_position,
+                    call_offset: sf.call_offset,
                     should_return: false,
                     is_initializer: sf.is_initializer,
                 }
@@ -813,6 +834,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             json_string_cache: JsonStringCache::default(),
             pending_file_effect: snapshot.pending_file_effect,
             recursion_depth: current_frame_depth,
+            namespace_scratch: Vec::new(),
         }
     }
 
@@ -2026,6 +2048,33 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
                 .map(LocationEntry::range)
                 .unwrap_or_default(),
         )
+    }
+
+    /// Returns the caller's raw bytecode offset for a call site, or `None` when
+    /// no frame is on the stack (host-initiated calls).
+    ///
+    /// The cheap counterpart to [`current_position`](Self::current_position):
+    /// it captures `instruction_ip` without scanning the location table, so it
+    /// is called on every function call. The offset is resolved to a
+    /// [`CodeRange`] lazily, only when a traceback is built (see
+    /// [`resolve_offset`](Self::resolve_offset)). Offsets beyond `u32::MAX`
+    /// (an invariant violation) degrade to `None` rather than panicking.
+    pub(super) fn current_offset(&self) -> Option<u32> {
+        self.frames.last()?;
+        u32::try_from(self.instruction_ip).ok()
+    }
+
+    /// Resolves a raw caller offset (from `CallFrame::call_offset`) to a source
+    /// [`CodeRange`] against the *current* frame's code.
+    ///
+    /// Called during traceback unwinding after the failing frame has been
+    /// popped, so the current frame is the caller that owns `offset`.
+    pub(super) fn resolve_offset(&self, offset: u32) -> CodeRange {
+        self.frames
+            .last()
+            .and_then(|frame| frame.code.location_for_offset(offset as usize))
+            .map(LocationEntry::range)
+            .unwrap_or_default()
     }
 
     // ========================================================================

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -356,15 +356,9 @@ pub struct CallFrame<'code> {
     /// Function ID (for tracebacks). None for module-level code.
     function_id: Option<FunctionId>,
 
-    /// Caller's bytecode offset at the call site, resolved to a source
-    /// [`CodeRange`] only when a traceback is actually built (see
-    /// [`current_offset`](Self::current_offset)).
-    ///
-    /// Stored raw rather than pre-resolved because resolving requires a linear
-    /// scan of the caller's location table — pure waste on the (common) path
-    /// where the call never raises. `None` for the root/module frame, which has
-    /// no caller. On unwind the offset is resolved against the *caller* frame's
-    /// `code`, which is the current frame once this frame has been popped.
+    /// Caller's bytecode offset at the call site (for tracebacks). Stored raw
+    /// and resolved to a `CodeRange` lazily on unwind (see `resolve_offset`) to
+    /// skip the location-table scan unless the call raises. `None` at the root.
     call_offset: Option<u32>,
 
     /// When this frame returns (or exits with an exception) the VM should exit the run loop
@@ -733,15 +727,9 @@ pub struct VM<'h, T: ResourceTracker> {
     /// count on `restore` and rebalanced per-task across async switches.
     recursion_depth: usize,
 
-    /// Reusable scratch buffer for building a sync call's locals region.
-    ///
-    /// `call_sync_function` binds arguments and installs cell/free-var slots
-    /// into this buffer, then drains it onto the operand stack. Reusing one
-    /// allocation across calls avoids a `malloc`/`free` per function call — a
-    /// major cost on call-heavy code (see the `fib` bench). The buffer is only
-    /// ever held transiently *within* `call_sync_function` (never across
-    /// user-code execution), so a single shared buffer is safe even under
-    /// recursion: it is always empty and back in place before the callee runs.
+    /// Reusable scratch buffer for building a sync call's locals, avoiding a
+    /// `malloc`/`free` per call. Only held transiently within
+    /// `call_sync_function`, so one shared buffer is safe under recursion.
     namespace_scratch: Vec<Value>,
 }
 
@@ -2050,25 +2038,20 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
         )
     }
 
-    /// Returns the caller's raw bytecode offset for a call site, or `None` when
-    /// no frame is on the stack (host-initiated calls).
+    /// Captures the caller's current bytecode offset for a call site, or `None`
+    /// when no frame is on the stack (host-initiated calls).
     ///
     /// The cheap counterpart to [`current_position`](Self::current_position):
-    /// it captures `instruction_ip` without scanning the location table, so it
-    /// is called on every function call. The offset is resolved to a
-    /// [`CodeRange`] lazily, only when a traceback is built (see
-    /// [`resolve_offset`](Self::resolve_offset)). Offsets beyond `u32::MAX`
-    /// (an invariant violation) degrade to `None` rather than panicking.
+    /// no location-table scan, so it is affordable on every call. Out-of-range
+    /// offsets (an invariant violation) degrade to `None` rather than panic.
     pub(super) fn current_offset(&self) -> Option<u32> {
         self.frames.last()?;
         u32::try_from(self.instruction_ip).ok()
     }
 
-    /// Resolves a raw caller offset (from `CallFrame::call_offset`) to a source
-    /// [`CodeRange`] against the *current* frame's code.
-    ///
-    /// Called during traceback unwinding after the failing frame has been
-    /// popped, so the current frame is the caller that owns `offset`.
+    /// Resolves a raw caller offset (`CallFrame::call_offset`) to a source
+    /// [`CodeRange`] against the current frame's code, during traceback unwind
+    /// once the failing frame has been popped so the current frame is the caller.
     pub(super) fn resolve_offset(&self, offset: u32) -> CodeRange {
         self.frames
             .last()

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -15,7 +15,6 @@ use crate::{
     exception_private::RunError,
     heap::{ContainsHeap, DropWithHeap, Heap, HeapId, HeapReadOutput, HeapReader},
     intern::FunctionId,
-    parse::CodeRange,
     resource::{ResourceError, ResourceTracker},
     value::Value,
 };
@@ -131,8 +130,9 @@ pub(crate) struct SerializedTaskFrame {
     /// Base index into the VM-wide `exception_stack` for this frame.
     /// See `CallFrame.exception_stack_base`.
     pub exception_stack_base: usize,
-    /// Call site position (for tracebacks).
-    pub call_position: Option<CodeRange>,
+    /// Caller's bytecode offset at the call site (for tracebacks). See
+    /// `CallFrame.call_offset`.
+    pub call_offset: Option<u32>,
     /// Whether this frame is a class `__init__` (see `CallFrame.is_initializer`).
     #[serde(default)]
     pub is_initializer: bool,

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -397,7 +397,11 @@ impl ExcType {
             Ok(key_value) => {
                 // `key_value` is a heap `str` `Value`; extract its text and drop it.
                 defer_drop!(key_value, vm);
-                key_value.to_str(vm).unwrap_or_default().to_owned()
+                if let Ok(s) = key_value.to_str(vm) {
+                    s.to_owned()
+                } else {
+                    format!("<{}>", key.py_type_name(vm))
+                }
             }
             Err(_) => format!("<{}>", key.py_type_name(vm)),
         };

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -394,7 +394,11 @@ impl ExcType {
     /// `KeyError` is always raised rather than a spurious `ValueError`.
     pub(crate) fn key_error(key: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunError {
         let key_str = match key.py_str(vm) {
-            Ok(s) => s.into_owned(),
+            Ok(key_value) => {
+                // `key_value` is a heap `str` `Value`; extract its text and drop it.
+                defer_drop!(key_value, vm);
+                key_value.to_str(vm).unwrap_or_default().to_owned()
+            }
             Err(_) => format!("<{}>", key.py_type_name(vm)),
         };
         SimpleException::new_msg(Self::KeyError, key_str).into()

--- a/crates/monty/src/fstring.rs
+++ b/crates/monty/src/fstring.rs
@@ -10,6 +10,7 @@ use std::{fmt, fmt::Write, iter, iter::Peekable, str, str::FromStr};
 
 use crate::{
     bytecode::VM,
+    defer_drop,
     exception_private::{ExcType, RunError, SimpleException},
     expressions::ExprLoc,
     heap::HeapData,
@@ -686,8 +687,9 @@ pub fn format_with_spec(
     // identical specs (`f"{x:#}"` and `f"{x!s:#}"` raise the same error).
     if value_type == Type::Str {
         validate_string_spec(spec)?;
-        let s = value.py_str(vm)?;
-        return Ok(format_string(&s, spec)?);
+        // `value` is already a `str`, so borrow it directly — no `py_str`
+        // round-trip (which would allocate a fresh heap copy just to drop it).
+        return Ok(format_string(value.to_str(vm)?, spec)?);
     }
 
     // A grouping option (`,`/`_`) is only legal for certain presentation
@@ -810,7 +812,8 @@ pub fn format_with_spec(
         // format. (`str` values are handled by the short-circuit above.)
         (_, None) => {
             let s = value.py_str(vm)?;
-            Ok(format_string(&s, spec)?)
+            defer_drop!(s, vm);
+            Ok(format_string(s.to_str(vm)?, spec)?)
         }
 
         // Type mismatch errors

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Cow,
     collections::hash_map::DefaultHasher,
     fmt::Write,
     hash::{Hash, Hasher},
@@ -803,20 +802,20 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         }
     }
 
-    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'h, str>> {
+    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         match self {
             // Strings return their value directly without quotes
-            Self::Str(s) => Ok(Cow::Owned(s.get(vm.heap).as_str().to_owned())),
+            Self::Str(s) => Ok(allocate_string(s.get(vm.heap).as_str(), vm.heap)?),
             // LongInt returns its string representation
             Self::LongInt(li) => {
                 let li = li.get(vm.heap);
                 li.check_str_digits_limit()?;
-                Ok(Cow::Owned(li.to_string()))
+                Ok(allocate_string(li.to_string(), vm.heap)?)
             }
             // Exceptions return just the message (or empty string if no message)
-            Self::Exception(e) => Ok(Cow::Owned(e.get(vm.heap).py_str())),
+            Self::Exception(e) => Ok(allocate_string(e.get(vm.heap).py_str(), vm.heap)?),
             // Paths return the path string without the PosixPath() wrapper
-            Self::Path(p) => Ok(Cow::Owned(p.get(vm.heap).as_str().to_owned())),
+            Self::Path(p) => Ok(allocate_string(p.get(vm.heap).as_str(), vm.heap)?),
             // Datetime types have their own str output
             Self::Date(d) => d.py_str(vm),
             Self::DateTime(d) => d.py_str(vm),

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -7,7 +7,6 @@ use std::{
     ops::Deref,
 };
 
-use ahash::AHashSet;
 use num_integer::Integer;
 
 use crate::{
@@ -21,8 +20,8 @@ use crate::{
     intern::FunctionId,
     types::{
         BoundMethod, Bytes, Class, Dataclass, Dict, DictItemsView, DictKeysView, DictValuesView, FrozenSet, Instance,
-        List, LongInt, Module, MontyIter, NamedTuple, OpenFile, Path, PyTrait, Range, ReMatch, RePattern, Set, Slice,
-        Str, Tuple, Type, date, datetime, str::allocate_string, timedelta, timezone,
+        LazyHeapSet, List, LongInt, Module, MontyIter, NamedTuple, OpenFile, Path, PyTrait, Range, ReMatch, RePattern,
+        Set, Slice, Str, Tuple, Type, date, datetime, str::allocate_string, timedelta, timezone,
     },
     value::{EitherStr, Value, eq_bigint, eq_bytes, eq_ext_function, eq_str},
 };
@@ -744,7 +743,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        heap_ids: &mut AHashSet<HeapId>,
+        heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         match self {
             Self::Str(s) => s.py_repr_fmt(f, vm, heap_ids),

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -804,7 +804,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         }
     }
 
-    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'h, str>> {
         match self {
             // Strings return their value directly without quotes
             Self::Str(s) => Ok(Cow::Owned(s.get(vm.heap).as_str().to_owned())),

--- a/crates/monty/src/intern.rs
+++ b/crates/monty/src/intern.rs
@@ -741,6 +741,21 @@ pub enum StaticStrings {
     /// insertion would shift every later id.
     #[strum(serialize = "__doc__")]
     DunderDoc,
+
+    // ==========================
+    // Singleton `repr()`/`str()` values. Interned so `str(None)`, `repr(True)`,
+    // `f"{...}"`, `print(False)` etc. resolve to an existing `StringId` instead
+    // of allocating a fresh heap string each time — see `Value::py_repr`.
+    // Appended at the enum end: discriminants are serialized `StringId`s, so
+    // mid-enum insertion would shift every later id.
+    #[strum(serialize = "None")]
+    NoneRepr,
+    #[strum(serialize = "True")]
+    TrueRepr,
+    #[strum(serialize = "False")]
+    FalseRepr,
+    #[strum(serialize = "Ellipsis")]
+    EllipsisRepr,
 }
 
 impl StaticStrings {

--- a/crates/monty/src/object.rs
+++ b/crates/monty/src/object.rs
@@ -1102,7 +1102,11 @@ impl MontyObject {
 /// descriptive error message if `py_repr` fails (e.g. INT_MAX_STR_DIGITS).
 fn repr_or_error(value: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> MontyObject {
     match value.py_repr(vm) {
-        Ok(s) => MontyObject::Repr(s.into_owned()),
+        Ok(s) => {
+            // `py_repr` yields a heap `str` `Value`; extract its text and drop it.
+            defer_drop!(s, vm);
+            MontyObject::Repr(s.to_str(vm).map(str::to_owned).unwrap_or_default())
+        }
         Err(e) => {
             let ty = value.py_type_name(vm);
             let msg = match &e {

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -72,10 +72,9 @@ use std::{
     mem, ops, str,
 };
 
-use ahash::AHashSet;
 use smallvec::smallvec;
 
-use super::{CmpOrder, MontyIter, PyTrait, Type};
+use super::{CmpOrder, LazyHeapSet, MontyIter, PyTrait, Type};
 use crate::{
     args::{ArgValues, FromArgs, StrArg},
     bytecode::{CallResult, VM},
@@ -295,7 +294,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Bytes> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        _heap_ids: &mut AHashSet<HeapId>,
+        _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         Ok(bytes_repr_fmt(&self.get(vm.heap).0, f)?)
     }

--- a/crates/monty/src/types/class.rs
+++ b/crates/monty/src/types/class.rs
@@ -1,8 +1,6 @@
 use std::{fmt::Write, mem};
 
-use ahash::AHashSet;
-
-use super::{Dict, PyTrait, Type};
+use super::{Dict, LazyHeapSet, PyTrait, Type};
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, VM},
@@ -102,7 +100,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Class> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        _heap_ids: &mut AHashSet<HeapId>,
+        _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         Ok(write!(f, "<class '{}'>", self.get(vm.heap).name.as_str(vm.interns))?)
     }

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -4,10 +4,9 @@ use std::{
     mem,
 };
 
-use ahash::AHashSet;
 use serde::ser::SerializeStruct;
 
-use super::{Dict, PyTrait};
+use super::{Dict, LazyHeapSet, PyTrait};
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, VM},
@@ -215,7 +214,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        heap_ids: &mut AHashSet<HeapId>,
+        heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         // Check depth limit before recursing
         let Ok(mut guard) = vm.recursion_guard() else {

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -132,10 +132,13 @@ impl<'h> HeapRead<'h, Dataclass> {
         vm: &mut VM<'h, impl ResourceTracker>,
     ) -> RunResult<Option<Value>> {
         if self.get(vm.heap).frozen {
-            // Get attribute name for error message
+            // Build the error message from the field name's repr (a heap `str`
+            // `Value`), dropping that temporary before dropping our own args.
+            let name_repr = name.py_repr(vm)?;
+            defer_drop!(name_repr, vm);
             let exc = SimpleException::new_msg(
                 ExcType::FrozenInstanceError,
-                format!("cannot assign to field {}", name.py_repr(vm)?),
+                format!("cannot assign to field {}", name_repr.to_str(vm)?),
             );
             // Drop the values we were given ownership of
             name.drop_with_heap(vm);

--- a/crates/monty/src/types/date.rs
+++ b/crates/monty/src/types/date.rs
@@ -4,7 +4,6 @@
 //! constructor validation and arithmetic behavior.
 
 use std::{
-    borrow::Cow,
     collections::hash_map::DefaultHasher,
     fmt::{self, Write},
     hash::{Hash, Hasher},
@@ -241,9 +240,9 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Date> {
         Ok(())
     }
 
-    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         let (year, month, day) = to_ymd(*self.get(vm.heap));
-        Ok(Cow::Owned(format!("{year:04}-{month:02}-{day:02}")))
+        Ok(allocate_string(format!("{year:04}-{month:02}-{day:02}"), vm.heap)?)
     }
 
     fn py_call_attr(

--- a/crates/monty/src/types/date.rs
+++ b/crates/monty/src/types/date.rs
@@ -11,7 +11,6 @@ use std::{
     mem,
 };
 
-use ahash::AHashSet;
 use chrono::{Datelike, NaiveDate, format::StrftimeItems};
 
 use crate::{
@@ -25,7 +24,7 @@ use crate::{
     os::OsFunctionCall,
     resource::{ResourceError, ResourceTracker},
     types::{
-        AttrCallResult, CmpOrder, PyTrait, TimeDelta, Type,
+        AttrCallResult, CmpOrder, LazyHeapSet, PyTrait, TimeDelta, Type,
         str::{allocate_string, allocate_string_no_interning},
         timedelta,
     },
@@ -235,7 +234,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Date> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        _heap_ids: &mut AHashSet<HeapId>,
+        _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         let (year, month, day) = to_ymd(*self.get(vm.heap));
         write!(f, "datetime.date({year}, {month}, {day})")?;

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -4,7 +4,6 @@
 //! constructor rules, aware/naive comparison semantics, and arithmetic on top.
 
 use std::{
-    borrow::Cow,
     collections::hash_map::DefaultHasher,
     fmt::Write,
     hash::{Hash, Hasher},
@@ -971,10 +970,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
         Ok(())
     }
 
-    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         let dt = self.get(vm.heap);
         let Some((year, month, day, hour, minute, second, microsecond)) = to_components(dt) else {
-            return Ok(Cow::Borrowed("<out of range>"));
+            return Ok(allocate_string("<out of range>", vm.heap)?);
         };
         let mut s = format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02}:{second:02}");
         if microsecond != 0 {
@@ -983,7 +982,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
         if let Some(offset) = offset_seconds(dt) {
             s.push_str(&timezone::format_offset_hms(offset));
         }
-        Ok(Cow::Owned(s))
+        Ok(allocate_string(s, vm.heap)?)
     }
 
     fn py_call_attr(

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -11,7 +11,6 @@ use std::{
     mem,
 };
 
-use ahash::AHashSet;
 use chrono::{
     Datelike, FixedOffset, NaiveDateTime, NaiveTime, TimeDelta as ChronoTimeDelta, Timelike, format::StrftimeItems,
 };
@@ -28,7 +27,7 @@ use crate::{
     os::OsFunctionCall,
     resource::{ResourceError, ResourceTracker},
     types::{
-        AttrCallResult, CmpOrder, PyTrait, TimeDelta, TimeZone, Type,
+        AttrCallResult, CmpOrder, LazyHeapSet, PyTrait, TimeDelta, TimeZone, Type,
         date::{self, StrftimeArgs},
         str::{StringRepr, allocate_string, allocate_string_no_interning},
         timedelta, timezone,
@@ -941,7 +940,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        _heap_ids: &mut AHashSet<HeapId>,
+        _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         let dt = self.get(vm.heap);
         let Some((year, month, day, hour, minute, second, microsecond)) = to_components(dt) else {

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -5,12 +5,11 @@ use std::{
     mem, slice, vec,
 };
 
-use ahash::AHashSet;
 use hashbrown::HashTable;
 use serde::ser::SerializeStruct;
 use smallvec::{SmallVec, smallvec};
 
-use super::{DictItemsView, DictKeysView, DictValuesView, MontyIter, PyTrait, allocate_tuple};
+use super::{DictItemsView, DictKeysView, DictValuesView, LazyHeapSet, MontyIter, PyTrait, allocate_tuple};
 use crate::{
     args::{ArgValues, FromArgs, KwargsValues},
     bytecode::{CallResult, ContainsVM, DropWithVM, RecursionToken, VM},
@@ -822,7 +821,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        heap_ids: &mut AHashSet<HeapId>,
+        heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         if self.get(vm.heap).is_empty() {
             return Ok(f.write_str("{}")?);

--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -1,6 +1,5 @@
 use std::{fmt::Write, mem};
 
-use ahash::AHashSet;
 use smallvec::smallvec;
 
 use crate::{
@@ -11,7 +10,7 @@ use crate::{
     heap::{Heap, HeapData, HeapGuard, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     resource::ResourceTracker,
-    types::{Dict, FrozenSet, MontyIter, PyTrait, Set, Type, allocate_tuple},
+    types::{Dict, FrozenSet, LazyHeapSet, MontyIter, PyTrait, Set, Type, allocate_tuple},
     value::{EitherStr, Value},
 };
 
@@ -162,7 +161,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictKeysView> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        heap_ids: &mut AHashSet<HeapId>,
+        heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         f.write_str("dict_keys([")?;
         write_dict_keys_contents(f, &self.dict(vm), vm, heap_ids)?;
@@ -318,7 +317,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictItemsView> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        heap_ids: &mut AHashSet<HeapId>,
+        heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         f.write_str("dict_items([")?;
         write_dict_items_contents(f, &self.dict(vm), vm, heap_ids)?;
@@ -410,7 +409,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictValuesView> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        heap_ids: &mut AHashSet<HeapId>,
+        heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         f.write_str("dict_values([")?;
         write_dict_values_contents(f, &self.dict(vm), vm, heap_ids)?;
@@ -484,7 +483,7 @@ fn write_dict_keys_contents<'h>(
     f: &mut impl Write,
     dict: &HeapRead<'h, Dict>,
     vm: &mut VM<'h, impl ResourceTracker>,
-    heap_ids: &mut AHashSet<HeapId>,
+    heap_ids: &mut LazyHeapSet,
 ) -> RunResult<()> {
     let iter = dict.iter(vm)?;
     defer_drop_vm_mut!(iter, vm);
@@ -504,7 +503,7 @@ fn write_dict_items_contents<'h>(
     f: &mut impl Write,
     dict: &HeapRead<'h, Dict>,
     vm: &mut VM<'h, impl ResourceTracker>,
-    heap_ids: &mut AHashSet<HeapId>,
+    heap_ids: &mut LazyHeapSet,
 ) -> RunResult<()> {
     let iter = dict.iter(vm)?;
     defer_drop_vm_mut!(iter, vm);
@@ -528,7 +527,7 @@ fn write_dict_values_contents<'h>(
     f: &mut impl Write,
     dict: &HeapRead<'h, Dict>,
     vm: &mut VM<'h, impl ResourceTracker>,
-    heap_ids: &mut AHashSet<HeapId>,
+    heap_ids: &mut LazyHeapSet,
 ) -> RunResult<()> {
     let iter = dict.iter(vm)?;
     defer_drop_vm_mut!(iter, vm);

--- a/crates/monty/src/types/file.rs
+++ b/crates/monty/src/types/file.rs
@@ -64,10 +64,8 @@
 
 use std::{borrow::Cow, fmt::Write, mem, str::FromStr};
 
-use ahash::AHashSet;
-
 use super::{
-    List, PyTrait, Type,
+    LazyHeapSet, List, PyTrait, Type,
     bytes::Bytes,
     str::{allocate_string, allocate_string_no_interning},
 };
@@ -539,7 +537,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, OpenFile> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        _heap_ids: &mut AHashSet<HeapId>,
+        _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         let file = self.get(vm.heap);
         write!(

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -1,8 +1,6 @@
 use std::{borrow::Cow, fmt::Write, mem};
 
-use ahash::AHashSet;
-
-use super::{Dict, PyTrait, Type};
+use super::{Dict, LazyHeapSet, PyTrait, Type};
 use crate::{
     args::{ArgValues, KwargsValues},
     builtins::Builtins,
@@ -113,7 +111,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Instance> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        _heap_ids: &mut AHashSet<HeapId>,
+        _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         let class_id = self.get(vm.heap).class;
         Ok(write!(f, "<{} object>", class_name(class_id, vm.heap, vm.interns))?)
@@ -279,7 +277,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, BoundMethod> {
         &self,
         f: &mut impl Write,
         _vm: &mut VM<'h, impl ResourceTracker>,
-        _heap_ids: &mut AHashSet<HeapId>,
+        _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         Ok(write!(f, "<bound method>")?)
     }

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     intern::Interns,
     resource::ResourceTracker,
+    types::allocate_string,
     value::{EitherStr, Value},
 };
 
@@ -350,16 +351,16 @@ pub(crate) fn instance_getattr(
 
 /// Produces `repr(instance)`, dispatching to a user `__repr__` if the class
 /// defines one, otherwise the default `<ClassName object at 0x..>`.
-pub(crate) fn instance_repr(self_id: HeapId, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+pub(crate) fn instance_repr(self_id: HeapId, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Value> {
     match instance_call_str_dunder(self_id, "__repr__", vm)? {
         Some(s) => Ok(s),
-        None => Ok(Cow::Owned(default_repr(self_id, vm))),
+        None => Ok(allocate_string(default_repr(self_id, vm), vm.heap)?),
     }
 }
 
 /// Produces `str(instance)`, dispatching to a user `__str__` if defined, else
 /// falling back to `repr` (which itself falls back to the default).
-pub(crate) fn instance_str(self_id: HeapId, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+pub(crate) fn instance_str(self_id: HeapId, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Value> {
     match instance_call_str_dunder(self_id, "__str__", vm)? {
         Some(s) => Ok(s),
         None => instance_repr(self_id, vm),
@@ -380,7 +381,7 @@ fn instance_call_str_dunder(
     self_id: HeapId,
     dunder: &'static str,
     vm: &mut VM<'_, impl ResourceTracker>,
-) -> RunResult<Option<Cow<'static, str>>> {
+) -> RunResult<Option<Value>> {
     let class_id = instance_class(self_id, vm);
     let Some(func) = class_member(class_id, dunder, vm) else {
         return Ok(None);
@@ -396,31 +397,17 @@ fn instance_call_str_dunder(
         ArgValues::Empty
     };
     let result = vm.evaluate_function(dunder, func, args)?;
-    value_into_string(result, dunder, vm).map(Some)
-}
-
-/// Converts a string-dunder return value into an owned string, raising `TypeError`
-/// if it is not a `str`. Consumes (drops) `value`.
-fn value_into_string(
-    value: Value,
-    dunder: &str,
-    vm: &mut VM<'_, impl ResourceTracker>,
-) -> RunResult<Cow<'static, str>> {
-    let extracted = match &value {
-        Value::InternString(id) => Some(vm.interns.get_str(*id).to_owned()),
-        Value::Ref(id) => match vm.heap.get(*id) {
-            HeapData::Str(s) => Some(s.as_str().to_owned()),
-            _ => None,
-        },
-        _ => None,
-    };
-    let type_name = value.py_type_name(vm);
-    value.drop_with_heap(vm);
-    match extracted {
-        Some(s) => Ok(Cow::Owned(s)),
-        None => Err(ExcType::type_error(format!(
-            "{dunder} returned non-string (type {type_name})"
-        ))),
+    // CPython requires `__repr__`/`__str__` to return a `str`; reject any other
+    // type with the same TypeError, dropping the offending return value.
+    if result.is_str(vm.heap) {
+        Ok(Some(result))
+    } else {
+        let exc = ExcType::type_error(format!(
+            "{dunder} returned non-string (type {})",
+            result.py_type_name(vm)
+        ));
+        result.drop_with_heap(vm);
+        Err(exc)
     }
 }
 

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -1,6 +1,5 @@
 use std::{cmp::Ordering, fmt::Write, mem};
 
-use ahash::AHashSet;
 use smallvec::SmallVec;
 
 use super::{CmpOrder, MontyIter, PyTrait};
@@ -14,7 +13,7 @@ use crate::{
     resource::{ResourceError, ResourceTracker},
     sorting::parse_and_sort,
     types::{
-        Type,
+        LazyHeapSet, Type,
         slice::{normalize_sequence_index, slice_collect_iterator},
     },
     value::{EitherStr, VALUE_SIZE, Value},
@@ -479,7 +478,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        heap_ids: &mut AHashSet<HeapId>,
+        heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         let len = self.get(vm.heap).len();
         repr_sequence_fmt('[', ']', len, |heap, i| &self.get(heap).as_slice()[i], f, vm, heap_ids)
@@ -893,7 +892,7 @@ pub(crate) fn repr_sequence_fmt<'h, T: ResourceTracker>(
     get_item: impl for<'r> Fn(&'r HeapReader<'h, T>, usize) -> &'r Value,
     f: &mut impl Write,
     vm: &mut VM<'h, T>,
-    heap_ids: &mut AHashSet<HeapId>,
+    heap_ids: &mut LazyHeapSet,
 ) -> RunResult<()> {
     // Check depth limit before recursing
     let Ok(mut guard) = vm.recursion_guard() else {

--- a/crates/monty/src/types/mod.rs
+++ b/crates/monty/src/types/mod.rs
@@ -47,7 +47,7 @@ pub(crate) use module::Module;
 pub(crate) use namedtuple::NamedTuple;
 pub(crate) use path::Path;
 pub(crate) use property::Property;
-pub(crate) use py_trait::{AttrCallResult, CmpOrder, PyTrait};
+pub(crate) use py_trait::{AttrCallResult, CmpOrder, LazyHeapSet, PyTrait};
 pub(crate) use range::Range;
 pub(crate) use re_match::ReMatch;
 pub(crate) use re_pattern::RePattern;

--- a/crates/monty/src/types/mod.rs
+++ b/crates/monty/src/types/mod.rs
@@ -53,7 +53,7 @@ pub(crate) use re_match::ReMatch;
 pub(crate) use re_pattern::RePattern;
 pub(crate) use set::{FrozenSet, Set};
 pub(crate) use slice::Slice;
-pub(crate) use str::Str;
+pub(crate) use str::{Str, allocate_string};
 pub(crate) use timedelta::TimeDelta;
 pub(crate) use timezone::TimeZone;
 pub(crate) use tuple::{Tuple, allocate_tuple};

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -23,8 +23,6 @@ use std::{
     mem,
 };
 
-use ahash::AHashSet;
-
 use super::PyTrait;
 use crate::{
     bytecode::{CallResult, ContainsVM, DropWithVM, RecursionToken, VM},
@@ -34,7 +32,7 @@ use crate::{
     heap::{HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StringId},
     resource::ResourceTracker,
-    types::Type,
+    types::{Type, py_trait::LazyHeapSet},
     value::{EitherStr, Value},
 };
 
@@ -351,7 +349,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        heap_ids: &mut AHashSet<HeapId>,
+        heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         // Check depth limit before recursing
         let Ok(mut guard) = vm.recursion_guard() else {

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -12,7 +12,6 @@ use std::{
     mem,
 };
 
-use ahash::AHashSet;
 use smallvec::SmallVec;
 
 use crate::{
@@ -26,7 +25,7 @@ use crate::{
     intern::{Interns, StaticStrings},
     os::{MontyPath, build_path_os_call, is_path_os_method},
     resource::ResourceTracker,
-    types::{PyTrait, Type, allocate_tuple, str::allocate_string},
+    types::{LazyHeapSet, PyTrait, Type, allocate_tuple, str::allocate_string},
     value::{EitherStr, Value},
 };
 
@@ -498,7 +497,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Path> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        _heap_ids: &mut AHashSet<HeapId>,
+        _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         // Format like: PosixPath('/usr/bin')
         Ok(write!(f, "PosixPath('{}')", self.get(vm.heap).path)?)

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -9,12 +9,11 @@
 ///
 /// The trait is designed to work with `enum_dispatch` for efficient virtual
 /// dispatch on `HeapData` without boxing overhead.
-use std::borrow::Cow;
 use std::{cmp::Ordering, fmt::Write};
 
 use ahash::AHashSet;
 
-use super::Type;
+use super::{Type, allocate_string};
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, VM},
@@ -234,39 +233,29 @@ pub(crate) trait PyTrait<'h> {
         heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()>;
 
-    /// Returns the Python `repr()` string for this value.
+    /// Returns the Python `repr()` string for this value as a heap `str` `Value`.
     ///
-    /// Convenience wrapper around `py_repr_fmt` that returns an owned string.
+    /// Convenience wrapper around `py_repr_fmt` that allocates the result.
     ///
     /// TODO: the intermediate `String` here is *not* tracked, so recursive
     /// `repr()` of nested containers can amplify into a multi-gigabyte
     /// host-side buffer before `allocate_string` consults the tracker.
-    /// `StringBuilder` is the canonical fix, but plugging it in requires
-    /// either (a) restructuring so `py_repr_fmt` no longer needs `&mut vm`
-    /// while the builder is alive, or (b) refactoring `py_str` / `py_repr`
-    /// to return `Value` directly so the builder can be consumed via
-    /// `StringBuilder::finish` *outside* the recursive call. Today's
-    /// per-type protections (`INT_MAX_STR_DIGITS`, `check_repeat_size`, etc.)
-    /// blunt the worst amplifications but don't fully cover container
-    /// `repr()`.
-    fn py_repr(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'h, str>> {
+    /// `StringBuilder` is the canonical fix: now that `py_repr` returns a
+    /// `Value`, the builder can be `finish`ed here (outside the recursion),
+    /// but `py_repr_fmt` still borrows `&mut vm` while writing, so plugging it
+    /// in first needs `py_repr_fmt` to no longer need `&mut vm` while the
+    /// builder is alive. Today's per-type protections (`INT_MAX_STR_DIGITS`,
+    /// `check_repeat_size`, etc.) blunt the worst amplifications but don't
+    /// fully cover container `repr()`.
+    fn py_repr(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         let mut s = String::new();
         let mut heap_ids = LazyHeapSet::default();
         self.py_repr_fmt(&mut s, vm, &mut heap_ids)?;
-        Ok(Cow::Owned(s))
+        Ok(allocate_string(s, vm.heap)?)
     }
 
     /// Returns the Python `str()` string for this value.
-    ///
-    /// TODO: should return a `Value` rather than `Cow<'static, str>` — see
-    /// the TODO on [`py_repr`](Self::py_repr). For `Value::InternString` /
-    /// heap `str` values, today's `Cow::Owned` impl clones the underlying
-    /// bytes; a `Value`-returning impl could just hand back the same
-    /// `Value`. Callers that need a `&str` (f-string formatters, the print
-    /// writer, error messages) would resolve the `Value` to `&str` via the
-    /// interns table / heap — equivalent to the existing `EitherStr`
-    /// accessor pattern.
-    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'h, str>> {
+    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         self.py_repr(vm)
     }
 

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -249,7 +249,7 @@ pub trait PyTrait<'h> {
     /// per-type protections (`INT_MAX_STR_DIGITS`, `check_repeat_size`, etc.)
     /// blunt the worst amplifications but don't fully cover container
     /// `repr()`.
-    fn py_repr(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_repr(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'h, str>> {
         let mut s = String::new();
         let mut heap_ids = AHashSet::new();
         self.py_repr_fmt(&mut s, vm, &mut heap_ids)?;
@@ -266,7 +266,7 @@ pub trait PyTrait<'h> {
     /// writer, error messages) would resolve the `Value` to `&str` via the
     /// interns table / heap — equivalent to the existing `EitherStr`
     /// accessor pattern.
-    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'h, str>> {
         self.py_repr(vm)
     }
 

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -138,7 +138,7 @@ impl CmpOrder {
 /// The lifetime `'h` is the heap borrow lifetime. For concrete types (e.g. `Dict`,
 /// `List`) this is unused and should be `'_`. For `HeapRead<'h, T>` implementers
 /// the lifetime connects the read handle to the VM's heap reference.
-pub trait PyTrait<'h> {
+pub(crate) trait PyTrait<'h> {
     /// Returns the Python type name for this value (e.g., "list", "str").
     ///
     /// Used for error messages and the `type()` builtin.
@@ -231,7 +231,7 @@ pub trait PyTrait<'h> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        heap_ids: &mut AHashSet<HeapId>,
+        heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()>;
 
     /// Returns the Python `repr()` string for this value.
@@ -251,7 +251,7 @@ pub trait PyTrait<'h> {
     /// `repr()`.
     fn py_repr(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'h, str>> {
         let mut s = String::new();
-        let mut heap_ids = AHashSet::new();
+        let mut heap_ids = LazyHeapSet::default();
         self.py_repr_fmt(&mut s, vm, &mut heap_ids)?;
         Ok(Cow::Owned(s))
     }
@@ -519,5 +519,33 @@ pub trait PyTrait<'h> {
     /// attribute access and a generic `AttributeError` should be raised by the caller.
     fn py_getattr(&self, _attr: &EitherStr, _vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
         Ok(None)
+    }
+}
+
+/// Lazy wrapper around [`AHashSet`] that only allocates the set when needed.
+#[derive(Default, Debug, Clone)]
+pub(crate) struct LazyHeapSet(Option<AHashSet<HeapId>>);
+
+impl LazyHeapSet {
+    pub fn insert(&mut self, heap_id: HeapId) {
+        if let Some(s) = self.0.as_mut() {
+            s.insert(heap_id);
+        } else {
+            let mut s = AHashSet::default();
+            s.insert(heap_id);
+            self.0 = Some(s);
+        }
+    }
+
+    #[expect(clippy::trivially_copy_pass_by_ref, reason = "Match AHashSet method")]
+    pub fn contains(&self, heap_id: &HeapId) -> bool {
+        self.0.as_ref().is_some_and(|s| s.contains(heap_id))
+    }
+
+    #[expect(clippy::trivially_copy_pass_by_ref, reason = "Match AHashSet method")]
+    pub fn remove(&mut self, heap_id: &HeapId) {
+        if let Some(s) = self.0.as_mut() {
+            s.remove(heap_id);
+        }
     }
 }

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -10,7 +10,6 @@ use std::{
     mem,
 };
 
-use ahash::AHashSet;
 use num_integer::div_ceil;
 
 use crate::{
@@ -21,7 +20,7 @@ use crate::{
     hash::HashValue,
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     resource::ResourceTracker,
-    types::{PyTrait, Type},
+    types::{LazyHeapSet, PyTrait, Type},
     value::Value,
 };
 
@@ -285,7 +284,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Range> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        _heap_ids: &mut AHashSet<HeapId>,
+        _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         let this = self.get(vm.heap);
         if this.step == 1 {

--- a/crates/monty/src/types/re_match.rs
+++ b/crates/monty/src/types/re_match.rs
@@ -10,7 +10,6 @@
 
 use std::{cmp::Ordering, fmt::Write, mem};
 
-use ahash::AHashSet;
 use smallvec::smallvec;
 
 use crate::{
@@ -22,7 +21,7 @@ use crate::{
     intern::StaticStrings,
     resource::ResourceTracker,
     types::{
-        Dict, PyTrait, Type, allocate_tuple,
+        Dict, LazyHeapSet, PyTrait, Type, allocate_tuple,
         str::{allocate_string, string_repr_fmt},
     },
     value::{EitherStr, Value},
@@ -298,7 +297,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        _heap_ids: &mut AHashSet<HeapId>,
+        _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         let m = self.get(vm.heap);
         write!(f, "<re.Match object; span=({}, {}), match=", m.start, m.end)?;

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -11,7 +11,6 @@
 
 use std::{borrow::Cow, cmp::Ordering, fmt::Write, iter, mem, str};
 
-use ahash::AHashSet;
 use fancy_regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use smallvec::SmallVec;
@@ -26,7 +25,7 @@ use crate::{
     modules::re::{ASCII, DOTALL, IGNORECASE, MULTILINE},
     resource::{ResourceTracker, check_estimated_size},
     types::{
-        List, PyTrait, ReMatch, Type, allocate_tuple,
+        LazyHeapSet, List, PyTrait, ReMatch, Type, allocate_tuple,
         str::{allocate_string, string_repr_fmt},
     },
     value::{EitherStr, Value},
@@ -298,7 +297,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, RePattern> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        _heap_ids: &mut AHashSet<HeapId>,
+        _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         let this = self.get(vm.heap);
         write!(f, "re.compile(")?;

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -1,6 +1,5 @@
 use std::{cell::Cell, fmt::Write, mem};
 
-use ahash::AHashSet;
 use hashbrown::HashTable;
 use smallvec::SmallVec;
 
@@ -17,7 +16,7 @@ use crate::{
     },
     intern::StaticStrings,
     resource::ResourceTracker,
-    types::Type,
+    types::{LazyHeapSet, Type},
     value::{EitherStr, Value},
 };
 
@@ -506,7 +505,7 @@ impl<'h> HeapRead<'h, SetStorage> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, T>,
-        heap_ids: &mut AHashSet<HeapId>,
+        heap_ids: &mut LazyHeapSet,
         type_name: &str,
     ) -> RunResult<()> {
         let len = self.get(vm.heap).len();
@@ -1005,7 +1004,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Set> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        heap_ids: &mut AHashSet<HeapId>,
+        heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         self.storage().repr_fmt(f, vm, heap_ids, "set")
     }
@@ -1296,7 +1295,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        heap_ids: &mut AHashSet<HeapId>,
+        heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         self.storage().repr_fmt(f, vm, heap_ids, "frozenset")
     }

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -11,8 +11,7 @@ use std::{
     mem,
 };
 
-use ahash::AHashSet;
-
+use super::LazyHeapSet;
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, VM},
@@ -194,7 +193,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Slice> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        _heap_ids: &mut AHashSet<HeapId>,
+        _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         f.write_str("slice(")?;
         format_option_i64(f, self.get(vm.heap).start)?;

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -69,6 +69,10 @@ impl Str {
         let StrInitArgs { object } = StrInitArgs::from_args(args, vm)?;
         match object {
             None => Ok(Value::InternString(StaticStrings::EmptyString.into())),
+            // Fast path: `str(int)` formats via itoa straight into a
+            // right-sized allocation, skipping the grow-then-shrink `String`
+            // that the generic `py_str`/`py_repr` path builds and then reboxes.
+            Some(Value::Int(i)) => Ok(allocate_string(itoa::Buffer::new().format(i), vm.heap)?),
             Some(v) => {
                 defer_drop!(v, vm);
                 let s = v.py_str(vm)?.into_owned();

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -2,7 +2,7 @@
 ///
 /// This type provides Python string semantics. Currently supports basic
 /// operations like length and equality comparison.
-use std::{borrow::Cow, cell::Cell, fmt, fmt::Write, mem, ops};
+use std::{cell::Cell, fmt, fmt::Write, mem, ops};
 
 use smallvec::smallvec;
 use unicode_general_category::{GeneralCategory, get_general_category};
@@ -72,10 +72,12 @@ impl Str {
             // right-sized allocation, skipping the grow-then-shrink `String`
             // that the generic `py_str`/`py_repr` path builds and then reboxes.
             Some(Value::Int(i)) => Ok(allocate_string(itoa::Buffer::new().format(i), vm.heap)?),
+            // `py_str` already yields the `str` `Value` that `str(x)` should
+            // return (the same object when `x` is already a `str`), so hand it
+            // straight back rather than copying its bytes into a new allocation.
             Some(v) => {
                 defer_drop!(v, vm);
-                let s = v.py_str(vm)?.into_owned();
-                Ok(allocate_string(s, vm.heap)?)
+                v.py_str(vm)
             }
         }
     }
@@ -250,8 +252,8 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
         Ok(string_repr_fmt(&self.get(vm.heap).0, f)?)
     }
 
-    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
-        Ok(self.get(vm.heap).0.clone().into_string().into())
+    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
+        Ok(allocate_string(self.get(vm.heap).as_str(), vm.heap)?)
     }
 
     fn py_add(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Value>, ResourceError> {

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -68,13 +68,6 @@ impl Str {
         let StrInitArgs { object } = StrInitArgs::from_args(args, vm)?;
         match object {
             None => Ok(Value::InternString(StaticStrings::EmptyString.into())),
-            // Fast path: `str(int)` formats via itoa straight into a
-            // right-sized allocation, skipping the grow-then-shrink `String`
-            // that the generic `py_str`/`py_repr` path builds and then reboxes.
-            Some(Value::Int(i)) => Ok(allocate_string(itoa::Buffer::new().format(i), vm.heap)?),
-            // `py_str` already yields the `str` `Value` that `str(x)` should
-            // return (the same object when `x` is already a `str`), so hand it
-            // straight back rather than copying its bytes into a new allocation.
             Some(v) => {
                 defer_drop!(v, vm);
                 v.py_str(vm)

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -4,7 +4,6 @@
 /// operations like length and equality comparison.
 use std::{borrow::Cow, cell::Cell, fmt, fmt::Write, mem, ops};
 
-use ahash::AHashSet;
 use smallvec::smallvec;
 use unicode_general_category::{GeneralCategory, get_general_category};
 
@@ -21,7 +20,7 @@ use crate::{
     resource::{ResourceError, ResourceTracker, check_replace_size},
     string_builder::StringBuilder,
     types::{
-        Type,
+        LazyHeapSet, Type,
         slice::{normalize_sequence_index, slice_collect_iterator},
     },
     value::{EitherStr, Value, eq_str},
@@ -246,7 +245,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        _heap_ids: &mut AHashSet<HeapId>,
+        _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         Ok(string_repr_fmt(&self.get(vm.heap).0, f)?)
     }

--- a/crates/monty/src/types/timedelta.rs
+++ b/crates/monty/src/types/timedelta.rs
@@ -13,7 +13,6 @@ use std::{
     mem,
 };
 
-use ahash::AHashSet;
 use chrono::TimeDelta as ChronoTimeDelta;
 
 use crate::{
@@ -24,7 +23,7 @@ use crate::{
     heap::{HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     resource::ResourceTracker,
-    types::{CmpOrder, PyTrait, Type},
+    types::{CmpOrder, LazyHeapSet, PyTrait, Type},
     value::{EitherStr, Value},
 };
 
@@ -342,7 +341,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeDelta> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        _heap_ids: &mut AHashSet<HeapId>,
+        _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         f.write_str(&format_repr(self.get(vm.heap)))?;
         Ok(())

--- a/crates/monty/src/types/timedelta.rs
+++ b/crates/monty/src/types/timedelta.rs
@@ -5,7 +5,6 @@
 //! and formatting.
 
 use std::{
-    borrow::Cow,
     cmp::Ordering,
     collections::hash_map::DefaultHasher,
     fmt::Write,
@@ -23,7 +22,7 @@ use crate::{
     heap::{HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     resource::ResourceTracker,
-    types::{CmpOrder, LazyHeapSet, PyTrait, Type},
+    types::{CmpOrder, LazyHeapSet, PyTrait, Type, str::allocate_string},
     value::{EitherStr, Value},
 };
 
@@ -347,7 +346,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeDelta> {
         Ok(())
     }
 
-    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         let (days, seconds, microseconds) = components(self.get(vm.heap));
         let hours = seconds / SECONDS_PER_HOUR;
         let minutes = (seconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE;
@@ -358,12 +357,13 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeDelta> {
             format!("{hours}:{minutes:02}:{second:02}.{microseconds:06}")
         };
 
-        if days == 0 {
-            return Ok(Cow::Owned(time));
-        }
-
-        let day_word = if days.abs() == 1 { "day" } else { "days" };
-        Ok(Cow::Owned(format!("{days} {day_word}, {time}")))
+        let s = if days == 0 {
+            time
+        } else {
+            let day_word = if days.abs() == 1 { "day" } else { "days" };
+            format!("{days} {day_word}, {time}")
+        };
+        Ok(allocate_string(s, vm.heap)?)
     }
 
     fn py_call_attr(

--- a/crates/monty/src/types/timezone.rs
+++ b/crates/monty/src/types/timezone.rs
@@ -10,8 +10,6 @@ use std::{
     mem,
 };
 
-use ahash::AHashSet;
-
 use crate::{
     args::{ArgValues, FromArgs},
     bytecode::VM,
@@ -22,7 +20,7 @@ use crate::{
     intern::Interns,
     resource::ResourceTracker,
     types::{
-        PyTrait, Type,
+        LazyHeapSet, PyTrait, Type,
         str::StringRepr,
         timedelta,
         timedelta::{MICROSECONDS_PER_SECOND, SECONDS_PER_HOUR, SECONDS_PER_MINUTE},
@@ -257,7 +255,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeZone> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        _heap_ids: &mut AHashSet<HeapId>,
+        _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         let tz = self.get(vm.heap);
         if tz.offset_seconds == 0 && tz.name.is_none() {

--- a/crates/monty/src/types/timezone.rs
+++ b/crates/monty/src/types/timezone.rs
@@ -3,7 +3,6 @@
 //! Phase 1 intentionally supports only fixed offsets (no DST or IANA database).
 
 use std::{
-    borrow::Cow,
     collections::hash_map::DefaultHasher,
     fmt::Write,
     hash::{Hash, Hasher},
@@ -21,7 +20,7 @@ use crate::{
     resource::ResourceTracker,
     types::{
         LazyHeapSet, PyTrait, Type,
-        str::StringRepr,
+        str::{StringRepr, allocate_string},
         timedelta,
         timedelta::{MICROSECONDS_PER_SECOND, SECONDS_PER_HOUR, SECONDS_PER_MINUTE},
     },
@@ -272,14 +271,15 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeZone> {
         Ok(())
     }
 
-    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         let tz = self.get(vm.heap);
-        if let Some(name) = &tz.name {
-            return Ok(Cow::Owned(name.clone()));
-        }
-        if tz.offset_seconds == 0 {
-            return Ok(Cow::Borrowed("UTC"));
-        }
-        Ok(Cow::Owned(format!("UTC{}", tz.format_utc_offset())))
+        let s = if let Some(name) = &tz.name {
+            name.clone()
+        } else if tz.offset_seconds == 0 {
+            "UTC".to_owned()
+        } else {
+            format!("UTC{}", tz.format_utc_offset())
+        };
+        Ok(allocate_string(s, vm.heap)?)
     }
 }

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -23,7 +23,6 @@ use std::{
     mem,
 };
 
-use ahash::AHashSet;
 use smallvec::SmallVec;
 
 use super::{CmpOrder, MontyIter, PyTrait};
@@ -37,7 +36,7 @@ use crate::{
     intern::StaticStrings,
     resource::{ResourceError, ResourceTracker},
     types::{
-        Type,
+        LazyHeapSet, Type,
         list::repr_sequence_fmt,
         slice::{normalize_sequence_index, slice_collect_iterator},
     },
@@ -446,7 +445,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'h, impl ResourceTracker>,
-        heap_ids: &mut AHashSet<HeapId>,
+        heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         let len = self.get(vm.heap).as_slice().len();
 

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -123,7 +123,7 @@ impl From<bool> for Value {
     }
 }
 
-impl PyTrait<'_> for Value {
+impl<'h> PyTrait<'h> for Value {
     fn py_type(&self, vm: &VM<'_, impl ResourceTracker>) -> Type {
         match self {
             Self::Undefined => panic!("Cannot get type of undefined value"),
@@ -377,9 +377,9 @@ impl PyTrait<'_> for Value {
         }
     }
 
-    fn py_str(&self, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Cow<'static, str>> {
+    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'h, str>> {
         match self {
-            Self::InternString(string_id) => Ok(vm.interns.get_str(*string_id).to_owned().into()),
+            Self::InternString(string_id) => Ok(vm.interns.get_str(*string_id).into()),
             // Instances dispatch to a user `__str__`/`__repr__` (needs the heap id).
             Self::Ref(id) if matches!(vm.heap.get(*id), HeapData::Instance(_)) => instance_str(*id, vm),
             Self::Ref(id) => vm.heap.read(*id).py_str(vm),

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -327,9 +327,8 @@ impl PyTrait<'_> for Value {
             Self::None => Ok(f.write_str("None")?),
             Self::Bool(true) => Ok(f.write_str("True")?),
             Self::Bool(false) => Ok(f.write_str("False")?),
-            // `itoa` formats integers directly into a fixed stack buffer, avoiding the
-            // generic `fmt`/`pad_integral` path and its repeated `RawVec` reallocation
-            // (a hot cost when `str(int)` runs in a loop — see `list_append_str` bench).
+            // `itoa` formats into a fixed stack buffer, skipping the generic
+            // `fmt`/`pad_integral` path and its repeated `RawVec` reallocation.
             Self::Int(v) => Ok(f.write_str(itoa::Buffer::new().format(*v))?),
             Self::InternLongInt(long_int_id) => {
                 let bi = interns.get_long_int(*long_int_id);

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -8,7 +8,6 @@ use std::{
     str::FromStr,
 };
 
-use ahash::AHashSet;
 use num_bigint::BigInt;
 use num_integer::Integer;
 use num_traits::{FromPrimitive, ToPrimitive, Zero};
@@ -28,7 +27,7 @@ use crate::{
         check_repeat_size,
     },
     types::{
-        Bytes, CmpOrder, List, LongInt, Property, PyTrait, Type, allocate_tuple,
+        Bytes, CmpOrder, LazyHeapSet, List, LongInt, Property, PyTrait, Type, allocate_tuple,
         bytes::{bytes_repr_fmt, get_byte_at_index},
         instance::{instance_getattr, instance_repr, instance_str},
         long_int::{bigint_cmp_f64, check_bits_str_digits_limit, i64_cmp_f64},
@@ -318,7 +317,7 @@ impl<'h> PyTrait<'h> for Value {
         &self,
         f: &mut impl Write,
         vm: &mut VM<'_, impl ResourceTracker>,
-        heap_ids: &mut AHashSet<HeapId>,
+        heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         let interns = vm.interns;
         match self {

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -378,6 +378,32 @@ impl<'h> PyTrait<'h> for Value {
         }
     }
 
+    /// Overrides the default `py_repr` with allocation-light fast paths for the
+    /// values whose repr is cheap to produce:
+    /// - singletons (`None`/`True`/`False`/`Ellipsis`) resolve to a pre-interned
+    ///   `StringId`, so `repr`/`str`/`print`/f-strings allocate nothing at all;
+    /// - `int` formats via `itoa` straight into a right-sized `allocate_string`,
+    ///   skipping the grow-then-shrink intermediate `String`.
+    ///
+    /// Every other variant takes the generic `py_repr_fmt` buffered path. `str`
+    /// is also served allocation-free, but by [`py_str`](Self::py_str) — `repr`
+    /// of a `str` still needs a buffer for quoting/escaping.
+    fn py_repr(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
+        match self {
+            Self::None => Ok(Self::InternString(StaticStrings::NoneRepr.into())),
+            Self::Bool(true) => Ok(Self::InternString(StaticStrings::TrueRepr.into())),
+            Self::Bool(false) => Ok(Self::InternString(StaticStrings::FalseRepr.into())),
+            Self::Ellipsis => Ok(Self::InternString(StaticStrings::EllipsisRepr.into())),
+            Self::Int(i) => Ok(allocate_string(itoa::Buffer::new().format(*i), vm.heap)?),
+            _ => {
+                let mut s = String::new();
+                let mut heap_ids = LazyHeapSet::default();
+                self.py_repr_fmt(&mut s, vm, &mut heap_ids)?;
+                Ok(allocate_string(s, vm.heap)?)
+            }
+        }
+    }
+
     fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         match self {
             // Interned/heap strings are already what `str()` returns — hand the

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -327,7 +327,10 @@ impl PyTrait<'_> for Value {
             Self::None => Ok(f.write_str("None")?),
             Self::Bool(true) => Ok(f.write_str("True")?),
             Self::Bool(false) => Ok(f.write_str("False")?),
-            Self::Int(v) => Ok(write!(f, "{v}")?),
+            // `itoa` formats integers directly into a fixed stack buffer, avoiding the
+            // generic `fmt`/`pad_integral` path and its repeated `RawVec` reallocation
+            // (a hot cost when `str(int)` runs in a loop — see `list_append_str` bench).
+            Self::Int(v) => Ok(f.write_str(itoa::Buffer::new().format(*v))?),
             Self::InternLongInt(long_int_id) => {
                 let bi = interns.get_long_int(*long_int_id);
                 check_bits_str_digits_limit(bi.bits())?;

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -16,6 +16,7 @@ use smallvec::SmallVec;
 use crate::{
     builtins::Builtins,
     bytecode::{CallResult, VM},
+    defer_drop,
     exception_private::{ExcType, RunError, RunResult, SimpleException},
     fstring::FormatFloat,
     hash::{HashValue, hash_python_long_int, hash_python_str},
@@ -362,8 +363,9 @@ impl<'h> PyTrait<'h> for Value {
                     // `evaluate_function` issue (see the "Recursive/deep `__repr__`/
                     // `__str__`" divergence in limitations/classes.md) that also
                     // affects `sorted`/`map`/`filter` callbacks.
-                    let s = instance_repr(*id, vm)?;
-                    Ok(f.write_str(&s)?)
+                    let str_value = instance_repr(*id, vm)?;
+                    defer_drop!(str_value, vm);
+                    Ok(f.write_str(str_value.to_str(vm)?)?)
                 } else {
                     heap_ids.insert(*id);
                     let result = vm.heap.read(*id).py_repr_fmt(f, vm, heap_ids);
@@ -376,9 +378,13 @@ impl<'h> PyTrait<'h> for Value {
         }
     }
 
-    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Cow<'h, str>> {
+    fn py_str(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
         match self {
-            Self::InternString(string_id) => Ok(vm.interns.get_str(*string_id).into()),
+            // Interned/heap strings are already what `str()` returns — hand the
+            // same value back (inc-ref'd for the heap case) instead of cloning
+            // the bytes into a fresh allocation.
+            Self::InternString(string_id) => Ok(Self::InternString(*string_id)),
+            Self::Ref(id) if matches!(vm.heap.get(*id), HeapData::Str(_)) => Ok(self.clone_with_heap(vm.heap)),
             // Instances dispatch to a user `__str__`/`__repr__` (needs the heap id).
             Self::Ref(id) if matches!(vm.heap.get(*id), HeapData::Instance(_)) => instance_str(*id, vm),
             Self::Ref(id) => vm.heap.read(*id).py_str(vm),
@@ -2135,20 +2141,31 @@ impl Value {
     /// argument it does not need to own; the borrow keeps `self` and the heap
     /// pinned, so drop/allocate only once it ends.
     pub(crate) fn to_str<'a>(&'a self, vm: &'a VM<'_, impl ResourceTracker>) -> RunResult<&'a str> {
+        self.to_str_heap(vm.heap, vm.interns)
+    }
+
+    /// [`to_str`](Self::to_str) for contexts without a `&VM` — takes `heap` and
+    /// `interns` separately so callers can keep a disjoint `&mut` borrow of
+    /// another `VM` field alive (e.g. resolving a `str` `Value` produced by
+    /// `py_str` while writing it to `vm.print_writer`).
+    pub(crate) fn to_str_heap<'a>(
+        &'a self,
+        heap: &'a Heap<impl ResourceTracker>,
+        interns: &'a Interns,
+    ) -> RunResult<&'a str> {
         match self {
-            Self::InternString(string_id) => Ok(vm.interns.get_str(*string_id)),
-            Self::Ref(heap_id) => match vm.heap.get(*heap_id) {
-                HeapData::Str(s) => Ok(s.as_str()),
-                _ => Err(ExcType::type_error(format!(
-                    "expected string, not {}",
-                    self.py_type_name(vm)
-                ))),
-            },
-            _ => Err(ExcType::type_error(format!(
-                "expected string, not {}",
-                self.py_type_name(vm)
-            ))),
+            Self::InternString(string_id) => return Ok(interns.get_str(*string_id)),
+            Self::Ref(heap_id) => {
+                if let HeapData::Str(s) = heap.get(*heap_id) {
+                    return Ok(s.as_str());
+                }
+            }
+            _ => {}
         }
+        Err(ExcType::type_error(format!(
+            "expected string, not {}",
+            self.py_type_name_heap(heap, interns)
+        )))
     }
 
     /// check if the value is a string.

--- a/crates/monty/test_cases/class__type_errors.py
+++ b/crates/monty/test_cases/class__type_errors.py
@@ -199,3 +199,28 @@ try:
     assert False, 'expected mixed-class + to fail'
 except TypeError as exc:
     assert str(exc) == "unsupported operand type(s) for +: 'Foo' and 'Bar'", 'both class names resolved'
+
+
+# === __repr__ / __str__ must return a str ===
+class BadRepr:
+    def __repr__(self):
+        return 42
+
+
+try:
+    repr(BadRepr())
+    assert False, 'expected repr to fail'
+except TypeError as exc:
+    assert str(exc) == '__repr__ returned non-string (type int)', '__repr__ returning non-string'
+
+
+class BadStr:
+    def __str__(self):
+        return 42
+
+
+try:
+    str(BadStr())
+    assert False, 'expected str to fail'
+except TypeError as exc:
+    assert str(exc) == '__str__ returned non-string (type int)', '__str__ returning non-string'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,8 @@ reportDeprecated = false
 reportWildcardImportFromLibrary = false
 # some test cases intentionally exercise invalid index assignment/runtime error paths
 reportIndexIssue = false
+# dunder tests intentionally return the wrong type (e.g. `__repr__` returning int)
+reportIncompatibleMethodOverride = false
 # `break`/`return`/`continue` inside `with` tests bind through Optional outer
 # variables that pyright can't narrow.
 reportOptionalMemberAccess = false


### PR DESCRIPTION
Numerous small optimizations.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized hot interpreter paths and string conversion by lazily resolving traceback locations, pooling frame locals, interning singleton `repr`s, speeding up `int` formatting and `str(int)`, adding a no-kwarg call fast path, and returning heap `str` `Value`s from `py_str`/`py_repr` with a faster `Value::to_str`. Bench: fib ~-14%, list_append_str ~-38%; no user-visible changes.

- **Performance**
  - Lazy traceback lookup: store `call_offset: Option<u32>` and resolve during unwind (`resolve_offset`); snapshots/async carry offsets.
  - Pooled frame locals: build in `namespace_scratch` under `HeapGuard`, then `append` to the stack; reuses the buffer across calls.
  - Faster ints: `Value::Int` `repr` via `itoa::Buffer`; `str(int)` formats via `itoa` in `Str::init` to a single right-sized allocation.
  - No-kwarg call fast path: handle simple signatures before constructing/guarding kwargs iterators.
  - String conversion: `py_str`/`py_repr` now return heap `str` `Value`s; added `Value::to_str`/`to_str_heap` to resolve without clones and avoid borrow conflicts; used in `print`, f-strings, `format`, and error paths.
  - Interned singleton `repr`s: `None`/`True`/`False`/`Ellipsis` return interned `str` values with zero allocation.
  - Lazy repr cycle guard: `LazyHeapSet` allocates only when needed.

- **Dependencies**
  - Added `itoa` to the workspace and `crates/monty`.

<sup>Written for commit 2148005297d26e389d03ec81c9d86c3bab75bc1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



