### PR TITLE
Public API fixes

### DIFF
--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -163,7 +163,7 @@ Mount host directories into the sandbox at virtual POSIX paths:
 ```ts
 import { MountDir } from '@pydantic/monty'
 
-const mount = new MountDir('/mnt/data', '/path/on/host', { mode: 'read-only' })
+const mount = new MountDir({ hostPath: '/path/on/host', virtualPath: '/mnt/data', mode: 'read-only' })
 await session.feedRun("open('/mnt/data/file.txt').read()", { mount })
 ```
 

--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -141,9 +141,9 @@ if (restored instanceof FunctionSnapshot) await restored.resume('value')
 ```
 
 `session.dump()` between feeds serializes an idle session instead; restore it
-with `await session.load(blob)` (which resolves to `void`) and keep feeding.
-Both `load` and `loadSnapshot` are valid only on a fresh session, before any
-feed; using the wrong one for a dump's kind throws.
+with `await session.loadSession(blob)` (which resolves to `void`) and keep
+feeding. Both `loadSession` and `loadSnapshot` are valid only on a fresh
+session, before any feed; using the wrong one for a dump's kind throws.
 
 ## Print Output
 

--- a/crates/monty-js/__test__/feed_start.spec.ts
+++ b/crates/monty-js/__test__/feed_start.spec.ts
@@ -102,7 +102,7 @@ test('dump at a suspension, then loadSnapshot and resume', async () => {
   }
 })
 
-test('load restores an idle session', async () => {
+test('loadSession restores an idle session', async () => {
   let blob: Buffer
   {
     const session = await pool().checkout()
@@ -112,14 +112,14 @@ test('load restores an idle session', async () => {
   }
   const session = await pool().checkout()
   try {
-    await session.load(blob)
+    await session.loadSession(blob)
     t.is(await session.feedRun('kept + 1'), 8)
   } finally {
     await session.close()
   }
 })
 
-test('load and loadSnapshot reject the wrong dump kind', async () => {
+test('loadSession and loadSnapshot reject the wrong dump kind', async () => {
   let idle: Buffer
   let suspended: Buffer
   {
@@ -136,7 +136,7 @@ test('load and loadSnapshot reject the wrong dump kind', async () => {
   {
     const session = await pool().checkout()
     await t.throwsAsync(() => session.loadSnapshot(idle), {
-      message: 'this dump is an idle session — use load() to restore it',
+      message: 'this dump is an idle session — use loadSession() to restore it',
     })
     // the failed load poisons the session — it is not retryable
     await t.throwsAsync(() => session.feedRun('1 + 1'))
@@ -144,7 +144,7 @@ test('load and loadSnapshot reject the wrong dump kind', async () => {
   }
   {
     const session = await pool().checkout()
-    await t.throwsAsync(() => session.load(suspended), {
+    await t.throwsAsync(() => session.loadSession(suspended), {
       message: 'this dump is a suspended snapshot — use loadSnapshot() to resume it',
     })
     await t.throwsAsync(() => session.feedRun('1 + 1'))
@@ -159,7 +159,7 @@ test('load after a feed is rejected', async () => {
     await session.feedRun('x = 1')
     await t.throwsAsync(() => session.loadSnapshot(blob), {
       message:
-        'load / loadSnapshot is only valid on a fresh session, before any feedRun / feedStart / load / loadSnapshot',
+        'loadSession / loadSnapshot is only valid on a fresh session, before any feedRun / feedStart / loadSession / loadSnapshot',
     })
   } finally {
     await session.close()

--- a/crates/monty-js/__test__/feed_start.spec.ts
+++ b/crates/monty-js/__test__/feed_start.spec.ts
@@ -187,7 +187,7 @@ test('mounts are re-supplied to loadSnapshot', async () => {
 
   const dir = await mkdtemp(join(tmpdir(), 'monty-js-snap-'))
   await writeFile(join(dir, 'hello.txt'), 'hi')
-  const mount = new MountDir('/data', dir, { mode: 'read-only' })
+  const mount = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
   const code = "f()\nfrom pathlib import Path\nPath('/data/hello.txt').read_text()"
 
   let blob: Buffer

--- a/crates/monty-js/__test__/mount.spec.ts
+++ b/crates/monty-js/__test__/mount.spec.ts
@@ -44,8 +44,8 @@ test('MountDir repr', (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-only' })
-    t.is(md.repr(), `MountDir(virtual_path='/data', host_path='${dir}', mode='read-only')`)
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    t.is(md.repr(), `MountDir(host_path='${dir}', virtual_path='/data', mode='read-only')`)
   } finally {
     cleanup()
   }
@@ -55,7 +55,7 @@ test('MountDir invalid mode', (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const error = t.throws(() => new MountDir('/data', dir, { mode: 'invalid' as never }))
+    const error = t.throws(() => new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'invalid' as never }))
     t.is(error?.message, "invalid mount mode: 'invalid'. Expected 'read-only', 'read-write' or 'overlay'")
   } finally {
     cleanup()
@@ -66,13 +66,13 @@ test('MountDir attributes', (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
     t.is(md.virtualPath, '/data')
     t.is(md.hostPath, dir)
     t.is(md.mode, 'read-only')
     t.is(md.memoryUsageLimit, 100_000_000)
 
-    const limited = new MountDir('/limited', dir, { memoryUsageLimit: 1234 })
+    const limited = new MountDir({ hostPath: dir, virtualPath: '/limited', memoryUsageLimit: 1234 })
     t.is(limited.memoryUsageLimit, 1234)
   } finally {
     cleanup()
@@ -83,7 +83,7 @@ test('MountDir nonexistent host path', async (ctx) => {
   skipIfBrowser(ctx)
   // Host paths are validated by the pool when the feed starts (not the
   // constructor). The OS-error suffix is platform specific.
-  const md = new MountDir('/data', '/nonexistent/path/that/does/not/exist')
+  const md = new MountDir({ hostPath: '/nonexistent/path/that/does/not/exist', virtualPath: '/data' })
   const error = await t.throwsAsync(() => run('1 + 1', { mount: md }), { instanceOf: MontyRuntimeError })
   t.true(error.message.startsWith("TypeError: cannot canonicalize host path '/nonexistent/path/that/does/not/exist':"))
 })
@@ -92,7 +92,7 @@ test('MountDir non-absolute virtual path', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('relative', dir)
+    const md = new MountDir({ hostPath: dir, virtualPath: 'relative' })
     const error = await t.throwsAsync(() => run('1 + 1', { mount: md }), { instanceOf: MontyRuntimeError })
     t.is(error.message, "TypeError: virtual path must be absolute, got: 'relative'")
   } finally {
@@ -104,7 +104,7 @@ test('MountDir default mode is overlay', (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir)
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data' })
     t.is(md.mode, 'overlay')
   } finally {
     cleanup()
@@ -115,10 +115,10 @@ test('MountDir write_bytes_limit', (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { writeBytesLimit: 1024 })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', writeBytesLimit: 1024 })
     t.is(md.writeBytesLimit, 1024)
 
-    const md2 = new MountDir('/data', dir)
+    const md2 = new MountDir({ hostPath: dir, virtualPath: '/data' })
     t.is(md2.writeBytesLimit, null)
   } finally {
     cleanup()
@@ -133,7 +133,7 @@ test('read_text via mount', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; Path('/data/hello.txt').read_text()", { mount: md })
     t.is(result, 'hello world')
   } finally {
@@ -145,7 +145,7 @@ test('read_bytes via mount', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; Path('/data/data.bin').read_bytes()", { mount: md })
     t.deepEqual(result, Buffer.from([0x00, 0x01, 0x02]))
   } finally {
@@ -157,7 +157,7 @@ test('path exists via mount', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
     const code = `
 from pathlib import Path
 exists_file = Path('/data/hello.txt').exists()
@@ -175,7 +175,7 @@ test('is_file and is_dir via mount', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
     const code = `
 from pathlib import Path
 [Path('/data/hello.txt').is_file(), Path('/data/hello.txt').is_dir(),
@@ -191,7 +191,7 @@ test('iterdir via mount', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
     const code = `
 from pathlib import Path
 sorted([p.name for p in Path('/data').iterdir()])
@@ -206,7 +206,7 @@ test('stat via mount', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
     const code = `
 from pathlib import Path
 s = Path('/data/hello.txt').stat()
@@ -222,7 +222,7 @@ test('read nested file via mount', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; Path('/data/subdir/nested.txt').read_text()", { mount: md })
     t.is(result, 'nested content')
   } finally {
@@ -238,7 +238,7 @@ test('write blocked on read-only mount', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(
       () => run("from pathlib import Path; Path('/data/new.txt').write_text('x')", { mount: md }),
       { instanceOf: MontyRuntimeError },
@@ -253,7 +253,7 @@ test('write succeeds on read-write mount', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-write' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-write' })
     const code = `
 from pathlib import Path
 Path('/data/new.txt').write_text('written by monty')
@@ -271,7 +271,7 @@ test('overlay write does not modify host', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'overlay' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
     const code = `
 from pathlib import Path
 Path('/data/overlay_file.txt').write_text('overlay content')
@@ -289,7 +289,7 @@ test('overlay read falls through to host', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'overlay' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
     const result = await run("from pathlib import Path; Path('/data/hello.txt').read_text()", { mount: md })
     t.is(result, 'hello world')
   } finally {
@@ -303,7 +303,7 @@ test('overlay writes do not persist across runs', async (ctx) => {
   // in-process API it does NOT persist across runs sharing the same MountDir.
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'overlay' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
     await run("from pathlib import Path; Path('/data/persistent.txt').write_text('run1')", { mount: md })
     const error = await t.throwsAsync(
       () => run("from pathlib import Path; Path('/data/persistent.txt').read_text()", { mount: md }),
@@ -319,7 +319,7 @@ test('overlay memory usage limit is aggregate', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'overlay', memoryUsageLimit: 1000 })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay', memoryUsageLimit: 1000 })
     const code = `
 from pathlib import Path
 p = Path('/data/retained.bin')
@@ -341,7 +341,7 @@ test('mkdir and rmdir via mount', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'overlay' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
     const code = `
 from pathlib import Path
 Path('/data/newdir').mkdir()
@@ -360,7 +360,7 @@ test('unlink via mount', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'overlay' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
     const code = `
 from pathlib import Path
 Path('/data/hello.txt').unlink()
@@ -378,7 +378,7 @@ test('rename via mount', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'overlay' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
     const code = `
 from pathlib import Path
 Path('/data/hello.txt').rename('/data/renamed.txt')
@@ -394,7 +394,7 @@ test('resolve via mount', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; str(Path('/data/subdir/../hello.txt').resolve())", {
       mount: md,
     })
@@ -412,7 +412,7 @@ test('path traversal blocked', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(
       () => run("from pathlib import Path; Path('/data/../../etc/passwd').read_text()", { mount: md }),
       { instanceOf: MontyRuntimeError },
@@ -427,7 +427,7 @@ test('unmounted path denied', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(
       () => run("from pathlib import Path; Path('/other/file.txt').exists()", { mount: md }),
       { instanceOf: MontyRuntimeError },
@@ -446,7 +446,7 @@ test('non-filesystem os call without fallback', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(() => run("import os; os.getenv('PATH')", { mount: md }), {
       instanceOf: MontyRuntimeError,
     })
@@ -466,7 +466,10 @@ test('multiple mounts with different modes', async (ctx) => {
   const dir2 = fs.mkdtempSync(path.join(os.tmpdir(), 'monty-mount-test2-'))
   fs.writeFileSync(path.join(dir2, 'file2.txt'), 'from mount2')
   try {
-    const mounts = [new MountDir('/ro', dir1, { mode: 'read-only' }), new MountDir('/rw', dir2, { mode: 'read-write' })]
+    const mounts = [
+      new MountDir({ hostPath: dir1, virtualPath: '/ro', mode: 'read-only' }),
+      new MountDir({ hostPath: dir2, virtualPath: '/rw', mode: 'read-write' }),
+    ]
     const code = `
 from pathlib import Path
 a = Path('/ro/hello.txt').read_text()
@@ -488,7 +491,7 @@ test('mount works with external functions', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
     const code = `
 from pathlib import Path
 content = Path('/data/hello.txt').read_text()
@@ -511,7 +514,7 @@ test('session feed with mount read', async (ctx) => {
   const { dir, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
     await session.feedRun('from pathlib import Path', { mount: md })
     t.is(await session.feedRun("Path('/data/hello.txt').read_text()", { mount: md }), 'hello world')
   } finally {
@@ -530,7 +533,7 @@ test('session overlay write is discarded between feeds', async (ctx) => {
   const { dir, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
-    const md = new MountDir('/data', dir, { mode: 'overlay' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
     await session.feedRun('from pathlib import Path', { mount: md })
     await session.feedRun("Path('/data/new.txt').write_text('from repl')", { mount: md })
     const error = await t.throwsAsync(() => session.feedRun("Path('/data/new.txt').read_text()", { mount: md }), {
@@ -550,7 +553,7 @@ test('session overlay overwrite reverts between feeds', async (ctx) => {
   const { dir, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
-    const md = new MountDir('/data', dir, { mode: 'overlay' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
     await session.feedRun('from pathlib import Path', { mount: md })
     await session.feedRun("Path('/data/hello.txt').write_text('version1')", { mount: md })
     // The next feed sees the pristine host content again ...
@@ -568,7 +571,7 @@ test('session overlay delete reverts between feeds', async (ctx) => {
   const { dir, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
-    const md = new MountDir('/data', dir, { mode: 'overlay' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
     await session.feedRun('from pathlib import Path', { mount: md })
     await session.feedRun("Path('/data/hello.txt').unlink()", { mount: md })
     // The deletion only lived inside the previous feed's overlay.
@@ -584,7 +587,7 @@ test('overlay mkdir and nested write within one feed', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'overlay' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
     const code = `
 from pathlib import Path
 Path('/data/mydir').mkdir()
@@ -602,7 +605,7 @@ test('overlay iterdir sees overlay files', async (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir('/data', dir, { mode: 'overlay' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
     const code = `
 from pathlib import Path
 Path('/data/extra.txt').write_text('extra')
@@ -619,7 +622,7 @@ test('session read-write mount writes to host', async (ctx) => {
   const { dir, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-write' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-write' })
     await session.feedRun('from pathlib import Path', { mount: md })
     await session.feedRun("Path('/data/rw_file.txt').write_text('written')", { mount: md })
     t.is(await session.feedRun("Path('/data/rw_file.txt').read_text()", { mount: md }), 'written')
@@ -636,7 +639,7 @@ test('session read-only mount blocks write', async (ctx) => {
   const { dir, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
-    const md = new MountDir('/data', dir, { mode: 'read-only' })
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
     await session.feedRun('from pathlib import Path', { mount: md })
     const error = await t.throwsAsync(() => session.feedRun("Path('/data/nope.txt').write_text('x')", { mount: md }), {
       instanceOf: MontyRuntimeError,

--- a/crates/monty-js/__test__/pool.spec.ts
+++ b/crates/monty-js/__test__/pool.spec.ts
@@ -180,7 +180,7 @@ test('special files in mounts are rejected without blocking', async (ctx) => {
     const error = await t.throwsAsync(
       () =>
         session.feedRun("from pathlib import Path\nPath('/mnt/pipe').read_text()", {
-          mount: new MountDir('/mnt', dir, { mode: 'read-only' }),
+          mount: new MountDir({ hostPath: dir, virtualPath: '/mnt', mode: 'read-only' }),
         }),
       { instanceOf: MontyRuntimeError },
     )

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -397,8 +397,8 @@ impl NativeSession {
 
     /// Restores a dump into this session's freshly configured worker. Resolves
     /// to a turn object: a suspension when the dump was mid-feed, or `loaded`
-    /// for an idle dump. The TypeScript `load` / `loadSnapshot` split inspects
-    /// the kind and enforces "fresh session only".
+    /// for an idle dump. The TypeScript `loadSession` / `loadSnapshot` split
+    /// inspects the kind and enforces "fresh session only".
     #[napi]
     pub fn restore<'env>(
         &self,
@@ -511,7 +511,7 @@ impl NativeSession {
     /// The shared turn machinery behind [`run_turn`](Self::run_turn): locks the
     /// checkout off the event loop, streams prints, and resolves the computed
     /// [`TurnOutcome`] to a JS turn object. `compute` returns the outcome
-    /// directly so the `load` turn (which yields `Option<TurnEvent>`) can map
+    /// directly so the restore turn (which yields `Option<TurnEvent>`) can map
     /// its idle case to [`TurnOutcome::LoadedIdle`].
     fn run_outcome<'env>(
         &self,
@@ -573,8 +573,8 @@ enum TurnOutcome {
     },
     /// The worker (or caller) violated the protocol; the session is lost.
     Protocol(String),
-    /// A `load` restored an idle (between-feeds) session — there is no
-    /// suspension to resume. Only produced by [`NativeSession::load`].
+    /// A restore of an idle (between-feeds) dump — there is no suspension to
+    /// resume. Only produced by [`NativeSession::restore`].
     LoadedIdle,
     /// A non-feed request succeeded with no value or suspension. Produced by
     /// [`NativeSession::install_dependencies`].

--- a/crates/monty-js/ts/mount.ts
+++ b/crates/monty-js/ts/mount.ts
@@ -12,8 +12,17 @@ const DEFAULT_MEMORY_USAGE_LIMIT = 100_000_000
 /** Sandbox access mode for a mounted directory. */
 export type MountDirMode = 'read-only' | 'read-write' | 'overlay'
 
-/** Options for [`MountDir`]. */
+/** Configuration for [`MountDir`]. The paths are named fields (never
+ *  positional): mount tools disagree on host-first (docker `-v`) vs
+ *  virtual-first (nginx `alias`) ordering, so requiring names removes the
+ *  ambiguity. */
 export interface MountDirOptions {
+  /** Real host directory to expose. Sandbox code can never see this path or
+   *  reach outside it. */
+  hostPath: string
+  /** Absolute virtual POSIX path prefix inside the sandbox (e.g. `'/data'`),
+   *  regardless of host OS. */
+  virtualPath: string
   /**
    * Access mode (default `'overlay'`): `'read-only'` rejects writes,
    * `'read-write'` writes through to the host, `'overlay'` keeps writes in
@@ -38,25 +47,25 @@ const VALID_MODES: Record<MountDirMode, true> = {
  * budget, `memoryUsageLimit` (100 MB by default).
  *
  * ```ts
- * const mount = new MountDir('/mnt/data', '/path/on/host', { mode: 'read-only' })
+ * const mount = new MountDir({ hostPath: '/path/on/host', virtualPath: '/mnt/data', mode: 'read-only' })
  * await session.feedRun("open('/mnt/data/file.txt').read()", { mount })
  * ```
  */
 export class MountDir {
-  readonly virtualPath: string
   readonly hostPath: string
+  readonly virtualPath: string
   readonly mode: MountDirMode
   readonly writeBytesLimit: number | null
   readonly memoryUsageLimit: number
 
-  constructor(virtualPath: string, hostPath: string, options: MountDirOptions = {}) {
+  constructor(options: MountDirOptions) {
     const mode = options.mode ?? 'overlay'
     // hasOwn, not `in`: prototype keys like 'toString' must not pass as modes
     if (!Object.hasOwn(VALID_MODES, mode)) {
       throw new Error(`invalid mount mode: '${mode}'. Expected 'read-only', 'read-write' or 'overlay'`)
     }
-    this.virtualPath = virtualPath
-    this.hostPath = hostPath
+    this.hostPath = options.hostPath
+    this.virtualPath = options.virtualPath
     this.mode = mode
     this.writeBytesLimit = options.writeBytesLimit ?? null
     this.memoryUsageLimit = options.memoryUsageLimit ?? DEFAULT_MEMORY_USAGE_LIMIT
@@ -67,7 +76,7 @@ export class MountDir {
 
   /** Returns a string representation of the mount. */
   repr(): string {
-    return `MountDir(virtual_path='${this.virtualPath}', host_path='${this.hostPath}', mode='${this.mode}')`
+    return `MountDir(host_path='${this.hostPath}', virtual_path='${this.virtualPath}', mode='${this.mode}')`
   }
 }
 

--- a/crates/monty-js/ts/native.ts
+++ b/crates/monty-js/ts/native.ts
@@ -102,8 +102,8 @@ export interface ProtocolTurn {
   message: string
 }
 
-/** A `load` restored an idle (between-feeds) session — no suspension to
- *  resume. Only produced by `NativeSession.load`. */
+/** A restore of an idle (between-feeds) dump — no suspension to resume. Only
+ *  produced by `NativeSession.restore`, surfaced by `MontySession.loadSession`. */
 export interface LoadedTurn {
   kind: 'loaded'
 }

--- a/crates/monty-js/ts/session.ts
+++ b/crates/monty-js/ts/session.ts
@@ -146,8 +146,8 @@ export class MontySession {
   /** Set once the session is unusable: crashed worker or protocol error. */
   private broken: Error | null = null
   private closed = false
-  /** Set once the session has been fed or restored; `loadSnapshot` is valid
-   *  only while unset (a fresh session). */
+  /** Set once the session has been fed or restored; `loadSession` /
+   *  `loadSnapshot` are valid only while unset (a fresh session). */
   private driven = false
 
   /** @internal — sessions are created by `Monty.checkout`. */
@@ -247,7 +247,7 @@ export class MontySession {
    * whole session); throws otherwise. The dump restores its own resource limits
    * and type-check state. Throws if the dump is actually a suspended snapshot.
    */
-  async load(state: Uint8Array): Promise<void> {
+  async loadSession(state: Uint8Array): Promise<void> {
     this.claimFresh()
     const printTarget = new PrintTarget(undefined)
     const turn = (await this.native.restore(bytesForNative(state), [], printTarget.write.bind(printTarget))) as
@@ -269,8 +269,8 @@ export class MontySession {
 
   /**
    * Restores a dumped **suspended** snapshot — bytes from `feedStart` +
-   * `snapshot.dump()` — and resolves to the snapshot to resume. Use [`load`]
-   * for a dump taken between feeds.
+   * `snapshot.dump()` — and resolves to the snapshot to resume. Use
+   * [`loadSession`] for a dump taken between feeds.
    *
    * Valid only on a fresh session, before any feed or load; throws otherwise.
    * Re-supply the same `mount`s the paused feed used (their host paths are not
@@ -284,7 +284,7 @@ export class MontySession {
       | NativeTurn
       | LoadedTurn
     if (turn.kind === 'loaded') {
-      throw await this.failedLoad(new Error('this dump is an idle session — use load() to restore it'))
+      throw await this.failedLoad(new Error('this dump is an idle session — use loadSession() to restore it'))
     }
     try {
       return await driver.advance(turn)
@@ -300,7 +300,7 @@ export class MontySession {
     this.ensureUsable()
     if (this.driven) {
       throw new Error(
-        'load / loadSnapshot is only valid on a fresh session, before any feedRun / feedStart / load / loadSnapshot',
+        'loadSession / loadSnapshot is only valid on a fresh session, before any feedRun / feedStart / loadSession / loadSnapshot',
       )
     }
     this.driven = true
@@ -352,8 +352,8 @@ export class MontySession {
    */
   async installDependencies(requirements: string[]): Promise<void> {
     this.ensureUsable()
-    // mark the session driven so a later load/loadSnapshot is rejected — it
-    // would discard the freshly installed environment
+    // mark the session driven so a later loadSession/loadSnapshot is rejected —
+    // it would discard the freshly installed environment
     this.driven = true
     const printTarget = new PrintTarget(undefined)
     const turn = (await this.native.installDependencies(requirements, printTarget.write.bind(printTarget))) as

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -234,7 +234,7 @@ impl Checkout {
     /// not-yet-fed) worker, returning the re-announced suspension event when the
     /// dump was taken mid-feed (`None` for an idle, between-feeds dump).
     ///
-    /// This is the low-level restore both `session.load` (idle dumps) and
+    /// This is the low-level restore both `session.load_session` (idle dumps) and
     /// `session.load_snapshot` (suspended dumps) drive: the caller inspects the
     /// returned `Option` to tell which kind of dump it was and reject a
     /// mismatch. Only valid before the worker has been fed (the child rejects a

--- a/crates/monty-python/README.md
+++ b/crates/monty-python/README.md
@@ -167,10 +167,11 @@ If the paused feed used filesystem `mount`s, re-supply the same ones to
 `load_snapshot(blob, mount=...)` — their host paths are not stored in the dump.
 
 `session.dump()` between feeds serializes an idle session instead; restore it
-with `session.load(blob)` (which returns `None`) and keep feeding. Both `load`
-and `load_snapshot` are valid only on a fresh session, before any feed; using
-the wrong one for a dump's kind raises. `AsyncMonty` sessions expose the same
-`feed_start` / `load` / `load_snapshot`, with awaitable `resume(...)`.
+with `session.load_session(blob)` (which returns `None`) and keep feeding. Both
+`load_session` and `load_snapshot` are valid only on a fresh session, before
+any feed; using the wrong one for a dump's kind raises. `AsyncMonty` sessions
+expose the same `feed_start` / `load_session` / `load_snapshot`, with awaitable
+`resume(...)`.
 
 ### Resource limits
 

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -496,14 +496,16 @@ class MontySession:
                 session was checked out with `type_check=True`.
         """
 
-    def load(self, state: bytes) -> None:
+    def load_session(self, state: bytes) -> None:
         """
-        Restore a dumped **idle** session — bytes from `session.dump()` taken
-        between feeds — so you can keep feeding it. Use `load_snapshot` for a
-        dump taken mid-execution.
+        Restore a session between feeds.
 
-        Valid only on a fresh session, before any feed or load; raises
-        `RuntimeError` otherwise. The dump restores its own `script_name` /
+        This method should take data from `session.dump()` taken when no block of
+        code is running (i.e. between feeds).
+
+        Use `load_snapshot` for a dump taken mid-execution.
+
+        The dump restores its own `script_name` /
         limits / type-check state (the `checkout()` config for those is not
         applied); the dataclass registry from `checkout()` is reused. Raises if
         the dump is actually a suspended snapshot.
@@ -519,9 +521,10 @@ class MontySession:
         os: OsHandler | None = None,
     ) -> SyncSnapshot:
         """
-        Restore a dumped **suspended** snapshot — bytes from `feed_start` +
-        `snapshot.dump()` — and return the re-announced snapshot to resume. Use
-        `load` for a dump taken between feeds.
+        Restore a snapshot generated while a block of code is running (e.g. after `start_feed`)
+        and return the re-announced snapshot to resume.
+
+        Use `load_session` for a dump taken between feeds.
 
         Valid only on a fresh session, before any feed or load; raises
         `RuntimeError` otherwise. The dump restores its own `script_name` /
@@ -805,9 +808,9 @@ class AsyncMontySession:
                 session was checked out with `type_check=True`.
         """
 
-    async def load(self, state: bytes) -> None:
+    async def load_session(self, state: bytes) -> None:
         """
-        Async counterpart of `MontySession.load`: restores a dumped idle
+        Async counterpart of `MontySession.load_session`: restores a dumped idle
         session. Valid only on a fresh session; raises if the dump is actually a
         suspended snapshot.
         """

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -67,30 +67,34 @@ class CollectString:
 class MountDir:
     """A mount point mapping a virtual path to a host directory."""
 
-    virtual_path: str
     host_path: str
+    virtual_path: str
     mode: Literal['read-only', 'read-write', 'overlay']
     write_bytes_limit: int | None
     memory_usage_limit: int
 
     def __new__(
         cls,
-        virtual_path: str,
-        host_path: str | Path,
         *,
+        host_path: str | Path,
+        virtual_path: str,
         mode: Literal['read-only', 'read-write', 'overlay'] = 'overlay',
         write_bytes_limit: int | None = None,
         memory_usage_limit: int = 100_000_000,
     ) -> MountDir:
         """Configure a mount point; validation happens here, not at feed time.
 
+        All arguments are keyword-only: mount tools disagree on host-first
+        (docker `-v`) vs virtual-first (nginx `alias`) ordering, so requiring
+        names removes the ambiguity.
+
         Arguments:
-            virtual_path: Absolute POSIX-style path prefix inside the sandbox
-                (e.g. `'/data'`), regardless of host OS. Raises `ValueError`
-                if not absolute.
             host_path: Real host directory to expose. Canonicalized at
                 construction; raises if it doesn't exist or isn't a directory.
                 Sandbox code can never see this path or reach outside it.
+            virtual_path: Absolute POSIX-style path prefix inside the sandbox
+                (e.g. `'/data'`), regardless of host OS. Raises `ValueError`
+                if not absolute.
             mode: `'read-only'` — reads only, writes raise `PermissionError`;
                 `'read-write'` — writes through to the host directory;
                 `'overlay'` (default) — reads fall through to the host, writes

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -525,8 +525,8 @@ class MontySession:
         os: OsHandler | None = None,
     ) -> SyncSnapshot:
         """
-        Restore a snapshot generated while a block of code is running (e.g. after `start_feed`)
-        and return the re-announced snapshot to resume.
+        Restore a snapshot generated while a block of code is running (e.g.
+        after `feed_start`) and return the re-announced snapshot to resume.
 
         Use `load_session` for a dump taken between feeds.
 
@@ -813,11 +813,7 @@ class AsyncMontySession:
         """
 
     async def load_session(self, state: bytes) -> None:
-        """
-        Async counterpart of `MontySession.load_session`: restores a dumped idle
-        session. Valid only on a fresh session; raises if the dump is actually a
-        suspended snapshot.
-        """
+        """Async counterpart of `MontySession.load_session`: restore a session between feeds."""
 
     async def load_snapshot(
         self,
@@ -829,10 +825,10 @@ class AsyncMontySession:
         os: OsHandler | None = None,
     ) -> AsyncSnapshot:
         """
-        Async counterpart of `MontySession.load_snapshot`: restores a dumped
-        suspended snapshot and resolves to it (whose `resume(...)` /
-        `resume_auto()` is awaitable). Valid only on a fresh session; raises if
-        the dump is actually an idle session.
+        Async counterpart of `MontySession.load_snapshot`.
+
+        Restore a snapshot generated while a block of code is running (e.g.
+        after `feed_start`) and return the re-announced snapshot to resume.
 
         `external_lookup` / `os` are captured for `resume_auto()`, with the same
         restored-snapshot caveats as the sync method (a restored `FutureSnapshot`

--- a/crates/monty-python/src/mount.rs
+++ b/crates/monty-python/src/mount.rs
@@ -34,11 +34,13 @@ pub struct PyMountDir {
 
 #[pymethods]
 impl PyMountDir {
-    /// Creates a new mount directory.
+    /// Creates a new mount directory. All arguments are keyword-only: mount
+    /// tools disagree on host-first (docker `-v`) vs virtual-first (nginx
+    /// `alias`) ordering, so requiring names removes the ambiguity.
     ///
     /// # Arguments
-    /// * `virtual_path` — absolute virtual path prefix (e.g. `"/data"`)
     /// * `host_path` — path to the real host directory
+    /// * `virtual_path` — absolute virtual path prefix (e.g. `"/data"`)
     /// * `mode` — access mode: `"read-only"`, `"read-write"`, or `"overlay"` (default)
     ///
     /// # Raises
@@ -46,9 +48,9 @@ impl PyMountDir {
     /// is not absolute, or the host path doesn't exist or isn't a directory.
     #[new]
     #[pyo3(signature = (
-        virtual_path,
-        host_path,
         *,
+        host_path,
+        virtual_path,
         mode = "overlay",
         // must stay a literal mirroring monty_fs::DEFAULT_MEMORY_USAGE_LIMIT: a
         // const default renders as `...` in the text signature, breaking stubtest
@@ -58,8 +60,8 @@ impl PyMountDir {
     #[expect(clippy::needless_pass_by_value)] // PyO3 requires owned PathBuf for conversion from Python str/Path
     fn new(
         py: Python<'_>,
-        virtual_path: &str,
         host_path: PathBuf,
+        virtual_path: &str,
         mode: &str,
         write_bytes_limit: Option<u64>,
         memory_usage_limit: u64,
@@ -82,16 +84,16 @@ impl PyMountDir {
         })
     }
 
-    /// The normalized virtual path prefix inside the sandbox.
-    #[getter]
-    fn virtual_path(&self) -> String {
-        self.spec.virtual_path.clone()
-    }
-
     /// The canonical host directory path.
     #[getter]
     fn host_path(&self) -> String {
         self.spec.host_path.display().to_string()
+    }
+
+    /// The normalized virtual path prefix inside the sandbox.
+    #[getter]
+    fn virtual_path(&self) -> String {
+        self.spec.virtual_path.clone()
     }
 
     /// The access mode: `"read-only"`, `"read-write"`, or `"overlay"`.
@@ -114,9 +116,9 @@ impl PyMountDir {
 
     fn __repr__(&self) -> String {
         format!(
-            "MountDir('{}', '{}', '{}')",
-            self.spec.virtual_path,
+            "MountDir(host_path='{}', virtual_path='{}', mode='{}')",
             self.spec.host_path.display(),
+            self.spec.virtual_path,
             mount_mode_name(self.spec.mode)
         )
     }

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -175,8 +175,9 @@ pub struct PyMontySession {
     repl_config: ReplConfig,
     dc_registry: DcRegistry,
     checkout: SharedCheckout,
-    /// Set once the session has been fed or restored. `load_snapshot` is valid
-    /// only while this is unset (a fresh, undriven session).
+    /// Set once the session has been fed or restored. `load_session` /
+    /// `load_snapshot` are valid only while this is unset (a fresh, undriven
+    /// session).
     used: AtomicBool,
 }
 
@@ -300,7 +301,7 @@ impl PyMontySession {
     /// limits / type-check state (the `checkout()` config for those is not
     /// applied); the dataclass registry from `checkout()` is reused. Raises if
     /// the dump is actually a suspended snapshot.
-    fn load(&self, py: Python<'_>, state: Vec<u8>) -> PyResult<()> {
+    fn load_session(&self, py: Python<'_>, state: Vec<u8>) -> PyResult<()> {
         // an idle session has no snapshot, so the restored script name is unused
         if self.restore_turn(py, state, Vec::new())?.0.is_some() {
             py.detach(|| discard_checkout(&self.checkout));
@@ -313,7 +314,7 @@ impl PyMontySession {
 
     /// Restores a dumped **suspended** snapshot — bytes from `feed_start` +
     /// `snapshot.dump()` — and returns the re-announced snapshot to resume. Use
-    /// [`load`](Self::load) for a dump taken between feeds.
+    /// [`load_session`](Self::load_session) for a dump taken between feeds.
     ///
     /// Valid only on a fresh session, before any feed or load; raises
     /// `RuntimeError` otherwise. `mount` re-establishes the suspended feed's
@@ -350,7 +351,7 @@ impl PyMontySession {
         let Some(event) = event else {
             py.detach(|| discard_checkout(&self.checkout));
             return Err(PyRuntimeError::new_err(
-                "this dump is an idle session — use load() to restore it",
+                "this dump is an idle session — use load_session() to restore it",
             ));
         };
         let ctx = DriveContext::new(
@@ -406,7 +407,8 @@ impl PyMontySession {
     /// restore off the GIL, returning the re-announced suspension (`Some`) or
     /// `None` for an idle dump, paired with the dump's adopted script name (for
     /// restored snapshots' `script_name`). The restore turn runs no sandbox
-    /// code, so it needs no print sink. Shared by [`load`](Self::load) and
+    /// code, so it needs no print sink. Shared by
+    /// [`load_session`](Self::load_session) and
     /// [`load_snapshot`](Self::load_snapshot).
     fn restore_turn(
         &self,
@@ -666,8 +668,9 @@ pub struct PyAsyncMontySession {
     repl_config: ReplConfig,
     dc_registry: DcRegistry,
     checkout: SharedCheckout,
-    /// Set once the session has been fed or restored; `load_snapshot` is valid
-    /// only while unset. See [`PyMontySession::load_snapshot`].
+    /// Set once the session has been fed or restored; `load_session` /
+    /// `load_snapshot` are valid only while unset. See
+    /// [`PyMontySession::load_snapshot`].
     used: AtomicBool,
 }
 
@@ -783,10 +786,10 @@ impl PyAsyncMontySession {
         feed_start_async(py, args, ext, self.repl_config.script_name.clone())
     }
 
-    /// Async counterpart of [`PyMontySession::load`]: the coroutine restores a
-    /// dumped idle session, resolving to `None`. Valid only on a fresh session;
-    /// raises if the dump is actually a suspended snapshot.
-    fn load<'py>(&self, py: Python<'py>, state: Vec<u8>) -> PyResult<Bound<'py, PyAny>> {
+    /// Async counterpart of [`PyMontySession::load_session`]: the coroutine
+    /// restores a dumped idle session, resolving to `None`. Valid only on a
+    /// fresh session; raises if the dump is actually a suspended snapshot.
+    fn load_session<'py>(&self, py: Python<'py>, state: Vec<u8>) -> PyResult<Bound<'py, PyAny>> {
         // claim the session in the synchronous prologue (which completes before
         // the future), so a concurrent call is rejected at call time and the
         // off-thread restore can't race onto a fresh session
@@ -847,7 +850,7 @@ impl PyAsyncMontySession {
                     .await
                     .map_err(join_error_to_py)?;
                 return Err(PyRuntimeError::new_err(
-                    "this dump is an idle session — use load() to restore it",
+                    "this dump is an idle session — use load_session() to restore it",
                 ));
             };
             // the dump's own script name, falling back to the session config
@@ -948,11 +951,12 @@ fn check_os_callable(py: Python<'_>, os: Option<&Py<PyAny>>) -> PyResult<()> {
     Ok(())
 }
 
-/// The error raised when `load` / `load_snapshot` is called on a session that
-/// has already been fed or restored (it would otherwise silently discard work).
+/// The error raised when `load_session` / `load_snapshot` is called on a
+/// session that has already been fed or restored (it would otherwise silently
+/// discard work).
 fn session_used_err() -> PyErr {
     PyRuntimeError::new_err(
-        "load / load_snapshot is only valid on a fresh session, before any feed_run / feed_start / load / load_snapshot",
+        "load_session / load_snapshot is only valid on a fresh session, before any feed_run / feed_start / load_session / load_snapshot",
     )
 }
 
@@ -960,7 +964,7 @@ fn session_used_err() -> PyErr {
 /// returning the re-announced suspension (`Some`) or `None` for an idle dump,
 /// paired with the dump's adopted script name. The restore turn runs no sandbox
 /// code, so it needs no print sink. Shared by the async
-/// [`PyAsyncMontySession::load`] / `load_snapshot`.
+/// [`PyAsyncMontySession::load_session`] / `load_snapshot`.
 async fn restore_turn_async(
     checkout: SharedCheckout,
     state: Vec<u8>,

--- a/crates/monty-python/tests/test_feed_start.py
+++ b/crates/monty-python/tests/test_feed_start.py
@@ -275,7 +275,7 @@ def test_load_accepts_mount_for_idle_dump(pool: Monty, tmp_path: Path):
 
     mount = MountDir('/data', str(tmp_path), mode='read-only')
     with pool.checkout() as session:
-        assert session.load(blob) is None
+        assert session.load_session(blob) is None
         assert session.feed_run('kept + 1', mount=mount) == snapshot(2)
 
 
@@ -285,7 +285,7 @@ def test_load_restores_idle_session(pool: Monty):
         blob = session.dump()
 
     with pool.checkout() as session:
-        assert session.load(blob) is None
+        assert session.load_session(blob) is None
         assert session.feed_run('kept + 1') == snapshot(8)
 
 
@@ -297,14 +297,14 @@ def test_load_snapshot_on_idle_dump_raises(pool: Monty):
     with pool.checkout() as session:
         with pytest.raises(RuntimeError) as exc_info:
             session.load_snapshot(blob)
-        assert str(exc_info.value) == snapshot('this dump is an idle session — use load() to restore it')
+        assert str(exc_info.value) == snapshot('this dump is an idle session — use load_session() to restore it')
         # the failed load poisons the session — it is not retryable
         with pytest.raises(RuntimeError):
             session.feed_run('1 + 1')
 
 
 def test_load_idle_dump_after_a_suspended_dump_path(pool: Monty):
-    # the converse mismatch: load() on a suspended snapshot raises
+    # the converse mismatch: load_session() on a suspended snapshot raises
     with pool.checkout() as session:
         snap = session.feed_start('f()')
         assert isinstance(snap, FunctionSnapshot)
@@ -312,7 +312,7 @@ def test_load_idle_dump_after_a_suspended_dump_path(pool: Monty):
 
     with pool.checkout() as session:
         with pytest.raises(RuntimeError) as exc_info:
-            session.load(blob)
+            session.load_session(blob)
         assert str(exc_info.value) == snapshot('this dump is a suspended snapshot — use load_snapshot() to resume it')
         # the failed load poisons the session — it is not retryable
         with pytest.raises(RuntimeError):
@@ -320,7 +320,7 @@ def test_load_idle_dump_after_a_suspended_dump_path(pool: Monty):
 
 
 def test_load_after_feed_raises(pool: Monty):
-    # load / load_snapshot are only valid on a fresh, undriven session.
+    # load_session / load_snapshot are only valid on a fresh, undriven session.
     with pool.checkout() as session:
         blob = session.dump()
     with pool.checkout() as session:
@@ -328,7 +328,7 @@ def test_load_after_feed_raises(pool: Monty):
         with pytest.raises(RuntimeError) as exc_info:
             session.load_snapshot(blob)
         assert str(exc_info.value) == snapshot(
-            'load / load_snapshot is only valid on a fresh session, before any feed_run / feed_start / load / load_snapshot'
+            'load_session / load_snapshot is only valid on a fresh session, before any feed_run / feed_start / load_session / load_snapshot'
         )
 
 

--- a/crates/monty-python/tests/test_feed_start.py
+++ b/crates/monty-python/tests/test_feed_start.py
@@ -224,7 +224,7 @@ def test_mounts_restored_on_load_when_resupplied(pool: Monty, tmp_path: Path):
     # Re-supplying the feed's mounts to load_snapshot rebuilds the mount table,
     # so the mounted read after resume is served in-worker and never surfaces.
     (tmp_path / 'hello.txt').write_text('hi')
-    mount = MountDir('/data', str(tmp_path), mode='read-only')
+    mount = MountDir(host_path=str(tmp_path), virtual_path='/data', mode='read-only')
     code = "f()\nfrom pathlib import Path\nPath('/data/hello.txt').read_text()"
     with pool.checkout() as session:
         snap = session.feed_start(code, mount=mount)
@@ -245,7 +245,7 @@ def test_load_without_resupplied_mount_degrades_to_os_calls(pool: Monty, tmp_pat
     # dump. A restore that omits them is not validated — the resumed feed's
     # filesystem calls simply surface as unhandled OS calls.
     (tmp_path / 'hello.txt').write_text('hi')
-    mount = MountDir('/data', str(tmp_path), mode='read-only')
+    mount = MountDir(host_path=str(tmp_path), virtual_path='/data', mode='read-only')
     code = "f()\nfrom pathlib import Path\nPath('/data/hello.txt').read_text()"
     with pool.checkout() as session:
         snap = session.feed_start(code, mount=mount)
@@ -273,7 +273,7 @@ def test_load_accepts_mount_for_idle_dump(pool: Monty, tmp_path: Path):
         session.feed_run('kept = 1')
         blob = session.dump()
 
-    mount = MountDir('/data', str(tmp_path), mode='read-only')
+    mount = MountDir(host_path=str(tmp_path), virtual_path='/data', mode='read-only')
     with pool.checkout() as session:
         assert session.load_session(blob) is None
         assert session.feed_run('kept + 1', mount=mount) == snapshot(2)

--- a/crates/monty-python/tests/test_mount_table.py
+++ b/crates/monty-python/tests/test_mount_table.py
@@ -47,37 +47,37 @@ def assert_mount_reusable(monty_run: RunMonty, md: MountDir) -> None:
 
 
 def test_mount_directory_repr(test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     assert 'MountDir' in repr(md)
     assert '/data' in repr(md)
 
 
 def test_mount_directory_invalid_mode():
     with pytest.raises(ValueError) as exc_info:
-        MountDir('/data', '/tmp', mode='invalid')  # pyright: ignore[reportArgumentType]
+        MountDir(host_path='/tmp', virtual_path='/data', mode='invalid')  # pyright: ignore[reportArgumentType]
     assert str(exc_info.value) == snapshot("Invalid mode 'invalid', expected 'read-only', 'read-write', or 'overlay'")
 
 
 def test_mount_directory_attributes(test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     assert md.virtual_path == '/data'
     assert md.mode == 'read-only'
     assert md.memory_usage_limit == 100_000_000
 
-    limited = MountDir('/limited', str(test_dir), memory_usage_limit=1234)
+    limited = MountDir(host_path=str(test_dir), virtual_path='/limited', memory_usage_limit=1234)
     assert limited.memory_usage_limit == 1234
 
 
 def test_mount_directory_accepts_path_object(test_dir: Path):
     """MountDir should accept both str and Path for host_path."""
-    md_str = MountDir('/data', str(test_dir), mode='read-only')
-    md_path = MountDir('/data', test_dir, mode='read-only')
+    md_str = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
+    md_path = MountDir(host_path=test_dir, virtual_path='/data', mode='read-only')
     assert md_path.virtual_path == '/data'
     assert md_path.host_path == md_str.host_path
 
 
 def test_mount_memory_usage_limit_is_enforced(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', test_dir, mode='overlay', memory_usage_limit=1000)
+    md = MountDir(host_path=test_dir, virtual_path='/data', mode='overlay', memory_usage_limit=1000)
     code = """
 from pathlib import Path
 p = Path('/data/retained.bin')
@@ -91,7 +91,7 @@ p.read_bytes()
 
 def test_nonexistent_host_path():
     with pytest.raises(TypeError) as exc_info:
-        MountDir('/data', '/nonexistent/path/that/does/not/exist')
+        MountDir(host_path='/nonexistent/path/that/does/not/exist', virtual_path='/data')
     assert str(exc_info.value) == snapshot(
         "cannot canonicalize host path '/nonexistent/path/that/does/not/exist': No such file or directory (os error 2)"
     )
@@ -99,7 +99,7 @@ def test_nonexistent_host_path():
 
 def test_non_absolute_virtual_path(test_dir: Path):
     with pytest.raises(TypeError) as exc_info:
-        MountDir('relative', str(test_dir))
+        MountDir(host_path=str(test_dir), virtual_path='relative')
     assert str(exc_info.value) == snapshot("virtual path must be absolute, got: 'relative'")
 
 
@@ -109,19 +109,19 @@ def test_non_absolute_virtual_path(test_dir: Path):
 
 
 def test_read_text(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     result = monty_run("from pathlib import Path; Path('/data/hello.txt').read_text()", mount=md)
     assert result == snapshot('hello world')
 
 
 def test_read_bytes(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     result = monty_run("from pathlib import Path; Path('/data/data.bin').read_bytes()", mount=md)
     assert result == snapshot(b'\x00\x01\x02')
 
 
 def test_path_exists(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     code = """
 from pathlib import Path
 exists_file = Path('/data/hello.txt').exists()
@@ -134,7 +134,7 @@ exists_missing = Path('/data/nope.txt').exists()
 
 
 def test_is_file_is_dir(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     code = """
 from pathlib import Path
 (Path('/data/hello.txt').is_file(), Path('/data/hello.txt').is_dir(),
@@ -145,7 +145,7 @@ from pathlib import Path
 
 
 def test_iterdir(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     code = """
 from pathlib import Path
 sorted([p.name for p in Path('/data').iterdir()])
@@ -155,7 +155,7 @@ sorted([p.name for p in Path('/data').iterdir()])
 
 
 def test_stat(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     code = """
 from pathlib import Path
 s = Path('/data/hello.txt').stat()
@@ -166,7 +166,7 @@ s.st_size
 
 
 def test_read_nested(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     result = monty_run("from pathlib import Path; Path('/data/subdir/nested.txt').read_text()", mount=md)
     assert result == snapshot('nested content')
 
@@ -177,14 +177,14 @@ def test_read_nested(monty_run: RunMonty, test_dir: Path):
 
 
 def test_write_read_only_blocked(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     with pytest.raises(MontyRuntimeError) as exc_info:
         monty_run("from pathlib import Path; Path('/data/new.txt').write_text('x')", mount=md)
     assert 'Read-only file system' in str(exc_info.value)
 
 
 def test_write_read_write(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='read-write')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-write')
     code = """
 from pathlib import Path
 Path('/data/new.txt').write_text('written by monty')
@@ -197,7 +197,7 @@ Path('/data/new.txt').read_text()
 
 
 def test_overlay_write_doesnt_modify_host(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='overlay')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='overlay')
     code = """
 from pathlib import Path
 Path('/data/overlay_file.txt').write_text('overlay content')
@@ -210,14 +210,14 @@ Path('/data/overlay_file.txt').read_text()
 
 
 def test_overlay_read_falls_through(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='overlay')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='overlay')
     result = monty_run("from pathlib import Path; Path('/data/hello.txt').read_text()", mount=md)
     assert result == snapshot('hello world')
 
 
 def test_overlay_discarded_across_runs(monty_run: RunMonty, test_dir: Path):
     """Overlay writes are worker-local: they do not persist to the next run."""
-    md = MountDir('/data', str(test_dir), mode='overlay')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='overlay')
     monty_run("from pathlib import Path; Path('/data/transient.txt').write_text('run1')", mount=md)
     result = monty_run("from pathlib import Path; Path('/data/transient.txt').exists()", mount=md)
     assert result is False
@@ -227,7 +227,7 @@ def test_overlay_discarded_across_runs(monty_run: RunMonty, test_dir: Path):
 
 def test_mount_reusable_after_runtime_error(monty_run: RunMonty, test_dir: Path):
     """A MountDir config works again after a run that raised mid-execution."""
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     code = """
 from pathlib import Path
 Path('/data/hello.txt').read_text()
@@ -241,7 +241,7 @@ Path('/data/hello.txt').read_text()
 
 def test_mount_reusable_after_resource_error(monty_run: RunMonty, test_dir: Path):
     """A MountDir config works again after a run that hit a resource limit."""
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     code = """
 from pathlib import Path
 Path('/data/hello.txt').read_text()
@@ -262,7 +262,7 @@ len(result)
 
 
 def test_mkdir_rmdir(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='overlay')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='overlay')
     code = """
 from pathlib import Path
 Path('/data/newdir').mkdir()
@@ -276,7 +276,7 @@ after = Path('/data/newdir').exists()
 
 
 def test_unlink(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='overlay')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='overlay')
     code = """
 from pathlib import Path
 Path('/data/hello.txt').unlink()
@@ -289,7 +289,7 @@ Path('/data/hello.txt').exists()
 
 
 def test_rename(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='overlay')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='overlay')
     code = """
 from pathlib import Path
 Path('/data/hello.txt').rename('/data/renamed.txt')
@@ -300,7 +300,7 @@ Path('/data/hello.txt').rename('/data/renamed.txt')
 
 
 def test_resolve(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     result = monty_run("from pathlib import Path; str(Path('/data/subdir/../hello.txt').resolve())", mount=md)
     assert result == snapshot('/data/hello.txt')
 
@@ -311,14 +311,14 @@ def test_resolve(monty_run: RunMonty, test_dir: Path):
 
 
 def test_path_traversal_blocked(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     with pytest.raises(MontyRuntimeError) as exc_info:
         monty_run("from pathlib import Path; Path('/data/../../etc/passwd').read_text()", mount=md)
     assert 'Permission denied' in str(exc_info.value)
 
 
 def test_unmounted_path_denied(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     with pytest.raises(MontyRuntimeError) as exc_info:
         monty_run("from pathlib import Path; Path('/other/file.txt').exists()", mount=md)
     assert 'Permission denied' in str(exc_info.value)
@@ -335,13 +335,13 @@ def test_fallback_for_getenv(monty_run: RunMonty, test_dir: Path):
             return 'my_value' if args[0] == 'MY_VAR' else None
         return None
 
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     result = monty_run("import os; os.getenv('MY_VAR')", mount=md, os=fallback)
     assert result == snapshot('my_value')
 
 
 def test_no_fallback_not_implemented(monty_run: RunMonty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     with pytest.raises(MontyRuntimeError) as exc_info:
         monty_run("import os; os.getenv('PATH')", mount=md)
     assert 'is not supported in this environment' in str(exc_info.value)
@@ -356,7 +356,7 @@ def test_mounted_calls_do_not_reach_os_callback(monty_run: RunMonty, test_dir: P
         calls.append(function_name)
         return None
 
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     result = monty_run("from pathlib import Path; Path('/data/hello.txt').read_text()", mount=md, os=fallback)
     assert result == snapshot('hello world')
     assert calls == []
@@ -373,8 +373,8 @@ def test_multiple_mounts_different_modes(monty_run: RunMonty, test_dir: Path):
         (p2 / 'file2.txt').write_text('from mount2')
 
         mounts = [
-            MountDir('/ro', str(test_dir), mode='read-only'),
-            MountDir('/rw', str(p2), mode='read-write'),
+            MountDir(host_path=str(test_dir), virtual_path='/ro', mode='read-only'),
+            MountDir(host_path=str(p2), virtual_path='/rw', mode='read-write'),
         ]
         code = """
 from pathlib import Path
@@ -392,7 +392,7 @@ b = Path('/rw/file2.txt').read_text()
 
 
 def test_session_feed_run_with_mount(pool: Monty, test_dir: Path):
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     with pool.checkout() as session:
         session.feed_run('from pathlib import Path', mount=md)
         result = session.feed_run("Path('/data/hello.txt').read_text()", mount=md)
@@ -401,7 +401,7 @@ def test_session_feed_run_with_mount(pool: Monty, test_dir: Path):
 
 def test_overlay_visible_within_feed(pool: Monty, test_dir: Path):
     """Overlay writes, deletes, and mkdirs are all visible within one feed."""
-    md = MountDir('/data', str(test_dir), mode='overlay')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='overlay')
     code = """
 from pathlib import Path
 Path('/data/new.txt').write_text('version1')
@@ -427,7 +427,7 @@ listing = sorted([p.name for p in Path('/data').iterdir()])
 def test_overlay_discarded_between_feeds(pool: Monty, test_dir: Path):
     """Overlay writes are discarded when the feed ends — the next feed in the
     same session sees the original host contents again."""
-    md = MountDir('/data', str(test_dir), mode='overlay')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='overlay')
     with pool.checkout() as session:
         session.feed_run('from pathlib import Path', mount=md)
         session.feed_run("Path('/data/new.txt').write_text('from feed1')", mount=md)
@@ -442,7 +442,7 @@ def test_overlay_discarded_between_feeds(pool: Monty, test_dir: Path):
 
 def test_session_read_write_mount(pool: Monty, test_dir: Path):
     """Read-write mounts write through to the host, so writes persist across feeds."""
-    md = MountDir('/data', str(test_dir), mode='read-write')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-write')
     with pool.checkout() as session:
         session.feed_run('from pathlib import Path', mount=md)
         session.feed_run("Path('/data/rw_file.txt').write_text('written')", mount=md)
@@ -454,7 +454,7 @@ def test_session_read_write_mount(pool: Monty, test_dir: Path):
 
 def test_session_read_only_mount_blocks_write(pool: Monty, test_dir: Path):
     """Read-only mounts in a session reject write operations."""
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     with pool.checkout() as session:
         session.feed_run('from pathlib import Path', mount=md)
         with pytest.raises(MontyRuntimeError) as exc_info:
@@ -471,7 +471,7 @@ def test_os_callback_marshalling_error(monty_run: RunMonty, test_dir: Path):
     """An os= callback returning an unconvertible value surfaces inside Monty
     as a `TypeError` wrapped in `MontyRuntimeError`, and the MountDir remains
     usable afterwards."""
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
 
     def os_cb(func: object, args: tuple[object, ...], kwargs: dict[str, object]) -> object:
         return object()  # unconvertible — surfaces inside Monty as TypeError
@@ -487,7 +487,7 @@ def test_os_callback_marshalling_error(monty_run: RunMonty, test_dir: Path):
 def test_os_callback_lone_surrogate_return_surfaces_inside_monty(monty_run: RunMonty, test_dir: Path):
     """An os= callback returning a lone-surrogate string surfaces inside Monty
     as a catchable `ValueError` rather than escaping as a raw `UnicodeEncodeError`."""
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
 
     def os_cb(func: object, args: tuple[object, ...], kwargs: dict[str, object]) -> object:
         return '\ud83d'  # unconvertible UTF-8 — surfaces as ValueError inside Monty
@@ -509,7 +509,7 @@ def test_os_callback_lone_surrogate_return_surfaces_inside_monty(monty_run: RunM
 def test_session_survives_os_callback_marshalling_error(pool: Monty, test_dir: Path):
     """A session keeps its state when an os= callback returns an unconvertible
     value — the error surfaces as MontyRuntimeError but the session survives."""
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
 
     def os_cb(func: object, args: tuple[object, ...], kwargs: dict[str, object]) -> object:
         return object()  # unconvertible — surfaces inside Monty as TypeError
@@ -531,7 +531,7 @@ def test_session_survives_os_callback_marshalling_error(pool: Monty, test_dir: P
 
 def test_open_returns_monty_file_handle(monty_run: RunMonty, test_dir: Path):
     """`open()` returned across the boundary surfaces as `MontyFileHandle`, not a stringified repr."""
-    md = MountDir('/data', str(test_dir), mode='read-only')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
     f = monty_run("open('/data/hello.txt')", mount=md)
     assert isinstance(f, MontyFileHandle)
     assert f.path == snapshot('/data/hello.txt')
@@ -543,7 +543,7 @@ def test_open_returns_monty_file_handle(monty_run: RunMonty, test_dir: Path):
 
 def test_open_binary_write_handle_attrs(monty_run: RunMonty, test_dir: Path):
     """Mode-derived attributes reflect the open() mode string for binary/write opens."""
-    md = MountDir('/data', str(test_dir), mode='read-write')
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-write')
     f = monty_run("open('/data/out.bin', 'wb')", mount=md)
     assert isinstance(f, MontyFileHandle)
     assert f.mode == snapshot('wb')

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -235,7 +235,7 @@ properties that real CPython does not provide, per the caveat above.
   block is just a comment and its dependencies are never installed.
 - **`dump()`** bytes use a subprocess-specific envelope and can only be
   restored into another subprocess worker of the same version, via
-  `session.load` / `session.load_snapshot` (Rust `Checkout::restore`).
+  `session.load_session` / `session.load_snapshot` (Rust `Checkout::restore`).
 - **`feed_start` snapshots are live cursors, not owned state.** The execution
   state lives in the worker, so only one suspension is live per session, each
   snapshot may be resumed at most once (a second resume raises
@@ -243,14 +243,14 @@ properties that real CPython does not provide, per the caveat above.
   pre-subprocess in-process API, where a snapshot owned freely-copyable state.
 - **Restoring a dump is a session method, split by dump kind.** The old
   module-level `load_snapshot` / `load_repl_snapshot` are replaced by two
-  fresh-session-only methods: `session.load(state)` restores a dump taken
-  between feeds (an idle session) so you can keep feeding it, and
+  fresh-session-only methods: `session.load_session(state)` restores a dump
+  taken between feeds (an idle session) so you can keep feeding it, and
   `session.load_snapshot(state, *, mount=…)` restores a dump taken mid-feed and
   returns the re-announced snapshot to resume. The caller knows which kind it
   dumped (`session.dump()` between feeds vs `snapshot.dump()`); using the wrong
   method raises. Both restore *into* a freshly checked-out worker, so they are
-  rejected (`RuntimeError`) after any `feed_run` / `feed_start` / `load` /
-  `load_snapshot` — restoring would otherwise discard work. The dump restores
+  rejected (`RuntimeError`) after any `feed_run` / `feed_start` / `load_session`
+  / `load_snapshot` — restoring would otherwise discard work. The dump restores
   its own `script_name` / limits / type-check state (the `checkout()` config
   for those is not applied); the dataclass registry from `checkout()` is reused.
   A *failed* load (wrong dump kind, or a protocol desync) poisons the session
@@ -264,8 +264,8 @@ properties that real CPython does not provide, per the caveat above.
   dump bytes — dump contents can never cause any directory to be mounted. To
   resume a suspended feed with its mounts, pass the same `mount=` the original
   `feed_start` used to `load_snapshot`; the pool rebuilds its mount table.
-  (`load` takes no `mount` — an idle session has no in-flight feed; the next
-  feed supplies its own.)
+  (`load_session` takes no `mount` — an idle session has no in-flight feed; the
+  next feed supplies its own.)
 - **Re-supplied mounts are not validated.** The dump records nothing about the
   feed's mounts, so `load_snapshot` cannot check what you pass: a mount
   silently omitted (or altered) simply degrades the resumed feed's covered


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed session restore methods and made mount paths explicit to clearly distinguish idle vs snapshot restores and prevent host/virtual path mixups across `pydantic_monty` and `@pydantic/monty`.

- **Migration**
  - Python (`pydantic_monty`): replace `session.load(...)` with `session.load_session(...)` (and `AsyncMontySession.load(...)` with `load_session(...)`); construct mounts with keywords: `MountDir(host_path=..., virtual_path=..., ...)`.
  - JavaScript/TypeScript (`@pydantic/monty`): replace `session.load(...)` with `session.loadSession(...)`; construct mounts with an options object: `new MountDir({ hostPath, virtualPath, ... })`.

<sup>Written for commit 307e7d640dc5e31b89efa38afd1d6f2ff9e14d8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

