### PR TITLE
Regex perf improvements

### DIFF
--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -742,11 +742,8 @@ pub struct VM<'h, T: ResourceTracker> {
     /// `debug_assert!`-checked in [`Self::snapshot`].
     run_reentry_depth: u8,
 
-    /// Per-run cache of compiled regex patterns for module-level `re.*` calls.
-    ///
-    /// Avoids recompiling the same pattern on every `re.search`/`re.split`/… call.
-    /// Not part of the snapshot (a pure performance cache), so it is default-
-    /// initialized on both `new` and `restore`.
+    /// Per-run cache of compiled patterns for module-level `re.*` calls. Not
+    /// snapshotted (a pure performance cache), so default-initialized on restore.
     pub(crate) re_pattern_cache: RePatternCache,
 }
 

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -35,7 +35,7 @@ use crate::{
     heap_data::{Closure, FunctionDefaults},
     intern::{FunctionId, Interns, StaticStrings, StringId},
     io::PrintWriter,
-    modules::{StandardLib, json::JsonStringCache},
+    modules::{StandardLib, json::JsonStringCache, re::RePatternCache},
     object::InvalidInputError,
     os::OsFunctionCall,
     parse::CodeRange,
@@ -741,6 +741,13 @@ pub struct VM<'h, T: ResourceTracker> {
     /// `evaluate_function`), so the budget is always full at a snapshot;
     /// `debug_assert!`-checked in [`Self::snapshot`].
     run_reentry_depth: u8,
+
+    /// Per-run cache of compiled regex patterns for module-level `re.*` calls.
+    ///
+    /// Avoids recompiling the same pattern on every `re.search`/`re.split`/… call.
+    /// Not part of the snapshot (a pure performance cache), so it is default-
+    /// initialized on both `new` and `restore`.
+    pub(crate) re_pattern_cache: RePatternCache,
 }
 
 impl<'h, T: ResourceTracker> VM<'h, T> {
@@ -768,6 +775,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             recursion_depth: 0,
             namespace_scratch: Vec::new(),
             run_reentry_depth: recursion::MAX_RUN_REENTRY_DEPTH,
+            re_pattern_cache: RePatternCache::default(),
         }
     }
 
@@ -836,6 +844,7 @@ impl<'h, T: ResourceTracker> VM<'h, T> {
             namespace_scratch: Vec::new(),
             // Always default value at a restore boundary — see the `run_reentry_depth` field doc.
             run_reentry_depth: recursion::MAX_RUN_REENTRY_DEPTH,
+            re_pattern_cache: RePatternCache::default(),
         }
     }
 

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -1635,6 +1635,13 @@ fn for_each_child_id<F: FnMut(HeapId)>(data: &HeapData, mut on_child: F) {
                 on_child(buffer_id);
             }
         }
+        HeapData::ReMatch(m) => {
+            // Mirror `py_dec_ref_ids_for_data`: a match holds one ref on its
+            // shared subject string (`None` for an interned subject).
+            if let Value::Ref(id) = m.subject_ref() {
+                on_child(*id);
+            }
+        }
         // Leaf types with no heap references
         _ => {}
     }
@@ -1725,6 +1732,8 @@ fn py_dec_ref_ids_for_data(data: &mut HeapData, stack: &mut Vec<HeapId>) {
             // never `close()`d).
             f.py_dec_ref_ids(stack);
         }
+        // Release the shared subject reference (mirrors `for_each_child_id`).
+        HeapData::ReMatch(m) => m.py_dec_ref_ids(stack),
         // other types have no nested heap references
         _ => {}
     }

--- a/crates/monty/src/modules/re.rs
+++ b/crates/monty/src/modules/re.rs
@@ -30,6 +30,8 @@
 //! - `re.ASCII` / `re.A` — ASCII-only matching for `\w`, `\d`, `\s` (value: 256)
 //! - `re.PatternError` / `re.error` — exception type for invalid patterns
 
+use std::{collections::HashMap, rc::Rc};
+
 use crate::{
     args::{ArgValues, FromArgs},
     builtins::Builtins,
@@ -217,7 +219,12 @@ pub(super) fn call(
 fn call_compile(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let ReCompileArgs { pattern, flags } = ReCompileArgs::from_args(args, vm)?;
     match resolve_pattern(pattern, flags, vm)? {
-        ResolvedPattern::Owned(compiled) => Ok(Value::Ref(vm.heap.allocate(HeapData::RePattern(compiled))?)),
+        // Clone the compiled pattern out of the shared cache entry into its own
+        // heap object — the returned `re.Pattern` is the user's to own and mutate
+        // (lazy anchored-variant compilation) independently of the cache.
+        ResolvedPattern::Cached(compiled) => Ok(Value::Ref(
+            vm.heap.allocate(HeapData::RePattern(Box::new((*compiled).clone())))?,
+        )),
         // Ownership of the extracted value transfers straight to the caller,
         // so the refcount taken at argument extraction is the caller's.
         ResolvedPattern::Heap(value) => Ok(value),
@@ -583,13 +590,13 @@ impl ReFlags {
     }
 }
 
-/// A pattern ready to run: freshly compiled from a string, or borrowed from a
-/// still-live `re.Pattern` heap value. The `Heap` variant's value must stay
-/// alive for the whole match call — callers guard it with `defer_drop!`.
+/// A pattern ready to run: a compiled pattern shared out of the per-run
+/// [`RePatternCache`], or borrowed from a still-live `re.Pattern` heap value. The
+/// `Heap` variant's value must stay alive for the whole match call — callers guard
+/// it with `defer_drop!`.
 enum ResolvedPattern {
-    /// Compiled here from a `str` pattern; boxed so the eventual
-    /// `HeapData::RePattern` allocation in `re.compile` reuses the box.
-    Owned(Box<RePattern>),
+    /// Compiled from a `str` pattern and shared (`Rc`) with the pattern cache.
+    Cached(Rc<RePattern>),
     /// A live `re.Pattern` heap value (always a `Value::Ref` to
     /// `HeapData::RePattern`, guaranteed by [`PatternArg::extract`]).
     Heap(Value),
@@ -599,7 +606,7 @@ impl ResolvedPattern {
     /// Borrows the compiled pattern (from the heap for the `Heap` variant).
     fn get<'a>(&'a self, heap: &'a Heap<impl ResourceTracker>) -> &'a RePattern {
         match self {
-            Self::Owned(pattern) => pattern,
+            Self::Cached(pattern) => pattern,
             Self::Heap(value) => {
                 let Value::Ref(heap_id) = value else {
                     unreachable!("ResolvedPattern::Heap always holds a heap ref")
@@ -618,6 +625,56 @@ impl DropWithHeap for ResolvedPattern {
         if let Self::Heap(value) = self {
             value.drop_with_heap(heap);
         }
+        // `Cached` holds only an `Rc<RePattern>` (no heap references); it drops here.
+    }
+}
+
+/// Per-run cache of compiled patterns for the module-level `re.*` convenience
+/// functions (`re.search`, `re.split`, …), mirroring CPython's `re._cache`.
+///
+/// Those functions take a raw pattern string and would otherwise recompile it on
+/// every call — `re.split(r'\s+', text)` inside a loop is the canonical case.
+/// Caching keyed on `(pattern, flags)` makes a pattern used in a loop compile
+/// once; compiled patterns are shared via `Rc`, so a cache hit is a refcount bump
+/// rather than a regex clone.
+///
+/// Lives on the VM but is **not** part of its snapshot — it is a pure performance
+/// cache, rebuilt on demand after restore (like [`JsonStringCache`]). It holds no
+/// Monty heap references, so it needs no `drop_with_heap` cleanup.
+///
+/// # Bounding
+///
+/// Compiled regexes live on the Rust heap, outside the [`ResourceTracker`]. To keep
+/// that retained memory bounded, the cache is cleared wholesale once it reaches
+/// [`RePatternCache::MAX_ENTRIES`] (as CPython clears `_cache` at `_MAXCACHE`),
+/// rather than growing without limit.
+///
+/// [`JsonStringCache`]: crate::modules::json::JsonStringCache
+#[derive(Default)]
+pub(crate) struct RePatternCache {
+    entries: HashMap<(String, u16), Rc<RePattern>>,
+}
+
+impl RePatternCache {
+    /// Maximum number of cached patterns before the cache is cleared. Bounds the
+    /// untracked compiled-regex memory a program can accumulate via distinct
+    /// module-level patterns; smaller than CPython's 512 given the sandbox's
+    /// resource-limit focus (the size is not observable behaviour).
+    const MAX_ENTRIES: usize = 128;
+
+    /// Returns the compiled pattern for `(pattern, flags)`, compiling and caching
+    /// it on a miss. Compile errors propagate and nothing is cached.
+    fn get_or_compile(&mut self, pattern: &str, flags: u16) -> RunResult<Rc<RePattern>> {
+        let key = (pattern.to_owned(), flags);
+        if let Some(compiled) = self.entries.get(&key) {
+            return Ok(Rc::clone(compiled));
+        }
+        let compiled = Rc::new(RePattern::compile(pattern.to_owned(), flags)?);
+        if self.entries.len() >= Self::MAX_ENTRIES {
+            self.entries.clear();
+        }
+        self.entries.insert(key, Rc::clone(&compiled));
+        Ok(compiled)
     }
 }
 
@@ -647,10 +704,9 @@ fn resolve_pattern(pattern: Value, flags: Value, vm: &mut VM<'_, impl ResourceTr
         }
     };
     match pattern {
-        PatternArg::Str(pattern) => Ok(ResolvedPattern::Owned(Box::new(RePattern::compile(
-            pattern,
-            flags.get(),
-        )?))),
+        PatternArg::Str(pattern) => Ok(ResolvedPattern::Cached(
+            vm.re_pattern_cache.get_or_compile(&pattern, flags.get())?,
+        )),
         PatternArg::Compiled(value) => {
             if flags.get() == 0 {
                 Ok(ResolvedPattern::Heap(value))

--- a/crates/monty/src/modules/re.rs
+++ b/crates/monty/src/modules/re.rs
@@ -647,27 +647,24 @@ const CACHE_CAPACITY: usize = 512;
 /// LRU-on-collision (jiter's `py_string_cache` design), so retained
 /// compiled-regex memory is hard-bounded by `CACHE_CAPACITY`. Mirrors CPython's
 /// `re._cache`; not snapshotted (rebuilt on demand).
-pub(crate) struct RePatternCache {
-    /// `CACHE_CAPACITY` slots — a boxed slice rather than a boxed `[_; N]` array
-    /// to build straight on the heap (no oversized stack array).
-    entries: Box<[ReCacheEntry]>,
-    hash_builder: RandomState,
-}
-
-impl Default for RePatternCache {
-    fn default() -> Self {
-        Self {
-            entries: vec![None; CACHE_CAPACITY].into_boxed_slice(),
-            hash_builder: RandomState::default(),
-        }
-    }
-}
+///
+/// The `CACHE_CAPACITY`-slot backing store is allocated lazily on first use:
+/// every VM constructs a `RePatternCache`, but the vast majority never touch
+/// `re`, and eagerly zeroing ~`CACHE_CAPACITY × size_of::<ReCacheEntry>()` bytes
+/// per VM measurably regressed setup-bound benchmarks (`add_two`, `func_call_*`).
+#[derive(Default)]
+pub(crate) struct RePatternCache(Option<(Box<[ReCacheEntry]>, RandomState)>);
 
 impl RePatternCache {
     /// Returns the compiled pattern for `(pattern, flags)`, compiling and caching
-    /// on a miss. Compile errors propagate and nothing is cached.
+    /// on a miss. Compile errors propagate and nothing is cached. The backing
+    /// store is allocated here on the first call.
     fn get_or_compile(&mut self, pattern: &str, flags: u16) -> RunResult<Rc<RePattern>> {
-        let hash = self.hash_builder.hash_one((pattern, flags));
+        let (entries, hash_builder) = self
+            .0
+            .get_or_insert_with(|| (vec![None; CACHE_CAPACITY].into_boxed_slice(), RandomState::default()));
+
+        let hash = hash_builder.hash_one((pattern, flags));
         // `hash % CACHE_CAPACITY` is < CACHE_CAPACITY, so it always fits usize.
         let hash_index = usize::try_from(hash % CACHE_CAPACITY as u64).expect("index < CACHE_CAPACITY");
 
@@ -675,7 +672,7 @@ impl RePatternCache {
         // empty slot to fill on a miss.
         let mut empty_slot = None;
         for index in hash_index..hash_index + 5 {
-            match self.entries.get(index) {
+            match entries.get(index) {
                 Some(Some((entry_hash, entry_pattern, entry_flags, compiled))) => {
                     if *entry_hash == hash && *entry_flags == flags && &**entry_pattern == pattern {
                         return Ok(Rc::clone(compiled));
@@ -695,7 +692,7 @@ impl RePatternCache {
         // (LRU-on-collision) when every probed slot was occupied.
         let compiled = Rc::new(RePattern::compile(pattern.to_owned(), flags)?);
         let slot = empty_slot.unwrap_or(hash_index);
-        self.entries[slot] = Some((hash, Box::from(pattern), flags, Rc::clone(&compiled)));
+        entries[slot] = Some((hash, Box::from(pattern), flags, Rc::clone(&compiled)));
         Ok(compiled)
     }
 }
@@ -823,9 +820,12 @@ fn should_escape(c: char) -> bool {
 mod tests {
     use super::*;
 
-    /// Counts the occupied slots in the cache.
+    /// Counts the occupied slots in the cache (0 while unallocated).
     fn occupied(cache: &RePatternCache) -> usize {
-        cache.entries.iter().filter(|e| e.is_some()).count()
+        cache
+            .0
+            .as_ref()
+            .map_or(0, |(entries, _)| entries.iter().filter(|e| e.is_some()).count())
     }
 
     #[test]

--- a/crates/monty/src/modules/re.rs
+++ b/crates/monty/src/modules/re.rs
@@ -32,7 +32,7 @@
 
 use std::rc::Rc;
 
-use ahash::AHashMap;
+use ahash::RandomState;
 
 use crate::{
     args::{ArgValues, FromArgs},
@@ -628,31 +628,70 @@ impl DropWithHeap for ResolvedPattern {
     }
 }
 
-/// Per-run cache of compiled patterns for module-level `re.*` calls, keyed on
-/// `(pattern, flags)` — so `re.split(r'\s+', text)` in a loop compiles once, not
-/// per call. Mirrors CPython's `re._cache`. Not snapshotted (rebuilt on demand).
-#[derive(Default)]
+/// One slot of [`RePatternCache`]: the key hash, the `(pattern, flags)` it was
+/// compiled from (rechecked on a hash hit to rule out collisions), and the
+/// compiled pattern shared with callers.
+type ReCacheEntry = Option<(u64, Box<str>, u16, Rc<RePattern>)>;
+
+/// Slot count of [`RePatternCache`] — power of two so the index modulo is a
+/// mask, sized like CPython's `re._MAXCACHE`.
+const CACHE_CAPACITY: usize = 512;
+
+/// Fixed-size, per-run cache of compiled patterns for module-level `re.*` calls,
+/// keyed on `(pattern, flags)` — so `re.split(r'\s+', text)` in a loop compiles
+/// once, not per call. Direct-mapped with 5-slot linear probing and
+/// LRU-on-collision (jiter's `py_string_cache` design), so retained
+/// compiled-regex memory is hard-bounded by `CACHE_CAPACITY`. Mirrors CPython's
+/// `re._cache`; not snapshotted (rebuilt on demand).
 pub(crate) struct RePatternCache {
-    entries: AHashMap<(String, u16), Rc<RePattern>>,
+    /// `CACHE_CAPACITY` slots — a boxed slice rather than a boxed `[_; N]` array
+    /// to build straight on the heap (no oversized stack array).
+    entries: Box<[ReCacheEntry]>,
+    hash_builder: RandomState,
+}
+
+impl Default for RePatternCache {
+    fn default() -> Self {
+        Self {
+            entries: vec![None; CACHE_CAPACITY].into_boxed_slice(),
+            hash_builder: RandomState::default(),
+        }
+    }
 }
 
 impl RePatternCache {
-    /// Cache size cap. Cleared wholesale on overflow to bound the compiled-regex
-    /// memory (untracked Rust heap) a program can retain via distinct patterns.
-    const MAX_ENTRIES: usize = 128;
-
     /// Returns the compiled pattern for `(pattern, flags)`, compiling and caching
     /// on a miss. Compile errors propagate and nothing is cached.
     fn get_or_compile(&mut self, pattern: &str, flags: u16) -> RunResult<Rc<RePattern>> {
-        let key = (pattern.to_owned(), flags);
-        if let Some(compiled) = self.entries.get(&key) {
-            return Ok(Rc::clone(compiled));
+        let hash = self.hash_builder.hash_one((pattern, flags));
+        // `hash % CACHE_CAPACITY` is < CACHE_CAPACITY, so it always fits usize.
+        let hash_index = usize::try_from(hash % CACHE_CAPACITY as u64).expect("index < CACHE_CAPACITY");
+
+        // Probe up to 5 contiguous slots for a match, remembering the first
+        // empty slot to fill on a miss.
+        let mut empty_slot = None;
+        for index in hash_index..hash_index + 5 {
+            match self.entries.get(index) {
+                Some(Some((entry_hash, entry_pattern, entry_flags, compiled))) => {
+                    if *entry_hash == hash && *entry_flags == flags && &**entry_pattern == pattern {
+                        return Ok(Rc::clone(compiled));
+                    }
+                }
+                // First empty slot — a miss lands here.
+                Some(None) => {
+                    empty_slot = Some(index);
+                    break;
+                }
+                // Ran past the end of the array.
+                None => break,
+            }
         }
+
+        // Miss: compile, then fill the empty slot, else evict `hash_index`
+        // (LRU-on-collision) when every probed slot was occupied.
         let compiled = Rc::new(RePattern::compile(pattern.to_owned(), flags)?);
-        if self.entries.len() >= Self::MAX_ENTRIES {
-            self.entries.clear();
-        }
-        self.entries.insert(key, Rc::clone(&compiled));
+        let slot = empty_slot.unwrap_or(hash_index);
+        self.entries[slot] = Some((hash, Box::from(pattern), flags, Rc::clone(&compiled)));
         Ok(compiled)
     }
 }
@@ -772,4 +811,53 @@ fn should_escape(c: char) -> bool {
             | '}'
             | '~'
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Counts the occupied slots in the cache.
+    fn occupied(cache: &RePatternCache) -> usize {
+        cache.entries.iter().filter(|e| e.is_some()).count()
+    }
+
+    #[test]
+    fn hit_shares_one_entry() {
+        let mut cache = RePatternCache::default();
+        let first = cache.get_or_compile(r"\s+", 0).unwrap();
+        let second = cache.get_or_compile(r"\s+", 0).unwrap();
+        // A hit returns the *same* compiled pattern, not a recompile.
+        assert!(Rc::ptr_eq(&first, &second));
+        assert_eq!(occupied(&cache), 1);
+    }
+
+    #[test]
+    fn flags_key_the_entry() {
+        let mut cache = RePatternCache::default();
+        let plain = cache.get_or_compile("abc", 0).unwrap();
+        let ignorecase = cache.get_or_compile("abc", IGNORECASE).unwrap();
+        // Same pattern text but different flags are distinct entries.
+        assert!(!Rc::ptr_eq(&plain, &ignorecase));
+        assert_eq!(occupied(&cache), 2);
+    }
+
+    #[test]
+    fn compile_error_caches_nothing() {
+        let mut cache = RePatternCache::default();
+        // Unbalanced parenthesis fails to compile.
+        assert!(cache.get_or_compile("(", 0).is_err());
+        assert_eq!(occupied(&cache), 0);
+    }
+
+    #[test]
+    fn occupancy_is_bounded_by_capacity() {
+        let mut cache = RePatternCache::default();
+        // Far more distinct patterns than slots: LRU-on-collision must keep
+        // the occupied count hard-bounded rather than growing unboundedly.
+        for i in 0..CACHE_CAPACITY * 4 {
+            cache.get_or_compile(&format!("pat{i}"), 0).unwrap();
+        }
+        assert!(occupied(&cache) <= CACHE_CAPACITY);
+    }
 }

--- a/crates/monty/src/modules/re.rs
+++ b/crates/monty/src/modules/re.rs
@@ -45,7 +45,7 @@ use crate::{
     modules::ModuleFunctions,
     resource::{ResourceError, ResourceTracker},
     types::{
-        Module, RePattern, Type,
+        BoundedCompileError, Module, RePattern, Type,
         re_pattern::{extract_count, extract_maxsplit},
         str::allocate_string,
     },
@@ -633,9 +633,9 @@ impl DropWithHeap for ResolvedPattern {
     }
 }
 
-/// One slot of [`RePatternCache`]: the key hash, the `(pattern, flags)` it was
-/// compiled from (rechecked on a hash hit to rule out collisions), and the
-/// compiled pattern shared with callers.
+/// One slot of [`RePatternCache`], holding the key hash, the pattern text, the
+/// flags (text + flags are rechecked on a hash hit to rule out collisions), and
+/// the compiled pattern shared with callers.
 type ReCacheEntry = Option<(u64, Box<str>, u16, Rc<RePattern>)>;
 
 /// Slot count of [`RePatternCache`] — power of two so the index modulo is a mask;
@@ -699,12 +699,15 @@ impl RePatternCache {
         }
 
         // Miss: compile size-bounded so a retained entry can never pin a huge
-        // compiled regex. If that fails — oversize, or a genuine syntax error —
-        // recompile at default limits and return the result uncached: oversize
-        // patterns still work (just recompiled per call), and syntax errors
-        // surface the same `re.PatternError` an unbounded compile raises.
-        let Ok(compiled) = RePattern::compile_bounded(pattern.to_owned(), flags, CACHED_SIZE_LIMIT) else {
-            return Ok(Rc::new(RePattern::compile(pattern.to_owned(), flags)?));
+        // compiled regex. A valid pattern that compiles past the cap is
+        // recompiled at default limits and returned uncached — it still works,
+        // just recompiled per call.
+        let compiled = match RePattern::compile_bounded(pattern.to_owned(), flags, CACHED_SIZE_LIMIT) {
+            Ok(compiled) => compiled,
+            Err(BoundedCompileError::TooBig) => {
+                return Ok(Rc::new(RePattern::compile(pattern.to_owned(), flags)?));
+            }
+            Err(BoundedCompileError::Invalid(err)) => return Err(err),
         };
 
         // Fill the empty slot, else evict `hash_index` (LRU-on-collision) when

--- a/crates/monty/src/modules/re.rs
+++ b/crates/monty/src/modules/re.rs
@@ -30,7 +30,9 @@
 //! - `re.ASCII` / `re.A` — ASCII-only matching for `\w`, `\d`, `\s` (value: 256)
 //! - `re.PatternError` / `re.error` — exception type for invalid patterns
 
-use std::{collections::HashMap, rc::Rc};
+use std::rc::Rc;
+
+use ahash::AHashMap;
 
 use crate::{
     args::{ArgValues, FromArgs},
@@ -652,7 +654,7 @@ impl DropWithHeap for ResolvedPattern {
 /// [`JsonStringCache`]: crate::modules::json::JsonStringCache
 #[derive(Default)]
 pub(crate) struct RePatternCache {
-    entries: HashMap<(String, u16), Rc<RePattern>>,
+    entries: AHashMap<(String, u16), Rc<RePattern>>,
 }
 
 impl RePatternCache {

--- a/crates/monty/src/modules/re.rs
+++ b/crates/monty/src/modules/re.rs
@@ -221,9 +221,8 @@ pub(super) fn call(
 fn call_compile(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let ReCompileArgs { pattern, flags } = ReCompileArgs::from_args(args, vm)?;
     match resolve_pattern(pattern, flags, vm)? {
-        // Clone the compiled pattern out of the shared cache entry into its own
-        // heap object — the returned `re.Pattern` is the user's to own and mutate
-        // (lazy anchored-variant compilation) independently of the cache.
+        // Clone out of the shared cache entry: the returned `re.Pattern` is the
+        // user's own object, independent of the cache.
         ResolvedPattern::Cached(compiled) => Ok(Value::Ref(
             vm.heap.allocate(HeapData::RePattern(Box::new((*compiled).clone())))?,
         )),
@@ -592,10 +591,8 @@ impl ReFlags {
     }
 }
 
-/// A pattern ready to run: a compiled pattern shared out of the per-run
-/// [`RePatternCache`], or borrowed from a still-live `re.Pattern` heap value. The
-/// `Heap` variant's value must stay alive for the whole match call — callers guard
-/// it with `defer_drop!`.
+/// A pattern ready to run: shared out of the [`RePatternCache`], or a still-live
+/// `re.Pattern` heap value (which callers keep alive with `defer_drop!`).
 enum ResolvedPattern {
     /// Compiled from a `str` pattern and shared (`Rc`) with the pattern cache.
     Cached(Rc<RePattern>),
@@ -631,41 +628,21 @@ impl DropWithHeap for ResolvedPattern {
     }
 }
 
-/// Per-run cache of compiled patterns for the module-level `re.*` convenience
-/// functions (`re.search`, `re.split`, …), mirroring CPython's `re._cache`.
-///
-/// Those functions take a raw pattern string and would otherwise recompile it on
-/// every call — `re.split(r'\s+', text)` inside a loop is the canonical case.
-/// Caching keyed on `(pattern, flags)` makes a pattern used in a loop compile
-/// once; compiled patterns are shared via `Rc`, so a cache hit is a refcount bump
-/// rather than a regex clone.
-///
-/// Lives on the VM but is **not** part of its snapshot — it is a pure performance
-/// cache, rebuilt on demand after restore (like [`JsonStringCache`]). It holds no
-/// Monty heap references, so it needs no `drop_with_heap` cleanup.
-///
-/// # Bounding
-///
-/// Compiled regexes live on the Rust heap, outside the [`ResourceTracker`]. To keep
-/// that retained memory bounded, the cache is cleared wholesale once it reaches
-/// [`RePatternCache::MAX_ENTRIES`] (as CPython clears `_cache` at `_MAXCACHE`),
-/// rather than growing without limit.
-///
-/// [`JsonStringCache`]: crate::modules::json::JsonStringCache
+/// Per-run cache of compiled patterns for module-level `re.*` calls, keyed on
+/// `(pattern, flags)` — so `re.split(r'\s+', text)` in a loop compiles once, not
+/// per call. Mirrors CPython's `re._cache`. Not snapshotted (rebuilt on demand).
 #[derive(Default)]
 pub(crate) struct RePatternCache {
     entries: AHashMap<(String, u16), Rc<RePattern>>,
 }
 
 impl RePatternCache {
-    /// Maximum number of cached patterns before the cache is cleared. Bounds the
-    /// untracked compiled-regex memory a program can accumulate via distinct
-    /// module-level patterns; smaller than CPython's 512 given the sandbox's
-    /// resource-limit focus (the size is not observable behaviour).
+    /// Cache size cap. Cleared wholesale on overflow to bound the compiled-regex
+    /// memory (untracked Rust heap) a program can retain via distinct patterns.
     const MAX_ENTRIES: usize = 128;
 
     /// Returns the compiled pattern for `(pattern, flags)`, compiling and caching
-    /// it on a miss. Compile errors propagate and nothing is cached.
+    /// on a miss. Compile errors propagate and nothing is cached.
     fn get_or_compile(&mut self, pattern: &str, flags: u16) -> RunResult<Rc<RePattern>> {
         let key = (pattern.to_owned(), flags);
         if let Some(compiled) = self.entries.get(&key) {

--- a/crates/monty/src/modules/re.rs
+++ b/crates/monty/src/modules/re.rs
@@ -598,7 +598,8 @@ impl ReFlags {
 /// A pattern ready to run: shared out of the [`RePatternCache`], or a still-live
 /// `re.Pattern` heap value (which callers keep alive with `defer_drop!`).
 enum ResolvedPattern {
-    /// Compiled from a `str` pattern and shared (`Rc`) with the pattern cache.
+    /// Compiled from a `str` pattern and shared (`Rc`) with the pattern cache
+    /// (or uncached when its compiled form exceeds [`CACHED_SIZE_LIMIT`]).
     Cached(Rc<RePattern>),
     /// A live `re.Pattern` heap value (always a `Value::Ref` to
     /// `HeapData::RePattern`, guaranteed by [`PatternArg::extract`]).
@@ -637,16 +638,24 @@ impl DropWithHeap for ResolvedPattern {
 /// compiled pattern shared with callers.
 type ReCacheEntry = Option<(u64, Box<str>, u16, Rc<RePattern>)>;
 
-/// Slot count of [`RePatternCache`] — power of two so the index modulo is a
-/// mask, sized like CPython's `re._MAXCACHE`.
-const CACHE_CAPACITY: usize = 512;
+/// Slot count of [`RePatternCache`] — power of two so the index modulo is a mask;
+/// 256 (vs CPython's 512 `re._MAXCACHE`) to halve the untracked worst-case retained
+/// memory of `CACHE_CAPACITY × CACHED_SIZE_LIMIT`.
+const CACHE_CAPACITY: usize = 256;
+
+/// `delegate_size_limit` for compiles that will be retained in the cache. The cache
+/// is invisible to the `ResourceTracker`, so this caps its worst-case footprint at
+/// ~`CACHE_CAPACITY × CACHED_SIZE_LIMIT`; patterns whose compiled form is bigger
+/// still work — they are recompiled per call at default limits and never retained.
+const CACHED_SIZE_LIMIT: usize = 64 * 1024;
 
 /// Fixed-size, per-run cache of compiled patterns for module-level `re.*` calls,
 /// keyed on `(pattern, flags)` — so `re.split(r'\s+', text)` in a loop compiles
 /// once, not per call. Direct-mapped with 5-slot linear probing and
 /// LRU-on-collision (jiter's `py_string_cache` design), so retained
-/// compiled-regex memory is hard-bounded by `CACHE_CAPACITY`. Mirrors CPython's
-/// `re._cache`; not snapshotted (rebuilt on demand).
+/// compiled-regex memory is hard-bounded by `CACHE_CAPACITY` entries of at most
+/// [`CACHED_SIZE_LIMIT`] each. Mirrors CPython's `re._cache`; not snapshotted
+/// (rebuilt on demand).
 ///
 /// The `CACHE_CAPACITY`-slot backing store is allocated lazily on first use:
 /// every VM constructs a `RePatternCache`, but the vast majority never touch
@@ -657,8 +666,9 @@ pub(crate) struct RePatternCache(Option<(Box<[ReCacheEntry]>, RandomState)>);
 
 impl RePatternCache {
     /// Returns the compiled pattern for `(pattern, flags)`, compiling and caching
-    /// on a miss. Compile errors propagate and nothing is cached. The backing
-    /// store is allocated here on the first call.
+    /// on a miss. Compile errors propagate and nothing is cached; patterns whose
+    /// compiled form exceeds [`CACHED_SIZE_LIMIT`] are returned uncached. The
+    /// backing store is allocated here on the first call.
     fn get_or_compile(&mut self, pattern: &str, flags: u16) -> RunResult<Rc<RePattern>> {
         let (entries, hash_builder) = self
             .0
@@ -688,9 +698,18 @@ impl RePatternCache {
             }
         }
 
-        // Miss: compile, then fill the empty slot, else evict `hash_index`
-        // (LRU-on-collision) when every probed slot was occupied.
-        let compiled = Rc::new(RePattern::compile(pattern.to_owned(), flags)?);
+        // Miss: compile size-bounded so a retained entry can never pin a huge
+        // compiled regex. If that fails — oversize, or a genuine syntax error —
+        // recompile at default limits and return the result uncached: oversize
+        // patterns still work (just recompiled per call), and syntax errors
+        // surface the same `re.PatternError` an unbounded compile raises.
+        let Ok(compiled) = RePattern::compile_bounded(pattern.to_owned(), flags, CACHED_SIZE_LIMIT) else {
+            return Ok(Rc::new(RePattern::compile(pattern.to_owned(), flags)?));
+        };
+
+        // Fill the empty slot, else evict `hash_index` (LRU-on-collision) when
+        // every probed slot was occupied.
+        let compiled = Rc::new(compiled);
         let slot = empty_slot.unwrap_or(hash_index);
         entries[slot] = Some((hash, Box::from(pattern), flags, Rc::clone(&compiled)));
         Ok(compiled)
@@ -854,6 +873,31 @@ mod tests {
         // Unbalanced parenthesis fails to compile.
         assert!(cache.get_or_compile("(", 0).is_err());
         assert_eq!(occupied(&cache), 0);
+    }
+
+    /// A counted repeat that expands far past [`CACHED_SIZE_LIMIT`] in the
+    /// delegated regex compiler while still compiling fine at default limits.
+    const OVERSIZE_PATTERN: &str = "a{5000}";
+
+    #[test]
+    fn oversize_pattern_compiles_but_is_not_retained() {
+        let mut cache = RePatternCache::default();
+        let first = cache.get_or_compile(OVERSIZE_PATTERN, 0).unwrap();
+        let second = cache.get_or_compile(OVERSIZE_PATTERN, 0).unwrap();
+        // Both calls succeed but nothing is retained: each call recompiles.
+        assert!(!Rc::ptr_eq(&first, &second));
+        assert_eq!(occupied(&cache), 0);
+    }
+
+    #[test]
+    fn oversize_pattern_does_not_disturb_cached_entries() {
+        let mut cache = RePatternCache::default();
+        let small = cache.get_or_compile("abc", 0).unwrap();
+        cache.get_or_compile(OVERSIZE_PATTERN, 0).unwrap();
+        let again = cache.get_or_compile("abc", 0).unwrap();
+        // The small pattern's entry survives the uncached oversize compile.
+        assert!(Rc::ptr_eq(&small, &again));
+        assert_eq!(occupied(&cache), 1);
     }
 
     #[test]

--- a/crates/monty/src/modules/re.rs
+++ b/crates/monty/src/modules/re.rs
@@ -241,7 +241,7 @@ fn call_search(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunRes
     defer_drop!(string, vm);
     let resolved = resolve_pattern(pattern, flags, vm)?;
     defer_drop!(resolved, vm);
-    resolved.get(vm.heap).search(subject_str(string, vm)?, vm.heap)
+    resolved.get(vm.heap).search(string, subject_str(string, vm)?, vm.heap)
 }
 
 /// `re.match(pattern, string, flags=0)` — match at the beginning of the string.
@@ -253,7 +253,9 @@ fn call_match(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResu
     defer_drop!(string, vm);
     let resolved = resolve_pattern(pattern, flags, vm)?;
     defer_drop!(resolved, vm);
-    resolved.get(vm.heap).match_start(subject_str(string, vm)?, vm.heap)
+    resolved
+        .get(vm.heap)
+        .match_start(string, subject_str(string, vm)?, vm.heap)
 }
 
 /// `re.fullmatch(pattern, string, flags=0)` — match the entire string.
@@ -265,7 +267,9 @@ fn call_fullmatch(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> Run
     defer_drop!(string, vm);
     let resolved = resolve_pattern(pattern, flags, vm)?;
     defer_drop!(resolved, vm);
-    resolved.get(vm.heap).fullmatch(subject_str(string, vm)?, vm.heap)
+    resolved
+        .get(vm.heap)
+        .fullmatch(string, subject_str(string, vm)?, vm.heap)
 }
 
 /// `re.findall(pattern, string, flags=0)` — find all non-overlapping matches.
@@ -748,7 +752,9 @@ fn call_finditer(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunR
     defer_drop!(string, vm);
     let resolved = resolve_pattern(pattern, flags, vm)?;
     defer_drop!(resolved, vm);
-    resolved.get(vm.heap).finditer(subject_str(string, vm)?, vm.heap)
+    resolved
+        .get(vm.heap)
+        .finditer(string, subject_str(string, vm)?, vm.heap)
 }
 
 /// `re.escape(pattern)` — escape special regex characters in a string.

--- a/crates/monty/src/types/mod.rs
+++ b/crates/monty/src/types/mod.rs
@@ -50,7 +50,7 @@ pub(crate) use property::Property;
 pub(crate) use py_trait::{AttrCallResult, CmpOrder, LazyHeapSet, PyTrait};
 pub(crate) use range::Range;
 pub(crate) use re_match::ReMatch;
-pub(crate) use re_pattern::RePattern;
+pub(crate) use re_pattern::{BoundedCompileError, RePattern};
 pub(crate) use set::{FrozenSet, Set};
 pub(crate) use slice::Slice;
 pub(crate) use str::{Str, allocate_string};

--- a/crates/monty/src/types/re_match.rs
+++ b/crates/monty/src/types/re_match.rs
@@ -8,7 +8,7 @@
 //! All data is stored as owned values (no heap references), so reference counting
 //! is trivial — `py_dec_ref_ids` is a no-op.
 
-use std::{cmp::Ordering, fmt::Write, mem};
+use std::{cmp::Ordering, fmt::Write, mem, sync::Arc};
 
 use smallvec::smallvec;
 
@@ -39,9 +39,11 @@ use crate::{
 ///
 /// # Position semantics
 ///
-/// Positions are returned as Unicode character offsets (not byte offsets) to
-/// match CPython's behavior. The conversion from byte offsets (used internally
-/// by the Rust `regex` crate) happens at construction time in `from_captures`.
+/// Positions are reported as Unicode character offsets (not byte offsets) to
+/// match CPython's behavior. Offsets are *stored* as byte offsets (the units the
+/// `regex` crate produces) and converted to character offsets lazily — only when
+/// `.start()`/`.end()`/`.span()` or `repr` actually read them. ASCII inputs need
+/// no conversion at all (byte offset == character offset), tracked by `all_ascii`.
 ///
 /// # Group Indexing
 ///
@@ -52,44 +54,56 @@ use crate::{
 pub(crate) struct ReMatch {
     /// The full matched text (equivalent to `group(0)`).
     full_match: String,
-    /// Start character position of the full match in the input string.
+    /// Start byte position of the full match in the input string.
     start: usize,
-    /// End character position of the full match in the input string.
+    /// End byte position of the full match in the input string.
     end: usize,
     /// Captured group strings (index 0 = group 1). `None` for unmatched optional groups.
     groups: Vec<Option<String>>,
-    /// Span positions per captured group (index 0 = group 1). `None` for unmatched optional groups.
+    /// Span byte positions per captured group (index 0 = group 1). `None` for unmatched optional groups.
     group_spans: Vec<Option<(usize, usize)>>,
     /// Named groups: maps group name → 1-based group index.
     named_groups: Vec<(String, usize)>,
-    /// Owned copy of the input string (returned by `.string` attribute).
-    input_string: String,
-    /// The original pattern string (used in repr output).
-    pattern_string: String,
+    /// The input string that was searched (returned by the `.string` attribute).
+    ///
+    /// Shared (`Arc`) so that all matches from one `finditer`/`findall` call point
+    /// at a single copy of the subject rather than each cloning it — the subject is
+    /// often large and this used to dominate regex-extraction workloads.
+    input_string: Arc<str>,
+    /// Whether the input is pure ASCII, so byte offsets equal character offsets and
+    /// position conversion is a no-op. Computed once per match-producing call.
+    all_ascii: bool,
+    /// The original pattern string (used in repr output). Shared for the same
+    /// reason as `input_string`.
+    pattern_string: Arc<str>,
 }
 
 impl ReMatch {
     /// Creates a `ReMatch` from a `fancy_regex::Captures` result.
     ///
-    /// Converts byte offsets from the regex crate into character offsets to match
-    /// CPython's behavior. The full match (group 0) is always present when captures
-    /// are successful.
+    /// Stores byte offsets directly (character-offset conversion is deferred to the
+    /// position accessors — see the type docs). The full match (group 0) is always
+    /// present when captures are successful. The subject and pattern are shared
+    /// (`Arc`) rather than copied, so producing many matches over one subject (e.g.
+    /// `finditer`) does not re-copy the whole subject per match.
     ///
     /// # Arguments
     /// * `caps` - The successful capture result from the regex engine
-    /// * `input` - The full input string that was searched
-    /// * `pattern` - The original pattern string (for repr)
+    /// * `input` - The full input string that was searched (shared)
+    /// * `all_ascii` - Whether `input` is pure ASCII (byte offset == char offset)
+    /// * `pattern` - The original pattern string, for repr (shared)
     /// * `regex` - The compiled regex, used to extract named group mappings
     pub fn from_captures(
         caps: &fancy_regex::Captures<'_>,
-        input: &str,
-        pattern: &str,
+        input: &Arc<str>,
+        all_ascii: bool,
+        pattern: &Arc<str>,
         regex: &fancy_regex::Regex,
     ) -> Self {
         let full = caps.get(0).expect("group 0 always exists on a successful match");
         let full_match = full.as_str().to_owned();
-        let start = byte_to_char_offset(input, full.start());
-        let end = byte_to_char_offset(input, full.end());
+        let start = full.start();
+        let end = full.end();
 
         let group_count = caps.len().saturating_sub(1);
         let mut groups = Vec::with_capacity(group_count);
@@ -98,10 +112,7 @@ impl ReMatch {
         for cap in caps.iter().skip(1) {
             if let Some(m) = cap {
                 groups.push(Some(m.as_str().to_owned()));
-                group_spans.push(Some((
-                    byte_to_char_offset(input, m.start()),
-                    byte_to_char_offset(input, m.end()),
-                )));
+                group_spans.push(Some((m.start(), m.end())));
             } else {
                 groups.push(None);
                 group_spans.push(None);
@@ -123,8 +134,19 @@ impl ReMatch {
             groups,
             group_spans,
             named_groups,
-            input_string: input.to_owned(),
-            pattern_string: pattern.to_owned(),
+            input_string: Arc::clone(input),
+            all_ascii,
+            pattern_string: Arc::clone(pattern),
+        }
+    }
+
+    /// Converts a stored byte offset into the subject to the Unicode character
+    /// offset CPython's position APIs report. ASCII subjects need no conversion.
+    fn char_offset(&self, byte_offset: usize) -> usize {
+        if self.all_ascii {
+            byte_offset
+        } else {
+            byte_to_char_offset(&self.input_string, byte_offset)
         }
     }
 
@@ -212,7 +234,7 @@ impl ReMatch {
     #[expect(clippy::cast_possible_wrap, reason = "positions are always small enough for i64")]
     fn get_start(&self, n: i64) -> RunResult<Value> {
         match n.cmp(&0) {
-            Ordering::Equal => Ok(Value::Int(self.start as i64)),
+            Ordering::Equal => Ok(Value::Int(self.char_offset(self.start) as i64)),
             Ordering::Less => Err(ExcType::re_match_group_index_error()),
             Ordering::Greater => {
                 let idx = group_index(n);
@@ -220,7 +242,7 @@ impl ReMatch {
                     return Err(ExcType::re_match_group_index_error());
                 }
                 match &self.group_spans[idx] {
-                    Some((s, _)) => Ok(Value::Int(*s as i64)),
+                    Some((s, _)) => Ok(Value::Int(self.char_offset(*s) as i64)),
                     None => Ok(Value::Int(-1)),
                 }
             }
@@ -233,7 +255,7 @@ impl ReMatch {
     #[expect(clippy::cast_possible_wrap, reason = "positions are always small enough for i64")]
     fn get_end(&self, n: i64) -> RunResult<Value> {
         match n.cmp(&0) {
-            Ordering::Equal => Ok(Value::Int(self.end as i64)),
+            Ordering::Equal => Ok(Value::Int(self.char_offset(self.end) as i64)),
             Ordering::Less => Err(ExcType::re_match_group_index_error()),
             Ordering::Greater => {
                 let idx = group_index(n);
@@ -241,7 +263,7 @@ impl ReMatch {
                     return Err(ExcType::re_match_group_index_error());
                 }
                 match &self.group_spans[idx] {
-                    Some((_, e)) => Ok(Value::Int(*e as i64)),
+                    Some((_, e)) => Ok(Value::Int(self.char_offset(*e) as i64)),
                     None => Ok(Value::Int(-1)),
                 }
             }
@@ -255,7 +277,10 @@ impl ReMatch {
     fn get_span(&self, n: i64, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
         match n.cmp(&0) {
             Ordering::Equal => Ok(allocate_tuple(
-                smallvec![Value::Int(self.start as i64), Value::Int(self.end as i64)],
+                smallvec![
+                    Value::Int(self.char_offset(self.start) as i64),
+                    Value::Int(self.char_offset(self.end) as i64)
+                ],
                 heap,
             )?),
             Ordering::Less => Err(ExcType::re_match_group_index_error()),
@@ -265,7 +290,7 @@ impl ReMatch {
                     return Err(ExcType::re_match_group_index_error());
                 }
                 let (s, e) = match &self.group_spans[idx] {
-                    Some((s, e)) => (*s as i64, *e as i64),
+                    Some((s, e)) => (self.char_offset(*s) as i64, self.char_offset(*e) as i64),
                     None => (-1, -1),
                 };
                 Ok(allocate_tuple(smallvec![Value::Int(s), Value::Int(e)], heap)?)
@@ -300,7 +325,12 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
         _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         let m = self.get(vm.heap);
-        write!(f, "<re.Match object; span=({}, {}), match=", m.start, m.end)?;
+        write!(
+            f,
+            "<re.Match object; span=({}, {}), match=",
+            m.char_offset(m.start),
+            m.char_offset(m.end)
+        )?;
         string_repr_fmt(&m.full_match, f)?;
         Ok(f.write_char('>')?)
     }
@@ -308,7 +338,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
     fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
         match attr.static_string() {
             Some(StaticStrings::StringAttr) => {
-                let v = allocate_string(self.get(vm.heap).input_string.as_str(), vm.heap)?;
+                let v = allocate_string(&*self.get(vm.heap).input_string, vm.heap)?;
                 Ok(Some(CallResult::Value(v)))
             }
             _ => Err(ExcType::attribute_error(Type::ReMatch, attr.as_str(vm.interns))),

--- a/crates/monty/src/types/re_match.rs
+++ b/crates/monty/src/types/re_match.rs
@@ -9,7 +9,7 @@
 //! is held as a single refcounted heap reference shared across every match from
 //! one `finditer`/`findall` call, so `py_dec_ref_ids` releases that reference.
 
-use std::{cmp::Ordering, fmt::Write, mem};
+use std::{cell::OnceCell, cmp::Ordering, fmt::Write, mem};
 
 use smallvec::smallvec;
 
@@ -43,7 +43,8 @@ use crate::{
 ///
 /// Offsets are stored as byte offsets (what the `regex` crate produces) and
 /// converted to the character offsets CPython reports lazily, only when
-/// `.start()`/`.end()`/`.span()`/`repr` read them. ASCII input needs no conversion.
+/// `.start()`/`.end()`/`.span()`/`repr` read them; the full match's conversion
+/// is memoized (`char_span`). ASCII input needs no conversion.
 ///
 /// # Group Indexing
 ///
@@ -70,6 +71,10 @@ pub(crate) struct ReMatch {
     subject: Value,
     /// Whether the subject is pure ASCII, so byte offset == character offset.
     all_ascii: bool,
+    /// Char-offset `(start, end)` of the full match, computed lazily by
+    /// [`ReMatch::char_span`]. A pure cache — skipped by serde, rebuilt on demand.
+    #[serde(skip)]
+    char_span: OnceCell<(i64, i64)>,
 }
 
 impl ReMatch {
@@ -120,6 +125,7 @@ impl ReMatch {
             named_groups,
             subject,
             all_ascii,
+            char_span: OnceCell::new(),
         }
     }
 
@@ -129,9 +135,28 @@ impl ReMatch {
         &self.subject
     }
 
+    /// The `(start, end)` char offsets of the full match — what `.start()`,
+    /// `.end()`, `.span()`, and `repr` report. Memoized: a non-ASCII subject is
+    /// scanned once (only up to the match end) on first access, O(1) after.
+    fn char_span(&self, vm: &VM<'_, impl ResourceTracker>) -> (i64, i64) {
+        *self.char_span.get_or_init(|| {
+            let (start, end) = if self.all_ascii {
+                (self.start, self.end)
+            } else {
+                let text = self.subject.to_str(vm).expect("subject is always a str");
+                let start = byte_to_char_offset(text, self.start);
+                // Count only the matched slice for `end` instead of rescanning from zero.
+                (start, start + text[self.start..self.end].chars().count())
+            };
+            (position_i64(start), position_i64(end))
+        })
+    }
+
     /// Converts a stored byte offset into the subject to the Unicode character
-    /// offset CPython's position APIs report. ASCII subjects need no conversion;
-    /// otherwise the subject text is read back from the heap for a forward scan.
+    /// offset CPython reports — used for capture-group positions (the full
+    /// match's span goes through the memoized [`ReMatch::char_span`] instead).
+    /// ASCII subjects need no conversion; otherwise the subject text is read
+    /// back from the heap for a forward scan.
     fn char_offset(&self, byte_offset: usize, vm: &VM<'_, impl ResourceTracker>) -> i64 {
         let char_offset = if self.all_ascii {
             byte_offset
@@ -139,8 +164,7 @@ impl ReMatch {
             let text = self.subject.to_str(vm).expect("subject is always a str");
             byte_to_char_offset(text, byte_offset)
         };
-        // positions should always be small enough for i64
-        i64::try_from(char_offset).unwrap_or(i64::MAX)
+        position_i64(char_offset)
     }
 
     /// Returns the match for a given group number.
@@ -226,7 +250,7 @@ impl ReMatch {
     /// Group 0 is the full match. Returns -1 for unmatched optional groups
     fn get_start(&self, n: i64, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> {
         match n.cmp(&0) {
-            Ordering::Equal => Ok(Value::Int(self.char_offset(self.start, vm))),
+            Ordering::Equal => Ok(Value::Int(self.char_span(vm).0)),
             Ordering::Less => Err(ExcType::re_match_group_index_error()),
             Ordering::Greater => {
                 let idx = group_index(n);
@@ -246,7 +270,7 @@ impl ReMatch {
     /// Group 0 is the full match. Returns -1 for unmatched optional groups
     fn get_end(&self, n: i64, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> {
         match n.cmp(&0) {
-            Ordering::Equal => Ok(Value::Int(self.char_offset(self.end, vm))),
+            Ordering::Equal => Ok(Value::Int(self.char_span(vm).1)),
             Ordering::Less => Err(ExcType::re_match_group_index_error()),
             Ordering::Greater => {
                 let idx = group_index(n);
@@ -266,13 +290,10 @@ impl ReMatch {
     /// Group 0 is the full match. Returns `(-1, -1)` for unmatched optional groups
     fn get_span(&self, n: i64, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> {
         match n.cmp(&0) {
-            Ordering::Equal => Ok(allocate_tuple(
-                smallvec![
-                    Value::Int(self.char_offset(self.start, vm)),
-                    Value::Int(self.char_offset(self.end, vm))
-                ],
-                vm.heap,
-            )?),
+            Ordering::Equal => {
+                let (start, end) = self.char_span(vm);
+                Ok(allocate_tuple(smallvec![Value::Int(start), Value::Int(end)], vm.heap)?)
+            }
             Ordering::Less => Err(ExcType::re_match_group_index_error()),
             Ordering::Greater => {
                 let idx = group_index(n);
@@ -315,12 +336,8 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
         _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
         let m = self.get(vm.heap);
-        write!(
-            f,
-            "<re.Match object; span=({}, {}), match=",
-            m.char_offset(m.start, vm),
-            m.char_offset(m.end, vm)
-        )?;
+        let (start, end) = m.char_span(vm);
+        write!(f, "<re.Match object; span=({start}, {end}), match=")?;
         string_repr_fmt(&m.full_match, f)?;
         Ok(f.write_char('>')?)
     }
@@ -517,6 +534,12 @@ fn extract_optional_group_arg(
 /// byte position.
 fn byte_to_char_offset(s: &str, byte_offset: usize) -> usize {
     s[..byte_offset].chars().count()
+}
+
+/// Converts a position to the `i64` Python-facing APIs report, saturating on
+/// the (practically impossible) overflow rather than wrapping negative.
+fn position_i64(offset: usize) -> i64 {
+    i64::try_from(offset).unwrap_or(i64::MAX)
 }
 
 /// Converts a positive group number (1-based) to a 0-based index.

--- a/crates/monty/src/types/re_match.rs
+++ b/crates/monty/src/types/re_match.rs
@@ -5,10 +5,11 @@
 //! Python-compatible access via `.group()`, `.groups()`, `.start()`, `.end()`,
 //! and `.span()` methods.
 //!
-//! All data is stored as owned values (no heap references), so reference counting
-//! is trivial — `py_dec_ref_ids` is a no-op.
+//! The matched substrings are owned copies, but the subject string (`.string`)
+//! is held as a single refcounted heap reference shared across every match from
+//! one `finditer`/`findall` call, so `py_dec_ref_ids` releases that reference.
 
-use std::{cmp::Ordering, fmt::Write, mem, sync::Arc};
+use std::{cmp::Ordering, fmt::Write, mem};
 
 use smallvec::smallvec;
 
@@ -18,7 +19,7 @@ use crate::{
     defer_drop_mut,
     exception_private::{ExcType, RunResult},
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead},
-    intern::StaticStrings,
+    intern::{Interns, StaticStrings},
     resource::ResourceTracker,
     types::{
         Dict, LazyHeapSet, PyTrait, Type, allocate_tuple,
@@ -30,9 +31,10 @@ use crate::{
 /// A regex match result, storing captured groups and positions.
 ///
 /// Created by `re.match()`, `re.search()`, `re.fullmatch()`, and their
-/// `Pattern` method equivalents. Stores all data as owned values (no heap
-/// references), which simplifies reference counting — `py_dec_ref_ids` is
-/// a no-op.
+/// `Pattern` method equivalents. The captured substrings are owned copies, but
+/// the subject (`.string`) is a refcounted heap reference (`subject`) shared
+/// across every match from one call rather than copied per match — so
+/// `py_dec_ref_ids` must release it, and its memory is tracked once.
 ///
 /// The `.re` attribute (reference back to the pattern) is intentionally omitted
 /// to avoid circular references between Match and Pattern objects.
@@ -48,7 +50,7 @@ use crate::{
 /// Group 0 is the full match, groups 1..N are capture groups.
 /// Both integer and named group access are supported — named groups are looked
 /// up via the `named_groups` mapping.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct ReMatch {
     /// The full matched text (equivalent to `group(0)`).
     full_match: String,
@@ -62,26 +64,24 @@ pub(crate) struct ReMatch {
     group_spans: Vec<Option<(usize, usize)>>,
     /// Named groups: maps group name → 1-based group index.
     named_groups: Vec<(String, usize)>,
-    /// The searched input (the `.string` attribute). Shared (`Arc`) so all matches
-    /// from one `finditer`/`findall` call point at one copy, not a copy each.
-    input_string: Arc<str>,
-    /// Whether the input is pure ASCII, so byte offset == character offset.
+    /// The searched subject (the `.string` attribute), held as a refcounted heap
+    /// reference so every match from one `finditer` shares one copy — tracked
+    /// once, not per match. Always a `str` `Value` (heap `Str` or interned).
+    subject: Value,
+    /// Whether the subject is pure ASCII, so byte offset == character offset.
     all_ascii: bool,
-    /// The original pattern string (for repr), shared like `input_string`.
-    pattern_string: Arc<str>,
 }
 
 impl ReMatch {
     /// Creates a `ReMatch` from a `fancy_regex::Captures` result.
     ///
-    /// Stores byte offsets (converted to char offsets lazily — see the type docs)
-    /// and shares the `Arc` subject/pattern rather than copying them per match.
-    /// `regex` is used only to extract named-group mappings.
+    /// Stores byte offsets (converted to char offsets lazily — see the type docs).
+    /// `subject` is the already-refcounted subject `Value` this match keeps alive
+    /// (the caller clones it per match); `regex` supplies named-group mappings.
     pub fn from_captures(
         caps: &fancy_regex::Captures<'_>,
-        input: &Arc<str>,
+        subject: Value,
         all_ascii: bool,
-        pattern: &Arc<str>,
         regex: &fancy_regex::Regex,
     ) -> Self {
         let full = caps.get(0).expect("group 0 always exists on a successful match");
@@ -118,19 +118,29 @@ impl ReMatch {
             groups,
             group_spans,
             named_groups,
-            input_string: Arc::clone(input),
+            subject,
             all_ascii,
-            pattern_string: Arc::clone(pattern),
         }
     }
 
+    /// The subject `Value` this match keeps alive (its `.string`). Lets the heap
+    /// walkers in `heap.rs` follow and release the shared subject reference.
+    pub(crate) fn subject_ref(&self) -> &Value {
+        &self.subject
+    }
+
     /// Converts a stored byte offset into the subject to the Unicode character
-    /// offset CPython's position APIs report. ASCII subjects need no conversion.
-    fn char_offset(&self, byte_offset: usize) -> usize {
+    /// offset CPython's position APIs report. ASCII subjects need no conversion;
+    /// otherwise the subject text is read back from the heap for a forward scan.
+    fn char_offset(&self, byte_offset: usize, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> usize {
         if self.all_ascii {
             byte_offset
         } else {
-            byte_to_char_offset(&self.input_string, byte_offset)
+            let text = self
+                .subject
+                .to_str_heap(heap, interns)
+                .expect("subject is always a str");
+            byte_to_char_offset(text, byte_offset)
         }
     }
 
@@ -216,9 +226,9 @@ impl ReMatch {
     ///
     /// Group 0 is the full match. Returns -1 for unmatched optional groups
     #[expect(clippy::cast_possible_wrap, reason = "positions are always small enough for i64")]
-    fn get_start(&self, n: i64) -> RunResult<Value> {
+    fn get_start(&self, n: i64, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<Value> {
         match n.cmp(&0) {
-            Ordering::Equal => Ok(Value::Int(self.char_offset(self.start) as i64)),
+            Ordering::Equal => Ok(Value::Int(self.char_offset(self.start, heap, interns) as i64)),
             Ordering::Less => Err(ExcType::re_match_group_index_error()),
             Ordering::Greater => {
                 let idx = group_index(n);
@@ -226,7 +236,7 @@ impl ReMatch {
                     return Err(ExcType::re_match_group_index_error());
                 }
                 match &self.group_spans[idx] {
-                    Some((s, _)) => Ok(Value::Int(self.char_offset(*s) as i64)),
+                    Some((s, _)) => Ok(Value::Int(self.char_offset(*s, heap, interns) as i64)),
                     None => Ok(Value::Int(-1)),
                 }
             }
@@ -237,9 +247,9 @@ impl ReMatch {
     ///
     /// Group 0 is the full match. Returns -1 for unmatched optional groups
     #[expect(clippy::cast_possible_wrap, reason = "positions are always small enough for i64")]
-    fn get_end(&self, n: i64) -> RunResult<Value> {
+    fn get_end(&self, n: i64, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<Value> {
         match n.cmp(&0) {
-            Ordering::Equal => Ok(Value::Int(self.char_offset(self.end) as i64)),
+            Ordering::Equal => Ok(Value::Int(self.char_offset(self.end, heap, interns) as i64)),
             Ordering::Less => Err(ExcType::re_match_group_index_error()),
             Ordering::Greater => {
                 let idx = group_index(n);
@@ -247,7 +257,7 @@ impl ReMatch {
                     return Err(ExcType::re_match_group_index_error());
                 }
                 match &self.group_spans[idx] {
-                    Some((_, e)) => Ok(Value::Int(self.char_offset(*e) as i64)),
+                    Some((_, e)) => Ok(Value::Int(self.char_offset(*e, heap, interns) as i64)),
                     None => Ok(Value::Int(-1)),
                 }
             }
@@ -258,12 +268,12 @@ impl ReMatch {
     ///
     /// Group 0 is the full match. Returns `(-1, -1)` for unmatched optional groups
     #[expect(clippy::cast_possible_wrap, reason = "positions are always small enough for i64")]
-    fn get_span(&self, n: i64, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
+    fn get_span(&self, n: i64, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<Value> {
         match n.cmp(&0) {
             Ordering::Equal => Ok(allocate_tuple(
                 smallvec![
-                    Value::Int(self.char_offset(self.start) as i64),
-                    Value::Int(self.char_offset(self.end) as i64)
+                    Value::Int(self.char_offset(self.start, heap, interns) as i64),
+                    Value::Int(self.char_offset(self.end, heap, interns) as i64)
                 ],
                 heap,
             )?),
@@ -274,7 +284,10 @@ impl ReMatch {
                     return Err(ExcType::re_match_group_index_error());
                 }
                 let (s, e) = match &self.group_spans[idx] {
-                    Some((s, e)) => (self.char_offset(*s) as i64, self.char_offset(*e) as i64),
+                    Some((s, e)) => (
+                        self.char_offset(*s, heap, interns) as i64,
+                        self.char_offset(*e, heap, interns) as i64,
+                    ),
                     None => (-1, -1),
                 };
                 Ok(allocate_tuple(smallvec![Value::Int(s), Value::Int(e)], heap)?)
@@ -312,8 +325,8 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
         write!(
             f,
             "<re.Match object; span=({}, {}), match=",
-            m.char_offset(m.start),
-            m.char_offset(m.end)
+            m.char_offset(m.start, vm.heap, vm.interns),
+            m.char_offset(m.end, vm.heap, vm.interns)
         )?;
         string_repr_fmt(&m.full_match, f)?;
         Ok(f.write_char('>')?)
@@ -322,7 +335,9 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
     fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Option<CallResult>> {
         match attr.static_string() {
             Some(StaticStrings::StringAttr) => {
-                let v = allocate_string(&*self.get(vm.heap).input_string, vm.heap)?;
+                // Hand back the same subject object (CPython's `m.string is s`),
+                // bumping its refcount rather than allocating a fresh copy.
+                let v = self.get(vm.heap).subject.clone_with_heap(vm);
                 Ok(Some(CallResult::Value(v)))
             }
             _ => Err(ExcType::attribute_error(Type::ReMatch, attr.as_str(vm.interns))),
@@ -351,15 +366,15 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
             }
             Some(StaticStrings::Start) => {
                 let n = extract_optional_group_arg(args, "re.Match.start", 0, vm.heap)?;
-                self.get(vm.heap).get_start(n)?
+                self.get(vm.heap).get_start(n, vm.heap, vm.interns)?
             }
             Some(StaticStrings::End) => {
                 let n = extract_optional_group_arg(args, "re.Match.end", 0, vm.heap)?;
-                self.get(vm.heap).get_end(n)?
+                self.get(vm.heap).get_end(n, vm.heap, vm.interns)?
             }
             Some(StaticStrings::Span) => {
                 let n = extract_optional_group_arg(args, "re.Match.span", 0, vm.heap)?;
-                self.get(vm.heap).get_span(n, vm.heap)?
+                self.get(vm.heap).get_span(n, vm.heap, vm.interns)?
             }
             _ => {
                 return Err(ExcType::attribute_error(Type::ReMatch, attr.as_str(vm.interns)));
@@ -390,10 +405,11 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
 
 impl HeapItem for ReMatch {
     fn py_estimate_size(&self) -> usize {
+        // The subject is NOT counted here: it is a shared refcounted heap `Str`
+        // charged once as its own entry, so counting it per match would inflate
+        // a `finditer` of N matches to N× the subject size (see `subject`).
         mem::size_of::<Self>()
             + self.full_match.len()
-            + self.input_string.len()
-            + self.pattern_string.len()
             + self
                 .groups
                 .iter()
@@ -406,8 +422,15 @@ impl HeapItem for ReMatch {
                 .sum::<usize>()
     }
 
-    fn py_dec_ref_ids(&mut self, _stack: &mut Vec<HeapId>) {
-        // No heap references — all data is owned strings and integers.
+    fn py_dec_ref_ids(&mut self, stack: &mut Vec<HeapId>) {
+        // Release the shared subject reference (no-op for an interned subject).
+        // `dec_ref_forget` neutralises the `Ref` so the struct's own `Drop`
+        // does not trip the `memory-model-checks` leak assertion.
+        if let Value::Ref(id) = &mut self.subject {
+            stack.push(*id);
+            #[cfg(feature = "memory-model-checks")]
+            self.subject.dec_ref_forget();
+        }
     }
 }
 

--- a/crates/monty/src/types/re_match.rs
+++ b/crates/monty/src/types/re_match.rs
@@ -19,7 +19,7 @@ use crate::{
     defer_drop_mut,
     exception_private::{ExcType, RunResult},
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead},
-    intern::{Interns, StaticStrings},
+    intern::StaticStrings,
     resource::ResourceTracker,
     types::{
         Dict, LazyHeapSet, PyTrait, Type, allocate_tuple,
@@ -132,16 +132,15 @@ impl ReMatch {
     /// Converts a stored byte offset into the subject to the Unicode character
     /// offset CPython's position APIs report. ASCII subjects need no conversion;
     /// otherwise the subject text is read back from the heap for a forward scan.
-    fn char_offset(&self, byte_offset: usize, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> usize {
-        if self.all_ascii {
+    fn char_offset(&self, byte_offset: usize, vm: &VM<'_, impl ResourceTracker>) -> i64 {
+        let char_offset = if self.all_ascii {
             byte_offset
         } else {
-            let text = self
-                .subject
-                .to_str_heap(heap, interns)
-                .expect("subject is always a str");
+            let text = self.subject.to_str(vm).expect("subject is always a str");
             byte_to_char_offset(text, byte_offset)
-        }
+        };
+        // positions should always be small enough for i64
+        i64::try_from(char_offset).unwrap_or(i64::MAX)
     }
 
     /// Returns the match for a given group number.
@@ -225,10 +224,9 @@ impl ReMatch {
     /// Returns the start character position for a given group.
     ///
     /// Group 0 is the full match. Returns -1 for unmatched optional groups
-    #[expect(clippy::cast_possible_wrap, reason = "positions are always small enough for i64")]
-    fn get_start(&self, n: i64, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<Value> {
+    fn get_start(&self, n: i64, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> {
         match n.cmp(&0) {
-            Ordering::Equal => Ok(Value::Int(self.char_offset(self.start, heap, interns) as i64)),
+            Ordering::Equal => Ok(Value::Int(self.char_offset(self.start, vm))),
             Ordering::Less => Err(ExcType::re_match_group_index_error()),
             Ordering::Greater => {
                 let idx = group_index(n);
@@ -236,7 +234,7 @@ impl ReMatch {
                     return Err(ExcType::re_match_group_index_error());
                 }
                 match &self.group_spans[idx] {
-                    Some((s, _)) => Ok(Value::Int(self.char_offset(*s, heap, interns) as i64)),
+                    Some((s, _)) => Ok(Value::Int(self.char_offset(*s, vm))),
                     None => Ok(Value::Int(-1)),
                 }
             }
@@ -246,10 +244,9 @@ impl ReMatch {
     /// Returns the end character position for a given group.
     ///
     /// Group 0 is the full match. Returns -1 for unmatched optional groups
-    #[expect(clippy::cast_possible_wrap, reason = "positions are always small enough for i64")]
-    fn get_end(&self, n: i64, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<Value> {
+    fn get_end(&self, n: i64, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> {
         match n.cmp(&0) {
-            Ordering::Equal => Ok(Value::Int(self.char_offset(self.end, heap, interns) as i64)),
+            Ordering::Equal => Ok(Value::Int(self.char_offset(self.end, vm))),
             Ordering::Less => Err(ExcType::re_match_group_index_error()),
             Ordering::Greater => {
                 let idx = group_index(n);
@@ -257,7 +254,7 @@ impl ReMatch {
                     return Err(ExcType::re_match_group_index_error());
                 }
                 match &self.group_spans[idx] {
-                    Some((_, e)) => Ok(Value::Int(self.char_offset(*e, heap, interns) as i64)),
+                    Some((_, e)) => Ok(Value::Int(self.char_offset(*e, vm))),
                     None => Ok(Value::Int(-1)),
                 }
             }
@@ -267,15 +264,14 @@ impl ReMatch {
     /// Returns a `(start, end)` tuple for a given group.
     ///
     /// Group 0 is the full match. Returns `(-1, -1)` for unmatched optional groups
-    #[expect(clippy::cast_possible_wrap, reason = "positions are always small enough for i64")]
-    fn get_span(&self, n: i64, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<Value> {
+    fn get_span(&self, n: i64, vm: &VM<'_, impl ResourceTracker>) -> RunResult<Value> {
         match n.cmp(&0) {
             Ordering::Equal => Ok(allocate_tuple(
                 smallvec![
-                    Value::Int(self.char_offset(self.start, heap, interns) as i64),
-                    Value::Int(self.char_offset(self.end, heap, interns) as i64)
+                    Value::Int(self.char_offset(self.start, vm)),
+                    Value::Int(self.char_offset(self.end, vm))
                 ],
-                heap,
+                vm.heap,
             )?),
             Ordering::Less => Err(ExcType::re_match_group_index_error()),
             Ordering::Greater => {
@@ -284,13 +280,10 @@ impl ReMatch {
                     return Err(ExcType::re_match_group_index_error());
                 }
                 let (s, e) = match &self.group_spans[idx] {
-                    Some((s, e)) => (
-                        self.char_offset(*s, heap, interns) as i64,
-                        self.char_offset(*e, heap, interns) as i64,
-                    ),
+                    Some((s, e)) => (self.char_offset(*s, vm), self.char_offset(*e, vm)),
                     None => (-1, -1),
                 };
-                Ok(allocate_tuple(smallvec![Value::Int(s), Value::Int(e)], heap)?)
+                Ok(allocate_tuple(smallvec![Value::Int(s), Value::Int(e)], vm.heap)?)
             }
         }
     }
@@ -325,8 +318,8 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
         write!(
             f,
             "<re.Match object; span=({}, {}), match=",
-            m.char_offset(m.start, vm.heap, vm.interns),
-            m.char_offset(m.end, vm.heap, vm.interns)
+            m.char_offset(m.start, vm),
+            m.char_offset(m.end, vm)
         )?;
         string_repr_fmt(&m.full_match, f)?;
         Ok(f.write_char('>')?)
@@ -366,15 +359,15 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
             }
             Some(StaticStrings::Start) => {
                 let n = extract_optional_group_arg(args, "re.Match.start", 0, vm.heap)?;
-                self.get(vm.heap).get_start(n, vm.heap, vm.interns)?
+                self.get(vm.heap).get_start(n, vm)?
             }
             Some(StaticStrings::End) => {
                 let n = extract_optional_group_arg(args, "re.Match.end", 0, vm.heap)?;
-                self.get(vm.heap).get_end(n, vm.heap, vm.interns)?
+                self.get(vm.heap).get_end(n, vm)?
             }
             Some(StaticStrings::Span) => {
                 let n = extract_optional_group_arg(args, "re.Match.span", 0, vm.heap)?;
-                self.get(vm.heap).get_span(n, vm.heap, vm.interns)?
+                self.get(vm.heap).get_span(n, vm)?
             }
             _ => {
                 return Err(ExcType::attribute_error(Type::ReMatch, attr.as_str(vm.interns)));

--- a/crates/monty/src/types/re_match.rs
+++ b/crates/monty/src/types/re_match.rs
@@ -39,11 +39,9 @@ use crate::{
 ///
 /// # Position semantics
 ///
-/// Positions are reported as Unicode character offsets (not byte offsets) to
-/// match CPython's behavior. Offsets are *stored* as byte offsets (the units the
-/// `regex` crate produces) and converted to character offsets lazily — only when
-/// `.start()`/`.end()`/`.span()` or `repr` actually read them. ASCII inputs need
-/// no conversion at all (byte offset == character offset), tracked by `all_ascii`.
+/// Offsets are stored as byte offsets (what the `regex` crate produces) and
+/// converted to the character offsets CPython reports lazily, only when
+/// `.start()`/`.end()`/`.span()`/`repr` read them. ASCII input needs no conversion.
 ///
 /// # Group Indexing
 ///
@@ -64,35 +62,21 @@ pub(crate) struct ReMatch {
     group_spans: Vec<Option<(usize, usize)>>,
     /// Named groups: maps group name → 1-based group index.
     named_groups: Vec<(String, usize)>,
-    /// The input string that was searched (returned by the `.string` attribute).
-    ///
-    /// Shared (`Arc`) so that all matches from one `finditer`/`findall` call point
-    /// at a single copy of the subject rather than each cloning it — the subject is
-    /// often large and this used to dominate regex-extraction workloads.
+    /// The searched input (the `.string` attribute). Shared (`Arc`) so all matches
+    /// from one `finditer`/`findall` call point at one copy, not a copy each.
     input_string: Arc<str>,
-    /// Whether the input is pure ASCII, so byte offsets equal character offsets and
-    /// position conversion is a no-op. Computed once per match-producing call.
+    /// Whether the input is pure ASCII, so byte offset == character offset.
     all_ascii: bool,
-    /// The original pattern string (used in repr output). Shared for the same
-    /// reason as `input_string`.
+    /// The original pattern string (for repr), shared like `input_string`.
     pattern_string: Arc<str>,
 }
 
 impl ReMatch {
     /// Creates a `ReMatch` from a `fancy_regex::Captures` result.
     ///
-    /// Stores byte offsets directly (character-offset conversion is deferred to the
-    /// position accessors — see the type docs). The full match (group 0) is always
-    /// present when captures are successful. The subject and pattern are shared
-    /// (`Arc`) rather than copied, so producing many matches over one subject (e.g.
-    /// `finditer`) does not re-copy the whole subject per match.
-    ///
-    /// # Arguments
-    /// * `caps` - The successful capture result from the regex engine
-    /// * `input` - The full input string that was searched (shared)
-    /// * `all_ascii` - Whether `input` is pure ASCII (byte offset == char offset)
-    /// * `pattern` - The original pattern string, for repr (shared)
-    /// * `regex` - The compiled regex, used to extract named group mappings
+    /// Stores byte offsets (converted to char offsets lazily — see the type docs)
+    /// and shares the `Arc` subject/pattern rather than copying them per match.
+    /// `regex` is used only to extract named-group mappings.
     pub fn from_captures(
         caps: &fancy_regex::Captures<'_>,
         input: &Arc<str>,

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -64,6 +64,12 @@ pub(crate) struct RePattern {
     /// alternations — e.g. `fullmatch('a|ab', 'ab')` must match `ab`, not fail
     /// because the engine found `a` first.
     compiled_fullmatch: OnceCell<Regex>,
+    /// The `delegate_size_limit` the plain regex was compiled with, forwarded to
+    /// the anchored variants above so a *cached* entry's total retained compiled
+    /// size stays bounded (the anchors add only O(1) bytes, so a pattern that fit
+    /// unanchored still fits anchored). `None` = the engine's default limit. Not
+    /// serialized — restored patterns recompile at the default limit.
+    delegate_size_limit: Option<usize>,
 }
 
 impl PartialEq for RePattern {
@@ -88,9 +94,9 @@ impl RePattern {
 
     /// As [`RePattern::compile`], but caps the compiled size of the delegated regex
     /// (`RegexBuilder::delegate_size_limit`) so the `re` module's pattern cache can
-    /// retain entries with a hard per-entry memory ceiling. The lazily-compiled
-    /// anchored variants keep default limits: they are the same size class as the
-    /// already-bounded plain regex, so retention stays bounded either way.
+    /// retain entries with a hard per-entry memory ceiling. The limit is retained
+    /// and applied to the lazily-compiled anchored `match`/`fullmatch` variants
+    /// too, so a cached entry cannot pin large regexes via `.match()`/`.fullmatch()`.
     pub(crate) fn compile_bounded(pattern: String, flags: u16, delegate_size_limit: usize) -> RunResult<Self> {
         Self::compile_inner(pattern, flags, Some(delegate_size_limit))
     }
@@ -104,6 +110,7 @@ impl RePattern {
             compiled,
             compiled_match: OnceCell::new(),
             compiled_fullmatch: OnceCell::new(),
+            delegate_size_limit,
         })
     }
 
@@ -115,7 +122,11 @@ impl RePattern {
         if let Some(regex) = self.compiled_match.get() {
             return Ok(regex);
         }
-        let compiled = compile_regex(&format!("\\A(?:{})", self.pattern), self.flags)?;
+        let compiled = compile_regex_limited(
+            &format!("\\A(?:{})", self.pattern),
+            self.flags,
+            self.delegate_size_limit,
+        )?;
         // `set` only fails on a concurrent init, impossible on the single-threaded VM.
         let _ = self.compiled_match.set(compiled);
         Ok(self.compiled_match.get().expect("cell was just initialised"))
@@ -126,7 +137,11 @@ impl RePattern {
         if let Some(regex) = self.compiled_fullmatch.get() {
             return Ok(regex);
         }
-        let compiled = compile_regex(&format!("\\A(?:{})\\z", self.pattern), self.flags)?;
+        let compiled = compile_regex_limited(
+            &format!("\\A(?:{})\\z", self.pattern),
+            self.flags,
+            self.delegate_size_limit,
+        )?;
         let _ = self.compiled_fullmatch.set(compiled);
         Ok(self.compiled_fullmatch.get().expect("cell was just initialised"))
     }
@@ -580,15 +595,13 @@ pub(crate) fn extract_count(val: Option<Value>, vm: &mut VM<'_, impl ResourceTra
 /// - `re.MULTILINE` (8) → `(?m)` prefix
 /// - `re.DOTALL` (16) → `(?s)` prefix
 ///
+/// `delegate_size_limit` optionally caps the compiled size of the delegated
+/// regex (`RegexBuilder::delegate_size_limit`) — used to bound cached patterns;
+/// `None` uses the engine's default limit.
+///
 /// # Errors
 ///
 /// Returns `re.PatternError(...)` if the pattern is invalid.
-pub(crate) fn compile_regex(pattern: &str, flags: u16) -> RunResult<Regex> {
-    compile_regex_limited(pattern, flags, None)
-}
-
-/// As [`compile_regex`], optionally capping the compiled size of the delegated
-/// regex (`RegexBuilder::delegate_size_limit`) — used to bound cached patterns.
 fn compile_regex_limited(pattern: &str, flags: u16, delegate_size_limit: Option<usize>) -> RunResult<Regex> {
     let mut prefix = String::new();
     if flags & IGNORECASE != 0 {

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -11,7 +11,7 @@
 
 use std::{borrow::Cow, cell::OnceCell, cmp::Ordering, fmt::Write, iter, mem, str};
 
-use fancy_regex::{Regex, RegexBuilder};
+use fancy_regex::{CompileError, Error as RegexError, Regex, RegexBuilder};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use smallvec::SmallVec;
 
@@ -19,7 +19,7 @@ use crate::{
     args::{ArgValues, FromArgs},
     bytecode::{CallResult, VM},
     defer_drop,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, RunError, RunResult},
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     modules::re::{ASCII, DOTALL, IGNORECASE, MULTILINE},
@@ -78,6 +78,16 @@ impl PartialEq for RePattern {
     }
 }
 
+/// Failure of [`RePattern::compile_bounded`], separating "valid pattern whose
+/// compiled form exceeds the size cap" (the caller retries uncached at default
+/// limits) from a genuine pattern error (reported to the user).
+pub(crate) enum BoundedCompileError {
+    /// The compiled regex exceeded the requested `delegate_size_limit`.
+    TooBig,
+    /// The pattern itself is invalid, already converted to `re.PatternError`.
+    Invalid(RunError),
+}
+
 impl RePattern {
     /// Creates a compiled pattern from a Python regex string and flags.
     ///
@@ -89,7 +99,7 @@ impl RePattern {
     ///
     /// Returns `re.PatternError` if the pattern is invalid.
     pub fn compile(pattern: String, flags: u16) -> RunResult<Self> {
-        Self::compile_inner(pattern, flags, None)
+        Self::compile_inner(pattern, flags, None).map_err(ExcType::re_pattern_error)
     }
 
     /// As [`RePattern::compile`], but caps the compiled size of the delegated regex
@@ -97,12 +107,22 @@ impl RePattern {
     /// retain entries with a hard per-entry memory ceiling. The limit is retained
     /// and applied to the lazily-compiled anchored `match`/`fullmatch` variants
     /// too, so a cached entry cannot pin large regexes via `.match()`/`.fullmatch()`.
-    pub(crate) fn compile_bounded(pattern: String, flags: u16, delegate_size_limit: usize) -> RunResult<Self> {
-        Self::compile_inner(pattern, flags, Some(delegate_size_limit))
+    pub(crate) fn compile_bounded(
+        pattern: String,
+        flags: u16,
+        delegate_size_limit: usize,
+    ) -> Result<Self, BoundedCompileError> {
+        Self::compile_inner(pattern, flags, Some(delegate_size_limit)).map_err(|err| {
+            if is_size_limit_error(&err) {
+                BoundedCompileError::TooBig
+            } else {
+                BoundedCompileError::Invalid(ExcType::re_pattern_error(err))
+            }
+        })
     }
 
     /// Shared constructor for [`RePattern::compile`] / [`RePattern::compile_bounded`].
-    fn compile_inner(pattern: String, flags: u16, delegate_size_limit: Option<usize>) -> RunResult<Self> {
+    fn compile_inner(pattern: String, flags: u16, delegate_size_limit: Option<usize>) -> Result<Self, RegexError> {
         let compiled = compile_regex_limited(&pattern, flags, delegate_size_limit)?;
         Ok(Self {
             pattern,
@@ -126,7 +146,8 @@ impl RePattern {
             &format!("\\A(?:{})", self.pattern),
             self.flags,
             self.delegate_size_limit,
-        )?;
+        )
+        .map_err(ExcType::re_pattern_error)?;
         // `set` only fails on a concurrent init, impossible on the single-threaded VM.
         let _ = self.compiled_match.set(compiled);
         Ok(self.compiled_match.get().expect("cell was just initialised"))
@@ -141,7 +162,8 @@ impl RePattern {
             &format!("\\A(?:{})\\z", self.pattern),
             self.flags,
             self.delegate_size_limit,
-        )?;
+        )
+        .map_err(ExcType::re_pattern_error)?;
         let _ = self.compiled_fullmatch.set(compiled);
         Ok(self.compiled_fullmatch.get().expect("cell was just initialised"))
     }
@@ -601,8 +623,10 @@ pub(crate) fn extract_count(val: Option<Value>, vm: &mut VM<'_, impl ResourceTra
 ///
 /// # Errors
 ///
-/// Returns `re.PatternError(...)` if the pattern is invalid.
-fn compile_regex_limited(pattern: &str, flags: u16, delegate_size_limit: Option<usize>) -> RunResult<Regex> {
+/// Returns the raw `fancy_regex` error so callers can distinguish a size-limit
+/// overflow from an invalid pattern (see [`is_size_limit_error`]) before
+/// converting to `re.PatternError`.
+fn compile_regex_limited(pattern: &str, flags: u16, delegate_size_limit: Option<usize>) -> Result<Regex, RegexError> {
     let mut prefix = String::new();
     if flags & IGNORECASE != 0 {
         prefix.push('i');
@@ -628,7 +652,19 @@ fn compile_regex_limited(pattern: &str, flags: u16, delegate_size_limit: Option<
     if let Some(limit) = delegate_size_limit {
         builder.delegate_size_limit(limit);
     }
-    builder.build().map_err(ExcType::re_pattern_error)
+    builder.build()
+}
+
+/// True when `err` is the delegated engine's exceeded-size-limit error: the
+/// pattern is valid, its compiled form just doesn't fit the requested cap.
+fn is_size_limit_error(err: &RegexError) -> bool {
+    match err {
+        RegexError::CompileError(compile_error) => match &**compile_error {
+            CompileError::InnerError(inner) => inner.size_limit().is_some(),
+            _ => false,
+        },
+        _ => false,
+    }
 }
 
 /// Translates Python-style replacement backreferences to `fancy_regex` syntax.

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -11,7 +11,7 @@
 
 use std::{borrow::Cow, cell::OnceCell, cmp::Ordering, fmt::Write, iter, mem, str};
 
-use fancy_regex::Regex;
+use fancy_regex::{Regex, RegexBuilder};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use smallvec::SmallVec;
 
@@ -83,7 +83,21 @@ impl RePattern {
     ///
     /// Returns `re.PatternError` if the pattern is invalid.
     pub fn compile(pattern: String, flags: u16) -> RunResult<Self> {
-        let compiled = compile_regex(&pattern, flags)?;
+        Self::compile_inner(pattern, flags, None)
+    }
+
+    /// As [`RePattern::compile`], but caps the compiled size of the delegated regex
+    /// (`RegexBuilder::delegate_size_limit`) so the `re` module's pattern cache can
+    /// retain entries with a hard per-entry memory ceiling. The lazily-compiled
+    /// anchored variants keep default limits: they are the same size class as the
+    /// already-bounded plain regex, so retention stays bounded either way.
+    pub(crate) fn compile_bounded(pattern: String, flags: u16, delegate_size_limit: usize) -> RunResult<Self> {
+        Self::compile_inner(pattern, flags, Some(delegate_size_limit))
+    }
+
+    /// Shared constructor for [`RePattern::compile`] / [`RePattern::compile_bounded`].
+    fn compile_inner(pattern: String, flags: u16, delegate_size_limit: Option<usize>) -> RunResult<Self> {
+        let compiled = compile_regex_limited(&pattern, flags, delegate_size_limit)?;
         Ok(Self {
             pattern,
             flags,
@@ -570,6 +584,12 @@ pub(crate) fn extract_count(val: Option<Value>, vm: &mut VM<'_, impl ResourceTra
 ///
 /// Returns `re.PatternError(...)` if the pattern is invalid.
 pub(crate) fn compile_regex(pattern: &str, flags: u16) -> RunResult<Regex> {
+    compile_regex_limited(pattern, flags, None)
+}
+
+/// As [`compile_regex`], optionally capping the compiled size of the delegated
+/// regex (`RegexBuilder::delegate_size_limit`) — used to bound cached patterns.
+fn compile_regex_limited(pattern: &str, flags: u16, delegate_size_limit: Option<usize>) -> RunResult<Regex> {
     let mut prefix = String::new();
     if flags & IGNORECASE != 0 {
         prefix.push('i');
@@ -591,7 +611,11 @@ pub(crate) fn compile_regex(pattern: &str, flags: u16) -> RunResult<Regex> {
         format!("(?{prefix}){pattern}")
     };
 
-    Regex::new(&full_pattern).map_err(ExcType::re_pattern_error)
+    let mut builder = RegexBuilder::new(&full_pattern);
+    if let Some(limit) = delegate_size_limit {
+        builder.delegate_size_limit(limit);
+    }
+    builder.build().map_err(ExcType::re_pattern_error)
 }
 
 /// Translates Python-style replacement backreferences to `fancy_regex` syntax.

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -9,7 +9,7 @@
 //! Custom serde serializes only the pattern string and flags, recompiling the regex
 //! on deserialization. This supports Monty's snapshot/restore feature.
 
-use std::{borrow::Cow, cell::OnceCell, cmp::Ordering, fmt::Write, iter, mem, str, sync::Arc};
+use std::{borrow::Cow, cell::OnceCell, cmp::Ordering, fmt::Write, iter, mem, str};
 
 use fancy_regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
@@ -117,26 +117,27 @@ impl RePattern {
         Ok(self.compiled_fullmatch.get().expect("cell was just initialised"))
     }
 
-    /// Builds a single `ReMatch` heap value from a capture result, wrapping the
-    /// subject and pattern in shared `Arc`s rather than copying them.
+    /// Builds a single `ReMatch` heap value from a capture result, keeping the
+    /// subject alive by refcount (`subject.clone_with_heap`) rather than copying
+    /// its text. `all_ascii` is precomputed by the caller (once per `finditer`).
     fn build_match(
         &self,
         caps: &fancy_regex::Captures<'_>,
-        text: &str,
+        subject: &Value,
+        all_ascii: bool,
         heap: &Heap<impl ResourceTracker>,
     ) -> RunResult<Value> {
-        let input: Arc<str> = Arc::from(text);
-        let pattern: Arc<str> = Arc::from(self.pattern.as_str());
-        let m = ReMatch::from_captures(caps, &input, text.is_ascii(), &pattern, &self.compiled);
+        let m = ReMatch::from_captures(caps, subject.clone_with_heap(heap), all_ascii, &self.compiled);
         Ok(Value::Ref(heap.allocate(HeapData::ReMatch(m))?))
     }
 
     /// `pattern.search(string)` — find first match anywhere in the string.
     ///
-    /// Returns a `ReMatch` heap object on success, or `Value::None` if no match.
-    pub fn search(&self, text: &str, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
+    /// `subject` is the subject `Value` (stored by the match); `text` is its
+    /// borrowed contents. Returns a `ReMatch` heap object, or `Value::None`.
+    pub fn search(&self, subject: &Value, text: &str, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
         match self.compiled.captures(text) {
-            Ok(Some(caps)) => self.build_match(&caps, text, heap),
+            Ok(Some(caps)) => self.build_match(&caps, subject, text.is_ascii(), heap),
             Ok(None) => Ok(Value::None),
             Err(err) => Err(ExcType::re_pattern_error(err)),
         }
@@ -149,9 +150,9 @@ impl RePattern {
     /// anchor forces the engine to try all alternatives at position 0.
     ///
     /// Returns a `ReMatch` heap object on success, or `Value::None` if no match.
-    pub fn match_start(&self, text: &str, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
+    pub fn match_start(&self, subject: &Value, text: &str, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
         match self.match_regex()?.captures(text) {
-            Ok(Some(caps)) => self.build_match(&caps, text, heap),
+            Ok(Some(caps)) => self.build_match(&caps, subject, text.is_ascii(), heap),
             Ok(None) => Ok(Value::None),
             Err(err) => Err(ExcType::re_pattern_error(err)),
         }
@@ -164,9 +165,9 @@ impl RePattern {
     /// anchors force the engine to try all alternatives for a full-string match.
     ///
     /// Returns a `ReMatch` heap object on success, or `Value::None` if no match.
-    pub fn fullmatch(&self, text: &str, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
+    pub fn fullmatch(&self, subject: &Value, text: &str, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
         match self.fullmatch_regex()?.captures(text) {
-            Ok(Some(caps)) => self.build_match(&caps, text, heap),
+            Ok(Some(caps)) => self.build_match(&caps, subject, text.is_ascii(), heap),
             Ok(None) => Ok(Value::None),
             Err(err) => Err(ExcType::re_pattern_error(err)),
         }
@@ -288,17 +289,14 @@ impl RePattern {
     /// Eagerly collects all match objects into a list. This differs from CPython's
     /// lazy iterator but produces the same results when iterated. The VM's `GetIter`
     /// opcode handles iteration over the returned list.
-    pub fn finditer(&self, text: &str, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
-        // Share one subject/pattern copy across every match, not one copy per match.
-        let input: Arc<str> = Arc::from(text);
-        let pattern: Arc<str> = Arc::from(self.pattern.as_str());
+    pub fn finditer(&self, subject: &Value, text: &str, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
+        // Every match shares one refcounted subject reference, not a copy each.
         let all_ascii = text.is_ascii();
 
         let mut results = Vec::new();
         for caps in self.compiled.captures_iter(text) {
             let caps = caps.map_err(ExcType::re_pattern_error)?;
-            let m = ReMatch::from_captures(&caps, &input, all_ascii, &pattern, &self.compiled);
-            results.push(Value::Ref(heap.allocate(HeapData::ReMatch(m))?));
+            results.push(self.build_match(&caps, subject, all_ascii, heap)?);
         }
 
         let list = List::new(results);
@@ -378,19 +376,19 @@ impl<'h> PyTrait<'h> for HeapRead<'h, RePattern> {
                 let arg = args.get_one_arg("Pattern.search", vm.heap)?;
                 defer_drop!(arg, vm);
                 let text = arg.to_str(vm)?;
-                self.get(vm.heap).search(text, vm.heap)
+                self.get(vm.heap).search(arg, text, vm.heap)
             }
             Some(StaticStrings::Match) => {
                 let arg = args.get_one_arg("Pattern.match", vm.heap)?;
                 defer_drop!(arg, vm);
                 let text = arg.to_str(vm)?;
-                self.get(vm.heap).match_start(text, vm.heap)
+                self.get(vm.heap).match_start(arg, text, vm.heap)
             }
             Some(StaticStrings::Fullmatch) => {
                 let arg = args.get_one_arg("Pattern.fullmatch", vm.heap)?;
                 defer_drop!(arg, vm);
                 let text = arg.to_str(vm)?;
-                self.get(vm.heap).fullmatch(text, vm.heap)
+                self.get(vm.heap).fullmatch(arg, text, vm.heap)
             }
             Some(StaticStrings::Findall) => {
                 let arg = args.get_one_arg("Pattern.findall", vm.heap)?;
@@ -404,7 +402,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, RePattern> {
                 let arg = args.get_one_arg("Pattern.finditer", vm.heap)?;
                 defer_drop!(arg, vm);
                 let text = arg.to_str(vm)?;
-                self.get(vm.heap).finditer(text, vm.heap)
+                self.get(vm.heap).finditer(arg, text, vm.heap)
             }
             _ => {
                 return Err(ExcType::attribute_error(Type::RePattern, attr.as_str(vm.interns)));

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -9,7 +9,7 @@
 //! Custom serde serializes only the pattern string and flags, recompiling the regex
 //! on deserialization. This supports Monty's snapshot/restore feature.
 
-use std::{borrow::Cow, cmp::Ordering, fmt::Write, iter, mem, str};
+use std::{borrow::Cow, cell::OnceCell, cmp::Ordering, fmt::Write, iter, mem, str, sync::Arc};
 
 use fancy_regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
@@ -48,20 +48,23 @@ pub(crate) struct RePattern {
     flags: u16,
     /// The compiled Rust regex, unanchored.
     compiled: Regex,
-    /// The compiled regex anchored with `\A(?:...)` for `match()`.
+    /// The regex anchored with `\A(?:...)` for `match()`, compiled lazily on first
+    /// `match()` call (many patterns are only ever used for `search`/`split`/`sub`,
+    /// so compiling all three variants up front is wasted work).
     ///
     /// Uses `\A` (absolute start anchor) instead of `^` so the MULTILINE flag
     /// doesn't cause it to match at line boundaries. This correctly handles
     /// alternations — e.g. `match('b|ab', 'ab')` must match `ab`, not fail
     /// because the engine found only `b` starting at position 1.
-    compiled_match: Regex,
-    /// The compiled regex anchored with `\A(?:...)\z` for `fullmatch()`.
+    compiled_match: OnceCell<Regex>,
+    /// The regex anchored with `\A(?:...)\z` for `fullmatch()`, compiled lazily on
+    /// first `fullmatch()` call (see `compiled_match`).
     ///
     /// Uses `\A`/`\z` (absolute anchors) instead of `^`/`$` so the MULTILINE flag
     /// doesn't cause them to match at line boundaries. This correctly handles
     /// alternations — e.g. `fullmatch('a|ab', 'ab')` must match `ab`, not fail
     /// because the engine found `a` first.
-    compiled_fullmatch: Regex,
+    compiled_fullmatch: OnceCell<Regex>,
 }
 
 impl PartialEq for RePattern {
@@ -74,23 +77,63 @@ impl RePattern {
     /// Creates a compiled pattern from a Python regex string and flags.
     ///
     /// Translates Python flag constants into inline regex flag prefixes and compiles
-    /// the pattern. Also pre-compiles anchored variants for `match` (`\A(?:pattern)`)
-    /// and `fullmatch` (`\A(?:pattern)\z`) to correctly handle alternations.
+    /// the unanchored pattern. The anchored variants used by `match`/`fullmatch` are
+    /// compiled lazily on first use (see [`RePattern::match_regex`]).
     ///
     /// # Errors
     ///
     /// Returns `re.PatternError` if the pattern is invalid.
     pub fn compile(pattern: String, flags: u16) -> RunResult<Self> {
         let compiled = compile_regex(&pattern, flags)?;
-        let compiled_match = compile_regex(&format!("\\A(?:{pattern})"), flags)?;
-        let compiled_fullmatch = compile_regex(&format!("\\A(?:{pattern})\\z"), flags)?;
         Ok(Self {
             pattern,
             flags,
             compiled,
-            compiled_match,
-            compiled_fullmatch,
+            compiled_match: OnceCell::new(),
+            compiled_fullmatch: OnceCell::new(),
         })
+    }
+
+    /// Returns the `\A(?:pattern)` regex for `match()`, compiling it on first use.
+    ///
+    /// A pattern that compiled unanchored virtually always compiles when wrapped in
+    /// `\A(?:…)`, so a compile error here is a pathological edge case surfaced (as
+    /// `re.PatternError`) at `match()` time rather than at `re.compile()` time.
+    fn match_regex(&self) -> RunResult<&Regex> {
+        if let Some(regex) = self.compiled_match.get() {
+            return Ok(regex);
+        }
+        let compiled = compile_regex(&format!("\\A(?:{})", self.pattern), self.flags)?;
+        // `set` only fails on a concurrent init, impossible on the single-threaded VM.
+        let _ = self.compiled_match.set(compiled);
+        Ok(self.compiled_match.get().expect("cell was just initialised"))
+    }
+
+    /// Returns the `\A(?:pattern)\z` regex for `fullmatch()`, compiling on first use.
+    /// See [`RePattern::match_regex`] for the lazy-compile-error caveat.
+    fn fullmatch_regex(&self) -> RunResult<&Regex> {
+        if let Some(regex) = self.compiled_fullmatch.get() {
+            return Ok(regex);
+        }
+        let compiled = compile_regex(&format!("\\A(?:{})\\z", self.pattern), self.flags)?;
+        let _ = self.compiled_fullmatch.set(compiled);
+        Ok(self.compiled_fullmatch.get().expect("cell was just initialised"))
+    }
+
+    /// Builds a single `ReMatch` heap value from a capture result.
+    ///
+    /// Wraps the subject and pattern in shared `Arc`s (one allocation each) so the
+    /// match holds a shared handle rather than its own copy of the subject.
+    fn build_match(
+        &self,
+        caps: &fancy_regex::Captures<'_>,
+        text: &str,
+        heap: &Heap<impl ResourceTracker>,
+    ) -> RunResult<Value> {
+        let input: Arc<str> = Arc::from(text);
+        let pattern: Arc<str> = Arc::from(self.pattern.as_str());
+        let m = ReMatch::from_captures(caps, &input, text.is_ascii(), &pattern, &self.compiled);
+        Ok(Value::Ref(heap.allocate(HeapData::ReMatch(m))?))
     }
 
     /// `pattern.search(string)` — find first match anywhere in the string.
@@ -98,10 +141,7 @@ impl RePattern {
     /// Returns a `ReMatch` heap object on success, or `Value::None` if no match.
     pub fn search(&self, text: &str, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
         match self.compiled.captures(text) {
-            Ok(Some(caps)) => {
-                let m = ReMatch::from_captures(&caps, text, &self.pattern, &self.compiled);
-                Ok(Value::Ref(heap.allocate(HeapData::ReMatch(m))?))
-            }
+            Ok(Some(caps)) => self.build_match(&caps, text, heap),
             Ok(None) => Ok(Value::None),
             Err(err) => Err(ExcType::re_pattern_error(err)),
         }
@@ -115,11 +155,8 @@ impl RePattern {
     ///
     /// Returns a `ReMatch` heap object on success, or `Value::None` if no match.
     pub fn match_start(&self, text: &str, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
-        match self.compiled_match.captures(text) {
-            Ok(Some(caps)) => {
-                let match_obj = ReMatch::from_captures(&caps, text, &self.pattern, &self.compiled);
-                Ok(Value::Ref(heap.allocate(HeapData::ReMatch(match_obj))?))
-            }
+        match self.match_regex()?.captures(text) {
+            Ok(Some(caps)) => self.build_match(&caps, text, heap),
             Ok(None) => Ok(Value::None),
             Err(err) => Err(ExcType::re_pattern_error(err)),
         }
@@ -133,11 +170,8 @@ impl RePattern {
     ///
     /// Returns a `ReMatch` heap object on success, or `Value::None` if no match.
     pub fn fullmatch(&self, text: &str, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
-        match self.compiled_fullmatch.captures(text) {
-            Ok(Some(caps)) => {
-                let match_obj = ReMatch::from_captures(&caps, text, &self.pattern, &self.compiled);
-                Ok(Value::Ref(heap.allocate(HeapData::ReMatch(match_obj))?))
-            }
+        match self.fullmatch_regex()?.captures(text) {
+            Ok(Some(caps)) => self.build_match(&caps, text, heap),
             Ok(None) => Ok(Value::None),
             Err(err) => Err(ExcType::re_pattern_error(err)),
         }
@@ -260,10 +294,17 @@ impl RePattern {
     /// lazy iterator but produces the same results when iterated. The VM's `GetIter`
     /// opcode handles iteration over the returned list.
     pub fn finditer(&self, text: &str, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
+        // Share one copy of the subject (and pattern) across every match rather than
+        // re-copying the whole subject per match — this was the dominant cost of
+        // regex-extraction workloads.
+        let input: Arc<str> = Arc::from(text);
+        let pattern: Arc<str> = Arc::from(self.pattern.as_str());
+        let all_ascii = text.is_ascii();
+
         let mut results = Vec::new();
         for caps in self.compiled.captures_iter(text) {
             let caps = caps.map_err(ExcType::re_pattern_error)?;
-            let m = ReMatch::from_captures(&caps, text, &self.pattern, &self.compiled);
+            let m = ReMatch::from_captures(&caps, &input, all_ascii, &pattern, &self.compiled);
             results.push(Value::Ref(heap.allocate(HeapData::ReMatch(m))?));
         }
 
@@ -343,34 +384,34 @@ impl<'h> PyTrait<'h> for HeapRead<'h, RePattern> {
             Some(StaticStrings::Search) => {
                 let arg = args.get_one_arg("Pattern.search", vm.heap)?;
                 defer_drop!(arg, vm);
-                let text = arg.to_str(vm)?.to_owned();
-                self.get(vm.heap).search(&text, vm.heap)
+                let text = arg.to_str(vm)?;
+                self.get(vm.heap).search(text, vm.heap)
             }
             Some(StaticStrings::Match) => {
                 let arg = args.get_one_arg("Pattern.match", vm.heap)?;
                 defer_drop!(arg, vm);
-                let text = arg.to_str(vm)?.to_owned();
-                self.get(vm.heap).match_start(&text, vm.heap)
+                let text = arg.to_str(vm)?;
+                self.get(vm.heap).match_start(text, vm.heap)
             }
             Some(StaticStrings::Fullmatch) => {
                 let arg = args.get_one_arg("Pattern.fullmatch", vm.heap)?;
                 defer_drop!(arg, vm);
-                let text = arg.to_str(vm)?.to_owned();
-                self.get(vm.heap).fullmatch(&text, vm.heap)
+                let text = arg.to_str(vm)?;
+                self.get(vm.heap).fullmatch(text, vm.heap)
             }
             Some(StaticStrings::Findall) => {
                 let arg = args.get_one_arg("Pattern.findall", vm.heap)?;
                 defer_drop!(arg, vm);
-                let text = arg.to_str(vm)?.to_owned();
-                self.get(vm.heap).findall(&text, vm.heap)
+                let text = arg.to_str(vm)?;
+                self.get(vm.heap).findall(text, vm.heap)
             }
             Some(StaticStrings::Sub) => call_pattern_sub(self, args, vm),
             Some(StaticStrings::Split) => call_pattern_split(self, args, vm),
             Some(StaticStrings::Finditer) => {
                 let arg = args.get_one_arg("Pattern.finditer", vm.heap)?;
                 defer_drop!(arg, vm);
-                let text = arg.to_str(vm)?.to_owned();
-                self.get(vm.heap).finditer(&text, vm.heap)
+                let text = arg.to_str(vm)?;
+                self.get(vm.heap).finditer(text, vm.heap)
             }
             _ => {
                 return Err(ExcType::attribute_error(Type::RePattern, attr.as_str(vm.interns)));

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -49,8 +49,7 @@ pub(crate) struct RePattern {
     /// The compiled Rust regex, unanchored.
     compiled: Regex,
     /// The regex anchored with `\A(?:...)` for `match()`, compiled lazily on first
-    /// `match()` call (many patterns are only ever used for `search`/`split`/`sub`,
-    /// so compiling all three variants up front is wasted work).
+    /// use (most patterns are only ever `search`/`split`/`sub`ed).
     ///
     /// Uses `\A` (absolute start anchor) instead of `^` so the MULTILINE flag
     /// doesn't cause it to match at line boundaries. This correctly handles
@@ -58,7 +57,7 @@ pub(crate) struct RePattern {
     /// because the engine found only `b` starting at position 1.
     compiled_match: OnceCell<Regex>,
     /// The regex anchored with `\A(?:...)\z` for `fullmatch()`, compiled lazily on
-    /// first `fullmatch()` call (see `compiled_match`).
+    /// first use (see `compiled_match`).
     ///
     /// Uses `\A`/`\z` (absolute anchors) instead of `^`/`$` so the MULTILINE flag
     /// doesn't cause them to match at line boundaries. This correctly handles
@@ -96,9 +95,8 @@ impl RePattern {
 
     /// Returns the `\A(?:pattern)` regex for `match()`, compiling it on first use.
     ///
-    /// A pattern that compiled unanchored virtually always compiles when wrapped in
-    /// `\A(?:…)`, so a compile error here is a pathological edge case surfaced (as
-    /// `re.PatternError`) at `match()` time rather than at `re.compile()` time.
+    /// Wrapping a pattern that already compiled essentially never fails, so any
+    /// error surfaces (as `re.PatternError`) at `match()` rather than `re.compile()`.
     fn match_regex(&self) -> RunResult<&Regex> {
         if let Some(regex) = self.compiled_match.get() {
             return Ok(regex);
@@ -110,7 +108,6 @@ impl RePattern {
     }
 
     /// Returns the `\A(?:pattern)\z` regex for `fullmatch()`, compiling on first use.
-    /// See [`RePattern::match_regex`] for the lazy-compile-error caveat.
     fn fullmatch_regex(&self) -> RunResult<&Regex> {
         if let Some(regex) = self.compiled_fullmatch.get() {
             return Ok(regex);
@@ -120,10 +117,8 @@ impl RePattern {
         Ok(self.compiled_fullmatch.get().expect("cell was just initialised"))
     }
 
-    /// Builds a single `ReMatch` heap value from a capture result.
-    ///
-    /// Wraps the subject and pattern in shared `Arc`s (one allocation each) so the
-    /// match holds a shared handle rather than its own copy of the subject.
+    /// Builds a single `ReMatch` heap value from a capture result, wrapping the
+    /// subject and pattern in shared `Arc`s rather than copying them.
     fn build_match(
         &self,
         caps: &fancy_regex::Captures<'_>,
@@ -294,9 +289,7 @@ impl RePattern {
     /// lazy iterator but produces the same results when iterated. The VM's `GetIter`
     /// opcode handles iteration over the returned list.
     pub fn finditer(&self, text: &str, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
-        // Share one copy of the subject (and pattern) across every match rather than
-        // re-copying the whole subject per match — this was the dominant cost of
-        // regex-extraction workloads.
+        // Share one subject/pattern copy across every match, not one copy per match.
         let input: Arc<str> = Arc::from(text);
         let pattern: Arc<str> = Arc::from(self.pattern.as_str());
         let all_ascii = text.is_ascii();

--- a/crates/monty/test_cases/re__basic.py
+++ b/crates/monty/test_cases/re__basic.py
@@ -933,10 +933,3 @@ assert len(matches) == 2, 'finditer with groups returns 2 matches'
 assert matches[0].group(1) == 'a', 'finditer group 1 of match 0'
 assert matches[0].group(2) == '1', 'finditer group 2 of match 0'
 assert matches[1].group(1) == 'b', 'finditer group 1 of match 1'
-
-# === Patterns whose compiled form is too big for the pattern cache ===
-# Monty recompiles these per call instead of retaining them; behavior is identical.
-m = re.fullmatch('(?:ab){3000}', 'ab' * 3000)
-assert m is not None, 'oversize counted repeat fullmatch succeeds'
-assert m.span() == (0, 6000), 'oversize counted repeat span'
-assert re.findall('a{5000}', 'a' * 5000) == ['a' * 5000], 'oversize pattern findall'

--- a/crates/monty/test_cases/re__basic.py
+++ b/crates/monty/test_cases/re__basic.py
@@ -933,3 +933,10 @@ assert len(matches) == 2, 'finditer with groups returns 2 matches'
 assert matches[0].group(1) == 'a', 'finditer group 1 of match 0'
 assert matches[0].group(2) == '1', 'finditer group 2 of match 0'
 assert matches[1].group(1) == 'b', 'finditer group 1 of match 1'
+
+# === Patterns whose compiled form is too big for the pattern cache ===
+# Monty recompiles these per call instead of retaining them; behavior is identical.
+m = re.fullmatch('(?:ab){3000}', 'ab' * 3000)
+assert m is not None, 'oversize counted repeat fullmatch succeeds'
+assert m.span() == (0, 6000), 'oversize counted repeat span'
+assert re.findall('a{5000}', 'a' * 5000) == ['a' * 5000], 'oversize pattern findall'

--- a/crates/monty/test_cases/re__match.py
+++ b/crates/monty/test_cases/re__match.py
@@ -3,9 +3,11 @@
 import re
 
 # === Match .string attribute ===
-m = re.search('hello', 'say hello')
+subject = 'say ' + 'hello'  # concatenate so it isn't interned
+m = re.search('hello', subject)
 assert m is not None, 'search finds match for .string test'
 assert m.string == 'say hello', '.string returns the input string'
+assert m.string is subject, '.string is the original subject object, not a copy'
 
 # === Match truthiness ===
 m = re.search(r'\d+', '123')

--- a/crates/monty/test_cases/re__match.py
+++ b/crates/monty/test_cases/re__match.py
@@ -148,3 +148,24 @@ try:
     assert False, 'out-of-range subscript should raise IndexError'
 except IndexError as e:
     assert str(e) == 'no such group', 'subscript IndexError message'
+
+# === Non-ASCII subjects: positions are character offsets, not bytes ===
+subject = 'héllo wörld date: 2026-07-06 ünd'
+m = re.search(r'\d{4}-\d{2}-\d{2}', subject)
+assert m is not None, 'search finds date in non-ASCII subject'
+assert m.span() == (18, 28), 'non-ASCII subject span is in characters'
+assert m.start() == 18, 'non-ASCII subject start is in characters'
+assert m.end() == 28, 'non-ASCII subject end is in characters'
+assert m.span() == (18, 28), 'repeated span call returns the same result'
+assert subject[m.start() : m.end()] == '2026-07-06', 'char offsets slice the subject correctly'
+
+# group spans and unmatched groups on a non-ASCII subject
+m = re.search(r'(\w+)@(\w+)(!)?', 'çontact: müller@pydantic é')
+assert m is not None, 'search finds match in non-ASCII subject with groups'
+assert m.span() == (9, 24), 'full-match span in characters'
+assert m.span(1) == (9, 15), 'group 1 span in characters'
+assert m.span(2) == (16, 24), 'group 2 span in characters'
+assert m.span(3) == (-1, -1), 'unmatched group span is (-1, -1)'
+assert m.start(2) == 16, 'group 2 start in characters'
+assert m.end(2) == 24, 'group 2 end in characters'
+assert repr(m) == "<re.Match object; span=(9, 24), match='müller@pydantic'>", 'repr span in characters'

--- a/crates/monty/test_cases/refcount__re_search_match.py
+++ b/crates/monty/test_cases/refcount__re_search_match.py
@@ -78,8 +78,9 @@ assert sub_result == 'hello world', 'negative count returns subject unchanged'
 
 # p: 1, m: 1, group_str: 1, m2: 1, full_str: 1
 # results: 1, r0: 2 (var + list), r1: 2 (var + list), r2: 2 (var + list + final expr)
-# subject: 2 (variable + sub_result aliasing it), sub_result: 2 (same object)
-# m3: 1
+# subject: 3 (variable + sub_result aliasing it + m3's retained .string reference)
+# sub_result: 3 (same object as subject)
+# m3: 1 (its shared reference to subject is counted under subject above)
 # re: 1
 r2
-# ref-counts={'p': 1, 'm': 1, 'group_str': 1, 'm2': 1, 'full_str': 1, 'results': 1, 'r0': 2, 'r1': 2, 'r2': 3, 'subject': 2, 'sub_result': 2, 'm3': 1, 're': 1}
+# ref-counts={'p': 1, 'm': 1, 'group_str': 1, 'm2': 1, 'full_str': 1, 'results': 1, 'r0': 2, 'r1': 2, 'r2': 3, 'subject': 3, 'sub_result': 3, 'm3': 1, 're': 1}

--- a/crates/monty/tests/regex.rs
+++ b/crates/monty/tests/regex.rs
@@ -1,7 +1,6 @@
-/// Tests for regex-specific behavior that differs from CPython.
-///
-/// These tests verify Monty-specific regex behavior that cannot be tested via
-/// the datatest runner (which runs tests against both CPython and Monty).
+/// Tests for regex behavior that cannot be tested via the datatest runner
+/// (which runs tests against both CPython and Monty) — engine divergences from
+/// CPython, and cases too slow for the runner's per-file timeout.
 /// In particular, `fancy_regex` enforces a backtrack limit that CPython lacks,
 /// so pathological patterns raise `PatternError` in Monty instead of hanging.
 ///
@@ -84,6 +83,24 @@ fn dfa_engine_handles_large_inputs() {
 import re
 m = re.search(r'(a+)+b', 'a' * 10000 + 'c')
 assert m is None, 'no match expected'
+'ok'
+");
+    assert_eq!(result, "ok");
+}
+
+/// Patterns whose compiled form exceeds the pattern cache's per-entry
+/// `delegate_size_limit` are recompiled per call instead of retained — they must
+/// still match identically. Lives here rather than `test_cases/` because
+/// debug-build compilation of the expanded counted repeats is too slow for the
+/// datatest runner's per-file timeout.
+#[test]
+fn oversize_pattern_not_cached_still_matches() {
+    let result = run(r"
+import re
+m = re.fullmatch('(?:ab){3000}', 'ab' * 3000)
+assert m is not None, 'oversize counted repeat fullmatch succeeds'
+assert m.span() == (0, 6000), 'oversize counted repeat span'
+assert re.findall('a{5000}', 'a' * 5000) == ['a' * 5000], 'oversize pattern findall'
 'ok'
 ");
     assert_eq!(result, "ok");

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -2317,3 +2317,25 @@ fn set_from_range_within_limit() {
     assert!(result.is_ok(), "small set/map construction should succeed: {result:?}");
     assert_eq!(result.unwrap(), MontyObject::Int(70));
 }
+
+/// Regression: `re.finditer` over a large subject with many matches shares one
+/// refcounted subject copy across every `re.Match`, so its memory accounting is
+/// bounded by the subject size, not `matches × subject`. When each match kept
+/// its own subject copy, this held ~48 MB (4000 × ~12 KB) and blew a limit far
+/// larger than the data actually in use.
+#[test]
+fn finditer_shares_subject_memory() {
+    // ~12 KB subject, 4000 word matches all held live in the returned list.
+    let code = "import re\nlen(re.finditer(r'\\w+', 'aa ' * 4000))";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![]).unwrap();
+
+    let limits = ResourceLimits::new()
+        .max_memory(8_388_608)
+        .max_duration(Duration::from_secs(30));
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    assert_eq!(
+        result.expect("finditer over a large subject must stay within the memory limit"),
+        MontyObject::Int(4000)
+    );
+}

--- a/limitations/re.md
+++ b/limitations/re.md
@@ -87,3 +87,6 @@ representation does not carry them.
 - Backreference syntax `\10` and higher is not recognized; only `\1`–`\9`.
 - Error messages for invalid patterns come from `fancy-regex` and do not
   match CPython's wording.
+- Patterns whose *compiled* form is very large — e.g. huge counted repeats
+  like `a{5000000}` — raise `re.PatternError` (`fancy-regex`/`regex` enforce a
+  compiled-size limit), whereas CPython compiles them.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Speeds up `re` by adding a fixed-size per-run pattern cache, sharing subjects in match objects, and compiling anchored variants lazily with a size cap. Fixes `finditer` memory accounting; `re_extract` drops from ~3.74ms to ~1.27ms locally.

- **Refactors**
  - Added per-run `RePatternCache` on the `VM` for module-level `re.*` (keyed by `(pattern, flags)`, 256 slots, 5-slot probe, LRU on collisions). Lazily allocated. Per-entry compiled size capped at 64 KiB; oversize patterns compile per call and aren’t cached. Tests cover hits, flags, capacity, errors, and oversize behavior.
  - Cache shares compiled regex via `Rc`; `re.compile` clones from cache into a heap `re.Pattern`. Anchored `\A(?:...)`/`\A(?:...)\z` variants compile on first use via `OnceCell` and forward the same size cap.
  - `ReMatch` retains `.string` as a refcounted heap `Value` (`m.string is subject`), stores byte offsets with an ASCII fast path, and lazily converts to character offsets, memoizing the full-match span. Heap walkers/dec-refs release the shared subject ref. Pattern methods stop copying the subject before matching.
  - Tests add a resource-limit check for `finditer` sharing, move oversize-pattern checks to `tests/regex.rs`, and ensure non-ASCII positions are correct. `limitations/re.md` documents the compiled-size limit divergence vs CPython.

<sup>Written for commit c81aca16de29fe6c2f16c980d7ae6df0012e8ee0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

