### PR TITLE
prep for beta release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -845,6 +845,11 @@ jobs:
       - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth
 
+      - id: check-version
+        uses: samuelcolvin/check-python-version@ee87cddb8049d2694cc03badc8569765a05cef00 # v5
+        with:
+          version_file_path: 'Cargo.toml'
+
       # Publishes every workspace member that is not `publish = false` (i.e. all
       # the library/bin crates, but not the `pydantic-monty`/`monty-js` bindings,
       # which ship to PyPI/npm). `--workspace` publishes in dependency order and
@@ -1152,6 +1157,11 @@ jobs:
           mv artifacts/wasm/wasi-worker.mjs artifacts/wasm/wasi-worker-browser.mjs npm/wasm32-wasi/
           ls -lR npm/
         working-directory: crates/monty-js
+
+      - id: check-version
+        uses: samuelcolvin/check-python-version@ee87cddb8049d2694cc03badc8569765a05cef00 # v5
+        with:
+          version_file_path: 'Cargo.toml'
 
       - name: Publish
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,7 +391,7 @@ NOT!
 
 ### Docstrings and comments.
 
-IMPORTANT: every struct, enum and function should have an concise docstring to
+IMPORTANT: every struct, enum and function should have a concise docstring to
 explain what it does and why; and any considerations or potential foot-guns of using that type.
 
 The only exception is trait implementation methods where a docstring is not necessary if the method is self-explanatory.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,7 +391,7 @@ NOT!
 
 ### Docstrings and comments.
 
-IMPORTANT: every struct, enum and function should have an informative but concise docstring to
+IMPORTANT: every struct, enum and function should have an concise docstring to
 explain what it does and why; and any considerations or potential foot-guns of using that type.
 
 The only exception is trait implementation methods where a docstring is not necessary if the method is self-explanatory.
@@ -399,6 +399,8 @@ The only exception is trait implementation methods where a docstring is not nece
 It's important that docstrings cover the motivation and primary usage patterns of code, not just the simple "what it does".
 
 Similarly, you should add comments to code, especially if the code is complex or esoteric.
+
+Comments and field docstrings should almost never be more than 3 lines, mostly 1 line. Function and struct docstrings should be concise, generally <= 5 lines.
 
 Only add examples to docstrings of public functions and structs, examples should be <=8 lines, if the example is more, remove it.
 
@@ -413,8 +415,6 @@ Always use single back-ticks in python docstrings - they should be markdown, not
 NOTE: COMMENTS AND DOCSTRINGS ARE EXTREMELY IMPORTANT TO THE LONG TERM HEALTH OF THE PROJECT.
 
 NOTE: COMMENTS AND DOCSTRINGS SHOULD BE CONCISE - EXCESSIVELY VERBOSE DOCSTRINGS MAKE THE CODE HARDER TO READ AND MAINTAIN!
-
-Comments and field docstrings should almost never be more than 3 lines, mostly 1 line. Function and struct docstrings should be concise, generally <= 5 lines.
 
 ## Tests
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "monty"
-version = "0.0.18"
+version = "0.0.19-beta.1"
 dependencies = [
  "ahash",
  "chrono",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "monty-bench"
-version = "0.0.18"
+version = "0.0.19-beta.1"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "monty-cli"
-version = "0.0.18"
+version = "0.0.19-beta.1"
 dependencies = [
  "clap",
  "monty",
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "monty-cpython"
-version = "0.0.18"
+version = "0.0.19-beta.1"
 dependencies = [
  "ahash",
  "clap",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "monty-datatest"
-version = "0.0.18"
+version = "0.0.19-beta.1"
 dependencies = [
  "ahash",
  "chrono",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "monty-fuzz"
-version = "0.0.18"
+version = "0.0.19-beta.1"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "monty-js"
-version = "0.0.18"
+version = "0.0.19-beta.1"
 dependencies = [
  "monty",
  "monty-pool",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "monty-macros"
-version = "0.0.18"
+version = "0.0.19-beta.1"
 dependencies = [
  "insta",
  "proc-macro2",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "monty-pool"
-version = "0.0.18"
+version = "0.0.19-beta.1"
 dependencies = [
  "monty",
  "monty-proto",
@@ -2128,7 +2128,7 @@ dependencies = [
 
 [[package]]
 name = "monty-proto"
-version = "0.0.18"
+version = "0.0.19-beta.1"
 dependencies = [
  "monty",
  "num-bigint",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "monty-type-checking"
-version = "0.0.18"
+version = "0.0.19-beta.1"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "monty-typeshed"
-version = "0.0.18"
+version = "0.0.19-beta.1"
 dependencies = [
  "path-slash",
  "ruff_db",
@@ -2712,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-monty"
-version = "0.0.18"
+version = "0.0.19-beta.1"
 dependencies = [
  "ahash",
  "monty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = ["crates/monty-cli"]
 
 [workspace.package]
 edition = "2024"
-version = "0.0.18"
+version = "0.0.19-beta.1"
 rust-version = "1.95"
 license = "MIT"
 authors = ["Samuel Colvin <samuel@pydantic.dev>"]
@@ -47,12 +47,12 @@ lto = false
 # rejects path-only dependencies). These versions MUST be kept in lockstep with
 # `workspace.package.version` above and bumped together on each release — see
 # RELEASING.md.
-monty = { path = "crates/monty", version = "0.0.18" }
-monty-macros = { path = "crates/monty-macros", version = "0.0.18" }
-monty-proto = { path = "crates/monty-proto", version = "0.0.18" }
-monty-pool = { path = "crates/monty-pool", version = "0.0.18" }
-monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.18" }
-monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.18" }
+monty = { path = "crates/monty", version = "0.0.19-beta.1" }
+monty-macros = { path = "crates/monty-macros", version = "0.0.19-beta.1" }
+monty-proto = { path = "crates/monty-proto", version = "0.0.19-beta.1" }
+monty-pool = { path = "crates/monty-pool", version = "0.0.19-beta.1" }
+monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.19-beta.1" }
+monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.19-beta.1" }
 # ruff, ty and related crates
 ruff_python_parser = "0.0.3"
 ruff_python_stdlib = "0.0.3"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,39 +2,28 @@
 
 ## 1. Bump Version
 
-Update version in both files:
+Edit `Cargo.toml` to bump the version (both the main `version` and the package versions)
+
+Run
 
 ```bash
-# Edit Cargo.toml - update workspace.package.version AND the internal crate
-#   versions in [workspace.dependencies] (monty, monty-macros, monty-proto,
-#   monty-pool, monty-type-checking, monty-typeshed). These must all equal
-#   workspace.package.version or `cargo publish` will fail.
-# Edit crates/monty-js/package.json - update version AND the optionalDependencies
-#   versions (they must all equal the package version; CI's
-#   create-platform-packages fails if they drift)
-
-# Update Cargo.lock
 make lint-rs
 ```
 
-`Cargo.toml` and `package.json` should have the same version (e.g., `0.0.2`).
+To update `Cargo.lock` and sync `package.json`/`package-lock.json` (these are updated via a `crates/monty-js/build.rs`).
 
 ## 2. Commit and Push
 
 ```bash
-git add Cargo.toml Cargo.lock crates/monty-js/package.json
+git checkout -b prepare-release-X.Y.Z
+git add .
 git commit -m "Bump version to X.Y.Z"
 git push
 ```
 
 ## 3. Create Release via GitHub UI
 
-1. Go to https://github.com/pydantic/monty/releases/new
-2. Click "Choose a tag" and type the new tag name (e.g., `v0.0.2`)
-3. Select "Create new tag on publish"
-4. Set the release title (e.g., `v0.0.2`)
-5. Add release notes
-6. Click "Publish release"
+Once the PR is merged, create a release in the GitHub UI with a tag matching the version in `Cargo.toml`.
 
 ## 4. CI Handles Publishing
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,7 +10,7 @@ Run
 make lint-rs
 ```
 
-To update `Cargo.lock` and sync `package.json`/`package-lock.json` (these are updated via a `crates/monty-js/build.rs`).
+This will update `Cargo.lock` and sync `package.json`/`package-lock.json` (these are updated via a `crates/monty-js/build.rs`).
 
 ## 2. Commit and Push
 

--- a/crates/monty-js/build.rs
+++ b/crates/monty-js/build.rs
@@ -1,19 +1,22 @@
-use std::{env, fs, path::Path, process::Command};
+use std::{borrow::Cow, env, fs, path::Path, process::Command};
 
-/// Build script that sets up napi bindings and syncs the package.json version
-/// with the Cargo workspace version.
+/// Build script that sets up napi bindings and syncs package.json's version
+/// fields with the Cargo workspace version.
 ///
 /// Cargo sets `CARGO_PKG_VERSION` in the environment when executing build scripts,
-/// so we use that as the single source of truth. If package.json has a different
-/// version, we update it in place.
+/// so we use that as the single source of truth. If package.json's top-level
+/// `version` or any `@pydantic/monty-*` platform pin in `optionalDependencies`
+/// differs, we update it in place (CI's create-platform-packages fails if the
+/// pins drift from the package version).
 fn main() {
-    // Re-run when package.json changes so we can re-check the version.
+    // Re-run when package.json changes so we can re-check the versions.
     println!("cargo:rerun-if-changed=package.json");
     sync_package_json_version();
     napi_build::setup();
 }
 
-/// Read the Cargo package version and update package.json if the version differs.
+/// Read the Cargo package version and update package.json if any version-bearing
+/// line differs, then refresh package-lock.json to match.
 ///
 /// Uses the runtime `CARGO_PKG_VERSION` env var (not `env!()`) so that the build
 /// script picks up version changes without needing to be recompiled.
@@ -23,25 +26,15 @@ fn sync_package_json_version() {
 
     let contents = fs::read_to_string(package_json_path).expect("failed to read package.json");
 
-    // Replace the top-level "version" field. We match lines starting with
-    // `  "version":` which is the standard prettier-formatted location.
-    let expected = format!("  \"version\": \"{cargo_version}\",");
     let mut result = String::with_capacity(contents.len());
     let mut changed = false;
 
     for line in contents.lines() {
-        // Only match the top-level "version" field (exactly 2-space indent),
-        // not nested ones like scripts.version (4-space indent).
-        if !changed && line.starts_with("  \"version\"") {
-            // version unchanged, exit early
-            if line == expected {
-                return;
-            }
-            result.push_str(&expected);
+        let synced = sync_line(line, &cargo_version);
+        if synced != line {
             changed = true;
-        } else {
-            result.push_str(line);
         }
+        result.push_str(&synced);
         result.push('\n');
     }
 
@@ -49,13 +42,36 @@ fn sync_package_json_version() {
         return;
     }
 
-    eprintln!("Updating package.json version to {cargo_version}");
+    eprintln!("Updating package.json versions to {cargo_version}");
     fs::write(package_json_path, &result).expect("failed to write package.json");
 
-    // Sync package-lock.json to match the updated version.
+    // Sync package-lock.json to match the updated versions.
     let status = Command::new("npm")
         .args(["install", "--package-lock-only"])
         .status()
         .expect("failed to run npm");
     assert!(status.success(), "npm install --package-lock-only failed");
+}
+
+/// Rewrite `line` with `version` if it is a version-bearing line: the top-level
+/// `"version"` field or a `@pydantic/monty-*` platform pin in
+/// `optionalDependencies`. All other lines pass through unchanged.
+///
+/// Matching is indentation-sensitive (prettier-formatted, 2-space indent per
+/// level): exactly 2 spaces for the top-level field — so nested `version` keys
+/// don't match — and exactly 4 for the platform pins.
+fn sync_line<'a>(line: &'a str, version: &str) -> Cow<'a, str> {
+    if line.starts_with("  \"version\"") {
+        Cow::Owned(format!("  \"version\": \"{version}\","))
+    } else if let Some(name) = line
+        .strip_prefix("    \"@pydantic/monty-")
+        .and_then(|rest| rest.split('"').next())
+    {
+        // Preserve the presence/absence of the trailing comma (the last entry
+        // in optionalDependencies has none).
+        let comma = if line.ends_with(',') { "," } else { "" };
+        Cow::Owned(format!("    \"@pydantic/monty-{name}\": \"{version}\"{comma}"))
+    } else {
+        Cow::Borrowed(line)
+    }
 }

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.18",
+  "version": "0.0.19-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pydantic/monty",
-      "version": "0.0.18",
+      "version": "0.0.19-beta.1",
       "license": "MIT",
       "devDependencies": {
         "@emnapi/core": "^1.5.0",
@@ -26,19 +26,19 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@pydantic/monty-darwin-arm64": "0.0.18",
-        "@pydantic/monty-darwin-x64": "0.0.18",
-        "@pydantic/monty-linux-arm64-gnu": "0.0.18",
-        "@pydantic/monty-linux-x64-gnu": "0.0.18",
-        "@pydantic/monty-wasm32-wasi": "0.0.18",
-        "@pydantic/monty-win32-x64-msvc": "0.0.18"
+        "@pydantic/monty-darwin-arm64": "0.0.19-beta.1",
+        "@pydantic/monty-darwin-x64": "0.0.19-beta.1",
+        "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.1",
+        "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.1",
+        "@pydantic/monty-wasm32-wasi": "0.0.19-beta.1",
+        "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.1"
       }
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
       "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
@@ -49,7 +49,7 @@
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
       "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
@@ -59,7 +59,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
@@ -1283,7 +1283,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
       "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tybys/wasm-util": "^0.10.2"
@@ -2417,106 +2417,22 @@
       }
     },
     "node_modules/@pydantic/monty-darwin-arm64": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-arm64/-/monty-darwin-arm64-0.0.18.tgz",
-      "integrity": "sha512-63R8YhyXHc8O9lei+oEW4ns58Ss+34AlRN0lmzKJdzEKRh6YQ/N0cZI0n9CCqSi7ERmiQXJ0NhwWIKxgStx3Tg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 6.14.2 < 7 || >= 8.11.2 < 9 || >= 9.11.0 < 10 || >= 10.0.0"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-darwin-x64": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-x64/-/monty-darwin-x64-0.0.18.tgz",
-      "integrity": "sha512-7ecWyb2sJxKnPPSiTqX8bdrMsKZZaP2/szZxbMa0wZVvoc5jLvkm3azg3n5L+vcVbP/vhlXTSno/huBt/Vvn+g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 6.14.2 < 7 || >= 8.11.2 < 9 || >= 9.11.0 < 10 || >= 10.0.0"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-linux-arm64-gnu": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-arm64-gnu/-/monty-linux-arm64-gnu-0.0.18.tgz",
-      "integrity": "sha512-IonXv0Er8QoHJKEoewurQRgnOoe2mwbrw8A0rj0FnsOkZaQ98KHMLxDsa1UUvTVmKx/XUYst3j9o/8nrfbW68g==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 6.14.2 < 7 || >= 8.11.2 < 9 || >= 9.11.0 < 10 || >= 10.0.0"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-linux-x64-gnu": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-x64-gnu/-/monty-linux-x64-gnu-0.0.18.tgz",
-      "integrity": "sha512-7QWTiVO7T8YxpIuTtoTafTMOm3tXgje/hSddVSS4pqQbrf2UDQcRW89azqYWTf1JKFGmO27YKyniz70+gOWMMw==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 6.14.2 < 7 || >= 8.11.2 < 9 || >= 9.11.0 < 10 || >= 10.0.0"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-wasm32-wasi": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-wasm32-wasi/-/monty-wasm32-wasi-0.0.18.tgz",
-      "integrity": "sha512-64AWbkeoFxvjX4w8VHoRlJCa5P4pxNtbly3hHD9jpDD9qrHcxYu0/g5b0peceQ5wRxIpCC/sWsC46SyFYnma4A==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.4"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-win32-x64-msvc": {
-      "version": "0.0.18",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-win32-x64-msvc/-/monty-win32-x64-msvc-0.0.18.tgz",
-      "integrity": "sha512-3Pvqu5LZHJhZilV3/uEK+d0BiUUo+con55O2/iBxal/9cXBk0CSENpleruPOLp0is96AsYwrKmK/MRsjisd10g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 6.14.2 < 7 || >= 8.11.2 < 9 || >= 9.11.0 < 10 || >= 10.0.0"
-      }
+      "optional": true
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.4.0",
@@ -2558,7 +2474,7 @@
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
@@ -4789,7 +4705,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/typanion": {

--- a/crates/monty-js/package.json
+++ b/crates/monty-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.18",
+  "version": "0.0.19-beta.1",
   "type": "module",
   "description": "Sandboxed Python interpreter running in crash-isolated subprocess workers",
   "main": "dist/index.js",
@@ -96,11 +96,11 @@
     "arrowParens": "always"
   },
   "optionalDependencies": {
-    "@pydantic/monty-darwin-x64": "0.0.18",
-    "@pydantic/monty-darwin-arm64": "0.0.18",
-    "@pydantic/monty-linux-x64-gnu": "0.0.18",
-    "@pydantic/monty-linux-arm64-gnu": "0.0.18",
-    "@pydantic/monty-win32-x64-msvc": "0.0.18",
-    "@pydantic/monty-wasm32-wasi": "0.0.18"
+    "@pydantic/monty-darwin-x64": "0.0.19-beta.1",
+    "@pydantic/monty-darwin-arm64": "0.0.19-beta.1",
+    "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.1",
+    "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.1",
+    "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.1",
+    "@pydantic/monty-wasm32-wasi": "0.0.19-beta.1"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepares the v0.0.19-beta.1 beta release. Bumps workspace and JS package versions, automates JS version syncing, and adds CI checks to reduce release friction.

- **Refactors**
  - Bump workspace and internal crate versions to 0.0.19-beta.1; update `crates/monty-js/package.json` and lockfile.
  - Enhance `crates/monty-js/build.rs` to sync the top-level `version` and `optionalDependencies` pins for `@pydantic/monty-*`, then regenerate `package-lock.json`.
  - CI: add `samuelcolvin/check-python-version` steps (pointed at `Cargo.toml`) before Rust and npm publish jobs.
  - Simplify RELEASING.md: `Cargo.toml` is the single source of truth; JS versions are auto-synced. Tighten docstring guidance in `CLAUDE.md`.

<sup>Written for commit dbc08261c689247251fcb663fe06887a2efc5709. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

