### PR TITLE
Support function decorators

### DIFF
--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -666,7 +666,7 @@ impl<'a> Compiler<'a> {
                     self.code.emit(Opcode::Reraise)?;
                 }
             }
-            Node::FunctionDef(func_def) => self.compile_function_def(func_def)?,
+            Node::FunctionDef { def, decorators } => self.compile_function_def(def, decorators)?,
             Node::ClassDef {
                 name,
                 body,
@@ -703,9 +703,26 @@ impl<'a> Compiler<'a> {
     /// 2. Creating a Function struct with the compiled Code
     /// 3. Adding the Function to the compiler's functions vector
     /// 4. Emitting bytecode to evaluate defaults and create the function at runtime
-    fn compile_function_def(&mut self, func_def: &PreparedFunctionDef) -> Result<(), CompileError> {
-        // Build the function object on the stack, then bind it to its name slot.
+    fn compile_function_def(
+        &mut self,
+        func_def: &PreparedFunctionDef,
+        decorators: &[ExprLoc],
+    ) -> Result<(), CompileError> {
+        // Pushed in source order so they sit below the function value: the
+        // applying calls below then run bottom-up, like CPython's `f = deco(f)`.
+        for decorator in decorators {
+            self.compile_expr(decorator)?;
+        }
+        // Build the function object on the stack...
         self.emit_make_function(func_def, "function")?;
+        // ...then apply each decorator, reversed so the bottom-most (last pushed)
+        // applies first, each located at its own decorator so a traceback pins the
+        // one that raised.
+        for decorator in decorators.iter().rev() {
+            self.code.set_location(decorator.position, None);
+            self.code.emit_u8(Opcode::CallFunction, 1)?;
+        }
+        // ...and bind the (possibly decorated) function to its name slot.
         self.compile_store(&func_def.name)?;
         Ok(())
     }

--- a/crates/monty/src/expressions.rs
+++ b/crates/monty/src/expressions.rs
@@ -636,7 +636,20 @@ pub enum Node<F> {
         body: Vec<Self>,
         or_else: Vec<Self>,
     },
-    FunctionDef(F),
+    /// Function definition (e.g. `def foo(): ...`).
+    ///
+    /// Decorators live on the statement rather than inside `F` because `F` is
+    /// also a class body and a method, neither of which can carry them — and
+    /// because a decorator is part of the `def` statement, not of the function
+    /// object it produces. Mirrors [`Node::ClassDef`].
+    FunctionDef {
+        /// The function itself: signature and body, riding the `F` =
+        /// Raw→Prepared pipeline.
+        def: F,
+        /// In source order; evaluated in the enclosing scope and applied
+        /// bottom-up (`foo = deco(foo)`), like CPython.
+        decorators: Vec<ExprLoc>,
+    },
     /// Class definition (e.g. `class Foo: ...`).
     ///
     /// Modelled on CPython's class-body code object: the class body is a

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -241,8 +241,8 @@ pub struct Parser<'a> {
     /// never records where `class` sat, and its range starts at the first
     /// decorator. CPython locates a statement at its keyword, so a decorated
     /// class's traceback frame needs the concrete position. Read only by
-    /// [`Parser::class_keyword_range`]; `def`/`async def` will want the same
-    /// treatment if function decorators are supported.
+    /// [`Parser::class_keyword_range`]. A decorated `def` needs no equivalent:
+    /// `MakeFunction` pushes no frame, so nothing locates a `def` statement.
     class_keyword_offsets: Vec<TextSize>,
 }
 
@@ -346,7 +346,10 @@ impl<'a> Parser<'a> {
 
     fn parse_statement_impl(&mut self, statement: Stmt) -> Result<ParseNode, ParseError> {
         match statement {
-            Stmt::FunctionDef(function) => Ok(Node::FunctionDef(self.parse_function_def(function)?)),
+            Stmt::FunctionDef(function) => {
+                let (def, decorators) = self.parse_function_def(function)?;
+                Ok(Node::FunctionDef { def, decorators })
+            }
             Stmt::ClassDef(c) => self.parse_class_def(c),
             Stmt::Return(ast::StmtReturn { value, .. }) => Ok(Node::Return(match value {
                 Some(value) => Some(self.parse_expression(*value)?),
@@ -711,21 +714,18 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Parses a `def` into a [`RawFunctionDef`].
+    /// Parses a `def` into a [`RawFunctionDef`] plus its decorators.
     ///
     /// Shared by the top-level `Stmt::FunctionDef` arm and by class-body method
-    /// parsing in [`parse_class_def`](Self::parse_class_def). Decorators are
-    /// rejected here rather than silently ignored — a silently-dropped decorator
-    /// changes behaviour without warning, which is unacceptable in a sandbox. The
-    /// class-body path rejects decorated methods earlier with a more specific
-    /// message, so this only fires for top-level `def`s in practice.
-    fn parse_function_def(&mut self, function: ast::StmtFunctionDef) -> Result<RawFunctionDef, ParseError> {
-        if !function.decorator_list.is_empty() {
-            return Err(ParseError::not_implemented(
-                "function decorators",
-                self.convert_range(function.range),
-            ));
-        }
+    /// parsing in [`parse_class_def`](Self::parse_class_def). The decorators are
+    /// returned separately because they belong to the statement, not the function
+    /// (see [`Node::FunctionDef`]); the class-body path rejects decorated methods
+    /// before calling here, so it always receives an empty list.
+    fn parse_function_def(
+        &mut self,
+        function: ast::StmtFunctionDef,
+    ) -> Result<(RawFunctionDef, Vec<ExprLoc>), ParseError> {
+        let decorators = self.parse_decorators(function.decorator_list)?;
 
         let params = &function.parameters;
 
@@ -757,12 +757,31 @@ impl<'a> Parser<'a> {
         let body = self.parse_statements(function.body)?;
         let is_async = function.is_async;
 
-        Ok(RawFunctionDef {
-            name,
-            signature,
-            body,
-            is_async,
-        })
+        Ok((
+            RawFunctionDef {
+                name,
+                signature,
+                body,
+                is_async,
+            },
+            decorators,
+        ))
+    }
+
+    /// Parses decorator expressions in source order.
+    ///
+    /// They are ordinary expressions evaluated in the enclosing scope; the
+    /// compiler emits the applying calls after building the decorated value.
+    /// Shared by [`parse_function_def`](Self::parse_function_def) and
+    /// [`parse_class_def`](Self::parse_class_def).
+    fn parse_decorators(
+        &mut self,
+        decorators: impl IntoIterator<Item = ast::Decorator>,
+    ) -> Result<Vec<ExprLoc>, ParseError> {
+        decorators
+            .into_iter()
+            .map(|d| self.parse_expression(d.expression))
+            .collect()
     }
 
     /// Parses a `class Foo: ...` definition into a [`Node::ClassDef`].
@@ -782,13 +801,7 @@ impl<'a> Parser<'a> {
     /// are rejected as not-implemented, reserving the syntax for later.
     fn parse_class_def(&mut self, class: ast::StmtClassDef) -> Result<ParseNode, ParseError> {
         let position = self.class_keyword_range(&class);
-        // Parsed as ordinary expressions; the compiler emits the apply calls
-        // after building the class.
-        let decorators = class
-            .decorator_list
-            .into_iter()
-            .map(|d| self.parse_expression(d.expression))
-            .collect::<Result<Vec<_>, ParseError>>()?;
+        let decorators = self.parse_decorators(class.decorator_list)?;
         // `class.arguments` carries base classes and metaclass keywords.
         if class
             .arguments
@@ -837,9 +850,16 @@ impl<'a> Parser<'a> {
                             self.reject_class_body_walrus(default)?;
                         }
                     }
-                    let method = self.parse_function_def(function)?;
+                    let (method, decorators) = self.parse_function_def(function)?;
+                    // Rejected above, so a decorated method never reaches the
+                    // class namespace — where a decorator's return value, not a
+                    // function, would end up bound as the member.
+                    debug_assert!(decorators.is_empty(), "method decorators are rejected above");
                     members.push(method.name);
-                    body.push(Node::FunctionDef(method));
+                    body.push(Node::FunctionDef {
+                        def: method,
+                        decorators,
+                    });
                 }
                 // `name = <expr>` — a class-level variable.
                 Stmt::Assign(ast::StmtAssign {

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -241,8 +241,7 @@ pub struct Parser<'a> {
     /// never records where `class` sat, and its range starts at the first
     /// decorator. CPython locates a statement at its keyword, so a decorated
     /// class's traceback frame needs the concrete position. Read only by
-    /// [`Parser::class_keyword_range`]. A decorated `def` needs no equivalent:
-    /// `MakeFunction` pushes no frame, so nothing locates a `def` statement.
+    /// [`Parser::class_keyword_range`].
     class_keyword_offsets: Vec<TextSize>,
 }
 

--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -806,12 +806,23 @@ impl<'i, 'g> Prepare<'i, 'g> {
                     let or_else = self.prepare_nodes(or_else)?;
                     new_nodes.push(Node::If { test, body, or_else });
                 }
-                Node::FunctionDef(RawFunctionDef {
-                    name,
-                    signature,
-                    body,
-                    is_async,
-                }) => {
+                Node::FunctionDef {
+                    def:
+                        RawFunctionDef {
+                            name,
+                            signature,
+                            body,
+                            is_async,
+                        },
+                    decorators,
+                } => {
+                    // Decorators evaluate in the enclosing scope, not the function
+                    // body, and before the name binds — so `@f def f()` sees the
+                    // previous `f`, as in CPython.
+                    let decorators = decorators
+                        .into_iter()
+                        .map(|d| self.prepare_expression(d))
+                        .collect::<Result<Vec<_>, ParseError>>()?;
                     let func = self.prepare_function_def(name, &signature, body, is_async)?;
                     // In a class body, the method name becomes a bound member
                     // only now — its own parameter defaults (evaluated in class
@@ -819,7 +830,7 @@ impl<'i, 'g> Prepare<'i, 'g> {
                     if self.is_class_scope {
                         self.bound_class_members.insert(func.name.name_id);
                     }
-                    new_nodes.push(Node::FunctionDef(func));
+                    new_nodes.push(Node::FunctionDef { def: func, decorators });
                 }
                 Node::ClassDef {
                     name,
@@ -2419,10 +2430,17 @@ fn collect_scope_info_from_node(
                 collect_scope_info_from_node(n, global_names, nonlocal_names, assigned_names, interner);
             }
         }
-        Node::FunctionDef(RawFunctionDef { name, .. }) => {
+        Node::FunctionDef {
+            def: RawFunctionDef { name, .. },
+            decorators,
+        } => {
             // Function definition creates a local binding for the function name
             // But we don't recurse into the function body - that's a separate scope
             assigned_names.insert(name.name_id);
+            // Decorators evaluate in *this* scope, so a walrus in one binds here.
+            for decorator in decorators {
+                collect_assigned_names_from_expr(decorator, assigned_names, interner);
+            }
         }
         Node::ClassDef { name, decorators, .. } => {
             // A class definition binds the class name in this scope, just like a `def`.
@@ -2701,8 +2719,16 @@ fn collect_cell_vars_from_node(
     interner: &InternerBuilder,
 ) {
     match node {
-        Node::FunctionDef(RawFunctionDef { signature, body, .. }) => {
+        Node::FunctionDef {
+            def: RawFunctionDef { signature, body, .. },
+            decorators,
+        } => {
             collect_cell_vars_from_function(signature, body, our_locals, cell_vars, interner);
+            // A nested scope inside a decorator expression (a lambda in decorator
+            // position, or one passed to a factory) can capture our locals too.
+            for decorator in decorators {
+                collect_cell_vars_from_expr(decorator, our_locals, cell_vars, interner);
+            }
         }
         Node::ClassDef { body, decorators, .. } => {
             // The class body is a nested scope of *this* scope, like a `def`: any
@@ -3237,12 +3263,19 @@ fn collect_referenced_names_from_node(
                 collect_referenced_names_from_node(n, referenced, interner);
             }
         }
-        Node::FunctionDef(RawFunctionDef { signature, body, .. }) => {
+        Node::FunctionDef {
+            def: RawFunctionDef { signature, body, .. },
+            decorators,
+        } => {
             // Recurse into the nested function's body so transitively-captured
             // names propagate out of it. Without this, an intermediate scope
             // that doesn't itself reference a deep capture would not see it
             // — the bug behind issue #477's multi-hop closures.
             collect_nested_function_references(signature, body, referenced, interner);
+            // Decorators evaluate in *our* scope, so their names are ours to collect.
+            for decorator in decorators {
+                collect_referenced_names_from_expr(decorator, referenced, interner);
+            }
         }
         Node::ClassDef { decorators, .. } => {
             // The class body is a separate scope and the name is a binding, so

--- a/crates/monty/test_cases/decorator__function.py
+++ b/crates/monty/test_cases/decorator__function.py
@@ -1,0 +1,464 @@
+# === Function decorator: identity returns the function unchanged ===
+def identity(fn):
+    return fn
+
+
+@identity
+def greet():
+    return 'hi'
+
+
+assert greet() == 'hi'
+
+
+# === Decorator can replace the function with any value ===
+def replace_with_number(fn):
+    return 42
+
+
+@replace_with_number
+def replaced():
+    return 'never runs'
+
+
+assert replaced == 42
+
+
+# === Wrapping: the classic decorator shape ===
+def shout(fn):
+    def wrapper(name):
+        return fn(name).upper()
+
+    return wrapper
+
+
+@shout
+def hello(name):
+    return 'hello ' + name
+
+
+assert hello('world') == 'HELLO WORLD'
+
+
+# === Wrapper forwarding positional and keyword arguments ===
+def double_result(fn):
+    def wrapper(a, b=10):
+        return fn(a, b) * 2
+
+    return wrapper
+
+
+@double_result
+def add(a, b):
+    return a + b
+
+
+assert add(1) == 22
+assert add(1, 2) == 6
+assert add(1, b=3) == 8
+
+
+# === Decorator factory (decorator with arguments) ===
+def repeat(times):
+    def deco(fn):
+        def wrapper():
+            return fn() * times
+
+        return wrapper
+
+    return deco
+
+
+@repeat(3)
+def ha():
+    return 'ha'
+
+
+assert ha() == 'hahaha'
+
+
+# === Stacked decorators apply bottom-up (nearest the def first) ===
+applied = []
+
+
+def tag(label):
+    def deco(fn):
+        applied.append(label)
+        return fn
+
+    return deco
+
+
+@tag('outer')
+@tag('middle')
+@tag('inner')
+def stacked():
+    pass
+
+
+assert applied == ['inner', 'middle', 'outer']
+
+
+# === Stacking composes in the right order ===
+def add_one(fn):
+    return lambda: fn() + 1
+
+
+def times_two(fn):
+    return lambda: fn() * 2
+
+
+@add_one
+@times_two
+def base():
+    return 5
+
+
+# times_two applies first (5 * 2 = 10), then add_one (10 + 1 = 11)
+assert base() == 11
+
+
+# === Registry pattern: decorator records the function and returns it ===
+# Keyed explicitly rather than by `fn.__name__` — Monty functions expose no
+# introspection attributes (see limitations/language.md).
+registry = {}
+
+
+def register_as(key):
+    def deco(fn):
+        registry[key] = fn
+        return fn
+
+    return deco
+
+
+@register_as('alpha')
+def alpha():
+    return 'a'
+
+
+@register_as('beta')
+def beta():
+    return 'b'
+
+
+assert sorted(registry) == ['alpha', 'beta']
+assert registry['alpha']() == 'a'
+assert registry['beta']() == 'b'
+
+
+# === Decorators are arbitrary expressions, not just names ===
+decos = [identity, replace_with_number]
+
+
+@decos[0]
+def via_subscript():
+    return 'sub'
+
+
+assert via_subscript() == 'sub'
+
+
+# === Attribute expressions work in decorator position ===
+class Holder:
+    pass
+
+
+Holder.deco = identity
+
+
+@Holder.deco
+def via_attribute():
+    return 'attr'
+
+
+assert via_attribute() == 'attr'
+
+
+# === Decorators evaluate in the enclosing scope and capture its locals ===
+def make_multiplier():
+    factor = 3
+
+    @(lambda fn: lambda: fn() * factor)
+    def inner():
+        return 7
+
+    return inner()
+
+
+assert make_multiplier() == 21
+
+
+# === Multi-hop capture: decorator lambda reaches through two scopes ===
+def outer_scope():
+    offset = 100
+
+    def middle():
+        @(lambda fn: lambda: fn() + offset)
+        def innermost():
+            return 5
+
+        return innermost()
+
+    return middle()
+
+
+assert outer_scope() == 105
+
+
+# === Decorator factory capturing an enclosing local ===
+def make_scaled():
+    scale = 4
+
+    def scaler(fn):
+        def wrapper():
+            return fn() * scale
+
+        return wrapper
+
+    @scaler
+    def value():
+        return 6
+
+    return value()
+
+
+assert make_scaled() == 24
+
+
+# === Decorators evaluate top-down, before the function is built ===
+evaluated = []
+
+
+def note(label):
+    evaluated.append(label)
+    return identity
+
+
+@note('first')
+@note('second')
+def ordering():
+    pass
+
+
+assert evaluated == ['first', 'second']
+
+
+# === A raising decorator unwinds cleanly and execution continues ===
+def explode(fn):
+    raise RuntimeError('boom')
+
+
+try:
+
+    @explode
+    def doomed():
+        pass
+
+    assert False, 'expected the decorator to raise'
+except RuntimeError as exc:
+    assert str(exc) == 'boom'
+
+# execution continues normally afterwards
+assert identity(greet)() == 'hi'
+
+
+# === The function name stays unbound when a decorator raises ===
+try:
+    undecorated_name
+    assert False, 'expected NameError before definition'
+except NameError:
+    pass
+
+try:
+
+    @explode
+    def undecorated_name():
+        pass
+
+except RuntimeError:
+    pass
+
+try:
+    undecorated_name
+    assert False, 'expected the name to stay unbound'
+except NameError:
+    pass
+
+
+# === A non-callable decorator raises TypeError ===
+not_callable = 5
+
+try:
+
+    @not_callable
+    def bad():
+        pass
+
+    assert False, 'expected TypeError'
+except TypeError as exc:
+    assert str(exc) == "'int' object is not callable"
+
+
+# === An identity decorator returns the very same function object ===
+def marker():
+    return 'marked'
+
+
+assert identity(marker) is marker
+
+
+# === Decorating a nested function binds in the enclosing function's scope ===
+def with_nested():
+    @identity
+    def helper():
+        return 'nested'
+
+    return helper()
+
+
+assert with_nested() == 'nested'
+
+
+# === Decorated async functions define and bind like any other ===
+# Awaiting one is covered by decorator__function_async.py, which needs `# run-async`.
+@replace_with_number
+async def async_replaced():
+    return 'never runs'
+
+
+assert async_replaced == 42
+
+
+# === A decorator name shadowed by the def it decorates is an unbound local ===
+# The `def` makes `shadowed` a local of `shadowing`, so the decorator lookup
+# cannot fall back to the global one — it reads the local before assignment.
+def shadowed(fn):
+    return fn
+
+
+def shadowing():
+    try:
+
+        @shadowed
+        def shadowed():
+            return 'inner'
+
+        assert False, 'expected UnboundLocalError'
+    except UnboundLocalError as exc:
+        return str(exc)
+
+
+assert shadowing() == "cannot access local variable 'shadowed' where it is not associated with a value"
+
+
+# === A walrus in a decorator expression binds in the enclosing scope ===
+# Decorators evaluate in the enclosing scope, so `:=` there makes a local of
+# that scope — it must not fall through to the module globals.
+def passthrough(v):
+    def deco(fn):
+        return fn
+
+    return deco
+
+
+shadowed = 'global'
+
+
+def walrus_binds_locally():
+    @passthrough(shadowed := 'local')
+    def f():
+        pass
+
+    return shadowed
+
+
+assert walrus_binds_locally() == 'local'
+assert shadowed == 'global'
+
+
+# The binding is a local, so it never escapes to the module namespace.
+def walrus_does_not_leak():
+    @passthrough(never_global := 'inner')
+    def f():
+        pass
+
+    return never_global
+
+
+assert walrus_does_not_leak() == 'inner'
+try:
+    never_global
+    assert False, 'expected NameError'
+except NameError as exc:
+    assert str(exc) == "name 'never_global' is not defined"
+
+
+# `global` still redirects the walrus to the module scope.
+promoted = 'before'
+
+
+def walrus_with_global():
+    global promoted
+
+    @passthrough(promoted := 'after')
+    def f():
+        pass
+
+
+walrus_with_global()
+assert promoted == 'after'
+
+
+# A walrus in a decorator can be captured by a nested function (needs a cell).
+def walrus_captured_by_closure():
+    @passthrough(captured := 11)
+    def f():
+        pass
+
+    def read():
+        return captured
+
+    return read()
+
+
+assert walrus_captured_by_closure() == 11
+
+
+# === A deep decorator stack applies in order ===
+depth_order = []
+
+
+def depth_tag(n):
+    def deco(fn):
+        depth_order.append(n)
+        return fn
+
+    return deco
+
+
+@depth_tag(0)
+@depth_tag(1)
+@depth_tag(2)
+@depth_tag(3)
+@depth_tag(4)
+@depth_tag(5)
+@depth_tag(6)
+@depth_tag(7)
+@depth_tag(8)
+@depth_tag(9)
+@depth_tag(10)
+@depth_tag(11)
+@depth_tag(12)
+@depth_tag(13)
+@depth_tag(14)
+@depth_tag(15)
+@depth_tag(16)
+@depth_tag(17)
+@depth_tag(18)
+@depth_tag(19)
+def deeply_stacked():
+    pass
+
+
+assert depth_order == list(reversed(range(20)))

--- a/crates/monty/test_cases/decorator__function_async.py
+++ b/crates/monty/test_cases/decorator__function_async.py
@@ -1,0 +1,62 @@
+# run-async
+# A decorated `async def` is awaited like any other coroutine — both when the
+# decorator returns the function untouched and when it wraps it in another
+# coroutine function.
+
+
+def identity(fn):
+    return fn
+
+
+def double(fn):
+    async def wrapper(n):
+        return await fn(n) * 2
+
+    return wrapper
+
+
+# === An identity decorator leaves the coroutine function alone ===
+@identity
+async def plain(n):
+    return n + 1
+
+
+assert (await plain(1)) == 2  # pyright: ignore
+
+
+# === A decorator may replace it with another coroutine function ===
+@double
+async def doubled(n):
+    return n + 1
+
+
+assert (await doubled(1)) == 4  # pyright: ignore
+
+
+# === Stacked: `double` applies first, then `identity` passes the wrapper on ===
+@identity
+@double
+async def stacked(n):
+    return n + 1
+
+
+assert (await stacked(3)) == 8  # pyright: ignore
+
+
+# === A decorator can capture an enclosing local and use it in the wrapper ===
+def make_offset(step):
+    def deco(fn):
+        async def wrapper(n):
+            return await fn(n) + step
+
+        return wrapper
+
+    return deco
+
+
+@make_offset(100)
+async def offset(n):
+    return n
+
+
+assert (await offset(5)) == 105  # pyright: ignore

--- a/crates/monty/test_cases/decorator__function_external.py
+++ b/crates/monty/test_cases/decorator__function_external.py
@@ -1,0 +1,36 @@
+# call-external
+# Decorators run as ordinary bytecode, so they may suspend on an external call
+# — both while the decorator body runs and inside the wrapper it returns.
+def scaled(fn):
+    factor = add_ints(2, 3)  # suspends while the decorator itself runs
+
+    def wrapper():
+        return add_ints(fn(), factor)  # suspends inside the returned wrapper
+
+    return wrapper
+
+
+@scaled
+def five():
+    return 5
+
+
+assert five() == 10
+
+
+# A decorator *factory* may suspend too, before the decorator is even built.
+def offset_by(n):
+    shift = add_ints(n, 100)
+
+    def deco(fn):
+        return lambda: add_ints(fn(), shift)
+
+    return deco
+
+
+@offset_by(1)
+def seven():
+    return 7
+
+
+assert seven() == 108

--- a/crates/monty/test_cases/decorator__function_traceback.py
+++ b/crates/monty/test_cases/decorator__function_traceback.py
@@ -1,0 +1,27 @@
+# A raising decorator in a stack is pinned to its own `@` line, not to the whole
+# `def` statement, so the traceback identifies which decorator failed.
+def ok(fn):
+    return fn
+
+
+def explode(fn):
+    raise RuntimeError('decorator failed')
+
+
+@ok
+@explode
+@ok
+def target():
+    pass
+
+
+"""
+TRACEBACK:
+Traceback (most recent call last):
+  File "decorator__function_traceback.py", line 12, in <module>
+    @explode
+     ~~~~~~~
+  File "decorator__function_traceback.py", line 8, in explode
+    raise RuntimeError('decorator failed')
+RuntimeError: decorator failed
+"""

--- a/crates/monty/tests/parse_errors.rs
+++ b/crates/monty/tests/parse_errors.rs
@@ -47,15 +47,6 @@ fn class_inheritance_returns_not_implemented_error() {
 }
 
 #[test]
-fn function_decorators_return_not_implemented_error() {
-    // A top-level `def` decorator is rejected rather than silently ignored:
-    // silently dropping a decorator would change behaviour without warning.
-    let err = get_parse_err("@deco\ndef foo(): pass");
-    assert_eq!(err.exc_type(), ExcType::NotImplementedError);
-    assert_snapshot!(err.message().unwrap(), @"The monty syntax parser does not yet support function decorators");
-}
-
-#[test]
 fn class_var_walrus_returns_not_implemented_error() {
     // A walrus target in a class-variable value binds in the class body, so
     // CPython makes it a class member; Monty's namespace assembly would

--- a/limitations/classes.md
+++ b/limitations/classes.md
@@ -179,9 +179,9 @@ e.g. return a `dict` of the fields.
   metaclass-driven namespace customization.
 - `__slots__`, descriptors (`__get__` / `__set__` / `__delete__`).
 - Abstract base classes (`abc.ABC`, `@abstractmethod`).
-- Function and method decorators — `@classmethod`, `@staticmethod`, `@property`,
-  and any decorator on a top-level `def` or a method (rejected at parse time).
-  Class decorators are supported.
+- Method decorators — `@classmethod`, `@staticmethod`, `@property`, and any
+  decorator on a `def` inside a class body (rejected at parse time). Decorators
+  on classes and on non-method functions are supported.
 - **Classes are barely introspectable**: `__dict__`, `__bases__` and `dir()`
   are all unavailable (`cls.__name__` and `cls.__annotations__` work — the
   latter with stringized values, see [typing.md](typing.md)).

--- a/limitations/language.md
+++ b/limitations/language.md
@@ -13,10 +13,11 @@ any code runs.
   class-body statements other than `def`, a simple `name [: T] = <expr>`
   assignment, `pass`, or a docstring. There is no inheritance and no general
   dunder protocol. See [classes.md](classes.md).
-- **Decorators** (`@deco`) — supported on classes, taking any callable in scope,
-  evaluated in the enclosing scope and applied bottom-up. Rejected at parse time
-  on functions and methods, so `@classmethod`, `@staticmethod`, `@property` and
-  any decorator on a `def` are unavailable. See [classes.md](classes.md).
+- **Decorators** (`@deco`) — supported on classes and on top-level or nested
+  `def`/`async def`, taking any callable in scope, evaluated in the enclosing
+  scope and applied bottom-up. Rejected at parse time on **methods**, so
+  `@classmethod`, `@staticmethod`, `@property` and any decorator on a `def`
+  inside a class body are unavailable. See [classes.md](classes.md).
 - **`async with` statements** — not yet supported
 - **`yield` / `yield from` expressions** — no generator functions. Generator
   *expressions* (`(x for x in ...)`) parse but currently materialize to a
@@ -131,6 +132,19 @@ exposing `None` would diverge on type — and a real loader is neither available
 nor safe to surface in the sandbox. `__file__` is omitted so no host path can
 leak into the sandbox.
 
+## Function objects
+
+A function exposes **no** attributes: `__name__`, `__doc__`, `__qualname__` and
+`__module__` all raise `AttributeError: 'function' object has no attribute
+'<name>'`, and new ones cannot be set — `fn.tag = True` raises `AttributeError:
+'function' object has no attribute 'tag' and no __dict__ for setting new
+attributes`. CPython supports all of these.
+
+This is the ceiling on what a decorator can do: it can call, wrap, store or
+replace the function it receives, but cannot ask the function about itself, so
+`functools.wraps`-style metadata copying, registries keyed by `fn.__name__`, and
+attribute tagging for later discovery all have no equivalent.
+
 ## Ordering comparisons
 
 `<`, `<=`, `>`, `>=` on operands with no defined ordering raise
@@ -157,8 +171,8 @@ give `False` on both.
 
 ## What *does* work
 
-- Functions (`def`, `async def`), nested functions, closures (but not
-  decorators — see above).
+- Functions (`def`, `async def`), nested functions, closures, and decorators on
+  them (but not on methods — see above).
 - List / dict / set comprehensions (generator comprehensions degrade to
   lists — see above).
 - `try` / `except` / `else` / `finally`, `raise ... from ...`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,11 +162,15 @@ reportPossiblyUnboundVariable = false
 reportUnboundVariable = false
 # attribute error tests intentionally access/assign non-existent attributes
 reportAttributeAccessIssue = false
-# class decorator tests deliberately use untyped decorators (incl. bare lambdas)
+# decorator tests deliberately use untyped decorators (incl. bare lambdas)
 reportUntypedClassDecorator = false
-# unused variables, classes and imports are fine in test cases
+reportUntypedFunctionDecorator = false
+# unused variables, classes, functions and imports are fine in test cases —
+# e.g. the walrus-in-decorator tests decorate a throwaway `def f(): pass`, the
+# same way the class-side ones decorate a throwaway `class C: pass`
 reportUnusedVariable = false
 reportUnusedClass = false
+reportUnusedFunction = false
 reportUnusedImport = false
 reportDuplicateImport = false
 reportAssignmentType = false


### PR DESCRIPTION
Enables `@deco def foo` on top-level and nested `def`/`async def`. Decorators evaluate in the enclosing scope and apply bottom-up (`foo = deco(foo)`), matching CPython.

Adds **no new capability**: `def f(): ...; f = deco(f)` was already possible — this is syntax sugar for it, previously rejected at parse time. **Method decorators remain rejected**, so `@classmethod`/`@staticmethod`/`@property` are still unavailable.

Follows #582 (class decorators) and reuses its machinery.

### Changes
- **expressions**: `Node::FunctionDef` becomes a struct variant carrying `decorators` alongside `def` — on the statement rather than inside the function struct, which is also used for class bodies and methods.
- **parse**: carry `decorator_list` instead of rejecting it, via a `parse_decorators` helper shared with `parse_class_def`.
- **prepare**: resolve decorators in the enclosing scope before the name binds; walk them in all three scope-analysis passes. The cell-var pass is load-bearing — a nested scope inside a decorator expression that captures an enclosing local needs a cell.
- **compiler**: push decorators, build the function, then one `CallFunction 1` each in reverse, each located at its own decorator so a traceback pins the one that raised.

### No traceback work needed
Unlike a class, a `def` runs no body frame at definition time, so nothing reports the statement's own position — locations come from the decorators and parameter defaults, which carry their own ranges. Verified against CPython for a raising decorator in a stack, `NameError` on a decorator, a default argument raising at definition time, and a decorated `async def`.

### The limitation that shapes this
Function objects expose no `__name__`/`__doc__`/`__qualname__`/`__module__` and accept no new attributes, so a decorator can wrap, replace and store — but cannot ask the function about itself. No `functools.wraps` emulation, no registries keyed by `fn.__name__`, no attribute tagging. Documented in `limitations/language.md`.

### Tests
`decorator__function.py` (wrapping, factories, stacking order, walrus battery, closure capture, clean unwind, 20-deep stack), plus `_traceback`, `_external` (suspension mid-decoration) and `_async` (`# run-async`) files. Dual-run green on Monty and CPython 3.14; full suite 1068, both halves of `make test-memory-model-checks` green, lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9FjDZYf5wVBUC7wJmhybd

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for decorators on top-level and nested `def`/`async def`, evaluated in the enclosing scope and applied bottom-up like CPython. Method decorators remain rejected; this is syntax sugar for `f = deco(f)` and keeps existing function-introspection limits.

- New Features
  - Use `@deco` on functions; decorators run before the name binds and apply in reverse order.
  - Works with `async def`; failures are pinned to the decorator line; decorators can suspend on external calls.

- Refactors
  - `Node::FunctionDef` now carries `decorators`; parser keeps them via a shared `parse_decorators`.
  - `prepare` evaluates decorators in the enclosing scope and includes them in assigned/referenced/cell-var analysis.
  - Compiler pushes decorators, builds the function, then calls each decorator in reverse with its own location.
  - Tests added for sync/async/external/traceback; removed the obsolete parse error. Updated `limitations/*` docs and `pyproject.toml` settings for decorator tests.

<sup>Written for commit 7e938fea9b11ff0adc85a4aa6af3fc3f5e99b49f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

