### PR TITLE
Add cargo-nextest for Rust tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,2 @@
+[profile.default]
+fail-fast = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,10 +106,6 @@ jobs:
         with:
           tool: cargo-llvm-cov
 
-      - uses: taiki-e/install-action@1ed3272338f573e042a2e6bca3893aa19f43b47a # v2.71.3
-        with:
-          tool: nextest
-
       # this means pyo3 will use Python 3.14 in tests
       - name: set up python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -121,21 +117,21 @@ jobs:
       - run: cargo llvm-cov clean --workspace
 
       # coverage for `make test-no-features`
-      - run: cargo llvm-cov --no-report nextest -p monty
+      - run: cargo llvm-cov --no-report -p monty
       - run: cargo llvm-cov run --no-report -p monty-datatest
       # coverage for `make test-memory-model-checks`
-      - run: cargo llvm-cov --no-report nextest -p monty --features memory-model-checks
+      - run: cargo llvm-cov --no-report -p monty --features memory-model-checks
       - run: cargo llvm-cov run --no-report -p monty-datatest --features memory-model-checks
       # coverage for `make test-ref-count-return`
-      - run: cargo llvm-cov --no-report nextest -p monty --features ref-count-return
+      - run: cargo llvm-cov --no-report -p monty --features ref-count-return
       - run: cargo llvm-cov run --no-report -p monty-datatest --features ref-count-return
       # coverage for `make test-type-checking`
-      - run: cargo llvm-cov --no-report nextest -p monty-type-checking -p monty-typeshed
+      - run: cargo llvm-cov --no-report -p monty-type-checking -p monty-typeshed
       # subprocess protocol + child mode + worker pool. The pool tests spawn a
       # real `monty` binary: build it plainly first (outside the llvm-cov
       # target dir) and point the tests at it explicitly.
       - run: cargo build -p monty-runtime
-      - run: cargo llvm-cov --no-report nextest -p monty-proto -p monty-runtime -p monty-pool
+      - run: cargo llvm-cov --no-report -p monty-proto -p monty-runtime -p monty-pool
         env:
           MONTY_TEST_BIN: ${{ github.workspace }}/target/debug/monty
       # Generating text report:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,10 @@ jobs:
         with:
           tool: cargo-llvm-cov
 
+      - uses: taiki-e/install-action@1ed3272338f573e042a2e6bca3893aa19f43b47a # v2.71.3
+        with:
+          tool: nextest
+
       # this means pyo3 will use Python 3.14 in tests
       - name: set up python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -117,21 +121,21 @@ jobs:
       - run: cargo llvm-cov clean --workspace
 
       # coverage for `make test-no-features`
-      - run: cargo llvm-cov --no-report -p monty
+      - run: cargo llvm-cov --no-report nextest -p monty
       - run: cargo llvm-cov run --no-report -p monty-datatest
       # coverage for `make test-memory-model-checks`
-      - run: cargo llvm-cov --no-report -p monty --features memory-model-checks
+      - run: cargo llvm-cov --no-report nextest -p monty --features memory-model-checks
       - run: cargo llvm-cov run --no-report -p monty-datatest --features memory-model-checks
       # coverage for `make test-ref-count-return`
-      - run: cargo llvm-cov --no-report -p monty --features ref-count-return
+      - run: cargo llvm-cov --no-report nextest -p monty --features ref-count-return
       - run: cargo llvm-cov run --no-report -p monty-datatest --features ref-count-return
       # coverage for `make test-type-checking`
-      - run: cargo llvm-cov --no-report -p monty-type-checking -p monty-typeshed
+      - run: cargo llvm-cov --no-report nextest -p monty-type-checking -p monty-typeshed
       # subprocess protocol + child mode + worker pool. The pool tests spawn a
       # real `monty` binary: build it plainly first (outside the llvm-cov
       # target dir) and point the tests at it explicitly.
       - run: cargo build -p monty-runtime
-      - run: cargo llvm-cov --no-report -p monty-proto -p monty-runtime -p monty-pool
+      - run: cargo llvm-cov --no-report nextest -p monty-proto -p monty-runtime -p monty-pool
         env:
           MONTY_TEST_BIN: ${{ github.workspace }}/target/debug/monty
       # Generating text report:
@@ -311,22 +315,26 @@ jobs:
           lookup-only: false # zizmor: ignore[cache-poisoning] -- Job does not produce release artifacts and does not have sensitive permissions
           cache-on-failure: true
 
+      - uses: taiki-e/install-action@1ed3272338f573e042a2e6bca3893aa19f43b47a # v2.71.3
+        with:
+          tool: nextest
+
       - name: set up python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.14'
 
-      - run: cargo test -p monty --features memory-model-checks
+      - run: cargo nextest run -p monty --features memory-model-checks
       - run: cargo run -p monty-datatest --features memory-model-checks
       - run: cargo build -p monty-runtime
       - name: Test subprocess crates (Unix)
         if: runner.os != 'Windows'
-        run: cargo test -p monty-proto -p monty-runtime -p monty-pool
+        run: cargo nextest run -p monty-proto -p monty-runtime -p monty-pool
         env:
           MONTY_TEST_BIN: ${{ github.workspace }}/target/debug/monty
       - name: Test subprocess crates (Windows)
         if: runner.os == 'Windows'
-        run: cargo test -p monty-proto -p monty-runtime -p monty-pool
+        run: cargo nextest run -p monty-proto -p monty-runtime -p monty-pool
         env:
           MONTY_TEST_BIN: ${{ github.workspace }}\target\debug\monty.exe
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Key rules:
 - Avoid `#[cfg(unix)]`-only code in the main crate — all features must work on all platforms
 - Tests in `crates/monty/tests/` should be cross-platform; use helper functions for
   OS-specific APIs like symlink creation (see `symlink_file`/`symlink_dir` in `fs_security.rs`)
-- CI runs `cargo nextest run -p monty --features memory-model-checks` on Linux, macOS, and Windows
+- CI runs `cargo nextest run -p monty --features memory-model-checks` on macOS and Windows; Linux coverage uses `cargo llvm-cov`
 
 ## Important Security Notice
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Key rules:
 - Avoid `#[cfg(unix)]`-only code in the main crate — all features must work on all platforms
 - Tests in `crates/monty/tests/` should be cross-platform; use helper functions for
   OS-specific APIs like symlink creation (see `symlink_file`/`symlink_dir` in `fs_security.rs`)
-- CI runs `cargo test -p monty --features memory-model-checks` on Linux, macOS, and Windows
+- CI runs `cargo nextest run -p monty --features memory-model-checks` on Linux, macOS, and Windows
 
 ## Important Security Notice
 
@@ -443,7 +443,7 @@ cargo test -p monty
 make test-cases
 
 # Run a specific test
-cargo test -p monty --test TEST str__ops
+cargo nextest run -p monty --test TEST str__ops
 cargo run -p monty-datatest str__ops
 
 # Run the interpreter on a Python file

--- a/Makefile
+++ b/Makefile
@@ -125,17 +125,17 @@ format-lint-py: format-py lint-py ## Format and lint Python code with ruff
 
 .PHONY: test-no-features
 test-no-features: ## Run rust tests without any features enabled
-	cargo test -p monty
+	cargo nextest run -p monty
 	cargo run -p monty-datatest
 
 .PHONY: test-memory-model-checks
 test-memory-model-checks: ## Run rust tests with memory-model-checks enabled - THIS IS EXTREMELY SLOW, SHOULD MOSTLY BE RUN IN CI OR IF ABSOLUTELY NECESSARY
-	cargo test -p monty --features "memory-model-checks test-hooks"
+	cargo nextest run -p monty --features "memory-model-checks test-hooks"
 	cargo run -p monty-datatest --features memory-model-checks
 
 .PHONY: test-ref-count-return
 test-ref-count-return: ## Run rust tests with ref-count-return enabled
-	cargo test -p monty --features ref-count-return
+	cargo nextest run -p monty --features ref-count-return
 	cargo run -p monty-datatest --features ref-count-return
 
 .PHONY: test-cases
@@ -152,12 +152,12 @@ miri-test-cases: ## Run library inline tests under miri (particularly relevant f
 
 .PHONY: test-type-checking
 test-type-checking: ## Run rust tests on monty-type-checking
-	cargo test -p monty-type-checking -p monty-typeshed
+	cargo nextest run -p monty-type-checking -p monty-typeshed
 
 .PHONY: test-subprocess
 test-subprocess: ## Run subprocess protocol, child-mode, and worker-pool tests
 	cargo build -p monty-runtime
-	cargo test -p monty-proto -p monty-runtime -p monty-pool
+	cargo nextest run -p monty-proto -p monty-runtime -p monty-pool
 
 .PHONY: pytest
 pytest: ## Run Python tests with pytest
@@ -177,18 +177,19 @@ test: test-memory-model-checks test-ref-count-return test-no-features test-type-
 .PHONY: testcov
 testcov: ## Run Rust tests with coverage, print table, and generate HTML report
 	@cargo llvm-cov --version > /dev/null 2>&1 || echo 'Please run: `cargo install cargo-llvm-cov`'
+	@cargo nextest --version > /dev/null 2>&1 || echo 'Please run: `cargo install cargo-nextest --locked`'
 	cargo llvm-cov clean --workspace
 	echo "coverage for `make test-no-features`"
-	cargo llvm-cov --no-report -p monty
+	cargo llvm-cov --no-report nextest -p monty
 	cargo llvm-cov run --no-report -p monty-datatest
 	echo "coverage for `make test-memory-model-checks`"
-	cargo llvm-cov --no-report -p monty --features memory-model-checks
+	cargo llvm-cov --no-report nextest -p monty --features memory-model-checks
 	cargo llvm-cov run --no-report -p monty-datatest --features memory-model-checks
 	echo "coverage for `make test-ref-count-return`"
-	cargo llvm-cov --no-report -p monty --features ref-count-return
+	cargo llvm-cov --no-report nextest -p monty --features ref-count-return
 	cargo llvm-cov run --no-report -p monty-datatest --features ref-count-return
 	echo "coverage for `make test-type-checking`"
-	cargo llvm-cov --no-report -p monty-type-checking -p monty-typeshed
+	cargo llvm-cov --no-report nextest -p monty-type-checking -p monty-typeshed
 	echo "Generating reports:"
 	cargo llvm-cov report --ignore-filename-regex '(tests/|test_cases/|/tests\.rs$$)'
 	cargo llvm-cov report --html --ignore-filename-regex '(tests/|test_cases/|/tests\.rs$$)'

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ endif
 .cargo: ## Check that cargo is installed
 	@cargo --version || echo 'Please install cargo: https://github.com/rust-lang/cargo'
 
+.PHONY: .nextest
+.nextest: ## Check that cargo-nextest is installed
+	@cargo nextest --version || echo 'Please install cargo-nextest: https://nexte.st/docs/installation/pre-built-binaries/'
+
 .PHONY: .uv
 .uv: ## Check that uv is installed
 	@uv --version || echo 'Please install uv: https://docs.astral.sh/uv/getting-started/installation/'
@@ -124,17 +128,17 @@ format-lint-rs: format-rs lint-rs ## Format and lint Rust code with fmt and clip
 format-lint-py: format-py lint-py ## Format and lint Python code with ruff
 
 .PHONY: test-no-features
-test-no-features: ## Run rust tests without any features enabled
+test-no-features: .nextest ## Run rust tests without any features enabled
 	cargo nextest run -p monty
 	cargo run -p monty-datatest
 
 .PHONY: test-memory-model-checks
-test-memory-model-checks: ## Run rust tests with memory-model-checks enabled - THIS IS EXTREMELY SLOW, SHOULD MOSTLY BE RUN IN CI OR IF ABSOLUTELY NECESSARY
+test-memory-model-checks: .nextest ## Run rust tests with memory-model-checks enabled - THIS IS EXTREMELY SLOW, SHOULD MOSTLY BE RUN IN CI OR IF ABSOLUTELY NECESSARY
 	cargo nextest run -p monty --features "memory-model-checks test-hooks"
 	cargo run -p monty-datatest --features memory-model-checks
 
 .PHONY: test-ref-count-return
-test-ref-count-return: ## Run rust tests with ref-count-return enabled
+test-ref-count-return: .nextest ## Run rust tests with ref-count-return enabled
 	cargo nextest run -p monty --features ref-count-return
 	cargo run -p monty-datatest --features ref-count-return
 
@@ -151,11 +155,11 @@ miri-test-cases: ## Run library inline tests under miri (particularly relevant f
 	MIRIFLAGS=-Zmiri-disable-isolation cargo +nightly miri run -p monty-datatest -- run_test_cases_monty
 
 .PHONY: test-type-checking
-test-type-checking: ## Run rust tests on monty-type-checking
+test-type-checking: .nextest ## Run rust tests on monty-type-checking
 	cargo nextest run -p monty-type-checking -p monty-typeshed
 
 .PHONY: test-subprocess
-test-subprocess: ## Run subprocess protocol, child-mode, and worker-pool tests
+test-subprocess: .nextest ## Run subprocess protocol, child-mode, and worker-pool tests
 	cargo build -p monty-runtime
 	cargo nextest run -p monty-proto -p monty-runtime -p monty-pool
 
@@ -177,19 +181,18 @@ test: test-memory-model-checks test-ref-count-return test-no-features test-type-
 .PHONY: testcov
 testcov: ## Run Rust tests with coverage, print table, and generate HTML report
 	@cargo llvm-cov --version > /dev/null 2>&1 || echo 'Please run: `cargo install cargo-llvm-cov`'
-	@cargo nextest --version > /dev/null 2>&1 || echo 'Please run: `cargo install cargo-nextest --locked`'
 	cargo llvm-cov clean --workspace
 	echo "coverage for `make test-no-features`"
-	cargo llvm-cov --no-report nextest -p monty
+	cargo llvm-cov --no-report -p monty
 	cargo llvm-cov run --no-report -p monty-datatest
 	echo "coverage for `make test-memory-model-checks`"
-	cargo llvm-cov --no-report nextest -p monty --features memory-model-checks
+	cargo llvm-cov --no-report -p monty --features memory-model-checks
 	cargo llvm-cov run --no-report -p monty-datatest --features memory-model-checks
 	echo "coverage for `make test-ref-count-return`"
-	cargo llvm-cov --no-report nextest -p monty --features ref-count-return
+	cargo llvm-cov --no-report -p monty --features ref-count-return
 	cargo llvm-cov run --no-report -p monty-datatest --features ref-count-return
 	echo "coverage for `make test-type-checking`"
-	cargo llvm-cov --no-report nextest -p monty-type-checking -p monty-typeshed
+	cargo llvm-cov --no-report -p monty-type-checking -p monty-typeshed
 	echo "Generating reports:"
 	cargo llvm-cov report --ignore-filename-regex '(tests/|test_cases/|/tests\.rs$$)'
 	cargo llvm-cov report --html --ignore-filename-regex '(tests/|test_cases/|/tests\.rs$$)'


### PR DESCRIPTION
## Summary
- Add a minimal nextest config with `fail-fast = false` so Rust test runs report the full failure set.
- Switch regular Rust `cargo test`-style Makefile commands and the macOS/Windows Rust CI matrix to `cargo nextest run`.
- Keep Linux coverage on `cargo llvm-cov`'s default test runner after the first PR CI run showed `cargo llvm-cov nextest` was slower there; custom datatest, doctest, miri, Python, JS, and wasm runners stay unchanged.

## Test plan
- `make -n test-no-features test-type-checking test-subprocess testcov`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "workflow yaml ok"'`
- Not run locally: `cargo nextest ...` and `cargo llvm-cov ...` because those cargo subcommands are not installed in this environment.