### PR TITLE
Retain the OS-call payload in suspended state and drop `OsFunctionCall::Used`

### DIFF
--- a/crates/monty-datatest/src/main.rs
+++ b/crates/monty-datatest/src/main.rs
@@ -1223,7 +1223,6 @@ fn dispatch_os_call(call: &OsFunctionCall) -> ExtFunctionResult {
                 .into()
             }
         }
-        OsFunctionCall::Used => unreachable!("OsFunctionCall::Used dispatched"),
     }
 }
 
@@ -1769,15 +1768,14 @@ fn run_mount_fs_iter_loop(
                 };
                 progress = lookup.resume(result, PrintWriter::Stdout)?;
             }
-            RunProgress::OsCall(mut call) => {
+            RunProgress::OsCall(call) => {
                 // Dispatch through the mount table first.
-                let ext_result = match mount_table.handle_os_call(call.take_function_call()) {
+                progress = call.resume_with(PrintWriter::Stdout, |fc| match mount_table.handle_os_call(fc) {
                     MountCallOutcome::Handled(Ok(obj)) => ExtFunctionResult::Return(obj),
                     MountCallOutcome::Handled(Err(err)) => ExtFunctionResult::Error(err.into_exception()),
                     // Non-filesystem operation — dispatch to the regular handler.
                     MountCallOutcome::NotHandled(function_call) => dispatch_os_call(&function_call),
-                };
-                progress = call.resume(ext_result, PrintWriter::Stdout)?;
+                })?;
             }
         }
     }

--- a/crates/monty-fs/src/dispatch.rs
+++ b/crates/monty-fs/src/dispatch.rs
@@ -172,7 +172,6 @@ pub(super) fn fs_request_from_call(call: OsFunctionCall) -> FsRequest {
         | OsFunctionCall::GetEnviron
         | OsFunctionCall::DateToday
         | OsFunctionCall::DateTimeNow(_) => unreachable!("non-filesystem OS function reached filesystem parser"),
-        OsFunctionCall::Used => unreachable!("OsFunctionCall::Used reached filesystem parser"),
     }
 }
 

--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -173,8 +173,12 @@ operations that exceed it raise a `MontyRuntimeError` wrapping `MemoryError`.
 
 Modes: `'read-only'`, `'read-write'`, and `'overlay'` (default — writes are
 kept in memory and discarded at the end of the feed). Mount I/O is serviced
-on the host side of the pool, so mounts work even for remote workers. OS
-calls mounts don't cover can be handled with the `os` callback:
+on the host side of the pool, so mounts work even for remote workers.
+
+`feedRun` answers every OS call automatically: mounts get first refusal, then
+the `os` callback. `feedStart` answers none — a mounted read surfaces as a
+`FunctionSnapshot` with `isOsFunction` set, and `resumeAuto()` is what consults
+the mounts and `os`. OS calls mounts don't cover reach the `os` callback:
 
 ```ts
 import { NOT_HANDLED } from '@pydantic/monty'

--- a/crates/monty-js/__test__/feed_start.spec.ts
+++ b/crates/monty-js/__test__/feed_start.spec.ts
@@ -50,7 +50,7 @@ test('a snapshot resumes at most once', async () => {
   }
 })
 
-test('os handler is auto-dispatched between snapshots', async () => {
+test('os handler is used by resumeAuto, not auto-dispatched', async () => {
   const session = await pool().checkout()
   try {
     const snap = await session.feedStart("from pathlib import Path\nPath('/data/x').read_text()", {
@@ -59,8 +59,12 @@ test('os handler is auto-dispatched between snapshots', async () => {
         return 'file body'
       },
     })
-    t.true(snap instanceof MontyComplete)
-    t.is((snap as MontyComplete).output, 'file body')
+    // feedStart surfaces every OS call; the handler only backs resumeAuto
+    t.true(snap instanceof FunctionSnapshot)
+    t.true((snap as FunctionSnapshot).isOsFunction)
+    const done = (await (snap as FunctionSnapshot).resumeAuto()) as MontyComplete
+    t.true(done instanceof MontyComplete)
+    t.is(done.output, 'file body')
   } finally {
     await session.close()
   }
@@ -198,11 +202,14 @@ test('mounts are re-supplied to loadSnapshot', async () => {
     await session.close()
   }
 
-  // re-supplied: the mounted read is served and execution completes
+  // re-supplied: the mounted read surfaces, and resumeAuto serves it from the
+  // rebuilt mount table
   {
     const session = await pool().checkout()
     const snap = (await session.loadSnapshot(blob, { mount })) as FunctionSnapshot
-    const done = (await snap.resume(null)) as MontyComplete
+    const read = (await snap.resume(null)) as FunctionSnapshot
+    t.true(read.isOsFunction)
+    const done = (await read.resumeAuto()) as MontyComplete
     t.is(done.output, 'hi')
     await session.close()
   }

--- a/crates/monty-js/native-addon.d.ts
+++ b/crates/monty-js/native-addon.d.ts
@@ -28,6 +28,7 @@ export declare class NativeSession {
   resumeError(...args: unknown[]): Promise<object>
   resumeNotFound(...args: unknown[]): Promise<object>
   resumeNotHandled(...args: unknown[]): Promise<object>
+  resumeFromMounts(...args: unknown[]): Promise<object>
   resumeFuture(...args: unknown[]): Promise<object>
   resumeNameLookup(...args: unknown[]): Promise<object>
   resolveFutures(...args: unknown[]): Promise<object>

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -544,7 +544,7 @@ impl NativeSession {
                     };
                     let outcome = compute(checkout, &mut on_print);
                     if let TurnOutcome::Event(TurnEvent::OsCall { not_handled_error, .. }) = &outcome {
-                        lock(&pending_not_handled).clone_from(not_handled_error);
+                        *lock(&pending_not_handled) = Some(not_handled_error.clone());
                     }
                     outcome
                 })
@@ -639,9 +639,7 @@ fn turn_to_js(env: &Env, outcome: TurnOutcome) -> Result<Object<'_>> {
             obj.set("args", values_to_js(env, &args)?)?;
             obj.set("kwargs", pairs_to_js(env, &kwargs)?)?;
             obj.set("callId", call_id)?;
-            if let Some(exc) = not_handled_error {
-                obj.set("notHandledError", exception_to_js(env, &exc)?)?;
-            }
+            obj.set("notHandledError", exception_to_js(env, &not_handled_error)?)?;
         }
         TurnOutcome::Event(TurnEvent::NameLookup { name }) => {
             obj.set("kind", "nameLookup")?;

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -184,7 +184,6 @@ impl NativePool {
                 ),
             },
             checkout: Arc::new(Mutex::new(None)),
-            pending_not_handled: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -208,10 +207,6 @@ pub struct NativeSession {
     pool: SharedPool,
     repl_config: ReplConfig,
     checkout: SharedCheckout,
-    /// The exception the sandbox raises when the host declines the pending
-    /// OS call. Kept Rust-side so the full exception (traceback included)
-    /// round-trips instead of being rebuilt from strings.
-    pending_not_handled: Arc<Mutex<Option<MontyException>>>,
 }
 
 #[napi]
@@ -295,18 +290,15 @@ impl NativeSession {
     }
 
     /// Answers an `osCall` suspension by declining it: the sandbox raises the
-    /// call's default exception (full traceback preserved Rust-side).
+    /// call's own no-handler default.
     #[napi]
     pub fn resume_not_handled<'env>(
         &self,
         env: &'env Env,
         on_print: PrintCallback<'env>,
     ) -> Result<PromiseRaw<'env, Object<'env>>> {
-        let exc = lock(&self.pending_not_handled)
-            .take()
-            .unwrap_or_else(|| MontyException::new(ExcType::RuntimeError, Some("OS call is not supported".to_owned())));
-        self.run_turn(env, on_print, move |checkout, on_print| {
-            checkout.resume(ResumeValue::Error(exc), on_print)
+        self.run_turn(env, on_print, |checkout, on_print| {
+            checkout.resume(ResumeValue::NotHandled, on_print)
         })
     }
 
@@ -521,7 +513,6 @@ impl NativeSession {
     ) -> Result<PromiseRaw<'env, Object<'env>>> {
         let tsfn = on_print.build_threadsafe_function().build()?;
         let slot = Arc::clone(&self.checkout);
-        let pending_not_handled = Arc::clone(&self.pending_not_handled);
         env.spawn_future_with_callback(
             async move {
                 spawn_blocking(move || {
@@ -542,11 +533,7 @@ impl NativeSession {
                         };
                         let _ = block_on(tsfn.call_async(FnArgs::from((stream.to_owned(), text.to_owned()))));
                     };
-                    let outcome = compute(checkout, &mut on_print);
-                    if let TurnOutcome::Event(TurnEvent::OsCall { not_handled_error, .. }) = &outcome {
-                        *lock(&pending_not_handled) = Some(not_handled_error.clone());
-                    }
-                    outcome
+                    compute(checkout, &mut on_print)
                 })
                 .await
                 .map_err(task_error)
@@ -632,14 +619,12 @@ fn turn_to_js(env: &Env, outcome: TurnOutcome) -> Result<Object<'_>> {
             args,
             kwargs,
             call_id,
-            not_handled_error,
         }) => {
             obj.set("kind", "osCall")?;
             obj.set("functionName", function_name)?;
             obj.set("args", values_to_js(env, &args)?)?;
             obj.set("kwargs", pairs_to_js(env, &kwargs)?)?;
             obj.set("callId", call_id)?;
-            obj.set("notHandledError", exception_to_js(env, &not_handled_error)?)?;
         }
         TurnOutcome::Event(TurnEvent::NameLookup { name }) => {
             obj.set("kind", "nameLookup")?;

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -302,6 +302,24 @@ impl NativeSession {
         })
     }
 
+    /// Offers an `osCall` suspension to this feed's mounts. Resolves to the
+    /// next turn when a mount serviced the call, or to `{kind: 'notMounted'}`
+    /// when none covered it and the caller must answer it itself.
+    #[napi]
+    pub fn resume_from_mounts<'env>(
+        &self,
+        env: &'env Env,
+        on_print: PrintCallback<'env>,
+    ) -> Result<PromiseRaw<'env, Object<'env>>> {
+        self.run_outcome(env, on_print, |checkout, on_print| {
+            match checkout.resume_from_mounts(on_print) {
+                Ok(Some(event)) => TurnOutcome::Event(event),
+                Ok(None) => TurnOutcome::NotMounted,
+                Err(err) => TurnOutcome::from(StdResult::<TurnEvent, PoolError>::Err(err)),
+            }
+        })
+    }
+
     /// Answers a `functionCall` suspension whose name has no handler: the
     /// sandbox raises `NameError`.
     #[napi]
@@ -563,6 +581,10 @@ enum TurnOutcome {
     /// A restore of an idle (between-feeds) dump — there is no suspension to
     /// resume. Only produced by [`NativeSession::restore`].
     LoadedIdle,
+    /// No mount covered the pending OS call, which is still suspended for the
+    /// caller to answer. Only produced by
+    /// [`NativeSession::resume_from_mounts`].
+    NotMounted,
     /// A non-feed request succeeded with no value or suspension. Produced by
     /// [`NativeSession::install_dependencies`].
     Ok,
@@ -660,6 +682,9 @@ fn turn_to_js(env: &Env, outcome: TurnOutcome) -> Result<Object<'_>> {
         }
         TurnOutcome::LoadedIdle => {
             obj.set("kind", "loaded")?;
+        }
+        TurnOutcome::NotMounted => {
+            obj.set("kind", "notMounted")?;
         }
         TurnOutcome::Ok => {
             obj.set("kind", "ok")?;

--- a/crates/monty-js/ts/native.ts
+++ b/crates/monty-js/ts/native.ts
@@ -56,12 +56,6 @@ export interface OsCallTurn {
   args: unknown[]
   kwargs: [unknown, unknown][]
   callId: number
-  /**
-   * Summary of the exception the sandbox raises when declined; the full
-   * exception (traceback included) is retained Rust-side and used by
-   * `resumeNotHandled`.
-   */
-  notHandledError: { excType: string; message: string; frames: NativeFrame[] }
 }
 
 /** The sandbox read an undefined name — answer with `resumeNameLookup`. */

--- a/crates/monty-js/ts/native.ts
+++ b/crates/monty-js/ts/native.ts
@@ -108,6 +108,12 @@ export interface OkTurn {
   kind: 'ok'
 }
 
+/** No mount covered the pending OS call, which stays suspended for the caller
+ *  to answer. Only produced by `NativeSession.resumeFromMounts`. */
+export interface NotMountedTurn {
+  kind: 'notMounted'
+}
+
 /** Everything one protocol turn can resolve to. */
 export type NativeTurn =
   | CompleteTurn

--- a/crates/monty-js/ts/native.ts
+++ b/crates/monty-js/ts/native.ts
@@ -61,7 +61,7 @@ export interface OsCallTurn {
    * exception (traceback included) is retained Rust-side and used by
    * `resumeNotHandled`.
    */
-  notHandledError?: { excType: string; message: string; frames: NativeFrame[] }
+  notHandledError: { excType: string; message: string; frames: NativeFrame[] }
 }
 
 /** The sandbox read an undefined name — answer with `resumeNameLookup`. */

--- a/crates/monty-js/ts/session.ts
+++ b/crates/monty-js/ts/session.ts
@@ -27,6 +27,7 @@ import type {
   NativeFutureResult,
   NativeTurn,
   OkTurn,
+  NotMountedTurn,
   OsCallTurn,
   ResolveFuturesTurn,
 } from './native.js'
@@ -94,9 +95,8 @@ export interface FeedStartOptions {
   printCallback?: PrintCallback
   /** Host directories mounted into the sandbox for this feed. */
   mount?: MountDir | MountDir[]
-  /** Handler for OS calls not covered by mounts; auto-dispatched between
-   *  snapshots (and used by `resumeAuto()`). Omit to surface OS calls as
-   *  snapshots instead. */
+  /** Handler for OS calls not covered by mounts. Consulted only by
+   *  `resumeAuto()` — `feedStart` always surfaces OS calls as snapshots. */
   os?: OsCallback
   /** Skip type checking for this feed even when the session enables it. */
   skipTypeCheck?: boolean
@@ -116,7 +116,7 @@ export interface LoadSnapshotOptions {
    * the previous process; resolve it manually with `resume([...])`.
    */
   externalLookup?: Record<string, unknown>
-  /** Handler for OS calls, auto-dispatched as in `feedStart`. */
+  /** Handler for OS calls, consulted by `resumeAuto()` as in `feedStart`. */
   os?: OsCallback
 }
 
@@ -218,11 +218,12 @@ export class MontySession {
    * while (!(snap instanceof MontyComplete)) snap = await snap.resumeAuto()
    * ```
    *
-   * Unlike `feedRun`, `externalLookup` is *not* consulted during this initial
-   * drive — external calls and name lookups are still surfaced as snapshots; it
-   * is only captured for later `resumeAuto()` calls. An `os` handler still
-   * auto-dispatches uncovered OS calls until the next non-OS event. Use
-   * `snapshot.dump()` to checkpoint the worker and `loadSnapshot` to restore it.
+   * Unlike `feedRun`, nothing is answered during this drive: external calls,
+   * name lookups and OS calls are all surfaced as snapshots, so even a
+   * mount-covered file read comes back as one. `externalLookup` / `os` are
+   * captured for later `resumeAuto()` calls, which also consult the feed's
+   * mounts. Use `snapshot.dump()` to checkpoint the worker and `loadSnapshot`
+   * to restore it.
    */
   async feedStart(code: string, options: FeedStartOptions = {}): Promise<Snapshot> {
     this.ensureUsable()
@@ -513,8 +514,15 @@ class TurnAnswerer {
     return this.native.resumeReturn(returned, onPrint)
   }
 
-  /** Dispatches an OS call to the `os` callback (or its default error). */
+  /**
+   * Answers an OS call: the feed's mounts get first refusal, then the `os`
+   * callback, then the sandbox's own no-handler default.
+   */
   async answerOsCall(call: OsCallTurn, onPrint: PrintCallback): Promise<object> {
+    const mounted = (await this.native.resumeFromMounts(onPrint)) as NativeTurn | NotMountedTurn
+    if (mounted.kind !== 'notMounted') {
+      return mounted
+    }
     if (this.os === undefined) {
       return await this.native.resumeNotHandled(onPrint)
     }
@@ -622,11 +630,10 @@ class PrintTarget {
 }
 
 /**
- * Drives a `feedStart` / `loadSnapshot` chain: runs each protocol turn,
- * auto-dispatches OS calls through the `os` handler (until a non-OS event),
- * and turns the result into the next [`Snapshot`]. One driver is shared across
- * a snapshot and every snapshot its `resume` produces, so they all answer the
- * same worker with the same print sink.
+ * Drives a `feedStart` / `loadSnapshot` chain: runs each protocol turn and
+ * turns the result into the next [`Snapshot`], answering nothing itself.
+ * One driver is shared across a snapshot and every snapshot its `resume`
+ * produces, so they all answer the same worker with the same print sink.
  */
 class SnapshotDriver {
   /** Exposed so the session's first turn can stream prints through it. */
@@ -641,7 +648,7 @@ class SnapshotDriver {
     this.onPrint = printTarget.write.bind(printTarget)
   }
 
-  /** Resolves a turn (after auto-dispatching OS calls) to the next snapshot. */
+  /** Resolves a turn to the next snapshot, answering nothing automatically. */
   async advance(turn: NativeTurn): Promise<Snapshot> {
     for (;;) {
       switch (turn.kind) {
@@ -659,13 +666,9 @@ class SnapshotDriver {
         case 'protocol':
           throw this.poison(new ProtocolError(turn.message))
         case 'osCall':
-          // With no os handler an OS call surfaces as a snapshot; otherwise it
-          // is auto-dispatched through the same path `resumeAuto` uses.
-          if (this.answerer.os === undefined) {
-            return new FunctionSnapshot(this, turn, true)
-          }
-          turn = (await this.answerer.answerOsCall(turn, this.onPrint)) as NativeTurn
-          continue
+          // Every OS call surfaces; mounts and the `os` callback are consulted
+          // only by `resumeAuto`.
+          return new FunctionSnapshot(this, turn, true)
         case 'functionCall':
           return new FunctionSnapshot(this, turn, false)
         case 'nameLookup':

--- a/crates/monty-js/ts/worker/transport.ts
+++ b/crates/monty-js/ts/worker/transport.ts
@@ -13,7 +13,7 @@
 // `traceback` strings are not yet rendered (frames are decoded; the rendered
 // string is a follow-up); mounts are rejected (no host filesystem in a worker).
 
-import type { NativeException, NativeFrame, NativeFutureResult, NativeTurn } from '../native.js'
+import type { NativeException, NativeFrame, NativeFutureResult, NativeTurn, NotMountedTurn } from '../native.js'
 import { type AssertMessageAnnotations, encodeAssertMessageAnnotations } from '../options.js'
 import type { Dispatcher } from './host.js'
 import { Reader, Wire, Writer, deframe, frame } from './proto.js'
@@ -151,6 +151,14 @@ export class WorkerTransport {
     // ExtFunctionResult.not_handled (Unit): the child raises the suspended
     // call's own no-handler default.
     return this.resumeCall(extResult(5, new Uint8Array()), onPrint)
+  }
+
+  /**
+   * Always reports "not covered": a wasm worker has no host filesystem, so
+   * `feed`/`restore` reject mounts outright and none can service a call.
+   */
+  resumeFromMounts(_onPrint: OnPrint): Promise<NotMountedTurn> {
+    return Promise.resolve({ kind: 'notMounted' })
   }
 
   resumeFuture(onPrint: OnPrint): Promise<NativeTurn> {

--- a/crates/monty-js/ts/worker/transport.ts
+++ b/crates/monty-js/ts/worker/transport.ts
@@ -76,7 +76,6 @@ export class WorkerTransport {
   /** The id/name of the suspension awaiting an answer, for the `resume*` family. */
   private pendingCallId = 0
   private pendingFunctionName = ''
-  private pendingNotHandled: { excType: string; message: string } | null = null
 
   /** No OS process backs a wasm worker. */
   readonly workerPid: number | null = null
@@ -149,8 +148,9 @@ export class WorkerTransport {
   }
 
   resumeNotHandled(onPrint: OnPrint): Promise<NativeTurn> {
-    const exc = this.pendingNotHandled ?? { excType: 'RuntimeError', message: 'OS call is not supported' }
-    return this.resumeCall(extResult(2, raisedException(exc.excType, exc.message)), onPrint)
+    // ExtFunctionResult.not_handled (Unit): the child raises the suspended
+    // call's own no-handler default.
+    return this.resumeCall(extResult(5, new Uint8Array()), onPrint)
   }
 
   resumeFuture(onPrint: OnPrint): Promise<NativeTurn> {
@@ -315,7 +315,6 @@ export class WorkerTransport {
         const call = decodeCall(event.bytes)
         this.pendingCallId = call.callId
         this.pendingFunctionName = call.functionName
-        this.pendingNotHandled = null
         return {
           kind: 'functionCall',
           functionName: call.functionName,
@@ -329,14 +328,12 @@ export class WorkerTransport {
         const call = decodeOsCall(event.bytes)
         this.pendingCallId = call.callId
         this.pendingFunctionName = call.functionName
-        this.pendingNotHandled = simpleExc(call.notHandledError)
         return {
           kind: 'osCall',
           functionName: call.functionName,
           args: call.args,
           kwargs: call.kwargs,
           callId: call.callId,
-          notHandledError: call.notHandledError,
         }
       }
       case Ev.NameLookup:
@@ -475,13 +472,12 @@ interface DecodedOsCall {
   args: unknown[]
   kwargs: [unknown, unknown][]
   callId: number
-  notHandledError: NativeException
 }
 
 /**
  * Decodes the typed `OsCall` oneof back into the `(name, args, kwargs)`
- * host-callback shape the native path surfaces, with the same per-call
- * not-handled error monty's `OsFunctionCall::on_no_handler` produces.
+ * host-callback shape the native path surfaces. Declining the call is
+ * answered child-side (see `resumeNotHandled`), so no error is built here.
  */
 function decodeOsCall(bytes: Uint8Array): DecodedOsCall {
   const reader = new Reader(bytes)
@@ -500,28 +496,27 @@ function decodeOsArm(field: number, bytes: Uint8Array): Omit<DecodedOsCall, 'cal
   const pathArm = OS_PATH_ARMS[field]
   if (pathArm !== undefined) {
     const path = decodeString(bytes)
-    return fsCall(pathArm, path, [path])
+    return osCall(pathArm, [path])
   }
   switch (field) {
     case Os.WriteText:
     case Os.AppendText: {
       const [path, data] = decodePathAndString(bytes)
-      return fsCall(field === Os.WriteText ? 'Path.write_text' : 'Path.append_text', path, [path, data])
+      return osCall(field === Os.WriteText ? 'Path.write_text' : 'Path.append_text', [path, data])
     }
     case Os.WriteBytes:
     case Os.AppendBytes: {
       const [path, data] = decodeBytesWrite(bytes)
-      return fsCall(field === Os.WriteBytes ? 'Path.write_bytes' : 'Path.append_bytes', path, [path, data])
+      return osCall(field === Os.WriteBytes ? 'Path.write_bytes' : 'Path.append_bytes', [path, data])
     }
     case Os.Open: {
       const [path, mode] = decodePathAndString(bytes)
-      return fsCall('open', path, [path, mode])
+      return osCall('open', [path, mode])
     }
     case Os.Mkdir: {
       const { path, parents, existOk } = decodeMkdir(bytes)
-      return fsCall(
+      return osCall(
         'Path.mkdir',
-        path,
         [path],
         [
           ['parents', parents],
@@ -531,63 +526,32 @@ function decodeOsArm(field: number, bytes: Uint8Array): Omit<DecodedOsCall, 'cal
     }
     case Os.Rename: {
       const [src, dst] = decodePathAndString(bytes)
-      return fsCall('Path.rename', src, [src, dst])
+      return osCall('Path.rename', [src, dst])
     }
     case Os.Getenv: {
       const [key, dflt] = decodeGetenv(bytes)
-      return nonFsCall('os.getenv', [key, dflt])
+      return osCall('os.getenv', [key, dflt])
     }
     case Os.GetEnviron:
-      return nonFsCall('os.environ', [])
+      return osCall('os.environ', [])
     case Os.DateToday:
-      return nonFsCall('date.today', [])
+      return osCall('date.today', [])
     case Os.DateTimeNow:
       // typed arm: `DateTimeNow.tz` (field 1) is an optional TimeZone
       // message; absent means a naive result (tz=None)
-      return nonFsCall('datetime.now', [decodeDateTimeNowTz(bytes)])
+      return osCall('datetime.now', [decodeDateTimeNowTz(bytes)])
     default:
       throw new Error(`unknown OsCall arm ${field}`)
   }
 }
 
-/**
- * A surfaced filesystem call: `on_no_handler` semantics are a
- * `PermissionError` naming the primary path. Plain single-quoting stands in
- * for Python's repr — exotic path characters may render differently than the
- * native parent, which is fine for an error message.
- */
-function fsCall(
-  name: string,
-  primaryPath: string,
+/** The `(name, args, kwargs)` host-callback shape for one decoded arm. */
+function osCall(
+  functionName: string,
   args: unknown[],
   kwargs: [unknown, unknown][] = [],
 ): Omit<DecodedOsCall, 'callId'> {
-  return {
-    functionName: name,
-    args,
-    kwargs,
-    notHandledError: {
-      excType: 'PermissionError',
-      message: `Permission denied: '${primaryPath}'`,
-      traceback: '',
-      frames: [],
-    },
-  }
-}
-
-/** A surfaced non-filesystem call: `on_no_handler` is a `RuntimeError`. */
-function nonFsCall(name: string, args: unknown[]): Omit<DecodedOsCall, 'callId'> {
-  return {
-    functionName: name,
-    args,
-    kwargs: [],
-    notHandledError: {
-      excType: 'RuntimeError',
-      message: `'${name}' is not supported in this environment`,
-      traceback: '',
-      frames: [],
-    },
-  }
+  return { functionName, args, kwargs }
 }
 
 /** `TextWrite`/`Open`/`Rename` bodies: two string fields. */
@@ -814,10 +778,6 @@ function functionValue(name: string): Uint8Array {
   const obj = new Writer()
   obj.lengthDelimited(25, fn.finish()) // MontyObject.function
   return obj.finish()
-}
-
-function simpleExc(exc: NativeException): { excType: string; message: string } {
-  return { excType: exc.excType, message: exc.message }
 }
 
 function crashed(message: string): NativeTurn {

--- a/crates/monty-js/ts/worker/transport.ts
+++ b/crates/monty-js/ts/worker/transport.ts
@@ -329,7 +329,7 @@ export class WorkerTransport {
         const call = decodeOsCall(event.bytes)
         this.pendingCallId = call.callId
         this.pendingFunctionName = call.functionName
-        this.pendingNotHandled = call.notHandledError ? simpleExc(call.notHandledError) : null
+        this.pendingNotHandled = simpleExc(call.notHandledError)
         return {
           kind: 'osCall',
           functionName: call.functionName,
@@ -452,7 +452,6 @@ const Os = {
   GetEnviron: 22,
   DateToday: 23,
   DateTimeNow: 24,
-  Consumed: 25,
 }
 
 /** Stable call name for each path-only arm (the string payload is the path). */
@@ -476,15 +475,13 @@ interface DecodedOsCall {
   args: unknown[]
   kwargs: [unknown, unknown][]
   callId: number
-  notHandledError?: NativeException
+  notHandledError: NativeException
 }
 
 /**
  * Decodes the typed `OsCall` oneof back into the `(name, args, kwargs)`
  * host-callback shape the native path surfaces, with the same per-call
- * not-handled error monty's `OsFunctionCall::on_no_handler` produces. A
- * `Consumed` re-announcement (after a snapshot restore) surfaces with an
- * empty name and no error.
+ * not-handled error monty's `OsFunctionCall::on_no_handler` produces.
  */
 function decodeOsCall(bytes: Uint8Array): DecodedOsCall {
   const reader = new Reader(bytes)
@@ -493,7 +490,7 @@ function decodeOsCall(bytes: Uint8Array): DecodedOsCall {
   while (!reader.done) {
     const f = reader.next()
     if (f.field === 1) callId = Number(f.value)
-    else if (f.field >= 2 && f.field <= 25) arm = { field: f.field, bytes: f.bytes }
+    else if (f.field >= 2 && f.field <= 24) arm = { field: f.field, bytes: f.bytes }
   }
   if (!arm) throw new Error('OsCall carried no call')
   return { callId, ...decodeOsArm(arm.field, arm.bytes) }
@@ -548,8 +545,6 @@ function decodeOsArm(field: number, bytes: Uint8Array): Omit<DecodedOsCall, 'cal
       // typed arm: `DateTimeNow.tz` (field 1) is an optional TimeZone
       // message; absent means a naive result (tz=None)
       return nonFsCall('datetime.now', [decodeDateTimeNowTz(bytes)])
-    case Os.Consumed:
-      return { functionName: '', args: [], kwargs: [] }
     default:
       throw new Error(`unknown OsCall arm ${field}`)
   }

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -112,9 +112,8 @@ pub enum TurnEvent {
         call_id: u32,
         /// The exception the sandbox would raise if nothing handles this
         /// call; a caller with no handler should resume with
-        /// `ResumeValue::Error(not_handled_error)`. `None` only for calls
-        /// re-announced after [`Checkout::restore`].
-        not_handled_error: Option<MontyException>,
+        /// `ResumeValue::Error(not_handled_error)`.
+        not_handled_error: MontyException,
     },
     /// The sandbox read an undefined name — answer with
     /// [`Checkout::resume_name_lookup`].
@@ -242,8 +241,11 @@ impl Checkout {
     ///
     /// `mounts` re-establish a suspended feed's mounts, which are never part of
     /// the dump (they are host configuration the parent services itself). Pass
-    /// the same mounts the original feed used — a mount silently omitted here
-    /// degrades its filesystem calls into surfaced [`TurnEvent::OsCall`]s.
+    /// the same mounts the original feed used — the re-announcement carries the
+    /// full call payload, so a dump taken mid-OS-call resumes transparently: a
+    /// mount-covered call is serviced right here and the returned event is
+    /// whatever the feed does next. A mount silently omitted degrades its
+    /// filesystem calls into surfaced [`TurnEvent::OsCall`]s.
     /// The session's resource budget is taken from the dump, so the prior
     /// `Configure` limits are dropped here and re-adopted from the worker's
     /// reply.
@@ -643,77 +645,64 @@ impl Checkout {
                     deadline_guard = None;
                     remaining = remaining.map(|allowance| allowance.saturating_sub(armed_at.elapsed()));
                     let call_id = call.call_id;
-                    // `Consumed` re-announcements (after `restore`) carry no
-                    // payload and always surface — the caller re-learns the
-                    // call from its own records. Everything else decodes into
-                    // a typed `OsFunctionCall`; a payload the child could
-                    // never legitimately produce is a protocol violation.
+                    // Every announcement (fresh or re-announced after
+                    // `restore`) decodes into a typed `OsFunctionCall`; a
+                    // payload the child could never legitimately produce is a
+                    // protocol violation.
                     let function_call = match call.call {
                         None => break Err(self.protocol_violation("OsCall event with no call")),
-                        Some(pb::os_call::Call::Consumed(_)) => None,
                         Some(kind) => match OsFunctionCall::try_from(kind) {
-                            Ok(function_call) => Some(function_call),
+                            Ok(function_call) => function_call,
                             Err(err) => {
                                 break Err(self.protocol_violation(&format!("invalid OS call payload: {err}")));
                             }
                         },
                     };
-                    let unhandled = match function_call {
-                        Some(function_call) => match self.try_mount_call(function_call) {
-                            MountCallOutcome::Handled(result) => {
-                                let wire_result = match result {
-                                    Ok(obj) => pb::ext_function_result::Kind::ReturnValue(obj.into()),
-                                    Err(err) => pb::ext_function_result::Kind::Error((&err.into_exception()).into()),
+                    let unhandled = match self.try_mount_call(function_call) {
+                        MountCallOutcome::Handled(result) => {
+                            let wire_result = match result {
+                                Ok(obj) => pb::ext_function_result::Kind::ReturnValue(obj.into()),
+                                Err(err) => pb::ext_function_result::Kind::Error((&err.into_exception()).into()),
+                            };
+                            // `armed_deadline` (the `Timeout` error's reported
+                            // value) stays at the turn deadline: the allowance
+                            // makes that the bound the whole turn is held to.
+                            let next_deadline = min_deadline(remaining, self.backstop_deadline());
+                            let worker = self.worker.as_mut().expect("checked above");
+                            armed_at = Instant::now();
+                            deadline_guard = self.pool.watchdog.arm(worker, next_deadline);
+                            if let Err(err) = send_internal_resume(worker, call_id, wire_result) {
+                                // an oversize result frame is rejected before any
+                                // bytes are written, so the stream is intact and
+                                // the suspended child can be resumed with a small,
+                                // catchable error instead; anything else is a real
+                                // I/O break
+                                let FrameError::FrameTooLarge { len, max } = err else {
+                                    break Err(self.poison("resuming a mount-covered OS call"));
                                 };
-                                // `armed_deadline` (the `Timeout` error's reported
-                                // value) stays at the turn deadline: the allowance
-                                // makes that the bound the whole turn is held to.
-                                let next_deadline = min_deadline(remaining, self.backstop_deadline());
-                                let worker = self.worker.as_mut().expect("checked above");
-                                armed_at = Instant::now();
-                                deadline_guard = self.pool.watchdog.arm(worker, next_deadline);
-                                if let Err(err) = send_internal_resume(worker, call_id, wire_result) {
-                                    // an oversize result frame is rejected before any
-                                    // bytes are written, so the stream is intact and
-                                    // the suspended child can be resumed with a small,
-                                    // catchable error instead; anything else is a real
-                                    // I/O break
-                                    let FrameError::FrameTooLarge { len, max } = err else {
-                                        break Err(self.poison("resuming a mount-covered OS call"));
-                                    };
-                                    let exc = MontyException::new(
-                                        ExcType::RuntimeError,
-                                        Some(format!(
-                                            "OS call result frame of {len} bytes exceeds the maximum of {max} bytes"
-                                        )),
-                                    );
-                                    let error_result = pb::ext_function_result::Kind::Error((&exc).into());
-                                    if send_internal_resume(worker, call_id, error_result).is_err() {
-                                        break Err(self.poison("resuming a mount-covered OS call"));
-                                    }
+                                let exc = MontyException::new(
+                                    ExcType::RuntimeError,
+                                    Some(format!(
+                                        "OS call result frame of {len} bytes exceeds the maximum of {max} bytes"
+                                    )),
+                                );
+                                let error_result = pb::ext_function_result::Kind::Error((&exc).into());
+                                if send_internal_resume(worker, call_id, error_result).is_err() {
+                                    break Err(self.poison("resuming a mount-covered OS call"));
                                 }
-                                // serviced internally — wait for the child's
-                                // next event
-                                continue;
                             }
-                            MountCallOutcome::NotHandled(function_call) => Some(function_call),
-                        },
-                        None => None,
+                            // serviced internally — wait for the child's
+                            // next event
+                            continue;
+                        }
+                        MountCallOutcome::NotHandled(function_call) => function_call,
                     };
                     // Not mount-covered: surface to the caller in the
                     // `(name, args, kwargs)` host-callback shape, with the
-                    // parent-computed no-handler error. A consumed
-                    // re-announcement surfaces with an empty name and no
-                    // error — the caller re-learns the call from its records.
-                    let (function_name, args, kwargs, not_handled_error) = match unhandled {
-                        Some(function_call) => {
-                            let not_handled_error = function_call.on_no_handler();
-                            let function_name = function_call.name().to_owned();
-                            let (args, kwargs) = function_call.to_args();
-                            (function_name, args, kwargs, Some(not_handled_error))
-                        }
-                        None => (String::new(), vec![], vec![], None),
-                    };
+                    // parent-computed no-handler error.
+                    let not_handled_error = unhandled.on_no_handler();
+                    let function_name = unhandled.name().to_owned();
+                    let (args, kwargs) = unhandled.to_args();
                     self.pending = Some(Pending::Call {
                         call_id,
                         function_name: function_name.clone(),

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -359,18 +359,7 @@ impl Checkout {
                 result: Some(pb::ExtFunctionResult { kind: Some(result) }),
             })),
         };
-        // An oversize frame is rejected before any bytes are written, so the
-        // child would never see this answer and would stay suspended for ever.
-        // Reject it while `pending` still marks the call as answerable, so the
-        // caller can retry with a smaller value or answer with an error.
-        if let Some(len) = exceeds_max_frame_len(&request) {
-            return Err(PoolError::Runtime(MontyException::new(
-                ExcType::RuntimeError,
-                Some(format!(
-                    "result frame of {len} bytes exceeds the maximum of {MAX_FRAME_LEN} bytes"
-                )),
-            )));
-        }
+        ensure_resume_frame_fits(&request)?;
         self.pending = None;
         self.expect_turn(&request, on_print)
     }
@@ -446,7 +435,6 @@ impl Checkout {
         if let Some(obj) = &value {
             ensure_sendable([obj])?;
         }
-        self.pending = None;
         let kind = match value {
             Some(obj) => pb::resume_name_lookup::Kind::Value(obj.into()),
             None => pb::resume_name_lookup::Kind::Undefined(pb::Unit {}),
@@ -456,6 +444,8 @@ impl Checkout {
                 kind: Some(kind),
             })),
         };
+        ensure_resume_frame_fits(&request)?;
+        self.pending = None;
         self.expect_turn(&request, on_print)
     }
 
@@ -491,10 +481,11 @@ impl Checkout {
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;
-        self.pending = None;
         let request = pb::ParentRequest {
             kind: Some(pb::parent_request::Kind::ResumeFutures(pb::ResumeFutures { results })),
         };
+        ensure_resume_frame_fits(&request)?;
+        self.pending = None;
         self.expect_turn(&request, on_print)
     }
 
@@ -908,6 +899,25 @@ fn ensure_sendable<'a>(values: impl IntoIterator<Item = &'a MontyObject>) -> Res
         )))
     } else {
         Ok(())
+    }
+}
+
+/// Rejects a resume request whose encoded frame exceeds the wire limit.
+///
+/// An oversize frame is rejected before any bytes are written, so the child
+/// would never see the answer and would stay suspended for ever. Every
+/// `resume*` method must call this *before* clearing `pending`, so the
+/// suspension stays answerable and the caller can retry with a smaller value
+/// or an error.
+fn ensure_resume_frame_fits(request: &pb::ParentRequest) -> Result<(), PoolError> {
+    match exceeds_max_frame_len(request) {
+        Some(len) => Err(PoolError::Runtime(MontyException::new(
+            ExcType::RuntimeError,
+            Some(format!(
+                "result frame of {len} bytes exceeds the maximum of {MAX_FRAME_LEN} bytes"
+            )),
+        ))),
+        None => Ok(()),
     }
 }
 

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -6,9 +6,7 @@ use monty::{
     AssertMessageAnnotations, ExcType, MontyException, MontyObject, OsFunctionCall, PrintStream, ResourceLimits,
 };
 use monty_fs::{MountCallOutcome, MountMode, MountTable, OverlayState};
-use monty_proto::{
-    FrameError, MAX_FRAME_LEN, MONTY_VERSION, exceeds_max_frame_len, exceeds_max_value_depth, pb, validate_requirement,
-};
+use monty_proto::{FrameError, MONTY_VERSION, exceeds_max_value_depth, pb, validate_requirement};
 
 use crate::{PoolError, pool::PoolInner, watchdog::DeadlineGuard, worker::Worker};
 
@@ -359,8 +357,10 @@ impl Checkout {
                 result: Some(pb::ExtFunctionResult { kind: Some(result) }),
             })),
         };
-        ensure_resume_frame_fits(&request)?;
-        self.pending = None;
+        // `pending` is deliberately NOT cleared here: an oversize answer is
+        // rejected by `Worker::send` before any bytes reach the child, and
+        // `request_turn` surfaces it with the suspension still answerable.
+        // Every turn-ending reply overwrites `pending` anyway.
         self.expect_turn(&request, on_print)
     }
 
@@ -404,8 +404,8 @@ impl Checkout {
                     // to encode), so the call is still suspended — answer it
                     // with that error instead, letting the sandbox raise a
                     // catchable exception rather than stranding the feed. Only
-                    // a pre-send rejection leaves `pending` set, so this cannot
-                    // catch a genuine sandbox exception.
+                    // a rejection before the frame is written leaves `pending`
+                    // set, so this cannot catch a genuine sandbox exception.
                     Err(PoolError::Runtime(exc)) if self.pending.is_some() => {
                         self.resume(ResumeValue::Error(exc), on_print).map(Some)
                     }
@@ -444,8 +444,7 @@ impl Checkout {
                 kind: Some(kind),
             })),
         };
-        ensure_resume_frame_fits(&request)?;
-        self.pending = None;
+        // `pending` left set — see the comment in [`Self::resume`]
         self.expect_turn(&request, on_print)
     }
 
@@ -484,8 +483,7 @@ impl Checkout {
         let request = pb::ParentRequest {
             kind: Some(pb::parent_request::Kind::ResumeFutures(pb::ResumeFutures { results })),
         };
-        ensure_resume_frame_fits(&request)?;
-        self.pending = None;
+        // `pending` left set — see the comment in [`Self::resume`]
         self.expect_turn(&request, on_print)
     }
 
@@ -642,8 +640,11 @@ impl Checkout {
             // `write_frame` rejects an oversize frame *before* writing any
             // bytes, so the worker never saw the request and is still synced —
             // surface a clean, catchable error instead of discarding a healthy
-            // worker as if it had crashed. Every other send failure is a real
-            // I/O break (dead worker / closed pipe).
+            // worker as if it had crashed. For a `resume*` request this also
+            // leaves `pending` set (nothing overwrites it on this path), so
+            // the suspension stays answerable with a smaller value. Every
+            // other send failure is a real I/O break (dead worker / closed
+            // pipe).
             return Err(match err {
                 FrameError::FrameTooLarge { len, max } => PoolError::Runtime(MontyException::new(
                     ExcType::RuntimeError,
@@ -899,25 +900,6 @@ fn ensure_sendable<'a>(values: impl IntoIterator<Item = &'a MontyObject>) -> Res
         )))
     } else {
         Ok(())
-    }
-}
-
-/// Rejects a resume request whose encoded frame exceeds the wire limit.
-///
-/// An oversize frame is rejected before any bytes are written, so the child
-/// would never see the answer and would stay suspended for ever. Every
-/// `resume*` method must call this *before* clearing `pending`, so the
-/// suspension stays answerable and the caller can retry with a smaller value
-/// or an error.
-fn ensure_resume_frame_fits(request: &pb::ParentRequest) -> Result<(), PoolError> {
-    match exceeds_max_frame_len(request) {
-        Some(len) => Err(PoolError::Runtime(MontyException::new(
-            ExcType::RuntimeError,
-            Some(format!(
-                "result frame of {len} bytes exceeds the maximum of {MAX_FRAME_LEN} bytes"
-            )),
-        ))),
-        None => Ok(()),
     }
 }
 

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -6,7 +6,9 @@ use monty::{
     AssertMessageAnnotations, ExcType, MontyException, MontyObject, OsFunctionCall, PrintStream, ResourceLimits,
 };
 use monty_fs::{MountCallOutcome, MountMode, MountTable, OverlayState};
-use monty_proto::{FrameError, MONTY_VERSION, exceeds_max_value_depth, pb, validate_requirement};
+use monty_proto::{
+    FrameError, MAX_FRAME_LEN, MONTY_VERSION, exceeds_max_frame_len, exceeds_max_value_depth, pb, validate_requirement,
+};
 
 use crate::{PoolError, pool::PoolInner, watchdog::DeadlineGuard, worker::Worker};
 
@@ -351,13 +353,25 @@ impl Checkout {
             ResumeValue::NotFound => pb::ext_function_result::Kind::NotFound(function_name),
             ResumeValue::NotHandled => pb::ext_function_result::Kind::NotHandled(pb::Unit {}),
         };
-        self.pending = None;
         let request = pb::ParentRequest {
             kind: Some(pb::parent_request::Kind::ResumeCall(pb::ResumeCall {
                 call_id,
                 result: Some(pb::ExtFunctionResult { kind: Some(result) }),
             })),
         };
+        // An oversize frame is rejected before any bytes are written, so the
+        // child would never see this answer and would stay suspended for ever.
+        // Reject it while `pending` still marks the call as answerable, so the
+        // caller can retry with a smaller value or answer with an error.
+        if let Some(len) = exceeds_max_frame_len(&request) {
+            return Err(PoolError::Runtime(MontyException::new(
+                ExcType::RuntimeError,
+                Some(format!(
+                    "result frame of {len} bytes exceeds the maximum of {MAX_FRAME_LEN} bytes"
+                )),
+            )));
+        }
+        self.pending = None;
         self.expect_turn(&request, on_print)
     }
 
@@ -396,7 +410,18 @@ impl Checkout {
                     Ok(obj) => ResumeValue::Return(obj),
                     Err(err) => ResumeValue::Error(err.into_exception()),
                 };
-                self.resume(value, on_print).map(Some)
+                match self.resume(value, on_print) {
+                    // The result never reached the child (too large or too deep
+                    // to encode), so the call is still suspended — answer it
+                    // with that error instead, letting the sandbox raise a
+                    // catchable exception rather than stranding the feed. Only
+                    // a pre-send rejection leaves `pending` set, so this cannot
+                    // catch a genuine sandbox exception.
+                    Err(PoolError::Runtime(exc)) if self.pending.is_some() => {
+                        self.resume(ResumeValue::Error(exc), on_print).map(Some)
+                    }
+                    other => other.map(Some),
+                }
             }
             MountCallOutcome::NotHandled(call) => {
                 let Some(Pending::Call { os_call, .. }) = &mut self.pending else {

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -104,16 +104,14 @@ pub enum TurnEvent {
         method_call: bool,
     },
     /// The sandbox performed an OS operation no mount handled (e.g.
-    /// `"Path.read_text"`) — answer with [`Checkout::resume`].
+    /// `"Path.read_text"`) — answer with [`Checkout::resume`]. A caller with
+    /// no handler should resume with [`ResumeValue::NotHandled`]; the sandbox
+    /// then raises the call's own no-handler default.
     OsCall {
         function_name: String,
         args: Vec<MontyObject>,
         kwargs: Vec<(MontyObject, MontyObject)>,
         call_id: u32,
-        /// The exception the sandbox would raise if nothing handles this
-        /// call; a caller with no handler should resume with
-        /// `ResumeValue::Error(not_handled_error)`.
-        not_handled_error: MontyException,
     },
     /// The sandbox read an undefined name — answer with
     /// [`Checkout::resume_name_lookup`].
@@ -140,6 +138,11 @@ pub enum ResumeValue {
     /// No handler exists for the called name — the sandbox raises
     /// `NameError`.
     NotFound,
+    /// No handler accepted this OS call — the sandbox raises the call's own
+    /// no-handler default (`PermissionError` naming the path for filesystem
+    /// calls, `RuntimeError` for the rest). Only valid answering a
+    /// [`TurnEvent::OsCall`].
+    NotHandled,
 }
 
 /// Callback receiving sandbox `print()` output streamed during a turn.
@@ -186,10 +189,13 @@ pub struct Checkout {
 /// Which kind of suspension is awaiting an answer.
 enum Pending {
     /// FunctionCall or OsCall; carries the call id and name (the name feeds
-    /// `ResumeValue::NotFound`'s NameError).
+    /// `ResumeValue::NotFound`'s NameError). `os_call` gates
+    /// [`ResumeValue::NotHandled`], which only an OS-call suspension can
+    /// resolve.
     Call {
         call_id: u32,
         function_name: String,
+        os_call: bool,
     },
     NameLookup,
     Futures,
@@ -322,10 +328,20 @@ impl Checkout {
 
     /// Answers a [`TurnEvent::FunctionCall`] or [`TurnEvent::OsCall`].
     pub fn resume(&mut self, value: ResumeValue, on_print: OnPrint<'_>) -> Result<TurnEvent, PoolError> {
-        let Some(Pending::Call { call_id, function_name }) = &self.pending else {
+        let Some(Pending::Call {
+            call_id,
+            function_name,
+            os_call,
+        }) = &self.pending
+        else {
             return Err(PoolError::Protocol("no suspended call to resume".to_owned()));
         };
-        let (call_id, function_name) = (*call_id, function_name.clone());
+        let (call_id, function_name, os_call) = (*call_id, function_name.clone(), *os_call);
+        if matches!(value, ResumeValue::NotHandled) && !os_call {
+            return Err(PoolError::Protocol(
+                "NotHandled is only valid answering an OS call".to_owned(),
+            ));
+        }
         if let ResumeValue::Return(obj) = &value {
             ensure_sendable([obj])?;
         }
@@ -334,6 +350,7 @@ impl Checkout {
             ResumeValue::Error(exc) => pb::ext_function_result::Kind::Error((&exc).into()),
             ResumeValue::Future => pb::ext_function_result::Kind::Future(call_id),
             ResumeValue::NotFound => pb::ext_function_result::Kind::NotFound(function_name),
+            ResumeValue::NotHandled => pb::ext_function_result::Kind::NotHandled(pb::Unit {}),
         };
         self.pending = None;
         let request = pb::ParentRequest {
@@ -391,7 +408,7 @@ impl Checkout {
                 let kind = match value {
                     ResumeValue::Return(obj) => pb::ext_function_result::Kind::ReturnValue(obj.into()),
                     ResumeValue::Error(exc) => pb::ext_function_result::Kind::Error((&exc).into()),
-                    ResumeValue::Future | ResumeValue::NotFound => {
+                    ResumeValue::Future | ResumeValue::NotFound | ResumeValue::NotHandled => {
                         return Err(PoolError::Protocol(format!(
                             "future {call_id} must resolve to Return or Error"
                         )));
@@ -612,6 +629,7 @@ impl Checkout {
                     self.pending = Some(Pending::Call {
                         call_id: call.call_id,
                         function_name: call.function_name.clone(),
+                        os_call: false,
                     });
                     break self.convert_turn(|| {
                         Ok(TurnEvent::FunctionCall {
@@ -698,21 +716,19 @@ impl Checkout {
                         MountCallOutcome::NotHandled(function_call) => function_call,
                     };
                     // Not mount-covered: surface to the caller in the
-                    // `(name, args, kwargs)` host-callback shape, with the
-                    // parent-computed no-handler error.
-                    let not_handled_error = unhandled.on_no_handler();
+                    // `(name, args, kwargs)` host-callback shape.
                     let function_name = unhandled.name().to_owned();
                     let (args, kwargs) = unhandled.to_args();
                     self.pending = Some(Pending::Call {
                         call_id,
                         function_name: function_name.clone(),
+                        os_call: true,
                     });
                     break Ok(ControlEvent::Turn(TurnEvent::OsCall {
                         function_name,
                         args,
                         kwargs,
                         call_id,
-                        not_handled_error,
                     }));
                 }
                 Some(pb::child_event::Kind::NameLookup(lookup)) => {

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -1,10 +1,6 @@
 //! A checked-out worker: one REPL session, driven turn by turn.
 
-use std::{
-    path::PathBuf,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{borrow::Cow, path::PathBuf, sync::Arc, time::Duration};
 
 use monty::{
     AssertMessageAnnotations, ExcType, MontyException, MontyObject, OsFunctionCall, PrintStream, ResourceLimits,
@@ -48,8 +44,9 @@ impl Default for ReplConfig {
 /// A host directory mounted into the sandbox for one feed. Mounts are handled
 /// entirely on the parent: the checkout services covered filesystem OS calls
 /// from the host path itself (so mounts work even when the worker runs on a
-/// remote machine), and OS calls the mounts don't cover surface as
-/// [`TurnEvent::OsCall`].
+/// remote machine). Every OS call still surfaces as a [`TurnEvent::OsCall`];
+/// mounts are consulted only when the caller asks, via
+/// [`Checkout::resume_from_mounts`].
 #[derive(Debug, Clone)]
 pub struct MountSpec {
     /// Absolute virtual POSIX path inside the sandbox, e.g. `/mnt/data`.
@@ -103,10 +100,12 @@ pub enum TurnEvent {
         call_id: u32,
         method_call: bool,
     },
-    /// The sandbox performed an OS operation no mount handled (e.g.
-    /// `"Path.read_text"`) — answer with [`Checkout::resume`]. A caller with
-    /// no handler should resume with [`ResumeValue::NotHandled`]; the sandbox
-    /// then raises the call's own no-handler default.
+    /// The sandbox performed an OS operation (e.g. `"Path.read_text"`).
+    /// Answer it from this feed's mounts with
+    /// [`Checkout::resume_from_mounts`], or directly with
+    /// [`Checkout::resume`]. A caller with no handler should resume with
+    /// [`ResumeValue::NotHandled`]; the sandbox then raises the call's own
+    /// no-handler default.
     OsCall {
         function_name: String,
         args: Vec<MontyObject>,
@@ -180,22 +179,23 @@ pub struct Checkout {
     restored_script_name: Option<String>,
     /// Parent-side mount table for the in-flight feed, built from the
     /// [`MountSpec`]s passed to [`Checkout::feed`] / [`Checkout::restore`].
-    /// Covered filesystem `OsCall` events are serviced from it inside
-    /// [`Checkout::request_turn`] without surfacing to the caller. Dropped
-    /// when the feed ends so overlay writes never leak into the next feed.
+    /// Consulted only by [`Checkout::resume_from_mounts`]. Dropped when the
+    /// feed ends so overlay writes never leak into the next feed.
     feed_mounts: Option<MountTable>,
 }
 
 /// Which kind of suspension is awaiting an answer.
 enum Pending {
     /// FunctionCall or OsCall; carries the call id and name (the name feeds
-    /// `ResumeValue::NotFound`'s NameError). `os_call` gates
-    /// [`ResumeValue::NotHandled`], which only an OS-call suspension can
-    /// resolve.
+    /// `ResumeValue::NotFound`'s NameError).
     Call {
         call_id: u32,
         function_name: String,
-        os_call: bool,
+        /// The typed OS call, retained so [`Checkout::resume_from_mounts`] can
+        /// offer it to this feed's mount table after the caller has seen it.
+        /// `None` for an external function call, which also gates
+        /// [`ResumeValue::NotHandled`] — only an OS call can resolve that way.
+        os_call: Option<Box<OsFunctionCall>>,
     },
     NameLookup,
     Futures,
@@ -231,7 +231,7 @@ impl Checkout {
         };
         match this.request_turn(&request, this.pool.config.request_timeout, &mut |_, _| {})? {
             ControlEvent::Ok => Ok(this),
-            other => Err(this.protocol_violation(&format!("unexpected reply to Configure: {other:?}"))),
+            other => Err(this.protocol_violation(format!("unexpected reply to Configure: {other:?}"))),
         }
     }
 
@@ -247,11 +247,10 @@ impl Checkout {
     ///
     /// `mounts` re-establish a suspended feed's mounts, which are never part of
     /// the dump (they are host configuration the parent services itself). Pass
-    /// the same mounts the original feed used — the re-announcement carries the
-    /// full call payload, so a dump taken mid-OS-call resumes transparently: a
-    /// mount-covered call is serviced right here and the returned event is
-    /// whatever the feed does next. A mount silently omitted degrades its
-    /// filesystem calls into surfaced [`TurnEvent::OsCall`]s.
+    /// the same mounts the original feed used, so the resumed feed's covered
+    /// calls can still be answered by [`Checkout::resume_from_mounts`]. A dump
+    /// taken mid-OS-call re-announces the call in full, so the returned event
+    /// is that same [`TurnEvent::OsCall`] — restoring never answers it here.
     /// The session's resource budget is taken from the dump, so the prior
     /// `Configure` limits are dropped here and re-adopted from the worker's
     /// reply.
@@ -279,7 +278,7 @@ impl Checkout {
             ControlEvent::Ok => None,
             ControlEvent::Turn(event) => Some(event),
             other @ ControlEvent::Dump(_) => {
-                return Err(self.protocol_violation(&format!("unexpected reply to Load: {other:?}")));
+                return Err(self.protocol_violation(format!("unexpected reply to Load: {other:?}")));
             }
         };
         Ok((event, self.restored_script_name.take()))
@@ -305,7 +304,7 @@ impl Checkout {
     ) -> Result<TurnEvent, PoolError> {
         if self.pending.is_some() {
             return Err(PoolError::Protocol(
-                "feed called while a suspension is awaiting an answer".to_owned(),
+                "feed called while a suspension is awaiting an answer".into(),
             ));
         }
         ensure_sendable(inputs.iter().map(|(_, value)| value))?;
@@ -334,12 +333,12 @@ impl Checkout {
             os_call,
         }) = &self.pending
         else {
-            return Err(PoolError::Protocol("no suspended call to resume".to_owned()));
+            return Err(PoolError::Protocol("no suspended call to resume".into()));
         };
-        let (call_id, function_name, os_call) = (*call_id, function_name.clone(), *os_call);
-        if matches!(value, ResumeValue::NotHandled) && !os_call {
+        let (call_id, function_name, is_os_call) = (*call_id, function_name.clone(), os_call.is_some());
+        if matches!(value, ResumeValue::NotHandled) && !is_os_call {
             return Err(PoolError::Protocol(
-                "NotHandled is only valid answering an OS call".to_owned(),
+                "NotHandled is only valid answering an OS call".into(),
             ));
         }
         if let ResumeValue::Return(obj) = &value {
@@ -362,6 +361,53 @@ impl Checkout {
         self.expect_turn(&request, on_print)
     }
 
+    /// Answers a pending [`TurnEvent::OsCall`] from this feed's mounts, when
+    /// they cover it.
+    ///
+    /// `Ok(None)` means no mount covers the call (or the feed has none): the
+    /// suspension is left intact for the caller to answer itself, typically via
+    /// its own `os` handler and then [`Checkout::resume`]. `Ok(Some(event))`
+    /// means a mount serviced the call — including servicing it into an error
+    /// such as `PermissionError` — and the feed ran on to `event`.
+    ///
+    /// This is how mounts are reached now that every OS call surfaces: an
+    /// auto-answering driver tries mounts first and falls back to its handler,
+    /// while a caller driving suspensions by hand can ignore mounts entirely.
+    /// Path containment inside covered calls is enforced by the [`MountTable`].
+    pub fn resume_from_mounts(&mut self, on_print: OnPrint<'_>) -> Result<Option<TurnEvent>, PoolError> {
+        let Some(Pending::Call { os_call, .. }) = &mut self.pending else {
+            return Err(PoolError::Protocol("no suspended call to resume".into()));
+        };
+        let Some(call) = os_call.take() else {
+            return Err(PoolError::Protocol(
+                "resume_from_mounts is only valid answering an OS call".into(),
+            ));
+        };
+        // The call is *moved* into the table so a covered write's payload
+        // reaches overlay storage without a copy; an uncovered call comes back
+        // unchanged and is put back for the caller to answer.
+        let outcome = match self.feed_mounts.as_mut() {
+            Some(mounts) => mounts.handle_os_call(*call),
+            None => MountCallOutcome::NotHandled(*call),
+        };
+        match outcome {
+            MountCallOutcome::Handled(result) => {
+                let value = match result {
+                    Ok(obj) => ResumeValue::Return(obj),
+                    Err(err) => ResumeValue::Error(err.into_exception()),
+                };
+                self.resume(value, on_print).map(Some)
+            }
+            MountCallOutcome::NotHandled(call) => {
+                let Some(Pending::Call { os_call, .. }) = &mut self.pending else {
+                    unreachable!("checked above");
+                };
+                *os_call = Some(Box::new(call));
+                Ok(None)
+            }
+        }
+    }
+
     /// Answers a [`TurnEvent::NameLookup`]: `Some(value)` resolves the name,
     /// `None` makes the sandbox raise `NameError`.
     pub fn resume_name_lookup(
@@ -370,7 +416,7 @@ impl Checkout {
         on_print: OnPrint<'_>,
     ) -> Result<TurnEvent, PoolError> {
         if !matches!(self.pending, Some(Pending::NameLookup)) {
-            return Err(PoolError::Protocol("no suspended name lookup to resume".to_owned()));
+            return Err(PoolError::Protocol("no suspended name lookup to resume".into()));
         }
         if let Some(obj) = &value {
             ensure_sendable([obj])?;
@@ -397,7 +443,7 @@ impl Checkout {
         on_print: OnPrint<'_>,
     ) -> Result<TurnEvent, PoolError> {
         if !matches!(self.pending, Some(Pending::Futures)) {
-            return Err(PoolError::Protocol("no suspended futures to resume".to_owned()));
+            return Err(PoolError::Protocol("no suspended futures to resume".into()));
         }
         let results = results
             .into_iter()
@@ -409,9 +455,9 @@ impl Checkout {
                     ResumeValue::Return(obj) => pb::ext_function_result::Kind::ReturnValue(obj.into()),
                     ResumeValue::Error(exc) => pb::ext_function_result::Kind::Error((&exc).into()),
                     ResumeValue::Future | ResumeValue::NotFound | ResumeValue::NotHandled => {
-                        return Err(PoolError::Protocol(format!(
-                            "future {call_id} must resolve to Return or Error"
-                        )));
+                        return Err(PoolError::Protocol(
+                            format!("future {call_id} must resolve to Return or Error").into(),
+                        ));
                     }
                 };
                 Ok(pb::FutureResult {
@@ -444,7 +490,7 @@ impl Checkout {
     pub fn install_dependencies(&mut self, requirements: Vec<String>) -> Result<(), PoolError> {
         if self.pending.is_some() {
             return Err(PoolError::Protocol(
-                "install_dependencies called while a suspension is awaiting an answer".to_owned(),
+                "install_dependencies called while a suspension is awaiting an answer".into(),
             ));
         }
         // Installing nothing trivially succeeds on any worker — including the
@@ -462,7 +508,7 @@ impl Checkout {
         };
         match self.request_turn(&request, self.pool.config.request_timeout, &mut |_, _| {})? {
             ControlEvent::Ok => Ok(()),
-            other => Err(self.protocol_violation(&format!("unexpected reply to InstallDependencies: {other:?}"))),
+            other => Err(self.protocol_violation(format!("unexpected reply to InstallDependencies: {other:?}"))),
         }
     }
 
@@ -475,7 +521,7 @@ impl Checkout {
         };
         match self.request_turn(&request, self.pool.config.request_timeout, &mut |_, _| {})? {
             ControlEvent::Dump(state) => Ok(state),
-            other => Err(self.protocol_violation(&format!("unexpected reply to Dump: {other:?}"))),
+            other => Err(self.protocol_violation(format!("unexpected reply to Dump: {other:?}"))),
         }
     }
 
@@ -506,7 +552,7 @@ impl Checkout {
                 }
                 Ok(())
             }
-            other => Err(self.protocol_violation(&format!("unexpected reply to Reset: {other:?}"))),
+            other => Err(self.protocol_violation(format!("unexpected reply to Reset: {other:?}"))),
         }
     }
 
@@ -525,7 +571,7 @@ impl Checkout {
         let deadline = min_deadline(self.pool.config.request_timeout, self.backstop_deadline());
         match self.request_turn(request, deadline, on_print)? {
             ControlEvent::Turn(event) => Ok(event),
-            other => Err(self.protocol_violation(&format!("expected a turn event, got {other:?}"))),
+            other => Err(self.protocol_violation(format!("expected a turn event, got {other:?}"))),
         }
     }
 
@@ -574,12 +620,7 @@ impl Checkout {
         // `Worker::reset_killed_for_timeout`).
         worker.reset_killed_for_timeout();
         self.armed_deadline = deadline;
-        // The turn's total worker-time allowance: each mount exchange consumes
-        // the interval the worker just ran, so a stream of covered OS calls
-        // cannot extend one turn beyond `deadline` of cumulative execution.
-        let mut remaining = deadline;
-        let mut armed_at = Instant::now();
-        let mut deadline_guard = self.pool.watchdog.arm(worker, deadline);
+        let deadline_guard = self.pool.watchdog.arm(worker, deadline);
 
         if let Err(err) = worker.send(request) {
             // `write_frame` rejects an oversize frame *before* writing any
@@ -605,7 +646,7 @@ impl Checkout {
                 // validation, which happens during decode) — the worker
                 // misbehaved, it didn't die
                 Err(FrameError::Decode(err)) => {
-                    return Err(self.protocol_violation(&format!("invalid payload from worker: {err}")));
+                    return Err(self.protocol_violation(format!("invalid payload from worker: {err}")));
                 }
                 Err(_) => return Err(self.poison("waiting for a reply")),
             };
@@ -629,7 +670,7 @@ impl Checkout {
                     self.pending = Some(Pending::Call {
                         call_id: call.call_id,
                         function_name: call.function_name.clone(),
-                        os_call: false,
+                        os_call: None,
                     });
                     break self.convert_turn(|| {
                         Ok(TurnEvent::FunctionCall {
@@ -642,26 +683,6 @@ impl Checkout {
                     });
                 }
                 Some(pb::child_event::Kind::OsCall(call)) => {
-                    // Parent-side mounts: service covered filesystem calls
-                    // here and resume the child directly — the caller never
-                    // sees them (mirroring `Print` handling). The watchdog is
-                    // disarmed around the local I/O (the child is idle,
-                    // blocked on our reply — a slow host filesystem must not
-                    // count against its deadline). Each exchange deducts the
-                    // worker's just-elapsed interval from `remaining`, so
-                    // issuing covered calls cannot reset the deadline: total
-                    // worker execution per turn stays bounded by `deadline`.
-                    //
-                    // Deliberate trade-off: the host I/O window itself is
-                    // deducted from nothing and runs with no watchdog, so a
-                    // feed's *wall clock* is not bounded by the deadline — a
-                    // stalled filesystem blocks it indefinitely, and a loop
-                    // of covered calls gets its (per-call budget-bounded)
-                    // host I/O for free. Only worker execution is a hard
-                    // bound; see "Mount I/O is not covered by
-                    // `request_timeout`" in limitations/pool-architecture.md.
-                    deadline_guard = None;
-                    remaining = remaining.map(|allowance| allowance.saturating_sub(armed_at.elapsed()));
                     let call_id = call.call_id;
                     // Every announcement (fresh or re-announced after
                     // `restore`) decodes into a typed `OsFunctionCall`; a
@@ -672,57 +693,21 @@ impl Checkout {
                         Some(kind) => match OsFunctionCall::try_from(kind) {
                             Ok(function_call) => function_call,
                             Err(err) => {
-                                break Err(self.protocol_violation(&format!("invalid OS call payload: {err}")));
+                                break Err(self.protocol_violation(format!("invalid OS call payload: {err}")));
                             }
                         },
                     };
-                    let unhandled = match self.try_mount_call(function_call) {
-                        MountCallOutcome::Handled(result) => {
-                            let wire_result = match result {
-                                Ok(obj) => pb::ext_function_result::Kind::ReturnValue(obj.into()),
-                                Err(err) => pb::ext_function_result::Kind::Error((&err.into_exception()).into()),
-                            };
-                            // `armed_deadline` (the `Timeout` error's reported
-                            // value) stays at the turn deadline: the allowance
-                            // makes that the bound the whole turn is held to.
-                            let next_deadline = min_deadline(remaining, self.backstop_deadline());
-                            let worker = self.worker.as_mut().expect("checked above");
-                            armed_at = Instant::now();
-                            deadline_guard = self.pool.watchdog.arm(worker, next_deadline);
-                            if let Err(err) = send_internal_resume(worker, call_id, wire_result) {
-                                // an oversize result frame is rejected before any
-                                // bytes are written, so the stream is intact and
-                                // the suspended child can be resumed with a small,
-                                // catchable error instead; anything else is a real
-                                // I/O break
-                                let FrameError::FrameTooLarge { len, max } = err else {
-                                    break Err(self.poison("resuming a mount-covered OS call"));
-                                };
-                                let exc = MontyException::new(
-                                    ExcType::RuntimeError,
-                                    Some(format!(
-                                        "OS call result frame of {len} bytes exceeds the maximum of {max} bytes"
-                                    )),
-                                );
-                                let error_result = pb::ext_function_result::Kind::Error((&exc).into());
-                                if send_internal_resume(worker, call_id, error_result).is_err() {
-                                    break Err(self.poison("resuming a mount-covered OS call"));
-                                }
-                            }
-                            // serviced internally — wait for the child's
-                            // next event
-                            continue;
-                        }
-                        MountCallOutcome::NotHandled(function_call) => function_call,
-                    };
-                    // Not mount-covered: surface to the caller in the
-                    // `(name, args, kwargs)` host-callback shape.
-                    let function_name = unhandled.name().to_owned();
-                    let (args, kwargs) = unhandled.to_args();
+                    // Every OS call surfaces, mount-covered or not: the caller
+                    // decides how to answer it, and reaches this feed's mounts
+                    // through `resume_from_mounts`. The typed call is retained
+                    // for that; the caller-facing `(name, args, kwargs)` shape
+                    // is projected from a clone.
+                    let function_name = function_call.name().to_owned();
+                    let (args, kwargs) = function_call.clone().to_args();
                     self.pending = Some(Pending::Call {
                         call_id,
                         function_name: function_name.clone(),
-                        os_call: true,
+                        os_call: Some(Box::new(function_call)),
                     });
                     break Ok(ControlEvent::Turn(TurnEvent::OsCall {
                         function_name,
@@ -766,7 +751,7 @@ impl Checkout {
                     };
                     break match MontyException::try_from(exception) {
                         Ok(exc) => Err(PoolError::Runtime(exc)),
-                        Err(err) => Err(self.protocol_violation(&format!("invalid exception payload: {err}"))),
+                        Err(err) => Err(self.protocol_violation(format!("invalid exception payload: {err}"))),
                     };
                 }
                 Some(pb::child_event::Kind::TypingError(typing)) => {
@@ -778,10 +763,9 @@ impl Checkout {
                 Some(pb::child_event::Kind::DumpResult(dump)) => break Ok(ControlEvent::Dump(dump.state)),
                 Some(pb::child_event::Kind::FatalError(fatal)) => {
                     self.discard_worker();
-                    break Err(PoolError::Protocol(format!(
-                        "worker reported fatal error: {}",
-                        fatal.message
-                    )));
+                    break Err(PoolError::Protocol(
+                        format!("worker reported fatal error: {}", fatal.message).into(),
+                    ));
                 }
                 None => {
                     return Err(self.protocol_violation("unexpected event"));
@@ -809,19 +793,6 @@ impl Checkout {
         }
     }
 
-    /// Routes a decoded OS call to this feed's parent-side mount table,
-    /// performing any covered host I/O here. The call is *moved* in so a
-    /// covered write's payload reaches overlay storage without a copy;
-    /// `NotHandled` hands it back for surfacing to the caller. With no
-    /// mounts this feed, every call comes back `NotHandled`. Path
-    /// containment inside covered calls is enforced by the `MountTable`.
-    fn try_mount_call(&mut self, call: OsFunctionCall) -> MountCallOutcome {
-        match self.feed_mounts.as_mut() {
-            Some(mounts) => mounts.handle_os_call(call),
-            None => MountCallOutcome::NotHandled(call),
-        }
-    }
-
     /// Runs a fallible payload conversion; conversion failures mean the
     /// worker sent garbage, which discards it.
     fn convert_turn(
@@ -830,7 +801,7 @@ impl Checkout {
     ) -> Result<ControlEvent, PoolError> {
         match convert() {
             Ok(event) => Ok(ControlEvent::Turn(event)),
-            Err(err) => Err(self.protocol_violation(&format!("invalid payload from worker: {err}"))),
+            Err(err) => Err(self.protocol_violation(format!("invalid payload from worker: {err}"))),
         }
     }
 
@@ -838,9 +809,9 @@ impl Checkout {
     /// (unexpected event kind, undecodable payload). Unlike [`Self::poison`]
     /// this is not a crash — the worker answered, just wrongly — so it maps
     /// to [`PoolError::Protocol`] rather than `Crashed`/`Timeout`.
-    fn protocol_violation(&mut self, context: &str) -> PoolError {
+    fn protocol_violation(&mut self, context: impl Into<Cow<'static, str>>) -> PoolError {
         self.discard_worker();
-        PoolError::Protocol(context.to_owned())
+        PoolError::Protocol(context.into())
     }
 
     /// Discards the worker after an I/O failure and classifies it as a
@@ -954,20 +925,4 @@ fn build_mount_table(mounts: Vec<MountSpec>) -> Result<Option<MountTable>, PoolE
         table.push_mount(mount);
     }
     Ok(Some(table))
-}
-
-/// Sends the `ResumeCall` answering a mount-serviced OS call. Free function
-/// (not a method) so [`Checkout::request_turn`] can call it while the worker
-/// is already mutably borrowed.
-fn send_internal_resume(
-    worker: &mut Worker,
-    call_id: u32,
-    result: pb::ext_function_result::Kind,
-) -> Result<(), FrameError> {
-    worker.send(&pb::ParentRequest {
-        kind: Some(pb::parent_request::Kind::ResumeCall(pb::ResumeCall {
-            call_id,
-            result: Some(pb::ExtFunctionResult { kind: Some(result) }),
-        })),
-    })
 }

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -754,8 +754,13 @@ impl Checkout {
                     });
                 }
                 Some(pb::child_event::Kind::Error(error)) => {
-                    self.pending = None;
-                    self.feed_mounts = None;
+                    // an error reply to `Dump` (e.g. an oversize dump) does not
+                    // end the in-flight feed — the child stays suspended and
+                    // resumable, so keep the pending call and mounts
+                    if !matches!(request.kind, Some(pb::parent_request::Kind::Dump(_))) {
+                        self.pending = None;
+                        self.feed_mounts = None;
+                    }
                     let Some(exception) = error.exception else {
                         return Err(self.protocol_violation("error event with no exception"));
                     };

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -5,7 +5,7 @@ mod pool;
 mod watchdog;
 mod worker;
 
-use std::{error, fmt, io, num::NonZero, path::PathBuf, process::ExitStatus, thread, time::Duration};
+use std::{borrow::Cow, error, fmt, io, num::NonZero, path::PathBuf, process::ExitStatus, thread, time::Duration};
 
 use monty::MontyException;
 pub use monty_proto::{MAX_VALUE_DEPTH, exceeds_max_value_depth};
@@ -121,7 +121,7 @@ pub enum PoolError {
     /// The worker violated the wire protocol, or the caller violated the
     /// checkout state machine. Worker-originated protocol failures discard the
     /// worker; caller misuse leaves it intact.
-    Protocol(String),
+    Protocol(Cow<'static, str>),
     /// The sandboxed code raised a Python exception. The worker and its
     /// session remain alive and usable.
     Runtime(MontyException),

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -55,6 +55,29 @@ fn expect_complete(event: TurnEvent) -> MontyObject {
     }
 }
 
+/// Drives a feed the way an auto-answering host does: every `OsCall` is offered
+/// to the feed's mounts, returning the first event no mount covers.
+///
+/// Mount-covered calls surface like any other suspension now, so a test that
+/// only cares about the *result* of mounted I/O runs its feed through this.
+#[track_caller]
+fn feed_with_mounts(
+    checkout: &mut monty_pool::Checkout,
+    result: Result<TurnEvent, PoolError>,
+) -> Result<TurnEvent, PoolError> {
+    let event = result?;
+    let mut event = event;
+    loop {
+        if !matches!(event, TurnEvent::OsCall { .. }) {
+            return Ok(event);
+        }
+        match checkout.resume_from_mounts(&mut no_print)? {
+            Some(next) => event = next,
+            None => return Ok(event),
+        }
+    }
+}
+
 /// Kills a process by pid with SIGKILL — simulates a hard crash.
 fn kill_pid(pid: u32) {
     #[cfg(unix)]
@@ -244,15 +267,14 @@ fn mounted_filesystem_ops_are_serviced_by_the_parent() {
     let pool = Pool::new(config()).unwrap();
     let mut session = pool.checkout(&ReplConfig::default()).unwrap();
 
-    let event = session
-        .feed(
-            "from pathlib import Path\nPath('/mnt/data.txt').read_text()",
-            vec![],
-            mount(),
-            false,
-            &mut no_print,
-        )
-        .unwrap();
+    let result = session.feed(
+        "from pathlib import Path\nPath('/mnt/data.txt').read_text()",
+        vec![],
+        mount(),
+        false,
+        &mut no_print,
+    );
+    let event = feed_with_mounts(&mut session, result).unwrap();
     assert_eq!(expect_complete(event), MontyObject::String("mounted!".to_owned()));
 
     let code = "\
@@ -262,7 +284,8 @@ Path('/mnt/sub/out.txt').rename('/mnt/sub/renamed.txt')
 with open('/mnt/sub/renamed.txt') as f:
     body = f.read()
 body";
-    let event = session.feed(code, vec![], mount(), false, &mut no_print).unwrap();
+    let result = session.feed(code, vec![], mount(), false, &mut no_print);
+    let event = feed_with_mounts(&mut session, result).unwrap();
     assert_eq!(expect_complete(event), MontyObject::String("written".to_owned()));
     assert_eq!(
         fs::read_to_string(dir.path().join("sub/renamed.txt")).unwrap(),
@@ -291,15 +314,14 @@ fn read_only_and_overlay_mount_semantics() {
     let pool = Pool::new(config()).unwrap();
     let mut session = pool.checkout(&ReplConfig::default()).unwrap();
 
-    let err = session
-        .feed(
-            "from pathlib import Path\nPath('/mnt/new.txt').write_text('x')",
-            vec![],
-            mount(MountSpecMode::ReadOnly),
-            false,
-            &mut no_print,
-        )
-        .unwrap_err();
+    let result = session.feed(
+        "from pathlib import Path\nPath('/mnt/new.txt').write_text('x')",
+        vec![],
+        mount(MountSpecMode::ReadOnly),
+        false,
+        &mut no_print,
+    );
+    let err = feed_with_mounts(&mut session, result).unwrap_err();
     let PoolError::Runtime(exc) = err else {
         panic!("expected Runtime, got {err:?}");
     };
@@ -309,21 +331,19 @@ fn read_only_and_overlay_mount_semantics() {
 from pathlib import Path
 Path('/mnt/data.txt').write_text('changed')
 Path('/mnt/data.txt').read_text()";
-    let event = session
-        .feed(code, vec![], mount(MountSpecMode::Overlay), false, &mut no_print)
-        .unwrap();
+    let result = session.feed(code, vec![], mount(MountSpecMode::Overlay), false, &mut no_print);
+    let event = feed_with_mounts(&mut session, result).unwrap();
     assert_eq!(expect_complete(event), MontyObject::String("changed".to_owned()));
     // the host file is untouched and the overlay does not persist to the next feed
     assert_eq!(fs::read_to_string(dir.path().join("data.txt")).unwrap(), "original");
-    let event = session
-        .feed(
-            "Path('/mnt/data.txt').read_text()",
-            vec![],
-            mount(MountSpecMode::Overlay),
-            false,
-            &mut no_print,
-        )
-        .unwrap();
+    let result = session.feed(
+        "Path('/mnt/data.txt').read_text()",
+        vec![],
+        mount(MountSpecMode::Overlay),
+        false,
+        &mut no_print,
+    );
+    let event = feed_with_mounts(&mut session, result).unwrap();
     assert_eq!(expect_complete(event), MontyObject::String("original".to_owned()));
     session.finish().unwrap();
 }
@@ -342,21 +362,20 @@ try:
 except OSError as exc:
     msg = str(exc)
 msg";
-    let event = session
-        .feed(
-            code,
-            vec![],
-            vec![MountSpec {
-                virtual_path: "/mnt".to_owned(),
-                host_path: dir.path().to_path_buf(),
-                mode: MountSpecMode::ReadWrite,
-                write_bytes_limit: Some(10),
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-            }],
-            false,
-            &mut no_print,
-        )
-        .unwrap();
+    let result = session.feed(
+        code,
+        vec![],
+        vec![MountSpec {
+            virtual_path: "/mnt".to_owned(),
+            host_path: dir.path().to_path_buf(),
+            mode: MountSpecMode::ReadWrite,
+            write_bytes_limit: Some(10),
+            memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
+        }],
+        false,
+        &mut no_print,
+    );
+    let event = feed_with_mounts(&mut session, result).unwrap();
     assert_eq!(
         expect_complete(event),
         MontyObject::String("disk write limit of 10 bytes exceeded".to_owned())
@@ -384,7 +403,8 @@ except MemoryError as exc:
 msg";
     let mut spec = MountSpec::new("/mnt".to_owned(), dir.path().to_path_buf(), MountSpecMode::Overlay);
     spec.memory_usage_limit = 1_000;
-    let event = session.feed(code, vec![], vec![spec], false, &mut no_print).unwrap();
+    let result = session.feed(code, vec![], vec![spec], false, &mut no_print);
+    let event = feed_with_mounts(&mut session, result).unwrap();
     assert_eq!(
         expect_complete(event),
         MontyObject::String("mount memory usage limit of 1 KB exceeded".to_owned())
@@ -392,8 +412,8 @@ msg";
     session.finish().unwrap();
 }
 
-/// OS calls no mount covers still surface as `TurnEvent::OsCall`, while
-/// covered ones are serviced silently within the same feed.
+/// Every OS call surfaces; offering each to the mounts answers the covered
+/// one and leaves the uncovered one for the caller.
 #[test]
 fn uncovered_os_calls_surface_alongside_mounted_ones() {
     let dir = tempfile::tempdir().unwrap();
@@ -405,21 +425,22 @@ fn uncovered_os_calls_surface_alongside_mounted_ones() {
 from pathlib import Path
 covered = Path('/mnt/data.txt').read_text()
 covered + ':' + Path('/elsewhere/file.txt').read_text()";
-    let event = session
-        .feed(
-            code,
-            vec![],
-            vec![MountSpec {
-                virtual_path: "/mnt".to_owned(),
-                host_path: dir.path().to_path_buf(),
-                mode: MountSpecMode::ReadOnly,
-                write_bytes_limit: None,
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-            }],
-            false,
-            &mut no_print,
-        )
-        .unwrap();
+    let result = session.feed(
+        code,
+        vec![],
+        vec![MountSpec {
+            virtual_path: "/mnt".to_owned(),
+            host_path: dir.path().to_path_buf(),
+            mode: MountSpecMode::ReadOnly,
+            write_bytes_limit: None,
+            memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
+        }],
+        false,
+        &mut no_print,
+    );
+    // the covered `/mnt` read is answered by the mount; the `/elsewhere` one
+    // is handed back for the caller to answer
+    let event = feed_with_mounts(&mut session, result).unwrap();
     let TurnEvent::OsCall {
         function_name, args, ..
     } = event
@@ -483,12 +504,12 @@ external + ' ' + Path('/mnt/data.txt').read_text()";
     };
     assert_eq!(function_name, "Path.read_text");
     assert_eq!(args, &vec![MontyObject::Path("/external/answer.txt".to_owned())]);
-    let event = restored
-        .resume(
-            ResumeValue::Return(MontyObject::String("hello".to_owned())),
-            &mut no_print,
-        )
-        .unwrap();
+    let result = restored.resume(
+        ResumeValue::Return(MontyObject::String("hello".to_owned())),
+        &mut no_print,
+    );
+    // the feed's remaining `/mnt` read is answered by the re-supplied mount
+    let event = feed_with_mounts(&mut restored, result).unwrap();
     assert_eq!(
         expect_complete(event),
         MontyObject::String("hello after resume".to_owned())
@@ -496,10 +517,9 @@ external + ' ' + Path('/mnt/data.txt').read_text()";
     restored.finish().unwrap();
 }
 
-/// A dump taken while suspended on a mount-coverable OS call restores
-/// transparently: the re-announced call carries its full payload, so mounts
-/// supplied to `restore` service it immediately and the feed runs to
-/// completion without the caller ever seeing the suspension.
+/// A dump taken while suspended on a mount-coverable OS call re-announces the
+/// call in full, so mounts supplied to `restore` can answer it — the payload
+/// survives the round trip even though the original feed had no mounts.
 #[test]
 fn restored_os_call_is_serviced_by_restore_mounts() {
     let dir = tempfile::tempdir().unwrap();
@@ -521,8 +541,8 @@ fn restored_os_call_is_serviced_by_restore_mounts() {
     let state = session.dump().unwrap();
     drop(session);
 
-    // restore WITH the mount: the re-announced call is now covered, so the
-    // parent services it during `restore` and the feed completes
+    // restore WITH the mount: the call is re-announced, and offering it to the
+    // now-present mount answers it and runs the feed to completion
     let mut restored = pool.checkout(&ReplConfig::default()).unwrap();
     let (event, _) = restored
         .restore(
@@ -538,6 +558,8 @@ fn restored_os_call_is_serviced_by_restore_mounts() {
         )
         .unwrap();
     let event = event.expect("suspended dump must re-announce a turn event");
+    assert!(matches!(event, TurnEvent::OsCall { .. }), "got {event:?}");
+    let event = feed_with_mounts(&mut restored, Ok(event)).unwrap();
     assert_eq!(expect_complete(event), MontyObject::String("from mount".to_owned()));
     restored.finish().unwrap();
 }
@@ -854,21 +876,20 @@ fn special_files_in_mounts_are_rejected_without_blocking() {
 
     let pool = Pool::new(config()).unwrap();
     let mut session = pool.checkout(&ReplConfig::default()).unwrap();
-    let err = session
-        .feed(
-            "from pathlib import Path\nPath('/mnt/pipe').read_text()",
-            vec![],
-            vec![MountSpec {
-                virtual_path: "/mnt".to_owned(),
-                host_path: dir.path().to_path_buf(),
-                mode: MountSpecMode::ReadOnly,
-                write_bytes_limit: None,
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-            }],
-            false,
-            &mut no_print,
-        )
-        .unwrap_err();
+    let result = session.feed(
+        "from pathlib import Path\nPath('/mnt/pipe').read_text()",
+        vec![],
+        vec![MountSpec {
+            virtual_path: "/mnt".to_owned(),
+            host_path: dir.path().to_path_buf(),
+            mode: MountSpecMode::ReadOnly,
+            write_bytes_limit: None,
+            memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
+        }],
+        false,
+        &mut no_print,
+    );
+    let err = feed_with_mounts(&mut session, result).unwrap_err();
     let PoolError::Runtime(exc) = err else {
         panic!("expected Runtime, got {err:?}");
     };

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -643,6 +643,36 @@ fn oversize_frames_are_rejected_without_killing_the_worker() {
     assert_eq!(expect_complete(event), MontyObject::Int(2));
 
     session.finish().unwrap();
+
+    // (4) parent -> child resume: a return value too large to send leaves the
+    // suspension *answerable*. The child never saw the oversize frame, so it is
+    // still waiting — clearing the pending call here would strand it for ever.
+    // A fresh checkout, so the earlier steps' namespace cannot interfere.
+    let mut session = pool.checkout(&ReplConfig::default()).unwrap();
+    let event = session
+        .feed("len(grab())", vec![], vec![], false, &mut no_print)
+        .unwrap();
+    assert!(matches!(event, TurnEvent::FunctionCall { .. }), "got {event:?}");
+    let huge = MontyObject::String("x".repeat(OVERSIZE));
+    let err = session.resume(ResumeValue::Return(huge), &mut no_print).unwrap_err();
+    let PoolError::Runtime(exc) = err else {
+        panic!("expected Runtime for oversize resume value, got {err:?}");
+    };
+    assert!(
+        exc.message()
+            .is_some_and(|m| m.contains("result frame") && m.contains("exceeds the maximum")),
+        "unexpected message: {:?}",
+        exc.message()
+    );
+    // the same suspension still answers to a value that fits
+    let event = session
+        .resume(
+            ResumeValue::Return(MontyObject::String("small".to_owned())),
+            &mut no_print,
+        )
+        .unwrap();
+    assert_eq!(expect_complete(event), MontyObject::Int(5));
+    session.finish().unwrap();
 }
 
 /// A `dump()` too large for the frame limit while the session is *suspended*

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -672,6 +672,56 @@ fn oversize_frames_are_rejected_without_killing_the_worker() {
         )
         .unwrap();
     assert_eq!(expect_complete(event), MontyObject::Int(5));
+
+    // (5) parent -> child name-lookup resume: same invariant as (4) — the
+    // rejected answer leaves the lookup answerable.
+    let event = session.feed("missing", vec![], vec![], false, &mut no_print).unwrap();
+    assert!(matches!(event, TurnEvent::NameLookup { ref name } if name == "missing"));
+    let huge = MontyObject::String("x".repeat(OVERSIZE));
+    let err = session.resume_name_lookup(Some(huge), &mut no_print).unwrap_err();
+    let PoolError::Runtime(exc) = err else {
+        panic!("expected Runtime for oversize name-lookup value, got {err:?}");
+    };
+    assert!(
+        exc.message()
+            .is_some_and(|m| m.contains("result frame") && m.contains("exceeds the maximum")),
+        "unexpected message: {:?}",
+        exc.message()
+    );
+    let event = session
+        .resume_name_lookup(Some(MontyObject::String("small".to_owned())), &mut no_print)
+        .unwrap();
+    assert_eq!(expect_complete(event), MontyObject::String("small".to_owned()));
+
+    // (6) parent -> child future resolution: the pending futures stay
+    // resolvable after an oversize result is rejected.
+    let code = "import asyncio\nasync def main():\n    return await go()\nasyncio.run(main())";
+    let event = session.feed(code, vec![], vec![], false, &mut no_print).unwrap();
+    let TurnEvent::FunctionCall { call_id, .. } = event else {
+        panic!("expected FunctionCall, got {event:?}");
+    };
+    let event = session.resume(ResumeValue::Future, &mut no_print).unwrap();
+    assert!(matches!(event, TurnEvent::ResolveFutures { .. }), "got {event:?}");
+    let huge = MontyObject::String("x".repeat(OVERSIZE));
+    let err = session
+        .resume_futures(vec![(call_id, ResumeValue::Return(huge))], &mut no_print)
+        .unwrap_err();
+    let PoolError::Runtime(exc) = err else {
+        panic!("expected Runtime for oversize future result, got {err:?}");
+    };
+    assert!(
+        exc.message()
+            .is_some_and(|m| m.contains("result frame") && m.contains("exceeds the maximum")),
+        "unexpected message: {:?}",
+        exc.message()
+    );
+    let event = session
+        .resume_futures(
+            vec![(call_id, ResumeValue::Return(MontyObject::Int(99)))],
+            &mut no_print,
+        )
+        .unwrap();
+    assert_eq!(expect_complete(event), MontyObject::Int(99));
     session.finish().unwrap();
 }
 

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -189,21 +189,20 @@ fn non_utf8_mount_path_works() {
 
     let pool = Pool::new(config()).unwrap();
     let mut session = pool.checkout(&ReplConfig::default()).unwrap();
-    let event = session
-        .feed(
-            "from pathlib import Path\nPath('/mnt/data/data.txt').read_text()",
-            vec![],
-            vec![MountSpec {
-                virtual_path: "/mnt/data".to_owned(),
-                host_path: weird_dir,
-                mode: MountSpecMode::ReadOnly,
-                write_bytes_limit: None,
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-            }],
-            false,
-            &mut no_print,
-        )
-        .unwrap();
+    let result = session.feed(
+        "from pathlib import Path\nPath('/mnt/data/data.txt').read_text()",
+        vec![],
+        vec![MountSpec {
+            virtual_path: "/mnt/data".to_owned(),
+            host_path: weird_dir,
+            mode: MountSpecMode::ReadOnly,
+            write_bytes_limit: None,
+            memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
+        }],
+        false,
+        &mut no_print,
+    );
+    let event = feed_with_mounts(&mut session, result).unwrap();
     assert_eq!(
         expect_complete(event),
         MontyObject::String("non-utf8 host dir".to_owned())

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -659,7 +659,7 @@ fn oversize_frames_are_rejected_without_killing_the_worker() {
     };
     assert!(
         exc.message()
-            .is_some_and(|m| m.contains("result frame") && m.contains("exceeds the maximum")),
+            .is_some_and(|m| m.contains("request frame") && m.contains("exceeds the maximum")),
         "unexpected message: {:?}",
         exc.message()
     );
@@ -683,7 +683,7 @@ fn oversize_frames_are_rejected_without_killing_the_worker() {
     };
     assert!(
         exc.message()
-            .is_some_and(|m| m.contains("result frame") && m.contains("exceeds the maximum")),
+            .is_some_and(|m| m.contains("request frame") && m.contains("exceeds the maximum")),
         "unexpected message: {:?}",
         exc.message()
     );
@@ -710,7 +710,7 @@ fn oversize_frames_are_rejected_without_killing_the_worker() {
     };
     assert!(
         exc.message()
-            .is_some_and(|m| m.contains("result frame") && m.contains("exceeds the maximum")),
+            .is_some_and(|m| m.contains("request frame") && m.contains("exceeds the maximum")),
         "unexpected message: {:?}",
         exc.message()
     );

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -623,6 +623,40 @@ fn oversize_frames_are_rejected_without_killing_the_worker() {
     session.finish().unwrap();
 }
 
+/// A `dump()` too large for the frame limit while the session is *suspended*
+/// must fail as a clean, session-preserving error — the suspension already
+/// announced its resume point, so the child stays suspended and resumable.
+///
+/// Allocates ~300 MiB in the worker (plus the dump copy), so it is
+/// memory-heavy; disable it if it proves flaky in CI.
+#[test]
+fn oversize_dump_while_suspended_fails_cleanly_and_resumes() {
+    let pool = Pool::new(config()).unwrap();
+    let mut session = pool.checkout(&ReplConfig::default()).unwrap();
+    // a tiny suspension announcement on top of a heap too big to dump
+    let code = "data = 'x' * (300 * 1024 * 1024)\nf()\nlen(data)";
+    let event = session.feed(code, vec![], vec![], false, &mut no_print).unwrap();
+    assert!(matches!(event, TurnEvent::FunctionCall { .. }), "got {event:?}");
+
+    let err = session.dump().unwrap_err();
+    let PoolError::Runtime(exc) = err else {
+        panic!("expected Runtime for oversize dump, got {err:?}");
+    };
+    assert!(
+        exc.message()
+            .is_some_and(|m| m.contains("result frame") && m.contains("exceeds the maximum")),
+        "unexpected message: {:?}",
+        exc.message()
+    );
+
+    // the suspension is untouched: resuming completes the feed
+    let event = session
+        .resume(ResumeValue::Return(MontyObject::None), &mut no_print)
+        .unwrap();
+    assert_eq!(expect_complete(event), MontyObject::Int(300 * 1024 * 1024));
+    session.finish().unwrap();
+}
+
 #[test]
 fn inputs_and_prints() {
     let pool = Pool::new(config()).unwrap();

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -471,11 +471,18 @@ external + ' ' + Path('/mnt/data.txt').read_text()";
 
     let mut restored = pool.checkout(&ReplConfig::default()).unwrap();
     let (event, _) = restored.restore(state, mount(), &mut no_print).unwrap();
-    // the suspension is re-announced with an empty payload (the wire carries
-    // no name/args on re-announcement, so it always surfaces even with mounts
-    // re-supplied); answering it lets the feed continue, and its remaining
-    // mounted read is serviced by the parent
-    assert!(matches!(&event, Some(TurnEvent::OsCall { .. })), "got {event:?}");
+    // the re-announcement carries the full call payload, so the uncovered
+    // call surfaces exactly like a fresh suspension — name and args intact;
+    // answering it lets the feed continue, and its remaining mounted read is
+    // serviced by the parent
+    let Some(TurnEvent::OsCall {
+        function_name, args, ..
+    }) = &event
+    else {
+        panic!("expected OsCall, got {event:?}");
+    };
+    assert_eq!(function_name, "Path.read_text");
+    assert_eq!(args, &vec![MontyObject::Path("/external/answer.txt".to_owned())]);
     let event = restored
         .resume(
             ResumeValue::Return(MontyObject::String("hello".to_owned())),
@@ -486,6 +493,52 @@ external + ' ' + Path('/mnt/data.txt').read_text()";
         expect_complete(event),
         MontyObject::String("hello after resume".to_owned())
     );
+    restored.finish().unwrap();
+}
+
+/// A dump taken while suspended on a mount-coverable OS call restores
+/// transparently: the re-announced call carries its full payload, so mounts
+/// supplied to `restore` service it immediately and the feed runs to
+/// completion without the caller ever seeing the suspension.
+#[test]
+fn restored_os_call_is_serviced_by_restore_mounts() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(dir.path().join("data.txt"), "from mount").unwrap();
+
+    let pool = Pool::new(config()).unwrap();
+    let mut session = pool.checkout(&ReplConfig::default()).unwrap();
+    // feed with NO mounts: the read surfaces as an uncovered OsCall
+    let event = session
+        .feed(
+            "from pathlib import Path\nPath('/mnt/data.txt').read_text()",
+            vec![],
+            vec![],
+            false,
+            &mut no_print,
+        )
+        .unwrap();
+    assert!(matches!(event, TurnEvent::OsCall { .. }), "got {event:?}");
+    let state = session.dump().unwrap();
+    drop(session);
+
+    // restore WITH the mount: the re-announced call is now covered, so the
+    // parent services it during `restore` and the feed completes
+    let mut restored = pool.checkout(&ReplConfig::default()).unwrap();
+    let (event, _) = restored
+        .restore(
+            state,
+            vec![MountSpec {
+                virtual_path: "/mnt".to_owned(),
+                host_path: dir.path().to_path_buf(),
+                mode: MountSpecMode::ReadOnly,
+                write_bytes_limit: None,
+                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
+            }],
+            &mut no_print,
+        )
+        .unwrap();
+    let event = event.expect("suspended dump must re-announce a turn event");
+    assert_eq!(expect_complete(event), MontyObject::String("from mount".to_owned()));
     restored.finish().unwrap();
 }
 

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -118,8 +118,8 @@ fn no_print(_: PrintStream, _: &str) {}
 
 /// The headline scenario for parent-side mounts: the worker lives on the far
 /// side of a WebSocket, yet a mounted read is serviced from the *parent's*
-/// filesystem — the mock child emits the `OsCall` and receives the file's
-/// contents back in a `ResumeCall` without the caller ever seeing the call.
+/// filesystem — the mock child emits the `OsCall` and `resume_from_mounts`
+/// answers it with the file's contents, no host path ever crossing the wire.
 #[test]
 fn mounted_reads_are_serviced_from_the_parent_filesystem() {
     let dir = tempfile::tempdir().unwrap();
@@ -141,8 +141,7 @@ fn mounted_reads_are_serviced_from_the_parent_filesystem() {
                 call: Some(pb::os_call::Call::ReadText("/mnt/data.txt".to_owned())),
             })),
         );
-        // the parent must answer with the mounted file's contents, not
-        // surface the call to its caller
+        // the parent answers with the mounted file's contents
         let pb::parent_request::Kind::ResumeCall(resume) = read_request(&mut socket) else {
             panic!("expected ResumeCall");
         };
@@ -177,6 +176,11 @@ fn mounted_reads_are_serviced_from_the_parent_filesystem() {
             &mut no_print,
         )
         .expect("feed");
+    assert!(matches!(event, TurnEvent::OsCall { .. }), "got {event:?}");
+    let event = checkout
+        .resume_from_mounts(&mut no_print)
+        .expect("mount servicing")
+        .expect("the mount covers /mnt/data.txt");
     assert!(
         matches!(&event, TurnEvent::Complete(MontyObject::String(s)) if s == "done"),
         "got {event:?}"
@@ -281,16 +285,21 @@ fn duration_backstop_kills_an_unresponsive_worker() {
     server.join().expect("mock child thread");
 }
 
-/// A worker cannot extend a turn indefinitely by issuing covered mount calls:
-/// each exchange deducts the elapsed worker interval from the turn's
-/// allowance, so cumulative worker execution stays bounded by
-/// `request_timeout` no matter how many covered calls the worker makes.
+/// A single turn is still bounded by `request_timeout` even when the worker is
+/// making mount-coverable calls: the OS call surfaces rather than being
+/// serviced inside the turn, so a worker that simply runs too long before
+/// announcing it is killed by the watchdog exactly as without mounts.
+///
+/// Servicing a covered call is now a separate turn with its own deadline (see
+/// "Mount I/O is not covered by `request_timeout`" in
+/// limitations/pool-architecture.md), so a *loop* of covered calls is bounded
+/// by `max_duration`, not by `request_timeout`.
 #[test]
-fn mount_calls_do_not_reset_the_request_deadline() {
+fn a_mounted_feed_turn_is_still_bounded_by_the_request_timeout() {
     let dir = tempfile::tempdir().unwrap();
 
     let (listener, mut config) = ws_pool_config();
-    config.request_timeout = Some(Duration::from_millis(500));
+    config.request_timeout = Some(Duration::from_millis(300));
     let server = thread::spawn(move || {
         let mut socket = accept_ws(&listener);
         assert!(matches!(
@@ -299,31 +308,8 @@ fn mount_calls_do_not_reset_the_request_deadline() {
         ));
         send_event(&mut socket, &event_kind(pb::child_event::Kind::Ok(pb::Ok {})));
         assert!(matches!(read_request(&mut socket), pb::parent_request::Kind::Feed(_)));
-        // "run" for 200ms then issue a covered call, repeatedly: with the old
-        // per-exchange reset this loop would finish all 20 rounds (each well
-        // under the 500ms timeout); the allowance must kill the worker once
-        // cumulative execution passes the timeout.
-        let mut rounds = 0_u32;
-        for call_id in 0..20 {
-            thread::sleep(Duration::from_millis(200));
-            let call = event_kind(pb::child_event::Kind::OsCall(pb::OsCall {
-                call_id,
-                call: Some(pb::os_call::Call::Exists("/mnt".to_owned())),
-            }));
-            let body = encode_to_capped_vec(&call).expect("encode event");
-            if socket.send(Message::Binary(body.into())).is_err() {
-                break; // killed by the watchdog
-            }
-            match socket.read() {
-                Ok(Message::Binary(_)) => rounds += 1,
-                _ => break, // killed by the watchdog
-            }
-        }
-        assert!(rounds >= 1, "at least one covered exchange should be serviced");
-        assert!(
-            rounds < 20,
-            "the watchdog never fired — the deadline was reset per exchange"
-        );
+        // never announce anything: the turn must be killed by the watchdog
+        thread::sleep(Duration::from_secs(2));
     });
 
     let pool = Pool::new(config).expect("pool");
@@ -340,13 +326,13 @@ fn mount_calls_do_not_reset_the_request_deadline() {
             false,
             &mut no_print,
         )
-        .expect_err("cumulative worker time must exhaust the turn allowance");
+        .expect_err("the turn must exhaust the request timeout");
     let PoolError::Timeout { timeout } = err else {
         panic!("expected Timeout, got {err:?}");
     };
-    // the reported timeout is the turn deadline, not a per-exchange residual
-    assert_eq!(timeout, Duration::from_millis(500));
-    server.join().expect("mock child thread");
+    assert_eq!(timeout, Duration::from_millis(300));
+    drop(checkout);
+    let _ = server.join();
 }
 
 /// A restored session re-adopts its `max_duration` budget from the timing

--- a/crates/monty-proto/proto/monty/v1/monty.proto
+++ b/crates/monty-proto/proto/monty/v1/monty.proto
@@ -540,11 +540,6 @@ message OsCall {
     Unit date_today = 23;   // date.today()
     // datetime.now(tz) — the timezone argument (absent for a naive result).
     DateTimeNow date_time_now = 24;
-
-    // Re-announced after `Load`: the argument payload was consumed when the
-    // call was first announced, before the dump was taken. The parent must
-    // answer from its own records (or with a not-handled error).
-    Unit consumed = 25;
   }
 
   message TextWrite {

--- a/crates/monty-proto/proto/monty/v1/monty.proto
+++ b/crates/monty-proto/proto/monty/v1/monty.proto
@@ -299,7 +299,8 @@ message ResourceLimits {
 // ============================================================================
 
 // Outcome of an external function / OS call, decided by the parent. Mirrors
-// monty's `ExtFunctionResult`.
+// monty's `ExtFunctionResult`, plus `not_handled` (which only the child can
+// resolve, against its suspended call).
 message ExtFunctionResult {
   oneof kind {
     // The call returned this value.
@@ -311,6 +312,11 @@ message ExtFunctionResult {
     uint32 future = 3;
     // No handler exists for this name — the child raises NameError.
     string not_found = 4;
+    // No handler accepted this OS call — the child raises the call's own
+    // no-handler default (PermissionError naming the path for filesystem
+    // calls, RuntimeError for the rest). Only valid answering an `OsCall`
+    // suspension; the child computes it from its retained call payload.
+    Unit not_handled = 5;
   }
 }
 
@@ -504,9 +510,10 @@ message FunctionCall {
 // file_handle); a mismatched result becomes a Python-level error inside the
 // sandbox.
 //
-// A parent with no handler should answer `ResumeCall` with the call's
-// not-handled error: PermissionError naming the path for filesystem calls,
-// RuntimeError for the rest — see monty's `OsFunctionCall::on_no_handler`.
+// A parent with no handler should answer `ResumeCall` with
+// `ExtFunctionResult.not_handled`: the child raises the call's own default
+// (PermissionError naming the path for filesystem calls, RuntimeError for
+// the rest — monty's `OsFunctionCall::on_no_handler`).
 message OsCall {
   uint32 call_id = 1;
 

--- a/crates/monty-proto/src/convert/os_call.rs
+++ b/crates/monty-proto/src/convert/os_call.rs
@@ -1,11 +1,6 @@
 //! Conversions for `OsCall` suspensions: the typed wire arms of
 //! `monty.v1.OsCall` and [`OsFunctionCall`] map 1:1, so payloads (write data,
 //! paths) *move* between the wire and the call — never clone.
-//!
-//! [`os_call::Call::Consumed`] is the one arm with no monty equivalent: it
-//! re-announces a call restored from a dump whose argument payload was
-//! consumed when the call was first announced. Receivers must match it before
-//! converting; `TryFrom` rejects it defensively.
 
 use monty::{
     GetenvArgs, MkdirCallArgs, MontyPath, MontyTimeZone, OpenCallArgs, OsFunctionCall, PathBytesDataArgs,
@@ -61,7 +56,6 @@ impl From<OsFunctionCall> for os_call::Call {
                     name: tz.name,
                 }),
             }),
-            OsFunctionCall::Used => unreachable!("OsFunctionCall::Used encoded after take_function_call"),
         }
     }
 }
@@ -115,14 +109,6 @@ impl TryFrom<os_call::Call> for OsFunctionCall {
                 offset_seconds: tz.offset_seconds,
                 name: tz.name,
             })),
-            // a consumed re-announcement carries no call — callers surface it
-            // to their fallback handler instead of converting it
-            os_call::Call::Consumed(_) => {
-                return Err(ProtoConvertError::InvalidValue {
-                    field: "OsCall.call",
-                    reason: "consumed re-announcement carries no call".to_owned(),
-                });
-            }
         })
     }
 }

--- a/crates/monty-proto/src/convert/resume.rs
+++ b/crates/monty-proto/src/convert/resume.rs
@@ -29,6 +29,14 @@ impl TryFrom<pb::ExtFunctionResult> for ExtFunctionResult {
             pb::ext_function_result::Kind::Error(err) => Ok(Self::Error(MontyException::try_from(err)?)),
             pb::ext_function_result::Kind::Future(call_id) => Ok(Self::Future(call_id)),
             pb::ext_function_result::Kind::NotFound(name) => Ok(Self::NotFound(name)),
+            // NotHandled has no monty equivalent: it resolves against the
+            // suspended OS call, so the child intercepts it before this
+            // conversion (see `Child::handle_resume_call`); anywhere else it
+            // is out of context
+            pb::ext_function_result::Kind::NotHandled(_) => Err(ProtoConvertError::InvalidValue {
+                field: "ExtFunctionResult.kind",
+                reason: "NotHandled is only valid answering a suspended OS call".to_owned(),
+            }),
         }
     }
 }

--- a/crates/monty-proto/src/frame.rs
+++ b/crates/monty-proto/src/frame.rs
@@ -81,6 +81,18 @@ impl From<io::Error> for FrameError {
     }
 }
 
+/// The encoded frame length of `msg` when it exceeds [`MAX_FRAME_LEN`]
+/// (saturating at [`u32::MAX`]), or `None` when it fits.
+///
+/// [`write_frame`] rejects an oversize frame anyway, but only once the caller
+/// is committed to sending. Peers that must not mutate their own state until
+/// the frame is known sendable — a parent about to mark a suspension answered,
+/// a child about to enter one — check it with this first.
+pub fn exceeds_max_frame_len(msg: &impl Message) -> Option<u32> {
+    let len = u32::try_from(msg.encoded_len()).unwrap_or(u32::MAX);
+    (len > MAX_FRAME_LEN).then_some(len)
+}
+
 /// Encodes `msg` and writes it to `writer` as one length-prefixed frame, then
 /// flushes (see the module docs for why flushing every frame is required).
 ///

--- a/crates/monty-proto/src/generated/monty.v1.rs
+++ b/crates/monty-proto/src/generated/monty.v1.rs
@@ -294,10 +294,11 @@ pub struct ResourceLimits {
     pub max_recursion_depth: ::core::option::Option<u64>,
 }
 /// Outcome of an external function / OS call, decided by the parent. Mirrors
-/// monty's `ExtFunctionResult`.
+/// monty's `ExtFunctionResult`, plus `not_handled` (which only the child can
+/// resolve, against its suspended call).
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExtFunctionResult {
-    #[prost(oneof = "ext_function_result::Kind", tags = "1, 2, 3, 4")]
+    #[prost(oneof = "ext_function_result::Kind", tags = "1, 2, 3, 4, 5")]
     pub kind: ::core::option::Option<ext_function_result::Kind>,
 }
 /// Nested message and enum types in `ExtFunctionResult`.
@@ -317,6 +318,12 @@ pub mod ext_function_result {
         /// No handler exists for this name — the child raises NameError.
         #[prost(string, tag = "4")]
         NotFound(::prost::alloc::string::String),
+        /// No handler accepted this OS call — the child raises the call's own
+        /// no-handler default (PermissionError naming the path for filesystem
+        /// calls, RuntimeError for the rest). Only valid answering an `OsCall`
+        /// suspension; the child computes it from its retained call payload.
+        #[prost(message, tag = "5")]
+        NotHandled(super::Unit),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -545,9 +552,10 @@ pub struct Print {
 /// file_handle); a mismatched result becomes a Python-level error inside the
 /// sandbox.
 ///
-/// A parent with no handler should answer `ResumeCall` with the call's
-/// not-handled error: PermissionError naming the path for filesystem calls,
-/// RuntimeError for the rest — see monty's `OsFunctionCall::on_no_handler`.
+/// A parent with no handler should answer `ResumeCall` with
+/// `ExtFunctionResult.not_handled`: the child raises the call's own default
+/// (PermissionError naming the path for filesystem calls, RuntimeError for
+/// the rest — monty's `OsFunctionCall::on_no_handler`).
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OsCall {
     #[prost(uint32, tag = "1")]

--- a/crates/monty-proto/src/generated/monty.v1.rs
+++ b/crates/monty-proto/src/generated/monty.v1.rs
@@ -554,7 +554,7 @@ pub struct OsCall {
     pub call_id: u32,
     #[prost(
         oneof = "os_call::Call",
-        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25"
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24"
     )]
     pub call: ::core::option::Option<os_call::Call>,
 }
@@ -689,11 +689,6 @@ pub mod os_call {
         /// datetime.now(tz) — the timezone argument (absent for a naive result).
         #[prost(message, tag = "24")]
         DateTimeNow(DateTimeNow),
-        /// Re-announced after `Load`: the argument payload was consumed when the
-        /// call was first announced, before the dump was taken. The parent must
-        /// answer from its own records (or with a not-handled error).
-        #[prost(message, tag = "25")]
-        Consumed(super::Unit),
     }
 }
 /// Suspension: the sandbox read an undefined name — typically probing whether

--- a/crates/monty-proto/src/lib.rs
+++ b/crates/monty-proto/src/lib.rs
@@ -21,7 +21,8 @@ pub const MONTY_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub use convert::{MAX_VALUE_DEPTH, ProtoConvertError, exceeds_max_value_depth, future_results_from_proto};
 pub use frame::{
-    DEFAULT_MAX_DECODE_BYTES, FrameError, FrameReader, MAX_FRAME_LEN, decode_frame, encode_to_capped_vec, write_frame,
+    DEFAULT_MAX_DECODE_BYTES, FrameError, FrameReader, MAX_FRAME_LEN, decode_frame, encode_to_capped_vec,
+    exceeds_max_frame_len, write_frame,
 };
 pub use generated::pb;
 pub use requirement::validate_requirement;

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -303,7 +303,7 @@ impl Child {
         };
         self.stamp_execution_time(&mut event);
         if let Err(err) = sink.send(&event) {
-            self.recover_send_error(err, sink)?;
+            self.recover_send_error(&event, err, sink)?;
         }
         Ok(HandleOutcome::Continue)
     }
@@ -323,16 +323,29 @@ impl Child {
     /// Recovers from a failure to write a turn-ending event.
     ///
     /// [`write_frame`] rejects an oversize frame *before* writing any bytes, so
-    /// the stream stays synced. When the session is not mid-suspension — e.g.
-    /// a `Complete` result that is merely larger than the frame limit — we can
-    /// answer with a clean, session-preserving error and keep serving instead
-    /// of crashing the worker. An oversize *suspension* announcement is
-    /// unrecoverable (the worker is already suspended but the parent never
-    /// learned the resume point), so it propagates to the host loop's fatal
-    /// handling, as does any genuine I/O break.
-    fn recover_send_error(&mut self, err: FrameError, sink: &mut dyn EventSink) -> Result<(), FrameError> {
+    /// the stream stays synced and an oversize event (a large `Complete`, or a
+    /// `DumpResult` while suspended) can be answered with a clean,
+    /// session-preserving error. An oversize *suspension announcement* is
+    /// unrecoverable — the worker is suspended but the parent never learned the
+    /// resume point — so it propagates to the host loop's fatal handling, as
+    /// does any genuine I/O break.
+    fn recover_send_error(
+        &mut self,
+        failed: &pb::ChildEvent,
+        err: FrameError,
+        sink: &mut dyn EventSink,
+    ) -> Result<(), FrameError> {
+        let announces_suspension = matches!(
+            failed.kind,
+            Some(
+                pb::child_event::Kind::FunctionCall(_)
+                    | pb::child_event::Kind::OsCall(_)
+                    | pb::child_event::Kind::NameLookup(_)
+                    | pb::child_event::Kind::ResolveFutures(_)
+            )
+        );
         match err {
-            FrameError::FrameTooLarge { len, max } if !matches!(self.state, SessionState::Suspended(_)) => {
+            FrameError::FrameTooLarge { len, max } if !announces_suspension => {
                 let mut event = error_event(
                     ExcType::RuntimeError,
                     &format!("result frame of {len} bytes exceeds the maximum of {max} bytes"),
@@ -618,16 +631,31 @@ impl Child {
                 Err(err) => protocol_violation(&format!("failed to load session: {err}")),
             },
             1 => match ReplProgress::load(payload) {
+                // the depth/oversize checks below can only fail on a forged or
+                // corrupted dump — `drive` enforces them on every fresh
+                // suspension before it is stored
                 Ok(ReplProgress::Complete { repl, value }) => {
-                    // a dump is never taken at Complete, but a forged/legacy
-                    // one could contain it; surface the value rather than fail
-                    self.state = SessionState::Ready(Box::new(repl));
-                    complete_event(value)
+                    if exceeds_max_value_depth(&value) {
+                        protocol_violation("dump value exceeds the maximum wire depth")
+                    } else {
+                        // a dump is never taken at Complete, but a forged one
+                        // could contain it; surface the value rather than fail
+                        self.state = SessionState::Ready(Box::new(repl));
+                        complete_event(value)
+                    }
                 }
                 Ok(progress) => {
-                    let event = suspension_event(&progress);
-                    self.state = SessionState::Suspended(Box::new(progress));
-                    event
+                    if suspension_args_too_deep(&progress) {
+                        protocol_violation("dump suspension arguments exceed the maximum wire depth")
+                    } else {
+                        let event = suspension_event(&progress);
+                        if let Some(message) = oversize_suspension_error_message(&event) {
+                            protocol_violation(&message)
+                        } else {
+                            self.state = SessionState::Suspended(Box::new(progress));
+                            event
+                        }
+                    }
                 }
                 Err(err) => protocol_violation(&format!("failed to load suspended session: {err}")),
             },
@@ -672,14 +700,7 @@ impl Child {
                     return complete_event(value);
                 }
                 Ok(ReplProgress::OsCall(call)) => {
-                    // only `os.getenv`'s default carries an arbitrary sandbox
-                    // value — every other arm is flat strings/bytes/typed
-                    // structs, which cannot nest
-                    let too_deep = match &call.function_call {
-                        OsFunctionCall::Getenv(args) => exceeds_max_value_depth(&args.default),
-                        _ => false,
-                    };
-                    if too_deep {
+                    if os_call_args_too_deep(&call) {
                         let err =
                             MontyException::new(ExcType::RuntimeError, Some("Max argument depth exceeded".to_owned()));
                         result = call.resume(ExtFunctionResult::Error(err), PrintWriter::Callback(print));
@@ -695,12 +716,7 @@ impl Child {
                 Ok(ReplProgress::FunctionCall(call)) => {
                     // arguments too deep for the wire resume the call with a
                     // catchable error instead of corrupting the protocol
-                    if call.args.iter().any(exceeds_max_value_depth)
-                        || call
-                            .kwargs
-                            .iter()
-                            .any(|(k, v)| exceeds_max_value_depth(k) || exceeds_max_value_depth(v))
-                    {
+                    if function_call_args_too_deep(&call) {
                         let err =
                             MontyException::new(ExcType::RuntimeError, Some("Max argument depth exceeded".to_owned()));
                         result = call.resume(ExtFunctionResult::Error(err), PrintWriter::Callback(print));
@@ -863,6 +879,35 @@ fn complete_event(value: MontyObject) -> pb::ChildEvent {
     event(pb::child_event::Kind::Complete(pb::Complete {
         value: Some(value.into()),
     }))
+}
+
+/// Whether a suspension's argument payload nests too deeply for the wire —
+/// used by `drive` (fresh) and `handle_load` (restored, i.e. forged dumps).
+fn suspension_args_too_deep(progress: &ReplProgress<Tracker>) -> bool {
+    match progress {
+        ReplProgress::FunctionCall(call) => function_call_args_too_deep(call),
+        ReplProgress::OsCall(call) => os_call_args_too_deep(call),
+        // name lookups / future resolutions carry no sandbox values
+        _ => false,
+    }
+}
+
+/// Whether an external call's args/kwargs nest too deeply for the wire.
+fn function_call_args_too_deep(call: &monty::ReplFunctionCall<Tracker>) -> bool {
+    call.args.iter().any(exceeds_max_value_depth)
+        || call
+            .kwargs
+            .iter()
+            .any(|(k, v)| exceeds_max_value_depth(k) || exceeds_max_value_depth(v))
+}
+
+/// Whether an OS call's payload nests too deeply for the wire — only
+/// `os.getenv`'s default carries an arbitrary (nestable) sandbox value.
+fn os_call_args_too_deep(call: &monty::ReplOsCall<Tracker>) -> bool {
+    match &call.function_call {
+        OsFunctionCall::Getenv(args) => exceeds_max_value_depth(&args.default),
+        _ => false,
+    }
 }
 
 /// Builds the suspension event for a non-`Complete` progress state. Used on

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -23,11 +23,10 @@ use monty::{
     MontyRepl, OsFunctionCall, PrintWriter, PrintWriterCallback, ReplProgress, ReplStartError,
 };
 use monty_type_checking::{SourceFile, type_check};
-use prost::Message;
 
 use super::{
-    FrameError, FrameReader, MAX_FRAME_LEN, MONTY_VERSION, WireFunctionCall, exceeds_max_value_depth,
-    future_results_from_proto, pb, write_frame,
+    FrameError, FrameReader, MAX_FRAME_LEN, MONTY_VERSION, WireFunctionCall, exceeds_max_frame_len,
+    exceeds_max_value_depth, future_results_from_proto, pb, write_frame,
 };
 
 /// The child always runs with `LimitedTracker`: an absent/empty limits message
@@ -851,8 +850,8 @@ fn error_event(exc_type: ExcType, message: &str) -> pb::ChildEvent {
 /// The child turns this into a host-visible error before entering the
 /// suspension, because the parent cannot resume a call it never received.
 fn oversize_suspension_error_message(event: &pb::ChildEvent) -> Option<String> {
-    let len = u32::try_from(event.encoded_len()).unwrap_or(u32::MAX);
-    (len > MAX_FRAME_LEN).then(|| format!("argument frame of {len} bytes exceeds the maximum of {MAX_FRAME_LEN} bytes"))
+    exceeds_max_frame_len(event)
+        .map(|len| format!("argument frame of {len} bytes exceeds the maximum of {MAX_FRAME_LEN} bytes"))
 }
 
 /// Builds the suspension event for a `FunctionCall` (depth-checked by the

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -469,13 +469,27 @@ impl Child {
                 resume.call_id
             ));
         }
-        let result: ExtFunctionResult = match resume.result {
-            Some(result) => match result.try_into() {
-                Ok(result) => result,
-                Err(err) => return protocol_violation(&format!("invalid result: {err}")),
-            },
-            None => return protocol_violation("ResumeCall has no result"),
+        let Some(wire_result) = resume.result else {
+            return protocol_violation("ResumeCall has no result");
         };
+        // NotHandled resolves against the suspended call itself — the child
+        // owns the no-handler semantics (`OsFunctionCall::on_no_handler`), so
+        // the parent never has to compute or echo the default exception.
+        let result: ExtFunctionResult =
+            if matches!(wire_result.kind, Some(pb::ext_function_result::Kind::NotHandled(_))) {
+                let SessionState::Suspended(progress) = &self.state else {
+                    unreachable!("checked above");
+                };
+                let ReplProgress::OsCall(call) = progress.as_ref() else {
+                    return protocol_violation("NotHandled is only valid answering a suspended OS call");
+                };
+                ExtFunctionResult::Error(call.function_call.on_no_handler())
+            } else {
+                match wire_result.try_into() {
+                    Ok(result) => result,
+                    Err(err) => return protocol_violation(&format!("invalid result: {err}")),
+                }
+            };
         let SessionState::Suspended(progress) = mem::replace(&mut self.state, SessionState::Configured(None)) else {
             unreachable!("checked above");
         };

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -429,6 +429,8 @@ impl Child {
         Ok(())
     }
 
+    /// Runs a `Feed` on the ready session: type-checks the snippet (unless
+    /// skipped), injects inputs, and drives execution to the turn-ending event.
     fn handle_repl_feed(&mut self, feed: pb::Feed, sink: &mut dyn EventSink) -> pb::ChildEvent {
         if let Err(event) = self.ensure_repl() {
             return *event;
@@ -464,6 +466,8 @@ impl Child {
         event
     }
 
+    /// Answers a suspended external function or OS call with the parent's
+    /// result, checking the `call_id` matches, then resumes execution.
     fn handle_resume_call(&mut self, resume: pb::ResumeCall, sink: &mut dyn EventSink) -> pb::ChildEvent {
         let expected_call_id = match &self.state {
             SessionState::Suspended(progress) => match progress.as_ref() {
@@ -517,6 +521,8 @@ impl Child {
         event
     }
 
+    /// Answers a suspended name lookup with the value (or absence) the parent
+    /// resolved, then resumes execution.
     fn handle_resume_name_lookup(&mut self, resume: pb::ResumeNameLookup, sink: &mut dyn EventSink) -> pb::ChildEvent {
         let SessionState::Suspended(progress) = &self.state else {
             return protocol_violation("ResumeNameLookup without a suspended name lookup");
@@ -541,6 +547,8 @@ impl Child {
         event
     }
 
+    /// Delivers the parent's resolved future results to a suspended
+    /// `ResolveFutures` state, then resumes execution.
     fn handle_resume_futures(&mut self, resume: pb::ResumeFutures, sink: &mut dyn EventSink) -> pb::ChildEvent {
         let SessionState::Suspended(progress) = &self.state else {
             return protocol_violation("ResumeFutures without suspended futures");

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -657,12 +657,11 @@ impl Child {
                     }
                     return complete_event(value);
                 }
-                Ok(ReplProgress::OsCall(mut call)) => {
-                    let function_call = call.take_function_call();
+                Ok(ReplProgress::OsCall(call)) => {
                     // only `os.getenv`'s default carries an arbitrary sandbox
                     // value — every other arm is flat strings/bytes/typed
                     // structs, which cannot nest
-                    let too_deep = match &function_call {
+                    let too_deep = match &call.function_call {
                         OsFunctionCall::Getenv(args) => exceeds_max_value_depth(&args.default),
                         _ => false,
                     };
@@ -672,10 +671,7 @@ impl Child {
                         result = call.resume(ExtFunctionResult::Error(err), PrintWriter::Callback(print));
                         continue;
                     }
-                    let event = event(pb::child_event::Kind::OsCall(pb::OsCall {
-                        call_id: call.call_id,
-                        call: Some(function_call.into()),
-                    }));
+                    let event = suspension_event_os_call(&call);
                     if let Some(message) = oversize_suspension_error_message(&event) {
                         return self.abort_feed_with_runtime_error(call.into_repl(), &message);
                     }
@@ -821,8 +817,8 @@ fn oversize_suspension_error_message(event: &pb::ChildEvent) -> Option<String> {
     (len > MAX_FRAME_LEN).then(|| format!("argument frame of {len} bytes exceeds the maximum of {MAX_FRAME_LEN} bytes"))
 }
 
-/// Builds the suspension event for a fresh `FunctionCall` (depth-checked by
-/// the caller).
+/// Builds the suspension event for a `FunctionCall` (depth-checked by the
+/// caller).
 ///
 /// Clones the argument payload: the suspension keeps its args so a `Dump` of
 /// the suspended state (and its replay on `Load`) stays complete.
@@ -836,48 +832,41 @@ fn suspension_event_function_call(call: &monty::ReplFunctionCall<Tracker>) -> pb
     }))
 }
 
+/// Builds the suspension event for an `OsCall` (depth-checked by the caller).
+///
+/// Clones the call payload: the suspension keeps its args so a `Dump` of the
+/// suspended state (and its re-announcement on `Load`) stays complete — a
+/// restored session's parent can service the call from mounts or its `os`
+/// callback exactly like a fresh one.
+fn suspension_event_os_call(call: &monty::ReplOsCall<Tracker>) -> pb::ChildEvent {
+    event(pb::child_event::Kind::OsCall(pb::OsCall {
+        call_id: call.call_id,
+        call: Some(call.function_call.clone().into()),
+    }))
+}
+
 fn complete_event(value: MontyObject) -> pb::ChildEvent {
     event(pb::child_event::Kind::Complete(pb::Complete {
         value: Some(value.into()),
     }))
 }
 
-/// Builds the suspension event for a non-`Complete`, non-`OsCall` progress
-/// state (OS calls are special-cased in `drive` because emitting them consumes
-/// the call's argument payload).
+/// Builds the suspension event for a non-`Complete` progress state. Used on
+/// `Load` to re-announce a restored suspension; fresh suspensions go through
+/// `drive`, which adds depth/oversize checks before delegating to the same
+/// per-variant builders.
 fn suspension_event(progress: &ReplProgress<Tracker>) -> pb::ChildEvent {
-    let kind = match progress {
-        ReplProgress::FunctionCall(call) => pb::child_event::Kind::FunctionCall(WireFunctionCall {
-            function_name: call.function_name.clone(),
-            args: call.args.clone(),
-            kwargs: call.kwargs.clone(),
-            call_id: call.call_id,
-            method_call: call.method_call,
-        }),
-        ReplProgress::OsCall(call) => {
-            // reached only on `Load` of a dumped OsCall suspension, where the
-            // payload was already consumed by `take_function_call` (leaving
-            // `Used`, announced as `Consumed` — the parent re-learns the call
-            // from its own records); a fresh suspension goes through `drive`
-            // instead, which moves the payload into the event
-            let kind = match &call.function_call {
-                OsFunctionCall::Used => pb::os_call::Call::Consumed(pb::Unit {}),
-                function_call => function_call.clone().into(),
-            };
-            pb::child_event::Kind::OsCall(pb::OsCall {
-                call_id: call.call_id,
-                call: Some(kind),
-            })
-        }
-        ReplProgress::NameLookup(lookup) => pb::child_event::Kind::NameLookup(pb::NameLookup {
+    match progress {
+        ReplProgress::FunctionCall(call) => suspension_event_function_call(call),
+        ReplProgress::OsCall(call) => suspension_event_os_call(call),
+        ReplProgress::NameLookup(lookup) => event(pb::child_event::Kind::NameLookup(pb::NameLookup {
             name: lookup.name.clone(),
-        }),
-        ReplProgress::ResolveFutures(state) => pb::child_event::Kind::ResolveFutures(pb::ResolveFutures {
+        })),
+        ReplProgress::ResolveFutures(state) => event(pb::child_event::Kind::ResolveFutures(pb::ResolveFutures {
             pending_call_ids: state.pending_call_ids().to_vec(),
-        }),
+        })),
         ReplProgress::Complete { .. } => unreachable!("Complete is handled before suspension_event"),
-    };
-    event(kind)
+    }
 }
 
 /// Appends a `u32 LE`-length-prefixed string field to a dump envelope.

--- a/crates/monty-proto/tests/dispatch.rs
+++ b/crates/monty-proto/tests/dispatch.rs
@@ -5,7 +5,7 @@
 //! `Child` state machine over the message-based transport without any wasm
 //! toolchain.
 
-use monty::MontyObject;
+use monty::{CompileOptions, LimitedTracker, MontyObject, MontyRepl, PrintWriter, ReplProgress, ResourceLimits};
 use monty_proto::{
     FrameReader, MONTY_VERSION, WireObject, pb,
     worker::{Child, HandleOutcome, dispatch_frame},
@@ -159,4 +159,56 @@ fn shutdown_request_reports_shutdown() {
         matches!(decode_events(&bytes).as_slice(), [pb::child_event::Kind::Ok(_)]),
         "Shutdown answers with a single Ok"
     );
+}
+
+/// A forged suspended dump whose call arguments nest deeper than the wire
+/// depth bound must be rejected at `Load` with a protocol violation — not
+/// re-announced as an event the parent cannot decode.
+#[test]
+fn load_rejects_dump_with_over_deep_suspension_args() {
+    // suspend in-process (no wire depth bound) at `f(x)` with x nested 100
+    // lists deep — over the ~48 wire bound, shallow enough that postcard's
+    // recursive deserialize doesn't overflow the test stack
+    let repl = MontyRepl::new(
+        "main.py",
+        LimitedTracker::new(ResourceLimits::new()),
+        CompileOptions::default(),
+    );
+    let code = "x = []\nfor _ in range(100):\n    x = [x]\nf(x)";
+    let progress = repl
+        .feed_start(code, vec![], PrintWriter::Stdout)
+        .expect("feed_start suspends");
+    assert!(
+        matches!(progress, ReplProgress::FunctionCall(_)),
+        "expected a FunctionCall suspension"
+    );
+    let payload = progress.dump().expect("in-process dump has no depth bound");
+
+    // Assemble the dump envelope the way `Dump` does: [version u16 LE]
+    // [tag u8 = 1 (suspended)][script_name str][type_check u8 = 0][payload].
+    let mut state = 5u16.to_le_bytes().to_vec();
+    state.push(1);
+    let script_name = b"main.py";
+    state.extend_from_slice(&u32::try_from(script_name.len()).unwrap().to_le_bytes());
+    state.extend_from_slice(script_name);
+    state.push(0);
+    state.extend_from_slice(&payload);
+
+    let mut child = Child::new();
+    create_repl(&mut child);
+    let request = frame_request(pb::parent_request::Kind::Load(pb::Load { state }));
+    let (bytes, outcome) = dispatch_frame(&mut child, &request);
+    assert_eq!(outcome, HandleOutcome::Continue);
+    let (_, event) = split_turn(&bytes);
+    let pb::child_event::Kind::Error(error) = event else {
+        panic!("expected an Error event, got {event:?}");
+    };
+    assert_eq!(
+        error.exception.unwrap().message.unwrap(),
+        "protocol violation: dump suspension arguments exceed the maximum wire depth"
+    );
+
+    // the rejected load adopted nothing: the child is still fresh and usable
+    let (_, event) = feed(&mut child, "1 + 1");
+    assert_eq!(expect_complete(event), MontyObject::Int(2));
 }

--- a/crates/monty-proto/tests/oracle/monty.v1.rs
+++ b/crates/monty-proto/tests/oracle/monty.v1.rs
@@ -667,7 +667,7 @@ pub struct OsCall {
     pub call_id: u32,
     #[prost(
         oneof = "os_call::Call",
-        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25"
+        tags = "2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24"
     )]
     pub call: ::core::option::Option<os_call::Call>,
 }
@@ -802,11 +802,6 @@ pub mod os_call {
         /// datetime.now(tz) — the timezone argument (absent for a naive result).
         #[prost(message, tag = "24")]
         DateTimeNow(DateTimeNow),
-        /// Re-announced after `Load`: the argument payload was consumed when the
-        /// call was first announced, before the dump was taken. The parent must
-        /// answer from its own records (or with a not-handled error).
-        #[prost(message, tag = "25")]
-        Consumed(super::Unit),
     }
 }
 /// Suspension: the sandbox read an undefined name — typically probing whether

--- a/crates/monty-proto/tests/oracle/monty.v1.rs
+++ b/crates/monty-proto/tests/oracle/monty.v1.rs
@@ -391,10 +391,11 @@ pub struct ResourceLimits {
     pub max_recursion_depth: ::core::option::Option<u64>,
 }
 /// Outcome of an external function / OS call, decided by the parent. Mirrors
-/// monty's `ExtFunctionResult`.
+/// monty's `ExtFunctionResult`, plus `not_handled` (which only the child can
+/// resolve, against its suspended call).
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExtFunctionResult {
-    #[prost(oneof = "ext_function_result::Kind", tags = "1, 2, 3, 4")]
+    #[prost(oneof = "ext_function_result::Kind", tags = "1, 2, 3, 4, 5")]
     pub kind: ::core::option::Option<ext_function_result::Kind>,
 }
 /// Nested message and enum types in `ExtFunctionResult`.
@@ -414,6 +415,12 @@ pub mod ext_function_result {
         /// No handler exists for this name — the child raises NameError.
         #[prost(string, tag = "4")]
         NotFound(::prost::alloc::string::String),
+        /// No handler accepted this OS call — the child raises the call's own
+        /// no-handler default (PermissionError naming the path for filesystem
+        /// calls, RuntimeError for the rest). Only valid answering an `OsCall`
+        /// suspension; the child computes it from its retained call payload.
+        #[prost(message, tag = "5")]
+        NotHandled(super::Unit),
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -658,9 +665,10 @@ pub struct FunctionCall {
 /// file_handle); a mismatched result becomes a Python-level error inside the
 /// sandbox.
 ///
-/// A parent with no handler should answer `ResumeCall` with the call's
-/// not-handled error: PermissionError naming the path for filesystem calls,
-/// RuntimeError for the rest — see monty's `OsFunctionCall::on_no_handler`.
+/// A parent with no handler should answer `ResumeCall` with
+/// `ExtFunctionResult.not_handled`: the child raises the call's own default
+/// (PermissionError naming the path for filesystem calls, RuntimeError for
+/// the rest — monty's `OsFunctionCall::on_no_handler`).
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OsCall {
     #[prost(uint32, tag = "1")]

--- a/crates/monty-proto/tests/roundtrip.rs
+++ b/crates/monty-proto/tests/roundtrip.rs
@@ -706,10 +706,4 @@ fn os_call_conversion_rejects_invalid_payloads() {
         OsFunctionCall::try_from(missing_default),
         Err(ProtoConvertError::MissingField("Getenv.default"))
     ));
-    // A consumed re-announcement carries no call — receivers must match it
-    // before converting.
-    assert!(matches!(
-        OsFunctionCall::try_from(pb::os_call::Call::Consumed(pb::Unit {})),
-        Err(ProtoConvertError::InvalidValue { .. })
-    ));
 }

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -541,13 +541,10 @@ class MontySession:
         if the dump is actually an idle session.
 
         `external_lookup` / `os` are captured for `resume_auto()`, exactly as on
-        `feed_start`. Two caveats apply to a *restored* snapshot: a restored
+        `feed_start`. One caveat applies to a *restored* snapshot: a restored
         `FutureSnapshot`'s pending coroutines are gone (they lived in the
         previous process), so `resume_auto()` on it raises — resolve it manually
-        with `resume({call_id: ...})`; and a re-announced OS-call snapshot
-        carries only its `not_handled_error`, not the original `args`/`kwargs`
-        (those were consumed before the dump), so prefer a manual `resume` /
-        `resume_not_handled` there.
+        with `resume({call_id: ...})`.
         """
 
     def dump(self) -> bytes:

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -492,10 +492,10 @@ class MontySession:
                 (there is no `mount=` on `resume`). `'overlay'` writes live in
                 the pool's per-feed mount table and are discarded when the feed
                 ends.
-            os: Fallback handler for OS calls not covered by a mount, invoked as
-                `(function_name, args, kwargs)`, or an `AbstractOS` instance. It
-                auto-dispatches uncovered OS calls until the next non-OS event;
-                omit it to surface OS calls as snapshots instead.
+            os: Fallback handler for OS calls not covered by a mount, invoked
+                as `(function_name, args, kwargs)`, or an `AbstractOS` instance.
+                Consulted only by `resume_auto()` — `feed_start` always surfaces
+                OS calls as snapshots.
             skip_type_check: Skip type checking for this feed even when the
                 session was checked out with `type_check=True`.
         """
@@ -800,11 +800,10 @@ class AsyncMontySession:
                 (there is no `mount=` on `resume`). `'overlay'` writes live in
                 the pool's per-feed mount table and are discarded when the feed
                 ends.
-            os: Fallback handler for OS calls not covered by a mount, invoked as
-                `(function_name, args, kwargs)`, or an `AbstractOS` instance. It
-                auto-dispatches uncovered OS calls until the next non-OS event;
-                omit it to surface OS calls as snapshots instead. Also captured
-                for `resume_auto()`.
+            os: Fallback handler for OS calls not covered by a mount, invoked
+                as `(function_name, args, kwargs)`, or an `AbstractOS` instance.
+                Consulted only by `resume_auto()` — `feed_start` always surfaces
+                OS calls as snapshots.
             skip_type_check: Skip type checking for this feed even when the
                 session was checked out with `type_check=True`.
         """
@@ -894,30 +893,27 @@ class FunctionSnapshot:
     def args(self) -> tuple[Any, ...]: ...
     @property
     def kwargs(self) -> dict[str, Any]: ...
-    def resume(
-        self,
-        result: ExternalResult,
-        *,
-        os: OsHandler | None = None,
-    ) -> SyncSnapshot:
+    def resume(self, result: ExternalResult) -> SyncSnapshot:
         """Resume with the call's result; resumes at most once.
 
-        Mounts are fixed when the feed starts, so there is no `mount=` here. An
-        `os=` handler auto-dispatches OS calls produced by the continuation
-        until the next non-OS event.
+        Answers only this call: the result is passed straight through, and
+        neither the feed's mounts nor the captured `os=` are consulted. Use
+        `resume_auto()` for those.
         """
 
-    def resume_not_handled(self, *, os: OsHandler | None = None) -> SyncSnapshot:
+    def resume_not_handled(self) -> SyncSnapshot:
         """Resume an OS-call snapshot with monty's default unhandled behaviour."""
 
     def resume_auto(self) -> SyncSnapshot:
-        """Answer this call automatically from the `external_lookup=` / `os=`
-        captured at `feed_start` / `load_snapshot`, then return the next snapshot
-        (or `MontyComplete`). Resumes at most once.
+        """Answer this call automatically, then return the next snapshot (or
+        `MontyComplete`). Resumes at most once.
 
-        A function name absent from `external_lookup` makes the sandbox raise
-        `NameError` (as in `feed_run`). A coroutine external raises `RuntimeError`
-        — use `AsyncMonty` for async externals."""
+        An OS call is offered to the feed's mounts first, falling back to the
+        `os=` captured at `feed_start` / `load_snapshot` and then to monty's
+        unhandled default. An external call is resolved through
+        `external_lookup=`; a name absent from it makes the sandbox raise
+        `NameError` (as in `feed_run`). A coroutine external raises
+        `RuntimeError` — use `AsyncMonty` for async externals."""
 
     def dump(self) -> bytes:
         """Serialize the suspended worker; restore via `MontySession.load_snapshot`."""
@@ -932,12 +928,7 @@ class NameLookupSnapshot:
     def script_name(self) -> str: ...
     @property
     def variable_name(self) -> str: ...
-    def resume(
-        self,
-        *,
-        value: Any = ...,
-        os: OsHandler | None = None,
-    ) -> SyncSnapshot:
+    def resume(self, *, value: Any = ...) -> SyncSnapshot:
         """Resume by binding the name to `value` (any value, including `None`), or
         omit `value` to leave the name undefined and raise `NameError`."""
 
@@ -959,12 +950,7 @@ class FutureSnapshot:
     def script_name(self) -> str: ...
     @property
     def pending_call_ids(self) -> list[int]: ...
-    def resume(
-        self,
-        results: dict[int, ExternalSettledResult],
-        *,
-        os: OsHandler | None = None,
-    ) -> SyncSnapshot:
+    def resume(self, results: dict[int, ExternalSettledResult]) -> SyncSnapshot:
         """Resume with settled results for one or more pending futures (by
         `call_id`); a future cannot resolve to another `future`."""
 
@@ -996,13 +982,8 @@ class AsyncFunctionSnapshot:
     def args(self) -> tuple[Any, ...]: ...
     @property
     def kwargs(self) -> dict[str, Any]: ...
-    async def resume(
-        self,
-        result: ExternalResult,
-        *,
-        os: OsHandler | None = None,
-    ) -> AsyncSnapshot: ...
-    async def resume_not_handled(self, *, os: OsHandler | None = None) -> AsyncSnapshot: ...
+    async def resume(self, result: ExternalResult) -> AsyncSnapshot: ...
+    async def resume_not_handled(self) -> AsyncSnapshot: ...
     async def resume_auto(self) -> AsyncSnapshot:
         """Async sibling of `FunctionSnapshot.resume_auto`. A coroutine external
         is spawned and answered with a pending future, so other sandbox tasks
@@ -1019,12 +1000,7 @@ class AsyncNameLookupSnapshot:
     def script_name(self) -> str: ...
     @property
     def variable_name(self) -> str: ...
-    async def resume(
-        self,
-        *,
-        value: Any = ...,
-        os: OsHandler | None = None,
-    ) -> AsyncSnapshot: ...
+    async def resume(self, *, value: Any = ...) -> AsyncSnapshot: ...
     async def resume_auto(self) -> AsyncSnapshot:
         """Async sibling of `NameLookupSnapshot.resume_auto`."""
 
@@ -1039,12 +1015,7 @@ class AsyncFutureSnapshot:
     def script_name(self) -> str: ...
     @property
     def pending_call_ids(self) -> list[int]: ...
-    async def resume(
-        self,
-        results: dict[int, ExternalSettledResult],
-        *,
-        os: OsHandler | None = None,
-    ) -> AsyncSnapshot: ...
+    async def resume(self, results: dict[int, ExternalSettledResult]) -> AsyncSnapshot: ...
     async def resume_auto(self) -> AsyncSnapshot:
         """Wait for one or more coroutine externals spawned by earlier
         `resume_auto` calls to settle, deliver them, and return the next

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -255,14 +255,14 @@ impl PyMontySession {
     /// resolution. The caller answers with `snapshot.resume(...)` and may
     /// `snapshot.dump()` to checkpoint the worker mid-execution.
     ///
-    /// Unlike [`feed_run`](Self::feed_run), external calls and name lookups are
-    /// surfaced as snapshots rather than auto-dispatched — that is the point of
-    /// `feed_start`. An `external_lookup` (and `os=`) may still be supplied: it
-    /// is *not* consulted during this drive but is captured on the snapshot so
-    /// `snapshot.resume_auto()` can answer subsequent suspensions from it,
-    /// letting a caller iterate to completion without resolving each call by
-    /// hand. An `os=` handler additionally auto-dispatches uncovered OS calls
-    /// until the next non-OS event, exactly as before.
+    /// Unlike [`feed_run`](Self::feed_run), *every* suspension is surfaced as a
+    /// snapshot rather than answered — external calls, name lookups and OS
+    /// calls alike, so even a mount-covered file read comes back as a snapshot.
+    /// That is the point of `feed_start`. An `external_lookup` / `os=` may
+    /// still be supplied: neither is consulted during this drive, but both are
+    /// captured on the snapshot so `snapshot.resume_auto()` can answer
+    /// subsequent suspensions from them (and from this feed's mounts), letting
+    /// a caller iterate to completion without resolving each call by hand.
     #[pyo3(signature = (code, *, inputs=None, external_lookup=None, print_callback=None, mount=None, os=None, skip_type_check=false))]
     #[expect(clippy::too_many_arguments)]
     fn feed_start(
@@ -1163,7 +1163,32 @@ fn drive_sync(py: Python<'_>, args: FeedArgs, external_lookup: Option<&Bound<'_,
         // answer discards the checkout (see `sync_turn_answer`).
         let resume_with = match event {
             TurnEvent::Complete(value) => return monty_to_py(py, &value, &dc_registry),
-            event => match sync_turn_answer(py, event, &lookup, os.as_ref(), &dc_registry) {
+            // This feed's mounts get first refusal on every OS call; only what
+            // they don't cover reaches the `os=` callback.
+            TurnEvent::OsCall {
+                function_name,
+                args,
+                kwargs,
+                ..
+            } => {
+                let (result, print_err) =
+                    py.detach(|| run_turn_blocking(&checkout, &print_target, Checkout::resume_from_mounts));
+                match finalize_turn(py, result, print_err)? {
+                    Some(next) => {
+                        event = next;
+                        continue;
+                    }
+                    None => TurnAnswer::Call(dispatch_os_parts(
+                        py,
+                        &function_name,
+                        &args,
+                        &kwargs,
+                        os.as_ref(),
+                        &dc_registry,
+                    )),
+                }
+            }
+            event => match sync_turn_answer(py, event, &lookup, &dc_registry) {
                 Ok(answer) => answer,
                 Err(err) => {
                     py.detach(|| discard_checkout(&checkout));
@@ -1190,7 +1215,6 @@ fn sync_turn_answer(
     py: Python<'_>,
     event: TurnEvent,
     lookup: &ExternalLookup<'_, '_>,
-    os: Option<&Py<PyAny>>,
     dc_registry: &DcRegistry,
 ) -> PyResult<TurnAnswer> {
     match event {
@@ -1208,22 +1232,11 @@ fn sync_turn_answer(
             };
             Ok(TurnAnswer::Call(ext_to_resume(result)?))
         }
-        TurnEvent::OsCall {
-            function_name,
-            args,
-            kwargs,
-            ..
-        } => Ok(TurnAnswer::Call(dispatch_os_parts(
-            py,
-            &function_name,
-            &args,
-            &kwargs,
-            os,
-            dc_registry,
-        ))),
         TurnEvent::NameLookup { name } => Ok(TurnAnswer::Name(lookup.resolve_name(&name)?)),
         TurnEvent::ResolveFutures { .. } => Err(PyRuntimeError::new_err("async external functions require AsyncMonty")),
-        TurnEvent::Complete(_) => unreachable!("Complete is handled by the drive loop"),
+        TurnEvent::Complete(_) | TurnEvent::OsCall { .. } => {
+            unreachable!("Complete and OsCall are handled by the drive loop")
+        }
     }
 }
 
@@ -1274,13 +1287,23 @@ async fn drive_async(args: FeedArgs, external_lookup: Option<Py<PyDict>>) -> PyR
                 event = run_turn_async(&checkout, &print_target, move |c, p| c.resume_futures(results, p)).await?;
                 continue;
             }
-            event => match async_turn_answer(
-                event,
-                external_lookup.as_ref(),
-                os.as_ref(),
-                &dc_registry,
-                &mut join_set,
-            ) {
+            // Mounts get first refusal, as in `drive_sync`.
+            TurnEvent::OsCall {
+                function_name,
+                args,
+                kwargs,
+                ..
+            } => {
+                if let Some(next) = run_turn_async(&checkout, &print_target, Checkout::resume_from_mounts).await? {
+                    event = next;
+                    continue;
+                }
+                let value = Python::attach(|py| {
+                    dispatch_os_parts(py, &function_name, &args, &kwargs, os.as_ref(), &dc_registry)
+                });
+                TurnAnswer::Call(value)
+            }
+            event => match async_turn_answer(event, external_lookup.as_ref(), &dc_registry, &mut join_set) {
                 Ok(answer) => answer,
                 Err(err) => {
                     discard_checkout_async(&checkout).await;
@@ -1302,7 +1325,6 @@ async fn drive_async(args: FeedArgs, external_lookup: Option<Py<PyDict>>) -> PyR
 fn async_turn_answer(
     event: TurnEvent,
     external_lookup: Option<&Py<PyDict>>,
-    os: Option<&Py<PyAny>>,
     dc_registry: &DcRegistry,
     join_set: &mut JoinSet<(u32, ExtFunctionResult)>,
 ) -> PyResult<TurnAnswer> {
@@ -1327,23 +1349,14 @@ fn async_turn_answer(
                 Ok(TurnAnswer::Call(ResumeValue::Future))
             }
         },
-        TurnEvent::OsCall {
-            function_name,
-            args,
-            kwargs,
-            ..
-        } => {
-            let value = Python::attach(|py| dispatch_os_parts(py, &function_name, &args, &kwargs, os, dc_registry));
-            Ok(TurnAnswer::Call(value))
-        }
         TurnEvent::NameLookup { name } => {
             let value = Python::attach(|py| {
                 ExternalLookup::new(py, external_lookup.map(|d| d.bind(py)), dc_registry).resolve_name(&name)
             })?;
             Ok(TurnAnswer::Name(value))
         }
-        TurnEvent::Complete(_) | TurnEvent::ResolveFutures { .. } => {
-            unreachable!("Complete and ResolveFutures are handled by the drive loop")
+        TurnEvent::Complete(_) | TurnEvent::ResolveFutures { .. } | TurnEvent::OsCall { .. } => {
+            unreachable!("Complete, ResolveFutures and OsCall are handled by the drive loop")
         }
     }
 }
@@ -1363,13 +1376,41 @@ enum TurnAnswer {
     Name(Option<MontyObject>),
 }
 
+/// What a turn helper may return, so one implementation serves both an
+/// ordinary resume ([`TurnEvent`]) and a mount attempt (`Option<TurnEvent>`,
+/// `None` when no mount covered the call).
+///
+/// Only [`run_turn_blocking`]'s print-failure cleanup needs to tell these
+/// apart: it must know whether the worker is left suspended.
+pub(crate) trait TurnOutcome {
+    /// Whether the worker is left waiting for a resume after this outcome.
+    fn left_suspended(&self) -> bool;
+}
+
+impl TurnOutcome for TurnEvent {
+    fn left_suspended(&self) -> bool {
+        matches!(
+            self,
+            Self::FunctionCall { .. } | Self::OsCall { .. } | Self::NameLookup { .. } | Self::ResolveFutures { .. }
+        )
+    }
+}
+
+impl TurnOutcome for Option<TurnEvent> {
+    /// `None` means no mount covered the call and no turn ran, so the OS-call
+    /// suspension the caller already held is still pending.
+    fn left_suspended(&self) -> bool {
+        self.as_ref().is_none_or(TurnEvent::left_suspended)
+    }
+}
+
 /// Runs one protocol turn against the (locked) checkout, streaming prints to
 /// `print_target` and capturing the first print-callback failure.
-pub(crate) fn run_turn_blocking(
+pub(crate) fn run_turn_blocking<T: TurnOutcome>(
     checkout: &SharedCheckout,
     print_target: &PrintTarget,
-    turn: impl FnOnce(&mut Checkout, monty_pool::OnPrint<'_>) -> Result<TurnEvent, PoolError>,
-) -> (Result<TurnEvent, PoolError>, Option<MontyException>) {
+    turn: impl FnOnce(&mut Checkout, monty_pool::OnPrint<'_>) -> Result<T, PoolError>,
+) -> (Result<T, PoolError>, Option<MontyException>) {
     let mut guard = lock(checkout);
     let Some(checkout) = guard.as_mut() else {
         return (Err(PoolError::Finished), None);
@@ -1389,26 +1430,18 @@ pub(crate) fn run_turn_blocking(
     // suspended awaiting a resume the aborted feed will never send, drop the
     // checkout so the session ends cleanly rather than wedging the next feed
     // with a dangling suspension.
-    if print_err.is_some()
-        && matches!(
-            result,
-            Ok(TurnEvent::FunctionCall { .. }
-                | TurnEvent::OsCall { .. }
-                | TurnEvent::NameLookup { .. }
-                | TurnEvent::ResolveFutures { .. })
-        )
-    {
+    if print_err.is_some() && result.as_ref().is_ok_and(TurnOutcome::left_suspended) {
         *guard = None;
     }
     (result, print_err)
 }
 
 /// `spawn_blocking` wrapper around [`run_turn_blocking`] for the async loop.
-pub(crate) async fn run_turn_async(
+pub(crate) async fn run_turn_async<T: TurnOutcome + Send + 'static>(
     checkout: &SharedCheckout,
     print_target: &PrintTarget,
-    turn: impl FnOnce(&mut Checkout, monty_pool::OnPrint<'_>) -> Result<TurnEvent, PoolError> + Send + 'static,
-) -> PyResult<TurnEvent> {
+    turn: impl FnOnce(&mut Checkout, monty_pool::OnPrint<'_>) -> Result<T, PoolError> + Send + 'static,
+) -> PyResult<T> {
     let checkout = Arc::clone(checkout);
     let print_target = print_target.clone_handle_detached();
     let (result, print_err) = spawn_blocking(move || run_turn_blocking(&checkout, &print_target, turn))
@@ -1419,15 +1452,16 @@ pub(crate) async fn run_turn_async(
 
 /// Converts a turn outcome into the next event, surfacing print-callback
 /// failures (which take precedence — they are host-side errors).
-pub(crate) fn finalize_turn(
+pub(crate) fn finalize_turn<T>(
     py: Python<'_>,
-    result: Result<TurnEvent, PoolError>,
+    result: Result<T, PoolError>,
     print_err: Option<MontyException>,
-) -> PyResult<TurnEvent> {
+) -> PyResult<T> {
     if let Some(err) = print_err {
-        return Err(MontyError::new_err(py, err));
+        Err(MontyError::new_err(py, err))
+    } else {
+        result.map_err(|e| pool_err_to_py(py, e))
     }
-    result.map_err(|e| pool_err_to_py(py, e))
 }
 
 // =============================================================================

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -34,7 +34,7 @@ use std::{
     time::Duration,
 };
 
-use ::monty::{AssertMessageAnnotations, ExcType, ExtFunctionResult, MontyException, MontyObject};
+use ::monty::{AssertMessageAnnotations, ExtFunctionResult, MontyException, MontyObject};
 use monty_pool::{Checkout, MountSpec, Pool, PoolConfig, PoolError, ReplConfig, ResumeValue, TurnEvent};
 use monty_proto::python::{DcRegistry, exc_py_to_monty, monty_to_py, py_to_monty_value};
 use pyo3::{
@@ -324,12 +324,10 @@ impl PyMontySession {
     /// `checkout()` is reused. Raises if the dump is actually an idle session.
     ///
     /// `external_lookup` / `os` are captured on the restored snapshot so it
-    /// supports `resume_auto()`, just like `feed_start`. Two caveats apply to a
+    /// supports `resume_auto()`, just like `feed_start`. One caveat applies to a
     /// restored snapshot: a restored `FutureSnapshot`'s pending coroutines are
     /// gone (they lived in the previous process), so async `resume_auto()` on it
-    /// raises — resolve it manually with `resume({call_id: ...})`; and a
-    /// restored OS-call snapshot carries no args/kwargs, so prefer manual
-    /// `resume` / `resume_not_handled` there rather than `resume_auto`.
+    /// raises — resolve it manually with `resume({call_id: ...})`.
     #[pyo3(signature = (state, *, mount=None, print_callback=None, external_lookup=None, os=None))]
     fn load_snapshot(
         &self,
@@ -1217,15 +1215,7 @@ fn sync_turn_answer(
             not_handled_error,
             ..
         } => {
-            let result = dispatch_os_parts(
-                py,
-                &function_name,
-                &args,
-                &kwargs,
-                not_handled_error.as_ref(),
-                os,
-                dc_registry,
-            );
+            let result = dispatch_os_parts(py, &function_name, &args, &kwargs, &not_handled_error, os, dc_registry);
             Ok(TurnAnswer::Call(ext_to_resume(result)?))
         }
         TurnEvent::NameLookup { name } => Ok(TurnAnswer::Name(lookup.resolve_name(&name)?)),
@@ -1342,15 +1332,7 @@ fn async_turn_answer(
             ..
         } => {
             let result = Python::attach(|py| {
-                dispatch_os_parts(
-                    py,
-                    &function_name,
-                    &args,
-                    &kwargs,
-                    not_handled_error.as_ref(),
-                    os,
-                    dc_registry,
-                )
+                dispatch_os_parts(py, &function_name, &args, &kwargs, &not_handled_error, os, dc_registry)
             });
             Ok(TurnAnswer::Call(ext_to_resume(result)?))
         }
@@ -1472,20 +1454,12 @@ pub(crate) fn dispatch_os_parts(
     function_name: &str,
     args: &[MontyObject],
     kwargs: &[(MontyObject, MontyObject)],
-    not_handled_error: Option<&MontyException>,
+    not_handled_error: &MontyException,
     os: Option<&Py<PyAny>>,
     dc_registry: &DcRegistry,
 ) -> ExtFunctionResult {
-    let on_no_handler = || {
-        not_handled_error.cloned().unwrap_or_else(|| {
-            MontyException::new(
-                ExcType::RuntimeError,
-                Some(format!("'{function_name}' is not supported in this environment")),
-            )
-        })
-    };
     let Some(os_callback) = os else {
-        return on_no_handler().into();
+        return not_handled_error.clone().into();
     };
     let call = || -> PyResult<ExtFunctionResult> {
         let py_args: Vec<Py<PyAny>> = args
@@ -1499,7 +1473,7 @@ pub(crate) fn dispatch_os_parts(
         }
         let result = os_callback.bind(py).call1((function_name, py_args, py_kwargs))?;
         if result.is(get_not_handled(py)?.bind(py)) {
-            return Ok(on_no_handler().into());
+            return Ok(not_handled_error.clone().into());
         }
         Ok(match py_to_monty_value(&result, dc_registry) {
             Ok(obj) => ExtFunctionResult::Return(obj),

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -1212,12 +1212,15 @@ fn sync_turn_answer(
             function_name,
             args,
             kwargs,
-            not_handled_error,
             ..
-        } => {
-            let result = dispatch_os_parts(py, &function_name, &args, &kwargs, &not_handled_error, os, dc_registry);
-            Ok(TurnAnswer::Call(ext_to_resume(result)?))
-        }
+        } => Ok(TurnAnswer::Call(dispatch_os_parts(
+            py,
+            &function_name,
+            &args,
+            &kwargs,
+            os,
+            dc_registry,
+        ))),
         TurnEvent::NameLookup { name } => Ok(TurnAnswer::Name(lookup.resolve_name(&name)?)),
         TurnEvent::ResolveFutures { .. } => Err(PyRuntimeError::new_err("async external functions require AsyncMonty")),
         TurnEvent::Complete(_) => unreachable!("Complete is handled by the drive loop"),
@@ -1328,13 +1331,10 @@ fn async_turn_answer(
             function_name,
             args,
             kwargs,
-            not_handled_error,
             ..
         } => {
-            let result = Python::attach(|py| {
-                dispatch_os_parts(py, &function_name, &args, &kwargs, &not_handled_error, os, dc_registry)
-            });
-            Ok(TurnAnswer::Call(ext_to_resume(result)?))
+            let value = Python::attach(|py| dispatch_os_parts(py, &function_name, &args, &kwargs, os, dc_registry));
+            Ok(TurnAnswer::Call(value))
         }
         TurnEvent::NameLookup { name } => {
             let value = Python::attach(|py| {
@@ -1447,21 +1447,20 @@ pub(crate) fn ext_to_resume(result: ExtFunctionResult) -> PyResult<ResumeValue> 
 }
 
 /// Calls the Python `os=` fallback for a bubbled OS call. With no callback —
-/// or when it returns `NOT_HANDLED` — answers with the pool-computed
-/// `not_handled_error`, preserving monty's per-call no-handler semantics.
+/// or when it returns `NOT_HANDLED` — answers [`ResumeValue::NotHandled`], so
+/// the sandbox raises monty's per-call no-handler default itself.
 pub(crate) fn dispatch_os_parts(
     py: Python<'_>,
     function_name: &str,
     args: &[MontyObject],
     kwargs: &[(MontyObject, MontyObject)],
-    not_handled_error: &MontyException,
     os: Option<&Py<PyAny>>,
     dc_registry: &DcRegistry,
-) -> ExtFunctionResult {
+) -> ResumeValue {
     let Some(os_callback) = os else {
-        return not_handled_error.clone().into();
+        return ResumeValue::NotHandled;
     };
-    let call = || -> PyResult<ExtFunctionResult> {
+    let call = || -> PyResult<ResumeValue> {
         let py_args: Vec<Py<PyAny>> = args
             .iter()
             .map(|arg| monty_to_py(py, arg, dc_registry))
@@ -1473,14 +1472,14 @@ pub(crate) fn dispatch_os_parts(
         }
         let result = os_callback.bind(py).call1((function_name, py_args, py_kwargs))?;
         if result.is(get_not_handled(py)?.bind(py)) {
-            return Ok(not_handled_error.clone().into());
+            return Ok(ResumeValue::NotHandled);
         }
         Ok(match py_to_monty_value(&result, dc_registry) {
-            Ok(obj) => ExtFunctionResult::Return(obj),
-            Err(exc) => ExtFunctionResult::Error(exc),
+            Ok(obj) => ResumeValue::Return(obj),
+            Err(exc) => ResumeValue::Error(exc),
         })
     };
-    call().unwrap_or_else(|err| ExtFunctionResult::Error(exc_py_to_monty(py, &err)))
+    call().unwrap_or_else(|err| ResumeValue::Error(exc_py_to_monty(py, &err)))
 }
 
 /// Extracts `MountDir | list[MountDir] | None` into mount specs for the pool,

--- a/crates/monty-python/src/snapshot.rs
+++ b/crates/monty-python/src/snapshot.rs
@@ -213,19 +213,9 @@ fn drive_sync(
                 function_name,
                 args,
                 kwargs,
-                not_handled_error,
                 ..
             } if os.is_some() => {
-                let result = dispatch_os_parts(
-                    py,
-                    &function_name,
-                    &args,
-                    &kwargs,
-                    &not_handled_error,
-                    os.as_ref(),
-                    &ctx.dc_registry,
-                );
-                let resume = ext_result_to_resume(result);
+                let resume = dispatch_os_parts(py, &function_name, &args, &kwargs, os.as_ref(), &ctx.dc_registry);
                 let (result, print_err) =
                     py.detach(|| run_turn_blocking(&ctx.checkout, &ctx.print_target, move |c, p| c.resume(resume, p)));
                 event = finalize_turn(py, result, print_err)?;
@@ -249,20 +239,10 @@ async fn drive_async(
                 function_name,
                 args,
                 kwargs,
-                not_handled_error,
                 ..
             } if os.is_some() => {
                 let resume = Python::attach(|py| {
-                    let result = dispatch_os_parts(
-                        py,
-                        &function_name,
-                        &args,
-                        &kwargs,
-                        &not_handled_error,
-                        os.as_ref(),
-                        &ctx.dc_registry,
-                    );
-                    ext_result_to_resume(result)
+                    dispatch_os_parts(py, &function_name, &args, &kwargs, os.as_ref(), &ctx.dc_registry)
                 });
                 event = run_turn_async(&ctx.checkout, &ctx.print_target, move |c, p| c.resume(resume, p)).await?;
             }
@@ -301,8 +281,8 @@ pub(crate) fn build_snapshot(
                 args,
                 kwargs,
                 call_id,
+                is_os_function: false,
                 is_method_call: method_call,
-                not_handled_error: None,
             };
             function_snapshot_py(py, ctx, call, is_async)
         }
@@ -311,15 +291,14 @@ pub(crate) fn build_snapshot(
             args,
             kwargs,
             call_id,
-            not_handled_error,
         } => {
             let call = FunctionCallData {
                 function_name,
                 args,
                 kwargs,
                 call_id,
+                is_os_function: true,
                 is_method_call: false,
-                not_handled_error: Some(not_handled_error),
             };
             function_snapshot_py(py, ctx, call, is_async)
         }
@@ -540,18 +519,8 @@ struct FunctionCallData {
     args: Vec<MontyObject>,
     kwargs: Vec<(MontyObject, MontyObject)>,
     call_id: u32,
+    is_os_function: bool,
     is_method_call: bool,
-    /// The exception the sandbox would raise with no handler — always present
-    /// for OS calls (which is what distinguishes them from external function
-    /// calls), and consumed by `resume_not_handled`.
-    not_handled_error: Option<MontyException>,
-}
-
-impl FunctionCallData {
-    /// Whether this is an OS call (vs an external function call).
-    fn is_os_function(&self) -> bool {
-        self.not_handled_error.is_some()
-    }
 }
 
 struct FunctionSnapshot {
@@ -564,12 +533,16 @@ impl FunctionSnapshot {
         parse_external_result(py, result, &self.snapshot.ctx.dc_registry)
     }
 
+    /// `ResumeValue::NotHandled` for an OS-call snapshot: the sandbox raises
+    /// the call's own no-handler default.
     fn not_handled_value(&self) -> PyResult<ResumeValue> {
-        let exc =
-            self.call.not_handled_error.clone().ok_or_else(|| {
-                PyRuntimeError::new_err("resume_not_handled() is only valid for OS function snapshots")
-            })?;
-        Ok(ResumeValue::Error(exc))
+        if self.call.is_os_function {
+            Ok(ResumeValue::NotHandled)
+        } else {
+            Err(PyRuntimeError::new_err(
+                "resume_not_handled() is only valid for OS function snapshots",
+            ))
+        }
     }
 }
 
@@ -587,7 +560,7 @@ impl PyFunctionSnapshot {
 
     #[getter]
     fn is_os_function(&self) -> bool {
-        self.0.call.is_os_function()
+        self.0.call.is_os_function
     }
 
     #[getter]
@@ -642,13 +615,12 @@ impl PyFunctionSnapshot {
     fn resume_auto(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let ctx = self.0.snapshot.claim(py)?;
         let call = &self.0.call;
-        let result = if let Some(not_handled_error) = &call.not_handled_error {
+        let value = if call.is_os_function {
             dispatch_os_parts(
                 py,
                 &call.function_name,
                 &call.args,
                 &call.kwargs,
-                not_handled_error,
                 ctx.os.as_ref(),
                 &ctx.dc_registry,
             )
@@ -661,7 +633,7 @@ impl PyFunctionSnapshot {
                 ctx.external_lookup.as_ref(),
                 &ctx.dc_registry,
             ) {
-                CallResult::Sync(result) => result,
+                CallResult::Sync(result) => ext_result_to_resume(result),
                 CallResult::Coroutine(coro) => {
                     // Close the un-awaited coroutine so it doesn't leak a
                     // "coroutine was never awaited" ResourceWarning: a sync
@@ -672,7 +644,6 @@ impl PyFunctionSnapshot {
                 }
             }
         };
-        let value = ext_result_to_resume(result);
         let os = ctx.clone_os(py);
         drive_sync(py, ctx, os, move |c, p| c.resume(value, p))
     }
@@ -684,8 +655,7 @@ impl PyFunctionSnapshot {
     fn __repr__(&self) -> String {
         format!(
             "FunctionSnapshot(function_name={:?}, is_os_function={})",
-            self.0.call.function_name,
-            self.0.call.is_os_function()
+            self.0.call.function_name, self.0.call.is_os_function
         )
     }
 }
@@ -704,7 +674,7 @@ impl PyAsyncFunctionSnapshot {
 
     #[getter]
     fn is_os_function(&self) -> bool {
-        self.0.call.is_os_function()
+        self.0.call.is_os_function
     }
 
     #[getter]
@@ -768,19 +738,17 @@ impl PyAsyncFunctionSnapshot {
         future_into_py(py, async move {
             // Dispatch inside the future: a coroutine's `into_future` needs the
             // asyncio task-locals that `future_into_py`'s scope establishes.
-            let answer: PyResult<ResumeValue> = if let Some(not_handled_error) = &call.not_handled_error {
-                let result = Python::attach(|py| {
+            let answer: PyResult<ResumeValue> = if call.is_os_function {
+                Ok(Python::attach(|py| {
                     dispatch_os_parts(
                         py,
                         &call.function_name,
                         &call.args,
                         &call.kwargs,
-                        not_handled_error,
                         ctx.os.as_ref(),
                         &ctx.dc_registry,
                     )
-                });
-                Ok(ext_result_to_resume(result))
+                }))
             } else {
                 match dispatch_function_call(
                     &call.function_name,
@@ -817,8 +785,7 @@ impl PyAsyncFunctionSnapshot {
     fn __repr__(&self) -> String {
         format!(
             "AsyncFunctionSnapshot(function_name={:?}, is_os_function={})",
-            self.0.call.function_name,
-            self.0.call.is_os_function()
+            self.0.call.function_name, self.0.call.is_os_function
         )
     }
 }

--- a/crates/monty-python/src/snapshot.rs
+++ b/crates/monty-python/src/snapshot.rs
@@ -15,14 +15,14 @@
 //! owned, freely-copyable state: only one suspension is live per session, each
 //! snapshot resumes at most once, and `resume` advances that worker forward.
 //!
-//! When a caller supplies an `os=` handler, OS calls the mounts don't cover are
-//! auto-dispatched through it (reusing the `feed_run` path) until the next
-//! non-OS event, matching the old behaviour. Mounts are fixed for the whole
-//! feed (passed to `feed_start`), so `resume` takes no `mount=`. Restoring a
-//! suspended feed with `load_snapshot` re-establishes those mounts — the
-//! caller re-supplies them (they are never part of the dump) and the pool
-//! services the restored feed's mount-covered file access on the parent side
-//! exactly as before the dump.
+//! Every suspension surfaces, OS calls included — `feed_start` never answers
+//! one for you, so a mounted file read comes back as a `FunctionSnapshot` with
+//! `is_os_function` set. The captured `external_lookup=` / `os=` and the feed's
+//! mounts are consulted only by `resume_auto`, which offers an OS call to the
+//! mounts first and falls back to `os=`. Mounts are fixed for the whole feed
+//! (passed to `feed_start`), so `resume` takes no `mount=`. Restoring a
+//! suspended feed with `load_snapshot` re-establishes those mounts — the caller
+//! re-supplies them, as they are never part of the dump.
 
 use std::{
     convert::Infallible,
@@ -66,8 +66,8 @@ use crate::{
 /// `feed_start` / `load_snapshot` and a session-persistent pool of pending
 /// coroutine externals: these back [`resume_auto`](PyFunctionSnapshot::resume_auto),
 /// which answers each suspension automatically instead of surfacing it to the
-/// caller. Plain `resume(...)` ignores `external_lookup` and takes its own
-/// per-call `os=`, so these fields only matter to `resume_auto`.
+/// caller. Plain `resume(...)` takes an explicit answer, so these fields only
+/// matter to `resume_auto`.
 pub(crate) struct DriveContext {
     checkout: SharedCheckout,
     dc_registry: DcRegistry,
@@ -76,10 +76,8 @@ pub(crate) struct DriveContext {
     /// `external_lookup=` captured at `feed_start` / `load_snapshot`; consulted
     /// only by `resume_auto` (plain `resume` never looks names up here).
     external_lookup: Option<Py<PyDict>>,
-    /// `os=` captured at `feed_start` / `load_snapshot`; used by `resume_auto`
-    /// and by the initial feed drive's OS auto-dispatch. Plain
-    /// `resume(*, os=None)` keeps its per-call argument and never falls back to
-    /// this.
+    /// `os=` captured at `feed_start` / `load_snapshot`; consulted only by
+    /// `resume_auto`, and only for OS calls this feed's mounts don't cover.
     os: Option<Py<PyAny>>,
     /// Pending coroutine externals spawned by async `resume_auto`, keyed by
     /// `call_id`. `Arc` so every `clone_ref`'d snapshot of one session shares a
@@ -120,11 +118,6 @@ impl DriveContext {
             pending_futures: Arc::clone(&self.pending_futures),
         }
     }
-
-    /// Clones the captured `os=` handle for a per-drive `os` argument.
-    fn clone_os(&self, py: Python<'_>) -> Option<Py<PyAny>> {
-        self.os.as_ref().map(|o| o.clone_ref(py))
-    }
 }
 
 // =============================================================================
@@ -132,9 +125,9 @@ impl DriveContext {
 // =============================================================================
 
 /// Runs the first feed turn synchronously and returns the resulting snapshot
-/// (or [`MontyComplete`]). `external_lookup` is stored on the [`DriveContext`]
-/// for later `resume_auto` calls; the initial drive still surfaces external
-/// calls as snapshots (only OS calls auto-dispatch through `os=`).
+/// (or [`MontyComplete`]). `external_lookup` / `os` are stored on the
+/// [`DriveContext`] for later `resume_auto` calls; every suspension the feed
+/// reaches — OS calls included — surfaces as a snapshot.
 pub(crate) fn feed_start_sync(
     py: Python<'_>,
     args: FeedArgs,
@@ -152,10 +145,7 @@ pub(crate) fn feed_start_sync(
         dc_registry,
     } = args;
     let ctx = DriveContext::new(checkout, dc_registry, print_target, script_name, external_lookup, os);
-    let os_for_drive = ctx.clone_os(py);
-    drive_sync(py, ctx, os_for_drive, move |c, p| {
-        c.feed(&code, inputs, mounts, skip_type_check, p)
-    })
+    drive_sync(py, ctx, move |c, p| c.feed(&code, inputs, mounts, skip_type_check, p))
 }
 
 /// Async counterpart of [`feed_start_sync`]: the returned coroutine runs the
@@ -178,77 +168,47 @@ pub(crate) fn feed_start_async(
         dc_registry,
     } = args;
     let ctx = DriveContext::new(checkout, dc_registry, print_target, script_name, external_lookup, os);
-    let os_for_drive = ctx.clone_os(py);
     future_into_py(py, async move {
-        drive_async(ctx, os_for_drive, move |c, p| {
-            c.feed(&code, inputs, mounts, skip_type_check, p)
-        })
-        .await
+        drive_async(ctx, move |c, p| c.feed(&code, inputs, mounts, skip_type_check, p)).await
     })
 }
 
 // =============================================================================
-// Drive loops: run one turn, auto-dispatch OS calls, then build the snapshot
+// Drive loops: run one turn, then build the snapshot for whatever it reached
 // =============================================================================
 
-/// Runs `initial` (a feed or resume turn) and any OS auto-dispatch turns it
-/// produces — with the GIL released for each worker round-trip — until a
-/// caller-visible event is reached, then builds the matching Python object.
+/// Runs `initial` (a feed or resume turn) with the GIL released, then builds
+/// the Python object for whatever event it reaches.
 ///
-/// Takes `os` by value (rather than by reference) so the pyclass `resume`
-/// methods, which receive it by value from pyo3, can hand it straight through
-/// without a `needless_pass_by_value` lint at every call site.
-#[expect(clippy::needless_pass_by_value)]
+/// Every suspension — OS calls included — surfaces to the caller. Nothing is
+/// answered automatically here; `resume_auto` is where mounts and the captured
+/// `os=` come in.
 fn drive_sync(
     py: Python<'_>,
     ctx: DriveContext,
-    os: Option<Py<PyAny>>,
     initial: impl FnOnce(&mut Checkout, OnPrint<'_>) -> Result<TurnEvent, PoolError> + Send,
 ) -> PyResult<Py<PyAny>> {
     let (result, print_err) = py.detach(|| run_turn_blocking(&ctx.checkout, &ctx.print_target, initial));
-    let mut event = finalize_turn(py, result, print_err)?;
-    loop {
-        match event {
-            TurnEvent::OsCall {
-                function_name,
-                args,
-                kwargs,
-                ..
-            } if os.is_some() => {
-                let resume = dispatch_os_parts(py, &function_name, &args, &kwargs, os.as_ref(), &ctx.dc_registry);
-                let (result, print_err) =
-                    py.detach(|| run_turn_blocking(&ctx.checkout, &ctx.print_target, move |c, p| c.resume(resume, p)));
-                event = finalize_turn(py, result, print_err)?;
-            }
-            other => break build_snapshot(py, ctx, other, false),
-        }
-    }
+    let event = finalize_turn(py, result, print_err)?;
+    build_snapshot(py, ctx, event, false)
 }
 
-/// Async counterpart of [`drive_sync`]: worker turns run via `spawn_blocking`
-/// and OS auto-dispatch re-attaches the GIL for the callback.
+/// Async counterpart of [`drive_sync`]: the worker turn runs via
+/// `spawn_blocking`.
 async fn drive_async(
     ctx: DriveContext,
-    os: Option<Py<PyAny>>,
     initial: impl FnOnce(&mut Checkout, OnPrint<'_>) -> Result<TurnEvent, PoolError> + Send + 'static,
 ) -> PyResult<Py<PyAny>> {
-    let mut event = run_turn_async(&ctx.checkout, &ctx.print_target, initial).await?;
-    loop {
-        match event {
-            TurnEvent::OsCall {
-                function_name,
-                args,
-                kwargs,
-                ..
-            } if os.is_some() => {
-                let resume = Python::attach(|py| {
-                    dispatch_os_parts(py, &function_name, &args, &kwargs, os.as_ref(), &ctx.dc_registry)
-                });
-                event = run_turn_async(&ctx.checkout, &ctx.print_target, move |c, p| c.resume(resume, p)).await?;
-            }
-            other => return Python::attach(|py| build_snapshot(py, ctx, other, true)),
-        }
-    }
+    let event = run_turn_async(&ctx.checkout, &ctx.print_target, initial).await?;
+    Python::attach(|py| build_snapshot(py, ctx, event, true))
+}
+
+/// Answers a suspended OS call from the feed's mounts, returning the next
+/// event when one covered it and `None` when the caller must answer it itself.
+fn try_mounts_sync(py: Python<'_>, ctx: &DriveContext) -> PyResult<Option<TurnEvent>> {
+    let (result, print_err) =
+        py.detach(|| run_turn_blocking(&ctx.checkout, &ctx.print_target, Checkout::resume_from_mounts));
+    finalize_turn(py, result, print_err)
 }
 
 /// Builds the Python object for a caller-visible turn event: a snapshot for a
@@ -589,33 +549,34 @@ impl PyFunctionSnapshot {
     }
 
     /// Resumes execution with an `ExternalResult` (return value, exception, or
-    /// future). Resumes once; OS calls produced by the continuation are
-    /// auto-dispatched through `os=` until the next non-OS event.
-    #[pyo3(signature = (result, *, os=None))]
-    fn resume(&self, py: Python<'_>, result: &Bound<'_, PyDict>, os: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
+    /// future), returning the next snapshot or [`MontyComplete`]. Resumes once.
+    fn resume(&self, py: Python<'_>, result: &Bound<'_, PyDict>) -> PyResult<Py<PyAny>> {
         let value = self.0.resume_value(py, result)?;
         let ctx = self.0.snapshot.claim(py)?;
-        drive_sync(py, ctx, os, move |c, p| c.resume(value, p))
+        drive_sync(py, ctx, move |c, p| c.resume(value, p))
     }
 
     /// Resumes an OS-call snapshot with monty's default unhandled-OS behaviour.
-    #[pyo3(signature = (*, os=None))]
-    fn resume_not_handled(&self, py: Python<'_>, os: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
+    fn resume_not_handled(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let value = self.0.not_handled_value()?;
         let ctx = self.0.snapshot.claim(py)?;
-        drive_sync(py, ctx, os, move |c, p| c.resume(value, p))
+        drive_sync(py, ctx, move |c, p| c.resume(value, p))
     }
 
-    /// Answers this call automatically from the `external_lookup=` / `os=`
-    /// captured at `feed_start` / `load_snapshot`, then drives to the next
-    /// snapshot (or [`MontyComplete`]). A function name absent from
-    /// `external_lookup` resolves to `NotFound`, so the sandbox raises
-    /// `NameError` — matching `feed_run`. A coroutine external raises
-    /// `RuntimeError` (async externals need `AsyncMonty`). Consumes the snapshot.
+    /// Answers this call automatically, then drives to the next snapshot (or
+    /// [`MontyComplete`]). An OS call is offered to the feed's mounts first and
+    /// falls back to the `os=` captured at `feed_start` / `load_snapshot`; an
+    /// external call is resolved through `external_lookup=`, and a name absent
+    /// from it resolves to `NotFound` so the sandbox raises `NameError` —
+    /// matching `feed_run`. A coroutine external raises `RuntimeError` (async
+    /// externals need `AsyncMonty`). Consumes the snapshot.
     fn resume_auto(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let ctx = self.0.snapshot.claim(py)?;
         let call = &self.0.call;
         let value = if call.is_os_function {
+            if let Some(event) = try_mounts_sync(py, &ctx)? {
+                return build_snapshot(py, ctx, event, false);
+            }
             dispatch_os_parts(
                 py,
                 &call.function_name,
@@ -644,8 +605,7 @@ impl PyFunctionSnapshot {
                 }
             }
         };
-        let os = ctx.clone_os(py);
-        drive_sync(py, ctx, os, move |c, p| c.resume(value, p))
+        drive_sync(py, ctx, move |c, p| c.resume(value, p))
     }
 
     fn dump(&self, py: Python<'_>) -> PyResult<Py<PyBytes>> {
@@ -702,28 +662,21 @@ impl PyAsyncFunctionSnapshot {
         kwargs_to_py(py, &self.0.call.kwargs, &self.0.snapshot.ctx.dc_registry)
     }
 
-    #[pyo3(signature = (result, *, os=None))]
-    fn resume<'py>(
-        &self,
-        py: Python<'py>,
-        result: &Bound<'_, PyDict>,
-        os: Option<Py<PyAny>>,
-    ) -> PyResult<Bound<'py, PyAny>> {
+    fn resume<'py>(&self, py: Python<'py>, result: &Bound<'_, PyDict>) -> PyResult<Bound<'py, PyAny>> {
         let value = self.0.resume_value(py, result)?;
         let ctx = self.0.snapshot.claim(py)?;
         future_into_py(
             py,
-            async move { drive_async(ctx, os, move |c, p| c.resume(value, p)).await },
+            async move { drive_async(ctx, move |c, p| c.resume(value, p)).await },
         )
     }
 
-    #[pyo3(signature = (*, os=None))]
-    fn resume_not_handled<'py>(&self, py: Python<'py>, os: Option<Py<PyAny>>) -> PyResult<Bound<'py, PyAny>> {
+    fn resume_not_handled<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let value = self.0.not_handled_value()?;
         let ctx = self.0.snapshot.claim(py)?;
         future_into_py(
             py,
-            async move { drive_async(ctx, os, move |c, p| c.resume(value, p)).await },
+            async move { drive_async(ctx, move |c, p| c.resume(value, p)).await },
         )
     }
 
@@ -739,16 +692,20 @@ impl PyAsyncFunctionSnapshot {
             // Dispatch inside the future: a coroutine's `into_future` needs the
             // asyncio task-locals that `future_into_py`'s scope establishes.
             let answer: PyResult<ResumeValue> = if call.is_os_function {
-                Ok(Python::attach(|py| {
-                    dispatch_os_parts(
-                        py,
-                        &call.function_name,
-                        &call.args,
-                        &call.kwargs,
-                        ctx.os.as_ref(),
-                        &ctx.dc_registry,
-                    )
-                }))
+                // mounts get first refusal, then the captured `os=`
+                match run_turn_async(&ctx.checkout, &ctx.print_target, Checkout::resume_from_mounts).await? {
+                    Some(event) => return Python::attach(|py| build_snapshot(py, ctx, event, true)),
+                    None => Ok(Python::attach(|py| {
+                        dispatch_os_parts(
+                            py,
+                            &call.function_name,
+                            &call.args,
+                            &call.kwargs,
+                            ctx.os.as_ref(),
+                            &ctx.dc_registry,
+                        )
+                    })),
+                }
             } else {
                 match dispatch_function_call(
                     &call.function_name,
@@ -773,8 +730,7 @@ impl PyAsyncFunctionSnapshot {
                     return Err(err);
                 }
             };
-            let os = Python::attach(|py| ctx.clone_os(py));
-            drive_async(ctx, os, move |c, p| c.resume(value, p)).await
+            drive_async(ctx, move |c, p| c.resume(value, p)).await
         })
     }
 
@@ -852,11 +808,11 @@ impl PyNameLookupSnapshot {
         &self.0.name
     }
 
-    #[pyo3(signature = (*, value=MaybeValue::Unset, os=None))]
-    fn resume(&self, py: Python<'_>, value: MaybeValue<'_>, os: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
+    #[pyo3(signature = (*, value=MaybeValue::Unset))]
+    fn resume(&self, py: Python<'_>, value: MaybeValue<'_>) -> PyResult<Py<PyAny>> {
         let value = self.0.resume_value(py, value)?;
         let ctx = self.0.snapshot.claim(py)?;
-        drive_sync(py, ctx, os, move |c, p| c.resume_name_lookup(value, p))
+        drive_sync(py, ctx, move |c, p| c.resume_name_lookup(value, p))
     }
 
     /// Answers this name lookup automatically from the captured
@@ -872,8 +828,7 @@ impl PyNameLookupSnapshot {
                 return Err(err);
             }
         };
-        let os = ctx.clone_os(py);
-        drive_sync(py, ctx, os, move |c, p| c.resume_name_lookup(value, p))
+        drive_sync(py, ctx, move |c, p| c.resume_name_lookup(value, p))
     }
 
     fn dump(&self, py: Python<'_>) -> PyResult<Py<PyBytes>> {
@@ -901,17 +856,12 @@ impl PyAsyncNameLookupSnapshot {
         &self.0.name
     }
 
-    #[pyo3(signature = (*, value=MaybeValue::Unset, os=None))]
-    fn resume<'py>(
-        &self,
-        py: Python<'py>,
-        value: MaybeValue<'_>,
-        os: Option<Py<PyAny>>,
-    ) -> PyResult<Bound<'py, PyAny>> {
+    #[pyo3(signature = (*, value=MaybeValue::Unset))]
+    fn resume<'py>(&self, py: Python<'py>, value: MaybeValue<'_>) -> PyResult<Bound<'py, PyAny>> {
         let value = self.0.resume_value(py, value)?;
         let ctx = self.0.snapshot.claim(py)?;
         future_into_py(py, async move {
-            drive_async(ctx, os, move |c, p| c.resume_name_lookup(value, p)).await
+            drive_async(ctx, move |c, p| c.resume_name_lookup(value, p)).await
         })
     }
 
@@ -927,8 +877,7 @@ impl PyAsyncNameLookupSnapshot {
                     return Err(err);
                 }
             };
-            let os = Python::attach(|py| ctx.clone_os(py));
-            drive_async(ctx, os, move |c, p| c.resume_name_lookup(value, p)).await
+            drive_async(ctx, move |c, p| c.resume_name_lookup(value, p)).await
         })
     }
 
@@ -994,11 +943,10 @@ impl PyFutureSnapshot {
         self.0.pending_call_ids.clone()
     }
 
-    #[pyo3(signature = (results, *, os=None))]
-    fn resume(&self, py: Python<'_>, results: &Bound<'_, PyDict>, os: Option<Py<PyAny>>) -> PyResult<Py<PyAny>> {
+    fn resume(&self, py: Python<'_>, results: &Bound<'_, PyDict>) -> PyResult<Py<PyAny>> {
         let resolved = self.0.resume_values(py, results)?;
         let ctx = self.0.snapshot.claim(py)?;
-        drive_sync(py, ctx, os, move |c, p| c.resume_futures(resolved, p))
+        drive_sync(py, ctx, move |c, p| c.resume_futures(resolved, p))
     }
 
     /// Sync sessions have no event loop to drive coroutine externals, so this
@@ -1034,17 +982,11 @@ impl PyAsyncFutureSnapshot {
         self.0.pending_call_ids.clone()
     }
 
-    #[pyo3(signature = (results, *, os=None))]
-    fn resume<'py>(
-        &self,
-        py: Python<'py>,
-        results: &Bound<'_, PyDict>,
-        os: Option<Py<PyAny>>,
-    ) -> PyResult<Bound<'py, PyAny>> {
+    fn resume<'py>(&self, py: Python<'py>, results: &Bound<'_, PyDict>) -> PyResult<Bound<'py, PyAny>> {
         let resolved = self.0.resume_values(py, results)?;
         let ctx = self.0.snapshot.claim(py)?;
         future_into_py(py, async move {
-            drive_async(ctx, os, move |c, p| c.resume_futures(resolved, p)).await
+            drive_async(ctx, move |c, p| c.resume_futures(resolved, p)).await
         })
     }
 
@@ -1073,8 +1015,7 @@ impl PyAsyncFutureSnapshot {
                     return Err(err);
                 }
             };
-            let os = Python::attach(|py| ctx.clone_os(py));
-            drive_async(ctx, os, move |c, p| c.resume_futures(results, p)).await
+            drive_async(ctx, move |c, p| c.resume_futures(results, p)).await
         })
     }
 

--- a/crates/monty-python/src/snapshot.rs
+++ b/crates/monty-python/src/snapshot.rs
@@ -221,7 +221,7 @@ fn drive_sync(
                     &function_name,
                     &args,
                     &kwargs,
-                    not_handled_error.as_ref(),
+                    &not_handled_error,
                     os.as_ref(),
                     &ctx.dc_registry,
                 );
@@ -258,7 +258,7 @@ async fn drive_async(
                         &function_name,
                         &args,
                         &kwargs,
-                        not_handled_error.as_ref(),
+                        &not_handled_error,
                         os.as_ref(),
                         &ctx.dc_registry,
                     );
@@ -301,7 +301,6 @@ pub(crate) fn build_snapshot(
                 args,
                 kwargs,
                 call_id,
-                is_os_function: false,
                 is_method_call: method_call,
                 not_handled_error: None,
             };
@@ -319,9 +318,8 @@ pub(crate) fn build_snapshot(
                 args,
                 kwargs,
                 call_id,
-                is_os_function: true,
                 is_method_call: false,
-                not_handled_error,
+                not_handled_error: Some(not_handled_error),
             };
             function_snapshot_py(py, ctx, call, is_async)
         }
@@ -542,11 +540,18 @@ struct FunctionCallData {
     args: Vec<MontyObject>,
     kwargs: Vec<(MontyObject, MontyObject)>,
     call_id: u32,
-    is_os_function: bool,
     is_method_call: bool,
-    /// The exception the sandbox would raise with no handler — present only for
-    /// OS calls, and consumed by `resume_not_handled`.
+    /// The exception the sandbox would raise with no handler — always present
+    /// for OS calls (which is what distinguishes them from external function
+    /// calls), and consumed by `resume_not_handled`.
     not_handled_error: Option<MontyException>,
+}
+
+impl FunctionCallData {
+    /// Whether this is an OS call (vs an external function call).
+    fn is_os_function(&self) -> bool {
+        self.not_handled_error.is_some()
+    }
 }
 
 struct FunctionSnapshot {
@@ -560,16 +565,10 @@ impl FunctionSnapshot {
     }
 
     fn not_handled_value(&self) -> PyResult<ResumeValue> {
-        if !self.call.is_os_function {
-            return Err(PyRuntimeError::new_err(
-                "resume_not_handled() is only valid for OS function snapshots",
-            ));
-        }
-        let exc = self
-            .call
-            .not_handled_error
-            .clone()
-            .ok_or_else(|| PyRuntimeError::new_err("OS snapshot has no default unhandled error"))?;
+        let exc =
+            self.call.not_handled_error.clone().ok_or_else(|| {
+                PyRuntimeError::new_err("resume_not_handled() is only valid for OS function snapshots")
+            })?;
         Ok(ResumeValue::Error(exc))
     }
 }
@@ -588,7 +587,7 @@ impl PyFunctionSnapshot {
 
     #[getter]
     fn is_os_function(&self) -> bool {
-        self.0.call.is_os_function
+        self.0.call.is_os_function()
     }
 
     #[getter]
@@ -643,13 +642,13 @@ impl PyFunctionSnapshot {
     fn resume_auto(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let ctx = self.0.snapshot.claim(py)?;
         let call = &self.0.call;
-        let result = if call.is_os_function {
+        let result = if let Some(not_handled_error) = &call.not_handled_error {
             dispatch_os_parts(
                 py,
                 &call.function_name,
                 &call.args,
                 &call.kwargs,
-                call.not_handled_error.as_ref(),
+                not_handled_error,
                 ctx.os.as_ref(),
                 &ctx.dc_registry,
             )
@@ -685,7 +684,8 @@ impl PyFunctionSnapshot {
     fn __repr__(&self) -> String {
         format!(
             "FunctionSnapshot(function_name={:?}, is_os_function={})",
-            self.0.call.function_name, self.0.call.is_os_function
+            self.0.call.function_name,
+            self.0.call.is_os_function()
         )
     }
 }
@@ -704,7 +704,7 @@ impl PyAsyncFunctionSnapshot {
 
     #[getter]
     fn is_os_function(&self) -> bool {
-        self.0.call.is_os_function
+        self.0.call.is_os_function()
     }
 
     #[getter]
@@ -768,14 +768,14 @@ impl PyAsyncFunctionSnapshot {
         future_into_py(py, async move {
             // Dispatch inside the future: a coroutine's `into_future` needs the
             // asyncio task-locals that `future_into_py`'s scope establishes.
-            let answer: PyResult<ResumeValue> = if call.is_os_function {
+            let answer: PyResult<ResumeValue> = if let Some(not_handled_error) = &call.not_handled_error {
                 let result = Python::attach(|py| {
                     dispatch_os_parts(
                         py,
                         &call.function_name,
                         &call.args,
                         &call.kwargs,
-                        call.not_handled_error.as_ref(),
+                        not_handled_error,
                         ctx.os.as_ref(),
                         &ctx.dc_registry,
                     )
@@ -817,7 +817,8 @@ impl PyAsyncFunctionSnapshot {
     fn __repr__(&self) -> String {
         format!(
             "AsyncFunctionSnapshot(function_name={:?}, is_os_function={})",
-            self.0.call.function_name, self.0.call.is_os_function
+            self.0.call.function_name,
+            self.0.call.is_os_function()
         )
     }
 }

--- a/crates/monty-python/tests/test_feed_start.py
+++ b/crates/monty-python/tests/test_feed_start.py
@@ -263,7 +263,7 @@ def test_load_snapshot_mid_os_call_serviced_by_mount(pool: Monty, tmp_path: Path
         assert snap.function_name == snapshot('Path.read_text')
         blob = snap.dump()
 
-    mount = MountDir('/data', str(tmp_path), mode='read-only')
+    mount = MountDir(host_path=(tmp_path), virtual_path='/data', mode='read-only')
     with pool.checkout() as session:
         loaded_snap = session.load_snapshot(blob, mount=mount)
         assert isinstance(loaded_snap, FunctionSnapshot)

--- a/crates/monty-python/tests/test_feed_start.py
+++ b/crates/monty-python/tests/test_feed_start.py
@@ -138,7 +138,9 @@ def test_os_call_surfaces_without_handler(session: MontySession):
     assert snap.function_name == snapshot('Path.read_text')
 
 
-def test_os_handler_auto_dispatched(session: MontySession):
+def test_os_handler_used_by_resume_auto(session: MontySession):
+    """`feed_start` surfaces the OS call even with `os=`; `resume_auto` answers it."""
+
     def handle_os(name: OsFunction, args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
         assert name == 'Path.read_text'
         return 'file body'
@@ -147,8 +149,11 @@ def test_os_handler_auto_dispatched(session: MontySession):
         "from pathlib import Path\nPath('/data/x').read_text()",
         os=handle_os,
     )
-    assert isinstance(snap, MontyComplete)
-    assert snap.output == snapshot('file body')
+    assert isinstance(snap, FunctionSnapshot)
+    assert snap.is_os_function == snapshot(True)
+    done = snap.resume_auto()
+    assert isinstance(done, MontyComplete)
+    assert done.output == snapshot('file body')
 
 
 def test_future_mechanism_sync(session: MontySession):
@@ -222,7 +227,7 @@ def test_loaded_snapshot_reports_the_dumps_script_name(pool: Monty):
 
 def test_mounts_restored_on_load_when_resupplied(pool: Monty, tmp_path: Path):
     # Re-supplying the feed's mounts to load_snapshot rebuilds the mount table,
-    # so the mounted read after resume is served in-worker and never surfaces.
+    # so `resume_auto` on the restored feed's mounted read is served from it.
     (tmp_path / 'hello.txt').write_text('hi')
     mount = MountDir(host_path=str(tmp_path), virtual_path='/data', mode='read-only')
     code = "f()\nfrom pathlib import Path\nPath('/data/hello.txt').read_text()"
@@ -235,15 +240,19 @@ def test_mounts_restored_on_load_when_resupplied(pool: Monty, tmp_path: Path):
     with pool.checkout() as session:
         loaded_snap = session.load_snapshot(blob, mount=mount)
         assert isinstance(loaded_snap, FunctionSnapshot)
-        done = loaded_snap.resume({'return_value': None})
+        read = loaded_snap.resume({'return_value': None})
+        assert isinstance(read, FunctionSnapshot)
+        assert read.is_os_function
+        assert read.function_name == snapshot('Path.read_text')
+        done = read.resume_auto()
         assert isinstance(done, MontyComplete)
         assert done.output == snapshot('hi')
 
 
 def test_load_snapshot_mid_os_call_serviced_by_mount(pool: Monty, tmp_path: Path):
-    # A dump taken while suspended on an OS call retains the call payload, so
-    # a mount supplied to load_snapshot services the re-announced call and the
-    # feed runs to completion without the suspension ever surfacing.
+    # A dump taken while suspended on an OS call retains the call payload, so a
+    # mount supplied to load_snapshot can answer the re-announced call even
+    # though the original feed had none.
     (tmp_path / 'hello.txt').write_text('hi')
     code = "from pathlib import Path\nPath('/data/hello.txt').read_text()"
     with pool.checkout() as session:
@@ -256,7 +265,10 @@ def test_load_snapshot_mid_os_call_serviced_by_mount(pool: Monty, tmp_path: Path
 
     mount = MountDir('/data', str(tmp_path), mode='read-only')
     with pool.checkout() as session:
-        done = session.load_snapshot(blob, mount=mount)
+        loaded_snap = session.load_snapshot(blob, mount=mount)
+        assert isinstance(loaded_snap, FunctionSnapshot)
+        assert loaded_snap.is_os_function
+        done = loaded_snap.resume_auto()
         assert isinstance(done, MontyComplete)
         assert done.output == snapshot('hi')
 

--- a/crates/monty-python/tests/test_feed_start.py
+++ b/crates/monty-python/tests/test_feed_start.py
@@ -240,6 +240,47 @@ def test_mounts_restored_on_load_when_resupplied(pool: Monty, tmp_path: Path):
         assert done.output == snapshot('hi')
 
 
+def test_load_snapshot_mid_os_call_serviced_by_mount(pool: Monty, tmp_path: Path):
+    # A dump taken while suspended on an OS call retains the call payload, so
+    # a mount supplied to load_snapshot services the re-announced call and the
+    # feed runs to completion without the suspension ever surfacing.
+    (tmp_path / 'hello.txt').write_text('hi')
+    code = "from pathlib import Path\nPath('/data/hello.txt').read_text()"
+    with pool.checkout() as session:
+        # no mount: the read surfaces as an OS-call snapshot
+        snap = session.feed_start(code)
+        assert isinstance(snap, FunctionSnapshot)
+        assert snap.is_os_function
+        assert snap.function_name == snapshot('Path.read_text')
+        blob = snap.dump()
+
+    mount = MountDir('/data', str(tmp_path), mode='read-only')
+    with pool.checkout() as session:
+        done = session.load_snapshot(blob, mount=mount)
+        assert isinstance(done, MontyComplete)
+        assert done.output == snapshot('hi')
+
+
+def test_load_snapshot_mid_os_call_retains_payload(pool: Monty, tmp_path: Path):
+    # Without a mount the re-announced OS call surfaces to the caller — with
+    # its full payload (name, args, and per-call not-handled error) intact.
+    code = "from pathlib import Path\nPath('/data/hello.txt').read_text()"
+    with pool.checkout() as session:
+        snap = session.feed_start(code)
+        assert isinstance(snap, FunctionSnapshot)
+        blob = snap.dump()
+
+    with pool.checkout() as session:
+        loaded_snap = session.load_snapshot(blob)
+        assert isinstance(loaded_snap, FunctionSnapshot)
+        assert loaded_snap.is_os_function
+        assert loaded_snap.function_name == snapshot('Path.read_text')
+        assert loaded_snap.args == snapshot((Path('/data/hello.txt'),))
+        with pytest.raises(MontyRuntimeError) as exc_info:
+            loaded_snap.resume_not_handled()
+    assert exc_info.value.display(format='msg') == snapshot("Permission denied: '/data/hello.txt'")
+
+
 def test_load_without_resupplied_mount_degrades_to_os_calls(pool: Monty, tmp_path: Path):
     # Mounts are host configuration serviced by the parent and never part of a
     # dump. A restore that omits them is not validated — the resumed feed's

--- a/crates/monty-runtime/src/main.rs
+++ b/crates/monty-runtime/src/main.rs
@@ -524,9 +524,8 @@ fn execute_repl_with_mounts<T: ResourceTracker>(
     loop {
         match progress {
             ReplProgress::Complete { repl, value } => return Ok((repl, value)),
-            ReplProgress::OsCall(mut call) => {
-                let result = handle_os_call(call.take_function_call(), mount_table);
-                match call.resume(result, PrintWriter::Stdout) {
+            ReplProgress::OsCall(call) => {
+                match call.resume_with(PrintWriter::Stdout, |fc| handle_os_call(fc, mount_table)) {
                     Ok(p) => progress = p,
                     Err(err) => return Err((err.repl, format!("{}", err.error))),
                 }
@@ -589,10 +588,9 @@ fn run_until_complete(
                     .resume(result, PrintWriter::Stdout)
                     .map_err(|err| format!("{err}"))?;
             }
-            RunProgress::OsCall(mut call) => {
-                let result = handle_os_call(call.take_function_call(), mount_table);
+            RunProgress::OsCall(call) => {
                 progress = call
-                    .resume(result, PrintWriter::Stdout)
+                    .resume_with(PrintWriter::Stdout, |fc| handle_os_call(fc, mount_table))
                     .map_err(|err| format!("{err}"))?;
             }
         }

--- a/crates/monty/src/os.rs
+++ b/crates/monty/src/os.rs
@@ -128,21 +128,12 @@ pub enum OsFunctionCall {
     /// Carries the timezone argument, `None` for a naive result.
     #[strum(serialize = "datetime.now")]
     DateTimeNow(Option<MontyTimeZone>),
-
-    /// Placeholder left behind by [`crate::OsCall::take_function_call`] and
-    /// [`crate::ReplOsCall::take_function_call`] after the real call has been
-    /// moved out for host dispatch. Never produced by the VM and never
-    /// dispatched — it just keeps the field droppable. Disabled for strum, so
-    /// [`OsFunctionCall::name`] panics on it.
-    #[strum(disabled)]
-    Used,
 }
 
 impl OsFunctionCall {
     /// Stable string name for this OS function — surfaces in
     /// [`Self::on_no_handler`] errors, host `os` callbacks, and serialised
-    /// snapshots. The strum `serialize` string on each variant. Panics on
-    /// [`Self::Used`], which is never surfaced.
+    /// snapshots. The strum `serialize` string on each variant.
     #[must_use]
     pub fn name(&self) -> &'static str {
         self.into()
@@ -176,7 +167,6 @@ impl OsFunctionCall {
             // Unit & single-value non-FS variants.
             Self::GetEnviron | Self::DateToday => (vec![], vec![]),
             Self::DateTimeNow(tz) => (vec![tz.map_or(MontyObject::None, MontyObject::TimeZone)], vec![]),
-            Self::Used => unreachable!("OsFunctionCall::Used dispatched after take_function_call"),
         }
     }
 
@@ -184,8 +174,8 @@ impl OsFunctionCall {
     /// Non-FS variants (`Getenv`, `GetEnviron`, `DateToday`, `DateTimeNow`)
     /// must fall through to the host callback.
     ///
-    /// Deliberately an allowlist: `Used` (and any future non-FS variant) must
-    /// return `false`, because `monty-fs` panics if a call without a
+    /// Deliberately an allowlist: any future non-FS variant must return
+    /// `false`, because `monty-fs` panics if a call without a
     /// [`Self::primary_path`] reaches its filesystem dispatch.
     #[must_use]
     pub fn is_filesystem(&self) -> bool {
@@ -266,7 +256,6 @@ impl OsFunctionCall {
             Self::Mkdir(a) => Some(a.path.as_str()),
             Self::Rename(a) => Some(a.src.as_str()),
             Self::Getenv(_) | Self::GetEnviron | Self::DateToday | Self::DateTimeNow(_) => None,
-            Self::Used => unreachable!("OsFunctionCall::Used inspected after take_function_call"),
         }
     }
 

--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -643,13 +643,16 @@ impl<T: ResourceTracker> ReplOsCall<T> {
         self.snapshot.run(result.into(), print)
     }
 
-    /// REPL mirror of [`crate::OsCall::take_function_call`] — takes the
-    /// call out for host dispatch, leaving an [`OsFunctionCall::Used`]
-    /// placeholder. Afterwards `self` is only valid for [`Self::resume`]
-    /// or [`Self::into_repl`].
-    #[must_use]
-    pub fn take_function_call(&mut self) -> OsFunctionCall {
-        mem::replace(&mut self.function_call, OsFunctionCall::Used)
+    /// REPL mirror of [`crate::OsCall::resume_with`] — dispatches the call
+    /// to `handler` (which receives the [`OsFunctionCall`] by value, so
+    /// write payloads move without cloning) and resumes with its result.
+    pub fn resume_with(
+        self,
+        print: PrintWriter<'_>,
+        handler: impl FnOnce(OsFunctionCall) -> ExtFunctionResult,
+    ) -> Result<ReplProgress<T>, Box<ReplStartError<T>>> {
+        let result = handler(self.function_call);
+        self.snapshot.run(result, print)
     }
 }
 

--- a/crates/monty/src/run_progress.rs
+++ b/crates/monty/src/run_progress.rs
@@ -258,14 +258,19 @@ impl<T: ResourceTracker> OsCall<T> {
         self.snapshot.run(result.into(), print)
     }
 
-    /// Takes the [`OsFunctionCall`] out by value, leaving an
-    /// [`OsFunctionCall::Used`] placeholder so the host can dispatch the
-    /// call without cloning large `WriteText` / `WriteBytes` payloads.
-    /// `self` is still safe to call [`Self::resume`] on; the placeholder
-    /// must not be inspected.
-    #[must_use]
-    pub fn take_function_call(&mut self) -> OsFunctionCall {
-        mem::replace(&mut self.function_call, OsFunctionCall::Used)
+    /// Dispatches the call to `handler` and resumes execution with its result.
+    ///
+    /// `handler` receives the [`OsFunctionCall`] by value, so large
+    /// `WriteText` / `WriteBytes` payloads move into the host without
+    /// cloning. Prefer this over reading [`Self::function_call`] and calling
+    /// [`Self::resume`] separately when the handler consumes the call.
+    pub fn resume_with(
+        self,
+        print: PrintWriter<'_>,
+        handler: impl FnOnce(OsFunctionCall) -> ExtFunctionResult,
+    ) -> Result<RunProgress<T>, MontyException> {
+        let result = handler(self.function_call);
+        self.snapshot.run(result, print)
     }
 
     /// Returns a reference to the resource tracker.

--- a/crates/monty/tests/os_tests.rs
+++ b/crates/monty/tests/os_tests.rs
@@ -75,7 +75,6 @@ fn mock_oscall_result(call: &monty::OsFunctionCall) -> MontyObject {
             offset_seconds: None,
             timezone_name: None,
         }),
-        monty::OsFunctionCall::Used => unreachable!("OsFunctionCall::Used in mock_oscall_result"),
     }
 }
 

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -274,12 +274,6 @@ properties that real CPython does not provide, per the caveat above.
 - **`'overlay'` writes are not preserved across a dump.** A restored overlay
   mount starts empty; `read-only` / `read-write` mounts have no overlay state
   and restore fully.
-- **A re-announced OS-call snapshot after `load_snapshot` carries no
-  payload** — its arguments were consumed before the dump, so it surfaces
-  with an empty function name and empty `args`/`kwargs`, and there is no
-  per-call default error to decline with: `resume_not_handled()` raises
-  `RuntimeError` instead of resuming, so the host must answer from its own
-  records via `resume(...)` / `resume_error(...)`.
 - **Natural-JSON host serialization was removed.** Results now cross the
   subprocess boundary as structured protocol values; the old
   `MontyComplete.output_json()` / `FunctionSnapshot.args_json()` /

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -114,6 +114,10 @@ properties that real CPython does not provide, per the caveat above.
   When an external-function argument makes the suspension announcement itself
   too large, the current feed is aborted with a host-visible `RuntimeError`;
   Monty code cannot catch that error inside the aborted feed.
+- The same frame limit applies to `dump()`: a session whose serialized state
+  (heap plus any retained suspension payload) exceeds 256 MiB cannot be
+  dumped. The call raises a `RuntimeError` and the session is unaffected — a
+  suspended session stays suspended and resumable.
 - Independently of the wire-byte limit, a frame is rejected if the values it
   decodes into would exceed a **per-frame host-memory budget** — a hard,
   non-configurable limit of 1 GiB of *resident* decoded bytes. The wire cap

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -77,8 +77,8 @@ properties that real CPython does not provide, per the caveat above.
   The in-sandbox limit normally fires first with a clean `TimeoutError`; the
   backstop covers cases where it cannot — a worker that stops answering
   (e.g. compromised or wedged) — and surfaces as `MontyCrashedError`, losing
-  the session. Mount I/O runs on the host between watchdog exchanges and does
-  not count against the worker's deadline. Because the budget and consumed time are also stamped onto the
+  the session. Mount I/O runs on the host between protocol turns and does not
+  count against the worker's deadline. Because the budget and consumed time are also stamped onto the
   worker's replies, sessions restored via the Rust `Pool::checkout_load`
   regain the backstop too. A *compromised* worker could under-report its
   total, stretching each turn to the full budget plus grace — turns stay
@@ -162,31 +162,34 @@ properties that real CPython does not provide, per the caveat above.
   `read-write` mounts write through to the real host directory as before. An
   invalid mount (host path missing / not a directory) raises at `feed` time,
   before the snippet runs, as a session-preserving error.
+- **Mounts only answer calls on the automatic path.** Every OS call the sandbox
+  makes surfaces as a suspension; the pool consults the mount table only when
+  the caller asks it to. `feed_run` (and the JS `feedRun`) asks on every OS
+  call, so mounted I/O is transparent there. `feed_start` never does: a mounted
+  read comes back as a `FunctionSnapshot` with `is_os_function` set, and it is
+  `resume_auto()` that offers the call to the mounts and then to `os=`.
+  Answering such a snapshot with an explicit `resume(...)` bypasses the mount
+  entirely — the value you supply is what the sandbox sees.
 - **Special files are rejected.** Reading, writing, or `open()`ing a
   non-regular file in a mounted directory (FIFO, socket, device) raises
   `PermissionError` instead of blocking — CPython would block until a peer
   appears, but mount I/O runs on the host thread driving the session and must
   never block on sandbox-reachable input.
-- **Mount I/O is not covered by `request_timeout`.** Covered filesystem calls
-  run synchronously on the host thread driving the session; the watchdog's
-  only lever is killing the worker, which cannot interrupt host-side I/O.
-  Sandbox code cannot *hang* the host this way (special files are rejected,
-  above), but a mount on a pathological host filesystem — a stalled NFS or
-  FUSE volume — blocks the feed with no timeout. Like a blocking
-  `print_callback` or external function, hang-free host I/O is the embedder's
-  responsibility: do not mount directories on filesystems that can hang.
-  Worker execution time is still hard-bounded: each covered call deducts the
-  worker's elapsed interval from the turn's allowance, so cumulative worker
-  execution per turn never exceeds `request_timeout` no matter how many
-  covered calls it makes. The parent-side I/O itself is deducted from
-  nothing, though, so sandbox code *can* stretch a feed's wall clock well
-  beyond `request_timeout` on a perfectly healthy filesystem — e.g. a loop of
-  large mounted reads pays only its own (bounded) execution time while the
-  host does up to a mount-memory-budget's worth of free I/O per call. Feed
-  wall clock with mounts is therefore not a hard bound; only worker execution
-  is.
-- **`os=` fallback** receives `(function_name, args, kwargs)`; mount-covered
-  filesystem calls are serviced by the pool and never reach the callback.
+- **Mount I/O is not bounded by any timeout.** Covered filesystem calls run
+  synchronously on the host *between* protocol turns, with no watchdog armed —
+  and its only lever, killing the worker, could not interrupt host I/O anyway.
+  Special files are rejected (above) so sandbox code cannot hang the host, but
+  a stalled NFS/FUSE volume blocks the feed indefinitely; hang-free host I/O is
+  the embedder's responsibility, as for `print_callback` and external
+  functions. Each covered call is answered by its own turn, so a *loop* of
+  mounted reads resets `request_timeout` every iteration, exactly like a loop
+  of external calls. `max_duration` still bounds such a feed's worker
+  execution, but nothing bounds its wall clock.
+- **`os=` fallback** receives `(function_name, args, kwargs)`. On the
+  automatic path (`feed_run`, `resume_auto`) mounts get first refusal, so
+  mount-covered filesystem calls never reach the callback. Under `feed_start`
+  the callback is consulted only by `resume_auto()` — it is never invoked
+  between snapshots.
 - **Mounts have a 100 MB memory budget by default.** Retained overlay data and
   transient filesystem results share the configurable per-mount budget.
   Oversized operations raise `MemoryError` inside the sandbox before protocol
@@ -260,8 +263,10 @@ properties that real CPython does not provide, per the caveat above.
   A *failed* load (wrong dump kind, or a protocol desync) poisons the session
   — its worker is discarded, so every later feed fails too; the load is not
   retryable and the caller must check out a fresh session.
-- **`resume` takes no `mount=`.** Mounts are fixed for the whole feed (passed
-  to `feed_start`), so there is no per-`resume` mount argument.
+- **`resume` takes no `mount=` or `os=`.** Mounts and the OS fallback are
+  fixed for the whole feed (passed to `feed_start` / `load_snapshot`), and a
+  plain `resume(...)` answers only the call in hand — it consults neither.
+  `resume_auto()` is the method that uses them.
 - **Mounts are re-supplied to `load_snapshot`, not stored in the dump.** Mounts
   are host configuration serviced by the host, not sandbox state, so nothing
   about them (host paths included) enters the (opaque, possibly-transmitted)
@@ -272,9 +277,11 @@ properties that real CPython does not provide, per the caveat above.
   next feed supplies its own.)
 - **Re-supplied mounts are not validated.** The dump records nothing about the
   feed's mounts, so `load_snapshot` cannot check what you pass: a mount
-  silently omitted (or altered) simply degrades the resumed feed's covered
-  filesystem calls into surfaced OS calls — unhandled ones raise
-  `PermissionError` inside the sandbox.
+  silently omitted (or altered) simply means `resume_auto()` finds nothing
+  covering the resumed feed's filesystem calls, and they fall through to `os=`
+  or raise `PermissionError` inside the sandbox. A dump taken *while suspended
+  on an OS call* re-announces that call in full, so a mount supplied only at
+  `load_snapshot` can still answer it.
 - **`'overlay'` writes are not preserved across a dump.** A restored overlay
   mount starts empty; `read-only` / `read-write` mounts have no overlay state
   and restore fully.


### PR DESCRIPTION
fix #577: a session dumped while suspended on an OS call re-announced it after Load with an empty payload, so restored sessions could not have the call serviced by mounts or host os callbacks.

The child now clones the payload into the OsCall wire event instead of consuming it, so the dump retains the full call and the Load re-announcement is identical to a fresh suspension — a mount supplied to restore services it transparently. DUMP_VERSION bumped to 5.

With no consumer left, OsFunctionCall::Used is removed entirely: OsCall / ReplOsCall gain a consuming resume_with(print, handler) (payloads still move into the host without cloning), the wire consumed arm is deleted from monty.proto, and TurnEvent::OsCall.not_handled_error is now non-optional, simplifying the Python and JS bindings.


Claude-Session: https://claude.ai/code/session_0129DtAVzhH5ZR1WfnrNzBz9

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suspended OS calls keep their full payload and re-announce identically after Load; every OS call surfaces, and mounts are only consulted when requested or by `resume_auto()`/`feedRun`. Dump/Load is hardened and oversize answers no longer strand sessions; DUMP_VERSION is 5.

- **Bug Fixes**
  - Re-announced OS calls include name/args/kwargs and call id; declines use a child-side not_handled default.
  - `feedRun` auto-answers via mounts; `feedStart` surfaces OS calls and `resume_auto()` tries mounts, then `os`.
  - Load validates restored dumps (depth/size) and rejects bad or oversize re-announcements without losing the suspension.
  - Oversize answers rely on send-time rejection; pending calls stay answerable. Name lookups and future results follow the same path.

- **Migration**
  - Replace `take_function_call` + `resume` with `OsCall::resume_with` / `ReplOsCall::resume_with`; remove `OsFunctionCall::Used`.
  - Decline with `ResumeValue::NotHandled`; remove `TurnEvent::OsCall.not_handled_error`. JS drops `notHandledError` and the pending store in `@pydantic/monty`.
  - New `Checkout::resume_from_mounts` (Rust) and `resumeFromMounts` (JS). `feedStart` no longer auto-dispatches `os`; per-snapshot `os=` resume args are removed; `resume_auto()` consults mounts then `os`.
  - Protobuf: add `ExtFunctionResult.not_handled`; remove `OsCall.consumed`. Snapshots require matching parent/worker version. `DUMP_VERSION` -> 5.
  - `PoolError::Protocol` now uses `Cow<'static, str>`.

<sup>Written for commit 836ad2c0a6b1dab59808e13b67350ec2826cadf6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

