### PR TITLE
HMAC signing  for `dump` / `restore`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2105,9 +2105,13 @@ dependencies = [
 name = "monty-pool"
 version = "0.0.19-beta.4"
 dependencies = [
+ "getrandom 0.3.4",
+ "hmac",
+ "insta",
  "monty",
  "monty-proto",
  "rustls",
+ "sha2",
  "tempfile",
  "tungstenite",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,10 @@ postcard = { version = "1.1", features = ["alloc"] }
 # so `make check-proto` (regenerate + git diff) is reproducible
 prost = "=0.14.4"
 sha2 = "0.10"
+# HMAC-SHA256 signing of dump payloads (host-side, in monty-pool).
+hmac = "0.12"
+# OS randomness for the pool's ephemeral dump-signing key.
+getrandom = "0.3"
 pretty_assertions = "1.4"
 insta = "1.47"
 clap = { version = "4", features = ["derive"] }

--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -150,7 +150,8 @@ forged or tampered with: `load` / `loadSnapshot` verify the signature before
 anything reaches a worker and throw `MontyInvalidDumpError` on a mismatch.
 When no `dumpKey` is given, each pool generates a random key, so its dumps
 only restore into sessions of that same pool object — pass the same
-`dumpKey` (at least 16 bytes) to two pools to restore dumps across them:
+`dumpKey` (raw bytes, or a string UTF-8-encoded; at least 16 bytes) to two
+pools to restore dumps across them:
 
 ```ts
 const pool = await Monty.create({ dumpKey: mySecretKey })

--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -145,6 +145,20 @@ with `await session.load(blob)` (which resolves to `void`) and keep feeding.
 Both `load` and `loadSnapshot` are valid only on a fresh session, before any
 feed; using the wrong one for a dump's kind throws.
 
+Dump bytes are HMAC-SHA256-signed with the pool's `dumpKey` so they cannot be
+forged or tampered with: `load` / `loadSnapshot` verify the signature before
+anything reaches a worker and throw `MontyInvalidDumpError` on a mismatch.
+When no `dumpKey` is given, each pool generates a random key, so its dumps
+only restore into sessions of that same pool object — pass the same
+`dumpKey` (at least 16 bytes) to two pools to restore dumps across them:
+
+```ts
+const pool = await Monty.create({ dumpKey: mySecretKey })
+```
+
+On the browser/wasm path, dump/load needs WebCrypto (`crypto.subtle`), which
+browsers only expose in a secure context; execution itself does not.
+
 ## Print Output
 
 ```ts

--- a/crates/monty-js/__test__/dump_sign.spec.ts
+++ b/crates/monty-js/__test__/dump_sign.spec.ts
@@ -106,6 +106,40 @@ test('short pool dumpKey is rejected at creation', async () => {
   await t.throwsAsync(() => Monty.create({ dumpKey: new Uint8Array(15) }), {
     message: 'dump key must be at least 16 bytes',
   })
+  await t.throwsAsync(() => Monty.create({ dumpKey: 'short' }), {
+    message: 'dump key must be at least 16 bytes',
+  })
+})
+
+// a string key is UTF-8-encoded: a pool keyed with the string restores dumps
+// from a pool keyed with the equivalent bytes, matching the Python binding
+test('string dumpKey encodes to the same key as bytes', async () => {
+  const poolA = await Monty.create({ dumpKey: SHARED_KEY })
+  let state: Uint8Array
+  try {
+    const session = await poolA.checkout()
+    try {
+      await session.feedRun('x = 42')
+      state = await session.dump()
+    } finally {
+      await session.close()
+    }
+  } finally {
+    await poolA.close()
+  }
+
+  const poolB = await Monty.create({ dumpKey: 'an example 32-byte test dump key' })
+  try {
+    const session = await poolB.checkout()
+    try {
+      await session.load(state)
+      t.is(await session.feedRun('x'), 42)
+    } finally {
+      await session.close()
+    }
+  } finally {
+    await poolB.close()
+  }
 })
 
 // The Rust signer (native pool) and the TS signer must be byte-compatible:

--- a/crates/monty-js/__test__/dump_sign.spec.ts
+++ b/crates/monty-js/__test__/dump_sign.spec.ts
@@ -1,0 +1,126 @@
+// Dump signing: the TS signer (wasm path), pool-level dumpKey behavior on
+// both backends, and Rust ↔ TS byte-format parity.
+
+import { test } from 'vitest'
+import { t } from './assertions.js'
+import { skipIfBrowser } from './env.js'
+
+import { Monty, MontyInvalidDumpError } from '@pydantic/monty'
+import { generateDumpKey, importDumpKey, MIN_DUMP_KEY_LEN, signDump, verifyDump } from '@pydantic/monty/wasm'
+
+const SHARED_KEY = new TextEncoder().encode('an example 32-byte test dump key')
+const TAMPERED_MESSAGE =
+  'invalid dump: signature verification failed — the dump was signed with a different key or corrupted'
+
+test('signer round-trips and rejects tampering', async () => {
+  const key = await importDumpKey(generateDumpKey())
+  const state = new TextEncoder().encode('inner dump envelope')
+  const signed = await signDump(key, state)
+  t.is(signed[0], 1) // pin the signed format version
+  t.deepEqual(Array.from(await verifyDump(key, signed)), Array.from(state))
+  const tampered = signed.slice()
+  tampered[tampered.length - 1]! ^= 0xff
+  await t.throwsAsync(() => verifyDump(key, tampered), { message: TAMPERED_MESSAGE })
+})
+
+test('signer rejects short keys, short dumps, and unknown versions', async () => {
+  t.throws(() => importDumpKey(new Uint8Array(MIN_DUMP_KEY_LEN - 1)), {
+    message: 'dump key must be at least 16 bytes',
+  })
+  const key = await importDumpKey(SHARED_KEY)
+  await t.throwsAsync(() => verifyDump(key, new Uint8Array(10)), {
+    message: 'invalid dump: too short to be a signed dump',
+  })
+  const wrongVersion = await signDump(key, new Uint8Array(1))
+  wrongVersion[0] = 2
+  await t.throwsAsync(() => verifyDump(key, wrongVersion), {
+    message: 'invalid dump: unsupported signed-dump version 2 (expected 1)',
+  })
+})
+
+test('dump restores across pools sharing a dumpKey', async () => {
+  const poolA = await Monty.create({ dumpKey: SHARED_KEY })
+  let state: Uint8Array
+  try {
+    const session = await poolA.checkout()
+    try {
+      await session.feedRun('x = 42')
+      state = await session.dump()
+    } finally {
+      await session.close()
+    }
+  } finally {
+    await poolA.close()
+  }
+
+  const poolB = await Monty.create({ dumpKey: SHARED_KEY })
+  try {
+    const session = await poolB.checkout()
+    try {
+      await session.load(state)
+      t.is(await session.feedRun('x'), 42)
+    } finally {
+      await session.close()
+    }
+  } finally {
+    await poolB.close()
+  }
+})
+
+test('ephemeral-key dumps do not restore into another pool', async () => {
+  const poolA = await Monty.create({})
+  let state: Uint8Array
+  try {
+    const session = await poolA.checkout()
+    try {
+      await session.feedRun('x = 1')
+      state = await session.dump()
+    } finally {
+      await session.close()
+    }
+  } finally {
+    await poolA.close()
+  }
+
+  const poolB = await Monty.create({})
+  try {
+    const session = await poolB.checkout()
+    const error = await t.throwsAsync(() => session.load(state), { instanceOf: MontyInvalidDumpError })
+    t.is(error.message, `ValueError: ${TAMPERED_MESSAGE}`)
+    await session.close()
+  } finally {
+    await poolB.close()
+  }
+})
+
+test('short pool dumpKey is rejected at creation', async () => {
+  await t.throwsAsync(() => Monty.create({ dumpKey: new Uint8Array(15) }), {
+    message: 'dump key must be at least 16 bytes',
+  })
+})
+
+// The Rust signer (native pool) and the TS signer must be byte-compatible:
+// a native dump signed with key K verifies in TS with the same key, and a
+// flipped byte is rejected. Node-only — the native pool needs subprocesses.
+test('native dumps verify with the TS signer (format parity)', async (ctx) => {
+  skipIfBrowser(ctx)
+  const pool = await Monty.create({ dumpKey: SHARED_KEY })
+  try {
+    const session = await pool.checkout()
+    let state: Uint8Array
+    try {
+      await session.feedRun('x = 1')
+      state = await session.dump()
+    } finally {
+      await session.close()
+    }
+    const key = await importDumpKey(SHARED_KEY)
+    const inner = await verifyDump(key, state)
+    t.true(inner.length > 0)
+    const tampered = new Uint8Array(state)
+    tampered[tampered.length - 1]! ^= 0xff
+    await t.throwsAsync(() => verifyDump(key, tampered), { message: TAMPERED_MESSAGE })
+  } finally {
+    await pool.close()
+  }
+})

--- a/crates/monty-js/__test__/dump_sign.spec.ts
+++ b/crates/monty-js/__test__/dump_sign.spec.ts
@@ -57,6 +57,12 @@ test('dump restores across pools sharing a dumpKey', async () => {
   try {
     const session = await poolB.checkout()
     try {
+      // a rejected load happens before any worker I/O and leaves the session
+      // fresh, so the load is retryable with the untampered bytes
+      // (new Uint8Array, not .slice(): `state` is a Buffer, whose slice aliases)
+      const tampered = new Uint8Array(state)
+      tampered[tampered.length - 1]! ^= 0xff
+      await t.throwsAsync(() => session.load(tampered), { instanceOf: MontyInvalidDumpError })
       await session.load(state)
       t.is(await session.feedRun('x'), 42)
     } finally {
@@ -87,6 +93,9 @@ test('ephemeral-key dumps do not restore into another pool', async () => {
     const session = await poolB.checkout()
     const error = await t.throwsAsync(() => session.load(state), { instanceOf: MontyInvalidDumpError })
     t.is(error.message, `ValueError: ${TAMPERED_MESSAGE}`)
+    // the rejection happened before any worker I/O — the session stays fresh
+    // and usable (a later load would also still be accepted)
+    t.is(await session.feedRun('1 + 1'), 2)
     await session.close()
   } finally {
     await poolB.close()

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -2508,19 +2508,90 @@
       "license": "MIT"
     },
     "node_modules/@pydantic/monty-darwin-arm64": {
-      "optional": true
+      "version": "0.0.19-beta.4",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-arm64/-/monty-darwin-arm64-0.0.19-beta.4.tgz",
+      "integrity": "sha512-lkNGSwQLQoGZKjhZaBIqI3hE6IU74GnpMRdTEDjqjsREB42tpRHOiFL2chWc9NXza56ph3AzX/JSKlh/FQp8bg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@pydantic/monty-darwin-x64": {
-      "optional": true
+      "version": "0.0.19-beta.4",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-x64/-/monty-darwin-x64-0.0.19-beta.4.tgz",
+      "integrity": "sha512-Vok4Po7uqqzuvPjVtouJ+CKcZk3RoCFkpAQsV3CCx8dRKJS7bjDcRLwVGKomqxYxaE94/Utr7oiS4fOAQogkSA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@pydantic/monty-linux-arm64-gnu": {
-      "optional": true
+      "version": "0.0.19-beta.4",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-arm64-gnu/-/monty-linux-arm64-gnu-0.0.19-beta.4.tgz",
+      "integrity": "sha512-yY1cSk8toNczVXTRKM5K6LAWKM+8EwVMCRu3kgbERBy39hgF4Z2sG3Phx5a20OLe+ff8eC1N3kDoAYkYs9SpyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@pydantic/monty-linux-x64-gnu": {
-      "optional": true
+      "version": "0.0.19-beta.4",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-x64-gnu/-/monty-linux-x64-gnu-0.0.19-beta.4.tgz",
+      "integrity": "sha512-Uhj2uOn5TYCcmD4MGe124Y/EvKNCILdHnJluhmVgyJLjqJYGE/7x1jOKhVM1Mxp+bk4gvi0B2k8qcoM6De8fzg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@pydantic/monty-win32-x64-msvc": {
-      "optional": true
+      "version": "0.0.19-beta.4",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-win32-x64-msvc/-/monty-win32-x64-msvc-0.0.19-beta.4.tgz",
+      "integrity": "sha512-PppMgYZE2NgqbrIbM0NDbB/z7O2i/WfrJY15Con8nu9TdCaiW/ZFMPWGPwIq5rNuIXmh44r4uSZ8oFFZXVePag==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -30,13 +30,13 @@ use std::{
 
 use monty::{ExcType, MontyException, MontyObject, PrintStream, StackFrame};
 use monty_pool::{
-    exceeds_max_value_depth, Checkout, MountSpec, MountSpecMode, OnPrint, Pool, PoolConfig, PoolError, ReplConfig,
-    ResumeValue, TurnEvent,
+    exceeds_max_value_depth, Checkout, DumpKey, MountSpec, MountSpecMode, OnPrint, Pool, PoolConfig, PoolError,
+    ReplConfig, ResumeValue, TurnEvent,
 };
 use napi::{
     bindgen_prelude::{
         block_on, spawn_blocking, Array, Buffer, FnArgs, FromNapiValue, Function, JsObjectValue, Object, PromiseRaw,
-        Unknown,
+        Uint8Array, Unknown,
     },
     threadsafe_function::UnknownReturnValue,
     Env, Result,
@@ -83,6 +83,9 @@ pub struct NativePoolOptions {
     pub duration_limit_grace_ms: Option<f64>,
     /// Recycle a worker after serving this many checkouts.
     pub max_checkouts_per_worker: Option<u32>,
+    /// Key (≥ 16 bytes) HMAC-signing `dump()` bytes and verifying them on
+    /// restore. Absent: a random per-pool key — dumps stay pool-local.
+    pub dump_key: Option<Uint8Array>,
 }
 
 /// Session options for `checkout()`.
@@ -132,6 +135,10 @@ impl NativePool {
         config.request_timeout = options.request_timeout_ms.map(duration_from_ms).transpose()?;
         config.duration_limit_grace = options.duration_limit_grace_ms.map(duration_from_ms).transpose()?;
         config.max_checkouts_per_worker = options.max_checkouts_per_worker;
+        config.dump_key = options
+            .dump_key
+            .map(|key| DumpKey::new(key.to_vec()).map_err(|err| invalid(&err.to_string())))
+            .transpose()?;
         if config.max_processes < 1 {
             return Err(invalid("maxProcesses must be at least 1"));
         }
@@ -561,6 +568,9 @@ enum TurnOutcome {
     },
     /// The worker (or caller) violated the protocol; the session is lost.
     Protocol(String),
+    /// A restore's dump bytes failed HMAC verification; nothing was sent to
+    /// the worker. Only produced by [`NativeSession::restore`].
+    InvalidDump(String),
     /// A `load` restored an idle (between-feeds) session — there is no
     /// suspension to resume. Only produced by [`NativeSession::load`].
     LoadedIdle,
@@ -585,6 +595,7 @@ impl From<StdResult<TurnEvent, PoolError>> for TurnOutcome {
                 timed_out: false,
                 exit_status: status.map(|status| status.to_string()),
             },
+            Err(err @ PoolError::InvalidDump(_)) => Self::InvalidDump(err.to_string()),
             Err(other) => Self::Protocol(other.to_string()),
         }
     }
@@ -661,6 +672,10 @@ fn turn_to_js(env: &Env, outcome: TurnOutcome) -> Result<Object<'_>> {
         }
         TurnOutcome::Protocol(message) => {
             obj.set("kind", "protocol")?;
+            obj.set("message", message)?;
+        }
+        TurnOutcome::InvalidDump(message) => {
+            obj.set("kind", "invalidDump")?;
             obj.set("message", message)?;
         }
         TurnOutcome::LoadedIdle => {

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -30,8 +30,8 @@ use std::{
 
 use monty::{ExcType, MontyException, MontyObject, PrintStream, StackFrame};
 use monty_pool::{
-    exceeds_max_value_depth, Checkout, DumpKey, MountSpec, MountSpecMode, OnPrint, Pool, PoolConfig, PoolError,
-    ReplConfig, ResumeValue, TurnEvent,
+    exceeds_max_value_depth, Checkout, DumpKey, DumpSigning, MountSpec, MountSpecMode, OnPrint, Pool, PoolConfig,
+    PoolError, ReplConfig, ResumeValue, TurnEvent,
 };
 use napi::{
     bindgen_prelude::{
@@ -135,10 +135,10 @@ impl NativePool {
         config.request_timeout = options.request_timeout_ms.map(duration_from_ms).transpose()?;
         config.duration_limit_grace = options.duration_limit_grace_ms.map(duration_from_ms).transpose()?;
         config.max_checkouts_per_worker = options.max_checkouts_per_worker;
-        config.dump_key = options
-            .dump_key
-            .map(|key| DumpKey::new(key.to_vec()).map_err(|err| invalid(&err.to_string())))
-            .transpose()?;
+        if let Some(key) = options.dump_key {
+            let key = DumpKey::new(key.to_vec()).map_err(|err| invalid(&err.to_string()))?;
+            config.dump_signing = DumpSigning::Key(key);
+        }
         if config.max_processes < 1 {
             return Err(invalid("maxProcesses must be at least 1"));
         }

--- a/crates/monty-js/ts/errors.ts
+++ b/crates/monty-js/ts/errors.ts
@@ -200,6 +200,20 @@ export class MontyCrashedError extends MontyError {
 }
 
 /**
+ * Raised by `load` / `loadSnapshot` when the dump's HMAC signature does not
+ * verify: a different `dumpKey` than the pool that produced it (including a
+ * pool-local ephemeral key), tampered/corrupted bytes, or not a signed dump
+ * at all. The bytes were never sent to a worker; like any failed load, the
+ * session is poisoned — check out a fresh one.
+ */
+export class MontyInvalidDumpError extends MontyError {
+  constructor(message: string) {
+    super('ValueError', message)
+    this.name = 'MontyInvalidDumpError'
+  }
+}
+
+/**
  * Raised when the worker (or a caller misusing the session) violated the
  * wire protocol. The worker has been discarded; the session is lost.
  */

--- a/crates/monty-js/ts/errors.ts
+++ b/crates/monty-js/ts/errors.ts
@@ -203,8 +203,8 @@ export class MontyCrashedError extends MontyError {
  * Raised by `load` / `loadSnapshot` when the dump's HMAC signature does not
  * verify: a different `dumpKey` than the pool that produced it (including a
  * pool-local ephemeral key), tampered/corrupted bytes, or not a signed dump
- * at all. The bytes were never sent to a worker; like any failed load, the
- * session is poisoned — check out a fresh one.
+ * at all. The bytes were never sent to a worker and the session stays fresh
+ * and usable — retry the load with valid bytes, or feed it.
  */
 export class MontyInvalidDumpError extends MontyError {
   constructor(message: string) {

--- a/crates/monty-js/ts/index.ts
+++ b/crates/monty-js/ts/index.ts
@@ -23,6 +23,7 @@ export {
 export {
   MontyCrashedError,
   MontyError,
+  MontyInvalidDumpError,
   MontyRuntimeError,
   MontySyntaxError,
   MontyTypingError,

--- a/crates/monty-js/ts/native.ts
+++ b/crates/monty-js/ts/native.ts
@@ -108,6 +108,14 @@ export interface LoadedTurn {
   kind: 'loaded'
 }
 
+/** A restore's dump bytes failed HMAC verification — wrong `dumpKey`,
+ *  tampered bytes, or not a signed dump. Nothing was sent to the worker.
+ *  Only produced by `NativeSession.restore`. */
+export interface InvalidDumpTurn {
+  kind: 'invalidDump'
+  message: string
+}
+
 /** A non-feed request succeeded with no value or suspension. Only produced by
  *  `NativeSession.installDependencies`. */
 export interface OkTurn {

--- a/crates/monty-js/ts/node.ts
+++ b/crates/monty-js/ts/node.ts
@@ -22,6 +22,7 @@ export { MountDir, type MountDirMode, type MountDirOptions } from './mount.js'
 export {
   MontyCrashedError,
   MontyError,
+  MontyInvalidDumpError,
   MontyRuntimeError,
   MontySyntaxError,
   MontyTypingError,

--- a/crates/monty-js/ts/pool.ts
+++ b/crates/monty-js/ts/pool.ts
@@ -8,6 +8,7 @@ import { availableParallelism } from 'node:os'
 import { NativePool } from '../native-addon.js'
 import { findMontyBinary } from './binary.js'
 import { MontySession } from './session.js'
+import { dumpKeyBytes } from './worker/dumpSign.js'
 
 /** Options for [`Monty`]. */
 export interface MontyOptions {
@@ -44,13 +45,13 @@ export interface MontyOptions {
   /** Recycle a worker (kill and replace) after serving this many sessions. */
   maxCheckoutsPerWorker?: number
   /**
-   * Key (at least 16 bytes) used to HMAC-sign `session.dump()` bytes and
-   * verify them on `load` / `loadSnapshot` (`MontyInvalidDumpError` on
-   * mismatch). Omitted: a random key is generated per pool, so dumps only
-   * restore into sessions of this same pool object — supply a key to restore
-   * dumps across pools or processes.
+   * Key used to HMAC-sign `session.dump()` bytes and verify them on `load` /
+   * `loadSnapshot` (`MontyInvalidDumpError` on mismatch) — raw bytes, or a
+   * string (UTF-8-encoded); at least 16 bytes. Omitted: a random key is
+   * generated per pool, so dumps only restore into sessions of this same pool
+   * object — supply a key to restore dumps across pools or processes.
    */
-  dumpKey?: Uint8Array
+  dumpKey?: string | Uint8Array
 }
 
 /** Options for [`Monty.checkout`], mirroring `pydantic_monty`. */
@@ -106,7 +107,7 @@ export class Monty {
         ? { durationLimitGraceMs: (options.durationLimitGrace ?? 1) * 1000 }
         : {}),
       ...(options.maxCheckoutsPerWorker !== undefined ? { maxCheckoutsPerWorker: options.maxCheckoutsPerWorker } : {}),
-      ...(options.dumpKey !== undefined ? { dumpKey: options.dumpKey } : {}),
+      ...(options.dumpKey !== undefined ? { dumpKey: dumpKeyBytes(options.dumpKey) } : {}),
     })
     await native.start()
     return new Monty(native)

--- a/crates/monty-js/ts/pool.ts
+++ b/crates/monty-js/ts/pool.ts
@@ -43,6 +43,14 @@ export interface MontyOptions {
   durationLimitGrace?: number | null
   /** Recycle a worker (kill and replace) after serving this many sessions. */
   maxCheckoutsPerWorker?: number
+  /**
+   * Key (at least 16 bytes) used to HMAC-sign `session.dump()` bytes and
+   * verify them on `load` / `loadSnapshot` (`MontyInvalidDumpError` on
+   * mismatch). Omitted: a random key is generated per pool, so dumps only
+   * restore into sessions of this same pool object — supply a key to restore
+   * dumps across pools or processes.
+   */
+  dumpKey?: Uint8Array
 }
 
 /** Options for [`Monty.checkout`], mirroring `pydantic_monty`. */
@@ -98,6 +106,7 @@ export class Monty {
         ? { durationLimitGraceMs: (options.durationLimitGrace ?? 1) * 1000 }
         : {}),
       ...(options.maxCheckoutsPerWorker !== undefined ? { maxCheckoutsPerWorker: options.maxCheckoutsPerWorker } : {}),
+      ...(options.dumpKey !== undefined ? { dumpKey: options.dumpKey } : {}),
     })
     await native.start()
     return new Monty(native)

--- a/crates/monty-js/ts/session.ts
+++ b/crates/monty-js/ts/session.ts
@@ -14,6 +14,7 @@ import {
   MontyCrashedError,
   MontyError,
   montyErrorFromNative,
+  MontyInvalidDumpError,
   MontyTypingError,
   notCallableMessage,
   ProtocolError,
@@ -22,6 +23,7 @@ import { PYTHON_EXC_NAMES } from './errors.js'
 import { mountsToNative, type MountDir } from './mount.js'
 import type {
   FunctionCallTurn,
+  InvalidDumpTurn,
   LoadedTurn,
   NameLookupTurn,
   NativeFutureResult,
@@ -244,7 +246,10 @@ export class MontySession {
    * taken mid-execution.
    *
    * Valid only on a fresh session, before any feed or load (it replaces the
-   * whole session); throws otherwise. The dump restores its own resource limits
+   * whole session); throws otherwise. The dump's HMAC signature is verified
+   * against the pool's `dumpKey` first — a tampered dump, or one from a pool
+   * with a different (or omitted, i.e. ephemeral) key, throws
+   * [`MontyInvalidDumpError`]. The dump restores its own resource limits
    * and type-check state. Throws if the dump is actually a suspended snapshot.
    */
   async load(state: Uint8Array): Promise<void> {
@@ -253,6 +258,7 @@ export class MontySession {
     const turn = (await this.native.restore(bytesForNative(state), [], printTarget.write.bind(printTarget))) as
       | NativeTurn
       | LoadedTurn
+      | InvalidDumpTurn
     switch (turn.kind) {
       case 'loaded':
         return
@@ -260,6 +266,8 @@ export class MontySession {
         throw await this.failedLoad(new MontyCrashedError(turn.message, turn))
       case 'protocol':
         throw await this.failedLoad(new ProtocolError(turn.message))
+      case 'invalidDump':
+        throw await this.failedLoad(new MontyInvalidDumpError(turn.message))
       case 'error':
         throw await this.failedLoad(montyErrorFromNative(turn.exception))
       default:
@@ -273,7 +281,10 @@ export class MontySession {
    * for a dump taken between feeds.
    *
    * Valid only on a fresh session, before any feed or load; throws otherwise.
-   * Re-supply the same `mount`s the paused feed used (their host paths are not
+   * The dump's HMAC signature is verified against the pool's `dumpKey` first —
+   * a tampered dump, or one from a pool with a different (or omitted, i.e.
+   * ephemeral) key, throws [`MontyInvalidDumpError`]. Re-supply the same
+   * `mount`s the paused feed used (their host paths are not
    * in the dump); a missing, extra, or altered mount throws. Throws if the dump
    * is actually an idle session.
    */
@@ -283,8 +294,12 @@ export class MontySession {
     const turn = (await this.native.restore(bytesForNative(state), mountsToNative(options.mount), driver.onPrint)) as
       | NativeTurn
       | LoadedTurn
+      | InvalidDumpTurn
     if (turn.kind === 'loaded') {
       throw await this.failedLoad(new Error('this dump is an idle session — use load() to restore it'))
+    }
+    if (turn.kind === 'invalidDump') {
+      throw await this.failedLoad(new MontyInvalidDumpError(turn.message))
     }
     try {
       return await driver.advance(turn)

--- a/crates/monty-js/ts/session.ts
+++ b/crates/monty-js/ts/session.ts
@@ -249,8 +249,9 @@ export class MontySession {
    * whole session); throws otherwise. The dump's HMAC signature is verified
    * against the pool's `dumpKey` first — a tampered dump, or one from a pool
    * with a different (or omitted, i.e. ephemeral) key, throws
-   * [`MontyInvalidDumpError`]. The dump restores its own resource limits
-   * and type-check state. Throws if the dump is actually a suspended snapshot.
+   * [`MontyInvalidDumpError`], leaving the session fresh and usable. The dump
+   * restores its own resource limits and type-check state. Throws if the dump
+   * is actually a suspended snapshot.
    */
   async load(state: Uint8Array): Promise<void> {
     this.claimFresh()
@@ -267,7 +268,7 @@ export class MontySession {
       case 'protocol':
         throw await this.failedLoad(new ProtocolError(turn.message))
       case 'invalidDump':
-        throw await this.failedLoad(new MontyInvalidDumpError(turn.message))
+        throw this.rejectedLoad(new MontyInvalidDumpError(turn.message))
       case 'error':
         throw await this.failedLoad(montyErrorFromNative(turn.exception))
       default:
@@ -283,10 +284,10 @@ export class MontySession {
    * Valid only on a fresh session, before any feed or load; throws otherwise.
    * The dump's HMAC signature is verified against the pool's `dumpKey` first —
    * a tampered dump, or one from a pool with a different (or omitted, i.e.
-   * ephemeral) key, throws [`MontyInvalidDumpError`]. Re-supply the same
-   * `mount`s the paused feed used (their host paths are not
-   * in the dump); a missing, extra, or altered mount throws. Throws if the dump
-   * is actually an idle session.
+   * ephemeral) key, throws [`MontyInvalidDumpError`], leaving the session
+   * fresh and usable. Re-supply the same `mount`s the paused feed used (their
+   * host paths are not in the dump); a missing, extra, or altered mount
+   * throws. Throws if the dump is actually an idle session.
    */
   async loadSnapshot(state: Uint8Array, options: LoadSnapshotOptions = {}): Promise<Snapshot> {
     this.claimFresh()
@@ -299,7 +300,7 @@ export class MontySession {
       throw await this.failedLoad(new Error('this dump is an idle session — use load() to restore it'))
     }
     if (turn.kind === 'invalidDump') {
-      throw await this.failedLoad(new MontyInvalidDumpError(turn.message))
+      throw this.rejectedLoad(new MontyInvalidDumpError(turn.message))
     }
     try {
       return await driver.advance(turn)
@@ -333,6 +334,14 @@ export class MontySession {
     } catch {
       // the worker was already discarded (e.g. it crashed) — nothing to release
     }
+    return err
+  }
+
+  /** A load rejected before any worker I/O (dump signature verification
+   *  failed): un-claims the session, which stays fresh and usable — unlike
+   *  [`failedLoad`], where the worker's state is no longer trustworthy. */
+  private rejectedLoad(err: Error): Error {
+    this.driven = false
     return err
   }
 

--- a/crates/monty-js/ts/worker/dumpSign.ts
+++ b/crates/monty-js/ts/worker/dumpSign.ts
@@ -43,6 +43,20 @@ export function importDumpKey(key: Uint8Array): Promise<CryptoKey> {
   return crypto.subtle.importKey('raw', copyBytes(key), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify'])
 }
 
+/**
+ * A memoizing lazy dump-key provider: validates `bytes` eagerly (so a short
+ * key fails at pool creation) but defers key generation and the WebCrypto
+ * import to the first call — pools that never dump touch no crypto, and a
+ * non-secure browser context only fails on actual dump/load use.
+ */
+export function lazyDumpKey(bytes?: Uint8Array): () => Promise<CryptoKey> {
+  if (bytes !== undefined && bytes.length < MIN_DUMP_KEY_LEN) {
+    throw new Error(`dump key must be at least ${MIN_DUMP_KEY_LEN} bytes`)
+  }
+  let key: Promise<CryptoKey> | undefined
+  return () => (key ??= importDumpKey(bytes ?? generateDumpKey()))
+}
+
 /** Signs a worker dump envelope, prepending the version byte and MAC tag. */
 export async function signDump(key: CryptoKey, state: Uint8Array): Promise<Uint8Array> {
   const tag = await crypto.subtle.sign('HMAC', key, withContext(state))

--- a/crates/monty-js/ts/worker/dumpSign.ts
+++ b/crates/monty-js/ts/worker/dumpSign.ts
@@ -24,6 +24,10 @@ const TAG_LEN = 32
 
 /** Generates a random 32-byte ephemeral dump key (pool-local dumps). */
 export function generateDumpKey(): Uint8Array {
+  // requireSubtle so a crypto-less environment gets the clear WebCrypto error
+  // here rather than a bare ReferenceError on `crypto` (and a key generated in
+  // a non-secure context would be unusable anyway — import needs `subtle`)
+  requireSubtle()
   return crypto.getRandomValues(new Uint8Array(32))
 }
 
@@ -44,10 +48,10 @@ export function importDumpKey(key: string | Uint8Array): Promise<CryptoKey> {
   if (bytes.length < MIN_DUMP_KEY_LEN) {
     throw new Error(`dump key must be at least ${MIN_DUMP_KEY_LEN} bytes`)
   }
-  if (typeof crypto === 'undefined' || crypto.subtle === undefined) {
-    throw new Error('dump signing needs WebCrypto (crypto.subtle) — unavailable outside a secure context')
-  }
-  return crypto.subtle.importKey('raw', copyBytes(bytes), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify'])
+  return requireSubtle().importKey('raw', copyBytes(bytes), { name: 'HMAC', hash: 'SHA-256' }, false, [
+    'sign',
+    'verify',
+  ])
 }
 
 /**
@@ -57,7 +61,9 @@ export function importDumpKey(key: string | Uint8Array): Promise<CryptoKey> {
  * non-secure browser context only fails on actual dump/load use.
  */
 export function lazyDumpKey(key?: string | Uint8Array): () => Promise<CryptoKey> {
-  const bytes = key === undefined ? undefined : dumpKeyBytes(key)
+  // snapshot the key bytes now — the import is deferred, and a caller mutating
+  // its Uint8Array after pool creation must not change the pool's signing key
+  const bytes = key === undefined ? undefined : copyBytes(dumpKeyBytes(key))
   if (bytes !== undefined && bytes.length < MIN_DUMP_KEY_LEN) {
     throw new Error(`dump key must be at least ${MIN_DUMP_KEY_LEN} bytes`)
   }
@@ -111,6 +117,15 @@ function withContext(state: Uint8Array): Uint8Array<ArrayBuffer> {
   buf.set(CONTEXT, 0)
   buf.set(state, CONTEXT.length)
   return buf
+}
+
+/** Returns `crypto.subtle`, throwing the standard dump-signing error when
+ *  WebCrypto is unavailable (a browser page not in a secure context). */
+function requireSubtle(): SubtleCrypto {
+  if (typeof crypto === 'undefined' || crypto.subtle === undefined) {
+    throw new Error('dump signing needs WebCrypto (crypto.subtle) — unavailable outside a secure context')
+  }
+  return crypto.subtle
 }
 
 /** Copies bytes into a fresh `ArrayBuffer`-backed array (WebCrypto rejects

--- a/crates/monty-js/ts/worker/dumpSign.ts
+++ b/crates/monty-js/ts/worker/dumpSign.ts
@@ -1,0 +1,93 @@
+// HMAC signing of dump payloads for the wasm worker path, mirroring the
+// native pool's host-side signing so dumps stay byte-portable between the two
+// backends when the same key is supplied.
+//
+// `crates/monty-pool/src/dump_sign.rs` is the source of truth for the format
+// and the error strings — keep this file byte-identical to it:
+//
+//   signed_dump := [version u8 = 0x01][tag: 32-byte HMAC-SHA256(key, CONTEXT || inner)][inner]
+//
+// Uses WebCrypto (async, constant-time verify), which both Node and
+// secure-context browsers provide as `crypto.subtle`.
+
+/** Minimum accepted dump-key length, matching `MIN_DUMP_KEY_LEN` in Rust. */
+export const MIN_DUMP_KEY_LEN = 16
+
+/** Format version prepended to every signed dump. */
+const SIGNED_DUMP_VERSION = 0x01
+
+/** Domain-separation prefix mixed into every MAC. */
+const CONTEXT = new TextEncoder().encode('monty-dump-sign-v1')
+
+/** HMAC-SHA256 output length in bytes. */
+const TAG_LEN = 32
+
+/** Generates a random 32-byte ephemeral dump key (pool-local dumps). */
+export function generateDumpKey(): Uint8Array {
+  return crypto.getRandomValues(new Uint8Array(32))
+}
+
+/**
+ * Imports raw dump-key bytes as a WebCrypto HMAC-SHA-256 key, rejecting keys
+ * shorter than [`MIN_DUMP_KEY_LEN`]. Throws when `crypto.subtle` is
+ * unavailable (a browser page not in a secure context) — dump/load needs it;
+ * execution does not.
+ */
+export function importDumpKey(key: Uint8Array): Promise<CryptoKey> {
+  if (key.length < MIN_DUMP_KEY_LEN) {
+    throw new Error(`dump key must be at least ${MIN_DUMP_KEY_LEN} bytes`)
+  }
+  if (typeof crypto === 'undefined' || crypto.subtle === undefined) {
+    throw new Error('dump signing needs WebCrypto (crypto.subtle) — unavailable outside a secure context')
+  }
+  return crypto.subtle.importKey('raw', copyBytes(key), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify'])
+}
+
+/** Signs a worker dump envelope, prepending the version byte and MAC tag. */
+export async function signDump(key: CryptoKey, state: Uint8Array): Promise<Uint8Array> {
+  const tag = await crypto.subtle.sign('HMAC', key, withContext(state))
+  const signed = new Uint8Array(1 + TAG_LEN + state.length)
+  signed[0] = SIGNED_DUMP_VERSION
+  signed.set(new Uint8Array(tag), 1)
+  signed.set(state, 1 + TAG_LEN)
+  return signed
+}
+
+/**
+ * Verifies a signed dump and returns the inner worker envelope, throwing an
+ * `Error` (whose message matches the Rust `PoolError::InvalidDump` display)
+ * on any mismatch — callers must never send unverified bytes to a worker.
+ */
+export async function verifyDump(key: CryptoKey, signed: Uint8Array): Promise<Uint8Array> {
+  if (signed.length < 1 + TAG_LEN) {
+    throw new Error('invalid dump: too short to be a signed dump')
+  }
+  if (signed[0] !== SIGNED_DUMP_VERSION) {
+    throw new Error(`invalid dump: unsupported signed-dump version ${signed[0]} (expected ${SIGNED_DUMP_VERSION})`)
+  }
+  const tag = copyBytes(signed.subarray(1, 1 + TAG_LEN))
+  const inner = signed.subarray(1 + TAG_LEN)
+  const ok = await crypto.subtle.verify('HMAC', key, tag, withContext(inner))
+  if (!ok) {
+    throw new Error(
+      'invalid dump: signature verification failed — the dump was signed with a different key or corrupted',
+    )
+  }
+  return inner
+}
+
+/** `CONTEXT || state`, the exact bytes the MAC covers. */
+function withContext(state: Uint8Array): Uint8Array<ArrayBuffer> {
+  const buf = new Uint8Array(CONTEXT.length + state.length)
+  buf.set(CONTEXT, 0)
+  buf.set(state, CONTEXT.length)
+  return buf
+}
+
+/** Copies bytes into a fresh `ArrayBuffer`-backed array (WebCrypto rejects
+ *  views over a possible `SharedArrayBuffer` at the type level). */
+function copyBytes(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
+  const copy = new Uint8Array(bytes.length)
+  copy.set(bytes)
+  return copy
+}

--- a/crates/monty-js/ts/worker/dumpSign.ts
+++ b/crates/monty-js/ts/worker/dumpSign.ts
@@ -3,7 +3,7 @@
 // backends when the same key is supplied.
 //
 // `crates/monty-pool/src/dump_sign.rs` is the source of truth for the format
-// and the error strings — keep this file byte-identical to it:
+// and the error strings — this file must stay byte-compatible with it:
 //
 //   signed_dump := [version u8 = 0x01][tag: 32-byte HMAC-SHA256(key, CONTEXT || inner)][inner]
 //
@@ -27,43 +27,55 @@ export function generateDumpKey(): Uint8Array {
   return crypto.getRandomValues(new Uint8Array(32))
 }
 
+/** Coerces a dump key — raw bytes, or a string (UTF-8-encoded, matching the
+ *  Python binding's `dump_key: str`) — to bytes. */
+export function dumpKeyBytes(key: string | Uint8Array): Uint8Array {
+  return typeof key === 'string' ? new TextEncoder().encode(key) : key
+}
+
 /**
- * Imports raw dump-key bytes as a WebCrypto HMAC-SHA-256 key, rejecting keys
- * shorter than [`MIN_DUMP_KEY_LEN`]. Throws when `crypto.subtle` is
- * unavailable (a browser page not in a secure context) — dump/load needs it;
- * execution does not.
+ * Imports a dump key — raw bytes, or a string (UTF-8-encoded) — as a WebCrypto
+ * HMAC-SHA-256 key, rejecting keys shorter than [`MIN_DUMP_KEY_LEN`] bytes.
+ * Throws when `crypto.subtle` is unavailable (a browser page not in a secure
+ * context) — dump/load needs it; execution does not.
  */
-export function importDumpKey(key: Uint8Array): Promise<CryptoKey> {
-  if (key.length < MIN_DUMP_KEY_LEN) {
+export function importDumpKey(key: string | Uint8Array): Promise<CryptoKey> {
+  const bytes = dumpKeyBytes(key)
+  if (bytes.length < MIN_DUMP_KEY_LEN) {
     throw new Error(`dump key must be at least ${MIN_DUMP_KEY_LEN} bytes`)
   }
   if (typeof crypto === 'undefined' || crypto.subtle === undefined) {
     throw new Error('dump signing needs WebCrypto (crypto.subtle) — unavailable outside a secure context')
   }
-  return crypto.subtle.importKey('raw', copyBytes(key), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify'])
+  return crypto.subtle.importKey('raw', copyBytes(bytes), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify'])
 }
 
 /**
- * A memoizing lazy dump-key provider: validates `bytes` eagerly (so a short
+ * A memoizing lazy dump-key provider: validates `key` eagerly (so a short
  * key fails at pool creation) but defers key generation and the WebCrypto
  * import to the first call — pools that never dump touch no crypto, and a
  * non-secure browser context only fails on actual dump/load use.
  */
-export function lazyDumpKey(bytes?: Uint8Array): () => Promise<CryptoKey> {
+export function lazyDumpKey(key?: string | Uint8Array): () => Promise<CryptoKey> {
+  const bytes = key === undefined ? undefined : dumpKeyBytes(key)
   if (bytes !== undefined && bytes.length < MIN_DUMP_KEY_LEN) {
     throw new Error(`dump key must be at least ${MIN_DUMP_KEY_LEN} bytes`)
   }
-  let key: Promise<CryptoKey> | undefined
-  return () => (key ??= importDumpKey(bytes ?? generateDumpKey()))
+  let imported: Promise<CryptoKey> | undefined
+  return () => (imported ??= importDumpKey(bytes ?? generateDumpKey()))
 }
 
 /** Signs a worker dump envelope, prepending the version byte and MAC tag. */
 export async function signDump(key: CryptoKey, state: Uint8Array): Promise<Uint8Array> {
-  const tag = await crypto.subtle.sign('HMAC', key, withContext(state))
+  // MAC and output are both built from the `withContext` copy, not `state`:
+  // `state` may be a view over a transport buffer, and re-reading it after the
+  // await could yield different bytes than were MAC'd
+  const payload = withContext(state)
+  const tag = await crypto.subtle.sign('HMAC', key, payload)
   const signed = new Uint8Array(1 + TAG_LEN + state.length)
   signed[0] = SIGNED_DUMP_VERSION
   signed.set(new Uint8Array(tag), 1)
-  signed.set(state, 1 + TAG_LEN)
+  signed.set(payload.subarray(CONTEXT.length), 1 + TAG_LEN)
   return signed
 }
 
@@ -80,14 +92,17 @@ export async function verifyDump(key: CryptoKey, signed: Uint8Array): Promise<Ui
     throw new Error(`invalid dump: unsupported signed-dump version ${signed[0]} (expected ${SIGNED_DUMP_VERSION})`)
   }
   const tag = copyBytes(signed.subarray(1, 1 + TAG_LEN))
-  const inner = signed.subarray(1 + TAG_LEN)
-  const ok = await crypto.subtle.verify('HMAC', key, tag, withContext(inner))
+  // the returned envelope is a view over the `withContext` copy, never the
+  // caller's buffer: `signed` could be mutated during the verify await,
+  // letting unverified bytes reach a worker
+  const payload = withContext(signed.subarray(1 + TAG_LEN))
+  const ok = await crypto.subtle.verify('HMAC', key, tag, payload)
   if (!ok) {
     throw new Error(
       'invalid dump: signature verification failed — the dump was signed with a different key or corrupted',
     )
   }
-  return inner
+  return payload.subarray(CONTEXT.length)
 }
 
 /** `CONTEXT || state`, the exact bytes the MAC covers. */

--- a/crates/monty-js/ts/worker/index.ts
+++ b/crates/monty-js/ts/worker/index.ts
@@ -30,6 +30,13 @@ export interface WasmPoolOptions {
   maxCheckoutsPerWorker?: number
   /** Overrides the worker entry URL used by the browser backend. */
   workerUrl?: string | URL
+  /**
+   * Key (at least 16 bytes) used to HMAC-sign `session.dump()` bytes and
+   * verify them on `load` / `loadSnapshot`, matching the native `dumpKey`.
+   * Omitted: a random per-pool key — dumps stay pool-local. Dump/load needs
+   * WebCrypto (`crypto.subtle`), i.e. a secure context in browsers.
+   */
+  dumpKey?: Uint8Array
 }
 
 /** Creates a pool over the best backend for this environment. */
@@ -43,6 +50,7 @@ export async function createWorkerPool(module: WebAssembly.Module, options: Wasm
     minWorkers: options.minProcesses,
     maxWorkers: options.maxProcesses,
     maxCheckoutsPerWorker: options.maxCheckoutsPerWorker,
+    ...(options.dumpKey !== undefined ? { dumpKey: options.dumpKey } : {}),
   })
 }
 
@@ -78,6 +86,7 @@ export type {
 export {
   MontyCrashedError,
   MontyError,
+  MontyInvalidDumpError,
   MontyRuntimeError,
   MontySyntaxError,
   MontyTypingError,
@@ -85,6 +94,7 @@ export {
   type ExceptionInfo,
   type Frame,
 } from '../errors.js'
+export { generateDumpKey, importDumpKey, MIN_DUMP_KEY_LEN, signDump, verifyDump } from './dumpSign.js'
 export {
   type MontyDate,
   type MontyDateTime,

--- a/crates/monty-js/ts/worker/index.ts
+++ b/crates/monty-js/ts/worker/index.ts
@@ -94,7 +94,7 @@ export {
   type ExceptionInfo,
   type Frame,
 } from '../errors.js'
-export { generateDumpKey, importDumpKey, MIN_DUMP_KEY_LEN, signDump, verifyDump } from './dumpSign.js'
+export { generateDumpKey, importDumpKey, lazyDumpKey, MIN_DUMP_KEY_LEN, signDump, verifyDump } from './dumpSign.js'
 export {
   type MontyDate,
   type MontyDateTime,

--- a/crates/monty-js/ts/worker/index.ts
+++ b/crates/monty-js/ts/worker/index.ts
@@ -31,12 +31,13 @@ export interface WasmPoolOptions {
   /** Overrides the worker entry URL used by the browser backend. */
   workerUrl?: string | URL
   /**
-   * Key (at least 16 bytes) used to HMAC-sign `session.dump()` bytes and
-   * verify them on `load` / `loadSnapshot`, matching the native `dumpKey`.
-   * Omitted: a random per-pool key — dumps stay pool-local. Dump/load needs
-   * WebCrypto (`crypto.subtle`), i.e. a secure context in browsers.
+   * Key used to HMAC-sign `session.dump()` bytes and verify them on `load` /
+   * `loadSnapshot`, matching the native `dumpKey` — raw bytes, or a string
+   * (UTF-8-encoded); at least 16 bytes. Omitted: a random per-pool key — dumps
+   * stay pool-local. Dump/load needs WebCrypto (`crypto.subtle`), i.e. a
+   * secure context in browsers.
    */
-  dumpKey?: Uint8Array
+  dumpKey?: string | Uint8Array
 }
 
 /** Creates a pool over the best backend for this environment. */

--- a/crates/monty-js/ts/worker/pool.ts
+++ b/crates/monty-js/ts/worker/pool.ts
@@ -18,6 +18,7 @@
 // interrupted, exactly as the plan notes.
 
 import { MontySession } from '../session.js'
+import { generateDumpKey, importDumpKey } from './dumpSign.js'
 import { WasmHost, type Dispatcher, inProcessDispatcher } from './host.js'
 import { WorkerTransport, type WorkerSessionConfig } from './transport.js'
 
@@ -67,6 +68,12 @@ export interface WorkerPoolOptions {
   maxWorkers?: number
   /** Recycle (terminate + replace) a worker after this many checkouts. */
   maxCheckoutsPerWorker?: number
+  /**
+   * Key (at least 16 bytes) used to HMAC-sign `session.dump()` bytes and
+   * verify them on `load` / `loadSnapshot`, matching the native pool's
+   * `dumpKey`. Omitted: a random per-pool key — dumps stay pool-local.
+   */
+  dumpKey?: Uint8Array
 }
 
 /** One pooled worker with its checkout bookkeeping. */
@@ -96,13 +103,15 @@ export class WorkerPool {
     private readonly factory: WorkerFactory,
     private readonly maxWorkers: number,
     private readonly maxCheckouts: number | undefined,
+    private readonly dumpKey: CryptoKey,
   ) {}
 
   /** Creates the pool and prewarms `minWorkers` idle workers. */
   static async create(factory: WorkerFactory, options: WorkerPoolOptions = {}): Promise<WorkerPool> {
     const max = Math.max(1, options.maxWorkers ?? 4)
     const min = Math.min(Math.max(0, options.minWorkers ?? 1), max)
-    const pool = new WorkerPool(factory, max, options.maxCheckoutsPerWorker)
+    const dumpKey = await importDumpKey(options.dumpKey ?? generateDumpKey())
+    const pool = new WorkerPool(factory, max, options.maxCheckoutsPerWorker, dumpKey)
     const warm = await Promise.all(Array.from({ length: min }, () => pool.spawn()))
     pool.idle.push(...warm)
     return pool
@@ -114,7 +123,7 @@ export class WorkerPool {
     const slot = await this.acquire()
     let transport: WorkerTransport
     try {
-      transport = await WorkerTransport.create(slot.worker.dispatch, config)
+      transport = await WorkerTransport.create(slot.worker.dispatch, config, this.dumpKey)
     } catch (err) {
       this.discard(slot)
       throw err

--- a/crates/monty-js/ts/worker/pool.ts
+++ b/crates/monty-js/ts/worker/pool.ts
@@ -69,11 +69,12 @@ export interface WorkerPoolOptions {
   /** Recycle (terminate + replace) a worker after this many checkouts. */
   maxCheckoutsPerWorker?: number
   /**
-   * Key (at least 16 bytes) used to HMAC-sign `session.dump()` bytes and
-   * verify them on `load` / `loadSnapshot`, matching the native pool's
-   * `dumpKey`. Omitted: a random per-pool key — dumps stay pool-local.
+   * Key used to HMAC-sign `session.dump()` bytes and verify them on `load` /
+   * `loadSnapshot`, matching the native pool's `dumpKey` — raw bytes, or a
+   * string (UTF-8-encoded); at least 16 bytes. Omitted: a random per-pool
+   * key — dumps stay pool-local.
    */
-  dumpKey?: Uint8Array
+  dumpKey?: string | Uint8Array
 }
 
 /** One pooled worker with its checkout bookkeeping. */

--- a/crates/monty-js/ts/worker/pool.ts
+++ b/crates/monty-js/ts/worker/pool.ts
@@ -18,7 +18,7 @@
 // interrupted, exactly as the plan notes.
 
 import { MontySession } from '../session.js'
-import { generateDumpKey, importDumpKey } from './dumpSign.js'
+import { lazyDumpKey } from './dumpSign.js'
 import { WasmHost, type Dispatcher, inProcessDispatcher } from './host.js'
 import { WorkerTransport, type WorkerSessionConfig } from './transport.js'
 
@@ -103,15 +103,16 @@ export class WorkerPool {
     private readonly factory: WorkerFactory,
     private readonly maxWorkers: number,
     private readonly maxCheckouts: number | undefined,
-    private readonly dumpKey: CryptoKey,
+    /** Lazy: the key is imported/generated on the first dump/restore. */
+    private readonly dumpKey: () => Promise<CryptoKey>,
   ) {}
 
   /** Creates the pool and prewarms `minWorkers` idle workers. */
   static async create(factory: WorkerFactory, options: WorkerPoolOptions = {}): Promise<WorkerPool> {
     const max = Math.max(1, options.maxWorkers ?? 4)
     const min = Math.min(Math.max(0, options.minWorkers ?? 1), max)
-    const dumpKey = await importDumpKey(options.dumpKey ?? generateDumpKey())
-    const pool = new WorkerPool(factory, max, options.maxCheckoutsPerWorker, dumpKey)
+    // validates the key length now; crypto happens on first dump/restore
+    const pool = new WorkerPool(factory, max, options.maxCheckoutsPerWorker, lazyDumpKey(options.dumpKey))
     const warm = await Promise.all(Array.from({ length: min }, () => pool.spawn()))
     pool.idle.push(...warm)
     return pool

--- a/crates/monty-js/ts/worker/transport.ts
+++ b/crates/monty-js/ts/worker/transport.ts
@@ -13,7 +13,8 @@
 // `traceback` strings are not yet rendered (frames are decoded; the rendered
 // string is a follow-up); mounts are rejected (no host filesystem in a worker).
 
-import type { NativeException, NativeFrame, NativeFutureResult, NativeTurn } from '../native.js'
+import type { InvalidDumpTurn, NativeException, NativeFrame, NativeFutureResult, NativeTurn } from '../native.js'
+import { generateDumpKey, importDumpKey, signDump, verifyDump } from './dumpSign.js'
 import type { Dispatcher } from './host.js'
 import { Reader, Wire, Writer, deframe, frame } from './proto.js'
 import { decodeMontyObject, encodeMontyObject } from './value.js'
@@ -38,8 +39,8 @@ export interface WorkerSessionConfig {
 }
 
 // ParentRequest oneof field numbers (see proto/monty/v1/monty.proto). Note
-// field 2 is InstallDependencies (CPython-only) and field 8 is Load, neither of
-// which the wasm transport sends — hence the gaps.
+// field 2 is InstallDependencies (CPython-only), which the wasm transport
+// never sends — hence the gap.
 const Req = {
   ReplCreate: 1,
   ReplFeed: 3,
@@ -87,11 +88,26 @@ export class WorkerTransport {
    */
   onFinish?: (reusable: boolean) => void
 
-  private constructor(private readonly dispatcher: Dispatcher) {}
+  private constructor(
+    private readonly dispatcher: Dispatcher,
+    private readonly dumpKey: CryptoKey,
+  ) {}
 
-  /** Creates the REPL session (`ReplCreate`) and returns the ready transport. */
-  static async create(dispatcher: Dispatcher, config: WorkerSessionConfig = {}): Promise<WorkerTransport> {
-    const transport = new WorkerTransport(dispatcher)
+  /**
+   * Creates the REPL session (`ReplCreate`) and returns the ready transport.
+   *
+   * `dumpKey` HMAC-signs `dump()` bytes and verifies them in `restore()`
+   * (`WorkerPool` passes its pool-wide key so dumps restore across sessions).
+   * Omitted: a random per-transport key — such dumps only restore into this
+   * same transport's session, which a fresh checkout never is, so standalone
+   * users who want `restore` must supply a key.
+   */
+  static async create(
+    dispatcher: Dispatcher,
+    config: WorkerSessionConfig = {},
+    dumpKey?: CryptoKey,
+  ): Promise<WorkerTransport> {
+    const transport = new WorkerTransport(dispatcher, dumpKey ?? (await importDumpKey(generateDumpKey())))
     const create = new Writer()
     create.string(1, config.scriptName ?? 'main.py') // ReplCreate.script_name
     if (config.limits) create.lengthDelimited(2, encodeLimits(config.limits)) // ReplCreate.limits
@@ -198,7 +214,7 @@ export class WorkerTransport {
     const reader = new Reader(event.bytes)
     while (!reader.done) {
       const f = reader.next()
-      if (f.field === 1) return f.bytes // DumpResult.state
+      if (f.field === 1) return signDump(this.dumpKey, f.bytes) // DumpResult.state
     }
     throw new Error('DumpResult carried no state')
   }
@@ -207,12 +223,19 @@ export class WorkerTransport {
     state: Uint8Array,
     mounts: readonly unknown[],
     onPrint: OnPrint,
-  ): Promise<NativeTurn | { kind: 'loaded' }> {
+  ): Promise<NativeTurn | { kind: 'loaded' } | InvalidDumpTurn> {
     if (mounts.length > 0) {
       throw new Error('the wasm worker does not support filesystem mounts (browser has no host filesystem)')
     }
+    // verify before anything reaches the worker, mirroring the native pool
+    let inner: Uint8Array
+    try {
+      inner = await verifyDump(this.dumpKey, state)
+    } catch (err) {
+      return { kind: 'invalidDump', message: err instanceof Error ? err.message : String(err) }
+    }
     const load = new Writer()
-    load.bytes(1, state) // Load.state
+    load.bytes(1, inner) // Load.state
     const event = await this.run(Req.Load, load.finish(), onPrint)
     if (!event) return crashed('worker exited without a turn-ending event')
     if (event.kind === Ev.Ok) return { kind: 'loaded' }

--- a/crates/monty-js/ts/worker/transport.ts
+++ b/crates/monty-js/ts/worker/transport.ts
@@ -228,10 +228,13 @@ export class WorkerTransport {
     if (mounts.length > 0) {
       throw new Error('the wasm worker does not support filesystem mounts (browser has no host filesystem)')
     }
+    // resolved outside the catch: an unavailable-WebCrypto/key failure must
+    // throw, not masquerade as an invalid dump
+    const key = await this.dumpKey()
     // verify before anything reaches the worker, mirroring the native pool
     let inner: Uint8Array
     try {
-      inner = await verifyDump(await this.dumpKey(), state)
+      inner = await verifyDump(key, state)
     } catch (err) {
       return { kind: 'invalidDump', message: err instanceof Error ? err.message : String(err) }
     }

--- a/crates/monty-js/ts/worker/transport.ts
+++ b/crates/monty-js/ts/worker/transport.ts
@@ -14,7 +14,7 @@
 // string is a follow-up); mounts are rejected (no host filesystem in a worker).
 
 import type { InvalidDumpTurn, NativeException, NativeFrame, NativeFutureResult, NativeTurn } from '../native.js'
-import { generateDumpKey, importDumpKey, signDump, verifyDump } from './dumpSign.js'
+import { lazyDumpKey, signDump, verifyDump } from './dumpSign.js'
 import type { Dispatcher } from './host.js'
 import { Reader, Wire, Writer, deframe, frame } from './proto.js'
 import { decodeMontyObject, encodeMontyObject } from './value.js'
@@ -90,24 +90,25 @@ export class WorkerTransport {
 
   private constructor(
     private readonly dispatcher: Dispatcher,
-    private readonly dumpKey: CryptoKey,
+    /** Lazy: the key is imported/generated on the first dump/restore. */
+    private readonly dumpKey: () => Promise<CryptoKey>,
   ) {}
 
   /**
    * Creates the REPL session (`ReplCreate`) and returns the ready transport.
    *
-   * `dumpKey` HMAC-signs `dump()` bytes and verifies them in `restore()`
-   * (`WorkerPool` passes its pool-wide key so dumps restore across sessions).
-   * Omitted: a random per-transport key — such dumps only restore into this
-   * same transport's session, which a fresh checkout never is, so standalone
-   * users who want `restore` must supply a key.
+   * `dumpKey` lazily provides the key that HMAC-signs `dump()` bytes and
+   * verifies them in `restore()` (`WorkerPool` passes its pool-wide provider
+   * so dumps restore across sessions). Omitted: a random per-transport key —
+   * such dumps only restore into this same transport's session, which a fresh
+   * checkout never is, so standalone users who want `restore` must supply one.
    */
   static async create(
     dispatcher: Dispatcher,
     config: WorkerSessionConfig = {},
-    dumpKey?: CryptoKey,
+    dumpKey?: () => Promise<CryptoKey>,
   ): Promise<WorkerTransport> {
-    const transport = new WorkerTransport(dispatcher, dumpKey ?? (await importDumpKey(generateDumpKey())))
+    const transport = new WorkerTransport(dispatcher, dumpKey ?? lazyDumpKey())
     const create = new Writer()
     create.string(1, config.scriptName ?? 'main.py') // ReplCreate.script_name
     if (config.limits) create.lengthDelimited(2, encodeLimits(config.limits)) // ReplCreate.limits
@@ -214,7 +215,7 @@ export class WorkerTransport {
     const reader = new Reader(event.bytes)
     while (!reader.done) {
       const f = reader.next()
-      if (f.field === 1) return signDump(this.dumpKey, f.bytes) // DumpResult.state
+      if (f.field === 1) return signDump(await this.dumpKey(), f.bytes) // DumpResult.state
     }
     throw new Error('DumpResult carried no state')
   }
@@ -230,7 +231,7 @@ export class WorkerTransport {
     // verify before anything reaches the worker, mirroring the native pool
     let inner: Uint8Array
     try {
-      inner = await verifyDump(this.dumpKey, state)
+      inner = await verifyDump(await this.dumpKey(), state)
     } catch (err) {
       return { kind: 'invalidDump', message: err instanceof Error ? err.message : String(err) }
     }

--- a/crates/monty-pool/Cargo.toml
+++ b/crates/monty-pool/Cargo.toml
@@ -25,9 +25,17 @@ tungstenite = { workspace = true }
 # Pulled in only so the pool can install a process-level rustls `CryptoProvider`
 # before the first `wss://` dial (see `install_crypto_provider` in worker.rs).
 rustls = { workspace = true }
+# HMAC-SHA256 signing of dump payloads: the parent signs `Checkout::dump` bytes
+# and verifies them in `Checkout::restore`, so tampered/forged dumps are
+# rejected before ever reaching a worker (see dump_sign.rs).
+hmac = { workspace = true }
+sha2 = { workspace = true }
+# OS randomness for the per-pool ephemeral dump key when none is configured.
+getrandom = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+insta = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/monty-pool/README.md
+++ b/crates/monty-pool/README.md
@@ -59,9 +59,11 @@ snippet; `Checkout::feed` accepts inputs (host values exposed as sandbox globals
 per-feed filesystem mounts (`MountSpec`). Sessions can be snapshotted with `Checkout::dump`
 and restored later — including on a different worker or machine — with `Checkout::restore`.
 
-Dump bytes are HMAC-SHA256-signed with the pool's `PoolConfig::dump_key` (a random per-pool
-key when unset) and verified on restore, so tampered or forged dumps are rejected
+Dump bytes are HMAC-SHA256-signed per the pool's `PoolConfig::dump_signing` (a random
+per-pool key by default) and verified on restore, so tampered or forged dumps are rejected
 (`PoolError::InvalidDump`) before they ever reach a worker; the key never leaves the parent.
+The WebSocket transport defaults to `DumpSigning::Disabled` — the dialed server owns
+signing, and dump bytes pass through the client untouched.
 
 ## Protections over in-process execution
 

--- a/crates/monty-pool/README.md
+++ b/crates/monty-pool/README.md
@@ -59,6 +59,10 @@ snippet; `Checkout::feed` accepts inputs (host values exposed as sandbox globals
 per-feed filesystem mounts (`MountSpec`). Sessions can be snapshotted with `Checkout::dump`
 and restored later — including on a different worker or machine — with `Checkout::restore`.
 
+Dump bytes are HMAC-SHA256-signed with the pool's `PoolConfig::dump_key` (a random per-pool
+key when unset) and verified on restore, so tampered or forged dumps are rejected
+(`PoolError::InvalidDump`) before they ever reach a worker; the key never leaves the parent.
+
 ## Protections over in-process execution
 
 - **Crash isolation** — a segfault, stack-overflow abort, or allocator abort in the sandbox

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -211,7 +211,8 @@ impl Checkout {
     /// (an idle dump), paired with the worker's adopted script name (the dump's,
     /// not the `Configure` one), which the parent surfaces in restored snapshots.
     ///
-    /// `state` must carry a valid HMAC signature from the pool's dump key —
+    /// Unless the pool's [`crate::DumpSigning`] is `Disabled`, `state` must
+    /// carry a valid HMAC signature from the pool's dump key —
     /// [`PoolError::InvalidDump`] otherwise, raised before the bytes ever
     /// reach the worker.
     pub fn restore(
@@ -220,7 +221,10 @@ impl Checkout {
         mounts: Vec<MountSpec>,
         on_print: OnPrint<'_>,
     ) -> Result<(Option<TurnEvent>, Option<String>), PoolError> {
-        let state = self.pool.dump_key().verify(state)?;
+        let state = match self.pool.dump_key() {
+            Some(key) => key.verify(state)?,
+            None => state,
+        };
         // the dump carries its own limits/consumed time/script name — forget
         // what the worker's Configure established and re-adopt from the reply
         self.pending = None;
@@ -415,14 +419,19 @@ impl Checkout {
     /// different worker after this one crashes. The session stays live.
     ///
     /// The returned bytes are HMAC-signed with the pool's dump key
-    /// ([`crate::PoolConfig::dump_key`]), so `restore` rejects tampered or
-    /// forged dumps and dumps from a pool with a different (or ephemeral) key.
+    /// ([`crate::PoolConfig::dump_signing`]), so `restore` rejects tampered or
+    /// forged dumps and dumps from a pool with a different (or ephemeral) key —
+    /// unless signing is `Disabled`, where the worker's bytes pass through
+    /// untouched.
     pub fn dump(&mut self) -> Result<Vec<u8>, PoolError> {
         let request = pb::ParentRequest {
             kind: Some(pb::parent_request::Kind::Dump(pb::Dump {})),
         };
         match self.request_turn(&request, self.pool.config.request_timeout, &mut |_, _| {})? {
-            ControlEvent::Dump(state) => Ok(self.pool.dump_key().sign(&state)),
+            ControlEvent::Dump(state) => Ok(match self.pool.dump_key() {
+                Some(key) => key.sign(&state),
+                None => state,
+            }),
             other => Err(self.protocol_violation(&format!("unexpected reply to Dump: {other:?}"))),
         }
     }

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -210,12 +210,17 @@ impl Checkout {
     /// Returns the re-announced suspension (`Some` — a suspended dump) or `None`
     /// (an idle dump), paired with the worker's adopted script name (the dump's,
     /// not the `Configure` one), which the parent surfaces in restored snapshots.
+    ///
+    /// `state` must carry a valid HMAC signature from the pool's dump key —
+    /// [`PoolError::InvalidDump`] otherwise, raised before the bytes ever
+    /// reach the worker.
     pub fn restore(
         &mut self,
         state: Vec<u8>,
         mounts: Vec<MountSpec>,
         on_print: OnPrint<'_>,
     ) -> Result<(Option<TurnEvent>, Option<String>), PoolError> {
+        let state = self.pool.dump_key.verify(state)?;
         // the dump carries its own limits/consumed time/script name — forget
         // what the worker's Configure established and re-adopt from the reply
         self.pending = None;
@@ -408,12 +413,16 @@ impl Checkout {
     /// Serializes the session (idle or suspended) into opaque bytes that
     /// [`Checkout::restore`] can restore — including into a
     /// different worker after this one crashes. The session stays live.
+    ///
+    /// The returned bytes are HMAC-signed with the pool's dump key
+    /// ([`crate::PoolConfig::dump_key`]), so `restore` rejects tampered or
+    /// forged dumps and dumps from a pool with a different (or ephemeral) key.
     pub fn dump(&mut self) -> Result<Vec<u8>, PoolError> {
         let request = pb::ParentRequest {
             kind: Some(pb::parent_request::Kind::Dump(pb::Dump {})),
         };
         match self.request_turn(&request, self.pool.config.request_timeout, &mut |_, _| {})? {
-            ControlEvent::Dump(state) => Ok(state),
+            ControlEvent::Dump(state) => Ok(self.pool.dump_key.sign(&state)),
             other => Err(self.protocol_violation(&format!("unexpected reply to Dump: {other:?}"))),
         }
     }

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -220,7 +220,7 @@ impl Checkout {
         mounts: Vec<MountSpec>,
         on_print: OnPrint<'_>,
     ) -> Result<(Option<TurnEvent>, Option<String>), PoolError> {
-        let state = self.pool.dump_key.verify(state)?;
+        let state = self.pool.dump_key().verify(state)?;
         // the dump carries its own limits/consumed time/script name — forget
         // what the worker's Configure established and re-adopt from the reply
         self.pending = None;
@@ -422,7 +422,7 @@ impl Checkout {
             kind: Some(pb::parent_request::Kind::Dump(pb::Dump {})),
         };
         match self.request_turn(&request, self.pool.config.request_timeout, &mut |_, _| {})? {
-            ControlEvent::Dump(state) => Ok(self.pool.dump_key.sign(&state)),
+            ControlEvent::Dump(state) => Ok(self.pool.dump_key().sign(&state)),
             other => Err(self.protocol_violation(&format!("unexpected reply to Dump: {other:?}"))),
         }
     }

--- a/crates/monty-pool/src/dump_sign.rs
+++ b/crates/monty-pool/src/dump_sign.rs
@@ -43,7 +43,7 @@ const TAG_LEN: usize = 32;
 ///
 /// Supply one via [`crate::PoolConfig::dump_key`] to make dumps restorable
 /// across pools/processes; without one the pool generates a random ephemeral
-/// key at creation, so its dumps only restore into that same pool instance.
+/// key on first use, so its dumps only restore into that same pool instance.
 #[derive(Clone)]
 pub struct DumpKey(Vec<u8>);
 
@@ -59,12 +59,13 @@ impl DumpKey {
     }
 
     /// Generates a random 32-byte key from OS randomness, used when
-    /// [`crate::PoolConfig::dump_key`] is `None`.
-    pub(crate) fn ephemeral() -> Result<Self, PoolError> {
+    /// [`crate::PoolConfig::dump_key`] is `None`. Created lazily on the first
+    /// dump/restore, so pools that never dump draw no randomness. Panics if
+    /// the OS RNG fails — an unrecoverable environment fault, not a pool error.
+    pub(crate) fn ephemeral() -> Self {
         let mut key = vec![0u8; 32];
-        getrandom::fill(&mut key)
-            .map_err(|err| PoolError::Spawn(format!("failed to generate an ephemeral dump key: {err}")))?;
-        Ok(Self(key))
+        getrandom::fill(&mut key).expect("OS randomness unavailable — cannot generate a dump signing key");
+        Self(key)
     }
 
     /// Signs a worker dump envelope, prepending the version byte and MAC tag.

--- a/crates/monty-pool/src/dump_sign.rs
+++ b/crates/monty-pool/src/dump_sign.rs
@@ -93,11 +93,15 @@ impl DumpKey {
                 signed[0]
             )));
         }
-        let inner = signed.split_off(1 + TAG_LEN);
         let mut mac = self.mac();
-        mac.update(&inner);
-        match mac.verify_slice(&signed[1..]) {
-            Ok(()) => Ok(inner),
+        mac.update(&signed[1 + TAG_LEN..]);
+        match mac.verify_slice(&signed[1..=TAG_LEN]) {
+            Ok(()) => {
+                // strip the header in place — dumps can be large (the whole
+                // heap), so avoid reallocating the envelope
+                signed.drain(..=TAG_LEN);
+                Ok(signed)
+            }
             Err(_) => Err(PoolError::InvalidDump(
                 "signature verification failed — the dump was signed with a different key or corrupted".to_owned(),
             )),

--- a/crates/monty-pool/src/dump_sign.rs
+++ b/crates/monty-pool/src/dump_sign.rs
@@ -30,7 +30,8 @@ use sha2::Sha256;
 use crate::PoolError;
 
 /// Minimum accepted [`DumpKey`] length; shorter keys are rejected at
-/// construction so weak keys never make it into a pool.
+/// construction. Length is the only check — the key must still be secret,
+/// high-entropy material (e.g. 32 bytes from a CSPRNG), not a password.
 pub const MIN_DUMP_KEY_LEN: usize = 16;
 
 /// Format version prepended to every signed dump.

--- a/crates/monty-pool/src/dump_sign.rs
+++ b/crates/monty-pool/src/dump_sign.rs
@@ -6,6 +6,9 @@
 //! attack surface. Every dump is therefore signed with the pool's [`DumpKey`]
 //! and verified before a `Load` is ever sent to a worker. The key lives only
 //! in the parent process; workers (which run untrusted code) never see it.
+//! The exception is [`DumpSigning::Disabled`] (the WebSocket-transport
+//! default), where the dialed server owns signing and the client passes dump
+//! bytes through untouched.
 //!
 //! Signed payload layout (`SIGNED_DUMP_VERSION` = 1):
 //!
@@ -39,11 +42,28 @@ const CONTEXT: &[u8] = b"monty-dump-sign-v1";
 /// HMAC-SHA256 output length in bytes.
 const TAG_LEN: usize = 32;
 
+/// How a pool signs [`crate::Checkout::dump`] bytes and verifies them in
+/// [`crate::Checkout::restore`]; set via [`crate::PoolConfig::dump_signing`].
+#[derive(Debug, Clone, Default)]
+pub enum DumpSigning {
+    /// A random key generated on the pool's first dump/restore: dumps only
+    /// restore into that same pool instance. The subprocess-transport default.
+    #[default]
+    Ephemeral,
+    /// A caller-supplied key: dumps restore across pools/processes sharing it.
+    Key(DumpKey),
+    /// No client-side signing — dump/restore bytes pass through untouched and
+    /// unverified. The WebSocket-transport default: the dialed server performs
+    /// the deserialization, so signing is its responsibility, and this client
+    /// only carries opaque bytes.
+    Disabled,
+}
+
 /// A pool's dump-signing key.
 ///
-/// Supply one via [`crate::PoolConfig::dump_key`] to make dumps restorable
-/// across pools/processes; without one the pool generates a random ephemeral
-/// key on first use, so its dumps only restore into that same pool instance.
+/// Supply one via [`DumpSigning::Key`] to make dumps restorable across
+/// pools/processes; the [`DumpSigning::Ephemeral`] default instead generates a
+/// random key on first use, so dumps only restore into that pool instance.
 #[derive(Clone)]
 pub struct DumpKey(Vec<u8>);
 
@@ -58,10 +78,10 @@ impl DumpKey {
         }
     }
 
-    /// Generates a random 32-byte key from OS randomness, used when
-    /// [`crate::PoolConfig::dump_key`] is `None`. Created lazily on the first
-    /// dump/restore, so pools that never dump draw no randomness. Panics if
-    /// the OS RNG fails — an unrecoverable environment fault, not a pool error.
+    /// Generates a random 32-byte key from OS randomness, backing
+    /// [`DumpSigning::Ephemeral`]. Created lazily on the first dump/restore,
+    /// so pools that never dump draw no randomness. Panics if the OS RNG
+    /// fails — an unrecoverable environment fault, not a pool error.
     pub(crate) fn ephemeral() -> Self {
         let mut key = vec![0u8; 32];
         getrandom::fill(&mut key).expect("OS randomness unavailable — cannot generate a dump signing key");

--- a/crates/monty-pool/src/dump_sign.rs
+++ b/crates/monty-pool/src/dump_sign.rs
@@ -1,0 +1,133 @@
+//! Host-side HMAC signing of dump payloads.
+//!
+//! [`crate::Checkout::dump`] bytes are persisted by callers and later fed back
+//! to [`crate::Checkout::restore`], where they reach deserialization of
+//! interpreter state inside a worker — so a forged or tampered dump is a real
+//! attack surface. Every dump is therefore signed with the pool's [`DumpKey`]
+//! and verified before a `Load` is ever sent to a worker. The key lives only
+//! in the parent process; workers (which run untrusted code) never see it.
+//!
+//! Signed payload layout (`SIGNED_DUMP_VERSION` = 1):
+//!
+//! ```text
+//! [version u8 = 0x01][tag: 32-byte HMAC-SHA256(key, CONTEXT || inner)][inner]
+//! ```
+//!
+//! where `inner` is the worker's opaque dump envelope, untouched. `CONTEXT`
+//! domain-separates the MAC so a dump key reused elsewhere cannot be tricked
+//! into signing/verifying non-dump data. The TypeScript mirror for the wasm
+//! worker path (`crates/monty-js/ts/worker/dumpSign.ts`) must stay
+//! byte-compatible with this file — it is the source of truth for the format.
+
+use std::{error, fmt};
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+use crate::PoolError;
+
+/// Minimum accepted [`DumpKey`] length; shorter keys are rejected at
+/// construction so weak keys never make it into a pool.
+pub const MIN_DUMP_KEY_LEN: usize = 16;
+
+/// Format version prepended to every signed dump.
+const SIGNED_DUMP_VERSION: u8 = 1;
+
+/// Domain-separation prefix mixed into every MAC (see module docs).
+const CONTEXT: &[u8] = b"monty-dump-sign-v1";
+
+/// HMAC-SHA256 output length in bytes.
+const TAG_LEN: usize = 32;
+
+/// A pool's dump-signing key.
+///
+/// Supply one via [`crate::PoolConfig::dump_key`] to make dumps restorable
+/// across pools/processes; without one the pool generates a random ephemeral
+/// key at creation, so its dumps only restore into that same pool instance.
+#[derive(Clone)]
+pub struct DumpKey(Vec<u8>);
+
+impl DumpKey {
+    /// Wraps user-supplied key bytes, rejecting keys shorter than
+    /// [`MIN_DUMP_KEY_LEN`].
+    pub fn new(key: Vec<u8>) -> Result<Self, InvalidDumpKey> {
+        if key.len() < MIN_DUMP_KEY_LEN {
+            Err(InvalidDumpKey)
+        } else {
+            Ok(Self(key))
+        }
+    }
+
+    /// Generates a random 32-byte key from OS randomness, used when
+    /// [`crate::PoolConfig::dump_key`] is `None`.
+    pub(crate) fn ephemeral() -> Result<Self, PoolError> {
+        let mut key = vec![0u8; 32];
+        getrandom::fill(&mut key)
+            .map_err(|err| PoolError::Spawn(format!("failed to generate an ephemeral dump key: {err}")))?;
+        Ok(Self(key))
+    }
+
+    /// Signs a worker dump envelope, prepending the version byte and MAC tag.
+    pub(crate) fn sign(&self, state: &[u8]) -> Vec<u8> {
+        let mut mac = self.mac();
+        mac.update(state);
+        let tag = mac.finalize().into_bytes();
+        let mut signed = Vec::with_capacity(1 + TAG_LEN + state.len());
+        signed.push(SIGNED_DUMP_VERSION);
+        signed.extend_from_slice(&tag);
+        signed.extend_from_slice(state);
+        signed
+    }
+
+    /// Verifies a signed dump and returns the inner worker envelope, or
+    /// [`PoolError::InvalidDump`] — the caller must not send unverified bytes
+    /// to a worker. The tag comparison is constant-time (`Mac::verify_slice`).
+    pub(crate) fn verify(&self, mut signed: Vec<u8>) -> Result<Vec<u8>, PoolError> {
+        if signed.len() < 1 + TAG_LEN {
+            return Err(PoolError::InvalidDump("too short to be a signed dump".to_owned()));
+        }
+        if signed[0] != SIGNED_DUMP_VERSION {
+            return Err(PoolError::InvalidDump(format!(
+                "unsupported signed-dump version {} (expected {SIGNED_DUMP_VERSION})",
+                signed[0]
+            )));
+        }
+        let inner = signed.split_off(1 + TAG_LEN);
+        let mut mac = self.mac();
+        mac.update(&inner);
+        match mac.verify_slice(&signed[1..]) {
+            Ok(()) => Ok(inner),
+            Err(_) => Err(PoolError::InvalidDump(
+                "signature verification failed — the dump was signed with a different key or corrupted".to_owned(),
+            )),
+        }
+    }
+
+    /// A MAC instance keyed with this key, pre-fed with the domain-separation
+    /// context.
+    fn mac(&self) -> Hmac<Sha256> {
+        let mut mac = Hmac::<Sha256>::new_from_slice(&self.0).expect("HMAC-SHA256 accepts keys of any length");
+        mac.update(CONTEXT);
+        mac
+    }
+}
+
+/// Redacted — key material must never reach logs (`PoolConfig` derives Debug).
+impl fmt::Debug for DumpKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("DumpKey(..)")
+    }
+}
+
+/// Error from [`DumpKey::new`]: the supplied key is shorter than
+/// [`MIN_DUMP_KEY_LEN`].
+#[derive(Debug)]
+pub struct InvalidDumpKey;
+
+impl fmt::Display for InvalidDumpKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "dump key must be at least {MIN_DUMP_KEY_LEN} bytes")
+    }
+}
+
+impl error::Error for InvalidDumpKey {}

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -74,9 +74,9 @@ pub struct PoolConfig {
     pub max_checkouts_per_worker: Option<u32>,
     /// Key used to HMAC-sign [`Checkout::dump`] bytes and verify them in
     /// [`Checkout::restore`]. `None` (the default) generates a random
-    /// ephemeral key at pool creation, so dumps only restore into that same
-    /// pool instance; supply a key for cross-pool or persistent restore. The
-    /// key stays in the parent — it is never sent to workers.
+    /// ephemeral key on the pool's first dump/restore, so dumps only restore
+    /// into that same pool instance; supply a key for cross-pool or persistent
+    /// restore. The key stays in the parent — it is never sent to workers.
     pub dump_key: Option<DumpKey>,
 }
 

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -13,7 +13,7 @@ pub use monty_proto::{MAX_VALUE_DEPTH, exceeds_max_value_depth};
 
 pub use crate::{
     checkout::{Checkout, MountSpec, MountSpecMode, OnPrint, ReplConfig, ResumeValue, TurnEvent},
-    dump_sign::{DumpKey, InvalidDumpKey, MIN_DUMP_KEY_LEN},
+    dump_sign::{DumpKey, DumpSigning, InvalidDumpKey, MIN_DUMP_KEY_LEN},
     pool::Pool,
 };
 
@@ -72,12 +72,11 @@ pub struct PoolConfig {
     /// Recycle (kill and respawn) a worker after this many checkouts, to
     /// bound the impact of any slow leak in a long-lived child.
     pub max_checkouts_per_worker: Option<u32>,
-    /// Key used to HMAC-sign [`Checkout::dump`] bytes and verify them in
-    /// [`Checkout::restore`]. `None` (the default) generates a random
-    /// ephemeral key on the pool's first dump/restore, so dumps only restore
-    /// into that same pool instance; supply a key for cross-pool or persistent
-    /// restore. The key stays in the parent — it is never sent to workers.
-    pub dump_key: Option<DumpKey>,
+    /// How [`Checkout::dump`] bytes are HMAC-signed and verified in
+    /// [`Checkout::restore`]. Defaults to [`DumpSigning::Ephemeral`] for the
+    /// subprocess transport and [`DumpSigning::Disabled`] for the WebSocket
+    /// transport (the server owns signing there).
+    pub dump_signing: DumpSigning,
 }
 
 impl PoolConfig {
@@ -89,10 +88,13 @@ impl PoolConfig {
     }
 
     /// Creates a WebSocket-transport config dialing `url` verbatim per checkout.
-    /// `min_processes` is 0 (no pre-warming — connections are made per-checkout).
+    /// `min_processes` is 0 (no pre-warming — connections are made per-checkout)
+    /// and dump signing is disabled: the dialed server owns signing, so dump
+    /// bytes pass through this client untouched.
     pub fn websocket(url: impl Into<String>) -> Self {
         let mut config = Self::with_transport(MontyTransport::Websocket(url.into()));
         config.min_processes = 0;
+        config.dump_signing = DumpSigning::Disabled;
         config
     }
 
@@ -106,7 +108,7 @@ impl PoolConfig {
             request_timeout: None,
             duration_limit_grace: Some(Duration::from_secs(1)),
             max_checkouts_per_worker: None,
-            dump_key: None,
+            dump_signing: DumpSigning::Ephemeral,
         }
     }
 }

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -140,7 +140,8 @@ pub enum PoolError {
     Typing(String),
     /// The dump handed to [`Checkout::restore`] failed HMAC verification (or
     /// is not a signed dump). Raised before the worker is contacted — the
-    /// untrusted bytes never reach it and no load happened.
+    /// untrusted bytes never reach it, no load happened, and the checkout
+    /// stays usable (unlike other restore failures).
     InvalidDump(String),
     /// No worker became available within `checkout_timeout`.
     Exhausted,

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 mod checkout;
+mod dump_sign;
 mod pool;
 mod watchdog;
 mod worker;
@@ -12,6 +13,7 @@ pub use monty_proto::{MAX_VALUE_DEPTH, exceeds_max_value_depth};
 
 pub use crate::{
     checkout::{Checkout, MountSpec, MountSpecMode, OnPrint, ReplConfig, ResumeValue, TurnEvent},
+    dump_sign::{DumpKey, InvalidDumpKey, MIN_DUMP_KEY_LEN},
     pool::Pool,
 };
 
@@ -70,6 +72,12 @@ pub struct PoolConfig {
     /// Recycle (kill and respawn) a worker after this many checkouts, to
     /// bound the impact of any slow leak in a long-lived child.
     pub max_checkouts_per_worker: Option<u32>,
+    /// Key used to HMAC-sign [`Checkout::dump`] bytes and verify them in
+    /// [`Checkout::restore`]. `None` (the default) generates a random
+    /// ephemeral key at pool creation, so dumps only restore into that same
+    /// pool instance; supply a key for cross-pool or persistent restore. The
+    /// key stays in the parent — it is never sent to workers.
+    pub dump_key: Option<DumpKey>,
 }
 
 impl PoolConfig {
@@ -98,6 +106,7 @@ impl PoolConfig {
             request_timeout: None,
             duration_limit_grace: Some(Duration::from_secs(1)),
             max_checkouts_per_worker: None,
+            dump_key: None,
         }
     }
 }
@@ -129,6 +138,10 @@ pub enum PoolError {
     /// `type_check`). The worker and session remain alive; the snippet did
     /// not run.
     Typing(String),
+    /// The dump handed to [`Checkout::restore`] failed HMAC verification (or
+    /// is not a signed dump). Raised before the worker is contacted — the
+    /// untrusted bytes never reach it and no load happened.
+    InvalidDump(String),
     /// No worker became available within `checkout_timeout`.
     Exhausted,
     /// A worker process could not be spawned.
@@ -150,6 +163,7 @@ impl fmt::Display for PoolError {
             Self::Protocol(msg) => write!(f, "monty worker protocol error: {msg}"),
             Self::Runtime(exc) => write!(f, "{exc}"),
             Self::Typing(diagnostics) => write!(f, "type checking failed:\n{diagnostics}"),
+            Self::InvalidDump(msg) => write!(f, "invalid dump: {msg}"),
             Self::Exhausted => f.write_str("no monty worker became available within the checkout timeout"),
             Self::Spawn(msg) => write!(f, "failed to spawn monty worker: {msg}"),
             Self::Finished => f.write_str("this checkout has already been finished"),

--- a/crates/monty-pool/src/pool.rs
+++ b/crates/monty-pool/src/pool.rs
@@ -10,7 +10,7 @@ use monty_proto::pb;
 use crate::{
     PoolConfig, PoolError,
     checkout::{Checkout, ReplConfig},
-    dump_sign::DumpKey,
+    dump_sign::{DumpKey, DumpSigning},
     watchdog::Watchdog,
     worker::{Worker, lock_ignore_poison},
 };
@@ -37,9 +37,9 @@ pub(crate) struct PoolInner {
     available: Condvar,
     pub(crate) watchdog: Watchdog,
     /// The pool's ephemeral dump-signing key, generated lazily by
-    /// [`PoolInner::dump_key`] on the first dump/restore — used only when
-    /// [`PoolConfig::dump_key`] is `None` (a configured key is borrowed from
-    /// the config directly).
+    /// [`PoolInner::dump_key`] on the first dump/restore — used only for
+    /// [`DumpSigning::Ephemeral`] (a configured key is borrowed from the
+    /// config directly; disabled signing uses no key at all).
     ephemeral_dump_key: OnceLock<DumpKey>,
 }
 
@@ -110,13 +110,15 @@ impl Pool {
 }
 
 impl PoolInner {
-    /// The pool's dump-signing key: the configured [`PoolConfig::dump_key`],
-    /// or a random ephemeral key generated on the first dump/restore — pools
-    /// that never dump draw no OS randomness.
-    pub(crate) fn dump_key(&self) -> &DumpKey {
-        match &self.config.dump_key {
-            Some(key) => key,
-            None => self.ephemeral_dump_key.get_or_init(DumpKey::ephemeral),
+    /// The pool's dump-signing key per [`PoolConfig::dump_signing`]: the
+    /// configured key, a random ephemeral key generated on the first
+    /// dump/restore (pools that never dump draw no OS randomness), or `None`
+    /// when signing is disabled (dump bytes pass through untouched).
+    pub(crate) fn dump_key(&self) -> Option<&DumpKey> {
+        match &self.config.dump_signing {
+            DumpSigning::Key(key) => Some(key),
+            DumpSigning::Ephemeral => Some(self.ephemeral_dump_key.get_or_init(DumpKey::ephemeral)),
+            DumpSigning::Disabled => None,
         }
     }
 

--- a/crates/monty-pool/src/pool.rs
+++ b/crates/monty-pool/src/pool.rs
@@ -1,7 +1,7 @@
 //! The elastic worker pool: prewarming, checkout, replacement, teardown.
 
 use std::{
-    sync::{Arc, Condvar, Mutex, PoisonError},
+    sync::{Arc, Condvar, Mutex, OnceLock, PoisonError},
     time::Instant,
 };
 
@@ -36,9 +36,11 @@ pub(crate) struct PoolInner {
     /// released, waking blocked `checkout` calls.
     available: Condvar,
     pub(crate) watchdog: Watchdog,
-    /// Signs every `Checkout::dump` and verifies every `Checkout::restore`:
-    /// the configured key, or a random per-pool ephemeral one.
-    pub(crate) dump_key: DumpKey,
+    /// The pool's ephemeral dump-signing key, generated lazily by
+    /// [`PoolInner::dump_key`] on the first dump/restore — used only when
+    /// [`PoolConfig::dump_key`] is `None` (a configured key is borrowed from
+    /// the config directly).
+    ephemeral_dump_key: OnceLock<DumpKey>,
 }
 
 struct PoolState {
@@ -59,7 +61,6 @@ impl Pool {
         }
         let watchdog =
             Watchdog::new().map_err(|err| PoolError::Spawn(format!("failed to spawn the watchdog thread: {err}")))?;
-        let dump_key = config.dump_key.clone().map_or_else(DumpKey::ephemeral, Ok)?;
         // Only the subprocess transport pre-warms workers; WebSocket connections
         // are made per-checkout (its `min_processes` is 0).
         let mut idle = Vec::with_capacity(config.min_processes);
@@ -75,7 +76,7 @@ impl Pool {
                 state: Mutex::new(PoolState { idle, total }),
                 available: Condvar::new(),
                 watchdog,
-                dump_key,
+                ephemeral_dump_key: OnceLock::new(),
             }),
         })
     }
@@ -109,6 +110,16 @@ impl Pool {
 }
 
 impl PoolInner {
+    /// The pool's dump-signing key: the configured [`PoolConfig::dump_key`],
+    /// or a random ephemeral key generated on the first dump/restore — pools
+    /// that never dump draw no OS randomness.
+    pub(crate) fn dump_key(&self) -> &DumpKey {
+        match &self.config.dump_key {
+            Some(key) => key,
+            None => self.ephemeral_dump_key.get_or_init(DumpKey::ephemeral),
+        }
+    }
+
     /// Takes a worker, reusing/spawning a local one or connecting a fresh remote
     /// one, waiting as capacity allows.
     fn acquire_worker(&self) -> Result<Worker, PoolError> {

--- a/crates/monty-pool/src/pool.rs
+++ b/crates/monty-pool/src/pool.rs
@@ -10,6 +10,7 @@ use monty_proto::pb;
 use crate::{
     PoolConfig, PoolError,
     checkout::{Checkout, ReplConfig},
+    dump_sign::DumpKey,
     watchdog::Watchdog,
     worker::{Worker, lock_ignore_poison},
 };
@@ -35,6 +36,9 @@ pub(crate) struct PoolInner {
     /// released, waking blocked `checkout` calls.
     available: Condvar,
     pub(crate) watchdog: Watchdog,
+    /// Signs every `Checkout::dump` and verifies every `Checkout::restore`:
+    /// the configured key, or a random per-pool ephemeral one.
+    pub(crate) dump_key: DumpKey,
 }
 
 struct PoolState {
@@ -55,6 +59,7 @@ impl Pool {
         }
         let watchdog =
             Watchdog::new().map_err(|err| PoolError::Spawn(format!("failed to spawn the watchdog thread: {err}")))?;
+        let dump_key = config.dump_key.clone().map_or_else(DumpKey::ephemeral, Ok)?;
         // Only the subprocess transport pre-warms workers; WebSocket connections
         // are made per-checkout (its `min_processes` is 0).
         let mut idle = Vec::with_capacity(config.min_processes);
@@ -70,6 +75,7 @@ impl Pool {
                 state: Mutex::new(PoolState { idle, total }),
                 available: Condvar::new(),
                 watchdog,
+                dump_key,
             }),
         })
     }

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -750,7 +750,8 @@ fn dump_x_42(pool: &Pool) -> Vec<u8> {
     state
 }
 
-/// Asserts that restoring `state` fails signature verification.
+/// Asserts that restoring `state` fails signature verification, and that the
+/// rejection is non-destructive: the session stays usable.
 #[track_caller]
 fn expect_invalid_dump(pool: &Pool, state: Vec<u8>) {
     let mut session = pool.checkout(&ReplConfig::default()).unwrap();
@@ -765,6 +766,11 @@ fn expect_invalid_dump(pool: &Pool, state: Vec<u8>) {
         err.to_string(),
         "invalid dump: signature verification failed — the dump was signed with a different key or corrupted"
     );
+    // verification failed before any worker I/O, so the session (and its
+    // worker) must remain fresh and usable
+    let event = session.feed("1 + 1", vec![], vec![], false, &mut no_print).unwrap();
+    assert_eq!(expect_complete(event), MontyObject::Int(2));
+    session.finish().unwrap();
 }
 
 #[test]

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -15,7 +15,9 @@ use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 
 use insta::assert_snapshot;
 use monty::{MontyObject, PrintStream, ResourceLimits};
-use monty_pool::{DumpKey, MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, ReplConfig, ResumeValue, TurnEvent};
+use monty_pool::{
+    DumpKey, DumpSigning, MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, ReplConfig, ResumeValue, TurnEvent,
+};
 
 /// Locates (building once if needed) the `monty` CLI binary for tests.
 fn monty_binary() -> PathBuf {
@@ -734,7 +736,7 @@ fn dump_survives_worker_death_and_loads_elsewhere() {
 /// A pool config with an explicit dump key, for cross-pool restore tests.
 fn config_with_key(key: &[u8]) -> PoolConfig {
     let mut config = config();
-    config.dump_key = Some(DumpKey::new(key.to_vec()).unwrap());
+    config.dump_signing = DumpSigning::Key(DumpKey::new(key.to_vec()).unwrap());
     config
 }
 
@@ -816,6 +818,46 @@ fn wrong_key_dump_is_rejected() {
     let state = dump_x_42(&pool_a);
     let pool_b = Pool::new(config_with_key(b"a different key for pool two....")).unwrap();
     expect_invalid_dump(&pool_b, state);
+}
+
+#[test]
+fn disabled_signing_passes_dumps_through() {
+    // both pools disable signing (the WebSocket-transport default, here on the
+    // subprocess transport): dumps are the worker's raw envelope, unsigned,
+    // and restore accepts them from any pool without verification
+    let mut config_a = config();
+    config_a.dump_signing = DumpSigning::Disabled;
+    let pool_a = Pool::new(config_a).unwrap();
+    let state = dump_x_42(&pool_a);
+    drop(pool_a);
+
+    let mut config_b = config();
+    config_b.dump_signing = DumpSigning::Disabled;
+    let pool_b = Pool::new(config_b).unwrap();
+    let mut restored = pool_b.checkout(&ReplConfig::default()).unwrap();
+    let (event, _script_name) = restored.restore(state, vec![], &mut no_print).unwrap();
+    assert!(event.is_none(), "an idle dump re-announces no suspension");
+    let event = restored.feed("x", vec![], vec![], false, &mut no_print).unwrap();
+    assert_eq!(expect_complete(event), MontyObject::Int(42));
+    restored.finish().unwrap();
+}
+
+#[test]
+fn unsigned_dump_is_rejected_by_a_signing_pool() {
+    // a dump from a signing-disabled pool is raw, so a (default, ephemeral-key)
+    // signing pool must reject it before it reaches a worker
+    let mut config_a = config();
+    config_a.dump_signing = DumpSigning::Disabled;
+    let pool_a = Pool::new(config_a).unwrap();
+    let state = dump_x_42(&pool_a);
+
+    let pool_b = Pool::new(config()).unwrap();
+    let mut session = pool_b.checkout(&ReplConfig::default()).unwrap();
+    let err = session.restore(state, vec![], &mut no_print).unwrap_err();
+    assert!(
+        matches!(err, PoolError::InvalidDump(_)),
+        "expected InvalidDump, got {err:?}"
+    );
 }
 
 #[test]

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -13,8 +13,9 @@ use std::{
 #[cfg(unix)]
 use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 
+use insta::assert_snapshot;
 use monty::{MontyObject, PrintStream, ResourceLimits};
-use monty_pool::{MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, ReplConfig, ResumeValue, TurnEvent};
+use monty_pool::{DumpKey, MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, ReplConfig, ResumeValue, TurnEvent};
 
 /// Locates (building once if needed) the `monty` CLI binary for tests.
 fn monty_binary() -> PathBuf {
@@ -724,6 +725,98 @@ fn dump_survives_worker_death_and_loads_elsewhere() {
         .unwrap();
     assert_eq!(expect_complete(event), MontyObject::Int(42));
     restored.finish().unwrap();
+}
+
+// =============================================================================
+// Dump signing
+// =============================================================================
+
+/// A pool config with an explicit dump key, for cross-pool restore tests.
+fn config_with_key(key: &[u8]) -> PoolConfig {
+    let mut config = config();
+    config.dump_key = Some(DumpKey::new(key.to_vec()).unwrap());
+    config
+}
+
+/// Dumps a fresh session holding `x = 42` and returns the signed bytes.
+fn dump_x_42(pool: &Pool) -> Vec<u8> {
+    let mut session = pool.checkout(&ReplConfig::default()).unwrap();
+    assert_eq!(
+        expect_complete(session.feed("x = 42", vec![], vec![], false, &mut no_print).unwrap()),
+        MontyObject::None
+    );
+    let state = session.dump().unwrap();
+    session.finish().unwrap();
+    state
+}
+
+/// Asserts that restoring `state` fails signature verification.
+#[track_caller]
+fn expect_invalid_dump(pool: &Pool, state: Vec<u8>) {
+    let mut session = pool.checkout(&ReplConfig::default()).unwrap();
+    let err = session.restore(state, vec![], &mut no_print).unwrap_err();
+    assert!(
+        matches!(err, PoolError::InvalidDump(_)),
+        "expected InvalidDump, got {err:?}"
+    );
+    // assert_eq!, not an inline snapshot — insta rejects the same inline
+    // snapshot location asserted from multiple tests (this helper is shared)
+    assert_eq!(
+        err.to_string(),
+        "invalid dump: signature verification failed — the dump was signed with a different key or corrupted"
+    );
+}
+
+#[test]
+fn tampered_dump_is_rejected() {
+    let pool = Pool::new(config()).unwrap();
+    let mut state = dump_x_42(&pool);
+    // pin the signed format: [version 0x01][32-byte tag][inner envelope]
+    assert_eq!(state[0], 1, "signed-dump format version");
+    // flip one byte of the inner payload — the tag no longer matches
+    let last = state.len() - 1;
+    state[last] ^= 0xff;
+    expect_invalid_dump(&pool, state);
+}
+
+#[test]
+fn dump_restores_across_pools_with_shared_key() {
+    let key = b"an example 32-byte test dump key";
+    let pool_a = Pool::new(config_with_key(key)).unwrap();
+    let state = dump_x_42(&pool_a);
+    drop(pool_a);
+
+    let pool_b = Pool::new(config_with_key(key)).unwrap();
+    let mut restored = pool_b.checkout(&ReplConfig::default()).unwrap();
+    let (event, _script_name) = restored.restore(state, vec![], &mut no_print).unwrap();
+    assert!(event.is_none(), "an idle dump re-announces no suspension");
+    let event = restored.feed("x", vec![], vec![], false, &mut no_print).unwrap();
+    assert_eq!(expect_complete(event), MontyObject::Int(42));
+    restored.finish().unwrap();
+}
+
+#[test]
+fn ephemeral_key_dump_does_not_restore_in_another_pool() {
+    // neither pool configures a key, so each generates its own ephemeral one
+    let pool_a = Pool::new(config()).unwrap();
+    let state = dump_x_42(&pool_a);
+    let pool_b = Pool::new(config()).unwrap();
+    expect_invalid_dump(&pool_b, state);
+}
+
+#[test]
+fn wrong_key_dump_is_rejected() {
+    let pool_a = Pool::new(config_with_key(b"the first pool's signing key....")).unwrap();
+    let state = dump_x_42(&pool_a);
+    let pool_b = Pool::new(config_with_key(b"a different key for pool two....")).unwrap();
+    expect_invalid_dump(&pool_b, state);
+}
+
+#[test]
+fn short_dump_key_is_rejected() {
+    let err = DumpKey::new(vec![0; 15]).unwrap_err();
+    assert_snapshot!(err.to_string(), @"dump key must be at least 16 bytes");
+    assert!(DumpKey::new(vec![0; 16]).is_ok());
 }
 
 // =============================================================================

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -294,6 +294,7 @@ class Monty:
         checkout_timeout: float | None = None,
         request_timeout: float | None = None,
         max_checkouts_per_worker: int | None = None,
+        dump_key: bytes | None = None,
     ) -> Self:
         """
         Configure a worker pool; the workers are spawned by `with`.
@@ -312,6 +313,11 @@ class Monty:
                 exceeds it is killed and the call raises `MontyCrashedError`
                 with `timed_out=True`. Backstops the sandbox `limits`.
             max_checkouts_per_worker: Recycle a worker after this many sessions.
+            dump_key: Key (at least 16 bytes) used to HMAC-sign `dump()` bytes
+                and verify them on `load` / `load_snapshot`; a short key raises
+                `ValueError`. When omitted a random key is generated per pool,
+                so dumps only restore into sessions of this same pool object —
+                supply a key to restore dumps across pools or processes.
         """
 
     def __enter__(self) -> Self: ...
@@ -471,10 +477,13 @@ class MontySession:
         dump taken mid-execution.
 
         Valid only on a fresh session, before any feed or load; raises
-        `RuntimeError` otherwise. The dump restores its own `script_name` /
-        limits / type-check state (the `checkout()` config for those is not
-        applied); the dataclass registry from `checkout()` is reused. Raises if
-        the dump is actually a suspended snapshot.
+        `RuntimeError` otherwise. The dump's HMAC signature is verified against
+        the pool's `dump_key` first — a tampered dump, or one from a pool with
+        a different (or omitted, i.e. ephemeral) key, raises `ValueError`. The
+        dump restores its own `script_name` / limits / type-check state (the
+        `checkout()` config for those is not applied); the dataclass registry
+        from `checkout()` is reused. Raises if the dump is actually a suspended
+        snapshot.
         """
 
     def load_snapshot(
@@ -492,9 +501,12 @@ class MontySession:
         `load` for a dump taken between feeds.
 
         Valid only on a fresh session, before any feed or load; raises
-        `RuntimeError` otherwise. The dump restores its own `script_name` /
-        limits / type-check state (the `checkout()` config for those is not
-        applied); the dataclass registry from `checkout()` is reused. `mount`
+        `RuntimeError` otherwise. The dump's HMAC signature is verified against
+        the pool's `dump_key` first — a tampered dump, or one from a pool with
+        a different (or omitted, i.e. ephemeral) key, raises `ValueError`. The
+        dump restores its own `script_name` / limits / type-check state (the
+        `checkout()` config for those is not applied); the dataclass registry
+        from `checkout()` is reused. `mount`
         re-establishes the suspended feed's mounts (whose host paths are not in
         the dump), validated against the dump's recorded requirements — a
         missing, extra, or altered mount raises. `'overlay'` writes made before
@@ -515,6 +527,9 @@ class MontySession:
         """
         Serialize the worker's session state (idle or suspended) to opaque
         bytes using monty's existing dump format. The session stays usable.
+
+        The bytes are HMAC-signed with the pool's `dump_key` (or its ephemeral
+        per-pool key), and `load` / `load_snapshot` verify the signature.
         """
 
     def install_dependencies(self, requirements: list[str]) -> None:
@@ -566,6 +581,7 @@ class AsyncMonty:
         checkout_timeout: float | None = None,
         request_timeout: float | None = None,
         max_checkouts_per_worker: int | None = None,
+        dump_key: bytes | None = None,
     ) -> Self:
         """
         Configure a worker pool; the workers are spawned by `async with`.
@@ -619,6 +635,7 @@ class AsyncMontyWebsocket:
         max_processes: int | None = None,
         checkout_timeout: float | None = None,
         request_timeout: float | None = 10.0,
+        dump_key: bytes | None = None,
     ) -> Self:
         """
         Configure a remote worker pool; connections are made by `async with` and
@@ -643,6 +660,10 @@ class AsyncMontyWebsocket:
                 10.0 is often too low for it — a real `uv pip install` can exceed
                 it. Raise `request_timeout` (or pass `None`) when installing
                 dependencies over the WebSocket transport.
+            dump_key: Key (at least 16 bytes) used to HMAC-sign `dump()` bytes
+                and verify them on `load` / `load_snapshot`, exactly as on
+                `Monty`. Omitted: a random per-pool key, so dumps only restore
+                into this same pool object.
         """
 
     async def __aenter__(self) -> Self: ...
@@ -801,6 +822,9 @@ class AsyncMontySession:
         """
         Serialize the worker's session state (idle or suspended) to opaque
         bytes using monty's existing dump format. The session stays usable.
+
+        The bytes are HMAC-signed with the pool's `dump_key` (or its ephemeral
+        per-pool key), and `load` / `load_snapshot` verify the signature.
         """
 
     async def install_dependencies(self, requirements: list[str]) -> None:

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -480,11 +480,11 @@ class MontySession:
         Valid only on a fresh session, before any feed or load; raises
         `RuntimeError` otherwise. The dump's HMAC signature is verified against
         the pool's `dump_key` first — a tampered dump, or one from a pool with
-        a different (or omitted, i.e. ephemeral) key, raises `ValueError`. The
-        dump restores its own `script_name` / limits / type-check state (the
-        `checkout()` config for those is not applied); the dataclass registry
-        from `checkout()` is reused. Raises if the dump is actually a suspended
-        snapshot.
+        a different (or omitted, i.e. ephemeral) key, raises `ValueError`,
+        leaving the session fresh and usable. The dump restores its own
+        `script_name` / limits / type-check state (the `checkout()` config for
+        those is not applied); the dataclass registry from `checkout()` is
+        reused. Raises if the dump is actually a suspended snapshot.
         """
 
     def load_snapshot(
@@ -504,10 +504,11 @@ class MontySession:
         Valid only on a fresh session, before any feed or load; raises
         `RuntimeError` otherwise. The dump's HMAC signature is verified against
         the pool's `dump_key` first — a tampered dump, or one from a pool with
-        a different (or omitted, i.e. ephemeral) key, raises `ValueError`. The
-        dump restores its own `script_name` / limits / type-check state (the
-        `checkout()` config for those is not applied); the dataclass registry
-        from `checkout()` is reused. `mount`
+        a different (or omitted, i.e. ephemeral) key, raises `ValueError`,
+        leaving the session fresh and usable. The dump restores its own
+        `script_name` / limits / type-check state (the `checkout()` config for
+        those is not applied); the dataclass registry from `checkout()` is
+        reused. `mount`
         re-establishes the suspended feed's mounts (whose host paths are not in
         the dump), validated against the dump's recorded requirements — a
         missing, extra, or altered mount raises. `'overlay'` writes made before

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -637,11 +637,14 @@ class AsyncMontyWebsocket:
         max_processes: int | None = None,
         checkout_timeout: float | None = None,
         request_timeout: float | None = 10.0,
-        dump_key: str | bytes | None = None,
     ) -> Self:
         """
         Configure a remote worker pool; connections are made by `async with` and
         each checkout (no workers are pre-warmed).
+
+        Unlike `Monty` / `AsyncMonty` there is no `dump_key`: this client does
+        not sign or verify `dump()` bytes — the dialed server owns dump signing,
+        and dumps pass through this client untouched.
 
         Arguments:
             url: `ws://`/`wss://` URL to dial — a relay, or any server that
@@ -662,10 +665,6 @@ class AsyncMontyWebsocket:
                 10.0 is often too low for it — a real `uv pip install` can exceed
                 it. Raise `request_timeout` (or pass `None`) when installing
                 dependencies over the WebSocket transport.
-            dump_key: Key used to HMAC-sign `dump()` bytes and verify them on
-                `load` / `load_snapshot`, exactly as on `Monty` (`bytes`, or a
-                `str` UTF-8-encoded; at least 16 bytes). Omitted: a random
-                per-pool key, so dumps only restore into this same pool object.
         """
 
     async def __aenter__(self) -> Self: ...

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -824,8 +824,10 @@ class AsyncMontySession:
         Serialize the worker's session state (idle or suspended) to opaque
         bytes using monty's existing dump format. The session stays usable.
 
-        The bytes are HMAC-signed with the pool's `dump_key` (or its ephemeral
-        per-pool key), and `load` / `load_snapshot` verify the signature.
+        For `AsyncMonty` pools, the bytes are HMAC-signed with the pool's
+        `dump_key` (or its ephemeral per-pool key), and `load` /
+        `load_snapshot` verify the signature. `AsyncMontyWebsocket` sessions
+        pass dump bytes through unsigned — the dialed server owns signing.
         """
 
     async def install_dependencies(self, requirements: list[str]) -> None:

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -294,7 +294,7 @@ class Monty:
         checkout_timeout: float | None = None,
         request_timeout: float | None = None,
         max_checkouts_per_worker: int | None = None,
-        dump_key: bytes | None = None,
+        dump_key: str | bytes | None = None,
     ) -> Self:
         """
         Configure a worker pool; the workers are spawned by `with`.
@@ -313,11 +313,12 @@ class Monty:
                 exceeds it is killed and the call raises `MontyCrashedError`
                 with `timed_out=True`. Backstops the sandbox `limits`.
             max_checkouts_per_worker: Recycle a worker after this many sessions.
-            dump_key: Key (at least 16 bytes) used to HMAC-sign `dump()` bytes
-                and verify them on `load` / `load_snapshot`; a short key raises
-                `ValueError`. When omitted a random key is generated per pool,
-                so dumps only restore into sessions of this same pool object —
-                supply a key to restore dumps across pools or processes.
+            dump_key: Key used to HMAC-sign `dump()` bytes and verify them on
+                `load` / `load_snapshot` — `bytes`, or a `str` (UTF-8-encoded).
+                At least 16 bytes; shorter raises `ValueError`. When omitted a
+                random key is generated per pool, so dumps only restore into
+                sessions of this same pool object — supply a key to restore
+                dumps across pools or processes.
         """
 
     def __enter__(self) -> Self: ...
@@ -581,7 +582,7 @@ class AsyncMonty:
         checkout_timeout: float | None = None,
         request_timeout: float | None = None,
         max_checkouts_per_worker: int | None = None,
-        dump_key: bytes | None = None,
+        dump_key: str | bytes | None = None,
     ) -> Self:
         """
         Configure a worker pool; the workers are spawned by `async with`.
@@ -635,7 +636,7 @@ class AsyncMontyWebsocket:
         max_processes: int | None = None,
         checkout_timeout: float | None = None,
         request_timeout: float | None = 10.0,
-        dump_key: bytes | None = None,
+        dump_key: str | bytes | None = None,
     ) -> Self:
         """
         Configure a remote worker pool; connections are made by `async with` and
@@ -660,10 +661,10 @@ class AsyncMontyWebsocket:
                 10.0 is often too low for it — a real `uv pip install` can exceed
                 it. Raise `request_timeout` (or pass `None`) when installing
                 dependencies over the WebSocket transport.
-            dump_key: Key (at least 16 bytes) used to HMAC-sign `dump()` bytes
-                and verify them on `load` / `load_snapshot`, exactly as on
-                `Monty`. Omitted: a random per-pool key, so dumps only restore
-                into this same pool object.
+            dump_key: Key used to HMAC-sign `dump()` bytes and verify them on
+                `load` / `load_snapshot`, exactly as on `Monty` (`bytes`, or a
+                `str` UTF-8-encoded; at least 16 bytes). Omitted: a random
+                per-pool key, so dumps only restore into this same pool object.
         """
 
     async def __aenter__(self) -> Self: ...

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -34,7 +34,9 @@ use std::{
 };
 
 use ::monty::{ExcType, ExtFunctionResult, MontyException, MontyObject};
-use monty_pool::{Checkout, MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, ReplConfig, ResumeValue, TurnEvent};
+use monty_pool::{
+    Checkout, DumpKey, MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, ReplConfig, ResumeValue, TurnEvent,
+};
 use monty_proto::python::{DcRegistry, exc_py_to_monty, monty_to_py, py_to_monty_value};
 use pyo3::{
     exceptions::{PyRuntimeError, PyTimeoutError, PyTypeError, PyValueError},
@@ -86,7 +88,9 @@ impl PyMonty {
         checkout_timeout = None,
         request_timeout = None,
         max_checkouts_per_worker = None,
+        dump_key = None,
     ))]
+    #[expect(clippy::too_many_arguments)]
     fn new(
         py: Python<'_>,
         binary_path: Option<PathBuf>,
@@ -95,6 +99,7 @@ impl PyMonty {
         checkout_timeout: Option<f64>,
         request_timeout: Option<f64>,
         max_checkouts_per_worker: Option<u32>,
+        dump_key: Option<Vec<u8>>,
     ) -> PyResult<Self> {
         Ok(Self {
             config: parse_pool_config(
@@ -105,6 +110,7 @@ impl PyMonty {
                 checkout_timeout,
                 request_timeout,
                 max_checkouts_per_worker,
+                dump_key,
             )?,
             pool: Arc::new(Mutex::new(None)),
         })
@@ -447,7 +453,9 @@ impl PyAsyncMonty {
         checkout_timeout = None,
         request_timeout = None,
         max_checkouts_per_worker = None,
+        dump_key = None,
     ))]
+    #[expect(clippy::too_many_arguments)]
     fn new(
         py: Python<'_>,
         binary_path: Option<PathBuf>,
@@ -456,6 +464,7 @@ impl PyAsyncMonty {
         checkout_timeout: Option<f64>,
         request_timeout: Option<f64>,
         max_checkouts_per_worker: Option<u32>,
+        dump_key: Option<Vec<u8>>,
     ) -> PyResult<Self> {
         Ok(Self {
             config: parse_pool_config(
@@ -466,6 +475,7 @@ impl PyAsyncMonty {
                 checkout_timeout,
                 request_timeout,
                 max_checkouts_per_worker,
+                dump_key,
             )?,
             pool: Arc::new(Mutex::new(None)),
         })
@@ -560,15 +570,17 @@ impl PyAsyncMontyWebsocket {
         max_processes = None,
         checkout_timeout = None,
         request_timeout = 10.0,
+        dump_key = None,
     ))]
     fn new(
         url: String,
         max_processes: Option<usize>,
         checkout_timeout: Option<f64>,
         request_timeout: Option<f64>,
+        dump_key: Option<Vec<u8>>,
     ) -> PyResult<Self> {
         Ok(Self {
-            config: parse_websocket_config(url, max_processes, checkout_timeout, request_timeout)?,
+            config: parse_websocket_config(url, max_processes, checkout_timeout, request_timeout, dump_key)?,
             pool: Arc::new(Mutex::new(None)),
         })
     }
@@ -875,6 +887,7 @@ impl PyAsyncMontySession {
 /// Builds the subprocess-transport `monty-pool` config from the (shared)
 /// `Monty`/`AsyncMonty` constructor arguments, resolving the binary via
 /// `pydantic_monty._binary` when not given explicitly.
+#[expect(clippy::too_many_arguments)]
 fn parse_pool_config(
     py: Python<'_>,
     binary_path: Option<PathBuf>,
@@ -883,6 +896,7 @@ fn parse_pool_config(
     checkout_timeout: Option<f64>,
     request_timeout: Option<f64>,
     max_checkouts_per_worker: Option<u32>,
+    dump_key: Option<Vec<u8>>,
 ) -> PyResult<PoolConfig> {
     let binary_path = match binary_path {
         Some(path) => path,
@@ -900,7 +914,16 @@ fn parse_pool_config(
     config.checkout_timeout = checkout_timeout.map(duration_from_secs).transpose()?;
     config.request_timeout = request_timeout.map(duration_from_secs).transpose()?;
     config.max_checkouts_per_worker = max_checkouts_per_worker;
+    config.dump_key = parse_dump_key(dump_key)?;
     Ok(config)
+}
+
+/// Validates a `dump_key=` constructor argument, rejecting short keys with a
+/// `ValueError` at pool construction rather than at the first dump.
+fn parse_dump_key(dump_key: Option<Vec<u8>>) -> PyResult<Option<DumpKey>> {
+    dump_key
+        .map(|key| DumpKey::new(key).map_err(|err| PyValueError::new_err(err.to_string())))
+        .transpose()
 }
 
 /// Rejects a non-callable `os=` handler with the same `TypeError` for every
@@ -974,6 +997,7 @@ fn parse_websocket_config(
     max_processes: Option<usize>,
     checkout_timeout: Option<f64>,
     request_timeout: Option<f64>,
+    dump_key: Option<Vec<u8>>,
 ) -> PyResult<PoolConfig> {
     let mut config = PoolConfig::websocket(url);
     if let Some(max) = max_processes {
@@ -981,6 +1005,7 @@ fn parse_websocket_config(
     }
     config.checkout_timeout = checkout_timeout.map(duration_from_secs).transpose()?;
     config.request_timeout = request_timeout.map(duration_from_secs).transpose()?;
+    config.dump_key = parse_dump_key(dump_key)?;
     Ok(config)
 }
 
@@ -1493,6 +1518,7 @@ pub(crate) fn pool_err_to_py(py: Python<'_>, err: PoolError) -> PyErr {
         }
         PoolError::Timeout { .. } => MontyCrashedError::new_err(py, message, true, None),
         PoolError::Exhausted => PyTimeoutError::new_err(message),
+        PoolError::InvalidDump(_) => PyValueError::new_err(message),
         PoolError::Protocol(_) | PoolError::Spawn(_) | PoolError::Finished => PyRuntimeError::new_err(message),
     }
 }

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -99,7 +99,7 @@ impl PyMonty {
         checkout_timeout: Option<f64>,
         request_timeout: Option<f64>,
         max_checkouts_per_worker: Option<u32>,
-        dump_key: Option<Vec<u8>>,
+        dump_key: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
         Ok(Self {
             config: parse_pool_config(
@@ -464,7 +464,7 @@ impl PyAsyncMonty {
         checkout_timeout: Option<f64>,
         request_timeout: Option<f64>,
         max_checkouts_per_worker: Option<u32>,
-        dump_key: Option<Vec<u8>>,
+        dump_key: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
         Ok(Self {
             config: parse_pool_config(
@@ -577,7 +577,7 @@ impl PyAsyncMontyWebsocket {
         max_processes: Option<usize>,
         checkout_timeout: Option<f64>,
         request_timeout: Option<f64>,
-        dump_key: Option<Vec<u8>>,
+        dump_key: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
         Ok(Self {
             config: parse_websocket_config(url, max_processes, checkout_timeout, request_timeout, dump_key)?,
@@ -896,7 +896,7 @@ fn parse_pool_config(
     checkout_timeout: Option<f64>,
     request_timeout: Option<f64>,
     max_checkouts_per_worker: Option<u32>,
-    dump_key: Option<Vec<u8>>,
+    dump_key: Option<&Bound<'_, PyAny>>,
 ) -> PyResult<PoolConfig> {
     let binary_path = match binary_path {
         Some(path) => path,
@@ -918,12 +918,27 @@ fn parse_pool_config(
     Ok(config)
 }
 
-/// Validates a `dump_key=` constructor argument, rejecting short keys with a
-/// `ValueError` at pool construction rather than at the first dump.
-fn parse_dump_key(dump_key: Option<Vec<u8>>) -> PyResult<Option<DumpKey>> {
-    dump_key
-        .map(|key| DumpKey::new(key).map_err(|err| PyValueError::new_err(err.to_string())))
-        .transpose()
+/// Coerces a `dump_key=` constructor argument — `str` (UTF-8-encoded) or
+/// `bytes` — into a [`DumpKey`], rejecting other types with a `TypeError` and
+/// short keys with a `ValueError` at pool construction, not at the first dump.
+fn parse_dump_key(dump_key: Option<&Bound<'_, PyAny>>) -> PyResult<Option<DumpKey>> {
+    if let Some(key) = dump_key {
+        let bytes = if let Ok(s) = key.cast::<PyString>() {
+            s.to_str()?.as_bytes().to_vec()
+        } else if let Ok(b) = key.cast::<PyBytes>() {
+            b.as_bytes().to_vec()
+        } else {
+            return Err(PyTypeError::new_err(format!(
+                "dump_key must be str or bytes, not {}",
+                key.get_type().name()?
+            )));
+        };
+        DumpKey::new(bytes)
+            .map(Some)
+            .map_err(|err| PyValueError::new_err(err.to_string()))
+    } else {
+        Ok(None)
+    }
 }
 
 /// Rejects a non-callable `os=` handler with the same `TypeError` for every
@@ -997,7 +1012,7 @@ fn parse_websocket_config(
     max_processes: Option<usize>,
     checkout_timeout: Option<f64>,
     request_timeout: Option<f64>,
-    dump_key: Option<Vec<u8>>,
+    dump_key: Option<&Bound<'_, PyAny>>,
 ) -> PyResult<PoolConfig> {
     let mut config = PoolConfig::websocket(url);
     if let Some(max) = max_processes {

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -35,7 +35,8 @@ use std::{
 
 use ::monty::{ExcType, ExtFunctionResult, MontyException, MontyObject};
 use monty_pool::{
-    Checkout, DumpKey, MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, ReplConfig, ResumeValue, TurnEvent,
+    Checkout, DumpKey, DumpSigning, MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, ReplConfig, ResumeValue,
+    TurnEvent,
 };
 use monty_proto::python::{DcRegistry, exc_py_to_monty, monty_to_py, py_to_monty_value};
 use pyo3::{
@@ -575,17 +576,15 @@ impl PyAsyncMontyWebsocket {
         max_processes = None,
         checkout_timeout = None,
         request_timeout = 10.0,
-        dump_key = None,
     ))]
     fn new(
         url: String,
         max_processes: Option<usize>,
         checkout_timeout: Option<f64>,
         request_timeout: Option<f64>,
-        dump_key: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Self> {
         Ok(Self {
-            config: parse_websocket_config(url, max_processes, checkout_timeout, request_timeout, dump_key)?,
+            config: parse_websocket_config(url, max_processes, checkout_timeout, request_timeout)?,
             pool: Arc::new(Mutex::new(None)),
         })
     }
@@ -922,7 +921,9 @@ fn parse_pool_config(
     config.checkout_timeout = checkout_timeout.map(duration_from_secs).transpose()?;
     config.request_timeout = request_timeout.map(duration_from_secs).transpose()?;
     config.max_checkouts_per_worker = max_checkouts_per_worker;
-    config.dump_key = parse_dump_key(dump_key)?;
+    if let Some(key) = parse_dump_key(dump_key)? {
+        config.dump_signing = DumpSigning::Key(key);
+    }
     Ok(config)
 }
 
@@ -1021,13 +1022,13 @@ pub(crate) fn discard_checkout(checkout: &SharedCheckout) {
 /// Builds the WebSocket-transport `monty-pool` config from the `AsyncMontyWebsocket`
 /// constructor arguments. Each checkout dials `url` verbatim; there is no
 /// pre-warming, so `min_processes` stays 0 and `max_processes` caps concurrent
-/// connections.
+/// connections. Dump signing stays [`DumpSigning::Disabled`] (the
+/// `PoolConfig::websocket` default): the dialed server owns signing.
 fn parse_websocket_config(
     url: String,
     max_processes: Option<usize>,
     checkout_timeout: Option<f64>,
     request_timeout: Option<f64>,
-    dump_key: Option<&Bound<'_, PyAny>>,
 ) -> PyResult<PoolConfig> {
     let mut config = PoolConfig::websocket(url);
     if let Some(max) = max_processes {
@@ -1035,7 +1036,6 @@ fn parse_websocket_config(
     }
     config.checkout_timeout = checkout_timeout.map(duration_from_secs).transpose()?;
     config.request_timeout = request_timeout.map(duration_from_secs).transpose()?;
-    config.dump_key = parse_dump_key(dump_key)?;
     Ok(config)
 }
 

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -420,11 +420,16 @@ impl PyMontySession {
                 .ok_or(PoolError::Finished)?
                 .restore(state, mounts, &mut |_, _| {})
         });
-        // a failed restore (bad mount, protocol desync, ...) leaves the worker
-        // in an untrusted state: discard it so a later feed fails fast rather
-        // than running on a half-restored session
-        if result.is_err() {
-            py.detach(|| discard_checkout(&checkout));
+        match &result {
+            // signature verification failed host-side, before any worker I/O —
+            // nothing happened, so un-claim the session: it stays fresh and
+            // usable (retry the load, or feed it)
+            Err(PoolError::InvalidDump(_)) => self.used.store(false, Ordering::Relaxed),
+            // any other failed restore (bad mount, protocol desync, ...) leaves
+            // the worker in an untrusted state: discard it so a later feed
+            // fails fast rather than running on a half-restored session
+            Err(_) => py.detach(|| discard_checkout(&checkout)),
+            Ok(_) => {}
         }
         result.map_err(|e| pool_err_to_py(py, e))
     }
@@ -529,7 +534,7 @@ impl PyAsyncMonty {
             repl_config: parse_repl_config(py, script_name, limits, type_check, type_check_stubs)?,
             dc_registry: DcRegistry::from_list(py, dataclass_registry)?,
             checkout: Arc::new(Mutex::new(None)),
-            used: AtomicBool::new(false),
+            used: Arc::new(AtomicBool::new(false)),
         })
     }
 }
@@ -633,7 +638,7 @@ impl PyAsyncMontyWebsocket {
             repl_config: parse_repl_config(py, script_name, limits, type_check, type_check_stubs)?,
             dc_registry: DcRegistry::from_list(py, dataclass_registry)?,
             checkout: Arc::new(Mutex::new(None)),
-            used: AtomicBool::new(false),
+            used: Arc::new(AtomicBool::new(false)),
         })
     }
 }
@@ -647,8 +652,9 @@ pub struct PyAsyncMontySession {
     dc_registry: DcRegistry,
     checkout: SharedCheckout,
     /// Set once the session has been fed or restored; `load_snapshot` is valid
-    /// only while unset. See [`PyMontySession::load_snapshot`].
-    used: AtomicBool,
+    /// only while unset. See [`PyMontySession::load_snapshot`]. `Arc` so the
+    /// off-thread restore can un-claim a load rejected before any worker I/O.
+    used: Arc<AtomicBool>,
 }
 
 #[pymethods]
@@ -774,9 +780,10 @@ impl PyAsyncMontySession {
             return Err(session_used_err());
         }
         let checkout = Arc::clone(&self.checkout);
+        let used = Arc::clone(&self.used);
         future_into_py(py, async move {
             // an idle session has no snapshot, so the restored name is unused
-            if restore_turn_async(Arc::clone(&checkout), state, Vec::new())
+            if restore_turn_async(Arc::clone(&checkout), used, state, Vec::new())
                 .await?
                 .0
                 .is_some()
@@ -818,10 +825,11 @@ impl PyAsyncMontySession {
             return Err(session_used_err());
         }
         let checkout = Arc::clone(&self.checkout);
+        let used = Arc::clone(&self.used);
         let dc_registry = self.dc_registry.clone_ref(py);
         let config_script_name = self.repl_config.script_name.clone();
         future_into_py(py, async move {
-            let (event, restored_script_name) = restore_turn_async(Arc::clone(&checkout), state, mounts).await?;
+            let (event, restored_script_name) = restore_turn_async(Arc::clone(&checkout), used, state, mounts).await?;
             let Some(event) = event else {
                 spawn_blocking(move || discard_checkout(&checkout))
                     .await
@@ -965,10 +973,12 @@ fn session_used_err() -> PyErr {
 /// Runs the low-level restore off the event loop (via `spawn_blocking`),
 /// returning the re-announced suspension (`Some`) or `None` for an idle dump,
 /// paired with the dump's adopted script name. The restore turn runs no sandbox
-/// code, so it needs no print sink. Shared by the async
-/// [`PyAsyncMontySession::load`] / `load_snapshot`.
+/// code, so it needs no print sink. `used` is the session's claim flag, reset
+/// on an [`PoolError::InvalidDump`] rejection (no worker I/O happened). Shared
+/// by the async [`PyAsyncMontySession::load`] / `load_snapshot`.
 async fn restore_turn_async(
     checkout: SharedCheckout,
+    used: Arc<AtomicBool>,
     state: Vec<u8>,
     mounts: Vec<MountSpec>,
 ) -> PyResult<(Option<TurnEvent>, Option<String>)> {
@@ -980,10 +990,15 @@ async fn restore_turn_async(
                 .ok_or(PoolError::Finished)
                 .and_then(|checkout| checkout.restore(state, mounts, &mut |_, _| {}))
         };
-        // discard the worker on failure (the lock is released above) so a later
-        // feed fails fast — a failed load is not retryable
-        if result.is_err() {
-            discard_checkout(&checkout);
+        match &result {
+            // signature verification failed host-side, before any worker I/O —
+            // nothing happened, so un-claim the session: it stays fresh and
+            // usable (retry the load, or feed it)
+            Err(PoolError::InvalidDump(_)) => used.store(false, Ordering::Relaxed),
+            // any other failure: discard the worker (the lock is released
+            // above) so a later feed fails fast — that load is not retryable
+            Err(_) => discard_checkout(&checkout),
+            Ok(_) => {}
         }
         result
     })

--- a/crates/monty-python/tests/test_pool.py
+++ b/crates/monty-python/tests/test_pool.py
@@ -88,6 +88,10 @@ def test_tampered_dump_raises_value_error(pool: Monty):
         with pytest.raises(ValueError) as exc_info:
             session.load(tampered)
         assert exc_info.value.args[0] == snapshot(TAMPERED_DUMP_MESSAGE)
+        # the rejection happened before any worker I/O, so the session stays
+        # fresh: the load is retryable with the untampered bytes
+        session.load(state)
+        assert session.feed_run('x') == snapshot(1)
 
 
 def test_ephemeral_dump_cross_pool_raises(pool: Monty):
@@ -103,6 +107,8 @@ def test_ephemeral_dump_cross_pool_raises(pool: Monty):
             with pytest.raises(ValueError) as exc_info:
                 session.load(state)
             assert exc_info.value.args[0] == snapshot(TAMPERED_DUMP_MESSAGE)
+            # the rejected session stays fresh and usable
+            assert session.feed_run('1 + 1') == snapshot(2)
 
 
 def test_str_dump_key_encodes_to_the_same_key_as_bytes():
@@ -295,6 +301,22 @@ async def test_async_dump_key_cross_pool_restore():
         async with pool_b.checkout() as session:
             await session.load(state)
             assert await session.feed_run('x') == snapshot(42)
+
+
+async def test_async_tampered_dump_raises_and_session_stays_fresh():
+    async with AsyncMonty(dump_key=DUMP_KEY) as pool:
+        async with pool.checkout() as session:
+            await session.feed_run('x = 1')
+            state = await session.dump()
+        tampered = state[:-1] + bytes([state[-1] ^ 0xFF])
+        async with pool.checkout() as session:
+            with pytest.raises(ValueError) as exc_info:
+                await session.load(tampered)
+            assert exc_info.value.args[0] == snapshot(TAMPERED_DUMP_MESSAGE)
+            # the rejection happened before any worker I/O, so the session
+            # stays fresh: the load is retryable with the untampered bytes
+            await session.load(state)
+            assert await session.feed_run('x') == snapshot(1)
 
 
 async def test_async_short_dump_key_raises():

--- a/crates/monty-python/tests/test_pool.py
+++ b/crates/monty-python/tests/test_pool.py
@@ -105,10 +105,32 @@ def test_ephemeral_dump_cross_pool_raises(pool: Monty):
             assert exc_info.value.args[0] == snapshot(TAMPERED_DUMP_MESSAGE)
 
 
+def test_str_dump_key_encodes_to_the_same_key_as_bytes():
+    # a str key is UTF-8-encoded: pool A keyed with the str restores in pool B
+    # keyed with the equivalent bytes
+    with Monty(dump_key=DUMP_KEY.decode()) as pool_a:
+        with pool_a.checkout() as session:
+            session.feed_run('x = 42')
+            state = session.dump()
+    with Monty(dump_key=DUMP_KEY) as pool_b:
+        with pool_b.checkout() as session:
+            session.load(state)
+            assert session.feed_run('x') == snapshot(42)
+
+
 def test_short_dump_key_raises():
     with pytest.raises(ValueError) as exc_info:
         Monty(dump_key=b'short')
     assert exc_info.value.args[0] == snapshot('dump key must be at least 16 bytes')
+    with pytest.raises(ValueError) as exc_info:
+        Monty(dump_key='short')
+    assert exc_info.value.args[0] == snapshot('dump key must be at least 16 bytes')
+
+
+def test_wrong_type_dump_key_raises():
+    with pytest.raises(TypeError) as exc_info:
+        Monty(dump_key=123)  # pyright: ignore[reportArgumentType]
+    assert exc_info.value.args[0] == snapshot('dump_key must be str or bytes, not int')
 
 
 def test_worker_crash_raises_crashed_error_and_pool_recovers(pool: Monty):

--- a/crates/monty-python/tests/test_pool.py
+++ b/crates/monty-python/tests/test_pool.py
@@ -62,6 +62,55 @@ def test_dump_returns_bytes(session: MontySession) -> None:
     assert len(state) > 0
 
 
+DUMP_KEY = b'an example 32-byte test dump key'
+TAMPERED_DUMP_MESSAGE = (
+    'invalid dump: signature verification failed — the dump was signed with a different key or corrupted'
+)
+
+
+def test_dump_key_cross_pool_restore():
+    with Monty(dump_key=DUMP_KEY) as pool_a:
+        with pool_a.checkout() as session:
+            session.feed_run('x = 42')
+            state = session.dump()
+    with Monty(dump_key=DUMP_KEY) as pool_b:
+        with pool_b.checkout() as session:
+            session.load(state)
+            assert session.feed_run('x') == snapshot(42)
+
+
+def test_tampered_dump_raises_value_error(pool: Monty):
+    with pool.checkout() as session:
+        session.feed_run('x = 1')
+        state = session.dump()
+    tampered = state[:-1] + bytes([state[-1] ^ 0xFF])
+    with pool.checkout() as session:
+        with pytest.raises(ValueError) as exc_info:
+            session.load(tampered)
+        assert exc_info.value.args[0] == snapshot(TAMPERED_DUMP_MESSAGE)
+
+
+def test_ephemeral_dump_cross_pool_raises(pool: Monty):
+    # `pool` configures no dump_key, so its dumps are signed with a random
+    # per-pool key and only restore into that same pool object
+    with pool.checkout() as session:
+        session.feed_run('x = 1')
+        state = session.dump()
+    with pool.checkout() as session:
+        session.load(state)  # same pool: the ephemeral key verifies
+    with Monty() as other_pool:
+        with other_pool.checkout() as session:
+            with pytest.raises(ValueError) as exc_info:
+                session.load(state)
+            assert exc_info.value.args[0] == snapshot(TAMPERED_DUMP_MESSAGE)
+
+
+def test_short_dump_key_raises():
+    with pytest.raises(ValueError) as exc_info:
+        Monty(dump_key=b'short')
+    assert exc_info.value.args[0] == snapshot('dump key must be at least 16 bytes')
+
+
 def test_worker_crash_raises_crashed_error_and_pool_recovers(pool: Monty):
     with pool.checkout() as session:
         pid = session.worker_pid
@@ -213,6 +262,23 @@ async def test_async_dump():
             state = await session.dump()
             assert isinstance(state, bytes)
             assert len(state) > 0
+
+
+async def test_async_dump_key_cross_pool_restore():
+    async with AsyncMonty(dump_key=DUMP_KEY) as pool_a:
+        async with pool_a.checkout() as session:
+            await session.feed_run('x = 42')
+            state = await session.dump()
+    async with AsyncMonty(dump_key=DUMP_KEY) as pool_b:
+        async with pool_b.checkout() as session:
+            await session.load(state)
+            assert await session.feed_run('x') == snapshot(42)
+
+
+async def test_async_short_dump_key_raises():
+    with pytest.raises(ValueError) as exc_info:
+        AsyncMonty(dump_key=b'short')
+    assert exc_info.value.args[0] == snapshot('dump key must be at least 16 bytes')
 
 
 async def test_async_pool_not_entered():

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -219,7 +219,11 @@ properties that real CPython does not provide, per the caveat above.
   supply a key to restore dumps across pools or processes. Dumps taken before
   signing existed no longer load (they fail with an "unsupported signed-dump
   version" error). Core `MontyRepl::dump` / `load` (the Rust embedder API
-  below the pool) remain unsigned. Signing provides integrity only, not
+  below the pool) remain unsigned. The WebSocket transport
+  (`AsyncMontyWebsocket`, Rust `PoolConfig::websocket`) does no client-side
+  signing at all — it has no `dump_key`, and dump bytes pass through the
+  client untouched: the dialed server performs the deserialization, so dump
+  signing is the server's responsibility. Signing provides integrity only, not
   confidentiality: dumps are not encrypted, and anyone holding the bytes can
   read the session's code and values. On the browser/wasm path, dump/load
   needs WebCrypto (`crypto.subtle`), i.e. a secure context; execution does not.

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -211,8 +211,9 @@ properties that real CPython does not provide, per the caveat above.
   the key is never sent to workers), and `load` / `load_snapshot` verify the
   signature before anything reaches a worker: a tampered or forged dump raises
   `ValueError` (Python) / `MontyInvalidDumpError` (JS) /
-  `PoolError::InvalidDump` (Rust) and, like any failed load, poisons the
-  session. The signing key comes from the pool constructor (`dump_key=` /
+  `PoolError::InvalidDump` (Rust). Unlike other failed loads this does not
+  poison the session — nothing reached the worker, so the session stays fresh
+  and usable. The signing key comes from the pool constructor (`dump_key=` /
   `dumpKey`, at least 16 bytes); when omitted, a random key is generated per
   pool, so unkeyed dumps only restore into sessions of the same pool object —
   supply a key to restore dumps across pools or processes. Dumps taken before

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -219,8 +219,10 @@ properties that real CPython does not provide, per the caveat above.
   supply a key to restore dumps across pools or processes. Dumps taken before
   signing existed no longer load (they fail with an "unsupported signed-dump
   version" error). Core `MontyRepl::dump` / `load` (the Rust embedder API
-  below the pool) remain unsigned. On the browser/wasm path, dump/load needs
-  WebCrypto (`crypto.subtle`), i.e. a secure context; execution does not.
+  below the pool) remain unsigned. Signing provides integrity only, not
+  confidentiality: dumps are not encrypted, and anyone holding the bytes can
+  read the session's code and values. On the browser/wasm path, dump/load
+  needs WebCrypto (`crypto.subtle`), i.e. a secure context; execution does not.
 - **`feed_start` snapshots are live cursors, not owned state.** The execution
   state lives in the worker, so only one suspension is live per session, each
   snapshot may be resumed at most once (a second resume raises

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -207,6 +207,19 @@ properties that real CPython does not provide, per the caveat above.
 - **`dump()`** bytes use a subprocess-specific envelope and can only be
   restored into another subprocess worker of the same version, via
   `session.load` / `session.load_snapshot` (Rust `Checkout::restore`).
+- **`dump()` bytes are HMAC-SHA256-signed by the host** (the parent process —
+  the key is never sent to workers), and `load` / `load_snapshot` verify the
+  signature before anything reaches a worker: a tampered or forged dump raises
+  `ValueError` (Python) / `MontyInvalidDumpError` (JS) /
+  `PoolError::InvalidDump` (Rust) and, like any failed load, poisons the
+  session. The signing key comes from the pool constructor (`dump_key=` /
+  `dumpKey`, at least 16 bytes); when omitted, a random key is generated per
+  pool, so unkeyed dumps only restore into sessions of the same pool object —
+  supply a key to restore dumps across pools or processes. Dumps taken before
+  signing existed no longer load (they fail with an "unsupported signed-dump
+  version" error). Core `MontyRepl::dump` / `load` (the Rust embedder API
+  below the pool) remain unsigned. On the browser/wasm path, dump/load needs
+  WebCrypto (`crypto.subtle`), i.e. a secure context; execution does not.
 - **`feed_start` snapshots are live cursors, not owned state.** The execution
   state lives in the worker, so only one suspension is live per session, each
   snapshot may be resumed at most once (a second resume raises


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Sign `dump()` bytes with HMAC-SHA256 and verify on restore to block forged or tampered dumps. Adds `dumpKey`/`dump_key` options (≥16 bytes), defaulting to a random per‑pool key; invalid dumps are rejected before contacting a worker.

- **New Features**
  - Host-side signing and verification for dumps (Rust); wasm path uses WebCrypto with the same byte format. Key import is lazy; caller-supplied key bytes are snapshotted; clear error when WebCrypto is unavailable in browsers.
  - JS (`@pydantic/monty`): `Monty.create({ dumpKey: string | Uint8Array })`; new `MontyInvalidDumpError`; worker transport signs/verifies; key is resolved lazily.
  - Python: `Monty(dump_key=...)` and `AsyncMonty(dump_key=...)` accept `str | bytes`; `ValueError` on mismatch/short keys; `AsyncMontyWebsocket` does no client-side signing.
  - Default is a random per-pool key; pass the same key to restore dumps across pools/processes.
  - On rejection, the session stays fresh and usable (no worker I/O happened).

- **Migration**
  - Old, unsigned dumps no longer load; take fresh dumps under the new scheme.
  - To share dumps across pools, set the same key (≥16 bytes).
  - Browser/wasm dump/load requires a secure context (WebCrypto); execution does not.
  - Expect `MontyInvalidDumpError` (JS) / `ValueError` (Python) on signature failure; sessions remain usable.
  - WebSocket transport: client does not sign/verify dumps; the server must handle signing.
  - Signing provides integrity only (dumps are not encrypted).

<sup>Written for commit 569bc72ab977d2169b262df09f42f9b0982cb444. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

