### PR TITLE
Fixing CI for`0.0.19-beta.2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
         # don't use .venv python in CI
       - run: rm .cargo/config.toml
 
-      # pydantic-monty depends on pydantic-monty-cli; install it from the
+      # pydantic-monty depends on pydantic-monty-runtime; install it from the
       # workspace so `maturin develop` can resolve it (plain build, outside
       # the llvm-cov env, so the worker binary is not instrumented)
       - run: uv run maturin develop --uv -m crates/monty-cli/Cargo.toml
@@ -554,7 +554,7 @@ jobs:
           docker-options: -e CI
           working-directory: crates/monty-python
 
-      # the pydantic-monty-cli wheel ships the `monty` worker binary
+      # the pydantic-monty-runtime wheel ships the `monty` worker binary
       # (bin bindings, one py3-none wheel per platform). `-i` is required so
       # maturin can find a Python to read pyproject.toml — the produced wheel
       # is `py3-none-<plat>` and doesn't depend on a specific Python version.
@@ -687,7 +687,7 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             python3 -m pip install typing_extensions
-            python3 -m pip install pydantic-monty pydantic-monty-cli --no-index --no-deps --find-links /dist --force-reinstall
+            python3 -m pip install pydantic-monty pydantic-monty-runtime --no-index --no-deps --find-links /dist --force-reinstall
             python3 - <<'EOF'
             from pydantic_monty import Monty
 
@@ -734,7 +734,7 @@ jobs:
       - run: python -c "import pydantic_monty; print(pydantic_monty.__version__)"
 
       # the cli wheel built for this platform must serve the worker pools
-      - run: pip install pydantic-monty-cli --no-index --no-deps --find-links dist --force-reinstall
+      - run: pip install pydantic-monty-runtime --no-index --no-deps --find-links dist --force-reinstall
       - name: smoke test worker pools
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1186,7 +1186,9 @@ jobs:
         run: |
           for dir in artifacts/monty-bin-*; do
             triple=${dir#artifacts/monty-bin-}
-            find "$dir" -name 'monty*' -exec mv {} "npm/$triple/" \;
+            # -type f: without it the artifact dir itself matches 'monty*' and
+            # gets moved wholesale, killing the find that is mid-traversal
+            find "$dir" -type f -name 'monty*' -exec mv {} "npm/$triple/" \;
           done
           chmod +x npm/*/monty npm/*/monty.exe 2>/dev/null || true
           mv artifacts/wasm/monty.wasm32-wasi.wasm npm/wasm32-wasi/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "monty"
-version = "0.0.19-beta.1"
+version = "0.0.19-beta.2"
 dependencies = [
  "ahash",
  "chrono",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "monty-bench"
-version = "0.0.19-beta.1"
+version = "0.0.19-beta.2"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "monty-cli"
-version = "0.0.19-beta.1"
+version = "0.0.19-beta.2"
 dependencies = [
  "clap",
  "monty",
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "monty-cpython"
-version = "0.0.19-beta.1"
+version = "0.0.19-beta.2"
 dependencies = [
  "ahash",
  "clap",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "monty-datatest"
-version = "0.0.19-beta.1"
+version = "0.0.19-beta.2"
 dependencies = [
  "ahash",
  "chrono",
@@ -2083,7 +2083,7 @@ dependencies = [
 
 [[package]]
 name = "monty-fuzz"
-version = "0.0.19-beta.1"
+version = "0.0.19-beta.2"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -2092,7 +2092,7 @@ dependencies = [
 
 [[package]]
 name = "monty-js"
-version = "0.0.19-beta.1"
+version = "0.0.19-beta.2"
 dependencies = [
  "monty",
  "monty-pool",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "monty-macros"
-version = "0.0.19-beta.1"
+version = "0.0.19-beta.2"
 dependencies = [
  "insta",
  "proc-macro2",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "monty-pool"
-version = "0.0.19-beta.1"
+version = "0.0.19-beta.2"
 dependencies = [
  "monty",
  "monty-proto",
@@ -2128,7 +2128,7 @@ dependencies = [
 
 [[package]]
 name = "monty-proto"
-version = "0.0.19-beta.1"
+version = "0.0.19-beta.2"
 dependencies = [
  "monty",
  "num-bigint",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "monty-type-checking"
-version = "0.0.19-beta.1"
+version = "0.0.19-beta.2"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "monty-typeshed"
-version = "0.0.19-beta.1"
+version = "0.0.19-beta.2"
 dependencies = [
  "path-slash",
  "ruff_db",
@@ -2712,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-monty"
-version = "0.0.19-beta.1"
+version = "0.0.19-beta.2"
 dependencies = [
  "ahash",
  "monty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = ["crates/monty-cli"]
 
 [workspace.package]
 edition = "2024"
-version = "0.0.19-beta.1"
+version = "0.0.19-beta.2"
 rust-version = "1.95"
 license = "MIT"
 authors = ["Samuel Colvin <samuel@pydantic.dev>"]
@@ -47,12 +47,12 @@ lto = false
 # rejects path-only dependencies). These versions MUST be kept in lockstep with
 # `workspace.package.version` above and bumped together on each release — see
 # RELEASING.md.
-monty = { path = "crates/monty", version = "0.0.19-beta.1" }
-monty-macros = { path = "crates/monty-macros", version = "0.0.19-beta.1" }
-monty-proto = { path = "crates/monty-proto", version = "0.0.19-beta.1" }
-monty-pool = { path = "crates/monty-pool", version = "0.0.19-beta.1" }
-monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.19-beta.1" }
-monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.19-beta.1" }
+monty = { path = "crates/monty", version = "0.0.19-beta.2" }
+monty-macros = { path = "crates/monty-macros", version = "0.0.19-beta.2" }
+monty-proto = { path = "crates/monty-proto", version = "0.0.19-beta.2" }
+monty-pool = { path = "crates/monty-pool", version = "0.0.19-beta.2" }
+monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.19-beta.2" }
+monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.19-beta.2" }
 # ruff, ty and related crates
 ruff_python_parser = "0.0.3"
 ruff_python_stdlib = "0.0.3"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-**Experimental** - This project is still in development, and not ready for the prime time.
+**Experimental** - This project is still in development, and not ready for prime time.
 
 A minimal, secure Python interpreter written in Rust for use by AI.
 

--- a/crates/monty-cli/README.md
+++ b/crates/monty-cli/README.md
@@ -1,4 +1,4 @@
-# pydantic-monty-cli
+# pydantic-monty-runtime
 
 The `monty` CLI binary, packaged for PyPI in the same way `uv` and `ruff`
 package theirs: installing this wheel places the compiled binary in the

--- a/crates/monty-cli/pyproject.toml
+++ b/crates/monty-cli/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=1.9.4,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "pydantic-monty-cli"
+name = "pydantic-monty-runtime"
 description = "The monty CLI binary — spawned as worker subprocesses by pydantic-monty"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.19-beta.1",
+  "version": "0.0.19-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pydantic/monty",
-      "version": "0.0.19-beta.1",
+      "version": "0.0.19-beta.2",
       "license": "MIT",
       "devDependencies": {
         "@emnapi/core": "^1.5.0",
@@ -28,12 +28,12 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@pydantic/monty-darwin-arm64": "0.0.19-beta.1",
-        "@pydantic/monty-darwin-x64": "0.0.19-beta.1",
-        "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.1",
-        "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.1",
-        "@pydantic/monty-wasm32-wasi": "0.0.19-beta.1",
-        "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.1"
+        "@pydantic/monty-darwin-arm64": "0.0.19-beta.2",
+        "@pydantic/monty-darwin-x64": "0.0.19-beta.2",
+        "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.2",
+        "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.2",
+        "@pydantic/monty-wasm32-wasi": "0.0.19-beta.2",
+        "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.2"
       }
     },
     "node_modules/@emnapi/core": {

--- a/crates/monty-js/package.json
+++ b/crates/monty-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.19-beta.1",
+  "version": "0.0.19-beta.2",
   "type": "module",
   "description": "Sandboxed Python interpreter running in crash-isolated subprocess workers",
   "main": "dist/index.js",
@@ -102,11 +102,11 @@
     "arrowParens": "always"
   },
   "optionalDependencies": {
-    "@pydantic/monty-darwin-x64": "0.0.19-beta.1",
-    "@pydantic/monty-darwin-arm64": "0.0.19-beta.1",
-    "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.1",
-    "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.1",
-    "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.1",
-    "@pydantic/monty-wasm32-wasi": "0.0.19-beta.1"
+    "@pydantic/monty-darwin-x64": "0.0.19-beta.2",
+    "@pydantic/monty-darwin-arm64": "0.0.19-beta.2",
+    "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.2",
+    "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.2",
+    "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.2",
+    "@pydantic/monty-wasm32-wasi": "0.0.19-beta.2"
   }
 }

--- a/crates/monty-python/README.md
+++ b/crates/monty-python/README.md
@@ -15,7 +15,7 @@ pip install pydantic-monty
 ```
 
 This installs the `monty` worker binary via the
-[`pydantic-monty-cli`](https://pypi.org/project/pydantic-monty-cli/)
+[`pydantic-monty-runtime`](https://pypi.org/project/pydantic-monty-runtime/)
 dependency (the same way `uv` and `ruff` ship their binaries).
 
 ## Usage

--- a/crates/monty-python/pyproject.toml
+++ b/crates/monty-python/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     # ships the `monty` binary spawned as worker subprocesses;
     # kept as a loose pin because the subprocess protocol is version-negotiated
     # in the Hello handshake (a mismatch fails fast with a clear error)
-    "pydantic-monty-cli>=0.0.18",
+    "pydantic-monty-runtime>=0.0.18",
 ]
 dynamic = ["license", "version"]
 
@@ -48,9 +48,9 @@ module-name = "pydantic_monty._monty"
 features = ["pyo3/extension-module"]
 
 [tool.uv.sources]
-# during development the cli package is built from this workspace rather than
-# fetched from PyPI
-pydantic-monty-cli = { workspace = true }
+# during development the runtime package is built from this workspace rather
+# than fetched from PyPI
+pydantic-monty-runtime = { workspace = true }
 
 [dependency-groups]
 dev = [

--- a/crates/monty-python/python/pydantic_monty/_binary.py
+++ b/crates/monty-python/python/pydantic_monty/_binary.py
@@ -1,6 +1,6 @@
 """Locates the `monty` CLI binary that worker pools run as subprocesses.
 
-The binary ships in the `pydantic-monty-cli` wheel (a maturin `bin`-bindings
+The binary ships in the `pydantic-monty-runtime` wheel (a maturin `bin`-bindings
 package, the same pattern `uv` and `ruff` use), which installs it into the
 environment's scripts directory.
 """
@@ -23,7 +23,7 @@ def find_monty_binary(explicit: str | Path | None = None) -> str:
 
     1. the explicit `binary_path` argument, when given
     2. the `MONTY_BIN` environment variable
-    3. the environment's scripts directory (where the `pydantic-monty-cli`
+    3. the environment's scripts directory (where the `pydantic-monty-runtime`
        wheel installs the binary)
     4. a `monty` executable on `PATH`
     5. a cargo-built binary in the monty workspace, when running from an
@@ -46,7 +46,7 @@ def find_monty_binary(explicit: str | Path | None = None) -> str:
         return str(dev)
     raise FileNotFoundError(
         'could not locate the `monty` binary required to run sandboxed code; '
-        'install it with `pip install pydantic-monty-cli` (or `make dev-py` in the monty repo), '
+        'install it with `pip install pydantic-monty-runtime` (or `make dev-py` in the monty repo), '
         'pass binary_path=..., or set the MONTY_BIN environment variable'
     )
 

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -301,7 +301,7 @@ class Monty:
         Arguments:
             binary_path: Path to the `monty` CLI binary. When omitted it is
                 resolved from the `MONTY_BIN` environment variable, the
-                environment's scripts directory (where the `pydantic-monty-cli`
+                environment's scripts directory (where the `pydantic-monty-runtime`
                 dependency installs it), or `PATH`.
             min_processes: Workers spawned eagerly and kept warm.
             max_processes: Cap on live workers (defaults to the CPU count);

--- a/crates/monty/Cargo.toml
+++ b/crates/monty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monty"
-readme = "../../README.md"
+readme = "README.md"
 version = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/monty/README.md
+++ b/crates/monty/README.md
@@ -6,7 +6,7 @@
 
 The core interpreter crate of [Monty](https://github.com/pydantic/monty) — a minimal, secure Python interpreter written in Rust for use by AI.
 
-**Experimental** — this project is still in development, and not ready for the prime time.
+**Experimental** — this project is still in development, and not ready for prime time.
 
 Monty lets you safely run Python code written by an LLM inside your own process, without the cost, latency and complexity of a container based sandbox. It parses Python with [Ruff](https://github.com/astral-sh/ruff)'s parser and executes it on its own bytecode VM — no CPython, no FFI, no C dependencies. Startup takes microseconds, not hundreds of milliseconds.
 

--- a/crates/monty/README.md
+++ b/crates/monty/README.md
@@ -1,0 +1,123 @@
+# monty
+
+[![CI](https://github.com/pydantic/monty/actions/workflows/ci.yml/badge.svg)](https://github.com/pydantic/monty/actions/workflows/ci.yml?query=branch%3Amain)
+[![crates.io](https://img.shields.io/crates/v/monty.svg)](https://crates.io/crates/monty)
+[![license](https://img.shields.io/github/license/pydantic/monty.svg?v=2)](https://github.com/pydantic/monty/blob/main/LICENSE)
+
+The core interpreter crate of [Monty](https://github.com/pydantic/monty) — a minimal, secure Python interpreter written in Rust for use by AI.
+
+**Experimental** — this project is still in development, and not ready for the prime time.
+
+Monty lets you safely run Python code written by an LLM inside your own process, without the cost, latency and complexity of a container based sandbox. It parses Python with [Ruff](https://github.com/astral-sh/ruff)'s parser and executes it on its own bytecode VM — no CPython, no FFI, no C dependencies. Startup takes microseconds, not hundreds of milliseconds.
+
+The sandbox has no ambient access to the host: filesystem, environment and network are only reachable through external function calls and mounts that you explicitly provide.
+
+This crate is the pure-Rust core. Most users want one of the bindings built on top of it:
+
+- **Python**: [`pydantic-monty`](https://pypi.org/project/pydantic-monty/)
+- **JavaScript/TypeScript**: [`@pydantic/monty`](https://www.npmjs.com/package/@pydantic/monty)
+- **CLI**: the `monty` binary from the [`monty-cli`](https://crates.io/crates/monty-cli) crate
+
+See the [project README](https://github.com/pydantic/monty) for the full feature matrix, motivation, and supported Python subset.
+
+## Basic usage
+
+`MontyRun` parses and compiles code once; `run` executes it with input values and returns the value of the final expression as a `MontyObject`:
+
+```rust
+use monty::{MontyRun, MontyObject, NoLimitTracker, PrintWriter};
+
+let code = r#"
+def fib(n):
+    if n <= 1:
+        return n
+    return fib(n - 1) + fib(n - 2)
+
+fib(x)
+"#;
+
+let runner = MontyRun::new(code.to_owned(), "fib.py", vec!["x".to_owned()]).unwrap();
+let result = runner.run(vec![MontyObject::Int(10)], NoLimitTracker, PrintWriter::Stdout).unwrap();
+assert_eq!(result, MontyObject::Int(55));
+```
+
+Errors are returned as `MontyException`, with a traceback matching what CPython would produce. `PrintWriter` controls where `print()` output goes: `Stdout`, `Disabled`, or collected into a `String` / `(stream, text)` tuples for the host to inspect.
+
+## Resource limits
+
+Untrusted code shouldn't be able to hog the host. `LimitedTracker` enforces limits on memory, allocation count, execution time, GC interval and recursion depth; exceeding one terminates execution with a `ResourceError`:
+
+```rust
+use std::time::Duration;
+use monty::{MontyRun, LimitedTracker, PrintWriter, ResourceLimits};
+
+let limits = ResourceLimits {
+    max_memory: Some(10 * 1024 * 1024),
+    max_duration: Some(Duration::from_millis(20)),
+    ..ResourceLimits::new()
+};
+
+let runner = MontyRun::new("while True: pass".to_owned(), "spin.py", vec![]).unwrap();
+let err = runner.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout).unwrap_err();
+assert!(err.to_string().contains("time limit exceeded"));
+```
+
+## External functions and snapshotting
+
+The defining feature of the crate: instead of running to completion, `MontyRun::start` returns a `RunProgress` that pauses execution whenever the sandboxed code calls a function provided by the host. The host runs the real function (an API call, a database query, an LLM tool) and resumes with the result:
+
+```rust
+use monty::{MontyRun, MontyObject, NoLimitTracker, PrintWriter, RunProgress};
+
+let code = "data = get_data(3)\ndata * 2";
+let runner = MontyRun::new(code.to_owned(), "main.py", vec!["get_data".to_owned()]).unwrap();
+
+// pass the external function in as an input
+let get_data = MontyObject::Function { name: "get_data".to_owned(), docstring: None };
+let progress = runner.start(vec![get_data], NoLimitTracker, PrintWriter::Stdout).unwrap();
+
+// execution pauses at the `get_data(3)` call
+let RunProgress::FunctionCall(call) = progress else { panic!("expected a function call") };
+assert_eq!(call.function_name, "get_data");
+assert_eq!(call.args, vec![MontyObject::Int(3)]);
+
+// the host computes the result and resumes
+let progress = call.resume(MontyObject::Int(21), PrintWriter::Stdout).unwrap();
+let RunProgress::Complete(result) = progress else { panic!("expected completion") };
+assert_eq!(result, MontyObject::Int(42));
+```
+
+A paused `RunProgress` is a self-contained snapshot of the interpreter: serialize it with `dump()`, store it in a file or database, and `load()` + resume it later — in a different process or on a different machine. `MontyRun` itself can also be dumped and loaded to cache parsed code:
+
+```rust
+use monty::{MontyRun, MontyObject, NoLimitTracker, PrintWriter};
+
+let runner = MontyRun::new("x + 1".to_owned(), "main.py", vec!["x".to_owned()]).unwrap();
+let bytes = runner.dump().unwrap();
+
+// later, restore and run
+let runner2 = MontyRun::load(&bytes).unwrap();
+let result = runner2.run(vec![MontyObject::Int(41)], NoLimitTracker, PrintWriter::Stdout).unwrap();
+assert_eq!(result, MontyObject::Int(42));
+```
+
+Async host functions are supported too: `FunctionCall::resume_pending` continues execution with a pending future the sandboxed code can `await`; when all tasks are blocked, execution yields `RunProgress::ResolveFutures` for the host to supply results.
+
+## Other pieces
+
+- `MontyRepl` — a REPL-style interface: feed code snippet by snippet with state persisting between snippets.
+- `fs` module — mount real host directories into the sandbox at virtual paths (read-write, read-only, or copy-on-write in-memory overlay), with path resolution hardened against escapes.
+- `RunProgress::OsCall` — filesystem and other `os`-level operations the host can intercept or delegate.
+
+## Related crates
+
+| Crate | Purpose |
+| --- | --- |
+| [`monty-cli`](https://crates.io/crates/monty-cli) | the `monty` binary: run files, REPL, and the subprocess worker mode |
+| [`monty-pool`](https://crates.io/crates/monty-pool) | elastic pool of crash-isolated `monty` worker subprocesses |
+| [`monty-proto`](https://crates.io/crates/monty-proto) | wire protocol between pool and workers |
+| [`monty-type-checking`](https://crates.io/crates/monty-type-checking) | optional type checking powered by [ty](https://docs.astral.sh/ty/) |
+
+## License
+
+MIT

--- a/crates/monty/src/lib.rs
+++ b/crates/monty/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../../../README.md")]
+#![doc = include_str!("../README.md")]
 // these files first because they include macros for the rest of the crate to use
 mod heap;
 mod heap_traits;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,11 @@ version = "0"
 requires-python = ">=3.10"
 
 [tool.uv.workspace]
-members = ["crates/monty-python", "crates/monty-cli"]
+members = [
+    "crates/monty-python",
+    "crates/monty-cli",
+    "hold",
+]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,7 @@ version = "0"
 requires-python = ">=3.10"
 
 [tool.uv.workspace]
-members = [
-    "crates/monty-python",
-    "crates/monty-cli",
-    "hold",
-]
+members = ["crates/monty-python", "crates/monty-cli"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,7 @@ exclude-newer-span = "P7D"
 members = [
     "monty-workspace",
     "pydantic-monty",
-    "pydantic-monty-cli",
+    "pydantic-monty-runtime",
 ]
 
 [[package]]
@@ -1371,7 +1371,7 @@ wheels = [
 name = "pydantic-monty"
 source = { editable = "crates/monty-python" }
 dependencies = [
-    { name = "pydantic-monty-cli" },
+    { name = "pydantic-monty-runtime" },
     { name = "typing-extensions" },
 ]
 
@@ -1388,7 +1388,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "pydantic-monty-cli", editable = "crates/monty-cli" },
+    { name = "pydantic-monty-runtime", editable = "crates/monty-cli" },
     { name = "typing-extensions", specifier = ">=4.5" },
 ]
 
@@ -1404,7 +1404,7 @@ dev = [
 ]
 
 [[package]]
-name = "pydantic-monty-cli"
+name = "pydantic-monty-runtime"
 source = { editable = "crates/monty-cli" }
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix CI by switching the Python runtime wheel from `pydantic-monty-cli` to `pydantic-monty-runtime`, updating all references, and bumping to `0.0.19-beta.2`. Also fixes docs packaging for the `monty` crate and the npm release step that arranges binaries.

- **Bug Fixes**
  - CI installs `pydantic-monty-runtime` in build and smoke tests; npm release "Arrange binaries" now restricts `find` to files so only binaries are moved.
  - Move `monty` README into the crate and update the doc include path, fixing docs/crates.io packaging.

- **Dependencies**
  - Rename and replace `pydantic-monty-cli` with `pydantic-monty-runtime` across `pyproject.toml`, Python sources, `uv.lock`, CI, and docs.
  - Bump versions to `0.0.19-beta.2` across Rust crates and `@pydantic/monty` optional binary packages.

<sup>Written for commit f7aa17a44c58971b54e8bc896f496b2f9dbbd10a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

