### PR TITLE
improve error messages from suspensions in `evaluate_function`

### DIFF
--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -363,13 +363,11 @@ impl<T: ResourceTracker> VM<'_, T> {
         }
     }
 
-    /// Evaluates a function in a position that doesn't yet support suspending.
+    /// Evaluates a function in a synchronous position that cannot suspend to the host.
     ///
-    /// Calls the function and, if it's a user-defined function that pushes a frame,
-    /// runs the VM until that frame returns.
-    ///
-    /// Returns an error for external/OS functions since those require the host to
-    /// execute them and resume, which this synchronous context cannot support.
+    /// User-defined functions run until their frame returns. An unresolved name raises
+    /// `NameError`; external, OS, method, and future suspensions raise a variant-specific
+    /// `NotImplementedError` because this context cannot preserve and resume its state.
     ///
     /// The nested `self.run()` below recurses on the native Rust stack, so
     /// re-entry is bounded via [`enter_run_reentry`](Self::enter_run_reentry)
@@ -390,7 +388,7 @@ impl<T: ResourceTracker> VM<'_, T> {
         let mut guard = RunReentryGuard::new(self);
         let this = &mut *guard;
 
-        match this.call_function(callable, args)? {
+        let exit = match this.call_function(callable, args)? {
             CallResult::Value(v) => return Ok(v),
             CallResult::FramePushed => {
                 // A new frame was pushed for a defined function call - we need to run it
@@ -401,22 +399,74 @@ impl<T: ResourceTracker> VM<'_, T> {
                 match this.run()? {
                     FrameExit::Return(v) => return Ok(v),
                     exit => {
-                        exit.drop_with(this);
                         // Pop frames off the stack from this failed evaluation
                         // (including the one just pushed)
                         while this.frames.len() >= stack_depth {
                             this.pop_frame();
                         }
+                        exit
                     }
                 }
             }
-            other => other.drop_with(this),
-        }
+            unsupported => return Err(this.unsupported_call_result(ctx, unsupported)),
+        };
 
-        Err(ExcType::not_implemented(format!(
-            "{ctx}: external functions are not yet supported in this context"
-        ))
-        .into())
+        Err(this.unsupported_frame_exit(ctx, exit))
+    }
+
+    /// Converts a direct call suspension into a specific synchronous-context error.
+    #[cold]
+    fn unsupported_call_result(&mut self, ctx: &'static str, result: CallResult) -> RunError {
+        let error = match &result {
+            CallResult::External(function_name, _) => ExcType::not_implemented(format!(
+                "{ctx}: external function '{}' is not yet supported in this context",
+                function_name.as_str(self.interns)
+            )),
+            CallResult::OsCall(function_call) => ExcType::not_implemented(format!(
+                "{ctx}: OS function '{}' is not yet supported in this context",
+                function_call.name()
+            )),
+            CallResult::OsCallStoreBuffer { call, .. } => ExcType::not_implemented(format!(
+                "{ctx}: OS function '{}' is not yet supported in this context",
+                call.name()
+            )),
+            CallResult::MethodCall(method_name, _) => ExcType::not_implemented(format!(
+                "{ctx}: method call '{}' is not yet supported in this context",
+                method_name.as_str(self.interns)
+            )),
+            CallResult::AwaitValue(_) => {
+                ExcType::not_implemented(format!("{ctx}: awaiting a value is not yet supported in this context"))
+            }
+            CallResult::Value(_) | CallResult::FramePushed => unreachable!("completed calls are handled above"),
+        };
+        result.drop_with(self);
+        error.into()
+    }
+
+    /// Converts a nested VM suspension into a specific synchronous-context error.
+    #[cold]
+    fn unsupported_frame_exit(&mut self, ctx: &'static str, exit: FrameExit) -> RunError {
+        let error = match &exit {
+            FrameExit::Return(_) => unreachable!("return exits are handled above"),
+            FrameExit::ExternalCall { function_name, .. } => ExcType::not_implemented(format!(
+                "{ctx}: external function '{}' is not yet supported in this context",
+                function_name.as_str(self.interns)
+            )),
+            FrameExit::OsCall { function_call, .. } => ExcType::not_implemented(format!(
+                "{ctx}: OS function '{}' is not yet supported in this context",
+                function_call.name()
+            )),
+            FrameExit::MethodCall { method_name, .. } => ExcType::not_implemented(format!(
+                "{ctx}: method call '{}' is not yet supported in this context",
+                method_name.as_str(self.interns)
+            )),
+            FrameExit::ResolveFutures(_) => ExcType::not_implemented(format!(
+                "{ctx}: resolving async futures is not yet supported in this context"
+            )),
+            FrameExit::NameLookup { name_id, .. } => ExcType::name_error(self.interns.get_str(*name_id)),
+        };
+        exit.drop_with(self);
+        error.into()
     }
 
     /// Calls a callable value with the given arguments.

--- a/crates/monty/tests/main.rs
+++ b/crates/monty/tests/main.rs
@@ -88,7 +88,7 @@ fn external_function_as_init_raises_not_implemented() {
         .unwrap_err();
     assert_eq!(
         err.to_string(),
-        "Traceback (most recent call last):\n  File \"test.py\", line 4, in <module>\n    Foo()\n    ~~~~~\nNotImplementedError: __init__: external functions are not yet supported in this context"
+        "Traceback (most recent call last):\n  File \"test.py\", line 4, in <module>\n    Foo()\n    ~~~~~\nNotImplementedError: __init__: external function 'ext_fn' is not yet supported in this context"
     );
 }
 

--- a/crates/monty/tests/name_lookup.rs
+++ b/crates/monty/tests/name_lookup.rs
@@ -510,14 +510,14 @@ fn resolve_function_with_non_interned_name() {
 }
 
 #[test]
-fn name_lookup_not_possible_inside_sort_callback() {
-    // `sorted([1], key=lambda x: missing)` cannot yet yield for external functions
-    // to resolve missing, should raise NotImplementedError
+fn name_lookup_inside_sort_callback_raises_name_error() {
+    // `evaluate_function` cannot suspend for the host to resolve the name, but
+    // must still distinguish an unresolved name from an external function call.
     let code = "
 try:
     sorted([1], key=lambda x: missing)
-except NotImplementedError as e:
-    assert str(e) == 'sorted() key argument: external functions are not yet supported in this context'
+except NameError as e:
+    assert str(e) == \"name 'missing' is not defined\"
 else:
     assert False
 

--- a/crates/monty/tests/repl.rs
+++ b/crates/monty/tests/repl.rs
@@ -776,7 +776,7 @@ fn call_function_that_calls_undefined_name_fails() {
     let err = s
         .call_function("call_missing", vec![], PrintWriter::Stdout)
         .unwrap_err();
-    assert_snapshot!(err, @"NotImplementedError: MontyRepl::call_function: external functions are not yet supported in this context");
+    assert_snapshot!(err, @"NotImplementedError: MontyRepl::call_function: external function 'unknown_func' is not yet supported in this context");
 }
 
 #[test]


### PR DESCRIPTION
Heading towards resolving #564 (fixes the bad error message but not the root cause).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve error reporting when evaluating functions in synchronous contexts that cannot suspend. Unresolved names now raise NameError, and suspensions produce clear NotImplementedError messages with the function/method name and context.

- **Bug Fixes**
  - Map VM suspensions to specific errors: NameError for unresolved names; NotImplementedError for external/OS/method/await/future cases with the exact name included.
  - Ensure frames are popped and suspended results are dropped before returning errors.

- **Refactors**
  - Added `unsupported_call_result` and `unsupported_frame_exit` helpers to centralize error mapping.

<sup>Written for commit 894c388f89ce7446d7e3fe6d6fad660033ad4359. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

