### PR TITLE
remove cargo config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,0 @@
-[env]
-# Use the project's venv Python for PyO3 builds
-PYO3_PYTHON = { value = ".venv/bin/python3", relative = true }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,6 @@ jobs:
 
       - run: rustc --version --verbose
       - run: python3 -V
-        # don't use .venv python in CI
-      - run: rm .cargo/config.toml
       - run: cargo llvm-cov clean --workspace
 
       # coverage for `make test-no-features`
@@ -182,8 +180,6 @@ jobs:
       - run: rustc --version --verbose
       - run: python3 -V
       - run: uv sync --all-packages --only-dev
-        # don't use .venv python in CI
-      - run: rm .cargo/config.toml
 
       # pydantic-monty depends on pydantic-monty-runtime; install it from the
       # workspace so `maturin develop` can resolve it (plain build, outside
@@ -320,14 +316,6 @@ jobs:
         with:
           python-version: '3.14'
 
-      # don't use .venv python in CI
-      - name: Remove cargo config (Unix)
-        if: runner.os != 'Windows'
-        run: rm .cargo/config.toml
-      - name: Remove cargo config (Windows)
-        if: runner.os == 'Windows'
-        run: Remove-Item .cargo/config.toml
-
       - run: cargo test -p monty --features memory-model-checks
       - run: cargo run -p monty-datatest --features memory-model-checks
       - run: cargo build -p monty-cli
@@ -365,9 +353,6 @@ jobs:
         with:
           python-version: '3.14'
 
-      # don't use .venv python in CI
-      - run: rm .cargo/config.toml
-
       - run: make dev-bench
 
   miri:
@@ -388,9 +373,6 @@ jobs:
         with:
           lookup-only: false # zizmor: ignore[cache-poisoning] -- Job does not produce release artifacts and does not have sensitive permissions
           cache-on-failure: true
-
-      # don't use .venv python in CI
-      - run: rm .cargo/config.toml
 
       - name: Run miri tests
         run: make miri
@@ -427,9 +409,6 @@ jobs:
 
       - if: steps.cache-rust.outputs.cache-hit != 'true'
         run: cargo install cargo-fuzz
-
-      # don't use .venv python in CI
-      - run: rm .cargo/config.toml
 
       - name: Run ${{ matrix.target }} fuzzer
         run: |
@@ -1021,9 +1000,6 @@ jobs:
             .cargo-cache
             target/
           key: wasm32-wasip1-threads-cargo-ubuntu-latest
-
-      # don't use .venv python in CI
-      - run: rm .cargo/config.toml
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -35,9 +35,6 @@ jobs:
         with:
           python-version: '3.14'
 
-      - name: Remove .cargo config to use system Python
-        run: rm .cargo/config.toml
-
       - name: Install cargo-codspeed
         run: cargo install cargo-codspeed
 


### PR DESCRIPTION
I don't think this is needed; makes it annoying to run `make test-cases` in short-lived worktrees because I have to install the venv first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove `.cargo/config.toml` that forced `PyO3` to use the repo `.venv`, so builds use system Python by default. This simplifies short-lived worktrees and removes redundant cleanup in CI.

- **Refactors**
  - Delete `.cargo/config.toml` and its `PYO3_PYTHON` override.
  - Remove all CI steps that deleted this file in `ci.yml` and `codspeed.yml`.
  - Running `make test-cases` no longer requires creating `.venv` first.

<sup>Written for commit 46f329f20505da7b45c70bc16f1bf974a77cc1b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

