### PR TITLE
Add benchmarks covering real agent workloads

### DIFF
--- a/crates/monty-bench/benches/main.rs
+++ b/crates/monty-bench/benches/main.rs
@@ -132,12 +132,6 @@ fn wrap_for_cpython(code: &str) -> String {
 
 const ADD_TWO: &str = "1 + 2";
 
-const LIST_APPEND: &str = "
-a = []
-a.append(42)
-a[0]
-";
-
 const LOOP_MOD_13: &str = "
 v = ''
 for i in range(1_000):
@@ -205,6 +199,141 @@ const EMPTY_TUPLES: &str = "len([() for _ in range(100_000)])";
 
 /// 2-tuple creation benchmark - creates 100,000 2-tuples in a list.
 const PAIR_TUPLES: &str = "len([(i, i + 1) for i in range(100_000)])";
+
+// --- Agent-workload benchmarks -------------------------------------------
+//
+// Monty's primary real-world use is "code mode" agents (pydantic-ai
+// CodeMode, the examples/ directory, pydantic/talks demos): LLM-written
+// Python that pulls rows out of a database/API via external functions,
+// aggregates them with plain dicts/lists, and formats a report. The
+// benchmarks below mirror those hot loops so regressions in the paths that
+// dominate real agent runs (str-keyed dict access, f-string formatting,
+// str parsing methods, datetime and re) show up in CI.
+
+/// Group-by aggregation over rows-of-dicts — the core loop of every
+/// data-analysis agent (group revenue by segment, rank, filter). Dominated
+/// by str-keyed dict get/insert, `sorted` with a lambda key, tuple
+/// unpacking, and a filtered generator-expression `sum`.
+const AGG_ROWS: &str = "
+regions = ['north', 'south', 'east', 'west']
+segments = ['consumer', 'smb', 'enterprise']
+channels = ['organic', 'paid', 'referral', 'email', 'social']
+rows = []
+for i in range(1_000):
+    rows.append({
+        'order_id': i,
+        'region': regions[i % 4],
+        'segment': segments[i % 3],
+        'channel': channels[i % 5],
+        'amount': (i * 37) % 500 + 1,
+        'quantity': i % 7 + 1,
+    })
+
+checksum = 0
+for _ in range(10):
+    revenue = {}
+    orders = {}
+    for row in rows:
+        key = row['region'] + '/' + row['segment']
+        value = row['amount'] * row['quantity']
+        revenue[key] = revenue.get(key, 0) + value
+        orders[key] = orders.get(key, 0) + 1
+    ranked = sorted(revenue.items(), key=lambda kv: kv[1], reverse=True)
+    top_key, top_revenue = ranked[0]
+    big = sum(1 for row in rows if row['amount'] > 400 and row['quantity'] >= 3)
+    checksum += top_revenue + big + top_revenue // orders[top_key]
+checksum
+";
+
+/// Report formatting with f-strings — how agents present results (markdown
+/// tables, aligned columns, percentages, thousands separators). Exercises
+/// the format mini-language (`fstring.rs`), float formatting, and
+/// `str.join` over a large list of tracked strings.
+const FSTRING_REPORT: &str = "
+total = 0.0
+lines = []
+for i in range(2_000):
+    name = 'product-' + str(i % 100)
+    price = (i * 7) % 300 + 0.99
+    share = (i % 100) / 100
+    total += price
+    lines.append(f'| {name:<14} | {price:>10.2f} | {share:>7.1%} | {i:06d} |')
+lines.append(f'total: {total:,.2f}')
+report = '\\n'.join(lines)
+len(report)
+";
+
+/// Line-oriented text parsing — the scraping/ETL shape (split lines, split
+/// fields, strip/lower/startswith/`in`, `int()` conversion). Measures str
+/// method throughput on real text rather than `FromArgs` binding (which
+/// `builtin_args` covers with tiny strings).
+const STR_PARSE: &str = "
+lines = []
+for i in range(500):
+    status = 'ACTIVE' if i % 3 else 'retired'
+    lines.append('  Widget-' + str(i) + ' ;  ' + str((i * 13) % 400) + ' ; ' + status + ' ; north-' + str(i % 7) + '  ')
+text = '\\n'.join(lines)
+
+count = 0
+total = 0
+for _ in range(10):
+    for line in text.split('\\n'):
+        parts = line.split(';')
+        name = parts[0].strip()
+        qty = int(parts[1].strip())
+        state = parts[2].strip().lower()
+        zone = parts[3].strip()
+        if state == 'active' and name.lower().startswith('widget') and 'north' in zone:
+            count += 1
+            total += qty
+count + total
+";
+
+/// Timestamp cohort analysis — parse ISO timestamps, bucket by weekday and
+/// `strftime` month key, subtract datetimes. The retention/day-of-week
+/// questions agents get asked constantly; covers `fromisoformat`,
+/// `strftime`, `weekday`, and timedelta arithmetic.
+const DATETIME_OPS: &str = "
+import datetime
+
+stamps = []
+for i in range(500):
+    stamps.append(f'2024-{i % 12 + 1:02d}-{i % 28 + 1:02d}T{i % 24:02d}:{i % 60:02d}:00')
+
+start = datetime.datetime(2024, 1, 1)
+weekday_counts = [0, 0, 0, 0, 0, 0, 0]
+cohorts = {}
+total_days = 0
+for _ in range(4):
+    for s in stamps:
+        dt = datetime.datetime.fromisoformat(s)
+        weekday_counts[dt.weekday()] += 1
+        cohorts[dt.strftime('%Y-%m')] = cohorts.get(dt.strftime('%Y-%m'), 0) + 1
+        total_days += (dt - start).days
+weekend = weekday_counts[5] + weekday_counts[6]
+total_days + weekend + len(cohorts)
+";
+
+/// Regex extraction over a large string — `finditer` with group capture and
+/// `re.split`. The engine is fancy-regex, but Monty's wrapper (match-object
+/// allocation, group extraction into tracked strings) is what this guards.
+const RE_EXTRACT: &str = "
+import re
+
+parts = []
+for i in range(300):
+    parts.append('name=item' + str(i) + ' qty=' + str(i % 50) + ' price=' + str((i * 7) % 900))
+text = ' '.join(parts)
+
+pattern = re.compile(r'qty=(\\d+) price=(\\d+)')
+total = 0
+for _ in range(5):
+    for m in pattern.finditer(text):
+        total += int(m.group(1)) + int(m.group(2))
+    words = re.split(r'\\s+', text)
+    total += len(words)
+total
+";
 
 /// Single-collection latency benchmark.
 ///
@@ -300,10 +429,6 @@ fn criterion_benchmark(c: &mut Criterion) {
     #[cfg(not(codspeed))]
     c.bench_function("add_two__cpython", |b| run_cpython(b, ADD_TWO, 3));
 
-    c.bench_function("list_append__monty", |b| run_monty(b, LIST_APPEND, 42));
-    #[cfg(not(codspeed))]
-    c.bench_function("list_append__cpython", |b| run_cpython(b, LIST_APPEND, 42));
-
     c.bench_function("loop_mod_13__monty", |b| run_monty(b, LOOP_MOD_13, 77));
     #[cfg(not(codspeed))]
     c.bench_function("loop_mod_13__cpython", |b| run_cpython(b, LOOP_MOD_13, 77));
@@ -372,6 +497,26 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("json_dumps__cpython", |b| {
         run_cpython_with_data(b, JSON_DUMPS, JSON_MEDIUM, 1815);
     });
+
+    c.bench_function("agg_rows__monty", |b| run_monty(b, AGG_ROWS, 909_800));
+    #[cfg(not(codspeed))]
+    c.bench_function("agg_rows__cpython", |b| run_cpython(b, AGG_ROWS, 909_800));
+
+    c.bench_function("fstring_report__monty", |b| run_monty(b, FSTRING_REPORT, 102_017));
+    #[cfg(not(codspeed))]
+    c.bench_function("fstring_report__cpython", |b| run_cpython(b, FSTRING_REPORT, 102_017));
+
+    c.bench_function("str_parse__monty", |b| run_monty(b, STR_PARSE, 655_040));
+    #[cfg(not(codspeed))]
+    c.bench_function("str_parse__cpython", |b| run_cpython(b, STR_PARSE, 655_040));
+
+    c.bench_function("datetime_ops__monty", |b| run_monty(b, DATETIME_OPS, 360_100));
+    #[cfg(not(codspeed))]
+    c.bench_function("datetime_ops__cpython", |b| run_cpython(b, DATETIME_OPS, 360_100));
+
+    c.bench_function("re_extract__monty", |b| run_monty(b, RE_EXTRACT, 652_500));
+    #[cfg(not(codspeed))]
+    c.bench_function("re_extract__cpython", |b| run_cpython(b, RE_EXTRACT, 652_500));
 
     c.bench_function("gc_collect__monty", |b| run_monty(b, GC_COLLECT, 0));
     #[cfg(not(codspeed))]

--- a/crates/monty-bench/benches/pool.rs
+++ b/crates/monty-bench/benches/pool.rs
@@ -163,7 +163,10 @@ fn make_rows() -> MontyObject {
                         MontyObject::String("region".to_owned()),
                         MontyObject::String("north".to_owned()),
                     ),
-                    (MontyObject::String("amount".to_owned()), MontyObject::Int((i * 37) % 500 + 1)),
+                    (
+                        MontyObject::String("amount".to_owned()),
+                        MontyObject::Int((i * 37) % 500 + 1),
+                    ),
                     (MontyObject::String("quantity".to_owned()), MontyObject::Int(i % 7 + 1)),
                 ])
             })
@@ -185,7 +188,9 @@ fn ext_call_rows(bench: &mut Bencher) {
     let pool = Pool::new(PoolConfig::subprocess(monty_binary())).unwrap();
     let mut session = pool.checkout(&ReplConfig::default()).unwrap();
     bench.iter(|| {
-        let mut event = session.feed(EXT_ROWS_LOOP, vec![], vec![], false, &mut no_print).unwrap();
+        let mut event = session
+            .feed(EXT_ROWS_LOOP, vec![], vec![], false, &mut no_print)
+            .unwrap();
         let value = loop {
             match event {
                 TurnEvent::Complete(value) => break value,

--- a/crates/monty-bench/benches/pool.rs
+++ b/crates/monty-bench/benches/pool.rs
@@ -135,11 +135,80 @@ fn ext_calls_1000(bench: &mut Bencher) {
     session.finish().unwrap();
 }
 
+/// Sums `amount * quantity` over every row of every external-call result —
+/// the aggregation a code-mode agent runs over a SQL tool's rows.
+const EXT_ROWS_LOOP: &str = "
+total = 0
+for i in range(20):
+    rows = fetch_rows(i)
+    for row in rows:
+        total += row['amount'] * row['quantity']
+total
+";
+
+/// Builds a 100-row result set shaped like a SQL tool reply: a list of dicts
+/// with string keys and mixed str/int values. This is the payload shape real
+/// agents pull across the wire on every external call.
+fn make_rows() -> MontyObject {
+    MontyObject::List(
+        (0..100)
+            .map(|i| {
+                MontyObject::dict(vec![
+                    (MontyObject::String("order_id".to_owned()), MontyObject::Int(i)),
+                    (
+                        MontyObject::String("customer".to_owned()),
+                        MontyObject::String(format!("customer-{i}@example.com")),
+                    ),
+                    (
+                        MontyObject::String("region".to_owned()),
+                        MontyObject::String("north".to_owned()),
+                    ),
+                    (MontyObject::String("amount".to_owned()), MontyObject::Int((i * 37) % 500 + 1)),
+                    (MontyObject::String("quantity".to_owned()), MontyObject::Int(i % 7 + 1)),
+                ])
+            })
+            .collect(),
+    )
+}
+
+/// Large-payload wire throughput: 20 external calls per iteration, each
+/// answered with a 100-row list-of-dicts. Unlike `ext_calls_1000` (which
+/// replies `None` and isolates framing), this measures WireObject
+/// encode/decode and heap conversion of realistic tool results — the
+/// dominant wire cost for data-analysis agents.
+fn ext_call_rows(bench: &mut Bencher) {
+    let rows = make_rows();
+    // Expected sandbox result: 20 identical calls, each summing amount * quantity.
+    let per_call: i64 = (0..100).map(|i| ((i * 37) % 500 + 1) * (i % 7 + 1)).sum();
+    let expected = MontyObject::Int(per_call * 20);
+
+    let pool = Pool::new(PoolConfig::subprocess(monty_binary())).unwrap();
+    let mut session = pool.checkout(&ReplConfig::default()).unwrap();
+    bench.iter(|| {
+        let mut event = session.feed(EXT_ROWS_LOOP, vec![], vec![], false, &mut no_print).unwrap();
+        let value = loop {
+            match event {
+                TurnEvent::Complete(value) => break value,
+                TurnEvent::FunctionCall { .. } => {
+                    event = session
+                        .resume(ResumeValue::Return(rows.clone()), &mut no_print)
+                        .unwrap();
+                }
+                other => panic!("expected Complete or FunctionCall, got {other:?}"),
+            }
+        };
+        assert_eq!(value, expected);
+        black_box(value);
+    });
+    session.finish().unwrap();
+}
+
 /// Configures the pool benchmarks.
 fn pool_benchmark(c: &mut Criterion) {
     c.bench_function("pool_create_session_run", pool_create_session_run);
     c.bench_function("session_checkout_run", session_checkout_run);
     c.bench_function("ext_calls_1000", ext_calls_1000);
+    c.bench_function("ext_call_rows", ext_call_rows);
 }
 
 // Use pprof flamegraph profiler when running locally on Unix (not on CodSpeed or Windows)


### PR DESCRIPTION
Monty's dominant real-world use is "code mode" agents (pydantic-ai
CodeMode, examples/, pydantic/talks demos): LLM-written Python that pulls
rows out of a database or API via external functions, aggregates them with
plain dicts and lists, and formats a report. The existing benchmarks
covered language micro-operations but none of these hot loops.

New interpreter benchmarks (benches/main.rs), each verified to produce
identical results on Monty and CPython:

- agg_rows: group-by aggregation over rows-of-dicts (str-keyed dict
  get/insert, sorted with a lambda key, filtered generator-expression sum)
- fstring_report: report/table formatting via the format mini-language
  (alignment, float precision, percent, thousands separators) plus
  str.join over many tracked strings
- str_parse: line-oriented text parsing (split, strip, lower, startswith,
  substring `in`, int conversion) measuring str method throughput on real
  text rather than argument-binding overhead
- datetime_ops: timestamp cohort analysis (fromisoformat, weekday,
  strftime bucketing, datetime subtraction and timedelta.days)
- re_extract: finditer with group capture and re.split over a large
  string, guarding Monty's match-object/group extraction wrapper

New pool benchmark (benches/pool.rs):

- ext_call_rows: 20 external calls each answered with a 100-row
  list-of-dicts, measuring WireObject encode/decode and heap conversion of
  realistic tool payloads (ext_calls_1000 only round-trips None)

Removed list_append: its 3 heap operations are indistinguishable from the
add_two per-run baseline, and list method throughput is already covered by
list_append_int / list_append_str.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NHcYvk1uKBYfjtU5gU6MKU

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add benchmark coverage for real code‑mode agent workloads to catch regressions in dict/string/date/regex hot loops and external-call payload handling. Removes the redundant `list_append` micro-benchmark.

- **New Features**
  - Interpreter: `agg_rows`, `fstring_report`, `str_parse`, `datetime_ops`, `re_extract` — mirror agent loops; outputs match CPython.
  - Pool: `ext_call_rows` — 20 calls returning a 100‑row list‑of‑dicts; measures WireObject encode/decode and heap conversion.

- **Refactors**
  - Removed `list_append`; applied nightly rustfmt to pool benches.

<sup>Written for commit bd73695f0c67bab49ec591d985e82d09c43bc8b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

