### PR TITLE
Enforce memory limits while building `repr()` and `json.dumps` output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,8 @@ builder.finish(vm.heap)
 
 When the input *is* already bounded (e.g. `s.to_lowercase()`, slicing, `to_owned()` of an existing tracked string), passing a plain `String` / `&str` to `allocate_string` is fine — the result is bounded by a known multiple of an already-tracked input, so no amplification is possible.
 
+Code that needs `&mut VM` while building cannot hold `StringBuilder`'s tracker borrow. For that there is the settle-point variant in the same file: the `py_repr_fmt` sink is `&mut impl ReprWrite`, and `Value::py_repr_fmt` calls `f.settle(vm.heap.tracker())` once per heap value, reserving the buffer's bytes as the recursion proceeds (`ReprBuilder` is the buffering sink; `json.dumps`'s `Encoder::settle` does the same per serialized value). Untracked slack between settles is bounded by a single value's leaf writes. `ReprBuilder` holds no tracker reference, so it MUST be consumed with `finish(heap)` or `cancel(tracker)` — plain drop leaks its reservation.
+
 ## Dev Commands
 
 **IMPORTANT**: before running `cargo build` or `cargo run`, it is likely necessary to run `make install-py` to ensure that the Python virtual environment is available for build.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,7 +263,7 @@ builder.finish(vm.heap)
 
 When the input *is* already bounded (e.g. `s.to_lowercase()`, slicing, `to_owned()` of an existing tracked string), passing a plain `String` / `&str` to `allocate_string` is fine — the result is bounded by a known multiple of an already-tracked input, so no amplification is possible.
 
-Code that needs `&mut VM` while building cannot hold `StringBuilder`'s tracker borrow. For that there is the settle-point variant in the same file: the `py_repr_fmt` sink is `&mut impl ReprWrite`, and `Value::py_repr_fmt` calls `f.settle(vm.heap.tracker())` once per heap value, reserving the buffer's bytes as the recursion proceeds (`ReprBuilder` is the buffering sink; `json.dumps`'s `Encoder::settle` does the same per serialized value). Untracked slack between settles is bounded by a single value's leaf writes. `ReprBuilder` holds no tracker reference, so it MUST be consumed with `finish(heap)` or `cancel(tracker)` — plain drop leaks its reservation.
+Code that needs `&mut VM` while building cannot hold `StringBuilder`'s tracker borrow. For that there is the settle-point variant in the same file: the `py_repr_fmt` sink is `&mut impl ReprWrite`, and `Value::py_repr_fmt` calls `f.settle(vm.heap.tracker())` once per value (every value, not just heap refs — an interned string is a 16-byte `Value` whose repr writes the whole payload), reserving the buffer's bytes as the recursion proceeds (`ReprBuilder` is the buffering sink; `json.dumps`'s `Encoder::settle` does the same per serialized value). Untracked slack between settles is bounded by a single value's leaf writes. `ReprBuilder` holds no tracker reference, so it MUST be consumed with `finish(heap)` or `cancel(tracker)` — plain drop leaks its reservation.
 
 ## Dev Commands
 

--- a/crates/monty/src/bytecode/vm/exceptions.rs
+++ b/crates/monty/src/bytecode/vm/exceptions.rs
@@ -11,6 +11,7 @@ use crate::{
     heap::{DropGuard, HeapData},
     intern::{StaticStrings, StringId},
     resource::ResourceTracker,
+    string_builder::ReprWrite,
     types::{LazyHeapSet, PyTrait, Type},
     value::Value,
 };
@@ -530,6 +531,9 @@ impl TruncatingWriter {
         self.buf
     }
 }
+
+/// The byte cap bounds the buffer, so no tracker settlement is needed.
+impl ReprWrite for TruncatingWriter {}
 
 impl Write for TruncatingWriter {
     fn write_str(&mut self, s: &str) -> fmt::Result {

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::hash_map::DefaultHasher,
-    fmt::Write,
     hash::{Hash, Hasher},
     mem,
     ops::Deref,
@@ -17,6 +16,7 @@ use crate::{
     hash::{HashValue, hash_python_str, identity_hash},
     heap::{DropWithContext, HeapId, HeapItem, HeapReadOutput},
     intern::FunctionId,
+    string_builder::ReprWrite,
     types::{
         BoundMethod, Bytes, Class, Dataclass, Dict, DictItemsView, DictKeysView, DictValuesView, FrozenSet, Instance,
         LazyHeapSet, List, LongInt, Module, MontyIter, NamedTuple, OpenFile, Path, PyTrait, Range, ReMatch, RePattern,
@@ -742,7 +742,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/modules/json/dump.rs
+++ b/crates/monty/src/modules/json/dump.rs
@@ -438,9 +438,10 @@ impl<'h, R: ResourceTracker> Encoder<'_, 'h, R> {
                     Ok(())
                 }
                 HeapReadOutput::List(list) => self.with_entered_container(*heap_id, |enc| {
+                    let is_empty = list.get(enc.vm.heap).as_slice().is_empty();
                     let iter = list.iter(enc.vm)?;
                     defer_drop_mut!(iter, enc);
-                    enc.serialize_array(depth, |enc, depth| {
+                    enc.serialize_array(depth, is_empty, |enc, depth| {
                         if let Some(item) = iter.next(enc.vm)? {
                             enc.serialize_value(item, depth)?;
                             Ok(true)
@@ -450,9 +451,10 @@ impl<'h, R: ResourceTracker> Encoder<'_, 'h, R> {
                     })
                 }),
                 HeapReadOutput::Tuple(tuple) => self.with_entered_container(*heap_id, |enc| {
+                    let is_empty = tuple.get(enc.vm.heap).as_slice().is_empty();
                     let iter = tuple.iter(enc.vm)?;
                     defer_drop_mut!(iter, enc);
-                    enc.serialize_array(depth, |enc, depth| {
+                    enc.serialize_array(depth, is_empty, |enc, depth| {
                         if let Some(item) = iter.next(enc.vm)? {
                             enc.serialize_value(item, depth)?;
                             Ok(true)
@@ -497,8 +499,16 @@ impl<'h, R: ResourceTracker> Encoder<'_, 'h, R> {
     fn serialize_array(
         &mut self,
         depth: usize,
+        is_empty: bool,
         mut write_next: impl FnMut(&mut Self, usize) -> RunResult<bool>,
     ) -> RunResult<()> {
+        // CPython short-circuits empty arrays before writing any indentation,
+        // so a huge `indent` must not trip the limit check in `write_indent`
+        // via the speculative prefix below when the output is just `[]`.
+        if is_empty {
+            self.out.push_str("[]");
+            return Ok(());
+        }
         self.out.push('[');
         let pretty = self.config.indent.is_some();
         let mut wrote_any = false;

--- a/crates/monty/src/modules/json/dump.rs
+++ b/crates/monty/src/modules/json/dump.rs
@@ -14,7 +14,7 @@ use crate::{
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult},
     heap::{ContainsHeap, DropGuard, Heap, HeapData, HeapId, HeapRead, HeapReadOutput},
-    resource::{ResourceError, ResourceTracker},
+    resource::{ResourceError, ResourceTracker, check_repeat_size},
     sorting::{apply_permutation, sort_indices},
     types::{Dict, PyTrait, long_int::check_bigint_str_digits_limit, str::allocate_string},
     value::Value,
@@ -512,7 +512,7 @@ impl<'h, R: ResourceTracker> Encoder<'_, 'h, R> {
             }
             if pretty {
                 self.out.push('\n');
-                write_indent(self.out, self.config, depth + 1);
+                self.write_indent(depth + 1)?;
             }
             let body_start = self.out.len();
             if !write_next(self, depth + 1)? {
@@ -527,7 +527,7 @@ impl<'h, R: ResourceTracker> Encoder<'_, 'h, R> {
         }
         if pretty && wrote_any {
             self.out.push('\n');
-            write_indent(self.out, self.config, depth);
+            self.write_indent(depth)?;
         }
         self.out.push(']');
         Ok(())
@@ -571,7 +571,7 @@ impl<'h, R: ResourceTracker> Encoder<'_, 'h, R> {
             }
             if pretty {
                 self.out.push('\n');
-                write_indent(self.out, self.config, depth + 1);
+                self.write_indent(depth + 1)?;
             }
             write_json_key(key, self.out, self.config, self.vm)?;
             self.out.push_str(&self.config.key_separator);
@@ -579,9 +579,29 @@ impl<'h, R: ResourceTracker> Encoder<'_, 'h, R> {
         }
         if pretty && !entries.is_empty() {
             self.out.push('\n');
-            write_indent(self.out, self.config, depth);
+            self.write_indent(depth)?;
         }
         self.out.push('}');
+        Ok(())
+    }
+
+    /// Writes indentation for pretty-printed JSON output: the `indent` string
+    /// repeated once per nesting level, matching CPython for both numeric and
+    /// string indentation.
+    ///
+    /// `indent` is an arbitrary user string, so `indent_len × depth` can dwarf
+    /// the memory limit in this single write — pre-check it like other repeat
+    /// operations, then settle so closing indents written while *unwinding*
+    /// (which no `serialize_value` entry settle follows) stay reserved too.
+    fn write_indent(&mut self, depth: usize) -> RunResult<()> {
+        let config = self.config;
+        if let Some(indent) = &config.indent {
+            check_repeat_size(indent.len(), depth, self.vm.heap.tracker())?;
+            for _ in 0..depth {
+                self.out.push_str(indent);
+            }
+            self.settle()?;
+        }
         Ok(())
     }
 
@@ -818,18 +838,6 @@ fn write_json_float_text(value: f64, out: &mut String) {
         write!(out, "{value}").expect("writing to String cannot fail");
         if !out[start..].contains('.') {
             out.push_str(".0");
-        }
-    }
-}
-
-/// Writes indentation for pretty-printed JSON output.
-///
-/// The `indent` string is repeated once for each nesting level, matching
-/// CPython's behavior for both numeric and string indentation.
-fn write_indent(out: &mut String, config: &JsonDumpsConfig, depth: usize) {
-    if let Some(indent) = &config.indent {
-        for _ in 0..depth {
-            out.push_str(indent);
         }
     }
 }

--- a/crates/monty/src/modules/json/dump.rs
+++ b/crates/monty/src/modules/json/dump.rs
@@ -14,7 +14,7 @@ use crate::{
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult},
     heap::{ContainsHeap, DropGuard, Heap, HeapData, HeapId, HeapRead, HeapReadOutput},
-    resource::ResourceTracker,
+    resource::{ResourceError, ResourceTracker},
     sorting::{apply_permutation, sort_indices},
     types::{Dict, PyTrait, long_int::check_bigint_str_digits_limit, str::allocate_string},
     value::Value,
@@ -146,19 +146,25 @@ pub(super) fn call_dumps(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues)
     let mut obj_guard = DropGuard::new(obj, vm);
     let mut output = String::new();
     let mut active_containers = Vec::new();
-    {
+    // Tracker bytes reserved for `output` (see `Encoder::settle`). Captured
+    // here so the reservation is released on success and error paths alike.
+    let mut reserved = 0usize;
+    let result = {
         let (obj, vm) = obj_guard.as_parts_mut();
         let mut encoder = Encoder {
             out: &mut output,
             config: &config,
             active_containers: &mut active_containers,
+            reserved: &mut reserved,
             vm,
         };
-        encoder.serialize_value(obj, 0)?;
-    }
+        encoder.serialize_value(obj, 0)
+    };
 
     let (obj, vm) = obj_guard.into_parts();
     obj.drop_with(vm);
+    vm.heap.tracker().on_free(|| reserved);
+    result?;
     Ok(allocate_string(output, vm.heap)?)
 }
 
@@ -346,6 +352,9 @@ struct Encoder<'a, 'h, R: ResourceTracker> {
     out: &'a mut String,
     config: &'a JsonDumpsConfig,
     active_containers: &'a mut Vec<HeapId>,
+    /// Bytes of `out` currently reserved with the resource tracker (borrowed
+    /// so `call_dumps` can release the reservation after the encoder is gone).
+    reserved: &'a mut usize,
     vm: &'a mut VM<'h, R>,
 }
 
@@ -382,6 +391,10 @@ impl<'h, R: ResourceTracker> Encoder<'_, 'h, R> {
     /// Handles immediate primitives directly and delegates to type-specific
     /// helpers for strings, long integers, lists, tuples, and dicts.
     fn serialize_value(&mut self, value: &Value, depth: usize) -> RunResult<()> {
+        // Settle once per value: `out` lives outside the tracker, so without
+        // this a shared (DAG) structure could amplify a small tracked heap
+        // into an unbounded untracked JSON buffer.
+        self.settle()?;
         match value {
             Value::None => {
                 self.out.push_str("null");
@@ -569,6 +582,19 @@ impl<'h, R: ResourceTracker> Encoder<'_, 'h, R> {
             write_indent(self.out, self.config, depth);
         }
         self.out.push('}');
+        Ok(())
+    }
+
+    /// Reserves `out` bytes written since the last settle with the resource
+    /// tracker. Doubling (like `StringBuilder`) keeps tracker calls `O(log n)`
+    /// for an `n`-byte document. Untracked slack between settles is bounded by
+    /// a single value's writes, themselves bounded by already-tracked input.
+    fn settle(&mut self) -> Result<(), ResourceError> {
+        if self.out.len() > *self.reserved {
+            let new_reserved = self.reserved.saturating_mul(2).max(self.out.len());
+            self.vm.heap.tracker().on_grow(new_reserved - *self.reserved)?;
+            *self.reserved = new_reserved;
+        }
         Ok(())
     }
 

--- a/crates/monty/src/string_builder.rs
+++ b/crates/monty/src/string_builder.rs
@@ -3,13 +3,18 @@
 //! `StringBuilder` is the canonical way to build a Python-visible string whose
 //! final size is *not* already bounded by an already-tracked input. Operations
 //! that grow a `String` in a loop — padding methods (`ljust`, `center`, …),
-//! tab expansion, string repetition, container `repr()`, etc. — must use
-//! `StringBuilder` rather than `String::with_capacity(...).push(...)`, because
-//! the intermediate `String` lives on the Rust heap *outside* the
-//! [`ResourceTracker`]. Without a builder, a malicious script can amplify a
-//! small tracked input into a multi-gigabyte intermediate before the final
+//! tab expansion, string repetition, etc. — must use `StringBuilder` rather
+//! than `String::with_capacity(...).push(...)`, because the intermediate
+//! `String` lives on the Rust heap *outside* the [`ResourceTracker`]. Without
+//! a builder, a malicious script can amplify a small tracked input into a
+//! multi-gigabyte intermediate before the final
 //! [`allocate_string`](crate::types::str::allocate_string) ever consults the
 //! tracker — bypassing the configured memory limit and OOMing the host.
+//!
+//! Code that needs `&mut VM` *while* building — the `py_repr_fmt` recursion,
+//! the `json.dumps` encoder — cannot hold `StringBuilder`'s tracker borrow;
+//! it uses the settle-point variant instead: [`ReprWrite`] + [`ReprBuilder`]
+//! (see their docs at the bottom of this file).
 //!
 //! # Active reservation, not preview
 //!
@@ -229,5 +234,88 @@ impl<T: ResourceTracker> Drop for StringBuilder<'_, T> {
         // `pending_error` short-circuiting `finish`). `finish`'s success path
         // zeroes `reserved` before this runs, so it's a no-op there.
         self.release();
+    }
+}
+
+/// Sink trait for `py_repr_fmt`: a [`fmt::Write`] that can additionally settle
+/// its untracked bytes with the resource tracker at heap-value boundaries.
+///
+/// `py_repr_fmt` borrows the VM mutably for the whole recursion, so its sink
+/// cannot hold a tracker reference the way [`StringBuilder`] does. Instead the
+/// recursion calls [`settle`](Self::settle) where the VM *is* in scope — once
+/// per heap value in `Value::py_repr_fmt` — keeping the untracked slack
+/// bounded by a single value's leaf writes, themselves bounded multiples of
+/// already-tracked input.
+pub trait ReprWrite: fmt::Write {
+    /// Reserves bytes written since the last settle with `tracker`. The
+    /// default is a no-op for sinks bounded some other way (e.g. a hard byte
+    /// cap, or a builder that reserves on every write).
+    fn settle(&mut self, _tracker: &impl ResourceTracker) -> Result<(), ResourceError> {
+        Ok(())
+    }
+}
+
+/// [`StringBuilder`] already reserves on every write, so `settle` stays a no-op.
+impl<T: ResourceTracker> ReprWrite for StringBuilder<'_, T> {}
+
+/// Tracker-reserved buffer for building `repr()` strings via `py_repr_fmt`.
+///
+/// Unlike [`StringBuilder`] this holds no tracker reference (see [`ReprWrite`]
+/// for why); reservation happens in `settle`, driven by the repr recursion.
+/// Because `Drop` cannot reach a tracker, callers MUST consume the builder
+/// with [`finish`](Self::finish) on success or [`cancel`](Self::cancel) on
+/// error — dropping it any other way leaks the reservation.
+#[derive(Default)]
+pub struct ReprBuilder {
+    inner: String,
+    /// Bytes currently reserved with the tracker via `on_grow`.
+    reserved: usize,
+}
+
+impl ReprBuilder {
+    /// Creates an empty builder with nothing reserved.
+    pub fn new() -> Self {
+        Self {
+            inner: String::new(),
+            reserved: 0,
+        }
+    }
+
+    /// Consumes the builder: releases the reservation, then allocates the
+    /// result via [`allocate_string`], which re-counts the exact final size
+    /// through `on_allocate` — so bytes written since the last settle are
+    /// still checked against the limit here.
+    pub fn finish(self, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
+        heap.tracker().on_free(|| self.reserved);
+        Ok(allocate_string(self.inner, heap)?)
+    }
+
+    /// Releases the reservation on error paths where no string is produced
+    /// (e.g. a user `__repr__` raising a catchable exception mid-recursion).
+    pub fn cancel(self, tracker: &impl ResourceTracker) {
+        tracker.on_free(|| self.reserved);
+    }
+}
+
+/// Writes are unconditionally buffered; the tracker catches up at the next
+/// [`ReprWrite::settle`] call (or in [`finish`](ReprBuilder::finish)).
+impl fmt::Write for ReprBuilder {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.inner.push_str(s);
+        Ok(())
+    }
+}
+
+impl ReprWrite for ReprBuilder {
+    fn settle(&mut self, tracker: &impl ResourceTracker) -> Result<(), ResourceError> {
+        if self.inner.len() > self.reserved {
+            // Double the reservation (saturating) but at least to the current
+            // length, matching `StringBuilder`'s policy: O(log n) tracker
+            // calls for an n-byte repr.
+            let new_reserved = self.reserved.saturating_mul(2).max(self.inner.len());
+            tracker.on_grow(new_reserved - self.reserved)?;
+            self.reserved = new_reserved;
+        }
+        Ok(())
     }
 }

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -85,6 +85,7 @@ use crate::{
     heap::{DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, heap_read_ref_as_field},
     intern::{StaticStrings, StringId},
     resource::{ResourceError, ResourceTracker, check_repeat_size, check_replace_size},
+    string_builder::ReprWrite,
     types::{
         List,
         slice::{normalize_sequence_index, slice_collect_iterator},
@@ -292,7 +293,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Bytes> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/types/class.rs
+++ b/crates/monty/src/types/class.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Write, mem};
+use std::mem;
 
 use super::{Dict, LazyHeapSet, PyTrait, Type};
 use crate::{
@@ -9,6 +9,7 @@ use crate::{
     hash::{HashValue, identity_hash},
     heap::{BorrowedHeapReadMut, DropWithContext, HeapId, HeapItem, HeapRead, heap_read_ref_as_field_mut},
     resource::ResourceTracker,
+    string_builder::ReprWrite,
     types::str::allocate_string,
     value::{EitherStr, Value},
 };
@@ -98,7 +99,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Class> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -1,5 +1,4 @@
 use std::{
-    fmt::Write,
     hash::{DefaultHasher, Hash, Hasher},
     mem,
 };
@@ -19,6 +18,7 @@ use crate::{
     },
     intern::Interns,
     resource::ResourceTracker,
+    string_builder::ReprWrite,
     types::Type,
     value::{EitherStr, Value},
 };
@@ -215,7 +215,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/types/date.rs
+++ b/crates/monty/src/types/date.rs
@@ -22,6 +22,7 @@ use crate::{
     intern::{Interns, StaticStrings},
     os::OsFunctionCall,
     resource::{ResourceError, ResourceTracker},
+    string_builder::ReprWrite,
     types::{
         AttrCallResult, CmpOrder, LazyHeapSet, PyTrait, TimeDelta, Type,
         str::{allocate_string, allocate_string_no_interning},
@@ -231,7 +232,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Date> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -25,6 +25,7 @@ use crate::{
     object::MontyObject,
     os::OsFunctionCall,
     resource::{ResourceError, ResourceTracker},
+    string_builder::ReprWrite,
     types::{
         AttrCallResult, CmpOrder, LazyHeapSet, PyTrait, TimeDelta, TimeZone, Type,
         date::{self, StrftimeArgs},
@@ -940,7 +941,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::hash_map::DefaultHasher,
-    fmt::Write,
     hash::{Hash, Hasher},
     mem, slice, vec,
 };
@@ -18,6 +17,7 @@ use crate::{
     heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     resource::ResourceTracker,
+    string_builder::ReprWrite,
     types::Type,
     value::{EitherStr, VALUE_SIZE, Value},
 };
@@ -819,7 +819,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Write, mem};
+use std::mem;
 
 use smallvec::smallvec;
 
@@ -10,6 +10,7 @@ use crate::{
     heap::{DropGuard, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     resource::ResourceTracker,
+    string_builder::ReprWrite,
     types::{Dict, FrozenSet, LazyHeapSet, MontyIter, PyTrait, Set, Type, allocate_tuple},
     value::{EitherStr, Value},
 };
@@ -159,7 +160,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictKeysView> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
@@ -315,7 +316,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictItemsView> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
@@ -407,7 +408,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictValuesView> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
@@ -480,7 +481,7 @@ fn dict_items_eq_set_like<'h, T: ResourceTracker>(
 
 /// Writes the repr payload for a keys view without its outer wrapper.
 fn write_dict_keys_contents<'h>(
-    f: &mut impl Write,
+    f: &mut impl ReprWrite,
     dict: &HeapRead<'h, Dict>,
     vm: &mut VM<'h, impl ResourceTracker>,
     heap_ids: &mut LazyHeapSet,
@@ -500,7 +501,7 @@ fn write_dict_keys_contents<'h>(
 
 /// Writes the repr payload for an items view without its outer wrapper.
 fn write_dict_items_contents<'h>(
-    f: &mut impl Write,
+    f: &mut impl ReprWrite,
     dict: &HeapRead<'h, Dict>,
     vm: &mut VM<'h, impl ResourceTracker>,
     heap_ids: &mut LazyHeapSet,
@@ -524,7 +525,7 @@ fn write_dict_items_contents<'h>(
 
 /// Writes the repr payload for a values view without its outer wrapper.
 fn write_dict_values_contents<'h>(
-    f: &mut impl Write,
+    f: &mut impl ReprWrite,
     dict: &HeapRead<'h, Dict>,
     vm: &mut VM<'h, impl ResourceTracker>,
     heap_ids: &mut LazyHeapSet,

--- a/crates/monty/src/types/file.rs
+++ b/crates/monty/src/types/file.rs
@@ -62,7 +62,7 @@
 //! Any code path that needs one of these should be added explicitly
 //! rather than relying on CPython parity.
 
-use std::{borrow::Cow, fmt::Write, mem, str::FromStr};
+use std::{borrow::Cow, mem, str::FromStr};
 
 use super::{
     LazyHeapSet, List, PyTrait, Type,
@@ -77,6 +77,7 @@ use crate::{
     intern::StaticStrings,
     os::{MontyPath, OsFunctionCall, PathBytesDataArgs, PathStringDataArgs},
     resource::ResourceTracker,
+    string_builder::ReprWrite,
     types::str::StringRepr,
     value::{EitherStr, Value},
 };
@@ -535,7 +536,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, OpenFile> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt::Write, mem};
+use std::{borrow::Cow, mem};
 
 use super::{Dict, LazyHeapSet, PyTrait, Type};
 use crate::{
@@ -14,6 +14,7 @@ use crate::{
     },
     intern::Interns,
     resource::ResourceTracker,
+    string_builder::ReprWrite,
     types::allocate_string,
     value::{EitherStr, Value},
 };
@@ -110,7 +111,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Instance> {
     /// never reached.
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
@@ -276,7 +277,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, BoundMethod> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         _vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, fmt::Write, mem};
+use std::{cmp::Ordering, mem};
 
 use smallvec::SmallVec;
 
@@ -12,6 +12,7 @@ use crate::{
     intern::StaticStrings,
     resource::{ResourceError, ResourceTracker},
     sorting::parse_and_sort,
+    string_builder::ReprWrite,
     types::{
         LazyHeapSet, Type,
         slice::{normalize_sequence_index, slice_collect_iterator},
@@ -476,7 +477,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
@@ -890,7 +891,7 @@ pub(crate) fn repr_sequence_fmt<'h, T: ResourceTracker>(
     end: char,
     len: usize,
     get_item: impl for<'r> Fn(&'r HeapReader<'h, T>, usize) -> &'r Value,
-    f: &mut impl Write,
+    f: &mut impl ReprWrite,
     vm: &mut VM<'h, T>,
     heap_ids: &mut LazyHeapSet,
 ) -> RunResult<()> {

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -18,7 +18,6 @@
 use std::{
     cell::Cell,
     collections::hash_map::DefaultHasher,
-    fmt::Write,
     hash::{Hash, Hasher},
     mem,
 };
@@ -32,6 +31,7 @@ use crate::{
     heap::{DropWithContext, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StringId},
     resource::ResourceTracker,
+    string_builder::ReprWrite,
     types::{Type, py_trait::LazyHeapSet},
     value::{EitherStr, Value},
 };
@@ -347,7 +347,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -7,7 +7,6 @@
 use std::{
     cell::Cell,
     collections::hash_map::DefaultHasher,
-    fmt::Write,
     hash::{Hash, Hasher},
     mem,
 };
@@ -25,6 +24,7 @@ use crate::{
     intern::{Interns, StaticStrings},
     os::{MontyPath, build_path_os_call, is_path_os_method},
     resource::ResourceTracker,
+    string_builder::ReprWrite,
     types::{LazyHeapSet, PyTrait, Type, allocate_tuple, str::allocate_string},
     value::{EitherStr, Value},
 };
@@ -495,7 +495,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Path> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -9,11 +9,11 @@
 ///
 /// The trait is designed to work with `enum_dispatch` for efficient virtual
 /// dispatch on `HeapData` without boxing overhead.
-use std::{cmp::Ordering, fmt::Write};
+use std::cmp::Ordering;
 
 use ahash::AHashSet;
 
-use super::{Type, allocate_string};
+use super::Type;
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, VM},
@@ -23,6 +23,7 @@ use crate::{
     intern::StringId,
     os::OsFunctionCall,
     resource::{ResourceError, ResourceTracker},
+    string_builder::{ReprBuilder, ReprWrite},
     value::{EitherStr, Value},
 };
 
@@ -228,30 +229,28 @@ pub(crate) trait PyTrait<'h> {
     /// * `heap_ids` - Set of heap IDs currently being repr'd (for cycle detection)
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()>;
 
     /// Returns the Python `repr()` string for this value as a heap `str` `Value`.
     ///
-    /// Convenience wrapper around `py_repr_fmt` that allocates the result.
-    ///
-    /// TODO: the intermediate `String` here is *not* tracked, so recursive
-    /// `repr()` of nested containers can amplify into a multi-gigabyte
-    /// host-side buffer before `allocate_string` consults the tracker.
-    /// `StringBuilder` is the canonical fix: now that `py_repr` returns a
-    /// `Value`, the builder can be `finish`ed here (outside the recursion),
-    /// but `py_repr_fmt` still borrows `&mut vm` while writing, so plugging it
-    /// in first needs `py_repr_fmt` to no longer need `&mut vm` while the
-    /// builder is alive. Today's per-type protections (`INT_MAX_STR_DIGITS`,
-    /// `check_repeat_size`, etc.) blunt the worst amplifications but don't
-    /// fully cover container `repr()`.
+    /// Convenience wrapper around `py_repr_fmt` that builds into a
+    /// [`ReprBuilder`], so the intermediate buffer is reserved with the
+    /// resource tracker as the recursion settles it (see [`ReprWrite`]) —
+    /// shared/nested containers cannot amplify a small tracked heap into an
+    /// unbounded host-side allocation.
     fn py_repr(&self, vm: &mut VM<'h, impl ResourceTracker>) -> RunResult<Value> {
-        let mut s = String::new();
+        let mut builder = ReprBuilder::new();
         let mut heap_ids = LazyHeapSet::default();
-        self.py_repr_fmt(&mut s, vm, &mut heap_ids)?;
-        Ok(allocate_string(s, vm.heap)?)
+        match self.py_repr_fmt(&mut builder, vm, &mut heap_ids) {
+            Ok(()) => builder.finish(vm.heap),
+            Err(e) => {
+                builder.cancel(vm.heap.tracker());
+                Err(e)
+            }
+        }
     }
 
     /// Returns the Python `str()` string for this value.

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -5,7 +5,6 @@
 
 use std::{
     collections::hash_map::DefaultHasher,
-    fmt::Write,
     hash::{Hash, Hasher},
     mem,
 };
@@ -20,6 +19,7 @@ use crate::{
     hash::HashValue,
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     resource::ResourceTracker,
+    string_builder::ReprWrite,
     types::{LazyHeapSet, PyTrait, Type},
     value::Value,
 };
@@ -282,7 +282,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Range> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/types/re_match.rs
+++ b/crates/monty/src/types/re_match.rs
@@ -9,7 +9,7 @@
 //! is held as a single refcounted heap reference shared across every match from
 //! one `finditer`/`findall` call, so `py_dec_ref_ids` releases that reference.
 
-use std::{cell::OnceCell, cmp::Ordering, fmt::Write, mem};
+use std::{cell::OnceCell, cmp::Ordering, mem};
 
 use smallvec::smallvec;
 
@@ -21,6 +21,7 @@ use crate::{
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead},
     intern::StaticStrings,
     resource::ResourceTracker,
+    string_builder::ReprWrite,
     types::{
         Dict, LazyHeapSet, PyTrait, Type, allocate_tuple,
         str::{allocate_string, string_repr_fmt},
@@ -331,7 +332,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -9,7 +9,7 @@
 //! Custom serde serializes only the pattern string and flags, recompiling the regex
 //! on deserialization. This supports Monty's snapshot/restore feature.
 
-use std::{borrow::Cow, cell::OnceCell, cmp::Ordering, fmt::Write, iter, mem, str};
+use std::{borrow::Cow, cell::OnceCell, cmp::Ordering, iter, mem, str};
 
 use fancy_regex::{CompileError, Error as RegexError, Regex, RegexBuilder};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
@@ -24,6 +24,7 @@ use crate::{
     intern::StaticStrings,
     modules::re::{ASCII, DOTALL, IGNORECASE, MULTILINE},
     resource::{ResourceTracker, check_estimated_size},
+    string_builder::ReprWrite,
     types::{
         LazyHeapSet, List, PyTrait, ReMatch, Type, allocate_tuple,
         str::{allocate_string, string_repr_fmt},
@@ -378,7 +379,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, RePattern> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -1,4 +1,4 @@
-use std::{cell::Cell, fmt::Write, mem};
+use std::{cell::Cell, mem};
 
 use hashbrown::HashTable;
 use smallvec::SmallVec;
@@ -16,6 +16,7 @@ use crate::{
     },
     intern::StaticStrings,
     resource::ResourceTracker,
+    string_builder::ReprWrite,
     types::{LazyHeapSet, Type},
     value::{EitherStr, Value},
 };
@@ -503,7 +504,7 @@ impl<'h> HeapRead<'h, SetStorage> {
     /// Writes the repr format to a formatter.
     fn repr_fmt<T: ResourceTracker>(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, T>,
         heap_ids: &mut LazyHeapSet,
         type_name: &str,
@@ -1002,7 +1003,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Set> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
@@ -1293,7 +1294,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -21,6 +21,7 @@ use crate::{
     heap::{HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     resource::ResourceTracker,
+    string_builder::ReprWrite,
     types::{PyTrait, Type},
     value::{EitherStr, Value},
 };
@@ -191,7 +192,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Slice> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -18,7 +18,7 @@ use crate::{
     heap::{DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, heap_read_ref_as_field},
     intern::{StaticStrings, StringId},
     resource::{ResourceError, ResourceTracker, check_replace_size},
-    string_builder::StringBuilder,
+    string_builder::{ReprWrite, StringBuilder},
     types::{
         LazyHeapSet, Type,
         slice::{normalize_sequence_index, slice_collect_iterator},
@@ -251,7 +251,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/types/timedelta.rs
+++ b/crates/monty/src/types/timedelta.rs
@@ -22,6 +22,7 @@ use crate::{
     heap::{HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     resource::ResourceTracker,
+    string_builder::ReprWrite,
     types::{CmpOrder, LazyHeapSet, PyTrait, Type, str::allocate_string},
     value::{EitherStr, Value},
 };
@@ -338,7 +339,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeDelta> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/types/timezone.rs
+++ b/crates/monty/src/types/timezone.rs
@@ -4,7 +4,6 @@
 
 use std::{
     collections::hash_map::DefaultHasher,
-    fmt::Write,
     hash::{Hash, Hasher},
     mem,
 };
@@ -18,6 +17,7 @@ use crate::{
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::Interns,
     resource::ResourceTracker,
+    string_builder::ReprWrite,
     types::{
         LazyHeapSet, PyTrait, Type,
         str::{StringRepr, allocate_string},
@@ -252,7 +252,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeZone> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         _heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -18,7 +18,6 @@ use std::{
     cell::Cell,
     cmp::Ordering,
     collections::hash_map::DefaultHasher,
-    fmt::Write,
     hash::{Hash, Hasher},
     mem,
 };
@@ -35,6 +34,7 @@ use crate::{
     heap::{DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     resource::{ResourceError, ResourceTracker},
+    string_builder::ReprWrite,
     types::{
         LazyHeapSet, Type,
         list::repr_sequence_fmt,
@@ -443,7 +443,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'h, impl ResourceTracker>,
         heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -344,6 +344,13 @@ impl<'h> PyTrait<'h> for Value {
         vm: &mut VM<'_, impl ResourceTracker>,
         heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
+        // Settle the sink once per value — every value, not just heap refs:
+        // an interned string/bytes is a 16-byte `Value` whose repr writes the
+        // whole interned payload, so a container aliasing a large source
+        // literal would otherwise amplify a small tracked heap into an
+        // unbounded untracked repr buffer. Untracked slack between settles
+        // stays bounded by a single value's leaf writes.
+        f.settle(vm.heap.tracker())?;
         let interns = vm.interns;
         match self {
             Self::Undefined => Ok(f.write_str("Undefined")?),
@@ -369,11 +376,6 @@ impl<'h> PyTrait<'h> for Value {
             Self::Marker(m) => Ok(m.py_repr_fmt(f)?),
             Self::Property(p) => Ok(write!(f, "<property {p:?}>")?),
             Self::Ref(id) => {
-                // Settle the sink before each heap value: untracked bytes in
-                // `f` stay bounded by a single value's writes between tracker
-                // reservations, so shared/nested structures cannot amplify a
-                // small tracked heap into a huge untracked repr buffer.
-                f.settle(vm.heap.tracker())?;
                 if heap_ids.contains(id) {
                     // Cycle detected - write type-specific placeholder following Python semantics
                     match vm.heap.get(*id) {

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -27,6 +27,7 @@ use crate::{
         ResourceError, ResourceTracker, check_div_size, check_lshift_size, check_mult_size, check_pow_size,
         check_repeat_size,
     },
+    string_builder::{ReprBuilder, ReprWrite},
     types::{
         Bytes, CmpOrder, LazyHeapSet, List, LongInt, Property, PyTrait, Type, allocate_tuple,
         bytes::{bytes_repr_fmt, get_byte_at_index},
@@ -339,7 +340,7 @@ impl<'h> PyTrait<'h> for Value {
 
     fn py_repr_fmt(
         &self,
-        f: &mut impl Write,
+        f: &mut impl ReprWrite,
         vm: &mut VM<'_, impl ResourceTracker>,
         heap_ids: &mut LazyHeapSet,
     ) -> RunResult<()> {
@@ -368,6 +369,11 @@ impl<'h> PyTrait<'h> for Value {
             Self::Marker(m) => Ok(m.py_repr_fmt(f)?),
             Self::Property(p) => Ok(write!(f, "<property {p:?}>")?),
             Self::Ref(id) => {
+                // Settle the sink before each heap value: untracked bytes in
+                // `f` stay bounded by a single value's writes between tracker
+                // reservations, so shared/nested structures cannot amplify a
+                // small tracked heap into a huge untracked repr buffer.
+                f.settle(vm.heap.tracker())?;
                 if heap_ids.contains(id) {
                     // Cycle detected - write type-specific placeholder following Python semantics
                     match vm.heap.get(*id) {
@@ -417,10 +423,15 @@ impl<'h> PyTrait<'h> for Value {
             Self::Ellipsis => Ok(Self::InternString(StaticStrings::EllipsisRepr.into())),
             Self::Int(i) => Ok(allocate_string(itoa::Buffer::new().format(*i), vm.heap)?),
             _ => {
-                let mut s = String::new();
+                let mut builder = ReprBuilder::new();
                 let mut heap_ids = LazyHeapSet::default();
-                self.py_repr_fmt(&mut s, vm, &mut heap_ids)?;
-                Ok(allocate_string(s, vm.heap)?)
+                match self.py_repr_fmt(&mut builder, vm, &mut heap_ids) {
+                    Ok(()) => builder.finish(vm.heap),
+                    Err(e) => {
+                        builder.cancel(vm.heap.tracker());
+                        Err(e)
+                    }
+                }
             }
         }
     }

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -2357,3 +2357,105 @@ fn finditer_shares_subject_memory() {
         MontyObject::Int(4000)
     );
 }
+
+/// Regression: `repr()` of an aliased container must be bounded by the memory
+/// limit *while formatting*, not only when the final string is allocated.
+///
+/// The tracked heap here is tiny (4000 pointers to one shared 500-char
+/// string, ~64 KB) but the repr is ~2 MB. Before `ReprBuilder` settled the
+/// buffer with the tracker per heap value, the whole repr was built in an
+/// untracked Rust `String`, so shared structures could grow host memory
+/// arbitrarily far past the configured limit.
+#[test]
+fn repr_shared_structure_memory_bounded() {
+    let code = "xs = ['x' * 500] * 4000\nrepr(xs)";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let limits = ResourceLimits::new()
+        .max_memory(1_048_576)
+        .max_duration(Duration::from_secs(30));
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    let exc = result.expect_err("2MB repr should exceed the 1MB memory limit");
+    assert_eq!(exc.exc_type(), ExcType::MemoryError);
+
+    // A small repr under the same limit is unaffected.
+    let ex = MontyRun::new(
+        "repr(['x' * 5] * 4)".to_owned(),
+        "test.py",
+        vec![],
+        CompileOptions::default(),
+    )
+    .unwrap();
+    let limits = ResourceLimits::new().max_memory(1_048_576);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+    assert_eq!(
+        result.expect("small repr should succeed"),
+        MontyObject::String("['xxxxx', 'xxxxx', 'xxxxx', 'xxxxx']".to_owned())
+    );
+}
+
+/// A raising user `__repr__` must release the repr buffer's tracker
+/// reservation (`ReprBuilder::cancel`): the exception is catchable, so a
+/// leaked reservation would accumulate across iterations and spuriously
+/// trip the memory limit even though no memory is actually retained.
+#[test]
+fn repr_error_path_releases_reservation() {
+    let code = r"
+class Bad:
+    def __repr__(self):
+        raise ValueError('nope')
+
+xs = ['x' * 500] * 100 + [Bad()]
+for i in range(100):
+    try:
+        repr(xs)
+    except ValueError:
+        pass
+'ok'
+";
+    // Each failed repr settles ~50 KB before `Bad.__repr__` raises; leaking
+    // those reservations would exceed the 2 MB limit well before the loop ends.
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let limits = ResourceLimits::new()
+        .max_memory(2_097_152)
+        .max_duration(Duration::from_secs(30));
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+    assert_eq!(
+        result.expect("cancelled repr reservations must not accumulate"),
+        MontyObject::String("ok".to_owned())
+    );
+}
+
+/// Regression: `json.dumps` output must be bounded by the memory limit while
+/// serializing. The encoder writes into a Rust `String` outside the tracker;
+/// before `Encoder::settle` a shared (DAG) structure like this one — ~64 KB
+/// of tracked heap serializing to ~2 MB of JSON — bypassed the limit
+/// entirely, since `json.dumps` never consulted the tracker until the final
+/// `allocate_string`.
+#[test]
+fn json_dumps_shared_structure_memory_bounded() {
+    let code = "import json\nx = ['a' * 500] * 4000\njson.dumps(x)";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let limits = ResourceLimits::new()
+        .max_memory(1_048_576)
+        .max_duration(Duration::from_secs(30));
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    let exc = result.expect_err("2MB JSON should exceed the 1MB memory limit");
+    assert_eq!(exc.exc_type(), ExcType::MemoryError);
+
+    // A small document under the same limit still serializes correctly.
+    let ex = MontyRun::new(
+        "import json\njson.dumps([1, 2])".to_owned(),
+        "test.py",
+        vec![],
+        CompileOptions::default(),
+    )
+    .unwrap();
+    let limits = ResourceLimits::new().max_memory(1_048_576);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+    assert_eq!(
+        result.expect("small json.dumps should succeed"),
+        MontyObject::String("[1, 2]".to_owned())
+    );
+}

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -2368,15 +2368,20 @@ fn finditer_shares_subject_memory() {
 /// arbitrarily far past the configured limit.
 #[test]
 fn repr_shared_structure_memory_bounded() {
-    let code = "xs = ['x' * 500] * 4000\nrepr(xs)";
-    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
-    let limits = ResourceLimits::new()
-        .max_memory(1_048_576)
-        .max_duration(Duration::from_secs(30));
-    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+    // `str(xs)` covers the `HeapReadOutput::py_str` → PyTrait-default
+    // `py_repr` entry, which starts the recursion at the container rather
+    // than at a `Value` — element settling must bound it identically.
+    for call in ["repr", "str"] {
+        let code = format!("xs = ['x' * 500] * 4000\n{call}(xs)");
+        let ex = MontyRun::new(code, "test.py", vec![], CompileOptions::default()).unwrap();
+        let limits = ResourceLimits::new()
+            .max_memory(1_048_576)
+            .max_duration(Duration::from_secs(30));
+        let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
 
-    let exc = result.expect_err("2MB repr should exceed the 1MB memory limit");
-    assert_eq!(exc.exc_type(), ExcType::MemoryError);
+        let exc = result.expect_err("2MB repr should exceed the 1MB memory limit");
+        assert_eq!(exc.exc_type(), ExcType::MemoryError, "{call}: wrong exc type");
+    }
 
     // A small repr under the same limit is unaffected.
     let ex = MontyRun::new(

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -2459,3 +2459,22 @@ fn json_dumps_shared_structure_memory_bounded() {
         MontyObject::String("[1, 2]".to_owned())
     );
 }
+
+/// Immediate (non-`Ref`) values must also settle the repr buffer: an interned
+/// string is a 16-byte `Value` whose repr writes the whole interned payload,
+/// so a container aliasing a large *source literal* amplifies without bound —
+/// here ~1.6 MB of tracked heap (100k pointers) whose repr is ~1 GB. Settling
+/// only at heap references would materialize the full untracked buffer before
+/// the final allocation check fired.
+#[test]
+fn repr_interned_literal_aliasing_memory_bounded() {
+    let code = format!("xs = ['{}'] * 100_000\nrepr(xs)", "x".repeat(10_000));
+    let ex = MontyRun::new(code, "test.py", vec![], CompileOptions::default()).unwrap();
+    let limits = ResourceLimits::new()
+        .max_memory(8_388_608)
+        .max_duration(Duration::from_secs(30));
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    let exc = result.expect_err("1GB repr of aliased interned literal should exceed the 8MB memory limit");
+    assert_eq!(exc.exc_type(), ExcType::MemoryError);
+}

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -2478,3 +2478,43 @@ fn repr_interned_literal_aliasing_memory_bounded() {
     let exc = result.expect_err("1GB repr of aliased interned literal should exceed the 8MB memory limit");
     assert_eq!(exc.exc_type(), ExcType::MemoryError);
 }
+
+/// Pretty-printed `json.dumps` indentation must be tracker-bounded: `indent`
+/// is an arbitrary user string written `depth` times per line, so
+/// `indent_len x depth` can dwarf the limit in a single untracked write, and
+/// closing indents on the unwind are not followed by any `serialize_value`
+/// entry settle. Here ~1 MB of tracked heap (the indent string plus 50 nested
+/// lists) would pretty-print to ~2.5 GB.
+#[test]
+fn json_dumps_indent_memory_bounded() {
+    let code = "
+import json
+x = []
+for i in range(50):
+    x = [x]
+json.dumps(x, indent=' ' * 1_000_000)
+";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let limits = ResourceLimits::new()
+        .max_memory(8_388_608)
+        .max_duration(Duration::from_secs(30));
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    let exc = result.expect_err("giant-indent pretty print should exceed the 8MB memory limit");
+    assert_eq!(exc.exc_type(), ExcType::MemoryError);
+
+    // A normal pretty print under the same limit is unaffected.
+    let ex = MontyRun::new(
+        "import json\njson.dumps([1, [2]], indent=2)".to_owned(),
+        "test.py",
+        vec![],
+        CompileOptions::default(),
+    )
+    .unwrap();
+    let limits = ResourceLimits::new().max_memory(8_388_608);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+    assert_eq!(
+        result.expect("small pretty json.dumps should succeed"),
+        MontyObject::String("[\n  1,\n  [\n    2\n  ]\n]".to_owned())
+    );
+}

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -2522,4 +2522,21 @@ json.dumps(x, indent=' ' * 1_000_000)
         result.expect("small pretty json.dumps should succeed"),
         MontyObject::String("[\n  1,\n  [\n    2\n  ]\n]".to_owned())
     );
+
+    // Empty containers never write indentation (CPython short-circuits them
+    // to `[]`/`{}`), so a huge indent must not trip the limit check.
+    let ex = MontyRun::new(
+        "import json\ni = ' ' * 6_000_000\njson.dumps([], indent=i) + json.dumps((), indent=i) + json.dumps({}, indent=i)"
+            .to_owned(),
+        "test.py",
+        vec![],
+        CompileOptions::default(),
+    )
+    .unwrap();
+    let limits = ResourceLimits::new().max_memory(8_388_608);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+    assert_eq!(
+        result.expect("empty containers with huge indent should succeed"),
+        MontyObject::String("[][]{}".to_owned())
+    );
 }

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -25,6 +25,12 @@ inside the sandbox).
   rather than attempting the allocation.
 - `bigint.pow(base, exp)` estimates result size as `bits(base) * exp` with
   a 4× safety multiplier to cover repeated-squaring intermediate values.
+- `repr()` / `str()` of containers and `json.dumps` reserve their output
+  buffer with the tracker incrementally while formatting (once per nested
+  value). Aliased/shared structures whose text form is much larger than the
+  tracked heap (e.g. `repr(['x' * 500] * 4000)` under a 1 MB limit) raise
+  `ResourceError` mid-format instead of bypassing the limit; CPython would
+  simply build the string.
 
 ## Integer-specific caps
 


### PR DESCRIPTION
repr()/str() of containers and json.dumps built their output in plain untracked Rust Strings, only consulting the resource tracker at the final allocate_string. Shared (DAG) structures could therefore amplify a small tracked heap into an arbitrarily large host-side buffer, bypassing the configured memory limit entirely.

py_repr_fmt's sink is now `&mut impl ReprWrite` — fmt::Write plus a settle(tracker) hook. Value::py_repr_fmt settles once per heap value, so untracked slack is bounded by a single value's leaf writes. The new ReprBuilder buffers and reserves via settle (it holds no tracker borrow, which is what blocked using StringBuilder here); py_repr cancels the reservation when a user __repr__ raises. The json.dumps Encoder settles per serialized value the same way. The assert path's TruncatingWriter is already byte-capped and keeps the no-op settle.


Claude-Session: https://claude.ai/code/session_01NjYHCBEuW8JJLD4sAbptir

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces memory limits while building `repr()`/`str()` of containers and `json.dumps` by reserving output with the resource tracker during formatting. Prevents DAG/shared structures and interned-literal aliasing from creating large untracked buffers that bypass limits.

- **Bug Fixes**
  - Introduced `ReprWrite` with a `settle(tracker)` hook; `Value::py_repr_fmt` settles once per value (including immediate/interned values).
  - Added `ReprBuilder` for `repr()` that reserves on settle and cancels the reservation if a user `__repr__` raises.
  - Updated `json.dumps` to settle per serialized value, pre-check and settle indentation writes, short-circuit empty arrays before indent, and release reserved bytes after encoding.
  - Kept assert-path `TruncatingWriter` as a no-op settle (byte-capped).
  - Added tests for shared-structure bounds, interned-literal aliasing, pretty-indent bursts (including empty arrays), `str(container)` entry, and error-path reservation release; updated `limitations/resource_limits.md` and `CLAUDE.md`.

<sup>Written for commit 741a8e1c7b18d1f0aa54c05e3ad2da375e65801b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

