### PR TITLE
build and release the `monty-cpython` container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -838,6 +838,61 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
+  release-containers:
+    name: release monty-cpython image to GHCR
+    needs: [check]
+    if: success() && (startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.run_release))
+    runs-on: ubuntu-latest
+
+    environment:
+      name: release-containers
+      url: https://github.com/pydantic/monty/pkgs/container/monty-cpython
+
+    # the workflow's own GITHUB_TOKEN authenticates the push to ghcr.io,
+    # no long-lived registry credential required
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # guard against the git tag and the workspace Cargo.toml version drifting apart
+      - id: check-version
+        uses: samuelcolvin/check-python-version@ee87cddb8049d2694cc03badc8569765a05cef00 # v5
+        with:
+          version_file_path: 'Cargo.toml'
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # derives the image tag (`vX.Y.Z[-pre]`) from the git tag; `latest` is
+      # added automatically only for stable (non-prerelease) releases
+      - id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/pydantic/monty-cpython
+          tags: type=semver,pattern=v{{version}}
+
+      # no build cache: this job publishes a release artifact, so layers must
+      # not be sourced from a poisonable cache (same policy as the other
+      # release jobs, see the zizmor cache-poisoning comments above)
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: crates/monty-cpython/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   test-js:
     name: test JS on ${{ matrix.os }} - node@${{ matrix.node }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,12 +431,16 @@ jobs:
       - test-browser
       - bench-test
       - fuzz
+      - build-cpython-image
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
+          # build-cpython-image only runs on main / tags / `Full Build` PRs;
+          # a skip on regular PRs must not fail the aggregate check
+          allowed-skips: build-cpython-image
 
   # Build source distribution
   build-sdist:
@@ -838,60 +842,48 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
-  release-containers:
-    name: release monty-cpython image to GHCR
-    needs: [check]
-    if: success() && (startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.run_release))
+  # Builds the monty-cpython image so Dockerfile, base-image and build-context
+  # regressions surface on main (or a `Full Build` PR), not first at release
+  # time. The Dockerfile's own smoke test (`monty-cpython --help` + uv + venv
+  # checks) runs as part of the build. The image is exported as a run artifact;
+  # on releases `release-containers` publishes this exact tested tarball rather
+  # than rebuilding. Deliberately uncached: the artifact is a release
+  # candidate, so layers must not come from a poisonable cache.
+  build-cpython-image:
+    name: build monty-cpython image
+    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'Full Build') || (github.event_name == 'workflow_dispatch' && inputs.run_release)
     runs-on: ubuntu-latest
-
-    environment:
-      name: release-containers
-      url: https://github.com/pydantic/monty/pkgs/container/monty-cpython
-
-    # the workflow's own GITHUB_TOKEN authenticates the push to ghcr.io,
-    # no long-lived registry credential required
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      # guard against the git tag and the workspace Cargo.toml version drifting apart
-      - id: check-version
-        uses: samuelcolvin/check-python-version@ee87cddb8049d2694cc03badc8569765a05cef00 # v5
-        with:
-          version_file_path: 'Cargo.toml'
-
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      # derives the image tag (`vX.Y.Z[-pre]`) from the git tag; `latest` is
-      # added automatically only for stable (non-prerelease) releases
+      # OCI labels (source repo, revision, licence) are baked in at build time
+      # since the release job pushes this image as-is
       - id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/pydantic/monty-cpython
-          tags: type=semver,pattern=v{{version}}
 
-      # no build cache: this job publishes a release artifact, so layers must
-      # not be sourced from a poisonable cache (same policy as the other
-      # release jobs, see the zizmor cache-poisoning comments above)
+      # `type=docker` produces a `docker load`-able tarball under the fixed
+      # `monty-cpython:ci` name; the release job retags it for publishing
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: crates/monty-cpython/Dockerfile
           platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: monty-cpython:ci
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=docker,dest=/tmp/monty-cpython-image.tar
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: cpython-image
+          path: /tmp/monty-cpython-image.tar
+          if-no-files-found: error
 
   test-js:
     name: test JS on ${{ matrix.os }} - node@${{ matrix.node }}
@@ -1236,3 +1228,64 @@ jobs:
             npm publish "$tarball" --provenance --access public "${TAG_ARG[@]}"
           done
           npm publish package-tarballs/monty-main.tgz --provenance --access public "${TAG_ARG[@]}"
+
+  # Publishes the exact image tarball built and smoke-tested by
+  # `build-cpython-image` — no rebuild, same pattern as the wheel/npm releases.
+  release-containers:
+    name: release monty-cpython image to GHCR
+    needs: [check, build-cpython-image, release-python]
+    if: success() && (startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.run_release))
+    runs-on: ubuntu-latest
+
+    environment:
+      name: release-containers
+      url: https://github.com/pydantic/monty/pkgs/container/monty-cpython
+
+    # the workflow's own GITHUB_TOKEN authenticates the push to ghcr.io,
+    # no long-lived registry credential required
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # guard against the git tag and the workspace Cargo.toml version drifting apart
+      - id: check-version
+        uses: samuelcolvin/check-python-version@ee87cddb8049d2694cc03badc8569765a05cef00 # v5
+        with:
+          version_file_path: 'Cargo.toml'
+
+      - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # derives the image tag (`vX.Y.Z[-pre]`) from the git tag; `latest` is
+      # added automatically only for stable (non-prerelease) releases
+      - id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/pydantic/monty-cpython
+          tags: type=semver,pattern=v{{version}}
+
+      - name: Download tested image tarball
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cpython-image
+          path: /tmp
+
+      # push the tested tarball under each release tag; layers upload once,
+      # subsequent tags are metadata-only
+      - name: Load, retag and push tested image
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          docker load --input /tmp/monty-cpython-image.tar
+          while read -r tag; do
+            docker tag monty-cpython:ci "$tag"
+            docker push "$tag"
+          done <<< "$TAGS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,6 +417,41 @@ jobs:
           # catching panics, not memory bugs.
           cargo fuzz run --fuzz-dir crates/fuzz --sanitizer none ${{ matrix.target }} -- -max_total_time=60
 
+  build-cpython-image:
+    name: build monty-cpython image
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      # OCI labels (source repo, revision, licence) are baked in at build time
+      # since the release job pushes this image as-is
+      - id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/pydantic/monty-cpython
+
+      # `type=docker` produces a `docker load`-able tarball under the fixed
+      # `monty-cpython:ci` name; the release job retags it for publishing
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: crates/monty-cpython/Dockerfile
+          platforms: linux/amd64
+          tags: monty-cpython:ci
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=docker,dest=/tmp/monty-cpython-image.tar
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: cpython-image
+          path: /tmp/monty-cpython-image.tar
+          if-no-files-found: error
+
   # https://github.com/marketplace/actions/alls-green#why used for branch protection checks
   check:
     if: always()
@@ -438,9 +473,6 @@ jobs:
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
-          # build-cpython-image only runs on main / tags / `Full Build` PRs;
-          # a skip on regular PRs must not fail the aggregate check
-          allowed-skips: build-cpython-image
 
   # Build source distribution
   build-sdist:
@@ -842,49 +874,6 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
-  # Builds the monty-cpython image so Dockerfile, base-image and build-context
-  # regressions surface on main (or a `Full Build` PR), not first at release
-  # time. The Dockerfile's own smoke test (`monty-cpython --help` + uv + venv
-  # checks) runs as part of the build. The image is exported as a run artifact;
-  # on releases `release-containers` publishes this exact tested tarball rather
-  # than rebuilding. Deliberately uncached: the artifact is a release
-  # candidate, so layers must not come from a poisonable cache.
-  build-cpython-image:
-    name: build monty-cpython image
-    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'Full Build') || (github.event_name == 'workflow_dispatch' && inputs.run_release)
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-
-      # OCI labels (source repo, revision, licence) are baked in at build time
-      # since the release job pushes this image as-is
-      - id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: ghcr.io/pydantic/monty-cpython
-
-      # `type=docker` produces a `docker load`-able tarball under the fixed
-      # `monty-cpython:ci` name; the release job retags it for publishing
-      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          file: crates/monty-cpython/Dockerfile
-          platforms: linux/amd64
-          tags: monty-cpython:ci
-          labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=docker,dest=/tmp/monty-cpython-image.tar
-
-      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: cpython-image
-          path: /tmp/monty-cpython-image.tar
-          if-no-files-found: error
-
   test-js:
     name: test JS on ${{ matrix.os }} - node@${{ matrix.node }}
     strategy:
@@ -1241,8 +1230,6 @@ jobs:
       name: release-containers
       url: https://github.com/pydantic/monty/pkgs/container/monty-cpython
 
-    # the workflow's own GITHUB_TOKEN authenticates the push to ghcr.io,
-    # no long-lived registry credential required
     permissions:
       contents: read
       packages: write

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -2508,19 +2508,90 @@
       "license": "MIT"
     },
     "node_modules/@pydantic/monty-darwin-arm64": {
-      "optional": true
+      "version": "0.0.19-beta.4",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-arm64/-/monty-darwin-arm64-0.0.19-beta.4.tgz",
+      "integrity": "sha512-lkNGSwQLQoGZKjhZaBIqI3hE6IU74GnpMRdTEDjqjsREB42tpRHOiFL2chWc9NXza56ph3AzX/JSKlh/FQp8bg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@pydantic/monty-darwin-x64": {
-      "optional": true
+      "version": "0.0.19-beta.4",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-x64/-/monty-darwin-x64-0.0.19-beta.4.tgz",
+      "integrity": "sha512-Vok4Po7uqqzuvPjVtouJ+CKcZk3RoCFkpAQsV3CCx8dRKJS7bjDcRLwVGKomqxYxaE94/Utr7oiS4fOAQogkSA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@pydantic/monty-linux-arm64-gnu": {
-      "optional": true
+      "version": "0.0.19-beta.4",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-arm64-gnu/-/monty-linux-arm64-gnu-0.0.19-beta.4.tgz",
+      "integrity": "sha512-yY1cSk8toNczVXTRKM5K6LAWKM+8EwVMCRu3kgbERBy39hgF4Z2sG3Phx5a20OLe+ff8eC1N3kDoAYkYs9SpyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@pydantic/monty-linux-x64-gnu": {
-      "optional": true
+      "version": "0.0.19-beta.4",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-x64-gnu/-/monty-linux-x64-gnu-0.0.19-beta.4.tgz",
+      "integrity": "sha512-Uhj2uOn5TYCcmD4MGe124Y/EvKNCILdHnJluhmVgyJLjqJYGE/7x1jOKhVM1Mxp+bk4gvi0B2k8qcoM6De8fzg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@pydantic/monty-win32-x64-msvc": {
-      "optional": true
+      "version": "0.0.19-beta.4",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-win32-x64-msvc/-/monty-win32-x64-msvc-0.0.19-beta.4.tgz",
+      "integrity": "sha512-PppMgYZE2NgqbrIbM0NDbB/z7O2i/WfrJY15Con8nu9TdCaiW/ZFMPWGPwIq5rNuIXmh44r4uSZ8oFFZXVePag==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -2508,90 +2508,19 @@
       "license": "MIT"
     },
     "node_modules/@pydantic/monty-darwin-arm64": {
-      "version": "0.0.19-beta.4",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-arm64/-/monty-darwin-arm64-0.0.19-beta.4.tgz",
-      "integrity": "sha512-lkNGSwQLQoGZKjhZaBIqI3hE6IU74GnpMRdTEDjqjsREB42tpRHOiFL2chWc9NXza56ph3AzX/JSKlh/FQp8bg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-darwin-x64": {
-      "version": "0.0.19-beta.4",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-x64/-/monty-darwin-x64-0.0.19-beta.4.tgz",
-      "integrity": "sha512-Vok4Po7uqqzuvPjVtouJ+CKcZk3RoCFkpAQsV3CCx8dRKJS7bjDcRLwVGKomqxYxaE94/Utr7oiS4fOAQogkSA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-linux-arm64-gnu": {
-      "version": "0.0.19-beta.4",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-arm64-gnu/-/monty-linux-arm64-gnu-0.0.19-beta.4.tgz",
-      "integrity": "sha512-yY1cSk8toNczVXTRKM5K6LAWKM+8EwVMCRu3kgbERBy39hgF4Z2sG3Phx5a20OLe+ff8eC1N3kDoAYkYs9SpyQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-linux-x64-gnu": {
-      "version": "0.0.19-beta.4",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-x64-gnu/-/monty-linux-x64-gnu-0.0.19-beta.4.tgz",
-      "integrity": "sha512-Uhj2uOn5TYCcmD4MGe124Y/EvKNCILdHnJluhmVgyJLjqJYGE/7x1jOKhVM1Mxp+bk4gvi0B2k8qcoM6De8fzg==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-win32-x64-msvc": {
-      "version": "0.0.19-beta.4",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-win32-x64-msvc/-/monty-win32-x64-msvc-0.0.19-beta.4.tgz",
-      "integrity": "sha512-PppMgYZE2NgqbrIbM0NDbB/z7O2i/WfrJY15Con8nu9TdCaiW/ZFMPWGPwIq5rNuIXmh44r4uSZ8oFFZXVePag==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Builds the `monty-cpython` container on main, tags, or `Full Build` PRs, and publishes the exact built image to GHCR on tagged releases or manual runs. Verifies the git tag matches the `Cargo.toml` version.

- **New Features**
  - Adds `build-cpython-image` job from `crates/monty-cpython/Dockerfile` for `linux/amd64`; bakes OCI labels and uploads a `docker load`-able tar artifact.
  - Adds `release-containers` job that loads the artifact and pushes to `ghcr.io/pydantic/monty-cpython`; tags via `docker/metadata-action` as `vX.Y.Z[-pre]`; authenticates with `GITHUB_TOKEN`.
  - Updates the `check` aggregate to include `build-cpython-image`.

<sup>Written for commit 0654531c0c1c5cead71875217e0b2e4142840f9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

