### PR TITLE
Restrict `git commit` and `git push` for claude

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,11 @@
 {
   "enabledPlugins": {
     "codspeed@claude-plugins-official": true
+  },
+  "permissions": {
+    "ask": [
+      "Bash(git push:*)",
+      "Bash(git commit:*)"
+    ]
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Require explicit approval before running `git commit` and `git push` via Claude’s Bash tool to prevent unintended repository changes. Adds ask-permissions for these commands in .claude/settings.json.

<sup>Written for commit 11cfad3a1a5d76f62836e5fc446ddb3537c3c9f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

