### PR TITLE
Arg fixes, `int()`, `str()`, `round()`

### DIFF
--- a/crates/monty-macros/README.md
+++ b/crates/monty-macros/README.md
@@ -96,6 +96,8 @@ are all incompatible.
   must be {expected}, not {got}`).
 - `kwarg_error_name = "..."` — override the function name in the
   unknown-kwarg error only (`json.dumps` reports `JSONEncoder.__init__`).
+  Under `style = unpack` it instead names the function in the blanket
+  `takes no keyword arguments` rejection (`unicodedata.name()`).
 - `kwargs_not_supported_yet` — reject every kwarg with a
   `NotImplementedError`; a Monty TODO marker.
 

--- a/crates/monty-macros/README.md
+++ b/crates/monty-macros/README.md
@@ -91,6 +91,12 @@ are all incompatible.
   don't. Only meaningful for the C-parser families (`clinic`/`c`/`c_named`)
   on signatures with a fixed maximum — rejected under `style = def` /
   `style = unpack` and with `varargs`/`varkwargs`.
+- `vectorcall` — kwarg-free calls check positional arity first with
+  `_PyArg_CheckPositional` wording (`{name} expected at most N arguments,
+  got M`), modeling `tp_vectorcall` fast paths (`int`, `str`) that only
+  fall back to the clinic parser when keywords are present. Requires the
+  default `clinic` style plus `at_most_total` (which supplies the
+  parenthesised wording for the kwargs path).
 - `bad_arg` / `bad_arg_named` — report `FromValue` wrong-type failures in
   CPython's `_PyArg_BadArgument` wording (`{name}() argument {pos|'arg'}
   must be {expected}, not {got}`).

--- a/crates/monty-macros/src/from_args.rs
+++ b/crates/monty-macros/src/from_args.rs
@@ -45,6 +45,10 @@ struct Signature {
     /// A per-function empirical fact, not derivable from fields or style —
     /// see the litmus test in `crates/monty-macros/README.md`.
     at_most_total: bool,
+    /// Kwarg-free calls check positional arity with `_PyArg_CheckPositional`
+    /// wording first, modeling `tp_vectorcall` fast paths (`int`, `str`) that
+    /// only fall back to the clinic parser when keywords are present.
+    vectorcall: bool,
     /// Override for the function name in the unknown-kwarg error only.
     /// Used by `json.dumps`, which forwards unmatched kwargs to
     /// `JSONEncoder.__init__` and so reports that name instead.
@@ -159,6 +163,7 @@ impl Signature {
             name: func_name,
             style,
             at_most_total,
+            vectorcall,
             kwarg_error_name,
             bad_arg,
             kwargs_not_supported_yet,
@@ -191,6 +196,7 @@ impl Signature {
             varargs_idx,
             varkwargs_idx,
             at_most_total,
+            vectorcall,
             kwarg_error_name,
             bad_arg,
             kwargs_not_supported_yet,
@@ -242,6 +248,11 @@ impl Signature {
                      — the up-front total-count check is only meaningful for \
                      signatures with a fixed maximum");
             }
+        }
+
+        if self.vectorcall && !(self.at_most_total && self.style == Style::Clinic) {
+            return err("`vectorcall` requires the default `clinic` style plus `at_most_total` \
+                 — it models a `tp_vectorcall` fast path in front of a clinic parser");
         }
 
         if self.kwarg_error_name.is_some() && !matches!(self.style, Style::Def | Style::Clinic | Style::Unpack) {
@@ -435,6 +446,7 @@ impl Signature {
         let varargs = self.varargs_idx.is_some();
         let varkwargs = self.varkwargs_idx.is_some();
         let at_most_total = self.at_most_total;
+        let vectorcall = self.vectorcall;
         let kwargs_not_supported_yet = self.kwargs_not_supported_yet;
         let kwarg_error_name = if let Some(name) = &self.kwarg_error_name {
             quote! { ::std::option::Option::Some(#name) }
@@ -452,6 +464,7 @@ impl Signature {
                 varargs: #varargs,
                 varkwargs: #varkwargs,
                 at_most_total: #at_most_total,
+                vectorcall: #vectorcall,
                 kwargs_not_supported_yet: #kwargs_not_supported_yet,
                 kwarg_error_name: #kwarg_error_name,
             };
@@ -739,6 +752,7 @@ struct StructAttrs {
     name: String,
     style: Style,
     at_most_total: bool,
+    vectorcall: bool,
     kwarg_error_name: Option<String>,
     bad_arg: Option<BadArgStyle>,
     kwargs_not_supported_yet: bool,
@@ -749,6 +763,7 @@ fn parse_struct_attrs(attrs: &[syn::Attribute]) -> syn::Result<StructAttrs> {
     let mut name: Option<String> = None;
     let mut style: Option<Style> = None;
     let mut at_most_total = false;
+    let mut vectorcall = false;
     let mut kwarg_error_name: Option<String> = None;
     let mut bad_arg: Option<BadArgStyle> = None;
     let mut kwargs_not_supported_yet = false;
@@ -783,6 +798,9 @@ fn parse_struct_attrs(attrs: &[syn::Attribute]) -> syn::Result<StructAttrs> {
             } else if meta.path.is_ident("at_most_total") {
                 at_most_total = true;
                 Ok(())
+            } else if meta.path.is_ident("vectorcall") {
+                vectorcall = true;
+                Ok(())
             } else if meta.path.is_ident("kwarg_error_name") {
                 let value: LitStr = meta.value()?.parse()?;
                 kwarg_error_name = Some(value.value());
@@ -805,7 +823,7 @@ fn parse_struct_attrs(attrs: &[syn::Attribute]) -> syn::Result<StructAttrs> {
             } else {
                 Err(meta.error(
                     "unknown struct attribute; expected `name = \"...\"`, `style = def|clinic|c|c_named|unpack`, \
-                     `at_most_total`, `kwarg_error_name = \"...\"`, `bad_arg`, `bad_arg_named`, \
+                     `at_most_total`, `vectorcall`, `kwarg_error_name = \"...\"`, `bad_arg`, `bad_arg_named`, \
                      or `kwargs_not_supported_yet`",
                 ))
             }
@@ -821,6 +839,7 @@ fn parse_struct_attrs(attrs: &[syn::Attribute]) -> syn::Result<StructAttrs> {
         name,
         style: style.unwrap_or(Style::Clinic),
         at_most_total,
+        vectorcall,
         kwarg_error_name,
         bad_arg,
         kwargs_not_supported_yet,
@@ -1039,12 +1058,33 @@ mod tests {
     }
 
     #[test]
+    fn vectorcall_requires_clinic_and_at_most_total() {
+        let err = expand_err(&parse_quote! {
+            #[from_args(name = "int", vectorcall)]
+            struct S {
+                #[from_args(pos_only, default)]
+                x: Value,
+            }
+        });
+        assert_snapshot!(err, @"`vectorcall` requires the default `clinic` style plus `at_most_total` — it models a `tp_vectorcall` fast path in front of a clinic parser");
+        expand_ok(&parse_quote! {
+            #[from_args(name = "int", at_most_total, vectorcall)]
+            struct S {
+                #[from_args(pos_only, default)]
+                x: Value,
+                #[from_args(default)]
+                base: Value,
+            }
+        });
+    }
+
+    #[test]
     fn kwarg_error_name_requires_def_or_clinic() {
         let err = expand_err(&parse_quote! {
             #[from_args(name = "f", style = c_named, kwarg_error_name = "g")]
             struct S { a: Value }
         });
-        assert_snapshot!(err, @"`kwarg_error_name` is only meaningful with `style = def` or the default `clinic` style — the C families defer unknown-kwarg errors past binding and `unpack` callables take no keywords worth renaming");
+        assert_snapshot!(err, @"`kwarg_error_name` is only meaningful with `style = def`, the default `clinic` style, or `style = unpack` (where it names the function in the `takes no keyword arguments` error) — the C families defer unknown-kwarg errors past binding");
     }
 
     #[test]

--- a/crates/monty-macros/src/from_args.rs
+++ b/crates/monty-macros/src/from_args.rs
@@ -244,12 +244,11 @@ impl Signature {
             }
         }
 
-        if self.kwarg_error_name.is_some() && !matches!(self.style, Style::Def | Style::Clinic) {
-            return err(
-                "`kwarg_error_name` is only meaningful with `style = def` or the default \
-                 `clinic` style — the C families defer unknown-kwarg errors past binding \
-                 and `unpack` callables take no keywords worth renaming",
-            );
+        if self.kwarg_error_name.is_some() && !matches!(self.style, Style::Def | Style::Clinic | Style::Unpack) {
+            return err("`kwarg_error_name` is only meaningful with `style = def`, the default \
+                 `clinic` style, or `style = unpack` (where it names the function in the \
+                 `takes no keyword arguments` error) — the C families defer unknown-kwarg \
+                 errors past binding");
         }
 
         if self.kwargs_not_supported_yet {

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -48,10 +48,9 @@ type Tracker = LimitedTracker;
 ///   `str` is a `u32 LE` byte length followed by UTF-8 bytes.
 ///
 /// The payload is monty's postcard format — only a monty child of the same
-/// version can restore it. Bumped to 4 when mounts moved to the parent: the
-/// child no longer sees mount configuration, so the meta's mount-requirements
-/// section was removed.
-const DUMP_VERSION: u16 = 4;
+/// version can restore it. Bumped to 5 because adding argument-name variants
+/// changed the serialized `StaticStrings` discriminants.
+const DUMP_VERSION: u16 = 5;
 
 /// A sink for framed [`pb::ChildEvent`]s, decoupling the child from its
 /// transport.

--- a/crates/monty/src/args/bind_native.rs
+++ b/crates/monty/src/args/bind_native.rs
@@ -136,6 +136,13 @@ fn bind_slow<const N: usize>(
             return Err(err);
         }
     }
+    // `tp_vectorcall` fast paths (`int`, `str`) check positional arity with
+    // `_PyArg_CheckPositional` before reaching the clinic parser, so kwarg-free
+    // overflow gets the un-parenthesised wording; with kwargs present the
+    // `at_most_total` check below fires with the clinic wording instead.
+    if spec.vectorcall && n_kw == 0 && n_pos > spec.n_positional {
+        return Err(ExcType::type_error_at_most(spec.func_name, spec.n_positional, n_pos));
+    }
     if spec.at_most_total && n_pos + n_kw > spec.n_positional {
         return Err(total_overflow_error(spec, n_pos + n_kw));
     }
@@ -291,6 +298,11 @@ pub(crate) struct ParamSpec {
     /// function from CPython's observed behaviour — not derivable from the
     /// field shapes (identical signatures differ by parser generation).
     pub at_most_total: bool,
+    /// Kwarg-free positional overflow uses `_PyArg_CheckPositional` wording
+    /// (`{name} expected at most N arguments, got M`) — models `tp_vectorcall`
+    /// fast paths (`int`, `str`) that bypass the clinic parser when no
+    /// keywords are passed. Requires `at_most_total` (enforced by the derive).
+    pub vectorcall: bool,
     /// Reject any kwarg up front with `NotImplementedError` — a Monty TODO
     /// marker for functions whose CPython kwargs aren't plumbed through yet.
     pub kwargs_not_supported_yet: bool,

--- a/crates/monty/src/args/bind_native.rs
+++ b/crates/monty/src/args/bind_native.rs
@@ -120,15 +120,21 @@ fn bind_slow<const N: usize>(
     let n_pos = state.pos.len();
     let n_kw = state.kwargs.len();
 
-    // Family pre-checks. Order matches CPython: `PyArg_UnpackTuple` checks its
-    // positional range first; `at_most_total` reproduces the
-    // `PyArg_ParseTupleAndKeywords` total pre-count; the "at least M
-    // positional" check reproduces `_PyArg_UnpackKeywords` for C methods whose
-    // required positional-only params cannot be filled by keyword.
-    if matches!(spec.family, ErrorFamily::Unpack)
-        && let Some(err) = unpack_arity_error(spec, n_pos)
-    {
-        return Err(err);
+    // Family pre-checks. Order matches CPython: `PyArg_UnpackTuple` callers
+    // reject keywords wholesale (`_PyArg_NoKeywords` / the `METH_FASTCALL`
+    // dispatch) before any arity check, then check the positional range;
+    // `at_most_total` reproduces the `PyArg_ParseTupleAndKeywords` total
+    // pre-count; the "at least M positional" check reproduces
+    // `_PyArg_UnpackKeywords` for C methods whose required positional-only
+    // params cannot be filled by keyword.
+    if matches!(spec.family, ErrorFamily::Unpack) {
+        if n_kw > 0 {
+            let name = spec.kwarg_error_name.unwrap_or(spec.func_name);
+            return Err(ExcType::type_error_no_kwargs(name));
+        }
+        if let Some(err) = unpack_arity_error(spec, n_pos) {
+            return Err(err);
+        }
     }
     if spec.at_most_total && n_pos + n_kw > spec.n_positional {
         return Err(total_overflow_error(spec, n_pos + n_kw));
@@ -358,9 +364,11 @@ pub(crate) enum ErrorFamily {
     /// (`:name` in the format string) — errors say `{name}() …`, and the
     /// unknown-kwarg error uses the named Python wording.
     CNamed,
-    /// `PyArg_UnpackTuple` (`style = unpack`): a fixed positional `min..max`
-    /// range checked before anything else, `{name} expected …` wording with
-    /// no parentheses. When `min == max` CPython collapses to
+    /// `PyArg_UnpackTuple` (`style = unpack`): any keyword argument is
+    /// rejected first with `{name}() takes no keyword arguments` (CPython's
+    /// `_PyArg_NoKeywords` / `METH_FASTCALL` dispatch), then a fixed
+    /// positional `min..max` range is checked, `{name} expected …` wording
+    /// with no parentheses. When `min == max` CPython collapses to
     /// `expected N argument(s)` — [`bind`] does the same.
     Unpack,
 }

--- a/crates/monty/src/builtins/enumerate.rs
+++ b/crates/monty/src/builtins/enumerate.rs
@@ -19,9 +19,11 @@ use crate::{
 /// Note: In Python this returns an iterator, but we return a list for simplicity.
 pub fn builtin_enumerate(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let (iterable, start) = extract_enumerate_args(args, vm)?;
+    // Guard `start` before building the iterator: a non-iterable `iterable`
+    // errors out of `MontyIter::new`, and a heap-backed start must not leak.
+    defer_drop!(start, vm);
     let iter = MontyIter::new(iterable, vm)?;
     defer_drop_mut!(iter, vm);
-    defer_drop!(start, vm);
 
     // Get start index (default 0)
     let mut index: i64 = match start {

--- a/crates/monty/src/builtins/enumerate.rs
+++ b/crates/monty/src/builtins/enumerate.rs
@@ -7,7 +7,7 @@ use crate::{
     bytecode::VM,
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult, SimpleException},
-    heap::{DropGuard, HeapData},
+    heap::{DropGuard, DropWithContext, HeapData},
     resource::ResourceTracker,
     types::{List, MontyIter, allocate_tuple},
     value::Value,
@@ -18,7 +18,7 @@ use crate::{
 /// Returns a list of (index, value) tuples.
 /// Note: In Python this returns an iterator, but we return a list for simplicity.
 pub fn builtin_enumerate(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-    let (iterable, start) = args.get_one_two_args("enumerate", vm.heap)?;
+    let (iterable, start) = extract_enumerate_args(args, vm)?;
     let iter = MontyIter::new(iterable, vm)?;
     defer_drop_mut!(iter, vm);
     defer_drop!(start, vm);
@@ -52,4 +52,111 @@ pub fn builtin_enumerate(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues)
     let (result, vm) = result_guard.into_parts();
     let heap_id = vm.heap.allocate(HeapData::List(List::new(result)))?;
     Ok(Value::Ref(heap_id))
+}
+
+/// Extracts `enumerate(iterable, start=0)` arguments, faithfully mirroring
+/// CPython's hand-written `enumerate_vectorcall` (Objects/enumobject.c) —
+/// which `#[derive(FromArgs)]` cannot express. Its quirks are deliberate:
+/// keyword names are validated by *position* against the accepted shapes, and
+/// zero positionals with an unrecognised keyword shape reports the missing
+/// `iterable` even when `iterable=` was actually passed.
+fn extract_enumerate_args(args: ArgValues, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<(Value, Option<Value>)> {
+    let (mut pos, kwargs) = args.into_parts();
+    let n_pos = pos.len();
+    let total = n_pos + kwargs.len();
+    let mut kw = kwargs.into_iter();
+    // Pull up to two of each stream; each accepted call shape is one pattern
+    // arm, and the catch-all owns the leftovers on the arity-error path.
+    match (pos.next(), pos.next(), kw.next(), kw.next()) {
+        // enumerate(x) / enumerate(x, s)
+        (Some(iterable), start, None, None) if total <= 2 => Ok((iterable, start)),
+        // enumerate(x, start=s)
+        (Some(iterable), None, Some(kv), None) => match take_kwarg(kv, "start", vm) {
+            Ok(start) => Ok((iterable, Some(start))),
+            Err(err) => {
+                iterable.drop_with(vm);
+                Err(err)
+            }
+        },
+        // enumerate(iterable=x)
+        (None, None, Some(kv), None) => Ok((take_kwarg(kv, "iterable", vm)?, None)),
+        // enumerate(iterable=x, start=s) — either keyword order
+        (None, None, Some(kv0), Some(kv1)) if total == 2 => two_kwarg_form(kv0, kv1, vm),
+        // Anything else is an arity error.
+        (p0, p1, k0, k1) => {
+            ((p0, p1), (k0, k1)).drop_with(vm);
+            pos.drop_with(vm);
+            kw.drop_with(vm);
+            if n_pos == 0 {
+                // CPython reports the missing `iterable` for every
+                // zero-positional shape it doesn't recognise — even
+                // `enumerate(start=1, x=1, iterable=[1])`.
+                Err(ExcType::type_error_missing_required_no_pos("enumerate", "iterable"))
+            } else {
+                Err(ExcType::type_error_method_at_most("enumerate", 2, total))
+            }
+        }
+    }
+}
+
+/// The `enumerate(iterable=..., start=...)` form: CPython accepts both
+/// keyword orders, checking `start` first and reporting the first
+/// out-of-place name.
+fn two_kwarg_form(
+    kv0: (Value, Value),
+    kv1: (Value, Value),
+    vm: &mut VM<'_, impl ResourceTracker>,
+) -> RunResult<(Value, Option<Value>)> {
+    // Decide the shape by reference before any ownership moves.
+    let swapped = key_check(&kv0.0, "start", vm).is_ok();
+    let checked = if swapped {
+        key_check(&kv1.0, "iterable", vm)
+    } else {
+        key_check(&kv0.0, "iterable", vm).and(key_check(&kv1.0, "start", vm))
+    };
+    match checked {
+        Ok(()) => {
+            let ((key0, val0), (key1, val1)) = (kv0, kv1);
+            (key0, key1).drop_with(vm);
+            Ok(if swapped {
+                (val1, Some(val0))
+            } else {
+                (val0, Some(val1))
+            })
+        }
+        Err(err) => {
+            (kv0, kv1).drop_with(vm);
+            Err(err)
+        }
+    }
+}
+
+/// Consumes a kwarg pair, returning its value if the key is `expected`.
+fn take_kwarg(kv: (Value, Value), expected: &str, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Value> {
+    match key_check(&kv.0, expected, vm) {
+        Ok(()) => {
+            let (key, value) = kv;
+            key.drop_with(vm);
+            Ok(value)
+        }
+        Err(err) => {
+            kv.drop_with(vm);
+            Err(err)
+        }
+    }
+}
+
+/// Errors unless `key` is the string `expected`, mirroring CPython's
+/// `check_keyword`: a non-string key raises `keywords must be strings`, any
+/// other name the `invalid keyword argument` wording.
+fn key_check(key: &Value, expected: &str, vm: &VM<'_, impl ResourceTracker>) -> RunResult<()> {
+    let Some(key) = key.as_either_str(vm.heap) else {
+        return Err(ExcType::type_error_kwargs_nonstring_key());
+    };
+    let key = key.as_str(vm.interns);
+    if key == expected {
+        Ok(())
+    } else {
+        Err(ExcType::type_error_invalid_keyword_argument("enumerate", key))
+    }
 }

--- a/crates/monty/src/builtins/next.rs
+++ b/crates/monty/src/builtins/next.rs
@@ -1,9 +1,26 @@
 //! Implementation of the next() builtin function.
 
 use crate::{
-    args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, resource::ResourceTracker,
-    types::iter::iterator_next, value::Value,
+    args::{ArgValues, FromArgs},
+    bytecode::VM,
+    defer_drop,
+    exception_private::RunResult,
+    resource::ResourceTracker,
+    types::iter::iterator_next,
+    value::Value,
 };
+
+/// Argument shape for `next(iterator, default=...)` — positional-only in
+/// CPython, so `style = unpack` gives the `PyArg_UnpackTuple` arity wording
+/// and the blanket `next() takes no keyword arguments` rejection.
+#[derive(FromArgs)]
+#[from_args(name = "next", style = unpack)]
+struct NextArgs {
+    #[from_args(pos_only)]
+    iterator: Value,
+    #[from_args(pos_only, default)]
+    default: Option<Value>,
+}
 
 /// Implementation of the next() builtin function.
 ///
@@ -15,7 +32,7 @@ use crate::{
 /// - `next(iterator, default)` - Returns the next item from the iterator, or
 ///   `default` if the iterator is exhausted.
 pub fn builtin_next(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-    let (iterator, default) = args.get_one_two_args("next", vm.heap)?;
+    let NextArgs { iterator, default } = NextArgs::from_args(args, vm)?;
     defer_drop!(iterator, vm);
     iterator_next(iterator, default, vm)
 }

--- a/crates/monty/src/builtins/reversed.rs
+++ b/crates/monty/src/builtins/reversed.rs
@@ -1,7 +1,7 @@
 //! Implementation of the reversed() builtin function.
 
 use crate::{
-    args::ArgValues,
+    args::{ArgValues, FromArgs},
     bytecode::VM,
     exception_private::{ExcType, RunResult},
     heap::HeapData,
@@ -10,24 +10,35 @@ use crate::{
     value::Value,
 };
 
+/// Argument shape for `reversed(sequence, /)` — positional-only, so
+/// `style = unpack` gives CPython's exact-arity wording
+/// (`reversed expected 1 argument, got 2`) and the blanket
+/// `reversed() takes no keyword arguments` rejection.
+#[derive(FromArgs)]
+#[from_args(name = "reversed", style = unpack)]
+struct ReversedArgs {
+    #[from_args(pos_only)]
+    sequence: Value,
+}
+
 /// Implementation of the reversed() builtin function.
 ///
 /// Returns a list with elements in reverse order.
 /// Note: In Python this returns an iterator, but we return a list for simplicity.
 pub fn builtin_reversed(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-    let value = args.get_one_arg("reversed", vm.heap)?;
+    let ReversedArgs { sequence } = ReversedArgs::from_args(args, vm)?;
 
     // Being iterable is not enough: CPython needs `__reversed__`, or
     // `__len__` + `__getitem__`. Check before iterating so unordered and
     // one-shot iterables are rejected rather than silently reversed.
-    if !is_reversible(&value, vm) {
-        let err = ExcType::type_error_not_reversible(&value.py_type_name(vm));
-        value.drop_with(vm);
+    if !is_reversible(&sequence, vm) {
+        let err = ExcType::type_error_not_reversible(&sequence.py_type_name(vm));
+        sequence.drop_with(vm);
         return Err(err);
     }
 
     // Collect all items
-    let mut items: Vec<_> = MontyIter::new(value, vm)?.collect(vm)?;
+    let mut items: Vec<_> = MontyIter::new(sequence, vm)?.collect(vm)?;
 
     // Reverse in place
     items.reverse();

--- a/crates/monty/src/builtins/round.rs
+++ b/crates/monty/src/builtins/round.rs
@@ -1,6 +1,6 @@
 //! Implementation of the round() builtin function.
 
-use num_bigint::Sign;
+use num_bigint::{BigInt, Sign};
 
 use crate::{
     args::{ArgValues, FromArgs, is_long_int},
@@ -9,6 +9,7 @@ use crate::{
     exception_private::{ExcType, RunResult, SimpleException},
     heap::HeapData,
     resource::ResourceTracker,
+    types::LongInt,
     value::Value,
 };
 
@@ -72,14 +73,29 @@ pub fn builtin_round(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> 
                     // Positive or zero digits: return the integer unchanged
                     Ok(Value::Int(*n))
                 } else {
-                    // Negative digits: round to tens, hundreds, etc. using banker's rounding
-                    // (`unsigned_abs` avoids the `-i64::MIN` overflow; an
-                    // out-of-u32 magnitude saturates the factor to i64::MAX)
-                    let exp = u32::try_from(d.unsigned_abs()).unwrap_or(u32::MAX);
-                    let factor = 10_i64.saturating_pow(exp);
-                    let rounded_f = bankers_round(*n as f64 / factor as f64);
-                    let rounded = f64_to_i64(rounded_f) * factor;
-                    Ok(Value::Int(rounded))
+                    // Negative digits: round to the nearest multiple of 10^|d|,
+                    // half to even, exactly in integers — f64 division corrupts
+                    // large values and an i64 write-back multiply can overflow.
+                    // |n| < 10^19, so any |d| >= 20 rounds to 0, and the i128
+                    // intermediates stay far below their limits.
+                    let result: i128 = match u32::try_from(d.unsigned_abs()) {
+                        Ok(exp @ ..=19) => {
+                            let factor = 10_i128.pow(exp);
+                            let n = i128::from(*n);
+                            let mut q = n / factor;
+                            let r2 = (n % factor).abs() * 2;
+                            if r2 > factor || (r2 == factor && q % 2 != 0) {
+                                q += if n < 0 { -1 } else { 1 };
+                            }
+                            q * factor
+                        }
+                        _ => 0,
+                    };
+                    // Rounding up can cross i64::MAX (e.g. round(2**63 - 1, -1)).
+                    Ok(match i64::try_from(result) {
+                        Ok(i) => Value::Int(i),
+                        Err(_) => LongInt::new(BigInt::from(result)).into_value(vm.heap)?,
+                    })
                 }
             } else {
                 // No digits specified: return the integer unchanged

--- a/crates/monty/src/builtins/round.rs
+++ b/crates/monty/src/builtins/round.rs
@@ -1,10 +1,13 @@
 //! Implementation of the round() builtin function.
 
+use num_bigint::Sign;
+
 use crate::{
-    args::{ArgValues, FromArgs},
+    args::{ArgValues, FromArgs, is_long_int},
     bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
+    heap::HeapData,
     resource::ResourceTracker,
     value::Value,
 };
@@ -44,6 +47,14 @@ pub fn builtin_round(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> 
         Value::None => None,
         Value::Int(n) => Some(*n),
         Value::Bool(b) => Some(i64::from(*b)),
+        // A genuine int wider than i64: clamp by sign — the saturating paths
+        // below then return the number unchanged (huge positive) or 0 / ±0.0
+        // (huge negative), matching CPython's `Py_ssize_t` clamp for floats.
+        v if is_long_int(v, vm) => Some(if long_int_is_negative(v, vm) {
+            i64::MIN
+        } else {
+            i64::MAX
+        }),
         v => {
             let type_name = v.py_type_name(vm);
             return Err(SimpleException::new_msg(
@@ -62,8 +73,9 @@ pub fn builtin_round(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> 
                     Ok(Value::Int(*n))
                 } else {
                     // Negative digits: round to tens, hundreds, etc. using banker's rounding
-                    // -d is positive since d < 0; use try_from to safely convert
-                    let exp = u32::try_from(-d).unwrap_or(u32::MAX);
+                    // (`unsigned_abs` avoids the `-i64::MIN` overflow; an
+                    // out-of-u32 magnitude saturates the factor to i64::MAX)
+                    let exp = u32::try_from(d.unsigned_abs()).unwrap_or(u32::MAX);
                     let factor = 10_i64.saturating_pow(exp);
                     let rounded_f = bankers_round(*n as f64 / factor as f64);
                     let rounded = f64_to_i64(rounded_f) * factor;
@@ -100,6 +112,16 @@ pub fn builtin_round(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> 
             )
             .into())
         }
+    }
+}
+
+/// True when a LongInt-valued `ndigits` (interned or heap-allocated) is
+/// negative — decides which i64 extreme [`builtin_round`] clamps it to.
+fn long_int_is_negative(value: &Value, vm: &VM<'_, impl ResourceTracker>) -> bool {
+    match value {
+        Value::InternLongInt(id) => vm.interns.get_long_int(*id).sign() == Sign::Minus,
+        Value::Ref(id) => matches!(vm.heap.get(*id), HeapData::LongInt(li) if li.is_negative()),
+        _ => false,
     }
 }
 

--- a/crates/monty/src/builtins/round.rs
+++ b/crates/monty/src/builtins/round.rs
@@ -1,7 +1,7 @@
 //! Implementation of the round() builtin function.
 
 use crate::{
-    args::ArgValues,
+    args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
@@ -16,24 +16,35 @@ pub fn normalize_bool_to_int(value: Value) -> Value {
     }
 }
 
+/// Argument shape for `round(number, ndigits=None)` — CPython parses it with
+/// `PyArg_ParseTupleAndKeywords("|OO:round")`, so both arguments are
+/// keyword-capable, missing-argument errors carry `(pos N)` (`c_named`), and
+/// the total pre-count reports `round() takes at most 2 arguments (3 given)`.
+#[derive(FromArgs)]
+#[from_args(name = "round", style = c_named, at_most_total)]
+struct RoundArgs {
+    number: Value,
+    #[from_args(default = Value::None)]
+    ndigits: Value,
+}
+
 /// Implementation of the round() builtin function.
 ///
 /// Rounds a number to a given precision in decimal digits.
 /// If ndigits is omitted or None, returns the nearest integer.
 /// Uses banker's rounding (round half to even).
 pub fn builtin_round(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-    let (number, ndigits) = args.get_one_two_args("round", vm.heap)?;
+    let RoundArgs { number, ndigits } = RoundArgs::from_args(args, vm)?;
     let number = normalize_bool_to_int(number);
     defer_drop!(number, vm);
     defer_drop!(ndigits, vm);
 
     // Determine the number of digits (None means round to integer)
-    // Extract digits value before potentially consuming ndigits for error handling
     let digits: Option<i64> = match ndigits {
-        Some(Value::None) => None,
-        Some(Value::Int(n)) => Some(*n),
-        Some(Value::Bool(b)) => Some(i64::from(*b)),
-        Some(v) => {
+        Value::None => None,
+        Value::Int(n) => Some(*n),
+        Value::Bool(b) => Some(i64::from(*b)),
+        v => {
             let type_name = v.py_type_name(vm);
             return Err(SimpleException::new_msg(
                 ExcType::TypeError,
@@ -41,7 +52,6 @@ pub fn builtin_round(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> 
             )
             .into());
         }
-        None => None,
     };
 
     match number {

--- a/crates/monty/src/builtins/round.rs
+++ b/crates/monty/src/builtins/round.rs
@@ -17,7 +17,7 @@ pub fn normalize_bool_to_int(value: Value) -> Value {
 }
 
 /// Argument shape for `round(number, ndigits=None)` — CPython parses it with
-/// `PyArg_ParseTupleAndKeywords("|OO:round")`, so both arguments are
+/// `PyArg_ParseTupleAndKeywords("O|O:round")`, so both arguments are
 /// keyword-capable, missing-argument errors carry `(pos N)` (`c_named`), and
 /// the total pre-count reports `round() takes at most 2 arguments (3 given)`.
 #[derive(FromArgs)]

--- a/crates/monty/src/builtins/sum.rs
+++ b/crates/monty/src/builtins/sum.rs
@@ -6,7 +6,7 @@ use crate::{
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, RunResult, SimpleException},
+    exception_private::{ExcType, RunResult},
     heap::DropGuard,
     resource::ResourceTracker,
     types::{MontyIter, PyTrait, Type},
@@ -29,8 +29,8 @@ struct SumArgs {
 /// Implementation of the sum() builtin function.
 ///
 /// Sums the items of an iterable from left to right with an optional start value.
-/// The default start value is 0. String start values are explicitly rejected
-/// (use `''.join(seq)` instead for string concatenation).
+/// The default start value is 0. Str and bytes start values are explicitly
+/// rejected, pointing at `''.join(seq)` / `b''.join(seq)` instead.
 pub fn builtin_sum(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
     let SumArgs { iterable, start } = SumArgs::from_args(args, vm)?;
     defer_drop_mut!(start, vm);
@@ -38,11 +38,11 @@ pub fn builtin_sum(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> Ru
     let iter = MontyIter::new(iterable, vm)?;
     defer_drop_mut!(iter, vm);
 
-    // Reject string start values - Python explicitly forbids this
-    if matches!(start.py_type(vm), Type::Str) {
-        return Err(
-            SimpleException::new_msg(ExcType::TypeError, "sum() can't sum strings [use ''.join(seq) instead]").into(),
-        );
+    // Reject str/bytes start values - Python explicitly forbids these
+    match start.py_type(vm) {
+        Type::Str => return Err(ExcType::type_error_sum_start("strings", "''")),
+        Type::Bytes => return Err(ExcType::type_error_sum_start("bytes", "b''")),
+        _ => {}
     }
     // Take the start value out of its guard (dropping `None` is a no-op).
     let accumulator = mem::replace(start, Value::None);

--- a/crates/monty/src/builtins/sum.rs
+++ b/crates/monty/src/builtins/sum.rs
@@ -3,7 +3,7 @@
 use std::mem;
 
 use crate::{
-    args::ArgValues,
+    args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult, SimpleException},
@@ -13,34 +13,39 @@ use crate::{
     value::Value,
 };
 
+/// Argument shape for `sum(iterable, /, start=0)` — Argument Clinic in
+/// CPython, so `start` is keyword-capable while `iterable` is positional-only.
+/// `at_most_total` reproduces `_PyArg_UnpackKeywords`' total pre-count
+/// (`sum() takes at most 2 arguments (3 given)`).
+#[derive(FromArgs)]
+#[from_args(name = "sum", at_most_total)]
+struct SumArgs {
+    #[from_args(pos_only)]
+    iterable: Value,
+    #[from_args(default = Value::Int(0))]
+    start: Value,
+}
+
 /// Implementation of the sum() builtin function.
 ///
 /// Sums the items of an iterable from left to right with an optional start value.
 /// The default start value is 0. String start values are explicitly rejected
 /// (use `''.join(seq)` instead for string concatenation).
 pub fn builtin_sum(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-    let (iterable, start) = args.get_one_two_args("sum", vm.heap)?;
+    let SumArgs { iterable, start } = SumArgs::from_args(args, vm)?;
     defer_drop_mut!(start, vm);
 
     let iter = MontyIter::new(iterable, vm)?;
     defer_drop_mut!(iter, vm);
 
-    // Get the start value, defaulting to 0
-    let accumulator = match start.take() {
-        Some(v) => {
-            // Reject string start values - Python explicitly forbids this
-            if matches!(v.py_type(vm), Type::Str) {
-                v.drop_with(vm);
-                return Err(SimpleException::new_msg(
-                    ExcType::TypeError,
-                    "sum() can't sum strings [use ''.join(seq) instead]",
-                )
-                .into());
-            }
-            v
-        }
-        None => Value::Int(0),
-    };
+    // Reject string start values - Python explicitly forbids this
+    if matches!(start.py_type(vm), Type::Str) {
+        return Err(
+            SimpleException::new_msg(ExcType::TypeError, "sum() can't sum strings [use ''.join(seq) instead]").into(),
+        );
+    }
+    // Take the start value out of its guard (dropping `None` is a no-op).
+    let accumulator = mem::replace(start, Value::None);
 
     // DropGuard for accumulator: on success we extract it via into_inner(),
     // on any error path it's dropped automatically

--- a/crates/monty/src/codecs.rs
+++ b/crates/monty/src/codecs.rs
@@ -84,6 +84,12 @@ impl Codec {
     /// CPython's `codecs.lookup_error` semantics. Only the ASCII codec can
     /// fail: UTF-8 is the native representation, and every Monty string is
     /// encodable as UTF-16/32 (no lone surrogates can exist).
+    ///
+    /// Like [`Codec::decode`], output is bounded by a small constant multiple
+    /// of the (already resource-tracked) input — ≤2x for UTF-16, ≤4x for
+    /// UTF-32, plus a BOM — so those paths need no tracked builder; only the
+    /// ASCII error handlers can amplify further, and they build through the
+    /// tracker.
     pub(crate) fn encode(self, s: &str, errors: &str, tracker: &impl ResourceTracker) -> RunResult<Vec<u8>> {
         match self {
             Self::Utf8 => Ok(s.as_bytes().to_vec()),

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -858,6 +858,31 @@ impl ExcType {
         .into()
     }
 
+    /// Creates a TypeError for a missing required argument without a position,
+    /// as raised by hand-written vectorcall fast paths like `enumerate`:
+    /// `{name}() missing required argument '{arg_name}'`
+    #[must_use]
+    pub(crate) fn type_error_missing_required_no_pos(name: &str, arg_name: &str) -> RunError {
+        SimpleException::new_msg(
+            Self::TypeError,
+            format!("{name}() missing required argument '{arg_name}'"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for a keyword rejected by a hand-written vectorcall
+    /// fast path (CPython's `enumerate` wording, distinct from the parser
+    /// families' "unexpected keyword argument"):
+    /// `'{key}' is an invalid keyword argument for {name}()`
+    #[must_use]
+    pub(crate) fn type_error_invalid_keyword_argument(name: &str, key: &str) -> RunError {
+        SimpleException::new_msg(
+            Self::TypeError,
+            format!("'{key}' is an invalid keyword argument for {name}()"),
+        )
+        .into()
+    }
+
     /// Creates a TypeError matching CPython's `_PyArg_BadArgument`
     /// positional-style wording: `{name}() argument {pos} must be
     /// {expected}, not {got}`.

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1392,7 +1392,9 @@ impl ExcType {
     pub(crate) fn value_error_int_too_large_for_str() -> RunError {
         SimpleException::new_msg(
             Self::ValueError,
-            format!("Exceeds the limit ({INT_MAX_STR_DIGITS} digits) for integer string conversion"),
+            format!(
+                "Exceeds the limit ({INT_MAX_STR_DIGITS} digits) for integer string conversion; use sys.set_int_max_str_digits() to increase the limit"
+            ),
         )
         .into()
     }
@@ -1405,7 +1407,7 @@ impl ExcType {
         SimpleException::new_msg(
             Self::ValueError,
             format!(
-                "Exceeds the limit ({INT_MAX_STR_DIGITS} digits) for integer string conversion: value has {digit_count} digits"
+                "Exceeds the limit ({INT_MAX_STR_DIGITS} digits) for integer string conversion: value has {digit_count} digits; use sys.set_int_max_str_digits() to increase the limit"
             ),
         )
         .into()
@@ -1413,15 +1415,41 @@ impl ExcType {
 
     /// Creates a ValueError for `int()` when a string cannot be parsed as an integer.
     ///
-    /// Matches CPython's format: `invalid literal for int() with base 10: '...'`.
-    /// The caller provides the value pre-formatted (e.g. via `StringRepr`).
+    /// Matches CPython's format: `invalid literal for int() with base {N}: '...'`.
+    /// `base` is the base the caller passed (0 included, before auto-detection);
+    /// the caller provides the value pre-formatted (e.g. via `StringRepr`).
     #[must_use]
-    pub(crate) fn value_error_invalid_literal_for_int(value: impl fmt::Display) -> RunError {
+    pub(crate) fn value_error_invalid_literal_for_int(base: u32, value: impl fmt::Display) -> RunError {
         SimpleException::new_msg(
             Self::ValueError,
-            format!("invalid literal for int() with base 10: {value}"),
+            format!("invalid literal for int() with base {base}: {value}"),
         )
         .into()
+    }
+
+    /// Creates a ValueError for an `int()` base outside `{0} ∪ 2..=36`.
+    ///
+    /// Matches CPython's message: `int() base must be >= 2 and <= 36, or 0`.
+    #[must_use]
+    pub(crate) fn value_error_int_base_range() -> RunError {
+        SimpleException::new_msg(Self::ValueError, "int() base must be >= 2 and <= 36, or 0").into()
+    }
+
+    /// Creates a TypeError for `int(base=N)` with no value to convert.
+    ///
+    /// Matches CPython's message: `int() missing string argument`. Raised
+    /// before the base is validated, matching `long_new_impl`'s ordering.
+    #[must_use]
+    pub(crate) fn type_error_int_missing_string_argument() -> RunError {
+        SimpleException::new_msg(Self::TypeError, "int() missing string argument").into()
+    }
+
+    /// Creates a TypeError for `int(x, base)` where `x` is not str/bytes.
+    ///
+    /// Matches CPython's message: `int() can't convert non-string with explicit base`.
+    #[must_use]
+    pub(crate) fn type_error_int_non_string_with_base() -> RunError {
+        SimpleException::new_msg(Self::TypeError, "int() can't convert non-string with explicit base").into()
     }
 
     /// Creates a ValueError for negative shift count in bitwise shift operations.
@@ -1638,6 +1666,50 @@ impl ExcType {
     #[must_use]
     pub(crate) fn lookup_error_unknown_encoding(encoding: &str) -> RunError {
         SimpleException::new_msg(Self::LookupError, format!("unknown encoding: {encoding}")).into()
+    }
+
+    /// Creates a TypeError for `str(s, encoding=...)` with a str object.
+    ///
+    /// Matches CPython's message: `decoding str is not supported`.
+    #[must_use]
+    pub(crate) fn type_error_decoding_str_not_supported() -> RunError {
+        SimpleException::new_msg(Self::TypeError, "decoding str is not supported").into()
+    }
+
+    /// Creates a TypeError for `str(x, encoding=...)` with a non-bytes object.
+    ///
+    /// Matches CPython's format: `decoding to str: need a bytes-like object, {type} found`.
+    #[must_use]
+    pub(crate) fn type_error_decoding_need_bytes(type_: impl Display) -> RunError {
+        SimpleException::new_msg(
+            Self::TypeError,
+            format!("decoding to str: need a bytes-like object, {type_} found"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for `bytes(s)` with a str source and no encoding.
+    ///
+    /// Matches CPython's message: `string argument without an encoding`.
+    #[must_use]
+    pub(crate) fn type_error_string_without_encoding() -> RunError {
+        SimpleException::new_msg(Self::TypeError, "string argument without an encoding").into()
+    }
+
+    /// Creates a TypeError for `bytes(x, encoding=...)` with a non-str source.
+    ///
+    /// Matches CPython's message: `encoding without a string argument`.
+    #[must_use]
+    pub(crate) fn type_error_encoding_without_string() -> RunError {
+        SimpleException::new_msg(Self::TypeError, "encoding without a string argument").into()
+    }
+
+    /// Creates a TypeError for `bytes(x, errors=...)` with a non-str source.
+    ///
+    /// Matches CPython's message: `errors without a string argument`.
+    #[must_use]
+    pub(crate) fn type_error_errors_without_string() -> RunError {
+        SimpleException::new_msg(Self::TypeError, "errors without a string argument").into()
     }
 
     /// Creates a UnicodeEncodeError for a run of `start..end` consecutive

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1712,6 +1712,19 @@ impl ExcType {
         SimpleException::new_msg(Self::TypeError, "errors without a string argument").into()
     }
 
+    /// Creates a TypeError for `sum()` rejecting a str/bytes `start` value.
+    ///
+    /// Matches CPython: `sum() can't sum {kind} [use {join}.join(seq) instead]`
+    /// — `("strings", "''")` for str, `("bytes", "b''")` for bytes.
+    #[must_use]
+    pub(crate) fn type_error_sum_start(kind: &str, join: &str) -> RunError {
+        SimpleException::new_msg(
+            Self::TypeError,
+            format!("sum() can't sum {kind} [use {join}.join(seq) instead]"),
+        )
+        .into()
+    }
+
     /// Creates a UnicodeEncodeError for a run of `start..end` consecutive
     /// characters (character indices, not byte offsets) of `object` — the
     /// full string being encoded — that can't be represented in the target

--- a/crates/monty/src/intern.rs
+++ b/crates/monty/src/intern.rs
@@ -576,6 +576,9 @@ pub enum StaticStrings {
     Offset,
     // datetime.now() kwarg
     Tz,
+    // round() kwargs
+    Number,
+    Ndigits,
     // date/datetime methods
     Isoformat,
     Strftime,

--- a/crates/monty/src/intern.rs
+++ b/crates/monty/src/intern.rs
@@ -217,6 +217,7 @@ pub enum StaticStrings {
     Obj,
     Object,
     Source,
+    Base,
     // Additional string methods
     Encode,
     Isidentifier,

--- a/crates/monty/src/modules/CLAUDE.md
+++ b/crates/monty/src/modules/CLAUDE.md
@@ -29,6 +29,7 @@ CPython-family table and the `at_most_total` litmus test).
 | `PyArg_ParseTupleAndKeywords`, anonymous `function` errors | `style = c` |
 | same, with the name embedded (`timezone() missing …`) | `style = c_named` |
 | `PyArg_UnpackTuple` (positional-only, `min..max` arity, kwargs rejected wholesale with `takes no keyword arguments`) | `style = unpack` |
+| `tp_vectorcall` fast path in front of a clinic parser (`int`, `str`: kwarg-free overflow says `int expected at most 2 arguments, got 3`, with kwargs `int() takes at most 2 arguments (3 given)`) | default style + `at_most_total, vectorcall` |
 
 The style controls wording *and* ordering (e.g. C families report leftover
 kwargs last; clinic/def bind fully before any conversion). When unsure, probe

--- a/crates/monty/src/modules/CLAUDE.md
+++ b/crates/monty/src/modules/CLAUDE.md
@@ -28,7 +28,7 @@ CPython-family table and the `at_most_total` litmus test).
 | Argument Clinic (most modern C builtins/methods) | default — omit `style` |
 | `PyArg_ParseTupleAndKeywords`, anonymous `function` errors | `style = c` |
 | same, with the name embedded (`timezone() missing …`) | `style = c_named` |
-| `PyArg_UnpackTuple` (positional-only, `min..max` arity) | `style = unpack` |
+| `PyArg_UnpackTuple` (positional-only, `min..max` arity, kwargs rejected wholesale with `takes no keyword arguments`) | `style = unpack` |
 
 The style controls wording *and* ordering (e.g. C families report leftover
 kwargs last; clinic/def bind fully before any conversion). When unsure, probe

--- a/crates/monty/src/modules/unicodedata.rs
+++ b/crates/monty/src/modules/unicodedata.rs
@@ -210,7 +210,7 @@ fn uni_is_normalized(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> 
 /// character has no name. `style = unpack` gives the `PyArg_UnpackTuple` arity
 /// wording CPython uses here (`name expected at most 2 arguments, got 3`).
 #[derive(FromArgs)]
-#[from_args(name = "name", style = unpack)]
+#[from_args(name = "name", style = unpack, kwarg_error_name = "unicodedata.name")]
 struct NameArgs {
     #[from_args(pos_only)]
     chr: Value,
@@ -228,7 +228,7 @@ struct NameArgs {
 /// `ValueError`. `style = unpack` (with min == max here) reproduces CPython's
 /// `normalize expected 2 arguments, got N` arity error.
 #[derive(FromArgs)]
-#[from_args(name = "normalize", style = unpack, bad_arg)]
+#[from_args(name = "normalize", style = unpack, bad_arg, kwarg_error_name = "unicodedata.normalize")]
 struct NormalizeArgs {
     #[from_args(pos_only)]
     form: StrArg,
@@ -238,7 +238,7 @@ struct NormalizeArgs {
 
 /// Argument shape for `is_normalized(form, unistr, /)` — see [`NormalizeArgs`].
 #[derive(FromArgs)]
-#[from_args(name = "is_normalized", style = unpack, bad_arg)]
+#[from_args(name = "is_normalized", style = unpack, bad_arg, kwarg_error_name = "unicodedata.is_normalized")]
 struct IsNormalizedArgs {
     #[from_args(pos_only)]
     form: StrArg,

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -157,13 +157,42 @@ impl Bytes {
     ///
     /// - `bytes()` with no args returns empty bytes
     /// - `bytes(int)` returns bytes of that length filled with zeros
-    /// - `bytes(string)` encodes the string as UTF-8 (simplified, no encoding param)
+    /// - `bytes(string, encoding, errors)` encodes via the codec registry —
+    ///   like CPython, a str source *requires* an encoding
     /// - `bytes(bytes)` returns a copy of the bytes
-    ///
-    /// Note: Full Python semantics for bytes() are more complex (encoding, errors params).
     pub fn init(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-        let BytesInitArgs { source } = BytesInitArgs::from_args(args, vm)?;
+        let BytesInitArgs {
+            source,
+            encoding,
+            errors,
+        } = BytesInitArgs::from_args(args, vm)?;
         defer_drop!(source, vm);
+        defer_drop!(encoding, vm);
+        defer_drop!(errors, vm);
+        let source_str = match source {
+            Some(v) if v.is_str(vm.heap) => Some(v),
+            _ => None,
+        };
+        // CPython's `bytes_new` ordering: an encoding demands a str source, a
+        // str source demands an encoding, and a lone `errors` is never valid.
+        if let Some(encoding) = encoding {
+            let Some(v) = source_str else {
+                return Err(ExcType::type_error_encoding_without_string());
+            };
+            let s = v.to_str(vm)?;
+            let errors = errors.as_ref().map_or("strict", |e| e.as_str(vm));
+            let encoding = encoding.as_str(vm);
+            let codec = Codec::find(encoding).ok_or_else(|| ExcType::lookup_error_unknown_encoding(encoding))?;
+            let encoded = codec.encode(s, errors, vm.heap.tracker())?;
+            let heap_id = vm.heap.allocate(HeapData::Bytes(Self::new(encoded)))?;
+            return Ok(Value::Ref(heap_id));
+        }
+        if source_str.is_some() {
+            return Err(ExcType::type_error_string_without_encoding());
+        }
+        if errors.is_some() {
+            return Err(ExcType::type_error_errors_without_string());
+        }
         let new_data = match source {
             None => Vec::new(),
             Some(Value::Int(n)) => {
@@ -179,16 +208,11 @@ impl Bytes {
                 check_repeat_size(size, 1, vm.heap.tracker())?;
                 vec![0u8; size]
             }
-            Some(Value::InternString(string_id)) => {
-                let s = vm.interns.get_str(*string_id);
-                s.as_bytes().to_vec()
-            }
             Some(Value::InternBytes(bytes_id)) => {
                 let b = vm.interns.get_bytes(*bytes_id);
                 b.to_vec()
             }
             Some(v @ Value::Ref(id)) => match vm.heap.get(*id) {
-                HeapData::Str(s) => s.as_str().as_bytes().to_vec(),
                 HeapData::Bytes(b) => b.as_slice().to_vec(),
                 _ => return Err(ExcType::type_error_bytes_init(&v.py_type_name(vm))),
             },
@@ -199,14 +223,19 @@ impl Bytes {
     }
 }
 
-/// Argument shape for `bytes(source=...)` — one optional pos-or-keyword arg
-/// (`source` is the CPython kwarg name) interpreted as the type-specific
-/// dispatch inside [`Bytes::init`].
+/// Argument shape for `bytes(source=..., encoding=..., errors=...)`, all
+/// pos-or-keyword. Unlike `str()`, CPython's `bytes_new` reports wrong-typed
+/// `encoding`/`errors` with `_PyArg_BadArgument`'s wording (`must be str, not
+/// None` for `None`), which is exactly the macro's `bad_arg_named` form.
 #[derive(FromArgs)]
-#[from_args(name = "bytes", style = c_named)]
+#[from_args(name = "bytes", at_most_total, bad_arg_named)]
 struct BytesInitArgs {
     #[from_args(default)]
     source: Option<Value>,
+    #[from_args(default)]
+    encoding: Option<StrArg>,
+    #[from_args(default)]
+    errors: Option<StrArg>,
 }
 
 impl From<Vec<u8>> for Bytes {

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -20,7 +20,7 @@ use crate::{
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult, SimpleException},
     hash::HashValue,
-    heap::{DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
+    heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     object::MontyTimeZone,
     os::OsFunctionCall,
@@ -259,88 +259,29 @@ struct DatetimeInitArgs {
 
 /// Classmethod implementation for `datetime.now(tz=None)`. Yields a
 /// `DateTimeNow` OS call carrying the tz argument as a typed
-/// [`Option<MontyTimeZone>`] — validation happened during extraction, so the
-/// call can never carry an arbitrary object.
+/// [`Option<MontyTimeZone>`] — validated here, so the call can never carry an
+/// arbitrary object.
 pub(crate) fn class_now(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<AttrCallResult> {
-    let tz_value = extract_now_tz(vm, args)?;
-    // `extract_now_tz` already validated the value, so this cannot fail; it
-    // reuses `tzinfo_from_value` purely for the None-or-timezone projection.
-    let tz = tzinfo_from_value(&tz_value, vm.heap, vm.interns)?
-        .0
-        .map(|tz| MontyTimeZone {
-            offset_seconds: tz.offset_seconds,
-            name: tz.name,
-        });
-    tz_value.drop_with(vm);
+    let NowArgs { tz } = NowArgs::from_args(args, vm)?;
+    defer_drop!(tz, vm);
+    let tz = tzinfo_from_value(tz, vm.heap, vm.interns)?.0.map(|tz| MontyTimeZone {
+        offset_seconds: tz.offset_seconds,
+        name: tz.name,
+    });
     Ok(AttrCallResult::OsCall(OsFunctionCall::DateTimeNow(tz)))
 }
 
-/// Extracts the single `tz` argument from `datetime.now()`'s args
-/// (defaulting to `Value::None`), draining the iterators on every path so
-/// refcounts stay balanced.
-fn extract_now_tz(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-    let interns = vm.interns;
-    let heap = &mut *vm.heap;
-    let (mut pos, kwargs) = args.into_parts();
-    let mut kwargs_iter = kwargs.into_iter();
-
-    let mut tz_value = Value::None;
-    let mut seen_tz = false;
-
-    for (index, arg) in pos.by_ref().enumerate() {
-        if index == 0 {
-            if let Err(e) = validate_tz_arg(&arg, heap, interns) {
-                arg.drop_with(heap);
-                pos.drop_with(heap);
-                kwargs_iter.drop_with(heap);
-
-                return Err(e);
-            }
-            tz_value = arg;
-            seen_tz = true;
-        } else {
-            arg.drop_with(heap);
-            pos.drop_with(heap);
-            kwargs_iter.drop_with(heap);
-            tz_value.drop_with(heap);
-            return Err(ExcType::type_error_method_at_most("now", 1, index + 1));
-        }
-    }
-
-    while let Some((key, value)) = kwargs_iter.next() {
-        let key_name = key.as_either_str(heap);
-        key.drop_with(heap);
-
-        let Some(key_name) = key_name else {
-            value.drop_with(heap);
-            kwargs_iter.drop_with(heap);
-            tz_value.drop_with(heap);
-            return Err(ExcType::type_error_kwargs_nonstring_key());
-        };
-        if key_name.string_id() != Some(StaticStrings::Tz.into()) {
-            value.drop_with(heap);
-            kwargs_iter.drop_with(heap);
-            tz_value.drop_with(heap);
-            return Err(ExcType::type_error_unexpected_keyword("now", key_name.as_str(interns)));
-        }
-        if seen_tz {
-            value.drop_with(heap);
-            kwargs_iter.drop_with(heap);
-            tz_value.drop_with(heap);
-            return Err(ExcType::type_error_method_at_most("now", 1, 2));
-        }
-
-        if let Err(e) = validate_tz_arg(&value, heap, interns) {
-            value.drop_with(heap);
-            kwargs_iter.drop_with(heap);
-            tz_value.drop_with(heap);
-
-            return Err(e);
-        }
-        tz_value = value;
-        seen_tz = true;
-    }
-    Ok(tz_value)
+/// Argument shape for `datetime.now(tz=None)`.
+///
+/// `tz` stays a raw [`Value`] so the None-or-timezone check runs in the body
+/// (`tzinfo_from_value`) with CPython's tzinfo wording. `at_most_total`
+/// matches CPython's `PyArg_ParseTupleAndKeywords` pre-count: a duplicate tz
+/// (`now(utc, tz=utc)`) reports "takes at most 1 argument (2 given)".
+#[derive(FromArgs)]
+#[from_args(name = "now", at_most_total)]
+struct NowArgs {
+    #[from_args(default = Value::None)]
+    tz: Value,
 }
 
 /// Classmethod `datetime.strptime(date_string, format)`.
@@ -619,22 +560,6 @@ fn tzinfo_from_value(
         Value::None => Ok((None, None)),
         Value::Ref(id) => match heap.get(*id) {
             HeapData::TimeZone(tz) => Ok((Some(tz.clone()), Some(*id))),
-            other => Err(ExcType::type_error_tzinfo(&other.py_type().name(heap, interns))),
-        },
-        _ => Err(ExcType::type_error_tzinfo(&value.py_type_shallow().name(heap, interns))),
-    }
-}
-
-/// Validates that a value is a valid timezone argument (`None` or `TimeZone`).
-///
-/// Used by `class_now` to validate the `tz` argument before passing it through
-/// to the OS call. Unlike `tzinfo_from_value`, this does not extract the timezone
-/// data — it only checks the type.
-fn validate_tz_arg(value: &Value, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> RunResult<()> {
-    match value {
-        Value::None => Ok(()),
-        Value::Ref(id) => match heap.get(*id) {
-            HeapData::TimeZone(_) => Ok(()),
             other => Err(ExcType::type_error_tzinfo(&other.py_type().name(heap, interns))),
         },
         _ => Err(ExcType::type_error_tzinfo(&value.py_type_shallow().name(heap, interns))),

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -62,17 +62,47 @@ impl Str {
 
     /// Creates a string from the `str()` constructor call.
     ///
-    /// - `str()` with no args returns an empty string
+    /// - `str()` with no args returns an empty string (even with `encoding=`)
     /// - `str(x)` converts x to its string representation using `py_str`
+    /// - `str(b, encoding, errors)` decodes a bytes object via the codec registry
     pub fn init(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
-        let StrInitArgs { object } = StrInitArgs::from_args(args, vm)?;
-        match object {
-            None => Ok(Value::InternString(StaticStrings::EmptyString.into())),
-            Some(v) => {
-                defer_drop!(v, vm);
-                v.py_str(vm)
-            }
+        let StrInitArgs {
+            object,
+            encoding,
+            errors,
+        } = StrInitArgs::from_args(args, vm)?;
+        defer_drop!(object, vm);
+        defer_drop!(encoding, vm);
+        defer_drop!(errors, vm);
+        if encoding.is_none() && errors.is_none() {
+            return match object {
+                None => Ok(Value::InternString(StaticStrings::EmptyString.into())),
+                Some(v) => v.py_str(vm),
+            };
         }
+        // Decoding mode. Type-check `encoding` then `errors` first — CPython's
+        // clinic converters run before the constructor body sees the object.
+        str_ctor_arg_check(encoding.as_ref(), "encoding", vm)?;
+        str_ctor_arg_check(errors.as_ref(), "errors", vm)?;
+        let Some(object) = object else {
+            // A missing object wins over the decoding args: `str(encoding='utf-8')` is ''.
+            return Ok(Value::InternString(StaticStrings::EmptyString.into()));
+        };
+        let bytes: &[u8] = match object {
+            Value::InternBytes(bytes_id) => vm.interns.get_bytes(*bytes_id),
+            Value::InternString(_) => return Err(ExcType::type_error_decoding_str_not_supported()),
+            Value::Ref(heap_id) => match vm.heap.get(*heap_id) {
+                HeapData::Bytes(b) => b.as_slice(),
+                HeapData::Str(_) => return Err(ExcType::type_error_decoding_str_not_supported()),
+                _ => return Err(ExcType::type_error_decoding_need_bytes(object.py_type_name(vm))),
+            },
+            _ => return Err(ExcType::type_error_decoding_need_bytes(object.py_type_name(vm))),
+        };
+        let encoding = ctor_str_arg(encoding.as_ref(), "utf-8", vm)?;
+        let errors = ctor_str_arg(errors.as_ref(), "strict", vm)?;
+        let codec = Codec::find(encoding).ok_or_else(|| ExcType::lookup_error_unknown_encoding(encoding))?;
+        let s = codec.decode(bytes, errors)?;
+        Ok(allocate_string(s, vm.heap)?)
     }
 
     /// Handles slice-based indexing for strings.
@@ -84,13 +114,49 @@ impl Str {
     }
 }
 
-/// Argument shape for `str(object='')` — accepts one optional pos-or-keyword
-/// `object` arg whose absence is the documented "return empty string" path.
+/// Argument shape for `str(object='', encoding='utf-8', errors='strict')`.
+///
+/// `encoding`/`errors` are raw `Value`s validated in the body: CPython's
+/// `unicode_new` names a wrong type by its `tp_name` (`must be str, not
+/// NoneType`), not `_PyArg_BadArgument`'s `None` special case, so the macro's
+/// `bad_arg_named` wording can't be used. `vectorcall` + `at_most_total`
+/// model `unicode_vectorcall`'s dual arity wording.
 #[derive(FromArgs)]
-#[from_args(name = "str", style = c_named)]
+#[from_args(name = "str", at_most_total, vectorcall)]
 struct StrInitArgs {
     #[from_args(default)]
     object: Option<Value>,
+    #[from_args(default)]
+    encoding: Option<Value>,
+    #[from_args(default)]
+    errors: Option<Value>,
+}
+
+/// Rejects a non-str `encoding`/`errors` argument to `str()` with CPython's
+/// `str() argument '{name}' must be str, not {tp_name}` wording.
+fn str_ctor_arg_check(arg: Option<&Value>, name: &str, vm: &VM<'_, impl ResourceTracker>) -> RunResult<()> {
+    match arg {
+        Some(v) if !v.is_str(vm.heap) => Err(ExcType::type_error_bad_arg_named(
+            "str",
+            name,
+            "str",
+            v.py_type_name(vm),
+        )),
+        _ => Ok(()),
+    }
+}
+
+/// Borrows a validated (str-typed) optional constructor argument's text,
+/// falling back to `default` when the argument was absent.
+fn ctor_str_arg<'a>(
+    arg: Option<&'a Value>,
+    default: &'a str,
+    vm: &'a VM<'_, impl ResourceTracker>,
+) -> RunResult<&'a str> {
+    match arg {
+        None => Ok(default),
+        Some(v) => v.to_str(vm),
+    }
 }
 
 /// Allocates a string, using interned versions when possible.

--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -596,14 +596,16 @@ fn parse_int_from_str(value: &str, base: u32, heap: &Heap<impl ResourceTracker>)
         return Ok(Value::Int(int));
     }
     let invalid = || ExcType::value_error_invalid_literal_for_int(base, StringRepr(value));
-    parse_int_digits(value, base, &invalid, heap)
+    parse_int_digits(value.trim(), base, &invalid, heap)
 }
 
-/// Parses a Python `int()` bytes argument — same rules as str parsing, but a
-/// failure reprs the input as a bytes literal (`b'...'`), matching CPython.
+/// Parses a Python `int()` bytes argument using ASCII whitespace rules.
+///
+/// Unlike `str`, bytes must not treat UTF-8 encodings of Unicode whitespace as
+/// separators. Failures repr the input as a bytes literal, matching CPython.
 fn parse_int_from_bytes(bytes: &[u8], base: u32, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
     let invalid = || ExcType::value_error_invalid_literal_for_int(base, bytes_repr(bytes));
-    match str::from_utf8(bytes) {
+    match str::from_utf8(bytes.trim_ascii()) {
         Ok(s) => parse_int_digits(s, base, &invalid, heap),
         Err(_) => Err(invalid()),
     }
@@ -619,19 +621,17 @@ enum IntScanState {
     Underscore,
 }
 
-/// The shared str/bytes int-literal parser: whitespace, sign, base prefix
-/// (`0x`/`0o`/`0b`, mandatory-zeros rule for `base=0`), underscore placement,
-/// the digit limit for non-power-of-two bases, and BigInt promotion.
+/// Parses a whitespace-trimmed str/bytes int literal: sign, base prefix,
+/// underscore placement, digit limits, and BigInt promotion.
 fn parse_int_digits(
     value: &str,
     base: u32,
     invalid: &impl Fn() -> RunError,
     heap: &Heap<impl ResourceTracker>,
 ) -> RunResult<Value> {
-    let trimmed = value.trim();
-    let (negative, body) = match trimmed.strip_prefix(['+', '-']) {
-        Some(rest) => (trimmed.starts_with('-'), rest),
-        None => (false, trimmed),
+    let (negative, body) = match value.strip_prefix(['+', '-']) {
+        Some(rest) => (value.starts_with('-'), rest),
+        None => (false, value),
     };
 
     // Resolve the effective base and strip any `0x`/`0o`/`0b` prefix. For

--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -595,8 +595,18 @@ fn parse_int_from_str(value: &str, base: u32, heap: &Heap<impl ResourceTracker>)
     {
         return Ok(Value::Int(int));
     }
-    let invalid = || ExcType::value_error_invalid_literal_for_int(base, StringRepr(value));
-    parse_int_digits(value.trim(), base, &invalid, heap)
+    let trimmed = value.trim();
+    // Preserve the allocation-free path for whitespace-padded i64 values
+    // without retrying unchanged inputs that already failed above.
+    if base == 10
+        && trimmed.len() != value.len()
+        && let Ok(int) = trimmed.parse::<i64>()
+    {
+        Ok(Value::Int(int))
+    } else {
+        let invalid = || ExcType::value_error_invalid_literal_for_int(base, StringRepr(value));
+        parse_int_digits(trimmed, base, &invalid, heap)
+    }
 }
 
 /// Parses a Python `int()` bytes argument using ASCII whitespace rules.

--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, fmt};
 use num_bigint::BigInt;
 
 use crate::{
-    args::ArgValues,
+    args::{ArgValues, FromArgs, is_long_int},
     bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunError, RunResult, SimpleException},
@@ -12,8 +12,14 @@ use crate::{
     resource::ResourceTracker,
     types::{
         AttrCallResult, Bytes, Dict, FrozenSet, List, LongInt, MontyIter, Path, PyTrait, Range, Set, Slice, Str,
-        TimeZone, Tuple, bytes::bytes_fromhex, date, datetime, dict::dict_fromkeys, instance::class_name,
-        long_int::INT_MAX_STR_DIGITS, str::StringRepr, timedelta,
+        TimeZone, Tuple,
+        bytes::{bytes_fromhex, bytes_repr},
+        date, datetime,
+        dict::dict_fromkeys,
+        instance::class_name,
+        long_int::INT_MAX_STR_DIGITS,
+        str::StringRepr,
+        timedelta,
     },
     value::Value,
 };
@@ -390,25 +396,7 @@ impl Type {
             Self::Path => Path::init(vm, args),
 
             // Primitive types - inline implementation
-            Self::Int => {
-                let interns = vm.interns;
-                let Some(v) = args.get_zero_one_arg("int", vm.heap)? else {
-                    return Ok(Value::Int(0));
-                };
-                defer_drop!(v, vm);
-                match v {
-                    Value::Int(i) => Ok(Value::Int(*i)),
-                    Value::Float(f) => Ok(Value::Int(f64_to_i64_truncate(*f))),
-                    Value::Bool(b) => Ok(Value::Int(i64::from(*b))),
-                    Value::InternString(string_id) => parse_int_from_str(interns.get_str(*string_id), vm.heap),
-                    Value::Ref(heap_id) => match vm.heap.get(*heap_id) {
-                        HeapData::Str(s) => parse_int_from_str(s.as_str(), vm.heap),
-                        HeapData::LongInt(_) => Ok(v.clone_with_heap(vm.heap)),
-                        _ => Err(ExcType::type_error_int_conversion(&v.py_type_name(vm))),
-                    },
-                    _ => Err(ExcType::type_error_int_conversion(&v.py_type_name(vm))),
-                }
-            }
+            Self::Int => int_init(vm, args),
             Self::Float => {
                 let interns = vm.interns;
                 let Some(v) = args.get_zero_one_arg("float", vm.heap)? else {
@@ -502,64 +490,223 @@ fn value_error_could_not_convert_string_to_float(value: &str) -> RunError {
     .into()
 }
 
-/// Parses a Python `int()` string argument into an `Int` or `LongInt`.
-///
-/// Handles whitespace stripping and removing `_` separators. Returns `Value::Int` if the value
-/// fits in i64, otherwise allocates a `LongInt` on the heap. Returns `ValueError` on failure.
-fn parse_int_from_str(value: &str, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
-    let invalid = || ExcType::value_error_invalid_literal_for_int(StringRepr(value));
-    // Try parsing as i64 first (fast path)
-    if let Ok(int) = value.parse::<i64>() {
-        return Ok(Value::Int(int));
-    }
-    let trimmed = value.trim();
+/// Argument shape for `int(x=..., /, base=...)`. `x` is positional-only with
+/// no kwarg id, so `int(x=1)` reports an unknown keyword exactly like CPython;
+/// `vectorcall` + `at_most_total` model `long_vectorcall`'s dual arity wording.
+#[derive(FromArgs)]
+#[from_args(name = "int", at_most_total, vectorcall)]
+struct IntArgs {
+    #[from_args(pos_only, default)]
+    x: Option<Value>,
+    #[from_args(default)]
+    base: Option<Value>,
+}
 
-    if let Ok(int) = trimmed.parse::<i64>() {
-        return Ok(Value::Int(int));
-    }
-
-    // Validate underscore placement before stripping.
-    // CPython rejects: leading _, trailing _, consecutive __, _ right after sign.
-    if !is_valid_int_underscores(trimmed) {
-        return Err(invalid());
-    }
-
-    // Strip underscores after validation
-    let normalized = trimmed.replace('_', "");
-    if let Ok(int) = normalized.parse::<i64>() {
-        Ok(Value::Int(int))
-    } else if normalized.len() > INT_MAX_STR_DIGITS {
-        // Only do detailed validation when the string is long enough to possibly
-        // exceed the digit limit — avoids the O(n) scan on short strings.
-        let digit_count = normalized.bytes().filter(u8::is_ascii_digit).count();
-        let has_sign = normalized.starts_with(['+', '-']);
-
-        if digit_count + usize::from(has_sign) != normalized.len() || digit_count == 0 {
-            // Non-digit chars present → "invalid literal" takes precedence
-            Err(invalid())
-        } else if digit_count > INT_MAX_STR_DIGITS {
-            Err(ExcType::value_error_int_str_too_large(digit_count))
-        } else {
-            // Sign pushed length over limit but digit count is within it — parse is safe
-            let bi = normalized.parse::<BigInt>().map_err(|_| invalid())?;
-            Ok(LongInt::new(bi).into_value(heap)?)
+/// Implements the `int()` constructor: numeric coercion, and str/bytes
+/// parsing with an optional base (auto-detected when `base=0`).
+fn int_init(vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    let IntArgs { x, base } = IntArgs::from_args(args, vm)?;
+    let Some(x) = x else {
+        // `int()` → 0; `int(base=N)` complains about the missing value even
+        // before validating the base, matching `long_new_impl`'s ordering.
+        return match base {
+            None => Ok(Value::Int(0)),
+            Some(base) => {
+                base.drop_with(vm);
+                Err(ExcType::type_error_int_missing_string_argument())
+            }
+        };
+    };
+    defer_drop!(x, vm);
+    match base {
+        None => int_convert(x, vm),
+        Some(base) => {
+            let base = int_base(base, vm)?;
+            let interns = vm.interns;
+            match x {
+                Value::InternString(string_id) => parse_int_from_str(interns.get_str(*string_id), base, vm.heap),
+                Value::InternBytes(bytes_id) => parse_int_from_bytes(interns.get_bytes(*bytes_id), base, vm.heap),
+                Value::Ref(heap_id) => match vm.heap.get(*heap_id) {
+                    HeapData::Str(s) => parse_int_from_str(s.as_str(), base, vm.heap),
+                    HeapData::Bytes(b) => parse_int_from_bytes(b.as_slice(), base, vm.heap),
+                    _ => Err(ExcType::type_error_int_non_string_with_base()),
+                },
+                _ => Err(ExcType::type_error_int_non_string_with_base()),
+            }
         }
-    } else if let Ok(bi) = normalized.parse::<BigInt>() {
-        Ok(LongInt::new(bi).into_value(heap)?)
-    } else {
-        Err(invalid())
     }
 }
 
-/// Validates underscore placement in an integer literal string.
-///
-/// Returns `false` for: leading `_`, trailing `_`, consecutive `__`,
-/// or `_` immediately after a sign character. Matches CPython's rules.
-fn is_valid_int_underscores(s: &str) -> bool {
-    if !s.contains('_') {
-        return true;
+/// `int(x)` with no base: numeric coercion plus base-10 str/bytes parsing.
+fn int_convert(x: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<Value> {
+    let interns = vm.interns;
+    match x {
+        Value::Int(i) => Ok(Value::Int(*i)),
+        Value::Float(f) => Ok(Value::Int(f64_to_i64_truncate(*f))),
+        Value::Bool(b) => Ok(Value::Int(i64::from(*b))),
+        Value::InternString(string_id) => parse_int_from_str(interns.get_str(*string_id), 10, vm.heap),
+        Value::InternBytes(bytes_id) => parse_int_from_bytes(interns.get_bytes(*bytes_id), 10, vm.heap),
+        Value::Ref(heap_id) => match vm.heap.get(*heap_id) {
+            HeapData::Str(s) => parse_int_from_str(s.as_str(), 10, vm.heap),
+            HeapData::Bytes(b) => parse_int_from_bytes(b.as_slice(), 10, vm.heap),
+            HeapData::LongInt(_) => Ok(x.clone_with_heap(vm.heap)),
+            _ => Err(ExcType::type_error_int_conversion(&x.py_type_name(vm))),
+        },
+        _ => Err(ExcType::type_error_int_conversion(&x.py_type_name(vm))),
     }
-    let digits = s.strip_prefix(['+', '-']).unwrap_or(s);
-    // No leading or trailing underscores, no consecutive underscores
-    !digits.starts_with('_') && !digits.ends_with('_') && !digits.contains("__")
+}
+
+/// Resolves the `base` argument to `0` or `2..=36`, consuming the value.
+///
+/// Mirrors CPython: the base goes through `PyNumber_AsSsize_t(obase, NULL)`,
+/// which *clamps* out-of-i64 ints instead of raising — so a `LongInt` base
+/// lands in the range error, not `OverflowError`; non-integers raise
+/// `TypeError` before the range is checked.
+fn int_base(base: Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunResult<u32> {
+    let n = match &base {
+        Value::Bool(b) => i64::from(*b),
+        Value::Int(i) => *i,
+        // Clamped by PyNumber_AsSsize_t: any i64-overflowing int is out of range.
+        _ if is_long_int(&base, vm) => i64::MAX,
+        _ => {
+            let err = ExcType::type_error_not_integer(&base.py_type_name(vm));
+            base.drop_with(vm);
+            return Err(err);
+        }
+    };
+    base.drop_with(vm);
+    match u32::try_from(n) {
+        Ok(0) => Ok(0),
+        Ok(b @ 2..=36) => Ok(b),
+        _ => Err(ExcType::value_error_int_base_range()),
+    }
+}
+
+/// Parses a Python `int()` string argument into an `Int` or `LongInt`.
+///
+/// `base` is `0` (auto-detect from a `0x`/`0o`/`0b` prefix) or `2..=36`.
+/// Returns `Value::Int` if the value fits in i64, otherwise allocates a
+/// `LongInt` on the heap. Returns `ValueError` on failure.
+fn parse_int_from_str(value: &str, base: u32, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
+    // Fast path: plain base-10 literals parse directly (no whitespace,
+    // underscores or prefix handling needed).
+    if base == 10
+        && let Ok(int) = value.parse::<i64>()
+    {
+        return Ok(Value::Int(int));
+    }
+    let invalid = || ExcType::value_error_invalid_literal_for_int(base, StringRepr(value));
+    parse_int_digits(value, base, &invalid, heap)
+}
+
+/// Parses a Python `int()` bytes argument — same rules as str parsing, but a
+/// failure reprs the input as a bytes literal (`b'...'`), matching CPython.
+fn parse_int_from_bytes(bytes: &[u8], base: u32, heap: &Heap<impl ResourceTracker>) -> RunResult<Value> {
+    let invalid = || ExcType::value_error_invalid_literal_for_int(base, bytes_repr(bytes));
+    match str::from_utf8(bytes) {
+        Ok(s) => parse_int_digits(s, base, &invalid, heap),
+        Err(_) => Err(invalid()),
+    }
+}
+
+/// Tracks what the previous character was while scanning an int literal, to
+/// enforce CPython's underscore rules: `_` allowed only between digits or
+/// directly after a base prefix, never leading, trailing, or doubled.
+enum IntScanState {
+    Start,
+    Prefix,
+    Digit,
+    Underscore,
+}
+
+/// The shared str/bytes int-literal parser: whitespace, sign, base prefix
+/// (`0x`/`0o`/`0b`, mandatory-zeros rule for `base=0`), underscore placement,
+/// the digit limit for non-power-of-two bases, and BigInt promotion.
+fn parse_int_digits(
+    value: &str,
+    base: u32,
+    invalid: &impl Fn() -> RunError,
+    heap: &Heap<impl ResourceTracker>,
+) -> RunResult<Value> {
+    let trimmed = value.trim();
+    let (negative, body) = match trimmed.strip_prefix(['+', '-']) {
+        Some(rest) => (trimmed.starts_with('-'), rest),
+        None => (false, trimmed),
+    };
+
+    // Resolve the effective base and strip any `0x`/`0o`/`0b` prefix. For
+    // `base=0` a leading zero *without* a prefix is only legal if every digit
+    // is zero (CPython rejects `010` as an ambiguous octal-looking literal).
+    let bytes = body.as_bytes();
+    let mut digits = body;
+    let mut effective_base = if base == 0 { 10 } else { base };
+    let mut error_if_nonzero = false;
+    if bytes.first() == Some(&b'0') {
+        let prefix_base = match bytes.get(1) {
+            Some(b'x' | b'X') => Some(16),
+            Some(b'o' | b'O') => Some(8),
+            Some(b'b' | b'B') => Some(2),
+            Some(_) if base == 0 => {
+                error_if_nonzero = true;
+                None
+            }
+            _ => None,
+        };
+        if let Some(prefix_base) = prefix_base
+            && (base == 0 || base == prefix_base)
+        {
+            effective_base = prefix_base;
+            digits = &body[2..];
+        }
+    }
+    let had_prefix = digits.len() != body.len();
+
+    // Validate digits and underscore placement, collecting the cleaned digits
+    // (no underscores) behind the sign. Untracked `String`, but bounded by the
+    // input which is itself an already-tracked string.
+    let mut cleaned = String::with_capacity(usize::from(negative) + digits.len());
+    if negative {
+        cleaned.push('-');
+    }
+    let mut state = if had_prefix {
+        IntScanState::Prefix
+    } else {
+        IntScanState::Start
+    };
+    for c in digits.chars() {
+        if c == '_' {
+            if !matches!(state, IntScanState::Digit | IntScanState::Prefix) {
+                return Err(invalid());
+            }
+            state = IntScanState::Underscore;
+        } else if c.is_digit(effective_base) {
+            cleaned.push(c);
+            state = IntScanState::Digit;
+        } else {
+            return Err(invalid());
+        }
+    }
+    // Must end on a digit: rejects empty input, a bare prefix/sign, and
+    // trailing underscores in one check.
+    if !matches!(state, IntScanState::Digit) {
+        return Err(invalid());
+    }
+    if error_if_nonzero && cleaned.bytes().any(|b| !matches!(b, b'0' | b'-')) {
+        return Err(invalid());
+    }
+
+    if let Ok(int) = i64::from_str_radix(&cleaned, effective_base) {
+        return Ok(Value::Int(int));
+    }
+    // CPython's int↔str digit limit applies only to bases that are not a
+    // power of two (where conversion cost is linear, not quadratic).
+    let digit_count = cleaned.len() - usize::from(negative);
+    if !effective_base.is_power_of_two() && digit_count > INT_MAX_STR_DIGITS {
+        return Err(ExcType::value_error_int_str_too_large(digit_count));
+    }
+    match BigInt::parse_bytes(cleaned.as_bytes(), effective_base) {
+        Some(bi) => Ok(LongInt::new(bi).into_value(heap)?),
+        // Unreachable in practice: every char was validated as a digit above.
+        None => Err(invalid()),
+    }
 }

--- a/crates/monty/test_cases/args__macro_errors.py
+++ b/crates/monty/test_cases/args__macro_errors.py
@@ -480,27 +480,27 @@ try:
     next(iter([]), 1, 2, bogus=1)
     assert False, 'next with kwargs should raise no-keyword error'
 except TypeError as e:
-    assert str(e) == 'next() takes no keyword arguments', f'unpack-no-kw-next: {e}'
+    assert str(e) == 'next() takes no keyword arguments'
 
 try:
     reversed(sequence=[1])
     assert False, 'reversed with kwargs should raise no-keyword error'
 except TypeError as e:
-    assert str(e) == 'reversed() takes no keyword arguments', f'unpack-no-kw-reversed: {e}'
+    assert str(e) == 'reversed() takes no keyword arguments'
 
 try:
     unicodedata.name('a', bogus=1)
     assert False, 'unicodedata.name with kwargs should raise no-keyword error'
 except TypeError as e:
     # `kwarg_error_name` qualifies the module function like CPython does.
-    assert str(e) == 'unicodedata.name() takes no keyword arguments', f'unpack-no-kw-qualified: {e}'
+    assert str(e) == 'unicodedata.name() takes no keyword arguments'
 
 # === unpack: exact arity (min == max collapses the wording) ===
 try:
     reversed([1], [2])
     assert False, 'reversed with 2 args should raise'
 except TypeError as e:
-    assert str(e) == 'reversed expected 1 argument, got 2', f'unpack-exact-arity: {e}'
+    assert str(e) == 'reversed expected 1 argument, got 2'
 
 # =====================================================================
 # === Newly bound builtins: sum (clinic), round (c_named)            ===
@@ -511,48 +511,48 @@ try:
     sum(iterable=[1])
     assert False, 'sum(iterable=...) should raise'
 except TypeError as e:
-    assert str(e) == 'sum() takes at least 1 positional argument (0 given)', f'sum-pos-only: {e}'
+    assert str(e) == 'sum() takes at least 1 positional argument (0 given)'
 
 # === sum: at_most_total pre-count ===
 try:
     sum([1], 1, 1)
     assert False, 'sum with 3 args should raise'
 except TypeError as e:
-    assert str(e) == 'sum() takes at most 2 arguments (3 given)', f'sum-at-most: {e}'
+    assert str(e) == 'sum() takes at most 2 arguments (3 given)'
 
 # === sum: unknown kwarg ===
 try:
     sum([1], bogus=1)
     assert False, 'sum with unknown kwarg should raise'
 except TypeError as e:
-    assert str(e) == "sum() got an unexpected keyword argument 'bogus'", f'sum-unknown-kw: {e}'
+    assert str(e) == "sum() got an unexpected keyword argument 'bogus'"
 
 # === round: c_named missing required argument ===
 try:
     round()
     assert False, 'round() should raise'
 except TypeError as e:
-    assert str(e) == "round() missing required argument 'number' (pos 1)", f'round-missing: {e}'
+    assert str(e) == "round() missing required argument 'number' (pos 1)"
 
 try:
     round(ndigits=1)
     assert False, 'round(ndigits=1) should raise'
 except TypeError as e:
-    assert str(e) == "round() missing required argument 'number' (pos 1)", f'round-missing-kw: {e}'
+    assert str(e) == "round() missing required argument 'number' (pos 1)"
 
 # === round: at_most_total pre-count ===
 try:
     round(1, 2, 3)
     assert False, 'round with 3 args should raise'
 except TypeError as e:
-    assert str(e) == 'round() takes at most 2 arguments (3 given)', f'round-at-most: {e}'
+    assert str(e) == 'round() takes at most 2 arguments (3 given)'
 
 # === round: unknown kwarg ===
 try:
     round(1, bogus=2)
     assert False, 'round with unknown kwarg should raise'
 except TypeError as e:
-    assert str(e) == "round() got an unexpected keyword argument 'bogus'", f'round-unknown-kw: {e}'
+    assert str(e) == "round() got an unexpected keyword argument 'bogus'"
 
 # =====================================================================
 # === enumerate — CPython's hand-written vectorcall parser           ===
@@ -565,7 +565,7 @@ try:
     enumerate()
     assert False, 'enumerate() should raise'
 except TypeError as e:
-    assert str(e) == "enumerate() missing required argument 'iterable'", f'enum-missing: {e}'
+    assert str(e) == "enumerate() missing required argument 'iterable'"
 
 # Quirk: any unrecognised zero-positional keyword shape reports the missing
 # iterable — even when `iterable=` was actually passed.
@@ -573,7 +573,7 @@ try:
     enumerate(start=1, bogus=1, iterable=[1])
     assert False, 'enumerate 3-kwarg form should raise'
 except TypeError as e:
-    assert str(e) == "enumerate() missing required argument 'iterable'", f'enum-quirk-missing: {e}'
+    assert str(e) == "enumerate() missing required argument 'iterable'"
 
 # Quirk: keyword names are validated positionally against the accepted
 # shapes, so a lone `start=` reports 'start' as invalid.
@@ -581,65 +581,65 @@ try:
     enumerate(start=1)
     assert False, 'enumerate(start=1) should raise'
 except TypeError as e:
-    assert str(e) == "'start' is an invalid keyword argument for enumerate()", f'enum-lone-start: {e}'
+    assert str(e) == "'start' is an invalid keyword argument for enumerate()"
 
 try:
     enumerate([1], iterable=[2])
     assert False, 'enumerate positional + iterable= should raise'
 except TypeError as e:
-    assert str(e) == "'iterable' is an invalid keyword argument for enumerate()", f'enum-conflict: {e}'
+    assert str(e) == "'iterable' is an invalid keyword argument for enumerate()"
 
 try:
     enumerate([1], bogus=1)
     assert False, 'enumerate with unknown kwarg should raise'
 except TypeError as e:
-    assert str(e) == "'bogus' is an invalid keyword argument for enumerate()", f'enum-unknown-kw: {e}'
+    assert str(e) == "'bogus' is an invalid keyword argument for enumerate()"
 
 # Total pre-count fires whenever at least one positional is present.
 try:
     enumerate([1], 0, 0)
     assert False, 'enumerate with 3 positionals should raise'
 except TypeError as e:
-    assert str(e) == 'enumerate() takes at most 2 arguments (3 given)', f'enum-at-most: {e}'
+    assert str(e) == 'enumerate() takes at most 2 arguments (3 given)'
 
 try:
     enumerate([1], bogus=1, worse=2)
     assert False, 'enumerate 1-pos 2-kwarg should raise'
 except TypeError as e:
-    assert str(e) == 'enumerate() takes at most 2 arguments (3 given)', f'enum-at-most-kw: {e}'
+    assert str(e) == 'enumerate() takes at most 2 arguments (3 given)'
 
 # === unpack: arity wording (`{name} expected …`, no parentheses) ===
 try:
     next()
     assert False, 'next() should raise'
 except TypeError as e:
-    assert str(e) == 'next expected at least 1 argument, got 0', f'unpack-at-least: {e}'
+    assert str(e) == 'next expected at least 1 argument, got 0'
 
 try:
     next(iter([]), 1, 2)
     assert False, 'next with 3 args should raise'
 except TypeError as e:
-    assert str(e) == 'next expected at most 2 arguments, got 3', f'unpack-at-most: {e}'
+    assert str(e) == 'next expected at most 2 arguments, got 3'
 
 try:
     reversed()
     assert False, 'reversed() should raise'
 except TypeError as e:
-    assert str(e) == 'reversed expected 1 argument, got 0', f'unpack-exact-zero: {e}'
+    assert str(e) == 'reversed expected 1 argument, got 0'
 
 # === sum: body type-check reachable through the keyword path ===
 try:
     sum([1], start='x')
     assert False, 'sum string start= should raise'
 except TypeError as e:
-    assert str(e) == "sum() can't sum strings [use ''.join(seq) instead]", f'sum-kw-str-start: {e}'
+    assert str(e) == "sum() can't sum strings [use ''.join(seq) instead]"
 
 # === enumerate: lone unknown keyword ===
 try:
     enumerate(bogus=1)
     assert False, 'enumerate(bogus=1) should raise'
 except TypeError as e:
-    assert str(e) == "'bogus' is an invalid keyword argument for enumerate()", f'enum-lone-unknown: {e}'
+    assert str(e) == "'bogus' is an invalid keyword argument for enumerate()"
 
 # === enumerate: two-kwarg form, each rejection branch ===
 # swapped order (start first) with a bad second name
@@ -647,31 +647,31 @@ try:
     enumerate(start=1, bogus=2)
     assert False, 'enumerate(start=, bogus=) should raise'
 except TypeError as e:
-    assert str(e) == "'bogus' is an invalid keyword argument for enumerate()", f'enum-2kw-swapped-bad: {e}'
+    assert str(e) == "'bogus' is an invalid keyword argument for enumerate()"
 
 # unswapped order with a bad first name
 try:
     enumerate(bogus=2, start=1)
     assert False, 'enumerate(bogus=, start=) should raise'
 except TypeError as e:
-    assert str(e) == "'bogus' is an invalid keyword argument for enumerate()", f'enum-2kw-bad-first: {e}'
+    assert str(e) == "'bogus' is an invalid keyword argument for enumerate()"
 
 # unswapped order with a good first and bad second name
 try:
     enumerate(iterable=[1], bogus=1)
     assert False, 'enumerate(iterable=, bogus=) should raise'
 except TypeError as e:
-    assert str(e) == "'bogus' is an invalid keyword argument for enumerate()", f'enum-2kw-bad-second: {e}'
+    assert str(e) == "'bogus' is an invalid keyword argument for enumerate()"
 
 # === enumerate: non-string keys reach its hand-written key check ===
 try:
     enumerate([1], **{1: 2})
     assert False, 'enumerate non-string key should raise'
 except TypeError as e:
-    assert str(e) == 'keywords must be strings', f'enum-nonstring-key: {e}'
+    assert str(e) == 'keywords must be strings'
 
 try:
     enumerate(**{1: 2})
     assert False, 'enumerate lone non-string key should raise'
 except TypeError as e:
-    assert str(e) == 'keywords must be strings', f'enum-lone-nonstring-key: {e}'
+    assert str(e) == 'keywords must be strings'

--- a/crates/monty/test_cases/args__macro_errors.py
+++ b/crates/monty/test_cases/args__macro_errors.py
@@ -14,6 +14,7 @@ import datetime
 import json
 import re
 import sys
+import unicodedata
 
 is_monty = sys.platform == 'monty'
 
@@ -469,3 +470,208 @@ try:
     assert False, 'datetime double conflict should report month'
 except TypeError as e:
     assert str(e) == "argument for function given by name ('month') and position (2)", f'c-earliest-conflict: {e}'
+
+# =====================================================================
+# === Unpack style (`style = unpack` — positional-only, no keywords) ===
+# =====================================================================
+
+# === unpack: any keyword is rejected wholesale, before arity ===
+try:
+    next(iter([]), 1, 2, bogus=1)
+    assert False, 'next with kwargs should raise no-keyword error'
+except TypeError as e:
+    assert str(e) == 'next() takes no keyword arguments', f'unpack-no-kw-next: {e}'
+
+try:
+    reversed(sequence=[1])
+    assert False, 'reversed with kwargs should raise no-keyword error'
+except TypeError as e:
+    assert str(e) == 'reversed() takes no keyword arguments', f'unpack-no-kw-reversed: {e}'
+
+try:
+    unicodedata.name('a', bogus=1)
+    assert False, 'unicodedata.name with kwargs should raise no-keyword error'
+except TypeError as e:
+    # `kwarg_error_name` qualifies the module function like CPython does.
+    assert str(e) == 'unicodedata.name() takes no keyword arguments', f'unpack-no-kw-qualified: {e}'
+
+# === unpack: exact arity (min == max collapses the wording) ===
+try:
+    reversed([1], [2])
+    assert False, 'reversed with 2 args should raise'
+except TypeError as e:
+    assert str(e) == 'reversed expected 1 argument, got 2', f'unpack-exact-arity: {e}'
+
+# =====================================================================
+# === Newly bound builtins: sum (clinic), round (c_named)            ===
+# =====================================================================
+
+# === sum: positional-only iterable cannot be passed by keyword ===
+try:
+    sum(iterable=[1])
+    assert False, 'sum(iterable=...) should raise'
+except TypeError as e:
+    assert str(e) == 'sum() takes at least 1 positional argument (0 given)', f'sum-pos-only: {e}'
+
+# === sum: at_most_total pre-count ===
+try:
+    sum([1], 1, 1)
+    assert False, 'sum with 3 args should raise'
+except TypeError as e:
+    assert str(e) == 'sum() takes at most 2 arguments (3 given)', f'sum-at-most: {e}'
+
+# === sum: unknown kwarg ===
+try:
+    sum([1], bogus=1)
+    assert False, 'sum with unknown kwarg should raise'
+except TypeError as e:
+    assert str(e) == "sum() got an unexpected keyword argument 'bogus'", f'sum-unknown-kw: {e}'
+
+# === round: c_named missing required argument ===
+try:
+    round()
+    assert False, 'round() should raise'
+except TypeError as e:
+    assert str(e) == "round() missing required argument 'number' (pos 1)", f'round-missing: {e}'
+
+try:
+    round(ndigits=1)
+    assert False, 'round(ndigits=1) should raise'
+except TypeError as e:
+    assert str(e) == "round() missing required argument 'number' (pos 1)", f'round-missing-kw: {e}'
+
+# === round: at_most_total pre-count ===
+try:
+    round(1, 2, 3)
+    assert False, 'round with 3 args should raise'
+except TypeError as e:
+    assert str(e) == 'round() takes at most 2 arguments (3 given)', f'round-at-most: {e}'
+
+# === round: unknown kwarg ===
+try:
+    round(1, bogus=2)
+    assert False, 'round with unknown kwarg should raise'
+except TypeError as e:
+    assert str(e) == "round() got an unexpected keyword argument 'bogus'", f'round-unknown-kw: {e}'
+
+# =====================================================================
+# === enumerate — CPython's hand-written vectorcall parser           ===
+# =====================================================================
+# CPython special-cases enumerate's argument parsing (enumobject.c
+# `enumerate_vectorcall`), so its errors match no parser family; Monty
+# mirrors that parser exactly, quirks included.
+
+try:
+    enumerate()
+    assert False, 'enumerate() should raise'
+except TypeError as e:
+    assert str(e) == "enumerate() missing required argument 'iterable'", f'enum-missing: {e}'
+
+# Quirk: any unrecognised zero-positional keyword shape reports the missing
+# iterable — even when `iterable=` was actually passed.
+try:
+    enumerate(start=1, bogus=1, iterable=[1])
+    assert False, 'enumerate 3-kwarg form should raise'
+except TypeError as e:
+    assert str(e) == "enumerate() missing required argument 'iterable'", f'enum-quirk-missing: {e}'
+
+# Quirk: keyword names are validated positionally against the accepted
+# shapes, so a lone `start=` reports 'start' as invalid.
+try:
+    enumerate(start=1)
+    assert False, 'enumerate(start=1) should raise'
+except TypeError as e:
+    assert str(e) == "'start' is an invalid keyword argument for enumerate()", f'enum-lone-start: {e}'
+
+try:
+    enumerate([1], iterable=[2])
+    assert False, 'enumerate positional + iterable= should raise'
+except TypeError as e:
+    assert str(e) == "'iterable' is an invalid keyword argument for enumerate()", f'enum-conflict: {e}'
+
+try:
+    enumerate([1], bogus=1)
+    assert False, 'enumerate with unknown kwarg should raise'
+except TypeError as e:
+    assert str(e) == "'bogus' is an invalid keyword argument for enumerate()", f'enum-unknown-kw: {e}'
+
+# Total pre-count fires whenever at least one positional is present.
+try:
+    enumerate([1], 0, 0)
+    assert False, 'enumerate with 3 positionals should raise'
+except TypeError as e:
+    assert str(e) == 'enumerate() takes at most 2 arguments (3 given)', f'enum-at-most: {e}'
+
+try:
+    enumerate([1], bogus=1, worse=2)
+    assert False, 'enumerate 1-pos 2-kwarg should raise'
+except TypeError as e:
+    assert str(e) == 'enumerate() takes at most 2 arguments (3 given)', f'enum-at-most-kw: {e}'
+
+# === unpack: arity wording (`{name} expected …`, no parentheses) ===
+try:
+    next()
+    assert False, 'next() should raise'
+except TypeError as e:
+    assert str(e) == 'next expected at least 1 argument, got 0', f'unpack-at-least: {e}'
+
+try:
+    next(iter([]), 1, 2)
+    assert False, 'next with 3 args should raise'
+except TypeError as e:
+    assert str(e) == 'next expected at most 2 arguments, got 3', f'unpack-at-most: {e}'
+
+try:
+    reversed()
+    assert False, 'reversed() should raise'
+except TypeError as e:
+    assert str(e) == 'reversed expected 1 argument, got 0', f'unpack-exact-zero: {e}'
+
+# === sum: body type-check reachable through the keyword path ===
+try:
+    sum([1], start='x')
+    assert False, 'sum string start= should raise'
+except TypeError as e:
+    assert str(e) == "sum() can't sum strings [use ''.join(seq) instead]", f'sum-kw-str-start: {e}'
+
+# === enumerate: lone unknown keyword ===
+try:
+    enumerate(bogus=1)
+    assert False, 'enumerate(bogus=1) should raise'
+except TypeError as e:
+    assert str(e) == "'bogus' is an invalid keyword argument for enumerate()", f'enum-lone-unknown: {e}'
+
+# === enumerate: two-kwarg form, each rejection branch ===
+# swapped order (start first) with a bad second name
+try:
+    enumerate(start=1, bogus=2)
+    assert False, 'enumerate(start=, bogus=) should raise'
+except TypeError as e:
+    assert str(e) == "'bogus' is an invalid keyword argument for enumerate()", f'enum-2kw-swapped-bad: {e}'
+
+# unswapped order with a bad first name
+try:
+    enumerate(bogus=2, start=1)
+    assert False, 'enumerate(bogus=, start=) should raise'
+except TypeError as e:
+    assert str(e) == "'bogus' is an invalid keyword argument for enumerate()", f'enum-2kw-bad-first: {e}'
+
+# unswapped order with a good first and bad second name
+try:
+    enumerate(iterable=[1], bogus=1)
+    assert False, 'enumerate(iterable=, bogus=) should raise'
+except TypeError as e:
+    assert str(e) == "'bogus' is an invalid keyword argument for enumerate()", f'enum-2kw-bad-second: {e}'
+
+# === enumerate: non-string keys reach its hand-written key check ===
+try:
+    enumerate([1], **{1: 2})
+    assert False, 'enumerate non-string key should raise'
+except TypeError as e:
+    assert str(e) == 'keywords must be strings', f'enum-nonstring-key: {e}'
+
+try:
+    enumerate(**{1: 2})
+    assert False, 'enumerate lone non-string key should raise'
+except TypeError as e:
+    assert str(e) == 'keywords must be strings', f'enum-lone-nonstring-key: {e}'

--- a/crates/monty/test_cases/builtin__iter_funcs.py
+++ b/crates/monty/test_cases/builtin__iter_funcs.py
@@ -9,6 +9,25 @@ assert sum(range(5)) == 10
 assert sum([1.5, 2.5, 3.0], 0.0) == 7.0
 # Note: sum of floats without start requires py_add to support int+float
 
+# str/bytes start values are rejected, pointing at join() instead
+try:
+    sum([], 'x')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "sum() can't sum strings [use ''.join(seq) instead]"
+
+try:
+    sum([], b'x')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "sum() can't sum bytes [use b''.join(seq) instead]"
+
+try:
+    sum([b'a'], start=b'')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "sum() can't sum bytes [use b''.join(seq) instead]"
+
 # sum with different iterables
 assert sum({1, 2, 3}) == 6
 assert sum({1: 'a', 2: 'b', 3: 'c'}) == 6

--- a/crates/monty/test_cases/builtin__iter_funcs.py
+++ b/crates/monty/test_cases/builtin__iter_funcs.py
@@ -2,6 +2,7 @@
 # Basic sum operations
 assert sum([1, 2, 3]) == 6
 assert sum([1, 2, 3], 10) == 16
+assert sum([1, 2, 3], start=10) == 16
 assert sum(()) == 0
 assert sum([], 5) == 5
 assert sum(range(5)) == 10

--- a/crates/monty/test_cases/builtin__math_funcs.py
+++ b/crates/monty/test_cases/builtin__math_funcs.py
@@ -23,6 +23,10 @@ assert round(5) == 5
 # round with ndigits
 assert round(3.14159, 2) == 3.14
 assert round(3.14159, 0) == 3.0
+# both round() arguments are keyword-capable in CPython
+assert round(3.14159, ndigits=2) == 3.14
+assert round(number=3.14159, ndigits=2) == 3.14
+assert round(ndigits=2, number=3.14159) == 3.14
 assert repr(round(-0.4, 0)) == '-0.0'
 assert repr(round(-0.5, 0)) == '-0.0'
 assert round(1234, -2) == 1200

--- a/crates/monty/test_cases/builtin__math_funcs.py
+++ b/crates/monty/test_cases/builtin__math_funcs.py
@@ -1,3 +1,7 @@
+import sys
+
+is_monty = sys.platform == 'monty'
+
 # === abs() ===
 # Basic abs operations
 assert abs(5) == 5
@@ -48,6 +52,22 @@ try:
 except TypeError:
     threw = True
 assert threw
+
+# ndigits wider than i64 is clamped by sign: huge positive returns the number
+# unchanged; huge negative rounds to 0 / ±0.0
+assert round(5, 10**30) == 5
+assert round(-5, 10**30) == -5
+assert round(2.675, 10**30) == 2.675
+assert round(5, 2**63 - 1) == 5
+assert round(1.5, -(10**30)) == 0.0
+assert repr(round(-1.5, -(10**30))) == '-0.0'
+assert round(1.5, -(2**63)) == 0.0
+assert round(12345, -(10**5)) == 0
+if is_monty:
+    # CPython tries to materialise 10**(10**30) here and dies with
+    # MemoryError; Monty's clamp returns 0 immediately (limitations/builtins.md)
+    assert round(5, -(10**30)) == 0
+    assert round(5, -(2**63)) == 0
 
 # round edge cases with extreme values
 assert isinstance(round(1e15), int)

--- a/crates/monty/test_cases/builtin__math_funcs.py
+++ b/crates/monty/test_cases/builtin__math_funcs.py
@@ -63,6 +63,16 @@ assert round(1.5, -(10**30)) == 0.0
 assert repr(round(-1.5, -(10**30))) == '-0.0'
 assert round(1.5, -(2**63)) == 0.0
 assert round(12345, -(10**5)) == 0
+
+# negative ndigits round exactly in integers (no float corruption), promoting
+# past i64 when rounding up crosses it
+assert round(2**63 - 1, -1) == 9223372036854775810
+assert round(2**63 - 1, -19) == 10**19
+assert round(-(2**63 - 1), -19) == -(10**19)
+assert round(5 * 10**18, -19) == 0
+assert round(2**63 - 1, -25) == 0
+assert round(1234567890123456789, -5) == 1234567890123500000
+assert round(-1250, -2) == -1200
 if is_monty:
     # CPython tries to materialise 10**(10**30) here and dies with
     # MemoryError; Monty's clamp returns 0 immediately (limitations/builtins.md)

--- a/crates/monty/test_cases/builtin__more_iter_funcs.py
+++ b/crates/monty/test_cases/builtin__more_iter_funcs.py
@@ -306,6 +306,14 @@ assert list(enumerate(['x'])) == [(0, 'x')]
 assert list(enumerate(['a', 'b'], 1)) == [(1, 'a'), (2, 'b')]
 assert list(enumerate(['a', 'b'], 10)) == [(10, 'a'), (11, 'b')]
 
+# a non-iterable errors out of iterator construction without leaking a
+# heap-backed start=
+try:
+    enumerate(1, start=10**30)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "'int' object is not iterable"
+
 # enumerate keyword forms (CPython's vectorcall accepts all of these)
 assert list(enumerate(['a', 'b'], start=1)) == [(1, 'a'), (2, 'b')]
 assert list(enumerate(iterable=['a'])) == [(0, 'a')]

--- a/crates/monty/test_cases/builtin__more_iter_funcs.py
+++ b/crates/monty/test_cases/builtin__more_iter_funcs.py
@@ -306,6 +306,13 @@ assert list(enumerate(['x'])) == [(0, 'x')]
 assert list(enumerate(['a', 'b'], 1)) == [(1, 'a'), (2, 'b')]
 assert list(enumerate(['a', 'b'], 10)) == [(10, 'a'), (11, 'b')]
 
+# enumerate keyword forms (CPython's vectorcall accepts all of these)
+assert list(enumerate(['a', 'b'], start=1)) == [(1, 'a'), (2, 'b')]
+assert list(enumerate(iterable=['a'])) == [(0, 'a')]
+assert list(enumerate(iterable=['a'], start=2)) == [(2, 'a')]
+assert list(enumerate(start=2, iterable=['a'])) == [(2, 'a')]
+assert list(enumerate(['a'], start=True)) == [(1, 'a')]
+
 # enumerate string
 assert list(enumerate('ab')) == [(0, 'a'), (1, 'b')]
 

--- a/crates/monty/test_cases/bytes__ops.py
+++ b/crates/monty/test_cases/bytes__ops.py
@@ -105,3 +105,105 @@ try:
     assert False, 'bytes pos + kwarg should raise'
 except TypeError as e:
     assert str(e) == "argument for bytes() given by name ('source') and position (1)", f'dup: {e}'
+
+# === bytes() encoding a str source ===
+assert bytes('x', 'utf-8') == b'x'
+assert bytes('x', encoding='utf-8') == b'x'
+assert bytes(source='x', encoding='utf-8') == b'x'
+assert bytes('€', 'utf-8') == b'\xe2\x82\xac'
+assert bytes('€', 'ascii', 'replace') == b'?'
+assert bytes('abc', 'ascii', 'strict') == b'abc'
+
+try:
+    bytes('€', 'ascii')
+    assert False, 'expected UnicodeEncodeError'
+except UnicodeEncodeError as e:
+    assert str(e) == "'ascii' codec can't encode character '\\u20ac' in position 0: ordinal not in range(128)"
+
+# a str source requires an encoding — no silent UTF-8 default
+try:
+    bytes('x')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'string argument without an encoding'
+
+try:
+    bytes('x', errors='strict')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'string argument without an encoding'
+
+# and an encoding requires a str source, checked before a lone errors
+try:
+    bytes(1, 'utf-8')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'encoding without a string argument'
+
+try:
+    bytes(b'x', 'utf-8')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'encoding without a string argument'
+
+try:
+    bytes(encoding='utf-8', errors='x')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'encoding without a string argument'
+
+try:
+    bytes(b'x', errors='strict')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'errors without a string argument'
+
+try:
+    bytes(errors='strict')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'errors without a string argument'
+
+# encoding/errors use the bad-arg wording ('None', not 'NoneType')
+try:
+    bytes('x', 1)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "bytes() argument 'encoding' must be str, not int"
+
+try:
+    bytes('x', None)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "bytes() argument 'encoding' must be str, not None"
+
+try:
+    bytes('x', 'utf-8', 1)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "bytes() argument 'errors' must be str, not int"
+
+try:
+    bytes('x', 'bogus')
+    assert False, 'expected LookupError'
+except LookupError as e:
+    assert str(e) == 'unknown encoding: bogus'
+
+# clinic's parenthesised total pre-count, with and without kwargs
+try:
+    bytes('x', 'utf-8', 'strict', 1)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'bytes() takes at most 3 arguments (4 given)'
+
+try:
+    bytes('x', 'utf-8', 'strict', bogus=1)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'bytes() takes at most 3 arguments (4 given)'
+
+try:
+    bytes('x', 'utf-8', encoding='q')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "argument for bytes() given by name ('encoding') and position (2)"

--- a/crates/monty/test_cases/datetime__core.py
+++ b/crates/monty/test_cases/datetime__core.py
@@ -779,13 +779,13 @@ try:
     datetime.datetime.now(123, 456)
     assert False, 'datetime.now(123, 456) should raise TypeError'
 except TypeError as e:
-    assert str(e) == 'now() takes at most 1 argument (2 given)', f'datetime.now arity before type: {e}'
+    assert str(e) == 'now() takes at most 1 argument (2 given)'
 
 try:
     datetime.datetime.now(datetime.timezone.utc, badkw=1)
     assert False, 'datetime.now(utc, badkw=1) should raise TypeError'
 except TypeError as e:
-    assert str(e) == 'now() takes at most 1 argument (2 given)', f'datetime.now pos+kwarg precount: {e}'
+    assert str(e) == 'now() takes at most 1 argument (2 given)'
 
 # === datetime.now() error: bad keyword argument (lines 370-374) ===
 

--- a/crates/monty/test_cases/datetime__core.py
+++ b/crates/monty/test_cases/datetime__core.py
@@ -773,6 +773,20 @@ try:
 except TypeError as e:
     assert str(e) == 'now() takes at most 1 argument (2 given)', f'datetime.now too many args: {e}'
 
+# === datetime.now() error: arity checked before tz type ===
+
+try:
+    datetime.datetime.now(123, 456)
+    assert False, 'datetime.now(123, 456) should raise TypeError'
+except TypeError as e:
+    assert str(e) == 'now() takes at most 1 argument (2 given)', f'datetime.now arity before type: {e}'
+
+try:
+    datetime.datetime.now(datetime.timezone.utc, badkw=1)
+    assert False, 'datetime.now(utc, badkw=1) should raise TypeError'
+except TypeError as e:
+    assert str(e) == 'now() takes at most 1 argument (2 given)', f'datetime.now pos+kwarg precount: {e}'
+
 # === datetime.now() error: bad keyword argument (lines 370-374) ===
 
 try:

--- a/crates/monty/test_cases/int__base.py
+++ b/crates/monty/test_cases/int__base.py
@@ -36,6 +36,14 @@ assert int('-0', 0) == 0
 assert int(b'12') == 12
 assert int(b'ff', 16) == 255
 assert int(b' -0x10 ', 0) == -16
+assert int('\u00a012\u00a0') == 12
+
+# Bytes accept ASCII whitespace only, not UTF-8 encodings of Unicode whitespace.
+try:
+    int(b'\xc2\xa012\xc2\xa0')
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == "invalid literal for int() with base 10: b'\\xc2\\xa012\\xc2\\xa0'"
 
 # === LongInt promotion with base ===
 assert int('f' * 40, 16) == 1461501637330902918203684832716283019655932542975

--- a/crates/monty/test_cases/int__base.py
+++ b/crates/monty/test_cases/int__base.py
@@ -1,0 +1,276 @@
+# === int() with explicit base ===
+assert int('ff', 16) == 255
+assert int('ff', base=16) == 255
+assert int('0xff', 16) == 255
+assert int('0Xff', 16) == 255
+assert int('-0xff', 16) == -255
+assert int('0o17', 8) == 15
+assert int('0b101', 2) == 5
+# 'b' is a valid hex digit, so '0b10' in base 16 is 0xb10
+assert int('0b10', 16) == 2832
+assert int('  ff  ', 16) == 255
+assert int('5\n', 16) == 5
+assert int(' 0x5 ', 16) == 5
+assert int('f_f', 16) == 255
+assert int('0x_ff', 16) == 255
+assert int('zz', 36) == 1295
+assert int('ZZ', 36) == 1295
+assert int('11', 2) == 3
+assert int('0', 2) == 0
+
+# === base 0 auto-detection ===
+assert int('+0xff', 0) == 255
+assert int('0x_ff', 0) == 255
+assert int('  -0x10  ', 0) == -16
+assert int('0o17', 0) == 15
+assert int('0O17', 0) == 15
+assert int('0b101', 0) == 5
+assert int('123', 0) == 123
+assert int('0', 0) == 0
+assert int('00', 0) == 0
+assert int('0_0', 0) == 0
+assert int('00_0', 0) == 0
+assert int('-0', 0) == 0
+
+# === bytes sources ===
+assert int(b'12') == 12
+assert int(b'ff', 16) == 255
+assert int(b' -0x10 ', 0) == -16
+
+# === LongInt promotion with base ===
+assert int('f' * 40, 16) == 1461501637330902918203684832716283019655932542975
+assert int('z' * 20, 36) == 13367494538843734067838845976575
+
+# === invalid literals report the given base ===
+try:
+    int('010', 0)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == "invalid literal for int() with base 0: '010'"
+
+try:
+    int('0xff', 8)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == "invalid literal for int() with base 8: '0xff'"
+
+try:
+    int('', 16)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == "invalid literal for int() with base 16: ''"
+
+try:
+    int('0x', 0)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == "invalid literal for int() with base 0: '0x'"
+
+try:
+    int(' zz ', 16)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == "invalid literal for int() with base 16: ' zz '"
+
+try:
+    int('12', 2)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == "invalid literal for int() with base 2: '12'"
+
+try:
+    int('++5', 16)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == "invalid literal for int() with base 16: '++5'"
+
+try:
+    int('0x0x5', 0)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == "invalid literal for int() with base 0: '0x0x5'"
+
+try:
+    int('0b2', 0)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == "invalid literal for int() with base 0: '0b2'"
+
+try:
+    int(b'zz', 16)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == "invalid literal for int() with base 16: b'zz'"
+
+# === underscore placement rules ===
+try:
+    int('_ff', 16)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == "invalid literal for int() with base 16: '_ff'"
+
+try:
+    int('ff_', 16)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == "invalid literal for int() with base 16: 'ff_'"
+
+try:
+    int('f__f', 16)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == "invalid literal for int() with base 16: 'f__f'"
+
+try:
+    int('0x__ff', 16)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == "invalid literal for int() with base 16: '0x__ff'"
+
+# === base validation ===
+try:
+    int('1', 1)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == 'int() base must be >= 2 and <= 36, or 0'
+
+try:
+    int('1', 37)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == 'int() base must be >= 2 and <= 36, or 0'
+
+try:
+    int('1', -2)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == 'int() base must be >= 2 and <= 36, or 0'
+
+try:
+    int('1', True)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == 'int() base must be >= 2 and <= 36, or 0'
+
+# an int wider than i64 clamps (PyNumber_AsSsize_t) and lands out of range
+try:
+    int('1', 10**20)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == 'int() base must be >= 2 and <= 36, or 0'
+
+try:
+    int('1', 16.0)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "'float' object cannot be interpreted as an integer"
+
+try:
+    int('1', '16')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "'str' object cannot be interpreted as an integer"
+
+try:
+    int('1', None)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "'NoneType' object cannot be interpreted as an integer"
+
+# === non-string with explicit base ===
+try:
+    int(5, 16)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "int() can't convert non-string with explicit base"
+
+try:
+    int(5.5, 16)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "int() can't convert non-string with explicit base"
+
+try:
+    int([], 16)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "int() can't convert non-string with explicit base"
+
+# base range is validated before the non-string check
+try:
+    int(5, 1)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert str(e) == 'int() base must be >= 2 and <= 36, or 0'
+
+# === argument binding quirks (long_vectorcall + clinic fallback) ===
+try:
+    int(x='5')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "int() got an unexpected keyword argument 'x'"
+
+try:
+    int(base=16)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'int() missing string argument'
+
+# the missing string argument beats base validation
+try:
+    int(base='q')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'int() missing string argument'
+
+try:
+    int('5', bogus=1)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "int() got an unexpected keyword argument 'bogus'"
+
+# no kwargs: the vectorcall fast path's un-parenthesised wording
+try:
+    int('5', 10, 3)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'int expected at most 2 arguments, got 3'
+
+# with kwargs: the clinic parser's parenthesised total-count wording
+try:
+    int('5', 10, base=16)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'int() takes at most 2 arguments (3 given)'
+
+# === digit limit applies only to non-power-of-two bases ===
+assert int('1' * 5000, 16) > 0
+assert int('1' * 5000, 2) > 0
+
+try:
+    int('1' * 5000, 10)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert (
+        str(e)
+        == 'Exceeds the limit (4300 digits) for integer string conversion: value has 5000 digits; use sys.set_int_max_str_digits() to increase the limit'
+    )
+
+try:
+    int('1' * 5000, 12)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert (
+        str(e)
+        == 'Exceeds the limit (4300 digits) for integer string conversion: value has 5000 digits; use sys.set_int_max_str_digits() to increase the limit'
+    )
+
+# base 0 resolves to 10 before the limit is applied
+try:
+    int('1' * 5000, 0)
+    assert False, 'expected ValueError'
+except ValueError as e:
+    assert (
+        str(e)
+        == 'Exceeds the limit (4300 digits) for integer string conversion: value has 5000 digits; use sys.set_int_max_str_digits() to increase the limit'
+    )

--- a/crates/monty/test_cases/str__ops.py
+++ b/crates/monty/test_cases/str__ops.py
@@ -180,3 +180,93 @@ try:
     assert False, 'str pos + kwarg should raise'
 except TypeError as e:
     assert str(e) == "argument for str() given by name ('object') and position (1)", f'dup: {e}'
+
+# === str() decoding bytes with encoding/errors ===
+assert str(b'x', 'utf-8') == 'x'
+assert str(b'x', encoding='utf-8') == 'x'
+assert str(object=b'x', encoding='utf-8') == 'x'
+assert str(b'\xe2\x82\xac', 'utf-8') == '€'
+assert str(b'\xff', 'utf-8', 'replace') == '�'
+assert str(b'\xff', errors='replace') == '�'
+assert str(b'x', errors='strict') == 'x'
+# a missing object wins over the decoding args
+assert str(encoding='utf-8') == ''
+assert str(errors='strict') == ''
+# without decoding args, bytes stringify to their repr
+assert str(b'x') == "b'x'"
+
+try:
+    str(b'\xff', 'utf-8')
+    assert False, 'expected UnicodeDecodeError'
+except UnicodeDecodeError as e:
+    assert str(e) == "'utf-8' codec can't decode byte 0xff in position 0: invalid start byte"
+
+try:
+    str('x', 'utf-8')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'decoding str is not supported'
+
+try:
+    str('x', errors='strict')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'decoding str is not supported'
+
+try:
+    str(1, 'utf-8')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'decoding to str: need a bytes-like object, int found'
+
+try:
+    str(None, 'utf-8')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'decoding to str: need a bytes-like object, NoneType found'
+
+# encoding/errors are named with the wrong value's type name (NoneType, not
+# the bad-arg 'None' special case used by bytes())
+try:
+    str(b'x', 1)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "str() argument 'encoding' must be str, not int"
+
+try:
+    str(b'x', None)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "str() argument 'encoding' must be str, not NoneType"
+
+try:
+    str(b'x', 'utf-8', 1)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "str() argument 'errors' must be str, not int"
+
+try:
+    str(b'x', 'bogus')
+    assert False, 'expected LookupError'
+except LookupError as e:
+    assert str(e) == 'unknown encoding: bogus'
+
+# no kwargs: unicode_vectorcall's un-parenthesised arity wording
+try:
+    str(b'x', 'utf-8', 'strict', 1)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'str expected at most 3 arguments, got 4'
+
+# with kwargs: the clinic parser's parenthesised total-count wording
+try:
+    str(b'x', 'utf-8', 'strict', 'x', bogus=1)
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == 'str() takes at most 3 arguments (5 given)'
+
+try:
+    str(b'x', 'utf-8', encoding='q')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "argument for str() given by name ('encoding') and position (2)"

--- a/crates/monty/tests/parse_large_literals.rs
+++ b/crates/monty/tests/parse_large_literals.rs
@@ -102,7 +102,7 @@ fn container_repr_with_huge_int_raises_value_error() {
     assert_eq!(err.exc_type(), ExcType::ValueError);
     assert_eq!(
         err.message().expect("should have a message"),
-        "Exceeds the limit (4300 digits) for integer string conversion"
+        "Exceeds the limit (4300 digits) for integer string conversion; use sys.set_int_max_str_digits() to increase the limit"
     );
 }
 
@@ -156,6 +156,6 @@ fn monty_object_repr_or_error_with_huge_int() {
     };
     assert_eq!(
         s,
-        "<dict_keys object, error on repr(): ValueError('Exceeds the limit (4300 digits) for integer string conversion')>"
+        "<dict_keys object, error on repr(): ValueError('Exceeds the limit (4300 digits) for integer string conversion; use sys.set_int_max_str_digits() to increase the limit')>"
     );
 }

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -50,6 +50,13 @@ mechanism beyond dataclass field inheritance.
   "getattr(): attribute is not a simple value"` rather than returning a
   bound method object. Use direct attribute access (`obj.name(...)`) for
   these.
+- **`int(x, base=10)`** — string/bytes parsing accepts ASCII digits only;
+  CPython also accepts non-ASCII Unicode decimal digits (`int('١٢')` == 12),
+  which Monty rejects with `invalid literal for int() with base 10`.
+- **`bytes(source)`** — an iterable of ints is not supported: CPython's
+  `bytes([65, 66])` == `b'AB'`, Monty raises `TypeError: cannot convert
+  'list' object to bytes`. The int / str-with-encoding / bytes source forms
+  all work.
 - **`isinstance(obj, T)`** — `T` must be a built-in type (`int`, `str`,
   `list`, ...), a built-in exception class, a sandbox-defined class (see
   [classes.md](classes.md)), or a tuple of those. Passing a host-supplied

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -66,8 +66,6 @@ mechanism beyond dataclass field inheritance.
   `u32::MAX` raise `OverflowError` (see [resource_limits.md](resource_limits.md)).
 - **`sorted(iterable, *, key=None, reverse=False)`** — `key` and `reverse`
   must be passed by keyword; positional forms raise `TypeError`.
-- **`round(x, n)`** — `n` must be an integer; CPython accepts and truncates
-  floats.
 - **`print`** — writes via the host print callback. `file=`, `flush=` are
   not honoured; `sep=` and `end=` are.
 - **`id(f)` / `hash(f)` / `f is g` / `f == g` for host-supplied callables**

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -66,6 +66,11 @@ mechanism beyond dataclass field inheritance.
   `u32::MAX` raise `OverflowError` (see [resource_limits.md](resource_limits.md)).
 - **`sorted(iterable, *, key=None, reverse=False)`** — `key` and `reverse`
   must be passed by keyword; positional forms raise `TypeError`.
+- **`round(n, ndigits)`** — `ndigits` values outside the i64 range are
+  clamped by sign. For floats this matches CPython (which clamps to
+  `Py_ssize_t`); for an int `n` with a hugely negative `ndigits`, CPython
+  tries to materialise `10**-ndigits` and dies with `MemoryError` where
+  Monty returns `0` immediately.
 - **`print`** — writes via the host print callback. `file=`, `flush=` are
   not honoured; `sep=` and `end=` are.
 - **`id(f)` / `hash(f)` / `f is g` / `f == g` for host-supplied callables**

--- a/limitations/encoding.md
+++ b/limitations/encoding.md
@@ -1,7 +1,9 @@
 # `str.encode()` / `bytes.decode()`
 
 Monty implements a fixed, small set of text codecs rather than the full
-`codecs`/`encodings` registry CPython ships.
+`codecs`/`encodings` registry CPython ships. The `str(b, encoding, errors)`
+and `bytes(s, encoding, errors)` constructor forms route through the same
+registry, so everything below applies to them too.
 
 ## Supported codecs
 

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -32,8 +32,10 @@ inside the sandbox).
   (≈ 4.3 × 10⁹) raises `OverflowError: "exponent too large"`.
 - `pow(base, exp, mod)` requires all integer arguments and rejects negative
   exponents (`ValueError`).
-- `int(str)` for very long decimal strings is rejected before the O(n²)
-  BigInt parse runs; the cut-off matches CPython's `sys.int_info.str_digits_check_threshold`.
+- `int(str_or_bytes, base)` rejects inputs over 4,300 digits before the
+  potentially quadratic BigInt parse when the effective base is not a power
+  of two. The fixed cap matches CPython's
+  `sys.int_info.default_max_str_digits`.
 
 ## Recursion
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Aligns builtin argument parsing and constructors with CPython, including exact arity wording/ordering, int(x, base) semantics, str/bytes encoding/decoding, and enumerate’s vectorcall quirks. Also fixes round(ndigits) for huge ints, makes int negative-ndigits integer rounding exact with big-int promotion, prevents an enumerate start leak, and makes sum() reject bytes start values with CPython’s message.

- New Features
  - Argument binding: moved builtins to `#[derive(FromArgs)]` with `at_most_total`, `style = unpack` (keywords rejected up front), and a new `vectorcall` flag to model CPython’s fast-path arity wording. `kwarg_error_name` now also applies under `style = unpack` to rename the `takes no keyword arguments` error.
  - Builtins:
    - `int(x, base)`: supports bases 2–36 and 0 (auto-detect), underscores, bytes input (ASCII whitespace only), BigInt promotion, and digit-limit checks only for non power-of-two bases. Errors match CPython, including base in “invalid literal”, base-range checks, “non-string with explicit base”, and vectorcall vs clinic arity wording.
    - `str(object, encoding, errors)`: decodes bytes via the codec registry; validates `encoding`/`errors` types with CPython wording; rejects decoding `str`; keeps vectorcall vs clinic arity wording.
    - `bytes(source, encoding, errors)`: encodes `str` via the codec registry; requires an explicit encoding for `str` sources; validates `encoding`/`errors` with CPython `_PyArg_BadArgument` wording.
    - `enumerate(iterable, start)`: hand-written vectorcall parser to mirror CPython (position-validated keyword names, zero-positional “missing iterable” quirk, and `'{key}' is an invalid keyword argument` wording). Guards `start` before iterator creation to avoid leaks if the iterable is invalid.
    - `next`, `reversed`, `sum`, `round`, `datetime.now(tz)`: bound to their CPython shapes (pos-only/clinic/c_named), enabling the keyword forms CPython accepts, correct arity wording, and right error ordering. `round` clamps an i64-overflowing `ndigits` by sign (huge positive unchanged; huge negative rounds to 0/±0.0); negative-`ndigits` integer rounding is now exact in i128 and promotes past i64, fixing precision and overflow issues; `sum` rejects a bytes start value with CPython’s “use b''.join(seq)” wording.
  - Exceptions: added precise CPython messages for missing/invalid keywords (including `enumerate`), missing-argument without a position, digit limits (with the `sys.set_int_max_str_digits()` hint), int-base validation, str/bytes encoding/decoding errors, and `sum()`’s start-type rejection.
  - Docs/tests: limitations and tests updated (e.g. `int()` bytes whitespace rules, `bytes()` iterable-of-ints still unsupported, `round()` big-int `ndigits` and exact negative-`ndigits` int rounding, `enumerate` start leak guard, `sum()` bytes start).

- Migration
  - `bytes('x')` now raises TypeError “string argument without an encoding”. Pass an encoding (for example, `bytes('x', 'utf-8')`) or use `'x'.encode('utf-8')`.
  - Monty dump format version bumped to 5; dumps from older versions are not compatible.

<sup>Written for commit 08a139b82a2d2631e651b6a1f6320e313be45daa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

