### PR TITLE
avoid collisions in `id`

### DIFF
--- a/crates/monty/src/builtins/id.rs
+++ b/crates/monty/src/builtins/id.rs
@@ -11,14 +11,5 @@ pub fn builtin_id(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> Run
     let value = args.get_one_arg("id", vm.heap)?;
     defer_drop!(value, vm);
 
-    let id = value.id(vm);
-
-    // Python's id() returns a signed integer; reinterpret bits for large values
-    // On 64-bit: large addresses wrap to negative; on 32-bit: always fits positive
-    #[expect(
-        clippy::cast_possible_wrap,
-        reason = "Python id() returns signed; wrapping intentional"
-    )]
-    let id_i64 = id as i64;
-    Ok(Value::Int(id_i64))
+    Ok(value.id(vm).into_value(vm.heap)?)
 }

--- a/crates/monty/src/function.rs
+++ b/crates/monty/src/function.rs
@@ -112,7 +112,7 @@ impl Function {
     }
 
     /// Writes the Python repr() string for this function to a formatter.
-    pub fn py_repr_fmt<W: Write>(&self, f: &mut W, interns: &Interns, py_id: usize) -> fmt::Result {
+    pub fn py_repr_fmt<W: Write>(&self, f: &mut W, interns: &Interns, py_id: impl fmt::LowerHex) -> fmt::Result {
         write!(
             f,
             "<function '{}' at 0x{:x}>",

--- a/crates/monty/src/identity.rs
+++ b/crates/monty/src/identity.rs
@@ -1,0 +1,211 @@
+//! Structural identities and their injective Python integer encoding.
+//!
+//! Immediate values need allocation-free identity comparison, while `id()`
+//! must distinguish every identity category. Compact identities remain inline
+//! Python integers; only encodings outside `i64` require a heap `LongInt`.
+
+use num_bigint::{BigInt, Sign};
+use serde::Serialize;
+use smallvec::SmallVec;
+
+use crate::{
+    builtins::Builtins,
+    bytecode::VM,
+    heap::{Heap, HeapData},
+    modules::ModuleFunctions,
+    resource::{ResourceError, ResourceTracker},
+    types::{LongInt, Property},
+    value::{Marker, Value},
+};
+
+/// Number of low bits reserved for the identity category.
+const TAG_BITS: u8 = 5;
+/// Largest byte payload that can be shifted into a `u128` after adding its sentinel.
+const MAX_FIXED_BYTES: usize = 14;
+
+/// Complete identity key for a runtime value.
+///
+/// Equality is the implementation of Python's `is`; the integer encoding is
+/// injective and used to expose the same key through `id()`.
+#[derive(PartialEq, Eq)]
+pub(crate) enum Identity<'a> {
+    /// Internal uninitialized-value sentinel.
+    Undefined,
+    /// Python's `Ellipsis` singleton.
+    Ellipsis,
+    /// Python's `None` singleton.
+    None,
+    /// Boolean singleton identity.
+    Bool(bool),
+    /// Value-based identity for an immediate integer.
+    Int(i64),
+    /// Bitwise identity for an immediate float.
+    Float(u64),
+    /// Identity of an interned string.
+    InternString(usize),
+    /// Identity of an interned bytes value.
+    InternBytes(usize),
+    /// Identity of an interned long integer literal.
+    InternLongInt(usize),
+    /// Identity of an interpreter builtin.
+    Builtin(Builtins),
+    /// Identity of a standard-library function.
+    ModuleFunction(ModuleFunctions),
+    /// Identity of a sandbox-defined function.
+    DefFunction(usize),
+    /// Name-based identity retained for host-supplied callables.
+    ExtFunction(&'a str),
+    /// Identity of an interpreter marker.
+    Marker(Marker),
+    /// Identity of an interpreter property descriptor.
+    Property(Property),
+    /// Identity of an arena-allocated object.
+    Heap(usize),
+}
+
+impl<'a> Identity<'a> {
+    /// Builds the structural identity used by both `is` and `id()`.
+    pub(crate) fn new(value: &Value, vm: &'a VM<'_, impl ResourceTracker>) -> Self {
+        match value {
+            Value::Undefined => Self::Undefined,
+            Value::Ellipsis => Self::Ellipsis,
+            Value::None => Self::None,
+            Value::Bool(value) => Self::Bool(*value),
+            Value::Int(value) => Self::Int(*value),
+            Value::Float(value) => Self::Float(value.to_bits()),
+            Value::InternString(id) => Self::InternString(id.index()),
+            Value::InternBytes(id) => Self::InternBytes(id.index()),
+            Value::InternLongInt(id) => Self::InternLongInt(id.index()),
+            Value::Builtin(builtin) => Self::Builtin(*builtin),
+            Value::ModuleFunction(function) => Self::ModuleFunction(*function),
+            Value::DefFunction(id) => Self::DefFunction(id.index()),
+            Value::ExtFunction(name) => Self::ExtFunction(vm.interns.get_str(*name)),
+            Value::Marker(marker) => Self::Marker(*marker),
+            Value::Property(property) => Self::Property(*property),
+            Value::Ref(id) => match vm.heap.get(*id) {
+                HeapData::ExtFunction(name) => Self::ExtFunction(name),
+                _ => Self::Heap(id.index()),
+            },
+            #[cfg(feature = "memory-model-checks")]
+            Value::Dereferenced => panic!("Cannot get identity of Dereferenced object"),
+        }
+    }
+
+    /// Encodes this key as a nonnegative Python integer.
+    ///
+    /// Results fitting `i64` remain immediate. Wider fixed identities and long
+    /// external-function names allocate a heap `LongInt` for the returned value.
+    pub(crate) fn into_value(self, heap: &Heap<impl ResourceTracker>) -> Result<Value, ResourceError> {
+        if let Some(encoded) = self.fixed_encoding() {
+            encoded_u128_to_value(encoded, heap)
+        } else if let Self::ExtFunction(name) = self {
+            encode_long_name(name, heap)
+        } else {
+            unreachable!("only long external-function names lack a fixed encoding")
+        }
+    }
+
+    /// Encodes identities that fit in a `u128`, avoiding temporary allocation.
+    fn fixed_encoding(&self) -> Option<u128> {
+        let payload = match self {
+            Self::Undefined | Self::Ellipsis | Self::None => 0,
+            Self::Bool(value) => u128::from(*value),
+            Self::Int(value) => u128::from(zigzag_i64(*value)),
+            Self::Float(bits) => u128::from(compact_float_bits(*bits)),
+            Self::InternString(index)
+            | Self::InternBytes(index)
+            | Self::InternLongInt(index)
+            | Self::DefFunction(index)
+            | Self::Heap(index) => u128::try_from(*index).expect("usize fits in u128"),
+            Self::Builtin(value) => fixed_serde_payload(value),
+            Self::ModuleFunction(value) => fixed_serde_payload(value),
+            Self::ExtFunction(name) if name.len() <= MAX_FIXED_BYTES => bytes_payload(name.as_bytes()),
+            Self::ExtFunction(_) => return None,
+            Self::Marker(value) => fixed_serde_payload(value),
+            Self::Property(value) => fixed_serde_payload(value),
+        };
+        Some((payload << TAG_BITS) | u128::from(self.tag()))
+    }
+
+    /// Returns the stable low-bit category tag for this identity variant.
+    fn tag(&self) -> u8 {
+        match self {
+            Self::Undefined => 0,
+            Self::Ellipsis => 1,
+            Self::None => 3,
+            Self::Bool(_) => 4,
+            Self::Int(_) => 5,
+            Self::Float(_) => 6,
+            Self::InternString(_) => 7,
+            Self::InternBytes(_) => 8,
+            Self::InternLongInt(_) => 9,
+            Self::Builtin(_) => 10,
+            Self::ModuleFunction(_) => 11,
+            Self::DefFunction(_) => 12,
+            Self::ExtFunction(_) => 13,
+            Self::Marker(_) => 14,
+            Self::Property(_) => 15,
+            Self::Heap(_) => 16,
+        }
+    }
+}
+
+/// Returns a prefix-preserving integer for a short byte sequence.
+fn bytes_payload(bytes: &[u8]) -> u128 {
+    bytes
+        .iter()
+        .fold(1, |payload, byte| (payload << u8::BITS) | u128::from(*byte))
+}
+
+/// Serializes a small enum payload into a stack buffer and preserves its length.
+fn fixed_serde_payload(value: &impl Serialize) -> u128 {
+    let mut buffer = [0; MAX_FIXED_BYTES];
+    let serialized = postcard::to_slice(value, &mut buffer).expect("identity enum payload fits in 14 bytes");
+    bytes_payload(serialized)
+}
+
+/// Maps signed integers into `u64` while keeping small magnitudes compact.
+fn zigzag_i64(value: i64) -> u64 {
+    if value >= 0 {
+        value.unsigned_abs() << 1
+    } else {
+        ((value.unsigned_abs() - 1) << 1) | 1
+    }
+}
+
+/// Reorders float fields so common powers of two have compact identities.
+fn compact_float_bits(bits: u64) -> u64 {
+    const MANTISSA_BITS: u8 = 52;
+    const EXPONENT_MASK: u64 = (1 << 11) - 1;
+    const MANTISSA_MASK: u64 = (1 << MANTISSA_BITS) - 1;
+
+    let sign = bits >> 63;
+    let exponent = (bits >> MANTISSA_BITS) & EXPONENT_MASK;
+    let mantissa = bits & MANTISSA_MASK;
+    (mantissa << 12) | (sign << 11) | exponent
+}
+
+/// Returns an immediate integer when possible, otherwise allocating a `LongInt`.
+fn encoded_u128_to_value(encoded: u128, heap: &Heap<impl ResourceTracker>) -> Result<Value, ResourceError> {
+    if let Ok(encoded) = i64::try_from(encoded) {
+        Ok(Value::Int(encoded))
+    } else {
+        allocate_identity_int(BigInt::from(encoded), heap)
+    }
+}
+
+/// Encodes an arbitrary external-function name into its necessarily wide identity.
+fn encode_long_name(name: &str, heap: &Heap<impl ResourceTracker>) -> Result<Value, ResourceError> {
+    let mut bytes = SmallVec::<[u8; 32]>::with_capacity(name.len() + 1);
+    bytes.push(1);
+    bytes.extend_from_slice(name.as_bytes());
+    let payload = BigInt::from_bytes_be(Sign::Plus, &bytes);
+    let encoded = (payload << TAG_BITS) + BigInt::from(Identity::ExtFunction(name).tag());
+    allocate_identity_int(encoded, heap)
+}
+
+/// Allocates a wide identity integer without repeating the known-failing `i64` check.
+fn allocate_identity_int(encoded: BigInt, heap: &Heap<impl ResourceTracker>) -> Result<Value, ResourceError> {
+    let id = heap.allocate(HeapData::LongInt(LongInt::new(encoded)))?;
+    Ok(Value::Ref(id))
+}

--- a/crates/monty/src/lib.rs
+++ b/crates/monty/src/lib.rs
@@ -16,6 +16,7 @@ mod fstring;
 mod function;
 mod hash;
 mod heap_data;
+mod identity;
 mod intern;
 mod io;
 mod modules;

--- a/crates/monty/src/modules/mod.rs
+++ b/crates/monty/src/modules/mod.rs
@@ -168,7 +168,7 @@ impl ModuleFunctions {
     }
 
     /// Writes the Python repr() string for this function to a formatter.
-    pub fn py_repr_fmt<W: Write>(self, f: &mut W, py_id: usize) -> fmt::Result {
+    pub fn py_repr_fmt<W: Write>(self, f: &mut W, py_id: impl fmt::LowerHex) -> fmt::Result {
         write!(f, "<function {self} at 0x{py_id:x}>")
     }
 }

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -1,9 +1,7 @@
 use std::{
     borrow::Cow,
     cmp::Ordering,
-    collections::hash_map::DefaultHasher,
     fmt::{self, Write},
-    hash::{Hash, Hasher},
     mem::{self, discriminant},
     str::FromStr,
 };
@@ -21,6 +19,7 @@ use crate::{
     fstring::FormatFloat,
     hash::{HashValue, hash_one, hash_python_long_int, hash_python_str},
     heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapReadOutput},
+    identity::Identity,
     intern::{BytesId, FunctionId, Interns, LongIntId, StaticStrings, StringId},
     modules::ModuleFunctions,
     resource::{
@@ -106,6 +105,37 @@ pub(crate) enum Value {
 /// Used for memory tracking when containers grow (e.g., `list.append`, `list.extend`).
 /// Must match the per-element unit used by `py_estimate_size` implementations.
 pub(crate) const VALUE_SIZE: usize = mem::size_of::<Value>();
+
+/// Borrowed integer payload used to format a Python `id()` in callable reprs.
+enum PythonIdDisplay<'a> {
+    /// Identity that fits Monty's immediate integer representation.
+    Int(i64),
+    /// Arbitrary-precision identity borrowed from its heap value.
+    LongInt(&'a BigInt),
+}
+
+impl<'a> PythonIdDisplay<'a> {
+    /// Extracts the integer payload returned by the structural identity encoder.
+    fn new(value: &'a Value, heap: &'a Heap<impl ResourceTracker>) -> Self {
+        match value {
+            Value::Int(value) => Self::Int(*value),
+            Value::Ref(id) => match heap.get(*id) {
+                HeapData::LongInt(value) => Self::LongInt(value.inner()),
+                _ => unreachable!("identity values are integers"),
+            },
+            _ => unreachable!("identity values are integers"),
+        }
+    }
+}
+
+impl fmt::LowerHex for PythonIdDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Int(value) => fmt::LowerHex::fmt(value, f),
+            Self::LongInt(value) => fmt::LowerHex::fmt(value, f),
+        }
+    }
+}
 
 /// Drop implementation that panics if a `Ref` variant is dropped without calling `drop_with`.
 /// This helps catch reference counting bugs during development/testing.
@@ -360,8 +390,18 @@ impl<'h> PyTrait<'h> for Value {
             }
             Self::Float(v) => Ok(write!(f, "{}", FormatFloat(*v))?),
             Self::Builtin(b) => Ok(b.py_repr_fmt(f)?),
-            Self::ModuleFunction(mf) => Ok(mf.py_repr_fmt(f, self.id(vm))?),
-            Self::DefFunction(f_id) => Ok(interns.get_function(*f_id).py_repr_fmt(f, interns, self.id(vm))?),
+            Self::ModuleFunction(mf) => {
+                let py_id = self.id(vm).into_value(vm.heap)?;
+                defer_drop!(py_id, vm);
+                Ok(mf.py_repr_fmt(f, PythonIdDisplay::new(py_id, vm.heap))?)
+            }
+            Self::DefFunction(f_id) => {
+                let py_id = self.id(vm).into_value(vm.heap)?;
+                defer_drop!(py_id, vm);
+                Ok(interns
+                    .get_function(*f_id)
+                    .py_repr_fmt(f, interns, PythonIdDisplay::new(py_id, vm.heap))?)
+            }
             Self::ExtFunction(name_id) => Ok(write!(f, "<function '{}' external>", interns.get_str(*name_id))?),
             Self::InternString(string_id) => Ok(string_repr_fmt(interns.get_str(*string_id), f)?),
             Self::InternBytes(bytes_id) => Ok(bytes_repr_fmt(interns.get_bytes(*bytes_id), f)?),
@@ -1509,63 +1549,12 @@ impl Value {
         }
     }
 
-    /// Returns the Python-visible `id()` for this value.
+    /// Returns this value's complete structural identity.
     ///
-    /// `ExtFunction` values (inline `Value::ExtFunction` or heap
-    /// `HeapData::ExtFunction`) get a name-derived id so that two external
-    /// function values with the same name always satisfy CPython's invariant
-    /// `a is b ⇒ id(a) == id(b)` — needed because `MontyObject::Function`
-    /// conversion has discarded host object identity. All other variants use
-    /// a representation-based id.
-    ///
-    /// For immediate values (Int, Float, Builtins), this computes a deterministic ID
-    /// based on the value's hash, avoiding heap allocation. This means `id(5) == id(5)` will
-    /// return True (unlike CPython for large integers outside the interning range).
-    ///
-    /// Singletons (None, True, False, etc.) return IDs from a dedicated tagged range.
-    /// Interned strings/bytes use their interner index for stable identity.
-    /// Heap-allocated values (Ref) reuse their `HeapId` inside the heap-tagged range,
-    /// except for heap `ExtFunction` which uses the name-derived id described above.
-    pub fn id(&self, vm: &VM<'_, impl ResourceTracker>) -> usize {
-        match self {
-            // ExtFunction id is name-derived so the inline and heap representations
-            // agree; this also keeps `is(a, b) ⇒ id(a) == id(b)`. The guarded `Ref`
-            // arm must precede the bare `Ref` arm below — match evaluation is
-            // top-to-bottom.
-            Self::ExtFunction(name_id) => ext_function_value_id(vm.interns.get_str(*name_id)),
-            Self::Ref(id) if let HeapData::ExtFunction(name) = vm.heap.get(*id) => ext_function_value_id(name.as_str()),
-            // Singletons have fixed tagged IDs
-            Self::Undefined => singleton_id(SingletonSlot::Undefined),
-            Self::Ellipsis => singleton_id(SingletonSlot::Ellipsis),
-            Self::None => singleton_id(SingletonSlot::None),
-            Self::Bool(b) => {
-                if *b {
-                    singleton_id(SingletonSlot::True)
-                } else {
-                    singleton_id(SingletonSlot::False)
-                }
-            }
-            // Interned strings/bytes/bigints use their index directly - the index is the stable identifier
-            Self::InternString(string_id) => INTERN_STR_ID_TAG | (string_id.index() & INTERN_STR_ID_MASK),
-            Self::InternBytes(bytes_id) => INTERN_BYTES_ID_TAG | (bytes_id.index() & INTERN_BYTES_ID_MASK),
-            Self::InternLongInt(long_int_id) => {
-                INTERN_LONG_INT_ID_TAG | (long_int_id.index() & INTERN_LONG_INT_ID_MASK)
-            }
-            // Already heap-allocated (includes Range and Exception), return id within a dedicated tag range
-            Self::Ref(id) => heap_tagged_id(*id),
-            // Value-based IDs for immediate types (no heap allocation!)
-            Self::Int(v) => int_value_id(*v),
-            Self::Float(v) => float_value_id(*v),
-            Self::Builtin(c) => builtin_value_id(*c),
-            Self::ModuleFunction(mf) => module_function_value_id(*mf),
-            Self::DefFunction(f_id) => function_value_id(*f_id),
-            // Markers get deterministic IDs based on discriminant
-            Self::Marker(m) => marker_value_id(*m),
-            // Properties get deterministic IDs based on discriminant
-            Self::Property(p) => property_value_id(*p),
-            #[cfg(feature = "memory-model-checks")]
-            Self::Dereferenced => panic!("Cannot get id of Dereferenced object"),
-        }
+    /// Immediate values retain Monty's value-derived identity, heap objects use
+    /// their arena index, and external functions remain identified by name.
+    pub(crate) fn id<'a>(&self, vm: &'a VM<'_, impl ResourceTracker>) -> Identity<'a> {
+        Identity::new(self, vm)
     }
 
     /// Returns the Ref ID if this value is a reference, otherwise returns None.
@@ -1589,9 +1578,10 @@ impl Value {
         }
     }
 
-    /// Python-visible `is` operator. Identity is name-based for `ExtFunction`
-    /// values via [`Value::id`], so two callables with the same `__name__`
-    /// compare identical regardless of representation.
+    /// Python-visible `is` operator using complete structural identity.
+    ///
+    /// External functions compare by name across inline and heap representations;
+    /// all other values compare using their full immediate or arena identity.
     pub fn is(&self, other: &Self, vm: &VM<'_, impl ResourceTracker>) -> bool {
         self.id(vm) == other.id(vm)
     }
@@ -2449,71 +2439,6 @@ impl Marker {
     }
 }
 
-/// High-bit tag reserved for literal singletons (None, Ellipsis, booleans).
-const SINGLETON_ID_TAG: usize = 1usize << (usize::BITS - 1);
-/// High-bit tag reserved for interned string `id()` values.
-const INTERN_STR_ID_TAG: usize = 1usize << (usize::BITS - 2);
-/// High-bit tag reserved for interned bytes `id()` values to avoid colliding with any other space.
-const INTERN_BYTES_ID_TAG: usize = 1usize << (usize::BITS - 3);
-/// High-bit tag reserved for heap-backed `HeapId`s.
-const HEAP_ID_TAG: usize = 1usize << (usize::BITS - 4);
-
-/// Mask that keeps pointer-derived bits below the bytes tag bit.
-const INTERN_BYTES_ID_MASK: usize = INTERN_BYTES_ID_TAG - 1;
-/// Mask that keeps pointer-derived bits below the string tag bit.
-const INTERN_STR_ID_MASK: usize = INTERN_STR_ID_TAG - 1;
-/// Mask that keeps per-singleton offsets below the singleton tag bit.
-const SINGLETON_ID_MASK: usize = SINGLETON_ID_TAG - 1;
-/// Mask that keeps heap value IDs below the heap tag bit.
-const HEAP_ID_MASK: usize = HEAP_ID_TAG - 1;
-
-/// High-bit tag for Int value-based IDs (no heap allocation needed).
-const INT_ID_TAG: usize = 1usize << (usize::BITS - 5);
-/// High-bit tag for Float value-based IDs.
-const FLOAT_ID_TAG: usize = 1usize << (usize::BITS - 6);
-/// High-bit tag for Callable value-based IDs.
-const BUILTIN_ID_TAG: usize = 1usize << (usize::BITS - 7);
-/// High-bit tag for Function value-based IDs.
-const FUNCTION_ID_TAG: usize = 1usize << (usize::BITS - 8);
-/// High-bit tag for External Function value-based IDs.
-const EXTFUNCTION_ID_TAG: usize = 1usize << (usize::BITS - 9);
-/// High-bit tag for Marker value-based IDs (stdout, stderr, etc.).
-const MARKER_ID_TAG: usize = 1usize << (usize::BITS - 10);
-/// High-bit tag for ModuleFunction value-based IDs.
-const MODULE_FUNCTION_ID_TAG: usize = 1usize << (usize::BITS - 12);
-/// High-bit tag for interned LongInt `id()` values.
-const INTERN_LONG_INT_ID_TAG: usize = 1usize << (usize::BITS - 13);
-/// High-bit tag for Property value-based IDs.
-const PROPERTY_ID_TAG: usize = 1usize << (usize::BITS - 14);
-
-/// Masks for value-based ID tags (keep bits below the tag bit).
-const INT_ID_MASK: usize = INT_ID_TAG - 1;
-const FLOAT_ID_MASK: usize = FLOAT_ID_TAG - 1;
-const BUILTIN_ID_MASK: usize = BUILTIN_ID_TAG - 1;
-const FUNCTION_ID_MASK: usize = FUNCTION_ID_TAG - 1;
-const EXTFUNCTION_ID_MASK: usize = EXTFUNCTION_ID_TAG - 1;
-const MARKER_ID_MASK: usize = MARKER_ID_TAG - 1;
-const MODULE_FUNCTION_ID_MASK: usize = MODULE_FUNCTION_ID_TAG - 1;
-const INTERN_LONG_INT_ID_MASK: usize = INTERN_LONG_INT_ID_TAG - 1;
-const PROPERTY_ID_MASK: usize = PROPERTY_ID_TAG - 1;
-
-/// Enumerates singleton literal slots so we can issue stable `id()` values without heap allocation.
-#[repr(usize)]
-#[derive(Copy, Clone)]
-enum SingletonSlot {
-    Undefined = 0,
-    Ellipsis = 1,
-    None = 2,
-    False = 3,
-    True = 4,
-}
-
-/// Returns the fully tagged `id()` value for the requested singleton literal.
-#[inline]
-const fn singleton_id(slot: SingletonSlot) -> usize {
-    SINGLETON_ID_TAG | ((slot as usize) & SINGLETON_ID_MASK)
-}
-
 /// Computes Python-style floor division and modulo.
 ///
 /// Python's division rounds toward negative infinity (floor division),
@@ -2547,100 +2472,6 @@ fn py_float_mod(a: f64, b: f64) -> f64 {
     } else {
         r
     }
-}
-
-/// Converts a heap `HeapId` into its tagged `id()` value, ensuring it never collides with other spaces.
-#[inline]
-pub fn heap_tagged_id(heap_id: HeapId) -> usize {
-    HEAP_ID_TAG | (heap_id.index() & HEAP_ID_MASK)
-}
-
-/// Computes a deterministic ID for an i64 integer value.
-/// Uses the value's hash combined with a type tag to ensure uniqueness across types.
-#[inline]
-fn int_value_id(value: i64) -> usize {
-    let mut hasher = DefaultHasher::new();
-    value.hash(&mut hasher);
-    let hash_u64 = hasher.finish();
-    // Mask to usize range before conversion to handle 32-bit platforms
-    let masked = hash_u64 & (usize::MAX as u64);
-    let hash_usize = usize::try_from(masked).expect("masked value fits in usize");
-    INT_ID_TAG | (hash_usize & INT_ID_MASK)
-}
-
-/// Computes a deterministic ID for an f64 float value.
-/// Uses the bit representation's hash for consistency (handles NaN, infinities, etc.).
-#[inline]
-fn float_value_id(value: f64) -> usize {
-    let mut hasher = DefaultHasher::new();
-    value.to_bits().hash(&mut hasher);
-    let hash_u64 = hasher.finish();
-    // Mask to usize range before conversion to handle 32-bit platforms
-    let masked = hash_u64 & (usize::MAX as u64);
-    let hash_usize = usize::try_from(masked).expect("masked value fits in usize");
-    FLOAT_ID_TAG | (hash_usize & FLOAT_ID_MASK)
-}
-
-/// Computes a deterministic ID for a builtin based on its discriminant.
-#[inline]
-fn builtin_value_id(b: Builtins) -> usize {
-    let mut hasher = DefaultHasher::new();
-    b.hash(&mut hasher);
-    let hash_u64 = hasher.finish();
-    // wrapping here is fine
-    #[expect(clippy::cast_possible_truncation)]
-    let hash_usize = hash_u64 as usize;
-    BUILTIN_ID_TAG | (hash_usize & BUILTIN_ID_MASK)
-}
-
-/// Computes a deterministic ID for a function based on its id.
-#[inline]
-fn function_value_id(f_id: FunctionId) -> usize {
-    FUNCTION_ID_TAG | (f_id.index() & FUNCTION_ID_MASK)
-}
-
-/// Computes a deterministic ID for an external function from its name string.
-///
-/// Used by [`Value::id`] so that inline `Value::ExtFunction` and heap
-/// `HeapData::ExtFunction` values referring to the same function name share
-/// the same Python-visible `id()` — required by CPython's
-/// `a is b ⇒ id(a) == id(b)` invariant. Collisions across distinct names are
-/// possible (the masked hash space is finite) but acceptable: Python's `id()`
-/// is allowed to collide across distinct objects.
-#[inline]
-fn ext_function_value_id(name: &str) -> usize {
-    let hash_u64 = hash_python_str(name).raw();
-    // Mask to usize range before conversion to handle 32-bit platforms.
-    let masked = hash_u64 & (usize::MAX as u64);
-    let hash_usize = usize::try_from(masked).expect("masked value fits in usize");
-    EXTFUNCTION_ID_TAG | (hash_usize & EXTFUNCTION_ID_MASK)
-}
-
-/// Computes a deterministic ID for a marker value based on its discriminant.
-#[inline]
-fn marker_value_id(m: Marker) -> usize {
-    MARKER_ID_TAG | ((m.0 as usize) & MARKER_ID_MASK)
-}
-
-/// Computes a deterministic ID for a property value based on its discriminant.
-#[inline]
-fn property_value_id(p: Property) -> usize {
-    let discriminant = match p {
-        Property::Os(os_fn) => os_fn as usize,
-    };
-    PROPERTY_ID_TAG | (discriminant & PROPERTY_ID_MASK)
-}
-
-/// Computes a deterministic ID for a module function based on its discriminant.
-#[inline]
-fn module_function_value_id(mf: ModuleFunctions) -> usize {
-    let mut hasher = DefaultHasher::new();
-    mf.hash(&mut hasher);
-    let hash_u64 = hasher.finish();
-    // wrapping here is fine
-    #[expect(clippy::cast_possible_truncation)]
-    let hash_usize = hash_u64 as usize;
-    MODULE_FUNCTION_ID_TAG | (hash_usize & MODULE_FUNCTION_ID_MASK)
 }
 
 /// Converts an i64 repeat count to usize, handling negative values and overflow.

--- a/crates/monty/test_cases/id__ops.py
+++ b/crates/monty/test_cases/id__ops.py
@@ -81,6 +81,15 @@ t = (1, 2)
 r = t
 assert id(t) == id(r)
 
+
+# === Function repr uses the same integer identity ===
+def identity_repr_target():
+    pass
+
+
+repr_address = repr(identity_repr_target).split(' at ')[-1]
+assert repr_address == f'{hex(id(identity_repr_target))}>'
+
 # === Boolean is tests ===
 assert (True is True) == True
 assert (False is False) == True

--- a/crates/monty/test_cases/id__ops.py
+++ b/crates/monty/test_cases/id__ops.py
@@ -81,15 +81,6 @@ t = (1, 2)
 r = t
 assert id(t) == id(r)
 
-
-# === Function repr uses the same integer identity ===
-def identity_repr_target():
-    pass
-
-
-repr_address = repr(identity_repr_target).split(' at ')[-1]
-assert repr_address == f'{hex(id(identity_repr_target))}>'
-
 # === Boolean is tests ===
 assert (True is True) == True
 assert (False is False) == True

--- a/crates/monty/tests/external_function_identity.rs
+++ b/crates/monty/tests/external_function_identity.rs
@@ -89,7 +89,7 @@ fn same_callable_round_trips_through_dict() {
 #[test]
 fn different_named_callables_remain_distinct() {
     let runner = MontyRun::new(
-        "(a is b, a == b)".to_owned(),
+        "(a is b, a == b, id(a) == id(b))".to_owned(),
         "test.py",
         vec!["a".to_owned(), "b".to_owned()],
         CompileOptions::default(),
@@ -109,7 +109,11 @@ fn different_named_callables_remain_distinct() {
         .unwrap();
     assert_eq!(
         result,
-        MontyObject::Tuple(vec![MontyObject::Bool(false), MontyObject::Bool(false)]),
+        MontyObject::Tuple(vec![
+            MontyObject::Bool(false),
+            MontyObject::Bool(false),
+            MontyObject::Bool(false),
+        ]),
     );
 }
 

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -169,6 +169,31 @@ result
     );
 }
 
+/// Compact structural identities remain immediate Python integers.
+#[test]
+fn compact_id_does_not_allocate() {
+    let run = MontyRun::new("id(42)".to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let limits = ResourceLimits::new().max_allocations(0);
+    let result = run
+        .run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout)
+        .unwrap();
+
+    assert!(matches!(result, MontyObject::Int(_)));
+}
+
+/// Identity integers wider than `i64` allocate a tracked `LongInt`.
+#[test]
+fn wide_id_respects_allocation_limit() {
+    let run = MontyRun::new("id(1.5)".to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let limits = ResourceLimits::new().max_allocations(0);
+    let exc = run
+        .run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout)
+        .unwrap_err();
+
+    assert_eq!(exc.exc_type(), ExcType::MemoryError);
+    assert_eq!(exc.message(), Some("allocation limit exceeded: 1 > 0"));
+}
+
 #[test]
 fn allocation_limit_not_exceeded() {
     // Single-digit strings are interned (no allocation), so this uses minimal heap


### PR DESCRIPTION
`id` currently requires on hashing and mixing into 64 bits even though the state space is larger than 64 bits. maybe we can reduce the state space back down, but for now this will avoid the collision problem.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `id()` collision-free by replacing hashing with a structural, injective identity encoding. `id()` now returns a real Python int (inline or heap `LongInt`), and function `repr` shows the exact 0x… from `hex(id(x))`.

- **Bug Fixes**
  - Removed 64-bit hashing/mixing that caused `id()` collisions.
  - External functions use name-based identities that are distinct across names and consistent across inline/heap forms.
  - `repr(function)` prints the same hex as `hex(id(function))`.

- **Refactors**
  - Added `identity` module: structural identities encode to Python ints; small ones are immediate, wide ones use heap `LongInt`.
  - `Value::is` compares full structural identities.
  - `id()` respects resource limits; wide identities may allocate.
  - Updated `py_repr_fmt` to accept `impl fmt::LowerHex` for IDs.
  - Tests: added allocation behavior for compact vs. wide `id()`; expanded external function tests to assert different names yield different `id()` values.

<sup>Written for commit 7103da343d14f75ac42e9712f990b8641eea7dd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

