### PR TITLE
Bound native `evaluate_function` re-entry to prevent infinite recursion

### DIFF
--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -372,7 +372,7 @@ impl<T: ResourceTracker> VM<'_, T> {
     /// execute them and resume, which this synchronous context cannot support.
     ///
     /// The nested `self.run()` below recurses on the native Rust stack, so
-    /// re-entry is bounded via [`incr_run_reentry`](Self::incr_run_reentry)
+    /// re-entry is bounded via [`enter_run_reentry`](Self::enter_run_reentry)
     /// at entry — before `call_function`, since a class-valued `__init__` can
     /// recurse back in without ever pushing a frame.
     pub(crate) fn evaluate_function(
@@ -381,7 +381,7 @@ impl<T: ResourceTracker> VM<'_, T> {
         callable: &Value,
         args: ArgValues,
     ) -> Result<Value, RunError> {
-        if let Err(e) = self.incr_run_reentry() {
+        if let Err(e) = self.enter_run_reentry() {
             // Bailing before `call_function` takes ownership of `args`, so
             // reclaim its refcounts here.
             args.drop_with_heap(self);

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -6,7 +6,7 @@
 
 use std::mem;
 
-use super::{CallFrame, VM};
+use super::{CallFrame, VM, recursion::RunReentryGuard};
 use crate::{
     args::{ArgValues, KwargsValues},
     asyncio::Coroutine,
@@ -370,33 +370,51 @@ impl<T: ResourceTracker> VM<'_, T> {
     ///
     /// Returns an error for external/OS functions since those require the host to
     /// execute them and resume, which this synchronous context cannot support.
+    ///
+    /// This is the one chokepoint where the interpreter recurses on the
+    /// native Rust stack (via the nested `self.run()` below) rather than the
+    /// heap-allocated `frames` vec, so native re-entry is bounded via
+    /// [`incr_run_reentry`](Self::incr_run_reentry) at entry — before
+    /// `call_function` runs, not merely around `self.run()` — since some
+    /// cycles (a class-valued `__init__`) recurse back into this function
+    /// entirely inside `call_function`, without ever pushing a frame.
     pub(crate) fn evaluate_function(
         &mut self,
         ctx: &'static str,
         callable: &Value,
         args: ArgValues,
     ) -> Result<Value, RunError> {
-        match self.call_function(callable, args)? {
+        if let Err(e) = self.incr_run_reentry() {
+            // `call_function` normally takes ownership of `args`; since
+            // we're bailing before that handoff, reclaim its refcounts here
+            // instead.
+            args.drop_with_heap(self);
+            return Err(e.into());
+        }
+        let mut guard = RunReentryGuard::new(self);
+        let this = &mut *guard;
+
+        match this.call_function(callable, args)? {
             CallResult::Value(v) => return Ok(v),
             CallResult::FramePushed => {
                 // A new frame was pushed for a defined function call - we need to run it
                 // to completion.
-                let stack_depth = self.frames.len();
+                let stack_depth = this.frames.len();
                 // Mark the frame as an exit point from the `run()` loop
-                self.current_frame_mut().should_return = true;
-                match self.run()? {
+                this.current_frame_mut().should_return = true;
+                match this.run()? {
                     FrameExit::Return(v) => return Ok(v),
                     exit => {
-                        exit.drop_with_heap(self);
+                        exit.drop_with_heap(this);
                         // Pop frames off the stack from this failed evaluation
                         // (including the one just pushed)
-                        while self.frames.len() >= stack_depth {
-                            self.pop_frame();
+                        while this.frames.len() >= stack_depth {
+                            this.pop_frame();
                         }
                     }
                 }
             }
-            other => other.drop_with_heap(self),
+            other => other.drop_with_heap(this),
         }
 
         Err(ExcType::not_implemented(format!(

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -371,13 +371,10 @@ impl<T: ResourceTracker> VM<'_, T> {
     /// Returns an error for external/OS functions since those require the host to
     /// execute them and resume, which this synchronous context cannot support.
     ///
-    /// This is the one chokepoint where the interpreter recurses on the
-    /// native Rust stack (via the nested `self.run()` below) rather than the
-    /// heap-allocated `frames` vec, so native re-entry is bounded via
-    /// [`incr_run_reentry`](Self::incr_run_reentry) at entry — before
-    /// `call_function` runs, not merely around `self.run()` — since some
-    /// cycles (a class-valued `__init__`) recurse back into this function
-    /// entirely inside `call_function`, without ever pushing a frame.
+    /// The nested `self.run()` below recurses on the native Rust stack, so
+    /// re-entry is bounded via [`incr_run_reentry`](Self::incr_run_reentry)
+    /// at entry — before `call_function`, since a class-valued `__init__` can
+    /// recurse back in without ever pushing a frame.
     pub(crate) fn evaluate_function(
         &mut self,
         ctx: &'static str,
@@ -385,9 +382,8 @@ impl<T: ResourceTracker> VM<'_, T> {
         args: ArgValues,
     ) -> Result<Value, RunError> {
         if let Err(e) = self.incr_run_reentry() {
-            // `call_function` normally takes ownership of `args`; since
-            // we're bailing before that handoff, reclaim its refcounts here
-            // instead.
+            // Bailing before `call_function` takes ownership of `args`, so
+            // reclaim its refcounts here.
             args.drop_with_heap(self);
             return Err(e.into());
         }

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -731,19 +731,16 @@ pub struct VM<'h, T: ResourceTracker> {
     /// `malloc`/`free` per call. Only held transiently within
     /// `call_sync_function`, so one shared buffer is safe under recursion.
     namespace_scratch: Vec<Value>,
-    /// Native Rust call-stack re-entry depth, charged only around
-    /// `evaluate_function`'s nested call into [`Self::run`] (the one place the
-    /// interpreter recurses on its own stack instead of the heap-allocated
-    /// `frames` vec). Each level costs a real Rust stack frame, so unlike
-    /// `recursion_depth` it is capped far lower — see
-    /// [`recursion::MAX_RUN_REENTRY_DEPTH`] — or a deep callback overflows the
-    /// native stack and aborts (SIGABRT).
+    /// Remaining native Rust call-stack re-entry budget, counted down from
+    /// [`recursion::MAX_RUN_REENTRY_DEPTH`] only around `evaluate_function`'s
+    /// nested call into [`Self::run`] (the one place the interpreter recurses
+    /// on its own stack instead of the heap-allocated `frames` vec).
     ///
     /// Not serialized: a nested `run()` never reaches a snapshot boundary (its
     /// non-`Return` exits are converted to `NotImplementedError` in
-    /// `evaluate_function`), so this is always 0 at a snapshot;
+    /// `evaluate_function`), so the budget is always full at a snapshot;
     /// `debug_assert!`-checked in [`Self::snapshot`].
-    run_reentry_depth: usize,
+    run_reentry_depth: u8,
 }
 
 impl<'h, T: ResourceTracker> VM<'h, T> {
@@ -770,7 +767,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             pending_file_effect: None,
             recursion_depth: 0,
             namespace_scratch: Vec::new(),
-            run_reentry_depth: 0,
+            run_reentry_depth: recursion::MAX_RUN_REENTRY_DEPTH,
         }
     }
 
@@ -837,8 +834,8 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             pending_file_effect: snapshot.pending_file_effect,
             recursion_depth: current_frame_depth,
             namespace_scratch: Vec::new(),
-            // Always 0 at a restore boundary — see the `run_reentry_depth` field doc.
-            run_reentry_depth: 0,
+            // Always default value at a restore boundary — see the `run_reentry_depth` field doc.
+            run_reentry_depth: recursion::MAX_RUN_REENTRY_DEPTH,
         }
     }
 
@@ -851,10 +848,11 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
     /// This is NOT a clone - it's a transfer. After calling this, the original VM
     /// is gone and only the snapshot (+ serialized heap/namespaces) represents the state.
     pub fn snapshot(mut self) -> VMSnapshot {
-        // Always 0 here — see the `run_reentry_depth` field doc. Asserted to
+        // Always fully released (== MAX) here — see the field doc. Asserted to
         // catch a future `run()` call site that can suspend mid-re-entry.
         debug_assert_eq!(
-            self.run_reentry_depth, 0,
+            self.run_reentry_depth,
+            recursion::MAX_RUN_REENTRY_DEPTH,
             "VM snapshotted while inside a nested evaluate_function re-entry"
         );
 

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -732,28 +732,17 @@ pub struct VM<'h, T: ResourceTracker> {
     /// `call_sync_function`, so one shared buffer is safe under recursion.
     namespace_scratch: Vec<Value>,
     /// Native Rust call-stack re-entry depth, charged only around
-    /// `evaluate_function`'s nested call into [`Self::run`].
+    /// `evaluate_function`'s nested call into [`Self::run`] (the one place the
+    /// interpreter recurses on its own stack instead of the heap-allocated
+    /// `frames` vec). Each level costs a real Rust stack frame, so unlike
+    /// `recursion_depth` it is capped far lower — see
+    /// [`recursion::MAX_RUN_REENTRY_DEPTH`] — or a deep callback overflows the
+    /// native stack and aborts (SIGABRT).
     ///
-    /// `evaluate_function` (`bytecode/vm/call.rs`) is the one place the
-    /// interpreter recurses on its own native stack instead of the
-    /// heap-allocated `frames` vec: it re-enters `self.run()` to drive a
-    /// synchronous callback (`map`/`filter`/`sorted(key=...)`, a user
-    /// `__repr__`/`__str__`, an "exotic" class-valued `__init__`) to
-    /// completion. Each level costs a real Rust stack frame (interpreter loop
-    /// and dispatch chain), so unlike `recursion_depth` (cheap per level,
-    /// capped at a depth of one thousand) this must be capped far lower — see
-    /// [`recursion::MAX_RUN_REENTRY_DEPTH`] — or a deep/cyclic callback
-    /// overflows the native stack and aborts the process (SIGABRT). That is
-    /// merely disruptive for a subprocess worker (the pool replaces it) but
-    /// fatal for the in-process/wasm API, which shares the host's stack.
-    ///
-    /// Not serialized: nested `run()` cannot itself reach a snapshot
-    /// boundary — any non-`Return` exit produced *inside* a nested `run()` is
-    /// intercepted and converted into `NotImplementedError` by
-    /// `evaluate_function` itself, never propagated up as a real suspend — so
-    /// this is always back to 0 by the time a snapshot is possible.
-    /// `debug_assert!`-checked in [`Self::snapshot`] rather than taken purely
-    /// on faith.
+    /// Not serialized: a nested `run()` never reaches a snapshot boundary (its
+    /// non-`Return` exits are converted to `NotImplementedError` in
+    /// `evaluate_function`), so this is always 0 at a snapshot;
+    /// `debug_assert!`-checked in [`Self::snapshot`].
     run_reentry_depth: usize,
 }
 
@@ -848,9 +837,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             pending_file_effect: snapshot.pending_file_effect,
             recursion_depth: current_frame_depth,
             namespace_scratch: Vec::new(),
-            // Always 0 at a restore boundary — see the field doc on
-            // `run_reentry_depth` for why nested `run()` re-entry can never
-            // itself reach a snapshot/restore point.
+            // Always 0 at a restore boundary — see the `run_reentry_depth` field doc.
             run_reentry_depth: 0,
         }
     }
@@ -864,10 +851,8 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
     /// This is NOT a clone - it's a transfer. After calling this, the original VM
     /// is gone and only the snapshot (+ serialized heap/namespaces) represents the state.
     pub fn snapshot(mut self) -> VMSnapshot {
-        // Must always be 0 here — see the field doc on `run_reentry_depth`.
-        // This assert exists to catch a future change that breaks the
-        // invariant (e.g. a new call site of `run()` that can suspend
-        // mid-re-entry) rather than relying on it silently.
+        // Always 0 here — see the `run_reentry_depth` field doc. Asserted to
+        // catch a future `run()` call site that can suspend mid-re-entry.
         debug_assert_eq!(
             self.run_reentry_depth, 0,
             "VM snapshotted while inside a nested evaluate_function re-entry"

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -731,6 +731,30 @@ pub struct VM<'h, T: ResourceTracker> {
     /// `malloc`/`free` per call. Only held transiently within
     /// `call_sync_function`, so one shared buffer is safe under recursion.
     namespace_scratch: Vec<Value>,
+    /// Native Rust call-stack re-entry depth, charged only around
+    /// `evaluate_function`'s nested call into [`Self::run`].
+    ///
+    /// `evaluate_function` (`bytecode/vm/call.rs`) is the one place the
+    /// interpreter recurses on its own native stack instead of the
+    /// heap-allocated `frames` vec: it re-enters `self.run()` to drive a
+    /// synchronous callback (`map`/`filter`/`sorted(key=...)`, a user
+    /// `__repr__`/`__str__`, an "exotic" class-valued `__init__`) to
+    /// completion. Each level costs a real Rust stack frame (interpreter loop
+    /// and dispatch chain), so unlike `recursion_depth` (cheap per level,
+    /// capped at a depth of one thousand) this must be capped far lower — see
+    /// [`recursion::MAX_RUN_REENTRY_DEPTH`] — or a deep/cyclic callback
+    /// overflows the native stack and aborts the process (SIGABRT). That is
+    /// merely disruptive for a subprocess worker (the pool replaces it) but
+    /// fatal for the in-process/wasm API, which shares the host's stack.
+    ///
+    /// Not serialized: nested `run()` cannot itself reach a snapshot
+    /// boundary — any non-`Return` exit produced *inside* a nested `run()` is
+    /// intercepted and converted into `NotImplementedError` by
+    /// `evaluate_function` itself, never propagated up as a real suspend — so
+    /// this is always back to 0 by the time a snapshot is possible.
+    /// `debug_assert!`-checked in [`Self::snapshot`] rather than taken purely
+    /// on faith.
+    run_reentry_depth: usize,
 }
 
 impl<'h, T: ResourceTracker> VM<'h, T> {
@@ -757,6 +781,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             pending_file_effect: None,
             recursion_depth: 0,
             namespace_scratch: Vec::new(),
+            run_reentry_depth: 0,
         }
     }
 
@@ -823,6 +848,10 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             pending_file_effect: snapshot.pending_file_effect,
             recursion_depth: current_frame_depth,
             namespace_scratch: Vec::new(),
+            // Always 0 at a restore boundary — see the field doc on
+            // `run_reentry_depth` for why nested `run()` re-entry can never
+            // itself reach a snapshot/restore point.
+            run_reentry_depth: 0,
         }
     }
 
@@ -835,6 +864,15 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
     /// This is NOT a clone - it's a transfer. After calling this, the original VM
     /// is gone and only the snapshot (+ serialized heap/namespaces) represents the state.
     pub fn snapshot(mut self) -> VMSnapshot {
+        // Must always be 0 here — see the field doc on `run_reentry_depth`.
+        // This assert exists to catch a future change that breaks the
+        // invariant (e.g. a new call site of `run()` that can suspend
+        // mid-re-entry) rather than relying on it silently.
+        debug_assert_eq!(
+            self.run_reentry_depth, 0,
+            "VM snapshotted while inside a nested evaluate_function re-entry"
+        );
+
         // Drop cached JSON strings before consuming the VM — they are not
         // included in the snapshot and their refcounts must be decremented.
         self.json_string_cache.drop_all(self.heap);

--- a/crates/monty/src/bytecode/vm/recursion.rs
+++ b/crates/monty/src/bytecode/vm/recursion.rs
@@ -101,6 +101,114 @@ impl<T: ResourceTracker> Drop for RecursionGuard<'_, '_, T> {
     }
 }
 
+/// Hard cap on native Rust call-stack re-entry, enforced by
+/// [`VM::incr_run_reentry`] and released by [`RunReentryGuard`].
+///
+/// Deliberately much smaller than the 1000-frame Python recursion limit:
+/// every level here costs a real nested call to [`VM::run`] (interpreter loop
+/// + dispatch chain), not a cheap push onto the heap-allocated `frames` vec.
+///
+/// Tuned empirically (bisecting the real SIGABRT depth of a self-recursive
+/// `map`/`filter`/`sorted`/`__repr__` re-entry chain) rather than guessed.
+/// The tightest *confirmed* constraint found: `crates/monty-datatest`'s test
+/// runner (`libtest-mimic`) spawns each test on a worker thread via
+/// `thread::scope`/`scope.spawn` with no explicit stack size, i.e. Rust's
+/// unconfigured default (~2 MiB) — not the larger main-thread stack a naive
+/// assumption might reach for. A debug build (with or without
+/// `memory-model-checks`) crashes such a thread at a re-entry depth of 19;
+/// this constant leaves roughly 1.5x margin under that, to absorb per-frame
+/// cost variance across platforms/toolchains (only measured on macOS/arm64
+/// here). Release builds — what the subprocess workers and the wasm/
+/// in-process API actually ship — are far cheaper per level (a 1 MiB stack
+/// only overflows around depth 65-75), so this constant has wide margin
+/// there too. The wasm host's actual thread stack size could not be
+/// independently verified from this repo (no `-z stack-size` linker config
+/// was found for the `wasm32-wasip1-threads` build) — if it's smaller than
+/// assumed, this constant may need lowering further.
+///
+/// This is a hard safety constant, not a Python-visible setting: unlike
+/// `recursion_depth` (bounded via the user-configurable `sys.setrecursionlimit`
+/// apparatus through [`ResourceTracker::check_recursion_depth`]), this cap does
+/// not go through the tracker and cannot be changed by sandboxed code.
+pub(crate) const MAX_RUN_REENTRY_DEPTH: usize = 12;
+
+impl<T: ResourceTracker> VM<'_, T> {
+    /// Checks the native re-entry depth against [`MAX_RUN_REENTRY_DEPTH`] and
+    /// increments it. Pair with [`RunReentryGuard::new`] to release the level
+    /// on every exit path.
+    ///
+    /// Used exclusively by `evaluate_function`, which must be able to run
+    /// custom cleanup (dropping owned arguments) on the failure path — unlike
+    /// [`recursion_guard`](Self::recursion_guard)'s combined
+    /// check-and-wrap, this is split into a plain `Result<(), _>` check (no
+    /// `Drop` type involved) so the caller can `if let Err(e) = ...` it
+    /// without the borrow-checker extending `self`'s borrow across the whole
+    /// match (which it would if a `Drop`-holding guard were part of the
+    /// matched temporary).
+    ///
+    /// Deliberately does not go through [`ResourceTracker::check_recursion_depth`]
+    /// (unlike [`incr_recursion`](Self::incr_recursion)) — this cap is a fixed
+    /// safety constant protecting the native stack, not a Python-visible,
+    /// user-configurable limit.
+    #[inline]
+    pub(crate) fn incr_run_reentry(&mut self) -> Result<(), ResourceError> {
+        if self.run_reentry_depth >= MAX_RUN_REENTRY_DEPTH {
+            return Err(ResourceError::Recursion {
+                limit: MAX_RUN_REENTRY_DEPTH,
+                depth: self.run_reentry_depth + 1,
+            });
+        }
+        self.run_reentry_depth += 1;
+        Ok(())
+    }
+
+    /// Releases one native re-entry level. Paired with
+    /// [`incr_run_reentry`](Self::incr_run_reentry); called only by
+    /// [`RunReentryGuard`]'s `Drop` impl.
+    #[inline]
+    pub(crate) fn decr_run_reentry(&mut self) {
+        debug_assert!(self.run_reentry_depth > 0, "decr_run_reentry called when depth is 0");
+        self.run_reentry_depth -= 1;
+    }
+}
+
+/// RAII guard for one level of native `run()` re-entry, wrapping a level
+/// already reserved via [`VM::incr_run_reentry`].
+///
+/// Derefs to the [`VM`] so the nested `call_function`/`run()` call runs
+/// through the guard; the reserved level is released when the guard is
+/// dropped on any code path (normal return, `?`, or early return).
+pub(crate) struct RunReentryGuard<'a, 'h, T: ResourceTracker> {
+    vm: &'a mut VM<'h, T>,
+}
+
+impl<'a, 'h, T: ResourceTracker> RunReentryGuard<'a, 'h, T> {
+    /// Wraps a re-entry level already charged by a prior
+    /// [`VM::incr_run_reentry`] call.
+    pub(crate) fn new(vm: &'a mut VM<'h, T>) -> Self {
+        Self { vm }
+    }
+}
+
+impl<'h, T: ResourceTracker> Deref for RunReentryGuard<'_, 'h, T> {
+    type Target = VM<'h, T>;
+    fn deref(&self) -> &Self::Target {
+        self.vm
+    }
+}
+
+impl<T: ResourceTracker> DerefMut for RunReentryGuard<'_, '_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.vm
+    }
+}
+
+impl<T: ResourceTracker> Drop for RunReentryGuard<'_, '_, T> {
+    fn drop(&mut self) {
+        self.vm.decr_run_reentry();
+    }
+}
+
 /// Zero-size reservation of one recursion level, returned by [`VM::incr_recursion`].
 ///
 /// Released via [`DropWithVM`] (it cannot reach the VM counter through the heap).

--- a/crates/monty/src/bytecode/vm/recursion.rs
+++ b/crates/monty/src/bytecode/vm/recursion.rs
@@ -102,34 +102,19 @@ impl<T: ResourceTracker> Drop for RecursionGuard<'_, '_, T> {
 }
 
 /// Hard cap on native Rust call-stack re-entry, enforced by
-/// [`VM::incr_run_reentry`] and released by [`RunReentryGuard`].
+/// [`VM::incr_run_reentry`] and released by [`RunReentryGuard`]. Much smaller
+/// than the 1000-frame Python recursion limit because each level costs a real
+/// nested call to [`VM::run`], not a push onto the heap-allocated `frames` vec.
 ///
-/// Deliberately much smaller than the 1000-frame Python recursion limit:
-/// every level here costs a real nested call to [`VM::run`] (interpreter loop
-/// + dispatch chain), not a cheap push onto the heap-allocated `frames` vec.
+/// Tuned empirically by bisecting the SIGABRT depth of a self-recursive
+/// `map`/`filter`/`sorted`/`__repr__` chain. The tightest case: a debug build
+/// on monty-datatest's ~2 MiB default worker-thread stack crashes at depth 19,
+/// so 12 leaves ~1.5x margin (measured on macOS/arm64; release builds have
+/// far more headroom).
 ///
-/// Tuned empirically (bisecting the real SIGABRT depth of a self-recursive
-/// `map`/`filter`/`sorted`/`__repr__` re-entry chain) rather than guessed.
-/// The tightest *confirmed* constraint found: `crates/monty-datatest`'s test
-/// runner (`libtest-mimic`) spawns each test on a worker thread via
-/// `thread::scope`/`scope.spawn` with no explicit stack size, i.e. Rust's
-/// unconfigured default (~2 MiB) — not the larger main-thread stack a naive
-/// assumption might reach for. A debug build (with or without
-/// `memory-model-checks`) crashes such a thread at a re-entry depth of 19;
-/// this constant leaves roughly 1.5x margin under that, to absorb per-frame
-/// cost variance across platforms/toolchains (only measured on macOS/arm64
-/// here). Release builds — what the subprocess workers and the wasm/
-/// in-process API actually ship — are far cheaper per level (a 1 MiB stack
-/// only overflows around depth 65-75), so this constant has wide margin
-/// there too. The wasm host's actual thread stack size could not be
-/// independently verified from this repo (no `-z stack-size` linker config
-/// was found for the `wasm32-wasip1-threads` build) — if it's smaller than
-/// assumed, this constant may need lowering further.
-///
-/// This is a hard safety constant, not a Python-visible setting: unlike
-/// `recursion_depth` (bounded via the user-configurable `sys.setrecursionlimit`
-/// apparatus through [`ResourceTracker::check_recursion_depth`]), this cap does
-/// not go through the tracker and cannot be changed by sandboxed code.
+/// A hard safety constant, not a Python-visible setting: unlike
+/// `recursion_depth` (configurable via `sys.setrecursionlimit`), it does not
+/// go through the tracker and cannot be changed by sandboxed code.
 pub(crate) const MAX_RUN_REENTRY_DEPTH: usize = 12;
 
 impl<T: ResourceTracker> VM<'_, T> {
@@ -137,19 +122,12 @@ impl<T: ResourceTracker> VM<'_, T> {
     /// increments it. Pair with [`RunReentryGuard::new`] to release the level
     /// on every exit path.
     ///
-    /// Used exclusively by `evaluate_function`, which must be able to run
-    /// custom cleanup (dropping owned arguments) on the failure path — unlike
-    /// [`recursion_guard`](Self::recursion_guard)'s combined
-    /// check-and-wrap, this is split into a plain `Result<(), _>` check (no
-    /// `Drop` type involved) so the caller can `if let Err(e) = ...` it
-    /// without the borrow-checker extending `self`'s borrow across the whole
-    /// match (which it would if a `Drop`-holding guard were part of the
-    /// matched temporary).
-    ///
-    /// Deliberately does not go through [`ResourceTracker::check_recursion_depth`]
-    /// (unlike [`incr_recursion`](Self::incr_recursion)) — this cap is a fixed
-    /// safety constant protecting the native stack, not a Python-visible,
-    /// user-configurable limit.
+    /// Split into a plain `Result<(), _>` check (unlike
+    /// [`recursion_guard`](Self::recursion_guard)'s combined check-and-wrap) so
+    /// `evaluate_function` can `if let Err(e) = ...` it and run its own cleanup
+    /// (dropping owned arguments) without a `Drop` guard extending `self`'s
+    /// borrow across the match. Bypasses the tracker: a fixed safety constant,
+    /// not a user-configurable limit.
     #[inline]
     pub(crate) fn incr_run_reentry(&mut self) -> Result<(), ResourceError> {
         if self.run_reentry_depth >= MAX_RUN_REENTRY_DEPTH {

--- a/crates/monty/src/bytecode/vm/recursion.rs
+++ b/crates/monty/src/bytecode/vm/recursion.rs
@@ -106,15 +106,15 @@ impl<T: ResourceTracker> Drop for RecursionGuard<'_, '_, T> {
 /// than the 1000-frame Python recursion limit because each level costs a real
 /// nested call to [`VM::run`], not a push onto the heap-allocated `frames` vec.
 ///
-/// Tuned empirically by bisecting the SIGABRT depth of a self-recursive
-/// `map`/`filter`/`sorted`/`__repr__` chain. The tightest case: a debug build
-/// on monty-datatest's ~2 MiB default worker-thread stack crashes at depth 19,
-/// so 12 leaves ~1.5x margin (measured on macOS/arm64; release builds have
-/// far more headroom).
+/// Tuned conservatively from the smallest native stack observed while fixing
+/// recursive callback crashes. A debug monty-datatest worker with an ~2 MiB
+/// stack crashed at depth 19 on macOS/arm64; keep this much lower and
+/// revalidate on all supported host targets before raising it.
 ///
-/// A hard safety constant, not a Python-visible setting: unlike
-/// `recursion_depth` (configurable via `sys.setrecursionlimit`), it does not
-/// go through the tracker and cannot be changed by sandboxed code.
+/// A hard safety constant, not a Python-visible setting: unlike ordinary
+/// recursion depth, it does not go through the tracker and cannot be changed
+/// by sandboxed code or test hooks.
+// TODO set this value to custom values per-OS/arch
 pub(crate) const MAX_RUN_REENTRY_DEPTH: u8 = 12;
 
 impl<T: ResourceTracker> VM<'_, T> {

--- a/crates/monty/src/bytecode/vm/recursion.rs
+++ b/crates/monty/src/bytecode/vm/recursion.rs
@@ -102,7 +102,7 @@ impl<T: ResourceTracker> Drop for RecursionGuard<'_, '_, T> {
 }
 
 /// Hard cap on native Rust call-stack re-entry, enforced by
-/// [`VM::incr_run_reentry`] and released by [`RunReentryGuard`]. Much smaller
+/// [`VM::enter_run_reentry`] and released by [`RunReentryGuard`]. Much smaller
 /// than the 1000-frame Python recursion limit because each level costs a real
 /// nested call to [`VM::run`], not a push onto the heap-allocated `frames` vec.
 ///
@@ -115,12 +115,12 @@ impl<T: ResourceTracker> Drop for RecursionGuard<'_, '_, T> {
 /// A hard safety constant, not a Python-visible setting: unlike
 /// `recursion_depth` (configurable via `sys.setrecursionlimit`), it does not
 /// go through the tracker and cannot be changed by sandboxed code.
-pub(crate) const MAX_RUN_REENTRY_DEPTH: usize = 12;
+pub(crate) const MAX_RUN_REENTRY_DEPTH: u8 = 12;
 
 impl<T: ResourceTracker> VM<'_, T> {
-    /// Checks the native re-entry depth against [`MAX_RUN_REENTRY_DEPTH`] and
-    /// increments it. Pair with [`RunReentryGuard::new`] to release the level
-    /// on every exit path.
+    /// Charges one native re-entry level, counting the remaining budget down
+    /// from [`MAX_RUN_REENTRY_DEPTH`]; errors when it's exhausted. Pair with
+    /// [`RunReentryGuard::new`] to release the level on every exit path.
     ///
     /// Split into a plain `Result<(), _>` check (unlike
     /// [`recursion_guard`](Self::recursion_guard)'s combined check-and-wrap) so
@@ -129,29 +129,33 @@ impl<T: ResourceTracker> VM<'_, T> {
     /// borrow across the match. Bypasses the tracker: a fixed safety constant,
     /// not a user-configurable limit.
     #[inline]
-    pub(crate) fn incr_run_reentry(&mut self) -> Result<(), ResourceError> {
-        if self.run_reentry_depth >= MAX_RUN_REENTRY_DEPTH {
-            return Err(ResourceError::Recursion {
-                limit: MAX_RUN_REENTRY_DEPTH,
-                depth: self.run_reentry_depth + 1,
-            });
+    pub(crate) fn enter_run_reentry(&mut self) -> Result<(), ResourceError> {
+        if let Some(new_value) = self.run_reentry_depth.checked_sub(1) {
+            self.run_reentry_depth = new_value;
+            Ok(())
+        } else {
+            Err(ResourceError::Recursion {
+                limit: MAX_RUN_REENTRY_DEPTH as usize,
+                depth: MAX_RUN_REENTRY_DEPTH as usize,
+            })
         }
-        self.run_reentry_depth += 1;
-        Ok(())
     }
 
     /// Releases one native re-entry level. Paired with
-    /// [`incr_run_reentry`](Self::incr_run_reentry); called only by
+    /// [`enter_run_reentry`](Self::enter_run_reentry); called only by
     /// [`RunReentryGuard`]'s `Drop` impl.
     #[inline]
-    pub(crate) fn decr_run_reentry(&mut self) {
-        debug_assert!(self.run_reentry_depth > 0, "decr_run_reentry called when depth is 0");
-        self.run_reentry_depth -= 1;
+    pub(crate) fn release_run_reentry(&mut self) {
+        debug_assert!(
+            self.run_reentry_depth < MAX_RUN_REENTRY_DEPTH,
+            "release_run_reentry called when depth is MAX_RUN_REENTRY_DEPTH"
+        );
+        self.run_reentry_depth += 1;
     }
 }
 
 /// RAII guard for one level of native `run()` re-entry, wrapping a level
-/// already reserved via [`VM::incr_run_reentry`].
+/// already reserved via [`VM::enter_run_reentry`].
 ///
 /// Derefs to the [`VM`] so the nested `call_function`/`run()` call runs
 /// through the guard; the reserved level is released when the guard is
@@ -162,7 +166,7 @@ pub(crate) struct RunReentryGuard<'a, 'h, T: ResourceTracker> {
 
 impl<'a, 'h, T: ResourceTracker> RunReentryGuard<'a, 'h, T> {
     /// Wraps a re-entry level already charged by a prior
-    /// [`VM::incr_run_reentry`] call.
+    /// [`VM::enter_run_reentry`] call.
     pub(crate) fn new(vm: &'a mut VM<'h, T>) -> Self {
         Self { vm }
     }
@@ -183,7 +187,7 @@ impl<T: ResourceTracker> DerefMut for RunReentryGuard<'_, '_, T> {
 
 impl<T: ResourceTracker> Drop for RunReentryGuard<'_, '_, T> {
     fn drop(&mut self) {
-        self.vm.decr_run_reentry();
+        self.vm.release_run_reentry();
     }
 }
 

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -374,9 +374,8 @@ pub(crate) fn instance_str(self_id: HeapId, vm: &mut VM<'_, impl ResourceTracker
 /// default). The method runs to completion synchronously via `evaluate_function`,
 /// so — unlike `__init__` — it cannot suspend on external/OS calls (see
 /// `limitations/classes.md`). Recursion (e.g. a `__repr__` that reprs `self`)
-/// re-enters the VM on the *Rust* stack; `evaluate_function`'s native
-/// re-entry guard bounds this well below the native stack limit, raising a
-/// catchable `RecursionError` — lower than CPython's effective depth for
+/// re-enters the VM on the *Rust* stack; `evaluate_function`'s re-entry guard
+/// bounds it with a catchable `RecursionError` — lower than CPython's depth for
 /// deep-but-finite chains, a documented divergence (`limitations/classes.md`).
 fn instance_call_str_dunder(
     self_id: HeapId,

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -373,10 +373,11 @@ pub(crate) fn instance_str(self_id: HeapId, vm: &mut VM<'_, impl ResourceTracker
 /// Returns `Ok(None)` if the class does not define the dunder (caller uses the
 /// default). The method runs to completion synchronously via `evaluate_function`,
 /// so — unlike `__init__` — it cannot suspend on external/OS calls (see
-/// `limitations/classes.md`). NOTE: recursion (e.g. a `__repr__` that reprs
-/// `self`) re-enters the VM on the *Rust* stack and is currently NOT bounded
-/// before the native stack overflows — a pre-existing `evaluate_function`
-/// limitation documented in `limitations/classes.md`.
+/// `limitations/classes.md`). Recursion (e.g. a `__repr__` that reprs `self`)
+/// re-enters the VM on the *Rust* stack; `evaluate_function`'s native
+/// re-entry guard bounds this well below the native stack limit, raising a
+/// catchable `RecursionError` — lower than CPython's effective depth for
+/// deep-but-finite chains, a documented divergence (`limitations/classes.md`).
 fn instance_call_str_dunder(
     self_id: HeapId,
     dunder: &'static str,

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -358,12 +358,9 @@ impl<'h> PyTrait<'h> for Value {
                     // Instances dispatch to a user `__repr__` (or the default), which
                     // needs the heap id to pass `self` — handled here, not at the heap
                     // level, so no `heap_ids` insertion happens. Recursion here
-                    // re-enters the VM on the *Rust* stack via `evaluate_function`'s
-                    // native re-entry guard (see the "Recursive/deep `__repr__`/
-                    // `__str__`" divergence in limitations/classes.md), bounded well
-                    // below the native stack limit but also below CPython's effective
-                    // recursion depth for deep-but-finite chains — the same guard
-                    // also covers `sorted`/`map`/`filter` callbacks.
+                    // re-enters the VM on the *Rust* stack, bounded by
+                    // `evaluate_function`'s re-entry guard (see the "Recursive/deep
+                    // `__repr__`/`__str__`" divergence in limitations/classes.md).
                     let str_value = instance_repr(*id, vm)?;
                     defer_drop!(str_value, vm);
                     Ok(f.write_str(str_value.to_str(vm)?)?)

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -357,12 +357,13 @@ impl<'h> PyTrait<'h> for Value {
                 } else if matches!(vm.heap.get(*id), HeapData::Instance(_)) {
                     // Instances dispatch to a user `__repr__` (or the default), which
                     // needs the heap id to pass `self` — handled here, not at the heap
-                    // level, so no `heap_ids` insertion happens. NOTE: recursion here
-                    // re-enters the VM on the *Rust* stack and is currently NOT
-                    // bounded before the native stack overflows — a pre-existing
-                    // `evaluate_function` issue (see the "Recursive/deep `__repr__`/
-                    // `__str__`" divergence in limitations/classes.md) that also
-                    // affects `sorted`/`map`/`filter` callbacks.
+                    // level, so no `heap_ids` insertion happens. Recursion here
+                    // re-enters the VM on the *Rust* stack via `evaluate_function`'s
+                    // native re-entry guard (see the "Recursive/deep `__repr__`/
+                    // `__str__`" divergence in limitations/classes.md), bounded well
+                    // below the native stack limit but also below CPython's effective
+                    // recursion depth for deep-but-finite chains — the same guard
+                    // also covers `sorted`/`map`/`filter` callbacks.
                     let str_value = instance_repr(*id, vm)?;
                     defer_drop!(str_value, vm);
                     Ok(f.write_str(str_value.to_str(vm)?)?)

--- a/crates/monty/test_cases/recursion__instance_repr.py
+++ b/crates/monty/test_cases/recursion__instance_repr.py
@@ -4,14 +4,17 @@
 import sys
 
 
-def assert_recursion_message(exc, context, *, while_calling=False):
+def assert_recursion_message(exc, context):
     msg = str(exc)
     if sys.platform == 'monty':
         assert msg == 'maximum recursion depth exceeded', f'unexpected {context} recursion message: {msg}'
     else:
-        stack_msg = msg.startswith('Stack overflow (used ') and msg.endswith(
-            ' kB) while calling a Python object' if while_calling else ' kB'
-        )
+        # CPython may hit its recursion counter, or (on smaller C stacks like the
+        # datatest worker / macOS / Windows CI) a native stack-overflow guard. That
+        # guard's message reports the kB used and appends a context-specific suffix
+        # (`) while calling a Python object`, `) while getting the repr of an
+        # object`, ... or nothing), all of which contain ` kB)`.
+        stack_msg = msg.startswith('Stack overflow (used ') and ' kB)' in msg
         assert msg == 'maximum recursion depth exceeded' or stack_msg, f'unexpected {context} recursion message: {msg}'
 
 
@@ -71,4 +74,4 @@ try:
     A()
     raise AssertionError('expected RecursionError from class-valued __init__ cycle')
 except RecursionError as exc:
-    assert_recursion_message(exc, '__init__', while_calling=True)
+    assert_recursion_message(exc, '__init__')

--- a/crates/monty/test_cases/recursion__instance_repr.py
+++ b/crates/monty/test_cases/recursion__instance_repr.py
@@ -1,7 +1,18 @@
-# Recursive `__repr__`/`__str__` re-enter the interpreter on the native Rust
-# stack via `evaluate_function`, exactly like the map/filter/sorted callbacks
-# in recursion__nested_eval.py. See that file's header for why both
-# interpreters raise RecursionError here rather than one crashing.
+# Recursive `__repr__`/`__str__` re-enter via `evaluate_function`; Monty must
+# raise `RecursionError` instead of overflowing the native Rust stack.
+
+import sys
+
+
+def assert_recursion_message(exc, context, *, while_calling=False):
+    msg = str(exc)
+    if sys.platform == 'monty':
+        assert msg == 'maximum recursion depth exceeded', f'unexpected {context} recursion message: {msg}'
+    else:
+        stack_msg = msg.startswith('Stack overflow (used ') and msg.endswith(
+            ' kB) while calling a Python object' if while_calling else ' kB'
+        )
+        assert msg == 'maximum recursion depth exceeded' or stack_msg, f'unexpected {context} recursion message: {msg}'
 
 
 class SelfRepr:
@@ -12,8 +23,8 @@ class SelfRepr:
 try:
     repr(SelfRepr())
     raise AssertionError('expected RecursionError from self-referential __repr__')
-except RecursionError:
-    pass
+except RecursionError as exc:
+    assert_recursion_message(exc, 'repr')
 
 
 class SelfStr:
@@ -24,8 +35,8 @@ class SelfStr:
 try:
     str(SelfStr())
     raise AssertionError('expected RecursionError from self-referential __str__')
-except RecursionError:
-    pass
+except RecursionError as exc:
+    assert_recursion_message(exc, 'str')
 
 
 # === Positive case: a modest finite chain still reprs correctly ===
@@ -41,25 +52,15 @@ class Node:
 
 
 chain = None
-for i in range(10):
+for i in range(5):
     chain = Node(i, chain)
 result = repr(chain)
-assert result.startswith('Node(9,'), f'unexpected repr: {result}'
+assert result == 'Node(4, Node(3, Node(2, Node(1, Node(0)))))', f'unexpected repr: {result}'
 
 
-# === CRITICAL regression test: guard-placement pin ===
-# `A.__init__ = A` makes `A`'s own initializer a *class value* — an "exotic"
-# initializer per `instantiate_class`. Calling `A()` cycles
-# `evaluate_function -> call_function -> instantiate_class -> evaluate_function
-# -> ...` entirely inside `call_function`, WITHOUT ever pushing a VM frame and
-# WITHOUT ever reaching `self.run()`. A native-reentry guard placed only
-# around the `self.run()` call inside `evaluate_function` (rather than at
-# `evaluate_function`'s entry, before `call_function` is even invoked) would
-# NOT catch this cycle, and this test would crash the test process instead of
-# cleanly raising RecursionError. If this test starts crashing the test
-# runner instead of passing, check that the native-reentry guard in
-# `evaluate_function` has not been "simplified" back to wrapping only the
-# `self.run()` call.
+# === Guard-placement regression ===
+# A class-valued `__init__` recurses inside `call_function` before any frame is
+# pushed, so the re-entry guard must be charged at `evaluate_function` entry.
 class A:
     pass
 
@@ -69,5 +70,5 @@ A.__init__ = A
 try:
     A()
     raise AssertionError('expected RecursionError from class-valued __init__ cycle')
-except RecursionError:
-    pass
+except RecursionError as exc:
+    assert_recursion_message(exc, '__init__', while_calling=True)

--- a/crates/monty/test_cases/recursion__instance_repr.py
+++ b/crates/monty/test_cases/recursion__instance_repr.py
@@ -1,0 +1,73 @@
+# Recursive `__repr__`/`__str__` re-enter the interpreter on the native Rust
+# stack via `evaluate_function`, exactly like the map/filter/sorted callbacks
+# in recursion__nested_eval.py. See that file's header for why both
+# interpreters raise RecursionError here rather than one crashing.
+
+
+class SelfRepr:
+    def __repr__(self):
+        return repr(self)
+
+
+try:
+    repr(SelfRepr())
+    raise AssertionError('expected RecursionError from self-referential __repr__')
+except RecursionError:
+    pass
+
+
+class SelfStr:
+    def __str__(self):
+        return str(self)
+
+
+try:
+    str(SelfStr())
+    raise AssertionError('expected RecursionError from self-referential __str__')
+except RecursionError:
+    pass
+
+
+# === Positive case: a modest finite chain still reprs correctly ===
+class Node:
+    def __init__(self, value, child=None):
+        self.value = value
+        self.child = child
+
+    def __repr__(self):
+        if self.child is None:
+            return f'Node({self.value})'
+        return f'Node({self.value}, {self.child!r})'
+
+
+chain = None
+for i in range(10):
+    chain = Node(i, chain)
+result = repr(chain)
+assert result.startswith('Node(9,'), f'unexpected repr: {result}'
+
+
+# === CRITICAL regression test: guard-placement pin ===
+# `A.__init__ = A` makes `A`'s own initializer a *class value* — an "exotic"
+# initializer per `instantiate_class`. Calling `A()` cycles
+# `evaluate_function -> call_function -> instantiate_class -> evaluate_function
+# -> ...` entirely inside `call_function`, WITHOUT ever pushing a VM frame and
+# WITHOUT ever reaching `self.run()`. A native-reentry guard placed only
+# around the `self.run()` call inside `evaluate_function` (rather than at
+# `evaluate_function`'s entry, before `call_function` is even invoked) would
+# NOT catch this cycle, and this test would crash the test process instead of
+# cleanly raising RecursionError. If this test starts crashing the test
+# runner instead of passing, check that the native-reentry guard in
+# `evaluate_function` has not been "simplified" back to wrapping only the
+# `self.run()` call.
+class A:
+    pass
+
+
+A.__init__ = A
+
+try:
+    A()
+    raise AssertionError('expected RecursionError from class-valued __init__ cycle')
+except RecursionError:
+    pass

--- a/crates/monty/test_cases/recursion__nested_eval.py
+++ b/crates/monty/test_cases/recursion__nested_eval.py
@@ -10,9 +10,12 @@ def assert_recursion_message(exc, context):
     if sys.platform == 'monty':
         assert msg == 'maximum recursion depth exceeded', f'unexpected {context} recursion message: {msg}'
     else:
-        # CPython may hit its recursion counter or the datatest worker's smaller C stack.
+        # CPython may hit its recursion counter, or (on smaller C stacks like the
+        # datatest worker / macOS / Windows CI) a native stack-overflow guard. That
+        # guard's message reports the kB used and appends a context-specific suffix
+        # (`) while calling a Python object`, ... or nothing), all containing ` kB)`.
         assert msg == 'maximum recursion depth exceeded' or (
-            msg.startswith('Stack overflow (used ') and msg.endswith(' kB)')
+            msg.startswith('Stack overflow (used ') and ' kB)' in msg
         ), f'unexpected {context} recursion message: {msg}'
 
 

--- a/crates/monty/test_cases/recursion__nested_eval.py
+++ b/crates/monty/test_cases/recursion__nested_eval.py
@@ -1,0 +1,53 @@
+# Recursive callbacks evaluated by map()/filter()/sorted(key=...) re-enter the
+# interpreter on the native Rust stack (via `evaluate_function`), not the
+# heap-allocated Python frame stack. Verifies this is bounded by a
+# RecursionError rather than a native stack overflow (SIGABRT) that would
+# take the whole process down. Also true for CPython (its own C stack has a
+# similar, if differently-sized, limit under recursive map/filter/sorted key
+# calls), so both interpreters take the try/except path here.
+
+# === Recursive map() ===
+def f_map(x):
+    return list(map(f_map, [x]))
+
+
+try:
+    f_map(1)
+    raise AssertionError('expected RecursionError from unbounded map() self-recursion')
+except RecursionError:
+    pass
+
+
+# === Recursive filter() ===
+def f_filter(x):
+    return list(filter(f_filter, [x]))
+
+
+try:
+    f_filter(1)
+    raise AssertionError('expected RecursionError from unbounded filter() self-recursion')
+except RecursionError:
+    pass
+
+
+# === Recursive sorted(key=...) ===
+def f_sorted(x):
+    return sorted([x], key=f_sorted)
+
+
+try:
+    f_sorted(1)
+    raise AssertionError('expected RecursionError from unbounded sorted(key=...) self-recursion')
+except RecursionError:
+    pass
+
+
+# === Positive case: comfortably under the cap, still correct ===
+def double_via_map(x):
+    if x <= 0:
+        return [0]
+    return list(map(lambda v: v, double_via_map(x - 1)))
+
+
+result = double_via_map(5)
+assert result == [0], f'expected [0], got {result}'

--- a/crates/monty/test_cases/recursion__nested_eval.py
+++ b/crates/monty/test_cases/recursion__nested_eval.py
@@ -1,10 +1,20 @@
-# Recursive callbacks evaluated by map()/filter()/sorted(key=...) re-enter the
-# interpreter on the native Rust stack (via `evaluate_function`), not the
-# heap-allocated Python frame stack. Verifies this is bounded by a
-# RecursionError rather than a native stack overflow (SIGABRT) that would
-# take the whole process down. Also true for CPython (its own C stack has a
-# similar, if differently-sized, limit under recursive map/filter/sorted key
-# calls), so both interpreters take the try/except path here.
+# Recursive synchronous callbacks re-enter the interpreter via
+# `evaluate_function`; Monty must raise `RecursionError` instead of overflowing
+# the native Rust stack.
+
+import sys
+
+
+def assert_recursion_message(exc, context):
+    msg = str(exc)
+    if sys.platform == 'monty':
+        assert msg == 'maximum recursion depth exceeded', f'unexpected {context} recursion message: {msg}'
+    else:
+        # CPython may hit its recursion counter or the datatest worker's smaller C stack.
+        assert msg == 'maximum recursion depth exceeded' or (
+            msg.startswith('Stack overflow (used ') and msg.endswith(' kB)')
+        ), f'unexpected {context} recursion message: {msg}'
+
 
 # === Recursive map() ===
 def f_map(x):
@@ -14,8 +24,8 @@ def f_map(x):
 try:
     f_map(1)
     raise AssertionError('expected RecursionError from unbounded map() self-recursion')
-except RecursionError:
-    pass
+except RecursionError as exc:
+    assert_recursion_message(exc, 'map')
 
 
 # === Recursive filter() ===
@@ -26,8 +36,8 @@ def f_filter(x):
 try:
     f_filter(1)
     raise AssertionError('expected RecursionError from unbounded filter() self-recursion')
-except RecursionError:
-    pass
+except RecursionError as exc:
+    assert_recursion_message(exc, 'filter')
 
 
 # === Recursive sorted(key=...) ===
@@ -38,8 +48,8 @@ def f_sorted(x):
 try:
     f_sorted(1)
     raise AssertionError('expected RecursionError from unbounded sorted(key=...) self-recursion')
-except RecursionError:
-    pass
+except RecursionError as exc:
+    assert_recursion_message(exc, 'sorted')
 
 
 # === Positive case: comfortably under the cap, still correct ===

--- a/limitations/classes.md
+++ b/limitations/classes.md
@@ -128,9 +128,10 @@ order and error wording, but with these divergences:
   recursion now raises `RecursionError` (matching CPython's outcome, though
   not its exact depth), but a deep-but-finite chain that CPython's default
   1000-frame limit would still successfully render may raise `RecursionError`
-  in Monty where CPython succeeds — a deliberate divergence traded for never
-  crashing the host process. The same cap also applies to recursive
-  `sorted(key=...)`/`map`/`filter` callbacks (see
+  in Monty where CPython succeeds — a deliberate divergence traded for avoiding
+  native stack overflow. The same cap also applies to synchronous callback
+  evaluation such as `map()`, `filter()`, `sorted()`/`list.sort(key=...)`,
+  `min()`/`max(key=...)`, and exotic `__init__` recursion (see
   `limitations/resource_limits.md`'s "Recursion" section).
 - **Comprehensions in the class body** can see class variables, because Monty
   inlines comprehensions into the enclosing scope. In CPython a comprehension

--- a/limitations/classes.md
+++ b/limitations/classes.md
@@ -115,15 +115,23 @@ order and error wording, but with these divergences:
   internally inconsistent object. CPython either reassigns the class (for a
   compatible class) or raises `TypeError: __class__ must be set to a class, not
   '...' object`.
-- **Recursive/deep `__repr__`/`__str__` aborts the process.** A `__repr__` (or
-  `__str__`) that reprs `self`, or a deep-but-finite chain of instances whose
-  reprs nest (a ~600-deep linked list), overflows the native Rust stack and
-  aborts (`fatal runtime error: stack overflow`) *before* the Python recursion
-  limit (1000) can raise a catchable `RecursionError`. This is a pre-existing
-  `evaluate_function` re-entry limitation that user classes make far easier to
-  reach; on subprocess workers the pool recovers, but on the in-process/wasm
-  API it takes the host process down. A bounded native-recursion guard is
-  planned; until it lands, avoid unbounded/very-deep repr recursion.
+- **Recursive/deep `__repr__`/`__str__` raises `RecursionError` earlier than
+  CPython.** A `__repr__` (or `__str__`) that reprs `self`, or a deep chain of
+  instances whose reprs nest (e.g. a long linked list), re-enters the
+  interpreter on the native Rust call stack once per nesting level (unlike
+  ordinary Python-level recursion, which lives on a heap-allocated frame stack
+  and is bounded at 1000 by the normal recursion limit). To avoid a native
+  stack overflow (which would abort the process — fatal for the
+  in-process/wasm API, which shares the host process), this native re-entry is
+  capped independently at a much lower, fixed depth, raising a catchable
+  `RecursionError` once exceeded. The practical effect: infinite `__repr__`
+  recursion now raises `RecursionError` (matching CPython's outcome, though
+  not its exact depth), but a deep-but-finite chain that CPython's default
+  1000-frame limit would still successfully render may raise `RecursionError`
+  in Monty where CPython succeeds — a deliberate divergence traded for never
+  crashing the host process. The same cap also applies to recursive
+  `sorted(key=...)`/`map`/`filter` callbacks (see
+  `limitations/resource_limits.md`'s "Recursion" section).
 - **Comprehensions in the class body** can see class variables, because Monty
   inlines comprehensions into the enclosing scope. In CPython a comprehension
   has its own scope that skips the class scope, so only the *leftmost iterable*

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -43,6 +43,15 @@ inside the sandbox).
   limit cannot be changed by sandboxed code.
 - Async stacks count toward the limit but each `await` boundary is treated
   as one frame, so `await`-chains do not amplify depth.
+- Callbacks evaluated synchronously by the interpreter itself — a `map()`,
+  `filter()`, or `sorted(key=...)` function argument that recursively calls
+  back into the same construct, and (once classes are involved) recursive
+  `__repr__`/`__str__` — re-enter the interpreter on the native Rust call
+  stack rather than the heap-allocated frame stack used by ordinary function
+  calls. This native re-entry is capped independently, at a lower fixed depth
+  than the 1000-frame Python limit, to guarantee it can never overflow the
+  native stack and abort the process. See `limitations/classes.md`'s
+  `__repr__`/`__str__` entry for the user-visible divergence this causes.
 
 ## Time
 

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -39,19 +39,21 @@ inside the sandbox).
 
 - Python-level call depth is hardcoded at **1000 frames**. The 1001st
   nested call raises `RecursionError`.
-- There is no `sys.getrecursionlimit()` / `setrecursionlimit()` — the
-  limit cannot be changed by sandboxed code.
+- Production sandbox code cannot change the recursion limit. Test builds may
+  expose `sys.setrecursionlimit()` as a lowering-only fixture hook; it cannot
+  raise the host-configured ceiling.
 - Async stacks count toward the limit but each `await` boundary is treated
   as one frame, so `await`-chains do not amplify depth.
-- Callbacks evaluated synchronously by the interpreter itself — a `map()`,
-  `filter()`, or `sorted(key=...)` function argument that recursively calls
-  back into the same construct, and (once classes are involved) recursive
-  `__repr__`/`__str__` — re-enter the interpreter on the native Rust call
-  stack rather than the heap-allocated frame stack used by ordinary function
-  calls. This native re-entry is capped independently, at a lower fixed depth
-  than the 1000-frame Python limit, to guarantee it can never overflow the
-  native stack and abort the process. See `limitations/classes.md`'s
-  `__repr__`/`__str__` entry for the user-visible divergence this causes.
+- Callbacks evaluated synchronously by the interpreter itself re-enter on the
+  native Rust call stack rather than the heap-allocated frame stack used by
+  ordinary function calls. This includes `map()`, `filter()`,
+  `sorted()`/`list.sort(key=...)`, `min()`/`max(key=...)`, recursive
+  `__repr__`/`__str__`, and non-plain-function `__init__` values that recurse
+  during construction. Native re-entry is capped independently at a lower
+  fixed depth than the 1000-frame Python limit, so Monty raises
+  `RecursionError` before a native stack overflow would abort the process. See
+  `limitations/classes.md`'s `__repr__`/`__str__` entry for the main
+  user-visible divergence this causes.
 
 ## Time
 

--- a/limitations/sys.md
+++ b/limitations/sys.md
@@ -19,8 +19,11 @@ Minimal. The module exposes only the attributes listed below; every other
 
 `argv`, `path`, `modules`, `prefix`, `executable`, `byteorder`,
 `maxsize`, `maxunicode`, `flags`, `float_info`, `int_info`, `hash_info`,
-`exit`, `exc_info`, `getrecursionlimit`, `setrecursionlimit`,
+`exit`, `exc_info`, `getrecursionlimit`,
 `getsizeof`, `getrefcount`, `intern`, `displayhook`, `excepthook`,
 `settrace`, `setprofile`, `stdin`, `__stdout__`, `_getframe`, `audit`.
 
-The recursion limit is hardcoded; see [resource_limits.md](resource_limits.md).
+Production builds do not expose `sys.setrecursionlimit`. Test builds expose a
+lowering-only hook so shared fixtures can force deterministic recursion errors;
+it cannot raise the host-configured ceiling. See
+[resource_limits.md](resource_limits.md).


### PR DESCRIPTION
A recursive Python callback evaluated through `VM::evaluate_function` (map/filter/ sorted key callbacks, __repr__/__str__ dispatch, class-valued __init__ cycles) re-entered the Rust interpreter loop on the native call stack with no depth limit, overflowing the stack and aborting the whole process before Monty's Python-level recursion limit could ever trip. This is fatal for the in-process wasm API, which shares the host process.

Adds a second, much lower recursion budget (MAX_RUN_REENTRY_DEPTH) dedicated to native re-entry, mirroring the existing RecursionGuard machinery, charged at evaluate_function's entry so it covers both the framed (map/filter/sorted/ __repr__) and frameless (class-valued __init__) re-entry cycles. The constant was tuned empirically by bisecting real SIGABRT depths rather than guessed.


Claude-Session: https://claude.ai/code/session_01MLmyMBZFoGpBzQzRjjMxah


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound native re-entry in `VM::evaluate_function` to prevent stack overflows. Recursive callbacks now raise `RecursionError` instead of crashing, including frameless class‑valued `__init__` cycles.

- **Bug Fixes**
  - Added fixed cap `MAX_RUN_REENTRY_DEPTH`, enforced via `run_reentry_depth` and `RunReentryGuard`, charged at `evaluate_function` entry to cover both framed callbacks and frameless `__init__` cycles.
  - Exceeding the cap raises `RecursionError` for recursive `map`/`filter`/`sorted(key=...)` and `__repr__`/`__str__`; modest finite chains still work.
  - `run_reentry_depth` resets on restore and is never serialized; `snapshot` asserts we’re not inside re-entry.
  - Added tests for nested eval, recursive `__repr__`/`__str__`, a finite chain, and the `A.__init__ = A` regression; updated `limitations/*` to document earlier recursion errors and test-only, lowering‑only `sys.setrecursionlimit`.

<sup>Written for commit 10885641fbefac5e5ba4d6fd35e95b08be9460e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



