### PR TITLE
use web-time for the resource-tracker clock so max_duration works on wasm32-unknown-unknown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,6 +2022,7 @@ dependencies = [
  "unicode-general-category",
  "unicode-normalization",
  "unicode_names2",
+ "web-time",
 ]
 
 [[package]]

--- a/crates/monty/Cargo.toml
+++ b/crates/monty/Cargo.toml
@@ -42,6 +42,12 @@ speedate = "0.17.0"
 itertools = "0.14.0"
 jiter = { version = "0.15.0", features = ["num-bigint"] }
 monty-macros = { workspace = true }
+# Portable monotonic clock: a drop-in for `std::time::Instant` that re-exports
+# std unchanged on native and WASI, and is backed by `performance.now()` on
+# `wasm32-unknown-unknown` (where `std::time::Instant::now()` panics). Keeps the
+# `max_duration` resource limit usable when `monty` is embedded directly in a
+# browser wasm module rather than run over WASI.
+web-time = "1.1"
 
 [features]
 # ref-count-return changes behavior to return information on reference counts to check they're correct

--- a/crates/monty/Cargo.toml
+++ b/crates/monty/Cargo.toml
@@ -42,11 +42,12 @@ speedate = "0.17.0"
 itertools = "0.14.0"
 jiter = { version = "0.15.0", features = ["num-bigint"] }
 monty-macros = { workspace = true }
-# Portable monotonic clock: a drop-in for `std::time::Instant` that re-exports
-# std unchanged on native and WASI, and is backed by `performance.now()` on
-# `wasm32-unknown-unknown` (where `std::time::Instant::now()` panics). Keeps the
-# `max_duration` resource limit usable when `monty` is embedded directly in a
-# browser wasm module rather than run over WASI.
+
+# `std::time::Instant` panics on `wasm32-unknown-unknown`, so the resource
+# tracker uses `web_time::Instant` (a `performance.now()`-backed drop-in) there
+# to keep `max_duration` working when `monty` is embedded directly in a browser
+# wasm module. Only that target needs it; every other target uses std directly.
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 web-time = "1.1"
 
 [features]

--- a/crates/monty/src/resource.rs
+++ b/crates/monty/src/resource.rs
@@ -1,11 +1,13 @@
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+use std::time::Instant;
 use std::{cell::Cell, error::Error, fmt, time::Duration};
 
-// `web_time::Instant` is `std::time::Instant` on native and WASI targets, and a
-// `performance.now()`-backed clock on `wasm32-unknown-unknown`, where the std
-// `Instant::now()` panics ("time not implemented on this platform"). This keeps
-// the `max_duration` time limit working when `monty` is embedded directly in a
-// browser wasm module. Time behavior on all currently-supported targets is
-// unchanged (it re-exports std verbatim there).
+// `std::time::Instant::now()` panics ("time not implemented on this platform")
+// on `wasm32-unknown-unknown`, so any `max_duration` limit aborts there. Swap in
+// `web_time::Instant` (a `performance.now()`-backed drop-in) only for that
+// target; every other target (native, WASI) keeps std, so the `web-time`
+// dependency is pulled in only where it's needed (see Cargo.toml).
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use web_time::Instant;
 
 use crate::{

--- a/crates/monty/src/resource.rs
+++ b/crates/monty/src/resource.rs
@@ -1,9 +1,12 @@
-use std::{
-    cell::Cell,
-    error::Error,
-    fmt,
-    time::{Duration, Instant},
-};
+use std::{cell::Cell, error::Error, fmt, time::Duration};
+
+// `web_time::Instant` is `std::time::Instant` on native and WASI targets, and a
+// `performance.now()`-backed clock on `wasm32-unknown-unknown`, where the std
+// `Instant::now()` panics ("time not implemented on this platform"). This keeps
+// the `max_duration` time limit working when `monty` is embedded directly in a
+// browser wasm module. Time behavior on all currently-supported targets is
+// unchanged (it re-exports std verbatim there).
+use web_time::Instant;
 
 use crate::{
     ExcType, MontyException,


### PR DESCRIPTION
`LimitedTracker` enforces `ResourceLimits::max_duration` via `std::time::Instant` (`crates/monty/src/resource.rs`). On `wasm32-unknown-unknown`, `Instant::now()` panics (`time not implemented on this platform`), so any run configured with a duration limit aborts. monty's wasm CI targets `wasm32-wasip1`, where `Instant` is implemented, so this path is green upstream and the gap is invisible there.

## Use case

We embed the `monty` crate directly as a `wasm32-unknown-unknown` wasm-bindgen module for in-process, browser-side Python in a cell (not the WASI/worker path). There, `max_duration` is the *only* limit that stops a non-allocating runaway such as `while True: pass` — `max_allocations` / `max_memory` never fire on it — and we can't arm it without panicking.

## Change

Swap the tracker clock to [`web_time::Instant`](https://crates.io/crates/web-time), a drop-in that re-exports `std::time::Instant` verbatim on native and WASI and is backed by `performance.now()` on `wasm32-unknown-unknown`. No behavior change on any currently-supported target.

## Verification

- Native: all resource-limit tests pass unchanged (incl. every `timeout_*` case and `suspension_time_does_not_count_toward_max_duration`).
- `wasm32-wasip1` (supported wasm target) and native compile clean; `clippy -D warnings` clean.
- `web_time::Instant` confirmed compiling for `wasm32-unknown-unknown` with monty's exact usage (`Instant::now()`, `Cell<Option<Instant>>`, `.elapsed()`).

I see the time code is in flux for the 0.19 subprocess model (#483) — happy to retarget or adjust timing to suit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the resource tracker to `web-time::Instant` so `max_duration` works on `wasm32-unknown-unknown` without panicking. No behavior change on native or `wasm32-wasip1`; restores duration limits for browser-embedded `monty`.

- **Bug Fixes**
  - Replace `std::time::Instant` with `web_time::Instant` in the tracker to avoid `Instant::now()` panic on `wasm32-unknown-unknown`.
  - Enables reliable timeouts for non-allocating runaways (e.g., `while True: pass`) in browser builds.

- **Dependencies**
  - Add `web-time` v1.1 as a target-gated dependency for `wasm32-unknown-unknown`; import `web_time::Instant` only there and use `std::time::Instant` everywhere else.

<sup>Written for commit ba9ba9aedf3352566b10c81f2badffdbe26a3008. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

