### PR TITLE
monty-wasm-runtime publish false, prep 0.0.19-beta.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "monty"
-version = "0.0.19-beta.3"
+version = "0.0.19-beta.4"
 dependencies = [
  "ahash",
  "chrono",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "monty-bench"
-version = "0.0.19-beta.3"
+version = "0.0.19-beta.4"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "monty-cpython"
-version = "0.0.19-beta.3"
+version = "0.0.19-beta.4"
 dependencies = [
  "ahash",
  "clap",
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "monty-datatest"
-version = "0.0.19-beta.3"
+version = "0.0.19-beta.4"
 dependencies = [
  "ahash",
  "chrono",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "monty-fuzz"
-version = "0.0.19-beta.3"
+version = "0.0.19-beta.4"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -2078,7 +2078,7 @@ dependencies = [
 
 [[package]]
 name = "monty-js"
-version = "0.0.19-beta.3"
+version = "0.0.19-beta.4"
 dependencies = [
  "monty",
  "monty-pool",
@@ -2093,7 +2093,7 @@ dependencies = [
 
 [[package]]
 name = "monty-macros"
-version = "0.0.19-beta.3"
+version = "0.0.19-beta.4"
 dependencies = [
  "insta",
  "proc-macro2",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "monty-pool"
-version = "0.0.19-beta.3"
+version = "0.0.19-beta.4"
 dependencies = [
  "monty",
  "monty-proto",
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "monty-proto"
-version = "0.0.19-beta.3"
+version = "0.0.19-beta.4"
 dependencies = [
  "monty",
  "monty-type-checking",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "monty-runtime"
-version = "0.0.19-beta.3"
+version = "0.0.19-beta.4"
 dependencies = [
  "clap",
  "monty",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "monty-type-checking"
-version = "0.0.19-beta.3"
+version = "0.0.19-beta.4"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "monty-typeshed"
-version = "0.0.19-beta.3"
+version = "0.0.19-beta.4"
 dependencies = [
  "path-slash",
  "ruff_db",
@@ -2168,7 +2168,7 @@ dependencies = [
 
 [[package]]
 name = "monty-wasm-runtime"
-version = "0.0.19-beta.3"
+version = "0.0.19-beta.4"
 dependencies = [
  "monty-proto",
  "prost",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-monty"
-version = "0.0.19-beta.3"
+version = "0.0.19-beta.4"
 dependencies = [
  "ahash",
  "monty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default-members = ["crates/monty-runtime"]
 
 [workspace.package]
 edition = "2024"
-version = "0.0.19-beta.3"
+version = "0.0.19-beta.4"
 rust-version = "1.95"
 license = "MIT"
 authors = ["Samuel Colvin <samuel@pydantic.dev>"]
@@ -48,12 +48,12 @@ lto = false
 # rejects path-only dependencies). These versions MUST be kept in lockstep with
 # `workspace.package.version` above and bumped together on each release — see
 # RELEASING.md.
-monty = { path = "crates/monty", version = "0.0.19-beta.3" }
-monty-macros = { path = "crates/monty-macros", version = "0.0.19-beta.3" }
-monty-proto = { path = "crates/monty-proto", version = "0.0.19-beta.3" }
-monty-pool = { path = "crates/monty-pool", version = "0.0.19-beta.3" }
-monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.19-beta.3" }
-monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.19-beta.3" }
+monty = { path = "crates/monty", version = "0.0.19-beta.4" }
+monty-macros = { path = "crates/monty-macros", version = "0.0.19-beta.4" }
+monty-proto = { path = "crates/monty-proto", version = "0.0.19-beta.4" }
+monty-pool = { path = "crates/monty-pool", version = "0.0.19-beta.4" }
+monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.19-beta.4" }
+monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.19-beta.4" }
 # ruff, ty and related crates
 ruff_python_parser = "0.0.3"
 ruff_python_stdlib = "0.0.3"

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.19-beta.3",
+  "version": "0.0.19-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pydantic/monty",
-      "version": "0.0.19-beta.3",
+      "version": "0.0.19-beta.4",
       "license": "MIT",
       "devDependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.1",
@@ -29,11 +29,11 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@pydantic/monty-darwin-arm64": "0.0.19-beta.3",
-        "@pydantic/monty-darwin-x64": "0.0.19-beta.3",
-        "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.3",
-        "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.3",
-        "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.3"
+        "@pydantic/monty-darwin-arm64": "0.0.19-beta.4",
+        "@pydantic/monty-darwin-x64": "0.0.19-beta.4",
+        "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.4",
+        "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.4",
+        "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.4"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/crates/monty-js/package.json
+++ b/crates/monty-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.19-beta.3",
+  "version": "0.0.19-beta.4",
   "type": "module",
   "description": "Sandboxed Python interpreter running in crash-isolated subprocess workers",
   "main": "dist/index.js",
@@ -91,10 +91,10 @@
     "arrowParens": "always"
   },
   "optionalDependencies": {
-    "@pydantic/monty-darwin-x64": "0.0.19-beta.3",
-    "@pydantic/monty-darwin-arm64": "0.0.19-beta.3",
-    "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.3",
-    "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.3",
-    "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.3"
+    "@pydantic/monty-darwin-x64": "0.0.19-beta.4",
+    "@pydantic/monty-darwin-arm64": "0.0.19-beta.4",
+    "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.4",
+    "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.4",
+    "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.4"
   }
 }

--- a/crates/monty-python/pyproject.toml
+++ b/crates/monty-python/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     # ships the `monty` binary spawned as worker subprocesses; released in
     # lockstep with this package, so the pin is exact and kept in sync with the
     # workspace version by build.rs — don't edit it by hand
-    "pydantic-monty-runtime==0.0.19b.3",
+    "pydantic-monty-runtime==0.0.19b.4",
 ]
 dynamic = ["license", "version"]
 

--- a/crates/monty-wasm-runtime/Cargo.toml
+++ b/crates/monty-wasm-runtime/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "monty-wasm-runtime"
+# Used by the monty-js build which is distributed via npm, not crates.io
+publish = false
 version = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepare the 0.0.19-beta.4 release across the workspace and prevent publishing `monty-wasm-runtime` to crates.io. Keeps Rust, JS, and Python packages aligned and avoids accidental crate releases for the WASM runtime used by `@pydantic/monty`.

- **Dependencies**
  - Bump all workspace crates to 0.0.19-beta.4 (`Cargo.toml`, `Cargo.lock`).
  - Update `@pydantic/monty` and optional native packages to 0.0.19-beta.4 (`package.json`, `package-lock.json`); pin `monty-python` to `pydantic-monty-runtime==0.0.19b.4`.
  - Set `publish = false` for `monty-wasm-runtime` (bundled via npm, not crates.io).

<sup>Written for commit 385d6ce9282995e064240e0a9868a7de8f8b14b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

