### PR TITLE
Prep for `0.0.19-beta.3`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "monty"
-version = "0.0.19-beta.2"
+version = "0.0.19-beta.3"
 dependencies = [
  "ahash",
  "chrono",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "monty-bench"
-version = "0.0.19-beta.2"
+version = "0.0.19-beta.3"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "monty-cpython"
-version = "0.0.19-beta.2"
+version = "0.0.19-beta.3"
 dependencies = [
  "ahash",
  "clap",
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "monty-datatest"
-version = "0.0.19-beta.2"
+version = "0.0.19-beta.3"
 dependencies = [
  "ahash",
  "chrono",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "monty-fuzz"
-version = "0.0.19-beta.2"
+version = "0.0.19-beta.3"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "monty-js"
-version = "0.0.19-beta.2"
+version = "0.0.19-beta.3"
 dependencies = [
  "monty",
  "monty-pool",
@@ -2093,7 +2093,7 @@ dependencies = [
 
 [[package]]
 name = "monty-macros"
-version = "0.0.19-beta.2"
+version = "0.0.19-beta.3"
 dependencies = [
  "insta",
  "proc-macro2",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "monty-pool"
-version = "0.0.19-beta.2"
+version = "0.0.19-beta.3"
 dependencies = [
  "monty",
  "monty-proto",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "monty-proto"
-version = "0.0.19-beta.2"
+version = "0.0.19-beta.3"
 dependencies = [
  "monty",
  "monty-type-checking",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "monty-runtime"
-version = "0.0.19-beta.2"
+version = "0.0.19-beta.3"
 dependencies = [
  "clap",
  "monty",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "monty-type-checking"
-version = "0.0.19-beta.2"
+version = "0.0.19-beta.3"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "monty-typeshed"
-version = "0.0.19-beta.2"
+version = "0.0.19-beta.3"
 dependencies = [
  "path-slash",
  "ruff_db",
@@ -2168,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "monty-wasm-runtime"
-version = "0.0.19-beta.2"
+version = "0.0.19-beta.3"
 dependencies = [
  "monty-proto",
  "prost",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-monty"
-version = "0.0.19-beta.2"
+version = "0.0.19-beta.3"
 dependencies = [
  "ahash",
  "monty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = ["crates/monty-runtime"]
 
 [workspace.package]
 edition = "2024"
-version = "0.0.19-beta.2"
+version = "0.0.19-beta.3"
 rust-version = "1.95"
 license = "MIT"
 authors = ["Samuel Colvin <samuel@pydantic.dev>"]
@@ -48,12 +48,12 @@ lto = false
 # rejects path-only dependencies). These versions MUST be kept in lockstep with
 # `workspace.package.version` above and bumped together on each release — see
 # RELEASING.md.
-monty = { path = "crates/monty", version = "0.0.19-beta.2" }
-monty-macros = { path = "crates/monty-macros", version = "0.0.19-beta.2" }
-monty-proto = { path = "crates/monty-proto", version = "0.0.19-beta.2" }
-monty-pool = { path = "crates/monty-pool", version = "0.0.19-beta.2" }
-monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.19-beta.2" }
-monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.19-beta.2" }
+monty = { path = "crates/monty", version = "0.0.19-beta.3" }
+monty-macros = { path = "crates/monty-macros", version = "0.0.19-beta.3" }
+monty-proto = { path = "crates/monty-proto", version = "0.0.19-beta.3" }
+monty-pool = { path = "crates/monty-pool", version = "0.0.19-beta.3" }
+monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.19-beta.3" }
+monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.19-beta.3" }
 # ruff, ty and related crates
 ruff_python_parser = "0.0.3"
 ruff_python_stdlib = "0.0.3"

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.19-beta.2",
+  "version": "0.0.19-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pydantic/monty",
-      "version": "0.0.19-beta.2",
+      "version": "0.0.19-beta.3",
       "license": "MIT",
       "devDependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.1",
@@ -29,11 +29,11 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@pydantic/monty-darwin-arm64": "0.0.19-beta.2",
-        "@pydantic/monty-darwin-x64": "0.0.19-beta.2",
-        "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.2",
-        "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.2",
-        "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.2"
+        "@pydantic/monty-darwin-arm64": "0.0.19-beta.3",
+        "@pydantic/monty-darwin-x64": "0.0.19-beta.3",
+        "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.3",
+        "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.3",
+        "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2508,90 +2508,19 @@
       "license": "MIT"
     },
     "node_modules/@pydantic/monty-darwin-arm64": {
-      "version": "0.0.19-beta.2",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-arm64/-/monty-darwin-arm64-0.0.19-beta.2.tgz",
-      "integrity": "sha512-KpWsOLCnyk/e0TnBfYLg6PQmPEegsG5iqRulG0g6SeXur617lZ4L/duMBrCmVRfG8F5aVbB1dKEkcXMaELWoYg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-darwin-x64": {
-      "version": "0.0.19-beta.2",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-x64/-/monty-darwin-x64-0.0.19-beta.2.tgz",
-      "integrity": "sha512-aTko0UqJBYHhcE4FpN8ssQ64UTHG/stDkFRrQqP8WTlCGbXpxfgAbW36kZHVS00Sy69DJIcVIaNVoek5K9GtfA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-linux-arm64-gnu": {
-      "version": "0.0.19-beta.2",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-arm64-gnu/-/monty-linux-arm64-gnu-0.0.19-beta.2.tgz",
-      "integrity": "sha512-sfyBDL3Cj60k+zJ/PXvquj82V2KXzopUJx3YO/cg/AnKgXQkmj3D75JXKoF+ZZ/WYiYt5ELrwGw0ekCbCvbPyQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-linux-x64-gnu": {
-      "version": "0.0.19-beta.2",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-x64-gnu/-/monty-linux-x64-gnu-0.0.19-beta.2.tgz",
-      "integrity": "sha512-R6OJ7SimnDTAsUtXa43S3Ql6OPs3e7eejuj/1y7KGCjqibNaWqV2UVeH3/xSiNKrm/6sk7eNjbaf9q8vkmxI9g==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-win32-x64-msvc": {
-      "version": "0.0.19-beta.2",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-win32-x64-msvc/-/monty-win32-x64-msvc-0.0.19-beta.2.tgz",
-      "integrity": "sha512-P0OdjlBQpFdzEJOo2Q/zG+6kEnG9CByZHWS/tfpB2eSyyQoTTPMVE1ukU+S4nWyu9Pv5EvuSNirnEQFkmtj8OQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",

--- a/crates/monty-js/package.json
+++ b/crates/monty-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.19-beta.2",
+  "version": "0.0.19-beta.3",
   "type": "module",
   "description": "Sandboxed Python interpreter running in crash-isolated subprocess workers",
   "main": "dist/index.js",
@@ -91,10 +91,10 @@
     "arrowParens": "always"
   },
   "optionalDependencies": {
-    "@pydantic/monty-darwin-x64": "0.0.19-beta.2",
-    "@pydantic/monty-darwin-arm64": "0.0.19-beta.2",
-    "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.2",
-    "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.2",
-    "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.2"
+    "@pydantic/monty-darwin-x64": "0.0.19-beta.3",
+    "@pydantic/monty-darwin-arm64": "0.0.19-beta.3",
+    "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.3",
+    "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.3",
+    "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.3"
   }
 }

--- a/crates/monty-python/pyproject.toml
+++ b/crates/monty-python/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     # ships the `monty` binary spawned as worker subprocesses; released in
     # lockstep with this package, so the pin is exact and kept in sync with the
     # workspace version by build.rs — don't edit it by hand
-    "pydantic-monty-runtime==0.0.19b.2",
+    "pydantic-monty-runtime==0.0.19b.3",
 ]
 dynamic = ["license", "version"]
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepare release 0.0.19-beta.3 across the monorepo. Aligns versions for Rust crates, the `@pydantic/monty` npm package (incl. platform binaries), and the Python runtime pin.

- **Dependencies**
  - Set workspace and all `monty*` crate versions to `0.0.19-beta.3` in Cargo.toml and Cargo.lock.
  - Bump `@pydantic/monty` to `0.0.19-beta.3` and update optional `@pydantic/monty-*` platform packages to `0.0.19-beta.3`; refresh package-lock.json.
  - Pin `pydantic-monty-runtime==0.0.19b.3` in `crates/monty-python/pyproject.toml`.

<sup>Written for commit f51f4dda6de552ce130d1f5fe24d7f7eafd6c95d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

