### PR TITLE
inline `clone_immediate` into `clone_with_heap`

### DIFF
--- a/crates/monty/src/bytecode/code.rs
+++ b/crates/monty/src/bytecode/code.rs
@@ -10,7 +10,7 @@ use crate::{intern::StringId, parse::CodeRange, value::Value};
 ///
 /// This is the output of the bytecode compiler and the input to the VM.
 /// Each function has its own Code object; module-level code also gets one.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct Code {
     /// Raw bytecode instructions as a byte vector.
     ///
@@ -145,13 +145,6 @@ impl Code {
 pub(crate) struct ConstPool {
     /// The constant values, indexed by the operand of `LoadConst`.
     values: Vec<Value>,
-}
-
-impl Clone for ConstPool {
-    fn clone(&self) -> Self {
-        let values = self.values.iter().map(Value::clone_immediate).collect();
-        Self { values }
-    }
 }
 
 impl ConstPool {

--- a/crates/monty/src/function.rs
+++ b/crates/monty/src/function.rs
@@ -1,4 +1,7 @@
-use std::fmt::{self, Write};
+use std::{
+    fmt::{self, Write},
+    sync::Arc,
+};
 
 use crate::{args::Signature, bytecode::Code, expressions::Identifier, intern::Interns, namespace::NamespaceId};
 
@@ -64,8 +67,8 @@ pub(crate) struct Function {
     /// immediately pushing a frame. The coroutine captures the bound arguments
     /// and starts execution only when awaited.
     pub is_async: bool,
-    /// Compiled bytecode for this function body.
-    pub code: Code,
+    /// Compiled bytecode for this function body. Wrapped in `Arc` to avoid deep clone.
+    pub code: Arc<Code>,
 }
 
 impl Function {
@@ -107,7 +110,7 @@ impl Function {
             cell_param_indices,
             defaults_count,
             is_async,
-            code,
+            code: Arc::new(code),
         }
     }
 

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -1,7 +1,10 @@
 //! Public interface for running Monty code.
 use std::{
     num::NonZeroU32,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
 };
 
 use ruff_python_stdlib::identifiers::is_identifier;
@@ -278,8 +281,8 @@ impl MontyRun {
 pub(crate) struct Executor {
     /// Module-level global names.
     pub(crate) globals: NameMap,
-    /// Compiled bytecode for the module.
-    pub(crate) module_code: Code,
+    /// Compiled bytecode for the module. Wrapped in `Arc` to avoid needing to deep clone.
+    pub(crate) module_code: Arc<Code>,
     /// Interned strings used for looking up names and filenames during execution.
     pub(crate) interns: Interns,
     /// Source code for error reporting (extracting preview lines for tracebacks).
@@ -341,7 +344,7 @@ impl Executor {
 
         Ok(Self {
             globals: prepared.globals,
-            module_code: compile_result.code,
+            module_code: Arc::new(compile_result.code),
             interns,
             code,
             input_slots: Vec::new(),
@@ -414,7 +417,7 @@ impl Executor {
 
         Ok(Self {
             globals: prepared.globals,
-            module_code: compile_result.code,
+            module_code: Arc::new(compile_result.code),
             interns,
             code,
             input_slots,

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -667,7 +667,7 @@ impl IntoIterator for Dict {
 /// Borrows a [`HeapRead`] for its lifetime, so the heap entry is pinned by
 /// the reader count for the duration of iteration.
 ///
-/// **Two yield modes.** Pick the variant that matches the caller's natural
+/// **Yield modes.** Pick the variant that matches the caller's natural
 /// pattern to avoid redundant `clone_with_heap` / `drop_with` work:
 ///
 /// - [`next`](Self::next) returns `Option<(&Value, &Value)>`. The iterator
@@ -675,13 +675,15 @@ impl IntoIterator for Dict {
 ///   empty sentinel) and drops the previous pair at the start of each call,
 ///   so "use and discard" call sites do **not** need a per-item
 ///   `defer_drop!`.
+/// - [`next_value`](Self::next_value) returns only a borrowed value, avoiding
+///   key refcount churn for value-only operations.
 /// - [`next_owned`](Self::next_owned) returns `Option<(Value, Value)>` and
 ///   clones straight into the return value, leaving the internal slot
 ///   `Undefined`. Prefer this when feeding pairs into a sink that takes
 ///   ownership (e.g. [`HeapRead::set`], `Set::add`) — going through `next`
 ///   forces a second `clone_with_heap` per element.
 ///
-/// Mixing the two modes is supported: every step drops whatever the slot
+/// Mixing the yield modes is supported: every step drops whatever the slot
 /// held before doing its work.
 ///
 /// **Recursion guard.** Acquires a [`RecursionToken`] at construction and
@@ -741,6 +743,20 @@ impl<'a, 'h> DictIter<'a, 'h> {
         Ok(Some((&self.current_key, &self.current_value)))
     }
 
+    /// Advances the iterator and returns a borrow of the next value.
+    ///
+    /// Prefer this for value-only operations so dictionary keys are not cloned.
+    /// The returned reference is valid until the next call that advances the
+    /// iterator, or until the iterator is dropped.
+    pub(crate) fn next_value<'i, R: ResourceTracker>(&'i mut self, vm: &mut VM<'h, R>) -> RunResult<Option<&'i Value>> {
+        let Some(entry_index) = self.advance(vm)? else {
+            return Ok(None);
+        };
+        let entry = &self.dict.get(vm.heap).entries[entry_index];
+        self.current_value = entry.value.clone_with_heap(vm.heap);
+        Ok(Some(&self.current_value))
+    }
+
     /// Advances the iterator and returns the next `(key, value)` pair as
     /// owned values, transferring ownership to the caller.
     ///
@@ -761,7 +777,7 @@ impl<'a, 'h> DictIter<'a, 'h> {
         Ok(Some(pair))
     }
 
-    /// Shared step for [`next`](Self::next) / [`next_owned`](Self::next_owned).
+    /// Shared step for the iterator's borrowed and owned yield modes.
     ///
     /// Releases the previously-yielded slot (no-op when each slot is
     /// `Undefined`), runs the per-step time check and the dict mutation

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -16,7 +16,7 @@ use smallvec::SmallVec;
 use crate::{
     builtins::Builtins,
     bytecode::{CallResult, VM},
-    defer_drop,
+    defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunError, RunResult, SimpleException},
     fstring::FormatFloat,
     hash::{HashValue, hash_one, hash_python_long_int, hash_python_str},
@@ -47,8 +47,7 @@ use crate::{
 /// inline, while heap-allocated values (List, Str, Dict, etc.) are stored in the arena
 /// and referenced via `Ref(HeapId)`.
 ///
-/// NOTE: `Clone` is intentionally NOT derived. Use `clone_with_heap()` for heap values
-/// or `clone_immediate()` for immediate values only. Direct cloning via `.clone()` would
+/// NOTE: `Clone` is intentionally NOT derived. Use `clone_with_heap()`. Direct cloning via `.clone()` would
 /// bypass reference counting and cause memory leaks.
 ///
 /// NOTE: it's important to keep this size small to minimize memory overhead!
@@ -1762,23 +1761,10 @@ impl Value {
                         let HeapReadOutput::Dict(dict) = vm.heap.read(dict_id) else {
                             panic!("dict_values view must reference a dict");
                         };
-                        // Iterate by index, cloning each value for py_eq comparison
-                        let len = dict.get(vm.heap).len();
-                        for i in 0..len {
-                            // Two-phase clone: read ref discriminant, then inc_ref
-                            let ref_id = match dict.get(vm.heap).value_at(i) {
-                                Some(Self::Ref(id)) => Some(*id),
-                                _ => None,
-                            };
-                            let el = if let Some(id) = ref_id {
-                                vm.heap.inc_ref(id);
-                                Self::Ref(id)
-                            } else {
-                                dict.get(vm.heap).value_at(i).expect("index valid").clone_immediate()
-                            };
-                            let eq = item.py_eq(&el, vm);
-                            el.drop_with(vm);
-                            if eq? {
+                        let iter = dict.iter(vm)?;
+                        defer_drop_mut!(iter, vm);
+                        while let Some(value) = iter.next_value(vm)? {
+                            if item.py_eq(value, vm)? {
                                 return Ok(true);
                             }
                         }
@@ -2047,7 +2033,7 @@ impl Value {
         }
     }
 
-    /// Clones an value with proper heap reference counting.
+    /// Clones a value with proper heap reference counting.
     ///
     /// For immediate values (Int, Bool, None, etc.), this performs a simple copy.
     /// For heap-allocated values (Ref variant), this increments the reference count
@@ -2064,12 +2050,27 @@ impl Value {
     #[must_use]
     pub fn clone_with_heap(&self, heap: &impl ContainsHeap) -> Self {
         match self {
+            Self::Undefined => Self::Undefined,
+            Self::Ellipsis => Self::Ellipsis,
+            Self::None => Self::None,
+            Self::Bool(b) => Self::Bool(*b),
+            Self::Int(v) => Self::Int(*v),
+            Self::Float(v) => Self::Float(*v),
+            Self::Builtin(b) => Self::Builtin(*b),
+            Self::ModuleFunction(mf) => Self::ModuleFunction(*mf),
+            Self::DefFunction(f) => Self::DefFunction(*f),
+            Self::ExtFunction(f) => Self::ExtFunction(*f),
+            Self::InternString(s) => Self::InternString(*s),
+            Self::InternBytes(b) => Self::InternBytes(*b),
+            Self::InternLongInt(bi) => Self::InternLongInt(*bi),
+            Self::Marker(m) => Self::Marker(*m),
+            Self::Property(p) => Self::Property(*p),
             Self::Ref(id) => {
                 heap.heap().inc_ref(*id);
                 Self::Ref(*id)
             }
-            // Immediate values can be copied without heap interaction
-            other => other.clone_immediate(),
+            #[cfg(feature = "memory-model-checks")]
+            Self::Dereferenced => panic!("Cannot copy Dereferenced object"),
         }
     }
 
@@ -2103,33 +2104,6 @@ impl Value {
         if let Self::Ref(id) = &old {
             heap.heap_mut().dec_ref(*id);
             mem::forget(old);
-        }
-    }
-
-    /// Internal helper for copying immediate values without heap interaction.
-    ///
-    /// This method should only be called by `clone_with_heap()` for immediate values.
-    /// Attempting to clone a Ref variant will panic.
-    pub fn clone_immediate(&self) -> Self {
-        match self {
-            Self::Undefined => Self::Undefined,
-            Self::Ellipsis => Self::Ellipsis,
-            Self::None => Self::None,
-            Self::Bool(b) => Self::Bool(*b),
-            Self::Int(v) => Self::Int(*v),
-            Self::Float(v) => Self::Float(*v),
-            Self::Builtin(b) => Self::Builtin(*b),
-            Self::ModuleFunction(mf) => Self::ModuleFunction(*mf),
-            Self::DefFunction(f) => Self::DefFunction(*f),
-            Self::ExtFunction(f) => Self::ExtFunction(*f),
-            Self::InternString(s) => Self::InternString(*s),
-            Self::InternBytes(b) => Self::InternBytes(*b),
-            Self::InternLongInt(bi) => Self::InternLongInt(*bi),
-            Self::Marker(m) => Self::Marker(*m),
-            Self::Property(p) => Self::Property(*p),
-            Self::Ref(_) => panic!("Ref clones must go through clone_with_heap to maintain refcounts"),
-            #[cfg(feature = "memory-model-checks")]
-            Self::Dereferenced => panic!("Cannot copy Dereferenced object"),
         }
     }
 


### PR DESCRIPTION
Should make a small perf win (and avoid a weird API split).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inline immediate-value cloning into `clone_with_heap` and remove `clone_immediate` to simplify the API and reduce refcount churn. `Code` is no longer `Clone`; callers now share it via `Arc<Code>`. Also adds a value-only dict iterator path used by `dict_values.__contains__` for a small perf win.

- **Refactors**
  - Removed `Value::clone_immediate`; `clone_with_heap` now handles all variants.
  - Dropped `Clone` from `Code`; wrap in `Arc` in `Function` and `Executor`.
  - Removed `ConstPool`’s `Clone` impl that depended on `clone_immediate`.
  - Added `DictIter::next_value` and used it in `dict_values.__contains__` to avoid key churn.

- **Migration**
  - Replace `Value::clone_immediate` calls with `Value::clone_with_heap`.
  - If you cloned `Code`, switch to sharing via `Arc<Code>`.
  - `ConstPool` is no longer `Clone`; update any code relying on that.

<sup>Written for commit 073bf113786fecba6846d0f2f245f092ce16c0ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

