### PR TITLE
JSON error data, and type conversion to cpython

### DIFF
--- a/crates/monty-proto/proto/monty/v1/monty.proto
+++ b/crates/monty-proto/proto/monty/v1/monty.proto
@@ -249,7 +249,8 @@ message UnicodeErrorData {
 message JsonErrorData {
   // Bare error message, without the ": line N column M (char K)" suffix.
   string msg = 1;
-  // The document being parsed; absent when larger than the sender's size cap.
+  // The document being parsed; absent when larger than the sender's size cap
+  // or when bytes input is not valid UTF-8.
   optional string doc = 2;
   // Character index of the error in `doc`.
   uint64 pos = 3;

--- a/crates/monty-proto/proto/monty/v1/monty.proto
+++ b/crates/monty-proto/proto/monty/v1/monty.proto
@@ -219,6 +219,7 @@ message RaisedException {
 message ExcData {
   oneof kind {
     UnicodeErrorData unicode = 1;
+    JsonErrorData json = 2;
   }
 }
 
@@ -240,6 +241,21 @@ message UnicodeErrorData {
   uint64 end = 5;
   // CPython's reason wording, e.g. "ordinal not in range(128)".
   string reason = 6;
+}
+
+// CPython's json.JSONDecodeError attribute fields (msg, doc, pos, lineno,
+// colno), letting hosts rebuild the real exception instead of a message-only
+// fallback. Mirrors monty's `JsonErrorData`.
+message JsonErrorData {
+  // Bare error message, without the ": line N column M (char K)" suffix.
+  string msg = 1;
+  // The document being parsed; absent when larger than the sender's size cap.
+  optional string doc = 2;
+  // Character index of the error in `doc`.
+  uint64 pos = 3;
+  // 1-based line and column of the error.
+  uint64 lineno = 4;
+  uint64 colno = 5;
 }
 
 // 1-based line/column source position (columns count characters, not bytes).

--- a/crates/monty-proto/src/convert/exception.rs
+++ b/crates/monty-proto/src/convert/exception.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use monty::{CodeLoc, ExcData, MontyException, StackFrame, UnicodeErrorData, UnicodeErrorObject};
+use monty::{CodeLoc, ExcData, JsonErrorData, MontyException, StackFrame, UnicodeErrorData, UnicodeErrorObject};
 
 use crate::{convert::ProtoConvertError, pb};
 
@@ -40,6 +40,7 @@ impl TryFrom<pb::RaisedException> for MontyException {
             Some(pb::exc_data::Kind::Unicode(unicode)) => {
                 sanitize_unicode_data(unicode).map_or(ExcData::None, ExcData::Unicode)
             }
+            Some(pb::exc_data::Kind::Json(json)) => sanitize_json_data(json).map_or(ExcData::None, ExcData::Json),
             None => ExcData::None,
         };
         Ok(Self::with_traceback(exc_type, err.message, traceback).with_data(data))
@@ -56,7 +57,60 @@ fn pb_exc_data(data: &ExcData) -> Option<pb::ExcData> {
                 unicode.as_ref(),
             ))),
         }),
+        ExcData::Json(json) => Some(pb::ExcData {
+            kind: Some(pb::exc_data::Kind::Json(pb::JsonErrorData::from(json.as_ref()))),
+        }),
     }
+}
+
+impl From<&JsonErrorData> for pb::JsonErrorData {
+    fn from(data: &JsonErrorData) -> Self {
+        Self {
+            msg: data.msg.clone(),
+            doc: data.doc.clone(),
+            pos: data.pos as u64,
+            lineno: data.lineno as u64,
+            colno: data.colno as u64,
+        }
+    }
+}
+
+/// Validates an untrusted wire `JsonErrorData`, returning `None` when any
+/// field is out of range. As with [`sanitize_unicode_data`], size caps stop a
+/// compromised child pinning large amounts of parent memory: legitimate `msg`
+/// values are short static phrases, and legitimate senders drop `doc` above
+/// [`JsonErrorData::MAX_DOC_LEN`].
+fn sanitize_json_data(data: pb::JsonErrorData) -> Option<Box<JsonErrorData>> {
+    if data.msg.len() > JsonErrorData::MAX_DOC_LEN {
+        return None;
+    }
+    if data
+        .doc
+        .as_ref()
+        .is_some_and(|doc| doc.len() > JsonErrorData::MAX_DOC_LEN)
+    {
+        return None;
+    }
+    let pos = usize::try_from(data.pos).ok()?;
+    let lineno = usize::try_from(data.lineno).ok()?;
+    let colno = usize::try_from(data.colno).ok()?;
+    // CPython's lineno/colno are 1-based; pos is a character index into doc
+    // and may equal its length (errors at end of input).
+    if lineno == 0 || colno == 0 {
+        return None;
+    }
+    if let Some(doc) = &data.doc
+        && pos > doc.chars().count()
+    {
+        return None;
+    }
+    Some(Box::new(JsonErrorData {
+        msg: data.msg,
+        doc: data.doc,
+        pos,
+        lineno,
+        colno,
+    }))
 }
 
 impl From<&UnicodeErrorData> for pb::UnicodeErrorData {

--- a/crates/monty-proto/src/generated/monty.v1.rs
+++ b/crates/monty-proto/src/generated/monty.v1.rs
@@ -181,7 +181,7 @@ pub struct RaisedException {
 /// payload" (`ExcData::None`).
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ExcData {
-    #[prost(oneof = "exc_data::Kind", tags = "1")]
+    #[prost(oneof = "exc_data::Kind", tags = "1, 2")]
     pub kind: ::core::option::Option<exc_data::Kind>,
 }
 /// Nested message and enum types in `ExcData`.
@@ -190,6 +190,8 @@ pub mod exc_data {
     pub enum Kind {
         #[prost(message, tag = "1")]
         Unicode(super::UnicodeErrorData),
+        #[prost(message, tag = "2")]
+        Json(super::JsonErrorData),
     }
 }
 /// CPython's UnicodeDecodeError/UnicodeEncodeError constructor fields
@@ -224,6 +226,26 @@ pub mod unicode_error_data {
         #[prost(string, tag = "3")]
         ObjectStr(::prost::alloc::string::String),
     }
+}
+/// CPython's json.JSONDecodeError attribute fields (msg, doc, pos, lineno,
+/// colno), letting hosts rebuild the real exception instead of a message-only
+/// fallback. Mirrors monty's `JsonErrorData`.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct JsonErrorData {
+    /// Bare error message, without the ": line N column M (char K)" suffix.
+    #[prost(string, tag = "1")]
+    pub msg: ::prost::alloc::string::String,
+    /// The document being parsed; absent when larger than the sender's size cap.
+    #[prost(string, optional, tag = "2")]
+    pub doc: ::core::option::Option<::prost::alloc::string::String>,
+    /// Character index of the error in `doc`.
+    #[prost(uint64, tag = "3")]
+    pub pos: u64,
+    /// 1-based line and column of the error.
+    #[prost(uint64, tag = "4")]
+    pub lineno: u64,
+    #[prost(uint64, tag = "5")]
+    pub colno: u64,
 }
 /// 1-based line/column source position (columns count characters, not bytes).
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]

--- a/crates/monty-proto/src/generated/monty.v1.rs
+++ b/crates/monty-proto/src/generated/monty.v1.rs
@@ -235,7 +235,8 @@ pub struct JsonErrorData {
     /// Bare error message, without the ": line N column M (char K)" suffix.
     #[prost(string, tag = "1")]
     pub msg: ::prost::alloc::string::String,
-    /// The document being parsed; absent when larger than the sender's size cap.
+    /// The document being parsed; absent when larger than the sender's size cap
+    /// or when bytes input is not valid UTF-8.
     #[prost(string, optional, tag = "2")]
     pub doc: ::core::option::Option<::prost::alloc::string::String>,
     /// Character index of the error in `doc`.

--- a/crates/monty-proto/src/python/exceptions.rs
+++ b/crates/monty-proto/src/python/exceptions.rs
@@ -269,7 +269,7 @@ fn py_err_to_exc_type(exc: &Bound<'_, exceptions::PyBaseException>) -> ExcType {
                 ExcType::NotADirectoryError
             } else if exceptions::PyPermissionError::type_check(exc) {
                 ExcType::PermissionError
-            // TimeoutError is an OSError subclass since Python 3.10, so it must
+            // TimeoutError is an OSError subclass since Python 3.3, so it must
             // be matched here — a standalone check after this branch is dead code
             } else if exceptions::PyTimeoutError::type_check(exc) {
                 ExcType::TimeoutError

--- a/crates/monty-proto/src/python/exceptions.rs
+++ b/crates/monty-proto/src/python/exceptions.rs
@@ -7,7 +7,7 @@
 //! snapshots). The Python-facing `MontyError` class hierarchy stays in
 //! `pydantic-monty` — this module only maps values.
 
-use monty::{ExcData, ExcType, MontyException, MontyObject, UnicodeErrorObject};
+use monty::{ExcData, ExcType, JsonErrorData, MontyException, MontyObject, UnicodeErrorObject};
 use pyo3::{
     PyTypeCheck,
     exceptions::{self},
@@ -61,7 +61,7 @@ pub fn exc_monty_to_py(py: Python<'_>, mut exc: MontyException) -> PyErr {
         ExcType::TypeError => exceptions::PyTypeError::new_err(msg),
         ExcType::ValueError => exceptions::PyValueError::new_err(msg),
         ExcType::UnicodeDecodeError | ExcType::UnicodeEncodeError => unicode_error_to_py(py, exc_type, exc_data, msg),
-        ExcType::JsonDecodeError => json_decode_error_to_py(py, msg),
+        ExcType::JsonDecodeError => json_decode_error_to_py(py, exc_data, msg),
         ExcType::ImportError => exceptions::PyImportError::new_err(msg),
         ExcType::ModuleNotFoundError => exceptions::PyModuleNotFoundError::new_err(msg),
         ExcType::OSError => exceptions::PyOSError::new_err(msg),
@@ -120,39 +120,28 @@ fn unicode_error_to_py(py: Python<'_>, exc_type: ExcType, exc_data: ExcData, msg
     exceptions::PyValueError::new_err(msg)
 }
 
-/// Builds a real `json.JSONDecodeError` from Monty's formatted message.
+/// Builds a real `json.JSONDecodeError` from the structured [`JsonErrorData`]
+/// Monty attaches to decode errors.
 ///
-/// The constructor requires `(msg, doc, pos)` and rebuilds the message and
-/// `lineno`/`colno` itself, but Monty only carries the formatted message —
-/// so we parse the location back out, construct with a placeholder, and
-/// overwrite the location attributes. `doc` is left as `''` since the
-/// original document is not preserved. Falls back to a plain `ValueError`
-/// when the message doesn't match CPython's shape (e.g. an exception raised
-/// manually inside the sandbox) or construction fails.
-fn json_decode_error_to_py(py: Python<'_>, msg: String) -> PyErr {
-    if let Ok(exc_cls) = get_json_decode_error(py)
-        && let Some((short_msg, line, column, pos)) = parse_json_decode_msg(&msg)
-        && let Ok(exc_instance) = exc_cls.call1((short_msg, "", 0))
-        && exc_instance.setattr("lineno", line).is_ok()
-        && exc_instance.setattr("colno", column).is_ok()
-        && exc_instance.setattr("pos", pos).is_ok()
+/// The constructor requires `(msg, doc, pos)` and recomputes `lineno`/`colno`
+/// and the formatted message from `doc` — correct when the payload carries
+/// the document, but wrong when `doc` was dropped (documents over
+/// `JsonErrorData::MAX_DOC_LEN`). The location attributes and `args` are
+/// therefore overwritten with the payload/message values, which are right in
+/// both cases. Falls back to a plain `ValueError` when the payload is absent
+/// (an exception raised manually inside the sandbox) or construction fails.
+fn json_decode_error_to_py(py: Python<'_>, exc_data: ExcData, msg: String) -> PyErr {
+    if let ExcData::Json(data) = exc_data
+        && let Ok(exc_cls) = get_json_decode_error(py)
+        && let Ok(exc_instance) = exc_cls.call1((&data.msg, data.doc.as_deref().unwrap_or(""), data.pos))
+        && exc_instance.setattr("lineno", data.lineno).is_ok()
+        && exc_instance.setattr("colno", data.colno).is_ok()
         && exc_instance.setattr("args", (PyString::new(py, &msg),)).is_ok()
     {
         PyErr::from_value(exc_instance)
     } else {
         exceptions::PyValueError::new_err(msg)
     }
-}
-
-/// Splits a `JSONDecodeError` message formatted by Monty
-/// (`{msg}: line {lineno} column {colno} (char {pos})`, matching CPython)
-/// back into its parts. Returns `None` when the message doesn't match.
-fn parse_json_decode_msg(msg: &str) -> Option<(&str, u64, u64, u64)> {
-    let (short_msg, rest) = msg.rsplit_once(": line ")?;
-    let (line, rest) = rest.split_once(" column ")?;
-    let (column, rest) = rest.split_once(" (char ")?;
-    let pos = rest.strip_suffix(')')?;
-    Some((short_msg, line.parse().ok()?, column.parse().ok()?, pos.parse().ok()?))
 }
 
 /// Converts a python exception to monty.
@@ -162,8 +151,32 @@ pub fn exc_py_to_monty(py: Python<'_>, py_err: &PyErr) -> MontyException {
     let exc = py_err.value(py);
     let exc_type = py_err_to_exc_type(exc);
     let arg = exc.str().ok().map(|s| s.to_string_lossy().into_owned());
+    let data = if exc_type == ExcType::JsonDecodeError {
+        json_data_from_py(exc)
+    } else {
+        ExcData::None
+    };
 
-    MontyException::new(exc_type, arg)
+    MontyException::new(exc_type, arg).with_data(data)
+}
+
+/// Reads the structured `msg`/`doc`/`pos`/`lineno`/`colno` attributes off a
+/// host-raised `json.JSONDecodeError` so they survive the trip into the
+/// sandbox and back out as a real exception. Returns [`ExcData::None`] when
+/// any attribute is missing or mistyped; over-long documents are dropped
+/// (matching the cap Monty applies when raising) while the rest is kept.
+fn json_data_from_py(exc: &Bound<'_, exceptions::PyBaseException>) -> ExcData {
+    let extract = || -> PyResult<JsonErrorData> {
+        let doc: String = exc.getattr("doc")?.extract()?;
+        Ok(JsonErrorData {
+            msg: exc.getattr("msg")?.extract()?,
+            doc: (doc.len() <= JsonErrorData::MAX_DOC_LEN).then_some(doc),
+            pos: exc.getattr("pos")?.extract()?,
+            lineno: exc.getattr("lineno")?.extract()?,
+            colno: exc.getattr("colno")?.extract()?,
+        })
+    };
+    extract().map_or(ExcData::None, |data| ExcData::Json(Box::new(data)))
 }
 
 /// Converts a Python exception to Monty's `MontyObject::Exception`.

--- a/crates/monty-proto/src/python/exceptions.rs
+++ b/crates/monty-proto/src/python/exceptions.rs
@@ -61,15 +61,7 @@ pub fn exc_monty_to_py(py: Python<'_>, mut exc: MontyException) -> PyErr {
         ExcType::TypeError => exceptions::PyTypeError::new_err(msg),
         ExcType::ValueError => exceptions::PyValueError::new_err(msg),
         ExcType::UnicodeDecodeError | ExcType::UnicodeEncodeError => unicode_error_to_py(py, exc_type, exc_data, msg),
-        ExcType::JsonDecodeError => {
-            if let Ok(json_decode_error) = get_json_decode_error(py)
-                && let Ok(exc_instance) = json_decode_error.call1((PyString::new(py, &msg),))
-            {
-                PyErr::from_value(exc_instance)
-            } else {
-                exceptions::PyValueError::new_err(msg)
-            }
-        }
+        ExcType::JsonDecodeError => json_decode_error_to_py(py, msg),
         ExcType::ImportError => exceptions::PyImportError::new_err(msg),
         ExcType::ModuleNotFoundError => exceptions::PyModuleNotFoundError::new_err(msg),
         ExcType::OSError => exceptions::PyOSError::new_err(msg),
@@ -126,6 +118,41 @@ fn unicode_error_to_py(py: Python<'_>, exc_type: ExcType, exc_data: ExcData, msg
         }
     }
     exceptions::PyValueError::new_err(msg)
+}
+
+/// Builds a real `json.JSONDecodeError` from Monty's formatted message.
+///
+/// The constructor requires `(msg, doc, pos)` and rebuilds the message and
+/// `lineno`/`colno` itself, but Monty only carries the formatted message —
+/// so we parse the location back out, construct with a placeholder, and
+/// overwrite the location attributes. `doc` is left as `''` since the
+/// original document is not preserved. Falls back to a plain `ValueError`
+/// when the message doesn't match CPython's shape (e.g. an exception raised
+/// manually inside the sandbox) or construction fails.
+fn json_decode_error_to_py(py: Python<'_>, msg: String) -> PyErr {
+    if let Ok(exc_cls) = get_json_decode_error(py)
+        && let Some((short_msg, line, column, pos)) = parse_json_decode_msg(&msg)
+        && let Ok(exc_instance) = exc_cls.call1((short_msg, "", 0))
+        && exc_instance.setattr("lineno", line).is_ok()
+        && exc_instance.setattr("colno", column).is_ok()
+        && exc_instance.setattr("pos", pos).is_ok()
+        && exc_instance.setattr("args", (PyString::new(py, &msg),)).is_ok()
+    {
+        PyErr::from_value(exc_instance)
+    } else {
+        exceptions::PyValueError::new_err(msg)
+    }
+}
+
+/// Splits a `JSONDecodeError` message formatted by Monty
+/// (`{msg}: line {lineno} column {colno} (char {pos})`, matching CPython)
+/// back into its parts. Returns `None` when the message doesn't match.
+fn parse_json_decode_msg(msg: &str) -> Option<(&str, u64, u64, u64)> {
+    let (short_msg, rest) = msg.rsplit_once(": line ")?;
+    let (line, rest) = rest.split_once(" column ")?;
+    let (column, rest) = rest.split_once(" (char ")?;
+    let pos = rest.strip_suffix(')')?;
+    Some((short_msg, line.parse().ok()?, column.parse().ok()?, pos.parse().ok()?))
 }
 
 /// Converts a python exception to monty.
@@ -229,14 +256,28 @@ fn py_err_to_exc_type(exc: &Bound<'_, exceptions::PyBaseException>) -> ExcType {
                 ExcType::NotADirectoryError
             } else if exceptions::PyPermissionError::type_check(exc) {
                 ExcType::PermissionError
+            // TimeoutError is an OSError subclass since Python 3.10, so it must
+            // be matched here — a standalone check after this branch is dead code
+            } else if exceptions::PyTimeoutError::type_check(exc) {
+                ExcType::TimeoutError
             } else {
                 ExcType::OSError
             }
+        // ImportError hierarchy (check ModuleNotFoundError first as it's a subclass)
+        } else if exceptions::PyImportError::type_check(exc) {
+            if exceptions::PyModuleNotFoundError::type_check(exc) {
+                ExcType::ModuleNotFoundError
+            } else {
+                ExcType::ImportError
+            }
         // other standalone exception types
-        } else if exceptions::PyTimeoutError::type_check(exc) {
-            ExcType::TimeoutError
         } else if exceptions::PyMemoryError::type_check(exc) {
             ExcType::MemoryError
+        } else if exceptions::PyStopIteration::type_check(exc) {
+            ExcType::StopIteration
+        // last as it needs a python isinstance call against an imported class
+        } else if is_re_pattern_error(exc) {
+            ExcType::RePatternError
         } else {
             ExcType::Exception
         }
@@ -266,6 +307,16 @@ fn is_frozen_instance_error(exc: &Bound<'_, exceptions::PyBaseException>) -> boo
 fn is_json_decode_error(exc: &Bound<'_, exceptions::PyBaseException>) -> bool {
     if let Ok(json_decode_error_cls) = get_json_decode_error(exc.py()) {
         exc.is_instance(json_decode_error_cls).unwrap_or(false)
+    } else {
+        false
+    }
+}
+
+/// Checks if an exception is a `re.PatternError` (a stdlib class, not a
+/// PyO3 built-in, so looked up lazily and cached).
+fn is_re_pattern_error(exc: &Bound<'_, exceptions::PyBaseException>) -> bool {
+    if let Ok(re_pattern_error_cls) = get_re_pattern_error(exc.py()) {
+        exc.is_instance(re_pattern_error_cls).unwrap_or(false)
     } else {
         false
     }

--- a/crates/monty-proto/tests/oracle/monty.v1.rs
+++ b/crates/monty-proto/tests/oracle/monty.v1.rs
@@ -332,7 +332,8 @@ pub struct JsonErrorData {
     /// Bare error message, without the ": line N column M (char K)" suffix.
     #[prost(string, tag = "1")]
     pub msg: ::prost::alloc::string::String,
-    /// The document being parsed; absent when larger than the sender's size cap.
+    /// The document being parsed; absent when larger than the sender's size cap
+    /// or when bytes input is not valid UTF-8.
     #[prost(string, optional, tag = "2")]
     pub doc: ::core::option::Option<::prost::alloc::string::String>,
     /// Character index of the error in `doc`.

--- a/crates/monty-proto/tests/oracle/monty.v1.rs
+++ b/crates/monty-proto/tests/oracle/monty.v1.rs
@@ -278,7 +278,7 @@ pub struct RaisedException {
 /// payload" (`ExcData::None`).
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ExcData {
-    #[prost(oneof = "exc_data::Kind", tags = "1")]
+    #[prost(oneof = "exc_data::Kind", tags = "1, 2")]
     pub kind: ::core::option::Option<exc_data::Kind>,
 }
 /// Nested message and enum types in `ExcData`.
@@ -287,6 +287,8 @@ pub mod exc_data {
     pub enum Kind {
         #[prost(message, tag = "1")]
         Unicode(super::UnicodeErrorData),
+        #[prost(message, tag = "2")]
+        Json(super::JsonErrorData),
     }
 }
 /// CPython's UnicodeDecodeError/UnicodeEncodeError constructor fields
@@ -321,6 +323,26 @@ pub mod unicode_error_data {
         #[prost(string, tag = "3")]
         ObjectStr(::prost::alloc::string::String),
     }
+}
+/// CPython's json.JSONDecodeError attribute fields (msg, doc, pos, lineno,
+/// colno), letting hosts rebuild the real exception instead of a message-only
+/// fallback. Mirrors monty's `JsonErrorData`.
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct JsonErrorData {
+    /// Bare error message, without the ": line N column M (char K)" suffix.
+    #[prost(string, tag = "1")]
+    pub msg: ::prost::alloc::string::String,
+    /// The document being parsed; absent when larger than the sender's size cap.
+    #[prost(string, optional, tag = "2")]
+    pub doc: ::core::option::Option<::prost::alloc::string::String>,
+    /// Character index of the error in `doc`.
+    #[prost(uint64, tag = "3")]
+    pub pos: u64,
+    /// 1-based line and column of the error.
+    #[prost(uint64, tag = "4")]
+    pub lineno: u64,
+    #[prost(uint64, tag = "5")]
+    pub colno: u64,
 }
 /// 1-based line/column source position (columns count characters, not bytes).
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]

--- a/crates/monty-proto/tests/roundtrip.rs
+++ b/crates/monty-proto/tests/roundtrip.rs
@@ -1,9 +1,9 @@
 use std::time::Duration;
 
 use monty::{
-    CodeLoc, DictPairs, ExcData, ExcType, ExtFunctionResult, MontyDate, MontyDateTime, MontyException, MontyFileHandle,
-    MontyObject, MontyRun, MontyTimeDelta, MontyTimeZone, MontyType, NameLookupResult, ResourceLimits, StackFrame,
-    UnicodeErrorData,
+    CodeLoc, DictPairs, ExcData, ExcType, ExtFunctionResult, JsonErrorData, MontyDate, MontyDateTime, MontyException,
+    MontyFileHandle, MontyObject, MontyRun, MontyTimeDelta, MontyTimeZone, MontyType, NameLookupResult, ResourceLimits,
+    StackFrame, UnicodeErrorData,
 };
 use monty_proto::{MAX_VALUE_DEPTH, ProtoConvertError, WireObject, exceeds_max_value_depth, pb};
 use num_bigint::BigInt;
@@ -343,6 +343,87 @@ fn bogus_unicode_payloads_are_dropped_not_trusted() {
     ))
     .unwrap();
     assert!(matches!(back.data(), ExcData::Unicode(data) if data.start == 1 && data.end == 2));
+}
+
+#[test]
+fn json_error_payload_round_trips() {
+    let data = JsonErrorData {
+        msg: "Expecting value".to_owned(),
+        doc: Some("[1,\n2,]".to_owned()),
+        pos: 6,
+        lineno: 2,
+        colno: 3,
+    };
+    let exc = MontyException::new(
+        ExcType::JsonDecodeError,
+        Some("Expecting value: line 2 column 3 (char 6)".to_owned()),
+    )
+    .with_data(ExcData::Json(Box::new(data)));
+    let back = MontyException::try_from(pb::RaisedException::from(&exc)).unwrap();
+    assert_eq!(back, exc);
+
+    // A payload without a document (dropped for oversized inputs) also survives.
+    let exc = MontyException::new(ExcType::JsonDecodeError, Some("boom".to_owned())).with_data(ExcData::Json(
+        Box::new(JsonErrorData {
+            msg: "Expecting value".to_owned(),
+            doc: None,
+            pos: 100_000,
+            lineno: 5,
+            colno: 2,
+        }),
+    ));
+    let back = MontyException::try_from(pb::RaisedException::from(&exc)).unwrap();
+    assert_eq!(back, exc);
+}
+
+/// Builds a wire `json.JSONDecodeError` whose payload fields a byzantine
+/// child controls, for probing the receive-side sanitizer.
+fn json_exception(msg: String, doc: Option<String>, pos: u64, lineno: u64, colno: u64) -> pb::RaisedException {
+    pb::RaisedException {
+        exc_type: "json.JSONDecodeError".to_owned(),
+        message: Some("boom".to_owned()),
+        traceback: vec![],
+        data: Some(pb::ExcData {
+            kind: Some(pb::exc_data::Kind::Json(pb::JsonErrorData {
+                msg,
+                doc,
+                pos,
+                lineno,
+                colno,
+            })),
+        }),
+    }
+}
+
+#[test]
+fn bogus_json_payloads_are_dropped_not_trusted() {
+    let oversized = "x".repeat(JsonErrorData::MAX_DOC_LEN + 1);
+    // As with unicode payloads, rejected data must not block conversion.
+    let bogus = [
+        json_exception(oversized.clone(), None, 0, 1, 1),
+        json_exception("msg".to_owned(), Some(oversized), 0, 1, 1),
+        // 0 is not a valid 1-based line/column
+        json_exception("msg".to_owned(), None, 0, 0, 1),
+        json_exception("msg".to_owned(), None, 0, 1, 0),
+        // pos beyond the document
+        json_exception("msg".to_owned(), Some("[]".to_owned()), 3, 1, 1),
+    ];
+    for proto in bogus {
+        let back = MontyException::try_from(proto).expect("malformed payload must not block conversion");
+        assert_eq!(back.data(), &ExcData::None);
+    }
+
+    // An in-bounds payload survives sanitization intact; pos may equal the
+    // document length (errors at end of input).
+    let back = MontyException::try_from(json_exception(
+        "Expecting value".to_owned(),
+        Some("[1,".to_owned()),
+        3,
+        1,
+        4,
+    ))
+    .unwrap();
+    assert!(matches!(back.data(), ExcData::Json(data) if data.pos == 3 && data.colno == 4));
 }
 
 #[test]

--- a/crates/monty-python/tests/test_exceptions.py
+++ b/crates/monty-python/tests/test_exceptions.py
@@ -94,6 +94,21 @@ def test_json_decode_error(monty_run: RunMonty):
     assert inner.doc == '[1,\n2,]'
 
 
+def test_json_decode_error_doc_dropped_for_huge_documents(monty_run: RunMonty):
+    # Documents over the payload size cap are not carried: `doc` is '' on the
+    # surfaced exception. The location attributes and message must still be
+    # right — the constructor recomputes them from `doc`, so this exercises
+    # the empty-doc overrides (a multi-line document makes wrong recomputed
+    # values distinguishable: from '' they would be lineno=1, colno=pos+1).
+    with pytest.raises(MontyRuntimeError) as exc_info:
+        monty_run("import json\njson.loads('[' + '1,\\n' * 30000 + 'x')")
+    inner = exc_info.value.exception()
+    assert isinstance(inner, json.JSONDecodeError)
+    assert str(inner) == snapshot('Expecting value: line 30001 column 1 (char 90001)')
+    assert (inner.msg, inner.lineno, inner.colno, inner.pos) == snapshot(('Expecting value', 30001, 1, 90001))
+    assert inner.doc == ''
+
+
 def test_json_decode_error_message_only_fallback(monty_run: RunMonty):
     # A `JSONDecodeError` raised manually inside the sandbox has no location
     # suffix to parse, so `.exception()` falls back to a `ValueError`.

--- a/crates/monty-python/tests/test_exceptions.py
+++ b/crates/monty-python/tests/test_exceptions.py
@@ -79,8 +79,8 @@ def test_unicode_error_message_only_fallback(monty_run: RunMonty):
 
 def test_json_decode_error(monty_run: RunMonty):
     # A `json.loads` failure inside the sandbox surfaces as a real
-    # `json.JSONDecodeError`: the location is parsed back out of the formatted
-    # message, but the original document is not preserved so `doc` is `''`.
+    # `json.JSONDecodeError`: the structured `msg`/`doc`/`pos`/`lineno`/`colno`
+    # fields travel with the exception, like unicode errors above.
     with pytest.raises(MontyRuntimeError) as exc_info:
         monty_run("import json\njson.loads('[1,\\n2,]')")
     inner = exc_info.value.exception()
@@ -91,7 +91,7 @@ def test_json_decode_error(monty_run: RunMonty):
     assert inner.lineno == snapshot(2)
     assert inner.colno == snapshot(2)
     assert inner.pos == snapshot(5)
-    assert inner.doc == ''
+    assert inner.doc == '[1,\n2,]'
 
 
 def test_json_decode_error_message_only_fallback(monty_run: RunMonty):

--- a/crates/monty-python/tests/test_exceptions.py
+++ b/crates/monty-python/tests/test_exceptions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 from conftest import RunMonty
 from inline_snapshot import snapshot
@@ -72,6 +74,34 @@ def test_unicode_error_message_only_fallback(monty_run: RunMonty):
     inner = exc_info.value.exception()
     assert isinstance(inner, ValueError)
     assert not isinstance(inner, UnicodeDecodeError)
+    assert str(inner) == snapshot('nope')
+
+
+def test_json_decode_error(monty_run: RunMonty):
+    # A `json.loads` failure inside the sandbox surfaces as a real
+    # `json.JSONDecodeError`: the location is parsed back out of the formatted
+    # message, but the original document is not preserved so `doc` is `''`.
+    with pytest.raises(MontyRuntimeError) as exc_info:
+        monty_run("import json\njson.loads('[1,\\n2,]')")
+    inner = exc_info.value.exception()
+    assert isinstance(inner, json.JSONDecodeError)
+    assert isinstance(inner, ValueError)
+    assert str(inner) == snapshot('Illegal trailing comma before end of array: line 2 column 2 (char 5)')
+    assert inner.msg == snapshot('Illegal trailing comma before end of array')
+    assert inner.lineno == snapshot(2)
+    assert inner.colno == snapshot(2)
+    assert inner.pos == snapshot(5)
+    assert inner.doc == ''
+
+
+def test_json_decode_error_message_only_fallback(monty_run: RunMonty):
+    # A `JSONDecodeError` raised manually inside the sandbox has no location
+    # suffix to parse, so `.exception()` falls back to a `ValueError`.
+    with pytest.raises(MontyRuntimeError) as exc_info:
+        monty_run("import json\nraise json.JSONDecodeError('nope')")
+    inner = exc_info.value.exception()
+    assert isinstance(inner, ValueError)
+    assert not isinstance(inner, json.JSONDecodeError)
     assert str(inner) == snapshot('nope')
 
 

--- a/crates/monty-python/tests/test_external.py
+++ b/crates/monty-python/tests/test_external.py
@@ -344,6 +344,24 @@ except json.JSONDecodeError as e:
     assert inner.doc == '[1,\n2,]'
 
 
+def test_external_function_json_decode_error_missing_attributes(monty_run: RunMonty):
+    """A host `JSONDecodeError` stripped of one of its attributes crosses into
+    the sandbox message-only (the structured capture is all-or-nothing), so it
+    surfaces back out as the plain `ValueError` fallback."""
+
+    def fail(*args: Any, **kwargs: Any) -> None:
+        exc = json.JSONDecodeError('Expecting value', '[', 1)
+        del exc.pos
+        raise exc
+
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        monty_run('fail()', external_lookup={'fail': fail})
+    inner = exc_info.value.exception()
+    assert type(inner) is ValueError
+    assert not isinstance(inner, json.JSONDecodeError)
+    assert str(inner) == snapshot('Expecting value: line 1 column 2 (char 1)')
+
+
 @pytest.mark.parametrize(
     'exception_class,exception_name',
     [

--- a/crates/monty-python/tests/test_external.py
+++ b/crates/monty-python/tests/test_external.py
@@ -330,17 +330,17 @@ except json.JSONDecodeError as e:
     raise e
 """
 
+    # Constructed directly rather than via `json.loads`, whose message wording
+    # varies across Python versions (3.13/3.14 reworded the error messages).
     def fail(*args: Any, **kwargs: Any) -> None:
-        json.loads('[1,\n2,]')
+        raise json.JSONDecodeError('Expecting value', '[1,\n2,]', 6)
 
     with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
         monty_run(code, external_lookup={'fail': fail})
     inner = exc_info.value.exception()
     assert type(inner) is json.JSONDecodeError
-    assert str(inner) == snapshot('Illegal trailing comma before end of array: line 2 column 2 (char 5)')
-    assert (inner.msg, inner.lineno, inner.colno, inner.pos) == snapshot(
-        ('Illegal trailing comma before end of array', 2, 2, 5)
-    )
+    assert str(inner) == snapshot('Expecting value: line 2 column 3 (char 6)')
+    assert (inner.msg, inner.lineno, inner.colno, inner.pos) == snapshot(('Expecting value', 2, 3, 6))
     assert inner.doc == '[1,\n2,]'
 
 

--- a/crates/monty-python/tests/test_external.py
+++ b/crates/monty-python/tests/test_external.py
@@ -341,6 +341,7 @@ except json.JSONDecodeError as e:
     assert (inner.msg, inner.lineno, inner.colno, inner.pos) == snapshot(
         ('Illegal trailing comma before end of array', 2, 2, 5)
     )
+    assert inner.doc == '[1,\n2,]'
 
 
 @pytest.mark.parametrize(

--- a/crates/monty-python/tests/test_external.py
+++ b/crates/monty-python/tests/test_external.py
@@ -404,7 +404,7 @@ def test_external_function_exception_hierarchy(
         (IndexError, LookupError, 'child'),
         # ImportError hierarchy
         (ModuleNotFoundError, ImportError, 'child'),
-        # OSError hierarchy (TimeoutError is a subclass since Python 3.10)
+        # OSError hierarchy (TimeoutError is a subclass since Python 3.3)
         (TimeoutError, OSError, 'child'),
     ],
 )

--- a/crates/monty-python/tests/test_external.py
+++ b/crates/monty-python/tests/test_external.py
@@ -1,5 +1,6 @@
 import datetime
 import io
+import json
 import pathlib
 import re
 from typing import Any
@@ -317,6 +318,31 @@ caught
     assert monty_run(code, external_lookup={'fail': fail}) == parent
 
 
+def test_external_function_json_decode_error_round_trip(monty_run: RunMonty):
+    """A host-raised `json.JSONDecodeError` survives the host→Monty→host
+    round-trip: the sandbox can catch it as `json.JSONDecodeError`, and the
+    surfaced exception is the real class with its location attributes."""
+    code = """
+import json
+try:
+    fail()
+except json.JSONDecodeError as e:
+    raise e
+"""
+
+    def fail(*args: Any, **kwargs: Any) -> None:
+        json.loads('[1,\n2,]')
+
+    with pytest.raises(pydantic_monty.MontyRuntimeError) as exc_info:
+        monty_run(code, external_lookup={'fail': fail})
+    inner = exc_info.value.exception()
+    assert type(inner) is json.JSONDecodeError
+    assert str(inner) == snapshot('Illegal trailing comma before end of array: line 2 column 2 (char 5)')
+    assert (inner.msg, inner.lineno, inner.colno, inner.pos) == snapshot(
+        ('Illegal trailing comma before end of array', 2, 2, 5)
+    )
+
+
 @pytest.mark.parametrize(
     'exception_class,exception_name',
     [
@@ -332,12 +358,21 @@ caught
         (KeyError, 'KeyError'),
         (IndexError, 'IndexError'),
         (LookupError, 'LookupError'),
+        # ImportError hierarchy
+        (ImportError, 'ImportError'),
+        (ModuleNotFoundError, 'ModuleNotFoundError'),
+        # OSError hierarchy
+        (TimeoutError, 'TimeoutError'),
+        (FileNotFoundError, 'FileNotFoundError'),
+        (OSError, 'OSError'),
         # Other exceptions
         (ValueError, 'ValueError'),
         (TypeError, 'TypeError'),
         (AttributeError, 'AttributeError'),
         (NameError, 'NameError'),
         (AssertionError, 'AssertionError'),
+        (StopIteration, 'StopIteration'),
+        (re.error, 're.PatternError'),
     ],
 )
 def test_external_function_exception_hierarchy(
@@ -366,6 +401,10 @@ def test_external_function_exception_hierarchy(
         # LookupError hierarchy
         (KeyError, LookupError, 'child'),
         (IndexError, LookupError, 'child'),
+        # ImportError hierarchy
+        (ModuleNotFoundError, ImportError, 'child'),
+        # OSError hierarchy (TimeoutError is a subclass since Python 3.10)
+        (TimeoutError, OSError, 'child'),
     ],
 )
 def test_external_function_exception_caught_by_parent(

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -123,13 +123,14 @@ pub enum ExcType {
     /// CPython.
     #[strum(serialize = "io.UnsupportedOperation")]
     UnsupportedOperation,
+    /// Subclass of OSError since Python 3.10 (when it absorbed `socket.timeout`).
+    TimeoutError,
 
     // --- Standalone exception types ---
     AssertionError,
     MemoryError,
     StopIteration,
     SyntaxError,
-    TimeoutError,
     TypeError,
 
     // --- Module-specific exception types ---
@@ -190,7 +191,8 @@ impl ExcType {
             // ImportError catches ModuleNotFoundError
             Self::ImportError => matches!(self, Self::ModuleNotFoundError),
             // OSError catches FileNotFoundError, FileExistsError, IsADirectoryError,
-            // NotADirectoryError, PermissionError, and io.UnsupportedOperation
+            // NotADirectoryError, PermissionError, io.UnsupportedOperation, and
+            // TimeoutError (an OSError subclass since Python 3.10)
             Self::OSError => matches!(
                 self,
                 Self::FileNotFoundError
@@ -199,6 +201,7 @@ impl ExcType {
                     | Self::NotADirectoryError
                     | Self::PermissionError
                     | Self::UnsupportedOperation
+                    | Self::TimeoutError
             ),
             // All other types only match exactly (handled by self == handler_type above)
             _ => false,

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -11,7 +11,7 @@ use crate::{
     args::ArgValues,
     bytecode::{CallResult, VM},
     defer_drop,
-    exception_public::{ExcData, MontyException, SourceMap, StackFrame, UnicodeErrorData},
+    exception_public::{ExcData, JsonErrorData, MontyException, SourceMap, StackFrame, UnicodeErrorData},
     fstring::{FormatError, ascii_escape},
     heap::{HeapData, HeapRead},
     intern::{Interns, StaticStrings, StringId},
@@ -1707,16 +1707,27 @@ impl ExcType {
         SimpleException::new_msg(Self::RePatternError, msg).into()
     }
 
-    /// Creates a `json.JSONDecodeError` with CPython-compatible location suffix.
+    /// Creates a `json.JSONDecodeError` with CPython-compatible location suffix,
+    /// formatted as `{message}: line {line} column {column} (char {index})`.
     ///
-    /// Matches CPython's format:
-    /// `{message}: line {line} column {column} (char {index})`
+    /// The fields also travel in a structured [`JsonErrorData`] payload
+    /// (with `doc` capped) so hosts can rebuild the real `json.JSONDecodeError`
+    /// with its `msg`/`doc`/`pos`/`lineno`/`colno` attributes.
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - The bare error message, without the location suffix
+    /// * `doc` - The document being parsed (CPython's `exc.doc`)
+    /// * `line` - 1-based line of the error (CPython's `exc.lineno`)
+    /// * `column` - 1-based column of the error (CPython's `exc.colno`)
+    /// * `index` - Character index of the error in `doc` (CPython's `exc.pos`)
     #[must_use]
-    pub(crate) fn json_decode_error(message: &str, line: usize, column: usize, index: usize) -> RunError {
+    pub(crate) fn json_decode_error(message: &str, doc: &[u8], line: usize, column: usize, index: usize) -> RunError {
         SimpleException::new_msg(
             Self::JsonDecodeError,
             format!("{message}: line {line} column {column} (char {index})"),
         )
+        .with_data(JsonErrorData::build(message, doc, index, line, column))
         .into()
     }
 

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -123,7 +123,7 @@ pub enum ExcType {
     /// CPython.
     #[strum(serialize = "io.UnsupportedOperation")]
     UnsupportedOperation,
-    /// Subclass of OSError since Python 3.10 (when it absorbed `socket.timeout`).
+    /// Subclass of OSError since Python 3.3 (PEP 3151).
     TimeoutError,
 
     // --- Standalone exception types ---
@@ -192,7 +192,7 @@ impl ExcType {
             Self::ImportError => matches!(self, Self::ModuleNotFoundError),
             // OSError catches FileNotFoundError, FileExistsError, IsADirectoryError,
             // NotADirectoryError, PermissionError, io.UnsupportedOperation, and
-            // TimeoutError (an OSError subclass since Python 3.10)
+            // TimeoutError (an OSError subclass since Python 3.3)
             Self::OSError => matches!(
                 self,
                 Self::FileNotFoundError

--- a/crates/monty/src/exception_public.rs
+++ b/crates/monty/src/exception_public.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     error,
     fmt::{self, Write},
-    mem,
+    mem, str,
     sync::Arc,
 };
 
@@ -31,10 +31,9 @@ pub struct MontyException {
 }
 
 /// Structured payload attached to exception types whose CPython counterparts
-/// carry more than a message. Currently only unicode errors have one; the
-/// enum leaves room for future variants (e.g. `OSError`'s `errno`/`filename`
-/// or `json.JSONDecodeError`'s `lineno`/`colno`/`pos`) without another
-/// field on every exception.
+/// carry more than a message. Currently unicode and json decode errors have
+/// one; the enum leaves room for future variants (e.g. `OSError`'s
+/// `errno`/`filename`) without another field on every exception.
 #[derive(Debug, Clone, Default, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum ExcData {
     /// No structured payload — every exception type without a variant below.
@@ -44,6 +43,9 @@ pub enum ExcData {
     /// Boxed to keep the common `None` case (and every exception embedding
     /// this enum) small.
     Unicode(Box<UnicodeErrorData>),
+    /// `json.JSONDecodeError` attribute fields. Boxed like
+    /// [`ExcData::Unicode`] to keep the enum small.
+    Json(Box<JsonErrorData>),
 }
 
 impl ExcData {
@@ -52,7 +54,16 @@ impl ExcData {
     pub fn unicode(&self) -> Option<&UnicodeErrorData> {
         match self {
             Self::Unicode(data) => Some(data),
-            Self::None => None,
+            _ => None,
+        }
+    }
+
+    /// The json-error fields, if this is [`ExcData::Json`].
+    #[must_use]
+    pub fn json(&self) -> Option<&JsonErrorData> {
+        match self {
+            Self::Json(data) => Some(data),
+            _ => None,
         }
     }
 
@@ -63,6 +74,7 @@ impl ExcData {
         match self {
             Self::None => 0,
             Self::Unicode(data) => data.estimate_size(),
+            Self::Json(data) => data.estimate_size(),
         }
     }
 }
@@ -154,6 +166,63 @@ impl UnicodeErrorData {
             UnicodeErrorObject::Str(s) => s.len(),
         };
         mem::size_of::<Self>() + self.encoding.len() + object_len + self.reason.len()
+    }
+}
+
+/// Structured fields of a `json.JSONDecodeError`, mirroring CPython's `msg` /
+/// `doc` / `pos` / `lineno` / `colno` exception attributes.
+///
+/// As with [`UnicodeErrorData`], the payload exists so host bindings can
+/// construct a real `json.JSONDecodeError` instead of falling back to a plain
+/// `ValueError`; sandboxed code never sees these fields. `lineno`/`colno` are
+/// carried explicitly rather than recomputed from `doc` because `doc` may be
+/// absent (see [`JsonErrorData::MAX_DOC_LEN`]).
+#[derive(Debug, Clone, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct JsonErrorData {
+    /// The bare error message, without the `: line N column M (char K)`
+    /// suffix the formatted exception message carries.
+    pub msg: String,
+    /// The document being parsed, matching CPython's `exc.doc`. `None` when
+    /// the document exceeds [`JsonErrorData::MAX_DOC_LEN`] or is not valid
+    /// UTF-8 (`json.loads` on `bytes` input).
+    pub doc: Option<String>,
+    /// Character index of the error in `doc`, matching CPython's `exc.pos`.
+    pub pos: usize,
+    /// 1-based line of the error, matching CPython's `exc.lineno`.
+    pub lineno: usize,
+    /// 1-based column of the error, matching CPython's `exc.colno`.
+    pub colno: usize,
+}
+
+impl JsonErrorData {
+    /// Document size cap, mirroring [`UnicodeErrorData::MAX_OBJECT_LEN`]:
+    /// exception payloads live outside the sandbox's resource tracker once
+    /// the exception escapes, so `doc` is dropped (not truncated — a partial
+    /// document would misplace `pos`) for larger inputs.
+    pub const MAX_DOC_LEN: usize = 64 * 1024;
+
+    /// Builds the payload for a decode error on `doc`, omitting the document
+    /// when it exceeds [`Self::MAX_DOC_LEN`] or is not valid UTF-8.
+    pub(crate) fn build(msg: &str, doc: &[u8], pos: usize, lineno: usize, colno: usize) -> ExcData {
+        let doc = if doc.len() <= Self::MAX_DOC_LEN {
+            str::from_utf8(doc).ok().map(ToOwned::to_owned)
+        } else {
+            None
+        };
+        ExcData::Json(Box::new(Self {
+            msg: msg.to_owned(),
+            doc,
+            pos,
+            lineno,
+            colno,
+        }))
+    }
+
+    /// Approximate byte footprint, used by the heap's memory accounting when
+    /// an exception carrying this payload is stored on the sandbox heap.
+    #[must_use]
+    pub(crate) fn estimate_size(&self) -> usize {
+        mem::size_of::<Self>() + self.msg.len() + self.doc.as_ref().map_or(0, String::len)
     }
 }
 
@@ -272,6 +341,13 @@ impl MontyException {
     #[must_use]
     pub fn unicode_data(&self) -> Option<&UnicodeErrorData> {
         self.data.unicode()
+    }
+
+    /// Structured `json.JSONDecodeError` fields, present only for decode
+    /// errors raised by `json.loads` (not for manually raised exceptions).
+    #[must_use]
+    pub fn json_data(&self) -> Option<&JsonErrorData> {
+        self.data.json()
     }
 
     /// Removes and returns the structured payload, for consumers (like the

--- a/crates/monty/src/lib.rs
+++ b/crates/monty/src/lib.rs
@@ -38,7 +38,9 @@ mod value;
 pub use crate::run::RefCountOutput;
 pub use crate::{
     exception_private::ExcType,
-    exception_public::{CodeLoc, ExcData, MontyException, StackFrame, UnicodeErrorData, UnicodeErrorObject},
+    exception_public::{
+        CodeLoc, ExcData, JsonErrorData, MontyException, StackFrame, UnicodeErrorData, UnicodeErrorObject,
+    },
     io::{PrintStream, PrintWriter, PrintWriterCallback},
     object::{
         DictPairs, InvalidInputError, MontyDate, MontyDateTime, MontyFileHandle, MontyObject, MontyTimeDelta,

--- a/crates/monty/src/modules/json/load.rs
+++ b/crates/monty/src/modules/json/load.rs
@@ -126,14 +126,14 @@ fn parse_json_bytes(bytes: &[u8], vm: &mut VM<'_, impl ResourceTracker>) -> RunR
     vm.json_string_cache = cache;
     let value = result.map_err(|error| match error {
         JsonLoadError::Parse(error) => json_number_out_of_range_to_run_error(&error, bytes)
-            .unwrap_or_else(|| json_error_to_run_error(&error, &jiter, bytes)),
+            .unwrap_or_else(|| json_error_to_run_error(&error, bytes)),
         JsonLoadError::Run(error) => error,
     })?;
     // The successfully parsed `value` must be dropped via `drop_with` if
     // `finish()` detects trailing data — a plain `?` would leak its refcount.
     if let Err(error) = jiter.finish() {
         value.drop_with(vm);
-        return Err(json_error_to_run_error(&error, &jiter, bytes));
+        return Err(json_error_to_run_error(&error, bytes));
     }
     Ok(value)
 }
@@ -382,14 +382,13 @@ fn is_json_number_byte(byte: u8) -> bool {
 
 /// Converts a `jiter` parse error into `json.JSONDecodeError`.
 ///
-/// `jiter` exposes the error byte index plus a helper for computing line and
-/// column, which is enough to reproduce CPython's message suffix exactly.
-fn json_error_to_run_error(error: &JiterError, jiter: &Jiter<'_>, bytes: &[u8]) -> RunError {
-    let (message, index, column_offset) = match &error.error_type {
+/// `jiter` exposes the error byte index; [`error_coordinates`] converts it to
+/// the character-based `pos`/`lineno`/`colno` CPython reports.
+fn json_error_to_run_error(error: &JiterError, bytes: &[u8]) -> RunError {
+    let (message, index) = match &error.error_type {
         JiterErrorType::JsonError(JsonErrorType::KeyMustBeAString) => (
             "Expecting property name enclosed in double quotes".to_owned(),
             error.index,
-            0,
         ),
         JiterErrorType::JsonError(JsonErrorType::TrailingComma) => {
             let comma_index = find_trailing_comma_index(bytes, error.index).unwrap_or(error.index);
@@ -401,25 +400,22 @@ fn json_error_to_run_error(error: &JiterError, jiter: &Jiter<'_>, bytes: &[u8]) 
                 Some(b']') => "Illegal trailing comma before end of array",
                 _ => "trailing comma",
             };
-            (message.to_owned(), comma_index, 0)
+            (message.to_owned(), comma_index)
         }
         JiterErrorType::JsonError(JsonErrorType::EofWhileParsingString) => (
             "Unterminated string starting at".to_owned(),
             find_unterminated_string_start(bytes, error.index).unwrap_or(error.index),
-            0,
         ),
         JiterErrorType::JsonError(JsonErrorType::EofWhileParsingValue | JsonErrorType::ExpectedSomeValue) => {
-            ("Expecting value".to_owned(), error.index, 0)
+            ("Expecting value".to_owned(), error.index)
         }
-        JiterErrorType::JsonError(JsonErrorType::ExpectedColon) => {
-            ("Expecting ':' delimiter".to_owned(), error.index, 0)
-        }
+        JiterErrorType::JsonError(JsonErrorType::ExpectedColon) => ("Expecting ':' delimiter".to_owned(), error.index),
         JiterErrorType::JsonError(
             JsonErrorType::ExpectedListCommaOrEnd
             | JsonErrorType::ExpectedObjectCommaOrEnd
             | JsonErrorType::EofWhileParsingList
             | JsonErrorType::EofWhileParsingObject,
-        ) => ("Expecting ',' delimiter".to_owned(), error.index, 1),
+        ) => ("Expecting ',' delimiter".to_owned(), error.index),
         JiterErrorType::JsonError(JsonErrorType::InvalidEscape) => {
             let escape_index = find_string_escape_start(bytes, error.index).unwrap_or(error.index);
             let is_unicode_escape = bytes.get(escape_index.saturating_add(1)) == Some(&b'u');
@@ -433,18 +429,41 @@ fn json_error_to_run_error(error: &JiterError, jiter: &Jiter<'_>, bytes: &[u8]) 
             } else {
                 escape_index
             };
-            (message.to_owned(), index, 0)
+            (message.to_owned(), index)
         }
-        JiterErrorType::JsonError(JsonErrorType::TrailingCharacters) => ("Extra data".to_owned(), error.index, 0),
-        JiterErrorType::JsonError(error_type) => (error_type.to_string(), error.index, 0),
-        JiterErrorType::WrongType { .. } => (error.error_type.to_string(), error.index, 0),
+        JiterErrorType::JsonError(JsonErrorType::TrailingCharacters) => ("Extra data".to_owned(), error.index),
+        JiterErrorType::JsonError(error_type) => (error_type.to_string(), error.index),
+        JiterErrorType::WrongType { .. } => (error.error_type.to_string(), error.index),
     };
-    let mut position = jiter.error_position(index);
-    if position.column == 0 {
-        position.column = 1;
+    let (pos, line, column) = error_coordinates(bytes, index);
+    ExcType::json_decode_error(&message, bytes, line, column, pos)
+}
+
+/// CPython-style error coordinates `(pos, lineno, colno)` for a byte offset
+/// into `bytes`: `pos` counts characters (UTF-8 sequence starts, not bytes),
+/// and `colno` is characters since the last newline + 1 — locked to `pos`
+/// exactly as `json.JSONDecodeError.__init__` derives them from `doc`.
+///
+/// This deliberately replaces `jiter`'s `error_position`, which counts bytes
+/// (wrong for multibyte documents) and clamps at end of input (wrong column
+/// for EOF errors).
+fn error_coordinates(bytes: &[u8], byte_index: usize) -> (usize, usize, usize) {
+    let prefix = &bytes[..byte_index.min(bytes.len())];
+    let mut pos = 0;
+    let mut lineno = 1;
+    let mut column_chars = 0;
+    for &byte in prefix {
+        // a character starts at every byte that is not a UTF-8 continuation byte
+        if !matches!(byte, 0x80..=0xBF) {
+            pos += 1;
+            column_chars += 1;
+        }
+        if byte == b'\n' {
+            lineno += 1;
+            column_chars = 0;
+        }
     }
-    position.column += column_offset;
-    ExcType::json_decode_error(&message, bytes, position.line, position.column, index)
+    (pos, lineno, column_chars + 1)
 }
 
 /// Finds the opening quote for an unterminated JSON string.

--- a/crates/monty/src/modules/json/load.rs
+++ b/crates/monty/src/modules/json/load.rs
@@ -444,7 +444,7 @@ fn json_error_to_run_error(error: &JiterError, jiter: &Jiter<'_>, bytes: &[u8]) 
         position.column = 1;
     }
     position.column += column_offset;
-    ExcType::json_decode_error(&message, position.line, position.column, index)
+    ExcType::json_decode_error(&message, bytes, position.line, position.column, index)
 }
 
 /// Finds the opening quote for an unterminated JSON string.

--- a/crates/monty/test_cases/json__loads_invalid_messages.py
+++ b/crates/monty/test_cases/json__loads_invalid_messages.py
@@ -78,6 +78,35 @@ invalid_cases = [
         'True',
         'Expecting value: line 1 column 1 (char 0)',
     ),
+    (
+        '[1 2]',
+        "Expecting ',' delimiter: line 1 column 4 (char 3)",
+    ),
+    (
+        '{"a": 1 "b": 2}',
+        "Expecting ',' delimiter: line 1 column 9 (char 8)",
+    ),
+    (
+        '[1,',
+        'Expecting value: line 1 column 4 (char 3)',
+    ),
+    (
+        '[1,2',
+        "Expecting ',' delimiter: line 1 column 5 (char 4)",
+    ),
+    # positions count characters, not bytes: multibyte input before the error
+    (
+        '["é", x]',
+        'Expecting value: line 1 column 7 (char 6)',
+    ),
+    (
+        '["é" 2]',
+        "Expecting ',' delimiter: line 1 column 6 (char 5)",
+    ),
+    (
+        '["日本語",\n "a", x]',
+        'Expecting value: line 2 column 7 (char 14)',
+    ),
 ]
 
 for source, expected in invalid_cases:

--- a/crates/monty/test_cases/try_except__all.py
+++ b/crates/monty/test_cases/try_except__all.py
@@ -333,6 +333,32 @@ except RuntimeError:
     caught_recursion_by_runtime = True
 assert caught_recursion_by_runtime, 'RuntimeError should catch RecursionError'
 
+# === Exception hierarchy: OSError ===
+# OSError should catch TimeoutError (subclass since Python 3.10)
+caught_timeout_by_oserror = False
+try:
+    raise TimeoutError('timed out')
+except OSError:
+    caught_timeout_by_oserror = True
+assert caught_timeout_by_oserror, 'OSError should catch TimeoutError'
+
+# TimeoutError should still be caught specifically before OSError
+caught_timeout_specifically = False
+try:
+    raise TimeoutError('timed out')
+except TimeoutError:
+    caught_timeout_specifically = True
+except OSError:
+    pass
+assert caught_timeout_specifically, 'TimeoutError handler should match TimeoutError'
+
+try:
+    raise TimeoutError('timed out')
+except TimeoutError as e:
+    assert isinstance(e, TimeoutError), 'exception should be instance of TimeoutError'
+    assert isinstance(e, OSError), 'TimeoutError should be instance of OSError'
+    assert not isinstance(e, ValueError), 'TimeoutError should not be ValueError'
+
 # === Exception hierarchy in tuple ===
 # Tuple containing base class should catch derived
 caught_by_tuple_base = False

--- a/crates/monty/test_cases/try_except__all.py
+++ b/crates/monty/test_cases/try_except__all.py
@@ -334,7 +334,7 @@ except RuntimeError:
 assert caught_recursion_by_runtime, 'RuntimeError should catch RecursionError'
 
 # === Exception hierarchy: OSError ===
-# OSError should catch TimeoutError (subclass since Python 3.10)
+# OSError should catch TimeoutError (subclass since Python 3.3)
 caught_timeout_by_oserror = False
 try:
     raise TimeoutError('timed out')

--- a/crates/monty/tests/json_error_data.rs
+++ b/crates/monty/tests/json_error_data.rs
@@ -65,6 +65,17 @@ fn json_error_doc_omitted_for_huge_documents() {
     assert_eq!(data.pos, JsonErrorData::MAX_DOC_LEN + 1);
 }
 
+/// `bytes` input that is not valid UTF-8 cannot be carried as a `str` `doc`;
+/// the rest of the payload is still attached.
+#[test]
+fn json_error_doc_omitted_for_invalid_utf8() {
+    let exc = run_exc("import json\njson.loads(b'[1, \\xff]')");
+    assert_eq!(exc.exc_type().to_string(), "json.JSONDecodeError");
+    let data = exc.json_data().unwrap();
+    assert_eq!(data.doc, None);
+    assert_eq!(data.pos, 4);
+}
+
 /// A manually raised `JSONDecodeError` is message-only — no payload, so hosts
 /// fall back to a plain `ValueError`.
 #[test]

--- a/crates/monty/tests/json_error_data.rs
+++ b/crates/monty/tests/json_error_data.rs
@@ -1,0 +1,62 @@
+//! Tests for the structured [`JsonErrorData`] payload attached to
+//! `json.JSONDecodeError`, which lets hosts rebuild the real CPython
+//! exception (`msg`/`doc`/`pos`/`lineno`/`colno`) instead of a message-only
+//! fallback. Host-facing payload behavior is invisible to `test_cases/`, so
+//! it is pinned here.
+
+use monty::{JsonErrorData, MontyException, MontyRun};
+
+/// Runs `code` and returns the resulting `MontyException`.
+fn run_exc(code: &str) -> MontyException {
+    MontyRun::new(code.to_owned(), "test.py", vec![])
+        .unwrap()
+        .run_no_limits(vec![])
+        .unwrap_err()
+}
+
+#[test]
+fn json_decode_error_carries_structured_data() {
+    let exc = run_exc("import json\njson.loads('[1,\\n2,]')");
+    assert_eq!(exc.exc_type().to_string(), "json.JSONDecodeError");
+    assert_eq!(
+        exc.message(),
+        Some("Illegal trailing comma before end of array: line 2 column 2 (char 5)")
+    );
+    let data = exc.json_data().unwrap();
+    assert_eq!(data.msg, "Illegal trailing comma before end of array");
+    assert_eq!(data.doc.as_deref(), Some("[1,\n2,]"));
+    assert_eq!(data.pos, 5);
+    assert_eq!(data.lineno, 2);
+    assert_eq!(data.colno, 2);
+}
+
+#[test]
+fn json_error_data_survives_reraise() {
+    let exc = run_exc("import json\ntry:\n    json.loads('nope')\nexcept ValueError as e:\n    raise e");
+    assert_eq!(exc.exc_type().to_string(), "json.JSONDecodeError");
+    assert!(exc.json_data().is_some());
+}
+
+/// Documents larger than `JsonErrorData::MAX_DOC_LEN` are dropped from the
+/// payload (the location fields are kept) so a huge input can't be pinned in
+/// memory, outside the sandbox's resource tracker, by its exception.
+#[test]
+fn json_error_doc_omitted_for_huge_documents() {
+    let exc = run_exc(&format!(
+        "import json\njson.loads('[' + '1,' * {} + 'x')",
+        JsonErrorData::MAX_DOC_LEN / 2
+    ));
+    assert_eq!(exc.exc_type().to_string(), "json.JSONDecodeError");
+    let data = exc.json_data().unwrap();
+    assert_eq!(data.doc, None);
+    assert_eq!(data.pos, JsonErrorData::MAX_DOC_LEN + 1);
+}
+
+/// A manually raised `JSONDecodeError` is message-only — no payload, so hosts
+/// fall back to a plain `ValueError`.
+#[test]
+fn manually_raised_json_decode_error_has_no_data() {
+    let exc = run_exc("import json\nraise json.JSONDecodeError('nope')");
+    assert_eq!(exc.exc_type().to_string(), "json.JSONDecodeError");
+    assert_eq!(exc.json_data(), None);
+}

--- a/crates/monty/tests/json_error_data.rs
+++ b/crates/monty/tests/json_error_data.rs
@@ -30,6 +30,19 @@ fn json_decode_error_carries_structured_data() {
     assert_eq!(data.colno, 2);
 }
 
+/// `pos`/`colno` count characters like CPython, not `jiter`'s byte offsets —
+/// multibyte UTF-8 before the error must not inflate them.
+#[test]
+fn json_error_positions_count_characters_not_bytes() {
+    let exc = run_exc("import json\njson.loads('[\"日本語\", x]')");
+    assert_eq!(exc.message(), Some("Expecting value: line 1 column 9 (char 8)"));
+    let data = exc.json_data().unwrap();
+    assert_eq!(data.doc.as_deref(), Some("[\"日本語\", x]"));
+    assert_eq!(data.pos, 8);
+    assert_eq!(data.lineno, 1);
+    assert_eq!(data.colno, 9);
+}
+
 #[test]
 fn json_error_data_survives_reraise() {
     let exc = run_exc("import json\ntry:\n    json.loads('nope')\nexcept ValueError as e:\n    raise e");

--- a/limitations/json.md
+++ b/limitations/json.md
@@ -40,7 +40,14 @@ Rejected with `TypeError` if passed:
 
 Inherits from `ValueError` (catchable as `except ValueError:`). The class
 qualified name is `json.JSONDecodeError`; `__name__` matches CPython.
-Error messages use the same `line N column M (char K)` suffix as CPython.
+Error messages use the same `line N column M (char K)` suffix as CPython
+(counting characters, not bytes).
+
+When the input ends inside an unclosed array or object (`'['`, `'{'`,
+`'{"a"'`, …), Monty always reports `Expecting ',' delimiter`, where CPython
+distinguishes what was expected at that point (`Expecting value`,
+`Expecting property name enclosed in double quotes`,
+`Expecting ':' delimiter`). Positions match; only the message text differs.
 
 Inside the sandbox the exception is message-only: the `msg`, `doc`, `pos`,
 `lineno` and `colno` attributes CPython sets are not available. When a

--- a/limitations/json.md
+++ b/limitations/json.md
@@ -41,3 +41,10 @@ Rejected with `TypeError` if passed:
 Inherits from `ValueError` (catchable as `except ValueError:`). The class
 qualified name is `json.JSONDecodeError`; `__name__` matches CPython.
 Error messages use the same `line N column M (char K)` suffix as CPython.
+
+Inside the sandbox the exception is message-only: the `msg`, `doc`, `pos`,
+`lineno` and `colno` attributes CPython sets are not available. When a
+sandbox `JSONDecodeError` surfaces to the host (e.g. via `pydantic_monty`),
+it is rebuilt as a real `json.JSONDecodeError` with `msg`/`lineno`/`colno`/
+`pos` parsed back out of the message — but the original document is not
+preserved, so `doc` is always `''`.

--- a/limitations/json.md
+++ b/limitations/json.md
@@ -45,6 +45,8 @@ Error messages use the same `line N column M (char K)` suffix as CPython.
 Inside the sandbox the exception is message-only: the `msg`, `doc`, `pos`,
 `lineno` and `colno` attributes CPython sets are not available. When a
 sandbox `JSONDecodeError` surfaces to the host (e.g. via `pydantic_monty`),
-it is rebuilt as a real `json.JSONDecodeError` with `msg`/`lineno`/`colno`/
-`pos` parsed back out of the message — but the original document is not
-preserved, so `doc` is always `''`.
+it is rebuilt as a real `json.JSONDecodeError` with all five attributes from
+a structured payload attached at raise time — except that documents larger
+than 64 KiB are not carried, in which case `doc` is `''`. A `JSONDecodeError`
+raised manually inside the sandbox has no payload and surfaces as a plain
+`ValueError` carrying the message.


### PR DESCRIPTION
Fixes from Cubic comments on #549.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured JSON decode error payloads and rebuilds real `json.JSONDecodeError` across host↔Monty; JSON error coordinates now count characters, matching CPython. Fixes Python exception type detection to align with CPython’s hierarchy.

- **New Features**
  - Added `ExcData::Json` payload (`msg`, `doc`, `pos`, `lineno`, `colno`) and proto `JsonErrorData`; sanitized on receive.
  - Cap `doc` at 64 KiB and drop it for non‑UTF‑8 inputs; location fields still propagate and the message stays correct.
  - Python bindings rebuild a real `json.JSONDecodeError`; host-raised errors round-trip with payload.

- **Bug Fixes**
  - Report JSON error coordinates in characters (not bytes) to match CPython; fixes wrong columns with multibyte input and some EOF cases.
  - Corrected exception mapping and subclass checks: `TimeoutError` as an `OSError` subclass; added detection for `ImportError`/`ModuleNotFoundError`, `StopIteration`, and `re.PatternError`.
  - Stabilized JSON round‑trip test on Python 3.10–3.12 by constructing `JSONDecodeError` directly.

<sup>Written for commit dd8aa434504e1bfe096d6a4a23436c504ba8784f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



