### PR TITLE
Make an existing iterator self-iterable

### DIFF
--- a/crates/monty/src/builtins/reversed.rs
+++ b/crates/monty/src/builtins/reversed.rs
@@ -3,7 +3,7 @@
 use crate::{
     args::ArgValues,
     bytecode::VM,
-    exception_private::RunResult,
+    exception_private::{ExcType, RunResult},
     heap::HeapData,
     resource::ResourceTracker,
     types::{List, MontyIter},
@@ -17,6 +17,15 @@ use crate::{
 pub fn builtin_reversed(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let value = args.get_one_arg("reversed", vm.heap)?;
 
+    // Being iterable is not enough: CPython needs `__reversed__`, or
+    // `__len__` + `__getitem__`. Check before iterating so unordered and
+    // one-shot iterables are rejected rather than silently reversed.
+    if !is_reversible(&value, vm) {
+        let err = ExcType::type_error_not_reversible(&value.py_type_name(vm));
+        value.drop_with(vm);
+        return Err(err);
+    }
+
     // Collect all items
     let mut items: Vec<_> = MontyIter::new(value, vm)?.collect(vm)?;
 
@@ -25,4 +34,31 @@ pub fn builtin_reversed(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) 
 
     let heap_id = vm.heap.allocate(HeapData::List(List::new(items)))?;
     Ok(Value::Ref(heap_id))
+}
+
+/// Whether `reversed()` accepts this value, mirroring CPython's requirement of
+/// `__reversed__` or `__len__` + `__getitem__`.
+///
+/// Deliberately a positive allowlist: a newly iterable type must opt in here
+/// rather than becoming reversible by accident. Sets and iterators are excluded
+/// (no ordering / one-shot), as are user instances — `__reversed__` is not
+/// dispatched, see `limitations/classes.md`.
+fn is_reversible(value: &Value, vm: &VM<'_, impl ResourceTracker>) -> bool {
+    match value {
+        Value::InternString(_) | Value::InternBytes(_) => true,
+        Value::Ref(id) => matches!(
+            vm.heap.get(*id),
+            HeapData::List(_)
+                | HeapData::Tuple(_)
+                | HeapData::NamedTuple(_)
+                | HeapData::Str(_)
+                | HeapData::Bytes(_)
+                | HeapData::Range(_)
+                | HeapData::Dict(_)
+                | HeapData::DictKeysView(_)
+                | HeapData::DictItemsView(_)
+                | HeapData::DictValuesView(_)
+        ),
+        _ => false,
+    }
 }

--- a/crates/monty/src/bytecode/vm/collections.rs
+++ b/crates/monty/src/bytecode/vm/collections.rs
@@ -7,7 +7,10 @@ use crate::{
     heap::{DropGuard, HeapData, HeapReadOutput},
     intern::StringId,
     resource::ResourceTracker,
-    types::{Dict, List, Set, Slice, allocate_tuple, slice::value_to_option_i64, str::allocate_char},
+    types::{
+        Dict, List, Set, Slice, allocate_tuple, collect_iterable, collect_iterable_bounded, slice::value_to_option_i64,
+        str::allocate_char,
+    },
     value::{VALUE_SIZE, Value},
 };
 
@@ -120,6 +123,8 @@ impl<T: ResourceTracker> VM<'_, T> {
                     }
                     items
                 }
+                // An iterator is drained, as CPython does.
+                HeapData::Iter(_) => collect_iterable(iterable, this)?,
                 _ => {
                     let type_ = iterable.py_type_name(this);
                     return Err(ExcType::type_error_value_after_star(&type_));
@@ -383,6 +388,8 @@ impl<T: ResourceTracker> VM<'_, T> {
                     }
                     items
                 }
+                // An iterator is drained, as CPython does.
+                HeapData::Iter(_) => collect_iterable(iterable, this)?,
                 _ => {
                     let type_ = iterable.py_type_name(this);
                     return Err(ExcType::type_error_not_iterable(&type_));
@@ -577,6 +584,24 @@ impl<T: ResourceTracker> VM<'_, T> {
                         }
                         return Ok(());
                     }
+                    // Pull one past `count` so a too-long iterator is detected
+                    // without draining it — CPython stops consuming there too,
+                    // and so reports no total in the "too many" message.
+                    HeapData::Iter(_) => {
+                        let items = collect_iterable_bounded(value, count + 1, this)?;
+                        if items.len() != count {
+                            let err = if items.len() > count {
+                                unpack_too_many_unknown_error(count)
+                            } else {
+                                unpack_size_error(count, items.len())
+                            };
+                            for item in items {
+                                item.drop_with(this);
+                            }
+                            return Err(err);
+                        }
+                        items
+                    }
                     _ => {
                         let type_name = value.py_type_name(this);
                         return Err(unpack_type_error(&type_name));
@@ -656,6 +681,18 @@ impl<T: ResourceTracker> VM<'_, T> {
                         }
                         items
                     }
+                    // An iterator is drained to unpack it, as CPython does.
+                    HeapData::Iter(_) => {
+                        let items = collect_iterable(value, this)?;
+                        if items.len() < min_items {
+                            let err = unpack_ex_too_few_error(min_items, items.len());
+                            for item in items {
+                                item.drop_with(this);
+                            }
+                            return Err(err);
+                        }
+                        items
+                    }
                     _ => {
                         let type_name = value.py_type_name(this);
                         return Err(unpack_type_error(&type_name));
@@ -727,6 +764,18 @@ fn unpack_size_error(expected: usize, actual: usize) -> RunError {
         format!("too many values to unpack (expected {expected}, got {actual})")
     };
     SimpleException::new_msg(ExcType::ValueError, message).into()
+}
+
+/// Creates the "too many values" ValueError when the total is unknown.
+///
+/// Unpacking an iterator stops at the first surplus item, so unlike
+/// [`unpack_size_error`] there is no total to report — matching CPython.
+fn unpack_too_many_unknown_error(expected: usize) -> RunError {
+    SimpleException::new_msg(
+        ExcType::ValueError,
+        format!("too many values to unpack (expected {expected})"),
+    )
+    .into()
 }
 
 /// Creates a TypeError for attempting to unpack a non-iterable type.

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1126,6 +1126,15 @@ impl ExcType {
         SimpleException::new_msg(Self::RuntimeError, "dictionary changed size during iteration").into()
     }
 
+    /// Creates a RuntimeError for an over-deep iterator delegation chain.
+    ///
+    /// Monty-specific (CPython builds no delegation chain at all) — see
+    /// `limitations/builtins.md`.
+    #[must_use]
+    pub(crate) fn runtime_error_iter_delegation_too_deep() -> RunError {
+        SimpleException::new_msg(Self::RuntimeError, "iterator delegation nested too deeply").into()
+    }
+
     /// Creates a RuntimeError for set mutation during iteration.
     ///
     /// Matches CPython's format: `RuntimeError: Set changed size during iteration`

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1126,6 +1126,14 @@ impl ExcType {
         SimpleException::new_msg(Self::RuntimeError, "dictionary changed size during iteration").into()
     }
 
+    /// Creates a TypeError for `reversed()` on a non-reversible object.
+    ///
+    /// Matches CPython's format: `TypeError: '{type}' object is not reversible`
+    #[must_use]
+    pub(crate) fn type_error_not_reversible(type_: &str) -> RunError {
+        SimpleException::new_msg(Self::TypeError, format!("'{type_}' object is not reversible")).into()
+    }
+
     /// Creates a RuntimeError for an over-deep iterator delegation chain.
     ///
     /// Monty-specific (CPython builds no delegation chain at all) — see

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1143,6 +1143,15 @@ impl ExcType {
         SimpleException::new_msg(Self::RuntimeError, "iterator delegation nested too deeply").into()
     }
 
+    /// Creates a RuntimeError for a delegating iterator pointing at a non-iterator.
+    ///
+    /// Unreachable from Python; only a malformed snapshot can produce it. Raised
+    /// rather than panicking so untrusted snapshot data cannot abort the process.
+    #[must_use]
+    pub(crate) fn runtime_error_iter_delegation_invalid() -> RunError {
+        SimpleException::new_msg(Self::RuntimeError, "iterator delegates to a non-iterator").into()
+    }
+
     /// Creates a RuntimeError for set mutation during iteration.
     ///
     /// Matches CPython's format: `RuntimeError: Set changed size during iteration`

--- a/crates/monty/src/types/iter.rs
+++ b/crates/monty/src/types/iter.rs
@@ -189,10 +189,8 @@ impl MontyIter {
                 Ok(Some(item))
             }
             IterValue::IterHeapRef { iter_id } => {
-                // Delegate to the terminal iterator so a wrapped iterator (from
-                // `list(iter(x))`, `for _ in iter(x)`, ...) advances the SAME
-                // iterator and shares its position. `self.value` keeps it alive
-                // and GC-traced, so `iter_id` always resolves to an Iter.
+                // Delegate to the terminal iterator so position is shared;
+                // `self.value` keeps it alive, so this always resolves to an Iter.
                 let Some(target) = resolve_delegate(*iter_id, vm.heap) else {
                     return Err(ExcType::runtime_error_iter_delegation_too_deep());
                 };
@@ -439,27 +437,59 @@ impl<'h> HeapRead<'h, MontyIter> {
     }
 }
 
+/// Collects every remaining item of an iterable into a `Vec`.
+///
+/// For the sites that need all items at once (sequence unpacking, `*` literal
+/// unpack). Clones `value`, so callers holding a borrowed value — e.g. behind
+/// `defer_drop!` — can use it without giving up ownership.
+pub fn collect_iterable(value: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Vec<Value>> {
+    let cloned = value.clone_with_heap(vm.heap);
+    MontyIter::new(cloned, vm)?.collect(vm)
+}
+
+/// Pulls at most `limit` items from an iterable, stopping early.
+///
+/// Sequence unpacking only needs to know whether there is one item too many, and
+/// CPython stops consuming there. Draining instead would over-consume a shared
+/// iterator and change the error message.
+pub fn collect_iterable_bounded(
+    value: &Value,
+    limit: usize,
+    vm: &mut VM<'_, impl ResourceTracker>,
+) -> RunResult<Vec<Value>> {
+    let cloned = value.clone_with_heap(vm.heap);
+    let iter = MontyIter::new(cloned, vm)?;
+    let mut guard = DropGuard::new(iter, vm);
+    let (iter, vm) = guard.as_parts_mut();
+    let mut items = Vec::new();
+    while items.len() < limit {
+        match iter.for_next(vm) {
+            Ok(Some(value)) => items.push(value),
+            Ok(None) => break,
+            Err(e) => {
+                for item in items {
+                    item.drop_with(vm);
+                }
+                return Err(e);
+            }
+        }
+    }
+    Ok(items)
+}
+
 /// The most `IterHeapRef` links [`resolve_delegate`] will follow before giving up.
 ///
-/// Chains deeper than this are pathological — normal code produces depth 1 (a
-/// wrapper over a real iterator). The cap exists only to bound the walk against
-/// a cyclic chain, which cannot occur by construction but could in principle be
-/// reconstructed from an untrusted snapshot.
+/// Normal code produces depth 1; the cap only bounds the walk against a cyclic
+/// chain, which is unreachable by construction but not from an untrusted snapshot.
 const MAX_DELEGATION_DEPTH: usize = 1000;
 
 /// Follows a chain of delegating (`IterHeapRef`) iterators to the terminal
-/// iterator that actually holds the iteration state. Returns `None` if the chain
-/// exceeds [`MAX_DELEGATION_DEPTH`] (i.e. is cyclic or absurdly deep).
+/// iterator holding the iteration state. `None` if the chain exceeds
+/// [`MAX_DELEGATION_DEPTH`] (cyclic or absurdly deep).
 ///
-/// Delegation MUST be resolved iteratively like this, never by recursing into
-/// `advance`/`for_next`: chain depth is attacker-controlled (each `iter()` on a
-/// user iterator allocates a fresh wrapper, so `for _ in range(n): o = iter(W(o))`
-/// builds a chain of length `n`), and native recursion would overflow the stack
-/// and abort the process — a crash the sandbox can neither catch nor bound with
-/// a `ResourceTracker` limit.
-///
-/// Resolving to the terminal is equivalent to forwarding step by step, because a
-/// delegating arm does nothing but forward: it keeps no index of its own.
+/// MUST stay iterative, never recursing into `advance`: chain depth is
+/// attacker-controlled, and native recursion would overflow the stack and abort
+/// the process — uncatchable, and beyond any `ResourceTracker` limit.
 fn resolve_delegate(start: HeapId, heap: &Heap<impl ResourceTracker>) -> Option<HeapId> {
     let mut current = start;
     for _ in 0..MAX_DELEGATION_DEPTH {
@@ -649,16 +679,11 @@ enum IterValue {
     },
     /// Iterating over interned bytes, yields `Value::Int` for each byte.
     InternBytes { bytes_id: BytesId, len: usize },
-    /// Delegating iterator: drives another heap-resident iterator by id.
+    /// Delegating iterator: drives another heap-resident iterator by id, so
+    /// re-iterating an iterator (`list(iter(x))`) shares its position.
     ///
-    /// Produced when an existing iterator is (re)iterated (`for _ in iter(x)`,
-    /// `list(iter(x))`), since an iterator is its own iterator. `for_next` /
-    /// `advance` forward to the underlying iterator, so iteration state is
-    /// shared. The parent `MontyIter`'s `value` holds the same iterator ref
-    /// (keeping it alive and GC-traced), and the parent's own `index` is unused.
-    ///
-    /// Chains of these are resolved iteratively by [`resolve_delegate`] — never
-    /// by recursing, see that function for why.
+    /// The parent's `value` holds the same ref (so it is GC-traced) and the
+    /// parent's `index` is unused.
     IterHeapRef { iter_id: HeapId },
     /// Iterating over a heap-allocated container (List, Tuple, NamedTuple, Dict, Bytes, Set, FrozenSet).
     ///

--- a/crates/monty/src/types/iter.rs
+++ b/crates/monty/src/types/iter.rs
@@ -798,9 +798,8 @@ impl IterValue {
             HeapData::Str(s) => Some(Self::from_str(s.as_str())),
             // Range: copy values for iteration
             HeapData::Range(range) => Some(Self::from_range(range)),
-            // An existing iterator is its own iterator: delegate to it so
-            // `for`/`list`/`sum`/comprehensions drive the SAME object and share
-            // its position, rather than restarting it.
+            // An iterator is its own iterator: delegate so consumers share its
+            // position rather than restarting it.
             HeapData::Iter(_) => Some(Self::IterHeapRef { iter_id: heap_id }),
             // other types are not iterable
             _ => None,

--- a/crates/monty/src/types/iter.rs
+++ b/crates/monty/src/types/iter.rs
@@ -19,7 +19,7 @@ use std::mem;
 use crate::{
     args::ArgValues,
     bytecode::VM,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, RunError, RunResult},
     heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{BytesId, Interns},
     resource::{ResourceError, ResourceTracker, check_estimated_size},
@@ -191,11 +191,9 @@ impl MontyIter {
             IterValue::IterHeapRef { iter_id } => {
                 // Delegate to the terminal iterator so position is shared;
                 // `self.value` keeps it alive, so this always resolves to an Iter.
-                let Some(target) = resolve_delegate(*iter_id, vm.heap) else {
-                    return Err(ExcType::runtime_error_iter_delegation_too_deep());
-                };
+                let target = resolve_delegate(*iter_id, vm.heap).map_err(DelegateError::into_exception)?;
                 let HeapReadOutput::Iter(mut inner) = vm.heap.read(target) else {
-                    panic!("IterHeapRef: underlying value is not an iterator")
+                    unreachable!("resolve_delegate only returns Ok for an Iter")
                 };
                 inner.advance(vm)
             }
@@ -222,12 +220,14 @@ impl MontyIter {
             // The wrapper's own index is unused; report the terminal iterator's
             // remaining length. A cyclic/over-deep chain degrades to 0, which is
             // safe: this is only a capacity hint.
+            // A broken chain degrades to 0: this is only a capacity hint, and the
+            // consuming site raises the real error.
             IterValue::IterHeapRef { iter_id } => match resolve_delegate(*iter_id, heap) {
-                Some(target) => match heap.get(target) {
+                Ok(target) => match heap.get(target) {
                     HeapData::Iter(inner) => inner.size_hint(heap),
                     _ => 0,
                 },
-                None => 0,
+                Err(_) => 0,
             },
         };
         len.saturating_sub(self.index)
@@ -425,11 +425,9 @@ impl<'h> HeapRead<'h, MontyIter> {
             IterValue::IterHeapRef { iter_id } => {
                 // Delegate to the terminal iterator (see `for_next`).
                 let iter_id = *iter_id;
-                let Some(target) = resolve_delegate(iter_id, vm.heap) else {
-                    return Err(ExcType::runtime_error_iter_delegation_too_deep());
-                };
+                let target = resolve_delegate(iter_id, vm.heap).map_err(DelegateError::into_exception)?;
                 let HeapReadOutput::Iter(mut inner) = vm.heap.read(target) else {
-                    panic!("IterHeapRef: underlying value is not an iterator")
+                    unreachable!("resolve_delegate only returns Ok for an Iter")
                 };
                 inner.advance(vm)
             }
@@ -483,28 +481,48 @@ pub fn collect_iterable_bounded(
 /// chain, which is unreachable by construction but not from an untrusted snapshot.
 const MAX_DELEGATION_DEPTH: usize = 1000;
 
+/// Why [`resolve_delegate`] could not reach a terminal iterator.
+///
+/// Neither variant is reachable from Python — a delegating iterator always
+/// points at an `Iter` and chains never exceed depth 1 — so both exist to keep
+/// malformed snapshot data on a catchable path instead of panicking.
+enum DelegateError {
+    /// The chain exceeded [`MAX_DELEGATION_DEPTH`]; cyclic or absurdly deep.
+    TooDeep,
+    /// A link pointed at a heap entry that is not an iterator.
+    NotAnIterator,
+}
+
+impl DelegateError {
+    /// Converts to the `RuntimeError` the consuming site raises.
+    fn into_exception(self) -> RunError {
+        match self {
+            Self::TooDeep => ExcType::runtime_error_iter_delegation_too_deep(),
+            Self::NotAnIterator => ExcType::runtime_error_iter_delegation_invalid(),
+        }
+    }
+}
+
 /// Follows a chain of delegating (`IterHeapRef`) iterators to the terminal
-/// iterator holding the iteration state. `None` if the chain exceeds
-/// [`MAX_DELEGATION_DEPTH`] (cyclic or absurdly deep).
+/// iterator holding the iteration state.
 ///
 /// MUST stay iterative, never recursing into `advance`: chain depth is
 /// attacker-controlled, and native recursion would overflow the stack and abort
-/// the process — uncatchable, and beyond any `ResourceTracker` limit.
-fn resolve_delegate(start: HeapId, heap: &Heap<impl ResourceTracker>) -> Option<HeapId> {
+/// the process — uncatchable, and beyond any `ResourceTracker` limit. For the
+/// same reason a non-iterator link is reported rather than passed on to the
+/// caller, whose `heap.read` would panic on it.
+fn resolve_delegate(start: HeapId, heap: &Heap<impl ResourceTracker>) -> Result<HeapId, DelegateError> {
     let mut current = start;
     for _ in 0..MAX_DELEGATION_DEPTH {
         let HeapData::Iter(inner) = heap.get(current) else {
-            // Not an iterator: by construction unreachable (a delegating
-            // iterator's target is always an `Iter`), so let the caller's
-            // `heap.read` tripwire report it.
-            return Some(current);
+            return Err(DelegateError::NotAnIterator);
         };
         match inner.iter_value {
             IterValue::IterHeapRef { iter_id } => current = iter_id,
-            _ => return Some(current),
+            _ => return Ok(current),
         }
     }
-    None
+    Err(DelegateError::TooDeep)
 }
 
 /// Gets an item from a heap-allocated container at the given index.
@@ -821,5 +839,70 @@ impl HeapItem for MontyIter {
 
     fn py_dec_ref_ids(&mut self, stack: &mut Vec<HeapId>) {
         self.value.py_dec_ref_ids(stack);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{resource::NoLimitTracker, types::List};
+
+    /// Builds a delegating iterator pointing at `target`.
+    ///
+    /// Constructed directly because Python cannot produce one: `iter()` returns
+    /// an existing iterator unchanged, so chains only arise from a snapshot.
+    fn delegating(target: HeapId) -> MontyIter {
+        MontyIter {
+            index: 0,
+            iter_value: IterValue::IterHeapRef { iter_id: target },
+            value: Value::None,
+        }
+    }
+
+    /// Builds a terminal (non-delegating) iterator over three ints.
+    fn terminal() -> MontyIter {
+        MontyIter {
+            index: 0,
+            iter_value: IterValue::Range {
+                next: 0,
+                step: 1,
+                len: 3,
+            },
+            value: Value::None,
+        }
+    }
+
+    /// A well-formed chain resolves to the terminal iterator holding the state.
+    #[test]
+    fn resolve_delegate_walks_to_the_terminal_iterator() {
+        let heap = Heap::new(16, NoLimitTracker);
+        let end = heap.allocate(HeapData::Iter(terminal())).unwrap();
+        let mid = heap.allocate(HeapData::Iter(delegating(end))).unwrap();
+        let start = heap.allocate(HeapData::Iter(delegating(mid))).unwrap();
+        assert_eq!(resolve_delegate(start, &heap).ok(), Some(end));
+    }
+
+    /// A link pointing at a live non-iterator must raise, not panic: the
+    /// consuming site's `heap.read` would abort the process on it.
+    #[test]
+    fn resolve_delegate_rejects_a_non_iterator_target() {
+        let heap = Heap::new(16, NoLimitTracker);
+        let list = heap.allocate(HeapData::List(List::new(vec![]))).unwrap();
+        let start = heap.allocate(HeapData::Iter(delegating(list))).unwrap();
+        let err = resolve_delegate(start, &heap).expect_err("a non-iterator target must not resolve");
+        assert!(matches!(err, DelegateError::NotAnIterator));
+    }
+
+    /// An over-long chain stops at the cap rather than walking forever, which
+    /// is what a cyclic chain from a snapshot degrades to.
+    #[test]
+    fn resolve_delegate_caps_an_over_long_chain() {
+        let heap = Heap::new(16, NoLimitTracker);
+        let mut current = heap.allocate(HeapData::Iter(terminal())).unwrap();
+        for _ in 0..=MAX_DELEGATION_DEPTH {
+            current = heap.allocate(HeapData::Iter(delegating(current))).unwrap();
+        }
+        let err = resolve_delegate(current, &heap).expect_err("a chain past the cap must not resolve");
+        assert!(matches!(err, DelegateError::TooDeep));
     }
 }

--- a/crates/monty/src/types/iter.rs
+++ b/crates/monty/src/types/iter.rs
@@ -188,6 +188,19 @@ impl MontyIter {
                 self.index += 1;
                 Ok(Some(item))
             }
+            IterValue::IterHeapRef { iter_id } => {
+                // Delegate to the terminal iterator so a wrapped iterator (from
+                // `list(iter(x))`, `for _ in iter(x)`, ...) advances the SAME
+                // iterator and shares its position. `self.value` keeps it alive
+                // and GC-traced, so `iter_id` always resolves to an Iter.
+                let Some(target) = resolve_delegate(*iter_id, vm.heap) else {
+                    return Err(ExcType::runtime_error_iter_delegation_too_deep());
+                };
+                let HeapReadOutput::Iter(mut inner) = vm.heap.read(target) else {
+                    panic!("IterHeapRef: underlying value is not an iterator")
+                };
+                inner.advance(vm)
+            }
         }
     }
 
@@ -208,6 +221,16 @@ impl MontyIter {
                     list.len()
                 })
             }
+            // The wrapper's own index is unused; report the terminal iterator's
+            // remaining length. A cyclic/over-deep chain degrades to 0, which is
+            // safe: this is only a capacity hint.
+            IterValue::IterHeapRef { iter_id } => match resolve_delegate(*iter_id, heap) {
+                Some(target) => match heap.get(target) {
+                    HeapData::Iter(inner) => inner.size_hint(heap),
+                    _ => 0,
+                },
+                None => 0,
+            },
         };
         len.saturating_sub(self.index)
     }
@@ -401,8 +424,57 @@ impl<'h> HeapRead<'h, MontyIter> {
                 self.get_mut(vm.heap).index += 1;
                 Ok(Some(item))
             }
+            IterValue::IterHeapRef { iter_id } => {
+                // Delegate to the terminal iterator (see `for_next`).
+                let iter_id = *iter_id;
+                let Some(target) = resolve_delegate(iter_id, vm.heap) else {
+                    return Err(ExcType::runtime_error_iter_delegation_too_deep());
+                };
+                let HeapReadOutput::Iter(mut inner) = vm.heap.read(target) else {
+                    panic!("IterHeapRef: underlying value is not an iterator")
+                };
+                inner.advance(vm)
+            }
         }
     }
+}
+
+/// The most `IterHeapRef` links [`resolve_delegate`] will follow before giving up.
+///
+/// Chains deeper than this are pathological — normal code produces depth 1 (a
+/// wrapper over a real iterator). The cap exists only to bound the walk against
+/// a cyclic chain, which cannot occur by construction but could in principle be
+/// reconstructed from an untrusted snapshot.
+const MAX_DELEGATION_DEPTH: usize = 1000;
+
+/// Follows a chain of delegating (`IterHeapRef`) iterators to the terminal
+/// iterator that actually holds the iteration state. Returns `None` if the chain
+/// exceeds [`MAX_DELEGATION_DEPTH`] (i.e. is cyclic or absurdly deep).
+///
+/// Delegation MUST be resolved iteratively like this, never by recursing into
+/// `advance`/`for_next`: chain depth is attacker-controlled (each `iter()` on a
+/// user iterator allocates a fresh wrapper, so `for _ in range(n): o = iter(W(o))`
+/// builds a chain of length `n`), and native recursion would overflow the stack
+/// and abort the process — a crash the sandbox can neither catch nor bound with
+/// a `ResourceTracker` limit.
+///
+/// Resolving to the terminal is equivalent to forwarding step by step, because a
+/// delegating arm does nothing but forward: it keeps no index of its own.
+fn resolve_delegate(start: HeapId, heap: &Heap<impl ResourceTracker>) -> Option<HeapId> {
+    let mut current = start;
+    for _ in 0..MAX_DELEGATION_DEPTH {
+        let HeapData::Iter(inner) = heap.get(current) else {
+            // Not an iterator: by construction unreachable (a delegating
+            // iterator's target is always an `Iter`), so let the caller's
+            // `heap.read` tripwire report it.
+            return Some(current);
+        };
+        match inner.iter_value {
+            IterValue::IterHeapRef { iter_id } => current = iter_id,
+            _ => return Some(current),
+        }
+    }
+    None
 }
 
 /// Gets an item from a heap-allocated container at the given index.
@@ -577,6 +649,17 @@ enum IterValue {
     },
     /// Iterating over interned bytes, yields `Value::Int` for each byte.
     InternBytes { bytes_id: BytesId, len: usize },
+    /// Delegating iterator: drives another heap-resident iterator by id.
+    ///
+    /// Produced when an existing iterator is (re)iterated (`for _ in iter(x)`,
+    /// `list(iter(x))`), since an iterator is its own iterator. `for_next` /
+    /// `advance` forward to the underlying iterator, so iteration state is
+    /// shared. The parent `MontyIter`'s `value` holds the same iterator ref
+    /// (keeping it alive and GC-traced), and the parent's own `index` is unused.
+    ///
+    /// Chains of these are resolved iteratively by [`resolve_delegate`] — never
+    /// by recursing, see that function for why.
+    IterHeapRef { iter_id: HeapId },
     /// Iterating over a heap-allocated container (List, Tuple, NamedTuple, Dict, Bytes, Set, FrozenSet).
     ///
     /// - `len`: `None` for List (checked dynamically since lists can mutate during iteration),
@@ -690,6 +773,10 @@ impl IterValue {
             HeapData::Str(s) => Some(Self::from_str(s.as_str())),
             // Range: copy values for iteration
             HeapData::Range(range) => Some(Self::from_range(range)),
+            // An existing iterator is its own iterator: delegate to it so
+            // `for`/`list`/`sum`/comprehensions drive the SAME object and share
+            // its position, rather than restarting it.
+            HeapData::Iter(_) => Some(Self::IterHeapRef { iter_id: heap_id }),
             // other types are not iterable
             _ => None,
         }

--- a/crates/monty/src/types/mod.rs
+++ b/crates/monty/src/types/mod.rs
@@ -40,7 +40,7 @@ pub(crate) use dict::Dict;
 pub(crate) use dict_view::{DictItemsView, DictKeysView, DictValuesView};
 pub(crate) use file::OpenFile;
 pub(crate) use instance::{BoundMethod, Instance};
-pub(crate) use iter::MontyIter;
+pub(crate) use iter::{MontyIter, collect_iterable, collect_iterable_bounded};
 pub(crate) use list::List;
 pub(crate) use long_int::LongInt;
 pub(crate) use module::Module;

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -16,7 +16,7 @@ use smallvec::SmallVec;
 use crate::{
     builtins::Builtins,
     bytecode::{CallResult, VM},
-    defer_drop,
+    defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunError, RunResult, SimpleException},
     fstring::FormatFloat,
     hash::{HashValue, hash_one, hash_python_long_int, hash_python_str},
@@ -28,7 +28,7 @@ use crate::{
         check_repeat_size,
     },
     types::{
-        Bytes, CmpOrder, LazyHeapSet, List, LongInt, Property, PyTrait, Type, allocate_tuple,
+        Bytes, CmpOrder, LazyHeapSet, List, LongInt, MontyIter, Property, PyTrait, Type, allocate_tuple,
         bytes::{bytes_repr_fmt, get_byte_at_index},
         instance::{instance_getattr, instance_repr, instance_str},
         long_int::{
@@ -1811,6 +1811,22 @@ impl Value {
                             _ => return Ok(false),
                         };
                         Ok(range.contains(n))
+                    }
+                    // An iterator is consumed until the item is found, as
+                    // CPython's `in` does for any iterable without `__contains__`.
+                    HeapReadOutput::Iter(_) => {
+                        let iter = MontyIter::new(self.clone_with_heap(vm.heap), vm)?;
+                        defer_drop_mut!(iter, vm);
+                        loop {
+                            let Some(el) = iter.for_next(vm)? else {
+                                break Ok(false);
+                            };
+                            let eq = item.py_eq(&el, vm);
+                            el.drop_with(vm);
+                            if eq? {
+                                break Ok(true);
+                            }
+                        }
                     }
                     _ => {
                         let type_name = self.py_type_name(vm);

--- a/crates/monty/test_cases/iter__consume.py
+++ b/crates/monty/test_cases/iter__consume.py
@@ -1,7 +1,6 @@
-# Phase 1a: an existing iterator is itself iterable (its __iter__ returns self),
-# so for-loops, list()/tuple()/sum(), and comprehensions all drive it.
-# Today only next(it) works on a bare iterator; these consumption sites fail
-# with "'iterator' object is not iterable".
+# An iterator is itself iterable (its __iter__ returns self), so for-loops,
+# list()/tuple()/sum() and comprehensions all drive an existing iterator,
+# sharing its position rather than restarting it.
 
 # === for-loop over an iterator ===
 out = []

--- a/crates/monty/test_cases/iter__consume.py
+++ b/crates/monty/test_cases/iter__consume.py
@@ -19,5 +19,13 @@ assert iter(it) is it
 assert next(it) == 10
 assert list(it) == [20, 30]
 
+# Repeated iter() returns the same object rather than nesting, so a delegation
+# chain deeper than 1 is not reachable from Python at all.
+deep = iter([1, 2, 3])
+for _ in range(200):
+    deep = iter(iter(deep))
+assert next(deep) == 1
+assert list(deep) == [2, 3]
+
 # === comprehension over an iterator ===
 assert [x * 2 for x in iter([1, 2, 3])] == [2, 4, 6]

--- a/crates/monty/test_cases/iter__consume.py
+++ b/crates/monty/test_cases/iter__consume.py
@@ -1,0 +1,24 @@
+# Phase 1a: an existing iterator is itself iterable (its __iter__ returns self),
+# so for-loops, list()/tuple()/sum(), and comprehensions all drive it.
+# Today only next(it) works on a bare iterator; these consumption sites fail
+# with "'iterator' object is not iterable".
+
+# === for-loop over an iterator ===
+out = []
+for x in iter([1, 2, 3]):
+    out.append(x)
+assert out == [1, 2, 3], 'for-loop drives an existing iterator'
+
+# === constructors consume an iterator ===
+assert list(iter([4, 5, 6])) == [4, 5, 6], 'list() consumes an iterator'
+assert tuple(iter([7, 8])) == (7, 8), 'tuple() consumes an iterator'
+assert sum(iter([1, 2, 3])) == 6, 'sum() consumes an iterator'
+
+# === iter(it) is it, and consumption shares the underlying state ===
+it = iter([10, 20, 30])
+assert iter(it) is it, 'iter() of an iterator returns the same object'
+assert next(it) == 10, 'next() advances the iterator'
+assert list(it) == [20, 30], 'list() continues where next() left off (shared state)'
+
+# === comprehension over an iterator ===
+assert [x * 2 for x in iter([1, 2, 3])] == [2, 4, 6], 'comprehension consumes an iterator'

--- a/crates/monty/test_cases/iter__consume.py
+++ b/crates/monty/test_cases/iter__consume.py
@@ -6,18 +6,18 @@
 out = []
 for x in iter([1, 2, 3]):
     out.append(x)
-assert out == [1, 2, 3], 'for-loop drives an existing iterator'
+assert out == [1, 2, 3]
 
 # === constructors consume an iterator ===
-assert list(iter([4, 5, 6])) == [4, 5, 6], 'list() consumes an iterator'
-assert tuple(iter([7, 8])) == (7, 8), 'tuple() consumes an iterator'
-assert sum(iter([1, 2, 3])) == 6, 'sum() consumes an iterator'
+assert list(iter([4, 5, 6])) == [4, 5, 6]
+assert tuple(iter([7, 8])) == (7, 8)
+assert sum(iter([1, 2, 3])) == 6
 
 # === iter(it) is it, and consumption shares the underlying state ===
 it = iter([10, 20, 30])
-assert iter(it) is it, 'iter() of an iterator returns the same object'
-assert next(it) == 10, 'next() advances the iterator'
-assert list(it) == [20, 30], 'list() continues where next() left off (shared state)'
+assert iter(it) is it
+assert next(it) == 10
+assert list(it) == [20, 30]
 
 # === comprehension over an iterator ===
-assert [x * 2 for x in iter([1, 2, 3])] == [2, 4, 6], 'comprehension consumes an iterator'
+assert [x * 2 for x in iter([1, 2, 3])] == [2, 4, 6]

--- a/crates/monty/test_cases/iter__consume_sites.py
+++ b/crates/monty/test_cases/iter__consume_sites.py
@@ -3,29 +3,29 @@
 # wiring to the iterator protocol separately.
 
 # === `in` consumes the iterator ===
-assert 2 in iter([1, 2, 3]), '`in` finds an item in an iterator'
-assert 9 not in iter([1, 2, 3]), '`in` reports a missing item as False'
+assert 2 in iter([1, 2, 3])
+assert 9 not in iter([1, 2, 3])
 it = iter([1, 2, 3])
-assert 2 in it, '`in` stops at the match'
-assert list(it) == [3], '`in` consumed only up to the match'
+assert 2 in it
+assert list(it) == [3]
 
 # === PEP 448 `*` unpack ===
-assert [*iter([1, 2]), 9] == [1, 2, 9], 'list literal unpacks an iterator'
-assert (*iter([1, 2]),) == (1, 2), 'tuple literal unpacks an iterator'
-assert {*iter([1, 2])} == {1, 2}, 'set literal unpacks an iterator'
+assert [*iter([1, 2]), 9] == [1, 2, 9]
+assert (*iter([1, 2]),) == (1, 2)
+assert {*iter([1, 2])} == {1, 2}
 
 # === sequence unpacking ===
 a, b = iter([1, 2])
-assert (a, b) == (1, 2), 'two-target unpack of an iterator'
+assert (a, b) == (1, 2)
 a, *rest = iter([1, 2, 3])
-assert (a, rest) == (1, [2, 3]), 'starred unpack of an iterator'
+assert (a, rest) == (1, [2, 3])
 
 # === unpack size errors, and how much is consumed ===
 try:
     a, b, c = iter([1, 2])
     assert False, 'expected ValueError for too few values'
 except ValueError as e:
-    assert str(e) == 'not enough values to unpack (expected 3, got 2)', 'too-few message'
+    assert str(e) == 'not enough values to unpack (expected 3, got 2)'
 
 # An over-long iterator stops at the first surplus item rather than draining,
 # so there is no total in the message and the rest stays available.
@@ -34,8 +34,8 @@ try:
     a, b = src
     assert False, 'expected ValueError for too many values'
 except ValueError as e:
-    assert str(e) == 'too many values to unpack (expected 2)', 'too-many message omits the total'
-assert list(src) == [4, 5], 'failed unpack consumed only one past the target count'
+    assert str(e) == 'too many values to unpack (expected 2)'
+assert list(src) == [4, 5]
 
 # === reversed() is not implied by being iterable ===
 # CPython needs __reversed__, or __len__ + __getitem__; a one-shot iterator and
@@ -52,7 +52,7 @@ try:
     reversed({1, 2})
     assert False, 'expected TypeError for reversed(set)'
 except TypeError as e:
-    assert str(e) == "'set' object is not reversible", 'reversed(set) message'
-assert list(reversed([1, 2])) == [2, 1], 'reversed still works on a list'
-assert list(reversed(range(3))) == [2, 1, 0], 'reversed still works on a range'
-assert list(reversed({'a': 1, 'b': 2})) == ['b', 'a'], 'reversed still works on a dict'
+    assert str(e) == "'set' object is not reversible"
+assert list(reversed([1, 2])) == [2, 1]
+assert list(reversed(range(3))) == [2, 1, 0]
+assert list(reversed({'a': 1, 'b': 2})) == ['b', 'a']

--- a/crates/monty/test_cases/iter__consume_sites.py
+++ b/crates/monty/test_cases/iter__consume_sites.py
@@ -1,0 +1,58 @@
+# Consumption sites that drive an existing iterator: `in`, PEP 448 `*` unpack,
+# and sequence unpacking. Each has its own iterable dispatch, so each needs
+# wiring to the iterator protocol separately.
+
+# === `in` consumes the iterator ===
+assert 2 in iter([1, 2, 3]), '`in` finds an item in an iterator'
+assert 9 not in iter([1, 2, 3]), '`in` reports a missing item as False'
+it = iter([1, 2, 3])
+assert 2 in it, '`in` stops at the match'
+assert list(it) == [3], '`in` consumed only up to the match'
+
+# === PEP 448 `*` unpack ===
+assert [*iter([1, 2]), 9] == [1, 2, 9], 'list literal unpacks an iterator'
+assert (*iter([1, 2]),) == (1, 2), 'tuple literal unpacks an iterator'
+assert {*iter([1, 2])} == {1, 2}, 'set literal unpacks an iterator'
+
+# === sequence unpacking ===
+a, b = iter([1, 2])
+assert (a, b) == (1, 2), 'two-target unpack of an iterator'
+a, *rest = iter([1, 2, 3])
+assert (a, rest) == (1, [2, 3]), 'starred unpack of an iterator'
+
+# === unpack size errors, and how much is consumed ===
+try:
+    a, b, c = iter([1, 2])
+    assert False, 'expected ValueError for too few values'
+except ValueError as e:
+    assert str(e) == 'not enough values to unpack (expected 3, got 2)', 'too-few message'
+
+# An over-long iterator stops at the first surplus item rather than draining,
+# so there is no total in the message and the rest stays available.
+src = iter([1, 2, 3, 4, 5])
+try:
+    a, b = src
+    assert False, 'expected ValueError for too many values'
+except ValueError as e:
+    assert str(e) == 'too many values to unpack (expected 2)', 'too-many message omits the total'
+assert list(src) == [4, 5], 'failed unpack consumed only one past the target count'
+
+# === reversed() is not implied by being iterable ===
+# CPython needs __reversed__, or __len__ + __getitem__; a one-shot iterator and
+# an unordered set have neither.
+try:
+    reversed(iter([1, 2]))
+    assert False, 'expected TypeError for reversed(iterator)'
+except TypeError as e:
+    # Only the tail is asserted here: Monty names every iterator `iterator`
+    # while CPython says `list_iterator` (a documented divergence), and this
+    # file is dual-run against both engines.
+    assert str(e).endswith('object is not reversible'), 'reversed(iterator) message'
+try:
+    reversed({1, 2})
+    assert False, 'expected TypeError for reversed(set)'
+except TypeError as e:
+    assert str(e) == "'set' object is not reversible", 'reversed(set) message'
+assert list(reversed([1, 2])) == [2, 1], 'reversed still works on a list'
+assert list(reversed(range(3))) == [2, 1, 0], 'reversed still works on a range'
+assert list(reversed({'a': 1, 'b': 2})) == ['b', 'a'], 'reversed still works on a dict'

--- a/crates/monty/test_cases/iter__delegation_depth.py
+++ b/crates/monty/test_cases/iter__delegation_depth.py
@@ -1,8 +1,0 @@
-# Re-iterating an iterator wraps it in a delegating iterator. Chains resolve
-# iteratively, so depth costs no native stack; the bound only stops a cyclic
-# chain spinning. Monty-specific: CPython builds no chain at all.
-o = iter([1, 2, 3])
-for _ in range(200):
-    o = iter(iter(o))
-assert next(o) == 1
-assert list(o) == [2, 3]

--- a/crates/monty/test_cases/iter__delegation_depth.py
+++ b/crates/monty/test_cases/iter__delegation_depth.py
@@ -1,0 +1,11 @@
+# Re-iterating an iterator wraps it in a delegating iterator. Chains are
+# resolved iteratively, so depth costs no native stack — but a bound still
+# applies so a cyclic chain cannot spin forever. Monty-specific: CPython
+# returns the iterator unchanged and builds no chain at all.
+#
+# Kept well under the 1000 limit so this stays a normal-operation test.
+o = iter([1, 2, 3])
+for _ in range(200):
+    o = iter(iter(o))
+assert next(o) == 1, 'a deep delegation chain still advances the terminal iterator'
+assert list(o) == [2, 3], 'and shares its position'

--- a/crates/monty/test_cases/iter__delegation_depth.py
+++ b/crates/monty/test_cases/iter__delegation_depth.py
@@ -1,9 +1,6 @@
-# Re-iterating an iterator wraps it in a delegating iterator. Chains are
-# resolved iteratively, so depth costs no native stack — but a bound still
-# applies so a cyclic chain cannot spin forever. Monty-specific: CPython
-# returns the iterator unchanged and builds no chain at all.
-#
-# Kept well under the 1000 limit so this stays a normal-operation test.
+# Re-iterating an iterator wraps it in a delegating iterator. Chains resolve
+# iteratively, so depth costs no native stack; the bound only stops a cyclic
+# chain spinning. Monty-specific: CPython builds no chain at all.
 o = iter([1, 2, 3])
 for _ in range(200):
     o = iter(iter(o))

--- a/crates/monty/test_cases/iter__delegation_depth.py
+++ b/crates/monty/test_cases/iter__delegation_depth.py
@@ -4,5 +4,5 @@
 o = iter([1, 2, 3])
 for _ in range(200):
     o = iter(iter(o))
-assert next(o) == 1, 'a deep delegation chain still advances the terminal iterator'
-assert list(o) == [2, 3], 'and shares its position'
+assert next(o) == 1
+assert list(o) == [2, 3]

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -102,3 +102,6 @@ mechanism beyond dataclass field inheritance.
   `RuntimeError: iterator delegation nested too deeply`; CPython builds no chain
   at all and has no such limit. Only reachable by repeatedly re-wrapping an
   iterator, which normal code does not do.
+- **`reversed(x)`** — the `TypeError` for a non-reversible argument names Monty's
+  single `iterator` type rather than CPython's specific one, e.g.
+  `'iterator' object is not reversible` where CPython says `'list_iterator'`.

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -96,12 +96,14 @@ mechanism beyond dataclass field inheritance.
     class) is not preserved as a type — it degrades to a callable, appearing inside
     the sandbox as a `function` rather than a `type`.
 
-- **Iterator delegation depth** — re-iterating an existing iterator (`for x in
-  iter(it)`, `list(iter(it))`) wraps it in a delegating iterator rather than
-  returning it unchanged. Chains deeper than 1000 raise
-  `RuntimeError: iterator delegation nested too deeply`; CPython builds no chain
-  at all and has no such limit. Only reachable by repeatedly re-wrapping an
-  iterator, which normal code does not do.
+- **Iterator delegation** — consuming an existing iterator (`for x in it`,
+  `list(it)`) wraps it in a delegating iterator that shares its position, where
+  CPython iterates it directly. Not observable from Python: `iter(it)` returns
+  `it` unchanged, so no chain deeper than 1 can be built. Two `RuntimeError`s
+  guard malformed snapshot data, which can craft what Python cannot —
+  `iterator delegation nested too deeply` past 1000 links, and
+  `iterator delegates to a non-iterator` for a link pointing elsewhere. CPython
+  has neither.
 - **`reversed(x)`** — the `TypeError` for a non-reversible argument names Monty's
   single `iterator` type rather than CPython's specific one, e.g.
   `'iterator' object is not reversible` where CPython says `'list_iterator'`.

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -95,3 +95,10 @@ mechanism beyond dataclass field inheritance.
     `PurePosixPath`). A host class Monty does **not** model (e.g. a user-defined
     class) is not preserved as a type — it degrades to a callable, appearing inside
     the sandbox as a `function` rather than a `type`.
+
+- **Iterator delegation depth** — re-iterating an existing iterator (`for x in
+  iter(it)`, `list(iter(it))`) wraps it in a delegating iterator rather than
+  returning it unchanged. Chains deeper than 1000 raise
+  `RuntimeError: iterator delegation nested too deeply`; CPython builds no chain
+  at all and has no such limit. Only reachable by repeatedly re-wrapping an
+  iterator, which normal code does not do.


### PR DESCRIPTION
An iterator is its own iterator in Python, but Monty only supported `next(it)`
on one — `for x in iter(lst)`, `list(iter(lst))`, `sum(iter(lst))` and
comprehensions all failed with `'iterator' object is not iterable`.

`IterValue::IterHeapRef` delegates to the underlying iterator by id, so a
wrapped iterator advances the SAME object and shares its position. The
wrapper's `value` slot holds the ref, so it is kept alive and GC-traced by the
existing path with no extra refcount wiring.

Delegation chains are resolved ITERATIVELY by `resolve_delegate`, never by
recursing into `advance`: native recursion there would overflow the stack and
abort the process — a crash the sandbox can neither catch nor resource-limit.
The walk is capped so a cyclic chain (only constructible from an untrusted
snapshot) raises `RuntimeError` instead of hanging.

## Consumption sites

`in`, PEP 448 `*` unpack (list/tuple/set literals) and sequence unpacking each
hand-roll their own iterable dispatch instead of going through `MontyIter`, so
none of them accepted an iterator. Each grows an `Iter` arm.

Sequence unpacking pulls only one item past the target count rather than
draining, matching how much CPython consumes and its `too many values to
unpack (expected N)` message, which omits the total precisely because it
stopped early.

## `reversed()`

`reversed()` was the opposite problem: it is just `MontyIter::new` +
`reverse()`, so every newly iterable type silently became reversible. CPython
requires `__reversed__`, or `__len__` + `__getitem__` — being iterable is not
enough. `is_reversible` is now a positive allowlist, so a new iterable type has
to opt in rather than inherit reversibility by accident.

That fixes `reversed(iter(...))` and also `reversed(set)` / `reversed(frozenset)`,
which diverged from CPython before this branch and were not documented as a
known divergence.

## Divergences

`limitations/builtins.md` records the two that remain: the delegation-depth
`RuntimeError` (CPython builds no chain at all, so has no such limit — only
reachable by repeatedly re-wrapping an iterator), and the `TypeError` for a
non-reversible argument naming Monty's single `iterator` type rather than
CPython's specific one (`'list_iterator'`).

## Testing

`iter__consume.py`, `iter__consume_sites.py` and `iter__delegation_depth.py`
cover the consumption sites, the unpack size errors and how much each consumes,
the `reversed` rejections, and a 200-deep delegation chain. `make test-cases`
and the `iter` subset under `memory-model-checks` pass, along with `make
lint-rs` / `make lint-py`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make existing iterators self-iterable and align iterator consumption and reversed() behavior with CPython. Iteration over an iterator now delegates to the same underlying iterator and shares position; malformed delegation chains now raise catchable errors instead of panicking.

- **New Features**
  - Iterators are now iterable. Re-iterating (`iter(it)`, `list(it)`, comprehensions) delegates to the same iterator via a lightweight wrapper so state is shared.
  - Delegation is resolved iteratively with a depth cap to avoid recursion and bound chains.

- **Bug Fixes**
  - `in`, PEP 448 `*` unpack (list/tuple/set literals), and sequence unpacking now accept and correctly consume iterators. Unpacking pulls one extra to detect “too many values” without draining, matching CPython’s error text.
  - `reversed()` now only accepts reversible types (has `__reversed__` or `__len__` + `__getitem__`). Iterators and sets are rejected with a CPython-style `TypeError`.
  - A delegating iterator that points at a non-iterator now raises `RuntimeError` instead of panicking; cyclic or over-deep chains also raise `RuntimeError`.
  - Documented remaining divergences: snapshot-only iterator delegation errors and the generic `iterator` type name in `reversed()` error messages.

<sup>Written for commit 1ce8af6ced6580e472312c7bba103311acba9bfa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

