### PR TITLE
remove mod eq optimization

### DIFF
--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -993,13 +993,7 @@ impl<'a> Compiler<'a> {
                 self.compile_expr(right)?;
                 // Restore the full comparison expression's position for traceback caret range
                 self.code.set_location(expr_loc.position, None);
-                // ModEq needs special handling - it has a constant operand
-                if let CmpOperator::ModEq(value) = op {
-                    let const_idx = self.code.add_const(Value::Int(*value))?;
-                    self.code.emit_u16(Opcode::CompareModEq, const_idx)?;
-                } else {
-                    self.code.emit(cmp_operator_to_opcode(op))?;
-                }
+                self.code.emit(cmp_operator_to_opcode(op))?;
             }
 
             Expr::ChainCmp { left, comparisons } => {
@@ -1531,12 +1525,7 @@ impl<'a> Compiler<'a> {
 
             // Emit comparison
             self.code.set_location(position, None);
-            if let CmpOperator::ModEq(value) = op {
-                let const_idx = self.code.add_const(Value::Int(*value))?;
-                self.code.emit_u16(Opcode::CompareModEq, const_idx)?;
-            } else {
-                self.code.emit(cmp_operator_to_opcode(op))?;
-            }
+            self.code.emit(cmp_operator_to_opcode(op))?;
 
             if !is_last {
                 // Short-circuit: if false, jump to cleanup
@@ -4018,8 +4007,6 @@ fn cmp_operator_to_opcode(op: &CmpOperator) -> Opcode {
         CmpOperator::IsNot => Opcode::CompareIsNot,
         CmpOperator::In => Opcode::CompareIn,
         CmpOperator::NotIn => Opcode::CompareNotIn,
-        // ModEq is handled specially at the call site (needs constant operand)
-        CmpOperator::ModEq(_) => unreachable!("ModEq handled at call site"),
     }
 }
 

--- a/crates/monty/src/bytecode/op.rs
+++ b/crates/monty/src/bytecode/op.rs
@@ -151,10 +151,9 @@ pub enum Opcode {
     CompareIn,
     /// Not membership: a not in b.
     CompareNotIn,
-    /// Modulo equality: a % b == k (operand: u16 constant index for k).
+    /// Compatibility opcode for historical `a % b == k` bytecode.
     ///
-    /// This is an optimization for patterns like `x % 3 == 0` which are common
-    /// in Python code. Pops b then a, computes `a % b`, then compares with k.
+    /// New code should emit `BinaryMod`, `LoadConst`, and `CompareEq` instead.
     CompareModEq,
 
     // === Unary Operations (no operand) ===
@@ -717,10 +716,10 @@ impl Opcode {
 
             // === Fixed-effect, U16 operand ===
             (LoadConst, Operand::U16(_)) => 1,
+            (CompareModEq, Operand::U16(_)) => -1,
             (LoadLocalW | LoadGlobal | LoadCell, Operand::U16(_)) => 1,
             (StoreLocalW | StoreGlobal | StoreCell, Operand::U16(_)) => -1,
             (DeleteGlobal, Operand::U16(_)) => 0,
-            (CompareModEq, Operand::U16(_)) => -1,
             (LoadAttr | LoadAttrImport, Operand::U16(_)) => 0,
             (StoreAttr, Operand::U16(_)) => -2,
             // `DictMerge` takes a u16 operand carrying the func_name_id for

--- a/crates/monty/src/bytecode/vm/compare.rs
+++ b/crates/monty/src/bytecode/vm/compare.rs
@@ -107,48 +107,15 @@ impl<T: ResourceTracker> VM<'_, T> {
         Ok(())
     }
 
-    /// Modulo equality comparison: a % b == k
+    /// Executes the legacy modulo-equality opcode as its component operations.
     ///
-    /// This is an optimization for patterns like `x % 3 == 0`. The constant k
-    /// is provided by the caller (fetched from the constant pool using the
-    /// cached code reference in the run loop).
-    ///
-    /// Uses a fast path for Int/Float types via `py_mod_eq`, and falls back to
-    /// computing `py_mod` then comparing with `py_eq` for other types (e.g., LongInt).
+    /// TODO: remove this opcode once serialized bytecode compatibility no longer
+    /// requires it; new compilation should emit the three ordinary operations.
     pub(super) fn compare_mod_eq(&mut self, k: &Value) -> Result<(), RunError> {
         let this = self;
 
-        let rhs = this.pop(); // divisor (b)
-        defer_drop!(rhs, this);
-        let lhs = this.pop(); // dividend (a)
-        defer_drop!(lhs, this);
-
-        // Try fast path for Int/Float types
-        let mod_result = match k {
-            Value::Int(k_val) => lhs.py_mod_eq(rhs, *k_val),
-            _ => None,
-        };
-
-        if let Some(is_equal) = mod_result {
-            // Fast path succeeded
-            this.push(Value::Bool(is_equal));
-            Ok(())
-        } else {
-            // Fallback: compute py_mod then compare with py_eq
-            // This handles LongInt and other Ref types
-            let mod_value = lhs.py_mod(rhs, this);
-
-            match mod_value {
-                Ok(Some(v)) => {
-                    defer_drop!(v, this);
-
-                    let is_equal = v.py_eq(k, this)?;
-                    this.push(Value::Bool(is_equal));
-                    Ok(())
-                }
-                Ok(None) => Err(ExcType::type_error("unsupported operand type(s) for %")),
-                Err(e) => Err(e),
-            }
-        }
+        this.binary_mod()?;
+        this.push(k.clone_with_heap(this.heap));
+        this.compare_eq()
     }
 }

--- a/crates/monty/src/expressions.rs
+++ b/crates/monty/src/expressions.rs
@@ -840,6 +840,4 @@ pub enum CmpOperator {
     IsNot,
     In,
     NotIn,
-    // we should support floats too, either via a Number type, or ModEqInt and ModEqFloat
-    ModEq(i64),
 }

--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -6,8 +6,8 @@ use crate::{
     args::{ArgExprs, CallArg, CallKwarg, Signature},
     builtins::Builtins,
     expressions::{
-        AssignTarget, Callable, CmpOperator, Comprehension, DictItem, Expr, ExprLoc, Identifier, ImportName, Literal,
-        NameScope, Node, Operator, PreparedFunctionDef, PreparedNode, SequenceItem, UnpackTarget,
+        AssignTarget, Callable, Comprehension, DictItem, Expr, ExprLoc, Identifier, ImportName, NameScope, Node,
+        PreparedFunctionDef, PreparedNode, SequenceItem, UnpackTarget,
     },
     fstring::{FStringPart, FormatSpec},
     intern::{InternerBuilder, StringId},
@@ -1003,8 +1003,6 @@ impl<'i, 'g> Prepare<'i, 'g> {
     /// - Function calls are resolved from identifiers to builtin types
     /// - Attribute calls validate that the object is already defined (not a new name)
     /// - Lists and tuples are recursively prepared
-    /// - Modulo equality patterns like `x % n == k` (constant right-hand side) are optimized to
-    ///   `CmpOperator::ModEq`
     ///
     /// # Errors
     /// Returns a NameError if an attribute call references an undefined variable
@@ -1171,32 +1169,6 @@ impl<'i, 'g> Prepare<'i, 'g> {
             }
             Expr::Await(value) => Expr::Await(Box::new(self.prepare_expression(*value)?)),
         };
-
-        // Optimization: Transform `(x % n) == value` with any constant right-hand side into a
-        // specialized ModEq operator.
-        // This is a common pattern in competitive programming (e.g., FizzBuzz checks like `i % 3 == 0`)
-        // and can be executed more efficiently with a single modulo operation + comparison
-        // instead of separate modulo, then equality check.
-        if let Expr::CmpOp { left, op, right } = &expr
-            && op == &CmpOperator::Eq
-            && let Expr::Literal(Literal::Int(value)) = right.expr
-            && let Expr::Op {
-                left: left2,
-                op,
-                right: right2,
-            } = &left.expr
-            && op == &Operator::Mod
-        {
-            let new_expr = Expr::CmpOp {
-                left: left2.clone(),
-                op: CmpOperator::ModEq(value),
-                right: right2.clone(),
-            };
-            return Ok(ExprLoc {
-                position: left.position,
-                expr: new_expr,
-            });
-        }
 
         Ok(ExprLoc { position, expr })
     }

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -283,11 +283,6 @@ pub(crate) trait PyTrait<'h> {
         Ok(None)
     }
 
-    /// Optimized helper for `(a % b) == c` comparisons.
-    fn py_mod_eq(&self, _other: &Self, _right_value: i64) -> Option<bool> {
-        None
-    }
-
     /// Python in-place addition (`__iadd__`).
     ///
     /// # Returns

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -605,25 +605,6 @@ impl<'h> PyTrait<'h> for Value {
         }
     }
 
-    fn py_mod_eq(&self, other: &Self, right_value: i64) -> Option<bool> {
-        match (self, other) {
-            (Self::Int(v1), Self::Int(v2)) => {
-                if let Some(r) = v1.checked_rem(*v2) {
-                    // Python modulo: result has same sign as divisor
-                    let result = if r != 0 && (*v1 < 0) != (*v2 < 0) { r + *v2 } else { r };
-                    Some(result == right_value)
-                } else {
-                    // checked_rem returns None for overflow (i64::MIN % -1) or zero division
-                    (*v2 != 0).then_some(0 == right_value)
-                }
-            }
-            (Self::Float(v1), Self::Float(v2)) => Some(v1 % v2 == right_value as f64),
-            (Self::Float(v1), Self::Int(v2)) => Some(v1 % (*v2 as f64) == right_value as f64),
-            (Self::Int(v1), Self::Float(v2)) => Some((*v1 as f64) % v2 == right_value as f64),
-            _ => None,
-        }
-    }
-
     fn py_iadd(
         &mut self,
         other: &Self,


### PR DESCRIPTION
As per https://github.com/pydantic/monty/pull/556#discussion_r3589925145, I think this optimization doesn't have real-world benefit for Monty's use cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the special-case optimization for `a % b == k` across the compiler and VM. New code now emits standard modulo + equality; existing bytecode with `CompareModEq` still runs via a compatibility path.

- **Refactors**
  - Removed `CmpOperator::ModEq` and the prepare-time rewrite for `(x % n) == k`.
  - Compiler no longer emits `CompareModEq`; it emits `BinaryMod`, `LoadConst`, then `CompareEq`.
  - VM executes legacy `CompareModEq` by performing modulo, pushing the const, and comparing for equality.
  - Deleted the `py_mod_eq` fast path from `PyTrait` and `Value`.
  - Updated opcode docs and stack effects; behavior remains unchanged for users.

<sup>Written for commit 5eb8f3781f82b9a61d8d8f9b0dbd3a641365b40f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

