### PR TITLE
Expose structured resource-limit data on MontyException

### DIFF
--- a/crates/monty-proto/proto/monty/v1/monty.proto
+++ b/crates/monty-proto/proto/monty/v1/monty.proto
@@ -277,11 +277,15 @@ message ResourceLimitData {
     uint64 limit = 1;
     uint64 count = 2;
   }
-  // Maximum execution time exceeded. Durations in microseconds, matching
-  // `ResourceLimits.max_duration_micros`.
+  // Maximum execution time exceeded. Durations in nanoseconds (unlike
+  // `ResourceLimits.max_duration_micros`) so the receive side's hit-validity
+  // check (`elapsed > limit`, see `is_genuine_hit`) can't be defeated by
+  // truncation: a genuine hit whose margin over the limit is sub-microsecond
+  // would otherwise round-trip to `elapsed_micros == limit_micros` and get
+  // rejected as implausible.
   message Time {
-    uint64 limit_micros = 1;
-    uint64 elapsed_micros = 2;
+    uint64 limit_nanos = 1;
+    uint64 elapsed_nanos = 2;
   }
   // Maximum memory usage exceeded, in bytes.
   message Memory {

--- a/crates/monty-proto/proto/monty/v1/monty.proto
+++ b/crates/monty-proto/proto/monty/v1/monty.proto
@@ -277,15 +277,19 @@ message ResourceLimitData {
     uint64 limit = 1;
     uint64 count = 2;
   }
-  // Maximum execution time exceeded. Durations in nanoseconds (unlike
-  // `ResourceLimits.max_duration_micros`) so the receive side's hit-validity
-  // check (`elapsed > limit`, see `is_genuine_hit`) can't be defeated by
-  // truncation: a genuine hit whose margin over the limit is sub-microsecond
-  // would otherwise round-trip to `elapsed_micros == limit_micros` and get
-  // rejected as implausible.
+  // Maximum execution time exceeded. Each duration is split into seconds +
+  // sub-second nanoseconds (mirroring `std::time::Duration`'s own
+  // representation) rather than a single nanosecond count, so encoding is
+  // always exact — no truncation at the low end (unlike
+  // `ResourceLimits.max_duration_micros`) and no saturation at the high end
+  // for any representable `Duration`. Either lossiness would let the receive
+  // side's hit-validity check (`elapsed > limit`, see `is_genuine_hit`)
+  // reject a genuine hit whose encoded value collapsed to equal its limit.
   message Time {
-    uint64 limit_nanos = 1;
-    uint64 elapsed_nanos = 2;
+    uint64 limit_secs = 1;
+    uint32 limit_subsec_nanos = 2;
+    uint64 elapsed_secs = 3;
+    uint32 elapsed_subsec_nanos = 4;
   }
   // Maximum memory usage exceeded, in bytes.
   message Memory {

--- a/crates/monty-proto/proto/monty/v1/monty.proto
+++ b/crates/monty-proto/proto/monty/v1/monty.proto
@@ -220,6 +220,7 @@ message ExcData {
   oneof kind {
     UnicodeErrorData unicode = 1;
     JsonErrorData json = 2;
+    ResourceLimitData resource_limit = 3;
   }
 }
 
@@ -257,6 +258,41 @@ message JsonErrorData {
   // 1-based line and column of the error.
   uint64 lineno = 4;
   uint64 colno = 5;
+}
+
+// Identifies which sandbox resource limit was hit and by how much, mirroring
+// monty's `ResourceLimitData`. Set only when an exception represents a
+// resource-limit hit rather than the same exception type raised by
+// sandboxed code — see `ExcData.resource_limit`.
+message ResourceLimitData {
+  oneof kind {
+    Allocation allocation = 1;
+    Time time = 2;
+    Memory memory = 3;
+    Recursion recursion = 4;
+  }
+
+  // Maximum number of allocations exceeded.
+  message Allocation {
+    uint64 limit = 1;
+    uint64 count = 2;
+  }
+  // Maximum execution time exceeded. Durations in microseconds, matching
+  // `ResourceLimits.max_duration_micros`.
+  message Time {
+    uint64 limit_micros = 1;
+    uint64 elapsed_micros = 2;
+  }
+  // Maximum memory usage exceeded, in bytes.
+  message Memory {
+    uint64 limit = 1;
+    uint64 used = 2;
+  }
+  // Maximum recursion depth exceeded.
+  message Recursion {
+    uint64 limit = 1;
+    uint64 depth = 2;
+  }
 }
 
 // 1-based line/column source position (columns count characters, not bytes).

--- a/crates/monty-proto/src/convert/exception.rs
+++ b/crates/monty-proto/src/convert/exception.rs
@@ -2,11 +2,17 @@
 //! frames so an exception raised on one side of the process boundary renders
 //! identically on the other.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
-use monty::{CodeLoc, ExcData, JsonErrorData, MontyException, StackFrame, UnicodeErrorData, UnicodeErrorObject};
+use monty::{
+    CodeLoc, ExcData, JsonErrorData, MontyException, ResourceLimitData, StackFrame, UnicodeErrorData,
+    UnicodeErrorObject,
+};
 
-use crate::{convert::ProtoConvertError, pb};
+use crate::{
+    convert::ProtoConvertError,
+    pb::{self, resource_limit_data},
+};
 
 impl From<&MontyException> for pb::RaisedException {
     fn from(exc: &MontyException) -> Self {
@@ -41,6 +47,8 @@ impl TryFrom<pb::RaisedException> for MontyException {
                 sanitize_unicode_data(unicode).map_or(ExcData::None, ExcData::Unicode)
             }
             Some(pb::exc_data::Kind::Json(json)) => sanitize_json_data(json).map_or(ExcData::None, ExcData::Json),
+            Some(pb::exc_data::Kind::ResourceLimit(resource_limit)) => resource_limit_data_from_wire(resource_limit)
+                .map_or(ExcData::None, |data| ExcData::ResourceLimit(Box::new(data))),
             None => ExcData::None,
         };
         Ok(Self::with_traceback(exc_type, err.message, traceback).with_data(data))
@@ -49,15 +57,9 @@ impl TryFrom<pb::RaisedException> for MontyException {
 
 /// Maps monty's `ExcData` onto the wire message; `ExcData::None` becomes an
 /// absent field rather than an empty message.
-///
-/// `ExcData::ResourceLimit` has no wire representation yet (no `pb::ExcData`
-/// oneof variant carries it) and is dropped here, same as `None` — a worker
-/// process's resource-limit classification does not yet survive the trip
-/// back to the parent. Extending the proto schema to close this gap is
-/// tracked as follow-up work.
 fn pb_exc_data(data: &ExcData) -> Option<pb::ExcData> {
     match data {
-        ExcData::None | ExcData::ResourceLimit(_) => None,
+        ExcData::None => None,
         ExcData::Unicode(unicode) => Some(pb::ExcData {
             kind: Some(pb::exc_data::Kind::Unicode(pb::UnicodeErrorData::from(
                 unicode.as_ref(),
@@ -66,7 +68,69 @@ fn pb_exc_data(data: &ExcData) -> Option<pb::ExcData> {
         ExcData::Json(json) => Some(pb::ExcData {
             kind: Some(pb::exc_data::Kind::Json(pb::JsonErrorData::from(json.as_ref()))),
         }),
+        ExcData::ResourceLimit(resource_limit) => Some(pb::ExcData {
+            kind: Some(pb::exc_data::Kind::ResourceLimit(pb::ResourceLimitData::from(
+                resource_limit.as_ref(),
+            ))),
+        }),
     }
+}
+
+impl From<&ResourceLimitData> for pb::ResourceLimitData {
+    fn from(data: &ResourceLimitData) -> Self {
+        let kind = match *data {
+            ResourceLimitData::Allocation { limit, count } => {
+                resource_limit_data::Kind::Allocation(resource_limit_data::Allocation {
+                    limit: limit as u64,
+                    count: count as u64,
+                })
+            }
+            ResourceLimitData::Time { limit, elapsed } => resource_limit_data::Kind::Time(resource_limit_data::Time {
+                limit_micros: u64::try_from(limit.as_micros()).unwrap_or(u64::MAX),
+                elapsed_micros: u64::try_from(elapsed.as_micros()).unwrap_or(u64::MAX),
+            }),
+            ResourceLimitData::Memory { limit, used } => {
+                resource_limit_data::Kind::Memory(resource_limit_data::Memory {
+                    limit: limit as u64,
+                    used: used as u64,
+                })
+            }
+            ResourceLimitData::Recursion { limit, depth } => {
+                resource_limit_data::Kind::Recursion(resource_limit_data::Recursion {
+                    limit: limit as u64,
+                    depth: depth as u64,
+                })
+            }
+        };
+        Self { kind: Some(kind) }
+    }
+}
+
+/// Converts a wire `ResourceLimitData`, dropping it (returning `None`) when
+/// the `kind` oneof is unset — the worst a compromised child sending an empty
+/// message can do, same posture as [`sanitize_unicode_data`]/[`sanitize_json_data`].
+/// Every field here is a plain integer with no attacker-controlled length, so
+/// unlike those two there is no amplification size cap to enforce.
+fn resource_limit_data_from_wire(data: pb::ResourceLimitData) -> Option<ResourceLimitData> {
+    let usize_field = |v: u64| usize::try_from(v).unwrap_or(usize::MAX);
+    Some(match data.kind? {
+        resource_limit_data::Kind::Allocation(a) => ResourceLimitData::Allocation {
+            limit: usize_field(a.limit),
+            count: usize_field(a.count),
+        },
+        resource_limit_data::Kind::Time(t) => ResourceLimitData::Time {
+            limit: Duration::from_micros(t.limit_micros),
+            elapsed: Duration::from_micros(t.elapsed_micros),
+        },
+        resource_limit_data::Kind::Memory(m) => ResourceLimitData::Memory {
+            limit: usize_field(m.limit),
+            used: usize_field(m.used),
+        },
+        resource_limit_data::Kind::Recursion(r) => ResourceLimitData::Recursion {
+            limit: usize_field(r.limit),
+            depth: usize_field(r.depth),
+        },
+    })
 }
 
 impl From<&JsonErrorData> for pb::JsonErrorData {

--- a/crates/monty-proto/src/convert/exception.rs
+++ b/crates/monty-proto/src/convert/exception.rs
@@ -123,8 +123,8 @@ fn resource_limit_data_from_wire(data: pb::ResourceLimitData) -> Option<Resource
             count: usize_field(a.count),
         },
         resource_limit_data::Kind::Time(t) => ResourceLimitData::Time {
-            limit: Duration::new(t.limit_secs, t.limit_subsec_nanos),
-            elapsed: Duration::new(t.elapsed_secs, t.elapsed_subsec_nanos),
+            limit: checked_duration(t.limit_secs, t.limit_subsec_nanos)?,
+            elapsed: checked_duration(t.elapsed_secs, t.elapsed_subsec_nanos)?,
         },
         resource_limit_data::Kind::Memory(m) => ResourceLimitData::Memory {
             limit: usize_field(m.limit),
@@ -136,6 +136,16 @@ fn resource_limit_data_from_wire(data: pb::ResourceLimitData) -> Option<Resource
         },
     };
     is_genuine_hit(&data).then_some(data)
+}
+
+/// Builds a `Duration` from wire seconds + sub-second nanoseconds, rejecting
+/// (returning `None`) an out-of-range `subsec_nanos` (`>= 1_000_000_000`)
+/// rather than passing it to `Duration::new`, which panics on the resulting
+/// carry into `secs` when `secs` is already at or near `u64::MAX`. The wire
+/// value is untrusted — a compromised child sending exactly that combination
+/// would otherwise crash the parent process.
+fn checked_duration(secs: u64, subsec_nanos: u32) -> Option<Duration> {
+    (subsec_nanos < 1_000_000_000).then(|| Duration::new(secs, subsec_nanos))
 }
 
 /// Whether `data`'s observed value actually exceeds its limit — true for

--- a/crates/monty-proto/src/convert/exception.rs
+++ b/crates/monty-proto/src/convert/exception.rs
@@ -86,8 +86,8 @@ impl From<&ResourceLimitData> for pb::ResourceLimitData {
                 })
             }
             ResourceLimitData::Time { limit, elapsed } => resource_limit_data::Kind::Time(resource_limit_data::Time {
-                limit_micros: u64::try_from(limit.as_micros()).unwrap_or(u64::MAX),
-                elapsed_micros: u64::try_from(elapsed.as_micros()).unwrap_or(u64::MAX),
+                limit_nanos: u64::try_from(limit.as_nanos()).unwrap_or(u64::MAX),
+                elapsed_nanos: u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX),
             }),
             ResourceLimitData::Memory { limit, used } => {
                 resource_limit_data::Kind::Memory(resource_limit_data::Memory {
@@ -121,8 +121,8 @@ fn resource_limit_data_from_wire(data: pb::ResourceLimitData) -> Option<Resource
             count: usize_field(a.count),
         },
         resource_limit_data::Kind::Time(t) => ResourceLimitData::Time {
-            limit: Duration::from_micros(t.limit_micros),
-            elapsed: Duration::from_micros(t.elapsed_micros),
+            limit: Duration::from_nanos(t.limit_nanos),
+            elapsed: Duration::from_nanos(t.elapsed_nanos),
         },
         resource_limit_data::Kind::Memory(m) => ResourceLimitData::Memory {
             limit: usize_field(m.limit),

--- a/crates/monty-proto/src/convert/exception.rs
+++ b/crates/monty-proto/src/convert/exception.rs
@@ -49,9 +49,15 @@ impl TryFrom<pb::RaisedException> for MontyException {
 
 /// Maps monty's `ExcData` onto the wire message; `ExcData::None` becomes an
 /// absent field rather than an empty message.
+///
+/// `ExcData::ResourceLimit` has no wire representation yet (no `pb::ExcData`
+/// oneof variant carries it) and is dropped here, same as `None` — a worker
+/// process's resource-limit classification does not yet survive the trip
+/// back to the parent. Extending the proto schema to close this gap is
+/// tracked as follow-up work.
 fn pb_exc_data(data: &ExcData) -> Option<pb::ExcData> {
     match data {
-        ExcData::None => None,
+        ExcData::None | ExcData::ResourceLimit(_) => None,
         ExcData::Unicode(unicode) => Some(pb::ExcData {
             kind: Some(pb::exc_data::Kind::Unicode(pb::UnicodeErrorData::from(
                 unicode.as_ref(),

--- a/crates/monty-proto/src/convert/exception.rs
+++ b/crates/monty-proto/src/convert/exception.rs
@@ -107,13 +107,15 @@ impl From<&ResourceLimitData> for pb::ResourceLimitData {
 }
 
 /// Converts a wire `ResourceLimitData`, dropping it (returning `None`) when
-/// the `kind` oneof is unset — the worst a compromised child sending an empty
-/// message can do, same posture as [`sanitize_unicode_data`]/[`sanitize_json_data`].
-/// Every field here is a plain integer with no attacker-controlled length, so
-/// unlike those two there is no amplification size cap to enforce.
+/// the `kind` oneof is unset or the decoded fields don't describe a genuine
+/// hit (see [`is_genuine_hit`]) — the worst a compromised child can do is
+/// fall back to an unclassified exception, same posture as
+/// [`sanitize_unicode_data`]/[`sanitize_json_data`]. Every field here is a
+/// plain integer with no attacker-controlled length, so unlike those two
+/// there is no amplification size cap to enforce.
 fn resource_limit_data_from_wire(data: pb::ResourceLimitData) -> Option<ResourceLimitData> {
     let usize_field = |v: u64| usize::try_from(v).unwrap_or(usize::MAX);
-    Some(match data.kind? {
+    let data = match data.kind? {
         resource_limit_data::Kind::Allocation(a) => ResourceLimitData::Allocation {
             limit: usize_field(a.limit),
             count: usize_field(a.count),
@@ -130,7 +132,24 @@ fn resource_limit_data_from_wire(data: pb::ResourceLimitData) -> Option<Resource
             limit: usize_field(r.limit),
             depth: usize_field(r.depth),
         },
-    })
+    };
+    is_genuine_hit(&data).then_some(data)
+}
+
+/// Whether `data`'s observed value actually exceeds its limit — true for
+/// every real `ResourceError`-derived construction (`on_allocate`/`on_grow`/
+/// `check_large_result` require `used/count > limit` before erroring,
+/// `check_time` requires `elapsed > limit`, `check_recursion_depth`/
+/// `enter_run_reentry` require `depth > limit`). A wire payload that fails
+/// this — e.g. an empty inner message decoding to `limit: 0, count: 0` — is
+/// not a real limit hit and must not be trusted as one.
+fn is_genuine_hit(data: &ResourceLimitData) -> bool {
+    match *data {
+        ResourceLimitData::Allocation { limit, count } => count > limit,
+        ResourceLimitData::Time { limit, elapsed } => elapsed > limit,
+        ResourceLimitData::Memory { limit, used } => used > limit,
+        ResourceLimitData::Recursion { limit, depth } => depth > limit,
+    }
 }
 
 impl From<&JsonErrorData> for pb::JsonErrorData {

--- a/crates/monty-proto/src/convert/exception.rs
+++ b/crates/monty-proto/src/convert/exception.rs
@@ -86,8 +86,10 @@ impl From<&ResourceLimitData> for pb::ResourceLimitData {
                 })
             }
             ResourceLimitData::Time { limit, elapsed } => resource_limit_data::Kind::Time(resource_limit_data::Time {
-                limit_nanos: u64::try_from(limit.as_nanos()).unwrap_or(u64::MAX),
-                elapsed_nanos: u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX),
+                limit_secs: limit.as_secs(),
+                limit_subsec_nanos: limit.subsec_nanos(),
+                elapsed_secs: elapsed.as_secs(),
+                elapsed_subsec_nanos: elapsed.subsec_nanos(),
             }),
             ResourceLimitData::Memory { limit, used } => {
                 resource_limit_data::Kind::Memory(resource_limit_data::Memory {
@@ -121,8 +123,8 @@ fn resource_limit_data_from_wire(data: pb::ResourceLimitData) -> Option<Resource
             count: usize_field(a.count),
         },
         resource_limit_data::Kind::Time(t) => ResourceLimitData::Time {
-            limit: Duration::from_nanos(t.limit_nanos),
-            elapsed: Duration::from_nanos(t.elapsed_nanos),
+            limit: Duration::new(t.limit_secs, t.limit_subsec_nanos),
+            elapsed: Duration::new(t.elapsed_secs, t.elapsed_subsec_nanos),
         },
         resource_limit_data::Kind::Memory(m) => ResourceLimitData::Memory {
             limit: usize_field(m.limit),

--- a/crates/monty-proto/src/generated/monty.v1.rs
+++ b/crates/monty-proto/src/generated/monty.v1.rs
@@ -181,7 +181,7 @@ pub struct RaisedException {
 /// payload" (`ExcData::None`).
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ExcData {
-    #[prost(oneof = "exc_data::Kind", tags = "1, 2")]
+    #[prost(oneof = "exc_data::Kind", tags = "1, 2, 3")]
     pub kind: ::core::option::Option<exc_data::Kind>,
 }
 /// Nested message and enum types in `ExcData`.
@@ -192,6 +192,8 @@ pub mod exc_data {
         Unicode(super::UnicodeErrorData),
         #[prost(message, tag = "2")]
         Json(super::JsonErrorData),
+        #[prost(message, tag = "3")]
+        ResourceLimit(super::ResourceLimitData),
     }
 }
 /// CPython's UnicodeDecodeError/UnicodeEncodeError constructor fields
@@ -247,6 +249,62 @@ pub struct JsonErrorData {
     pub lineno: u64,
     #[prost(uint64, tag = "5")]
     pub colno: u64,
+}
+/// Identifies which sandbox resource limit was hit and by how much, mirroring
+/// monty's `ResourceLimitData`. Set only when an exception represents a
+/// resource-limit hit rather than the same exception type raised by
+/// sandboxed code — see `ExcData.resource_limit`.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ResourceLimitData {
+    #[prost(oneof = "resource_limit_data::Kind", tags = "1, 2, 3, 4")]
+    pub kind: ::core::option::Option<resource_limit_data::Kind>,
+}
+/// Nested message and enum types in `ResourceLimitData`.
+pub mod resource_limit_data {
+    /// Maximum number of allocations exceeded.
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+    pub struct Allocation {
+        #[prost(uint64, tag = "1")]
+        pub limit: u64,
+        #[prost(uint64, tag = "2")]
+        pub count: u64,
+    }
+    /// Maximum execution time exceeded. Durations in microseconds, matching
+    /// `ResourceLimits.max_duration_micros`.
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+    pub struct Time {
+        #[prost(uint64, tag = "1")]
+        pub limit_micros: u64,
+        #[prost(uint64, tag = "2")]
+        pub elapsed_micros: u64,
+    }
+    /// Maximum memory usage exceeded, in bytes.
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+    pub struct Memory {
+        #[prost(uint64, tag = "1")]
+        pub limit: u64,
+        #[prost(uint64, tag = "2")]
+        pub used: u64,
+    }
+    /// Maximum recursion depth exceeded.
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+    pub struct Recursion {
+        #[prost(uint64, tag = "1")]
+        pub limit: u64,
+        #[prost(uint64, tag = "2")]
+        pub depth: u64,
+    }
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum Kind {
+        #[prost(message, tag = "1")]
+        Allocation(Allocation),
+        #[prost(message, tag = "2")]
+        Time(Time),
+        #[prost(message, tag = "3")]
+        Memory(Memory),
+        #[prost(message, tag = "4")]
+        Recursion(Recursion),
+    }
 }
 /// 1-based line/column source position (columns count characters, not bytes).
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]

--- a/crates/monty-proto/src/generated/monty.v1.rs
+++ b/crates/monty-proto/src/generated/monty.v1.rs
@@ -269,18 +269,24 @@ pub mod resource_limit_data {
         #[prost(uint64, tag = "2")]
         pub count: u64,
     }
-    /// Maximum execution time exceeded. Durations in nanoseconds (unlike
-    /// `ResourceLimits.max_duration_micros`) so the receive side's hit-validity
-    /// check (`elapsed > limit`, see `is_genuine_hit`) can't be defeated by
-    /// truncation: a genuine hit whose margin over the limit is sub-microsecond
-    /// would otherwise round-trip to `elapsed_micros == limit_micros` and get
-    /// rejected as implausible.
+    /// Maximum execution time exceeded. Each duration is split into seconds +
+    /// sub-second nanoseconds (mirroring `std::time::Duration`'s own
+    /// representation) rather than a single nanosecond count, so encoding is
+    /// always exact — no truncation at the low end (unlike
+    /// `ResourceLimits.max_duration_micros`) and no saturation at the high end
+    /// for any representable `Duration`. Either lossiness would let the receive
+    /// side's hit-validity check (`elapsed > limit`, see `is_genuine_hit`)
+    /// reject a genuine hit whose encoded value collapsed to equal its limit.
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct Time {
         #[prost(uint64, tag = "1")]
-        pub limit_nanos: u64,
-        #[prost(uint64, tag = "2")]
-        pub elapsed_nanos: u64,
+        pub limit_secs: u64,
+        #[prost(uint32, tag = "2")]
+        pub limit_subsec_nanos: u32,
+        #[prost(uint64, tag = "3")]
+        pub elapsed_secs: u64,
+        #[prost(uint32, tag = "4")]
+        pub elapsed_subsec_nanos: u32,
     }
     /// Maximum memory usage exceeded, in bytes.
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]

--- a/crates/monty-proto/src/generated/monty.v1.rs
+++ b/crates/monty-proto/src/generated/monty.v1.rs
@@ -269,14 +269,18 @@ pub mod resource_limit_data {
         #[prost(uint64, tag = "2")]
         pub count: u64,
     }
-    /// Maximum execution time exceeded. Durations in microseconds, matching
-    /// `ResourceLimits.max_duration_micros`.
+    /// Maximum execution time exceeded. Durations in nanoseconds (unlike
+    /// `ResourceLimits.max_duration_micros`) so the receive side's hit-validity
+    /// check (`elapsed > limit`, see `is_genuine_hit`) can't be defeated by
+    /// truncation: a genuine hit whose margin over the limit is sub-microsecond
+    /// would otherwise round-trip to `elapsed_micros == limit_micros` and get
+    /// rejected as implausible.
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct Time {
         #[prost(uint64, tag = "1")]
-        pub limit_micros: u64,
+        pub limit_nanos: u64,
         #[prost(uint64, tag = "2")]
-        pub elapsed_micros: u64,
+        pub elapsed_nanos: u64,
     }
     /// Maximum memory usage exceeded, in bytes.
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]

--- a/crates/monty-proto/tests/oracle/monty.v1.rs
+++ b/crates/monty-proto/tests/oracle/monty.v1.rs
@@ -366,18 +366,24 @@ pub mod resource_limit_data {
         #[prost(uint64, tag = "2")]
         pub count: u64,
     }
-    /// Maximum execution time exceeded. Durations in nanoseconds (unlike
-    /// `ResourceLimits.max_duration_micros`) so the receive side's hit-validity
-    /// check (`elapsed > limit`, see `is_genuine_hit`) can't be defeated by
-    /// truncation: a genuine hit whose margin over the limit is sub-microsecond
-    /// would otherwise round-trip to `elapsed_micros == limit_micros` and get
-    /// rejected as implausible.
+    /// Maximum execution time exceeded. Each duration is split into seconds +
+    /// sub-second nanoseconds (mirroring `std::time::Duration`'s own
+    /// representation) rather than a single nanosecond count, so encoding is
+    /// always exact — no truncation at the low end (unlike
+    /// `ResourceLimits.max_duration_micros`) and no saturation at the high end
+    /// for any representable `Duration`. Either lossiness would let the receive
+    /// side's hit-validity check (`elapsed > limit`, see `is_genuine_hit`)
+    /// reject a genuine hit whose encoded value collapsed to equal its limit.
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct Time {
         #[prost(uint64, tag = "1")]
-        pub limit_nanos: u64,
-        #[prost(uint64, tag = "2")]
-        pub elapsed_nanos: u64,
+        pub limit_secs: u64,
+        #[prost(uint32, tag = "2")]
+        pub limit_subsec_nanos: u32,
+        #[prost(uint64, tag = "3")]
+        pub elapsed_secs: u64,
+        #[prost(uint32, tag = "4")]
+        pub elapsed_subsec_nanos: u32,
     }
     /// Maximum memory usage exceeded, in bytes.
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]

--- a/crates/monty-proto/tests/oracle/monty.v1.rs
+++ b/crates/monty-proto/tests/oracle/monty.v1.rs
@@ -278,7 +278,7 @@ pub struct RaisedException {
 /// payload" (`ExcData::None`).
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ExcData {
-    #[prost(oneof = "exc_data::Kind", tags = "1, 2")]
+    #[prost(oneof = "exc_data::Kind", tags = "1, 2, 3")]
     pub kind: ::core::option::Option<exc_data::Kind>,
 }
 /// Nested message and enum types in `ExcData`.
@@ -289,6 +289,8 @@ pub mod exc_data {
         Unicode(super::UnicodeErrorData),
         #[prost(message, tag = "2")]
         Json(super::JsonErrorData),
+        #[prost(message, tag = "3")]
+        ResourceLimit(super::ResourceLimitData),
     }
 }
 /// CPython's UnicodeDecodeError/UnicodeEncodeError constructor fields
@@ -344,6 +346,62 @@ pub struct JsonErrorData {
     pub lineno: u64,
     #[prost(uint64, tag = "5")]
     pub colno: u64,
+}
+/// Identifies which sandbox resource limit was hit and by how much, mirroring
+/// monty's `ResourceLimitData`. Set only when an exception represents a
+/// resource-limit hit rather than the same exception type raised by
+/// sandboxed code — see `ExcData.resource_limit`.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ResourceLimitData {
+    #[prost(oneof = "resource_limit_data::Kind", tags = "1, 2, 3, 4")]
+    pub kind: ::core::option::Option<resource_limit_data::Kind>,
+}
+/// Nested message and enum types in `ResourceLimitData`.
+pub mod resource_limit_data {
+    /// Maximum number of allocations exceeded.
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+    pub struct Allocation {
+        #[prost(uint64, tag = "1")]
+        pub limit: u64,
+        #[prost(uint64, tag = "2")]
+        pub count: u64,
+    }
+    /// Maximum execution time exceeded. Durations in microseconds, matching
+    /// `ResourceLimits.max_duration_micros`.
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+    pub struct Time {
+        #[prost(uint64, tag = "1")]
+        pub limit_micros: u64,
+        #[prost(uint64, tag = "2")]
+        pub elapsed_micros: u64,
+    }
+    /// Maximum memory usage exceeded, in bytes.
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+    pub struct Memory {
+        #[prost(uint64, tag = "1")]
+        pub limit: u64,
+        #[prost(uint64, tag = "2")]
+        pub used: u64,
+    }
+    /// Maximum recursion depth exceeded.
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
+    pub struct Recursion {
+        #[prost(uint64, tag = "1")]
+        pub limit: u64,
+        #[prost(uint64, tag = "2")]
+        pub depth: u64,
+    }
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Oneof)]
+    pub enum Kind {
+        #[prost(message, tag = "1")]
+        Allocation(Allocation),
+        #[prost(message, tag = "2")]
+        Time(Time),
+        #[prost(message, tag = "3")]
+        Memory(Memory),
+        #[prost(message, tag = "4")]
+        Recursion(Recursion),
+    }
 }
 /// 1-based line/column source position (columns count characters, not bytes).
 #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]

--- a/crates/monty-proto/tests/oracle/monty.v1.rs
+++ b/crates/monty-proto/tests/oracle/monty.v1.rs
@@ -366,14 +366,18 @@ pub mod resource_limit_data {
         #[prost(uint64, tag = "2")]
         pub count: u64,
     }
-    /// Maximum execution time exceeded. Durations in microseconds, matching
-    /// `ResourceLimits.max_duration_micros`.
+    /// Maximum execution time exceeded. Durations in nanoseconds (unlike
+    /// `ResourceLimits.max_duration_micros`) so the receive side's hit-validity
+    /// check (`elapsed > limit`, see `is_genuine_hit`) can't be defeated by
+    /// truncation: a genuine hit whose margin over the limit is sub-microsecond
+    /// would otherwise round-trip to `elapsed_micros == limit_micros` and get
+    /// rejected as implausible.
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
     pub struct Time {
         #[prost(uint64, tag = "1")]
-        pub limit_micros: u64,
+        pub limit_nanos: u64,
         #[prost(uint64, tag = "2")]
-        pub elapsed_micros: u64,
+        pub elapsed_nanos: u64,
     }
     /// Maximum memory usage exceeded, in bytes.
     #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]

--- a/crates/monty-proto/tests/roundtrip.rs
+++ b/crates/monty-proto/tests/roundtrip.rs
@@ -408,11 +408,11 @@ fn resource_limit_data_round_trips() {
 
 /// Regression: a genuine time-limit hit whose margin over the limit is
 /// sub-microsecond must still round-trip and pass the receive side's
-/// hit-validity check. Before the wire format used nanosecond precision, both
-/// durations truncated to microseconds before that check, so a hit this close
-/// to its limit would decode to `elapsed_nanos == limit_nanos` and get
-/// dropped as implausible — exactly the failure mode a lossy encoding
-/// introduces.
+/// hit-validity check. Before the wire format used sub-second-nanosecond
+/// precision, both durations truncated to microseconds before that check, so
+/// a hit this close to its limit would decode to an equal `elapsed`/`limit`
+/// and get dropped as implausible — exactly the failure mode a lossy
+/// encoding introduces.
 #[test]
 fn sub_microsecond_time_limit_hit_survives_round_trip() {
     let data = ResourceLimitData::Time {
@@ -426,6 +426,29 @@ fn sub_microsecond_time_limit_hit_survives_round_trip() {
     assert!(
         back.resource_limit_data().is_some(),
         "sub-microsecond-margin hit must survive as a genuine classification"
+    );
+}
+
+/// Regression: a genuine time-limit hit at a magnitude beyond ~584 years
+/// (`u64::MAX` nanoseconds) must still round-trip. A single-nanosecond-count
+/// wire encoding saturates durations past that point to `u64::MAX`, which
+/// would make an even-more-extreme `elapsed` collapse to equal `limit` and
+/// get dropped as implausible; encoding as seconds + sub-second nanoseconds
+/// has no such ceiling for any representable `Duration`.
+#[test]
+fn extreme_duration_time_limit_hit_survives_round_trip() {
+    let limit = Duration::from_secs(20_000_000_000); // ~634 years > u64::MAX nanoseconds
+    let data = ResourceLimitData::Time {
+        limit,
+        elapsed: limit + Duration::from_nanos(500),
+    };
+    let exc = MontyException::new(ExcType::TimeoutError, Some("time limit exceeded".to_owned()))
+        .with_data(ExcData::ResourceLimit(Box::new(data)));
+    let back = MontyException::try_from(pb::RaisedException::from(&exc)).unwrap();
+    assert_eq!(back, exc);
+    assert!(
+        back.resource_limit_data().is_some(),
+        "extreme-magnitude hit must survive as a genuine classification"
     );
 }
 
@@ -457,16 +480,20 @@ fn implausible_resource_limit_data_is_dropped_not_trusted() {
         pb::resource_limit_data::Kind::Allocation(pb::resource_limit_data::Allocation { limit: 0, count: 0 }),
         pb::resource_limit_data::Kind::Allocation(pb::resource_limit_data::Allocation { limit: 5, count: 5 }),
         pb::resource_limit_data::Kind::Time(pb::resource_limit_data::Time {
-            limit_nanos: 50_000,
-            elapsed_nanos: 40_000,
+            limit_secs: 0,
+            limit_subsec_nanos: 50_000,
+            elapsed_secs: 0,
+            elapsed_subsec_nanos: 40_000,
         }),
-        // Equal-to-the-nanosecond is exactly the boundary case the nanosecond
+        // Equal-to-the-nanosecond is exactly the boundary case the exact
         // wire precision exists to get right: not a hit (must be dropped),
         // and must not be conflated with a genuine hit that merely lost
-        // precision through a lossy micros round trip.
+        // precision through a lossy round trip.
         pb::resource_limit_data::Kind::Time(pb::resource_limit_data::Time {
-            limit_nanos: 50_000,
-            elapsed_nanos: 50_000,
+            limit_secs: 0,
+            limit_subsec_nanos: 50_000,
+            elapsed_secs: 0,
+            elapsed_subsec_nanos: 50_000,
         }),
         pb::resource_limit_data::Kind::Memory(pb::resource_limit_data::Memory { limit: 100, used: 100 }),
         pb::resource_limit_data::Kind::Recursion(pb::resource_limit_data::Recursion { limit: 10, depth: 10 }),

--- a/crates/monty-proto/tests/roundtrip.rs
+++ b/crates/monty-proto/tests/roundtrip.rs
@@ -423,6 +423,39 @@ fn empty_resource_limit_data_is_dropped_not_trusted() {
     assert_eq!(back.data(), &ExcData::None);
 }
 
+/// A well-formed but impossible `ResourceLimitData` payload — e.g. an empty
+/// `Allocation { limit: 0, count: 0 }`, which no real limit hit can ever
+/// produce (`count > limit` always holds — see `is_genuine_hit`) — must be
+/// dropped rather than trusted as a genuine classification. Covers all four
+/// variants, each with its observed value at or below its limit.
+#[test]
+fn implausible_resource_limit_data_is_dropped_not_trusted() {
+    let implausible_payloads = [
+        pb::resource_limit_data::Kind::Allocation(pb::resource_limit_data::Allocation { limit: 0, count: 0 }),
+        pb::resource_limit_data::Kind::Allocation(pb::resource_limit_data::Allocation { limit: 5, count: 5 }),
+        pb::resource_limit_data::Kind::Time(pb::resource_limit_data::Time {
+            limit_micros: 50_000,
+            elapsed_micros: 40_000,
+        }),
+        pb::resource_limit_data::Kind::Memory(pb::resource_limit_data::Memory { limit: 100, used: 100 }),
+        pb::resource_limit_data::Kind::Recursion(pb::resource_limit_data::Recursion { limit: 10, depth: 10 }),
+    ];
+    for kind in implausible_payloads {
+        let wire = pb::RaisedException {
+            exc_type: "MemoryError".to_owned(),
+            message: Some("limit exceeded".to_owned()),
+            traceback: vec![],
+            data: Some(pb::ExcData {
+                kind: Some(pb::exc_data::Kind::ResourceLimit(pb::ResourceLimitData {
+                    kind: Some(kind),
+                })),
+            }),
+        };
+        let back = MontyException::try_from(wire).unwrap();
+        assert_eq!(back.data(), &ExcData::None);
+    }
+}
+
 /// Builds a wire `json.JSONDecodeError` whose payload fields a byzantine
 /// child controls, for probing the receive-side sanitizer.
 fn json_exception(msg: String, doc: Option<String>, pos: u64, lineno: u64, colno: u64) -> pb::RaisedException {

--- a/crates/monty-proto/tests/roundtrip.rs
+++ b/crates/monty-proto/tests/roundtrip.rs
@@ -518,26 +518,41 @@ fn implausible_resource_limit_data_is_dropped_not_trusted() {
 /// forces a carry that overflows `secs`. A compromised child sending
 /// `secs: u64::MAX, subsec_nanos: u32::MAX` must not crash the parent
 /// process — the payload is dropped (like every other malformed field here),
-/// not passed through to `Duration::new` unchecked.
+/// not passed through to `Duration::new` unchecked. `checked_duration` is
+/// called once for `limit` and once for `elapsed`, each independently
+/// capable of rejecting the payload; covers both — an invalid `limit` (where
+/// the `?` short-circuits before `elapsed`'s check ever runs) and an invalid
+/// `elapsed` alongside a valid `limit` (so `elapsed`'s own rejection path is
+/// exercised, not just short-circuited past).
 #[test]
 fn out_of_range_subsec_nanos_is_dropped_not_a_panic() {
-    let wire = pb::RaisedException {
-        exc_type: "TimeoutError".to_owned(),
-        message: Some("limit exceeded".to_owned()),
-        traceback: vec![],
-        data: Some(pb::ExcData {
-            kind: Some(pb::exc_data::Kind::ResourceLimit(pb::ResourceLimitData {
-                kind: Some(pb::resource_limit_data::Kind::Time(pb::resource_limit_data::Time {
-                    limit_secs: u64::MAX,
-                    limit_subsec_nanos: u32::MAX,
-                    elapsed_secs: u64::MAX,
-                    elapsed_subsec_nanos: u32::MAX,
+    for time in [
+        pb::resource_limit_data::Time {
+            limit_secs: u64::MAX,
+            limit_subsec_nanos: u32::MAX,
+            elapsed_secs: u64::MAX,
+            elapsed_subsec_nanos: u32::MAX,
+        },
+        pb::resource_limit_data::Time {
+            limit_secs: 0,
+            limit_subsec_nanos: 0,
+            elapsed_secs: u64::MAX,
+            elapsed_subsec_nanos: u32::MAX,
+        },
+    ] {
+        let wire = pb::RaisedException {
+            exc_type: "TimeoutError".to_owned(),
+            message: Some("limit exceeded".to_owned()),
+            traceback: vec![],
+            data: Some(pb::ExcData {
+                kind: Some(pb::exc_data::Kind::ResourceLimit(pb::ResourceLimitData {
+                    kind: Some(pb::resource_limit_data::Kind::Time(time)),
                 })),
-            })),
-        }),
-    };
-    let back = MontyException::try_from(wire).unwrap();
-    assert_eq!(back.data(), &ExcData::None);
+            }),
+        };
+        let back = MontyException::try_from(wire).unwrap();
+        assert_eq!(back.data(), &ExcData::None);
+    }
 }
 
 /// Builds a wire `json.JSONDecodeError` whose payload fields a byzantine

--- a/crates/monty-proto/tests/roundtrip.rs
+++ b/crates/monty-proto/tests/roundtrip.rs
@@ -406,6 +406,29 @@ fn resource_limit_data_round_trips() {
     }
 }
 
+/// Regression: a genuine time-limit hit whose margin over the limit is
+/// sub-microsecond must still round-trip and pass the receive side's
+/// hit-validity check. Before the wire format used nanosecond precision, both
+/// durations truncated to microseconds before that check, so a hit this close
+/// to its limit would decode to `elapsed_nanos == limit_nanos` and get
+/// dropped as implausible — exactly the failure mode a lossy encoding
+/// introduces.
+#[test]
+fn sub_microsecond_time_limit_hit_survives_round_trip() {
+    let data = ResourceLimitData::Time {
+        limit: Duration::from_micros(50),
+        elapsed: Duration::from_micros(50) + Duration::from_nanos(200),
+    };
+    let exc = MontyException::new(ExcType::TimeoutError, Some("time limit exceeded".to_owned()))
+        .with_data(ExcData::ResourceLimit(Box::new(data)));
+    let back = MontyException::try_from(pb::RaisedException::from(&exc)).unwrap();
+    assert_eq!(back, exc);
+    assert!(
+        back.resource_limit_data().is_some(),
+        "sub-microsecond-margin hit must survive as a genuine classification"
+    );
+}
+
 /// An empty `ResourceLimitData` wire message (a compromised or buggy child
 /// sending no `kind`) must be dropped, not trusted — same posture as
 /// [`bogus_unicode_payloads_are_dropped_not_trusted`]/[`bogus_json_payloads_are_dropped_not_trusted`].
@@ -434,8 +457,16 @@ fn implausible_resource_limit_data_is_dropped_not_trusted() {
         pb::resource_limit_data::Kind::Allocation(pb::resource_limit_data::Allocation { limit: 0, count: 0 }),
         pb::resource_limit_data::Kind::Allocation(pb::resource_limit_data::Allocation { limit: 5, count: 5 }),
         pb::resource_limit_data::Kind::Time(pb::resource_limit_data::Time {
-            limit_micros: 50_000,
-            elapsed_micros: 40_000,
+            limit_nanos: 50_000,
+            elapsed_nanos: 40_000,
+        }),
+        // Equal-to-the-nanosecond is exactly the boundary case the nanosecond
+        // wire precision exists to get right: not a hit (must be dropped),
+        // and must not be conflated with a genuine hit that merely lost
+        // precision through a lossy micros round trip.
+        pb::resource_limit_data::Kind::Time(pb::resource_limit_data::Time {
+            limit_nanos: 50_000,
+            elapsed_nanos: 50_000,
         }),
         pb::resource_limit_data::Kind::Memory(pb::resource_limit_data::Memory { limit: 100, used: 100 }),
         pb::resource_limit_data::Kind::Recursion(pb::resource_limit_data::Recursion { limit: 10, depth: 10 }),

--- a/crates/monty-proto/tests/roundtrip.rs
+++ b/crates/monty-proto/tests/roundtrip.rs
@@ -4,7 +4,7 @@ use monty::{
     CodeLoc, CompileOptions, DictPairs, ExcData, ExcType, ExtFunctionResult, GetenvArgs, JsonErrorData, MkdirCallArgs,
     MontyDate, MontyDateTime, MontyException, MontyFileHandle, MontyObject, MontyPath, MontyRun, MontyTimeDelta,
     MontyTimeZone, MontyType, NameLookupResult, OpenCallArgs, OsFunctionCall, PathBytesDataArgs, PathStringDataArgs,
-    RenameCallArgs, ResourceLimits, StackFrame, UnicodeErrorData,
+    RenameCallArgs, ResourceLimitData, ResourceLimits, StackFrame, UnicodeErrorData,
 };
 use monty_proto::{MAX_VALUE_DEPTH, ProtoConvertError, WireObject, exceeds_max_value_depth, pb};
 use num_bigint::BigInt;
@@ -381,6 +381,46 @@ fn json_error_payload_round_trips() {
     ));
     let back = MontyException::try_from(pb::RaisedException::from(&exc)).unwrap();
     assert_eq!(back, exc);
+}
+
+/// All four `ResourceLimitData` variants survive the trip through
+/// `monty-pool`'s subprocess wire format — this is the primary execution
+/// path for embedders using `monty-pool`/`pydantic_monty`, so a resource
+/// limit hit in a worker must still classify correctly once it reaches the
+/// parent process.
+#[test]
+fn resource_limit_data_round_trips() {
+    for data in [
+        ResourceLimitData::Allocation { limit: 4, count: 5 },
+        ResourceLimitData::Time {
+            limit: Duration::from_millis(50),
+            elapsed: Duration::from_millis(52),
+        },
+        ResourceLimitData::Memory { limit: 100, used: 128 },
+        ResourceLimitData::Recursion { limit: 10, depth: 11 },
+    ] {
+        let exc = MontyException::new(ExcType::MemoryError, Some("limit exceeded".to_owned()))
+            .with_data(ExcData::ResourceLimit(Box::new(data)));
+        let back = MontyException::try_from(pb::RaisedException::from(&exc)).unwrap();
+        assert_eq!(back, exc, "{data:?} did not round-trip");
+    }
+}
+
+/// An empty `ResourceLimitData` wire message (a compromised or buggy child
+/// sending no `kind`) must be dropped, not trusted — same posture as
+/// [`bogus_unicode_payloads_are_dropped_not_trusted`]/[`bogus_json_payloads_are_dropped_not_trusted`].
+#[test]
+fn empty_resource_limit_data_is_dropped_not_trusted() {
+    let wire = pb::RaisedException {
+        exc_type: "MemoryError".to_owned(),
+        message: Some("limit exceeded".to_owned()),
+        traceback: vec![],
+        data: Some(pb::ExcData {
+            kind: Some(pb::exc_data::Kind::ResourceLimit(pb::ResourceLimitData { kind: None })),
+        }),
+    };
+    let back = MontyException::try_from(wire).unwrap();
+    assert_eq!(back.data(), &ExcData::None);
 }
 
 /// Builds a wire `json.JSONDecodeError` whose payload fields a byzantine

--- a/crates/monty-proto/tests/roundtrip.rs
+++ b/crates/monty-proto/tests/roundtrip.rs
@@ -514,6 +514,32 @@ fn implausible_resource_limit_data_is_dropped_not_trusted() {
     }
 }
 
+/// Regression: `Duration::new` panics if `subsec_nanos >= 1_000_000_000`
+/// forces a carry that overflows `secs`. A compromised child sending
+/// `secs: u64::MAX, subsec_nanos: u32::MAX` must not crash the parent
+/// process — the payload is dropped (like every other malformed field here),
+/// not passed through to `Duration::new` unchecked.
+#[test]
+fn out_of_range_subsec_nanos_is_dropped_not_a_panic() {
+    let wire = pb::RaisedException {
+        exc_type: "TimeoutError".to_owned(),
+        message: Some("limit exceeded".to_owned()),
+        traceback: vec![],
+        data: Some(pb::ExcData {
+            kind: Some(pb::exc_data::Kind::ResourceLimit(pb::ResourceLimitData {
+                kind: Some(pb::resource_limit_data::Kind::Time(pb::resource_limit_data::Time {
+                    limit_secs: u64::MAX,
+                    limit_subsec_nanos: u32::MAX,
+                    elapsed_secs: u64::MAX,
+                    elapsed_subsec_nanos: u32::MAX,
+                })),
+            })),
+        }),
+    };
+    let back = MontyException::try_from(wire).unwrap();
+    assert_eq!(back.data(), &ExcData::None);
+}
+
 /// Builds a wire `json.JSONDecodeError` whose payload fields a byzantine
 /// child controls, for probing the receive-side sanitizer.
 fn json_exception(msg: String, doc: Option<String>, pos: u64, lineno: u64, colno: u64) -> pb::RaisedException {

--- a/crates/monty/src/bytecode/vm/recursion.rs
+++ b/crates/monty/src/bytecode/vm/recursion.rs
@@ -133,7 +133,11 @@ impl<T: ResourceTracker> VM<'_, T> {
         } else {
             Err(ResourceError::Recursion {
                 limit: MAX_RUN_REENTRY_DEPTH as usize,
-                depth: MAX_RUN_REENTRY_DEPTH as usize,
+                // +1: this is the depth the rejected re-entry would have
+                // reached, matching `ResourceError::Recursion`'s documented
+                // meaning elsewhere (e.g. `check_recursion_depth`'s
+                // `current_depth + 1`) — not `MAX_RUN_REENTRY_DEPTH` itself.
+                depth: MAX_RUN_REENTRY_DEPTH as usize + 1,
             })
         }
     }

--- a/crates/monty/src/exception_public.rs
+++ b/crates/monty/src/exception_public.rs
@@ -52,8 +52,9 @@ pub enum ExcData {
     /// configured [`ResourceLimits`](crate::ResourceLimits) bound was
     /// exceeded) rather than an exception raised by sandboxed code of the
     /// same type. Lets embedders distinguish the two without parsing the
-    /// message.
-    ResourceLimit(ResourceLimitData),
+    /// message. Boxed like [`ExcData::Unicode`]/[`ExcData::Json`] to keep the
+    /// enum small.
+    ResourceLimit(Box<ResourceLimitData>),
 }
 
 impl ExcData {

--- a/crates/monty/src/exception_public.rs
+++ b/crates/monty/src/exception_public.rs
@@ -4,6 +4,7 @@ use std::{
     fmt::{self, Write},
     mem, str,
     sync::Arc,
+    time::Duration,
 };
 
 use crate::{
@@ -46,6 +47,13 @@ pub enum ExcData {
     /// `json.JSONDecodeError` attribute fields. Boxed like
     /// [`ExcData::Unicode`] to keep the enum small.
     Json(Box<JsonErrorData>),
+    /// Set when this exception represents a sandbox resource-limit hit
+    /// (`MemoryError`/`TimeoutError`/`RecursionError` raised because a
+    /// configured [`ResourceLimits`](crate::ResourceLimits) bound was
+    /// exceeded) rather than an exception raised by sandboxed code of the
+    /// same type. Lets embedders distinguish the two without parsing the
+    /// message.
+    ResourceLimit(ResourceLimitData),
 }
 
 impl ExcData {
@@ -67,6 +75,15 @@ impl ExcData {
         }
     }
 
+    /// The resource-limit fields, if this is [`ExcData::ResourceLimit`].
+    #[must_use]
+    pub fn resource_limit(&self) -> Option<&ResourceLimitData> {
+        match self {
+            Self::ResourceLimit(data) => Some(data),
+            _ => None,
+        }
+    }
+
     /// Approximate byte footprint, used by the heap's memory accounting when
     /// an exception carrying this payload is stored on the sandbox heap.
     #[must_use]
@@ -75,8 +92,45 @@ impl ExcData {
             Self::None => 0,
             Self::Unicode(data) => data.estimate_size(),
             Self::Json(data) => data.estimate_size(),
+            Self::ResourceLimit(_) => mem::size_of::<ResourceLimitData>(),
         }
     }
+}
+
+/// Structured fields identifying which resource limit was hit and by how
+/// much. Mirrors the limit-hit variants of `ResourceError` (its
+/// `ResourceError::Exception` variant is not a limit hit, so has no
+/// counterpart here) — see [`ExcData::ResourceLimit`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum ResourceLimitData {
+    /// Maximum number of allocations exceeded.
+    Allocation {
+        /// The configured allocation-count limit.
+        limit: usize,
+        /// The allocation count that would have resulted.
+        count: usize,
+    },
+    /// Maximum execution time exceeded.
+    Time {
+        /// The configured duration limit.
+        limit: Duration,
+        /// The elapsed execution time observed.
+        elapsed: Duration,
+    },
+    /// Maximum memory usage exceeded.
+    Memory {
+        /// The configured memory limit, in bytes.
+        limit: usize,
+        /// The memory usage that would have resulted, in bytes.
+        used: usize,
+    },
+    /// Maximum recursion depth exceeded.
+    Recursion {
+        /// The configured recursion-depth limit.
+        limit: usize,
+        /// The call-stack depth that would have resulted.
+        depth: usize,
+    },
 }
 
 /// Structured fields of a `UnicodeDecodeError` / `UnicodeEncodeError`,
@@ -350,6 +404,14 @@ impl MontyException {
     #[must_use]
     pub fn json_data(&self) -> Option<&JsonErrorData> {
         self.data.json()
+    }
+
+    /// Structured resource-limit fields, present only when this exception
+    /// represents a sandbox resource-limit hit rather than an exception of
+    /// the same type raised by sandboxed code (e.g. `raise MemoryError()`).
+    #[must_use]
+    pub fn resource_limit_data(&self) -> Option<&ResourceLimitData> {
+        self.data.resource_limit()
     }
 
     /// Removes and returns the structured payload, for consumers (like the

--- a/crates/monty/src/exception_public.rs
+++ b/crates/monty/src/exception_public.rs
@@ -32,9 +32,11 @@ pub struct MontyException {
 }
 
 /// Structured payload attached to exception types whose CPython counterparts
-/// carry more than a message. Currently unicode and json decode errors have
-/// one; the enum leaves room for future variants (e.g. `OSError`'s
-/// `errno`/`filename`) without another field on every exception.
+/// carry more than a message, or that need to distinguish a sandbox
+/// resource-limit hit from an ordinary exception of the same type. Currently
+/// unicode errors, json decode errors, and resource-limit hits have one; the
+/// enum leaves room for future variants (e.g. `OSError`'s `errno`/`filename`)
+/// without another field on every exception.
 #[derive(Debug, Clone, Default, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum ExcData {
     /// No structured payload — every exception type without a variant below.

--- a/crates/monty/src/lib.rs
+++ b/crates/monty/src/lib.rs
@@ -39,7 +39,8 @@ pub use crate::{
     codecs::utf8_error_reason,
     exception_private::{ExcType, unicode_decode_error_msg},
     exception_public::{
-        CodeLoc, ExcData, JsonErrorData, MontyException, StackFrame, UnicodeErrorData, UnicodeErrorObject,
+        CodeLoc, ExcData, JsonErrorData, MontyException, ResourceLimitData, StackFrame, UnicodeErrorData,
+        UnicodeErrorObject,
     },
     io::{PrintStream, PrintWriter, PrintWriterCallback},
     object::{

--- a/crates/monty/src/resource.rs
+++ b/crates/monty/src/resource.rs
@@ -744,3 +744,21 @@ impl ResourceTracker for LimitedTracker {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `ResourceError::Exception` is not a limit hit — it wraps a
+    /// propagating exception — so `into_exception` must pass its type and
+    /// message through unchanged and attach no `ExcData::ResourceLimit`
+    /// payload, unlike the four true limit-hit variants above it.
+    #[test]
+    fn exception_variant_carries_no_resource_limit_data() {
+        let inner = MontyException::new(ExcType::ValueError, Some("boom".to_owned()));
+        let raised = ResourceError::Exception(inner).into_exception(None);
+        assert_eq!(raised.exc.exc_type(), ExcType::ValueError);
+        assert_eq!(raised.exc.arg().map(String::as_str), Some("boom"));
+        assert_eq!(raised.exc.data(), &ExcData::None);
+    }
+}

--- a/crates/monty/src/resource.rs
+++ b/crates/monty/src/resource.rs
@@ -197,22 +197,22 @@ impl ResourceError {
             Self::Allocation { limit, count } => (
                 ExcType::MemoryError,
                 Some(format!("allocation limit exceeded: {count} > {limit}")),
-                ExcData::ResourceLimit(ResourceLimitData::Allocation { limit, count }),
+                ExcData::ResourceLimit(Box::new(ResourceLimitData::Allocation { limit, count })),
             ),
             Self::Memory { limit, used } => (
                 ExcType::MemoryError,
                 Some(format!("memory limit exceeded: {used} bytes > {limit} bytes")),
-                ExcData::ResourceLimit(ResourceLimitData::Memory { limit, used }),
+                ExcData::ResourceLimit(Box::new(ResourceLimitData::Memory { limit, used })),
             ),
             Self::Time { limit, elapsed } => (
                 ExcType::TimeoutError,
                 Some(format!("time limit exceeded: {elapsed:?} > {limit:?}")),
-                ExcData::ResourceLimit(ResourceLimitData::Time { limit, elapsed }),
+                ExcData::ResourceLimit(Box::new(ResourceLimitData::Time { limit, elapsed })),
             ),
             Self::Recursion { limit, depth } => (
                 ExcType::RecursionError,
                 Some("maximum recursion depth exceeded".to_string()),
-                ExcData::ResourceLimit(ResourceLimitData::Recursion { limit, depth }),
+                ExcData::ResourceLimit(Box::new(ResourceLimitData::Recursion { limit, depth })),
             ),
             Self::Exception(exc) => (exc.exc_type(), exc.into_message(), ExcData::None),
         };

--- a/crates/monty/src/resource.rs
+++ b/crates/monty/src/resource.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use crate::{
-    ExcType, MontyException,
+    ExcData, ExcType, MontyException, ResourceLimitData,
     exception_private::{ExceptionRaise, RawStackFrame, RunError, SimpleException},
 };
 
@@ -186,28 +186,37 @@ impl ResourceError {
     /// - `Memory` → `MemoryError`
     /// - `Time` → `TimeoutError`
     /// - `Recursion` → `RecursionError`
+    ///
+    /// The four limit-hit variants also attach an [`ExcData::ResourceLimit`]
+    /// payload carrying the original typed fields, so embedders can tell a
+    /// limit hit apart from sandboxed code raising the same exception type
+    /// (e.g. `raise MemoryError()`) without parsing the message.
     #[must_use]
     pub(crate) fn into_exception(self, frame: Option<RawStackFrame>) -> ExceptionRaise {
-        let (exc_type, msg) = match self {
+        let (exc_type, msg, data) = match self {
             Self::Allocation { limit, count } => (
                 ExcType::MemoryError,
                 Some(format!("allocation limit exceeded: {count} > {limit}")),
+                ExcData::ResourceLimit(ResourceLimitData::Allocation { limit, count }),
             ),
             Self::Memory { limit, used } => (
                 ExcType::MemoryError,
                 Some(format!("memory limit exceeded: {used} bytes > {limit} bytes")),
+                ExcData::ResourceLimit(ResourceLimitData::Memory { limit, used }),
             ),
             Self::Time { limit, elapsed } => (
                 ExcType::TimeoutError,
                 Some(format!("time limit exceeded: {elapsed:?} > {limit:?}")),
+                ExcData::ResourceLimit(ResourceLimitData::Time { limit, elapsed }),
             ),
-            Self::Recursion { .. } => (
+            Self::Recursion { limit, depth } => (
                 ExcType::RecursionError,
                 Some("maximum recursion depth exceeded".to_string()),
+                ExcData::ResourceLimit(ResourceLimitData::Recursion { limit, depth }),
             ),
-            Self::Exception(exc) => (exc.exc_type(), exc.into_message()),
+            Self::Exception(exc) => (exc.exc_type(), exc.into_message(), ExcData::None),
         };
-        let exc = SimpleException::new(exc_type, msg);
+        let exc = SimpleException::new(exc_type, msg).with_data(data);
         match frame {
             Some(f) => exc.with_frame(f),
             None => exc.into(),

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -9,7 +9,7 @@ use std::{
 
 use monty::{
     CompileOptions, ExcType, LimitedTracker, MontyObject, MontyRepl, MontyRun, NameLookupResult, PrintWriter,
-    ResourceLimits, RunProgress,
+    ResourceLimitData, ResourceLimits, RunProgress,
 };
 
 /// Resolves consecutive `NameLookup` yields by providing a `Function` object for each name.
@@ -2355,5 +2355,128 @@ fn finditer_shares_subject_memory() {
     assert_eq!(
         result.expect("finditer over a large subject must stay within the memory limit"),
         MontyObject::Int(4000)
+    );
+}
+
+// === `ExcData::ResourceLimit` classification ===
+// These tests verify that resource-limit hits carry structured
+// `ResourceLimitData` (see `ResourceError::into_exception`), and that
+// sandboxed code raising the same exception types manually does not —
+// callers must be able to tell the two apart without parsing the message.
+
+/// Test that an allocation-limit hit carries `ResourceLimitData::Allocation`.
+#[test]
+fn allocation_limit_carries_resource_limit_data() {
+    let code = r"
+result = []
+for i in range(100, 115):
+    result.append(str(i))
+result
+";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+
+    let limits = ResourceLimits::new().max_allocations(4);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    let exc = result.expect_err("should exceed allocation limit");
+    match exc.resource_limit_data() {
+        Some(ResourceLimitData::Allocation { limit, count }) => {
+            assert_eq!(*limit, 4);
+            assert_eq!(*count, 5);
+        }
+        other => panic!("expected ResourceLimitData::Allocation, got {other:?}"),
+    }
+}
+
+/// Test that a memory-limit hit carries `ResourceLimitData::Memory`.
+#[test]
+fn memory_limit_carries_resource_limit_data() {
+    let code = r"
+result = []
+for i in range(100):
+    result.append([1, 2, 3, 4, 5])
+result
+";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+
+    let limits = ResourceLimits::new().max_memory(100);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    let exc = result.expect_err("should exceed memory limit");
+    match exc.resource_limit_data() {
+        Some(ResourceLimitData::Memory { limit, used }) => {
+            assert_eq!(*limit, 100);
+            assert!(*used > 100);
+        }
+        other => panic!("expected ResourceLimitData::Memory, got {other:?}"),
+    }
+}
+
+/// Test that a time-limit hit carries `ResourceLimitData::Time`.
+#[test]
+fn time_limit_carries_resource_limit_data() {
+    let code = r"
+x = 0
+for i in range(100000000):
+    x = x + 1
+x
+";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+
+    let limits = ResourceLimits::new().max_duration(Duration::from_millis(50));
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    let exc = result.expect_err("should exceed time limit");
+    match exc.resource_limit_data() {
+        Some(ResourceLimitData::Time { limit, elapsed }) => {
+            assert_eq!(*limit, Duration::from_millis(50));
+            assert!(*elapsed >= *limit);
+        }
+        other => panic!("expected ResourceLimitData::Time, got {other:?}"),
+    }
+}
+
+/// Test that a recursion-depth-limit hit carries `ResourceLimitData::Recursion`.
+#[test]
+fn recursion_limit_carries_resource_limit_data() {
+    let code = r"
+def recurse(n):
+    return recurse(n - 1)
+recurse(50)
+";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+
+    let limits = ResourceLimits::new().max_recursion_depth(Some(10));
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    let exc = result.expect_err("should exceed recursion depth");
+    match exc.resource_limit_data() {
+        Some(ResourceLimitData::Recursion { limit, depth }) => {
+            assert_eq!(*limit, 10);
+            assert!(*depth > 10);
+        }
+        other => panic!("expected ResourceLimitData::Recursion, got {other:?}"),
+    }
+}
+
+/// Regression: sandboxed code raising `MemoryError`/`TimeoutError` itself —
+/// not a real resource-limit hit — must NOT carry `ResourceLimitData`. This
+/// is exactly the ambiguity `ExcData::ResourceLimit` exists to resolve: both
+/// cases produce the same `exc_type()` and a message that can look like the
+/// limit-hit wording, so only the structured payload disambiguates them.
+#[test]
+fn sandboxed_memory_error_does_not_carry_resource_limit_data() {
+    let code = "raise MemoryError('allocation limit exceeded: 4 > 3')";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+
+    let limits = ResourceLimits::new().max_memory(1_000_000);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    let exc = result.expect_err("should propagate the raised MemoryError");
+    assert_eq!(exc.exc_type(), ExcType::MemoryError);
+    assert_eq!(
+        exc.resource_limit_data(),
+        None,
+        "manually raised exception must not be classified as a resource-limit hit"
     );
 }


### PR DESCRIPTION
## Summary

`ResourceError::into_exception` collapsed `Allocation`/`Time`/`Memory`/`Recursion` into a generic `ExcType` plus a formatted message, so an embedder could only tell "the sandbox hit a resource limit" apart from "sandboxed code raised the same exception type itself" (e.g. `raise MemoryError()`) by matching substrings of the message — fragile, and spoofable from inside the sandbox.

This adds `ExcData::ResourceLimit(Box<ResourceLimitData>)`, following the existing `Unicode`/`Json` payload pattern, populated with the original typed fields from `ResourceError`. `MontyException::resource_limit_data()` exposes it, mirroring `unicode_data()`/`json_data()`.

- `ResourceLimitData` mirrors `ResourceError`'s four limit-hit variants (`Allocation`, `Time`, `Memory`, `Recursion`); `ResourceError::Exception` isn't a limit hit, so gets `ExcData::None` as before.
- Extended the proto schema (`ResourceLimitData` message + `ExcData` oneof arm) and wired both conversion directions, so the classification survives the `monty-pool` subprocess boundary — not just in-process embedding.
- Fixed a latent inconsistency in `enter_run_reentry()`'s hard-cap native-recursion error: it reported `depth == limit` instead of `depth == limit + 1` like every other recursion-limit call site. Harmless while the fields were discarded internally, but became an inaccurate public value once `ResourceLimitData::Recursion` exposed it.

## Test plan

- [x] `cargo test -p monty` — new tests: one per limit kind (`allocation_limit_carries_resource_limit_data`, `memory_limit_carries_resource_limit_data`, `time_limit_carries_resource_limit_data`, `recursion_limit_carries_resource_limit_data`) plus a regression proving sandboxed code raising `MemoryError` manually does *not* get classified as a limit hit
- [x] `cargo test -p monty-proto` — round-trip test per `ResourceLimitData` variant through the wire format, plus a malformed-payload-is-dropped test matching the existing unicode/json sanitizer tests
- [x] `cargo clippy --workspace --tests --all-features -- -D warnings`
- [x] `cargo fmt --check` / `./scripts/check_imports.py`
- [x] `make generate-proto` (checked-in generated code matches the `.proto` schema)

Fixes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose structured resource-limit data on exceptions so embedders can tell sandbox limit hits from user-raised errors. Data survives the `monty-pool` boundary, is validated on receive, uses exact seconds+nanos encoding, and drops malformed durations to prevent parent crashes. Fixes #585.

- New Features
  - Added `ExcData::ResourceLimit(Box<ResourceLimitData>)` with `Allocation`, `Time`, `Memory`, and `Recursion`, plus `MontyException::resource_limit_data()`.
  - Extended the `monty-proto` schema and conversions; added round-trip tests and a receive-side check that drops empty or non-genuine hits (observed value must exceed limit).
  - Time-limit data now encodes as seconds + sub-second nanoseconds to avoid precision loss and `u64` nanosecond saturation; added regressions.

- Bug Fixes
  - Dropped wire `Time` payloads with out-of-range `subsec_nanos` to avoid a `Duration::new` panic from a compromised child; added coverage for both invalid limit and invalid elapsed paths.
  - Fixed native re-entry recursion reporting to use `depth == limit + 1` to match other call sites.

<sup>Written for commit c4a9bb2ccdb22f178b909e400579201d6480d134. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

