### PR TITLE
`monty-types` crate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,8 +23,11 @@ The public data types (`MontyObject`, `MontyException`/`ExcType`, `OsFunctionCal
 its arg structs, `ResourceLimits`/`ResourceTracker`, `PrintStream`/`PrintWriter`,
 `CompileOptions`, `ExtFunctionResult`, `FileMode`, ...) live in `crates/monty-types`,
 which depends on no other monty crate except the `monty-macros` derives. `monty`
-depends on `monty-types` and re-exports everything, so `monty::MontyObject` etc.
-keep working unchanged.
+depends on `monty-types` but does not blanket re-export it — only a few types
+are re-exported inline where they appear in `monty`'s public API (e.g.
+`run::CompileOptions`, `run_progress::{ExtFunctionResult, NameLookupResult}`).
+Code needing `MontyObject`, `MontyException`, `OsFunctionCall`, etc. must
+depend on `monty-types` directly.
 
 Host-side crates (`monty-fs`, `monty-pool`, `monty-proto` without its `worker`
 feature, `monty-python`, `monty-js`) MUST depend on `monty-types`, NOT `monty` —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,27 @@ Project goals:
 - **Cross-platform**: Runs on Linux, macOS, and Windows (and any other OS that can run Rust)
 - Targets the latest stable version of Python, currently Python 3.14
 
+## `monty-types` — shared boundary types
+
+The public data types (`MontyObject`, `MontyException`/`ExcType`, `OsFunctionCall` +
+its arg structs, `ResourceLimits`/`ResourceTracker`, `PrintStream`/`PrintWriter`,
+`CompileOptions`, `ExtFunctionResult`, `FileMode`, ...) live in `crates/monty-types`,
+which depends on no other monty crate except the `monty-macros` derives. `monty`
+depends on `monty-types` and re-exports everything, so `monty::MontyObject` etc.
+keep working unchanged.
+
+Host-side crates (`monty-fs`, `monty-pool`, `monty-proto` without its `worker`
+feature, `monty-python`, `monty-js`) MUST depend on `monty-types`, NOT `monty` —
+this keeps the interpreter out of their binaries. Only the worker side
+(`monty-runtime`, `monty-wasm-runtime`, `monty-proto` with `worker`) links the
+interpreter. Don't add a `monty` dependency to a host-side crate; if it needs a
+type, that type belongs in `monty-types`.
+
+Interpreter-coupled methods on these types live in `monty` as `pub(crate)`
+extension traits (`ExcTypeExt`, `MontyObjectExt`, `MontyTypeExt`, `StackFrameExt`,
+`FileModeExt`, `BuiltinsFunctionsExt`, `ExtFunctionResultExt`) — import the trait
+to call e.g. `ExcType::type_error(...)` or `MontyObject::new(value, vm)`.
+
 ## Cross-Platform Requirements
 
 Monty must work identically on Linux, macOS, and Windows. Within the Monty sandbox,
@@ -102,6 +123,9 @@ subprocesses:
   regenerated and CI-checked together with the main codegen). Parents must
   treat frames from a (possibly compromised) child as untrusted — wire
   decoding and proto→Rust conversions validate everything and never panic.
+  `monty-proto` depends only on `monty-types` by default; its `worker` feature
+  (enabled by `monty-runtime`/`monty-wasm-runtime`) pulls in the full `monty`
+  interpreter for the child-side `worker` state machine.
 - `monty subprocess` (in `crates/monty-runtime/src/subprocess.rs`) — the child:
   reads framed requests on stdin, writes framed events on stdout, serving one
   REPL session per checkout. Strict alternation: one request in, zero or more

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2033,6 +2033,7 @@ dependencies = [
  "criterion",
  "monty",
  "monty-pool",
+ "monty-types",
  "pprof",
  "pyo3",
  "pyo3-build-config",
@@ -2047,6 +2048,7 @@ dependencies = [
  "datatest-stable",
  "monty",
  "monty-fs",
+ "monty-types",
  "pyo3",
  "pyo3-build-config",
  "similar 2.7.0",
@@ -2069,6 +2071,7 @@ dependencies = [
  "arbitrary",
  "libfuzzer-sys",
  "monty",
+ "monty-types",
 ]
 
 [[package]]
@@ -2131,6 +2134,7 @@ dependencies = [
  "monty-fs",
  "monty-proto",
  "monty-type-checking",
+ "monty-types",
  "rustyline",
  "tempfile",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,6 +2005,7 @@ dependencies = [
  "jiter",
  "libm",
  "monty-macros",
+ "monty-types",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -2022,7 +2023,6 @@ dependencies = [
  "unicode-general-category",
  "unicode-normalization",
  "unicode_names2",
- "web-time",
 ]
 
 [[package]]
@@ -2058,7 +2058,7 @@ name = "monty-fs"
 version = "0.0.19-beta.4"
 dependencies = [
  "ahash",
- "monty",
+ "monty-types",
  "tempfile",
 ]
 
@@ -2075,9 +2075,9 @@ dependencies = [
 name = "monty-js"
 version = "0.0.19-beta.4"
 dependencies = [
- "monty",
  "monty-pool",
  "monty-type-checking",
+ "monty-types",
  "napi",
  "napi-build",
  "napi-derive",
@@ -2100,9 +2100,9 @@ dependencies = [
 name = "monty-pool"
 version = "0.0.19-beta.4"
 dependencies = [
- "monty",
  "monty-fs",
  "monty-proto",
+ "monty-types",
  "rustls",
  "tempfile",
  "tungstenite",
@@ -2114,6 +2114,7 @@ version = "0.0.19-beta.4"
 dependencies = [
  "monty",
  "monty-type-checking",
+ "monty-types",
  "num-bigint",
  "prost",
  "prost-build",
@@ -2151,6 +2152,21 @@ dependencies = [
  "ty_module_resolver",
  "ty_python_core",
  "ty_python_semantic",
+]
+
+[[package]]
+name = "monty-types"
+version = "0.0.19-beta.4"
+dependencies = [
+ "chrono",
+ "indexmap",
+ "monty-macros",
+ "num-bigint",
+ "num-traits",
+ "serde",
+ "strum 0.27.2",
+ "unicode-general-category",
+ "web-time",
 ]
 
 [[package]]
@@ -2722,10 +2738,10 @@ name = "pydantic-monty"
 version = "0.0.19-beta.4"
 dependencies = [
  "ahash",
- "monty",
  "monty-fs",
  "monty-pool",
  "monty-proto",
+ "monty-types",
  "num-bigint",
  "pyo3",
  "pyo3-async-runtimes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,8 +1562,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1998,7 +1996,6 @@ dependencies = [
  "chrono",
  "fancy-regex 0.17.0",
  "hashbrown 0.16.1",
- "indexmap",
  "insta",
  "itertools 0.14.0",
  "itoa",
@@ -2163,7 +2160,6 @@ name = "monty-types"
 version = "0.0.19-beta.4"
 dependencies = [
  "chrono",
- "indexmap",
  "monty-macros",
  "num-bigint",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,6 @@ chrono = { version = "0.4", features = ["serde"] }
 strum = { version = "0.27", features = ["derive"] }
 itoa = "1"
 ahash = { version = "0.8.0", features = ["serde"] }
-indexmap = { version = "2.9", features = ["serde"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 postcard = { version = "1.1", features = ["alloc"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/monty",
+    "crates/monty-types",
     "crates/monty-fs",
     "crates/monty-runtime",
     "crates/monty-proto",
@@ -49,6 +50,7 @@ lto = false
 # `workspace.package.version` above and bumped together on each release — see
 # RELEASING.md.
 monty = { path = "crates/monty", version = "0.0.19-beta.4" }
+monty-types = { path = "crates/monty-types", version = "0.0.19-beta.4" }
 monty-fs = { path = "crates/monty-fs", version = "0.0.19-beta.4" }
 monty-macros = { path = "crates/monty-macros", version = "0.0.19-beta.4" }
 monty-proto = { path = "crates/monty-proto", version = "0.0.19-beta.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,8 @@ num-integer = "0.1"
 pyo3 = "0.28"
 pyo3-build-config = { version = "0.28", features = ["resolve-config"] }
 # others
+chrono = { version = "0.4", features = ["serde"] }
+strum = { version = "0.27", features = ["derive"] }
 itoa = "1"
 ahash = { version = "0.8.0", features = ["serde"] }
 indexmap = { version = "2.9", features = ["serde"] }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -32,7 +32,7 @@ Once the tag is pushed, CI will:
 - Build wheels for all platforms
 - Publish to PyPI (`pydantic-monty`)
 - Publish to NPM (`@pydantic/monty` + the platform packages carrying the napi library, the `monty` binary, and the wasm build)
-- Publish the Rust crates to crates.io (`monty`, `monty-fs`, `monty-runtime`, `monty-macros`, `monty-proto`, `monty-pool`, `monty-type-checking`, `monty-typeshed`) via `cargo publish --workspace`
+- Publish the Rust crates to crates.io (`monty`, `monty-types`, `monty-fs`, `monty-runtime`, `monty-macros`, `monty-proto`, `monty-pool`, `monty-type-checking`, `monty-typeshed`) via `cargo publish --workspace`
 
 Monitor the workflow at https://github.com/pydantic/monty/actions
 

--- a/crates/fuzz/Cargo.toml
+++ b/crates/fuzz/Cargo.toml
@@ -11,6 +11,7 @@ cargo-fuzz = true
 arbitrary = { version = "1", features = ["derive"] }
 libfuzzer-sys = "0.4"
 monty = { workspace = true }
+monty-types = { workspace = true }
 
 [[bin]]
 name = "string_input_panic"

--- a/crates/fuzz/fuzz_targets/string_input_panic.rs
+++ b/crates/fuzz/fuzz_targets/string_input_panic.rs
@@ -10,7 +10,8 @@
 use std::time::Duration;
 
 use libfuzzer_sys::fuzz_target;
-use monty::{CompileOptions, LimitedTracker, MontyRun, PrintWriter, ResourceLimits};
+use monty::MontyRun;
+use monty_types::{CompileOptions, LimitedTracker, PrintWriter, ResourceLimits};
 
 /// Resource limits for fuzzing - restrictive to prevent hangs and memory issues.
 fn fuzz_limits() -> LimitedTracker {

--- a/crates/fuzz/fuzz_targets/tokens_input_panic.rs
+++ b/crates/fuzz/fuzz_targets/tokens_input_panic.rs
@@ -12,7 +12,8 @@ use std::{
 
 use arbitrary::Arbitrary;
 use libfuzzer_sys::fuzz_target;
-use monty::{CompileOptions, LimitedTracker, MontyRun, PrintWriter, ResourceLimits};
+use monty::MontyRun;
+use monty_types::{CompileOptions, LimitedTracker, PrintWriter, ResourceLimits};
 
 /// A token representing a piece of Python syntax.
 #[derive(Debug, Clone, Arbitrary)]

--- a/crates/monty-bench/Cargo.toml
+++ b/crates/monty-bench/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 
 [dependencies]
 monty = { workspace = true, features = ["test-hooks"] }
+monty-types = { workspace = true }
 monty-pool = { workspace = true }
 pyo3 = { workspace = true, features = ["auto-initialize"] }
 codspeed-criterion-compat = "4.2.1"

--- a/crates/monty-bench/benches/main.rs
+++ b/crates/monty-bench/benches/main.rs
@@ -6,7 +6,8 @@ use std::ffi::CString;
 use codspeed_criterion_compat::{Bencher, Criterion, black_box, criterion_group, criterion_main};
 #[cfg(not(codspeed))]
 use criterion::{Bencher, Criterion, black_box, criterion_group, criterion_main};
-use monty::{CompileOptions, MontyObject, MontyRun};
+use monty::MontyRun;
+use monty_types::{CompileOptions, MontyObject};
 #[cfg(all(not(codspeed), unix))]
 use pprof::criterion::{Output, PProfProfiler};
 // CPython benchmarks are only run locally, not on CodSpeed CI (requires Python + pyo3 setup)

--- a/crates/monty-bench/benches/pool.rs
+++ b/crates/monty-bench/benches/pool.rs
@@ -18,8 +18,8 @@ use std::{
 use codspeed_criterion_compat::{Bencher, Criterion, black_box, criterion_group, criterion_main};
 #[cfg(not(codspeed))]
 use criterion::{Bencher, Criterion, black_box, criterion_group, criterion_main};
-use monty::{MontyObject, PrintStream};
 use monty_pool::{Checkout, Pool, PoolConfig, ReplConfig, ResumeValue, TurnEvent};
+use monty_types::{MontyObject, PrintStream};
 #[cfg(all(not(codspeed), unix))]
 use pprof::criterion::{Output, PProfProfiler};
 

--- a/crates/monty-datatest/Cargo.toml
+++ b/crates/monty-datatest/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 [dependencies]
 monty = { workspace = true, features = ["test-hooks"] }
 monty-fs = { workspace = true }
+monty-types = { workspace = true }
 pyo3 = { workspace = true, features = ["auto-initialize"] }
 ahash = { workspace = true }
 chrono = { workspace = true }

--- a/crates/monty-datatest/Cargo.toml
+++ b/crates/monty-datatest/Cargo.toml
@@ -13,7 +13,7 @@ monty = { workspace = true, features = ["test-hooks"] }
 monty-fs = { workspace = true }
 pyo3 = { workspace = true, features = ["auto-initialize"] }
 ahash = { workspace = true }
-chrono = "0.4"
+chrono = { workspace = true }
 datatest-stable = "0.2"
 similar = "2.7.0"
 tempfile = "3"

--- a/crates/monty-datatest/src/main.rs
+++ b/crates/monty-datatest/src/main.rs
@@ -24,12 +24,13 @@ use std::{
 
 use ahash::AHashMap;
 use chrono::{Datelike, Timelike};
-use monty::{
-    CompileOptions, ExcType, ExtFunctionResult, FileMode, LimitedTracker, MontyDate, MontyDateTime, MontyException,
-    MontyFileHandle, MontyObject, MontyRun, MontyTimeZone, NameLookupResult, OsFunctionCall, PrintWriter,
-    ResourceLimits, RunProgress, dir_stat, file_stat,
-};
+use monty::{MontyRun, RunProgress};
 use monty_fs::{MountCallOutcome, MountMode, MountTable, OverlayState};
+use monty_types::{
+    CompileOptions, ExcType, ExtFunctionResult, FileMode, LimitedTracker, MontyDate, MontyDateTime, MontyException,
+    MontyFileHandle, MontyObject, MontyTimeZone, NameLookupResult, OsFunctionCall, PrintWriter, ResourceLimits,
+    dir_stat, file_stat,
+};
 use pyo3::{prelude::*, types::PyDict};
 use similar::TextDiff;
 

--- a/crates/monty-fs/Cargo.toml
+++ b/crates/monty-fs/Cargo.toml
@@ -16,7 +16,7 @@ repository = { workspace = true }
 name = "monty_fs"
 
 [dependencies]
-monty = { workspace = true }
+monty-types = { workspace = true }
 ahash = { workspace = true }
 
 [dev-dependencies]

--- a/crates/monty-fs/README.md
+++ b/crates/monty-fs/README.md
@@ -26,6 +26,7 @@ budget; oversized operations return `MemoryError` before an unbounded read.
 ## Monty crates
 
 - [`monty`](https://crates.io/crates/monty) — the core interpreter: Python parser, bytecode VM, and sandbox.
+- [`monty-types`](https://crates.io/crates/monty-types) — the shared boundary data types (values, exceptions, OS calls, resource limits) hosts use without linking the interpreter.
 - [`monty-fs`](https://crates.io/crates/monty-fs) — host-side filesystem mounts: maps virtual sandbox paths to real host directories. **this crate**
 - [`monty-runtime`](https://crates.io/crates/monty-runtime) — the `monty` binary: REPL, file runner, and subprocess worker mode.
 - [`monty-pool`](https://crates.io/crates/monty-pool) — an elastic pool of crash-isolated `monty` worker subprocesses.

--- a/crates/monty-fs/src/common.rs
+++ b/crates/monty-fs/src/common.rs
@@ -11,7 +11,7 @@ use std::{
     time::SystemTime,
 };
 
-use monty::{MontyObject, UnicodeErrorData, dir_stat, file_stat, utf8_error_reason};
+use monty_types::{MontyObject, UnicodeErrorData, dir_stat, file_stat, utf8_error_reason};
 
 use super::error::MountError;
 

--- a/crates/monty-fs/src/direct.rs
+++ b/crates/monty-fs/src/direct.rs
@@ -5,7 +5,7 @@
 
 use std::{fs, path::PathBuf};
 
-use monty::{FileMode, MontyObject};
+use monty_types::{FileMode, MontyObject};
 
 use super::{
     common::{

--- a/crates/monty-fs/src/dispatch.rs
+++ b/crates/monty-fs/src/dispatch.rs
@@ -7,7 +7,7 @@
 //! Ownership matters: write payloads are *moved* through here so overlay
 //! storage can retain them without a copy.
 
-use monty::{FileMode, MontyFileHandle, MontyObject, MontyPath, OsFunctionCall};
+use monty_types::{FileMode, MontyFileHandle, MontyObject, MontyPath, OsFunctionCall};
 
 use super::{
     common::MountContext, direct, error::MountError, mount_mode::MountMode, overlay,

--- a/crates/monty-fs/src/error.rs
+++ b/crates/monty-fs/src/error.rs
@@ -6,7 +6,7 @@ use std::{
     io::{self, ErrorKind},
 };
 
-use monty::{ExcData, ExcType, MontyException, StringRepr, unicode_decode_error_msg};
+use monty_types::{ExcData, ExcType, MontyException, StringRepr, unicode_decode_error_msg};
 
 /// Errors from mount configuration or filesystem operations.
 #[derive(Debug)]
@@ -37,7 +37,7 @@ pub enum MountError {
 
     /// A file contained bytes that could not be decoded as UTF-8. Carries the
     /// details needed to reproduce CPython's `UnicodeDecodeError` wording
-    /// exactly (see [`monty::unicode_decode_error_msg`]).
+    /// exactly (see [`monty_types::unicode_decode_error_msg`]).
     InvalidUtf8 {
         /// Byte offset of the first invalid byte.
         start: usize,
@@ -46,7 +46,7 @@ pub enum MountError {
         end: usize,
         /// The first invalid byte value, shown in the single-byte message form.
         first_byte: u8,
-        /// CPython's reason wording, from [`monty::utf8_error_reason`].
+        /// CPython's reason wording, from [`monty_types::utf8_error_reason`].
         reason: &'static str,
         /// Structured exception fields including the undecodable file bytes
         /// (omitted for files above `UnicodeErrorData::MAX_OBJECT_LEN`), so

--- a/crates/monty-fs/src/lib.rs
+++ b/crates/monty-fs/src/lib.rs
@@ -9,7 +9,7 @@
 //! only by host/parent crates (`monty-pool`, the CLI, bindings). The `monty`
 //! interpreter crate deliberately does not depend on it — sandboxed code can
 //! only *request* filesystem operations by suspending with an
-//! [`OsFunctionCall`](monty::OsFunctionCall), which a host holding a
+//! [`OsFunctionCall`](monty_types::OsFunctionCall), which a host holding a
 //! [`MountTable`] services via [`MountTable::handle_os_call`].
 //!
 //! # Security

--- a/crates/monty-fs/src/mount_table.rs
+++ b/crates/monty-fs/src/mount_table.rs
@@ -8,7 +8,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use monty::{MontyObject, OsFunctionCall};
+use monty_types::{MontyObject, OsFunctionCall};
 
 use super::{
     common::MountContext, dispatch, error::MountError, mount_mode::MountMode, path_security::normalize_virtual_path,

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use ahash::AHashSet;
-use monty::{FileMode, MontyObject, dir_stat, file_stat};
+use monty_types::{FileMode, MontyObject, dir_stat, file_stat};
 
 use super::{
     common::{

--- a/crates/monty-fs/tests/fs.rs
+++ b/crates/monty-fs/tests/fs.rs
@@ -10,11 +10,11 @@ use std::os::unix::fs::symlink as unix_symlink;
 use std::os::windows::fs::symlink_file as win_symlink_file;
 use std::{fs, path::Path};
 
-use monty::{
+use monty_fs::{DEFAULT_MEMORY_USAGE_LIMIT, Mount, MountCallOutcome, MountError, MountMode, MountTable, OverlayState};
+use monty_types::{
     ExcType, MkdirCallArgs, MontyException, MontyObject, OsFunctionCall, PathBytesDataArgs, PathStringDataArgs,
     RenameCallArgs, UnicodeErrorData, UnicodeErrorObject,
 };
-use monty_fs::{DEFAULT_MEMORY_USAGE_LIMIT, Mount, MountCallOutcome, MountError, MountMode, MountTable, OverlayState};
 use tempfile::TempDir;
 
 // =============================================================================
@@ -1563,7 +1563,7 @@ fn non_filesystem_ops_not_handled() {
     let dir = create_test_dir();
     let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
 
-    let result = mt.handle_os_call(OsFunctionCall::Getenv(monty::GetenvArgs {
+    let result = mt.handle_os_call(OsFunctionCall::Getenv(monty_types::GetenvArgs {
         key: "PATH".to_owned(),
         default: MontyObject::None,
     }));

--- a/crates/monty-fs/tests/fs_security.rs
+++ b/crates/monty-fs/tests/fs_security.rs
@@ -10,11 +10,11 @@ use std::os::unix::fs::symlink;
 use std::os::windows::fs::{symlink_dir as win_symlink_dir, symlink_file as win_symlink_file};
 use std::{fmt, fs, path::Path};
 
-use monty::{
+use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable, OverlayState};
+use monty_types::{
     FileMode, MkdirCallArgs, MontyObject, MontyPath, OpenCallArgs, OsFunctionCall, PathBytesDataArgs,
     PathStringDataArgs,
 };
-use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable, OverlayState};
 use tempfile::TempDir;
 
 // =============================================================================
@@ -1042,7 +1042,7 @@ fn rename_traversal_src() {
 
     let result = dispatch(
         &mut mt,
-        OsFunctionCall::Rename(monty::RenameCallArgs {
+        OsFunctionCall::Rename(monty_types::RenameCallArgs {
             src: MontyPath::new("/mnt/../etc/passwd".to_owned()),
             dst: MontyPath::new("/mnt/stolen.txt".to_owned()),
         }),
@@ -1063,7 +1063,7 @@ fn rename_traversal_dst() {
 
     let result = dispatch(
         &mut mt,
-        OsFunctionCall::Rename(monty::RenameCallArgs {
+        OsFunctionCall::Rename(monty_types::RenameCallArgs {
             src: MontyPath::new("/mnt/hello.txt".to_owned()),
             dst: MontyPath::new("/mnt/../escape.txt".to_owned()),
         }),
@@ -1113,7 +1113,7 @@ fn rename_symlink_escape_overlay_read_text() {
     // Step 1: Rename the symlink within the mount.
     let rename_result = dispatch(
         &mut mt,
-        OsFunctionCall::Rename(monty::RenameCallArgs {
+        OsFunctionCall::Rename(monty_types::RenameCallArgs {
             src: MontyPath::new("/mnt/escape_link".to_owned()),
             dst: MontyPath::new("/mnt/renamed".to_owned()),
         }),
@@ -1161,7 +1161,7 @@ fn rename_symlink_escape_overlay_read_bytes() {
 
     let rename_result = dispatch(
         &mut mt,
-        OsFunctionCall::Rename(monty::RenameCallArgs {
+        OsFunctionCall::Rename(monty_types::RenameCallArgs {
             src: MontyPath::new("/mnt/escape_link".to_owned()),
             dst: MontyPath::new("/mnt/renamed".to_owned()),
         }),

--- a/crates/monty-js/Cargo.toml
+++ b/crates/monty-js/Cargo.toml
@@ -19,7 +19,7 @@ repository = { workspace = true }
 crate-type = ["cdylib"]
 
 [dependencies]
-monty = { workspace = true }
+monty-types = { workspace = true }
 monty-pool = { workspace = true }
 monty-type-checking = { workspace = true }
 napi = { version = "3.8", default-features = false, features = ["napi6", "compat-mode", "tokio_rt"] }

--- a/crates/monty-js/src/convert.rs
+++ b/crates/monty-js/src/convert.rs
@@ -28,7 +28,7 @@
 
 use std::{collections::HashMap, ptr};
 
-use monty::{DictPairs, ExcType, MontyDate, MontyDateTime, MontyObject, MontyTimeDelta, MontyTimeZone};
+use monty_types::{DictPairs, ExcType, MontyDate, MontyDateTime, MontyObject, MontyTimeDelta, MontyTimeZone};
 use napi::{bindgen_prelude::*, sys::Status};
 use num_bigint::BigInt as NumBigInt;
 

--- a/crates/monty-js/src/exceptions.rs
+++ b/crates/monty-js/src/exceptions.rs
@@ -9,7 +9,7 @@
 //!
 //! ## Architecture
 //!
-//! - `JsMontyException`: Thin wrapper around `monty::MontyException`. The JS wrapper
+//! - `JsMontyException`: Thin wrapper around `monty_types::MontyException`. The JS wrapper
 //!   checks `exception.typeName` to distinguish syntax errors from runtime errors.
 //! - `MontyTypingError`: Wraps `TypeCheckingDiagnostics` for static type checking errors.
 //!   This is separate because type errors come from static analysis, not Python execution.
@@ -31,7 +31,7 @@ use serde::{Deserialize, Serialize};
 /// JavaScript wrapper to construct appropriate error types (`MontySyntaxError`
 /// or `MontyRuntimeError`) based on the exception type.
 #[napi(js_name = "MontyException")]
-pub struct JsMontyException(monty::MontyException);
+pub struct JsMontyException(monty_types::MontyException);
 
 impl fmt::Display for JsMontyException {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -142,7 +142,7 @@ impl JsMontyException {
 impl JsMontyException {
     /// Creates a new JsMontyException from a core MontyException.
     #[must_use]
-    pub fn new(exc: monty::MontyException) -> Self {
+    pub fn new(exc: monty_types::MontyException) -> Self {
         Self(exc)
     }
 }

--- a/crates/monty-js/src/limits.rs
+++ b/crates/monty-js/src/limits.rs
@@ -5,7 +5,7 @@
 
 use std::time::Duration;
 
-use monty::{ResourceLimits, DEFAULT_MAX_RECURSION_DEPTH};
+use monty_types::{ResourceLimits, DEFAULT_MAX_RECURSION_DEPTH};
 use napi::{Error, Result, Status};
 use napi_derive::napi;
 

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -28,11 +28,11 @@ use std::{
     time::Duration,
 };
 
-use monty::{AssertMessageAnnotations, ExcType, MontyException, MontyObject, PrintStream, StackFrame};
 use monty_pool::{
     exceeds_max_value_depth, Checkout, MountSpec, MountSpecMode, OnPrint, Pool, PoolConfig, PoolError, ReplConfig,
     ResumeValue, TurnEvent,
 };
+use monty_types::{AssertMessageAnnotations, ExcType, MontyException, MontyObject, PrintStream, StackFrame};
 use napi::{
     bindgen_prelude::{
         block_on, spawn_blocking, Array, Buffer, FnArgs, FromNapiValue, Function, JsObjectValue, Object, PromiseRaw,

--- a/crates/monty-macros/README.md
+++ b/crates/monty-macros/README.md
@@ -133,6 +133,7 @@ Cross-crate use would need `proc-macro-crate` plus switching to
 ## Monty crates
 
 - [`monty`](https://crates.io/crates/monty) — the core interpreter: Python parser, bytecode VM, and sandbox.
+- [`monty-types`](https://crates.io/crates/monty-types) — the shared boundary data types (values, exceptions, OS calls, resource limits) hosts use without linking the interpreter.
 - [`monty-fs`](https://crates.io/crates/monty-fs) — host-side filesystem mounts: maps virtual sandbox paths to real host directories.
 - [`monty-runtime`](https://crates.io/crates/monty-runtime) — the `monty` binary: REPL, file runner, and subprocess worker mode.
 - [`monty-pool`](https://crates.io/crates/monty-pool) — an elastic pool of crash-isolated `monty` worker subprocesses.

--- a/crates/monty-macros/src/from_args.rs
+++ b/crates/monty-macros/src/from_args.rs
@@ -394,7 +394,7 @@ impl Signature {
                 /// struct's `DropWithContext` impl (driven by a `DropGuard`).
                 pub(crate) fn from_args(
                     args: crate::args::ArgValues,
-                    vm: &mut crate::bytecode::VM<'_, impl crate::resource::ResourceTracker>,
+                    vm: &mut crate::bytecode::VM<'_, impl crate::ResourceTracker>,
                 ) -> crate::exception_private::RunResult<Self> {
                     #spec
 

--- a/crates/monty-macros/src/from_args.rs
+++ b/crates/monty-macros/src/from_args.rs
@@ -394,7 +394,7 @@ impl Signature {
                 /// struct's `DropWithContext` impl (driven by a `DropGuard`).
                 pub(crate) fn from_args(
                     args: crate::args::ArgValues,
-                    vm: &mut crate::bytecode::VM<'_, impl crate::ResourceTracker>,
+                    vm: &mut crate::bytecode::VM<'_, impl ::monty_types::ResourceTracker>,
                 ) -> crate::exception_private::RunResult<Self> {
                     #spec
 

--- a/crates/monty-pool/Cargo.toml
+++ b/crates/monty-pool/Cargo.toml
@@ -16,7 +16,7 @@ repository = { workspace = true }
 name = "monty_pool"
 
 [dependencies]
-monty = { workspace = true }
+monty-types = { workspace = true }
 monty-fs = { workspace = true }
 monty-proto = { workspace = true }
 # Blocking WebSocket client for the remote (Websocket) transport. The pool is

--- a/crates/monty-pool/README.md
+++ b/crates/monty-pool/README.md
@@ -90,6 +90,7 @@ session remain alive and usable.
 ## Monty crates
 
 - [`monty`](https://crates.io/crates/monty) — the core interpreter: Python parser, bytecode VM, and sandbox.
+- [`monty-types`](https://crates.io/crates/monty-types) — the shared boundary data types (values, exceptions, OS calls, resource limits) hosts use without linking the interpreter.
 - [`monty-fs`](https://crates.io/crates/monty-fs) — host-side filesystem mounts: maps virtual sandbox paths to real host directories.
 - [`monty-runtime`](https://crates.io/crates/monty-runtime) — the `monty` binary: REPL, file runner, and subprocess worker mode.
 - [`monty-pool`](https://crates.io/crates/monty-pool) — an elastic pool of crash-isolated `monty` worker subprocesses. **this crate**

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -2,11 +2,11 @@
 
 use std::{borrow::Cow, path::PathBuf, sync::Arc, time::Duration};
 
-use monty::{
-    AssertMessageAnnotations, ExcType, MontyException, MontyObject, OsFunctionCall, PrintStream, ResourceLimits,
-};
 use monty_fs::{MountCallOutcome, MountMode, MountTable, OverlayState};
 use monty_proto::{FrameError, MONTY_VERSION, exceeds_max_value_depth, pb, validate_requirement};
+use monty_types::{
+    AssertMessageAnnotations, ExcType, MontyException, MontyObject, OsFunctionCall, PrintStream, ResourceLimits,
+};
 
 use crate::{PoolError, pool::PoolInner, watchdog::DeadlineGuard, worker::Worker};
 

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -7,8 +7,8 @@ mod worker;
 
 use std::{borrow::Cow, error, fmt, io, num::NonZero, path::PathBuf, process::ExitStatus, thread, time::Duration};
 
-use monty::MontyException;
 pub use monty_proto::{MAX_VALUE_DEPTH, exceeds_max_value_depth};
+use monty_types::MontyException;
 
 pub use crate::{
     checkout::{Checkout, MountSpec, MountSpecMode, OnPrint, ReplConfig, ResumeValue, TurnEvent},

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -13,8 +13,8 @@ use std::{
 #[cfg(target_os = "linux")]
 use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 
-use monty::{MontyObject, PrintStream, ResourceLimits};
 use monty_pool::{MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, ReplConfig, ResumeValue, TurnEvent};
+use monty_types::{MontyObject, PrintStream, ResourceLimits};
 
 /// Locates (building once if needed) the `monty` CLI binary for tests.
 fn monty_binary() -> PathBuf {

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -10,9 +10,9 @@ use std::{
     time::Duration,
 };
 
-use monty::{AssertMessageAnnotations, MontyObject, PrintStream, ResourceLimits};
 use monty_pool::{MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, ReplConfig, TurnEvent};
 use monty_proto::{decode_frame, encode_to_capped_vec, pb};
+use monty_types::{AssertMessageAnnotations, MontyObject, PrintStream, ResourceLimits};
 use tungstenite::{Message, WebSocket};
 
 /// A mock child: accepts one WebSocket connection and answers each request with

--- a/crates/monty-proto/Cargo.toml
+++ b/crates/monty-proto/Cargo.toml
@@ -16,8 +16,10 @@ repository = { workspace = true }
 name = "monty_proto"
 
 [dependencies]
-monty = { workspace = true }
+monty-types = { workspace = true }
 num-bigint = { workspace = true }
+# Optional: the worker feature's Child state machine drives the interpreter
+monty = { workspace = true, optional = true }
 prost = { workspace = true }
 # Optional: used with the worker feature
 monty-type-checking = { workspace = true, optional = true }
@@ -36,8 +38,10 @@ generate = ["dep:prost-build", "dep:protox"]
 # and `MontyObject`/`MontyException`. Off by default so pure-Rust consumers
 # (monty-pool, monty-runtime) never build or link against libpython.
 python = ["dep:pyo3"]
-# enable the worker feature
-worker = ["dep:monty-type-checking"]
+# Enables the `worker` module: the child-side Child state machine that drives
+# the interpreter. Off by default so host-side consumers (monty-pool, the
+# bindings) never link the interpreter itself.
+worker = ["dep:monty", "dep:monty-type-checking"]
 
 [[bin]]
 name = "generate-proto"
@@ -49,6 +53,9 @@ required-features = ["generate"]
 [[test]]
 name = "dispatch"
 required-features = ["worker"]
+
+[dev-dependencies]
+monty = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/monty-proto/README.md
+++ b/crates/monty-proto/README.md
@@ -59,6 +59,7 @@ A transport-agnostic Monty protocol-child state machine, shared by the native su
 ## Monty crates
 
 - [`monty`](https://crates.io/crates/monty) — the core interpreter: Python parser, bytecode VM, and sandbox.
+- [`monty-types`](https://crates.io/crates/monty-types) — the shared boundary data types (values, exceptions, OS calls, resource limits) hosts use without linking the interpreter.
 - [`monty-fs`](https://crates.io/crates/monty-fs) — host-side filesystem mounts: maps virtual sandbox paths to real host directories.
 - [`monty-runtime`](https://crates.io/crates/monty-runtime) — the `monty` binary: REPL, file runner, and subprocess worker mode.
 - [`monty-pool`](https://crates.io/crates/monty-pool) — an elastic pool of crash-isolated `monty` worker subprocesses.

--- a/crates/monty-proto/src/bin/generate.rs
+++ b/crates/monty-proto/src/bin/generate.rs
@@ -8,7 +8,7 @@
 //! - `src/generated/monty.v1.rs` — the protocol messages, with the
 //!   `monty.v1.MontyObject` message mapped via `extern_path` onto the
 //!   hand-written [`WireObject`](../wire.rs) so values encode/decode straight
-//!   to `monty::MontyObject` with no mirror struct.
+//!   to `monty_types::MontyObject` with no mirror struct.
 //! - `tests/oracle/monty.v1.rs` — the same schema *without* the mapping: a
 //!   fully prost-generated mirror used only by `tests/differential.rs` to
 //!   prove the hand-written implementation is byte-compatible with prost.

--- a/crates/monty-proto/src/convert/exception.rs
+++ b/crates/monty-proto/src/convert/exception.rs
@@ -4,7 +4,7 @@
 
 use std::sync::Arc;
 
-use monty::{CodeLoc, ExcData, JsonErrorData, MontyException, StackFrame, UnicodeErrorData, UnicodeErrorObject};
+use monty_types::{CodeLoc, ExcData, JsonErrorData, MontyException, StackFrame, UnicodeErrorData, UnicodeErrorObject};
 
 use crate::{convert::ProtoConvertError, pb};
 

--- a/crates/monty-proto/src/convert/limits.rs
+++ b/crates/monty-proto/src/convert/limits.rs
@@ -7,7 +7,7 @@
 
 use std::time::Duration;
 
-use monty::{DEFAULT_MAX_RECURSION_DEPTH, ResourceLimits};
+use monty_types::{DEFAULT_MAX_RECURSION_DEPTH, ResourceLimits};
 
 use crate::pb;
 

--- a/crates/monty-proto/src/convert/mod.rs
+++ b/crates/monty-proto/src/convert/mod.rs
@@ -22,7 +22,7 @@ mod resume;
 
 use std::{error, fmt};
 
-use monty::{DictPairs, MontyObject};
+use monty_types::{DictPairs, MontyObject};
 pub use resume::future_results_from_proto;
 
 /// Why a wire value could not be converted into its monty equivalent.

--- a/crates/monty-proto/src/convert/os_call.rs
+++ b/crates/monty-proto/src/convert/os_call.rs
@@ -2,7 +2,7 @@
 //! `monty.v1.OsCall` and [`OsFunctionCall`] map 1:1, so payloads (write data,
 //! paths) *move* between the wire and the call — never clone.
 
-use monty::{
+use monty_types::{
     GetenvArgs, MkdirCallArgs, MontyPath, MontyTimeZone, OpenCallArgs, OsFunctionCall, PathBytesDataArgs,
     PathStringDataArgs, RenameCallArgs,
 };

--- a/crates/monty-proto/src/convert/resume.rs
+++ b/crates/monty-proto/src/convert/resume.rs
@@ -1,7 +1,7 @@
 //! Conversions for resume payloads: the parent's answers to suspension
 //! events (`ResumeCall`, `ResumeNameLookup`, `ResumeFutures`).
 
-use monty::{ExtFunctionResult, MontyException, NameLookupResult};
+use monty_types::{ExtFunctionResult, MontyException, NameLookupResult};
 
 use crate::{convert::ProtoConvertError, pb};
 

--- a/crates/monty-proto/src/python/convert.rs
+++ b/crates/monty-proto/src/python/convert.rs
@@ -3,7 +3,7 @@
 
 use std::borrow::Cow;
 
-use monty::{
+use monty_types::{
     FileMode, MontyDate, MontyDateTime, MontyException, MontyFileHandle, MontyObject, MontyTimeDelta, MontyTimeZone,
     MontyType, StringRepr,
 };

--- a/crates/monty-proto/src/python/dataclass.rs
+++ b/crates/monty-proto/src/python/dataclass.rs
@@ -10,7 +10,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use monty::{DictPairs, MontyObject};
+use monty_types::{DictPairs, MontyObject};
 use pyo3::{
     Bound,
     exceptions::{PyAttributeError, PyTypeError},

--- a/crates/monty-proto/src/python/exceptions.rs
+++ b/crates/monty-proto/src/python/exceptions.rs
@@ -7,7 +7,7 @@
 //! snapshots). The Python-facing `MontyError` class hierarchy stays in
 //! `pydantic-monty` — this module only maps values.
 
-use monty::{ExcData, ExcType, JsonErrorData, MontyException, MontyObject, UnicodeErrorObject};
+use monty_types::{ExcData, ExcType, JsonErrorData, MontyException, MontyObject, UnicodeErrorObject};
 use pyo3::{
     PyTypeCheck,
     exceptions::{self},

--- a/crates/monty-proto/src/wire.rs
+++ b/crates/monty-proto/src/wire.rs
@@ -31,7 +31,7 @@
 
 use std::{cell::Cell, fmt::Display, ops::RangeInclusive};
 
-use monty::{
+use monty_types::{
     DictPairs, MontyDate, MontyDateTime, MontyFileHandle, MontyObject, MontyTimeDelta, MontyTimeZone, MontyType,
 };
 use num_bigint::{BigInt, Sign};

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -18,11 +18,12 @@
 
 use std::{borrow::Cow, mem};
 
-use monty::{
-    AssertMessageAnnotations, CompileOptions, ExcType, ExtFunctionResult, LimitedTracker, MontyException, MontyObject,
-    MontyRepl, OsFunctionCall, PrintWriter, PrintWriterCallback, ReplProgress, ReplStartError,
-};
+use monty::{MontyRepl, ReplProgress, ReplStartError};
 use monty_type_checking::{SourceFile, type_check};
+use monty_types::{
+    AssertMessageAnnotations, CompileOptions, ExcType, ExtFunctionResult, LimitedTracker, MontyException, MontyObject,
+    OsFunctionCall, PrintWriter, PrintWriterCallback,
+};
 
 use super::{
     FrameError, FrameReader, MAX_FRAME_LEN, MONTY_VERSION, WireFunctionCall, exceeds_max_frame_len,

--- a/crates/monty-proto/tests/differential.rs
+++ b/crates/monty-proto/tests/differential.rs
@@ -15,11 +15,12 @@
 //! validation now happens during decode, so these tests pin the exact error
 //! messages a misbehaving peer produces.
 
-use monty::{
-    CompileOptions, DictPairs, ExcType, MontyDate, MontyDateTime, MontyFileHandle, MontyObject, MontyRun,
-    MontyTimeDelta, MontyTimeZone, MontyType,
-};
+use monty::MontyRun;
 use monty_proto::{WireFunctionCall, WireObject, pb};
+use monty_types::{
+    CompileOptions, DictPairs, ExcType, MontyDate, MontyDateTime, MontyFileHandle, MontyObject, MontyTimeDelta,
+    MontyTimeZone, MontyType,
+};
 use num_bigint::{BigInt, Sign};
 use prost::Message;
 

--- a/crates/monty-proto/tests/dispatch.rs
+++ b/crates/monty-proto/tests/dispatch.rs
@@ -5,12 +5,13 @@
 //! `Child` state machine over the message-based transport without any wasm
 //! toolchain.
 
-use monty::{CompileOptions, LimitedTracker, MontyObject, MontyRepl, PrintWriter, ReplProgress, ResourceLimits};
+use monty::{MontyRepl, ReplProgress};
 use monty_proto::{
     FrameReader, MONTY_VERSION, WireObject, pb,
     worker::{Child, HandleOutcome, dispatch_frame},
     write_frame,
 };
+use monty_types::{CompileOptions, LimitedTracker, MontyObject, PrintWriter, ResourceLimits};
 
 /// Frames one request the way a host transport would before posting it.
 fn frame_request(kind: pb::parent_request::Kind) -> Vec<u8> {

--- a/crates/monty-proto/tests/roundtrip.rs
+++ b/crates/monty-proto/tests/roundtrip.rs
@@ -1,12 +1,13 @@
 use std::time::Duration;
 
-use monty::{
-    CodeLoc, CompileOptions, DictPairs, ExcData, ExcType, ExtFunctionResult, GetenvArgs, JsonErrorData, MkdirCallArgs,
-    MontyDate, MontyDateTime, MontyException, MontyFileHandle, MontyObject, MontyPath, MontyRun, MontyTimeDelta,
-    MontyTimeZone, MontyType, NameLookupResult, OpenCallArgs, OsFunctionCall, PathBytesDataArgs, PathStringDataArgs,
-    RenameCallArgs, ResourceLimits, StackFrame, UnicodeErrorData,
-};
+use monty::MontyRun;
 use monty_proto::{MAX_VALUE_DEPTH, ProtoConvertError, WireObject, exceeds_max_value_depth, pb};
+use monty_types::{
+    CodeLoc, CompileOptions, DictPairs, ExcData, ExcType, ExtFunctionResult, GetenvArgs, JsonErrorData, MkdirCallArgs,
+    MontyDate, MontyDateTime, MontyException, MontyFileHandle, MontyObject, MontyPath, MontyTimeDelta, MontyTimeZone,
+    MontyType, NameLookupResult, OpenCallArgs, OsFunctionCall, PathBytesDataArgs, PathStringDataArgs, RenameCallArgs,
+    ResourceLimits, StackFrame, UnicodeErrorData,
+};
 use num_bigint::BigInt;
 use prost::Message;
 

--- a/crates/monty-python/Cargo.toml
+++ b/crates/monty-python/Cargo.toml
@@ -23,7 +23,7 @@ crate-type = ["cdylib"]
 ahash = { workspace = true }
 monty-pool = { workspace = true }
 monty-proto = { workspace = true, features = ["python"] }
-monty = { workspace = true }
+monty-types = { workspace = true }
 monty-fs = { workspace = true }
 pyo3 = { workspace = true, features = ["indexmap", "generate-import-lib", "num-bigint"] }
 num-bigint = { workspace = true }
@@ -36,8 +36,6 @@ pyo3-build-config = { workspace = true }
 [features]
 # make extensions visible to cargo vendor
 extension-module = ["pyo3/generate-import-lib"]
-# Forwards `monty`'s `test-hooks` feature for test harness builds.
-test-hooks = ["monty/test-hooks"]
 
 [lints]
 workspace = true

--- a/crates/monty-python/pyproject.toml
+++ b/crates/monty-python/pyproject.toml
@@ -46,6 +46,7 @@ Source = "https://github.com/pydantic/monty"
 python-source = "python"
 module-name = "pydantic_monty._monty"
 features = ["pyo3/extension-module"]
+exclude = ["python/pydantic_monty/*.so", "python/pydantic_monty/__pycache__/**"]
 
 [tool.uv.sources]
 # during development the runtime package is built from this workspace rather

--- a/crates/monty-python/src/async_dispatch.rs
+++ b/crates/monty-python/src/async_dispatch.rs
@@ -5,8 +5,8 @@
 //! (`ResolveFutures`), the completed task results are batched back to the
 //! worker.
 
-use ::monty::{ExtFunctionResult, MontyObject};
 use monty_proto::python::DcRegistry;
+use monty_types::{ExtFunctionResult, MontyObject};
 use pyo3::{exceptions::PyRuntimeError, prelude::*, types::PyDict};
 use pyo3_async_runtimes::tokio::into_future;
 use tokio::task::{JoinError, JoinSet};

--- a/crates/monty-python/src/build.rs
+++ b/crates/monty-python/src/build.rs
@@ -6,8 +6,8 @@
 //! unconvertible values) into the matching `MontyError` subclasses rather
 //! than leaking raw PyO3 errors.
 
-use ::monty::{ExcType, MontyException, MontyObject};
 use monty_proto::python::{DcRegistry, exc_py_to_monty, py_to_monty_value};
+use monty_types::{ExcType, MontyException, MontyObject};
 use pyo3::{
     prelude::*,
     types::{PyDict, PyString},

--- a/crates/monty-python/src/exceptions.rs
+++ b/crates/monty-python/src/exceptions.rs
@@ -17,9 +17,9 @@
 
 use std::sync::Arc;
 
-use ::monty::{ExcType, MontyException};
 use ahash::AHashMap;
 use monty_proto::python::exc_monty_to_py;
+use monty_types::{ExcType, MontyException};
 use pyo3::{
     PyClassInitializer,
     exceptions::{self},

--- a/crates/monty-python/src/external.rs
+++ b/crates/monty-python/src/external.rs
@@ -7,8 +7,8 @@
 //! one place. Dataclass method calls (`dispatch_method_call*`) are a separate
 //! concern: they consult the dataclass instance, not `external_lookup`.
 
-use ::monty::{ExtFunctionResult, MontyObject};
 use monty_proto::python::{DcRegistry, exc_py_to_monty, monty_to_py, py_to_monty, py_to_monty_value};
+use monty_types::{ExtFunctionResult, MontyObject};
 use pyo3::{
     exceptions::{PyAttributeError, PyRuntimeError},
     prelude::*,

--- a/crates/monty-python/src/limits.rs
+++ b/crates/monty-python/src/limits.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use monty::DEFAULT_MAX_RECURSION_DEPTH;
+use monty_types::DEFAULT_MAX_RECURSION_DEPTH;
 use pyo3::{exceptions::PyValueError, prelude::*, types::PyDict};
 
 /// Extracts resource limits from a Python dict.
@@ -19,7 +19,7 @@ use pyo3::{exceptions::PyValueError, prelude::*, types::PyDict};
 ///
 /// Raises `TypeError` if a value is present but has the wrong type.
 /// Raises `ValueError` if `max_duration_secs` is not a valid duration value.
-pub fn extract_limits(dict: &Bound<'_, PyDict>) -> PyResult<monty::ResourceLimits> {
+pub fn extract_limits(dict: &Bound<'_, PyDict>) -> PyResult<monty_types::ResourceLimits> {
     let max_allocations = extract_optional_usize(dict, "max_allocations")?;
     let max_duration_secs = extract_optional_f64(dict, "max_duration_secs")?;
     let max_memory = extract_optional_usize(dict, "max_memory")?;
@@ -27,7 +27,7 @@ pub fn extract_limits(dict: &Bound<'_, PyDict>) -> PyResult<monty::ResourceLimit
     let max_recursion_depth =
         extract_optional_usize(dict, "max_recursion_depth")?.or(Some(DEFAULT_MAX_RECURSION_DEPTH));
 
-    let mut limits = monty::ResourceLimits::new().max_recursion_depth(max_recursion_depth);
+    let mut limits = monty_types::ResourceLimits::new().max_recursion_depth(max_recursion_depth);
 
     if let Some(max) = max_allocations {
         limits = limits.max_allocations(max);

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -34,9 +34,9 @@ use std::{
     time::Duration,
 };
 
-use ::monty::{AssertMessageAnnotations, ExtFunctionResult, MontyException, MontyObject};
 use monty_pool::{Checkout, MountSpec, Pool, PoolConfig, PoolError, ReplConfig, ResumeValue, TurnEvent};
 use monty_proto::python::{DcRegistry, exc_py_to_monty, monty_to_py, py_to_monty_value};
+use monty_types::{AssertMessageAnnotations, ExtFunctionResult, MontyException, MontyObject};
 use pyo3::{
     Borrowed,
     exceptions::{PyRuntimeError, PyTimeoutError, PyTypeError, PyValueError},

--- a/crates/monty-python/src/print_target.rs
+++ b/crates/monty-python/src/print_target.rs
@@ -16,8 +16,8 @@
 
 use std::sync::{Arc, Mutex, PoisonError};
 
-use monty::{MontyException, PrintStream};
 use monty_proto::python::exc_py_to_monty;
+use monty_types::{MontyException, PrintStream};
 use pyo3::{
     PyRef,
     exceptions::PyTypeError,

--- a/crates/monty-python/src/snapshot.rs
+++ b/crates/monty-python/src/snapshot.rs
@@ -32,9 +32,9 @@ use std::{
     },
 };
 
-use ::monty::{ExtFunctionResult, MontyException, MontyObject};
 use monty_pool::{Checkout, OnPrint, PoolError, ResumeValue, TurnEvent};
 use monty_proto::python::{DcRegistry, exc_py_to_monty, monty_to_py, py_to_monty_value};
+use monty_types::{ExtFunctionResult, MontyException, MontyObject};
 use pyo3::{
     Borrowed,
     exceptions::{PyBaseException, PyRuntimeError, PyTypeError},

--- a/crates/monty-runtime/Cargo.toml
+++ b/crates/monty-runtime/Cargo.toml
@@ -22,6 +22,7 @@ monty = { workspace = true }
 monty-fs = { workspace = true }
 monty-proto = { workspace = true, features = ["worker"] }
 monty-type-checking = { workspace = true }
+monty-types = { workspace = true }
 rustyline = "15"
 
 [dev-dependencies]

--- a/crates/monty-runtime/README.md
+++ b/crates/monty-runtime/README.md
@@ -46,6 +46,7 @@ install it directly.
 ## Monty crates
 
 - [`monty`](https://crates.io/crates/monty) — the core interpreter: Python parser, bytecode VM, and sandbox.
+- [`monty-types`](https://crates.io/crates/monty-types) — the shared boundary data types (values, exceptions, OS calls, resource limits) hosts use without linking the interpreter.
 - [`monty-fs`](https://crates.io/crates/monty-fs) — host-side filesystem mounts: maps virtual sandbox paths to real host directories.
 - [`monty-runtime`](https://crates.io/crates/monty-runtime) — the `monty` binary: REPL, file runner, and subprocess worker mode. **this crate**
 - [`monty-pool`](https://crates.io/crates/monty-pool) — an elastic pool of crash-isolated `monty` worker subprocesses.

--- a/crates/monty-runtime/src/main.rs
+++ b/crates/monty-runtime/src/main.rs
@@ -7,11 +7,12 @@ use std::{
 };
 
 use clap::{Parser, Subcommand};
-use monty::{
-    CompileOptions, LimitedTracker, MontyObject, MontyRepl, MontyRun, NameLookupResult, NoLimitTracker, PrintWriter,
-    ReplContinuationMode, ReplProgress, ResourceLimits, ResourceTracker, RunProgress, detect_repl_continuation_mode,
-};
+use monty::{MontyRepl, MontyRun, ReplContinuationMode, ReplProgress, RunProgress, detect_repl_continuation_mode};
 use monty_fs::{MountCallOutcome, MountMode, MountTable, OverlayState};
+use monty_types::{
+    CompileOptions, ExtFunctionResult, LimitedTracker, MontyObject, NameLookupResult, NoLimitTracker, OsFunctionCall,
+    PrintWriter, ResourceLimits, ResourceTracker,
+};
 use rustyline::{DefaultEditor, error::ReadlineError};
 // disabled due to format failing on https://github.com/pydantic/monty/pull/75 where CI and local wanted imports ordered differently
 // TODO re-enabled soon!
@@ -603,7 +604,7 @@ fn run_until_complete(
 /// returns the operation result as an `ExtFunctionResult` — either a
 /// successful `MontyObject` or an exception for errors / unsupported
 /// operations.
-fn handle_os_call(call: monty::OsFunctionCall, mount_table: &mut Option<MountTable>) -> monty::ExtFunctionResult {
+fn handle_os_call(call: OsFunctionCall, mount_table: &mut Option<MountTable>) -> ExtFunctionResult {
     match mount_table.as_mut() {
         Some(mounts) => match mounts.handle_os_call(call) {
             MountCallOutcome::Handled(Ok(obj)) => obj.into(),

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -10,8 +10,8 @@ use std::{
     time::Duration,
 };
 
-use monty::MontyObject;
 use monty_proto::{FrameError, FrameReader, WireObject, pb, write_frame};
+use monty_types::MontyObject;
 
 /// A spawned `monty subprocess` child with framed pipes.
 struct ChildProc {

--- a/crates/monty-type-checking/README.md
+++ b/crates/monty-type-checking/README.md
@@ -49,6 +49,7 @@ concurrent checks on different databases.
 ## Monty crates
 
 - [`monty`](https://crates.io/crates/monty) — the core interpreter: Python parser, bytecode VM, and sandbox.
+- [`monty-types`](https://crates.io/crates/monty-types) — the shared boundary data types (values, exceptions, OS calls, resource limits) hosts use without linking the interpreter.
 - [`monty-fs`](https://crates.io/crates/monty-fs) — host-side filesystem mounts: maps virtual sandbox paths to real host directories.
 - [`monty-runtime`](https://crates.io/crates/monty-runtime) — the `monty` binary: REPL, file runner, and subprocess worker mode.
 - [`monty-pool`](https://crates.io/crates/monty-pool) — an elastic pool of crash-isolated `monty` worker subprocesses.

--- a/crates/monty-types/Cargo.toml
+++ b/crates/monty-types/Cargo.toml
@@ -16,8 +16,8 @@ name = "monty_types"
 
 [dependencies]
 serde = { workspace = true }
-strum = { version = "0.27", features = ["derive"] }
-chrono = { version = "0.4", features = ["serde"] }
+strum = { workspace = true }
+chrono = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
 indexmap = { workspace = true }

--- a/crates/monty-types/Cargo.toml
+++ b/crates/monty-types/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "monty-types"
+readme = "README.md"
 version = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/monty-types/Cargo.toml
+++ b/crates/monty-types/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "monty-types"
+version = { workspace = true }
+license = { workspace = true }
+rust-version = { workspace = true }
+edition = { workspace = true }
+authors = { workspace = true }
+description = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+
+[lib]
+name = "monty_types"
+
+[dependencies]
+serde = { workspace = true }
+strum = { version = "0.27", features = ["derive"] }
+chrono = { version = "0.4", features = ["serde"] }
+num-bigint = { workspace = true }
+num-traits = { workspace = true }
+indexmap = { workspace = true }
+unicode-general-category = { workspace = true }
+monty-macros = { workspace = true }
+
+# `std::time::Instant` panics on `wasm32-unknown-unknown`, so the resource
+# tracker uses `web_time::Instant` (a `performance.now()`-backed drop-in) there
+# to keep `max_duration` working when `monty` is embedded directly in a browser
+# wasm module. Only that target needs it; every other target uses std directly.
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+web-time = "1.1"
+
+[features]
+# test-hooks exposes small internal helpers needed by integration tests that
+# exercise production behavior (e.g. `ResourceTracker::lower_recursion_limit`
+# backing `sys.setrecursionlimit`). Forwarded by monty's own `test-hooks`.
+test-hooks = []
+
+[lints]
+workspace = true

--- a/crates/monty-types/Cargo.toml
+++ b/crates/monty-types/Cargo.toml
@@ -16,14 +16,13 @@ repository = { workspace = true }
 name = "monty_types"
 
 [dependencies]
+monty-macros = { workspace = true }
 serde = { workspace = true }
 strum = { workspace = true }
 chrono = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
-indexmap = { workspace = true }
 unicode-general-category = { workspace = true }
-monty-macros = { workspace = true }
 
 # `std::time::Instant` panics on `wasm32-unknown-unknown`, so the resource
 # tracker uses `web_time::Instant` (a `performance.now()`-backed drop-in) there

--- a/crates/monty-types/README.md
+++ b/crates/monty-types/README.md
@@ -40,3 +40,19 @@ use monty_types::MontyObject;
 let value = MontyObject::List(vec![MontyObject::Int(1), MontyObject::String("x".to_owned())]);
 assert_eq!(value.py_repr(), "[1, 'x']");
 ```
+
+## Monty crates
+
+- [`monty`](https://crates.io/crates/monty) — the core interpreter: Python parser, bytecode VM, and sandbox.
+- [`monty-types`](https://crates.io/crates/monty-types) — the shared boundary data types (values, exceptions, OS calls, resource limits) hosts use without linking the interpreter. **this crate**
+- [`monty-fs`](https://crates.io/crates/monty-fs) — host-side filesystem mounts: maps virtual sandbox paths to real host directories.
+- [`monty-runtime`](https://crates.io/crates/monty-runtime) — the `monty` binary: REPL, file runner, and subprocess worker mode.
+- [`monty-pool`](https://crates.io/crates/monty-pool) — an elastic pool of crash-isolated `monty` worker subprocesses.
+- [`monty-proto`](https://crates.io/crates/monty-proto) — the protobuf wire protocol spoken between pool parents and workers.
+- [`monty-type-checking`](https://crates.io/crates/monty-type-checking) — type checking of sandboxed code, powered by [ty](https://docs.astral.sh/ty/).
+- [`monty-typeshed`](https://crates.io/crates/monty-typeshed) — the trimmed typeshed stubs describing the stdlib subset Monty implements.
+- [`monty-macros`](https://crates.io/crates/monty-macros) — the proc macros behind `monty`'s argument parsing.
+
+## License
+
+MIT

--- a/crates/monty-types/README.md
+++ b/crates/monty-types/README.md
@@ -1,0 +1,42 @@
+# monty-types
+
+Shared boundary types for [Monty](https://github.com/pydantic/monty), the
+sandboxed Python interpreter — the owned, heap-free data types that cross
+between the interpreter and the hosts that embed it, with **no interpreter
+implementation**.
+
+## What's here
+
+- `MontyObject` / `MontyType` — Python values and their types at the host
+  boundary, including the `datetime` family (`MontyDate`, `MontyDateTime`,
+  `MontyTimeDelta`, `MontyTimeZone`), `DictPairs` and `MontyFileHandle`.
+- `MontyException` / `ExcType` — exceptions with tracebacks (`StackFrame`,
+  `CodeLoc`) and structured payloads (`ExcData`).
+- `OsFunctionCall` — the typed OS-call payloads sandboxed code suspends with
+  (file reads/writes, `open()`, `os.getenv`, ...), plus the `stat_result`
+  builders hosts use to answer them.
+- `ResourceTracker` / `ResourceLimits` — the resource-limit trait the
+  interpreter is generic over, with the stock `NoLimitTracker` and
+  `LimitedTracker` implementations.
+- `PrintStream` / `PrintWriter` — `print()` output capture.
+- `CompileOptions`, `ExtFunctionResult`, `NameLookupResult`, `FileMode`, and
+  the CPython-compatible formatting helpers behind their `repr()`s.
+
+## Who should depend on it
+
+Host-side crates that talk to Monty workers over the wire — `monty-fs`,
+`monty-pool`, the `pydantic-monty` Python bindings and the `@pydantic/monty`
+JS bindings — depend on this crate **instead of `monty`**, so their binaries
+never link the interpreter itself. Only the worker side (`monty-runtime`,
+`monty-wasm-runtime`) links `monty`.
+
+The `monty` crate depends on `monty-types` and re-exports everything, so if
+you already depend on `monty` you can use these types under the names you
+know (`monty::MontyObject`, ...).
+
+```rust
+use monty_types::MontyObject;
+
+let value = MontyObject::List(vec![MontyObject::Int(1), MontyObject::String("x".to_owned())]);
+assert_eq!(value.py_repr(), "[1, 'x']");
+```

--- a/crates/monty-types/README.md
+++ b/crates/monty-types/README.md
@@ -30,10 +30,6 @@ JS bindings — depend on this crate **instead of `monty`**, so their binaries
 never link the interpreter itself. Only the worker side (`monty-runtime`,
 `monty-wasm-runtime`) links `monty`.
 
-The `monty` crate depends on `monty-types` and re-exports everything, so if
-you already depend on `monty` you can use these types under the names you
-know (`monty::MontyObject`, ...).
-
 ```rust
 use monty_types::MontyObject;
 

--- a/crates/monty-types/README.md
+++ b/crates/monty-types/README.md
@@ -24,11 +24,14 @@ implementation**.
 
 ## Who should depend on it
 
-Host-side crates that talk to Monty workers over the wire — `monty-fs`,
-`monty-pool`, the `pydantic-monty` Python bindings and the `@pydantic/monty`
-JS bindings — depend on this crate **instead of `monty`**, so their binaries
-never link the interpreter itself. Only the worker side (`monty-runtime`,
-`monty-wasm-runtime`) links `monty`.
+Host-side crates that need these types without linking the interpreter —
+`monty-fs` (which services `OsFunctionCall`s locally via
+`MountTable::handle_os_call`), `monty-pool` (which talks to Monty workers
+over the wire), the `pydantic-monty` Python bindings and the
+`@pydantic/monty` JS bindings — depend on this crate **instead of `monty`**,
+so their binaries never link the interpreter itself. Only worker-side crates
+(`monty-runtime`, `monty-wasm-runtime`, and `monty-proto` with its `worker`
+feature) link `monty`.
 
 ```rust
 use monty_types::MontyObject;

--- a/crates/monty-types/src/args.rs
+++ b/crates/monty-types/src/args.rs
@@ -1,24 +1,24 @@
-//! `ToMontyObject` — owned-value projection into [`crate::MontyObject`].
-//!
-//! Inverse of [`crate::args::FromValue`]. Used by `#[derive(ToArgs)]` to walk
-//! a typed args struct and push each field onto the
-//! `(Vec<MontyObject>, Vec<(MontyObject, MontyObject)>)` pair host callbacks
-//! consume. Owned-value semantics (consumes `self`) avoid an extra clone for
-//! large fields like `String` / `Vec<u8>`.
-//!
-//! Impls live here for the leaf types that ToArgs structs use directly
-//! (`String`, `Vec<u8>`, `bool`, `MontyObject` identity, [`FileMode`]). Each
-//! domain newtype (notably [`crate::os::MontyPath`]) implements `ToMontyObject`
-//! next to its definition.
+//! [`ToArgs`] / [`ToMontyObject`] — projection of typed args structs into
+//! the `(positional, keyword)` [`MontyObject`] pairs host callbacks consume.
+//! The `#[derive(ToArgs)]` macro in `monty-macros` emits impls of these
+//! traits via `crate::args::…` paths, which resolve in this crate.
 
-use crate::{FileMode, MontyObject};
-
+use crate::{file_mode::FileMode, object::MontyObject};
+/// Projects a typed args struct into the `(positional, keyword)` `MontyObject`
+/// pair host callbacks expect. Consumes `self` to avoid cloning owned fields.
+///
+/// Inverse of `monty`'s internal `FromArgs` (`ArgValues` → struct); `ToArgs`
+/// is struct → host-facing `(args, kwargs)`. Driven by
+/// [`crate::os::OsFunctionCall::to_args`] for the monty-python / monty-js bindings.
+pub trait ToArgs {
+    fn to_args(self) -> (Vec<MontyObject>, Vec<(MontyObject, MontyObject)>);
+}
 /// Consume `self` into a [`MontyObject`].
 ///
 /// `MontyObject` is the host-facing, heap-free representation. Implementers
 /// just shape themselves into the most natural `MontyObject` variant —
 /// `String` → `MontyObject::String`, `Vec<u8>` → `MontyObject::Bytes`, etc.
-pub(crate) trait ToMontyObject {
+pub trait ToMontyObject {
     fn into_monty_object(self) -> MontyObject;
 }
 

--- a/crates/monty-types/src/builtins.rs
+++ b/crates/monty-types/src/builtins.rs
@@ -1,0 +1,102 @@
+//! [`BuiltinsFunctions`] — the name-level identity of every interpreter-native
+//! Python builtin, carried by [`MontyObject::BuiltinFunction`](crate::object::MontyObject).
+
+use strum::{Display, EnumString, FromRepr, IntoStaticStr};
+/// Enumerates every interpreter-native Python builtin function.
+///
+/// Listed alphabetically per <https://docs.python.org/3/library/functions.html>
+/// Commented-out variants are not yet implemented.
+///
+/// Note: Type constructors are handled by the `Type` enum, not here.
+///
+/// Uses strum derives for automatic `Display`, `FromStr`, and `IntoStaticStr` implementations.
+/// All variants serialize to lowercase (e.g., `Print` -> "print").
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    Display,
+    EnumString,
+    FromRepr,
+    IntoStaticStr,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[strum(serialize_all = "lowercase")]
+#[repr(u8)]
+pub enum BuiltinsFunctions {
+    Abs,
+    // Aiter,
+    All,
+    // Anext,
+    Any,
+    // Ascii,
+    Bin,
+    // bool - handled by Type enum
+    // Breakpoint,
+    // bytearray - handled by Type enum
+    // bytes - handled by Type enum
+    // Callable,
+    Chr,
+    // Classmethod,
+    // Compile,
+    // complex - handled by Type enum
+    // Delattr,
+    // dict - handled by Type enum
+    // Dir,
+    Divmod,
+    Enumerate,
+    // Eval,
+    // Exec,
+    Filter,
+    // float - handled by Type enum
+    // Format,
+    // frozenset - handled by Type enum
+    Getattr,
+    // Globals,
+    Hasattr,
+    Hash,
+    // Help,
+    Hex,
+    Id,
+    // Input,
+    // int - handled by Type enum
+    Isinstance,
+    // Issubclass,
+    // Iter - handled by Type enum
+    Len,
+    // list - handled by Type enum
+    // Locals,
+    Map,
+    Max,
+    // memoryview - handled by Type enum
+    Min,
+    Next,
+    // object - handled by Type enum
+    Oct,
+    Open,
+    Ord,
+    Pow,
+    Print,
+    // Property,
+    // range - handled by Type enum
+    Repr,
+    Reversed,
+    Round,
+    // set - handled by Type enum
+    Setattr,
+    // Slice,
+    Sorted,
+    // Staticmethod,
+    // str - handled by Type enum
+    Sum,
+    // Super,
+    // tuple - handled by Type enum
+    Type,
+    // Vars,
+    Zip,
+    // __import__ - not planned
+}

--- a/crates/monty-types/src/exceptions.rs
+++ b/crates/monty-types/src/exceptions.rs
@@ -1,18 +1,221 @@
+//! Public exception types: [`ExcType`], [`MontyException`] and its
+//! traceback/payload components ([`StackFrame`], [`CodeLoc`], [`ExcData`]).
+
 use std::{
-    collections::HashMap,
     error,
     fmt::{self, Write},
     mem, str,
     sync::Arc,
 };
 
-use crate::{
-    exception_private::{ExcType, RawStackFrame},
-    intern::Interns,
-    parse::CodeRange,
-    types::str::StringRepr,
-};
+use serde::{Deserialize, Serialize};
+use strum::{Display, EnumString, IntoStaticStr};
 
+use crate::format::StringRepr;
+/// Python exception types supported by the interpreter.
+///
+/// Uses strum derives for automatic `Display`, `FromStr`, and `Into<&'static str>` implementations.
+/// The string representation matches the variant name exactly (e.g., `ValueError` -> "ValueError").
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Display, EnumString, IntoStaticStr, Serialize, Deserialize,
+)]
+pub enum ExcType {
+    /// primary exception class - matches any exception in isinstance checks.
+    ///
+    /// Also the `Default` — required so `Type` (which embeds an `ExcType` in
+    /// its `Exception` variant) can derive `strum::EnumIter`.
+    #[default]
+    Exception,
+
+    /// System exit exceptions
+    BaseException,
+    SystemExit,
+    KeyboardInterrupt,
+
+    // --- ArithmeticError hierarchy ---
+    /// Intermediate class for arithmetic errors.
+    ArithmeticError,
+    /// Subclass of ArithmeticError.
+    OverflowError,
+    /// Subclass of ArithmeticError.
+    ZeroDivisionError,
+
+    // --- LookupError hierarchy ---
+    /// Intermediate class for lookup errors.
+    LookupError,
+    /// Subclass of LookupError.
+    IndexError,
+    /// Subclass of LookupError.
+    KeyError,
+
+    // --- RuntimeError hierarchy ---
+    /// Intermediate class for runtime errors.
+    RuntimeError,
+    /// Subclass of RuntimeError.
+    NotImplementedError,
+    /// Subclass of RuntimeError.
+    RecursionError,
+
+    // --- AttributeError hierarchy ---
+    AttributeError,
+    /// Subclass of AttributeError (from dataclasses module).
+    FrozenInstanceError,
+
+    // --- NameError hierarchy ---
+    NameError,
+    /// Subclass of NameError - for accessing local variable before assignment.
+    UnboundLocalError,
+
+    // --- ValueError hierarchy ---
+    ValueError,
+    /// Subclass of ValueError - for encoding/decoding errors.
+    UnicodeDecodeError,
+    /// Subclass of ValueError - for encoding errors (e.g. `str.encode('ascii')`
+    /// on a string containing non-ASCII characters).
+    UnicodeEncodeError,
+    /// Subclass of ValueError for invalid JSON syntax in `json.loads()`.
+    #[strum(serialize = "json.JSONDecodeError")]
+    JsonDecodeError,
+
+    // --- ImportError hierarchy ---
+    /// Import-related errors (module not found, name not in module).
+    ImportError,
+    /// Subclass of ImportError - for when a module cannot be found.
+    ModuleNotFoundError,
+
+    // --- OSError hierarchy ---
+    /// OS-related errors (file not found, permission denied, etc.)
+    OSError,
+    /// Subclass of OSError - for when a file or directory cannot be found.
+    FileNotFoundError,
+    /// Subclass of OSError - for when a file already exists.
+    FileExistsError,
+    /// Subclass of OSError - for when a path is a directory but a file was expected.
+    IsADirectoryError,
+    /// Subclass of OSError - for when a path is not a directory but one was expected.
+    NotADirectoryError,
+    /// Subclass of OSError - for when an operation is not permitted (e.g., writing
+    /// to a read-only mount, or attempting to access a path outside a mounted directory).
+    PermissionError,
+    /// `io.UnsupportedOperation` - raised by file objects when a requested
+    /// operation isn't allowed by the open mode (e.g. `read()` on `'w'`).
+    ///
+    /// In CPython this inherits from both `OSError` and `ValueError`. Monty's
+    /// `ExcType` enum models single parents, but [`Self::is_subclass_of`]
+    /// matches `UnsupportedOperation` against both `OSError` and `ValueError`
+    /// so `except ValueError:` and `except OSError:` both catch it as in
+    /// CPython.
+    #[strum(serialize = "io.UnsupportedOperation")]
+    UnsupportedOperation,
+    /// Subclass of OSError since Python 3.3 (PEP 3151).
+    TimeoutError,
+
+    // --- Standalone exception types ---
+    AssertionError,
+    MemoryError,
+    StopIteration,
+    SyntaxError,
+    TypeError,
+
+    // --- Module-specific exception types ---
+
+    // --- re module ---
+    /// `re.PatternError` - raised for invalid regex patterns or unsupported regex features.
+    ///
+    /// # Behavior Note
+    ///
+    /// Limited to monty's exception type, `PatternError` does not provide `pattern`, `pos`,
+    /// `lineno` and `colno` attributes.
+    ///
+    /// As per CPython's implementation, it would be hard to convert `fancy-regex`'s error
+    /// representations into the required attributes.
+    #[strum(serialize = "re.PatternError")]
+    RePatternError,
+}
+impl ExcType {
+    /// Checks if this exception type is a subclass of another exception type.
+    ///
+    /// Implements Python's exception hierarchy for try/except matching:
+    /// - `Exception` is the base class for all standard exceptions
+    /// - `LookupError` is the base for `KeyError` and `IndexError`
+    /// - `ArithmeticError` is the base for `ZeroDivisionError` and `OverflowError`
+    /// - `RuntimeError` is the base for `RecursionError` and `NotImplementedError`
+    ///
+    /// Returns true if `self` would be caught by `except handler_type:`.
+    #[must_use]
+    pub fn is_subclass_of(self, handler_type: Self) -> bool {
+        if self == handler_type {
+            return true;
+        }
+        match handler_type {
+            // BaseException catches all exceptions
+            Self::BaseException => true,
+            // Exception catches everything except BaseException, and direct subclasses: KeyboardInterrupt, SystemExit
+            Self::Exception => !matches!(self, Self::BaseException | Self::KeyboardInterrupt | Self::SystemExit),
+            // LookupError catches KeyError and IndexError
+            Self::LookupError => matches!(self, Self::KeyError | Self::IndexError),
+            // ArithmeticError catches ZeroDivisionError and OverflowError
+            Self::ArithmeticError => matches!(self, Self::ZeroDivisionError | Self::OverflowError),
+            // RuntimeError catches RecursionError and NotImplementedError
+            Self::RuntimeError => matches!(self, Self::RecursionError | Self::NotImplementedError),
+            // AttributeError catches FrozenInstanceError
+            Self::AttributeError => matches!(self, Self::FrozenInstanceError),
+            // NameError catches UnboundLocalError
+            Self::NameError => matches!(self, Self::UnboundLocalError),
+            // ValueError catches UnicodeDecodeError, UnicodeEncodeError, json.JSONDecodeError,
+            // and io.UnsupportedOperation (which in CPython has dual OSError + ValueError parentage)
+            Self::ValueError => matches!(
+                self,
+                Self::UnicodeDecodeError
+                    | Self::UnicodeEncodeError
+                    | Self::JsonDecodeError
+                    | Self::UnsupportedOperation
+            ),
+            // ImportError catches ModuleNotFoundError
+            Self::ImportError => matches!(self, Self::ModuleNotFoundError),
+            // OSError catches FileNotFoundError, FileExistsError, IsADirectoryError,
+            // NotADirectoryError, PermissionError, io.UnsupportedOperation, and
+            // TimeoutError (an OSError subclass since Python 3.3)
+            Self::OSError => matches!(
+                self,
+                Self::FileNotFoundError
+                    | Self::FileExistsError
+                    | Self::IsADirectoryError
+                    | Self::NotADirectoryError
+                    | Self::PermissionError
+                    | Self::UnsupportedOperation
+                    | Self::TimeoutError
+            ),
+            // All other types only match exactly (handled by self == handler_type above)
+            _ => false,
+        }
+    }
+}
+/// Formats the message for a `UnicodeDecodeError` covering the byte range
+/// `start..end`: CPython's single-byte form (`byte 0x{first_byte:02x} in
+/// position {start}`) when the range is one byte, otherwise the range form
+/// (`bytes in position {start}-{end - 1}`).
+///
+/// A free function (rather than folded into `ExcType::unicode_decode_error`),
+/// public and re-exported at the crate root, so `monty-fs` can produce the
+/// identical wording when converting a `MountError::InvalidUtf8` from a
+/// text-mode file read into an exception.
+#[must_use]
+pub fn unicode_decode_error_msg(codec: &str, first_byte: u8, start: usize, end: usize, reason: &str) -> String {
+    // Callers must pass a non-empty range; checked in debug builds only so a
+    // wrong caller can't panic the VM in release (it gets a garbled message
+    // position instead, which is harmless).
+    debug_assert!(
+        end > start,
+        "unicode_decode_error_msg: end ({end}) must be > start ({start})"
+    );
+    if end - start == 1 {
+        format!("'{codec}' codec can't decode byte 0x{first_byte:02x} in position {start}: {reason}")
+    } else {
+        let last = end - 1;
+        format!("'{codec}' codec can't decode bytes in position {start}-{last}: {reason}")
+    }
+}
 /// Public representation of a Monty exception.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct MontyException {
@@ -27,7 +230,7 @@ pub struct MontyException {
     /// non-self-describing snapshot formats where skipped fields break
     /// deserialization.
     #[serde(default)]
-    pub(crate) data: ExcData,
+    data: ExcData,
 }
 
 /// Structured payload attached to exception types whose CPython counterparts
@@ -70,7 +273,7 @@ impl ExcData {
     /// Approximate byte footprint, used by the heap's memory accounting when
     /// an exception carrying this payload is stored on the sandbox heap.
     #[must_use]
-    pub(crate) fn estimate_size(&self) -> usize {
+    pub fn estimate_size(&self) -> usize {
         match self {
             Self::None => 0,
             Self::Unicode(data) => data.estimate_size(),
@@ -127,7 +330,8 @@ impl UnicodeErrorData {
 
     /// Builds the payload for an encode error on `object`, or
     /// [`ExcData::None`] when `object` exceeds [`Self::MAX_OBJECT_LEN`].
-    pub(crate) fn encode(encoding: &str, object: &str, start: usize, end: usize, reason: &str) -> ExcData {
+    #[must_use]
+    pub fn encode(encoding: &str, object: &str, start: usize, end: usize, reason: &str) -> ExcData {
         if object.len() <= Self::MAX_OBJECT_LEN {
             ExcData::Unicode(Box::new(Self {
                 encoding: encoding.to_owned(),
@@ -162,7 +366,7 @@ impl UnicodeErrorData {
     /// Approximate byte footprint, used by the heap's memory accounting when
     /// an exception carrying this payload is stored on the sandbox heap.
     #[must_use]
-    pub(crate) fn estimate_size(&self) -> usize {
+    pub fn estimate_size(&self) -> usize {
         let object_len = match &self.object {
             UnicodeErrorObject::Bytes(b) => b.len(),
             UnicodeErrorObject::Str(s) => s.len(),
@@ -205,7 +409,8 @@ impl JsonErrorData {
 
     /// Builds the payload for a decode error on `doc`, omitting the document
     /// when it exceeds [`Self::MAX_DOC_LEN`] or is not valid UTF-8.
-    pub(crate) fn build(msg: &str, doc: &[u8], pos: usize, lineno: usize, colno: usize) -> ExcData {
+    #[must_use]
+    pub fn build(msg: &str, doc: &[u8], pos: usize, lineno: usize, colno: usize) -> ExcData {
         let doc = if doc.len() <= Self::MAX_DOC_LEN {
             str::from_utf8(doc).ok().map(ToOwned::to_owned)
         } else {
@@ -223,7 +428,7 @@ impl JsonErrorData {
     /// Approximate byte footprint, used by the heap's memory accounting when
     /// an exception carrying this payload is stored on the sandbox heap.
     #[must_use]
-    pub(crate) fn estimate_size(&self) -> usize {
+    pub fn estimate_size(&self) -> usize {
         mem::size_of::<Self>() + self.msg.len() + self.doc.as_ref().map_or(0, String::len)
     }
 }
@@ -295,15 +500,6 @@ impl MontyException {
         }
     }
 
-    pub(crate) fn new_full(exc_type: ExcType, message: Option<String>, traceback: Vec<StackFrame>) -> Self {
-        Self {
-            exc_type,
-            message,
-            traceback,
-            data: ExcData::None,
-        }
-    }
-
     /// Creates an exception with an explicit traceback.
     ///
     /// Most callers should use [`MontyException::new`] — the traceback is
@@ -365,7 +561,11 @@ impl MontyException {
         self.traceback.extend(traceback);
     }
 
-    pub(crate) fn runtime_error(err: impl fmt::Display) -> Self {
+    /// Shorthand for a traceback-free `RuntimeError` wrapping `err`'s display
+    /// output — used at host boundaries (input conversion, REPL feeds) where
+    /// no sandbox stack frames exist.
+    #[must_use]
+    pub fn runtime_error(err: impl fmt::Display) -> Self {
         Self {
             exc_type: ExcType::RuntimeError,
             message: Some(err.to_string()),
@@ -537,84 +737,6 @@ impl fmt::Display for StackFrame {
         Ok(())
     }
 }
-
-impl StackFrame {
-    /// Builds a runtime `StackFrame` from an internal `RawStackFrame`.
-    ///
-    /// Resolves the raw filename/frame-name `StringId`s via `interns` and
-    /// expands the position's byte offsets to line/column and a preview
-    /// line via `source_map`.
-    pub(crate) fn from_raw(f: &RawStackFrame, interns: &Interns, source_map: &mut SourceMap<'_>) -> Self {
-        let filename = interns.get_str(f.position.filename).to_string();
-        let (start, end, preview_line) = source_map.resolve_range(f.position);
-        Self {
-            filename,
-            start,
-            end,
-            frame_name: f.frame_name.map(|id| interns.get_str(id).to_string()),
-            preview_line,
-            hide_caret: f.hide_caret,
-            hide_frame_name: false,
-        }
-    }
-
-    /// Builds a `StackFrame` for a `SyntaxError`.
-    ///
-    /// Sets `hide_frame_name: true` because CPython's SyntaxError format
-    /// omits the trailing `, in <module>` part.
-    pub(crate) fn from_position_syntax_error(
-        position: CodeRange,
-        filename: &str,
-        source_map: &mut SourceMap<'_>,
-    ) -> Self {
-        let (start, end, preview_line) = source_map.resolve_range(position);
-        Self {
-            filename: filename.to_string(),
-            start,
-            end,
-            frame_name: None,
-            preview_line,
-            hide_caret: false,
-            hide_frame_name: true,
-        }
-    }
-
-    /// Builds a generic `StackFrame` from a `CodeRange` and filename.
-    ///
-    /// Used for runtime-style errors raised outside the VM's frame tracking
-    /// (e.g. parse-phase `NotImplementedError`) where caret markers and the
-    /// `, in <module>` suffix are both shown.
-    pub(crate) fn from_position(position: CodeRange, filename: &str, source_map: &mut SourceMap<'_>) -> Self {
-        let (start, end, preview_line) = source_map.resolve_range(position);
-        Self {
-            filename: filename.to_string(),
-            start,
-            end,
-            frame_name: None,
-            preview_line,
-            hide_caret: false,
-            hide_frame_name: false,
-        }
-    }
-
-    /// Builds a `StackFrame` with caret markers suppressed.
-    ///
-    /// Used for errors like `ImportError` and `ModuleNotFoundError`, where
-    /// CPython shows the source preview line but no `~~~` carets beneath it.
-    pub(crate) fn from_position_no_caret(position: CodeRange, filename: &str, source_map: &mut SourceMap<'_>) -> Self {
-        let (start, end, preview_line) = source_map.resolve_range(position);
-        Self {
-            filename: filename.to_string(),
-            start,
-            end,
-            frame_name: None,
-            preview_line,
-            hide_caret: true,
-            hide_frame_name: false,
-        }
-    }
-}
-
 /// A line and column position in source code.
 ///
 /// Uses 1-based indexing for both line and column to match Python's conventions.
@@ -649,172 +771,5 @@ impl CodeLoc {
             line: line.saturating_add(1),
             column: column.saturating_add(1),
         }
-    }
-}
-
-/// Lazy resolver from raw byte offsets (stored on every [`CodeRange`]) back to
-/// human-readable line/column/preview-line information.
-///
-/// Monty's parser stores only byte offsets per AST node to keep the post-parse
-/// hot path O(1) per node. `SourceMap` is built once at the diagnostic
-/// boundary — when converting an internal error into a public
-/// [`MontyException`] — and used to resolve every frame in the traceback.
-/// Building it scans the source once to index line starts; with a 100k-line
-/// source this is a few hundred microseconds and fires only when an exception
-/// is actually raised.
-///
-/// Column semantics remain exactly CPython-compatible: columns count Unicode
-/// scalar values, not bytes. The ASCII fast path (the overwhelmingly common
-/// case for Python source) skips the `chars()` iterator entirely.
-pub struct SourceMap<'s> {
-    source: &'s str,
-    /// Byte offset of the start of each line. Length equals the number of
-    /// lines; `line_starts[0]` is always 0.
-    line_starts: Vec<u32>,
-    /// Cache of preview lines, keyed by 0-based line index.
-    ///
-    /// Lets every `StackFrame` referencing the same source line share a
-    /// single `Arc<str>` allocation rather than each cloning the line into
-    /// its own `String`. This matters for deep recursion: without the
-    /// cache, a 1 MiB line referenced by 1000 frames would allocate ~1 GiB;
-    /// with the cache it allocates ~1 MiB. Built lazily — entries materialize
-    /// only as `resolve_range` actually requests them.
-    line_cache: HashMap<usize, Arc<str>>,
-}
-
-impl<'s> SourceMap<'s> {
-    /// Builds a line-start index over `source`.
-    ///
-    /// Amortizes across every frame in the traceback — one O(n) scan, then
-    /// O(log n) lookups per frame.
-    #[must_use]
-    pub fn new(source: &'s str) -> Self {
-        let mut line_starts = Vec::with_capacity(source.len() / 40 + 1);
-        line_starts.push(0);
-        for (i, b) in source.bytes().enumerate() {
-            if b == b'\n' {
-                // source should never exceed 4 GB
-                let start = u32::try_from(i + 1).unwrap_or(u32::MAX);
-                line_starts.push(start);
-            }
-        }
-        Self {
-            source,
-            line_starts,
-            line_cache: HashMap::new(),
-        }
-    }
-
-    /// Resolves a `CodeRange` into `(start, end, preview_line)`.
-    ///
-    /// When `start` and `end` lie on the same line, `preview_line` is that
-    /// single source line. The returned `Arc<str>` is shared with any other
-    /// frame in this traceback resolving to the same line, so repeated
-    /// lookups for the same line are O(1) and allocate only on the first
-    /// lookup.
-    ///
-    /// When the range spans multiple lines, `preview_line` holds a
-    /// pre-rendered CPython-style block (see
-    /// [`multiline_preview`](Self::multiline_preview)); the renderer
-    /// distinguishes the two cases by comparing `start`/`end` lines.
-    pub(crate) fn resolve_range(&mut self, range: CodeRange) -> (CodeLoc, CodeLoc, Option<Arc<str>>) {
-        let (start_line_idx, start) = self.resolve_byte(range.start_byte);
-        let (end_line_idx, end) = self.resolve_byte(range.end_byte);
-        let preview_line = if start_line_idx == end_line_idx {
-            // Cache materializes lazily — first request for a given line allocates
-            // the `Arc<str>`, subsequent requests for the same line clone the Arc.
-            let line_text = self.line_text(start_line_idx);
-            Some(Arc::clone(
-                self.line_cache
-                    .entry(start_line_idx)
-                    .or_insert_with(|| Arc::from(line_text)),
-            ))
-        } else {
-            // Multi-line ranges are rare (e.g. a traceback frame covering a
-            // whole `class` statement), so no caching.
-            Some(Arc::from(self.multiline_preview(start_line_idx, end_line_idx)))
-        };
-        (start, end, preview_line)
-    }
-
-    /// Renders the source preview for a range spanning several lines,
-    /// mirroring CPython's traceback formatting: all lines when the range
-    /// covers at most three, otherwise the first and last around a
-    /// `...<N lines>...` elision marker. Displayed lines are dedented by
-    /// their common leading whitespace; the caller adds the 4-space frame
-    /// indent (and no caret markers — CPython omits them for these
-    /// full-statement ranges).
-    fn multiline_preview(&self, start_line_idx: usize, end_line_idx: usize) -> String {
-        let total = end_line_idx - start_line_idx + 1;
-        let displayed: Vec<&str> = if total <= 3 {
-            (start_line_idx..=end_line_idx).map(|i| self.line_text(i)).collect()
-        } else {
-            vec![self.line_text(start_line_idx), self.line_text(end_line_idx)]
-        };
-        // Common leading-whitespace prefix across non-blank displayed lines.
-        let dedent = displayed
-            .iter()
-            .filter(|line| !line.trim().is_empty())
-            .map(|line| line.len() - line.trim_start().len())
-            .min()
-            .unwrap_or(0);
-        let stripped = |line: &str| line.get(dedent..).unwrap_or("").to_owned();
-        if total <= 3 {
-            displayed
-                .iter()
-                .map(|line| stripped(line))
-                .collect::<Vec<_>>()
-                .join("\n")
-        } else {
-            format!(
-                "{}\n...<{} lines>...\n{}",
-                stripped(displayed[0]),
-                total - 2,
-                stripped(displayed[1])
-            )
-        }
-    }
-
-    /// Resolves a raw byte offset to `(0-based line index, CodeLoc)`.
-    ///
-    /// Column is the number of Unicode scalar values between the line start
-    /// and the offset; uses an ASCII fast path when the preceding slice is
-    /// pure ASCII.
-    fn resolve_byte(&self, byte: u32) -> (usize, CodeLoc) {
-        // partition_point(|&s| s <= byte) gives the index of the first line
-        // whose start is strictly greater than `byte`; subtracting one maps
-        // `byte` back to the line it actually lies on.
-        let line_idx = self.line_starts.partition_point(|&s| s <= byte).saturating_sub(1);
-        let line_start = self.line_starts[line_idx];
-        let slice_start = line_start as usize;
-        let slice_end = (byte as usize).min(self.source.len());
-        let slice = &self.source[slice_start..slice_end];
-        // Ruff caps source files at 4 GiB, so any byte-based column count fits
-        // comfortably in `u32`; saturate defensively if that ever changes.
-        let col = if slice.is_ascii() {
-            u32::try_from(slice.len()).unwrap_or(u32::MAX)
-        } else {
-            u32::try_from(slice.chars().count()).unwrap_or(u32::MAX)
-        };
-        (
-            line_idx,
-            CodeLoc::new(u32::try_from(line_idx).expect("line number exceeds u32"), col),
-        )
-    }
-
-    /// Returns the raw text of a 0-based line index, without the trailing
-    /// newline.
-    fn line_text(&self, line_idx: usize) -> &'s str {
-        let start = self.line_starts[line_idx] as usize;
-        let end = self
-            .line_starts
-            .get(line_idx + 1)
-            .map_or(self.source.len(), |&next| next.saturating_sub(1) as usize);
-        // Guard against a trailing empty "line" past the last newline with no
-        // content (e.g. when `start == source.len()`).
-        let end = end.max(start);
-        // Strip a trailing `\r` if the source uses CRLF line endings.
-        let line = &self.source[start..end];
-        line.strip_suffix('\r').unwrap_or(line)
     }
 }

--- a/crates/monty-types/src/exceptions.rs
+++ b/crates/monty-types/src/exceptions.rs
@@ -12,210 +12,7 @@ use serde::{Deserialize, Serialize};
 use strum::{Display, EnumString, IntoStaticStr};
 
 use crate::format::StringRepr;
-/// Python exception types supported by the interpreter.
-///
-/// Uses strum derives for automatic `Display`, `FromStr`, and `Into<&'static str>` implementations.
-/// The string representation matches the variant name exactly (e.g., `ValueError` -> "ValueError").
-#[derive(
-    Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Display, EnumString, IntoStaticStr, Serialize, Deserialize,
-)]
-pub enum ExcType {
-    /// primary exception class - matches any exception in isinstance checks.
-    ///
-    /// Also the `Default` — required so `Type` (which embeds an `ExcType` in
-    /// its `Exception` variant) can derive `strum::EnumIter`.
-    #[default]
-    Exception,
 
-    /// System exit exceptions
-    BaseException,
-    SystemExit,
-    KeyboardInterrupt,
-
-    // --- ArithmeticError hierarchy ---
-    /// Intermediate class for arithmetic errors.
-    ArithmeticError,
-    /// Subclass of ArithmeticError.
-    OverflowError,
-    /// Subclass of ArithmeticError.
-    ZeroDivisionError,
-
-    // --- LookupError hierarchy ---
-    /// Intermediate class for lookup errors.
-    LookupError,
-    /// Subclass of LookupError.
-    IndexError,
-    /// Subclass of LookupError.
-    KeyError,
-
-    // --- RuntimeError hierarchy ---
-    /// Intermediate class for runtime errors.
-    RuntimeError,
-    /// Subclass of RuntimeError.
-    NotImplementedError,
-    /// Subclass of RuntimeError.
-    RecursionError,
-
-    // --- AttributeError hierarchy ---
-    AttributeError,
-    /// Subclass of AttributeError (from dataclasses module).
-    FrozenInstanceError,
-
-    // --- NameError hierarchy ---
-    NameError,
-    /// Subclass of NameError - for accessing local variable before assignment.
-    UnboundLocalError,
-
-    // --- ValueError hierarchy ---
-    ValueError,
-    /// Subclass of ValueError - for encoding/decoding errors.
-    UnicodeDecodeError,
-    /// Subclass of ValueError - for encoding errors (e.g. `str.encode('ascii')`
-    /// on a string containing non-ASCII characters).
-    UnicodeEncodeError,
-    /// Subclass of ValueError for invalid JSON syntax in `json.loads()`.
-    #[strum(serialize = "json.JSONDecodeError")]
-    JsonDecodeError,
-
-    // --- ImportError hierarchy ---
-    /// Import-related errors (module not found, name not in module).
-    ImportError,
-    /// Subclass of ImportError - for when a module cannot be found.
-    ModuleNotFoundError,
-
-    // --- OSError hierarchy ---
-    /// OS-related errors (file not found, permission denied, etc.)
-    OSError,
-    /// Subclass of OSError - for when a file or directory cannot be found.
-    FileNotFoundError,
-    /// Subclass of OSError - for when a file already exists.
-    FileExistsError,
-    /// Subclass of OSError - for when a path is a directory but a file was expected.
-    IsADirectoryError,
-    /// Subclass of OSError - for when a path is not a directory but one was expected.
-    NotADirectoryError,
-    /// Subclass of OSError - for when an operation is not permitted (e.g., writing
-    /// to a read-only mount, or attempting to access a path outside a mounted directory).
-    PermissionError,
-    /// `io.UnsupportedOperation` - raised by file objects when a requested
-    /// operation isn't allowed by the open mode (e.g. `read()` on `'w'`).
-    ///
-    /// In CPython this inherits from both `OSError` and `ValueError`. Monty's
-    /// `ExcType` enum models single parents, but [`Self::is_subclass_of`]
-    /// matches `UnsupportedOperation` against both `OSError` and `ValueError`
-    /// so `except ValueError:` and `except OSError:` both catch it as in
-    /// CPython.
-    #[strum(serialize = "io.UnsupportedOperation")]
-    UnsupportedOperation,
-    /// Subclass of OSError since Python 3.3 (PEP 3151).
-    TimeoutError,
-
-    // --- Standalone exception types ---
-    AssertionError,
-    MemoryError,
-    StopIteration,
-    SyntaxError,
-    TypeError,
-
-    // --- Module-specific exception types ---
-
-    // --- re module ---
-    /// `re.PatternError` - raised for invalid regex patterns or unsupported regex features.
-    ///
-    /// # Behavior Note
-    ///
-    /// Limited to monty's exception type, `PatternError` does not provide `pattern`, `pos`,
-    /// `lineno` and `colno` attributes.
-    ///
-    /// As per CPython's implementation, it would be hard to convert `fancy-regex`'s error
-    /// representations into the required attributes.
-    #[strum(serialize = "re.PatternError")]
-    RePatternError,
-}
-impl ExcType {
-    /// Checks if this exception type is a subclass of another exception type.
-    ///
-    /// Implements Python's exception hierarchy for try/except matching:
-    /// - `Exception` is the base class for all standard exceptions
-    /// - `LookupError` is the base for `KeyError` and `IndexError`
-    /// - `ArithmeticError` is the base for `ZeroDivisionError` and `OverflowError`
-    /// - `RuntimeError` is the base for `RecursionError` and `NotImplementedError`
-    ///
-    /// Returns true if `self` would be caught by `except handler_type:`.
-    #[must_use]
-    pub fn is_subclass_of(self, handler_type: Self) -> bool {
-        if self == handler_type {
-            return true;
-        }
-        match handler_type {
-            // BaseException catches all exceptions
-            Self::BaseException => true,
-            // Exception catches everything except BaseException, and direct subclasses: KeyboardInterrupt, SystemExit
-            Self::Exception => !matches!(self, Self::BaseException | Self::KeyboardInterrupt | Self::SystemExit),
-            // LookupError catches KeyError and IndexError
-            Self::LookupError => matches!(self, Self::KeyError | Self::IndexError),
-            // ArithmeticError catches ZeroDivisionError and OverflowError
-            Self::ArithmeticError => matches!(self, Self::ZeroDivisionError | Self::OverflowError),
-            // RuntimeError catches RecursionError and NotImplementedError
-            Self::RuntimeError => matches!(self, Self::RecursionError | Self::NotImplementedError),
-            // AttributeError catches FrozenInstanceError
-            Self::AttributeError => matches!(self, Self::FrozenInstanceError),
-            // NameError catches UnboundLocalError
-            Self::NameError => matches!(self, Self::UnboundLocalError),
-            // ValueError catches UnicodeDecodeError, UnicodeEncodeError, json.JSONDecodeError,
-            // and io.UnsupportedOperation (which in CPython has dual OSError + ValueError parentage)
-            Self::ValueError => matches!(
-                self,
-                Self::UnicodeDecodeError
-                    | Self::UnicodeEncodeError
-                    | Self::JsonDecodeError
-                    | Self::UnsupportedOperation
-            ),
-            // ImportError catches ModuleNotFoundError
-            Self::ImportError => matches!(self, Self::ModuleNotFoundError),
-            // OSError catches FileNotFoundError, FileExistsError, IsADirectoryError,
-            // NotADirectoryError, PermissionError, io.UnsupportedOperation, and
-            // TimeoutError (an OSError subclass since Python 3.3)
-            Self::OSError => matches!(
-                self,
-                Self::FileNotFoundError
-                    | Self::FileExistsError
-                    | Self::IsADirectoryError
-                    | Self::NotADirectoryError
-                    | Self::PermissionError
-                    | Self::UnsupportedOperation
-                    | Self::TimeoutError
-            ),
-            // All other types only match exactly (handled by self == handler_type above)
-            _ => false,
-        }
-    }
-}
-/// Formats the message for a `UnicodeDecodeError` covering the byte range
-/// `start..end`: CPython's single-byte form (`byte 0x{first_byte:02x} in
-/// position {start}`) when the range is one byte, otherwise the range form
-/// (`bytes in position {start}-{end - 1}`).
-///
-/// A free function (rather than folded into `ExcType::unicode_decode_error`),
-/// public and re-exported at the crate root, so `monty-fs` can produce the
-/// identical wording when converting a `MountError::InvalidUtf8` from a
-/// text-mode file read into an exception.
-#[must_use]
-pub fn unicode_decode_error_msg(codec: &str, first_byte: u8, start: usize, end: usize, reason: &str) -> String {
-    // Callers must pass a non-empty range; checked in debug builds only so a
-    // wrong caller can't panic the VM in release (it gets a garbled message
-    // position instead, which is harmless).
-    debug_assert!(
-        end > start,
-        "unicode_decode_error_msg: end ({end}) must be > start ({start})"
-    );
-    if end - start == 1 {
-        format!("'{codec}' codec can't decode byte 0x{first_byte:02x} in position {start}: {reason}")
-    } else {
-        let last = end - 1;
-        format!("'{codec}' codec can't decode bytes in position {start}-{last}: {reason}")
-    }
-}
 /// Public representation of a Monty exception.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct MontyException {
@@ -231,206 +28,6 @@ pub struct MontyException {
     /// deserialization.
     #[serde(default)]
     data: ExcData,
-}
-
-/// Structured payload attached to exception types whose CPython counterparts
-/// carry more than a message. Currently unicode and json decode errors have
-/// one; the enum leaves room for future variants (e.g. `OSError`'s
-/// `errno`/`filename`) without another field on every exception.
-#[derive(Debug, Clone, Default, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
-pub enum ExcData {
-    /// No structured payload — every exception type without a variant below.
-    #[default]
-    None,
-    /// `UnicodeDecodeError` / `UnicodeEncodeError` constructor fields.
-    /// Boxed to keep the common `None` case (and every exception embedding
-    /// this enum) small.
-    Unicode(Box<UnicodeErrorData>),
-    /// `json.JSONDecodeError` attribute fields. Boxed like
-    /// [`ExcData::Unicode`] to keep the enum small.
-    Json(Box<JsonErrorData>),
-}
-
-impl ExcData {
-    /// The unicode-error fields, if this is [`ExcData::Unicode`].
-    #[must_use]
-    pub fn unicode(&self) -> Option<&UnicodeErrorData> {
-        match self {
-            Self::Unicode(data) => Some(data),
-            _ => None,
-        }
-    }
-
-    /// The json-error fields, if this is [`ExcData::Json`].
-    #[must_use]
-    pub fn json(&self) -> Option<&JsonErrorData> {
-        match self {
-            Self::Json(data) => Some(data),
-            _ => None,
-        }
-    }
-
-    /// Approximate byte footprint, used by the heap's memory accounting when
-    /// an exception carrying this payload is stored on the sandbox heap.
-    #[must_use]
-    pub fn estimate_size(&self) -> usize {
-        match self {
-            Self::None => 0,
-            Self::Unicode(data) => data.estimate_size(),
-            Self::Json(data) => data.estimate_size(),
-        }
-    }
-}
-
-/// Structured fields of a `UnicodeDecodeError` / `UnicodeEncodeError`,
-/// mirroring CPython's `encoding` / `object` / `start` / `end` / `reason`
-/// exception attributes.
-///
-/// Monty exceptions are otherwise message-only; unicode errors additionally
-/// carry these fields so host bindings (e.g. `pydantic_monty`) can construct
-/// real `UnicodeDecodeError` / `UnicodeEncodeError` instances instead of
-/// falling back to a plain `ValueError`. The payload is omitted when the
-/// offending object is larger than [`UnicodeErrorData::MAX_OBJECT_LEN`] —
-/// exceptions can be stored and copied outside the sandbox's resource
-/// tracker, so an unbounded payload would let huge inputs evade memory
-/// limits. Sandboxed code never sees these fields (in-sandbox exceptions
-/// expose only `args`).
-#[derive(Debug, Clone, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
-pub struct UnicodeErrorData {
-    /// The codec name as CPython reports it, e.g. `"utf-8"`, `"ascii"`.
-    pub encoding: String,
-    /// The full input that failed to encode/decode (`str` for encode errors,
-    /// `bytes` for decode errors), matching CPython's `exc.object`.
-    pub object: UnicodeErrorObject,
-    /// Start of the failing range: a character index for encode errors, a
-    /// byte offset for decode errors.
-    pub start: usize,
-    /// Exclusive end of the failing range, in the same units as `start`.
-    pub end: usize,
-    /// CPython's reason wording, e.g. `"ordinal not in range(128)"`.
-    pub reason: String,
-}
-
-/// The `object` attribute of a unicode error: the input being converted.
-#[derive(Debug, Clone, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
-pub enum UnicodeErrorObject {
-    /// A decode error's input `bytes`.
-    Bytes(Vec<u8>),
-    /// An encode error's input `str`.
-    Str(String),
-}
-
-impl UnicodeErrorData {
-    /// Payload size cap: unicode errors on objects larger than this carry no
-    /// structured data (hosts fall back to the message-only `ValueError`).
-    /// Exception payloads live outside the sandbox's resource tracker once
-    /// the exception escapes, so the cap bounds how much untracked memory a
-    /// single raise can pin.
-    pub const MAX_OBJECT_LEN: usize = 64 * 1024;
-
-    /// Builds the payload for an encode error on `object`, or
-    /// [`ExcData::None`] when `object` exceeds [`Self::MAX_OBJECT_LEN`].
-    #[must_use]
-    pub fn encode(encoding: &str, object: &str, start: usize, end: usize, reason: &str) -> ExcData {
-        if object.len() <= Self::MAX_OBJECT_LEN {
-            ExcData::Unicode(Box::new(Self {
-                encoding: encoding.to_owned(),
-                object: UnicodeErrorObject::Str(object.to_owned()),
-                start,
-                end,
-                reason: reason.to_owned(),
-            }))
-        } else {
-            ExcData::None
-        }
-    }
-
-    /// Builds the payload for a decode error on `object`, or
-    /// [`ExcData::None`] when `object` exceeds [`Self::MAX_OBJECT_LEN`].
-    /// Public so `monty-fs` can build the payload for text-mode file reads.
-    #[must_use]
-    pub fn decode(encoding: &str, object: &[u8], start: usize, end: usize, reason: &str) -> ExcData {
-        if object.len() <= Self::MAX_OBJECT_LEN {
-            ExcData::Unicode(Box::new(Self {
-                encoding: encoding.to_owned(),
-                object: UnicodeErrorObject::Bytes(object.to_vec()),
-                start,
-                end,
-                reason: reason.to_owned(),
-            }))
-        } else {
-            ExcData::None
-        }
-    }
-
-    /// Approximate byte footprint, used by the heap's memory accounting when
-    /// an exception carrying this payload is stored on the sandbox heap.
-    #[must_use]
-    pub fn estimate_size(&self) -> usize {
-        let object_len = match &self.object {
-            UnicodeErrorObject::Bytes(b) => b.len(),
-            UnicodeErrorObject::Str(s) => s.len(),
-        };
-        mem::size_of::<Self>() + self.encoding.len() + object_len + self.reason.len()
-    }
-}
-
-/// Structured fields of a `json.JSONDecodeError`, mirroring CPython's `msg` /
-/// `doc` / `pos` / `lineno` / `colno` exception attributes.
-///
-/// As with [`UnicodeErrorData`], the payload exists so host bindings can
-/// construct a real `json.JSONDecodeError` instead of falling back to a plain
-/// `ValueError`; sandboxed code never sees these fields. `lineno`/`colno` are
-/// carried explicitly rather than recomputed from `doc` because `doc` may be
-/// absent (see [`JsonErrorData::MAX_DOC_LEN`]).
-#[derive(Debug, Clone, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
-pub struct JsonErrorData {
-    /// The bare error message, without the `: line N column M (char K)`
-    /// suffix the formatted exception message carries.
-    pub msg: String,
-    /// The document being parsed, matching CPython's `exc.doc`. `None` when
-    /// the document exceeds [`JsonErrorData::MAX_DOC_LEN`] or is not valid
-    /// UTF-8 (`json.loads` on `bytes` input).
-    pub doc: Option<String>,
-    /// Character index of the error in `doc`, matching CPython's `exc.pos`.
-    pub pos: usize,
-    /// 1-based line of the error, matching CPython's `exc.lineno`.
-    pub lineno: usize,
-    /// 1-based column of the error, matching CPython's `exc.colno`.
-    pub colno: usize,
-}
-
-impl JsonErrorData {
-    /// Document size cap, mirroring [`UnicodeErrorData::MAX_OBJECT_LEN`]:
-    /// exception payloads live outside the sandbox's resource tracker once
-    /// the exception escapes, so `doc` is dropped (not truncated — a partial
-    /// document would misplace `pos`) for larger inputs.
-    pub const MAX_DOC_LEN: usize = 64 * 1024;
-
-    /// Builds the payload for a decode error on `doc`, omitting the document
-    /// when it exceeds [`Self::MAX_DOC_LEN`] or is not valid UTF-8.
-    #[must_use]
-    pub fn build(msg: &str, doc: &[u8], pos: usize, lineno: usize, colno: usize) -> ExcData {
-        let doc = if doc.len() <= Self::MAX_DOC_LEN {
-            str::from_utf8(doc).ok().map(ToOwned::to_owned)
-        } else {
-            None
-        };
-        ExcData::Json(Box::new(Self {
-            msg: msg.to_owned(),
-            doc,
-            pos,
-            lineno,
-            colno,
-        }))
-    }
-
-    /// Approximate byte footprint, used by the heap's memory accounting when
-    /// an exception carrying this payload is stored on the sandbox heap.
-    #[must_use]
-    pub fn estimate_size(&self) -> usize {
-        mem::size_of::<Self>() + self.msg.len() + self.doc.as_ref().map_or(0, String::len)
-    }
 }
 
 /// Number of identical consecutive frames to show before collapsing.
@@ -639,6 +236,386 @@ fn frames_are_identical(a: &StackFrame, b: &StackFrame) -> bool {
     a.filename == b.filename && a.start.line == b.start.line && a.frame_name == b.frame_name
 }
 
+/// Python exception types supported by the interpreter.
+///
+/// Uses strum derives for automatic `Display`, `FromStr`, and `Into<&'static str>` implementations.
+/// The string representation matches the variant name exactly (e.g., `ValueError` -> "ValueError").
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Display, EnumString, IntoStaticStr, Serialize, Deserialize,
+)]
+pub enum ExcType {
+    /// primary exception class - matches any exception in isinstance checks.
+    ///
+    /// Also the `Default` — required so `Type` (which embeds an `ExcType` in
+    /// its `Exception` variant) can derive `strum::EnumIter`.
+    #[default]
+    Exception,
+
+    /// System exit exceptions
+    BaseException,
+    SystemExit,
+    KeyboardInterrupt,
+
+    // --- ArithmeticError hierarchy ---
+    /// Intermediate class for arithmetic errors.
+    ArithmeticError,
+    /// Subclass of ArithmeticError.
+    OverflowError,
+    /// Subclass of ArithmeticError.
+    ZeroDivisionError,
+
+    // --- LookupError hierarchy ---
+    /// Intermediate class for lookup errors.
+    LookupError,
+    /// Subclass of LookupError.
+    IndexError,
+    /// Subclass of LookupError.
+    KeyError,
+
+    // --- RuntimeError hierarchy ---
+    /// Intermediate class for runtime errors.
+    RuntimeError,
+    /// Subclass of RuntimeError.
+    NotImplementedError,
+    /// Subclass of RuntimeError.
+    RecursionError,
+
+    // --- AttributeError hierarchy ---
+    AttributeError,
+    /// Subclass of AttributeError (from dataclasses module).
+    FrozenInstanceError,
+
+    // --- NameError hierarchy ---
+    NameError,
+    /// Subclass of NameError - for accessing local variable before assignment.
+    UnboundLocalError,
+
+    // --- ValueError hierarchy ---
+    ValueError,
+    /// Subclass of ValueError - for encoding/decoding errors.
+    UnicodeDecodeError,
+    /// Subclass of ValueError - for encoding errors (e.g. `str.encode('ascii')`
+    /// on a string containing non-ASCII characters).
+    UnicodeEncodeError,
+    /// Subclass of ValueError for invalid JSON syntax in `json.loads()`.
+    #[strum(serialize = "json.JSONDecodeError")]
+    JsonDecodeError,
+
+    // --- ImportError hierarchy ---
+    /// Import-related errors (module not found, name not in module).
+    ImportError,
+    /// Subclass of ImportError - for when a module cannot be found.
+    ModuleNotFoundError,
+
+    // --- OSError hierarchy ---
+    /// OS-related errors (file not found, permission denied, etc.)
+    OSError,
+    /// Subclass of OSError - for when a file or directory cannot be found.
+    FileNotFoundError,
+    /// Subclass of OSError - for when a file already exists.
+    FileExistsError,
+    /// Subclass of OSError - for when a path is a directory but a file was expected.
+    IsADirectoryError,
+    /// Subclass of OSError - for when a path is not a directory but one was expected.
+    NotADirectoryError,
+    /// Subclass of OSError - for when an operation is not permitted (e.g., writing
+    /// to a read-only mount, or attempting to access a path outside a mounted directory).
+    PermissionError,
+    /// `io.UnsupportedOperation` - raised by file objects when a requested
+    /// operation isn't allowed by the open mode (e.g. `read()` on `'w'`).
+    ///
+    /// In CPython this inherits from both `OSError` and `ValueError`. Monty's
+    /// `ExcType` enum models single parents, but [`Self::is_subclass_of`]
+    /// matches `UnsupportedOperation` against both `OSError` and `ValueError`
+    /// so `except ValueError:` and `except OSError:` both catch it as in
+    /// CPython.
+    #[strum(serialize = "io.UnsupportedOperation")]
+    UnsupportedOperation,
+    /// Subclass of OSError since Python 3.3 (PEP 3151).
+    TimeoutError,
+
+    // --- Standalone exception types ---
+    AssertionError,
+    MemoryError,
+    StopIteration,
+    SyntaxError,
+    TypeError,
+
+    // --- Module-specific exception types ---
+
+    // --- re module ---
+    /// `re.PatternError` - raised for invalid regex patterns or unsupported regex features.
+    ///
+    /// # Behavior Note
+    ///
+    /// Limited to monty's exception type, `PatternError` does not provide `pattern`, `pos`,
+    /// `lineno` and `colno` attributes.
+    ///
+    /// As per CPython's implementation, it would be hard to convert `fancy-regex`'s error
+    /// representations into the required attributes.
+    #[strum(serialize = "re.PatternError")]
+    RePatternError,
+}
+impl ExcType {
+    /// Checks if this exception type is a subclass of another exception type.
+    ///
+    /// Implements Python's exception hierarchy for try/except matching:
+    /// - `Exception` is the base class for all standard exceptions
+    /// - `LookupError` is the base for `KeyError` and `IndexError`
+    /// - `ArithmeticError` is the base for `ZeroDivisionError` and `OverflowError`
+    /// - `RuntimeError` is the base for `RecursionError` and `NotImplementedError`
+    ///
+    /// Returns true if `self` would be caught by `except handler_type:`.
+    #[must_use]
+    pub fn is_subclass_of(self, handler_type: Self) -> bool {
+        if self == handler_type {
+            return true;
+        }
+        match handler_type {
+            // BaseException catches all exceptions
+            Self::BaseException => true,
+            // Exception catches everything except BaseException, and direct subclasses: KeyboardInterrupt, SystemExit
+            Self::Exception => !matches!(self, Self::BaseException | Self::KeyboardInterrupt | Self::SystemExit),
+            // LookupError catches KeyError and IndexError
+            Self::LookupError => matches!(self, Self::KeyError | Self::IndexError),
+            // ArithmeticError catches ZeroDivisionError and OverflowError
+            Self::ArithmeticError => matches!(self, Self::ZeroDivisionError | Self::OverflowError),
+            // RuntimeError catches RecursionError and NotImplementedError
+            Self::RuntimeError => matches!(self, Self::RecursionError | Self::NotImplementedError),
+            // AttributeError catches FrozenInstanceError
+            Self::AttributeError => matches!(self, Self::FrozenInstanceError),
+            // NameError catches UnboundLocalError
+            Self::NameError => matches!(self, Self::UnboundLocalError),
+            // ValueError catches UnicodeDecodeError, UnicodeEncodeError, json.JSONDecodeError,
+            // and io.UnsupportedOperation (which in CPython has dual OSError + ValueError parentage)
+            Self::ValueError => matches!(
+                self,
+                Self::UnicodeDecodeError
+                    | Self::UnicodeEncodeError
+                    | Self::JsonDecodeError
+                    | Self::UnsupportedOperation
+            ),
+            // ImportError catches ModuleNotFoundError
+            Self::ImportError => matches!(self, Self::ModuleNotFoundError),
+            // OSError catches FileNotFoundError, FileExistsError, IsADirectoryError,
+            // NotADirectoryError, PermissionError, io.UnsupportedOperation, and
+            // TimeoutError (an OSError subclass since Python 3.3)
+            Self::OSError => matches!(
+                self,
+                Self::FileNotFoundError
+                    | Self::FileExistsError
+                    | Self::IsADirectoryError
+                    | Self::NotADirectoryError
+                    | Self::PermissionError
+                    | Self::UnsupportedOperation
+                    | Self::TimeoutError
+            ),
+            // All other types only match exactly (handled by self == handler_type above)
+            _ => false,
+        }
+    }
+}
+
+/// Structured payload attached to exception types whose CPython counterparts
+/// carry more than a message. Currently unicode and json decode errors have
+/// one; the enum leaves room for future variants (e.g. `OSError`'s
+/// `errno`/`filename`) without another field on every exception.
+#[derive(Debug, Clone, Default, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum ExcData {
+    /// No structured payload — every exception type without a variant below.
+    #[default]
+    None,
+    /// `UnicodeDecodeError` / `UnicodeEncodeError` constructor fields.
+    /// Boxed to keep the common `None` case (and every exception embedding
+    /// this enum) small.
+    Unicode(Box<UnicodeErrorData>),
+    /// `json.JSONDecodeError` attribute fields. Boxed like
+    /// [`ExcData::Unicode`] to keep the enum small.
+    Json(Box<JsonErrorData>),
+}
+
+impl ExcData {
+    /// The unicode-error fields, if this is [`ExcData::Unicode`].
+    #[must_use]
+    pub fn unicode(&self) -> Option<&UnicodeErrorData> {
+        match self {
+            Self::Unicode(data) => Some(data),
+            _ => None,
+        }
+    }
+
+    /// The json-error fields, if this is [`ExcData::Json`].
+    #[must_use]
+    pub fn json(&self) -> Option<&JsonErrorData> {
+        match self {
+            Self::Json(data) => Some(data),
+            _ => None,
+        }
+    }
+
+    /// Approximate byte footprint, used by the heap's memory accounting when
+    /// an exception carrying this payload is stored on the sandbox heap.
+    #[must_use]
+    pub fn estimate_size(&self) -> usize {
+        match self {
+            Self::None => 0,
+            Self::Unicode(data) => data.estimate_size(),
+            Self::Json(data) => data.estimate_size(),
+        }
+    }
+}
+
+/// Structured fields of a `UnicodeDecodeError` / `UnicodeEncodeError`,
+/// mirroring CPython's `encoding` / `object` / `start` / `end` / `reason`
+/// exception attributes.
+///
+/// Monty exceptions are otherwise message-only; unicode errors additionally
+/// carry these fields so host bindings (e.g. `pydantic_monty`) can construct
+/// real `UnicodeDecodeError` / `UnicodeEncodeError` instances instead of
+/// falling back to a plain `ValueError`. The payload is omitted when the
+/// offending object is larger than [`UnicodeErrorData::MAX_OBJECT_LEN`] —
+/// exceptions can be stored and copied outside the sandbox's resource
+/// tracker, so an unbounded payload would let huge inputs evade memory
+/// limits. Sandboxed code never sees these fields (in-sandbox exceptions
+/// expose only `args`).
+#[derive(Debug, Clone, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct UnicodeErrorData {
+    /// The codec name as CPython reports it, e.g. `"utf-8"`, `"ascii"`.
+    pub encoding: String,
+    /// The full input that failed to encode/decode (`str` for encode errors,
+    /// `bytes` for decode errors), matching CPython's `exc.object`.
+    pub object: UnicodeErrorObject,
+    /// Start of the failing range: a character index for encode errors, a
+    /// byte offset for decode errors.
+    pub start: usize,
+    /// Exclusive end of the failing range, in the same units as `start`.
+    pub end: usize,
+    /// CPython's reason wording, e.g. `"ordinal not in range(128)"`.
+    pub reason: String,
+}
+
+/// The `object` attribute of a unicode error: the input being converted.
+#[derive(Debug, Clone, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum UnicodeErrorObject {
+    /// A decode error's input `bytes`.
+    Bytes(Vec<u8>),
+    /// An encode error's input `str`.
+    Str(String),
+}
+
+impl UnicodeErrorData {
+    /// Payload size cap: unicode errors on objects larger than this carry no
+    /// structured data (hosts fall back to the message-only `ValueError`).
+    /// Exception payloads live outside the sandbox's resource tracker once
+    /// the exception escapes, so the cap bounds how much untracked memory a
+    /// single raise can pin.
+    pub const MAX_OBJECT_LEN: usize = 64 * 1024;
+
+    /// Builds the payload for an encode error on `object`, or
+    /// [`ExcData::None`] when `object` exceeds [`Self::MAX_OBJECT_LEN`].
+    #[must_use]
+    pub fn encode(encoding: &str, object: &str, start: usize, end: usize, reason: &str) -> ExcData {
+        if object.len() <= Self::MAX_OBJECT_LEN {
+            ExcData::Unicode(Box::new(Self {
+                encoding: encoding.to_owned(),
+                object: UnicodeErrorObject::Str(object.to_owned()),
+                start,
+                end,
+                reason: reason.to_owned(),
+            }))
+        } else {
+            ExcData::None
+        }
+    }
+
+    /// Builds the payload for a decode error on `object`, or
+    /// [`ExcData::None`] when `object` exceeds [`Self::MAX_OBJECT_LEN`].
+    /// Public so `monty-fs` can build the payload for text-mode file reads.
+    #[must_use]
+    pub fn decode(encoding: &str, object: &[u8], start: usize, end: usize, reason: &str) -> ExcData {
+        if object.len() <= Self::MAX_OBJECT_LEN {
+            ExcData::Unicode(Box::new(Self {
+                encoding: encoding.to_owned(),
+                object: UnicodeErrorObject::Bytes(object.to_vec()),
+                start,
+                end,
+                reason: reason.to_owned(),
+            }))
+        } else {
+            ExcData::None
+        }
+    }
+
+    /// Approximate byte footprint, used by the heap's memory accounting when
+    /// an exception carrying this payload is stored on the sandbox heap.
+    #[must_use]
+    pub fn estimate_size(&self) -> usize {
+        let object_len = match &self.object {
+            UnicodeErrorObject::Bytes(b) => b.len(),
+            UnicodeErrorObject::Str(s) => s.len(),
+        };
+        mem::size_of::<Self>() + self.encoding.len() + object_len + self.reason.len()
+    }
+}
+
+/// Structured fields of a `json.JSONDecodeError`, mirroring CPython's `msg` /
+/// `doc` / `pos` / `lineno` / `colno` exception attributes.
+///
+/// As with [`UnicodeErrorData`], the payload exists so host bindings can
+/// construct a real `json.JSONDecodeError` instead of falling back to a plain
+/// `ValueError`; sandboxed code never sees these fields. `lineno`/`colno` are
+/// carried explicitly rather than recomputed from `doc` because `doc` may be
+/// absent (see [`JsonErrorData::MAX_DOC_LEN`]).
+#[derive(Debug, Clone, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct JsonErrorData {
+    /// The bare error message, without the `: line N column M (char K)`
+    /// suffix the formatted exception message carries.
+    pub msg: String,
+    /// The document being parsed, matching CPython's `exc.doc`. `None` when
+    /// the document exceeds [`JsonErrorData::MAX_DOC_LEN`] or is not valid
+    /// UTF-8 (`json.loads` on `bytes` input).
+    pub doc: Option<String>,
+    /// Character index of the error in `doc`, matching CPython's `exc.pos`.
+    pub pos: usize,
+    /// 1-based line of the error, matching CPython's `exc.lineno`.
+    pub lineno: usize,
+    /// 1-based column of the error, matching CPython's `exc.colno`.
+    pub colno: usize,
+}
+
+impl JsonErrorData {
+    /// Document size cap, mirroring [`UnicodeErrorData::MAX_OBJECT_LEN`]:
+    /// exception payloads live outside the sandbox's resource tracker once
+    /// the exception escapes, so `doc` is dropped (not truncated — a partial
+    /// document would misplace `pos`) for larger inputs.
+    pub const MAX_DOC_LEN: usize = 64 * 1024;
+
+    /// Builds the payload for a decode error on `doc`, omitting the document
+    /// when it exceeds [`Self::MAX_DOC_LEN`] or is not valid UTF-8.
+    #[must_use]
+    pub fn build(msg: &str, doc: &[u8], pos: usize, lineno: usize, colno: usize) -> ExcData {
+        let doc = if doc.len() <= Self::MAX_DOC_LEN {
+            str::from_utf8(doc).ok().map(ToOwned::to_owned)
+        } else {
+            None
+        };
+        ExcData::Json(Box::new(Self {
+            msg: msg.to_owned(),
+            doc,
+            pos,
+            lineno,
+            colno,
+        }))
+    }
+
+    /// Approximate byte footprint, used by the heap's memory accounting when
+    /// an exception carrying this payload is stored on the sandbox heap.
+    #[must_use]
+    pub fn estimate_size(&self) -> usize {
+        mem::size_of::<Self>() + self.msg.len() + self.doc.as_ref().map_or(0, String::len)
+    }
+}
+
 /// A single frame in a Python traceback.
 ///
 /// Contains all the information needed to display a traceback line:
@@ -737,6 +714,7 @@ impl fmt::Display for StackFrame {
         Ok(())
     }
 }
+
 /// A line and column position in source code.
 ///
 /// Uses 1-based indexing for both line and column to match Python's conventions.
@@ -771,5 +749,31 @@ impl CodeLoc {
             line: line.saturating_add(1),
             column: column.saturating_add(1),
         }
+    }
+}
+
+/// Formats the message for a `UnicodeDecodeError` covering the byte range
+/// `start..end`: CPython's single-byte form (`byte 0x{first_byte:02x} in
+/// position {start}`) when the range is one byte, otherwise the range form
+/// (`bytes in position {start}-{end - 1}`).
+///
+/// A free function (rather than folded into `ExcType::unicode_decode_error`),
+/// public and re-exported at the crate root, so `monty-fs` can produce the
+/// identical wording when converting a `MountError::InvalidUtf8` from a
+/// text-mode file read into an exception.
+#[must_use]
+pub fn unicode_decode_error_msg(codec: &str, first_byte: u8, start: usize, end: usize, reason: &str) -> String {
+    // Callers must pass a non-empty range; checked in debug builds only so a
+    // wrong caller can't panic the VM in release (it gets a garbled message
+    // position instead, which is harmless).
+    debug_assert!(
+        end > start,
+        "unicode_decode_error_msg: end ({end}) must be > start ({start})"
+    );
+    if end - start == 1 {
+        format!("'{codec}' codec can't decode byte 0x{first_byte:02x} in position {start}: {reason}")
+    } else {
+        let last = end - 1;
+        format!("'{codec}' codec can't decode bytes in position {start}-{last}: {reason}")
     }
 }

--- a/crates/monty-types/src/file_mode.rs
+++ b/crates/monty-types/src/file_mode.rs
@@ -1,0 +1,213 @@
+//! [`FileMode`] — the parsed, validated form of a Python `open()` mode
+//! string, carried by [`MontyFileHandle`](crate::object::MontyFileHandle).
+
+use std::{borrow::Cow, str::FromStr};
+/// A parsed Python `open()` mode.
+///
+/// This single enum captures everything that matters about how a file was
+/// opened: the access pattern (`r`/`w`/`a` and the `+` update flag) and
+/// whether the file is binary. The variant name encodes the access pattern;
+/// the `bool` payload is `true` for binary and `false` for text — i.e.
+/// `Read(true)` is `'rb'` and `Read(false)` is `'r'`.
+///
+/// Construct one with the [`FromStr`] impl (`mode_str.parse::<FileMode>()`).
+/// The original input string is
+/// intentionally not preserved; [`FileMode::as_str`] rebuilds the canonical
+/// CPython form (`'r'`, `'rb+'`, `'wb'`, …), matching how CPython itself
+/// normalizes input like `'rt'` → `'r'` and `'r+b'` → `'rb+'`.
+///
+/// `+` update modes (`ReadUpdate`/`WriteUpdate`/`AppendUpdate`) are reserved
+/// in the enum so the mode space is fully represented, but [`FromStr`]
+/// currently rejects them — properly modelling them needs read-position
+/// tracking that the file wrapper does not yet implement. Treat the `Update`
+/// variants as unreachable at runtime; do not pattern-match against them as
+/// if they were a valid result of parsing user input.
+///
+/// Carried publicly by [`MontyObject::FileHandle`](crate::object::MontyObject) so a host servicing file
+/// operations can inspect the mode without re-parsing the raw string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub enum FileMode {
+    /// `r` / `rb`: read-only; the file must already exist.
+    Read(bool),
+    /// `r+` / `rb+`: read and write an existing file. Reserved; not yet
+    /// produced by [`FromStr`].
+    ReadUpdate(bool),
+    /// `w` / `wb`: write-only; truncate the file (creating it if missing) on open.
+    Write(bool),
+    /// `w+` / `wb+`: read and write; truncate the file (creating it if missing).
+    /// Reserved; not yet produced by [`FromStr`].
+    WriteUpdate(bool),
+    /// `a` / `ab`: write-only appending; create the file if missing, preserving content.
+    Append(bool),
+    /// `a+` / `ab+`: read and append; create the file if missing, preserving content.
+    /// Reserved; not yet produced by [`FromStr`].
+    AppendUpdate(bool),
+}
+impl FileMode {
+    /// Returns the canonical Python `open()` mode string for this mode,
+    /// matching what CPython exposes via `file.mode`.
+    ///
+    /// The result is always one of the 12 well-formed mode strings (`r`, `rb`,
+    /// `r+`, `rb+`, `w`, `wb`, `w+`, `wb+`, `a`, `ab`, `a+`, `ab+`). This is
+    /// the canonical form CPython itself normalizes user input into — e.g.
+    /// `'rt'` → `'r'`, `'r+b'` → `'rb+'`, `'br'` → `'rb'`.
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Read(false) => "r",
+            Self::Read(true) => "rb",
+            Self::ReadUpdate(false) => "r+",
+            Self::ReadUpdate(true) => "rb+",
+            Self::Write(false) => "w",
+            Self::Write(true) => "wb",
+            Self::WriteUpdate(false) => "w+",
+            Self::WriteUpdate(true) => "wb+",
+            Self::Append(false) => "a",
+            Self::Append(true) => "ab",
+            Self::AppendUpdate(false) => "a+",
+            Self::AppendUpdate(true) => "ab+",
+        }
+    }
+
+    /// Whether the file is binary (`'rb'`, `'wb'`, …) rather than text.
+    #[must_use]
+    pub fn is_binary(&self) -> bool {
+        let (Self::Read(b)
+        | Self::ReadUpdate(b)
+        | Self::Write(b)
+        | Self::WriteUpdate(b)
+        | Self::Append(b)
+        | Self::AppendUpdate(b)) = self;
+        *b
+    }
+
+    /// Whether `read()` is allowed by this mode.
+    #[must_use]
+    pub fn readable(&self) -> bool {
+        matches!(
+            self,
+            Self::Read(_) | Self::ReadUpdate(_) | Self::WriteUpdate(_) | Self::AppendUpdate(_)
+        )
+    }
+
+    /// Whether `write()` is allowed by this mode.
+    #[must_use]
+    pub fn writable(&self) -> bool {
+        matches!(
+            self,
+            Self::Write(_) | Self::WriteUpdate(_) | Self::Append(_) | Self::AppendUpdate(_) | Self::ReadUpdate(_)
+        )
+    }
+
+    /// Whether writes should always append (`a`/`a+`).
+    #[must_use]
+    pub fn is_append(&self) -> bool {
+        matches!(self, Self::Append(_) | Self::AppendUpdate(_))
+    }
+
+    /// Whether `open()` must truncate the file to empty immediately (`w`/`w+`).
+    #[must_use]
+    pub fn truncate(&self) -> bool {
+        matches!(self, Self::Write(_) | Self::WriteUpdate(_))
+    }
+
+    /// Whether `open()` must create the file immediately if missing.
+    ///
+    /// True for the `w`/`w+` and `a`/`a+` families. For append modes this must
+    /// not disturb existing content.
+    #[must_use]
+    pub fn create(&self) -> bool {
+        matches!(
+            self,
+            Self::Write(_) | Self::WriteUpdate(_) | Self::Append(_) | Self::AppendUpdate(_)
+        )
+    }
+    /// Returns the bare Python type name (`type(f).__name__`) for this mode.
+    #[must_use]
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            _ if !self.is_binary() => "TextIOWrapper",
+            Self::ReadUpdate(_) | Self::WriteUpdate(_) | Self::AppendUpdate(_) => "BufferedRandom",
+            Self::Read(_) => "BufferedReader",
+            Self::Write(_) | Self::Append(_) => "BufferedWriter",
+        }
+    }
+
+    /// Returns the fully-qualified `_io` wrapper type name a file opened with
+    /// this mode presents as, matching CPython's `repr(f)` (e.g.
+    /// `"_io.TextIOWrapper"`). The module-less form is [`type_name`](Self::type_name).
+    #[must_use]
+    pub fn file_type_name(&self) -> &'static str {
+        match self {
+            _ if !self.is_binary() => "_io.TextIOWrapper",
+            Self::ReadUpdate(_) | Self::WriteUpdate(_) | Self::AppendUpdate(_) => "_io.BufferedRandom",
+            Self::Read(_) => "_io.BufferedReader",
+            Self::Write(_) | Self::Append(_) => "_io.BufferedWriter",
+        }
+    }
+}
+/// Parses a Python `open()` mode string into a [`FileMode`].
+///
+/// Monty supports the common read, write, append, and update combinations in
+/// text or binary form. Exclusive creation (`x`) is rejected for now because
+/// it needs a dedicated mount-table operation to be race-free.
+///
+/// The `Err` payload is a CPython-matched message — empty input, an unknown
+/// mode character, duplicated `b`/`t`/`+`, conflicting binary+text flags, or
+/// more than one of the `r`/`w`/`a` actions.
+impl FromStr for FileMode {
+    type Err = Cow<'static, str>;
+
+    fn from_str(mode: &str) -> Result<Self, Self::Err> {
+        if mode.is_empty() {
+            // CPython's empty-mode error message, mirrored verbatim. Note: the
+            // duplicate-action message is different (lowercase, no `... and at most one
+            // plus` suffix) — see the `'r' | 'w' | 'a'` arm.
+            return Err("Must have exactly one of create/read/write/append mode and at most one plus".into());
+        }
+
+        let mut action = None;
+        let mut binary = false;
+        let mut text = false;
+
+        for ch in mode.chars() {
+            match ch {
+                'r' | 'w' | 'a' => {
+                    if action.replace(ch).is_some() {
+                        return Err("must have exactly one of create/read/write/append mode".into());
+                    }
+                }
+                'x' => return Err("exclusive creation mode is not supported".into()),
+                'b' => {
+                    if binary {
+                        return Err("invalid mode: binary mode specified twice".into());
+                    }
+                    binary = true;
+                }
+                't' => {
+                    if text {
+                        return Err("invalid mode: text mode specified twice".into());
+                    }
+                    text = true;
+                }
+                // `+` modes (`r+`, `w+`, `a+`, and their `b` variants) need
+                // read-position tracking that Monty does not yet implement.
+                // Reject them outright rather than silently truncating on the
+                // first write (which would happen because the OS-level read
+                // and write ops are full-file one-shots).
+                '+' => return Err("update modes ('+') are not yet supported".into()),
+                _ => return Err(format!("invalid mode: {ch:?}").into()),
+            }
+        }
+
+        if binary && text {
+            return Err("can't have text and binary mode at once".into());
+        }
+
+        Ok(match action.unwrap_or('r') {
+            'w' => Self::Write(binary),
+            'a' => Self::Append(binary),
+            _ => Self::Read(binary),
+        })
+    }
+}

--- a/crates/monty-types/src/format.rs
+++ b/crates/monty-types/src/format.rs
@@ -1,0 +1,299 @@
+//! Pure CPython-compatible formatting helpers shared by the boundary types:
+//! string/bytes `repr()` escaping, shortest-round-trip float rendering, and
+//! timezone-offset `timedelta` reprs.
+
+use std::fmt::{self, Write};
+
+use unicode_general_category::{GeneralCategory, get_general_category};
+/// Writes a Python `repr()` string for a given string slice to a formatter.
+///
+/// Quote choice matches CPython: single quotes by default, switching to double
+/// quotes only when the string contains a `'` but no `"` (so the quote needn't
+/// be escaped). Backslash, the active quote, and `\n`/`\t`/`\r` use the short
+/// escapes; any other **non-printable** character is escaped numerically
+/// (`\xNN`/`\uNNNN`/`\UNNNNNNNN`), e.g. `repr('\x00') == "'\\x00'"` and
+/// `repr('\xa0') == "'\\xa0'"`.
+///
+/// "Non-printable" matches CPython's `str.isprintable` (see
+/// `repr_needs_escape`): Unicode categories `C*` and `Z*`, except the ASCII
+/// space. Category data comes from `unicode-general-category`, whose Unicode
+/// version may differ slightly from CPython's, affecting only recently
+/// (re)assigned code points.
+pub fn string_repr_fmt(s: &str, f: &mut impl Write) -> fmt::Result {
+    let quote = if s.contains('\'') && !s.contains('"') {
+        '"'
+    } else {
+        '\''
+    };
+    f.write_char(quote)?;
+    for c in s.chars() {
+        match c {
+            '\\' => f.write_str("\\\\")?,
+            '\n' => f.write_str("\\n")?,
+            '\t' => f.write_str("\\t")?,
+            '\r' => f.write_str("\\r")?,
+            _ if c == quote => {
+                f.write_char('\\')?;
+                f.write_char(quote)?;
+            }
+            _ if repr_needs_escape(c) => write_char_escape(c, f)?,
+            _ => f.write_char(c)?,
+        }
+    }
+    f.write_char(quote)
+}
+
+/// Whether `c` is escaped numerically in a Python `repr` — i.e. it is not
+/// "printable" in CPython's sense.
+///
+/// Non-printable = Unicode general categories `Other` (`Cc`, `Cf`, `Cs`, `Co`,
+/// `Cn`) and `Separator` (`Zl`, `Zp`, `Zs`), with the sole exception of the
+/// ASCII space `U+0020`. The `\t`/`\n`/`\r` short escapes are handled by the
+/// caller before this is consulted.
+fn repr_needs_escape(c: char) -> bool {
+    c != ' '
+        && matches!(
+            get_general_category(c),
+            GeneralCategory::Control
+                | GeneralCategory::Format
+                | GeneralCategory::Surrogate
+                | GeneralCategory::PrivateUse
+                | GeneralCategory::Unassigned
+                | GeneralCategory::LineSeparator
+                | GeneralCategory::ParagraphSeparator
+                | GeneralCategory::SpaceSeparator
+        )
+}
+
+/// Writes the numeric repr escape for a single character, matching CPython's
+/// width selection: `\xNN` for code points `<= 0xFF`, `\uNNNN` for `<= 0xFFFF`,
+/// otherwise `\UNNNNNNNN`.
+fn write_char_escape(c: char, f: &mut impl Write) -> fmt::Result {
+    let cp = c as u32;
+    if cp <= 0xFF {
+        write!(f, "\\x{cp:02x}")
+    } else if cp <= 0xFFFF {
+        write!(f, "\\u{cp:04x}")
+    } else {
+        write!(f, "\\U{cp:08x}")
+    }
+}
+
+/// Formatter for a Python repr() string.
+#[derive(Debug)]
+pub struct StringRepr<'a>(pub &'a str);
+
+impl fmt::Display for StringRepr<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        string_repr_fmt(self.0, f)
+    }
+}
+/// Writes a CPython-compatible repr string for bytes to a formatter.
+///
+/// Format: `b'...'` or `b"..."` depending on content.
+/// - Uses single quotes by default
+/// - Switches to double quotes if bytes contain `'` but not `"`
+/// - Escapes: `\\`, `\t`, `\n`, `\r`, `\xNN` for non-printable bytes
+pub fn bytes_repr_fmt(bytes: &[u8], f: &mut impl Write) -> fmt::Result {
+    // Determine quote character: use double quotes if single quote present but not double
+    let has_single = bytes.contains(&b'\'');
+    let has_double = bytes.contains(&b'"');
+    let quote = if has_single && !has_double { '"' } else { '\'' };
+
+    f.write_char('b')?;
+    f.write_char(quote)?;
+
+    for &byte in bytes {
+        match byte {
+            b'\\' => f.write_str("\\\\")?,
+            b'\t' => f.write_str("\\t")?,
+            b'\n' => f.write_str("\\n")?,
+            b'\r' => f.write_str("\\r")?,
+            b'\'' if quote == '\'' => f.write_str("\\'")?,
+            b'"' if quote == '"' => f.write_str("\\\"")?,
+            // Printable ASCII (32-126)
+            0x20..=0x7e => f.write_char(byte as char)?,
+            // Non-printable: use \xNN format
+            _ => write!(f, "\\x{byte:02x}")?,
+        }
+    }
+
+    f.write_char(quote)
+}
+
+/// Returns a CPython-compatible repr string for bytes.
+///
+/// Convenience wrapper around `bytes_repr_fmt` that returns an owned String.
+#[must_use]
+#[expect(clippy::missing_panics_doc, reason = "writing to a String cannot fail")]
+pub fn bytes_repr(bytes: &[u8]) -> String {
+    let mut result = String::new();
+    // Writing to String never fails
+    bytes_repr_fmt(bytes, &mut result).unwrap();
+    result
+}
+/// A [`Display`](fmt::Display) adapter that writes a float exactly as CPython's
+/// `repr()`/`str()` (identical for floats in Python 3): the shortest decimal
+/// string that round-trips, switching to scientific notation when the base-10
+/// exponent is `< -4` or `>= 16`, and always keeping at least one fractional
+/// digit (`1.0`, never `1`) — `1e16` → `"1e+16"`, `1234.5` → `"1234.5"`,
+/// `inf`/`nan` lowercased.
+///
+/// This is the default rendering for a bare `f"{x}"`, `str(x)`, `repr(x)` and
+/// floats inside container reprs — *not* the format mini-language (that's
+/// `format_float_g` et al, in `monty`). Rust can't do this directly: its `f64` `Display`
+/// never uses scientific notation (`1e16` prints as `10000000000000000`) and
+/// renders NaN as `"NaN"`.
+///
+/// As a `Display` adapter it writes straight to the caller's sink with **no
+/// heap allocation**: it borrows Rust's *shortest-digits* guarantee via `{:e}`
+/// into a small stack buffer (an `f64` `{:e}` is ASCII and ≤ 24 bytes) and
+/// re-lays-out those digits per CPython's rules.
+pub struct FormatFloat(pub f64);
+
+impl fmt::Display for FormatFloat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let v = self.0;
+        if v.is_nan() {
+            return f.write_str("nan");
+        }
+        if v.is_sign_negative() {
+            f.write_char('-')?;
+        }
+        if v.is_infinite() {
+            return f.write_str("inf");
+        }
+        // Rust's shortest scientific form gives minimal round-tripping digits
+        // plus the base-10 exponent (`1234.5` → `"1.2345e3"`, `0.0` → `"0e0"`),
+        // captured in a stack buffer so nothing touches the heap.
+        let mut sci = StackStr::new();
+        write!(sci, "{:e}", v.abs())?;
+        let sci = sci.as_str();
+        let (mantissa, exp_str) = sci.split_once('e').ok_or(fmt::Error)?;
+        // `{:e}` always emits a single leading digit, so the integer part is one
+        // char and the fraction (if any) follows the `.`.
+        let (int_part, frac) = mantissa.split_once('.').unwrap_or((mantissa, ""));
+        let exp10: i32 = exp_str.parse().map_err(|_| fmt::Error)?;
+        let ndigits = int_part.len() + frac.len();
+        // `decpt` = number of digits to the left of the decimal point.
+        let decpt = exp10 + 1;
+
+        if !(-4..16).contains(&exp10) {
+            // Scientific: leading digit, optional fraction, then `e±NN`.
+            f.write_str(int_part)?;
+            if !frac.is_empty() {
+                f.write_char('.')?;
+                f.write_str(frac)?;
+            }
+            let exp_sign = if exp10 < 0 { '-' } else { '+' };
+            write!(f, "e{exp_sign}{:02}", exp10.unsigned_abs())
+        } else if decpt <= 0 {
+            // `0.00…digits` — `-decpt` leading zeros after the point.
+            f.write_str("0.")?;
+            for _ in 0..-decpt {
+                f.write_char('0')?;
+            }
+            f.write_str(int_part)?;
+            f.write_str(frac)
+        } else {
+            let decpt = usize::try_from(decpt).expect("decpt is positive in this branch");
+            if decpt >= ndigits {
+                // Integer-valued: digits, zeros up to the point, then `.0`.
+                f.write_str(int_part)?;
+                f.write_str(frac)?;
+                for _ in 0..decpt - ndigits {
+                    f.write_char('0')?;
+                }
+                f.write_str(".0")
+            } else {
+                // Point falls inside the digit run. `int_part` is a single digit
+                // and `decpt >= 1`, so the split always lands within `frac`.
+                f.write_str(int_part)?;
+                let split = decpt - int_part.len();
+                f.write_str(&frac[..split])?;
+                f.write_char('.')?;
+                f.write_str(&frac[split..])
+            }
+        }
+    }
+}
+
+/// A fixed-capacity [`fmt::Write`] sink backed by a stack array, used to capture
+/// a bounded `{:e}` rendering without a heap allocation.
+///
+/// 32 bytes comfortably holds any `f64` `{:e}` output (the longest is ~24 ASCII
+/// bytes, e.g. `2.2250738585072014e-308`). A write that would overflow returns
+/// [`fmt::Error`] rather than panicking — unreachable for the bounded `f64`
+/// case, but it keeps the type panic-free for any future caller.
+struct StackStr {
+    buf: [u8; 32],
+    len: usize,
+}
+
+impl StackStr {
+    fn new() -> Self {
+        Self { buf: [0; 32], len: 0 }
+    }
+
+    fn as_str(&self) -> &str {
+        // Only `{:e}` of an `f64` is written here, which is always valid ASCII.
+        str::from_utf8(&self.buf[..self.len]).unwrap_or("")
+    }
+}
+
+impl fmt::Write for StackStr {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        let end = self.len.checked_add(s.len()).ok_or(fmt::Error)?;
+        let slot = self.buf.get_mut(self.len..end).ok_or(fmt::Error)?;
+        slot.copy_from_slice(s.as_bytes());
+        self.len = end;
+        Ok(())
+    }
+}
+/// Classifies an invalid-UTF-8 error into CPython's reason wording, from the
+/// first unexpected byte and `Utf8Error::error_len()`.
+///
+/// `error_len == None` means the input ended mid-sequence (`unexpected end of
+/// data`); otherwise a byte that is a legal multi-byte lead (0xC2–0xF4) was
+/// followed by an invalid continuation, and anything else (stray
+/// continuation bytes, the overlong leads 0xC0/0xC1, 0xF5–0xFF) is an
+/// `invalid start byte`. Public (re-exported at the crate root) so `monty-fs`
+/// produces identical wording for text-mode file reads.
+#[must_use]
+pub fn utf8_error_reason(first_bad_byte: u8, error_len: Option<usize>) -> &'static str {
+    if error_len.is_none() {
+        "unexpected end of data"
+    } else if (0xC2..=0xF4).contains(&first_bad_byte) {
+        "invalid continuation byte"
+    } else {
+        "invalid start byte"
+    }
+}
+
+/// Formats the canonical `datetime.timedelta(...)` repr for a fixed timezone
+/// offset in seconds, normalized like Python's `timedelta` (`days` may be
+/// negative, `seconds` in `0..86400`) — e.g. `-18000` →
+/// `datetime.timedelta(days=-1, seconds=68400)`. Used by the
+/// `datetime.timezone` reprs of [`MontyObject`](crate::object::MontyObject).
+#[must_use]
+pub fn format_offset_timedelta_repr(offset_seconds: i32) -> String {
+    const SECONDS_PER_DAY: i32 = 86_400;
+    let days = offset_seconds.div_euclid(SECONDS_PER_DAY);
+    let seconds = offset_seconds.rem_euclid(SECONDS_PER_DAY);
+    if days == 0 && seconds == 0 {
+        "datetime.timedelta(0)".to_owned()
+    } else {
+        let mut out = String::from("datetime.timedelta(");
+        if days != 0 {
+            write!(out, "days={days}").expect("writing to String never fails");
+        }
+        if seconds != 0 {
+            if days != 0 {
+                out.push_str(", ");
+            }
+            write!(out, "seconds={seconds}").expect("writing to String never fails");
+        }
+        out.push(')');
+        out
+    }
+}

--- a/crates/monty-types/src/io.rs
+++ b/crates/monty-types/src/io.rs
@@ -1,7 +1,9 @@
+//! Print-output plumbing: [`PrintStream`], [`PrintWriter`] and the
+//! [`PrintWriterCallback`] trait used by hosts to capture `print()` output.
+
 use std::borrow::Cow;
 
-use crate::exception_public::MontyException;
-
+use crate::exceptions::MontyException;
 /// Identifies the output stream for a single print fragment.
 ///
 /// Today the `print()` builtin only writes to `Stdout`. The `Stderr` variant is

--- a/crates/monty-types/src/lib.rs
+++ b/crates/monty-types/src/lib.rs
@@ -1,12 +1,4 @@
-//! Public data types shared between the `monty` interpreter and its host-side
-//! crates (`monty-proto`, `monty-pool`, the Python/JS bindings).
-//!
-//! This crate contains only owned, heap-free boundary types — values
-//! ([`MontyObject`]), exceptions ([`MontyException`]), OS-call payloads
-//! ([`OsFunctionCall`]), resource limits ([`ResourceLimits`]) and print
-//! plumbing — with **no interpreter implementation**. Hosts that only spawn
-//! `monty` worker subprocesses depend on this crate instead of `monty`, so
-//! their binaries never link the interpreter itself.
+#![doc = include_str!("../README.md")]
 
 pub mod args;
 mod builtins;

--- a/crates/monty-types/src/lib.rs
+++ b/crates/monty-types/src/lib.rs
@@ -1,0 +1,46 @@
+//! Public data types shared between the `monty` interpreter and its host-side
+//! crates (`monty-proto`, `monty-pool`, the Python/JS bindings).
+//!
+//! This crate contains only owned, heap-free boundary types — values
+//! ([`MontyObject`]), exceptions ([`MontyException`]), OS-call payloads
+//! ([`OsFunctionCall`]), resource limits ([`ResourceLimits`]) and print
+//! plumbing — with **no interpreter implementation**. Hosts that only spawn
+//! `monty` worker subprocesses depend on this crate instead of `monty`, so
+//! their binaries never link the interpreter itself.
+
+pub mod args;
+mod builtins;
+mod exceptions;
+mod file_mode;
+pub mod format;
+mod io;
+mod object;
+mod os;
+mod resource;
+mod results;
+mod run_options;
+
+pub use crate::{
+    builtins::BuiltinsFunctions,
+    exceptions::{
+        CodeLoc, ExcData, ExcType, JsonErrorData, MontyException, StackFrame, UnicodeErrorData, UnicodeErrorObject,
+        unicode_decode_error_msg,
+    },
+    file_mode::FileMode,
+    format::{FormatFloat, StringRepr, bytes_repr, bytes_repr_fmt, string_repr_fmt, utf8_error_reason},
+    io::{PrintStream, PrintWriter, PrintWriterCallback},
+    object::{
+        ConversionError, DictPairs, InvalidInputError, MontyDate, MontyDateTime, MontyFileHandle, MontyObject,
+        MontyTimeDelta, MontyTimeZone, MontyType,
+    },
+    os::{
+        GetenvArgs, MkdirCallArgs, MontyPath, OpenCallArgs, OsFunctionCall, PathBytesDataArgs, PathStringDataArgs,
+        RenameCallArgs, dir_stat, file_stat, stat_result, symlink_stat,
+    },
+    resource::{
+        DEFAULT_MAX_RECURSION_DEPTH, LARGE_RESULT_THRESHOLD, LimitedTracker, NoLimitTracker, ResourceError,
+        ResourceLimits, ResourceTracker,
+    },
+    results::{ExtFunctionResult, NameLookupResult},
+    run_options::{AssertMessageAnnotations, CompileOptions},
+};

--- a/crates/monty-types/src/object.rs
+++ b/crates/monty-types/src/object.rs
@@ -22,159 +22,7 @@ use crate::{
     format::{FormatFloat, StringRepr, bytes_repr, format_offset_timedelta_repr, string_repr_fmt},
     resource::ResourceError,
 };
-/// A Python `datetime.date` value with year, month, and day components.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-pub struct MontyDate {
-    /// Gregorian year in range 1..=9999.
-    pub year: i32,
-    /// Month component in range 1..=12.
-    pub month: u8,
-    /// Day component valid for the given month/year.
-    pub day: u8,
-}
 
-/// A Python `datetime.datetime` value with date, time, and optional timezone components.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct MontyDateTime {
-    /// Gregorian year in range 1..=9999.
-    pub year: i32,
-    /// Month component in range 1..=12.
-    pub month: u8,
-    /// Day component valid for the given month/year.
-    pub day: u8,
-    /// Hour in range 0..=23.
-    pub hour: u8,
-    /// Minute in range 0..=59.
-    pub minute: u8,
-    /// Second in range 0..=59.
-    pub second: u8,
-    /// Microsecond in range 0..=999_999.
-    pub microsecond: u32,
-    /// Fixed offset seconds for aware datetimes, or `None` for naive values.
-    pub offset_seconds: Option<i32>,
-    /// Optional explicit timezone name for aware datetimes.
-    ///
-    /// Must be `None` when `offset_seconds` is `None`.
-    pub timezone_name: Option<String>,
-}
-
-/// A Python `datetime.timedelta` value representing a duration.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-pub struct MontyTimeDelta {
-    /// Day component.
-    pub days: i32,
-    /// Seconds component in normalized range 0..86400.
-    pub seconds: i32,
-    /// Microseconds component in normalized range 0..1_000_000.
-    pub microseconds: i32,
-}
-
-/// A Python `datetime.timezone` fixed-offset timezone.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct MontyTimeZone {
-    /// Fixed UTC offset in seconds.
-    pub offset_seconds: i32,
-    /// Optional display name.
-    pub name: Option<String>,
-}
-
-impl PartialEq for MontyDateTime {
-    fn eq(&self, other: &Self) -> bool {
-        let self_aware = self.offset_seconds.is_some();
-        let other_aware = other.offset_seconds.is_some();
-        if self_aware != other_aware {
-            return false;
-        }
-
-        if self_aware {
-            return monty_datetime_utc_micros(self)
-                .zip(monty_datetime_utc_micros(other))
-                .is_some_and(|(lhs, rhs)| lhs == rhs)
-                || monty_datetime_raw_eq(self, other);
-        }
-
-        monty_datetime_local_micros(self)
-            .zip(monty_datetime_local_micros(other))
-            .is_some_and(|(lhs, rhs)| lhs == rhs)
-            || monty_datetime_raw_eq(self, other)
-    }
-}
-
-impl Eq for MontyDateTime {}
-
-impl Hash for MontyDateTime {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        if self.offset_seconds.is_some()
-            && let Some(utc_micros) = monty_datetime_utc_micros(self)
-        {
-            utc_micros.hash(state);
-            return;
-        }
-        if let Some(local_micros) = monty_datetime_local_micros(self) {
-            local_micros.hash(state);
-            return;
-        }
-
-        // Invalid carrier values should still hash deterministically instead of panicking.
-        self.year.hash(state);
-        self.month.hash(state);
-        self.day.hash(state);
-        self.hour.hash(state);
-        self.minute.hash(state);
-        self.second.hash(state);
-        self.microsecond.hash(state);
-        self.offset_seconds.hash(state);
-        self.timezone_name.hash(state);
-    }
-}
-
-impl PartialEq for MontyTimeZone {
-    fn eq(&self, other: &Self) -> bool {
-        self.offset_seconds == other.offset_seconds
-    }
-}
-
-impl Eq for MontyTimeZone {}
-
-impl Hash for MontyTimeZone {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.offset_seconds.hash(state);
-    }
-}
-
-fn monty_datetime_local_micros(datetime: &MontyDateTime) -> Option<i64> {
-    monty_datetime_naive(datetime).map(|naive| naive.and_utc().timestamp_micros())
-}
-
-fn monty_datetime_raw_eq(a: &MontyDateTime, b: &MontyDateTime) -> bool {
-    a.year == b.year
-        && a.month == b.month
-        && a.day == b.day
-        && a.hour == b.hour
-        && a.minute == b.minute
-        && a.second == b.second
-        && a.microsecond == b.microsecond
-        && a.offset_seconds == b.offset_seconds
-        && a.timezone_name == b.timezone_name
-}
-
-fn monty_datetime_utc_micros(datetime: &MontyDateTime) -> Option<i64> {
-    let offset_seconds = datetime.offset_seconds?;
-    let offset_delta = ChronoTimeDelta::try_seconds(i64::from(offset_seconds))?;
-    let utc = monty_datetime_naive(datetime)?.checked_sub_signed(offset_delta)?;
-    Some(utc.and_utc().timestamp_micros())
-}
-
-fn monty_datetime_naive(datetime: &MontyDateTime) -> Option<NaiveDateTime> {
-    let date = NaiveDate::from_ymd_opt(datetime.year, u32::from(datetime.month), u32::from(datetime.day))?;
-    let time = NaiveTime::from_hms_micro_opt(
-        u32::from(datetime.hour),
-        u32::from(datetime.minute),
-        u32::from(datetime.second),
-        datetime.microsecond,
-    )?;
-    Some(date.and_time(time))
-}
 /// A Python value that can be passed to or returned from the interpreter.
 ///
 /// This is the public-facing type for Python values. It owns all its data and can be
@@ -313,141 +161,7 @@ pub enum MontyObject {
     /// This is output-only and cannot be used as an input to the interpreter.
     Cycle(usize, String),
 }
-/// The Python type of a value at the host boundary — the public mirror of the
-/// internal runtime `Type` enum.
-///
-/// Where the runtime `Type::Instance` carries a transient heap id, the public
-/// [`MontyType::Instance`] carries the *resolved class name* as an owned
-/// `String`, so a `MontyType` is always self-contained: it can be serialized,
-/// sent over the subprocess wire protocol, and displayed without heap access.
-///
-/// `Instance` is output-only: a class binding cannot be reconstructed from a
-/// name, so passing `MontyType::Instance` as an *input* is rejected with an
-/// [`InvalidInputError`] (see [`MontyObject`] input conversion).
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    Eq,
-    serde::Serialize,
-    serde::Deserialize,
-    strum::EnumIter,
-    strum::EnumString,
-    strum::IntoStaticStr,
-)]
-#[strum(serialize_all = "lowercase")]
-pub enum MontyType {
-    Ellipsis,
-    Type,
-    #[strum(serialize = "NoneType")]
-    NoneType,
-    Bool,
-    Int,
-    Float,
-    Range,
-    Slice,
-    Date,
-    #[strum(serialize = "datetime.datetime")]
-    DateTime,
-    TimeDelta,
-    TimeZone,
-    Str,
-    Bytes,
-    List,
-    #[strum(serialize = "list_iterator")]
-    ListIterator,
-    #[strum(serialize = "callable_iterator")]
-    CallableIterator,
-    Tuple,
-    NamedTuple,
-    Dict,
-    #[strum(serialize = "dict_keys")]
-    DictKeys,
-    #[strum(serialize = "dict_items")]
-    DictItems,
-    #[strum(serialize = "dict_values")]
-    DictValues,
-    Set,
-    FrozenSet,
-    Dataclass,
-    /// An instance of a sandbox-defined class (`class Foo: ...`), carrying the
-    /// resolved class name (e.g. `"Foo"`). Output-only — rejected as an input.
-    ///
-    /// `#[strum(disabled)]`: excluded from `EnumIter` (no meaningful default
-    /// name; the name round-trip tests iterate the nameable variants only).
-    #[strum(disabled)]
-    Instance(String),
-    /// Exception types render/parse via `ExcType`'s own strum name
-    /// (`"ValueError"`, `"json.JSONDecodeError"`, ...), so this variant is
-    /// `#[strum(disabled)]`: [`name`](Self::name) and
-    /// [`from_type_name`](Self::from_type_name) peel `Exception` off
-    /// explicitly.
-    #[strum(disabled)]
-    Exception(ExcType),
-    Function,
-    #[strum(serialize = "builtin_function_or_method")]
-    BuiltinFunction,
-    Cell,
-    Iterator,
-    Coroutine,
-    Module,
-    #[strum(serialize = "_io.TextIOWrapper")]
-    TextIOWrapper,
-    #[strum(serialize = "_io.BufferedReader")]
-    BufferedReader,
-    #[strum(serialize = "_io.BufferedWriter")]
-    BufferedWriter,
-    #[strum(serialize = "_io.BufferedRandom")]
-    BufferedRandom,
-    #[strum(serialize = "typing._SpecialForm")]
-    SpecialForm,
-    #[strum(serialize = "PosixPath")]
-    Path,
-    Property,
-    #[strum(serialize = "re.Pattern")]
-    RePattern,
-    #[strum(serialize = "re.Match")]
-    ReMatch,
-}
 
-impl fmt::Display for MontyType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.name())
-    }
-}
-
-impl MontyType {
-    /// The Python-visible name of this type (`"int"`, `"datetime.datetime"`,
-    /// `"ValueError"`, or the class name for [`Instance`](Self::Instance)).
-    #[must_use]
-    pub fn name(&self) -> &str {
-        match self {
-            Self::Instance(name) => name,
-            Self::Exception(exc_type) => (*exc_type).into(),
-            // Every remaining variant is named by strum's `IntoStaticStr`
-            // (`Exception`/`Instance` are peeled off above).
-            other => other.into(),
-        }
-    }
-
-    /// Parses a name produced by [`Display`](fmt::Display)/[`name`](Self::name)
-    /// back to the `MontyType` — the wire-protocol decode path for builtin
-    /// type names. Never yields [`Instance`](Self::Instance) (`"object"` and
-    /// class names return `None`); the wire carries instance types in a
-    /// dedicated field instead.
-    ///
-    /// `EnumString` parses via the same strum `serialize` attributes that
-    /// `IntoStaticStr` renders with, so the two stay in lockstep by
-    /// construction. Exception types display as their exception name
-    /// ("ValueError", "json.JSONDecodeError", ...) — fall back to the
-    /// `ExcType` parser.
-    #[must_use]
-    pub fn from_type_name(name: &str) -> Option<Self> {
-        name.parse::<Self>()
-            .ok()
-            .or_else(|| name.parse::<ExcType>().ok().map(Self::Exception))
-    }
-}
 impl fmt::Display for MontyObject {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -459,6 +173,7 @@ impl fmt::Display for MontyObject {
         }
     }
 }
+
 impl MontyObject {
     /// Creates a new `MontyObject` from something that can be converted into a `DictPairs`.
     pub fn dict(dict: impl Into<DictPairs>) -> Self {
@@ -513,8 +228,7 @@ impl MontyObject {
         };
         BASE + payload
     }
-}
-impl MontyObject {
+
     /// Returns the Python `repr()` string for this value.
     ///
     /// # Panics
@@ -971,6 +685,262 @@ impl AsRef<Self> for MontyObject {
     }
 }
 
+/// The Python type of a value at the host boundary — the public mirror of the
+/// internal runtime `Type` enum.
+///
+/// Where the runtime `Type::Instance` carries a transient heap id, the public
+/// [`MontyType::Instance`] carries the *resolved class name* as an owned
+/// `String`, so a `MontyType` is always self-contained: it can be serialized,
+/// sent over the subprocess wire protocol, and displayed without heap access.
+///
+/// `Instance` is output-only: a class binding cannot be reconstructed from a
+/// name, so passing `MontyType::Instance` as an *input* is rejected with an
+/// [`InvalidInputError`] (see [`MontyObject`] input conversion).
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    strum::EnumIter,
+    strum::EnumString,
+    strum::IntoStaticStr,
+)]
+#[strum(serialize_all = "lowercase")]
+pub enum MontyType {
+    Ellipsis,
+    Type,
+    #[strum(serialize = "NoneType")]
+    NoneType,
+    Bool,
+    Int,
+    Float,
+    Range,
+    Slice,
+    Date,
+    #[strum(serialize = "datetime.datetime")]
+    DateTime,
+    TimeDelta,
+    TimeZone,
+    Str,
+    Bytes,
+    List,
+    #[strum(serialize = "list_iterator")]
+    ListIterator,
+    #[strum(serialize = "callable_iterator")]
+    CallableIterator,
+    Tuple,
+    NamedTuple,
+    Dict,
+    #[strum(serialize = "dict_keys")]
+    DictKeys,
+    #[strum(serialize = "dict_items")]
+    DictItems,
+    #[strum(serialize = "dict_values")]
+    DictValues,
+    Set,
+    FrozenSet,
+    Dataclass,
+    /// An instance of a sandbox-defined class (`class Foo: ...`), carrying the
+    /// resolved class name (e.g. `"Foo"`). Output-only — rejected as an input.
+    ///
+    /// `#[strum(disabled)]`: excluded from `EnumIter` (no meaningful default
+    /// name; the name round-trip tests iterate the nameable variants only).
+    #[strum(disabled)]
+    Instance(String),
+    /// Exception types render/parse via `ExcType`'s own strum name
+    /// (`"ValueError"`, `"json.JSONDecodeError"`, ...), so this variant is
+    /// `#[strum(disabled)]`: [`name`](Self::name) and
+    /// [`from_type_name`](Self::from_type_name) peel `Exception` off
+    /// explicitly.
+    #[strum(disabled)]
+    Exception(ExcType),
+    Function,
+    #[strum(serialize = "builtin_function_or_method")]
+    BuiltinFunction,
+    Cell,
+    Iterator,
+    Coroutine,
+    Module,
+    #[strum(serialize = "_io.TextIOWrapper")]
+    TextIOWrapper,
+    #[strum(serialize = "_io.BufferedReader")]
+    BufferedReader,
+    #[strum(serialize = "_io.BufferedWriter")]
+    BufferedWriter,
+    #[strum(serialize = "_io.BufferedRandom")]
+    BufferedRandom,
+    #[strum(serialize = "typing._SpecialForm")]
+    SpecialForm,
+    #[strum(serialize = "PosixPath")]
+    Path,
+    Property,
+    #[strum(serialize = "re.Pattern")]
+    RePattern,
+    #[strum(serialize = "re.Match")]
+    ReMatch,
+}
+
+impl fmt::Display for MontyType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+impl MontyType {
+    /// The Python-visible name of this type (`"int"`, `"datetime.datetime"`,
+    /// `"ValueError"`, or the class name for [`Instance`](Self::Instance)).
+    #[must_use]
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Instance(name) => name,
+            Self::Exception(exc_type) => (*exc_type).into(),
+            // Every remaining variant is named by strum's `IntoStaticStr`
+            // (`Exception`/`Instance` are peeled off above).
+            other => other.into(),
+        }
+    }
+
+    /// Parses a name produced by [`Display`](fmt::Display)/[`name`](Self::name)
+    /// back to the `MontyType` — the wire-protocol decode path for builtin
+    /// type names. Never yields [`Instance`](Self::Instance) (`"object"` and
+    /// class names return `None`); the wire carries instance types in a
+    /// dedicated field instead.
+    ///
+    /// `EnumString` parses via the same strum `serialize` attributes that
+    /// `IntoStaticStr` renders with, so the two stay in lockstep by
+    /// construction. Exception types display as their exception name
+    /// ("ValueError", "json.JSONDecodeError", ...) — fall back to the
+    /// `ExcType` parser.
+    #[must_use]
+    pub fn from_type_name(name: &str) -> Option<Self> {
+        name.parse::<Self>()
+            .ok()
+            .or_else(|| name.parse::<ExcType>().ok().map(Self::Exception))
+    }
+}
+
+/// A Python `datetime.date` value with year, month, and day components.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct MontyDate {
+    /// Gregorian year in range 1..=9999.
+    pub year: i32,
+    /// Month component in range 1..=12.
+    pub month: u8,
+    /// Day component valid for the given month/year.
+    pub day: u8,
+}
+
+/// A Python `datetime.datetime` value with date, time, and optional timezone components.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MontyDateTime {
+    /// Gregorian year in range 1..=9999.
+    pub year: i32,
+    /// Month component in range 1..=12.
+    pub month: u8,
+    /// Day component valid for the given month/year.
+    pub day: u8,
+    /// Hour in range 0..=23.
+    pub hour: u8,
+    /// Minute in range 0..=59.
+    pub minute: u8,
+    /// Second in range 0..=59.
+    pub second: u8,
+    /// Microsecond in range 0..=999_999.
+    pub microsecond: u32,
+    /// Fixed offset seconds for aware datetimes, or `None` for naive values.
+    pub offset_seconds: Option<i32>,
+    /// Optional explicit timezone name for aware datetimes.
+    ///
+    /// Must be `None` when `offset_seconds` is `None`.
+    pub timezone_name: Option<String>,
+}
+
+/// A Python `datetime.timedelta` value representing a duration.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct MontyTimeDelta {
+    /// Day component.
+    pub days: i32,
+    /// Seconds component in normalized range 0..86400.
+    pub seconds: i32,
+    /// Microseconds component in normalized range 0..1_000_000.
+    pub microseconds: i32,
+}
+
+/// A Python `datetime.timezone` fixed-offset timezone.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct MontyTimeZone {
+    /// Fixed UTC offset in seconds.
+    pub offset_seconds: i32,
+    /// Optional display name.
+    pub name: Option<String>,
+}
+
+impl PartialEq for MontyDateTime {
+    fn eq(&self, other: &Self) -> bool {
+        let self_aware = self.offset_seconds.is_some();
+        let other_aware = other.offset_seconds.is_some();
+        if self_aware != other_aware {
+            return false;
+        }
+
+        if self_aware {
+            return monty_datetime_utc_micros(self)
+                .zip(monty_datetime_utc_micros(other))
+                .is_some_and(|(lhs, rhs)| lhs == rhs)
+                || monty_datetime_raw_eq(self, other);
+        }
+
+        monty_datetime_local_micros(self)
+            .zip(monty_datetime_local_micros(other))
+            .is_some_and(|(lhs, rhs)| lhs == rhs)
+            || monty_datetime_raw_eq(self, other)
+    }
+}
+
+impl Eq for MontyDateTime {}
+
+impl Hash for MontyDateTime {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        if self.offset_seconds.is_some()
+            && let Some(utc_micros) = monty_datetime_utc_micros(self)
+        {
+            utc_micros.hash(state);
+            return;
+        }
+        if let Some(local_micros) = monty_datetime_local_micros(self) {
+            local_micros.hash(state);
+            return;
+        }
+
+        // Invalid carrier values should still hash deterministically instead of panicking.
+        self.year.hash(state);
+        self.month.hash(state);
+        self.day.hash(state);
+        self.hour.hash(state);
+        self.minute.hash(state);
+        self.second.hash(state);
+        self.microsecond.hash(state);
+        self.offset_seconds.hash(state);
+        self.timezone_name.hash(state);
+    }
+}
+
+impl PartialEq for MontyTimeZone {
+    fn eq(&self, other: &Self) -> bool {
+        self.offset_seconds == other.offset_seconds
+    }
+}
+
+impl Eq for MontyTimeZone {}
+
+impl Hash for MontyTimeZone {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.offset_seconds.hash(state);
+    }
+}
+
 /// Error returned when a `MontyObject` cannot be converted to the requested Rust type.
 ///
 /// This error is returned by the `TryFrom` implementations when attempting to extract
@@ -1193,4 +1163,38 @@ impl fmt::Display for MontyFileHandle {
             StringRepr(self.mode.as_str())
         )
     }
+}
+
+fn monty_datetime_local_micros(datetime: &MontyDateTime) -> Option<i64> {
+    monty_datetime_naive(datetime).map(|naive| naive.and_utc().timestamp_micros())
+}
+
+fn monty_datetime_raw_eq(a: &MontyDateTime, b: &MontyDateTime) -> bool {
+    a.year == b.year
+        && a.month == b.month
+        && a.day == b.day
+        && a.hour == b.hour
+        && a.minute == b.minute
+        && a.second == b.second
+        && a.microsecond == b.microsecond
+        && a.offset_seconds == b.offset_seconds
+        && a.timezone_name == b.timezone_name
+}
+
+fn monty_datetime_utc_micros(datetime: &MontyDateTime) -> Option<i64> {
+    let offset_seconds = datetime.offset_seconds?;
+    let offset_delta = ChronoTimeDelta::try_seconds(i64::from(offset_seconds))?;
+    let utc = monty_datetime_naive(datetime)?.checked_sub_signed(offset_delta)?;
+    Some(utc.and_utc().timestamp_micros())
+}
+
+fn monty_datetime_naive(datetime: &MontyDateTime) -> Option<NaiveDateTime> {
+    let date = NaiveDate::from_ymd_opt(datetime.year, u32::from(datetime.month), u32::from(datetime.day))?;
+    let time = NaiveTime::from_hms_micro_opt(
+        u32::from(datetime.hour),
+        u32::from(datetime.minute),
+        u32::from(datetime.second),
+        datetime.microsecond,
+    )?;
+    Some(date.and_time(time))
 }

--- a/crates/monty-types/src/object.rs
+++ b/crates/monty-types/src/object.rs
@@ -1,3 +1,6 @@
+//! [`MontyObject`] — the owned, heap-free representation of a Python value
+//! at the host boundary — plus [`MontyType`] and the datetime value types.
+
 use std::{
     borrow::Cow,
     error::Error,
@@ -7,36 +10,18 @@ use std::{
     vec::IntoIter,
 };
 
-use ahash::AHashSet;
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime, TimeDelta as ChronoTimeDelta};
 use indexmap::IndexMap;
 use num_bigint::BigInt;
 use num_traits::{ToPrimitive, Zero};
 
 use crate::{
-    builtins::{Builtins, BuiltinsFunctions},
-    bytecode::VM,
-    defer_drop,
-    exception_private::{ExcType, RunError, SimpleException},
-    fstring::FormatFloat,
-    heap::{Heap, HeapData, HeapId, HeapReadOutput},
-    intern::Interns,
-    resource::{ResourceError, ResourceTracker},
-    types::{
-        Dataclass, LongInt, NamedTuple, OpenFile, Path, PyTrait, TimeZone, Type, allocate_tuple,
-        bytes::{Bytes, bytes_repr},
-        date as date_type, datetime as datetime_type,
-        dict::Dict,
-        file::FileMode,
-        instance::class_name,
-        list::List,
-        set::{FrozenSet, Set},
-        str::{StringRepr, allocate_string, string_repr_fmt},
-        timedelta as timedelta_type, timezone as timezone_type,
-    },
-    value::{EitherStr, Value},
+    builtins::BuiltinsFunctions,
+    exceptions::ExcType,
+    file_mode::FileMode,
+    format::{FormatFloat, StringRepr, bytes_repr, format_offset_timedelta_repr, string_repr_fmt},
+    resource::ResourceError,
 };
-
 /// A Python `datetime.date` value with year, month, and day components.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct MontyDate {
@@ -190,7 +175,6 @@ fn monty_datetime_naive(datetime: &MontyDateTime) -> Option<NaiveDateTime> {
     )?;
     Some(date.and_time(time))
 }
-
 /// A Python value that can be passed to or returned from the interpreter.
 ///
 /// This is the public-facing type for Python values. It owns all its data and can be
@@ -199,7 +183,7 @@ fn monty_datetime_naive(datetime: &MontyDateTime) -> Option<NaiveDateTime> {
 ///
 /// # Input vs Output Variants
 ///
-/// Most variants can be used both as inputs (passed to `Executor::run()`) and outputs
+/// Most variants can be used both as inputs (passed to the interpreter) and outputs
 /// (returned from execution). However:
 /// - `Repr` is output-only: represents values that have no direct `MontyObject` mapping
 /// - `Cycle` is output-only: marks where a cyclic structure referred back to itself
@@ -315,7 +299,7 @@ pub enum MontyObject {
     ///
     /// Contains the `repr()` string of the original value.
     ///
-    /// This is output-only and cannot be used as an input to `Executor::run()`.
+    /// This is output-only and cannot be used as an input to the interpreter.
     Repr(String),
     /// Represents a cycle detected during Value-to-MontyObject conversion.
     ///
@@ -326,10 +310,9 @@ pub enum MontyObject {
     /// type-specific placeholder string (e.g., `"[...]"` for lists, `"{...}"` for
     /// dicts). Two `Cycle` values compare equal if they refer to the same object.
     ///
-    /// This is output-only and cannot be used as an input to `Executor::run()`.
+    /// This is output-only and cannot be used as an input to the interpreter.
     Cycle(usize, String),
 }
-
 /// The Python type of a value at the host boundary — the public mirror of the
 /// internal runtime `Type` enum.
 ///
@@ -341,11 +324,22 @@ pub enum MontyObject {
 /// `Instance` is output-only: a class binding cannot be reconstructed from a
 /// name, so passing `MontyType::Instance` as an *input* is rejected with an
 /// [`InvalidInputError`] (see [`MontyObject`] input conversion).
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, strum::EnumIter)]
-#[non_exhaustive]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    strum::EnumIter,
+    strum::EnumString,
+    strum::IntoStaticStr,
+)]
+#[strum(serialize_all = "lowercase")]
 pub enum MontyType {
     Ellipsis,
     Type,
+    #[strum(serialize = "NoneType")]
     NoneType,
     Bool,
     Int,
@@ -353,19 +347,25 @@ pub enum MontyType {
     Range,
     Slice,
     Date,
+    #[strum(serialize = "datetime.datetime")]
     DateTime,
     TimeDelta,
     TimeZone,
     Str,
     Bytes,
     List,
+    #[strum(serialize = "list_iterator")]
     ListIterator,
+    #[strum(serialize = "callable_iterator")]
     CallableIterator,
     Tuple,
     NamedTuple,
     Dict,
+    #[strum(serialize = "dict_keys")]
     DictKeys,
+    #[strum(serialize = "dict_items")]
     DictItems,
+    #[strum(serialize = "dict_values")]
     DictValues,
     Set,
     FrozenSet,
@@ -377,21 +377,36 @@ pub enum MontyType {
     /// name; the name round-trip tests iterate the nameable variants only).
     #[strum(disabled)]
     Instance(String),
+    /// Exception types render/parse via `ExcType`'s own strum name
+    /// (`"ValueError"`, `"json.JSONDecodeError"`, ...), so this variant is
+    /// `#[strum(disabled)]`: [`name`](Self::name) and
+    /// [`from_type_name`](Self::from_type_name) peel `Exception` off
+    /// explicitly.
+    #[strum(disabled)]
     Exception(ExcType),
     Function,
+    #[strum(serialize = "builtin_function_or_method")]
     BuiltinFunction,
     Cell,
     Iterator,
     Coroutine,
     Module,
+    #[strum(serialize = "_io.TextIOWrapper")]
     TextIOWrapper,
+    #[strum(serialize = "_io.BufferedReader")]
     BufferedReader,
+    #[strum(serialize = "_io.BufferedWriter")]
     BufferedWriter,
+    #[strum(serialize = "_io.BufferedRandom")]
     BufferedRandom,
+    #[strum(serialize = "typing._SpecialForm")]
     SpecialForm,
+    #[strum(serialize = "PosixPath")]
     Path,
     Property,
+    #[strum(serialize = "re.Pattern")]
     RePattern,
+    #[strum(serialize = "re.Match")]
     ReMatch,
 }
 
@@ -409,11 +424,9 @@ impl MontyType {
         match self {
             Self::Instance(name) => name,
             Self::Exception(exc_type) => (*exc_type).into(),
-            // `to_internal` is `Some` for every remaining variant, and strum's
-            // `IntoStaticStr` on `Type` names them all (`Exception`/`Instance`
-            // are peeled off above); the fallback is unreachable but keeps
-            // this panic-free.
-            other => other.to_internal().map_or("object", Into::into),
+            // Every remaining variant is named by strum's `IntoStaticStr`
+            // (`Exception`/`Instance` are peeled off above).
+            other => other.into(),
         }
     }
 
@@ -422,130 +435,19 @@ impl MontyType {
     /// type names. Never yields [`Instance`](Self::Instance) (`"object"` and
     /// class names return `None`); the wire carries instance types in a
     /// dedicated field instead.
+    ///
+    /// `EnumString` parses via the same strum `serialize` attributes that
+    /// `IntoStaticStr` renders with, so the two stay in lockstep by
+    /// construction. Exception types display as their exception name
+    /// ("ValueError", "json.JSONDecodeError", ...) — fall back to the
+    /// `ExcType` parser.
     #[must_use]
     pub fn from_type_name(name: &str) -> Option<Self> {
-        Type::from_type_name(name).map(Self::from_internal_static)
-    }
-
-    /// The internal runtime [`Type`] this variant mirrors, or `None` for
-    /// [`Instance`](Self::Instance) — a class binding cannot be reconstructed
-    /// from a name, which is exactly why `Instance` inputs are rejected.
-    ///
-    /// Keep in lockstep with [`from_internal_static`](Self::from_internal_static);
-    /// both matches are exhaustive so the compiler enforces totality.
-    pub(crate) fn to_internal(&self) -> Option<Type> {
-        match self {
-            Self::Ellipsis => Some(Type::Ellipsis),
-            Self::Type => Some(Type::Type),
-            Self::NoneType => Some(Type::NoneType),
-            Self::Bool => Some(Type::Bool),
-            Self::Int => Some(Type::Int),
-            Self::Float => Some(Type::Float),
-            Self::Range => Some(Type::Range),
-            Self::Slice => Some(Type::Slice),
-            Self::Date => Some(Type::Date),
-            Self::DateTime => Some(Type::DateTime),
-            Self::TimeDelta => Some(Type::TimeDelta),
-            Self::TimeZone => Some(Type::TimeZone),
-            Self::Str => Some(Type::Str),
-            Self::Bytes => Some(Type::Bytes),
-            Self::List => Some(Type::List),
-            Self::ListIterator => Some(Type::ListIterator),
-            Self::CallableIterator => Some(Type::CallableIterator),
-            Self::Tuple => Some(Type::Tuple),
-            Self::NamedTuple => Some(Type::NamedTuple),
-            Self::Dict => Some(Type::Dict),
-            Self::DictKeys => Some(Type::DictKeys),
-            Self::DictItems => Some(Type::DictItems),
-            Self::DictValues => Some(Type::DictValues),
-            Self::Set => Some(Type::Set),
-            Self::FrozenSet => Some(Type::FrozenSet),
-            Self::Dataclass => Some(Type::Dataclass),
-            Self::Instance(_) => None,
-            Self::Exception(exc_type) => Some(Type::Exception(*exc_type)),
-            Self::Function => Some(Type::Function),
-            Self::BuiltinFunction => Some(Type::BuiltinFunction),
-            Self::Cell => Some(Type::Cell),
-            Self::Iterator => Some(Type::Iterator),
-            Self::Coroutine => Some(Type::Coroutine),
-            Self::Module => Some(Type::Module),
-            Self::TextIOWrapper => Some(Type::TextIOWrapper),
-            Self::BufferedReader => Some(Type::BufferedReader),
-            Self::BufferedWriter => Some(Type::BufferedWriter),
-            Self::BufferedRandom => Some(Type::BufferedRandom),
-            Self::SpecialForm => Some(Type::SpecialForm),
-            Self::Path => Some(Type::Path),
-            Self::Property => Some(Type::Property),
-            Self::RePattern => Some(Type::RePattern),
-            Self::ReMatch => Some(Type::ReMatch),
-        }
-    }
-
-    /// Mirrors a runtime [`Type`] whose class identity is NOT needed. Use
-    /// [`from_internal`](Self::from_internal) when a heap is available.
-    ///
-    /// # Panics
-    /// On `Instance`, whose class name cannot be resolved without a heap; it
-    /// is unreachable on every current call path (`Builtins::Type` and
-    /// `from_type_name` never hold/produce it).
-    pub(crate) fn from_internal_static(ty: Type) -> Self {
-        match ty {
-            Type::Ellipsis => Self::Ellipsis,
-            Type::Type => Self::Type,
-            Type::NoneType => Self::NoneType,
-            Type::Bool => Self::Bool,
-            Type::Int => Self::Int,
-            Type::Float => Self::Float,
-            Type::Range => Self::Range,
-            Type::Slice => Self::Slice,
-            Type::Date => Self::Date,
-            Type::DateTime => Self::DateTime,
-            Type::TimeDelta => Self::TimeDelta,
-            Type::TimeZone => Self::TimeZone,
-            Type::Str => Self::Str,
-            Type::Bytes => Self::Bytes,
-            Type::List => Self::List,
-            Type::ListIterator => Self::ListIterator,
-            Type::CallableIterator => Self::CallableIterator,
-            Type::Tuple => Self::Tuple,
-            Type::NamedTuple => Self::NamedTuple,
-            Type::Dict => Self::Dict,
-            Type::DictKeys => Self::DictKeys,
-            Type::DictItems => Self::DictItems,
-            Type::DictValues => Self::DictValues,
-            Type::Set => Self::Set,
-            Type::FrozenSet => Self::FrozenSet,
-            Type::Dataclass => Self::Dataclass,
-            Type::Instance(_) => unreachable!("Type::Instance requires heap access — use MontyType::from_internal"),
-            Type::Exception(exc_type) => Self::Exception(exc_type),
-            Type::Function => Self::Function,
-            Type::BuiltinFunction => Self::BuiltinFunction,
-            Type::Cell => Self::Cell,
-            Type::Iterator => Self::Iterator,
-            Type::Coroutine => Self::Coroutine,
-            Type::Module => Self::Module,
-            Type::TextIOWrapper => Self::TextIOWrapper,
-            Type::BufferedReader => Self::BufferedReader,
-            Type::BufferedWriter => Self::BufferedWriter,
-            Type::BufferedRandom => Self::BufferedRandom,
-            Type::SpecialForm => Self::SpecialForm,
-            Type::Path => Self::Path,
-            Type::Property => Self::Property,
-            Type::RePattern => Self::RePattern,
-            Type::ReMatch => Self::ReMatch,
-        }
-    }
-
-    /// The total mirror of a runtime [`Type`]: `Instance` resolves its class
-    /// name via the heap.
-    pub(crate) fn from_internal(ty: Type, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> Self {
-        match ty {
-            Type::Instance(class_id) => Self::Instance(class_name(class_id, heap, interns).into_owned()),
-            other => Self::from_internal_static(other),
-        }
+        name.parse::<Self>()
+            .ok()
+            .or_else(|| name.parse::<ExcType>().ok().map(Self::Exception))
     }
 }
-
 impl fmt::Display for MontyObject {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -557,20 +459,7 @@ impl fmt::Display for MontyObject {
         }
     }
 }
-
 impl MontyObject {
-    /// Converts a `Value` into a `MontyObject`, properly handling reference counting.
-    ///
-    /// Takes ownership of the `Value`, extracts its content to create a MontyObject,
-    /// then properly drops the Value via `drop_with` to maintain reference counting.
-    ///
-    /// The `interns` parameter is used to look up interned string/bytes content.
-    pub(crate) fn new(value: Value, vm: &mut VM<'_, impl ResourceTracker>) -> Self {
-        let py_obj = Self::from_value(&value, vm);
-        value.drop_with(vm);
-        py_obj
-    }
-
     /// Creates a new `MontyObject` from something that can be converted into a `DictPairs`.
     pub fn dict(dict: impl Into<DictPairs>) -> Self {
         Self::Dict(dict.into())
@@ -587,193 +476,11 @@ impl MontyObject {
         name.parse::<BuiltinsFunctions>().ok().map(Self::BuiltinFunction)
     }
 
-    /// Converts this `MontyObject` into an `Value`, allocating on the heap if needed.
-    ///
-    /// Immediate values (None, Bool, Int, Float, Ellipsis, Exception) are created directly.
-    /// Heap-allocated values (String, Bytes, List, Tuple, Dict) are allocated
-    /// via the heap and wrapped in `Value::Ref`.
-    ///
-    /// # Errors
-    /// Returns `InvalidInputError` if called on the `Repr` variant,
-    /// as it is only valid as an output from code execution, not as an input.
-    pub(crate) fn to_value(self, vm: &mut VM<'_, impl ResourceTracker>) -> Result<Value, InvalidInputError> {
-        match self {
-            Self::Ellipsis => Ok(Value::Ellipsis),
-            Self::None => Ok(Value::None),
-            Self::Bool(b) => Ok(Value::Bool(b)),
-            Self::Int(i) => Ok(Value::Int(i)),
-            Self::BigInt(bi) => Ok(LongInt::new(bi).into_value(vm.heap)?),
-            Self::Float(f) => Ok(Value::Float(f)),
-            Self::String(s) => Ok(allocate_string(s, vm.heap)?),
-            Self::Bytes(b) => Ok(Value::Ref(vm.heap.allocate(HeapData::Bytes(Bytes::new(b)))?)),
-            Self::List(items) => {
-                let values: Vec<Value> = items
-                    .into_iter()
-                    .map(|item| item.to_value(vm))
-                    .collect::<Result<_, _>>()?;
-                Ok(Value::Ref(vm.heap.allocate(HeapData::List(List::new(values)))?))
-            }
-            Self::Tuple(items) => {
-                let values = items
-                    .into_iter()
-                    .map(|item| item.to_value(vm))
-                    .collect::<Result<_, _>>()?;
-                allocate_tuple(values, vm.heap).map_err(InvalidInputError::Resource)
-            }
-            Self::NamedTuple {
-                type_name,
-                field_names,
-                values,
-            } => {
-                let values: Vec<Value> = values
-                    .into_iter()
-                    .map(|item| item.to_value(vm))
-                    .collect::<Result<_, _>>()?;
-                let field_name_strs: Vec<EitherStr> = field_names.into_iter().map(Into::into).collect();
-                let nt = NamedTuple::new(type_name, field_name_strs, values);
-                Ok(Value::Ref(vm.heap.allocate(HeapData::NamedTuple(nt))?))
-            }
-            Self::Dict(map) => {
-                let pairs: Result<Vec<(Value, Value)>, InvalidInputError> = map
-                    .into_iter()
-                    .map(|(k, v)| Ok((k.to_value(vm)?, v.to_value(vm)?)))
-                    .collect();
-                let dict = Dict::from_pairs(pairs?, vm)
-                    .map_err(|_| InvalidInputError::invalid_type("unhashable dict keys"))?;
-                Ok(Value::Ref(vm.heap.allocate(HeapData::Dict(dict))?))
-            }
-            Self::Set(items) => {
-                let mut set = Set::new();
-                for item in items {
-                    let value = item.to_value(vm)?;
-                    set.add(value, vm)
-                        .map_err(|_| InvalidInputError::invalid_type("unhashable set element"))?;
-                }
-                Ok(Value::Ref(vm.heap.allocate(HeapData::Set(set))?))
-            }
-            Self::FrozenSet(items) => {
-                let mut set = Set::new();
-                for item in items {
-                    let value = item.to_value(vm)?;
-                    set.add(value, vm)
-                        .map_err(|_| InvalidInputError::invalid_type("unhashable frozenset element"))?;
-                }
-                // Convert to frozenset by extracting storage
-                let frozenset = FrozenSet::from_set(set);
-                Ok(Value::Ref(vm.heap.allocate(HeapData::FrozenSet(frozenset))?))
-            }
-            Self::Date(date) => {
-                let value = date_type::from_ymd(date.year, i32::from(date.month), i32::from(date.day))
-                    .map_err(|_| InvalidInputError::invalid_type("date"))?;
-                Ok(Value::Ref(vm.heap.allocate(HeapData::Date(value))?))
-            }
-            Self::DateTime(datetime) => {
-                let MontyDateTime {
-                    year,
-                    month,
-                    day,
-                    hour,
-                    minute,
-                    second,
-                    microsecond,
-                    offset_seconds,
-                    timezone_name,
-                } = datetime;
-                if offset_seconds.is_none() && timezone_name.is_some() {
-                    return Err(InvalidInputError::invalid_type("datetime"));
-                }
-                let tzinfo = offset_seconds
-                    .map(|offset| TimeZone::new(offset, timezone_name))
-                    .transpose()
-                    .map_err(|_| InvalidInputError::invalid_type("datetime"))?;
-                let value = datetime_type::from_components(
-                    year,
-                    i32::from(month),
-                    i32::from(day),
-                    i32::from(hour),
-                    i32::from(minute),
-                    i32::from(second),
-                    i32::try_from(microsecond).map_err(|_| InvalidInputError::invalid_type("datetime"))?,
-                    tzinfo,
-                    None,
-                    vm.heap,
-                )
-                .map_err(|_| InvalidInputError::invalid_type("datetime"))?;
-                Ok(Value::Ref(vm.heap.allocate(HeapData::DateTime(value))?))
-            }
-            Self::TimeDelta(delta) => {
-                let delta = timedelta_type::new(delta.days, delta.seconds, delta.microseconds)
-                    .map_err(|_| InvalidInputError::invalid_type("timedelta"))?;
-                Ok(Value::Ref(vm.heap.allocate(HeapData::TimeDelta(delta))?))
-            }
-            Self::TimeZone(tz) => {
-                if tz.offset_seconds == 0 && tz.name.is_none() {
-                    vm.heap
-                        .get_timezone_utc()
-                        .map_err(|_| InvalidInputError::invalid_type("timezone"))
-                } else {
-                    let tz = TimeZone::new(tz.offset_seconds, tz.name)
-                        .map_err(|_| InvalidInputError::invalid_type("timezone"))?;
-                    Ok(Value::Ref(vm.heap.allocate(HeapData::TimeZone(tz))?))
-                }
-            }
-            Self::Exception { exc_type, arg } => {
-                let exc = SimpleException::new(exc_type, arg);
-                Ok(Value::Ref(vm.heap.allocate(HeapData::Exception(exc))?))
-            }
-            Self::Dataclass {
-                name,
-                type_id,
-                field_names,
-                attrs,
-                frozen,
-            } => {
-                // Convert attrs to Dict
-                let pairs: Result<Vec<(Value, Value)>, InvalidInputError> = attrs
-                    .into_iter()
-                    .map(|(k, v)| Ok((k.to_value(vm)?, v.to_value(vm)?)))
-                    .collect();
-                let dict = Dict::from_pairs(pairs?, vm)
-                    .map_err(|_| InvalidInputError::invalid_type("unhashable dataclass attr keys"))?;
-                let dc = Dataclass::new(name, type_id, field_names, dict, frozen);
-                Ok(Value::Ref(vm.heap.allocate(HeapData::Dataclass(dc))?))
-            }
-            Self::Path(s) => Ok(Value::Ref(vm.heap.allocate(HeapData::Path(Path::new(s)))?)),
-            Self::FileHandle(handle) => {
-                let file = OpenFile::with_state(handle.path, handle.mode, handle.position);
-                Ok(Value::Ref(vm.heap.allocate(HeapData::OpenFile(file))?))
-            }
-            Self::Type(t) => match t.to_internal() {
-                Some(ty) => Ok(Value::Builtin(Builtins::Type(ty))),
-                // `MontyType::Instance` carries only a class name — the class
-                // binding cannot be reconstructed inside the sandbox (see the
-                // invariant on the runtime `Type::Instance` variant).
-                None => Err(InvalidInputError::invalid_type(
-                    "a sandbox class type object is not a valid input value",
-                )),
-            },
-            Self::BuiltinFunction(f) => Ok(Value::Builtin(Builtins::Function(f))),
-            Self::Function { name, .. } => {
-                // Try to intern the function name. If the name is already interned
-                // (common case: the function has the same name as the variable it was
-                // assigned to), use the lightweight `Value::ExtFunction(StringId)`.
-                // Otherwise, allocate a `HeapData::ExtFunction(String)` on the heap.
-                if let Some(string_id) = vm.interns.get_string_id_by_name(&name) {
-                    Ok(Value::ExtFunction(string_id))
-                } else {
-                    Ok(Value::Ref(vm.heap.allocate(HeapData::ExtFunction(name))?))
-                }
-            }
-            Self::Repr(_) => Err(InvalidInputError::invalid_type("'Repr' is not a valid input value")),
-            Self::Cycle(_, _) => Err(InvalidInputError::invalid_type("'Cycle' is not a valid input value")),
-        }
-    }
-
     /// Shallow host footprint of a freshly decoded `obj`: the fixed [`MontyObject`]
     /// size plus any leaf payload it owns *directly* (string/bytes/bigint bytes, and
     /// the `Vec<String>` field names of structured values, which aren't themselves
     /// `MontyObject`s and would otherwise be uncharged). Container elements are
-    /// excluded — each charges its own size via [`decode_field`], so a list charges
+    /// excluded — each charges its own size via `monty-proto`'s `decode_field`, so a list charges
     /// 88 bytes here.
     pub fn host_size(&self) -> usize {
         /// Fixed size of one `MontyObject` (88 bytes today) — the per-element cost
@@ -806,325 +513,7 @@ impl MontyObject {
         };
         BASE + payload
     }
-
-    /// Top-level entry into [`from_value_inner`], allocating the visited-set used
-    /// for cycle detection.
-    fn from_value(object: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> Self {
-        let mut visited = AHashSet::new();
-        Self::from_value_inner(object, vm, &mut visited)
-    }
-
-    /// Internal helper for converting Value to MontyObject with cycle detection.
-    ///
-    /// Non-`Ref` variants are produced inline using only the interner — they
-    /// never recurse through the heap. `Ref` variants dispatch via
-    /// `vm.heap.read(id)` so the resulting [`HeapRead`] keeps the heap entry
-    /// alive (through its reader count) without retaining a borrow on
-    /// `vm.heap`. Container children are walked via short-lived borrows that
-    /// `clone_with_heap` the next child before recursing — the `inc_ref` makes
-    /// it safe for a future user-defined `__repr__` to mutate the surrounding
-    /// container during the recursive call without freeing the value mid-format.
-    fn from_value_inner(object: &Value, vm: &mut VM<'_, impl ResourceTracker>, visited: &mut AHashSet<HeapId>) -> Self {
-        // Check depth limit before processing
-        let Ok(mut guard) = vm.recursion_guard() else {
-            return Self::Repr("<deeply nested>".to_owned());
-        };
-        let vm = &mut *guard;
-
-        let interns = vm.interns;
-        match object {
-            Value::Undefined => panic!("Undefined found while converting to MontyObject"),
-            Value::Ellipsis => Self::Ellipsis,
-            Value::None => Self::None,
-            Value::Bool(b) => Self::Bool(*b),
-            Value::Int(i) => Self::Int(*i),
-            Value::Float(f) => Self::Float(*f),
-            Value::InternString(string_id) => Self::String(interns.get_str(*string_id).to_owned()),
-            Value::InternBytes(bytes_id) => Self::Bytes(interns.get_bytes(*bytes_id).to_owned()),
-            Value::InternLongInt(li_id) => Self::BigInt(interns.get_long_int(*li_id).clone()),
-            Value::Ref(id) => {
-                // Check for cycle
-                if visited.contains(id) {
-                    // Cycle detected - return appropriate placeholder
-                    return match vm.heap.get(*id) {
-                        HeapData::List(_) => Self::Cycle(id.index(), "[...]".to_owned()),
-                        HeapData::Tuple(_) | HeapData::NamedTuple(_) => Self::Cycle(id.index(), "(...)".to_owned()),
-                        HeapData::Dict(_) => Self::Cycle(id.index(), "{...}".to_owned()),
-                        _ => Self::Cycle(id.index(), "...".to_owned()),
-                    };
-                }
-
-                // Mark this id as being visited
-                visited.insert(*id);
-
-                let result = match vm.heap.read(*id) {
-                    HeapReadOutput::Str(s) => Self::String(s.get(vm.heap).as_str().to_owned()),
-                    HeapReadOutput::Bytes(b) => Self::Bytes(b.get(vm.heap).as_slice().to_owned()),
-                    HeapReadOutput::List(list) => {
-                        let len = list.get(vm.heap).len();
-                        let mut items = Vec::with_capacity(len);
-                        for i in 0..len {
-                            let item = list.get(vm.heap).as_slice()[i].clone_with_heap(vm.heap);
-                            defer_drop!(item, vm);
-                            items.push(Self::from_value_inner(item, vm, visited));
-                        }
-                        Self::List(items)
-                    }
-                    HeapReadOutput::Tuple(tuple) => {
-                        let len = tuple.get(vm.heap).as_slice().len();
-                        let mut items = Vec::with_capacity(len);
-                        for i in 0..len {
-                            let item = tuple.get(vm.heap).as_slice()[i].clone_with_heap(vm.heap);
-                            defer_drop!(item, vm);
-                            items.push(Self::from_value_inner(item, vm, visited));
-                        }
-                        Self::Tuple(items)
-                    }
-                    HeapReadOutput::NamedTuple(nt) => {
-                        let type_name = nt.get(vm.heap).name(vm.interns).to_owned();
-                        let field_names = nt
-                            .get(vm.heap)
-                            .field_names()
-                            .iter()
-                            .map(|fname| fname.as_str(vm.interns).to_owned())
-                            .collect::<Vec<_>>();
-                        let len = nt.get(vm.heap).len();
-                        let mut values = Vec::with_capacity(len);
-                        for i in 0..len {
-                            let item = nt.get(vm.heap).as_vec()[i].clone_with_heap(vm.heap);
-                            defer_drop!(item, vm);
-                            values.push(Self::from_value_inner(item, vm, visited));
-                        }
-                        Self::NamedTuple {
-                            type_name,
-                            field_names,
-                            values,
-                        }
-                    }
-                    HeapReadOutput::Dict(dict) => {
-                        let len = dict.get(vm.heap).len();
-                        let mut pairs = Vec::with_capacity(len);
-                        for i in 0..len {
-                            let key = dict
-                                .get(vm.heap)
-                                .key_at(i)
-                                .expect("index in range")
-                                .clone_with_heap(vm.heap);
-                            defer_drop!(key, vm);
-                            let k = Self::from_value_inner(key, vm, visited);
-                            let value = dict
-                                .get(vm.heap)
-                                .value_at(i)
-                                .expect("index in range")
-                                .clone_with_heap(vm.heap);
-                            defer_drop!(value, vm);
-                            let v = Self::from_value_inner(value, vm, visited);
-                            pairs.push((k, v));
-                        }
-                        Self::Dict(DictPairs(pairs))
-                    }
-                    HeapReadOutput::Set(set) => {
-                        let len = set.get(vm.heap).len();
-                        let mut items = Vec::with_capacity(len);
-                        for i in 0..len {
-                            let item = set
-                                .get(vm.heap)
-                                .storage()
-                                .value_at(i)
-                                .expect("index in range")
-                                .clone_with_heap(vm.heap);
-                            defer_drop!(item, vm);
-                            items.push(Self::from_value_inner(item, vm, visited));
-                        }
-                        Self::Set(items)
-                    }
-                    HeapReadOutput::FrozenSet(fs) => {
-                        let len = fs.get(vm.heap).len();
-                        let mut items = Vec::with_capacity(len);
-                        for i in 0..len {
-                            let item = fs
-                                .get(vm.heap)
-                                .storage()
-                                .value_at(i)
-                                .expect("index in range")
-                                .clone_with_heap(vm.heap);
-                            defer_drop!(item, vm);
-                            items.push(Self::from_value_inner(item, vm, visited));
-                        }
-                        Self::FrozenSet(items)
-                    }
-                    // Cells are internal closure implementation details — show
-                    // the contents directly without exposing the wrapper.
-                    HeapReadOutput::Cell(cell) => {
-                        let inner = cell.get(vm.heap).0.clone_with_heap(vm.heap);
-                        defer_drop!(inner, vm);
-                        Self::from_value_inner(inner, vm, visited)
-                    }
-                    HeapReadOutput::Date(d) => {
-                        let (year, month, day) = date_type::to_ymd(*d.get(vm.heap));
-                        Self::Date(MontyDate {
-                            year,
-                            month: u8::try_from(month).expect("month is always 1..=12"),
-                            day: u8::try_from(day).expect("day is always 1..=31"),
-                        })
-                    }
-                    HeapReadOutput::DateTime(dt) => {
-                        if let Some((year, month, day, hour, minute, second, microsecond)) =
-                            datetime_type::to_components(dt.get(vm.heap))
-                        {
-                            Self::DateTime(MontyDateTime {
-                                year,
-                                month,
-                                day,
-                                hour,
-                                minute,
-                                second,
-                                microsecond,
-                                offset_seconds: datetime_type::offset_seconds(dt.get(vm.heap)),
-                                timezone_name: datetime_type::timezone_info(dt.get(vm.heap)).and_then(|tz| tz.name),
-                            })
-                        } else {
-                            repr_or_error(object, vm)
-                        }
-                    }
-                    HeapReadOutput::TimeDelta(td) => {
-                        let (days, seconds, microseconds) = timedelta_type::components(td.get(vm.heap));
-                        Self::TimeDelta(MontyTimeDelta {
-                            days,
-                            seconds,
-                            microseconds,
-                        })
-                    }
-                    HeapReadOutput::TimeZone(tz) => {
-                        let tz_ref = tz.get(vm.heap);
-                        Self::TimeZone(MontyTimeZone {
-                            offset_seconds: tz_ref.offset_seconds,
-                            name: tz_ref.name.clone(),
-                        })
-                    }
-                    HeapReadOutput::Exception(exc) => {
-                        let exc_ref = exc.get(vm.heap);
-                        Self::Exception {
-                            exc_type: exc_ref.exc_type(),
-                            arg: exc_ref.arg().map(ToString::to_string),
-                        }
-                    }
-                    HeapReadOutput::Dataclass(dc) => {
-                        let (name, type_id, field_names, frozen, attrs_len) = {
-                            let dc_ref = dc.get(vm.heap);
-                            (
-                                dc_ref.name(vm.interns).to_owned(),
-                                dc_ref.type_id(),
-                                dc_ref.field_names().to_vec(),
-                                dc_ref.is_frozen(),
-                                dc_ref.attrs().len(),
-                            )
-                        };
-                        let mut pairs = Vec::with_capacity(attrs_len);
-                        for i in 0..attrs_len {
-                            let key = dc
-                                .get(vm.heap)
-                                .attrs()
-                                .key_at(i)
-                                .expect("index in range")
-                                .clone_with_heap(vm.heap);
-                            defer_drop!(key, vm);
-                            let k = Self::from_value_inner(key, vm, visited);
-                            let value = dc
-                                .get(vm.heap)
-                                .attrs()
-                                .value_at(i)
-                                .expect("index in range")
-                                .clone_with_heap(vm.heap);
-                            defer_drop!(value, vm);
-                            let v = Self::from_value_inner(value, vm, visited);
-                            pairs.push((k, v));
-                        }
-                        Self::Dataclass {
-                            name,
-                            type_id,
-                            field_names,
-                            attrs: DictPairs(pairs),
-                            frozen,
-                        }
-                    }
-                    // Iterators are internal objects — represent as a fixed type
-                    // string rather than recursing.
-                    HeapReadOutput::Iter(_) => Self::Repr("<iterator>".to_owned()),
-                    HeapReadOutput::LongInt(li) => Self::BigInt(li.get(vm.heap).inner().clone()),
-                    HeapReadOutput::Module(m) => {
-                        Self::Repr(format!("<module '{}'>", vm.interns.get_str(m.get(vm.heap).name())))
-                    }
-                    HeapReadOutput::Coroutine(coro) => {
-                        let func_id = coro.get(vm.heap).func_id;
-                        let func = vm.interns.get_function(func_id);
-                        let name = vm.interns.get_str(func.name.name_id);
-                        Self::Repr(format!("<coroutine object {name}>"))
-                    }
-                    HeapReadOutput::GatherFuture(gather) => {
-                        Self::Repr(format!("<gather({})>", gather.get(vm.heap).item_count()))
-                    }
-                    HeapReadOutput::Path(path) => Self::Path(path.get(vm.heap).as_str().to_owned()),
-                    // File objects carry no heap refs (leaf type) — no recursion.
-                    // This is how `file.read()`/`write()` deliver the open file
-                    // to the host as the first OS-call argument.
-                    HeapReadOutput::OpenFile(file) => {
-                        let file = file.get(vm.heap);
-                        Self::FileHandle(MontyFileHandle {
-                            path: file.path().to_owned(),
-                            mode: *file.file_mode(),
-                            position: file.position(),
-                        })
-                    }
-                    HeapReadOutput::ExtFunction(name) => Self::Function {
-                        name: name.get(vm.heap).clone(),
-                        docstring: None,
-                    },
-                    _ => repr_or_error(object, vm),
-                };
-
-                // Remove from visited set after processing
-                visited.remove(id);
-                result
-            }
-            Value::Builtin(Builtins::Type(t)) => Self::Type(MontyType::from_internal(*t, vm.heap, vm.interns)),
-            Value::Builtin(Builtins::ExcType(e)) => Self::Type(MontyType::Exception(*e)),
-            Value::Builtin(Builtins::Function(f)) => Self::BuiltinFunction(*f),
-            // Inline external function: export under the same shape as the heap
-            // path's `HeapReadOutput::ExtFunction` arm above, so an interned
-            // function name round-trips through Monty as `MontyObject::Function`
-            // regardless of which representation it took (issue #345).
-            Value::ExtFunction(name_id) => Self::Function {
-                name: vm.interns.get_str(*name_id).to_owned(),
-                docstring: None,
-            },
-            #[cfg(feature = "memory-model-checks")]
-            Value::Dereferenced => panic!("Dereferenced found while converting to MontyObject"),
-            _ => repr_or_error(object, vm),
-        }
-    }
 }
-
-/// Converts a value to its repr string for `MontyObject`, falling back to a
-/// descriptive error message if `py_repr` fails (e.g. INT_MAX_STR_DIGITS).
-fn repr_or_error(value: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> MontyObject {
-    match value.py_repr(vm) {
-        Ok(s) => {
-            // `py_repr` yields a heap `str` `Value`; extract its text and drop it.
-            defer_drop!(s, vm);
-            MontyObject::Repr(s.to_str(vm).map(str::to_owned).unwrap_or_default())
-        }
-        Err(e) => {
-            let ty = value.py_type_name(vm);
-            let msg = match &e {
-                RunError::Internal(s) => s.to_string(),
-                RunError::Exc(exc) | RunError::UncatchableExc(exc) => exc.exc.to_string(),
-            };
-            MontyObject::Repr(format!("<{ty} object, error on repr(): {msg}>"))
-        }
-    }
-}
-
 impl MontyObject {
     /// Returns the Python `repr()` string for this value.
     ///
@@ -1257,7 +646,7 @@ impl MontyObject {
                     if offset == 0 && datetime.timezone_name.is_none() {
                         f.write_str(", tzinfo=datetime.timezone.utc")?;
                     } else {
-                        let timedelta_repr = timezone_type::format_offset_timedelta_repr(offset);
+                        let timedelta_repr = format_offset_timedelta_repr(offset);
                         write!(f, ", tzinfo=datetime.timezone({timedelta_repr}")?;
                         if let Some(name) = &datetime.timezone_name {
                             write!(f, ", {}", StringRepr(name))?;
@@ -1296,7 +685,7 @@ impl MontyObject {
                 if tz.offset_seconds == 0 && tz.name.is_none() {
                     return f.write_str("datetime.timezone.utc");
                 }
-                let timedelta_repr = timezone_type::format_offset_timedelta_repr(tz.offset_seconds);
+                let timedelta_repr = format_offset_timedelta_repr(tz.offset_seconds);
                 write!(f, "datetime.timezone({timedelta_repr}")?;
                 if let Some(name) = &tz.name {
                     write!(f, ", {}", StringRepr(name))?;
@@ -1773,14 +1162,14 @@ impl DictPairs {
 
 /// An open file object (the result of `open()`).
 ///
-/// This is the boundary representation of Monty's heap [`OpenFile`](crate::types::OpenFile)
+/// This is the boundary representation of Monty's heap `OpenFile`
 /// wrapper. It carries everything needed to service a file operation from a
 /// host that holds no live OS handle: the virtual `path`, the `mode`, and
 /// the byte `position` for seek-aware reads.
 ///
 /// The host produces a `FileHandle` as the result of an
-/// [`OsFunction::Open`](crate::os::OsFunction::Open) call; `to_value` then
-/// builds the `OpenFile` heap wrapper from it. Conversely, a heap file
+/// [`OsFunctionCall::Open`](crate::os::OsFunctionCall::Open) call; the
+/// interpreter then builds its heap file wrapper from it. Conversely, a heap file
 /// object passed as an argument to a `read`/`write` OS call is converted
 /// back to a `FileHandle` so the host receives this state.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -1799,7 +1188,7 @@ impl fmt::Display for MontyFileHandle {
         write!(
             f,
             "<{} name={} mode={}>",
-            self.mode.file_type(),
+            self.mode.file_type_name(),
             StringRepr(&self.path),
             StringRepr(self.mode.as_str())
         )

--- a/crates/monty-types/src/object.rs
+++ b/crates/monty-types/src/object.rs
@@ -22,19 +22,21 @@ use crate::{
     resource::ResourceError,
 };
 
-/// A Python value that can be passed to or returned from the interpreter.
+/// An owned Python value exchanged between Monty and its host.
 ///
-/// This is the public-facing type for Python values. It owns all its data and can be
-/// freely cloned, serialized, or stored. Unlike the internal `Value` type, `MontyObject`
-/// does not require a heap for operations.
+/// Construct `MontyObject` values to provide globals, external-function
+/// results, and other inputs to sandboxed code. Execution results and values
+/// passed to host callbacks use the same representation.
 ///
-/// # Input vs Output Variants
+/// Most common Python values have a direct variant, including nested
+/// collections and datetime values. [`Repr`](Self::Repr) and
+/// [`Cycle`](Self::Cycle) can only appear in output because they cannot be
+/// reconstructed as executable Python values. [`Exception`](Self::Exception)
+/// can be used both to raise an exception and to represent one returned by
+/// execution.
 ///
-/// Most variants can be used both as inputs (passed to the interpreter) and outputs
-/// (returned from execution). However:
-/// - `Repr` is output-only: represents values that have no direct `MontyObject` mapping
-/// - `Cycle` is output-only: marks where a cyclic structure referred back to itself
-/// - `Exception` can be used as input (to raise) or output (when code raises)
+/// Collections are owned snapshots: modifying a returned `MontyObject` does
+/// not modify the corresponding value in a running session.
 ///
 /// # Hashability
 ///

--- a/crates/monty-types/src/object.rs
+++ b/crates/monty-types/src/object.rs
@@ -11,7 +11,6 @@ use std::{
 };
 
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime, TimeDelta as ChronoTimeDelta};
-use indexmap::IndexMap;
 use num_bigint::BigInt;
 use num_traits::{ToPrimitive, Zero};
 
@@ -1074,18 +1073,6 @@ pub struct DictPairs(Vec<(MontyObject, MontyObject)>);
 impl From<Vec<(MontyObject, MontyObject)>> for DictPairs {
     fn from(pairs: Vec<(MontyObject, MontyObject)>) -> Self {
         Self(pairs)
-    }
-}
-
-impl From<IndexMap<MontyObject, MontyObject>> for DictPairs {
-    fn from(map: IndexMap<MontyObject, MontyObject>) -> Self {
-        Self(map.into_iter().collect())
-    }
-}
-
-impl From<DictPairs> for IndexMap<MontyObject, MontyObject> {
-    fn from(pairs: DictPairs) -> Self {
-        pairs.into_iter().collect()
     }
 }
 

--- a/crates/monty-types/src/os.rs
+++ b/crates/monty-types/src/os.rs
@@ -1,39 +1,23 @@
 //! OS-level operations that require host system access.
 //!
 //! Defines [`OsFunctionCall`] — a tagged dispatch value whose variants carry
-//! the typed args each OS-call accepts. Type methods and builtins return one
-//! as [`CallResult::OsCall`](crate::bytecode::CallResult::OsCall); the VM
-//! yields [`FrameExit::OsCall`](crate::bytecode::FrameExit::OsCall) so the
-//! host decides whether to permit it. The interpreter itself never performs
-//! I/O.
+//! the typed args each OS-call accepts. Sandboxed code suspends with one of
+//! these; the host (a `MountTable`, an `os` callback) decides whether to
+//! permit it. The interpreter itself never performs I/O.
 //!
 //! The fs/ layer matches on the enum directly (no `MontyObject` introspection);
 //! host bindings get a generic `(positional, keyword)` view via
 //! [`OsFunctionCall::to_args`].
-//!
-//! # Adding a new OS call
-//!
-//! Add a variant carrying a struct (reuse [`PathStringDataArgs`] etc. if the
-//! shape matches), derive `ToArgs` on the struct, update
-//! [`OsFunctionCall::name`] and the other inherent methods, add a matching
-//! typed arm to `monty.proto`'s `OsCall` and `monty-proto`'s conversions,
-//! then wire the new variant into the fs/ dispatcher and any host backends.
 
 use std::{fmt, ops::Deref};
 
 use crate::{
-    ExcType, MontyException, MontyObject,
-    args::{ArgValues, FromArgs, LaxBool, ToArgs, ToMontyObject},
-    bytecode::VM,
-    exception_private::RunResult,
-    heap::{ContainsHeap, DropWithContext, Heap, HeapData},
-    intern::{Interns, StaticStrings},
-    object::MontyTimeZone,
-    resource::ResourceTracker,
-    types::{file::FileMode, str::StringRepr},
-    value::Value,
+    args::{ToArgs, ToMontyObject},
+    exceptions::{ExcType, MontyException},
+    file_mode::FileMode,
+    format::StringRepr,
+    object::{MontyObject, MontyTimeZone},
 };
-
 // =============================================================================
 // OsFunctionCall — the central public dispatch value.
 // =============================================================================
@@ -294,14 +278,6 @@ impl fmt::Display for OsFunctionCall {
         f.write_str(self.name())
     }
 }
-impl<C: ContainsHeap> DropWithContext<C> for OsFunctionCall {
-    // Owned args (String/Vec<u8>/bool/MontyPath/MontyObject) hold no live
-    // heap references, so a plain drop is correct.
-    fn drop_with(self, _heap: &mut C) {
-        drop(self);
-    }
-}
-
 // =============================================================================
 // Args structs — per-variant payloads carried by `OsFunctionCall`.
 // =============================================================================
@@ -415,245 +391,6 @@ impl ToMontyObject for MontyPath {
         MontyObject::Path(self.0)
     }
 }
-
-// =============================================================================
-// Path-method dispatcher (used by `types/path.rs`).
-// =============================================================================
-
-/// Pre-flight check for [`build_path_os_call`]: lets the caller decide whether
-/// to commit ownership of the path/args to the builder.
-#[must_use]
-pub(crate) fn is_path_os_method(method: StaticStrings) -> bool {
-    matches!(
-        method,
-        StaticStrings::Exists
-            | StaticStrings::IsFile
-            | StaticStrings::IsDir
-            | StaticStrings::IsSymlink
-            | StaticStrings::ReadText
-            | StaticStrings::ReadBytes
-            | StaticStrings::StatMethod
-            | StaticStrings::Iterdir
-            | StaticStrings::Resolve
-            | StaticStrings::Absolute
-            | StaticStrings::Unlink
-            | StaticStrings::Rmdir
-            | StaticStrings::WriteText
-            | StaticStrings::AppendText
-            | StaticStrings::WriteBytes
-            | StaticStrings::AppendBytes
-            | StaticStrings::Mkdir
-            | StaticStrings::Rename
-    )
-}
-
-/// Builds an [`OsFunctionCall`] for a `pathlib.Path` method invocation —
-/// dispatches on `method` and pulls any extra args out of `args` into the
-/// matching typed struct.
-///
-/// Returns `Ok(None)` if `method` isn't an OS call. Owns `path`/`args` and
-/// is responsible for refcount cleanup on every code path.
-pub(crate) fn build_path_os_call(
-    method: StaticStrings,
-    path: MontyPath,
-    args: ArgValues,
-    vm: &mut VM<'_, impl ResourceTracker>,
-) -> RunResult<Option<OsFunctionCall>> {
-    // Simple "no extra args" path operations are bundled into one arm to avoid
-    // 12 near-identical case lines.
-    macro_rules! path_only {
-        ($name:literal, $variant:ident) => {{
-            args.check_zero_args($name, vm.heap)?;
-            OsFunctionCall::$variant(path)
-        }};
-    }
-
-    let call = match method {
-        StaticStrings::Exists => path_only!("exists", Exists),
-        StaticStrings::IsFile => path_only!("is_file", IsFile),
-        StaticStrings::IsDir => path_only!("is_dir", IsDir),
-        StaticStrings::IsSymlink => path_only!("is_symlink", IsSymlink),
-        StaticStrings::ReadText => path_only!("read_text", ReadText),
-        StaticStrings::ReadBytes => path_only!("read_bytes", ReadBytes),
-        StaticStrings::StatMethod => path_only!("stat", Stat),
-        StaticStrings::Iterdir => path_only!("iterdir", Iterdir),
-        StaticStrings::Resolve => path_only!("resolve", Resolve),
-        StaticStrings::Absolute => path_only!("absolute", Absolute),
-        StaticStrings::Unlink => path_only!("unlink", Unlink),
-        StaticStrings::Rmdir => path_only!("rmdir", Rmdir),
-        StaticStrings::WriteText => {
-            OsFunctionCall::WriteText(extract_str_data("write_text", path, args, vm.heap, vm.interns)?)
-        }
-        StaticStrings::AppendText => {
-            OsFunctionCall::AppendText(extract_str_data("append_text", path, args, vm.heap, vm.interns)?)
-        }
-        StaticStrings::WriteBytes => {
-            OsFunctionCall::WriteBytes(extract_bytes_data("write_bytes", path, args, vm.heap, vm.interns)?)
-        }
-        StaticStrings::AppendBytes => {
-            OsFunctionCall::AppendBytes(extract_bytes_data("append_bytes", path, args, vm.heap, vm.interns)?)
-        }
-        StaticStrings::Mkdir => OsFunctionCall::Mkdir(extract_mkdir_args(path, args, vm)?),
-        StaticStrings::Rename => OsFunctionCall::Rename(extract_rename_args(path, args, vm.heap, vm.interns)?),
-        _ => {
-            // Unreachable in practice — callers gate on `is_path_os_method`.
-            // Drop the owned inputs anyway so a stray call doesn't leak refs.
-            let _ = path;
-            args.drop_with(vm.heap);
-            return Ok(None);
-        }
-    };
-    Ok(Some(call))
-}
-
-/// Extracts the `data` arg for `write_text` / `append_text`. Error wording
-/// matches the legacy `fs/` dispatcher so existing tests stay green.
-fn extract_str_data(
-    method: &'static str,
-    path: MontyPath,
-    args: ArgValues,
-    heap: &mut Heap<impl ResourceTracker>,
-    interns: &Interns,
-) -> RunResult<PathStringDataArgs> {
-    let data = arg_or_missing_data(method, args, heap)?;
-    let data_str = value_to_owned_string(&data, heap, interns);
-
-    let py_type = data.py_type_name_heap(heap, interns);
-    data.drop_with(heap);
-
-    match data_str {
-        Some(data) => Ok(PathStringDataArgs { path, data }),
-        None => Err(ExcType::type_error(format!("data must be str, not {py_type}"))),
-    }
-}
-
-/// Extracts the `data` arg for `write_bytes` / `append_bytes` — binary
-/// companion to [`extract_str_data`].
-fn extract_bytes_data(
-    method: &'static str,
-    path: MontyPath,
-    args: ArgValues,
-    heap: &mut Heap<impl ResourceTracker>,
-    interns: &Interns,
-) -> RunResult<PathBytesDataArgs> {
-    let data = arg_or_missing_data(method, args, heap)?;
-    let bytes = value_to_owned_bytes(&data, heap, interns);
-
-    let py_type = data.py_type_name_heap(heap, interns);
-    data.drop_with(heap);
-
-    match bytes {
-        Some(data) => Ok(PathBytesDataArgs { path, data }),
-        None => Err(ExcType::type_error(format!(
-            "memoryview: a bytes-like object is required, not '{py_type}'"
-        ))),
-    }
-}
-
-/// Python-facing argument shape for `Path.mkdir(mode=0o777, parents=False, exist_ok=False)`.
-///
-/// `Path.mkdir` is a pure-Python `def` in CPython, hence `style = def` (its
-/// duplicate-arg error is `got multiple values for argument`). The
-/// too-many-positional count still diverges: CPython counts the bound `self`
-/// (`takes from 1 to 4 …`), Monty does not — see `limitations/open.md`.
-///
-/// Monty parses `mode` for signature compatibility and arity validation, but
-/// filesystem backends do not model POSIX permission bits. `parents` and
-/// `exist_ok` use [`LaxBool`] so they accept any truth-tested value (matching
-/// CPython, which evaluates them via `bool()`).
-#[derive(FromArgs)]
-#[from_args(name = "Path.mkdir", style = def)]
-struct PathMkdirArgs {
-    #[from_args(default = 0o777_i64)]
-    mode: i64,
-    #[from_args(default = LaxBool::new(false))]
-    parents: LaxBool,
-    #[from_args(default = LaxBool::new(false))]
-    exist_ok: LaxBool,
-}
-
-/// Extracts `mode`/`parents`/`exist_ok` for `mkdir`, rejecting unknown or
-/// excessive arguments before the host sees the OS call.
-fn extract_mkdir_args(
-    path: MontyPath,
-    args: ArgValues,
-    vm: &mut VM<'_, impl ResourceTracker>,
-) -> RunResult<MkdirCallArgs> {
-    let PathMkdirArgs {
-        mode,
-        parents,
-        exist_ok,
-    } = PathMkdirArgs::from_args(args, vm)?;
-    let _ = mode;
-    Ok(MkdirCallArgs {
-        path,
-        parents: parents.bool(),
-        exist_ok: exist_ok.bool(),
-    })
-}
-
-/// Extracts the `target` arg for `Path.rename(target)`.
-fn extract_rename_args(
-    src: MontyPath,
-    args: ArgValues,
-    heap: &mut Heap<impl ResourceTracker>,
-    interns: &Interns,
-) -> RunResult<RenameCallArgs> {
-    let target = args.get_one_arg("rename", heap)?;
-    let dst_str = value_to_owned_string(&target, heap, interns);
-    target.drop_with(heap);
-    match dst_str {
-        Some(dst) => Ok(RenameCallArgs {
-            src,
-            dst: MontyPath::new(dst),
-        }),
-        None => Err(ExcType::type_error(
-            "Path.rename() argument 'target' must be str or Path".to_owned(),
-        )),
-    }
-}
-
-/// Pulls the single `data` arg out of `args`, raising the CPython-style
-/// `missing 1 required positional argument: 'data'` error when absent.
-fn arg_or_missing_data(
-    method: &'static str,
-    args: ArgValues,
-    heap: &mut Heap<impl ResourceTracker>,
-) -> RunResult<Value> {
-    if matches!(args, ArgValues::Empty) {
-        return Err(ExcType::type_error(format!(
-            "Path.{method}() missing 1 required positional argument: 'data'"
-        )));
-    }
-    args.get_one_arg(method, heap)
-}
-
-/// Owned `String` if `value` is a `str` or `Path`, else `None`. Caller drops
-/// the source value afterwards.
-fn value_to_owned_string(value: &Value, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> Option<String> {
-    match value {
-        Value::InternString(id) => Some(interns.get_str(*id).to_owned()),
-        Value::Ref(id) => match heap.get(*id) {
-            HeapData::Str(s) => Some(s.as_str().to_owned()),
-            HeapData::Path(p) => Some(p.as_str().to_owned()),
-            _ => None,
-        },
-        _ => None,
-    }
-}
-
-/// Owned `Vec<u8>` if `value` is a `bytes` (interned or heap), else `None`.
-fn value_to_owned_bytes(value: &Value, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> Option<Vec<u8>> {
-    match value {
-        Value::InternBytes(id) => Some(interns.get_bytes(*id).to_owned()),
-        Value::Ref(id) => match heap.get(*id) {
-            HeapData::Bytes(b) => Some(b.as_slice().to_owned()),
-            _ => None,
-        },
-        _ => None,
-    }
-}
-
 // =============================================================================
 // stat_result builders — separate utility API used by host backends.
 // =============================================================================

--- a/crates/monty-types/src/resource.rs
+++ b/crates/monty-types/src/resource.rs
@@ -1,3 +1,7 @@
+//! Resource limits: the [`ResourceTracker`] trait the interpreter heap/VM
+//! are generic over, plus the stock [`NoLimitTracker`]/[`LimitedTracker`]
+//! implementations and their [`ResourceLimits`] configuration.
+
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 use std::time::Instant;
 use std::{cell::Cell, error::Error, fmt, time::Duration};
@@ -10,11 +14,7 @@ use std::{cell::Cell, error::Error, fmt, time::Duration};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use web_time::Instant;
 
-use crate::{
-    ExcType, MontyException,
-    exception_private::{ExceptionRaise, RawStackFrame, RunError, SimpleException},
-};
-
+use crate::exceptions::MontyException;
 /// Threshold in bytes above which `check_large_result` is called.
 ///
 /// Operations that may produce results larger than this threshold (100KB) should call
@@ -22,125 +22,6 @@ use crate::{
 /// where operations like `2 ** 10_000_000` allocate huge amounts of memory before
 /// the allocation check can catch them.
 pub const LARGE_RESULT_THRESHOLD: usize = 100_000;
-
-/// Pre-checks that an operation producing `item_len * count` bytes won't exceed resource limits.
-///
-/// Used for sequence repeats (`'x' * 999_999_999`), padding operations
-/// (`str.ljust`, `str.center`, `str.zfill`, etc.), and any other operation
-/// where the result size is a simple product of two known values.
-pub fn check_repeat_size(item_len: usize, count: usize, tracker: &impl ResourceTracker) -> Result<(), ResourceError> {
-    check_estimated_size(item_len.saturating_mul(count), tracker)
-}
-
-/// Pre-checks that `base ** exponent` won't exceed resource limits before computing.
-///
-/// The result of `base ** exp` has approximately `base_bits * exp` bits.
-/// For bases with 0 or 1 significant bits (0, 1, -1), the result is always
-/// small regardless of exponent, so the check is skipped.
-///
-/// The estimate includes a 4× safety multiplier because `BigInt::pow` uses repeated squaring,
-/// which allocates intermediate values on the Rust heap (not tracked by the resource tracker).
-/// At peak, old/new base and old/new accumulator coexist simultaneously during each
-/// multiplication step, requiring roughly 4× the final result size in memory.
-pub fn check_pow_size(base_bits: u64, exponent: u64, tracker: &impl ResourceTracker) -> Result<(), ResourceError> {
-    // 0**n = 0, 1**n = 1, (-1)**n = ±1 — always small
-    if base_bits <= 1 {
-        return Ok(());
-    }
-    let result_bytes = estimate_bits_to_bytes(base_bits.saturating_mul(exponent));
-    // Repeated squaring needs ~4× result size in peak memory (old/new base + old/new accumulator
-    // coexist during each multiplication step), and these are Rust heap allocations not tracked
-    // by the resource tracker.
-    check_estimated_size(result_bytes.saturating_mul(4), tracker)
-}
-
-/// Pre-checks that an integer multiplication won't exceed resource limits.
-///
-/// The result of multiplying two numbers has at most `a_bits + b_bits` bits.
-pub fn check_mult_size(a_bits: u64, b_bits: u64, tracker: &impl ResourceTracker) -> Result<(), ResourceError> {
-    check_estimated_size(estimate_bits_to_bytes(a_bits.saturating_add(b_bits)), tracker)
-}
-
-/// Pre-checks that a left shift won't exceed resource limits.
-///
-/// The result of `value << shift` has approximately `value_bits + shift` bits.
-/// For zero values the result is always zero, so the check is skipped.
-pub fn check_lshift_size(
-    value_bits: u64,
-    shift_amount: u64,
-    tracker: &impl ResourceTracker,
-) -> Result<(), ResourceError> {
-    if value_bits == 0 {
-        return Ok(());
-    }
-    check_estimated_size(estimate_bits_to_bytes(value_bits.saturating_add(shift_amount)), tracker)
-}
-
-/// Pre-checks that an integer division overflow promotion won't exceed resource limits.
-///
-/// Division results are bounded by the dividend size, but we still check for consistency
-/// with other BigInt promotion paths.
-pub fn check_div_size(dividend_bits: u64, tracker: &impl ResourceTracker) -> Result<(), ResourceError> {
-    check_estimated_size(estimate_bits_to_bytes(dividend_bits), tracker)
-}
-
-/// Pre-checks that a string/bytes replace won't exceed resource limits before allocating.
-///
-/// This prevents DoS via expressions like `('a' * 1000).replace('a', 'b' * 10_000_000)`
-/// where a small tracked input is amplified into a huge untracked Rust `String`/`Vec`
-/// by `String::replace()` before `allocate_string()` can check the result.
-///
-/// The upper bound on result size is: if `old` is non-empty, at most `input_len / old_len`
-/// replacements can occur, each producing `new_len` bytes instead of `old_len`. When `count`
-/// is specified, replacements are capped to that value.
-pub fn check_replace_size(
-    input_len: usize,
-    old_len: usize,
-    new_len: usize,
-    count: i64,
-    tracker: &impl ResourceTracker,
-) -> Result<(), ResourceError> {
-    // Empty pattern (old_len == 0): inserts before each element + after the last = input_len + 1
-    let max_replacements = input_len
-        .checked_div(old_len)
-        .unwrap_or_else(|| input_len.saturating_add(1));
-
-    let replacements = if count < 0 {
-        max_replacements
-    } else {
-        max_replacements.min(usize::try_from(count).unwrap_or(usize::MAX))
-    };
-
-    // Result = input_len - (replacements * old_len) + (replacements * new_len)
-    let removed = replacements.saturating_mul(old_len);
-    let added = replacements.saturating_mul(new_len);
-    let estimated = input_len.saturating_sub(removed).saturating_add(added);
-
-    check_estimated_size(estimated, tracker)
-}
-
-/// Checks an estimated result size against the resource tracker.
-///
-/// Only calls the tracker when the estimate exceeds `LARGE_RESULT_THRESHOLD`
-/// to avoid overhead on small operations.
-pub(crate) fn check_estimated_size(
-    estimated_bytes: usize,
-    tracker: &impl ResourceTracker,
-) -> Result<(), ResourceError> {
-    if estimated_bytes > LARGE_RESULT_THRESHOLD {
-        tracker.check_large_result(estimated_bytes)?;
-    }
-    Ok(())
-}
-
-/// Converts an estimated bit count to bytes, saturating to `usize::MAX` on overflow.
-///
-/// Overflow means the result is astronomically large, so saturating ensures
-/// the resource limit check always triggers rather than being silently skipped.
-fn estimate_bits_to_bytes(bits: u64) -> usize {
-    usize::try_from(bits.saturating_add(7) / 8).unwrap_or(usize::MAX)
-}
-
 /// Error returned when a resource limit is exceeded during execution.
 ///
 /// This allows the sandbox to enforce strict limits on allocation count,
@@ -182,57 +63,6 @@ impl fmt::Display for ResourceError {
 }
 
 impl Error for ResourceError {}
-
-impl ResourceError {
-    /// Converts this resource error to a Python exception with optional stack frame.
-    ///
-    /// Maps resource error types to Python exception types:
-    /// - `Allocation` → `MemoryError`
-    /// - `Memory` → `MemoryError`
-    /// - `Time` → `TimeoutError`
-    /// - `Recursion` → `RecursionError`
-    #[must_use]
-    pub(crate) fn into_exception(self, frame: Option<RawStackFrame>) -> ExceptionRaise {
-        let (exc_type, msg) = match self {
-            Self::Allocation { limit, count } => (
-                ExcType::MemoryError,
-                Some(format!("allocation limit exceeded: {count} > {limit}")),
-            ),
-            Self::Memory { limit, used } => (
-                ExcType::MemoryError,
-                Some(format!("memory limit exceeded: {used} bytes > {limit} bytes")),
-            ),
-            Self::Time { limit, elapsed } => (
-                ExcType::TimeoutError,
-                Some(format!("time limit exceeded: {elapsed:?} > {limit:?}")),
-            ),
-            Self::Recursion { .. } => (
-                ExcType::RecursionError,
-                Some("maximum recursion depth exceeded".to_string()),
-            ),
-            Self::Exception(exc) => (exc.exc_type(), exc.into_message()),
-        };
-        let exc = SimpleException::new(exc_type, msg);
-        match frame {
-            Some(f) => exc.with_frame(f),
-            None => exc.into(),
-        }
-    }
-}
-
-impl From<ResourceError> for RunError {
-    fn from(err: ResourceError) -> Self {
-        // RecursionError is catchable in CPython, so it must be catchable here too.
-        // Other resource errors (memory, time, allocation) remain uncatchable to prevent
-        // untrusted code from suppressing resource limit violations.
-        if matches!(err, ResourceError::Recursion { .. }) {
-            Self::Exc(err.into_exception(None))
-        } else {
-            Self::UncatchableExc(err.into_exception(None))
-        }
-    }
-}
-
 /// Trait for tracking resource usage and scheduling garbage collection.
 ///
 /// Implementations can enforce limits on allocations, time, and memory,

--- a/crates/monty-types/src/results.rs
+++ b/crates/monty-types/src/results.rs
@@ -1,0 +1,50 @@
+//! Host-supplied results fed back into a suspended run:
+//! [`NameLookupResult`] and [`ExtFunctionResult`].
+
+use crate::{exceptions::MontyException, object::MontyObject};
+/// Result of a name lookup from the host.
+///
+/// When the VM encounters an unresolved name, the host provides one of these:
+/// - `Value(obj)`: The name resolves to this value (cached in the namespace for future access).
+/// - `Undefined`: The name is truly undefined, causing `NameError`.
+#[derive(Debug)]
+pub enum NameLookupResult {
+    /// The name resolves to this value.
+    Value(MontyObject),
+    /// The name is undefined — VM will raise `NameError`.
+    Undefined,
+}
+
+impl From<MontyObject> for NameLookupResult {
+    fn from(value: MontyObject) -> Self {
+        Self::Value(value)
+    }
+}
+
+/// Return value or exception from an external function.
+#[derive(Debug)]
+pub enum ExtFunctionResult {
+    /// Continues execution with the return value from the external function.
+    Return(MontyObject),
+    /// Continues execution with the exception raised by the external function.
+    Error(MontyException),
+    /// Pending future — the external function is a coroutine.
+    ///
+    /// The `u32` is the `call_id` from the `FunctionCall` that created this
+    /// snapshot. It is used to track the pending future so it can be resolved
+    /// later via `ResolveFutures::resume()`.
+    Future(u32),
+    /// The function was not found, should result in a `NameError` exception.
+    NotFound(String),
+}
+impl From<MontyObject> for ExtFunctionResult {
+    fn from(value: MontyObject) -> Self {
+        Self::Return(value)
+    }
+}
+
+impl From<MontyException> for ExtFunctionResult {
+    fn from(exception: MontyException) -> Self {
+        Self::Error(exception)
+    }
+}

--- a/crates/monty-types/src/run_options.rs
+++ b/crates/monty-types/src/run_options.rs
@@ -1,0 +1,73 @@
+//! Compile-time configuration: [`CompileOptions`] and the
+//! [`AssertMessageAnnotations`] introspected-assert setting.
+
+use std::num::NonZeroU32;
+/// Options controlling how Monty behavior diverges from plain CPython.
+///
+/// Consumed when code is compiled: a `MontyRun` bakes the choices into the
+/// program at construction, while a `MontyRepl` stores them so every snippet
+/// fed to the session compiles the same way.
+#[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
+pub struct CompileOptions {
+    /// Give failed `assert` statements pytest-style introspected messages,
+    /// deliberately diverging from CPython; see `limitations/assert.md`.
+    /// On by default with a 120-byte operand-repr truncation.
+    pub assert_message_annotations: AssertMessageAnnotations,
+}
+
+/// Controls the pytest-style introspected `assert` failure messages of
+/// [`CompileOptions::assert_message_annotations`].
+///
+/// The choice is baked in at compile time (whether the introspecting opcodes
+/// are emitted) but the truncation limit is applied at runtime, so it also
+/// travels with serialized sessions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum AssertMessageAnnotations {
+    /// Disable introspection; bare asserts use CPython's empty message.
+    Off,
+    /// Retain at most this many UTF-8 bytes per operand before any `…` suffix.
+    /// Non-zero because `0` encodes [`Off`](Self::Off) on the wire.
+    MaxBytes(NonZeroU32),
+}
+
+impl AssertMessageAnnotations {
+    /// Operand-repr truncation used by [`Default`] and `From<bool>`.
+    pub const DEFAULT_MAX_BYTES: NonZeroU32 = NonZeroU32::new(120).expect("120 is non-zero");
+
+    /// Whether the compiler should emit introspecting assert opcodes.
+    #[must_use]
+    pub fn enabled(self) -> bool {
+        !matches!(self, Self::Off)
+    }
+
+    /// Returns the wire value: `0` when disabled, otherwise the UTF-8 byte cap.
+    #[must_use]
+    pub fn max_bytes(self) -> u32 {
+        match self {
+            Self::Off => 0,
+            Self::MaxBytes(n) => n.get(),
+        }
+    }
+
+    /// Decodes the wire value: `0` is off and any other value is the byte cap.
+    #[must_use]
+    pub fn from_max_bytes(value: u32) -> Self {
+        match NonZeroU32::new(value) {
+            Some(n) => Self::MaxBytes(n),
+            None => Self::Off,
+        }
+    }
+}
+
+impl Default for AssertMessageAnnotations {
+    fn default() -> Self {
+        Self::MaxBytes(Self::DEFAULT_MAX_BYTES)
+    }
+}
+
+impl From<bool> for AssertMessageAnnotations {
+    /// `true` enables the 120-byte default; `false` disables annotations.
+    fn from(enabled: bool) -> Self {
+        if enabled { Self::default() } else { Self::Off }
+    }
+}

--- a/crates/monty-typeshed/README.md
+++ b/crates/monty-typeshed/README.md
@@ -45,6 +45,7 @@ assert!(typeshed.exists("stdlib/builtins.pyi"));
 ## Monty crates
 
 - [`monty`](https://crates.io/crates/monty) — the core interpreter: Python parser, bytecode VM, and sandbox.
+- [`monty-types`](https://crates.io/crates/monty-types) — the shared boundary data types (values, exceptions, OS calls, resource limits) hosts use without linking the interpreter.
 - [`monty-fs`](https://crates.io/crates/monty-fs) — host-side filesystem mounts: maps virtual sandbox paths to real host directories.
 - [`monty-runtime`](https://crates.io/crates/monty-runtime) — the `monty` binary: REPL, file runner, and subprocess worker mode.
 - [`monty-pool`](https://crates.io/crates/monty-pool) — an elastic pool of crash-isolated `monty` worker subprocesses.

--- a/crates/monty/Cargo.toml
+++ b/crates/monty/Cargo.toml
@@ -17,13 +17,14 @@ name = "monty"
 path = "src/lib.rs"
 
 [dependencies]
+monty-macros = { workspace = true }
+monty-types = { workspace = true }
 ruff_python_parser = { workspace = true }
 ruff_python_stdlib = { workspace = true }
 ruff_python_ast = { workspace = true }
 ruff_text_size = { workspace = true }
 ahash = { workspace = true }
 itoa = { workspace = true }
-indexmap = { workspace = true }
 serde = { workspace = true }
 postcard = { workspace = true }
 strum = { workspace = true }
@@ -41,8 +42,6 @@ chrono = { workspace = true }
 speedate = "0.17.0"
 itertools = "0.14.0"
 jiter = { version = "0.15.0", features = ["num-bigint"] }
-monty-macros = { workspace = true }
-monty-types = { workspace = true }
 
 [features]
 # ref-count-return changes behavior to return information on reference counts to check they're correct

--- a/crates/monty/Cargo.toml
+++ b/crates/monty/Cargo.toml
@@ -42,13 +42,7 @@ speedate = "0.17.0"
 itertools = "0.14.0"
 jiter = { version = "0.15.0", features = ["num-bigint"] }
 monty-macros = { workspace = true }
-
-# `std::time::Instant` panics on `wasm32-unknown-unknown`, so the resource
-# tracker uses `web_time::Instant` (a `performance.now()`-backed drop-in) there
-# to keep `max_duration` working when `monty` is embedded directly in a browser
-# wasm module. Only that target needs it; every other target uses std directly.
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-web-time = "1.1"
+monty-types = { workspace = true }
 
 [features]
 # ref-count-return changes behavior to return information on reference counts to check they're correct
@@ -61,7 +55,7 @@ ref-count-return = ["test-hooks"]
 memory-model-checks = []
 # test-hooks exposes small internal helpers needed by integration tests that
 # exercise production behavior without duplicating implementation details.
-test-hooks = []
+test-hooks = ["monty-types/test-hooks"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/monty/Cargo.toml
+++ b/crates/monty/Cargo.toml
@@ -26,7 +26,7 @@ itoa = { workspace = true }
 indexmap = { workspace = true }
 serde = { workspace = true }
 postcard = { workspace = true }
-strum = { version = "0.27", features = ["derive"] }
+strum = { workspace = true }
 hashbrown = "0.16"
 num-bigint = { workspace = true }
 num-traits = { workspace = true }
@@ -37,7 +37,7 @@ unicode-normalization = { workspace = true }
 smallvec = { version = "1.13", features = ["serde"] }
 fancy-regex = "0.17.0"
 libm = "0.2"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true }
 speedate = "0.17.0"
 itertools = "0.14.0"
 jiter = { version = "0.15.0", features = ["num-bigint"] }

--- a/crates/monty/README.md
+++ b/crates/monty/README.md
@@ -112,6 +112,7 @@ Async host functions are supported too: `FunctionCall::resume_pending` continues
 ## Monty crates
 
 - [`monty`](https://crates.io/crates/monty) — the core interpreter: Python parser, bytecode VM, and sandbox. **this crate**
+- [`monty-types`](https://crates.io/crates/monty-types) — the shared boundary data types (values, exceptions, OS calls, resource limits) hosts use without linking the interpreter.
 - [`monty-fs`](https://crates.io/crates/monty-fs) — host-side filesystem mounts: maps virtual sandbox paths to real host directories.
 - [`monty-runtime`](https://crates.io/crates/monty-runtime) — the `monty` binary: REPL, file runner, and subprocess worker mode.
 - [`monty-pool`](https://crates.io/crates/monty-pool) — an elastic pool of crash-isolated `monty` worker subprocesses.

--- a/crates/monty/README.md
+++ b/crates/monty/README.md
@@ -25,7 +25,8 @@ See the [project README](https://github.com/pydantic/monty) for the full feature
 `MontyRun` parses and compiles code once; `run` executes it with input values and returns the value of the final expression as a `MontyObject`:
 
 ```rust
-use monty::{CompileOptions, MontyRun, MontyObject, NoLimitTracker, PrintWriter};
+use monty::MontyRun;
+use monty_types::{CompileOptions, MontyObject, NoLimitTracker, PrintWriter};
 
 let code = r#"
 def fib(n):
@@ -49,7 +50,8 @@ Untrusted code shouldn't be able to hog the host. `LimitedTracker` enforces limi
 
 ```rust
 use std::time::Duration;
-use monty::{CompileOptions, MontyRun, LimitedTracker, PrintWriter, ResourceLimits};
+use monty::MontyRun;
+use monty_types::{CompileOptions, LimitedTracker, PrintWriter, ResourceLimits};
 
 let limits = ResourceLimits {
     max_memory: Some(10 * 1024 * 1024),
@@ -67,7 +69,8 @@ assert!(err.to_string().contains("time limit exceeded"));
 The defining feature of the crate: instead of running to completion, `MontyRun::start` returns a `RunProgress` that pauses execution whenever the sandboxed code calls a function provided by the host. The host runs the real function (an API call, a database query, an LLM tool) and resumes with the result:
 
 ```rust
-use monty::{CompileOptions, MontyRun, MontyObject, NoLimitTracker, PrintWriter, RunProgress};
+use monty::{MontyRun, RunProgress};
+use monty_types::{CompileOptions, MontyObject, NoLimitTracker, PrintWriter};
 
 let code = "data = get_data(3)\ndata * 2";
 let runner = MontyRun::new(code.to_owned(), "main.py", vec!["get_data".to_owned()], CompileOptions::default()).unwrap();
@@ -90,7 +93,8 @@ assert_eq!(result, MontyObject::Int(42));
 A paused `RunProgress` is a self-contained snapshot of the interpreter: serialize it with `dump()`, store it in a file or database, and `load()` + resume it later — in a different process or on a different machine. `MontyRun` itself can also be dumped and loaded to cache parsed code:
 
 ```rust
-use monty::{CompileOptions, MontyRun, MontyObject, NoLimitTracker, PrintWriter};
+use monty::MontyRun;
+use monty_types::{CompileOptions, MontyObject, NoLimitTracker, PrintWriter};
 
 let runner = MontyRun::new("x + 1".to_owned(), "main.py", vec!["x".to_owned()], CompileOptions::default()).unwrap();
 let bytes = runner.dump().unwrap();

--- a/crates/monty/src/args/bind_native.rs
+++ b/crates/monty/src/args/bind_native.rs
@@ -33,8 +33,9 @@
 
 use std::{mem, ptr};
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::{ArgPosIter, ArgValues, KwargsValues, KwargsValuesIter},
     bytecode::VM,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult},

--- a/crates/monty/src/args/bind_native.rs
+++ b/crates/monty/src/args/bind_native.rs
@@ -37,7 +37,7 @@ use crate::{
     ResourceTracker,
     args::{ArgPosIter, ArgValues, KwargsValues, KwargsValuesIter},
     bytecode::VM,
-    exception_private::{ExcType, RunError, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
     heap::{ContainsHeap, DropGuard, DropWithContext},
     intern::{Interns, StringId},
     value::{EitherStr, Value},

--- a/crates/monty/src/args/bind_python.rs
+++ b/crates/monty/src/args/bind_python.rs
@@ -15,8 +15,9 @@
 //! change both; coverage lives in `test_cases/function__arity_defaults.py`
 //! and `test_cases/args__macro_errors.py`.
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::{ArgPosIter, ArgValues},
     bytecode::VM,
     defer_drop_mut,

--- a/crates/monty/src/args/bind_python.rs
+++ b/crates/monty/src/args/bind_python.rs
@@ -16,14 +16,14 @@
 //! and `test_cases/args__macro_errors.py`.
 
 use crate::{
+    ResourceTracker,
     args::{ArgPosIter, ArgValues},
     bytecode::VM,
     defer_drop_mut,
-    exception_private::{ExcType, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
     expressions::Identifier,
     heap::{DropGuard, DropWithContext, HeapData},
     intern::{Interns, StringId},
-    resource::ResourceTracker,
     types::{Dict, allocate_tuple},
     value::Value,
 };

--- a/crates/monty/src/args/from_value.rs
+++ b/crates/monty/src/args/from_value.rs
@@ -18,10 +18,10 @@
 use std::borrow::Cow;
 
 use crate::{
+    ResourceTracker,
     bytecode::VM,
-    exception_private::{ExcType, RunError, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     heap::{ContainsHeap, DropWithContext, HeapData},
-    resource::ResourceTracker,
     types::PyTrait,
     value::Value,
 };

--- a/crates/monty/src/args/from_value.rs
+++ b/crates/monty/src/args/from_value.rs
@@ -17,8 +17,9 @@
 
 use std::borrow::Cow;
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     bytecode::VM,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     heap::{ContainsHeap, DropWithContext, HeapData},

--- a/crates/monty/src/args/mod.rs
+++ b/crates/monty/src/args/mod.rs
@@ -1,37 +1,26 @@
 mod bind_native;
 mod bind_python;
 mod from_value;
-mod to_monty_object;
 
 use std::{mem, slice, vec::IntoIter};
 
 pub(crate) use bind_native::{Bound, ErrorFamily, Param, ParamKind, ParamSpec, bind};
 pub(crate) use bind_python::Signature;
 pub(crate) use from_value::{ArgErrCtx, FromValue, FromValueFail, LaxBool, StrArg, is_long_int};
-pub(crate) use monty_macros::{FromArgs, ToArgs};
-pub(crate) use to_monty_object::ToMontyObject;
+pub(crate) use monty_macros::FromArgs;
 
 use crate::{
     MontyObject, ResourceTracker,
     bytecode::VM,
-    exception_private::{ExcType, RunError, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
     expressions::{ExprLoc, Identifier},
     heap::{ContainsHeap, DropWithContext, Heap},
     intern::StringId,
+    object_bridge::MontyObjectExt,
     parse::ParseError,
     types::{Dict, dict::DictIntoIter},
     value::Value,
 };
-
-/// Projects a typed args struct into the `(positional, keyword)` `MontyObject`
-/// pair host callbacks expect. Consumes `self` to avoid cloning owned fields.
-///
-/// Inverse of [`FromArgs`]: `FromArgs` is internal `ArgValues` → struct,
-/// `ToArgs` is struct → host-facing `(args, kwargs)`. Driven by
-/// [`crate::os::OsFunctionCall::to_args`] for the monty-python / monty-js bindings.
-pub trait ToArgs {
-    fn to_args(self) -> (Vec<MontyObject>, Vec<(MontyObject, MontyObject)>);
-}
 
 /// Type for method call arguments.
 ///

--- a/crates/monty/src/args/mod.rs
+++ b/crates/monty/src/args/mod.rs
@@ -8,9 +8,9 @@ pub(crate) use bind_native::{Bound, ErrorFamily, Param, ParamKind, ParamSpec, bi
 pub(crate) use bind_python::Signature;
 pub(crate) use from_value::{ArgErrCtx, FromValue, FromValueFail, LaxBool, StrArg, is_long_int};
 pub(crate) use monty_macros::FromArgs;
+use monty_types::{MontyObject, ResourceTracker};
 
 use crate::{
-    MontyObject, ResourceTracker,
     bytecode::VM,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
     expressions::{ExprLoc, Identifier},

--- a/crates/monty/src/builtins/abs.rs
+++ b/crates/monty/src/builtins/abs.rs
@@ -4,12 +4,12 @@ use num_bigint::BigInt;
 use num_traits::Signed;
 
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
     heap::HeapData,
-    resource::ResourceTracker,
     types::{LongInt, timedelta},
     value::Value,
 };

--- a/crates/monty/src/builtins/abs.rs
+++ b/crates/monty/src/builtins/abs.rs
@@ -1,10 +1,10 @@
 //! Implementation of the abs() builtin function.
 
+use monty_types::ResourceTracker;
 use num_bigint::BigInt;
 use num_traits::Signed;
 
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/builtins/all.rs
+++ b/crates/monty/src/builtins/all.rs
@@ -1,9 +1,8 @@
 //! Implementation of the all() builtin function.
 
-use crate::{
-    ResourceTracker, args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, types::PyTrait,
-    value::Value,
-};
+use monty_types::ResourceTracker;
+
+use crate::{args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, types::PyTrait, value::Value};
 
 /// Implementation of the all() builtin function.
 ///

--- a/crates/monty/src/builtins/all.rs
+++ b/crates/monty/src/builtins/all.rs
@@ -1,7 +1,7 @@
 //! Implementation of the all() builtin function.
 
 use crate::{
-    args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, resource::ResourceTracker, types::PyTrait,
+    ResourceTracker, args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, types::PyTrait,
     value::Value,
 };
 

--- a/crates/monty/src/builtins/any.rs
+++ b/crates/monty/src/builtins/any.rs
@@ -1,7 +1,7 @@
 //! Implementation of the any() builtin function.
 
 use crate::{
-    args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, resource::ResourceTracker, types::PyTrait,
+    ResourceTracker, args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, types::PyTrait,
     value::Value,
 };
 

--- a/crates/monty/src/builtins/any.rs
+++ b/crates/monty/src/builtins/any.rs
@@ -1,9 +1,8 @@
 //! Implementation of the any() builtin function.
 
-use crate::{
-    ResourceTracker, args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, types::PyTrait,
-    value::Value,
-};
+use monty_types::ResourceTracker;
+
+use crate::{args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, types::PyTrait, value::Value};
 
 /// Implementation of the any() builtin function.
 ///

--- a/crates/monty/src/builtins/bin.rs
+++ b/crates/monty/src/builtins/bin.rs
@@ -4,12 +4,12 @@ use num_bigint::BigInt;
 use num_traits::Signed;
 
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::HeapData,
-    resource::ResourceTracker,
     types::str::allocate_string_no_interning,
     value::Value,
 };

--- a/crates/monty/src/builtins/bin.rs
+++ b/crates/monty/src/builtins/bin.rs
@@ -1,10 +1,10 @@
 //! Implementation of the bin() builtin function.
 
+use monty_types::ResourceTracker;
 use num_bigint::BigInt;
 use num_traits::Signed;
 
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/builtins/chr.rs
+++ b/crates/monty/src/builtins/chr.rs
@@ -1,7 +1,8 @@
 //! Implementation of the chr() builtin function.
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/builtins/chr.rs
+++ b/crates/monty/src/builtins/chr.rs
@@ -1,11 +1,11 @@
 //! Implementation of the chr() builtin function.
 
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
-    resource::ResourceTracker,
     types::str::allocate_char,
     value::Value,
 };

--- a/crates/monty/src/builtins/divmod.rs
+++ b/crates/monty/src/builtins/divmod.rs
@@ -5,12 +5,13 @@ use num_integer::Integer;
 use smallvec::smallvec;
 
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
     heap::HeapData,
-    resource::{ResourceTracker, check_div_size},
+    resource_checks::check_div_size,
     types::{LongInt, allocate_tuple},
     value::{Value, floor_divmod},
 };

--- a/crates/monty/src/builtins/divmod.rs
+++ b/crates/monty/src/builtins/divmod.rs
@@ -1,11 +1,11 @@
 //! Implementation of the divmod() builtin function.
 
+use monty_types::ResourceTracker;
 use num_bigint::BigInt;
 use num_integer::Integer;
 use smallvec::smallvec;
 
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/builtins/enumerate.rs
+++ b/crates/monty/src/builtins/enumerate.rs
@@ -1,9 +1,9 @@
 //! Implementation of the enumerate() builtin function.
 
+use monty_types::ResourceTracker;
 use smallvec::smallvec;
 
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/builtins/enumerate.rs
+++ b/crates/monty/src/builtins/enumerate.rs
@@ -3,12 +3,12 @@
 use smallvec::smallvec;
 
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
     heap::{DropGuard, DropWithContext, HeapData},
-    resource::ResourceTracker,
     types::{List, allocate_tuple},
     value::Value,
 };

--- a/crates/monty/src/builtins/filter.rs
+++ b/crates/monty/src/builtins/filter.rs
@@ -8,12 +8,12 @@
 //! - User-defined functions (via `vm.evaluate_function`)
 
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,
     exception_private::RunResult,
     heap::{DropGuard, HeapData},
-    resource::ResourceTracker,
     types::{List, PyTrait},
     value::Value,
 };

--- a/crates/monty/src/builtins/filter.rs
+++ b/crates/monty/src/builtins/filter.rs
@@ -7,8 +7,9 @@
 //! - Type constructors (int, str, float, etc.)
 //! - User-defined functions (via `vm.evaluate_function`)
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/builtins/getattr.rs
+++ b/crates/monty/src/builtins/getattr.rs
@@ -1,7 +1,8 @@
 //! Implementation of the getattr() builtin function.
 
+use monty_types::{ExcType, ResourceTracker};
+
 use crate::{
-    ExcType, ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     defer_drop,

--- a/crates/monty/src/builtins/getattr.rs
+++ b/crates/monty/src/builtins/getattr.rs
@@ -1,13 +1,12 @@
 //! Implementation of the getattr() builtin function.
 
 use crate::{
-    ExcType,
+    ExcType, ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     defer_drop,
-    exception_private::{RunError, RunResult, SimpleException},
+    exception_private::{ExcTypeExt, RunError, RunResult, SimpleException},
     heap::DropWithContext,
-    resource::ResourceTracker,
     value::Value,
 };
 

--- a/crates/monty/src/builtins/hasattr.rs
+++ b/crates/monty/src/builtins/hasattr.rs
@@ -1,7 +1,8 @@
 //! Implementation of the hasattr() builtin function.
 
+use monty_types::{ExcType, ResourceTracker};
+
 use crate::{
-    ExcType, ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     defer_drop,

--- a/crates/monty/src/builtins/hasattr.rs
+++ b/crates/monty/src/builtins/hasattr.rs
@@ -1,13 +1,12 @@
 //! Implementation of the hasattr() builtin function.
 
 use crate::{
-    ExcType,
+    ExcType, ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     defer_drop,
-    exception_private::{RunError, RunResult, SimpleException},
+    exception_private::{ExcTypeExt, RunError, RunResult, SimpleException},
     heap::DropWithContext,
-    resource::ResourceTracker,
     value::Value,
 };
 

--- a/crates/monty/src/builtins/hash.rs
+++ b/crates/monty/src/builtins/hash.rs
@@ -1,11 +1,11 @@
 //! Implementation of the hash() builtin function.
 
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, RunResult},
-    resource::ResourceTracker,
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     value::Value,
 };
 

--- a/crates/monty/src/builtins/hash.rs
+++ b/crates/monty/src/builtins/hash.rs
@@ -1,7 +1,8 @@
 //! Implementation of the hash() builtin function.
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/builtins/hex.rs
+++ b/crates/monty/src/builtins/hex.rs
@@ -4,12 +4,12 @@ use num_bigint::BigInt;
 use num_traits::Signed;
 
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::HeapData,
-    resource::ResourceTracker,
     types::str::allocate_string_no_interning,
     value::Value,
 };

--- a/crates/monty/src/builtins/hex.rs
+++ b/crates/monty/src/builtins/hex.rs
@@ -1,10 +1,10 @@
 //! Implementation of the hex() builtin function.
 
+use monty_types::ResourceTracker;
 use num_bigint::BigInt;
 use num_traits::Signed;
 
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/builtins/id.rs
+++ b/crates/monty/src/builtins/id.rs
@@ -1,8 +1,6 @@
 //! Implementation of the id() builtin function.
 
-use crate::{
-    args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, resource::ResourceTracker, value::Value,
-};
+use crate::{ResourceTracker, args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, value::Value};
 
 /// Implementation of the id() builtin function.
 ///

--- a/crates/monty/src/builtins/id.rs
+++ b/crates/monty/src/builtins/id.rs
@@ -1,6 +1,8 @@
 //! Implementation of the id() builtin function.
 
-use crate::{ResourceTracker, args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, value::Value};
+use monty_types::ResourceTracker;
+
+use crate::{args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, value::Value};
 
 /// Implementation of the id() builtin function.
 ///

--- a/crates/monty/src/builtins/isinstance.rs
+++ b/crates/monty/src/builtins/isinstance.rs
@@ -2,12 +2,12 @@
 
 use super::Builtins;
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::{HeapData, HeapId, HeapRead, HeapReadOutput},
-    resource::ResourceTracker,
     types::{PyTrait, Tuple, Type},
     value::Value,
 };

--- a/crates/monty/src/builtins/isinstance.rs
+++ b/crates/monty/src/builtins/isinstance.rs
@@ -1,8 +1,9 @@
 //! Implementation of the isinstance() builtin function.
 
+use monty_types::ResourceTracker;
+
 use super::Builtins;
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/builtins/len.rs
+++ b/crates/monty/src/builtins/len.rs
@@ -1,7 +1,8 @@
 //! Implementation of the len() builtin function.
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/builtins/len.rs
+++ b/crates/monty/src/builtins/len.rs
@@ -1,11 +1,11 @@
 //! Implementation of the len() builtin function.
 
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, RunResult, SimpleException},
-    resource::ResourceTracker,
+    exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
     types::PyTrait,
     value::Value,
 };

--- a/crates/monty/src/builtins/map.rs
+++ b/crates/monty/src/builtins/map.rs
@@ -3,12 +3,12 @@
 use std::{iter, mem};
 
 use crate::{
+    ResourceTracker,
     args::{ArgValues, FromArgs, KwargsValues},
     bytecode::VM,
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::{DropWithContext, HeapData},
-    resource::ResourceTracker,
     types::{List, PyTrait, iter::checked_preallocation_hint},
     value::Value,
 };

--- a/crates/monty/src/builtins/map.rs
+++ b/crates/monty/src/builtins/map.rs
@@ -2,8 +2,9 @@
 
 use std::{iter, mem};
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::{ArgValues, FromArgs, KwargsValues},
     bytecode::VM,
     defer_drop, defer_drop_mut,

--- a/crates/monty/src/builtins/min_max.rs
+++ b/crates/monty/src/builtins/min_max.rs
@@ -3,12 +3,12 @@
 use std::{cmp::Ordering, mem};
 
 use crate::{
+    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, RunError, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     heap::DropGuard,
-    resource::ResourceTracker,
     types::{CmpOrder, PyTrait},
     value::Value,
 };

--- a/crates/monty/src/builtins/min_max.rs
+++ b/crates/monty/src/builtins/min_max.rs
@@ -2,8 +2,9 @@
 
 use std::{cmp::Ordering, mem};
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop, defer_drop_mut,

--- a/crates/monty/src/builtins/mod.rs
+++ b/crates/monty/src/builtins/mod.rs
@@ -37,8 +37,9 @@ mod zip;
 
 use std::{fmt, fmt::Write, str::FromStr};
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     exception_private::{ExcType, ExcTypeExt, RunResult},
@@ -65,7 +66,7 @@ impl Builtins {
     /// Most builtins complete synchronously and produce a [`CallResult::Value`].
     /// `open()` is the exception: it must touch the host filesystem at call
     /// time to perform the open-time effect, so it returns a
-    /// [`CallResult::OsCall`] for [`OsFunctionCall::Open`](crate::OsFunctionCall) (see
+    /// [`CallResult::OsCall`] for [`OsFunctionCall::Open`](monty_types::OsFunctionCall) (see
     /// [`crate::builtins::open`]).
     pub fn call(self, vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<CallResult> {
         match self {

--- a/crates/monty/src/builtins/mod.rs
+++ b/crates/monty/src/builtins/mod.rs
@@ -37,13 +37,11 @@ mod zip;
 
 use std::{fmt, fmt::Write, str::FromStr};
 
-use strum::{Display, EnumString, FromRepr, IntoStaticStr};
-
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
-    exception_private::{ExcType, RunResult},
-    resource::ResourceTracker,
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     types::Type,
 };
 
@@ -67,7 +65,7 @@ impl Builtins {
     /// Most builtins complete synchronously and produce a [`CallResult::Value`].
     /// `open()` is the exception: it must touch the host filesystem at call
     /// time to perform the open-time effect, so it returns a
-    /// [`CallResult::OsCall`] for [`crate::os::OsFunction::Open`] (see
+    /// [`CallResult::OsCall`] for [`OsFunctionCall::Open`](crate::OsFunctionCall) (see
     /// [`crate::builtins::open`]).
     pub fn call(self, vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<CallResult> {
         match self {
@@ -114,116 +112,14 @@ impl FromStr for Builtins {
     }
 }
 
-/// Enumerates every interpreter-native Python builtin function.
-///
-/// Listed alphabetically per https://docs.python.org/3/library/functions.html
-/// Commented-out variants are not yet implemented.
-///
-/// Note: Type constructors are handled by the `Type` enum, not here.
-///
-/// Uses strum derives for automatic `Display`, `FromStr`, and `IntoStaticStr` implementations.
-/// All variants serialize to lowercase (e.g., `Print` -> "print").
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    Display,
-    EnumString,
-    FromRepr,
-    IntoStaticStr,
-    PartialEq,
-    Eq,
-    Hash,
-    serde::Serialize,
-    serde::Deserialize,
-)]
-#[strum(serialize_all = "lowercase")]
-#[repr(u8)]
-pub enum BuiltinsFunctions {
-    Abs,
-    // Aiter,
-    All,
-    // Anext,
-    Any,
-    // Ascii,
-    Bin,
-    // bool - handled by Type enum
-    // Breakpoint,
-    // bytearray - handled by Type enum
-    // bytes - handled by Type enum
-    // Callable,
-    Chr,
-    // Classmethod,
-    // Compile,
-    // complex - handled by Type enum
-    // Delattr,
-    // dict - handled by Type enum
-    // Dir,
-    Divmod,
-    Enumerate,
-    // Eval,
-    // Exec,
-    Filter,
-    // float - handled by Type enum
-    // Format,
-    // frozenset - handled by Type enum
-    Getattr,
-    // Globals,
-    Hasattr,
-    Hash,
-    // Help,
-    Hex,
-    Id,
-    // Input,
-    // int - handled by Type enum
-    Isinstance,
-    // Issubclass,
-    // Iter - handled by Type enum
-    Len,
-    // list - handled by Type enum
-    // Locals,
-    Map,
-    Max,
-    // memoryview - handled by Type enum
-    Min,
-    Next,
-    // object - handled by Type enum
-    Oct,
-    Open,
-    Ord,
-    Pow,
-    Print,
-    // Property,
-    // range - handled by Type enum
-    Repr,
-    Reversed,
-    Round,
-    // set - handled by Type enum
-    Setattr,
-    // Slice,
-    Sorted,
-    // Staticmethod,
-    // str - handled by Type enum
-    Sum,
-    // Super,
-    // tuple - handled by Type enum
-    Type,
-    // Vars,
-    Zip,
-    // __import__ - not planned
+pub use monty_types::BuiltinsFunctions;
+
+pub(crate) trait BuiltinsFunctionsExt: Sized {
+    fn call(self, vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<CallResult>;
 }
 
-impl BuiltinsFunctions {
-    /// Executes the builtin with the provided arguments.
-    ///
-    /// All builtins receive the full VM context, which provides access to the
-    /// heap, interned strings, and print output.
-    ///
-    /// Almost every builtin completes synchronously and produces a
-    /// [`CallResult::Value`]. `open()` is the exception: it performs the
-    /// open-time file effect via a host filesystem round-trip, so it returns a
-    /// [`CallResult::OsCall`] directly.
-    pub(crate) fn call(self, vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<CallResult> {
+impl BuiltinsFunctionsExt for BuiltinsFunctions {
+    fn call(self, vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<CallResult> {
         let r = match self {
             Self::Abs => abs::builtin_abs(vm, args),
             Self::All => all::builtin_all(vm, args),

--- a/crates/monty/src/builtins/next.rs
+++ b/crates/monty/src/builtins/next.rs
@@ -1,7 +1,8 @@
 //! Implementation of the next() builtin function.
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/builtins/next.rs
+++ b/crates/monty/src/builtins/next.rs
@@ -1,11 +1,11 @@
 //! Implementation of the next() builtin function.
 
 use crate::{
+    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop,
     exception_private::RunResult,
-    resource::ResourceTracker,
     types::iter::iterator_next,
     value::Value,
 };

--- a/crates/monty/src/builtins/oct.rs
+++ b/crates/monty/src/builtins/oct.rs
@@ -4,12 +4,12 @@ use num_bigint::BigInt;
 use num_traits::Signed;
 
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::HeapData,
-    resource::ResourceTracker,
     types::str::allocate_string_no_interning,
     value::Value,
 };

--- a/crates/monty/src/builtins/oct.rs
+++ b/crates/monty/src/builtins/oct.rs
@@ -1,10 +1,10 @@
 //! Implementation of the oct() builtin function.
 
+use monty_types::ResourceTracker;
 use num_bigint::BigInt;
 use num_traits::Signed;
 
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/builtins/open.rs
+++ b/crates/monty/src/builtins/open.rs
@@ -11,13 +11,12 @@
 use std::str;
 
 use crate::{
+    MontyPath, OpenCallArgs, OsFunctionCall, ResourceTracker,
     args::{ArgValues, FromArgs, StrArg},
     bytecode::{CallResult, VM},
     defer_drop,
-    exception_private::{ExcType, RunError, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     heap::{DropGuard, HeapData},
-    os::{MontyPath, OpenCallArgs, OsFunctionCall},
-    resource::ResourceTracker,
     types::{PyTrait, file::FileMode},
     value::Value,
 };

--- a/crates/monty/src/builtins/open.rs
+++ b/crates/monty/src/builtins/open.rs
@@ -3,15 +3,16 @@
 //! `open()` itself allocates no heap object. It validates its arguments and
 //! yields an [`OsFunction::Open`] OS call; the host performs the open-time
 //! effect (truncate / create / existence-check) and returns a
-//! [`MontyObject::FileHandle`](crate::MontyObject::FileHandle), which the
+//! [`MontyObject::FileHandle`](monty_types::MontyObject::FileHandle), which the
 //! generic resume path converts into the heap [`OpenFile`](crate::types::OpenFile)
 //! wrapper. `read()`/`write()` then delegate to full-file OS calls, so all
 //! filesystem access remains behind `OsFunction`.
 
 use std::str;
 
+use monty_types::{MontyPath, OpenCallArgs, OsFunctionCall, ResourceTracker};
+
 use crate::{
-    MontyPath, OpenCallArgs, OsFunctionCall, ResourceTracker,
     args::{ArgValues, FromArgs, StrArg},
     bytecode::{CallResult, VM},
     defer_drop,

--- a/crates/monty/src/builtins/ord.rs
+++ b/crates/monty/src/builtins/ord.rs
@@ -1,7 +1,8 @@
 //! Implementation of the ord() builtin function.
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/builtins/ord.rs
+++ b/crates/monty/src/builtins/ord.rs
@@ -1,12 +1,12 @@
 //! Implementation of the ord() builtin function.
 
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
     heap::HeapData,
-    resource::ResourceTracker,
     value::Value,
 };
 

--- a/crates/monty/src/builtins/pow.rs
+++ b/crates/monty/src/builtins/pow.rs
@@ -6,12 +6,13 @@ use num_bigint::BigInt;
 use num_traits::{Signed, ToPrimitive, Zero};
 
 use crate::{
+    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
     heap::{Heap, HeapData},
-    resource::{ResourceTracker, check_pow_size},
+    resource_checks::check_pow_size,
     types::{LongInt, PyTrait},
     value::Value,
 };

--- a/crates/monty/src/builtins/pow.rs
+++ b/crates/monty/src/builtins/pow.rs
@@ -2,11 +2,11 @@
 
 use std::num::NonZero;
 
+use monty_types::ResourceTracker;
 use num_bigint::BigInt;
 use num_traits::{Signed, ToPrimitive, Zero};
 
 use crate::{
-    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/builtins/print.rs
+++ b/crates/monty/src/builtins/print.rs
@@ -1,12 +1,12 @@
 //! Implementation of the print() builtin function.
 
 use crate::{
+    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
     heap::HeapData,
-    resource::ResourceTracker,
     types::PyTrait,
     value::Value,
 };

--- a/crates/monty/src/builtins/print.rs
+++ b/crates/monty/src/builtins/print.rs
@@ -1,7 +1,8 @@
 //! Implementation of the print() builtin function.
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/builtins/repr.rs
+++ b/crates/monty/src/builtins/repr.rs
@@ -1,9 +1,8 @@
 //! Implementation of the repr() builtin function.
 
-use crate::{
-    ResourceTracker, args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, types::PyTrait,
-    value::Value,
-};
+use monty_types::ResourceTracker;
+
+use crate::{args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, types::PyTrait, value::Value};
 
 /// Implementation of the repr() builtin function.
 ///

--- a/crates/monty/src/builtins/repr.rs
+++ b/crates/monty/src/builtins/repr.rs
@@ -1,7 +1,7 @@
 //! Implementation of the repr() builtin function.
 
 use crate::{
-    args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, resource::ResourceTracker, types::PyTrait,
+    ResourceTracker, args::ArgValues, bytecode::VM, defer_drop, exception_private::RunResult, types::PyTrait,
     value::Value,
 };
 

--- a/crates/monty/src/builtins/reversed.rs
+++ b/crates/monty/src/builtins/reversed.rs
@@ -1,7 +1,8 @@
 //! Implementation of the reversed() builtin function.
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     exception_private::{ExcType, ExcTypeExt, RunResult},

--- a/crates/monty/src/builtins/reversed.rs
+++ b/crates/monty/src/builtins/reversed.rs
@@ -1,11 +1,11 @@
 //! Implementation of the reversed() builtin function.
 
 use crate::{
+    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::HeapData,
-    resource::ResourceTracker,
     types::{List, iter::collect_owned_iterable},
     value::Value,
 };

--- a/crates/monty/src/builtins/round.rs
+++ b/crates/monty/src/builtins/round.rs
@@ -3,12 +3,12 @@
 use num_bigint::{BigInt, Sign};
 
 use crate::{
+    ResourceTracker,
     args::{ArgValues, FromArgs, is_long_int},
     bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunResult, SimpleException},
     heap::HeapData,
-    resource::ResourceTracker,
     types::LongInt,
     value::Value,
 };

--- a/crates/monty/src/builtins/round.rs
+++ b/crates/monty/src/builtins/round.rs
@@ -1,9 +1,9 @@
 //! Implementation of the round() builtin function.
 
+use monty_types::ResourceTracker;
 use num_bigint::{BigInt, Sign};
 
 use crate::{
-    ResourceTracker,
     args::{ArgValues, FromArgs, is_long_int},
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/builtins/setattr.rs
+++ b/crates/monty/src/builtins/setattr.rs
@@ -1,7 +1,8 @@
 //! Implementation of the setattr() builtin function.
 
+use monty_types::{ExcType, ResourceTracker};
+
 use crate::{
-    ExcType, ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/builtins/setattr.rs
+++ b/crates/monty/src/builtins/setattr.rs
@@ -1,12 +1,11 @@
 //! Implementation of the setattr() builtin function.
 
 use crate::{
-    ExcType,
+    ExcType, ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,
-    exception_private::{RunResult, SimpleException},
-    resource::ResourceTracker,
+    exception_private::{ExcTypeExt, RunResult, SimpleException},
     value::Value,
 };
 

--- a/crates/monty/src/builtins/sorted.rs
+++ b/crates/monty/src/builtins/sorted.rs
@@ -1,7 +1,8 @@
 //! Implementation of the sorted() builtin function.
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     exception_private::{ExcType, ExcTypeExt, RunResult},

--- a/crates/monty/src/builtins/sorted.rs
+++ b/crates/monty/src/builtins/sorted.rs
@@ -1,11 +1,11 @@
 //! Implementation of the sorted() builtin function.
 
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::{DropGuard, DropWithContext, HeapData},
-    resource::ResourceTracker,
     sorting::parse_and_sort,
     types::{List, iter::collect_owned_iterable},
     value::Value,

--- a/crates/monty/src/builtins/sum.rs
+++ b/crates/monty/src/builtins/sum.rs
@@ -2,8 +2,9 @@
 
 use std::mem;
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop, defer_drop_mut,

--- a/crates/monty/src/builtins/sum.rs
+++ b/crates/monty/src/builtins/sum.rs
@@ -3,12 +3,12 @@
 use std::mem;
 
 use crate::{
+    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::DropGuard,
-    resource::ResourceTracker,
     types::{PyTrait, Type},
     value::Value,
 };

--- a/crates/monty/src/builtins/type_.rs
+++ b/crates/monty/src/builtins/type_.rs
@@ -1,8 +1,9 @@
 //! Implementation of the type() builtin function.
 
+use monty_types::ResourceTracker;
+
 use super::Builtins;
 use crate::{
-    ResourceTracker,
     args::{ArgValues, KwargsValues},
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/builtins/type_.rs
+++ b/crates/monty/src/builtins/type_.rs
@@ -2,13 +2,13 @@
 
 use super::Builtins;
 use crate::{
+    ResourceTracker,
     args::{ArgValues, KwargsValues},
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::{DropWithContext, HeapData},
     intern::StaticStrings,
-    resource::ResourceTracker,
     types::{Class, Dict, PyTrait},
     value::Value,
 };

--- a/crates/monty/src/builtins/zip.rs
+++ b/crates/monty/src/builtins/zip.rs
@@ -1,12 +1,12 @@
 //! Implementation of the zip() builtin function.
 
 use crate::{
+    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunError, RunResult, SimpleException},
     heap::{DropGuard, HeapData},
-    resource::ResourceTracker,
     types::{List, PyTrait, allocate_tuple, tuple::TupleVec},
     value::Value,
 };

--- a/crates/monty/src/builtins/zip.rs
+++ b/crates/monty/src/builtins/zip.rs
@@ -1,7 +1,8 @@
 //! Implementation of the zip() builtin function.
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop, defer_drop_mut,

--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -19,10 +19,10 @@ use super::{
     op::{FORMAT_VALUE_HAS_SPEC, FORMAT_VALUE_STATIC_SPEC, Opcode, assert_flags},
 };
 use crate::{
+    MontyException, StackFrame,
     args::{ArgExprs, CallArg, CallKwarg, Kwarg},
     builtins::{Builtins, BuiltinsFunctions},
     exception_private::ExcType,
-    exception_public::{MontyException, SourceMap, StackFrame},
     expressions::{
         AssignTarget, Callable, CmpOperator, Comprehension, DictItem, Expr, ExprLoc, Identifier, Literal, NameScope,
         Node, Operator, PreparedFunctionDef, PreparedNode, SequenceItem, UnpackTarget,
@@ -34,6 +34,7 @@ use crate::{
     name_map::NameMap,
     parse::{CodeRange, ExceptHandler, Try},
     run::CompileOptions,
+    source_map::{SourceMap, StackFrameExt},
     value::{EitherStr, Value},
 };
 
@@ -4027,7 +4028,7 @@ impl CompileError {
         if self.exc_type == ExcType::ModuleNotFoundError {
             frame.hide_caret = true;
         }
-        MontyException::new_full(self.exc_type, Some(self.message.into_owned()), vec![frame])
+        MontyException::with_traceback(self.exc_type, Some(self.message.into_owned()), vec![frame])
     }
 }
 

--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -11,6 +11,7 @@
 use std::{borrow::Cow, mem};
 
 use ahash::AHashSet;
+use monty_types::{MontyException, StackFrame};
 
 use super::{
     RESERVED_MODULE_DUNDERS,
@@ -19,7 +20,6 @@ use super::{
     op::{FORMAT_VALUE_HAS_SPEC, FORMAT_VALUE_STATIC_SPEC, Opcode, assert_flags},
 };
 use crate::{
-    MontyException, StackFrame,
     args::{ArgExprs, CallArg, CallKwarg, Kwarg},
     builtins::{Builtins, BuiltinsFunctions},
     exception_private::ExcType,

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -9,11 +9,11 @@
 use std::{collections::hash_map::Entry, mem, task::Poll};
 
 use ahash::AHashMap;
+use monty_types::{MontyException, ResourceTracker};
 use smallvec::{SmallVec, smallvec};
 
 use super::{AwaitResult, CallFrame, FrameExit, VM};
 use crate::{
-    MontyException, ResourceTracker,
     asyncio::{
         AwaitedGather, Awaiter, CallId, Coroutine, CoroutineState, ExternalFuture, ExternalFutureState, GatherFuture,
         GatherState, TaskId, awaited_state_size,

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -13,18 +13,18 @@ use smallvec::{SmallVec, smallvec};
 
 use super::{AwaitResult, CallFrame, FrameExit, VM};
 use crate::{
-    MontyException,
+    MontyException, ResourceTracker,
     asyncio::{
         AwaitedGather, Awaiter, CallId, Coroutine, CoroutineState, ExternalFuture, ExternalFutureState, GatherFuture,
         GatherState, TaskId, awaited_state_size,
     },
     bytecode::vm::scheduler::{Scheduler, SerializedTaskFrame, TaskState},
     defer_drop,
-    exception_private::{ExcType, RunError, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     heap::{DropGuard, DropWithContext, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput, HeapReader},
     intern::FunctionId,
-    resource::ResourceTracker,
-    run_progress::ExtFunctionResult,
+    object_bridge::MontyObjectExt,
+    run_progress::{ExtFunctionResult, ExtFunctionResultExt},
     types::List,
     value::Value,
 };

--- a/crates/monty/src/bytecode/vm/attr.rs
+++ b/crates/monty/src/bytecode/vm/attr.rs
@@ -1,8 +1,9 @@
 //! Attribute access helpers for the VM.
 
+use monty_types::ResourceTracker;
+
 use super::VM;
 use crate::{
-    ResourceTracker,
     bytecode::vm::CallResult,
     defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunError},

--- a/crates/monty/src/bytecode/vm/attr.rs
+++ b/crates/monty/src/bytecode/vm/attr.rs
@@ -2,11 +2,11 @@
 
 use super::VM;
 use crate::{
+    ResourceTracker,
     bytecode::vm::CallResult,
     defer_drop,
-    exception_private::{ExcType, RunError},
+    exception_private::{ExcType, ExcTypeExt, RunError},
     intern::StringId,
-    resource::ResourceTracker,
     value::EitherStr,
 };
 

--- a/crates/monty/src/bytecode/vm/binary.rs
+++ b/crates/monty/src/bytecode/vm/binary.rs
@@ -2,10 +2,9 @@
 
 use super::VM;
 use crate::{
-    defer_drop,
-    exception_private::{ExcType, RunError},
+    ResourceTracker, defer_drop,
+    exception_private::{ExcType, ExcTypeExt, RunError},
     heap::{DropGuard, HeapData, HeapReadOutput},
-    resource::ResourceTracker,
     types::{PyTrait, Set, dict_view::collect_iterable_to_set, set::SetBinaryOp},
     value::{BitwiseOp, Value},
 };

--- a/crates/monty/src/bytecode/vm/binary.rs
+++ b/crates/monty/src/bytecode/vm/binary.rs
@@ -1,8 +1,10 @@
 //! Binary and in-place operation helpers for the VM.
 
+use monty_types::ResourceTracker;
+
 use super::VM;
 use crate::{
-    ResourceTracker, defer_drop,
+    defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunError},
     heap::{DropGuard, HeapData, HeapReadOutput},
     types::{PyTrait, Set, dict_view::collect_iterable_to_set, set::SetBinaryOp},

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -8,18 +8,17 @@ use std::mem;
 
 use super::{CallFrame, VM, recursion::RunReentryGuard};
 use crate::{
+    OsFunctionCall, ResourceTracker,
     args::{ArgValues, KwargsValues},
     asyncio::Coroutine,
-    builtins::{Builtins, BuiltinsFunctions},
+    builtins::{Builtins, BuiltinsFunctions, BuiltinsFunctionsExt},
     bytecode::FrameExit,
     defer_drop,
-    exception_private::{ExcType, RunError},
+    exception_private::{ExcType, ExcTypeExt, RunError},
     function::Function,
     heap::{ContainsHeap, DropGuard, DropWithContext, HeapData, HeapId},
     heap_data::CellValue,
     intern::{FunctionId, StaticStrings, StringId},
-    os::OsFunctionCall,
-    resource::ResourceTracker,
     types::{Dict, Instance, PyTrait, Type, bytes::call_bytes_method, instance::class_name, str::call_str_method},
     value::{EitherStr, Value},
 };

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -6,9 +6,10 @@
 
 use std::mem;
 
+use monty_types::{OsFunctionCall, ResourceTracker};
+
 use super::{CallFrame, VM, recursion::RunReentryGuard};
 use crate::{
-    OsFunctionCall, ResourceTracker,
     args::{ArgValues, KwargsValues},
     asyncio::Coroutine,
     builtins::{Builtins, BuiltinsFunctions, BuiltinsFunctionsExt},

--- a/crates/monty/src/bytecode/vm/collections.rs
+++ b/crates/monty/src/bytecode/vm/collections.rs
@@ -1,8 +1,10 @@
 //! Collection building and unpacking helpers for the VM.
 
+use monty_types::ResourceTracker;
+
 use super::VM;
 use crate::{
-    ResourceTracker, defer_drop, defer_drop_mut,
+    defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunError, SimpleException},
     heap::{DropGuard, HeapData, HeapReadOutput},
     intern::StringId,

--- a/crates/monty/src/bytecode/vm/collections.rs
+++ b/crates/monty/src/bytecode/vm/collections.rs
@@ -2,11 +2,10 @@
 
 use super::VM;
 use crate::{
-    defer_drop, defer_drop_mut,
-    exception_private::{ExcType, RunError, SimpleException},
+    ResourceTracker, defer_drop, defer_drop_mut,
+    exception_private::{ExcType, ExcTypeExt, RunError, SimpleException},
     heap::{DropGuard, HeapData, HeapReadOutput},
     intern::StringId,
-    resource::ResourceTracker,
     types::{
         Dict, List, PyTrait, Set, Slice, allocate_tuple, collect_iterable, collect_iterable_bounded,
         slice::value_to_option_i64,

--- a/crates/monty/src/bytecode/vm/compare.rs
+++ b/crates/monty/src/bytecode/vm/compare.rs
@@ -2,10 +2,9 @@
 
 use super::VM;
 use crate::{
-    defer_drop,
-    exception_private::{ExcType, RunError, RunResult},
+    ResourceTracker, defer_drop,
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
     expressions::CmpOperator,
-    resource::ResourceTracker,
     types::{CmpOrder, PyTrait},
     value::Value,
 };

--- a/crates/monty/src/bytecode/vm/compare.rs
+++ b/crates/monty/src/bytecode/vm/compare.rs
@@ -1,8 +1,10 @@
 //! Comparison operation helpers for the VM.
 
+use monty_types::ResourceTracker;
+
 use super::VM;
 use crate::{
-    ResourceTracker, defer_drop,
+    defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
     expressions::CmpOperator,
     types::{CmpOrder, PyTrait},

--- a/crates/monty/src/bytecode/vm/context_manager.rs
+++ b/crates/monty/src/bytecode/vm/context_manager.rs
@@ -9,9 +9,8 @@
 
 use super::{CallResult, VM};
 use crate::{
-    defer_drop,
-    exception_private::{ExcType, RunError, RunResult},
-    resource::ResourceTracker,
+    ResourceTracker, defer_drop,
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
     types::PyTrait,
     value::Value,
 };

--- a/crates/monty/src/bytecode/vm/context_manager.rs
+++ b/crates/monty/src/bytecode/vm/context_manager.rs
@@ -7,9 +7,11 @@
 //! call (e.g. `OpenFile.__exit__` issues an `OsCall` to close the file); the
 //! caller routes the result through `handle_call_result!`.
 
+use monty_types::ResourceTracker;
+
 use super::{CallResult, VM};
 use crate::{
-    ResourceTracker, defer_drop,
+    defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
     types::PyTrait,
     value::Value,

--- a/crates/monty/src/bytecode/vm/exceptions.rs
+++ b/crates/monty/src/bytecode/vm/exceptions.rs
@@ -2,9 +2,10 @@
 
 use std::fmt::{self, Write};
 
+use monty_types::ResourceTracker;
+
 use super::VM;
 use crate::{
-    ResourceTracker,
     builtins::Builtins,
     defer_drop,
     exception_private::{ExcType, ExcTypeExt, ExceptionRaise, RawStackFrame, RunError, RunResult, SimpleException},

--- a/crates/monty/src/bytecode/vm/exceptions.rs
+++ b/crates/monty/src/bytecode/vm/exceptions.rs
@@ -4,13 +4,13 @@ use std::fmt::{self, Write};
 
 use super::VM;
 use crate::{
+    ResourceTracker,
     builtins::Builtins,
     defer_drop,
-    exception_private::{ExcType, ExceptionRaise, RawStackFrame, RunError, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, ExceptionRaise, RawStackFrame, RunError, RunResult, SimpleException},
     expressions::CmpOperator,
     heap::{DropGuard, HeapData},
     intern::{StaticStrings, StringId},
-    resource::ResourceTracker,
     types::{LazyHeapSet, PyTrait, Type},
     value::Value,
 };

--- a/crates/monty/src/bytecode/vm/format.rs
+++ b/crates/monty/src/bytecode/vm/format.rs
@@ -1,8 +1,9 @@
 //! F-string and value formatting helpers for the VM.
 
+use monty_types::ResourceTracker;
+
 use super::VM;
 use crate::{
-    ResourceTracker,
     bytecode::op::{FORMAT_VALUE_HAS_SPEC, FORMAT_VALUE_STATIC_SPEC},
     defer_drop,
     exception_private::{ExcType, RunError, SimpleException},

--- a/crates/monty/src/bytecode/vm/format.rs
+++ b/crates/monty/src/bytecode/vm/format.rs
@@ -2,6 +2,7 @@
 
 use super::VM;
 use crate::{
+    ResourceTracker,
     bytecode::op::{FORMAT_VALUE_HAS_SPEC, FORMAT_VALUE_STATIC_SPEC},
     defer_drop,
     exception_private::{ExcType, RunError, SimpleException},
@@ -9,7 +10,7 @@ use crate::{
         ParsedFormatSpec, ascii_escape, decode_format_spec, format_string, format_with_spec, validate_string_spec,
     },
     heap::HeapReadOutput,
-    resource::{ResourceTracker, check_repeat_size},
+    resource_checks::check_repeat_size,
     types::{PyTrait, date::format_date_strftime, datetime::format_datetime_strftime, str::allocate_string},
     value::Value,
 };

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -22,7 +22,7 @@ pub(crate) use recursion::{ContainsVM, RecursionToken};
 use scheduler::Scheduler;
 
 use crate::{
-    MontyObject,
+    InvalidInputError, MontyObject, OsFunctionCall, PrintWriter, ResourceTracker,
     args::ArgValues,
     asyncio::{CallId, TaskId},
     builtins::Builtins,
@@ -30,16 +30,13 @@ use crate::{
         code::{Code, LocationEntry},
         op::{Opcode, decode_assert_flags},
     },
-    exception_private::{ExcType, RunError, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapReadOutput, HeapReader},
     heap_data::{Closure, FunctionDefaults},
     intern::{FunctionId, Interns, StaticStrings, StringId},
-    io::PrintWriter,
     modules::{StandardLib, json::JsonStringCache, re::RePatternCache},
-    object::InvalidInputError,
-    os::OsFunctionCall,
+    object_bridge::MontyObjectExt,
     parse::CodeRange,
-    resource::ResourceTracker,
     types::{
         Dict, LongInt, PyTrait,
         file::{PendingFileEffect, apply_buffer_store, apply_write_position},

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -18,11 +18,11 @@ mod scheduler;
 use std::mem;
 
 pub(crate) use call::CallResult;
+use monty_types::{InvalidInputError, MontyObject, OsFunctionCall, PrintWriter, ResourceTracker};
 pub(crate) use recursion::{ContainsVM, RecursionToken};
 use scheduler::Scheduler;
 
 use crate::{
-    InvalidInputError, MontyObject, OsFunctionCall, PrintWriter, ResourceTracker,
     args::ArgValues,
     asyncio::{CallId, TaskId},
     builtins::Builtins,

--- a/crates/monty/src/bytecode/vm/recursion.rs
+++ b/crates/monty/src/bytecode/vm/recursion.rs
@@ -20,8 +20,8 @@ use std::ops::{Deref, DerefMut};
 
 use super::VM;
 use crate::{
+    ResourceError, ResourceTracker,
     heap::{ContainsHeap, DropWithContext},
-    resource::{ResourceError, ResourceTracker},
 };
 
 impl<'h, T: ResourceTracker> VM<'h, T> {

--- a/crates/monty/src/bytecode/vm/recursion.rs
+++ b/crates/monty/src/bytecode/vm/recursion.rs
@@ -18,11 +18,10 @@
 
 use std::ops::{Deref, DerefMut};
 
+use monty_types::{ResourceError, ResourceTracker};
+
 use super::VM;
-use crate::{
-    ResourceError, ResourceTracker,
-    heap::{ContainsHeap, DropWithContext},
-};
+use crate::heap::{ContainsHeap, DropWithContext};
 
 impl<'h, T: ResourceTracker> VM<'h, T> {
     /// Enters a lexically-scoped recursive operation, returning a guard that

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -9,9 +9,9 @@
 use std::{collections::VecDeque, mem};
 
 use ahash::AHashMap;
+use monty_types::{ResourceError, ResourceTracker};
 
 use crate::{
-    ResourceError, ResourceTracker,
     asyncio::{Awaiter, CallId, ExternalFutureState, TaskId},
     exception_private::RunError,
     heap::{ContainsHeap, DropWithContext, Heap, HeapId, HeapReadOutput, HeapReader},

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -11,11 +11,11 @@ use std::{collections::VecDeque, mem};
 use ahash::AHashMap;
 
 use crate::{
+    ResourceError, ResourceTracker,
     asyncio::{Awaiter, CallId, ExternalFutureState, TaskId},
     exception_private::RunError,
     heap::{ContainsHeap, DropWithContext, Heap, HeapId, HeapReadOutput, HeapReader},
     intern::FunctionId,
-    resource::{ResourceError, ResourceTracker},
     value::Value,
 };
 

--- a/crates/monty/src/codecs.rs
+++ b/crates/monty/src/codecs.rs
@@ -17,9 +17,11 @@ use std::{
     str,
 };
 
+pub use monty_types::utf8_error_reason;
+
 use crate::{
-    exception_private::{ExcType, RunError, RunResult},
-    resource::ResourceTracker,
+    ResourceTracker,
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
     string_builder::StringBuilder,
 };
 
@@ -426,26 +428,6 @@ fn decode_utf8(bytes: &[u8], errors: &str) -> RunResult<String> {
         }
     }
     Ok(out)
-}
-
-/// Classifies an invalid-UTF-8 error into CPython's reason wording, from the
-/// first unexpected byte and `Utf8Error::error_len()`.
-///
-/// `error_len == None` means the input ended mid-sequence (`unexpected end of
-/// data`); otherwise a byte that is a legal multi-byte lead (0xC2–0xF4) was
-/// followed by an invalid continuation, and anything else (stray
-/// continuation bytes, the overlong leads 0xC0/0xC1, 0xF5–0xFF) is an
-/// `invalid start byte`. Public (re-exported at the crate root) so `monty-fs`
-/// produces identical wording for text-mode file reads.
-#[must_use]
-pub fn utf8_error_reason(first_bad_byte: u8, error_len: Option<usize>) -> &'static str {
-    if error_len.is_none() {
-        "unexpected end of data"
-    } else if (0xC2..=0xF4).contains(&first_bad_byte) {
-        "invalid continuation byte"
-    } else {
-        "invalid start byte"
-    }
 }
 
 /// Returns true if `rest` starts with a complete CESU-8-encoded surrogate

--- a/crates/monty/src/codecs.rs
+++ b/crates/monty/src/codecs.rs
@@ -17,10 +17,10 @@ use std::{
     str,
 };
 
+use monty_types::ResourceTracker;
 pub use monty_types::utf8_error_reason;
 
 use crate::{
-    ResourceTracker,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
     string_builder::StringBuilder,
 };

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -3,11 +3,10 @@ use std::{
     fmt::{self, Display, Write},
 };
 
-use monty_types::{ExcData, JsonErrorData, MontyException, StackFrame, UnicodeErrorData};
+use monty_types::{ExcData, JsonErrorData, MontyException, ResourceTracker, StackFrame, UnicodeErrorData};
 use smallvec::smallvec;
 
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     defer_drop,

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -3,20 +3,19 @@ use std::{
     fmt::{self, Display, Write},
 };
 
-use serde::{Deserialize, Serialize};
+use monty_types::{ExcData, JsonErrorData, MontyException, StackFrame, UnicodeErrorData};
 use smallvec::smallvec;
-use strum::{Display, EnumString, IntoStaticStr};
 
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     defer_drop,
-    exception_public::{ExcData, JsonErrorData, MontyException, SourceMap, StackFrame, UnicodeErrorData},
     fstring::{FormatError, ascii_escape},
     heap::{HeapData, HeapRead},
     intern::{Interns, StaticStrings, StringId},
     parse::CodeRange,
-    resource::ResourceTracker,
+    source_map::{SourceMap, StackFrameExt},
     types::{
         PyTrait, Type, allocate_tuple,
         long_int::INT_MAX_STR_DIGITS,
@@ -28,186 +27,1699 @@ use crate::{
 /// Result type alias for operations that can produce a runtime error.
 pub type RunResult<T> = Result<T, RunError>;
 
-/// Python exception types supported by the interpreter.
+pub use monty_types::{ExcType, unicode_decode_error_msg};
+
+/// Crate-internal error constructors on [`ExcType`].
 ///
-/// Uses strum derives for automatic `Display`, `FromStr`, and `Into<&'static str>` implementations.
-/// The string representation matches the variant name exactly (e.g., `ValueError` -> "ValueError").
-#[derive(
-    Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Display, EnumString, IntoStaticStr, Serialize, Deserialize,
-)]
-pub enum ExcType {
-    /// primary exception class - matches any exception in isinstance checks.
+/// `ExcType` itself lives in `monty-types`; these constructors build
+/// interpreter-side [`RunError`]s (which carry raw stack frames), so they
+/// stay in `monty` as a `pub(crate)` extension trait with default bodies.
+/// Import the trait to call them as `ExcType::type_error(...)`.
+pub(crate) trait ExcTypeExt: Sized {
+    /// Creates an exception instance from an exception type and arguments,
+    /// handling constructor calls like `ValueError('message')`.
+    fn call(self, vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value>;
+
+    /// Creates an AttributeError for when an attribute is not found (GET operation).
     ///
-    /// Also the `Default` — required so `Type` (which embeds an `ExcType` in
-    /// its `Exception` variant) can derive `strum::EnumIter`.
-    #[default]
-    Exception,
-
-    /// System exit exceptions
-    BaseException,
-    SystemExit,
-    KeyboardInterrupt,
-
-    // --- ArithmeticError hierarchy ---
-    /// Intermediate class for arithmetic errors.
-    ArithmeticError,
-    /// Subclass of ArithmeticError.
-    OverflowError,
-    /// Subclass of ArithmeticError.
-    ZeroDivisionError,
-
-    // --- LookupError hierarchy ---
-    /// Intermediate class for lookup errors.
-    LookupError,
-    /// Subclass of LookupError.
-    IndexError,
-    /// Subclass of LookupError.
-    KeyError,
-
-    // --- RuntimeError hierarchy ---
-    /// Intermediate class for runtime errors.
-    RuntimeError,
-    /// Subclass of RuntimeError.
-    NotImplementedError,
-    /// Subclass of RuntimeError.
-    RecursionError,
-
-    // --- AttributeError hierarchy ---
-    AttributeError,
-    /// Subclass of AttributeError (from dataclasses module).
-    FrozenInstanceError,
-
-    // --- NameError hierarchy ---
-    NameError,
-    /// Subclass of NameError - for accessing local variable before assignment.
-    UnboundLocalError,
-
-    // --- ValueError hierarchy ---
-    ValueError,
-    /// Subclass of ValueError - for encoding/decoding errors.
-    UnicodeDecodeError,
-    /// Subclass of ValueError - for encoding errors (e.g. `str.encode('ascii')`
-    /// on a string containing non-ASCII characters).
-    UnicodeEncodeError,
-    /// Subclass of ValueError for invalid JSON syntax in `json.loads()`.
-    #[strum(serialize = "json.JSONDecodeError")]
-    JsonDecodeError,
-
-    // --- ImportError hierarchy ---
-    /// Import-related errors (module not found, name not in module).
-    ImportError,
-    /// Subclass of ImportError - for when a module cannot be found.
-    ModuleNotFoundError,
-
-    // --- OSError hierarchy ---
-    /// OS-related errors (file not found, permission denied, etc.)
-    OSError,
-    /// Subclass of OSError - for when a file or directory cannot be found.
-    FileNotFoundError,
-    /// Subclass of OSError - for when a file already exists.
-    FileExistsError,
-    /// Subclass of OSError - for when a path is a directory but a file was expected.
-    IsADirectoryError,
-    /// Subclass of OSError - for when a path is not a directory but one was expected.
-    NotADirectoryError,
-    /// Subclass of OSError - for when an operation is not permitted (e.g., writing
-    /// to a read-only mount, or attempting to access a path outside a mounted directory).
-    PermissionError,
-    /// `io.UnsupportedOperation` - raised by file objects when a requested
-    /// operation isn't allowed by the open mode (e.g. `read()` on `'w'`).
-    ///
-    /// In CPython this inherits from both `OSError` and `ValueError`. Monty's
-    /// `ExcType` enum models single parents, but [`Self::is_subclass_of`]
-    /// matches `UnsupportedOperation` against both `OSError` and `ValueError`
-    /// so `except ValueError:` and `except OSError:` both catch it as in
-    /// CPython.
-    #[strum(serialize = "io.UnsupportedOperation")]
-    UnsupportedOperation,
-    /// Subclass of OSError since Python 3.3 (PEP 3151).
-    TimeoutError,
-
-    // --- Standalone exception types ---
-    AssertionError,
-    MemoryError,
-    StopIteration,
-    SyntaxError,
-    TypeError,
-
-    // --- Module-specific exception types ---
-
-    // --- re module ---
-    /// `re.PatternError` - raised for invalid regex patterns or unsupported regex features.
-    ///
-    /// # Behavior Note
-    ///
-    /// Limited to monty's exception type, `PatternError` does not provide `pattern`, `pos`,
-    /// `lineno` and `colno` attributes.
-    ///
-    /// As per CPython's implementation, it would be hard to convert `fancy-regex`'s error
-    /// representations into the required attributes.
-    #[strum(serialize = "re.PatternError")]
-    RePatternError,
-}
-
-impl ExcType {
-    /// Checks if this exception type is a subclass of another exception type.
-    ///
-    /// Implements Python's exception hierarchy for try/except matching:
-    /// - `Exception` is the base class for all standard exceptions
-    /// - `LookupError` is the base for `KeyError` and `IndexError`
-    /// - `ArithmeticError` is the base for `ZeroDivisionError` and `OverflowError`
-    /// - `RuntimeError` is the base for `RecursionError` and `NotImplementedError`
-    ///
-    /// Returns true if `self` would be caught by `except handler_type:`.
+    /// Sets `hide_caret: true` because CPython doesn't show carets for attribute GET errors.
     #[must_use]
-    pub fn is_subclass_of(self, handler_type: Self) -> bool {
-        if self == handler_type {
-            return true;
-        }
-        match handler_type {
-            // BaseException catches all exceptions
-            Self::BaseException => true,
-            // Exception catches everything except BaseException, and direct subclasses: KeyboardInterrupt, SystemExit
-            Self::Exception => !matches!(self, Self::BaseException | Self::KeyboardInterrupt | Self::SystemExit),
-            // LookupError catches KeyError and IndexError
-            Self::LookupError => matches!(self, Self::KeyError | Self::IndexError),
-            // ArithmeticError catches ZeroDivisionError and OverflowError
-            Self::ArithmeticError => matches!(self, Self::ZeroDivisionError | Self::OverflowError),
-            // RuntimeError catches RecursionError and NotImplementedError
-            Self::RuntimeError => matches!(self, Self::RecursionError | Self::NotImplementedError),
-            // AttributeError catches FrozenInstanceError
-            Self::AttributeError => matches!(self, Self::FrozenInstanceError),
-            // NameError catches UnboundLocalError
-            Self::NameError => matches!(self, Self::UnboundLocalError),
-            // ValueError catches UnicodeDecodeError, UnicodeEncodeError, json.JSONDecodeError,
-            // and io.UnsupportedOperation (which in CPython has dual OSError + ValueError parentage)
-            Self::ValueError => matches!(
-                self,
-                Self::UnicodeDecodeError
-                    | Self::UnicodeEncodeError
-                    | Self::JsonDecodeError
-                    | Self::UnsupportedOperation
-            ),
-            // ImportError catches ModuleNotFoundError
-            Self::ImportError => matches!(self, Self::ModuleNotFoundError),
-            // OSError catches FileNotFoundError, FileExistsError, IsADirectoryError,
-            // NotADirectoryError, PermissionError, io.UnsupportedOperation, and
-            // TimeoutError (an OSError subclass since Python 3.3)
-            Self::OSError => matches!(
-                self,
-                Self::FileNotFoundError
-                    | Self::FileExistsError
-                    | Self::IsADirectoryError
-                    | Self::NotADirectoryError
-                    | Self::PermissionError
-                    | Self::UnsupportedOperation
-                    | Self::TimeoutError
-            ),
-            // All other types only match exactly (handled by self == handler_type above)
-            _ => false,
+    fn attribute_error(type_name: impl Display, attr: &str) -> RunError {
+        let exc = SimpleException::new_msg(
+            ExcType::AttributeError,
+            format!("'{type_name}' object has no attribute '{attr}'"),
+        );
+        RunError::Exc(ExceptionRaise {
+            exc,
+            frame: None,
+            hide_caret: true, // CPython doesn't show carets for attribute GET errors
+        })
+    }
+
+    /// Creates an AttributeError for a missing attribute on a class object.
+    ///
+    /// Matches CPython's wording for type objects: `type object 'Foo' has no
+    /// attribute 'nope'` (instances use [`Self::attribute_error`] instead).
+    /// Sets `hide_caret: true` because CPython doesn't show carets for attribute GET errors.
+    #[must_use]
+    fn attribute_error_type(class_name: &str, attr: &str) -> RunError {
+        let exc = SimpleException::new_msg(
+            ExcType::AttributeError,
+            format!("type object '{class_name}' has no attribute '{attr}'"),
+        );
+        RunError::Exc(ExceptionRaise {
+            exc,
+            frame: None,
+            hide_caret: true, // CPython doesn't show carets for attribute GET errors
+        })
+    }
+
+    /// Creates an AttributeError for attribute assignment on types that don't support it.
+    ///
+    /// Matches CPython's format for setting attributes on built-in types.
+    #[must_use]
+    fn attribute_error_no_setattr(type_: &str, attr_name: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::AttributeError,
+            format!("'{type_}' object has no attribute '{attr_name}' and no __dict__ for setting new attributes"),
+        )
+        .into()
+    }
+
+    /// Creates an AttributeError for a missing module attribute.
+    ///
+    /// Matches CPython's format: `AttributeError: module 'name' has no attribute 'attr'`
+    /// Sets `hide_caret: true` because CPython doesn't show carets for attribute GET errors.
+    #[must_use]
+    fn attribute_error_module(module_name: &str, attr_name: &str) -> RunError {
+        let exc = SimpleException::new_msg(
+            ExcType::AttributeError,
+            format!("module '{module_name}' has no attribute '{attr_name}'"),
+        );
+        RunError::Exc(ExceptionRaise {
+            exc,
+            frame: None,
+            hide_caret: true, // CPython doesn't show carets for attribute GET errors
+        })
+    }
+
+    #[must_use]
+    fn type_error_not_sub(type_: &str) -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, format!("'{type_}' object is not subscriptable")).into()
+    }
+
+    /// Creates the TypeError for an ordering comparison (`<`, `<=`, `>`, `>=`)
+    /// between values whose types define no ordering, e.g. `1 < 'a'` or two
+    /// instances of a user class without comparison dunders.
+    ///
+    /// Matches CPython's format:
+    /// `TypeError: '{op}' not supported between instances of '{left}' and '{right}'`
+    #[must_use]
+    fn type_error_ordering(operator: &str, left_type: &str, right_type: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("'{operator}' not supported between instances of '{left_type}' and '{right_type}'"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for awaiting a non-awaitable object.
+    ///
+    /// Matches CPython's format: `TypeError: '{type}' object can't be awaited`
+    #[must_use]
+    fn object_not_awaitable(type_: &str) -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, format!("'{type_}' object can't be awaited")).into()
+    }
+
+    /// Creates the canonical `RuntimeError: cannot reuse already awaited coroutine`,
+    /// raised on direct re-await and on cross-gather coroutine reuse.
+    #[must_use]
+    fn cannot_reuse_already_awaited_coroutine() -> RunError {
+        SimpleException::new_msg(ExcType::RuntimeError, "cannot reuse already awaited coroutine").into()
+    }
+
+    /// Creates a TypeError for item assignment on types that don't support it.
+    ///
+    /// Matches CPython's format: `TypeError: '{type}' object does not support item assignment`
+    #[must_use]
+    fn type_error_not_sub_assignment(type_: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("'{type_}' object does not support item assignment"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for unhashable types when calling `hash()`.
+    ///
+    /// This matches Python 3.14's error message: `TypeError: unhashable type: 'list'`
+    #[must_use]
+    fn type_error_unhashable(type_: &str) -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, format!("unhashable type: '{type_}'")).into()
+    }
+
+    /// Creates a TypeError for unhashable types used as dict keys.
+    ///
+    /// This matches Python 3.14's error message:
+    /// `TypeError: cannot use 'list' as a dict key (unhashable type: 'list')`
+    #[must_use]
+    fn type_error_unhashable_dict_key(type_: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("cannot use '{type_}' as a dict key (unhashable type: '{type_}')"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for unhashable types used as set elements.
+    ///
+    /// This matches Python 3.14's error message:
+    /// `TypeError: cannot use 'list' as a set element (unhashable type: 'list')`
+    #[must_use]
+    fn type_error_unhashable_set_element(type_: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("cannot use '{type_}' as a set element (unhashable type: '{type_}')"),
+        )
+        .into()
+    }
+
+    /// Creates a KeyError for a missing dict key.
+    ///
+    /// For string keys, uses the raw string value without extra quoting.
+    /// If the key's string conversion fails (e.g. huge LongInt exceeding
+    /// `INT_MAX_STR_DIGITS`), falls back to the type name so that a
+    /// `KeyError` is always raised rather than a spurious `ValueError`.
+    fn key_error(key: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunError {
+        let key_str = match key.py_str(vm) {
+            Ok(key_value) => {
+                // `key_value` is a heap `str` `Value`; extract its text and drop it.
+                defer_drop!(key_value, vm);
+                if let Ok(s) = key_value.to_str(vm) {
+                    s.to_owned()
+                } else {
+                    format!("<{}>", key.py_type_name(vm))
+                }
+            }
+            Err(_) => format!("<{}>", key.py_type_name(vm)),
+        };
+        SimpleException::new_msg(ExcType::KeyError, key_str).into()
+    }
+
+    /// Creates a KeyError for popping from an empty set.
+    ///
+    /// Matches CPython's error format: `KeyError: 'pop from an empty set'`
+    #[must_use]
+    fn key_error_pop_empty_set() -> RunError {
+        SimpleException::new_msg(ExcType::KeyError, "pop from an empty set").into()
+    }
+
+    /// Creates a TypeError for when a function receives the wrong number of arguments.
+    ///
+    /// Matches CPython's error format exactly:
+    /// - For 1 expected arg: `{name}() takes exactly one argument ({actual} given)`
+    /// - For N expected args: `{name} expected {expected} arguments, got {actual}`
+    ///
+    /// # Arguments
+    /// * `name` - The function name (e.g., "len" for builtins, "list.append" for methods)
+    /// * `expected` - Number of expected arguments
+    /// * `actual` - Number of arguments actually provided
+    #[must_use]
+    fn type_error_arg_count(name: &str, expected: usize, actual: usize) -> RunError {
+        if expected == 1 {
+            // CPython: "len() takes exactly one argument (2 given)"
+            SimpleException::new_msg(
+                ExcType::TypeError,
+                format!("{name}() takes exactly one argument ({actual} given)"),
+            )
+            .into()
+        } else {
+            // CPython: "insert expected 2 arguments, got 1"
+            SimpleException::new_msg(
+                ExcType::TypeError,
+                format!("{name} expected {expected} arguments, got {actual}"),
+            )
+            .into()
         }
     }
 
+    /// Creates a TypeError for when a method that takes no arguments receives some.
+    ///
+    /// Matches CPython's format: `{name}() takes no arguments ({actual} given)`
+    ///
+    /// # Arguments
+    /// * `name` - The method name (e.g., "dict.keys")
+    /// * `actual` - Number of arguments actually provided
+    #[must_use]
+    fn type_error_no_args(name: &str, actual: usize) -> RunError {
+        // CPython: "dict.keys() takes no arguments (1 given)"
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("{name}() takes no arguments ({actual} given)"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for when a function receives fewer arguments than required.
+    ///
+    /// Matches CPython's format: `{name} expected at least {min} argument, got {actual}`
+    ///
+    /// # Arguments
+    /// * `name` - The function name (e.g., "get", "pop")
+    /// * `min` - Minimum number of required arguments
+    /// * `actual` - Number of arguments actually provided
+    #[must_use]
+    fn type_error_at_least(name: &str, min: usize, actual: usize) -> RunError {
+        // CPython: "get expected at least 1 argument, got 0"
+        let plural = if min == 1 { "" } else { "s" };
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("{name} expected at least {min} argument{plural}, got {actual}"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for when a function receives more arguments than allowed.
+    ///
+    /// Matches CPython's `PyArg_UnpackTuple` format:
+    /// - `{name} expected at most {max} argument, got {actual}` (singular when max=1)
+    /// - `{name} expected at most {max} arguments, got {actual}` (plural otherwise)
+    ///
+    /// # Arguments
+    /// * `name` - The function name (e.g., "get", "pop")
+    /// * `max` - Maximum number of allowed arguments
+    /// * `actual` - Number of arguments actually provided
+    #[must_use]
+    fn type_error_at_most(name: &str, max: usize, actual: usize) -> RunError {
+        let plural = if max == 1 { "" } else { "s" };
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("{name} expected at most {max} argument{plural}, got {actual}"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for a `startswith`/`endswith` affix argument that is
+    /// neither the expected string type nor a tuple.
+    ///
+    /// Matches CPython: `{method} first arg must be {expected} or a tuple of {expected}, not {type}`
+    /// (`expected` is `str` for `str` methods, `bytes` for `bytes` methods).
+    #[must_use]
+    fn type_error_affix_arg(method: &str, expected: &str, type_name: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("{method} first arg must be {expected} or a tuple of {expected}, not {type_name}"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for a non-string element in a `startswith`/`endswith`
+    /// affix tuple.
+    ///
+    /// Matches CPython: `tuple for {method} must only contain {expected}, not {type}`.
+    /// Raised lazily while matching — elements after a successful match are never checked.
+    #[must_use]
+    fn type_error_affix_tuple_item(method: &str, expected: &str, type_name: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("tuple for {method} must only contain {expected}, not {type_name}"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for too many arguments to a method or named function.
+    ///
+    /// Matches CPython's format for method-style calls:
+    /// `{name}() takes at most {max} argument ({actual} given)` (singular when max=1)
+    /// `{name}() takes at most {max} arguments ({actual} given)` (plural otherwise)
+    ///
+    /// Use this instead of `type_error_at_most` for methods and type constructors that
+    /// CPython formats with parentheses, e.g. `now()`, `timezone()`, `expandtabs()`.
+    #[must_use]
+    fn type_error_method_at_most(name: &str, max: usize, actual: usize) -> RunError {
+        let plural = if max == 1 { "" } else { "s" };
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("{name}() takes at most {max} argument{plural} ({actual} given)"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for too few positional arguments to a method-style call.
+    ///
+    /// Matches CPython's format used by methods like `str.replace`:
+    /// `{name}() takes at least {min} positional argument ({actual} given)` (singular when min=1)
+    /// `{name}() takes at least {min} positional arguments ({actual} given)` (plural otherwise)
+    ///
+    /// Distinct from [`type_error_at_least`] which uses CPython's
+    /// `PyArg_UnpackTuple` wording (no parens, no "positional"). Emitted by
+    /// `FromArgs` for any struct with required positional-only fields,
+    /// matching CPython's C-method `_PyArg_UnpackKeywords` dispatch.
+    #[must_use]
+    fn type_error_at_least_positional(name: &str, min: usize, actual: usize) -> RunError {
+        let plural = if min == 1 { "" } else { "s" };
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("{name}() takes at least {min} positional argument{plural} ({actual} given)"),
+        )
+        .into()
+    }
+
+    /// Creates the bespoke `map()` arity error that CPython hard-codes.
+    ///
+    /// CPython's `map()` uses a single fixed message regardless of whether
+    /// 0 or 1 args were given: `map() must have at least two arguments.`
+    /// (note the trailing period). We mirror it here so `map()` / `map(f)`
+    /// match byte-for-byte rather than falling through to the generic
+    /// "missing N required positional arguments" wording the macro would
+    /// otherwise emit.
+    #[must_use]
+    fn type_error_map_arity() -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, "map() must have at least two arguments.".to_owned()).into()
+    }
+
+    /// Creates a TypeError for exact-arity functions reporting too many *or* too few.
+    ///
+    /// Matches CPython's `PyArg_UnpackTuple` wording for fixed-arity callables
+    /// (e.g. `sorted`):
+    /// `{name} expected {exact} argument, got {actual}` (singular when exact=1)
+    /// `{name} expected {exact} arguments, got {actual}` (plural otherwise)
+    ///
+    /// Use this for the macro's `expected_exact` attribute.
+    #[must_use]
+    fn type_error_expected_exact(name: &str, exact: usize, actual: usize) -> RunError {
+        let plural = if exact == 1 { "" } else { "s" };
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("{name} expected {exact} argument{plural}, got {actual}"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for missing positional arguments.
+    ///
+    /// Matches CPython's format: `{name}() missing {count} required positional argument(s): 'a' and 'b'`
+    #[must_use]
+    fn type_error_missing_positional_with_names(name: &str, missing_names: &[&str]) -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, Self::missing_positional_msg(name, missing_names)).into()
+    }
+
+    /// Message body for [`type_error_missing_positional_with_names`], exposed
+    /// separately so `args/bind_python.rs` can attach a call position to the same
+    /// CPython-exact wording.
+    #[must_use]
+    fn missing_positional_msg(name: &str, missing_names: &[&str]) -> String {
+        let count = missing_names.len();
+        let names_str = format_param_names(missing_names);
+        if count == 1 {
+            format!("{name}() missing 1 required positional argument: {names_str}")
+        } else {
+            format!("{name}() missing {count} required positional arguments: {names_str}")
+        }
+    }
+
+    /// Creates a TypeError for missing keyword-only arguments.
+    ///
+    /// Matches CPython's format: `{name}() missing {count} required keyword-only argument(s): 'a' and 'b'`
+    #[must_use]
+    fn type_error_missing_kwonly_with_names(name: &str, missing_names: &[&str]) -> RunError {
+        let count = missing_names.len();
+        let names_str = format_param_names(missing_names);
+        if count == 1 {
+            SimpleException::new_msg(
+                ExcType::TypeError,
+                format!("{name}() missing 1 required keyword-only argument: {names_str}"),
+            )
+            .into()
+        } else {
+            SimpleException::new_msg(
+                ExcType::TypeError,
+                format!("{name}() missing {count} required keyword-only arguments: {names_str}"),
+            )
+            .into()
+        }
+    }
+
+    /// Creates a TypeError for too many positional arguments to a callable whose
+    /// positional count is a range (some positional parameters have defaults).
+    ///
+    /// Matches CPython's pure-Python `def` wording: when `min == max` it emits
+    /// `{name}() takes {max} positional argument(s) but {actual} was/were given`;
+    /// otherwise `{name}() takes from {min} to {max} positional arguments but
+    /// {actual} were given` (always-plural "arguments" in the range form). Both
+    /// get the `(and N keyword-only argument(s))` suffix when `kwonly_given > 0`.
+    /// Used by `FromArgs` structs marked `py_def` and by user `def` bindings.
+    #[must_use]
+    fn type_error_too_many_positional_range(
+        name: &str,
+        min: usize,
+        max: usize,
+        actual: usize,
+        kwonly_given: usize,
+    ) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            Self::too_many_positional_range_msg(name, min, max, actual, kwonly_given),
+        )
+        .into()
+    }
+
+    /// Message body for [`type_error_too_many_positional_range`], exposed
+    /// separately so `args/bind_python.rs` can attach a call position to the same
+    /// CPython-exact wording.
+    #[must_use]
+    fn too_many_positional_range_msg(name: &str, min: usize, max: usize, actual: usize, kwonly_given: usize) -> String {
+        let takes = if min == max {
+            // `max == 0` still reads "0 positional arguments" (plural) in CPython.
+            let takes_word = if max == 1 { "argument" } else { "arguments" };
+            format!("{max} positional {takes_word}")
+        } else {
+            format!("from {min} to {max} positional arguments")
+        };
+        if kwonly_given > 0 {
+            // CPython includes keyword-only args in the "given" part when present
+            let given_word = if actual == 1 { "argument" } else { "arguments" };
+            let kwonly_word = if kwonly_given == 1 { "argument" } else { "arguments" };
+            format!(
+                "{name}() takes {takes} but {actual} positional {given_word} (and {kwonly_given} keyword-only {kwonly_word}) were given"
+            )
+        } else {
+            let was_were = if actual == 1 { "was" } else { "were" };
+            format!("{name}() takes {takes} but {actual} {was_were} given")
+        }
+    }
+
+    /// Creates a TypeError for positional-only parameter passed as keyword.
+    ///
+    /// Matches CPython's format: `{name}() got some positional-only arguments passed as keyword arguments: '{param}'`
+    #[must_use]
+    fn type_error_positional_only(name: &str, param: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("{name}() got some positional-only arguments passed as keyword arguments: '{param}'"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for duplicate argument.
+    ///
+    /// Matches CPython's format: `{name}() got multiple values for argument '{param}'`
+    #[must_use]
+    fn type_error_duplicate_arg(name: &str, param: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("{name}() got multiple values for argument '{param}'"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for duplicate keyword argument.
+    ///
+    /// Matches CPython's format: `{name}() got multiple values for keyword argument '{key}'`
+    #[must_use]
+    fn type_error_multiple_values(name: &str, key: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("{name}() got multiple values for keyword argument '{key}'"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for when a positional argument conflicts with a keyword argument
+    /// of the same name in a C-implemented type constructor.
+    ///
+    /// Matches CPython's `PyArg_ParseTupleAndKeywords` format:
+    /// `argument for function given by name ('{key}') and position ({pos})`
+    ///
+    /// The position is 1-indexed, matching CPython's convention. The `func_descriptor` is
+    /// typically `"function"` for most C types (like `datetime`), matching CPython's generic
+    /// wording for `PyArg_ParseTupleAndKeywords`.
+    #[must_use]
+    fn type_error_positional_keyword_conflict(func_descriptor: &str, key: &str, pos: usize) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("argument for {func_descriptor} given by name ('{key}') and position ({pos})"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for unexpected keyword argument.
+    ///
+    /// Matches CPython's format: `{name}() got an unexpected keyword argument '{key}'`
+    #[must_use]
+    fn type_error_unexpected_keyword(name: &str, key: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("{name}() got an unexpected keyword argument '{key}'"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for unexpected keyword argument in C-implemented types.
+    ///
+    /// Matches CPython's `PyArg_ParseTupleAndKeywords` format:
+    /// `this function got an unexpected keyword argument '{key}'`
+    #[must_use]
+    fn type_error_c_unexpected_keyword(key: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("this function got an unexpected keyword argument '{key}'"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for too many arguments to a C-implemented type.
+    ///
+    /// Matches CPython's `PyArg_ParseTupleAndKeywords` format:
+    /// `function takes at most {max} arguments ({actual} given)`
+    #[must_use]
+    fn type_error_c_at_most(max: usize, actual: usize) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("function takes at most {max} arguments ({actual} given)"),
+        )
+        .into()
+    }
+
+    /// Variant of [`type_error_c_at_most`] used by C constructors that explicitly
+    /// say "positional arguments" (e.g. `datetime`):
+    /// `function takes at most {max} positional arguments ({actual} given)`
+    #[must_use]
+    fn type_error_c_at_most_positional(max: usize, actual: usize) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("function takes at most {max} positional arguments ({actual} given)"),
+        )
+        .into()
+    }
+
+    /// Hybrid wording used by C constructors that mix positional-or-keyword
+    /// slots with keyword-only slots (e.g. `datetime`, where `fold` is
+    /// keyword-only). CPython's `PyArg_ParseTupleAndKeywords` emits two
+    /// distinct messages depending on whether the caller could conceivably
+    /// have meant the overflow args to fill the keyword-only tail:
+    ///
+    /// - `actual <= max_total`: the extra positionals *could* have filled the
+    ///   trailing keyword-only slots, so the error pins blame on positional
+    ///   overflow specifically — `function takes at most {max_pos} positional
+    ///   arguments ({actual} given)`.
+    /// - `actual > max_total`: there is no slot of any kind for the extras,
+    ///   so the error reports the total slot count without the "positional"
+    ///   qualifier — `function takes at most {max_total} arguments ({actual}
+    ///   given)`.
+    ///
+    /// `max_pos` is the number of positional-or-keyword slots; `max_total`
+    /// adds the trailing keyword-only slot count. When `max_total == max_pos`
+    /// (no kw-only fields) this collapses to [`type_error_c_at_most_positional`].
+    #[must_use]
+    fn type_error_c_at_most_positional_or_total(max_pos: usize, max_total: usize, actual: usize) -> RunError {
+        if actual > max_total && max_total > max_pos {
+            Self::type_error_c_at_most(max_total, actual)
+        } else {
+            Self::type_error_c_at_most_positional(max_pos, actual)
+        }
+    }
+
+    /// Creates a TypeError for a missing required argument in a C-implemented type.
+    ///
+    /// Matches CPython's `PyArg_ParseTupleAndKeywords` format:
+    /// `function missing required argument '{arg_name}' (pos {pos})`
+    #[must_use]
+    fn type_error_c_missing_required(arg_name: &str, pos: usize) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("function missing required argument '{arg_name}' (pos {pos})"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for a missing required argument in a C-implemented type,
+    /// with a function name prefix.
+    ///
+    /// Matches CPython's format for types like `timezone`:
+    /// `{name}() missing required argument '{arg_name}' (pos {pos})`
+    #[must_use]
+    fn type_error_c_missing_required_named(name: &str, arg_name: &str, pos: usize) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("{name}() missing required argument '{arg_name}' (pos {pos})"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for a missing required argument without a position,
+    /// as raised by hand-written vectorcall fast paths like `enumerate`:
+    /// `{name}() missing required argument '{arg_name}'`
+    #[must_use]
+    fn type_error_missing_required_no_pos(name: &str, arg_name: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("{name}() missing required argument '{arg_name}'"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for a keyword rejected by a hand-written vectorcall
+    /// fast path (CPython's `enumerate` wording, distinct from the parser
+    /// families' "unexpected keyword argument"):
+    /// `'{key}' is an invalid keyword argument for {name}()`
+    #[must_use]
+    fn type_error_invalid_keyword_argument(name: &str, key: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("'{key}' is an invalid keyword argument for {name}()"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError matching CPython's `_PyArg_BadArgument`
+    /// positional-style wording: `{name}() argument {pos} must be
+    /// {expected}, not {got}`.
+    ///
+    /// Used by the `#[derive(FromArgs)]` macro when the struct opts into
+    /// `bad_arg` errors — emitted in place of the inner [`FromValue`]
+    /// failure so the caller sees the same wording as CPython's C-implemented
+    /// functions (e.g. `strftime() argument 1 must be str, not None`).
+    ///
+    /// The `got` type label should come from `Type::cpython_arg_name` so
+    /// that `NoneType` becomes `"None"` to match CPython's special case.
+    ///
+    /// [`FromValue`]: crate::args::FromValue
+    #[must_use]
+    fn type_error_bad_arg_pos(name: &str, pos: usize, expected: &str, got: impl fmt::Display) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("{name}() argument {pos} must be {expected}, not {got}"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError matching CPython's `_PyArg_BadArgument`
+    /// named-style wording: `{name}() argument '{arg_name}' must be
+    /// {expected}, not {got}`.
+    ///
+    /// CPython uses this form for C-implemented functions that register
+    /// their arguments by name (`open`, `str.encode`, `bytes.decode`, …).
+    /// Sibling to [`type_error_bad_arg_pos`]; pick the variant matching the
+    /// CPython output for the function being modelled.
+    #[must_use]
+    fn type_error_bad_arg_named(name: &str, arg_name: &str, expected: &str, got: impl fmt::Display) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("{name}() argument '{arg_name}' must be {expected}, not {got}"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for **kwargs argument that is not a mapping.
+    ///
+    /// Matches CPython's format: `{name}() argument after ** must be a mapping, not {type_name}`
+    #[must_use]
+    fn type_error_kwargs_not_mapping(name: &str, type_name: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("{name}() argument after ** must be a mapping, not {type_name}"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for `{**x}` dict-literal unpacking where `x` is not a mapping.
+    ///
+    /// Matches CPython's format: `'{type_name}' object is not a mapping`
+    ///
+    /// Note: this differs from [`type_error_kwargs_not_mapping`] which is used for
+    /// function-call `**kwargs` and includes the function name in the message.
+    #[must_use]
+    fn type_error_not_mapping(type_: &str) -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, format!("'{type_}' object is not a mapping")).into()
+    }
+
+    /// Creates a TypeError for **kwargs with non-string keys.
+    ///
+    /// Matches CPython's format: `{name}() keywords must be strings`
+    #[must_use]
+    fn type_error_kwargs_nonstring_key() -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, "keywords must be strings").into()
+    }
+
+    /// Creates a TypeError for an invalid `tzinfo` argument.
+    ///
+    /// Matches CPython: `tzinfo argument must be None or of a tzinfo subclass, not type 'int'`
+    #[must_use]
+    fn type_error_tzinfo(ty: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("tzinfo argument must be None or of a tzinfo subclass, not type '{ty}'"),
+        )
+        .into()
+    }
+
+    /// Creates a simple TypeError with a custom message.
+    #[must_use]
+    fn type_error(msg: impl fmt::Display) -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, msg).into()
+    }
+
+    /// Creates the TypeError raised when a `with` statement's context expression
+    /// does not implement the context-manager protocol.
+    ///
+    /// Matches CPython 3.14's wording, which names the specific missing dunder:
+    /// `__exit__` when the protocol check fails outright (`BeforeWith`'s
+    /// [`py_is_context_manager`](crate::types::PyTrait::py_is_context_manager)
+    /// gate), `__enter__` when a user class defines `__exit__` but not
+    /// `__enter__`.
+    #[must_use]
+    fn type_error_not_context_manager(type_name: impl Display, missing_dunder: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!(
+                "'{type_name}' object does not support the context manager protocol (missed {missing_dunder} method)"
+            ),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for `__init__` returning a value other than `None`.
+    ///
+    /// Matches CPython's format: `TypeError: __init__() should return None, not '{type}'`
+    #[must_use]
+    fn type_error_init_return(type_name: impl Display) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("__init__() should return None, not '{type_name}'"),
+        )
+        .into()
+    }
+
+    /// Creates a generic `ValueError` with a custom message.
+    fn value_error(msg: impl fmt::Display) -> RunError {
+        SimpleException::new_msg(ExcType::ValueError, msg).into()
+    }
+
+    /// Creates a TypeError for bytes() constructor with invalid type.
+    ///
+    /// Matches CPython's format: `TypeError: cannot convert '{type}' object to bytes`
+    #[must_use]
+    fn type_error_bytes_init(type_: &str) -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, format!("cannot convert '{type_}' object to bytes")).into()
+    }
+
+    /// Creates a TypeError for calling a non-callable type.
+    ///
+    /// Matches CPython's format: `TypeError: cannot create '{type}' instances`
+    #[must_use]
+    fn type_error_not_callable(type_: &str) -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, format!("cannot create '{type_}' instances")).into()
+    }
+
+    /// Creates a TypeError for calling a non-callable object.
+    ///
+    /// Matches CPython's format: `TypeError: '{type}' object is not callable`
+    #[must_use]
+    fn type_error_not_callable_object(type_: &str) -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, format!("'{type_}' object is not callable")).into()
+    }
+
+    /// Creates a TypeError for non-iterable type in list/tuple/etc constructors.
+    ///
+    /// Matches CPython's format: `TypeError: '{type}' object is not iterable`
+    #[must_use]
+    fn type_error_not_iterable(type_: &str) -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, format!("'{type_}' object is not iterable")).into()
+    }
+
+    /// Creates a TypeError when `next()` receives a non-iterator.
+    ///
+    /// Matches CPython's format: `TypeError: '{type}' object is not an iterator`
+    #[must_use]
+    fn type_error_not_iterator(type_: &str) -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, format!("'{type_}' object is not an iterator")).into()
+    }
+
+    /// Creates a TypeError for non-iterable type in PEP 448 `*value` literal unpack.
+    ///
+    /// Used when `[*expr]`, `(*expr,)` literal unpack encounters a non-iterable — distinct
+    /// from [`type_error_not_iterable`] because CPython uses a different message for this context.
+    ///
+    /// Matches CPython's format: `TypeError: Value after * must be an iterable, not {type}`
+    #[must_use]
+    fn type_error_value_after_star(type_: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("Value after * must be an iterable, not {type_}"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for int() constructor with invalid type.
+    ///
+    /// Matches CPython's format: `TypeError: int() argument must be a string, a bytes-like object or a real number, not '{type}'`
+    #[must_use]
+    fn type_error_int_conversion(type_: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("int() argument must be a string, a bytes-like object or a real number, not '{type_}'"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for float() constructor with invalid type.
+    ///
+    /// Matches CPython's format: `TypeError: float() argument must be a string or a real number, not '{type}'`
+    #[must_use]
+    fn type_error_float_conversion(type_: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("float() argument must be a string or a real number, not '{type_}'"),
+        )
+        .into()
+    }
+
+    /// Creates a ValueError for negative count in bytes().
+    ///
+    /// Matches CPython's format: `ValueError: negative count`
+    #[must_use]
+    fn value_error_negative_bytes_count() -> RunError {
+        SimpleException::new_msg(ExcType::ValueError, "negative count").into()
+    }
+
+    /// Creates a TypeError for isinstance() arg 2.
+    ///
+    /// Matches CPython's format: `TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union`
+    #[must_use]
+    fn isinstance_arg2_error() -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            "isinstance() arg 2 must be a type, a tuple of types, or a union",
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for invalid exception type in except clause.
+    ///
+    /// Matches CPython's format: `TypeError: catching classes that do not inherit from BaseException is not allowed`
+    #[must_use]
+    fn except_invalid_type_error() -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            "catching classes that do not inherit from BaseException is not allowed",
+        )
+        .into()
+    }
+
+    /// Creates a ValueError for range() step argument being zero.
+    ///
+    /// Matches CPython's format: `ValueError: range() arg 3 must not be zero`
+    #[must_use]
+    fn value_error_range_step_zero() -> RunError {
+        SimpleException::new_msg(ExcType::ValueError, "range() arg 3 must not be zero").into()
+    }
+
+    /// Creates a ValueError for slice step being zero.
+    ///
+    /// Matches CPython's format: `ValueError: slice step cannot be zero`
+    #[must_use]
+    fn value_error_slice_step_zero() -> RunError {
+        SimpleException::new_msg(ExcType::ValueError, "slice step cannot be zero").into()
+    }
+
+    /// Creates a TypeError for slice indices that are not integers or None.
+    ///
+    /// Matches CPython's format: `TypeError: slice indices must be integers or None or have an __index__ method`
+    #[must_use]
+    fn type_error_slice_indices() -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            "slice indices must be integers or None or have an __index__ method",
+        )
+        .into()
+    }
+
+    /// Creates a RuntimeError for dict mutation during iteration.
+    ///
+    /// Matches CPython's format: `RuntimeError: dictionary changed size during iteration`
+    #[must_use]
+    fn runtime_error_dict_changed_size() -> RunError {
+        SimpleException::new_msg(ExcType::RuntimeError, "dictionary changed size during iteration").into()
+    }
+
+    /// Creates a TypeError for `reversed()` on a non-reversible object.
+    ///
+    /// Matches CPython's format: `TypeError: '{type}' object is not reversible`
+    #[must_use]
+    fn type_error_not_reversible(type_: &str) -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, format!("'{type_}' object is not reversible")).into()
+    }
+
+    /// Creates a RuntimeError for an over-deep iterator delegation chain.
+    ///
+    /// Monty-specific (CPython builds no delegation chain at all) — see
+    /// `limitations/builtins.md`.
+    #[must_use]
+    fn runtime_error_iter_delegation_too_deep() -> RunError {
+        SimpleException::new_msg(ExcType::RuntimeError, "iterator delegation nested too deeply").into()
+    }
+
+    /// Creates a RuntimeError for a delegating iterator pointing at a non-iterator.
+    ///
+    /// Unreachable from Python; only a malformed snapshot can produce it. Raised
+    /// rather than panicking so untrusted snapshot data cannot abort the process.
+    #[must_use]
+    fn runtime_error_iter_delegation_invalid() -> RunError {
+        SimpleException::new_msg(ExcType::RuntimeError, "iterator delegates to a non-iterator").into()
+    }
+
+    /// Creates a RuntimeError for set mutation during iteration.
+    ///
+    /// Matches CPython's format: `RuntimeError: Set changed size during iteration`
+    #[must_use]
+    fn runtime_error_set_changed_size() -> RunError {
+        SimpleException::new_msg(ExcType::RuntimeError, "Set changed size during iteration").into()
+    }
+
+    /// Creates a TypeError for functions that don't accept keyword arguments.
+    ///
+    /// Matches CPython's format: `TypeError: {name}() takes no keyword arguments`
+    #[must_use]
+    fn type_error_no_kwargs(name: &str) -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, format!("{name}() takes no keyword arguments")).into()
+    }
+
+    /// Creates a NotImplementedError for functions that don't accept keyword arguments.
+    #[must_use]
+    fn kwargs_not_implemented(name: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::NotImplementedError,
+            format!("{name}() does not yet support keyword arguments"),
+        )
+        .into()
+    }
+
+    /// Creates an IndexError for list index out of range (getitem).
+    ///
+    /// Matches CPython's format: `IndexError('list index out of range')`
+    #[must_use]
+    fn list_index_error() -> RunError {
+        SimpleException::new_msg(ExcType::IndexError, "list index out of range").into()
+    }
+
+    /// Creates an IndexError for list assignment index out of range (setitem).
+    ///
+    /// Matches CPython's format: `IndexError('list assignment index out of range')`
+    #[must_use]
+    fn list_assignment_index_error() -> RunError {
+        SimpleException::new_msg(ExcType::IndexError, "list assignment index out of range").into()
+    }
+
+    /// Creates an IndexError for tuple index out of range.
+    ///
+    /// Matches CPython's format: `IndexError('tuple index out of range')`
+    #[must_use]
+    fn tuple_index_error() -> RunError {
+        SimpleException::new_msg(ExcType::IndexError, "tuple index out of range").into()
+    }
+
+    /// Creates an IndexError for string index out of range.
+    ///
+    /// Matches CPython's format: `IndexError('string index out of range')`
+    #[must_use]
+    fn str_index_error() -> RunError {
+        SimpleException::new_msg(ExcType::IndexError, "string index out of range").into()
+    }
+
+    /// Creates an IndexError for bytes index out of range.
+    ///
+    /// Matches CPython's format: `IndexError('index out of range')`
+    #[must_use]
+    fn bytes_index_error() -> RunError {
+        SimpleException::new_msg(ExcType::IndexError, "index out of range").into()
+    }
+
+    /// Creates an IndexError for range index out of range.
+    ///
+    /// Matches CPython's format: `IndexError('range object index out of range')`
+    #[must_use]
+    fn range_index_error() -> RunError {
+        SimpleException::new_msg(ExcType::IndexError, "range object index out of range").into()
+    }
+
+    /// Creates an IndexError for `re.Match` group index out of range.
+    ///
+    /// Matches CPython's format: `IndexError('no such group')`
+    #[must_use]
+    fn re_match_group_index_error() -> RunError {
+        SimpleException::new_msg(ExcType::IndexError, "no such group").into()
+    }
+
+    /// Creates a TypeError for non-integer sequence indices (getitem).
+    ///
+    /// Matches CPython's format: `TypeError('{type}' indices must be integers, not '{index_type}')`
+    #[must_use]
+    fn type_error_indices(type_str: Type, index_type: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("{type_str} indices must be integers, not '{index_type}'"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for non-integer list indices (setitem/assignment).
+    ///
+    /// Matches CPython's format: `TypeError('list indices must be integers or slices, not {index_type}')`
+    #[must_use]
+    fn type_error_list_assignment_indices(index_type: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("list indices must be integers or slices, not {index_type}"),
+        )
+        .into()
+    }
+
+    /// Creates a NameError for accessing a free variable (nonlocal/closure) before it's assigned.
+    ///
+    /// Matches CPython's format: `NameError: cannot access free variable 'x' where it is not
+    /// associated with a value in enclosing scope`
+    #[must_use]
+    fn name_error_free_variable(name: &str) -> SimpleException {
+        SimpleException::new_msg(
+            ExcType::NameError,
+            format!("cannot access free variable '{name}' where it is not associated with a value in enclosing scope"),
+        )
+    }
+
+    /// Creates a NameError for accessing an undefined variable.
+    ///
+    /// Matches CPython's format: `NameError: name 'x' is not defined`
+    #[must_use]
+    fn name_error(name: &str) -> SimpleException {
+        let mut msg = format!("name '{name}' is not defined");
+        // add the same suffix as cpython, but only for the modules supported by Monty
+        if matches!(name, "asyncio" | "sys" | "typing" | "types" | "re" | "json") {
+            write!(&mut msg, ". Did you forget to import '{name}'?").unwrap();
+        }
+        SimpleException::new_msg(ExcType::NameError, msg)
+    }
+
+    /// Creates an UnboundLocalError for accessing a local variable before assignment.
+    ///
+    /// Matches CPython's format: `UnboundLocalError: cannot access local variable 'x' where it is not associated with a value`
+    #[must_use]
+    fn unbound_local_error(name: &str) -> SimpleException {
+        SimpleException::new_msg(
+            ExcType::UnboundLocalError,
+            format!("cannot access local variable '{name}' where it is not associated with a value"),
+        )
+    }
+
+    /// Creates a ModuleNotFoundError for when a module cannot be found.
+    ///
+    /// Matches CPython's format: `ModuleNotFoundError: No module named 'name'`
+    /// Sets `hide_caret: true` because CPython doesn't show carets for module not found errors.
+    #[must_use]
+    fn module_not_found_error(module_name: &str) -> RunError {
+        let exc = SimpleException::new_msg(ExcType::ModuleNotFoundError, format!("No module named '{module_name}'"));
+        RunError::Exc(ExceptionRaise {
+            exc,
+            frame: None,
+            hide_caret: true, // CPython doesn't show carets for module not found errors
+        })
+    }
+
+    /// Creates a NotImplementedError for an unimplemented Python feature.
+    ///
+    /// Used during parsing when encountering Python syntax that Monty doesn't yet support.
+    /// The message format is: "The monty syntax parser does not yet support {feature}"
+    #[must_use]
+    fn not_implemented(msg: impl fmt::Display) -> SimpleException {
+        SimpleException::new_msg(ExcType::NotImplementedError, msg)
+    }
+
+    /// Creates a ZeroDivisionError for division by zero.
+    ///
+    /// Matches CPython 3.14's format: `ZeroDivisionError('division by zero')`
+    #[must_use]
+    fn zero_division() -> SimpleException {
+        SimpleException::new_msg(ExcType::ZeroDivisionError, "division by zero")
+    }
+
+    /// Creates an OverflowError for string/sequence repetition with count too large.
+    ///
+    /// Matches CPython's format: `OverflowError('cannot fit 'int' into an index-sized integer')`
+    #[must_use]
+    fn overflow_repeat_count() -> SimpleException {
+        SimpleException::new_msg(ExcType::OverflowError, "cannot fit 'int' into an index-sized integer")
+    }
+
+    /// Creates an IndexError for when an integer index is too large to fit in i64.
+    ///
+    /// Matches CPython's format: `IndexError: cannot fit 'int' into an index-sized integer`
+    #[must_use]
+    fn index_error_int_too_large() -> RunError {
+        SimpleException::new_msg(ExcType::IndexError, "cannot fit 'int' into an index-sized integer").into()
+    }
+
+    /// Creates an ImportError for when a name cannot be imported from a module.
+    ///
+    /// Matches CPython's format for built-in modules:
+    /// `ImportError: cannot import name 'name' from 'module' (unknown location)`
+    ///
+    /// Sets `hide_caret: true` because CPython doesn't show carets for import errors.
+    #[must_use]
+    fn cannot_import_name(name: &str, module_name: &str) -> RunError {
+        let exc = SimpleException::new_msg(
+            ExcType::ImportError,
+            format!("cannot import name '{name}' from '{module_name}' (unknown location)"),
+        );
+        RunError::Exc(ExceptionRaise {
+            exc,
+            frame: None,
+            hide_caret: true,
+        })
+    }
+
+    /// Creates a ValueError when an integer is too large to convert to a decimal string.
+    ///
+    /// Matches CPython 3.11+'s `sys.int_max_str_digits` error message.
+    #[must_use]
+    fn value_error_int_too_large_for_str() -> RunError {
+        SimpleException::new_msg(
+            ExcType::ValueError,
+            format!(
+                "Exceeds the limit ({INT_MAX_STR_DIGITS} digits) for integer string conversion; use sys.set_int_max_str_digits() to increase the limit"
+            ),
+        )
+        .into()
+    }
+
+    /// Creates a ValueError when a decimal string has too many digits for `int()` conversion.
+    ///
+    /// Includes the actual digit count to help users diagnose the issue.
+    #[must_use]
+    fn value_error_int_str_too_large(digit_count: usize) -> RunError {
+        SimpleException::new_msg(
+            ExcType::ValueError,
+            format!(
+                "Exceeds the limit ({INT_MAX_STR_DIGITS} digits) for integer string conversion: value has {digit_count} digits; use sys.set_int_max_str_digits() to increase the limit"
+            ),
+        )
+        .into()
+    }
+
+    /// Creates a ValueError for `int()` when a string cannot be parsed as an integer.
+    ///
+    /// Matches CPython's format: `invalid literal for int() with base {N}: '...'`.
+    /// `base` is the base the caller passed (0 included, before auto-detection);
+    /// the caller provides the value pre-formatted (e.g. via `StringRepr`).
+    #[must_use]
+    fn value_error_invalid_literal_for_int(base: u32, value: impl fmt::Display) -> RunError {
+        SimpleException::new_msg(
+            ExcType::ValueError,
+            format!("invalid literal for int() with base {base}: {value}"),
+        )
+        .into()
+    }
+
+    /// Creates a ValueError for an `int()` base outside `{0} ∪ 2..=36`.
+    ///
+    /// Matches CPython's message: `int() base must be >= 2 and <= 36, or 0`.
+    #[must_use]
+    fn value_error_int_base_range() -> RunError {
+        SimpleException::new_msg(ExcType::ValueError, "int() base must be >= 2 and <= 36, or 0").into()
+    }
+
+    /// Creates a TypeError for `int(base=N)` with no value to convert.
+    ///
+    /// Matches CPython's message: `int() missing string argument`. Raised
+    /// before the base is validated, matching `long_new_impl`'s ordering.
+    #[must_use]
+    fn type_error_int_missing_string_argument() -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, "int() missing string argument").into()
+    }
+
+    /// Creates a TypeError for `int(x, base)` where `x` is not str/bytes.
+    ///
+    /// Matches CPython's message: `int() can't convert non-string with explicit base`.
+    #[must_use]
+    fn type_error_int_non_string_with_base() -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, "int() can't convert non-string with explicit base").into()
+    }
+
+    /// Creates a ValueError for negative shift count in bitwise shift operations.
+    ///
+    /// Matches CPython's format: `ValueError: negative shift count`
+    #[must_use]
+    fn value_error_negative_shift_count() -> RunError {
+        SimpleException::new_msg(ExcType::ValueError, "negative shift count").into()
+    }
+
+    /// Creates an OverflowError when converting values to C ssize_t (i64) for operations like length checks.
+    ///
+    /// Matches CPython's format: `OverflowError: Python int too large to convert to C ssize_t`
+    /// Note: CPython uses this message because it tries to convert to ssize_t for the shift amount.
+    #[must_use]
+    fn overflow_c_ssize_t() -> RunError {
+        SimpleException::new_msg(ExcType::OverflowError, "Python int too large to convert to C ssize_t").into()
+    }
+
+    /// Creates an OverflowError when a Python int doesn't fit into a C `int` (i32).
+    ///
+    /// Matches CPython's format: `OverflowError: Python int too large to convert to C int`
+    /// Used by builtins (e.g. `bytes.hex`) that parse arguments via the `i` format code.
+    #[must_use]
+    fn overflow_c_int() -> RunError {
+        SimpleException::new_msg(ExcType::OverflowError, "Python int too large to convert to C int").into()
+    }
+
+    /// Creates an OverflowError when a Python int doesn't fit into a C `long` (i64).
+    ///
+    /// Matches CPython's format: `OverflowError: Python int too large to convert to C long`
+    /// CPython's `i` format code converts through C long first, so ints beyond
+    /// i64 report this even for C-int parameters (e.g. `datetime.date(2**100, 1, 1)`).
+    #[must_use]
+    fn overflow_c_long() -> RunError {
+        SimpleException::new_msg(ExcType::OverflowError, "Python int too large to convert to C long").into()
+    }
+
+    /// Creates a TypeError for unsupported binary operations.
+    ///
+    /// For `+` or `+=` with str/list on the left side, uses CPython's special format:
+    /// `can only concatenate {type} (not "{other}") to {type}`
+    ///
+    /// For other cases, uses the generic format:
+    /// `unsupported operand type(s) for {op}: '{left}' and '{right}'`
+    #[must_use]
+    fn binary_type_error(op: &str, lhs_type: Type, lhs_name: impl Display, rhs_name: impl Display) -> RunError {
+        let message = if (op == "+" || op == "+=") && matches!(lhs_type, Type::Str | Type::List) {
+            format!("can only concatenate {lhs_name} (not \"{rhs_name}\") to {lhs_name}")
+        } else {
+            format!("unsupported operand type(s) for {op}: '{lhs_name}' and '{rhs_name}'")
+        };
+        SimpleException::new_msg(ExcType::TypeError, message).into()
+    }
+
+    /// Creates a TypeError for unsupported unary operations.
+    ///
+    /// Uses CPython's format: `bad operand type for unary {op}: '{type}'`
+    #[must_use]
+    fn unary_type_error(op: &str, value_type: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("bad operand type for unary {op}: '{value_type}'"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for functions that require an integer argument.
+    ///
+    /// Matches CPython's format: `TypeError: '{type}' object cannot be interpreted as an integer`
+    #[must_use]
+    fn type_error_not_integer(type_: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("'{type_}' object cannot be interpreted as an integer"),
+        )
+        .into()
+    }
+
+    /// Creates a ZeroDivisionError for zero raised to a negative power.
+    ///
+    /// Matches CPython's format: `ZeroDivisionError: zero to a negative power`
+    /// Note: CPython uses the same message for both int and float zero ** negative.
+    #[must_use]
+    fn zero_negative_power() -> RunError {
+        SimpleException::new_msg(ExcType::ZeroDivisionError, "zero to a negative power").into()
+    }
+
+    /// Creates an OverflowError for exponents that are too large.
+    ///
+    /// Matches CPython's format: `OverflowError: exponent too large`
+    #[must_use]
+    fn overflow_exponent_too_large() -> RunError {
+        SimpleException::new_msg(ExcType::OverflowError, "exponent too large").into()
+    }
+
+    /// Creates a ZeroDivisionError for divmod by zero (both integer and float).
+    ///
+    /// Matches CPython's format: `ZeroDivisionError: division by zero`
+    /// Note: CPython uses the same message for both integer and float divmod.
+    #[must_use]
+    fn divmod_by_zero() -> RunError {
+        SimpleException::new_msg(ExcType::ZeroDivisionError, "division by zero").into()
+    }
+
+    /// Creates a TypeError for str.join() when an item is not a string.
+    ///
+    /// Matches CPython's format: `TypeError: sequence item {index}: expected str instance, {type} found`
+    #[must_use]
+    fn type_error_join_item(index: usize, item_type: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("sequence item {index}: expected str instance, {item_type} found"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for str.join() when the argument is not iterable.
+    ///
+    /// Matches CPython's format: `TypeError: can only join an iterable`
+    #[must_use]
+    fn type_error_join_not_iterable() -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, "can only join an iterable").into()
+    }
+
+    /// Creates a ValueError for str.index()/str.rindex() when substring is not found.
+    ///
+    /// Matches CPython's format: `ValueError: substring not found`
+    #[must_use]
+    fn value_error_substring_not_found() -> RunError {
+        SimpleException::new_msg(ExcType::ValueError, "substring not found").into()
+    }
+
+    /// Creates a ValueError for str.partition()/str.rpartition() with empty separator.
+    ///
+    /// Matches CPython's format: `ValueError: empty separator`
+    #[must_use]
+    fn value_error_empty_separator() -> RunError {
+        SimpleException::new_msg(ExcType::ValueError, "empty separator").into()
+    }
+
+    /// Creates a TypeError for fillchar argument that is not a single character.
+    ///
+    /// Matches CPython's format: `TypeError: The fill character must be exactly one character long`
+    #[must_use]
+    fn type_error_fillchar_must_be_single_char() -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            "The fill character must be exactly one character long",
+        )
+        .into()
+    }
+
+    /// Creates a StopIteration exception for when an iterator is exhausted.
+    ///
+    /// Matches CPython's format: `StopIteration`
+    #[must_use]
+    fn stop_iteration() -> RunError {
+        SimpleException::new_none(ExcType::StopIteration).into()
+    }
+
+    /// Creates a ValueError for list.index() when item is not found.
+    ///
+    /// Matches CPython's format: `ValueError: list.index(x): x not in list`
+    #[must_use]
+    fn value_error_not_in_list() -> RunError {
+        SimpleException::new_msg(ExcType::ValueError, "list.index(x): x not in list").into()
+    }
+
+    /// Creates a ValueError for tuple.index() when item is not found.
+    ///
+    /// Matches CPython's format: `ValueError: tuple.index(x): x not in tuple`
+    #[must_use]
+    fn value_error_not_in_tuple() -> RunError {
+        SimpleException::new_msg(ExcType::ValueError, "tuple.index(x): x not in tuple").into()
+    }
+
+    /// Creates a ValueError for list.remove() when item is not found.
+    ///
+    /// Matches CPython's format: `ValueError: list.remove(x): x not in list`
+    #[must_use]
+    fn value_error_remove_not_in_list() -> RunError {
+        SimpleException::new_msg(ExcType::ValueError, "list.remove(x): x not in list").into()
+    }
+
+    /// Creates an IndexError for popping from an empty list.
+    ///
+    /// Matches CPython's format: `IndexError: pop from empty list`
+    #[must_use]
+    fn index_error_pop_empty_list() -> RunError {
+        SimpleException::new_msg(ExcType::IndexError, "pop from empty list").into()
+    }
+
+    /// Creates an IndexError for list.pop(index) with invalid index.
+    ///
+    /// Matches CPython's format: `IndexError: pop index out of range`
+    #[must_use]
+    fn index_error_pop_out_of_range() -> RunError {
+        SimpleException::new_msg(ExcType::IndexError, "pop index out of range").into()
+    }
+
+    /// Creates a KeyError for popping from an empty dict.
+    ///
+    /// Matches CPython's format: `KeyError: 'popitem(): dictionary is empty'`
+    #[must_use]
+    fn key_error_popitem_empty_dict() -> RunError {
+        SimpleException::new_msg(ExcType::KeyError, "'popitem(): dictionary is empty'").into()
+    }
+
+    /// Creates a LookupError for unknown encoding.
+    ///
+    /// Matches CPython's format: `LookupError: unknown encoding: {encoding}`
+    #[must_use]
+    fn lookup_error_unknown_encoding(encoding: &str) -> RunError {
+        SimpleException::new_msg(ExcType::LookupError, format!("unknown encoding: {encoding}")).into()
+    }
+
+    /// Creates a TypeError for `str(s, encoding=...)` with a str object.
+    ///
+    /// Matches CPython's message: `decoding str is not supported`.
+    #[must_use]
+    fn type_error_decoding_str_not_supported() -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, "decoding str is not supported").into()
+    }
+
+    /// Creates a TypeError for `str(x, encoding=...)` with a non-bytes object.
+    ///
+    /// Matches CPython's format: `decoding to str: need a bytes-like object, {type} found`.
+    #[must_use]
+    fn type_error_decoding_need_bytes(type_: impl Display) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("decoding to str: need a bytes-like object, {type_} found"),
+        )
+        .into()
+    }
+
+    /// Creates a TypeError for `bytes(s)` with a str source and no encoding.
+    ///
+    /// Matches CPython's message: `string argument without an encoding`.
+    #[must_use]
+    fn type_error_string_without_encoding() -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, "string argument without an encoding").into()
+    }
+
+    /// Creates a TypeError for `bytes(x, encoding=...)` with a non-str source.
+    ///
+    /// Matches CPython's message: `encoding without a string argument`.
+    #[must_use]
+    fn type_error_encoding_without_string() -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, "encoding without a string argument").into()
+    }
+
+    /// Creates a TypeError for `bytes(x, errors=...)` with a non-str source.
+    ///
+    /// Matches CPython's message: `errors without a string argument`.
+    #[must_use]
+    fn type_error_errors_without_string() -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, "errors without a string argument").into()
+    }
+
+    /// Creates a TypeError for `sum()` rejecting a str/bytes `start` value.
+    ///
+    /// Matches CPython: `sum() can't sum {kind} [use {join}.join(seq) instead]`
+    /// — `("strings", "''")` for str, `("bytes", "b''")` for bytes.
+    #[must_use]
+    fn type_error_sum_start(kind: &str, join: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("sum() can't sum {kind} [use {join}.join(seq) instead]"),
+        )
+        .into()
+    }
+
+    /// Creates a UnicodeEncodeError for a run of `start..end` consecutive
+    /// characters (character indices, not byte offsets) of `object` — the
+    /// full string being encoded — that can't be represented in the target
+    /// `codec`. `first_char` is the character at `start`, used for the
+    /// single-character message form.
+    ///
+    /// Matches CPython's format, which differs for a single character vs. a run:
+    /// `UnicodeEncodeError: 'ascii' codec can't encode character '\xe9' in
+    /// position 1: ordinal not in range(128)` or `... can't encode characters
+    /// in position 1-2: ordinal not in range(128)`.
+    #[must_use]
+    fn unicode_encode_error(
+        codec: &str,
+        object: &str,
+        first_char: char,
+        start: usize,
+        end: usize,
+        reason: &str,
+    ) -> RunError {
+        // Callers must pass a non-empty range; checked in debug builds only so
+        // a wrong caller can't panic the VM in release (it gets a garbled
+        // message position instead, which is harmless).
+        debug_assert!(
+            end > start,
+            "unicode_encode_error: end ({end}) must be > start ({start})"
+        );
+        let msg = if end - start == 1 {
+            format!(
+                "'{codec}' codec can't encode character '{}' in position {start}: {reason}",
+                ascii_escape(&first_char.to_string())
+            )
+        } else {
+            let last = end - 1;
+            format!("'{codec}' codec can't encode characters in position {start}-{last}: {reason}")
+        };
+        SimpleException::new_msg(ExcType::UnicodeEncodeError, msg)
+            .with_data(UnicodeErrorData::encode(codec, object, start, end, reason))
+            .into()
+    }
+
+    /// Creates a UnicodeDecodeError for the undecodable byte range `start..end`
+    /// (byte offsets into `object` — the full input being decoded).
+    ///
+    /// Matches CPython's format, which differs for a single byte vs. a run:
+    /// `UnicodeDecodeError: 'ascii' codec can't decode byte 0xe9 in position 6:
+    /// ordinal not in range(128)` or `'utf-8' codec can't decode bytes in
+    /// position 0-1: unexpected end of data`.
+    #[must_use]
+    fn unicode_decode_error(codec: &str, object: &[u8], start: usize, end: usize, reason: &str) -> RunError {
+        // Defensive `get`: `start` always indexes a real byte for the errors
+        // Monty produces, but a wrong caller must not be able to panic the VM.
+        let first_byte = object.get(start).copied().unwrap_or(0);
+        SimpleException::new_msg(
+            ExcType::UnicodeDecodeError,
+            unicode_decode_error_msg(codec, first_byte, start, end, reason),
+        )
+        .with_data(UnicodeErrorData::decode(codec, object, start, end, reason))
+        .into()
+    }
+
+    /// Creates a ValueError for subsequence not found in bytes/str.
+    ///
+    /// Matches CPython's format: `ValueError: subsection not found`
+    #[must_use]
+    fn value_error_subsequence_not_found() -> RunError {
+        SimpleException::new_msg(ExcType::ValueError, "subsection not found").into()
+    }
+
+    /// Creates a LookupError for unknown error handler.
+    ///
+    /// Matches CPython's format: `LookupError: unknown error handler name '{name}'`
+    #[must_use]
+    fn lookup_error_unknown_error_handler(name: &str) -> RunError {
+        SimpleException::new_msg(ExcType::LookupError, format!("unknown error handler name '{name}'")).into()
+    }
+
+    /// Creates a TypeError for an encode-only error handler (`xmlcharrefreplace`,
+    /// `namereplace`) invoked for a decode error.
+    ///
+    /// Matches CPython's format: `TypeError: don't know how to handle
+    /// UnicodeDecodeError in error callback`
+    #[must_use]
+    fn type_error_decode_error_callback() -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            "don't know how to handle UnicodeDecodeError in error callback",
+        )
+        .into()
+    }
+
+    /// Creates a NotImplementedError for a decode error handler that would
+    /// produce lone surrogates (`surrogateescape` always; `surrogatepass` when
+    /// the input actually contains an encoded surrogate).
+    ///
+    /// CPython's handlers put lone surrogates (e.g. U+DC80–U+DCFF for
+    /// `surrogateescape`) in the resulting string. Monty strings are strict
+    /// UTF-8 and cannot represent lone surrogates, so these cases cannot be
+    /// supported — see `limitations/encoding.md`.
+    #[must_use]
+    fn not_implemented_surrogate_handler_decode(handler: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::NotImplementedError,
+            format!(
+                "the '{handler}' error handler is not supported by Monty for decoding: \
+                 Monty strings cannot contain the lone surrogate characters it produces"
+            ),
+        )
+        .into()
+    }
+
+    /// Creates a `re.PatternError` for an invalid regex pattern or unsupported regex feature.
+    ///
+    /// Matches CPython's exception type: `re.PatternError: {message}`
+    #[must_use]
+    fn re_pattern_error(msg: impl fmt::Display) -> RunError {
+        SimpleException::new_msg(ExcType::RePatternError, msg).into()
+    }
+
+    /// Creates a `json.JSONDecodeError` with CPython-compatible location suffix,
+    /// formatted as `{message}: line {line} column {column} (char {index})`.
+    ///
+    /// The fields also travel in a structured [`JsonErrorData`] payload
+    /// (with `doc` capped) so hosts can rebuild the real `json.JSONDecodeError`
+    /// with its `msg`/`doc`/`pos`/`lineno`/`colno` attributes.
+    ///
+    /// # Arguments
+    ///
+    /// * `message` - The bare error message, without the location suffix
+    /// * `doc` - The document being parsed (CPython's `exc.doc`)
+    /// * `line` - 1-based line of the error (CPython's `exc.lineno`)
+    /// * `column` - 1-based column of the error (CPython's `exc.colno`)
+    /// * `index` - Character index of the error in `doc` (CPython's `exc.pos`)
+    #[must_use]
+    fn json_decode_error(message: &str, doc: &[u8], line: usize, column: usize, index: usize) -> RunError {
+        SimpleException::new_msg(
+            ExcType::JsonDecodeError,
+            format!("{message}: line {line} column {column} (char {index})"),
+        )
+        .with_data(JsonErrorData::build(message, doc, index, line, column))
+        .into()
+    }
+
+    /// Creates the `TypeError` used by `json.loads()` for unsupported input types.
+    ///
+    /// Matches CPython's format:
+    /// `the JSON object must be str, bytes or bytearray, not {type}`
+    #[must_use]
+    fn json_loads_type_error(type_: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("the JSON object must be str, bytes or bytearray, not {type_}"),
+        )
+        .into()
+    }
+
+    /// Creates the `ValueError` used by `json.dumps()` for circular containers.
+    ///
+    /// Matches CPython's format: `Circular reference detected`
+    #[must_use]
+    fn json_circular_reference_error() -> RunError {
+        SimpleException::new_msg(ExcType::ValueError, "Circular reference detected").into()
+    }
+
+    /// Creates the `TypeError` used by `json.dumps()` for unsupported object types.
+    ///
+    /// Matches CPython's format:
+    /// `Object of type {type} is not JSON serializable`
+    #[must_use]
+    fn json_not_serializable_error(type_: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("Object of type {type_} is not JSON serializable"),
+        )
+        .into()
+    }
+
+    /// Creates the `TypeError` used by `json.dumps()` for unsupported dict keys.
+    ///
+    /// Matches CPython's format:
+    /// `keys must be str, int, float, bool or None, not {type}`
+    #[must_use]
+    fn json_invalid_key_error(type_: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("keys must be str, int, float, bool or None, not {type_}"),
+        )
+        .into()
+    }
+
+    /// Creates the `ValueError` used by `json.dumps(..., allow_nan=False)`.
+    ///
+    /// Matches CPython's format:
+    /// `Out of range float values are not JSON compliant: {value}`
+    #[must_use]
+    fn json_nan_error(value: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::ValueError,
+            format!("Out of range float values are not JSON compliant: {value}"),
+        )
+        .into()
+    }
+}
+
+impl ExcTypeExt for ExcType {
     /// Creates an exception instance from an exception type and arguments.
     ///
     /// Handles exception constructors like `ValueError('message')`.
@@ -215,7 +1727,7 @@ impl ExcType {
     ///
     /// The `interns` parameter provides access to interned string content.
     /// Returns a heap-allocated exception value.
-    pub(crate) fn call(self, vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
+    fn call(self, vm: &mut VM<'_, impl ResourceTracker>, args: ArgValues) -> RunResult<Value> {
         defer_drop!(args, vm);
         let exc = match args {
             ArgValues::Empty => Ok(SimpleException::new_none(self)),
@@ -243,1722 +1755,6 @@ impl ExcType {
         }?;
         let heap_id = vm.heap.allocate(HeapData::Exception(exc))?;
         Ok(Value::Ref(heap_id))
-    }
-
-    /// Creates an AttributeError for when an attribute is not found (GET operation).
-    ///
-    /// Sets `hide_caret: true` because CPython doesn't show carets for attribute GET errors.
-    #[must_use]
-    pub(crate) fn attribute_error(type_name: impl Display, attr: &str) -> RunError {
-        let exc = SimpleException::new_msg(
-            Self::AttributeError,
-            format!("'{type_name}' object has no attribute '{attr}'"),
-        );
-        RunError::Exc(ExceptionRaise {
-            exc,
-            frame: None,
-            hide_caret: true, // CPython doesn't show carets for attribute GET errors
-        })
-    }
-
-    /// Creates an AttributeError for a missing attribute on a class object.
-    ///
-    /// Matches CPython's wording for type objects: `type object 'Foo' has no
-    /// attribute 'nope'` (instances use [`Self::attribute_error`] instead).
-    /// Sets `hide_caret: true` because CPython doesn't show carets for attribute GET errors.
-    #[must_use]
-    pub(crate) fn attribute_error_type(class_name: &str, attr: &str) -> RunError {
-        let exc = SimpleException::new_msg(
-            Self::AttributeError,
-            format!("type object '{class_name}' has no attribute '{attr}'"),
-        );
-        RunError::Exc(ExceptionRaise {
-            exc,
-            frame: None,
-            hide_caret: true, // CPython doesn't show carets for attribute GET errors
-        })
-    }
-
-    /// Creates an AttributeError for attribute assignment on types that don't support it.
-    ///
-    /// Matches CPython's format for setting attributes on built-in types.
-    #[must_use]
-    pub(crate) fn attribute_error_no_setattr(type_: &str, attr_name: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::AttributeError,
-            format!("'{type_}' object has no attribute '{attr_name}' and no __dict__ for setting new attributes"),
-        )
-        .into()
-    }
-
-    /// Creates an AttributeError for a missing module attribute.
-    ///
-    /// Matches CPython's format: `AttributeError: module 'name' has no attribute 'attr'`
-    /// Sets `hide_caret: true` because CPython doesn't show carets for attribute GET errors.
-    #[must_use]
-    pub(crate) fn attribute_error_module(module_name: &str, attr_name: &str) -> RunError {
-        let exc = SimpleException::new_msg(
-            Self::AttributeError,
-            format!("module '{module_name}' has no attribute '{attr_name}'"),
-        );
-        RunError::Exc(ExceptionRaise {
-            exc,
-            frame: None,
-            hide_caret: true, // CPython doesn't show carets for attribute GET errors
-        })
-    }
-
-    #[must_use]
-    pub(crate) fn type_error_not_sub(type_: &str) -> RunError {
-        SimpleException::new_msg(Self::TypeError, format!("'{type_}' object is not subscriptable")).into()
-    }
-
-    /// Creates the TypeError for an ordering comparison (`<`, `<=`, `>`, `>=`)
-    /// between values whose types define no ordering, e.g. `1 < 'a'` or two
-    /// instances of a user class without comparison dunders.
-    ///
-    /// Matches CPython's format:
-    /// `TypeError: '{op}' not supported between instances of '{left}' and '{right}'`
-    #[must_use]
-    pub(crate) fn type_error_ordering(operator: &str, left_type: &str, right_type: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("'{operator}' not supported between instances of '{left_type}' and '{right_type}'"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for awaiting a non-awaitable object.
-    ///
-    /// Matches CPython's format: `TypeError: '{type}' object can't be awaited`
-    #[must_use]
-    pub(crate) fn object_not_awaitable(type_: &str) -> RunError {
-        SimpleException::new_msg(Self::TypeError, format!("'{type_}' object can't be awaited")).into()
-    }
-
-    /// Creates the canonical `RuntimeError: cannot reuse already awaited coroutine`,
-    /// raised on direct re-await and on cross-gather coroutine reuse.
-    #[must_use]
-    pub(crate) fn cannot_reuse_already_awaited_coroutine() -> RunError {
-        SimpleException::new_msg(Self::RuntimeError, "cannot reuse already awaited coroutine").into()
-    }
-
-    /// Creates a TypeError for item assignment on types that don't support it.
-    ///
-    /// Matches CPython's format: `TypeError: '{type}' object does not support item assignment`
-    #[must_use]
-    pub(crate) fn type_error_not_sub_assignment(type_: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("'{type_}' object does not support item assignment"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for unhashable types when calling `hash()`.
-    ///
-    /// This matches Python 3.14's error message: `TypeError: unhashable type: 'list'`
-    #[must_use]
-    pub(crate) fn type_error_unhashable(type_: &str) -> RunError {
-        SimpleException::new_msg(Self::TypeError, format!("unhashable type: '{type_}'")).into()
-    }
-
-    /// Creates a TypeError for unhashable types used as dict keys.
-    ///
-    /// This matches Python 3.14's error message:
-    /// `TypeError: cannot use 'list' as a dict key (unhashable type: 'list')`
-    #[must_use]
-    pub(crate) fn type_error_unhashable_dict_key(type_: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("cannot use '{type_}' as a dict key (unhashable type: '{type_}')"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for unhashable types used as set elements.
-    ///
-    /// This matches Python 3.14's error message:
-    /// `TypeError: cannot use 'list' as a set element (unhashable type: 'list')`
-    #[must_use]
-    pub(crate) fn type_error_unhashable_set_element(type_: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("cannot use '{type_}' as a set element (unhashable type: '{type_}')"),
-        )
-        .into()
-    }
-
-    /// Creates a KeyError for a missing dict key.
-    ///
-    /// For string keys, uses the raw string value without extra quoting.
-    /// If the key's string conversion fails (e.g. huge LongInt exceeding
-    /// `INT_MAX_STR_DIGITS`), falls back to the type name so that a
-    /// `KeyError` is always raised rather than a spurious `ValueError`.
-    pub(crate) fn key_error(key: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> RunError {
-        let key_str = match key.py_str(vm) {
-            Ok(key_value) => {
-                // `key_value` is a heap `str` `Value`; extract its text and drop it.
-                defer_drop!(key_value, vm);
-                if let Ok(s) = key_value.to_str(vm) {
-                    s.to_owned()
-                } else {
-                    format!("<{}>", key.py_type_name(vm))
-                }
-            }
-            Err(_) => format!("<{}>", key.py_type_name(vm)),
-        };
-        SimpleException::new_msg(Self::KeyError, key_str).into()
-    }
-
-    /// Creates a KeyError for popping from an empty set.
-    ///
-    /// Matches CPython's error format: `KeyError: 'pop from an empty set'`
-    #[must_use]
-    pub(crate) fn key_error_pop_empty_set() -> RunError {
-        SimpleException::new_msg(Self::KeyError, "pop from an empty set").into()
-    }
-
-    /// Creates a TypeError for when a function receives the wrong number of arguments.
-    ///
-    /// Matches CPython's error format exactly:
-    /// - For 1 expected arg: `{name}() takes exactly one argument ({actual} given)`
-    /// - For N expected args: `{name} expected {expected} arguments, got {actual}`
-    ///
-    /// # Arguments
-    /// * `name` - The function name (e.g., "len" for builtins, "list.append" for methods)
-    /// * `expected` - Number of expected arguments
-    /// * `actual` - Number of arguments actually provided
-    #[must_use]
-    pub(crate) fn type_error_arg_count(name: &str, expected: usize, actual: usize) -> RunError {
-        if expected == 1 {
-            // CPython: "len() takes exactly one argument (2 given)"
-            SimpleException::new_msg(
-                Self::TypeError,
-                format!("{name}() takes exactly one argument ({actual} given)"),
-            )
-            .into()
-        } else {
-            // CPython: "insert expected 2 arguments, got 1"
-            SimpleException::new_msg(
-                Self::TypeError,
-                format!("{name} expected {expected} arguments, got {actual}"),
-            )
-            .into()
-        }
-    }
-
-    /// Creates a TypeError for when a method that takes no arguments receives some.
-    ///
-    /// Matches CPython's format: `{name}() takes no arguments ({actual} given)`
-    ///
-    /// # Arguments
-    /// * `name` - The method name (e.g., "dict.keys")
-    /// * `actual` - Number of arguments actually provided
-    #[must_use]
-    pub(crate) fn type_error_no_args(name: &str, actual: usize) -> RunError {
-        // CPython: "dict.keys() takes no arguments (1 given)"
-        SimpleException::new_msg(Self::TypeError, format!("{name}() takes no arguments ({actual} given)")).into()
-    }
-
-    /// Creates a TypeError for when a function receives fewer arguments than required.
-    ///
-    /// Matches CPython's format: `{name} expected at least {min} argument, got {actual}`
-    ///
-    /// # Arguments
-    /// * `name` - The function name (e.g., "get", "pop")
-    /// * `min` - Minimum number of required arguments
-    /// * `actual` - Number of arguments actually provided
-    #[must_use]
-    pub(crate) fn type_error_at_least(name: &str, min: usize, actual: usize) -> RunError {
-        // CPython: "get expected at least 1 argument, got 0"
-        let plural = if min == 1 { "" } else { "s" };
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("{name} expected at least {min} argument{plural}, got {actual}"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for when a function receives more arguments than allowed.
-    ///
-    /// Matches CPython's `PyArg_UnpackTuple` format:
-    /// - `{name} expected at most {max} argument, got {actual}` (singular when max=1)
-    /// - `{name} expected at most {max} arguments, got {actual}` (plural otherwise)
-    ///
-    /// # Arguments
-    /// * `name` - The function name (e.g., "get", "pop")
-    /// * `max` - Maximum number of allowed arguments
-    /// * `actual` - Number of arguments actually provided
-    #[must_use]
-    pub(crate) fn type_error_at_most(name: &str, max: usize, actual: usize) -> RunError {
-        let plural = if max == 1 { "" } else { "s" };
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("{name} expected at most {max} argument{plural}, got {actual}"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for a `startswith`/`endswith` affix argument that is
-    /// neither the expected string type nor a tuple.
-    ///
-    /// Matches CPython: `{method} first arg must be {expected} or a tuple of {expected}, not {type}`
-    /// (`expected` is `str` for `str` methods, `bytes` for `bytes` methods).
-    #[must_use]
-    pub(crate) fn type_error_affix_arg(method: &str, expected: &str, type_name: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("{method} first arg must be {expected} or a tuple of {expected}, not {type_name}"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for a non-string element in a `startswith`/`endswith`
-    /// affix tuple.
-    ///
-    /// Matches CPython: `tuple for {method} must only contain {expected}, not {type}`.
-    /// Raised lazily while matching — elements after a successful match are never checked.
-    #[must_use]
-    pub(crate) fn type_error_affix_tuple_item(method: &str, expected: &str, type_name: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("tuple for {method} must only contain {expected}, not {type_name}"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for too many arguments to a method or named function.
-    ///
-    /// Matches CPython's format for method-style calls:
-    /// `{name}() takes at most {max} argument ({actual} given)` (singular when max=1)
-    /// `{name}() takes at most {max} arguments ({actual} given)` (plural otherwise)
-    ///
-    /// Use this instead of `type_error_at_most` for methods and type constructors that
-    /// CPython formats with parentheses, e.g. `now()`, `timezone()`, `expandtabs()`.
-    #[must_use]
-    pub(crate) fn type_error_method_at_most(name: &str, max: usize, actual: usize) -> RunError {
-        let plural = if max == 1 { "" } else { "s" };
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("{name}() takes at most {max} argument{plural} ({actual} given)"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for too few positional arguments to a method-style call.
-    ///
-    /// Matches CPython's format used by methods like `str.replace`:
-    /// `{name}() takes at least {min} positional argument ({actual} given)` (singular when min=1)
-    /// `{name}() takes at least {min} positional arguments ({actual} given)` (plural otherwise)
-    ///
-    /// Distinct from [`type_error_at_least`] which uses CPython's
-    /// `PyArg_UnpackTuple` wording (no parens, no "positional"). Emitted by
-    /// `FromArgs` for any struct with required positional-only fields,
-    /// matching CPython's C-method `_PyArg_UnpackKeywords` dispatch.
-    #[must_use]
-    pub(crate) fn type_error_at_least_positional(name: &str, min: usize, actual: usize) -> RunError {
-        let plural = if min == 1 { "" } else { "s" };
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("{name}() takes at least {min} positional argument{plural} ({actual} given)"),
-        )
-        .into()
-    }
-
-    /// Creates the bespoke `map()` arity error that CPython hard-codes.
-    ///
-    /// CPython's `map()` uses a single fixed message regardless of whether
-    /// 0 or 1 args were given: `map() must have at least two arguments.`
-    /// (note the trailing period). We mirror it here so `map()` / `map(f)`
-    /// match byte-for-byte rather than falling through to the generic
-    /// "missing N required positional arguments" wording the macro would
-    /// otherwise emit.
-    #[must_use]
-    pub(crate) fn type_error_map_arity() -> RunError {
-        SimpleException::new_msg(Self::TypeError, "map() must have at least two arguments.".to_owned()).into()
-    }
-
-    /// Creates a TypeError for exact-arity functions reporting too many *or* too few.
-    ///
-    /// Matches CPython's `PyArg_UnpackTuple` wording for fixed-arity callables
-    /// (e.g. `sorted`):
-    /// `{name} expected {exact} argument, got {actual}` (singular when exact=1)
-    /// `{name} expected {exact} arguments, got {actual}` (plural otherwise)
-    ///
-    /// Use this for the macro's `expected_exact` attribute.
-    #[must_use]
-    pub(crate) fn type_error_expected_exact(name: &str, exact: usize, actual: usize) -> RunError {
-        let plural = if exact == 1 { "" } else { "s" };
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("{name} expected {exact} argument{plural}, got {actual}"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for missing positional arguments.
-    ///
-    /// Matches CPython's format: `{name}() missing {count} required positional argument(s): 'a' and 'b'`
-    #[must_use]
-    pub(crate) fn type_error_missing_positional_with_names(name: &str, missing_names: &[&str]) -> RunError {
-        SimpleException::new_msg(Self::TypeError, Self::missing_positional_msg(name, missing_names)).into()
-    }
-
-    /// Message body for [`type_error_missing_positional_with_names`], exposed
-    /// separately so `args/bind_python.rs` can attach a call position to the same
-    /// CPython-exact wording.
-    #[must_use]
-    pub(crate) fn missing_positional_msg(name: &str, missing_names: &[&str]) -> String {
-        let count = missing_names.len();
-        let names_str = format_param_names(missing_names);
-        if count == 1 {
-            format!("{name}() missing 1 required positional argument: {names_str}")
-        } else {
-            format!("{name}() missing {count} required positional arguments: {names_str}")
-        }
-    }
-
-    /// Creates a TypeError for missing keyword-only arguments.
-    ///
-    /// Matches CPython's format: `{name}() missing {count} required keyword-only argument(s): 'a' and 'b'`
-    #[must_use]
-    pub(crate) fn type_error_missing_kwonly_with_names(name: &str, missing_names: &[&str]) -> RunError {
-        let count = missing_names.len();
-        let names_str = format_param_names(missing_names);
-        if count == 1 {
-            SimpleException::new_msg(
-                Self::TypeError,
-                format!("{name}() missing 1 required keyword-only argument: {names_str}"),
-            )
-            .into()
-        } else {
-            SimpleException::new_msg(
-                Self::TypeError,
-                format!("{name}() missing {count} required keyword-only arguments: {names_str}"),
-            )
-            .into()
-        }
-    }
-
-    /// Creates a TypeError for too many positional arguments to a callable whose
-    /// positional count is a range (some positional parameters have defaults).
-    ///
-    /// Matches CPython's pure-Python `def` wording: when `min == max` it emits
-    /// `{name}() takes {max} positional argument(s) but {actual} was/were given`;
-    /// otherwise `{name}() takes from {min} to {max} positional arguments but
-    /// {actual} were given` (always-plural "arguments" in the range form). Both
-    /// get the `(and N keyword-only argument(s))` suffix when `kwonly_given > 0`.
-    /// Used by `FromArgs` structs marked `py_def` and by user `def` bindings.
-    #[must_use]
-    pub(crate) fn type_error_too_many_positional_range(
-        name: &str,
-        min: usize,
-        max: usize,
-        actual: usize,
-        kwonly_given: usize,
-    ) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            Self::too_many_positional_range_msg(name, min, max, actual, kwonly_given),
-        )
-        .into()
-    }
-
-    /// Message body for [`type_error_too_many_positional_range`], exposed
-    /// separately so `args/bind_python.rs` can attach a call position to the same
-    /// CPython-exact wording.
-    #[must_use]
-    pub(crate) fn too_many_positional_range_msg(
-        name: &str,
-        min: usize,
-        max: usize,
-        actual: usize,
-        kwonly_given: usize,
-    ) -> String {
-        let takes = if min == max {
-            // `max == 0` still reads "0 positional arguments" (plural) in CPython.
-            let takes_word = if max == 1 { "argument" } else { "arguments" };
-            format!("{max} positional {takes_word}")
-        } else {
-            format!("from {min} to {max} positional arguments")
-        };
-        if kwonly_given > 0 {
-            // CPython includes keyword-only args in the "given" part when present
-            let given_word = if actual == 1 { "argument" } else { "arguments" };
-            let kwonly_word = if kwonly_given == 1 { "argument" } else { "arguments" };
-            format!(
-                "{name}() takes {takes} but {actual} positional {given_word} (and {kwonly_given} keyword-only {kwonly_word}) were given"
-            )
-        } else {
-            let was_were = if actual == 1 { "was" } else { "were" };
-            format!("{name}() takes {takes} but {actual} {was_were} given")
-        }
-    }
-
-    /// Creates a TypeError for positional-only parameter passed as keyword.
-    ///
-    /// Matches CPython's format: `{name}() got some positional-only arguments passed as keyword arguments: '{param}'`
-    #[must_use]
-    pub(crate) fn type_error_positional_only(name: &str, param: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("{name}() got some positional-only arguments passed as keyword arguments: '{param}'"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for duplicate argument.
-    ///
-    /// Matches CPython's format: `{name}() got multiple values for argument '{param}'`
-    #[must_use]
-    pub(crate) fn type_error_duplicate_arg(name: &str, param: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("{name}() got multiple values for argument '{param}'"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for duplicate keyword argument.
-    ///
-    /// Matches CPython's format: `{name}() got multiple values for keyword argument '{key}'`
-    #[must_use]
-    pub(crate) fn type_error_multiple_values(name: &str, key: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("{name}() got multiple values for keyword argument '{key}'"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for when a positional argument conflicts with a keyword argument
-    /// of the same name in a C-implemented type constructor.
-    ///
-    /// Matches CPython's `PyArg_ParseTupleAndKeywords` format:
-    /// `argument for function given by name ('{key}') and position ({pos})`
-    ///
-    /// The position is 1-indexed, matching CPython's convention. The `func_descriptor` is
-    /// typically `"function"` for most C types (like `datetime`), matching CPython's generic
-    /// wording for `PyArg_ParseTupleAndKeywords`.
-    #[must_use]
-    pub(crate) fn type_error_positional_keyword_conflict(func_descriptor: &str, key: &str, pos: usize) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("argument for {func_descriptor} given by name ('{key}') and position ({pos})"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for unexpected keyword argument.
-    ///
-    /// Matches CPython's format: `{name}() got an unexpected keyword argument '{key}'`
-    #[must_use]
-    pub(crate) fn type_error_unexpected_keyword(name: &str, key: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("{name}() got an unexpected keyword argument '{key}'"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for unexpected keyword argument in C-implemented types.
-    ///
-    /// Matches CPython's `PyArg_ParseTupleAndKeywords` format:
-    /// `this function got an unexpected keyword argument '{key}'`
-    #[must_use]
-    pub(crate) fn type_error_c_unexpected_keyword(key: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("this function got an unexpected keyword argument '{key}'"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for too many arguments to a C-implemented type.
-    ///
-    /// Matches CPython's `PyArg_ParseTupleAndKeywords` format:
-    /// `function takes at most {max} arguments ({actual} given)`
-    #[must_use]
-    pub(crate) fn type_error_c_at_most(max: usize, actual: usize) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("function takes at most {max} arguments ({actual} given)"),
-        )
-        .into()
-    }
-
-    /// Variant of [`type_error_c_at_most`] used by C constructors that explicitly
-    /// say "positional arguments" (e.g. `datetime`):
-    /// `function takes at most {max} positional arguments ({actual} given)`
-    #[must_use]
-    pub(crate) fn type_error_c_at_most_positional(max: usize, actual: usize) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("function takes at most {max} positional arguments ({actual} given)"),
-        )
-        .into()
-    }
-
-    /// Hybrid wording used by C constructors that mix positional-or-keyword
-    /// slots with keyword-only slots (e.g. `datetime`, where `fold` is
-    /// keyword-only). CPython's `PyArg_ParseTupleAndKeywords` emits two
-    /// distinct messages depending on whether the caller could conceivably
-    /// have meant the overflow args to fill the keyword-only tail:
-    ///
-    /// - `actual <= max_total`: the extra positionals *could* have filled the
-    ///   trailing keyword-only slots, so the error pins blame on positional
-    ///   overflow specifically — `function takes at most {max_pos} positional
-    ///   arguments ({actual} given)`.
-    /// - `actual > max_total`: there is no slot of any kind for the extras,
-    ///   so the error reports the total slot count without the "positional"
-    ///   qualifier — `function takes at most {max_total} arguments ({actual}
-    ///   given)`.
-    ///
-    /// `max_pos` is the number of positional-or-keyword slots; `max_total`
-    /// adds the trailing keyword-only slot count. When `max_total == max_pos`
-    /// (no kw-only fields) this collapses to [`type_error_c_at_most_positional`].
-    #[must_use]
-    pub(crate) fn type_error_c_at_most_positional_or_total(
-        max_pos: usize,
-        max_total: usize,
-        actual: usize,
-    ) -> RunError {
-        if actual > max_total && max_total > max_pos {
-            Self::type_error_c_at_most(max_total, actual)
-        } else {
-            Self::type_error_c_at_most_positional(max_pos, actual)
-        }
-    }
-
-    /// Creates a TypeError for a missing required argument in a C-implemented type.
-    ///
-    /// Matches CPython's `PyArg_ParseTupleAndKeywords` format:
-    /// `function missing required argument '{arg_name}' (pos {pos})`
-    #[must_use]
-    pub(crate) fn type_error_c_missing_required(arg_name: &str, pos: usize) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("function missing required argument '{arg_name}' (pos {pos})"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for a missing required argument in a C-implemented type,
-    /// with a function name prefix.
-    ///
-    /// Matches CPython's format for types like `timezone`:
-    /// `{name}() missing required argument '{arg_name}' (pos {pos})`
-    #[must_use]
-    pub(crate) fn type_error_c_missing_required_named(name: &str, arg_name: &str, pos: usize) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("{name}() missing required argument '{arg_name}' (pos {pos})"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for a missing required argument without a position,
-    /// as raised by hand-written vectorcall fast paths like `enumerate`:
-    /// `{name}() missing required argument '{arg_name}'`
-    #[must_use]
-    pub(crate) fn type_error_missing_required_no_pos(name: &str, arg_name: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("{name}() missing required argument '{arg_name}'"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for a keyword rejected by a hand-written vectorcall
-    /// fast path (CPython's `enumerate` wording, distinct from the parser
-    /// families' "unexpected keyword argument"):
-    /// `'{key}' is an invalid keyword argument for {name}()`
-    #[must_use]
-    pub(crate) fn type_error_invalid_keyword_argument(name: &str, key: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("'{key}' is an invalid keyword argument for {name}()"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError matching CPython's `_PyArg_BadArgument`
-    /// positional-style wording: `{name}() argument {pos} must be
-    /// {expected}, not {got}`.
-    ///
-    /// Used by the `#[derive(FromArgs)]` macro when the struct opts into
-    /// `bad_arg` errors — emitted in place of the inner [`FromValue`]
-    /// failure so the caller sees the same wording as CPython's C-implemented
-    /// functions (e.g. `strftime() argument 1 must be str, not None`).
-    ///
-    /// The `got` type label should come from `Type::cpython_arg_name` so
-    /// that `NoneType` becomes `"None"` to match CPython's special case.
-    ///
-    /// [`FromValue`]: crate::args::FromValue
-    #[must_use]
-    pub(crate) fn type_error_bad_arg_pos(name: &str, pos: usize, expected: &str, got: impl fmt::Display) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("{name}() argument {pos} must be {expected}, not {got}"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError matching CPython's `_PyArg_BadArgument`
-    /// named-style wording: `{name}() argument '{arg_name}' must be
-    /// {expected}, not {got}`.
-    ///
-    /// CPython uses this form for C-implemented functions that register
-    /// their arguments by name (`open`, `str.encode`, `bytes.decode`, …).
-    /// Sibling to [`type_error_bad_arg_pos`]; pick the variant matching the
-    /// CPython output for the function being modelled.
-    #[must_use]
-    pub(crate) fn type_error_bad_arg_named(
-        name: &str,
-        arg_name: &str,
-        expected: &str,
-        got: impl fmt::Display,
-    ) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("{name}() argument '{arg_name}' must be {expected}, not {got}"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for **kwargs argument that is not a mapping.
-    ///
-    /// Matches CPython's format: `{name}() argument after ** must be a mapping, not {type_name}`
-    #[must_use]
-    pub(crate) fn type_error_kwargs_not_mapping(name: &str, type_name: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("{name}() argument after ** must be a mapping, not {type_name}"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for `{**x}` dict-literal unpacking where `x` is not a mapping.
-    ///
-    /// Matches CPython's format: `'{type_name}' object is not a mapping`
-    ///
-    /// Note: this differs from [`type_error_kwargs_not_mapping`] which is used for
-    /// function-call `**kwargs` and includes the function name in the message.
-    #[must_use]
-    pub(crate) fn type_error_not_mapping(type_: &str) -> RunError {
-        SimpleException::new_msg(Self::TypeError, format!("'{type_}' object is not a mapping")).into()
-    }
-
-    /// Creates a TypeError for **kwargs with non-string keys.
-    ///
-    /// Matches CPython's format: `{name}() keywords must be strings`
-    #[must_use]
-    pub(crate) fn type_error_kwargs_nonstring_key() -> RunError {
-        SimpleException::new_msg(Self::TypeError, "keywords must be strings").into()
-    }
-
-    /// Creates a TypeError for an invalid `tzinfo` argument.
-    ///
-    /// Matches CPython: `tzinfo argument must be None or of a tzinfo subclass, not type 'int'`
-    #[must_use]
-    pub(crate) fn type_error_tzinfo(ty: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("tzinfo argument must be None or of a tzinfo subclass, not type '{ty}'"),
-        )
-        .into()
-    }
-
-    /// Creates a simple TypeError with a custom message.
-    #[must_use]
-    pub(crate) fn type_error(msg: impl fmt::Display) -> RunError {
-        SimpleException::new_msg(Self::TypeError, msg).into()
-    }
-
-    /// Creates the TypeError raised when a `with` statement's context expression
-    /// does not implement the context-manager protocol.
-    ///
-    /// Matches CPython 3.14's wording, which names the specific missing dunder:
-    /// `__exit__` when the protocol check fails outright (`BeforeWith`'s
-    /// [`py_is_context_manager`](crate::types::PyTrait::py_is_context_manager)
-    /// gate), `__enter__` when a user class defines `__exit__` but not
-    /// `__enter__`.
-    #[must_use]
-    pub(crate) fn type_error_not_context_manager(type_name: impl Display, missing_dunder: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!(
-                "'{type_name}' object does not support the context manager protocol (missed {missing_dunder} method)"
-            ),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for `__init__` returning a value other than `None`.
-    ///
-    /// Matches CPython's format: `TypeError: __init__() should return None, not '{type}'`
-    #[must_use]
-    pub(crate) fn type_error_init_return(type_name: impl Display) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("__init__() should return None, not '{type_name}'"),
-        )
-        .into()
-    }
-
-    /// Creates a generic `ValueError` with a custom message.
-    pub(crate) fn value_error(msg: impl fmt::Display) -> RunError {
-        SimpleException::new_msg(Self::ValueError, msg).into()
-    }
-
-    /// Creates a TypeError for bytes() constructor with invalid type.
-    ///
-    /// Matches CPython's format: `TypeError: cannot convert '{type}' object to bytes`
-    #[must_use]
-    pub(crate) fn type_error_bytes_init(type_: &str) -> RunError {
-        SimpleException::new_msg(Self::TypeError, format!("cannot convert '{type_}' object to bytes")).into()
-    }
-
-    /// Creates a TypeError for calling a non-callable type.
-    ///
-    /// Matches CPython's format: `TypeError: cannot create '{type}' instances`
-    #[must_use]
-    pub(crate) fn type_error_not_callable(type_: &str) -> RunError {
-        SimpleException::new_msg(Self::TypeError, format!("cannot create '{type_}' instances")).into()
-    }
-
-    /// Creates a TypeError for calling a non-callable object.
-    ///
-    /// Matches CPython's format: `TypeError: '{type}' object is not callable`
-    #[must_use]
-    pub(crate) fn type_error_not_callable_object(type_: &str) -> RunError {
-        SimpleException::new_msg(Self::TypeError, format!("'{type_}' object is not callable")).into()
-    }
-
-    /// Creates a TypeError for non-iterable type in list/tuple/etc constructors.
-    ///
-    /// Matches CPython's format: `TypeError: '{type}' object is not iterable`
-    #[must_use]
-    pub(crate) fn type_error_not_iterable(type_: &str) -> RunError {
-        SimpleException::new_msg(Self::TypeError, format!("'{type_}' object is not iterable")).into()
-    }
-
-    /// Creates a TypeError when `next()` receives a non-iterator.
-    ///
-    /// Matches CPython's format: `TypeError: '{type}' object is not an iterator`
-    #[must_use]
-    pub(crate) fn type_error_not_iterator(type_: &str) -> RunError {
-        SimpleException::new_msg(Self::TypeError, format!("'{type_}' object is not an iterator")).into()
-    }
-
-    /// Creates a TypeError for non-iterable type in PEP 448 `*value` literal unpack.
-    ///
-    /// Used when `[*expr]`, `(*expr,)` literal unpack encounters a non-iterable — distinct
-    /// from [`type_error_not_iterable`] because CPython uses a different message for this context.
-    ///
-    /// Matches CPython's format: `TypeError: Value after * must be an iterable, not {type}`
-    #[must_use]
-    pub(crate) fn type_error_value_after_star(type_: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("Value after * must be an iterable, not {type_}"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for int() constructor with invalid type.
-    ///
-    /// Matches CPython's format: `TypeError: int() argument must be a string, a bytes-like object or a real number, not '{type}'`
-    #[must_use]
-    pub(crate) fn type_error_int_conversion(type_: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("int() argument must be a string, a bytes-like object or a real number, not '{type_}'"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for float() constructor with invalid type.
-    ///
-    /// Matches CPython's format: `TypeError: float() argument must be a string or a real number, not '{type}'`
-    #[must_use]
-    pub(crate) fn type_error_float_conversion(type_: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("float() argument must be a string or a real number, not '{type_}'"),
-        )
-        .into()
-    }
-
-    /// Creates a ValueError for negative count in bytes().
-    ///
-    /// Matches CPython's format: `ValueError: negative count`
-    #[must_use]
-    pub(crate) fn value_error_negative_bytes_count() -> RunError {
-        SimpleException::new_msg(Self::ValueError, "negative count").into()
-    }
-
-    /// Creates a TypeError for isinstance() arg 2.
-    ///
-    /// Matches CPython's format: `TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union`
-    #[must_use]
-    pub(crate) fn isinstance_arg2_error() -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            "isinstance() arg 2 must be a type, a tuple of types, or a union",
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for invalid exception type in except clause.
-    ///
-    /// Matches CPython's format: `TypeError: catching classes that do not inherit from BaseException is not allowed`
-    #[must_use]
-    pub(crate) fn except_invalid_type_error() -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            "catching classes that do not inherit from BaseException is not allowed",
-        )
-        .into()
-    }
-
-    /// Creates a ValueError for range() step argument being zero.
-    ///
-    /// Matches CPython's format: `ValueError: range() arg 3 must not be zero`
-    #[must_use]
-    pub(crate) fn value_error_range_step_zero() -> RunError {
-        SimpleException::new_msg(Self::ValueError, "range() arg 3 must not be zero").into()
-    }
-
-    /// Creates a ValueError for slice step being zero.
-    ///
-    /// Matches CPython's format: `ValueError: slice step cannot be zero`
-    #[must_use]
-    pub(crate) fn value_error_slice_step_zero() -> RunError {
-        SimpleException::new_msg(Self::ValueError, "slice step cannot be zero").into()
-    }
-
-    /// Creates a TypeError for slice indices that are not integers or None.
-    ///
-    /// Matches CPython's format: `TypeError: slice indices must be integers or None or have an __index__ method`
-    #[must_use]
-    pub(crate) fn type_error_slice_indices() -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            "slice indices must be integers or None or have an __index__ method",
-        )
-        .into()
-    }
-
-    /// Creates a RuntimeError for dict mutation during iteration.
-    ///
-    /// Matches CPython's format: `RuntimeError: dictionary changed size during iteration`
-    #[must_use]
-    pub(crate) fn runtime_error_dict_changed_size() -> RunError {
-        SimpleException::new_msg(Self::RuntimeError, "dictionary changed size during iteration").into()
-    }
-
-    /// Creates a TypeError for `reversed()` on a non-reversible object.
-    ///
-    /// Matches CPython's format: `TypeError: '{type}' object is not reversible`
-    #[must_use]
-    pub(crate) fn type_error_not_reversible(type_: &str) -> RunError {
-        SimpleException::new_msg(Self::TypeError, format!("'{type_}' object is not reversible")).into()
-    }
-
-    /// Creates a RuntimeError for an over-deep iterator delegation chain.
-    ///
-    /// Monty-specific (CPython builds no delegation chain at all) — see
-    /// `limitations/builtins.md`.
-    #[must_use]
-    pub(crate) fn runtime_error_iter_delegation_too_deep() -> RunError {
-        SimpleException::new_msg(Self::RuntimeError, "iterator delegation nested too deeply").into()
-    }
-
-    /// Creates a RuntimeError for a delegating iterator pointing at a non-iterator.
-    ///
-    /// Unreachable from Python; only a malformed snapshot can produce it. Raised
-    /// rather than panicking so untrusted snapshot data cannot abort the process.
-    #[must_use]
-    pub(crate) fn runtime_error_iter_delegation_invalid() -> RunError {
-        SimpleException::new_msg(Self::RuntimeError, "iterator delegates to a non-iterator").into()
-    }
-
-    /// Creates a RuntimeError for set mutation during iteration.
-    ///
-    /// Matches CPython's format: `RuntimeError: Set changed size during iteration`
-    #[must_use]
-    pub(crate) fn runtime_error_set_changed_size() -> RunError {
-        SimpleException::new_msg(Self::RuntimeError, "Set changed size during iteration").into()
-    }
-
-    /// Creates a TypeError for functions that don't accept keyword arguments.
-    ///
-    /// Matches CPython's format: `TypeError: {name}() takes no keyword arguments`
-    #[must_use]
-    pub(crate) fn type_error_no_kwargs(name: &str) -> RunError {
-        SimpleException::new_msg(Self::TypeError, format!("{name}() takes no keyword arguments")).into()
-    }
-
-    /// Creates a NotImplementedError for functions that don't accept keyword arguments.
-    #[must_use]
-    pub(crate) fn kwargs_not_implemented(name: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::NotImplementedError,
-            format!("{name}() does not yet support keyword arguments"),
-        )
-        .into()
-    }
-
-    /// Creates an IndexError for list index out of range (getitem).
-    ///
-    /// Matches CPython's format: `IndexError('list index out of range')`
-    #[must_use]
-    pub(crate) fn list_index_error() -> RunError {
-        SimpleException::new_msg(Self::IndexError, "list index out of range").into()
-    }
-
-    /// Creates an IndexError for list assignment index out of range (setitem).
-    ///
-    /// Matches CPython's format: `IndexError('list assignment index out of range')`
-    #[must_use]
-    pub(crate) fn list_assignment_index_error() -> RunError {
-        SimpleException::new_msg(Self::IndexError, "list assignment index out of range").into()
-    }
-
-    /// Creates an IndexError for tuple index out of range.
-    ///
-    /// Matches CPython's format: `IndexError('tuple index out of range')`
-    #[must_use]
-    pub(crate) fn tuple_index_error() -> RunError {
-        SimpleException::new_msg(Self::IndexError, "tuple index out of range").into()
-    }
-
-    /// Creates an IndexError for string index out of range.
-    ///
-    /// Matches CPython's format: `IndexError('string index out of range')`
-    #[must_use]
-    pub(crate) fn str_index_error() -> RunError {
-        SimpleException::new_msg(Self::IndexError, "string index out of range").into()
-    }
-
-    /// Creates an IndexError for bytes index out of range.
-    ///
-    /// Matches CPython's format: `IndexError('index out of range')`
-    #[must_use]
-    pub(crate) fn bytes_index_error() -> RunError {
-        SimpleException::new_msg(Self::IndexError, "index out of range").into()
-    }
-
-    /// Creates an IndexError for range index out of range.
-    ///
-    /// Matches CPython's format: `IndexError('range object index out of range')`
-    #[must_use]
-    pub(crate) fn range_index_error() -> RunError {
-        SimpleException::new_msg(Self::IndexError, "range object index out of range").into()
-    }
-
-    /// Creates an IndexError for `re.Match` group index out of range.
-    ///
-    /// Matches CPython's format: `IndexError('no such group')`
-    #[must_use]
-    pub(crate) fn re_match_group_index_error() -> RunError {
-        SimpleException::new_msg(Self::IndexError, "no such group").into()
-    }
-
-    /// Creates a TypeError for non-integer sequence indices (getitem).
-    ///
-    /// Matches CPython's format: `TypeError('{type}' indices must be integers, not '{index_type}')`
-    #[must_use]
-    pub(crate) fn type_error_indices(type_str: Type, index_type: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("{type_str} indices must be integers, not '{index_type}'"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for non-integer list indices (setitem/assignment).
-    ///
-    /// Matches CPython's format: `TypeError('list indices must be integers or slices, not {index_type}')`
-    #[must_use]
-    pub(crate) fn type_error_list_assignment_indices(index_type: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("list indices must be integers or slices, not {index_type}"),
-        )
-        .into()
-    }
-
-    /// Creates a NameError for accessing a free variable (nonlocal/closure) before it's assigned.
-    ///
-    /// Matches CPython's format: `NameError: cannot access free variable 'x' where it is not
-    /// associated with a value in enclosing scope`
-    #[must_use]
-    pub(crate) fn name_error_free_variable(name: &str) -> SimpleException {
-        SimpleException::new_msg(
-            Self::NameError,
-            format!("cannot access free variable '{name}' where it is not associated with a value in enclosing scope"),
-        )
-    }
-
-    /// Creates a NameError for accessing an undefined variable.
-    ///
-    /// Matches CPython's format: `NameError: name 'x' is not defined`
-    #[must_use]
-    pub(crate) fn name_error(name: &str) -> SimpleException {
-        let mut msg = format!("name '{name}' is not defined");
-        // add the same suffix as cpython, but only for the modules supported by Monty
-        if matches!(name, "asyncio" | "sys" | "typing" | "types" | "re" | "json") {
-            write!(&mut msg, ". Did you forget to import '{name}'?").unwrap();
-        }
-        SimpleException::new_msg(Self::NameError, msg)
-    }
-
-    /// Creates an UnboundLocalError for accessing a local variable before assignment.
-    ///
-    /// Matches CPython's format: `UnboundLocalError: cannot access local variable 'x' where it is not associated with a value`
-    #[must_use]
-    pub(crate) fn unbound_local_error(name: &str) -> SimpleException {
-        SimpleException::new_msg(
-            Self::UnboundLocalError,
-            format!("cannot access local variable '{name}' where it is not associated with a value"),
-        )
-    }
-
-    /// Creates a ModuleNotFoundError for when a module cannot be found.
-    ///
-    /// Matches CPython's format: `ModuleNotFoundError: No module named 'name'`
-    /// Sets `hide_caret: true` because CPython doesn't show carets for module not found errors.
-    #[must_use]
-    pub(crate) fn module_not_found_error(module_name: &str) -> RunError {
-        let exc = SimpleException::new_msg(Self::ModuleNotFoundError, format!("No module named '{module_name}'"));
-        RunError::Exc(ExceptionRaise {
-            exc,
-            frame: None,
-            hide_caret: true, // CPython doesn't show carets for module not found errors
-        })
-    }
-
-    /// Creates a NotImplementedError for an unimplemented Python feature.
-    ///
-    /// Used during parsing when encountering Python syntax that Monty doesn't yet support.
-    /// The message format is: "The monty syntax parser does not yet support {feature}"
-    #[must_use]
-    pub(crate) fn not_implemented(msg: impl fmt::Display) -> SimpleException {
-        SimpleException::new_msg(Self::NotImplementedError, msg)
-    }
-
-    /// Creates a ZeroDivisionError for division by zero.
-    ///
-    /// Matches CPython 3.14's format: `ZeroDivisionError('division by zero')`
-    #[must_use]
-    pub(crate) fn zero_division() -> SimpleException {
-        SimpleException::new_msg(Self::ZeroDivisionError, "division by zero")
-    }
-
-    /// Creates an OverflowError for string/sequence repetition with count too large.
-    ///
-    /// Matches CPython's format: `OverflowError('cannot fit 'int' into an index-sized integer')`
-    #[must_use]
-    pub(crate) fn overflow_repeat_count() -> SimpleException {
-        SimpleException::new_msg(Self::OverflowError, "cannot fit 'int' into an index-sized integer")
-    }
-
-    /// Creates an IndexError for when an integer index is too large to fit in i64.
-    ///
-    /// Matches CPython's format: `IndexError: cannot fit 'int' into an index-sized integer`
-    #[must_use]
-    pub(crate) fn index_error_int_too_large() -> RunError {
-        SimpleException::new_msg(Self::IndexError, "cannot fit 'int' into an index-sized integer").into()
-    }
-
-    /// Creates an ImportError for when a name cannot be imported from a module.
-    ///
-    /// Matches CPython's format for built-in modules:
-    /// `ImportError: cannot import name 'name' from 'module' (unknown location)`
-    ///
-    /// Sets `hide_caret: true` because CPython doesn't show carets for import errors.
-    #[must_use]
-    pub(crate) fn cannot_import_name(name: &str, module_name: &str) -> RunError {
-        let exc = SimpleException::new_msg(
-            Self::ImportError,
-            format!("cannot import name '{name}' from '{module_name}' (unknown location)"),
-        );
-        RunError::Exc(ExceptionRaise {
-            exc,
-            frame: None,
-            hide_caret: true,
-        })
-    }
-
-    /// Creates a ValueError when an integer is too large to convert to a decimal string.
-    ///
-    /// Matches CPython 3.11+'s `sys.int_max_str_digits` error message.
-    #[must_use]
-    pub(crate) fn value_error_int_too_large_for_str() -> RunError {
-        SimpleException::new_msg(
-            Self::ValueError,
-            format!(
-                "Exceeds the limit ({INT_MAX_STR_DIGITS} digits) for integer string conversion; use sys.set_int_max_str_digits() to increase the limit"
-            ),
-        )
-        .into()
-    }
-
-    /// Creates a ValueError when a decimal string has too many digits for `int()` conversion.
-    ///
-    /// Includes the actual digit count to help users diagnose the issue.
-    #[must_use]
-    pub(crate) fn value_error_int_str_too_large(digit_count: usize) -> RunError {
-        SimpleException::new_msg(
-            Self::ValueError,
-            format!(
-                "Exceeds the limit ({INT_MAX_STR_DIGITS} digits) for integer string conversion: value has {digit_count} digits; use sys.set_int_max_str_digits() to increase the limit"
-            ),
-        )
-        .into()
-    }
-
-    /// Creates a ValueError for `int()` when a string cannot be parsed as an integer.
-    ///
-    /// Matches CPython's format: `invalid literal for int() with base {N}: '...'`.
-    /// `base` is the base the caller passed (0 included, before auto-detection);
-    /// the caller provides the value pre-formatted (e.g. via `StringRepr`).
-    #[must_use]
-    pub(crate) fn value_error_invalid_literal_for_int(base: u32, value: impl fmt::Display) -> RunError {
-        SimpleException::new_msg(
-            Self::ValueError,
-            format!("invalid literal for int() with base {base}: {value}"),
-        )
-        .into()
-    }
-
-    /// Creates a ValueError for an `int()` base outside `{0} ∪ 2..=36`.
-    ///
-    /// Matches CPython's message: `int() base must be >= 2 and <= 36, or 0`.
-    #[must_use]
-    pub(crate) fn value_error_int_base_range() -> RunError {
-        SimpleException::new_msg(Self::ValueError, "int() base must be >= 2 and <= 36, or 0").into()
-    }
-
-    /// Creates a TypeError for `int(base=N)` with no value to convert.
-    ///
-    /// Matches CPython's message: `int() missing string argument`. Raised
-    /// before the base is validated, matching `long_new_impl`'s ordering.
-    #[must_use]
-    pub(crate) fn type_error_int_missing_string_argument() -> RunError {
-        SimpleException::new_msg(Self::TypeError, "int() missing string argument").into()
-    }
-
-    /// Creates a TypeError for `int(x, base)` where `x` is not str/bytes.
-    ///
-    /// Matches CPython's message: `int() can't convert non-string with explicit base`.
-    #[must_use]
-    pub(crate) fn type_error_int_non_string_with_base() -> RunError {
-        SimpleException::new_msg(Self::TypeError, "int() can't convert non-string with explicit base").into()
-    }
-
-    /// Creates a ValueError for negative shift count in bitwise shift operations.
-    ///
-    /// Matches CPython's format: `ValueError: negative shift count`
-    #[must_use]
-    pub(crate) fn value_error_negative_shift_count() -> RunError {
-        SimpleException::new_msg(Self::ValueError, "negative shift count").into()
-    }
-
-    /// Creates an OverflowError when converting values to C ssize_t (i64) for operations like length checks.
-    ///
-    /// Matches CPython's format: `OverflowError: Python int too large to convert to C ssize_t`
-    /// Note: CPython uses this message because it tries to convert to ssize_t for the shift amount.
-    #[must_use]
-    pub(crate) fn overflow_c_ssize_t() -> RunError {
-        SimpleException::new_msg(Self::OverflowError, "Python int too large to convert to C ssize_t").into()
-    }
-
-    /// Creates an OverflowError when a Python int doesn't fit into a C `int` (i32).
-    ///
-    /// Matches CPython's format: `OverflowError: Python int too large to convert to C int`
-    /// Used by builtins (e.g. `bytes.hex`) that parse arguments via the `i` format code.
-    #[must_use]
-    pub(crate) fn overflow_c_int() -> RunError {
-        SimpleException::new_msg(Self::OverflowError, "Python int too large to convert to C int").into()
-    }
-
-    /// Creates an OverflowError when a Python int doesn't fit into a C `long` (i64).
-    ///
-    /// Matches CPython's format: `OverflowError: Python int too large to convert to C long`
-    /// CPython's `i` format code converts through C long first, so ints beyond
-    /// i64 report this even for C-int parameters (e.g. `datetime.date(2**100, 1, 1)`).
-    #[must_use]
-    pub(crate) fn overflow_c_long() -> RunError {
-        SimpleException::new_msg(Self::OverflowError, "Python int too large to convert to C long").into()
-    }
-
-    /// Creates a TypeError for unsupported binary operations.
-    ///
-    /// For `+` or `+=` with str/list on the left side, uses CPython's special format:
-    /// `can only concatenate {type} (not "{other}") to {type}`
-    ///
-    /// For other cases, uses the generic format:
-    /// `unsupported operand type(s) for {op}: '{left}' and '{right}'`
-    #[must_use]
-    pub(crate) fn binary_type_error(
-        op: &str,
-        lhs_type: Type,
-        lhs_name: impl Display,
-        rhs_name: impl Display,
-    ) -> RunError {
-        let message = if (op == "+" || op == "+=") && matches!(lhs_type, Type::Str | Type::List) {
-            format!("can only concatenate {lhs_name} (not \"{rhs_name}\") to {lhs_name}")
-        } else {
-            format!("unsupported operand type(s) for {op}: '{lhs_name}' and '{rhs_name}'")
-        };
-        SimpleException::new_msg(Self::TypeError, message).into()
-    }
-
-    /// Creates a TypeError for unsupported unary operations.
-    ///
-    /// Uses CPython's format: `bad operand type for unary {op}: '{type}'`
-    #[must_use]
-    pub(crate) fn unary_type_error(op: &str, value_type: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("bad operand type for unary {op}: '{value_type}'"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for functions that require an integer argument.
-    ///
-    /// Matches CPython's format: `TypeError: '{type}' object cannot be interpreted as an integer`
-    #[must_use]
-    pub(crate) fn type_error_not_integer(type_: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("'{type_}' object cannot be interpreted as an integer"),
-        )
-        .into()
-    }
-
-    /// Creates a ZeroDivisionError for zero raised to a negative power.
-    ///
-    /// Matches CPython's format: `ZeroDivisionError: zero to a negative power`
-    /// Note: CPython uses the same message for both int and float zero ** negative.
-    #[must_use]
-    pub(crate) fn zero_negative_power() -> RunError {
-        SimpleException::new_msg(Self::ZeroDivisionError, "zero to a negative power").into()
-    }
-
-    /// Creates an OverflowError for exponents that are too large.
-    ///
-    /// Matches CPython's format: `OverflowError: exponent too large`
-    #[must_use]
-    pub(crate) fn overflow_exponent_too_large() -> RunError {
-        SimpleException::new_msg(Self::OverflowError, "exponent too large").into()
-    }
-
-    /// Creates a ZeroDivisionError for divmod by zero (both integer and float).
-    ///
-    /// Matches CPython's format: `ZeroDivisionError: division by zero`
-    /// Note: CPython uses the same message for both integer and float divmod.
-    #[must_use]
-    pub(crate) fn divmod_by_zero() -> RunError {
-        SimpleException::new_msg(Self::ZeroDivisionError, "division by zero").into()
-    }
-
-    /// Creates a TypeError for str.join() when an item is not a string.
-    ///
-    /// Matches CPython's format: `TypeError: sequence item {index}: expected str instance, {type} found`
-    #[must_use]
-    pub(crate) fn type_error_join_item(index: usize, item_type: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("sequence item {index}: expected str instance, {item_type} found"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for str.join() when the argument is not iterable.
-    ///
-    /// Matches CPython's format: `TypeError: can only join an iterable`
-    #[must_use]
-    pub(crate) fn type_error_join_not_iterable() -> RunError {
-        SimpleException::new_msg(Self::TypeError, "can only join an iterable").into()
-    }
-
-    /// Creates a ValueError for str.index()/str.rindex() when substring is not found.
-    ///
-    /// Matches CPython's format: `ValueError: substring not found`
-    #[must_use]
-    pub(crate) fn value_error_substring_not_found() -> RunError {
-        SimpleException::new_msg(Self::ValueError, "substring not found").into()
-    }
-
-    /// Creates a ValueError for str.partition()/str.rpartition() with empty separator.
-    ///
-    /// Matches CPython's format: `ValueError: empty separator`
-    #[must_use]
-    pub(crate) fn value_error_empty_separator() -> RunError {
-        SimpleException::new_msg(Self::ValueError, "empty separator").into()
-    }
-
-    /// Creates a TypeError for fillchar argument that is not a single character.
-    ///
-    /// Matches CPython's format: `TypeError: The fill character must be exactly one character long`
-    #[must_use]
-    pub(crate) fn type_error_fillchar_must_be_single_char() -> RunError {
-        SimpleException::new_msg(Self::TypeError, "The fill character must be exactly one character long").into()
-    }
-
-    /// Creates a StopIteration exception for when an iterator is exhausted.
-    ///
-    /// Matches CPython's format: `StopIteration`
-    #[must_use]
-    pub(crate) fn stop_iteration() -> RunError {
-        SimpleException::new_none(Self::StopIteration).into()
-    }
-
-    /// Creates a ValueError for list.index() when item is not found.
-    ///
-    /// Matches CPython's format: `ValueError: list.index(x): x not in list`
-    #[must_use]
-    pub(crate) fn value_error_not_in_list() -> RunError {
-        SimpleException::new_msg(Self::ValueError, "list.index(x): x not in list").into()
-    }
-
-    /// Creates a ValueError for tuple.index() when item is not found.
-    ///
-    /// Matches CPython's format: `ValueError: tuple.index(x): x not in tuple`
-    #[must_use]
-    pub(crate) fn value_error_not_in_tuple() -> RunError {
-        SimpleException::new_msg(Self::ValueError, "tuple.index(x): x not in tuple").into()
-    }
-
-    /// Creates a ValueError for list.remove() when item is not found.
-    ///
-    /// Matches CPython's format: `ValueError: list.remove(x): x not in list`
-    #[must_use]
-    pub(crate) fn value_error_remove_not_in_list() -> RunError {
-        SimpleException::new_msg(Self::ValueError, "list.remove(x): x not in list").into()
-    }
-
-    /// Creates an IndexError for popping from an empty list.
-    ///
-    /// Matches CPython's format: `IndexError: pop from empty list`
-    #[must_use]
-    pub(crate) fn index_error_pop_empty_list() -> RunError {
-        SimpleException::new_msg(Self::IndexError, "pop from empty list").into()
-    }
-
-    /// Creates an IndexError for list.pop(index) with invalid index.
-    ///
-    /// Matches CPython's format: `IndexError: pop index out of range`
-    #[must_use]
-    pub(crate) fn index_error_pop_out_of_range() -> RunError {
-        SimpleException::new_msg(Self::IndexError, "pop index out of range").into()
-    }
-
-    /// Creates a KeyError for popping from an empty dict.
-    ///
-    /// Matches CPython's format: `KeyError: 'popitem(): dictionary is empty'`
-    #[must_use]
-    pub(crate) fn key_error_popitem_empty_dict() -> RunError {
-        SimpleException::new_msg(Self::KeyError, "'popitem(): dictionary is empty'").into()
-    }
-
-    /// Creates a LookupError for unknown encoding.
-    ///
-    /// Matches CPython's format: `LookupError: unknown encoding: {encoding}`
-    #[must_use]
-    pub(crate) fn lookup_error_unknown_encoding(encoding: &str) -> RunError {
-        SimpleException::new_msg(Self::LookupError, format!("unknown encoding: {encoding}")).into()
-    }
-
-    /// Creates a TypeError for `str(s, encoding=...)` with a str object.
-    ///
-    /// Matches CPython's message: `decoding str is not supported`.
-    #[must_use]
-    pub(crate) fn type_error_decoding_str_not_supported() -> RunError {
-        SimpleException::new_msg(Self::TypeError, "decoding str is not supported").into()
-    }
-
-    /// Creates a TypeError for `str(x, encoding=...)` with a non-bytes object.
-    ///
-    /// Matches CPython's format: `decoding to str: need a bytes-like object, {type} found`.
-    #[must_use]
-    pub(crate) fn type_error_decoding_need_bytes(type_: impl Display) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("decoding to str: need a bytes-like object, {type_} found"),
-        )
-        .into()
-    }
-
-    /// Creates a TypeError for `bytes(s)` with a str source and no encoding.
-    ///
-    /// Matches CPython's message: `string argument without an encoding`.
-    #[must_use]
-    pub(crate) fn type_error_string_without_encoding() -> RunError {
-        SimpleException::new_msg(Self::TypeError, "string argument without an encoding").into()
-    }
-
-    /// Creates a TypeError for `bytes(x, encoding=...)` with a non-str source.
-    ///
-    /// Matches CPython's message: `encoding without a string argument`.
-    #[must_use]
-    pub(crate) fn type_error_encoding_without_string() -> RunError {
-        SimpleException::new_msg(Self::TypeError, "encoding without a string argument").into()
-    }
-
-    /// Creates a TypeError for `bytes(x, errors=...)` with a non-str source.
-    ///
-    /// Matches CPython's message: `errors without a string argument`.
-    #[must_use]
-    pub(crate) fn type_error_errors_without_string() -> RunError {
-        SimpleException::new_msg(Self::TypeError, "errors without a string argument").into()
-    }
-
-    /// Creates a TypeError for `sum()` rejecting a str/bytes `start` value.
-    ///
-    /// Matches CPython: `sum() can't sum {kind} [use {join}.join(seq) instead]`
-    /// — `("strings", "''")` for str, `("bytes", "b''")` for bytes.
-    #[must_use]
-    pub(crate) fn type_error_sum_start(kind: &str, join: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("sum() can't sum {kind} [use {join}.join(seq) instead]"),
-        )
-        .into()
-    }
-
-    /// Creates a UnicodeEncodeError for a run of `start..end` consecutive
-    /// characters (character indices, not byte offsets) of `object` — the
-    /// full string being encoded — that can't be represented in the target
-    /// `codec`. `first_char` is the character at `start`, used for the
-    /// single-character message form.
-    ///
-    /// Matches CPython's format, which differs for a single character vs. a run:
-    /// `UnicodeEncodeError: 'ascii' codec can't encode character '\xe9' in
-    /// position 1: ordinal not in range(128)` or `... can't encode characters
-    /// in position 1-2: ordinal not in range(128)`.
-    #[must_use]
-    pub(crate) fn unicode_encode_error(
-        codec: &str,
-        object: &str,
-        first_char: char,
-        start: usize,
-        end: usize,
-        reason: &str,
-    ) -> RunError {
-        // Callers must pass a non-empty range; checked in debug builds only so
-        // a wrong caller can't panic the VM in release (it gets a garbled
-        // message position instead, which is harmless).
-        debug_assert!(
-            end > start,
-            "unicode_encode_error: end ({end}) must be > start ({start})"
-        );
-        let msg = if end - start == 1 {
-            format!(
-                "'{codec}' codec can't encode character '{}' in position {start}: {reason}",
-                ascii_escape(&first_char.to_string())
-            )
-        } else {
-            let last = end - 1;
-            format!("'{codec}' codec can't encode characters in position {start}-{last}: {reason}")
-        };
-        SimpleException::new_msg(Self::UnicodeEncodeError, msg)
-            .with_data(UnicodeErrorData::encode(codec, object, start, end, reason))
-            .into()
-    }
-
-    /// Creates a UnicodeDecodeError for the undecodable byte range `start..end`
-    /// (byte offsets into `object` — the full input being decoded).
-    ///
-    /// Matches CPython's format, which differs for a single byte vs. a run:
-    /// `UnicodeDecodeError: 'ascii' codec can't decode byte 0xe9 in position 6:
-    /// ordinal not in range(128)` or `'utf-8' codec can't decode bytes in
-    /// position 0-1: unexpected end of data`.
-    #[must_use]
-    pub(crate) fn unicode_decode_error(codec: &str, object: &[u8], start: usize, end: usize, reason: &str) -> RunError {
-        // Defensive `get`: `start` always indexes a real byte for the errors
-        // Monty produces, but a wrong caller must not be able to panic the VM.
-        let first_byte = object.get(start).copied().unwrap_or(0);
-        SimpleException::new_msg(
-            Self::UnicodeDecodeError,
-            unicode_decode_error_msg(codec, first_byte, start, end, reason),
-        )
-        .with_data(UnicodeErrorData::decode(codec, object, start, end, reason))
-        .into()
-    }
-
-    /// Creates a ValueError for subsequence not found in bytes/str.
-    ///
-    /// Matches CPython's format: `ValueError: subsection not found`
-    #[must_use]
-    pub(crate) fn value_error_subsequence_not_found() -> RunError {
-        SimpleException::new_msg(Self::ValueError, "subsection not found").into()
-    }
-
-    /// Creates a LookupError for unknown error handler.
-    ///
-    /// Matches CPython's format: `LookupError: unknown error handler name '{name}'`
-    #[must_use]
-    pub(crate) fn lookup_error_unknown_error_handler(name: &str) -> RunError {
-        SimpleException::new_msg(Self::LookupError, format!("unknown error handler name '{name}'")).into()
-    }
-
-    /// Creates a TypeError for an encode-only error handler (`xmlcharrefreplace`,
-    /// `namereplace`) invoked for a decode error.
-    ///
-    /// Matches CPython's format: `TypeError: don't know how to handle
-    /// UnicodeDecodeError in error callback`
-    #[must_use]
-    pub(crate) fn type_error_decode_error_callback() -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            "don't know how to handle UnicodeDecodeError in error callback",
-        )
-        .into()
-    }
-
-    /// Creates a NotImplementedError for a decode error handler that would
-    /// produce lone surrogates (`surrogateescape` always; `surrogatepass` when
-    /// the input actually contains an encoded surrogate).
-    ///
-    /// CPython's handlers put lone surrogates (e.g. U+DC80–U+DCFF for
-    /// `surrogateescape`) in the resulting string. Monty strings are strict
-    /// UTF-8 and cannot represent lone surrogates, so these cases cannot be
-    /// supported — see `limitations/encoding.md`.
-    #[must_use]
-    pub(crate) fn not_implemented_surrogate_handler_decode(handler: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::NotImplementedError,
-            format!(
-                "the '{handler}' error handler is not supported by Monty for decoding: \
-                 Monty strings cannot contain the lone surrogate characters it produces"
-            ),
-        )
-        .into()
-    }
-
-    /// Creates a `re.PatternError` for an invalid regex pattern or unsupported regex feature.
-    ///
-    /// Matches CPython's exception type: `re.PatternError: {message}`
-    #[must_use]
-    pub(crate) fn re_pattern_error(msg: impl fmt::Display) -> RunError {
-        SimpleException::new_msg(Self::RePatternError, msg).into()
-    }
-
-    /// Creates a `json.JSONDecodeError` with CPython-compatible location suffix,
-    /// formatted as `{message}: line {line} column {column} (char {index})`.
-    ///
-    /// The fields also travel in a structured [`JsonErrorData`] payload
-    /// (with `doc` capped) so hosts can rebuild the real `json.JSONDecodeError`
-    /// with its `msg`/`doc`/`pos`/`lineno`/`colno` attributes.
-    ///
-    /// # Arguments
-    ///
-    /// * `message` - The bare error message, without the location suffix
-    /// * `doc` - The document being parsed (CPython's `exc.doc`)
-    /// * `line` - 1-based line of the error (CPython's `exc.lineno`)
-    /// * `column` - 1-based column of the error (CPython's `exc.colno`)
-    /// * `index` - Character index of the error in `doc` (CPython's `exc.pos`)
-    #[must_use]
-    pub(crate) fn json_decode_error(message: &str, doc: &[u8], line: usize, column: usize, index: usize) -> RunError {
-        SimpleException::new_msg(
-            Self::JsonDecodeError,
-            format!("{message}: line {line} column {column} (char {index})"),
-        )
-        .with_data(JsonErrorData::build(message, doc, index, line, column))
-        .into()
-    }
-
-    /// Creates the `TypeError` used by `json.loads()` for unsupported input types.
-    ///
-    /// Matches CPython's format:
-    /// `the JSON object must be str, bytes or bytearray, not {type}`
-    #[must_use]
-    pub(crate) fn json_loads_type_error(type_: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("the JSON object must be str, bytes or bytearray, not {type_}"),
-        )
-        .into()
-    }
-
-    /// Creates the `ValueError` used by `json.dumps()` for circular containers.
-    ///
-    /// Matches CPython's format: `Circular reference detected`
-    #[must_use]
-    pub(crate) fn json_circular_reference_error() -> RunError {
-        SimpleException::new_msg(Self::ValueError, "Circular reference detected").into()
-    }
-
-    /// Creates the `TypeError` used by `json.dumps()` for unsupported object types.
-    ///
-    /// Matches CPython's format:
-    /// `Object of type {type} is not JSON serializable`
-    #[must_use]
-    pub(crate) fn json_not_serializable_error(type_: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("Object of type {type_} is not JSON serializable"),
-        )
-        .into()
-    }
-
-    /// Creates the `TypeError` used by `json.dumps()` for unsupported dict keys.
-    ///
-    /// Matches CPython's format:
-    /// `keys must be str, int, float, bool or None, not {type}`
-    #[must_use]
-    pub(crate) fn json_invalid_key_error(type_: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::TypeError,
-            format!("keys must be str, int, float, bool or None, not {type_}"),
-        )
-        .into()
-    }
-
-    /// Creates the `ValueError` used by `json.dumps(..., allow_nan=False)`.
-    ///
-    /// Matches CPython's format:
-    /// `Out of range float values are not JSON compliant: {value}`
-    #[must_use]
-    pub(crate) fn json_nan_error(value: &str) -> RunError {
-        SimpleException::new_msg(
-            Self::ValueError,
-            format!("Out of range float values are not JSON compliant: {value}"),
-        )
-        .into()
-    }
-}
-
-/// Formats the message for a `UnicodeDecodeError` covering the byte range
-/// `start..end`: CPython's single-byte form (`byte 0x{first_byte:02x} in
-/// position {start}`) when the range is one byte, otherwise the range form
-/// (`bytes in position {start}-{end - 1}`).
-///
-/// A free function (rather than folded into `ExcType::unicode_decode_error`),
-/// public and re-exported at the crate root, so `monty-fs` can produce the
-/// identical wording when converting a `MountError::InvalidUtf8` from a
-/// text-mode file read into an exception.
-#[must_use]
-pub fn unicode_decode_error_msg(codec: &str, first_byte: u8, start: usize, end: usize, reason: &str) -> String {
-    // Callers must pass a non-empty range; checked in debug builds only so a
-    // wrong caller can't panic the VM in release (it gets a garbled message
-    // position instead, which is harmless).
-    debug_assert!(
-        end > start,
-        "unicode_decode_error_msg: end ({end}) must be > start ({start})"
-    );
-    if end - start == 1 {
-        format!("'{codec}' codec can't decode byte 0x{first_byte:02x} in position {start}: {reason}")
-    } else {
-        let last = end - 1;
-        format!("'{codec}' codec can't decode bytes in position {start}-{last}: {reason}")
     }
 }
 
@@ -2247,7 +2043,7 @@ impl ExceptionRaise {
             })
             .unwrap_or_default();
 
-        MontyException::new_full(self.exc.exc_type, self.exc.arg, traceback).with_data(self.exc.data)
+        MontyException::with_traceback(self.exc.exc_type, self.exc.arg, traceback).with_data(self.exc.data)
     }
 }
 

--- a/crates/monty/src/fstring.rs
+++ b/crates/monty/src/fstring.rs
@@ -9,9 +9,9 @@
 use std::{fmt, fmt::Write, iter, iter::Peekable, str, str::FromStr};
 
 pub use monty_types::FormatFloat;
+use monty_types::ResourceTracker;
 
 use crate::{
-    ResourceTracker,
     bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunError, SimpleException},

--- a/crates/monty/src/fstring.rs
+++ b/crates/monty/src/fstring.rs
@@ -8,14 +8,17 @@
 
 use std::{fmt, fmt::Write, iter, iter::Peekable, str, str::FromStr};
 
+pub use monty_types::FormatFloat;
+
 use crate::{
+    ResourceTracker,
     bytecode::VM,
     defer_drop,
     exception_private::{ExcType, RunError, SimpleException},
     expressions::ExprLoc,
     heap::HeapData,
     intern::StringId,
-    resource::{ResourceTracker, check_repeat_size},
+    resource_checks::check_repeat_size,
     types::{LongInt, PyTrait, Type, long_int::check_bits_str_digits_limit},
     value::Value,
 };
@@ -1578,125 +1581,6 @@ fn format_float_default(f: f64, spec: &ParsedFormatSpec) -> String {
     let abs_str = maybe_alternate_point(FormatFloat(abs_val).to_string(), abs_val, spec);
     let sign = numeric_sign(is_negative, &abs_str, spec);
     pad_signed_numeric(sign, "", &abs_str, spec)
-}
-
-/// A [`Display`](fmt::Display) adapter that writes a float exactly as CPython's
-/// `repr()`/`str()` (identical for floats in Python 3): the shortest decimal
-/// string that round-trips, switching to scientific notation when the base-10
-/// exponent is `< -4` or `>= 16`, and always keeping at least one fractional
-/// digit (`1.0`, never `1`) — `1e16` → `"1e+16"`, `1234.5` → `"1234.5"`,
-/// `inf`/`nan` lowercased.
-///
-/// This is the default rendering for a bare `f"{x}"`, `str(x)`, `repr(x)` and
-/// floats inside container reprs — *not* the format mini-language (that's
-/// [`format_float_g`] et al). Rust can't do this directly: its `f64` `Display`
-/// never uses scientific notation (`1e16` prints as `10000000000000000`) and
-/// renders NaN as `"NaN"`.
-///
-/// As a `Display` adapter it writes straight to the caller's sink with **no
-/// heap allocation**: it borrows Rust's *shortest-digits* guarantee via `{:e}`
-/// into a small stack buffer (an `f64` `{:e}` is ASCII and ≤ 24 bytes) and
-/// re-lays-out those digits per CPython's rules.
-pub struct FormatFloat(pub f64);
-
-impl fmt::Display for FormatFloat {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let v = self.0;
-        if v.is_nan() {
-            return f.write_str("nan");
-        }
-        if v.is_sign_negative() {
-            f.write_char('-')?;
-        }
-        if v.is_infinite() {
-            return f.write_str("inf");
-        }
-        // Rust's shortest scientific form gives minimal round-tripping digits
-        // plus the base-10 exponent (`1234.5` → `"1.2345e3"`, `0.0` → `"0e0"`),
-        // captured in a stack buffer so nothing touches the heap.
-        let mut sci = StackStr::new();
-        write!(sci, "{:e}", v.abs())?;
-        let sci = sci.as_str();
-        let (mantissa, exp_str) = sci.split_once('e').ok_or(fmt::Error)?;
-        // `{:e}` always emits a single leading digit, so the integer part is one
-        // char and the fraction (if any) follows the `.`.
-        let (int_part, frac) = mantissa.split_once('.').unwrap_or((mantissa, ""));
-        let exp10: i32 = exp_str.parse().map_err(|_| fmt::Error)?;
-        let ndigits = int_part.len() + frac.len();
-        // `decpt` = number of digits to the left of the decimal point.
-        let decpt = exp10 + 1;
-
-        if !(-4..16).contains(&exp10) {
-            // Scientific: leading digit, optional fraction, then `e±NN`.
-            f.write_str(int_part)?;
-            if !frac.is_empty() {
-                f.write_char('.')?;
-                f.write_str(frac)?;
-            }
-            let exp_sign = if exp10 < 0 { '-' } else { '+' };
-            write!(f, "e{exp_sign}{:02}", exp10.unsigned_abs())
-        } else if decpt <= 0 {
-            // `0.00…digits` — `-decpt` leading zeros after the point.
-            f.write_str("0.")?;
-            for _ in 0..-decpt {
-                f.write_char('0')?;
-            }
-            f.write_str(int_part)?;
-            f.write_str(frac)
-        } else {
-            let decpt = usize::try_from(decpt).expect("decpt is positive in this branch");
-            if decpt >= ndigits {
-                // Integer-valued: digits, zeros up to the point, then `.0`.
-                f.write_str(int_part)?;
-                f.write_str(frac)?;
-                for _ in 0..decpt - ndigits {
-                    f.write_char('0')?;
-                }
-                f.write_str(".0")
-            } else {
-                // Point falls inside the digit run. `int_part` is a single digit
-                // and `decpt >= 1`, so the split always lands within `frac`.
-                f.write_str(int_part)?;
-                let split = decpt - int_part.len();
-                f.write_str(&frac[..split])?;
-                f.write_char('.')?;
-                f.write_str(&frac[split..])
-            }
-        }
-    }
-}
-
-/// A fixed-capacity [`fmt::Write`] sink backed by a stack array, used to capture
-/// a bounded `{:e}` rendering without a heap allocation.
-///
-/// 32 bytes comfortably holds any `f64` `{:e}` output (the longest is ~24 ASCII
-/// bytes, e.g. `2.2250738585072014e-308`). A write that would overflow returns
-/// [`fmt::Error`] rather than panicking — unreachable for the bounded `f64`
-/// case, but it keeps the type panic-free for any future caller.
-struct StackStr {
-    buf: [u8; 32],
-    len: usize,
-}
-
-impl StackStr {
-    fn new() -> Self {
-        Self { buf: [0; 32], len: 0 }
-    }
-
-    fn as_str(&self) -> &str {
-        // Only `{:e}` of an `f64` is written here, which is always valid ASCII.
-        str::from_utf8(&self.buf[..self.len]).unwrap_or("")
-    }
-}
-
-impl fmt::Write for StackStr {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        let end = self.len.checked_add(s.len()).ok_or(fmt::Error)?;
-        let slot = self.buf.get_mut(self.len..end).ok_or(fmt::Error)?;
-        slot.copy_from_slice(s.as_bytes());
-        self.len = end;
-        Ok(())
-    }
 }
 
 /// Applies ASCII conversion to a string (escapes non-ASCII characters).

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -7,6 +7,7 @@ use std::{
     ptr::{self, NonNull},
 };
 
+use monty_types::{ResourceError, ResourceTracker};
 use serde::ser::SerializeStruct;
 
 // Re-export items moved to `heap_traits` so that `crate::heap::DropGuard` etc. continue
@@ -14,7 +15,6 @@ use serde::ser::SerializeStruct;
 pub(crate) use crate::heap_data::HeapData;
 pub(crate) use crate::heap_traits::{ContainsHeap, DropGuard, DropWithContext, HeapItem};
 use crate::{
-    ResourceError, ResourceTracker,
     asyncio::{Awaiter, Coroutine, ExternalFuture, ExternalFutureState, GatherFuture, GatherState},
     exception_private::SimpleException,
     heap_data::{CellValue, Closure, FunctionDefaults},
@@ -392,7 +392,7 @@ macro_rules! heap_read_ref_as_field {
         let offset = std::mem::offset_of!($ty, $field);
         #[expect(unreachable_code)]
         let type_hint = |read: &$crate::heap::HeapRead<'_, $ty>| {
-            &raw const read.get::<$crate::NoLimitTracker>(unreachable!()).$field
+            &raw const read.get::<::monty_types::NoLimitTracker>(unreachable!()).$field
         };
         // SAFETY: (DH)
         //  - `std::mem::offset_of!` guarantees there is a field at fixed offset
@@ -439,7 +439,7 @@ macro_rules! heap_read_ref_as_field_mut {
         let offset = std::mem::offset_of!($ty, $field);
         #[expect(unreachable_code)]
         let type_hint = |read: &$crate::heap::HeapRead<'_, $ty>| {
-            &raw const read.get::<$crate::NoLimitTracker>(unreachable!()).$field
+            &raw const read.get::<::monty_types::NoLimitTracker>(unreachable!()).$field
         };
         // SAFETY: (DH)
         //  - `std::mem::offset_of!` guarantees there is a field at fixed offset
@@ -1775,9 +1775,10 @@ mod heap_reader_compile_fail_cases;
 /// mark–sweep collector.
 #[cfg(test)]
 mod tests {
+    use monty_types::NoLimitTracker;
+
     use super::*;
     use crate::{
-        NoLimitTracker,
         types::{List, callable_iterator::CallableIterator},
         value::Value,
     };

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -14,10 +14,10 @@ use serde::ser::SerializeStruct;
 pub(crate) use crate::heap_data::HeapData;
 pub(crate) use crate::heap_traits::{ContainsHeap, DropGuard, DropWithContext, HeapItem};
 use crate::{
+    ResourceError, ResourceTracker,
     asyncio::{Awaiter, Coroutine, ExternalFuture, ExternalFutureState, GatherFuture, GatherState},
     exception_private::SimpleException,
     heap_data::{CellValue, Closure, FunctionDefaults},
-    resource::{ResourceError, ResourceTracker},
     types::{
         BoundMethod, Bytes, Class, Dataclass, Dict, DictItemsView, DictKeysView, DictValuesView, FrozenSet, Instance,
         List, LongInt, Module, MontyIter, NamedTuple, OpenFile, Path, Range, ReMatch, RePattern, Set, Slice, Str,
@@ -1777,7 +1777,7 @@ mod heap_reader_compile_fail_cases;
 mod tests {
     use super::*;
     use crate::{
-        resource::NoLimitTracker,
+        NoLimitTracker,
         types::{List, callable_iterator::CallableIterator},
         value::Value,
     };

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -6,10 +6,10 @@ use std::{
     ops::Deref,
 };
 
+use monty_types::{ExcType, ResourceError, ResourceTracker};
 use num_integer::Integer;
 
 use crate::{
-    ExcType, ResourceTracker,
     args::ArgValues,
     asyncio::{Awaiter, Coroutine, ExternalFuture, ExternalFutureState, GatherFuture, GatherState, awaited_state_size},
     bytecode::{CallResult, VM},
@@ -906,11 +906,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         }
     }
 
-    fn py_add(
-        &self,
-        other: &Self,
-        vm: &mut VM<'h, impl ResourceTracker>,
-    ) -> Result<Option<Value>, crate::ResourceError> {
+    fn py_add(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Value>, ResourceError> {
         match (self, other) {
             (HeapReadOutput::Str(a), HeapReadOutput::Str(b)) => Ok(Some(concat_allocate_str(
                 a.get(vm.heap).as_str(),
@@ -957,11 +953,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         }
     }
 
-    fn py_sub(
-        &self,
-        other: &Self,
-        vm: &mut VM<'h, impl ResourceTracker>,
-    ) -> Result<Option<Value>, crate::ResourceError> {
+    fn py_sub(&self, other: &Self, vm: &mut VM<'h, impl ResourceTracker>) -> Result<Option<Value>, ResourceError> {
         match (self, other) {
             (HeapReadOutput::LongInt(a), HeapReadOutput::LongInt(b)) => {
                 let bi = a.get(vm.heap).inner() - b.get(vm.heap).inner();
@@ -1021,7 +1013,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         other: &Value,
         vm: &mut VM<'h, impl ResourceTracker>,
         self_id: Option<HeapId>,
-    ) -> Result<bool, crate::ResourceError> {
+    ) -> Result<bool, ResourceError> {
         match self {
             HeapReadOutput::List(list) => list.py_iadd(other, vm, self_id),
             _ => Ok(false),

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -13,7 +13,7 @@ use crate::{
     args::ArgValues,
     asyncio::{Awaiter, Coroutine, ExternalFuture, ExternalFutureState, GatherFuture, GatherState, awaited_state_size},
     bytecode::{CallResult, VM},
-    exception_private::{RunError, RunResult, SimpleException},
+    exception_private::{ExcTypeExt, RunError, RunResult, SimpleException},
     hash::{HashValue, hash_python_str, identity_hash},
     heap::{DropWithContext, HeapId, HeapItem, HeapReadOutput},
     intern::FunctionId,

--- a/crates/monty/src/heap_traits.rs
+++ b/crates/monty/src/heap_traits.rs
@@ -4,10 +4,10 @@ use std::{
     vec::{Drain, IntoIter},
 };
 
+use monty_types::ResourceTracker;
 use smallvec::SmallVec;
 
 use crate::{
-    ResourceTracker,
     heap::{Heap, HeapId},
     value::Value,
 };

--- a/crates/monty/src/identity.rs
+++ b/crates/monty/src/identity.rs
@@ -9,11 +9,11 @@ use serde::Serialize;
 use smallvec::SmallVec;
 
 use crate::{
+    ResourceError, ResourceTracker,
     builtins::Builtins,
     bytecode::VM,
     heap::{Heap, HeapData},
     modules::ModuleFunctions,
-    resource::{ResourceError, ResourceTracker},
     types::{LongInt, Property},
     value::{Marker, Value},
 };

--- a/crates/monty/src/identity.rs
+++ b/crates/monty/src/identity.rs
@@ -4,12 +4,12 @@
 //! must distinguish every identity category. Compact identities remain inline
 //! Python integers; only encodings outside `i64` require a heap `LongInt`.
 
+use monty_types::{ResourceError, ResourceTracker};
 use num_bigint::{BigInt, Sign};
 use serde::Serialize;
 use smallvec::SmallVec;
 
 use crate::{
-    ResourceError, ResourceTracker,
     builtins::Builtins,
     bytecode::VM,
     heap::{Heap, HeapData},

--- a/crates/monty/src/lib.rs
+++ b/crates/monty/src/lib.rs
@@ -9,7 +9,6 @@ mod builtins;
 mod bytecode;
 mod codecs;
 mod exception_private;
-mod exception_public;
 mod expressions;
 mod fstring;
 mod function;
@@ -17,50 +16,40 @@ mod hash;
 mod heap_data;
 mod identity;
 mod intern;
-mod io;
 mod modules;
 mod name_map;
 mod namespace;
-mod object;
-mod os;
+mod object_bridge;
+mod os_dispatch;
 mod parse;
 mod prepare;
 mod repl;
-mod resource;
+mod resource_checks;
 mod run;
 mod run_progress;
 mod sorting;
+mod source_map;
 mod string_builder;
 mod types;
 mod value;
 
+pub use monty_types::{
+    AssertMessageAnnotations, CodeLoc, CompileOptions, DEFAULT_MAX_RECURSION_DEPTH, DictPairs, ExcData, ExcType,
+    ExtFunctionResult, FileMode, GetenvArgs, InvalidInputError, JsonErrorData, LimitedTracker, MkdirCallArgs,
+    MontyDate, MontyDateTime, MontyException, MontyFileHandle, MontyObject, MontyPath, MontyTimeDelta, MontyTimeZone,
+    MontyType, NameLookupResult, NoLimitTracker, OpenCallArgs, OsFunctionCall, PathBytesDataArgs, PathStringDataArgs,
+    PrintStream, PrintWriter, PrintWriterCallback, RenameCallArgs, ResourceError, ResourceLimits, ResourceTracker,
+    StackFrame, StringRepr, UnicodeErrorData, UnicodeErrorObject, dir_stat, file_stat, stat_result, symlink_stat,
+    unicode_decode_error_msg, utf8_error_reason,
+};
+
 #[cfg(feature = "ref-count-return")]
 pub use crate::run::RefCountOutput;
 pub use crate::{
-    codecs::utf8_error_reason,
-    exception_private::{ExcType, unicode_decode_error_msg},
-    exception_public::{
-        CodeLoc, ExcData, JsonErrorData, MontyException, StackFrame, UnicodeErrorData, UnicodeErrorObject,
-    },
-    io::{PrintStream, PrintWriter, PrintWriterCallback},
-    object::{
-        DictPairs, InvalidInputError, MontyDate, MontyDateTime, MontyFileHandle, MontyObject, MontyTimeDelta,
-        MontyTimeZone, MontyType,
-    },
-    os::{
-        GetenvArgs, MkdirCallArgs, MontyPath, OpenCallArgs, OsFunctionCall, PathBytesDataArgs, PathStringDataArgs,
-        RenameCallArgs, dir_stat, file_stat, stat_result, symlink_stat,
-    },
     repl::{
         MontyRepl, ReplContinuationMode, ReplFunctionCall, ReplNameLookup, ReplOsCall, ReplProgress,
         ReplResolveFutures, ReplStartError, detect_repl_continuation_mode,
     },
-    resource::{
-        DEFAULT_MAX_RECURSION_DEPTH, LimitedTracker, NoLimitTracker, ResourceError, ResourceLimits, ResourceTracker,
-    },
-    run::{AssertMessageAnnotations, CompileOptions, MontyRun},
-    run_progress::{
-        ExtFunctionResult, FunctionCall, NameLookup, NameLookupResult, OsCall, ResolveFutures, RunProgress,
-    },
-    types::{file::FileMode, str::StringRepr},
+    run::MontyRun,
+    run_progress::{FunctionCall, NameLookup, OsCall, ResolveFutures, RunProgress},
 };

--- a/crates/monty/src/lib.rs
+++ b/crates/monty/src/lib.rs
@@ -33,16 +33,6 @@ mod string_builder;
 mod types;
 mod value;
 
-pub use monty_types::{
-    AssertMessageAnnotations, CodeLoc, CompileOptions, DEFAULT_MAX_RECURSION_DEPTH, DictPairs, ExcData, ExcType,
-    ExtFunctionResult, FileMode, GetenvArgs, InvalidInputError, JsonErrorData, LimitedTracker, MkdirCallArgs,
-    MontyDate, MontyDateTime, MontyException, MontyFileHandle, MontyObject, MontyPath, MontyTimeDelta, MontyTimeZone,
-    MontyType, NameLookupResult, NoLimitTracker, OpenCallArgs, OsFunctionCall, PathBytesDataArgs, PathStringDataArgs,
-    PrintStream, PrintWriter, PrintWriterCallback, RenameCallArgs, ResourceError, ResourceLimits, ResourceTracker,
-    StackFrame, StringRepr, UnicodeErrorData, UnicodeErrorObject, dir_stat, file_stat, stat_result, symlink_stat,
-    unicode_decode_error_msg, utf8_error_reason,
-};
-
 #[cfg(feature = "ref-count-return")]
 pub use crate::run::RefCountOutput;
 pub use crate::{

--- a/crates/monty/src/modules/asyncio.rs
+++ b/crates/monty/src/modules/asyncio.rs
@@ -8,15 +8,15 @@
 //! The host acts as the event loop - Monty yields control when tasks are blocked.
 
 use crate::{
+    ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs},
     asyncio::GatherFuture,
     bytecode::{CallResult, VM},
     defer_drop_mut,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::{Heap, HeapData, HeapId},
     intern::StaticStrings,
     modules::ModuleFunctions,
-    resource::{ResourceError, ResourceTracker},
     types::Module,
     value::Value,
 };

--- a/crates/monty/src/modules/asyncio.rs
+++ b/crates/monty/src/modules/asyncio.rs
@@ -7,8 +7,9 @@
 //! Other asyncio functions (`create_task`, `sleep`, `wait`, etc.) are not implemented.
 //! The host acts as the event loop - Monty yields control when tasks are blocked.
 
+use monty_types::{ResourceError, ResourceTracker};
+
 use crate::{
-    ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs},
     asyncio::GatherFuture,
     bytecode::{CallResult, VM},

--- a/crates/monty/src/modules/datetime.rs
+++ b/crates/monty/src/modules/datetime.rs
@@ -9,8 +9,9 @@
 //! Behavior for constructors, arithmetic, and classmethods is implemented by the
 //! corresponding runtime types.
 
+use monty_types::{ResourceError, ResourceTracker};
+
 use crate::{
-    ResourceError, ResourceTracker,
     builtins::Builtins,
     bytecode::VM,
     heap::{HeapData, HeapId},

--- a/crates/monty/src/modules/datetime.rs
+++ b/crates/monty/src/modules/datetime.rs
@@ -10,11 +10,11 @@
 //! corresponding runtime types.
 
 use crate::{
+    ResourceError, ResourceTracker,
     builtins::Builtins,
     bytecode::VM,
     heap::{HeapData, HeapId},
     intern::StaticStrings,
-    resource::{ResourceError, ResourceTracker},
     types::{Module, Type},
     value::Value,
 };

--- a/crates/monty/src/modules/gc.rs
+++ b/crates/monty/src/modules/gc.rs
@@ -13,8 +13,9 @@
 //! - `gc.disable()` / `gc.enable()` — toggle automatic collection.
 //!   Explicit `gc.collect()` calls still run while disabled.
 
+use monty_types::{ResourceError, ResourceTracker};
+
 use crate::{
-    ResourceError, ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     exception_private::RunResult,

--- a/crates/monty/src/modules/gc.rs
+++ b/crates/monty/src/modules/gc.rs
@@ -14,13 +14,13 @@
 //!   Explicit `gc.collect()` calls still run while disabled.
 
 use crate::{
+    ResourceError, ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     exception_private::RunResult,
     heap::{HeapData, HeapId},
     intern::StaticStrings,
     modules::ModuleFunctions,
-    resource::{ResourceError, ResourceTracker},
     types::Module,
     value::Value,
 };

--- a/crates/monty/src/modules/json/dump.rs
+++ b/crates/monty/src/modules/json/dump.rs
@@ -9,12 +9,12 @@ use std::{
 };
 
 use crate::{
+    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::{ContainsVM, VM},
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::{ContainsHeap, DropGuard, Heap, HeapData, HeapId, HeapRead, HeapReadOutput},
-    resource::ResourceTracker,
     sorting::{apply_permutation, sort_indices},
     types::{Dict, PyTrait, long_int::check_bigint_str_digits_limit, str::allocate_string},
     value::Value,

--- a/crates/monty/src/modules/json/dump.rs
+++ b/crates/monty/src/modules/json/dump.rs
@@ -8,8 +8,9 @@ use std::{
     fmt::{Display, Write},
 };
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::{ContainsVM, VM},
     defer_drop, defer_drop_mut,

--- a/crates/monty/src/modules/json/load.rs
+++ b/crates/monty/src/modules/json/load.rs
@@ -9,11 +9,11 @@ use jiter::{Jiter, JiterError, JiterErrorType, JsonErrorType, NumberAny, NumberI
 
 use super::JsonStringCache;
 use crate::{
+    ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
-    exception_private::{ExcType, RunError, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
     heap::{ContainsHeap, DropGuard, HeapData, HeapReader},
-    resource::{ResourceError, ResourceTracker},
     types::{
         Dict, List, LongInt,
         long_int::{check_decimal_digit_count, decimal_digit_count_ascii},

--- a/crates/monty/src/modules/json/load.rs
+++ b/crates/monty/src/modules/json/load.rs
@@ -6,10 +6,10 @@
 use std::{borrow::Cow, mem};
 
 use jiter::{Jiter, JiterError, JiterErrorType, JsonErrorType, NumberAny, NumberInt, Peek};
+use monty_types::{ResourceError, ResourceTracker};
 
 use super::JsonStringCache;
 use crate::{
-    ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult},

--- a/crates/monty/src/modules/json/mod.rs
+++ b/crates/monty/src/modules/json/mod.rs
@@ -14,11 +14,11 @@ mod dump;
 mod load;
 mod string_cache;
 
+use monty_types::{ResourceError, ResourceTracker};
 pub(crate) use string_cache::JsonStringCache;
 
 use super::ModuleFunctions;
 use crate::{
-    ResourceError, ResourceTracker,
     args::ArgValues,
     builtins::Builtins,
     bytecode::VM,

--- a/crates/monty/src/modules/json/mod.rs
+++ b/crates/monty/src/modules/json/mod.rs
@@ -18,13 +18,13 @@ pub(crate) use string_cache::JsonStringCache;
 
 use super::ModuleFunctions;
 use crate::{
+    ResourceError, ResourceTracker,
     args::ArgValues,
     builtins::Builtins,
     bytecode::VM,
     exception_private::{ExcType, RunResult},
     heap::{HeapData, HeapId},
     intern::StaticStrings,
-    resource::{ResourceError, ResourceTracker},
     types::Module,
     value::Value,
 };

--- a/crates/monty/src/modules/json/string_cache.rs
+++ b/crates/monty/src/modules/json/string_cache.rs
@@ -21,8 +21,8 @@ use std::iter;
 use ahash::RandomState;
 
 use crate::{
+    ResourceError, ResourceTracker,
     heap::{ContainsHeap, HeapReader},
-    resource::{ResourceError, ResourceTracker},
     types::str::{allocate_string, allocate_string_no_interning},
     value::Value,
 };

--- a/crates/monty/src/modules/json/string_cache.rs
+++ b/crates/monty/src/modules/json/string_cache.rs
@@ -19,9 +19,9 @@
 use std::iter;
 
 use ahash::RandomState;
+use monty_types::{ResourceError, ResourceTracker};
 
 use crate::{
-    ResourceError, ResourceTracker,
     heap::{ContainsHeap, HeapReader},
     types::str::{allocate_string, allocate_string_no_interning},
     value::Value,

--- a/crates/monty/src/modules/math.rs
+++ b/crates/monty/src/modules/math.rs
@@ -24,11 +24,11 @@
 
 use std::f64::consts;
 
+use monty_types::{ResourceError, ResourceTracker};
 use num_bigint::BigInt;
 use smallvec::smallvec;
 
 use crate::{
-    ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop, defer_drop_mut,

--- a/crates/monty/src/modules/math.rs
+++ b/crates/monty/src/modules/math.rs
@@ -28,14 +28,14 @@ use num_bigint::BigInt;
 use smallvec::smallvec;
 
 use crate::{
+    ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, RunError, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     heap::{Heap, HeapData, HeapId},
     intern::StaticStrings,
     modules::ModuleFunctions,
-    resource::{ResourceError, ResourceTracker},
     types::{LongInt, Module, allocate_tuple},
     value::Value,
 };

--- a/crates/monty/src/modules/mod.rs
+++ b/crates/monty/src/modules/mod.rs
@@ -8,12 +8,12 @@ use std::fmt::{self, Write};
 use strum::FromRepr;
 
 use crate::{
+    ResourceError, ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     exception_private::RunResult,
     heap::HeapId,
     intern::{StaticStrings, StringId},
-    resource::{ResourceError, ResourceTracker},
 };
 
 pub(crate) mod asyncio;

--- a/crates/monty/src/modules/mod.rs
+++ b/crates/monty/src/modules/mod.rs
@@ -5,10 +5,10 @@
 
 use std::fmt::{self, Write};
 
+use monty_types::{ResourceError, ResourceTracker};
 use strum::FromRepr;
 
 use crate::{
-    ResourceError, ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     exception_private::RunResult,

--- a/crates/monty/src/modules/os.rs
+++ b/crates/monty/src/modules/os.rs
@@ -9,15 +9,14 @@
 //! which executes the operation and returns the result.
 
 use crate::{
-    MontyObject,
+    GetenvArgs, MontyObject, OsFunctionCall, ResourceError, ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::{HeapData, HeapId},
     intern::StaticStrings,
     modules::ModuleFunctions,
-    os::{GetenvArgs, OsFunctionCall},
-    resource::{ResourceError, ResourceTracker},
+    object_bridge::MontyObjectExt,
     types::{Module, Property, property::ZeroArgOsProperty},
     value::Value,
 };

--- a/crates/monty/src/modules/os.rs
+++ b/crates/monty/src/modules/os.rs
@@ -8,8 +8,9 @@
 //! via the `OsFunction` callback mechanism - Monty yields control to the host
 //! which executes the operation and returns the result.
 
+use monty_types::{GetenvArgs, MontyObject, OsFunctionCall, ResourceError, ResourceTracker};
+
 use crate::{
-    GetenvArgs, MontyObject, OsFunctionCall, ResourceError, ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     exception_private::{ExcType, ExcTypeExt, RunResult},

--- a/crates/monty/src/modules/pathlib.rs
+++ b/crates/monty/src/modules/pathlib.rs
@@ -7,11 +7,11 @@
 //! filesystem methods (require I/O, yield external function calls for host resolution).
 
 use crate::{
+    ResourceError, ResourceTracker,
     builtins::Builtins,
     bytecode::VM,
     heap::{HeapData, HeapId},
     intern::StaticStrings,
-    resource::{ResourceError, ResourceTracker},
     types::{Module, Type},
     value::Value,
 };

--- a/crates/monty/src/modules/pathlib.rs
+++ b/crates/monty/src/modules/pathlib.rs
@@ -6,8 +6,9 @@
 //! The `Path` class supports both pure methods (no I/O, handled directly) and
 //! filesystem methods (require I/O, yield external function calls for host resolution).
 
+use monty_types::{ResourceError, ResourceTracker};
+
 use crate::{
-    ResourceError, ResourceTracker,
     builtins::Builtins,
     bytecode::VM,
     heap::{HeapData, HeapId},

--- a/crates/monty/src/modules/re.rs
+++ b/crates/monty/src/modules/re.rs
@@ -35,15 +35,15 @@ use std::rc::Rc;
 use ahash::RandomState;
 
 use crate::{
+    ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs},
     builtins::Builtins,
     bytecode::{CallResult, VM},
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::{ContainsHeap, DropWithContext, Heap, HeapData, HeapId},
     intern::StaticStrings,
     modules::ModuleFunctions,
-    resource::{ResourceError, ResourceTracker},
     types::{
         BoundedCompileError, Module, RePattern, Type,
         re_pattern::{extract_count, extract_maxsplit},

--- a/crates/monty/src/modules/re.rs
+++ b/crates/monty/src/modules/re.rs
@@ -33,9 +33,9 @@
 use std::rc::Rc;
 
 use ahash::RandomState;
+use monty_types::{ResourceError, ResourceTracker};
 
 use crate::{
-    ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs},
     builtins::Builtins,
     bytecode::{CallResult, VM},

--- a/crates/monty/src/modules/sys.rs
+++ b/crates/monty/src/modules/sys.rs
@@ -12,19 +12,19 @@
 //!   can simulate Monty's lower default depth on CPython too. Only allows
 //!   *lowering* the host-configured ceiling — see [`SysFunctions`].
 
-#[cfg(feature = "test-hooks")]
 use crate::{
-    args::ArgValues,
-    exception_private::{ExcType, RunResult},
-    modules::ModuleFunctions,
-};
-use crate::{
+    ResourceError, ResourceTracker,
     bytecode::VM,
     heap::{HeapData, HeapId},
     intern::StaticStrings,
-    resource::{ResourceError, ResourceTracker},
     types::{Module, NamedTuple},
     value::{Marker, Value},
+};
+#[cfg(feature = "test-hooks")]
+use crate::{
+    args::ArgValues,
+    exception_private::{ExcType, ExcTypeExt, RunResult},
+    modules::ModuleFunctions,
 };
 
 /// Functions exposed by the `sys` module under the `test-hooks` feature.

--- a/crates/monty/src/modules/sys.rs
+++ b/crates/monty/src/modules/sys.rs
@@ -12,19 +12,20 @@
 //!   can simulate Monty's lower default depth on CPython too. Only allows
 //!   *lowering* the host-configured ceiling — see [`SysFunctions`].
 
-use crate::{
-    ResourceError, ResourceTracker,
-    bytecode::VM,
-    heap::{HeapData, HeapId},
-    intern::StaticStrings,
-    types::{Module, NamedTuple},
-    value::{Marker, Value},
-};
+use monty_types::{ResourceError, ResourceTracker};
+
 #[cfg(feature = "test-hooks")]
 use crate::{
     args::ArgValues,
     exception_private::{ExcType, ExcTypeExt, RunResult},
     modules::ModuleFunctions,
+};
+use crate::{
+    bytecode::VM,
+    heap::{HeapData, HeapId},
+    intern::StaticStrings,
+    types::{Module, NamedTuple},
+    value::{Marker, Value},
 };
 
 /// Functions exposed by the `sys` module under the `test-hooks` feature.

--- a/crates/monty/src/modules/typing.rs
+++ b/crates/monty/src/modules/typing.rs
@@ -7,8 +7,9 @@
 //! These markers exist so code that imports typing constructs works correctly,
 //! though Monty doesn't perform static type checking.
 
+use monty_types::{ResourceError, ResourceTracker};
+
 use crate::{
-    ResourceError, ResourceTracker,
     bytecode::VM,
     heap::{HeapData, HeapId},
     intern::StaticStrings,

--- a/crates/monty/src/modules/typing.rs
+++ b/crates/monty/src/modules/typing.rs
@@ -8,10 +8,10 @@
 //! though Monty doesn't perform static type checking.
 
 use crate::{
+    ResourceError, ResourceTracker,
     bytecode::VM,
     heap::{HeapData, HeapId},
     intern::StaticStrings,
-    resource::{ResourceError, ResourceTracker},
     types::Module,
     value::{Marker, Value},
 };

--- a/crates/monty/src/modules/unicodedata.rs
+++ b/crates/monty/src/modules/unicodedata.rs
@@ -24,11 +24,11 @@
 //! they return `Value` directly (wrapped in `CallResult::Value` by the dispatch
 //! in [`super`]).
 
+use monty_types::{ResourceError, ResourceTracker};
 use unicode_general_category::{GeneralCategory, get_general_category};
 use unicode_normalization::{UnicodeNormalization, char::canonical_combining_class};
 
 use crate::{
-    ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs, StrArg},
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/modules/unicodedata.rs
+++ b/crates/monty/src/modules/unicodedata.rs
@@ -28,14 +28,14 @@ use unicode_general_category::{GeneralCategory, get_general_category};
 use unicode_normalization::{UnicodeNormalization, char::canonical_combining_class};
 
 use crate::{
+    ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs, StrArg},
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
     heap::{Heap, HeapData, HeapId},
     intern::StaticStrings,
     modules::ModuleFunctions,
-    resource::{ResourceError, ResourceTracker},
     string_builder::StringBuilder,
     types::{Module, str::allocate_string},
     value::Value,

--- a/crates/monty/src/object_bridge.rs
+++ b/crates/monty/src/object_bridge.rs
@@ -30,139 +30,6 @@ use crate::{
     value::{EitherStr, Value},
 };
 
-/// Crate-internal bridge between [`MontyType`] and the runtime [`Type`].
-///
-/// `MontyType` lives in `monty-types` (it is pure data), but mapping it to and
-/// from the runtime `Type` needs heap/intern access, so the conversions stay
-/// here as a `pub(crate)` extension trait.
-pub(crate) trait MontyTypeExt: Sized {
-    fn to_internal(&self) -> Option<Type>;
-
-    fn from_internal_static(ty: Type) -> Self;
-
-    fn from_internal(ty: Type, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> Self;
-}
-
-impl MontyTypeExt for MontyType {
-    /// The internal runtime [`Type`] this variant mirrors, or `None` for
-    /// [`Instance`](Self::Instance) — a class binding cannot be reconstructed
-    /// from a name, which is exactly why `Instance` inputs are rejected.
-    ///
-    /// Keep in lockstep with [`from_internal_static`](Self::from_internal_static);
-    /// both matches are exhaustive so the compiler enforces totality.
-    fn to_internal(&self) -> Option<Type> {
-        match self {
-            Self::Ellipsis => Some(Type::Ellipsis),
-            Self::Type => Some(Type::Type),
-            Self::NoneType => Some(Type::NoneType),
-            Self::Bool => Some(Type::Bool),
-            Self::Int => Some(Type::Int),
-            Self::Float => Some(Type::Float),
-            Self::Range => Some(Type::Range),
-            Self::Slice => Some(Type::Slice),
-            Self::Date => Some(Type::Date),
-            Self::DateTime => Some(Type::DateTime),
-            Self::TimeDelta => Some(Type::TimeDelta),
-            Self::TimeZone => Some(Type::TimeZone),
-            Self::Str => Some(Type::Str),
-            Self::Bytes => Some(Type::Bytes),
-            Self::List => Some(Type::List),
-            Self::ListIterator => Some(Type::ListIterator),
-            Self::CallableIterator => Some(Type::CallableIterator),
-            Self::Tuple => Some(Type::Tuple),
-            Self::NamedTuple => Some(Type::NamedTuple),
-            Self::Dict => Some(Type::Dict),
-            Self::DictKeys => Some(Type::DictKeys),
-            Self::DictItems => Some(Type::DictItems),
-            Self::DictValues => Some(Type::DictValues),
-            Self::Set => Some(Type::Set),
-            Self::FrozenSet => Some(Type::FrozenSet),
-            Self::Dataclass => Some(Type::Dataclass),
-            Self::Instance(_) => None,
-            Self::Exception(exc_type) => Some(Type::Exception(*exc_type)),
-            Self::Function => Some(Type::Function),
-            Self::BuiltinFunction => Some(Type::BuiltinFunction),
-            Self::Cell => Some(Type::Cell),
-            Self::Iterator => Some(Type::Iterator),
-            Self::Coroutine => Some(Type::Coroutine),
-            Self::Module => Some(Type::Module),
-            Self::TextIOWrapper => Some(Type::TextIOWrapper),
-            Self::BufferedReader => Some(Type::BufferedReader),
-            Self::BufferedWriter => Some(Type::BufferedWriter),
-            Self::BufferedRandom => Some(Type::BufferedRandom),
-            Self::SpecialForm => Some(Type::SpecialForm),
-            Self::Path => Some(Type::Path),
-            Self::Property => Some(Type::Property),
-            Self::RePattern => Some(Type::RePattern),
-            Self::ReMatch => Some(Type::ReMatch),
-        }
-    }
-
-    /// Mirrors a runtime [`Type`] whose class identity is NOT needed. Use
-    /// [`from_internal`](Self::from_internal) when a heap is available.
-    ///
-    /// # Panics
-    /// On `Instance`, whose class name cannot be resolved without a heap; it
-    /// is unreachable on every current call path (`Builtins::Type` and
-    /// `from_type_name` never hold/produce it).
-    fn from_internal_static(ty: Type) -> Self {
-        match ty {
-            Type::Ellipsis => Self::Ellipsis,
-            Type::Type => Self::Type,
-            Type::NoneType => Self::NoneType,
-            Type::Bool => Self::Bool,
-            Type::Int => Self::Int,
-            Type::Float => Self::Float,
-            Type::Range => Self::Range,
-            Type::Slice => Self::Slice,
-            Type::Date => Self::Date,
-            Type::DateTime => Self::DateTime,
-            Type::TimeDelta => Self::TimeDelta,
-            Type::TimeZone => Self::TimeZone,
-            Type::Str => Self::Str,
-            Type::Bytes => Self::Bytes,
-            Type::List => Self::List,
-            Type::ListIterator => Self::ListIterator,
-            Type::CallableIterator => Self::CallableIterator,
-            Type::Tuple => Self::Tuple,
-            Type::NamedTuple => Self::NamedTuple,
-            Type::Dict => Self::Dict,
-            Type::DictKeys => Self::DictKeys,
-            Type::DictItems => Self::DictItems,
-            Type::DictValues => Self::DictValues,
-            Type::Set => Self::Set,
-            Type::FrozenSet => Self::FrozenSet,
-            Type::Dataclass => Self::Dataclass,
-            Type::Instance(_) => unreachable!("Type::Instance requires heap access — use MontyType::from_internal"),
-            Type::Exception(exc_type) => Self::Exception(exc_type),
-            Type::Function => Self::Function,
-            Type::BuiltinFunction => Self::BuiltinFunction,
-            Type::Cell => Self::Cell,
-            Type::Iterator => Self::Iterator,
-            Type::Coroutine => Self::Coroutine,
-            Type::Module => Self::Module,
-            Type::TextIOWrapper => Self::TextIOWrapper,
-            Type::BufferedReader => Self::BufferedReader,
-            Type::BufferedWriter => Self::BufferedWriter,
-            Type::BufferedRandom => Self::BufferedRandom,
-            Type::SpecialForm => Self::SpecialForm,
-            Type::Path => Self::Path,
-            Type::Property => Self::Property,
-            Type::RePattern => Self::RePattern,
-            Type::ReMatch => Self::ReMatch,
-        }
-    }
-
-    /// The total mirror of a runtime [`Type`]: `Instance` resolves its class
-    /// name via the heap.
-    fn from_internal(ty: Type, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> Self {
-        match ty {
-            Type::Instance(class_id) => Self::Instance(class_name(class_id, heap, interns).into_owned()),
-            other => Self::from_internal_static(other),
-        }
-    }
-}
-
 /// Crate-internal conversions between [`MontyObject`] and the VM's `Value`.
 ///
 /// `MontyObject` lives in `monty-types`; building one from a heap `Value` (and
@@ -675,6 +542,139 @@ impl MontyObjectExt for MontyObject {
             #[cfg(feature = "memory-model-checks")]
             Value::Dereferenced => panic!("Dereferenced found while converting to MontyObject"),
             _ => repr_or_error(object, vm),
+        }
+    }
+}
+
+/// Crate-internal bridge between [`MontyType`] and the runtime [`Type`].
+///
+/// `MontyType` lives in `monty-types` (it is pure data), but mapping it to and
+/// from the runtime `Type` needs heap/intern access, so the conversions stay
+/// here as a `pub(crate)` extension trait.
+pub(crate) trait MontyTypeExt: Sized {
+    fn to_internal(&self) -> Option<Type>;
+
+    fn from_internal_static(ty: Type) -> Self;
+
+    fn from_internal(ty: Type, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> Self;
+}
+
+impl MontyTypeExt for MontyType {
+    /// The internal runtime [`Type`] this variant mirrors, or `None` for
+    /// [`Instance`](Self::Instance) — a class binding cannot be reconstructed
+    /// from a name, which is exactly why `Instance` inputs are rejected.
+    ///
+    /// Keep in lockstep with [`from_internal_static`](Self::from_internal_static);
+    /// both matches are exhaustive so the compiler enforces totality.
+    fn to_internal(&self) -> Option<Type> {
+        match self {
+            Self::Ellipsis => Some(Type::Ellipsis),
+            Self::Type => Some(Type::Type),
+            Self::NoneType => Some(Type::NoneType),
+            Self::Bool => Some(Type::Bool),
+            Self::Int => Some(Type::Int),
+            Self::Float => Some(Type::Float),
+            Self::Range => Some(Type::Range),
+            Self::Slice => Some(Type::Slice),
+            Self::Date => Some(Type::Date),
+            Self::DateTime => Some(Type::DateTime),
+            Self::TimeDelta => Some(Type::TimeDelta),
+            Self::TimeZone => Some(Type::TimeZone),
+            Self::Str => Some(Type::Str),
+            Self::Bytes => Some(Type::Bytes),
+            Self::List => Some(Type::List),
+            Self::ListIterator => Some(Type::ListIterator),
+            Self::CallableIterator => Some(Type::CallableIterator),
+            Self::Tuple => Some(Type::Tuple),
+            Self::NamedTuple => Some(Type::NamedTuple),
+            Self::Dict => Some(Type::Dict),
+            Self::DictKeys => Some(Type::DictKeys),
+            Self::DictItems => Some(Type::DictItems),
+            Self::DictValues => Some(Type::DictValues),
+            Self::Set => Some(Type::Set),
+            Self::FrozenSet => Some(Type::FrozenSet),
+            Self::Dataclass => Some(Type::Dataclass),
+            Self::Instance(_) => None,
+            Self::Exception(exc_type) => Some(Type::Exception(*exc_type)),
+            Self::Function => Some(Type::Function),
+            Self::BuiltinFunction => Some(Type::BuiltinFunction),
+            Self::Cell => Some(Type::Cell),
+            Self::Iterator => Some(Type::Iterator),
+            Self::Coroutine => Some(Type::Coroutine),
+            Self::Module => Some(Type::Module),
+            Self::TextIOWrapper => Some(Type::TextIOWrapper),
+            Self::BufferedReader => Some(Type::BufferedReader),
+            Self::BufferedWriter => Some(Type::BufferedWriter),
+            Self::BufferedRandom => Some(Type::BufferedRandom),
+            Self::SpecialForm => Some(Type::SpecialForm),
+            Self::Path => Some(Type::Path),
+            Self::Property => Some(Type::Property),
+            Self::RePattern => Some(Type::RePattern),
+            Self::ReMatch => Some(Type::ReMatch),
+        }
+    }
+
+    /// Mirrors a runtime [`Type`] whose class identity is NOT needed. Use
+    /// [`from_internal`](Self::from_internal) when a heap is available.
+    ///
+    /// # Panics
+    /// On `Instance`, whose class name cannot be resolved without a heap; it
+    /// is unreachable on every current call path (`Builtins::Type` and
+    /// `from_type_name` never hold/produce it).
+    fn from_internal_static(ty: Type) -> Self {
+        match ty {
+            Type::Ellipsis => Self::Ellipsis,
+            Type::Type => Self::Type,
+            Type::NoneType => Self::NoneType,
+            Type::Bool => Self::Bool,
+            Type::Int => Self::Int,
+            Type::Float => Self::Float,
+            Type::Range => Self::Range,
+            Type::Slice => Self::Slice,
+            Type::Date => Self::Date,
+            Type::DateTime => Self::DateTime,
+            Type::TimeDelta => Self::TimeDelta,
+            Type::TimeZone => Self::TimeZone,
+            Type::Str => Self::Str,
+            Type::Bytes => Self::Bytes,
+            Type::List => Self::List,
+            Type::ListIterator => Self::ListIterator,
+            Type::CallableIterator => Self::CallableIterator,
+            Type::Tuple => Self::Tuple,
+            Type::NamedTuple => Self::NamedTuple,
+            Type::Dict => Self::Dict,
+            Type::DictKeys => Self::DictKeys,
+            Type::DictItems => Self::DictItems,
+            Type::DictValues => Self::DictValues,
+            Type::Set => Self::Set,
+            Type::FrozenSet => Self::FrozenSet,
+            Type::Dataclass => Self::Dataclass,
+            Type::Instance(_) => unreachable!("Type::Instance requires heap access — use MontyType::from_internal"),
+            Type::Exception(exc_type) => Self::Exception(exc_type),
+            Type::Function => Self::Function,
+            Type::BuiltinFunction => Self::BuiltinFunction,
+            Type::Cell => Self::Cell,
+            Type::Iterator => Self::Iterator,
+            Type::Coroutine => Self::Coroutine,
+            Type::Module => Self::Module,
+            Type::TextIOWrapper => Self::TextIOWrapper,
+            Type::BufferedReader => Self::BufferedReader,
+            Type::BufferedWriter => Self::BufferedWriter,
+            Type::BufferedRandom => Self::BufferedRandom,
+            Type::SpecialForm => Self::SpecialForm,
+            Type::Path => Self::Path,
+            Type::Property => Self::Property,
+            Type::RePattern => Self::RePattern,
+            Type::ReMatch => Self::ReMatch,
+        }
+    }
+
+    /// The total mirror of a runtime [`Type`]: `Instance` resolves its class
+    /// name via the heap.
+    fn from_internal(ty: Type, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> Self {
+        match ty {
+            Type::Instance(class_id) => Self::Instance(class_name(class_id, heap, interns).into_owned()),
+            other => Self::from_internal_static(other),
         }
     }
 }

--- a/crates/monty/src/object_bridge.rs
+++ b/crates/monty/src/object_bridge.rs
@@ -1,0 +1,700 @@
+//! Interpreter-side bridge for the boundary value types in `monty-types`:
+//! conversions between [`MontyObject`]/[`MontyType`] and the VM's internal
+//! `Value`/`Type` representations. The types themselves (and their pure
+//! methods — reprs, hashing, truthiness) live in `monty-types`.
+
+use ahash::AHashSet;
+use monty_types::{
+    InvalidInputError, MontyDate, MontyDateTime, MontyFileHandle, MontyObject, MontyTimeDelta, MontyTimeZone, MontyType,
+};
+
+use crate::{
+    ResourceTracker,
+    builtins::Builtins,
+    bytecode::VM,
+    defer_drop,
+    exception_private::{RunError, SimpleException},
+    heap::{Heap, HeapData, HeapId, HeapReadOutput},
+    intern::Interns,
+    types::{
+        Dataclass, LongInt, NamedTuple, OpenFile, Path, PyTrait, TimeZone, Type, allocate_tuple,
+        bytes::Bytes,
+        date as date_type, datetime as datetime_type,
+        dict::Dict,
+        instance::class_name,
+        list::List,
+        set::{FrozenSet, Set},
+        str::allocate_string,
+        timedelta as timedelta_type,
+    },
+    value::{EitherStr, Value},
+};
+
+/// Crate-internal bridge between [`MontyType`] and the runtime [`Type`].
+///
+/// `MontyType` lives in `monty-types` (it is pure data), but mapping it to and
+/// from the runtime `Type` needs heap/intern access, so the conversions stay
+/// here as a `pub(crate)` extension trait.
+pub(crate) trait MontyTypeExt: Sized {
+    fn to_internal(&self) -> Option<Type>;
+
+    fn from_internal_static(ty: Type) -> Self;
+
+    fn from_internal(ty: Type, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> Self;
+}
+
+impl MontyTypeExt for MontyType {
+    /// The internal runtime [`Type`] this variant mirrors, or `None` for
+    /// [`Instance`](Self::Instance) — a class binding cannot be reconstructed
+    /// from a name, which is exactly why `Instance` inputs are rejected.
+    ///
+    /// Keep in lockstep with [`from_internal_static`](Self::from_internal_static);
+    /// both matches are exhaustive so the compiler enforces totality.
+    fn to_internal(&self) -> Option<Type> {
+        match self {
+            Self::Ellipsis => Some(Type::Ellipsis),
+            Self::Type => Some(Type::Type),
+            Self::NoneType => Some(Type::NoneType),
+            Self::Bool => Some(Type::Bool),
+            Self::Int => Some(Type::Int),
+            Self::Float => Some(Type::Float),
+            Self::Range => Some(Type::Range),
+            Self::Slice => Some(Type::Slice),
+            Self::Date => Some(Type::Date),
+            Self::DateTime => Some(Type::DateTime),
+            Self::TimeDelta => Some(Type::TimeDelta),
+            Self::TimeZone => Some(Type::TimeZone),
+            Self::Str => Some(Type::Str),
+            Self::Bytes => Some(Type::Bytes),
+            Self::List => Some(Type::List),
+            Self::ListIterator => Some(Type::ListIterator),
+            Self::CallableIterator => Some(Type::CallableIterator),
+            Self::Tuple => Some(Type::Tuple),
+            Self::NamedTuple => Some(Type::NamedTuple),
+            Self::Dict => Some(Type::Dict),
+            Self::DictKeys => Some(Type::DictKeys),
+            Self::DictItems => Some(Type::DictItems),
+            Self::DictValues => Some(Type::DictValues),
+            Self::Set => Some(Type::Set),
+            Self::FrozenSet => Some(Type::FrozenSet),
+            Self::Dataclass => Some(Type::Dataclass),
+            Self::Instance(_) => None,
+            Self::Exception(exc_type) => Some(Type::Exception(*exc_type)),
+            Self::Function => Some(Type::Function),
+            Self::BuiltinFunction => Some(Type::BuiltinFunction),
+            Self::Cell => Some(Type::Cell),
+            Self::Iterator => Some(Type::Iterator),
+            Self::Coroutine => Some(Type::Coroutine),
+            Self::Module => Some(Type::Module),
+            Self::TextIOWrapper => Some(Type::TextIOWrapper),
+            Self::BufferedReader => Some(Type::BufferedReader),
+            Self::BufferedWriter => Some(Type::BufferedWriter),
+            Self::BufferedRandom => Some(Type::BufferedRandom),
+            Self::SpecialForm => Some(Type::SpecialForm),
+            Self::Path => Some(Type::Path),
+            Self::Property => Some(Type::Property),
+            Self::RePattern => Some(Type::RePattern),
+            Self::ReMatch => Some(Type::ReMatch),
+        }
+    }
+
+    /// Mirrors a runtime [`Type`] whose class identity is NOT needed. Use
+    /// [`from_internal`](Self::from_internal) when a heap is available.
+    ///
+    /// # Panics
+    /// On `Instance`, whose class name cannot be resolved without a heap; it
+    /// is unreachable on every current call path (`Builtins::Type` and
+    /// `from_type_name` never hold/produce it).
+    fn from_internal_static(ty: Type) -> Self {
+        match ty {
+            Type::Ellipsis => Self::Ellipsis,
+            Type::Type => Self::Type,
+            Type::NoneType => Self::NoneType,
+            Type::Bool => Self::Bool,
+            Type::Int => Self::Int,
+            Type::Float => Self::Float,
+            Type::Range => Self::Range,
+            Type::Slice => Self::Slice,
+            Type::Date => Self::Date,
+            Type::DateTime => Self::DateTime,
+            Type::TimeDelta => Self::TimeDelta,
+            Type::TimeZone => Self::TimeZone,
+            Type::Str => Self::Str,
+            Type::Bytes => Self::Bytes,
+            Type::List => Self::List,
+            Type::ListIterator => Self::ListIterator,
+            Type::CallableIterator => Self::CallableIterator,
+            Type::Tuple => Self::Tuple,
+            Type::NamedTuple => Self::NamedTuple,
+            Type::Dict => Self::Dict,
+            Type::DictKeys => Self::DictKeys,
+            Type::DictItems => Self::DictItems,
+            Type::DictValues => Self::DictValues,
+            Type::Set => Self::Set,
+            Type::FrozenSet => Self::FrozenSet,
+            Type::Dataclass => Self::Dataclass,
+            Type::Instance(_) => unreachable!("Type::Instance requires heap access — use MontyType::from_internal"),
+            Type::Exception(exc_type) => Self::Exception(exc_type),
+            Type::Function => Self::Function,
+            Type::BuiltinFunction => Self::BuiltinFunction,
+            Type::Cell => Self::Cell,
+            Type::Iterator => Self::Iterator,
+            Type::Coroutine => Self::Coroutine,
+            Type::Module => Self::Module,
+            Type::TextIOWrapper => Self::TextIOWrapper,
+            Type::BufferedReader => Self::BufferedReader,
+            Type::BufferedWriter => Self::BufferedWriter,
+            Type::BufferedRandom => Self::BufferedRandom,
+            Type::SpecialForm => Self::SpecialForm,
+            Type::Path => Self::Path,
+            Type::Property => Self::Property,
+            Type::RePattern => Self::RePattern,
+            Type::ReMatch => Self::ReMatch,
+        }
+    }
+
+    /// The total mirror of a runtime [`Type`]: `Instance` resolves its class
+    /// name via the heap.
+    fn from_internal(ty: Type, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> Self {
+        match ty {
+            Type::Instance(class_id) => Self::Instance(class_name(class_id, heap, interns).into_owned()),
+            other => Self::from_internal_static(other),
+        }
+    }
+}
+
+/// Crate-internal conversions between [`MontyObject`] and the VM's `Value`.
+///
+/// `MontyObject` lives in `monty-types`; building one from a heap `Value` (and
+/// back) requires the VM, so the conversions stay here as a `pub(crate)`
+/// extension trait.
+pub(crate) trait MontyObjectExt: Sized {
+    /// Converts a `Value` into a `MontyObject`, properly handling reference
+    /// counting: takes ownership of the `Value` and drops it via `drop_with`.
+    fn new(value: Value, vm: &mut VM<'_, impl ResourceTracker>) -> Self;
+
+    /// Converts this `MontyObject` into a `Value`, allocating on the heap if
+    /// needed. Fails with `InvalidInputError` on output-only variants
+    /// (`Repr`, `Cycle`, sandbox class `Type`s) or when a resource limit is hit.
+    fn to_value(self, vm: &mut VM<'_, impl ResourceTracker>) -> Result<Value, InvalidInputError>;
+
+    /// Top-level entry into [`from_value_inner`](Self::from_value_inner),
+    /// allocating the visited-set used for cycle detection.
+    fn from_value(object: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> Self;
+
+    /// Converts a `Value` to a `MontyObject` with cycle detection via `visited`.
+    fn from_value_inner(object: &Value, vm: &mut VM<'_, impl ResourceTracker>, visited: &mut AHashSet<HeapId>) -> Self;
+}
+
+impl MontyObjectExt for MontyObject {
+    /// Converts a `Value` into a `MontyObject`, properly handling reference counting.
+    ///
+    /// Takes ownership of the `Value`, extracts its content to create a MontyObject,
+    /// then properly drops the Value via `drop_with` to maintain reference counting.
+    ///
+    /// The `interns` parameter is used to look up interned string/bytes content.
+    fn new(value: Value, vm: &mut VM<'_, impl ResourceTracker>) -> Self {
+        let py_obj = Self::from_value(&value, vm);
+        value.drop_with(vm);
+        py_obj
+    }
+
+    /// Converts this `MontyObject` into an `Value`, allocating on the heap if needed.
+    ///
+    /// Immediate values (None, Bool, Int, Float, Ellipsis, Exception) are created directly.
+    /// Heap-allocated values (String, Bytes, List, Tuple, Dict) are allocated
+    /// via the heap and wrapped in `Value::Ref`.
+    ///
+    /// # Errors
+    /// Returns `InvalidInputError` if called on the `Repr` variant,
+    /// as it is only valid as an output from code execution, not as an input.
+    fn to_value(self, vm: &mut VM<'_, impl ResourceTracker>) -> Result<Value, InvalidInputError> {
+        match self {
+            Self::Ellipsis => Ok(Value::Ellipsis),
+            Self::None => Ok(Value::None),
+            Self::Bool(b) => Ok(Value::Bool(b)),
+            Self::Int(i) => Ok(Value::Int(i)),
+            Self::BigInt(bi) => Ok(LongInt::new(bi).into_value(vm.heap)?),
+            Self::Float(f) => Ok(Value::Float(f)),
+            Self::String(s) => Ok(allocate_string(s, vm.heap)?),
+            Self::Bytes(b) => Ok(Value::Ref(vm.heap.allocate(HeapData::Bytes(Bytes::new(b)))?)),
+            Self::List(items) => {
+                let values: Vec<Value> = items
+                    .into_iter()
+                    .map(|item| item.to_value(vm))
+                    .collect::<Result<_, _>>()?;
+                Ok(Value::Ref(vm.heap.allocate(HeapData::List(List::new(values)))?))
+            }
+            Self::Tuple(items) => {
+                let values = items
+                    .into_iter()
+                    .map(|item| item.to_value(vm))
+                    .collect::<Result<_, _>>()?;
+                allocate_tuple(values, vm.heap).map_err(InvalidInputError::Resource)
+            }
+            Self::NamedTuple {
+                type_name,
+                field_names,
+                values,
+            } => {
+                let values: Vec<Value> = values
+                    .into_iter()
+                    .map(|item| item.to_value(vm))
+                    .collect::<Result<_, _>>()?;
+                let field_name_strs: Vec<EitherStr> = field_names.into_iter().map(Into::into).collect();
+                let nt = NamedTuple::new(type_name, field_name_strs, values);
+                Ok(Value::Ref(vm.heap.allocate(HeapData::NamedTuple(nt))?))
+            }
+            Self::Dict(map) => {
+                let pairs: Result<Vec<(Value, Value)>, InvalidInputError> = map
+                    .into_iter()
+                    .map(|(k, v)| Ok((k.to_value(vm)?, v.to_value(vm)?)))
+                    .collect();
+                let dict = Dict::from_pairs(pairs?, vm)
+                    .map_err(|_| InvalidInputError::invalid_type("unhashable dict keys"))?;
+                Ok(Value::Ref(vm.heap.allocate(HeapData::Dict(dict))?))
+            }
+            Self::Set(items) => {
+                let mut set = Set::new();
+                for item in items {
+                    let value = item.to_value(vm)?;
+                    set.add(value, vm)
+                        .map_err(|_| InvalidInputError::invalid_type("unhashable set element"))?;
+                }
+                Ok(Value::Ref(vm.heap.allocate(HeapData::Set(set))?))
+            }
+            Self::FrozenSet(items) => {
+                let mut set = Set::new();
+                for item in items {
+                    let value = item.to_value(vm)?;
+                    set.add(value, vm)
+                        .map_err(|_| InvalidInputError::invalid_type("unhashable frozenset element"))?;
+                }
+                // Convert to frozenset by extracting storage
+                let frozenset = FrozenSet::from_set(set);
+                Ok(Value::Ref(vm.heap.allocate(HeapData::FrozenSet(frozenset))?))
+            }
+            Self::Date(date) => {
+                let value = date_type::from_ymd(date.year, i32::from(date.month), i32::from(date.day))
+                    .map_err(|_| InvalidInputError::invalid_type("date"))?;
+                Ok(Value::Ref(vm.heap.allocate(HeapData::Date(value))?))
+            }
+            Self::DateTime(datetime) => {
+                let MontyDateTime {
+                    year,
+                    month,
+                    day,
+                    hour,
+                    minute,
+                    second,
+                    microsecond,
+                    offset_seconds,
+                    timezone_name,
+                } = datetime;
+                if offset_seconds.is_none() && timezone_name.is_some() {
+                    return Err(InvalidInputError::invalid_type("datetime"));
+                }
+                let tzinfo = offset_seconds
+                    .map(|offset| TimeZone::new(offset, timezone_name))
+                    .transpose()
+                    .map_err(|_| InvalidInputError::invalid_type("datetime"))?;
+                let value = datetime_type::from_components(
+                    year,
+                    i32::from(month),
+                    i32::from(day),
+                    i32::from(hour),
+                    i32::from(minute),
+                    i32::from(second),
+                    i32::try_from(microsecond).map_err(|_| InvalidInputError::invalid_type("datetime"))?,
+                    tzinfo,
+                    None,
+                    vm.heap,
+                )
+                .map_err(|_| InvalidInputError::invalid_type("datetime"))?;
+                Ok(Value::Ref(vm.heap.allocate(HeapData::DateTime(value))?))
+            }
+            Self::TimeDelta(delta) => {
+                let delta = timedelta_type::new(delta.days, delta.seconds, delta.microseconds)
+                    .map_err(|_| InvalidInputError::invalid_type("timedelta"))?;
+                Ok(Value::Ref(vm.heap.allocate(HeapData::TimeDelta(delta))?))
+            }
+            Self::TimeZone(tz) => {
+                if tz.offset_seconds == 0 && tz.name.is_none() {
+                    vm.heap
+                        .get_timezone_utc()
+                        .map_err(|_| InvalidInputError::invalid_type("timezone"))
+                } else {
+                    let tz = TimeZone::new(tz.offset_seconds, tz.name)
+                        .map_err(|_| InvalidInputError::invalid_type("timezone"))?;
+                    Ok(Value::Ref(vm.heap.allocate(HeapData::TimeZone(tz))?))
+                }
+            }
+            Self::Exception { exc_type, arg } => {
+                let exc = SimpleException::new(exc_type, arg);
+                Ok(Value::Ref(vm.heap.allocate(HeapData::Exception(exc))?))
+            }
+            Self::Dataclass {
+                name,
+                type_id,
+                field_names,
+                attrs,
+                frozen,
+            } => {
+                // Convert attrs to Dict
+                let pairs: Result<Vec<(Value, Value)>, InvalidInputError> = attrs
+                    .into_iter()
+                    .map(|(k, v)| Ok((k.to_value(vm)?, v.to_value(vm)?)))
+                    .collect();
+                let dict = Dict::from_pairs(pairs?, vm)
+                    .map_err(|_| InvalidInputError::invalid_type("unhashable dataclass attr keys"))?;
+                let dc = Dataclass::new(name, type_id, field_names, dict, frozen);
+                Ok(Value::Ref(vm.heap.allocate(HeapData::Dataclass(dc))?))
+            }
+            Self::Path(s) => Ok(Value::Ref(vm.heap.allocate(HeapData::Path(Path::new(s)))?)),
+            Self::FileHandle(handle) => {
+                let file = OpenFile::with_state(handle.path, handle.mode, handle.position);
+                Ok(Value::Ref(vm.heap.allocate(HeapData::OpenFile(file))?))
+            }
+            Self::Type(t) => match t.to_internal() {
+                Some(ty) => Ok(Value::Builtin(Builtins::Type(ty))),
+                // `MontyType::Instance` carries only a class name — the class
+                // binding cannot be reconstructed inside the sandbox (see the
+                // invariant on the runtime `Type::Instance` variant).
+                None => Err(InvalidInputError::invalid_type(
+                    "a sandbox class type object is not a valid input value",
+                )),
+            },
+            Self::BuiltinFunction(f) => Ok(Value::Builtin(Builtins::Function(f))),
+            Self::Function { name, .. } => {
+                // Try to intern the function name. If the name is already interned
+                // (common case: the function has the same name as the variable it was
+                // assigned to), use the lightweight `Value::ExtFunction(StringId)`.
+                // Otherwise, allocate a `HeapData::ExtFunction(String)` on the heap.
+                if let Some(string_id) = vm.interns.get_string_id_by_name(&name) {
+                    Ok(Value::ExtFunction(string_id))
+                } else {
+                    Ok(Value::Ref(vm.heap.allocate(HeapData::ExtFunction(name))?))
+                }
+            }
+            Self::Repr(_) => Err(InvalidInputError::invalid_type("'Repr' is not a valid input value")),
+            Self::Cycle(_, _) => Err(InvalidInputError::invalid_type("'Cycle' is not a valid input value")),
+        }
+    }
+
+    /// Top-level entry into [`from_value_inner`], allocating the visited-set used
+    /// for cycle detection.
+    fn from_value(object: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> Self {
+        let mut visited = AHashSet::new();
+        Self::from_value_inner(object, vm, &mut visited)
+    }
+
+    /// Internal helper for converting Value to MontyObject with cycle detection.
+    ///
+    /// Non-`Ref` variants are produced inline using only the interner — they
+    /// never recurse through the heap. `Ref` variants dispatch via
+    /// `vm.heap.read(id)` so the resulting [`HeapRead`] keeps the heap entry
+    /// alive (through its reader count) without retaining a borrow on
+    /// `vm.heap`. Container children are walked via short-lived borrows that
+    /// `clone_with_heap` the next child before recursing — the `inc_ref` makes
+    /// it safe for a future user-defined `__repr__` to mutate the surrounding
+    /// container during the recursive call without freeing the value mid-format.
+    fn from_value_inner(object: &Value, vm: &mut VM<'_, impl ResourceTracker>, visited: &mut AHashSet<HeapId>) -> Self {
+        // Check depth limit before processing
+        let Ok(mut guard) = vm.recursion_guard() else {
+            return Self::Repr("<deeply nested>".to_owned());
+        };
+        let vm = &mut *guard;
+
+        let interns = vm.interns;
+        match object {
+            Value::Undefined => panic!("Undefined found while converting to MontyObject"),
+            Value::Ellipsis => Self::Ellipsis,
+            Value::None => Self::None,
+            Value::Bool(b) => Self::Bool(*b),
+            Value::Int(i) => Self::Int(*i),
+            Value::Float(f) => Self::Float(*f),
+            Value::InternString(string_id) => Self::String(interns.get_str(*string_id).to_owned()),
+            Value::InternBytes(bytes_id) => Self::Bytes(interns.get_bytes(*bytes_id).to_owned()),
+            Value::InternLongInt(li_id) => Self::BigInt(interns.get_long_int(*li_id).clone()),
+            Value::Ref(id) => {
+                // Check for cycle
+                if visited.contains(id) {
+                    // Cycle detected - return appropriate placeholder
+                    return match vm.heap.get(*id) {
+                        HeapData::List(_) => Self::Cycle(id.index(), "[...]".to_owned()),
+                        HeapData::Tuple(_) | HeapData::NamedTuple(_) => Self::Cycle(id.index(), "(...)".to_owned()),
+                        HeapData::Dict(_) => Self::Cycle(id.index(), "{...}".to_owned()),
+                        _ => Self::Cycle(id.index(), "...".to_owned()),
+                    };
+                }
+
+                // Mark this id as being visited
+                visited.insert(*id);
+
+                let result = match vm.heap.read(*id) {
+                    HeapReadOutput::Str(s) => Self::String(s.get(vm.heap).as_str().to_owned()),
+                    HeapReadOutput::Bytes(b) => Self::Bytes(b.get(vm.heap).as_slice().to_owned()),
+                    HeapReadOutput::List(list) => {
+                        let len = list.get(vm.heap).len();
+                        let mut items = Vec::with_capacity(len);
+                        for i in 0..len {
+                            let item = list.get(vm.heap).as_slice()[i].clone_with_heap(vm.heap);
+                            defer_drop!(item, vm);
+                            items.push(Self::from_value_inner(item, vm, visited));
+                        }
+                        Self::List(items)
+                    }
+                    HeapReadOutput::Tuple(tuple) => {
+                        let len = tuple.get(vm.heap).as_slice().len();
+                        let mut items = Vec::with_capacity(len);
+                        for i in 0..len {
+                            let item = tuple.get(vm.heap).as_slice()[i].clone_with_heap(vm.heap);
+                            defer_drop!(item, vm);
+                            items.push(Self::from_value_inner(item, vm, visited));
+                        }
+                        Self::Tuple(items)
+                    }
+                    HeapReadOutput::NamedTuple(nt) => {
+                        let type_name = nt.get(vm.heap).name(vm.interns).to_owned();
+                        let field_names = nt
+                            .get(vm.heap)
+                            .field_names()
+                            .iter()
+                            .map(|fname| fname.as_str(vm.interns).to_owned())
+                            .collect::<Vec<_>>();
+                        let len = nt.get(vm.heap).len();
+                        let mut values = Vec::with_capacity(len);
+                        for i in 0..len {
+                            let item = nt.get(vm.heap).as_vec()[i].clone_with_heap(vm.heap);
+                            defer_drop!(item, vm);
+                            values.push(Self::from_value_inner(item, vm, visited));
+                        }
+                        Self::NamedTuple {
+                            type_name,
+                            field_names,
+                            values,
+                        }
+                    }
+                    HeapReadOutput::Dict(dict) => {
+                        let len = dict.get(vm.heap).len();
+                        let mut pairs = Vec::with_capacity(len);
+                        for i in 0..len {
+                            let key = dict
+                                .get(vm.heap)
+                                .key_at(i)
+                                .expect("index in range")
+                                .clone_with_heap(vm.heap);
+                            defer_drop!(key, vm);
+                            let k = Self::from_value_inner(key, vm, visited);
+                            let value = dict
+                                .get(vm.heap)
+                                .value_at(i)
+                                .expect("index in range")
+                                .clone_with_heap(vm.heap);
+                            defer_drop!(value, vm);
+                            let v = Self::from_value_inner(value, vm, visited);
+                            pairs.push((k, v));
+                        }
+                        Self::Dict(pairs.into())
+                    }
+                    HeapReadOutput::Set(set) => {
+                        let len = set.get(vm.heap).len();
+                        let mut items = Vec::with_capacity(len);
+                        for i in 0..len {
+                            let item = set
+                                .get(vm.heap)
+                                .storage()
+                                .value_at(i)
+                                .expect("index in range")
+                                .clone_with_heap(vm.heap);
+                            defer_drop!(item, vm);
+                            items.push(Self::from_value_inner(item, vm, visited));
+                        }
+                        Self::Set(items)
+                    }
+                    HeapReadOutput::FrozenSet(fs) => {
+                        let len = fs.get(vm.heap).len();
+                        let mut items = Vec::with_capacity(len);
+                        for i in 0..len {
+                            let item = fs
+                                .get(vm.heap)
+                                .storage()
+                                .value_at(i)
+                                .expect("index in range")
+                                .clone_with_heap(vm.heap);
+                            defer_drop!(item, vm);
+                            items.push(Self::from_value_inner(item, vm, visited));
+                        }
+                        Self::FrozenSet(items)
+                    }
+                    // Cells are internal closure implementation details — show
+                    // the contents directly without exposing the wrapper.
+                    HeapReadOutput::Cell(cell) => {
+                        let inner = cell.get(vm.heap).0.clone_with_heap(vm.heap);
+                        defer_drop!(inner, vm);
+                        Self::from_value_inner(inner, vm, visited)
+                    }
+                    HeapReadOutput::Date(d) => {
+                        let (year, month, day) = date_type::to_ymd(*d.get(vm.heap));
+                        Self::Date(MontyDate {
+                            year,
+                            month: u8::try_from(month).expect("month is always 1..=12"),
+                            day: u8::try_from(day).expect("day is always 1..=31"),
+                        })
+                    }
+                    HeapReadOutput::DateTime(dt) => {
+                        if let Some((year, month, day, hour, minute, second, microsecond)) =
+                            datetime_type::to_components(dt.get(vm.heap))
+                        {
+                            Self::DateTime(MontyDateTime {
+                                year,
+                                month,
+                                day,
+                                hour,
+                                minute,
+                                second,
+                                microsecond,
+                                offset_seconds: datetime_type::offset_seconds(dt.get(vm.heap)),
+                                timezone_name: datetime_type::timezone_info(dt.get(vm.heap)).and_then(|tz| tz.name),
+                            })
+                        } else {
+                            repr_or_error(object, vm)
+                        }
+                    }
+                    HeapReadOutput::TimeDelta(td) => {
+                        let (days, seconds, microseconds) = timedelta_type::components(td.get(vm.heap));
+                        Self::TimeDelta(MontyTimeDelta {
+                            days,
+                            seconds,
+                            microseconds,
+                        })
+                    }
+                    HeapReadOutput::TimeZone(tz) => {
+                        let tz_ref = tz.get(vm.heap);
+                        Self::TimeZone(MontyTimeZone {
+                            offset_seconds: tz_ref.offset_seconds,
+                            name: tz_ref.name.clone(),
+                        })
+                    }
+                    HeapReadOutput::Exception(exc) => {
+                        let exc_ref = exc.get(vm.heap);
+                        Self::Exception {
+                            exc_type: exc_ref.exc_type(),
+                            arg: exc_ref.arg().map(ToString::to_string),
+                        }
+                    }
+                    HeapReadOutput::Dataclass(dc) => {
+                        let (name, type_id, field_names, frozen, attrs_len) = {
+                            let dc_ref = dc.get(vm.heap);
+                            (
+                                dc_ref.name(vm.interns).to_owned(),
+                                dc_ref.type_id(),
+                                dc_ref.field_names().to_vec(),
+                                dc_ref.is_frozen(),
+                                dc_ref.attrs().len(),
+                            )
+                        };
+                        let mut pairs = Vec::with_capacity(attrs_len);
+                        for i in 0..attrs_len {
+                            let key = dc
+                                .get(vm.heap)
+                                .attrs()
+                                .key_at(i)
+                                .expect("index in range")
+                                .clone_with_heap(vm.heap);
+                            defer_drop!(key, vm);
+                            let k = Self::from_value_inner(key, vm, visited);
+                            let value = dc
+                                .get(vm.heap)
+                                .attrs()
+                                .value_at(i)
+                                .expect("index in range")
+                                .clone_with_heap(vm.heap);
+                            defer_drop!(value, vm);
+                            let v = Self::from_value_inner(value, vm, visited);
+                            pairs.push((k, v));
+                        }
+                        Self::Dataclass {
+                            name,
+                            type_id,
+                            field_names,
+                            attrs: pairs.into(),
+                            frozen,
+                        }
+                    }
+                    // Iterators are internal objects — represent as a fixed type
+                    // string rather than recursing.
+                    HeapReadOutput::Iter(_) => Self::Repr("<iterator>".to_owned()),
+                    HeapReadOutput::LongInt(li) => Self::BigInt(li.get(vm.heap).inner().clone()),
+                    HeapReadOutput::Module(m) => {
+                        Self::Repr(format!("<module '{}'>", vm.interns.get_str(m.get(vm.heap).name())))
+                    }
+                    HeapReadOutput::Coroutine(coro) => {
+                        let func_id = coro.get(vm.heap).func_id;
+                        let func = vm.interns.get_function(func_id);
+                        let name = vm.interns.get_str(func.name.name_id);
+                        Self::Repr(format!("<coroutine object {name}>"))
+                    }
+                    HeapReadOutput::GatherFuture(gather) => {
+                        Self::Repr(format!("<gather({})>", gather.get(vm.heap).item_count()))
+                    }
+                    HeapReadOutput::Path(path) => Self::Path(path.get(vm.heap).as_str().to_owned()),
+                    // File objects carry no heap refs (leaf type) — no recursion.
+                    // This is how `file.read()`/`write()` deliver the open file
+                    // to the host as the first OS-call argument.
+                    HeapReadOutput::OpenFile(file) => {
+                        let file = file.get(vm.heap);
+                        Self::FileHandle(MontyFileHandle {
+                            path: file.path().to_owned(),
+                            mode: *file.file_mode(),
+                            position: file.position(),
+                        })
+                    }
+                    HeapReadOutput::ExtFunction(name) => Self::Function {
+                        name: name.get(vm.heap).clone(),
+                        docstring: None,
+                    },
+                    _ => repr_or_error(object, vm),
+                };
+
+                // Remove from visited set after processing
+                visited.remove(id);
+                result
+            }
+            Value::Builtin(Builtins::Type(t)) => Self::Type(MontyType::from_internal(*t, vm.heap, vm.interns)),
+            Value::Builtin(Builtins::ExcType(e)) => Self::Type(MontyType::Exception(*e)),
+            Value::Builtin(Builtins::Function(f)) => Self::BuiltinFunction(*f),
+            // Inline external function: export under the same shape as the heap
+            // path's `HeapReadOutput::ExtFunction` arm above, so an interned
+            // function name round-trips through Monty as `MontyObject::Function`
+            // regardless of which representation it took (issue #345).
+            Value::ExtFunction(name_id) => Self::Function {
+                name: vm.interns.get_str(*name_id).to_owned(),
+                docstring: None,
+            },
+            #[cfg(feature = "memory-model-checks")]
+            Value::Dereferenced => panic!("Dereferenced found while converting to MontyObject"),
+            _ => repr_or_error(object, vm),
+        }
+    }
+}
+
+/// Converts a value to its repr string for `MontyObject`, falling back to a
+/// descriptive error message if `py_repr` fails (e.g. INT_MAX_STR_DIGITS).
+fn repr_or_error(value: &Value, vm: &mut VM<'_, impl ResourceTracker>) -> MontyObject {
+    match value.py_repr(vm) {
+        Ok(s) => {
+            // `py_repr` yields a heap `str` `Value`; extract its text and drop it.
+            defer_drop!(s, vm);
+            MontyObject::Repr(s.to_str(vm).map(str::to_owned).unwrap_or_default())
+        }
+        Err(e) => {
+            let ty = value.py_type_name(vm);
+            let msg = match &e {
+                RunError::Internal(s) => s.to_string(),
+                RunError::Exc(exc) | RunError::UncatchableExc(exc) => exc.exc.to_string(),
+            };
+            MontyObject::Repr(format!("<{ty} object, error on repr(): {msg}>"))
+        }
+    }
+}

--- a/crates/monty/src/object_bridge.rs
+++ b/crates/monty/src/object_bridge.rs
@@ -5,11 +5,11 @@
 
 use ahash::AHashSet;
 use monty_types::{
-    InvalidInputError, MontyDate, MontyDateTime, MontyFileHandle, MontyObject, MontyTimeDelta, MontyTimeZone, MontyType,
+    InvalidInputError, MontyDate, MontyDateTime, MontyFileHandle, MontyObject, MontyTimeDelta, MontyTimeZone,
+    MontyType, ResourceTracker,
 };
 
 use crate::{
-    ResourceTracker,
     builtins::Builtins,
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/os_dispatch.rs
+++ b/crates/monty/src/os_dispatch.rs
@@ -20,10 +20,10 @@
 
 use monty_types::{
     ExcType, MkdirCallArgs, MontyPath, OsFunctionCall, PathBytesDataArgs, PathStringDataArgs, RenameCallArgs,
+    ResourceTracker,
 };
 
 use crate::{
-    ResourceTracker,
     args::{ArgValues, FromArgs, LaxBool},
     bytecode::VM,
     exception_private::{ExcTypeExt, RunResult},

--- a/crates/monty/src/os_dispatch.rs
+++ b/crates/monty/src/os_dispatch.rs
@@ -1,0 +1,279 @@
+//! Interpreter-side plumbing for OS-level operations.
+//!
+//! [`OsFunctionCall`] itself (and its typed arg structs) lives in
+//! `monty-types` so host crates can match on it without linking the
+//! interpreter; it is re-exported here. Type methods and builtins return one
+//! as [`CallResult::OsCall`](crate::bytecode::CallResult::OsCall); the VM
+//! yields [`FrameExit::OsCall`](crate::bytecode::FrameExit::OsCall) so the
+//! host decides whether to permit it. The interpreter itself never performs
+//! I/O. This module keeps the `pathlib.Path` method dispatcher that builds
+//! the calls from VM values.
+//!
+//! # Adding a new OS call
+//!
+//! Add a variant carrying a struct in `monty-types` (reuse
+//! [`PathStringDataArgs`] etc. if the shape matches, derive `ToArgs` on the
+//! struct, update [`OsFunctionCall::name`] and the other inherent methods),
+//! add a matching typed arm to `monty.proto`'s `OsCall` and `monty-proto`'s
+//! conversions, then wire the new variant into the fs/ dispatcher and any
+//! host backends.
+
+use monty_types::{
+    ExcType, MkdirCallArgs, MontyPath, OsFunctionCall, PathBytesDataArgs, PathStringDataArgs, RenameCallArgs,
+};
+
+use crate::{
+    ResourceTracker,
+    args::{ArgValues, FromArgs, LaxBool},
+    bytecode::VM,
+    exception_private::{ExcTypeExt, RunResult},
+    heap::{ContainsHeap, DropWithContext, Heap, HeapData},
+    intern::{Interns, StaticStrings},
+    value::Value,
+};
+
+impl<C: ContainsHeap> DropWithContext<C> for OsFunctionCall {
+    // Owned args (String/Vec<u8>/bool/MontyPath/MontyObject) hold no live
+    // heap references, so a plain drop is correct.
+    fn drop_with(self, _heap: &mut C) {
+        drop(self);
+    }
+}
+
+// =============================================================================
+// Path-method dispatcher (used by `types/path.rs`).
+// =============================================================================
+
+/// Pre-flight check for [`build_path_os_call`]: lets the caller decide whether
+/// to commit ownership of the path/args to the builder.
+#[must_use]
+pub(crate) fn is_path_os_method(method: StaticStrings) -> bool {
+    matches!(
+        method,
+        StaticStrings::Exists
+            | StaticStrings::IsFile
+            | StaticStrings::IsDir
+            | StaticStrings::IsSymlink
+            | StaticStrings::ReadText
+            | StaticStrings::ReadBytes
+            | StaticStrings::StatMethod
+            | StaticStrings::Iterdir
+            | StaticStrings::Resolve
+            | StaticStrings::Absolute
+            | StaticStrings::Unlink
+            | StaticStrings::Rmdir
+            | StaticStrings::WriteText
+            | StaticStrings::AppendText
+            | StaticStrings::WriteBytes
+            | StaticStrings::AppendBytes
+            | StaticStrings::Mkdir
+            | StaticStrings::Rename
+    )
+}
+
+/// Builds an [`OsFunctionCall`] for a `pathlib.Path` method invocation —
+/// dispatches on `method` and pulls any extra args out of `args` into the
+/// matching typed struct.
+///
+/// Returns `Ok(None)` if `method` isn't an OS call. Owns `path`/`args` and
+/// is responsible for refcount cleanup on every code path.
+pub(crate) fn build_path_os_call(
+    method: StaticStrings,
+    path: MontyPath,
+    args: ArgValues,
+    vm: &mut VM<'_, impl ResourceTracker>,
+) -> RunResult<Option<OsFunctionCall>> {
+    // Simple "no extra args" path operations are bundled into one arm to avoid
+    // 12 near-identical case lines.
+    macro_rules! path_only {
+        ($name:literal, $variant:ident) => {{
+            args.check_zero_args($name, vm.heap)?;
+            OsFunctionCall::$variant(path)
+        }};
+    }
+
+    let call = match method {
+        StaticStrings::Exists => path_only!("exists", Exists),
+        StaticStrings::IsFile => path_only!("is_file", IsFile),
+        StaticStrings::IsDir => path_only!("is_dir", IsDir),
+        StaticStrings::IsSymlink => path_only!("is_symlink", IsSymlink),
+        StaticStrings::ReadText => path_only!("read_text", ReadText),
+        StaticStrings::ReadBytes => path_only!("read_bytes", ReadBytes),
+        StaticStrings::StatMethod => path_only!("stat", Stat),
+        StaticStrings::Iterdir => path_only!("iterdir", Iterdir),
+        StaticStrings::Resolve => path_only!("resolve", Resolve),
+        StaticStrings::Absolute => path_only!("absolute", Absolute),
+        StaticStrings::Unlink => path_only!("unlink", Unlink),
+        StaticStrings::Rmdir => path_only!("rmdir", Rmdir),
+        StaticStrings::WriteText => {
+            OsFunctionCall::WriteText(extract_str_data("write_text", path, args, vm.heap, vm.interns)?)
+        }
+        StaticStrings::AppendText => {
+            OsFunctionCall::AppendText(extract_str_data("append_text", path, args, vm.heap, vm.interns)?)
+        }
+        StaticStrings::WriteBytes => {
+            OsFunctionCall::WriteBytes(extract_bytes_data("write_bytes", path, args, vm.heap, vm.interns)?)
+        }
+        StaticStrings::AppendBytes => {
+            OsFunctionCall::AppendBytes(extract_bytes_data("append_bytes", path, args, vm.heap, vm.interns)?)
+        }
+        StaticStrings::Mkdir => OsFunctionCall::Mkdir(extract_mkdir_args(path, args, vm)?),
+        StaticStrings::Rename => OsFunctionCall::Rename(extract_rename_args(path, args, vm.heap, vm.interns)?),
+        _ => {
+            // Unreachable in practice — callers gate on `is_path_os_method`.
+            // Drop the owned inputs anyway so a stray call doesn't leak refs.
+            let _ = path;
+            args.drop_with(vm.heap);
+            return Ok(None);
+        }
+    };
+    Ok(Some(call))
+}
+
+/// Extracts the `data` arg for `write_text` / `append_text`. Error wording
+/// matches the legacy `fs/` dispatcher so existing tests stay green.
+fn extract_str_data(
+    method: &'static str,
+    path: MontyPath,
+    args: ArgValues,
+    heap: &mut Heap<impl ResourceTracker>,
+    interns: &Interns,
+) -> RunResult<PathStringDataArgs> {
+    let data = arg_or_missing_data(method, args, heap)?;
+    let data_str = value_to_owned_string(&data, heap, interns);
+
+    let py_type = data.py_type_name_heap(heap, interns);
+    data.drop_with(heap);
+
+    match data_str {
+        Some(data) => Ok(PathStringDataArgs { path, data }),
+        None => Err(ExcType::type_error(format!("data must be str, not {py_type}"))),
+    }
+}
+
+/// Extracts the `data` arg for `write_bytes` / `append_bytes` — binary
+/// companion to [`extract_str_data`].
+fn extract_bytes_data(
+    method: &'static str,
+    path: MontyPath,
+    args: ArgValues,
+    heap: &mut Heap<impl ResourceTracker>,
+    interns: &Interns,
+) -> RunResult<PathBytesDataArgs> {
+    let data = arg_or_missing_data(method, args, heap)?;
+    let bytes = value_to_owned_bytes(&data, heap, interns);
+
+    let py_type = data.py_type_name_heap(heap, interns);
+    data.drop_with(heap);
+
+    match bytes {
+        Some(data) => Ok(PathBytesDataArgs { path, data }),
+        None => Err(ExcType::type_error(format!(
+            "memoryview: a bytes-like object is required, not '{py_type}'"
+        ))),
+    }
+}
+
+/// Python-facing argument shape for `Path.mkdir(mode=0o777, parents=False, exist_ok=False)`.
+///
+/// `Path.mkdir` is a pure-Python `def` in CPython, hence `style = def` (its
+/// duplicate-arg error is `got multiple values for argument`). The
+/// too-many-positional count still diverges: CPython counts the bound `self`
+/// (`takes from 1 to 4 …`), Monty does not — see `limitations/open.md`.
+///
+/// Monty parses `mode` for signature compatibility and arity validation, but
+/// filesystem backends do not model POSIX permission bits. `parents` and
+/// `exist_ok` use [`LaxBool`] so they accept any truth-tested value (matching
+/// CPython, which evaluates them via `bool()`).
+#[derive(FromArgs)]
+#[from_args(name = "Path.mkdir", style = def)]
+struct PathMkdirArgs {
+    #[from_args(default = 0o777_i64)]
+    mode: i64,
+    #[from_args(default = LaxBool::new(false))]
+    parents: LaxBool,
+    #[from_args(default = LaxBool::new(false))]
+    exist_ok: LaxBool,
+}
+
+/// Extracts `mode`/`parents`/`exist_ok` for `mkdir`, rejecting unknown or
+/// excessive arguments before the host sees the OS call.
+fn extract_mkdir_args(
+    path: MontyPath,
+    args: ArgValues,
+    vm: &mut VM<'_, impl ResourceTracker>,
+) -> RunResult<MkdirCallArgs> {
+    let PathMkdirArgs {
+        mode,
+        parents,
+        exist_ok,
+    } = PathMkdirArgs::from_args(args, vm)?;
+    let _ = mode;
+    Ok(MkdirCallArgs {
+        path,
+        parents: parents.bool(),
+        exist_ok: exist_ok.bool(),
+    })
+}
+
+/// Extracts the `target` arg for `Path.rename(target)`.
+fn extract_rename_args(
+    src: MontyPath,
+    args: ArgValues,
+    heap: &mut Heap<impl ResourceTracker>,
+    interns: &Interns,
+) -> RunResult<RenameCallArgs> {
+    let target = args.get_one_arg("rename", heap)?;
+    let dst_str = value_to_owned_string(&target, heap, interns);
+    target.drop_with(heap);
+    match dst_str {
+        Some(dst) => Ok(RenameCallArgs {
+            src,
+            dst: MontyPath::new(dst),
+        }),
+        None => Err(ExcType::type_error(
+            "Path.rename() argument 'target' must be str or Path".to_owned(),
+        )),
+    }
+}
+
+/// Pulls the single `data` arg out of `args`, raising the CPython-style
+/// `missing 1 required positional argument: 'data'` error when absent.
+fn arg_or_missing_data(
+    method: &'static str,
+    args: ArgValues,
+    heap: &mut Heap<impl ResourceTracker>,
+) -> RunResult<Value> {
+    if matches!(args, ArgValues::Empty) {
+        return Err(ExcType::type_error(format!(
+            "Path.{method}() missing 1 required positional argument: 'data'"
+        )));
+    }
+    args.get_one_arg(method, heap)
+}
+
+/// Owned `String` if `value` is a `str` or `Path`, else `None`. Caller drops
+/// the source value afterwards.
+fn value_to_owned_string(value: &Value, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> Option<String> {
+    match value {
+        Value::InternString(id) => Some(interns.get_str(*id).to_owned()),
+        Value::Ref(id) => match heap.get(*id) {
+            HeapData::Str(s) => Some(s.as_str().to_owned()),
+            HeapData::Path(p) => Some(p.as_str().to_owned()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Owned `Vec<u8>` if `value` is a `bytes` (interned or heap), else `None`.
+fn value_to_owned_bytes(value: &Value, heap: &Heap<impl ResourceTracker>, interns: &Interns) -> Option<Vec<u8>> {
+    match value {
+        Value::InternBytes(id) => Some(interns.get_bytes(*id).to_owned()),
+        Value::Ref(id) => match heap.get(*id) {
+            HeapData::Bytes(b) => Some(b.as_slice().to_owned()),
+            _ => None,
+        },
+        _ => None,
+    }
+}

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, fmt};
 
+use monty_types::{MontyException, StackFrame};
 use num_bigint::BigInt;
 use num_traits::Num;
 use ruff_python_ast::{
@@ -13,7 +14,6 @@ use ruff_python_parser::parse_module;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::{
-    MontyException, StackFrame,
     args::{ArgExprs, CallArg, CallKwarg, Kwarg},
     exception_private::ExcType,
     expressions::{

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -13,16 +13,16 @@ use ruff_python_parser::parse_module;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::{
-    StackFrame,
+    MontyException, StackFrame,
     args::{ArgExprs, CallArg, CallKwarg, Kwarg},
     exception_private::ExcType,
-    exception_public::{MontyException, SourceMap},
     expressions::{
         AssignTarget, Callable, CmpOperator, Comprehension, DictItem, Expr, ExprLoc, Identifier, ImportName, Literal,
         Node, Operator, SequenceItem, UnpackTarget,
     },
     fstring::{ConversionFlag, FStringPart, FormatSpec, ParsedFormatSpec, encode_format_spec},
     intern::{InternerBuilder, StringId},
+    source_map::{SourceMap, StackFrameExt},
     types::long_int::INT_MAX_STR_DIGITS,
     value::EitherStr,
 };
@@ -2237,7 +2237,7 @@ impl ParseError {
     pub fn into_python_exc(self, filename: &str, source: &str) -> MontyException {
         let mut source_map = SourceMap::new(source);
         match self {
-            Self::Syntax { msg, position } => MontyException::new_full(
+            Self::Syntax { msg, position } => MontyException::with_traceback(
                 ExcType::SyntaxError,
                 Some(msg.into_owned()),
                 vec![StackFrame::from_position_syntax_error(
@@ -2246,17 +2246,17 @@ impl ParseError {
                     &mut source_map,
                 )],
             ),
-            Self::NotImplemented { msg, position } => MontyException::new_full(
+            Self::NotImplemented { msg, position } => MontyException::with_traceback(
                 ExcType::NotImplementedError,
                 Some(format!("The monty syntax parser does not yet support {msg}")),
                 vec![StackFrame::from_position(position, filename, &mut source_map)],
             ),
-            Self::NotSupported { msg, position } => MontyException::new_full(
+            Self::NotSupported { msg, position } => MontyException::with_traceback(
                 ExcType::NotImplementedError,
                 Some(msg.into_owned()),
                 vec![StackFrame::from_position(position, filename, &mut source_map)],
             ),
-            Self::Import { msg, position } => MontyException::new_full(
+            Self::Import { msg, position } => MontyException::with_traceback(
                 ExcType::ImportError,
                 Some(msg.into_owned()),
                 vec![StackFrame::from_position_no_caret(position, filename, &mut source_map)],

--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -12,22 +12,19 @@ use ruff_python_parser::{InterpolatedStringErrorType, LexicalErrorType, ParseErr
 use serde::de::DeserializeOwned;
 
 use crate::{
-    ExcType, MontyException,
+    ExcType, MontyException, MontyObject, OsFunctionCall, PrintWriter, ResourceTracker,
     args::{ArgValues, KwargsValues},
     asyncio::CallId,
     bytecode::{VM, VMSnapshot},
     defer_drop,
-    exception_private::RunError,
+    exception_private::{ExcTypeExt, RunError},
     heap::{DropWithContext, Heap, HeapReader},
     heap_data::HeapData,
     intern::{InternerBuilder, Interns},
-    io::PrintWriter,
     name_map::NameMap,
-    object::MontyObject,
-    os::OsFunctionCall,
-    resource::ResourceTracker,
+    object_bridge::MontyObjectExt,
     run::{CompileOptions, Executor},
-    run_progress::{ConvertedExit, ExtFunctionResult, NameLookupResult, convert_frame_exit},
+    run_progress::{ConvertedExit, ExtFunctionResult, ExtFunctionResultExt, NameLookupResult, convert_frame_exit},
     value::Value,
 };
 

--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -7,12 +7,12 @@
 use std::mem;
 
 use ahash::AHashMap;
+use monty_types::{ExcType, MontyException, MontyObject, OsFunctionCall, PrintWriter, ResourceTracker};
 use ruff_python_ast::token::TokenKind;
 use ruff_python_parser::{InterpolatedStringErrorType, LexicalErrorType, ParseErrorType, parse_module};
 use serde::de::DeserializeOwned;
 
 use crate::{
-    ExcType, MontyException, MontyObject, OsFunctionCall, PrintWriter, ResourceTracker,
     args::{ArgValues, KwargsValues},
     asyncio::CallId,
     bytecode::{VM, VMSnapshot},

--- a/crates/monty/src/resource_checks.rs
+++ b/crates/monty/src/resource_checks.rs
@@ -1,0 +1,168 @@
+use monty_types::{ExcType, LARGE_RESULT_THRESHOLD, ResourceError, ResourceTracker};
+
+use crate::exception_private::{ExceptionRaise, RawStackFrame, RunError, SimpleException};
+
+/// Pre-checks that an operation producing `item_len * count` bytes won't exceed resource limits.
+///
+/// Used for sequence repeats (`'x' * 999_999_999`), padding operations
+/// (`str.ljust`, `str.center`, `str.zfill`, etc.), and any other operation
+/// where the result size is a simple product of two known values.
+pub fn check_repeat_size(item_len: usize, count: usize, tracker: &impl ResourceTracker) -> Result<(), ResourceError> {
+    check_estimated_size(item_len.saturating_mul(count), tracker)
+}
+
+/// Pre-checks that `base ** exponent` won't exceed resource limits before computing.
+///
+/// The result of `base ** exp` has approximately `base_bits * exp` bits.
+/// For bases with 0 or 1 significant bits (0, 1, -1), the result is always
+/// small regardless of exponent, so the check is skipped.
+///
+/// The estimate includes a 4× safety multiplier because `BigInt::pow` uses repeated squaring,
+/// which allocates intermediate values on the Rust heap (not tracked by the resource tracker).
+/// At peak, old/new base and old/new accumulator coexist simultaneously during each
+/// multiplication step, requiring roughly 4× the final result size in memory.
+pub fn check_pow_size(base_bits: u64, exponent: u64, tracker: &impl ResourceTracker) -> Result<(), ResourceError> {
+    // 0**n = 0, 1**n = 1, (-1)**n = ±1 — always small
+    if base_bits <= 1 {
+        return Ok(());
+    }
+    let result_bytes = estimate_bits_to_bytes(base_bits.saturating_mul(exponent));
+    // Repeated squaring needs ~4× result size in peak memory (old/new base + old/new accumulator
+    // coexist during each multiplication step), and these are Rust heap allocations not tracked
+    // by the resource tracker.
+    check_estimated_size(result_bytes.saturating_mul(4), tracker)
+}
+
+/// Pre-checks that an integer multiplication won't exceed resource limits.
+///
+/// The result of multiplying two numbers has at most `a_bits + b_bits` bits.
+pub fn check_mult_size(a_bits: u64, b_bits: u64, tracker: &impl ResourceTracker) -> Result<(), ResourceError> {
+    check_estimated_size(estimate_bits_to_bytes(a_bits.saturating_add(b_bits)), tracker)
+}
+
+/// Pre-checks that a left shift won't exceed resource limits.
+///
+/// The result of `value << shift` has approximately `value_bits + shift` bits.
+/// For zero values the result is always zero, so the check is skipped.
+pub fn check_lshift_size(
+    value_bits: u64,
+    shift_amount: u64,
+    tracker: &impl ResourceTracker,
+) -> Result<(), ResourceError> {
+    if value_bits == 0 {
+        return Ok(());
+    }
+    check_estimated_size(estimate_bits_to_bytes(value_bits.saturating_add(shift_amount)), tracker)
+}
+
+/// Pre-checks that an integer division overflow promotion won't exceed resource limits.
+///
+/// Division results are bounded by the dividend size, but we still check for consistency
+/// with other BigInt promotion paths.
+pub fn check_div_size(dividend_bits: u64, tracker: &impl ResourceTracker) -> Result<(), ResourceError> {
+    check_estimated_size(estimate_bits_to_bytes(dividend_bits), tracker)
+}
+
+/// Pre-checks that a string/bytes replace won't exceed resource limits before allocating.
+///
+/// This prevents DoS via expressions like `('a' * 1000).replace('a', 'b' * 10_000_000)`
+/// where a small tracked input is amplified into a huge untracked Rust `String`/`Vec`
+/// by `String::replace()` before `allocate_string()` can check the result.
+///
+/// The upper bound on result size is: if `old` is non-empty, at most `input_len / old_len`
+/// replacements can occur, each producing `new_len` bytes instead of `old_len`. When `count`
+/// is specified, replacements are capped to that value.
+pub fn check_replace_size(
+    input_len: usize,
+    old_len: usize,
+    new_len: usize,
+    count: i64,
+    tracker: &impl ResourceTracker,
+) -> Result<(), ResourceError> {
+    // Empty pattern (old_len == 0): inserts before each element + after the last = input_len + 1
+    let max_replacements = input_len
+        .checked_div(old_len)
+        .unwrap_or_else(|| input_len.saturating_add(1));
+
+    let replacements = if count < 0 {
+        max_replacements
+    } else {
+        max_replacements.min(usize::try_from(count).unwrap_or(usize::MAX))
+    };
+
+    // Result = input_len - (replacements * old_len) + (replacements * new_len)
+    let removed = replacements.saturating_mul(old_len);
+    let added = replacements.saturating_mul(new_len);
+    let estimated = input_len.saturating_sub(removed).saturating_add(added);
+
+    check_estimated_size(estimated, tracker)
+}
+
+/// Checks an estimated result size against the resource tracker.
+///
+/// Only calls the tracker when the estimate exceeds `LARGE_RESULT_THRESHOLD`
+/// to avoid overhead on small operations.
+pub(crate) fn check_estimated_size(
+    estimated_bytes: usize,
+    tracker: &impl ResourceTracker,
+) -> Result<(), ResourceError> {
+    if estimated_bytes > LARGE_RESULT_THRESHOLD {
+        tracker.check_large_result(estimated_bytes)?;
+    }
+    Ok(())
+}
+
+/// Converts an estimated bit count to bytes, saturating to `usize::MAX` on overflow.
+///
+/// Overflow means the result is astronomically large, so saturating ensures
+/// the resource limit check always triggers rather than being silently skipped.
+fn estimate_bits_to_bytes(bits: u64) -> usize {
+    usize::try_from(bits.saturating_add(7) / 8).unwrap_or(usize::MAX)
+}
+
+/// Converts a resource error to a Python exception with optional stack frame.
+///
+/// Maps resource error types to Python exception types:
+/// - `Allocation` → `MemoryError`
+/// - `Memory` → `MemoryError`
+/// - `Time` → `TimeoutError`
+/// - `Recursion` → `RecursionError`
+pub(crate) fn resource_error_into_exception(err: ResourceError, frame: Option<RawStackFrame>) -> ExceptionRaise {
+    let (exc_type, msg) = match err {
+        ResourceError::Allocation { limit, count } => (
+            ExcType::MemoryError,
+            Some(format!("allocation limit exceeded: {count} > {limit}")),
+        ),
+        ResourceError::Memory { limit, used } => (
+            ExcType::MemoryError,
+            Some(format!("memory limit exceeded: {used} bytes > {limit} bytes")),
+        ),
+        ResourceError::Time { limit, elapsed } => (
+            ExcType::TimeoutError,
+            Some(format!("time limit exceeded: {elapsed:?} > {limit:?}")),
+        ),
+        ResourceError::Recursion { .. } => (
+            ExcType::RecursionError,
+            Some("maximum recursion depth exceeded".to_string()),
+        ),
+        ResourceError::Exception(exc) => (exc.exc_type(), exc.into_message()),
+    };
+    let exc = SimpleException::new(exc_type, msg);
+    match frame {
+        Some(f) => exc.with_frame(f),
+        None => exc.into(),
+    }
+}
+
+impl From<ResourceError> for RunError {
+    fn from(err: ResourceError) -> Self {
+        // RecursionError is catchable in CPython, so it must be catchable here too.
+        // Other resource errors (memory, time, allocation) remain uncatchable to prevent
+        // untrusted code from suppressing resource limit violations.
+        if matches!(err, ResourceError::Recursion { .. }) {
+            Self::Exc(resource_error_into_exception(err, None))
+        } else {
+            Self::UncatchableExc(resource_error_into_exception(err, None))
+        }
+    }
+}

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -1,101 +1,27 @@
 //! Public interface for running Monty code.
-use std::{
-    num::NonZeroU32,
-    sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    },
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
 };
 
+pub use monty_types::CompileOptions;
 use ruff_python_stdlib::identifiers::is_identifier;
 
 use crate::{
-    ExcType, MontyException,
+    ExcType, MontyException, MontyObject, NoLimitTracker, PrintWriter, ResourceTracker,
     bytecode::{Code, Compiler, FrameExit, VM},
-    exception_private::RunResult,
+    exception_private::{ExcTypeExt, RunResult},
     heap::{DropWithContext, Heap, HeapReader},
     intern::{InternerBuilder, Interns},
-    io::PrintWriter,
     name_map::NameMap,
     namespace::NamespaceId,
-    object::MontyObject,
+    object_bridge::MontyObjectExt,
     parse::{CodeRange, parse, parse_with_interner},
     prepare::{prepare, prepare_with_existing_names},
-    resource::{NoLimitTracker, ResourceTracker},
     run_progress::{RunProgress, build_run_progress, check_snapshot_from_converted, convert_frame_exit},
     types::str::StringRepr,
     value::Value,
 };
-
-/// Options controlling how Monty behavior diverges from plain CPython.
-///
-/// Consumed when code is compiled: a [`MontyRun`] bakes the choices into the
-/// program at construction, while a `MontyRepl` stores them so every snippet
-/// fed to the session compiles the same way.
-#[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
-pub struct CompileOptions {
-    /// Give failed `assert` statements pytest-style introspected messages,
-    /// deliberately diverging from CPython; see `limitations/assert.md`.
-    /// On by default with a 120-byte operand-repr truncation.
-    pub assert_message_annotations: AssertMessageAnnotations,
-}
-
-/// Controls the pytest-style introspected `assert` failure messages of
-/// [`CompileOptions::assert_message_annotations`].
-///
-/// The choice is baked in at compile time (whether the introspecting opcodes
-/// are emitted) but the truncation limit is applied at runtime, so it also
-/// travels with serialized sessions.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum AssertMessageAnnotations {
-    /// Disable introspection; bare asserts use CPython's empty message.
-    Off,
-    /// Retain at most this many UTF-8 bytes per operand before any `…` suffix.
-    /// Non-zero because `0` encodes [`Off`](Self::Off) on the wire.
-    MaxBytes(NonZeroU32),
-}
-
-impl AssertMessageAnnotations {
-    /// Operand-repr truncation used by [`Default`] and `From<bool>`.
-    pub const DEFAULT_MAX_BYTES: NonZeroU32 = NonZeroU32::new(120).expect("120 is non-zero");
-
-    /// Whether the compiler should emit introspecting assert opcodes.
-    #[must_use]
-    pub fn enabled(self) -> bool {
-        !matches!(self, Self::Off)
-    }
-
-    /// Returns the wire value: `0` when disabled, otherwise the UTF-8 byte cap.
-    #[must_use]
-    pub fn max_bytes(self) -> u32 {
-        match self {
-            Self::Off => 0,
-            Self::MaxBytes(n) => n.get(),
-        }
-    }
-
-    /// Decodes the wire value: `0` is off and any other value is the byte cap.
-    #[must_use]
-    pub fn from_max_bytes(value: u32) -> Self {
-        match NonZeroU32::new(value) {
-            Some(n) => Self::MaxBytes(n),
-            None => Self::Off,
-        }
-    }
-}
-
-impl Default for AssertMessageAnnotations {
-    fn default() -> Self {
-        Self::MaxBytes(Self::DEFAULT_MAX_BYTES)
-    }
-}
-
-impl From<bool> for AssertMessageAnnotations {
-    /// `true` enables the 120-byte default; `false` disables annotations.
-    fn from(enabled: bool) -> Self {
-        if enabled { Self::default() } else { Self::Off }
-    }
-}
 
 /// Primary interface for running Monty code.
 ///

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -5,10 +5,10 @@ use std::sync::{
 };
 
 pub use monty_types::CompileOptions;
+use monty_types::{ExcType, MontyException, MontyObject, NoLimitTracker, PrintWriter, ResourceTracker};
 use ruff_python_stdlib::identifiers::is_identifier;
 
 use crate::{
-    ExcType, MontyException, MontyObject, NoLimitTracker, PrintWriter, ResourceTracker,
     bytecode::{Code, Compiler, FrameExit, VM},
     exception_private::{ExcTypeExt, RunResult},
     heap::{DropWithContext, Heap, HeapReader},
@@ -32,7 +32,8 @@ use crate::{
 ///
 /// # Example
 /// ```
-/// use monty::{CompileOptions, MontyRun, MontyObject};
+/// use monty::MontyRun;
+/// use monty_types::{CompileOptions, MontyObject};
 ///
 /// let runner = MontyRun::new(
 ///     "x + 1".to_owned(),

--- a/crates/monty/src/run_progress.rs
+++ b/crates/monty/src/run_progress.rs
@@ -8,10 +8,10 @@
 
 use std::mem;
 
+use monty_types::{ExcType, MontyException, MontyObject, OsFunctionCall, PrintWriter, ResourceTracker};
 use serde::de::DeserializeOwned;
 
 use crate::{
-    ExcType, MontyException, MontyObject, OsFunctionCall, PrintWriter, ResourceTracker,
     asyncio::CallId,
     bytecode::{FrameExit, VM, VMSnapshot},
     exception_private::{ExcTypeExt, RunError, RunResult},

--- a/crates/monty/src/run_progress.rs
+++ b/crates/monty/src/run_progress.rs
@@ -11,15 +11,12 @@ use std::mem;
 use serde::de::DeserializeOwned;
 
 use crate::{
-    ExcType, MontyException,
+    ExcType, MontyException, MontyObject, OsFunctionCall, PrintWriter, ResourceTracker,
     asyncio::CallId,
     bytecode::{FrameExit, VM, VMSnapshot},
-    exception_private::{RunError, RunResult},
+    exception_private::{ExcTypeExt, RunError, RunResult},
     heap::{Heap, HeapReader},
-    io::PrintWriter,
-    object::MontyObject,
-    os::OsFunctionCall,
-    resource::ResourceTracker,
+    object_bridge::MontyObjectExt,
     run::Executor,
 };
 
@@ -600,60 +597,20 @@ impl<T: ResourceTracker> Snapshot<T> {
     }
 }
 
-/// Result of a name lookup from the host.
-///
-/// When the VM encounters an unresolved name, the host provides one of these:
-/// - `Value(obj)`: The name resolves to this value (cached in the namespace for future access).
-/// - `Undefined`: The name is truly undefined, causing `NameError`.
-#[derive(Debug)]
-pub enum NameLookupResult {
-    /// The name resolves to this value.
-    Value(MontyObject),
-    /// The name is undefined — VM will raise `NameError`.
-    Undefined,
-}
+pub use monty_types::{ExtFunctionResult, NameLookupResult};
 
-impl From<MontyObject> for NameLookupResult {
-    fn from(value: MontyObject) -> Self {
-        Self::Value(value)
-    }
-}
-
-/// Return value or exception from an external function.
-#[derive(Debug)]
-pub enum ExtFunctionResult {
-    /// Continues execution with the return value from the external function.
-    Return(MontyObject),
-    /// Continues execution with the exception raised by the external function.
-    Error(MontyException),
-    /// Pending future — the external function is a coroutine.
-    ///
-    /// The `u32` is the `call_id` from the `FunctionCall` that created this
-    /// snapshot. It is used to track the pending future so it can be resolved
-    /// later via `ResolveFutures::resume()`.
-    Future(u32),
-    /// The function was not found, should result in a `NameError` exception.
-    NotFound(String),
-}
-
-impl ExtFunctionResult {
-    pub(crate) fn not_found_exc(function_name: &str) -> RunError {
+/// Crate-internal extension for [`ExtFunctionResult`] (which lives in
+/// `monty-types`): builds the interpreter-side `RunError` for a missing
+/// external function.
+pub(crate) trait ExtFunctionResultExt {
+    /// The `NameError` raised when the host reports the function isn't defined.
+    fn not_found_exc(function_name: &str) -> RunError {
         let msg = format!("name '{function_name}' is not defined");
         MontyException::new(ExcType::NameError, Some(msg)).into()
     }
 }
 
-impl From<MontyObject> for ExtFunctionResult {
-    fn from(value: MontyObject) -> Self {
-        Self::Return(value)
-    }
-}
-
-impl From<MontyException> for ExtFunctionResult {
-    fn from(exception: MontyException) -> Self {
-        Self::Error(exception)
-    }
-}
+impl ExtFunctionResultExt for ExtFunctionResult {}
 
 // ---------------------------------------------------------------------------
 // handle_vm_result

--- a/crates/monty/src/sorting.rs
+++ b/crates/monty/src/sorting.rs
@@ -11,11 +11,11 @@
 use std::cmp::Ordering;
 
 use crate::{
+    ResourceTracker,
     args::{ArgValues, FromArgs, LaxBool},
     bytecode::VM,
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, RunError, RunResult},
-    resource::ResourceTracker,
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
     types::{CmpOrder, PyTrait},
     value::Value,
 };

--- a/crates/monty/src/sorting.rs
+++ b/crates/monty/src/sorting.rs
@@ -10,8 +10,9 @@
 
 use std::cmp::Ordering;
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::{ArgValues, FromArgs, LaxBool},
     bytecode::VM,
     defer_drop, defer_drop_mut,

--- a/crates/monty/src/source_map.rs
+++ b/crates/monty/src/source_map.rs
@@ -1,0 +1,250 @@
+use std::{collections::HashMap, sync::Arc};
+
+use monty_types::{CodeLoc, StackFrame};
+
+use crate::{exception_private::RawStackFrame, intern::Interns, parse::CodeRange};
+
+/// Crate-internal builders for [`StackFrame`] (which lives in `monty-types`):
+/// they resolve interned names and raw byte offsets via [`Interns`] /
+/// [`SourceMap`], which only exist interpreter-side.
+pub(crate) trait StackFrameExt {
+    /// Builds a runtime `StackFrame` from an internal `RawStackFrame`.
+    ///
+    /// Resolves the raw filename/frame-name `StringId`s via `interns` and
+    /// expands the position's byte offsets to line/column and a preview
+    /// line via `source_map`.
+    fn from_raw(f: &RawStackFrame, interns: &Interns, source_map: &mut SourceMap<'_>) -> StackFrame {
+        let filename = interns.get_str(f.position.filename).to_string();
+        let (start, end, preview_line) = source_map.resolve_range(f.position);
+        StackFrame {
+            filename,
+            start,
+            end,
+            frame_name: f.frame_name.map(|id| interns.get_str(id).to_string()),
+            preview_line,
+            hide_caret: f.hide_caret,
+            hide_frame_name: false,
+        }
+    }
+
+    /// Builds a `StackFrame` for a `SyntaxError`.
+    ///
+    /// Sets `hide_frame_name: true` because CPython's SyntaxError format
+    /// omits the trailing `, in <module>` part.
+    fn from_position_syntax_error(position: CodeRange, filename: &str, source_map: &mut SourceMap<'_>) -> StackFrame {
+        let (start, end, preview_line) = source_map.resolve_range(position);
+        StackFrame {
+            filename: filename.to_string(),
+            start,
+            end,
+            frame_name: None,
+            preview_line,
+            hide_caret: false,
+            hide_frame_name: true,
+        }
+    }
+
+    /// Builds a generic `StackFrame` from a `CodeRange` and filename.
+    ///
+    /// Used for runtime-style errors raised outside the VM's frame tracking
+    /// (e.g. parse-phase `NotImplementedError`) where caret markers and the
+    /// `, in <module>` suffix are both shown.
+    fn from_position(position: CodeRange, filename: &str, source_map: &mut SourceMap<'_>) -> StackFrame {
+        let (start, end, preview_line) = source_map.resolve_range(position);
+        StackFrame {
+            filename: filename.to_string(),
+            start,
+            end,
+            frame_name: None,
+            preview_line,
+            hide_caret: false,
+            hide_frame_name: false,
+        }
+    }
+
+    /// Builds a `StackFrame` with caret markers suppressed.
+    ///
+    /// Used for errors like `ImportError` and `ModuleNotFoundError`, where
+    /// CPython shows the source preview line but no `~~~` carets beneath it.
+    fn from_position_no_caret(position: CodeRange, filename: &str, source_map: &mut SourceMap<'_>) -> StackFrame {
+        let (start, end, preview_line) = source_map.resolve_range(position);
+        StackFrame {
+            filename: filename.to_string(),
+            start,
+            end,
+            frame_name: None,
+            preview_line,
+            hide_caret: true,
+            hide_frame_name: false,
+        }
+    }
+}
+
+impl StackFrameExt for StackFrame {}
+
+/// Lazy resolver from raw byte offsets (stored on every [`CodeRange`]) back to
+/// human-readable line/column/preview-line information.
+///
+/// Monty's parser stores only byte offsets per AST node to keep the post-parse
+/// hot path O(1) per node. `SourceMap` is built once at the diagnostic
+/// boundary — when converting an internal error into a public
+/// [`MontyException`] — and used to resolve every frame in the traceback.
+/// Building it scans the source once to index line starts; with a 100k-line
+/// source this is a few hundred microseconds and fires only when an exception
+/// is actually raised.
+///
+/// Column semantics remain exactly CPython-compatible: columns count Unicode
+/// scalar values, not bytes. The ASCII fast path (the overwhelmingly common
+/// case for Python source) skips the `chars()` iterator entirely.
+pub struct SourceMap<'s> {
+    source: &'s str,
+    /// Byte offset of the start of each line. Length equals the number of
+    /// lines; `line_starts[0]` is always 0.
+    line_starts: Vec<u32>,
+    /// Cache of preview lines, keyed by 0-based line index.
+    ///
+    /// Lets every `StackFrame` referencing the same source line share a
+    /// single `Arc<str>` allocation rather than each cloning the line into
+    /// its own `String`. This matters for deep recursion: without the
+    /// cache, a 1 MiB line referenced by 1000 frames would allocate ~1 GiB;
+    /// with the cache it allocates ~1 MiB. Built lazily — entries materialize
+    /// only as `resolve_range` actually requests them.
+    line_cache: HashMap<usize, Arc<str>>,
+}
+
+impl<'s> SourceMap<'s> {
+    /// Builds a line-start index over `source`.
+    ///
+    /// Amortizes across every frame in the traceback — one O(n) scan, then
+    /// O(log n) lookups per frame.
+    #[must_use]
+    pub fn new(source: &'s str) -> Self {
+        let mut line_starts = Vec::with_capacity(source.len() / 40 + 1);
+        line_starts.push(0);
+        for (i, b) in source.bytes().enumerate() {
+            if b == b'\n' {
+                // source should never exceed 4 GB
+                let start = u32::try_from(i + 1).unwrap_or(u32::MAX);
+                line_starts.push(start);
+            }
+        }
+        Self {
+            source,
+            line_starts,
+            line_cache: HashMap::new(),
+        }
+    }
+
+    /// Resolves a `CodeRange` into `(start, end, preview_line)`.
+    ///
+    /// When `start` and `end` lie on the same line, `preview_line` is that
+    /// single source line. The returned `Arc<str>` is shared with any other
+    /// frame in this traceback resolving to the same line, so repeated
+    /// lookups for the same line are O(1) and allocate only on the first
+    /// lookup.
+    ///
+    /// When the range spans multiple lines, `preview_line` holds a
+    /// pre-rendered CPython-style block (see
+    /// [`multiline_preview`](Self::multiline_preview)); the renderer
+    /// distinguishes the two cases by comparing `start`/`end` lines.
+    pub(crate) fn resolve_range(&mut self, range: CodeRange) -> (CodeLoc, CodeLoc, Option<Arc<str>>) {
+        let (start_line_idx, start) = self.resolve_byte(range.start_byte);
+        let (end_line_idx, end) = self.resolve_byte(range.end_byte);
+        let preview_line = if start_line_idx == end_line_idx {
+            // Cache materializes lazily — first request for a given line allocates
+            // the `Arc<str>`, subsequent requests for the same line clone the Arc.
+            let line_text = self.line_text(start_line_idx);
+            Some(Arc::clone(
+                self.line_cache
+                    .entry(start_line_idx)
+                    .or_insert_with(|| Arc::from(line_text)),
+            ))
+        } else {
+            // Multi-line ranges are rare (e.g. a traceback frame covering a
+            // whole `class` statement), so no caching.
+            Some(Arc::from(self.multiline_preview(start_line_idx, end_line_idx)))
+        };
+        (start, end, preview_line)
+    }
+
+    /// Renders the source preview for a range spanning several lines,
+    /// mirroring CPython's traceback formatting: all lines when the range
+    /// covers at most three, otherwise the first and last around a
+    /// `...<N lines>...` elision marker. Displayed lines are dedented by
+    /// their common leading whitespace; the caller adds the 4-space frame
+    /// indent (and no caret markers — CPython omits them for these
+    /// full-statement ranges).
+    fn multiline_preview(&self, start_line_idx: usize, end_line_idx: usize) -> String {
+        let total = end_line_idx - start_line_idx + 1;
+        let displayed: Vec<&str> = if total <= 3 {
+            (start_line_idx..=end_line_idx).map(|i| self.line_text(i)).collect()
+        } else {
+            vec![self.line_text(start_line_idx), self.line_text(end_line_idx)]
+        };
+        // Common leading-whitespace prefix across non-blank displayed lines.
+        let dedent = displayed
+            .iter()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| line.len() - line.trim_start().len())
+            .min()
+            .unwrap_or(0);
+        let stripped = |line: &str| line.get(dedent..).unwrap_or("").to_owned();
+        if total <= 3 {
+            displayed
+                .iter()
+                .map(|line| stripped(line))
+                .collect::<Vec<_>>()
+                .join("\n")
+        } else {
+            format!(
+                "{}\n...<{} lines>...\n{}",
+                stripped(displayed[0]),
+                total - 2,
+                stripped(displayed[1])
+            )
+        }
+    }
+
+    /// Resolves a raw byte offset to `(0-based line index, CodeLoc)`.
+    ///
+    /// Column is the number of Unicode scalar values between the line start
+    /// and the offset; uses an ASCII fast path when the preceding slice is
+    /// pure ASCII.
+    fn resolve_byte(&self, byte: u32) -> (usize, CodeLoc) {
+        // partition_point(|&s| s <= byte) gives the index of the first line
+        // whose start is strictly greater than `byte`; subtracting one maps
+        // `byte` back to the line it actually lies on.
+        let line_idx = self.line_starts.partition_point(|&s| s <= byte).saturating_sub(1);
+        let line_start = self.line_starts[line_idx];
+        let slice_start = line_start as usize;
+        let slice_end = (byte as usize).min(self.source.len());
+        let slice = &self.source[slice_start..slice_end];
+        // Ruff caps source files at 4 GiB, so any byte-based column count fits
+        // comfortably in `u32`; saturate defensively if that ever changes.
+        let col = if slice.is_ascii() {
+            u32::try_from(slice.len()).unwrap_or(u32::MAX)
+        } else {
+            u32::try_from(slice.chars().count()).unwrap_or(u32::MAX)
+        };
+        (
+            line_idx,
+            CodeLoc::new(u32::try_from(line_idx).expect("line number exceeds u32"), col),
+        )
+    }
+
+    /// Returns the raw text of a 0-based line index, without the trailing
+    /// newline.
+    fn line_text(&self, line_idx: usize) -> &'s str {
+        let start = self.line_starts[line_idx] as usize;
+        let end = self
+            .line_starts
+            .get(line_idx + 1)
+            .map_or(self.source.len(), |&next| next.saturating_sub(1) as usize);
+        // Guard against a trailing empty "line" past the last newline with no
+        // content (e.g. when `start == source.len()`).
+        let end = end.max(start);
+        // Strip a trailing `\r` if the source uses CRLF line endings.
+        let line = &self.source[start..end];
+        line.strip_suffix('\r').unwrap_or(line)
+    }
+}

--- a/crates/monty/src/source_map.rs
+++ b/crates/monty/src/source_map.rs
@@ -4,84 +4,6 @@ use monty_types::{CodeLoc, StackFrame};
 
 use crate::{exception_private::RawStackFrame, intern::Interns, parse::CodeRange};
 
-/// Crate-internal builders for [`StackFrame`] (which lives in `monty-types`):
-/// they resolve interned names and raw byte offsets via [`Interns`] /
-/// [`SourceMap`], which only exist interpreter-side.
-pub(crate) trait StackFrameExt {
-    /// Builds a runtime `StackFrame` from an internal `RawStackFrame`.
-    ///
-    /// Resolves the raw filename/frame-name `StringId`s via `interns` and
-    /// expands the position's byte offsets to line/column and a preview
-    /// line via `source_map`.
-    fn from_raw(f: &RawStackFrame, interns: &Interns, source_map: &mut SourceMap<'_>) -> StackFrame {
-        let filename = interns.get_str(f.position.filename).to_string();
-        let (start, end, preview_line) = source_map.resolve_range(f.position);
-        StackFrame {
-            filename,
-            start,
-            end,
-            frame_name: f.frame_name.map(|id| interns.get_str(id).to_string()),
-            preview_line,
-            hide_caret: f.hide_caret,
-            hide_frame_name: false,
-        }
-    }
-
-    /// Builds a `StackFrame` for a `SyntaxError`.
-    ///
-    /// Sets `hide_frame_name: true` because CPython's SyntaxError format
-    /// omits the trailing `, in <module>` part.
-    fn from_position_syntax_error(position: CodeRange, filename: &str, source_map: &mut SourceMap<'_>) -> StackFrame {
-        let (start, end, preview_line) = source_map.resolve_range(position);
-        StackFrame {
-            filename: filename.to_string(),
-            start,
-            end,
-            frame_name: None,
-            preview_line,
-            hide_caret: false,
-            hide_frame_name: true,
-        }
-    }
-
-    /// Builds a generic `StackFrame` from a `CodeRange` and filename.
-    ///
-    /// Used for runtime-style errors raised outside the VM's frame tracking
-    /// (e.g. parse-phase `NotImplementedError`) where caret markers and the
-    /// `, in <module>` suffix are both shown.
-    fn from_position(position: CodeRange, filename: &str, source_map: &mut SourceMap<'_>) -> StackFrame {
-        let (start, end, preview_line) = source_map.resolve_range(position);
-        StackFrame {
-            filename: filename.to_string(),
-            start,
-            end,
-            frame_name: None,
-            preview_line,
-            hide_caret: false,
-            hide_frame_name: false,
-        }
-    }
-
-    /// Builds a `StackFrame` with caret markers suppressed.
-    ///
-    /// Used for errors like `ImportError` and `ModuleNotFoundError`, where
-    /// CPython shows the source preview line but no `~~~` carets beneath it.
-    fn from_position_no_caret(position: CodeRange, filename: &str, source_map: &mut SourceMap<'_>) -> StackFrame {
-        let (start, end, preview_line) = source_map.resolve_range(position);
-        StackFrame {
-            filename: filename.to_string(),
-            start,
-            end,
-            frame_name: None,
-            preview_line,
-            hide_caret: true,
-            hide_frame_name: false,
-        }
-    }
-}
-
-impl StackFrameExt for StackFrame {}
-
 /// Lazy resolver from raw byte offsets (stored on every [`CodeRange`]) back to
 /// human-readable line/column/preview-line information.
 ///
@@ -248,3 +170,81 @@ impl<'s> SourceMap<'s> {
         line.strip_suffix('\r').unwrap_or(line)
     }
 }
+
+/// Crate-internal builders for [`StackFrame`] (which lives in `monty-types`):
+/// they resolve interned names and raw byte offsets via [`Interns`] /
+/// [`SourceMap`], which only exist interpreter-side.
+pub(crate) trait StackFrameExt {
+    /// Builds a runtime `StackFrame` from an internal `RawStackFrame`.
+    ///
+    /// Resolves the raw filename/frame-name `StringId`s via `interns` and
+    /// expands the position's byte offsets to line/column and a preview
+    /// line via `source_map`.
+    fn from_raw(f: &RawStackFrame, interns: &Interns, source_map: &mut SourceMap<'_>) -> StackFrame {
+        let filename = interns.get_str(f.position.filename).to_string();
+        let (start, end, preview_line) = source_map.resolve_range(f.position);
+        StackFrame {
+            filename,
+            start,
+            end,
+            frame_name: f.frame_name.map(|id| interns.get_str(id).to_string()),
+            preview_line,
+            hide_caret: f.hide_caret,
+            hide_frame_name: false,
+        }
+    }
+
+    /// Builds a `StackFrame` for a `SyntaxError`.
+    ///
+    /// Sets `hide_frame_name: true` because CPython's SyntaxError format
+    /// omits the trailing `, in <module>` part.
+    fn from_position_syntax_error(position: CodeRange, filename: &str, source_map: &mut SourceMap<'_>) -> StackFrame {
+        let (start, end, preview_line) = source_map.resolve_range(position);
+        StackFrame {
+            filename: filename.to_string(),
+            start,
+            end,
+            frame_name: None,
+            preview_line,
+            hide_caret: false,
+            hide_frame_name: true,
+        }
+    }
+
+    /// Builds a generic `StackFrame` from a `CodeRange` and filename.
+    ///
+    /// Used for runtime-style errors raised outside the VM's frame tracking
+    /// (e.g. parse-phase `NotImplementedError`) where caret markers and the
+    /// `, in <module>` suffix are both shown.
+    fn from_position(position: CodeRange, filename: &str, source_map: &mut SourceMap<'_>) -> StackFrame {
+        let (start, end, preview_line) = source_map.resolve_range(position);
+        StackFrame {
+            filename: filename.to_string(),
+            start,
+            end,
+            frame_name: None,
+            preview_line,
+            hide_caret: false,
+            hide_frame_name: false,
+        }
+    }
+
+    /// Builds a `StackFrame` with caret markers suppressed.
+    ///
+    /// Used for errors like `ImportError` and `ModuleNotFoundError`, where
+    /// CPython shows the source preview line but no `~~~` carets beneath it.
+    fn from_position_no_caret(position: CodeRange, filename: &str, source_map: &mut SourceMap<'_>) -> StackFrame {
+        let (start, end, preview_line) = source_map.resolve_range(position);
+        StackFrame {
+            filename: filename.to_string(),
+            start,
+            end,
+            frame_name: None,
+            preview_line,
+            hide_caret: true,
+            hide_frame_name: false,
+        }
+    }
+}
+
+impl StackFrameExt for StackFrame {}

--- a/crates/monty/src/string_builder.rs
+++ b/crates/monty/src/string_builder.rs
@@ -53,11 +53,7 @@
 use std::{fmt, mem};
 
 use crate::{
-    exception_private::RunResult,
-    heap::Heap,
-    resource::{ResourceError, ResourceTracker},
-    types::str::allocate_string,
-    value::Value,
+    ResourceError, ResourceTracker, exception_private::RunResult, heap::Heap, types::str::allocate_string, value::Value,
 };
 
 /// Resource-tracked builder for a `String`.

--- a/crates/monty/src/string_builder.rs
+++ b/crates/monty/src/string_builder.rs
@@ -52,9 +52,9 @@
 
 use std::{fmt, mem};
 
-use crate::{
-    ResourceError, ResourceTracker, exception_private::RunResult, heap::Heap, types::str::allocate_string, value::Value,
-};
+use monty_types::{ResourceError, ResourceTracker};
+
+use crate::{exception_private::RunResult, heap::Heap, types::str::allocate_string, value::Value};
 
 /// Resource-tracked builder for a `String`.
 ///

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -1,9 +1,5 @@
 use std::{cell::Cell, ffi::c_int, fmt::Write, mem, ops, str};
 
-pub use monty_types::{bytes_repr, bytes_repr_fmt};
-use smallvec::smallvec;
-
-use super::{CmpOrder, LazyHeapSet, PyTrait, Type};
 /// Python bytes type, wrapping a `Vec<u8>`.
 ///
 /// This type provides Python bytes semantics with operations on ASCII bytes only.
@@ -71,14 +67,17 @@ use super::{CmpOrder, LazyHeapSet, PyTrait, Type};
 /// - `expandtabs(tabsize=8)` - Tab expansion
 /// - `translate(table[, delete])` - Character translation
 /// - `maketrans(frm, to)` - Create translation table (staticmethod)
-use crate::exception_private::ExcTypeExt;
+use monty_types::{ResourceError, ResourceTracker};
+pub use monty_types::{bytes_repr, bytes_repr_fmt};
+use smallvec::smallvec;
+
+use super::{CmpOrder, LazyHeapSet, PyTrait, Type};
 use crate::{
-    ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs, StrArg},
     bytecode::{CallResult, VM},
     codecs::Codec,
     defer_drop,
-    exception_private::{ExcType, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
     hash::{HashValue, hash_python_bytes},
     heap::{DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, heap_read_ref_as_field},
     intern::{StaticStrings, StringId},

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -1,3 +1,9 @@
+use std::{cell::Cell, ffi::c_int, fmt::Write, mem, ops, str};
+
+pub use monty_types::{bytes_repr, bytes_repr_fmt};
+use smallvec::smallvec;
+
+use super::{CmpOrder, LazyHeapSet, PyTrait, Type};
 /// Python bytes type, wrapping a `Vec<u8>`.
 ///
 /// This type provides Python bytes semantics with operations on ASCII bytes only.
@@ -65,17 +71,9 @@
 /// - `expandtabs(tabsize=8)` - Tab expansion
 /// - `translate(table[, delete])` - Character translation
 /// - `maketrans(frm, to)` - Create translation table (staticmethod)
-use std::{
-    cell::Cell,
-    ffi::c_int,
-    fmt::{self, Write},
-    mem, ops, str,
-};
-
-use smallvec::smallvec;
-
-use super::{CmpOrder, LazyHeapSet, PyTrait, Type};
+use crate::exception_private::ExcTypeExt;
 use crate::{
+    ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs, StrArg},
     bytecode::{CallResult, VM},
     codecs::Codec,
@@ -84,7 +82,7 @@ use crate::{
     hash::{HashValue, hash_python_bytes},
     heap::{DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, heap_read_ref_as_field},
     intern::{StaticStrings, StringId},
-    resource::{ResourceError, ResourceTracker, check_repeat_size, check_replace_size},
+    resource_checks::{check_repeat_size, check_replace_size},
     types::{
         List,
         slice::{normalize_sequence_index, slice_collect_iterator},
@@ -485,50 +483,6 @@ fn call_bytes_method_impl<'h>(
             Err(ExcType::attribute_error(Type::Bytes, method.into()))
         }
     }
-}
-
-/// Writes a CPython-compatible repr string for bytes to a formatter.
-///
-/// Format: `b'...'` or `b"..."` depending on content.
-/// - Uses single quotes by default
-/// - Switches to double quotes if bytes contain `'` but not `"`
-/// - Escapes: `\\`, `\t`, `\n`, `\r`, `\xNN` for non-printable bytes
-pub fn bytes_repr_fmt(bytes: &[u8], f: &mut impl Write) -> fmt::Result {
-    // Determine quote character: use double quotes if single quote present but not double
-    let has_single = bytes.contains(&b'\'');
-    let has_double = bytes.contains(&b'"');
-    let quote = if has_single && !has_double { '"' } else { '\'' };
-
-    f.write_char('b')?;
-    f.write_char(quote)?;
-
-    for &byte in bytes {
-        match byte {
-            b'\\' => f.write_str("\\\\")?,
-            b'\t' => f.write_str("\\t")?,
-            b'\n' => f.write_str("\\n")?,
-            b'\r' => f.write_str("\\r")?,
-            b'\'' if quote == '\'' => f.write_str("\\'")?,
-            b'"' if quote == '"' => f.write_str("\\\"")?,
-            // Printable ASCII (32-126)
-            0x20..=0x7e => f.write_char(byte as char)?,
-            // Non-printable: use \xNN format
-            _ => write!(f, "\\x{byte:02x}")?,
-        }
-    }
-
-    f.write_char(quote)
-}
-
-/// Returns a CPython-compatible repr string for bytes.
-///
-/// Convenience wrapper around `bytes_repr_fmt` that returns an owned String.
-#[must_use]
-pub fn bytes_repr(bytes: &[u8]) -> String {
-    let mut result = String::new();
-    // Writing to String never fails
-    bytes_repr_fmt(bytes, &mut result).unwrap();
-    result
 }
 
 /// Implements Python's `bytes.decode([encoding[, errors]])` method.

--- a/crates/monty/src/types/callable_iterator.rs
+++ b/crates/monty/src/types/callable_iterator.rs
@@ -7,10 +7,10 @@
 
 use std::mem;
 
+use monty_types::ResourceTracker;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/types/class.rs
+++ b/crates/monty/src/types/class.rs
@@ -1,8 +1,9 @@
 use std::{fmt::Write, mem};
 
+use monty_types::ResourceTracker;
+
 use super::{Dict, LazyHeapSet, PyTrait, Type};
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     defer_drop,

--- a/crates/monty/src/types/class.rs
+++ b/crates/monty/src/types/class.rs
@@ -2,13 +2,13 @@ use std::{fmt::Write, mem};
 
 use super::{Dict, LazyHeapSet, PyTrait, Type};
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     defer_drop,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     hash::{HashValue, identity_hash},
     heap::{BorrowedHeapReadMut, DropWithContext, HeapId, HeapItem, HeapRead, heap_read_ref_as_field_mut},
-    resource::ResourceTracker,
     types::str::allocate_string,
     value::{EitherStr, Value},
 };

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -4,11 +4,11 @@ use std::{
     mem,
 };
 
+use monty_types::ResourceTracker;
 use serde::ser::SerializeStruct;
 
 use super::{Dict, LazyHeapSet, PyTrait};
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     defer_drop,

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -8,17 +8,17 @@ use serde::ser::SerializeStruct;
 
 use super::{Dict, LazyHeapSet, PyTrait};
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     defer_drop,
-    exception_private::{ExcType, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
     hash::HashValue,
     heap::{
         BorrowedHeapRead, BorrowedHeapReadMut, HeapId, HeapItem, HeapRead, HeapReadOutput, heap_read_ref_as_field,
         heap_read_ref_as_field_mut,
     },
     intern::Interns,
-    resource::ResourceTracker,
     types::Type,
     value::{EitherStr, Value},
 };

--- a/crates/monty/src/types/date.rs
+++ b/crates/monty/src/types/date.rs
@@ -13,15 +13,14 @@ use std::{
 use chrono::{Datelike, NaiveDate, format::StrftimeItems};
 
 use crate::{
+    OsFunctionCall, ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs, StrArg},
     bytecode::{CallResult, VM},
     defer_drop,
-    exception_private::{ExcType, RunError, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     hash::HashValue,
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
-    os::OsFunctionCall,
-    resource::{ResourceError, ResourceTracker},
     types::{
         AttrCallResult, CmpOrder, LazyHeapSet, PyTrait, TimeDelta, Type,
         str::{allocate_string, allocate_string_no_interning},

--- a/crates/monty/src/types/date.rs
+++ b/crates/monty/src/types/date.rs
@@ -11,9 +11,9 @@ use std::{
 };
 
 use chrono::{Datelike, NaiveDate, format::StrftimeItems};
+use monty_types::{OsFunctionCall, ResourceError, ResourceTracker};
 
 use crate::{
-    OsFunctionCall, ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs, StrArg},
     bytecode::{CallResult, VM},
     defer_drop,

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -15,16 +15,14 @@ use chrono::{
 };
 
 use crate::{
+    MontyTimeZone, OsFunctionCall, ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::{CallResult, VM},
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
     hash::HashValue,
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
-    object::MontyTimeZone,
-    os::OsFunctionCall,
-    resource::{ResourceError, ResourceTracker},
     types::{
         AttrCallResult, CmpOrder, LazyHeapSet, PyTrait, TimeDelta, TimeZone, Type,
         date::{self, StrftimeArgs},

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -13,9 +13,9 @@ use std::{
 use chrono::{
     Datelike, FixedOffset, NaiveDateTime, NaiveTime, TimeDelta as ChronoTimeDelta, Timelike, format::StrftimeItems,
 };
+use monty_types::{MontyTimeZone, OsFunctionCall, ResourceError, ResourceTracker};
 
 use crate::{
-    MontyTimeZone, OsFunctionCall, ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::{CallResult, VM},
     defer_drop, defer_drop_mut,

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -11,13 +11,13 @@ use smallvec::{SmallVec, smallvec};
 
 use super::{DictItemsView, DictKeysView, DictValuesView, LazyHeapSet, PyTrait, allocate_tuple};
 use crate::{
+    ResourceTracker,
     args::{ArgValues, FromArgs, KwargsValues},
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
-    resource::ResourceTracker,
     types::Type,
     value::{EitherStr, VALUE_SIZE, Value},
 };

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -6,12 +6,12 @@ use std::{
 };
 
 use hashbrown::HashTable;
+use monty_types::ResourceTracker;
 use serde::ser::SerializeStruct;
 use smallvec::{SmallVec, smallvec};
 
 use super::{DictItemsView, DictKeysView, DictValuesView, LazyHeapSet, PyTrait, allocate_tuple};
 use crate::{
-    ResourceTracker,
     args::{ArgValues, FromArgs, KwargsValues},
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
     defer_drop, defer_drop_mut,

--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -3,13 +3,13 @@ use std::{fmt::Write, mem};
 use smallvec::smallvec;
 
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, RunError, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
     heap::{DropGuard, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
-    resource::ResourceTracker,
     types::{Dict, FrozenSet, LazyHeapSet, PyTrait, Set, Type, allocate_tuple, iter::checked_preallocation_hint},
     value::{EitherStr, Value},
 };

--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -1,9 +1,9 @@
 use std::{fmt::Write, mem};
 
+use monty_types::ResourceTracker;
 use smallvec::smallvec;
 
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     defer_drop, defer_drop_mut,

--- a/crates/monty/src/types/file.rs
+++ b/crates/monty/src/types/file.rs
@@ -4,7 +4,7 @@
 //! objects store only the virtual path, requested mode, a small Python-visible
 //! state such as `closed`, and (lazily) a heap-resident full-file buffer
 //! populated on the first sized/line read or `seek()`. Each OS round-trip is a
-//! complete one-shot [`OsFunctionCall`](crate::OsFunctionCall) operation, so host
+//! complete one-shot [`OsFunctionCall`] operation, so host
 //! filesystem access remains mediated by the same boundary used by
 //! `pathlib.Path`.
 //!
@@ -64,13 +64,14 @@
 
 use std::{fmt::Write, mem};
 
+use monty_types::{MontyPath, OsFunctionCall, PathBytesDataArgs, PathStringDataArgs, ResourceTracker};
+
 use super::{
     LazyHeapSet, List, PyTrait, Type,
     bytes::Bytes,
     str::{allocate_string, allocate_string_no_interning},
 };
 use crate::{
-    MontyPath, OsFunctionCall, PathBytesDataArgs, PathStringDataArgs, ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
@@ -245,7 +246,7 @@ struct BufferMeta {
 impl OpenFile {
     /// Creates a path-backed file wrapper from a parsed `open()` mode and the
     /// `position` carried across the host boundary by a
-    /// [`MontyObject::FileHandle`](crate::MontyObject::FileHandle).
+    /// [`monty_types::MontyObject::FileHandle`].
     ///
     /// Truncating modes (`w`/`w+`) have already had the file emptied by the
     /// host at `open()` time, so the wrapper starts with `first_write_done`

--- a/crates/monty/src/types/file.rs
+++ b/crates/monty/src/types/file.rs
@@ -4,7 +4,7 @@
 //! objects store only the virtual path, requested mode, a small Python-visible
 //! state such as `closed`, and (lazily) a heap-resident full-file buffer
 //! populated on the first sized/line read or `seek()`. Each OS round-trip is a
-//! complete one-shot [`OsFunction`](crate::os::OsFunction) operation, so host
+//! complete one-shot [`OsFunctionCall`](crate::OsFunctionCall) operation, so host
 //! filesystem access remains mediated by the same boundary used by
 //! `pathlib.Path`.
 //!
@@ -62,7 +62,7 @@
 //! Any code path that needs one of these should be added explicitly
 //! rather than relying on CPython parity.
 
-use std::{borrow::Cow, fmt::Write, mem, str::FromStr};
+use std::{fmt::Write, mem};
 
 use super::{
     LazyHeapSet, List, PyTrait, Type,
@@ -70,13 +70,12 @@ use super::{
     str::{allocate_string, allocate_string_no_interning},
 };
 use crate::{
+    MontyPath, OsFunctionCall, PathBytesDataArgs, PathStringDataArgs, ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
-    exception_private::{ExcType, RunError, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     heap::{DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
-    os::{MontyPath, OsFunctionCall, PathBytesDataArgs, PathStringDataArgs},
-    resource::ResourceTracker,
     types::str::StringRepr,
     value::{EitherStr, Value},
 };
@@ -131,214 +130,23 @@ pub(crate) enum PendingFileEffect {
     },
 }
 
-/// A parsed Python `open()` mode.
-///
-/// This single enum captures everything that matters about how a file was
-/// opened: the access pattern (`r`/`w`/`a` and the `+` update flag) and
-/// whether the file is binary. The variant name encodes the access pattern;
-/// the `bool` payload is `true` for binary and `false` for text — i.e.
-/// `Read(true)` is `'rb'` and `Read(false)` is `'r'`.
-///
-/// Construct one with the [`FromStr`] impl (`mode_str.parse::<FileMode>()`).
-/// The original input string is
-/// intentionally not preserved; [`FileMode::as_str`] rebuilds the canonical
-/// CPython form (`'r'`, `'rb+'`, `'wb'`, …), matching how CPython itself
-/// normalizes input like `'rt'` → `'r'` and `'r+b'` → `'rb+'`.
-///
-/// `+` update modes (`ReadUpdate`/`WriteUpdate`/`AppendUpdate`) are reserved
-/// in the enum so the mode space is fully represented, but [`FromStr`]
-/// currently rejects them — properly modelling them needs read-position
-/// tracking that the file wrapper does not yet implement. Treat the `Update`
-/// variants as unreachable at runtime; do not pattern-match against them as
-/// if they were a valid result of parsing user input.
-///
-/// Carried publicly by [`MontyObject::FileHandle`] so a host servicing file
-/// operations can inspect the mode without re-parsing the raw string.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-pub enum FileMode {
-    /// `r` / `rb`: read-only; the file must already exist.
-    Read(bool),
-    /// `r+` / `rb+`: read and write an existing file. Reserved; not yet
-    /// produced by [`FromStr`].
-    ReadUpdate(bool),
-    /// `w` / `wb`: write-only; truncate the file (creating it if missing) on open.
-    Write(bool),
-    /// `w+` / `wb+`: read and write; truncate the file (creating it if missing).
-    /// Reserved; not yet produced by [`FromStr`].
-    WriteUpdate(bool),
-    /// `a` / `ab`: write-only appending; create the file if missing, preserving content.
-    Append(bool),
-    /// `a+` / `ab+`: read and append; create the file if missing, preserving content.
-    /// Reserved; not yet produced by [`FromStr`].
-    AppendUpdate(bool),
+pub use monty_types::FileMode;
+
+/// Crate-internal extension mapping a [`FileMode`] to the runtime `_io`
+/// wrapper [`Type`] (`FileMode` lives in `monty-types`, `Type` does not).
+pub(crate) trait FileModeExt {
+    /// Returns the `_io` wrapper type a file opened with this mode presents as.
+    fn file_type(&self) -> Type;
 }
 
-impl FileMode {
-    /// Returns the canonical Python `open()` mode string for this mode,
-    /// matching what CPython exposes via `file.mode`.
-    ///
-    /// The result is always one of the 12 well-formed mode strings (`r`, `rb`,
-    /// `r+`, `rb+`, `w`, `wb`, `w+`, `wb+`, `a`, `ab`, `a+`, `ab+`). This is
-    /// the canonical form CPython itself normalizes user input into — e.g.
-    /// `'rt'` → `'r'`, `'r+b'` → `'rb+'`, `'br'` → `'rb'`.
-    #[must_use]
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Read(false) => "r",
-            Self::Read(true) => "rb",
-            Self::ReadUpdate(false) => "r+",
-            Self::ReadUpdate(true) => "rb+",
-            Self::Write(false) => "w",
-            Self::Write(true) => "wb",
-            Self::WriteUpdate(false) => "w+",
-            Self::WriteUpdate(true) => "wb+",
-            Self::Append(false) => "a",
-            Self::Append(true) => "ab",
-            Self::AppendUpdate(false) => "a+",
-            Self::AppendUpdate(true) => "ab+",
-        }
-    }
-
-    /// Whether the file is binary (`'rb'`, `'wb'`, …) rather than text.
-    #[must_use]
-    pub fn is_binary(&self) -> bool {
-        let (Self::Read(b)
-        | Self::ReadUpdate(b)
-        | Self::Write(b)
-        | Self::WriteUpdate(b)
-        | Self::Append(b)
-        | Self::AppendUpdate(b)) = self;
-        *b
-    }
-
-    /// Whether `read()` is allowed by this mode.
-    #[must_use]
-    pub fn readable(&self) -> bool {
-        matches!(
-            self,
-            Self::Read(_) | Self::ReadUpdate(_) | Self::WriteUpdate(_) | Self::AppendUpdate(_)
-        )
-    }
-
-    /// Whether `write()` is allowed by this mode.
-    #[must_use]
-    pub fn writable(&self) -> bool {
-        matches!(
-            self,
-            Self::Write(_) | Self::WriteUpdate(_) | Self::Append(_) | Self::AppendUpdate(_) | Self::ReadUpdate(_)
-        )
-    }
-
-    /// Whether writes should always append (`a`/`a+`).
-    #[must_use]
-    pub fn is_append(&self) -> bool {
-        matches!(self, Self::Append(_) | Self::AppendUpdate(_))
-    }
-
-    /// Whether `open()` must truncate the file to empty immediately (`w`/`w+`).
-    #[must_use]
-    pub fn truncate(&self) -> bool {
-        matches!(self, Self::Write(_) | Self::WriteUpdate(_))
-    }
-
-    /// Whether `open()` must create the file immediately if missing.
-    ///
-    /// True for the `w`/`w+` and `a`/`a+` families. For append modes this must
-    /// not disturb existing content.
-    #[must_use]
-    pub fn create(&self) -> bool {
-        matches!(
-            self,
-            Self::Write(_) | Self::WriteUpdate(_) | Self::Append(_) | Self::AppendUpdate(_)
-        )
-    }
-
-    /// Returns the `_io` wrapper type a file opened with this mode presents as.
-    #[must_use]
-    pub fn file_type(&self) -> Type {
+impl FileModeExt for FileMode {
+    fn file_type(&self) -> Type {
         match self {
             _ if !self.is_binary() => Type::TextIOWrapper,
             Self::ReadUpdate(_) | Self::WriteUpdate(_) | Self::AppendUpdate(_) => Type::BufferedRandom,
             Self::Read(_) => Type::BufferedReader,
             Self::Write(_) | Self::Append(_) => Type::BufferedWriter,
         }
-    }
-
-    /// Returns the bare Python type name (`type(f).__name__`) for this mode.
-    #[must_use]
-    pub fn type_name(&self) -> &'static str {
-        match self {
-            _ if !self.is_binary() => "TextIOWrapper",
-            Self::ReadUpdate(_) | Self::WriteUpdate(_) | Self::AppendUpdate(_) => "BufferedRandom",
-            Self::Read(_) => "BufferedReader",
-            Self::Write(_) | Self::Append(_) => "BufferedWriter",
-        }
-    }
-}
-
-/// Parses a Python `open()` mode string into a [`FileMode`].
-///
-/// Monty supports the common read, write, append, and update combinations in
-/// text or binary form. Exclusive creation (`x`) is rejected for now because
-/// it needs a dedicated mount-table operation to be race-free.
-///
-/// The `Err` payload is a CPython-matched message — empty input, an unknown
-/// mode character, duplicated `b`/`t`/`+`, conflicting binary+text flags, or
-/// more than one of the `r`/`w`/`a` actions.
-impl FromStr for FileMode {
-    type Err = Cow<'static, str>;
-
-    fn from_str(mode: &str) -> Result<Self, Self::Err> {
-        if mode.is_empty() {
-            // CPython's empty-mode error message, mirrored verbatim. Note: the
-            // duplicate-action message is different (lowercase, no `... and at most one
-            // plus` suffix) — see the `'r' | 'w' | 'a'` arm.
-            return Err("Must have exactly one of create/read/write/append mode and at most one plus".into());
-        }
-
-        let mut action = None;
-        let mut binary = false;
-        let mut text = false;
-
-        for ch in mode.chars() {
-            match ch {
-                'r' | 'w' | 'a' => {
-                    if action.replace(ch).is_some() {
-                        return Err("must have exactly one of create/read/write/append mode".into());
-                    }
-                }
-                'x' => return Err("exclusive creation mode is not supported".into()),
-                'b' => {
-                    if binary {
-                        return Err("invalid mode: binary mode specified twice".into());
-                    }
-                    binary = true;
-                }
-                't' => {
-                    if text {
-                        return Err("invalid mode: text mode specified twice".into());
-                    }
-                    text = true;
-                }
-                // `+` modes (`r+`, `w+`, `a+`, and their `b` variants) need
-                // read-position tracking that Monty does not yet implement.
-                // Reject them outright rather than silently truncating on the
-                // first write (which would happen because the OS-level read
-                // and write ops are full-file one-shots).
-                '+' => return Err("update modes ('+') are not yet supported".into()),
-                _ => return Err(format!("invalid mode: {ch:?}").into()),
-            }
-        }
-
-        if binary && text {
-            return Err("can't have text and binary mode at once".into());
-        }
-
-        Ok(match action.unwrap_or('r') {
-            'w' => Self::Write(binary),
-            'a' => Self::Append(binary),
-            _ => Self::Read(binary),
-        })
     }
 }
 

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -1,8 +1,9 @@
 use std::{borrow::Cow, fmt::Write, mem};
 
+use monty_types::ResourceTracker;
+
 use super::{Dict, LazyHeapSet, PyTrait, Type};
 use crate::{
-    ResourceTracker,
     args::{ArgValues, KwargsValues},
     builtins::Builtins,
     bytecode::{CallResult, VM},

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -2,18 +2,18 @@ use std::{borrow::Cow, fmt::Write, mem};
 
 use super::{Dict, LazyHeapSet, PyTrait, Type};
 use crate::{
+    ResourceTracker,
     args::{ArgValues, KwargsValues},
     builtins::Builtins,
     bytecode::{CallResult, VM},
     defer_drop,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     hash::{HashValue, identity_hash},
     heap::{
         BorrowedHeapReadMut, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput,
         heap_read_ref_as_field_mut,
     },
     intern::Interns,
-    resource::ResourceTracker,
     types::allocate_string,
     value::{EitherStr, Value},
 };

--- a/crates/monty/src/types/iter.rs
+++ b/crates/monty/src/types/iter.rs
@@ -16,8 +16,9 @@
 
 use std::mem;
 
+use monty_types::{ResourceError, ResourceTracker};
+
 use crate::{
-    ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/types/iter.rs
+++ b/crates/monty/src/types/iter.rs
@@ -17,13 +17,14 @@
 use std::mem;
 
 use crate::{
+    ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, RunError, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
     heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{BytesId, Interns},
-    resource::{ResourceError, ResourceTracker, check_estimated_size},
+    resource_checks::check_estimated_size,
     types::{PyTrait, Range, Type, callable_iterator::CallableIterator, dict_view::DictView, str::allocate_char},
     value::{VALUE_SIZE, Value, ValueRead},
 };

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -5,13 +5,13 @@ use smallvec::SmallVec;
 
 use super::{CmpOrder, PyTrait, iter::collect_owned_iterable};
 use crate::{
+    ResourceError, ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, RunError, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     heap::{DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput, HeapReader},
     intern::StaticStrings,
-    resource::{ResourceError, ResourceTracker},
     sorting::parse_and_sort,
     types::{
         LazyHeapSet, Type,
@@ -1012,11 +1012,9 @@ mod tests {
 
     use super::*;
     use crate::{
-        PrintWriter,
+        AssertMessageAnnotations, NoLimitTracker, PrintWriter,
         heap::{Heap, HeapReader},
         intern::{InternerBuilder, Interns},
-        resource::NoLimitTracker,
-        run::AssertMessageAnnotations,
         types::LongInt,
     };
 

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -1,11 +1,11 @@
 use std::{cmp::Ordering, fmt::Write, mem};
 
+use monty_types::{ResourceError, ResourceTracker};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
 use super::{CmpOrder, PyTrait, iter::collect_owned_iterable};
 use crate::{
-    ResourceError, ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
     defer_drop, defer_drop_mut,
@@ -1008,11 +1008,11 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ListIterator> {
 
 #[cfg(test)]
 mod tests {
+    use monty_types::{AssertMessageAnnotations, NoLimitTracker, PrintWriter};
     use num_bigint::BigInt;
 
     use super::*;
     use crate::{
-        AssertMessageAnnotations, NoLimitTracker, PrintWriter,
         heap::{Heap, HeapReader},
         intern::{InternerBuilder, Interns},
         types::LongInt,

--- a/crates/monty/src/types/long_int.rs
+++ b/crates/monty/src/types/long_int.rs
@@ -16,11 +16,11 @@ use std::{
     sync::OnceLock,
 };
 
+use monty_types::{ResourceError, ResourceTracker};
 use num_bigint::BigInt;
 use num_traits::{FromPrimitive, Signed, ToPrimitive, Zero};
 
 use crate::{
-    ResourceError, ResourceTracker,
     exception_private::{ExcType, ExcTypeExt, RunResult},
     hash::{HashValue, hash_python_long_int},
     heap::{Heap, HeapData},

--- a/crates/monty/src/types/long_int.rs
+++ b/crates/monty/src/types/long_int.rs
@@ -20,10 +20,10 @@ use num_bigint::BigInt;
 use num_traits::{FromPrimitive, Signed, ToPrimitive, Zero};
 
 use crate::{
-    exception_private::{ExcType, RunResult},
+    ResourceError, ResourceTracker,
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     hash::{HashValue, hash_python_long_int},
     heap::{Heap, HeapData},
-    resource::{ResourceError, ResourceTracker},
     value::Value,
 };
 

--- a/crates/monty/src/types/module.rs
+++ b/crates/monty/src/types/module.rs
@@ -2,8 +2,9 @@
 
 use std::mem;
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     defer_drop,

--- a/crates/monty/src/types/module.rs
+++ b/crates/monty/src/types/module.rs
@@ -3,13 +3,13 @@
 use std::mem;
 
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     defer_drop,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::{DropGuard, HeapId, HeapItem, HeapRead},
     intern::StringId,
-    resource::ResourceTracker,
     types::Dict,
     value::{EitherStr, Value},
 };

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -1,3 +1,12 @@
+use std::{
+    cell::Cell,
+    collections::hash_map::DefaultHasher,
+    fmt::Write,
+    hash::{Hash, Hasher},
+    mem,
+};
+
+use super::PyTrait;
 /// Python named tuple type, combining tuple-like indexing with named attribute access.
 ///
 /// Named tuples are like regular tuples but with field names, providing two ways
@@ -15,23 +24,15 @@
 ///
 /// This type is used for `sys.version_info` and similar structured tuples where
 /// named access improves usability and readability.
-use std::{
-    cell::Cell,
-    collections::hash_map::DefaultHasher,
-    fmt::Write,
-    hash::{Hash, Hasher},
-    mem,
-};
-
-use super::PyTrait;
+use crate::exception_private::ExcTypeExt;
 use crate::{
+    ResourceTracker,
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, RunResult},
     hash::HashValue,
     heap::{DropWithContext, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StringId},
-    resource::ResourceTracker,
     types::{Type, py_trait::LazyHeapSet},
     value::{EitherStr, Value},
 };

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -6,7 +6,6 @@ use std::{
     mem,
 };
 
-use super::PyTrait;
 /// Python named tuple type, combining tuple-like indexing with named attribute access.
 ///
 /// Named tuples are like regular tuples but with field names, providing two ways
@@ -24,12 +23,13 @@ use super::PyTrait;
 ///
 /// This type is used for `sys.version_info` and similar structured tuples where
 /// named access improves usability and readability.
-use crate::exception_private::ExcTypeExt;
+use monty_types::ResourceTracker;
+
+use super::PyTrait;
 use crate::{
-    ResourceTracker,
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     hash::HashValue,
     heap::{DropWithContext, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StringId},

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -12,10 +12,10 @@ use std::{
     mem,
 };
 
+use monty_types::{MontyPath, ResourceTracker};
 use smallvec::SmallVec;
 
 use crate::{
-    MontyPath, ResourceTracker,
     args::ArgValues,
     builtins::open::builtin_open,
     bytecode::{CallResult, VM},

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -15,16 +15,16 @@ use std::{
 use smallvec::SmallVec;
 
 use crate::{
+    MontyPath, ResourceTracker,
     args::ArgValues,
     builtins::open::builtin_open,
     bytecode::{CallResult, VM},
     defer_drop,
-    exception_private::{ExcType, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
     hash::HashValue,
     heap::{DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
-    os::{MontyPath, build_path_os_call, is_path_os_method},
-    resource::ResourceTracker,
+    os_dispatch::{build_path_os_call, is_path_os_method},
     types::{LazyHeapSet, PyTrait, Type, allocate_tuple, str::allocate_string},
     value::{EitherStr, Value},
 };

--- a/crates/monty/src/types/property.rs
+++ b/crates/monty/src/types/property.rs
@@ -4,7 +4,7 @@
 //! When a Property is retrieved via `py_getattr`, its getter is invoked
 //! rather than returning the Property itself.
 
-use crate::{bytecode::CallResult, os::OsFunctionCall};
+use crate::{OsFunctionCall, bytecode::CallResult};
 
 /// Property descriptor for computed attributes (mirrors Python's descriptor
 /// protocol — accessing the property invokes its getter).

--- a/crates/monty/src/types/property.rs
+++ b/crates/monty/src/types/property.rs
@@ -4,7 +4,9 @@
 //! When a Property is retrieved via `py_getattr`, its getter is invoked
 //! rather than returning the Property itself.
 
-use crate::{OsFunctionCall, bytecode::CallResult};
+use monty_types::OsFunctionCall;
+
+use crate::bytecode::CallResult;
 
 /// Property descriptor for computed attributes (mirrors Python's descriptor
 /// protocol — accessing the property invokes its getter).

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -1,8 +1,6 @@
 use std::{cmp::Ordering, fmt::Write};
 
 use ahash::AHashSet;
-
-use super::{MontyIter, Type, allocate_string};
 /// Trait for heap-allocated Python values that need common operations.
 ///
 /// This trait abstracts over container types (List, Tuple, Str, Bytes) stored
@@ -14,12 +12,13 @@ use super::{MontyIter, Type, allocate_string};
 ///
 /// The trait is designed to work with `enum_dispatch` for efficient virtual
 /// dispatch on `HeapData` without boxing overhead.
-use crate::exception_private::ExcTypeExt;
+use monty_types::{OsFunctionCall, ResourceError, ResourceTracker};
+
+use super::{MontyIter, Type, allocate_string};
 use crate::{
-    OsFunctionCall, ResourceError, ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
-    exception_private::{ExcType, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
     hash::HashValue,
     heap::{DropWithContext, HeapData, HeapId},
     intern::StringId,

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -1,3 +1,8 @@
+use std::{cmp::Ordering, fmt::Write};
+
+use ahash::AHashSet;
+
+use super::{MontyIter, Type, allocate_string};
 /// Trait for heap-allocated Python values that need common operations.
 ///
 /// This trait abstracts over container types (List, Tuple, Str, Bytes) stored
@@ -9,20 +14,15 @@
 ///
 /// The trait is designed to work with `enum_dispatch` for efficient virtual
 /// dispatch on `HeapData` without boxing overhead.
-use std::{cmp::Ordering, fmt::Write};
-
-use ahash::AHashSet;
-
-use super::{MontyIter, Type, allocate_string};
+use crate::exception_private::ExcTypeExt;
 use crate::{
+    OsFunctionCall, ResourceError, ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     exception_private::{ExcType, RunResult, SimpleException},
     hash::HashValue,
     heap::{DropWithContext, HeapData, HeapId},
     intern::StringId,
-    os::OsFunctionCall,
-    resource::{ResourceError, ResourceTracker},
     value::{EitherStr, Value},
 };
 

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -10,10 +10,10 @@ use std::{
     mem,
 };
 
+use monty_types::ResourceTracker;
 use num_integer::div_ceil;
 
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -13,13 +13,13 @@ use std::{
 use num_integer::div_ceil;
 
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     hash::HashValue,
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
-    resource::ResourceTracker,
     types::{LazyHeapSet, PyTrait, Type},
     value::Value,
 };

--- a/crates/monty/src/types/re_match.rs
+++ b/crates/monty/src/types/re_match.rs
@@ -14,13 +14,13 @@ use std::{cell::OnceCell, cmp::Ordering, fmt::Write, mem};
 use smallvec::smallvec;
 
 use crate::{
+    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::{CallResult, VM},
     defer_drop_mut,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead},
     intern::StaticStrings,
-    resource::ResourceTracker,
     types::{
         Dict, LazyHeapSet, PyTrait, Type, allocate_tuple,
         str::{allocate_string, string_repr_fmt},

--- a/crates/monty/src/types/re_match.rs
+++ b/crates/monty/src/types/re_match.rs
@@ -11,10 +11,10 @@
 
 use std::{cell::OnceCell, cmp::Ordering, fmt::Write, mem};
 
+use monty_types::ResourceTracker;
 use smallvec::smallvec;
 
 use crate::{
-    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::{CallResult, VM},
     defer_drop_mut,

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -16,14 +16,15 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use smallvec::SmallVec;
 
 use crate::{
+    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::{CallResult, VM},
     defer_drop,
-    exception_private::{ExcType, RunError, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     modules::re::{ASCII, DOTALL, IGNORECASE, MULTILINE},
-    resource::{ResourceTracker, check_estimated_size},
+    resource_checks::check_estimated_size,
     types::{
         LazyHeapSet, List, PyTrait, ReMatch, Type, allocate_tuple,
         str::{allocate_string, string_repr_fmt},

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -12,11 +12,11 @@
 use std::{borrow::Cow, cell::OnceCell, cmp::Ordering, fmt::Write, iter, mem, str};
 
 use fancy_regex::{CompileError, Error as RegexError, Regex, RegexBuilder};
+use monty_types::ResourceTracker;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use smallvec::SmallVec;
 
 use crate::{
-    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::{CallResult, VM},
     defer_drop,

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -5,17 +5,17 @@ use smallvec::SmallVec;
 
 use super::{PyTrait, iter::checked_preallocation_hint};
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     hash::HashValue,
     heap::{
         BorrowedHeapRead, BorrowedHeapReadMut, ContainsHeap, DropGuard, DropWithContext, HeapData, HeapId, HeapItem,
         HeapRead, HeapReadOutput, heap_read_ref_as_field, heap_read_ref_as_field_mut,
     },
     intern::StaticStrings,
-    resource::ResourceTracker,
     types::{LazyHeapSet, Type},
     value::{EitherStr, Value},
 };

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -1,11 +1,11 @@
 use std::{cell::Cell, fmt::Write, mem};
 
 use hashbrown::HashTable;
+use monty_types::ResourceTracker;
 use smallvec::SmallVec;
 
 use super::{PyTrait, iter::checked_preallocation_hint};
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
     defer_drop, defer_drop_mut,

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -13,14 +13,14 @@ use std::{
 
 use super::LazyHeapSet;
 use crate::{
+    ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     defer_drop,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     hash::HashValue,
     heap::{HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
-    resource::ResourceTracker,
     types::{PyTrait, Type},
     value::{EitherStr, Value},
 };

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -11,9 +11,10 @@ use std::{
     mem,
 };
 
+use monty_types::ResourceTracker;
+
 use super::LazyHeapSet;
 use crate::{
-    ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, VM},
     defer_drop,

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -1,14 +1,16 @@
+use std::{cell::Cell, fmt::Write, mem, ops};
+
+pub use monty_types::{StringRepr, string_repr_fmt};
+use smallvec::smallvec;
+
+use super::{Bytes, CmpOrder, PyTrait};
 /// Python string type, wrapping a Rust `String`.
 ///
 /// This type provides Python string semantics. Currently supports basic
 /// operations like length and equality comparison.
-use std::{cell::Cell, fmt, fmt::Write, mem, ops};
-
-use smallvec::smallvec;
-use unicode_general_category::{GeneralCategory, get_general_category};
-
-use super::{Bytes, CmpOrder, PyTrait};
+use crate::exception_private::ExcTypeExt;
 use crate::{
+    ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs, StrArg},
     bytecode::{CallResult, VM},
     codecs::Codec,
@@ -17,7 +19,7 @@ use crate::{
     hash::{HashValue, hash_python_str},
     heap::{DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, heap_read_ref_as_field},
     intern::{StaticStrings, StringId},
-    resource::{ResourceError, ResourceTracker, check_replace_size},
+    resource_checks::check_replace_size,
     string_builder::StringBuilder,
     types::{
         LazyHeapSet, Type,
@@ -580,90 +582,6 @@ fn str_join<'h>(
 
     // Allocate result (uses interned empty string if result is empty)
     Ok(allocate_string(result, vm.heap)?)
-}
-
-/// Writes a Python `repr()` string for a given string slice to a formatter.
-///
-/// Quote choice matches CPython: single quotes by default, switching to double
-/// quotes only when the string contains a `'` but no `"` (so the quote needn't
-/// be escaped). Backslash, the active quote, and `\n`/`\t`/`\r` use the short
-/// escapes; any other **non-printable** character is escaped numerically
-/// (`\xNN`/`\uNNNN`/`\UNNNNNNNN`), e.g. `repr('\x00') == "'\\x00'"` and
-/// `repr('\xa0') == "'\\xa0'"`.
-///
-/// "Non-printable" matches CPython's `str.isprintable` (see
-/// [`repr_needs_escape`]): Unicode categories `C*` and `Z*`, except the ASCII
-/// space. Category data comes from `unicode-general-category`, whose Unicode
-/// version may differ slightly from CPython's, affecting only recently
-/// (re)assigned code points.
-pub fn string_repr_fmt(s: &str, f: &mut impl Write) -> fmt::Result {
-    let quote = if s.contains('\'') && !s.contains('"') {
-        '"'
-    } else {
-        '\''
-    };
-    f.write_char(quote)?;
-    for c in s.chars() {
-        match c {
-            '\\' => f.write_str("\\\\")?,
-            '\n' => f.write_str("\\n")?,
-            '\t' => f.write_str("\\t")?,
-            '\r' => f.write_str("\\r")?,
-            _ if c == quote => {
-                f.write_char('\\')?;
-                f.write_char(quote)?;
-            }
-            _ if repr_needs_escape(c) => write_char_escape(c, f)?,
-            _ => f.write_char(c)?,
-        }
-    }
-    f.write_char(quote)
-}
-
-/// Whether `c` is escaped numerically in a Python `repr` — i.e. it is not
-/// "printable" in CPython's sense.
-///
-/// Non-printable = Unicode general categories `Other` (`Cc`, `Cf`, `Cs`, `Co`,
-/// `Cn`) and `Separator` (`Zl`, `Zp`, `Zs`), with the sole exception of the
-/// ASCII space `U+0020`. The `\t`/`\n`/`\r` short escapes are handled by the
-/// caller before this is consulted.
-fn repr_needs_escape(c: char) -> bool {
-    c != ' '
-        && matches!(
-            get_general_category(c),
-            GeneralCategory::Control
-                | GeneralCategory::Format
-                | GeneralCategory::Surrogate
-                | GeneralCategory::PrivateUse
-                | GeneralCategory::Unassigned
-                | GeneralCategory::LineSeparator
-                | GeneralCategory::ParagraphSeparator
-                | GeneralCategory::SpaceSeparator
-        )
-}
-
-/// Writes the numeric repr escape for a single character, matching CPython's
-/// width selection: `\xNN` for code points `<= 0xFF`, `\uNNNN` for `<= 0xFFFF`,
-/// otherwise `\UNNNNNNNN`.
-fn write_char_escape(c: char, f: &mut impl Write) -> fmt::Result {
-    let cp = c as u32;
-    if cp <= 0xFF {
-        write!(f, "\\x{cp:02x}")
-    } else if cp <= 0xFFFF {
-        write!(f, "\\u{cp:04x}")
-    } else {
-        write!(f, "\\U{cp:08x}")
-    }
-}
-
-/// Formatter for a Python repr() string.
-#[derive(Debug)]
-pub struct StringRepr<'a>(pub &'a str);
-
-impl fmt::Display for StringRepr<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        string_repr_fmt(self.0, f)
-    }
 }
 
 // =============================================================================

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -1,21 +1,20 @@
 use std::{cell::Cell, fmt::Write, mem, ops};
 
-pub use monty_types::{StringRepr, string_repr_fmt};
-use smallvec::smallvec;
-
-use super::{Bytes, CmpOrder, PyTrait};
 /// Python string type, wrapping a Rust `String`.
 ///
 /// This type provides Python string semantics. Currently supports basic
 /// operations like length and equality comparison.
-use crate::exception_private::ExcTypeExt;
+use monty_types::{ResourceError, ResourceTracker};
+pub use monty_types::{StringRepr, string_repr_fmt};
+use smallvec::smallvec;
+
+use super::{Bytes, CmpOrder, PyTrait};
 use crate::{
-    ResourceError, ResourceTracker,
     args::{ArgValues, FromArgs, StrArg},
     bytecode::{CallResult, VM},
     codecs::Codec,
     defer_drop,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     hash::{HashValue, hash_python_str},
     heap::{DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, heap_read_ref_as_field},
     intern::{StaticStrings, StringId},

--- a/crates/monty/src/types/timedelta.rs
+++ b/crates/monty/src/types/timedelta.rs
@@ -15,13 +15,13 @@ use std::{
 use chrono::TimeDelta as ChronoTimeDelta;
 
 use crate::{
+    ResourceTracker,
     args::{ArgValues, FromArgs, FromValue, FromValueFail, is_long_int},
     bytecode::{CallResult, VM},
-    exception_private::{ExcType, RunError, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     hash::HashValue,
     heap::{HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
-    resource::ResourceTracker,
     types::{CmpOrder, LazyHeapSet, PyTrait, Type, str::allocate_string},
     value::{EitherStr, Value},
 };

--- a/crates/monty/src/types/timedelta.rs
+++ b/crates/monty/src/types/timedelta.rs
@@ -13,9 +13,9 @@ use std::{
 };
 
 use chrono::TimeDelta as ChronoTimeDelta;
+use monty_types::ResourceTracker;
 
 use crate::{
-    ResourceTracker,
     args::{ArgValues, FromArgs, FromValue, FromValueFail, is_long_int},
     bytecode::{CallResult, VM},
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},

--- a/crates/monty/src/types/timezone.rs
+++ b/crates/monty/src/types/timezone.rs
@@ -9,8 +9,9 @@ use std::{
     mem,
 };
 
+use monty_types::ResourceTracker;
+
 use crate::{
-    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/types/timezone.rs
+++ b/crates/monty/src/types/timezone.rs
@@ -10,14 +10,14 @@ use std::{
 };
 
 use crate::{
+    ResourceTracker,
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, RunError, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     hash::HashValue,
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::Interns,
-    resource::ResourceTracker,
     types::{
         LazyHeapSet, PyTrait, Type,
         str::{StringRepr, allocate_string},

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -7,9 +7,6 @@ use std::{
     mem,
 };
 
-use smallvec::SmallVec;
-
-use super::{CmpOrder, PyTrait, iter::collect_owned_iterable};
 /// Python tuple type using `SmallVec` for inline storage of small tuples.
 ///
 /// This type provides Python tuple semantics. Tuples are immutable sequences
@@ -26,13 +23,15 @@ use super::{CmpOrder, PyTrait, iter::collect_owned_iterable};
 /// - `count(value)` - Count occurrences
 ///
 /// All tuple methods from Python's builtins are implemented.
-use crate::exception_private::ExcTypeExt;
+use monty_types::{ResourceError, ResourceTracker};
+use smallvec::SmallVec;
+
+use super::{CmpOrder, PyTrait, iter::collect_owned_iterable};
 use crate::{
-    ResourceError, ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
     hash::HashValue,
     heap::{DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -1,3 +1,15 @@
+use std::{
+    cell::Cell,
+    cmp::Ordering,
+    collections::hash_map::DefaultHasher,
+    fmt::Write,
+    hash::{Hash, Hasher},
+    mem,
+};
+
+use smallvec::SmallVec;
+
+use super::{CmpOrder, PyTrait, iter::collect_owned_iterable};
 /// Python tuple type using `SmallVec` for inline storage of small tuples.
 ///
 /// This type provides Python tuple semantics. Tuples are immutable sequences
@@ -14,19 +26,9 @@
 /// - `count(value)` - Count occurrences
 ///
 /// All tuple methods from Python's builtins are implemented.
-use std::{
-    cell::Cell,
-    cmp::Ordering,
-    collections::hash_map::DefaultHasher,
-    fmt::Write,
-    hash::{Hash, Hasher},
-    mem,
-};
-
-use smallvec::SmallVec;
-
-use super::{CmpOrder, PyTrait, iter::collect_owned_iterable};
+use crate::exception_private::ExcTypeExt;
 use crate::{
+    ResourceError, ResourceTracker,
     args::ArgValues,
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
     defer_drop, defer_drop_mut,
@@ -34,7 +36,6 @@ use crate::{
     hash::HashValue,
     heap::{DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
-    resource::{ResourceError, ResourceTracker},
     types::{
         LazyHeapSet, Type,
         list::repr_sequence_fmt,

--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -1,9 +1,9 @@
 use std::{borrow::Cow, fmt};
 
+use monty_types::ResourceTracker;
 use num_bigint::BigInt;
 
 use crate::{
-    ResourceTracker,
     args::{ArgValues, FromArgs, is_long_int},
     bytecode::VM,
     defer_drop,

--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -3,13 +3,13 @@ use std::{borrow::Cow, fmt};
 use num_bigint::BigInt;
 
 use crate::{
+    ResourceTracker,
     args::{ArgValues, FromArgs, is_long_int},
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, RunError, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     heap::{DropWithContext, Heap, HeapData, HeapId},
     intern::{Interns, StaticStrings, StringId},
-    resource::ResourceTracker,
     types::{
         AttrCallResult, Bytes, Dict, FrozenSet, List, LongInt, MontyIter, Path, PyTrait, Range, Set, Slice, Str,
         TimeZone, Tuple,
@@ -251,29 +251,6 @@ impl Type {
             "property" => Some(Self::Property),
             _ => None,
         }
-    }
-
-    /// The inverse of `Display`: resolves any string it produces back to the
-    /// `Type`, including internal names (`"iterator"`,
-    /// `"_io.TextIOWrapper"`, ...) and exception types.
-    ///
-    /// Unlike [`Type::from_builtin_name`] this is NOT restricted to nameable
-    /// builtins — it exists for boundaries that serialize a type by its
-    /// display name (e.g. the subprocess wire protocol) and must round-trip
-    /// every variant; the round-trip is enforced by a test over all variants.
-    /// [`Instance`](Self::Instance) is intentionally excluded (`"object"`
-    /// returns `None`): its `HeapId` payload cannot be reconstructed from a
-    /// name, and no boundary may carry it.
-    #[must_use]
-    pub(crate) fn from_type_name(name: &str) -> Option<Self> {
-        // `EnumString` parses via the same strum `serialize` attributes that
-        // `IntoStaticStr`/`Display` render with, so the two stay in lockstep
-        // by construction. Exception types display as their exception name
-        // ("ValueError", "json.JSONDecodeError", ...) — fall back to the
-        // ExcType parser.
-        name.parse::<Self>()
-            .ok()
-            .or_else(|| name.parse::<ExcType>().ok().map(Self::Exception))
     }
 
     /// Checks if a value of type `self` is an instance of `other`.

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -12,20 +12,18 @@ use num_traits::{FromPrimitive, ToPrimitive, Zero};
 use smallvec::SmallVec;
 
 use crate::{
+    ResourceError, ResourceTracker,
     builtins::Builtins,
     bytecode::{CallResult, VM},
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, RunError, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     fstring::FormatFloat,
     hash::{HashValue, hash_one, hash_python_long_int, hash_python_str},
     heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapReadOutput},
     identity::Identity,
     intern::{BytesId, FunctionId, Interns, LongIntId, StaticStrings, StringId},
     modules::ModuleFunctions,
-    resource::{
-        ResourceError, ResourceTracker, check_div_size, check_lshift_size, check_mult_size, check_pow_size,
-        check_repeat_size,
-    },
+    resource_checks::{check_div_size, check_lshift_size, check_mult_size, check_pow_size, check_repeat_size},
     types::{
         Bytes, CmpOrder, LazyHeapSet, List, LongInt, MontyIter, Property, PyTrait, Type, allocate_tuple,
         bytes::{bytes_repr_fmt, get_byte_at_index},
@@ -2722,9 +2720,7 @@ mod tests {
     use num_bigint::BigInt;
 
     use super::*;
-    use crate::{
-        PrintWriter, heap::HeapReader, intern::InternerBuilder, resource::NoLimitTracker, run::AssertMessageAnnotations,
-    };
+    use crate::{AssertMessageAnnotations, NoLimitTracker, PrintWriter, heap::HeapReader, intern::InternerBuilder};
 
     /// Creates a heap and directly allocates a LongInt with the given BigInt value.
     ///

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -6,13 +6,13 @@ use std::{
     str::FromStr,
 };
 
+use monty_types::{ResourceError, ResourceTracker};
 use num_bigint::BigInt;
 use num_integer::Integer;
 use num_traits::{FromPrimitive, ToPrimitive, Zero};
 use smallvec::SmallVec;
 
 use crate::{
-    ResourceError, ResourceTracker,
     builtins::Builtins,
     bytecode::{CallResult, VM},
     defer_drop, defer_drop_mut,
@@ -2717,10 +2717,11 @@ fn bigint_pow(base: BigInt, exp: u64) -> BigInt {
 
 #[cfg(test)]
 mod tests {
+    use monty_types::{AssertMessageAnnotations, NoLimitTracker, PrintWriter};
     use num_bigint::BigInt;
 
     use super::*;
-    use crate::{AssertMessageAnnotations, NoLimitTracker, PrintWriter, heap::HeapReader, intern::InternerBuilder};
+    use crate::{heap::HeapReader, intern::InternerBuilder};
 
     /// Creates a heap and directly allocates a LongInt with the given BigInt value.
     ///

--- a/crates/monty/tests/assert_messages.rs
+++ b/crates/monty/tests/assert_messages.rs
@@ -4,9 +4,10 @@
 //! See `limitations/assert.md`.
 
 use insta::assert_snapshot;
-use monty::{
-    AssertMessageAnnotations, CompileOptions, ExcType, LimitedTracker, MontyException, MontyObject, MontyRepl,
-    MontyRun, NoLimitTracker, PrintWriter, ResourceLimits,
+use monty::{MontyRepl, MontyRun};
+use monty_types::{
+    AssertMessageAnnotations, CompileOptions, ExcType, LimitedTracker, MontyException, MontyObject, NoLimitTracker,
+    PrintWriter, ResourceLimits,
 };
 
 /// Runs `code` and returns the exception it raises.

--- a/crates/monty/tests/async_memory_limits.rs
+++ b/crates/monty/tests/async_memory_limits.rs
@@ -5,9 +5,10 @@
 
 use std::{mem, rc::Rc, time::Duration};
 
-use monty::{
-    CompileOptions, ExcType, ExtFunctionResult, LimitedTracker, MontyException, MontyObject, MontyRun,
-    NameLookupResult, PrintWriter, ResourceError, ResourceLimits, ResourceTracker, RunProgress,
+use monty::{MontyRun, RunProgress};
+use monty_types::{
+    CompileOptions, ExcType, ExtFunctionResult, LimitedTracker, MontyException, MontyObject, NameLookupResult,
+    PrintWriter, ResourceError, ResourceLimits, ResourceTracker,
 };
 
 /// Wraps `LimitedTracker` in `Rc` so a test can hold its own handle for
@@ -71,9 +72,7 @@ impl ResourceTracker for SharedTracker {
 /// Used by the gather bookkeeping witness, which expects the run to
 /// raise `MemoryError` inside the gather await *before* it would
 /// otherwise settle at `ResolveFutures`.
-fn drive_until_settled<T: monty::ResourceTracker>(
-    mut progress: RunProgress<T>,
-) -> Result<RunProgress<T>, monty::MontyException> {
+fn drive_until_settled<T: ResourceTracker>(mut progress: RunProgress<T>) -> Result<RunProgress<T>, MontyException> {
     loop {
         match progress {
             RunProgress::NameLookup(lookup) => {

--- a/crates/monty/tests/asyncio.rs
+++ b/crates/monty/tests/asyncio.rs
@@ -3,9 +3,10 @@
 //! These tests verify the behavior of the async execution model, specifically around
 //! resolving external futures incrementally via `ResolveFutures::resume()`.
 
-use monty::{
-    CompileOptions, ExcType, ExtFunctionResult, MontyException, MontyObject, MontyRun, NameLookupResult,
-    NoLimitTracker, PrintWriter, ResolveFutures, RunProgress,
+use monty::{MontyRun, ResolveFutures, RunProgress};
+use monty_types::{
+    CompileOptions, ExcType, ExtFunctionResult, MontyException, MontyObject, NameLookupResult, NoLimitTracker,
+    PrintWriter, ResourceTracker,
 };
 
 /// Helper to create a MontyRun for async external function tests.
@@ -40,9 +41,7 @@ await main()
 }
 
 /// Resolves consecutive `NameLookup` yields by providing a `Function` object for each name.
-fn resolve_name_lookups<T: monty::ResourceTracker>(
-    mut progress: RunProgress<T>,
-) -> Result<RunProgress<T>, monty::MontyException> {
+fn resolve_name_lookups<T: ResourceTracker>(mut progress: RunProgress<T>) -> Result<RunProgress<T>, MontyException> {
     while let RunProgress::NameLookup(lookup) = progress {
         let name = lookup.name.clone();
         progress = lookup.resume(
@@ -57,7 +56,7 @@ fn resolve_name_lookups<T: monty::ResourceTracker>(
 ///
 /// Returns (pending_call_ids, state, collected_call_ids) where collected_call_ids
 /// are the call_ids from all the FunctionCalls we processed with resume_pending().
-fn drive_to_resolve_futures<T: monty::ResourceTracker>(mut progress: RunProgress<T>) -> (ResolveFutures<T>, Vec<u32>) {
+fn drive_to_resolve_futures<T: ResourceTracker>(mut progress: RunProgress<T>) -> (ResolveFutures<T>, Vec<u32>) {
     let mut collected_call_ids = Vec::new();
 
     loop {
@@ -679,9 +678,7 @@ fn gather_three_all_at_once_mixed() {
 /// Helper to drive execution, collecting function calls and resolving them async,
 /// until we reach ResolveFutures. Returns the snapshot and a vec of
 /// (call_id, function_name) pairs for all external calls made.
-fn drive_collecting_calls<T: monty::ResourceTracker>(
-    mut progress: RunProgress<T>,
-) -> (ResolveFutures<T>, Vec<(u32, String)>) {
+fn drive_collecting_calls<T: ResourceTracker>(mut progress: RunProgress<T>) -> (ResolveFutures<T>, Vec<(u32, String)>) {
     let mut collected = Vec::new();
 
     loop {

--- a/crates/monty/tests/binary_serde.rs
+++ b/crates/monty/tests/binary_serde.rs
@@ -4,12 +4,13 @@
 //! - Caching parsed code to avoid re-parsing
 //! - Snapshotting execution state for external function calls
 
-use monty::{CompileOptions, MontyObject, MontyRun, NameLookupResult, NoLimitTracker, PrintWriter, RunProgress};
+use monty::{MontyRun, RunProgress};
+use monty_types::{
+    CompileOptions, MontyException, MontyObject, NameLookupResult, NoLimitTracker, PrintWriter, ResourceTracker,
+};
 
 /// Resolves consecutive `NameLookup` yields by providing a `Function` object for each name.
-fn resolve_name_lookups<T: monty::ResourceTracker>(
-    mut progress: RunProgress<T>,
-) -> Result<RunProgress<T>, monty::MontyException> {
+fn resolve_name_lookups<T: ResourceTracker>(mut progress: RunProgress<T>) -> Result<RunProgress<T>, MontyException> {
     while let RunProgress::NameLookup(lookup) = progress {
         let name = lookup.name.clone();
         progress = lookup.resume(

--- a/crates/monty/tests/bytecode_limits.rs
+++ b/crates/monty/tests/bytecode_limits.rs
@@ -9,7 +9,8 @@
 
 use std::fmt::Write;
 
-use monty::{CompileOptions, ExcType, MontyRun};
+use monty::MontyRun;
+use monty_types::{CompileOptions, ExcType, MontyException};
 
 /// Generates Python code with N local variables in a function.
 ///
@@ -79,7 +80,7 @@ fn generate_many_parameters(count: usize) -> String {
 }
 
 /// Asserts that a MontyRun result is a SyntaxError with a message containing the expected text.
-fn assert_syntax_error(result: Result<MontyRun, monty::MontyException>, expected_msg: &str) {
+fn assert_syntax_error(result: Result<MontyRun, MontyException>, expected_msg: &str) {
     let err = result.expect_err("expected SyntaxError");
     assert_eq!(
         err.exc_type(),

--- a/crates/monty/tests/datetime_format.rs
+++ b/crates/monty/tests/datetime_format.rs
@@ -8,7 +8,8 @@
 //! test_case would fail on a macOS CI runner. They live here instead. See
 //! limitations/datetime.md.
 
-use monty::{CompileOptions, MontyObject, MontyRun};
+use monty::MontyRun;
+use monty_types::{CompileOptions, MontyObject};
 
 /// Runs a snippet and returns its result as a `String`.
 fn run_str(code: &str) -> String {

--- a/crates/monty/tests/encoding.rs
+++ b/crates/monty/tests/encoding.rs
@@ -3,7 +3,8 @@
 //! which therefore cannot live in `test_cases/` — that suite runs every file
 //! against CPython too.
 
-use monty::{CompileOptions, MontyException, MontyRun, UnicodeErrorData, UnicodeErrorObject};
+use monty::MontyRun;
+use monty_types::{CompileOptions, MontyException, UnicodeErrorData, UnicodeErrorObject};
 
 /// Runs `code` and returns the resulting error's full traceback rendering.
 fn run_err(code: &str) -> String {

--- a/crates/monty/tests/error_locations.rs
+++ b/crates/monty/tests/error_locations.rs
@@ -2,7 +2,8 @@
 
 use std::sync::Arc;
 
-use monty::{CompileOptions, ExcType, LimitedTracker, MontyRun, PrintWriter, ResourceLimits};
+use monty::MontyRun;
+use monty_types::{CompileOptions, ExcType, LimitedTracker, PrintWriter, ResourceLimits};
 
 #[test]
 fn non_ascii_earlier_line_does_not_shift_column() {

--- a/crates/monty/tests/external_function_identity.rs
+++ b/crates/monty/tests/external_function_identity.rs
@@ -10,7 +10,8 @@
 //! conversion must agree on a single answer based on the name string, regardless
 //! of which path the conversion took.
 
-use monty::{CompileOptions, MontyObject, MontyRepl, MontyRun, NameLookupResult, NoLimitTracker, PrintWriter};
+use monty::{MontyRepl, MontyRun};
+use monty_types::{CompileOptions, MontyObject, NameLookupResult, NoLimitTracker, PrintWriter};
 
 /// Builds two `MontyObject::Function` inputs with the same `__name__` ("foo")
 /// and runs `code` against them as inputs `a` and `b`.

--- a/crates/monty/tests/file_error_paths.rs
+++ b/crates/monty/tests/file_error_paths.rs
@@ -6,9 +6,10 @@
 //! interned-string return value that hits the `InternBytes`/empty-string
 //! materialisation branch of [`apply_buffer_store`]).
 
-use monty::{
-    CompileOptions, ExcType, ExtFunctionResult, FileMode, MontyException, MontyFileHandle, MontyObject, MontyRun,
-    NoLimitTracker, PrintWriter,
+use monty::MontyRun;
+use monty_types::{
+    CompileOptions, ExcType, ExtFunctionResult, FileMode, MontyException, MontyFileHandle, MontyObject, NoLimitTracker,
+    PrintWriter,
 };
 
 /// Drives an `open()` followed by a single read/write OS call, then resumes

--- a/crates/monty/tests/file_resource_tracking.rs
+++ b/crates/monty/tests/file_resource_tracking.rs
@@ -7,8 +7,9 @@
 //! successful read raises `current_memory()` by roughly the file size, and
 //! `close()` drops it back down.
 
-use monty::{
-    CompileOptions, ExcType, FileMode, LimitedTracker, MontyFileHandle, MontyObject, MontyRun, PrintWriter,
+use monty::{MontyRun, RunProgress};
+use monty_types::{
+    CompileOptions, ExcType, FileMode, LimitedTracker, MontyException, MontyFileHandle, MontyObject, PrintWriter,
     ResourceLimits,
 };
 
@@ -32,7 +33,7 @@ fn open_then_read(
     handle: MontyFileHandle,
     io_result: MontyObject,
     limits: ResourceLimits,
-) -> Result<(usize, MontyObject), monty::MontyException> {
+) -> Result<(usize, MontyObject), MontyException> {
     let runner = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
     let progress = runner
         .start(vec![], LimitedTracker::new(limits), PrintWriter::Stdout)
@@ -49,7 +50,7 @@ fn open_then_read(
     // reading — typically a follow-up OS call inserted by the test to
     // observe state. Tests that complete immediately use `into_complete`.
     match progress {
-        monty::RunProgress::OsCall(next_call) => {
+        RunProgress::OsCall(next_call) => {
             let mem = next_call.tracker().current_memory();
             // Resume the follow-up call so the runner can finish — tests
             // typically use a no-op `Getenv` for this purpose.
@@ -59,7 +60,7 @@ fn open_then_read(
             let complete = progress.into_complete().expect("expected Complete");
             Ok((mem, complete))
         }
-        monty::RunProgress::Complete(value) => Ok((0, value)),
+        RunProgress::Complete(value) => Ok((0, value)),
         _ => panic!("unexpected progress variant"),
     }
 }

--- a/crates/monty/tests/heap_reader_compile_fail_cases/cases.rs
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/cases.rs
@@ -153,7 +153,7 @@ fn smuggle_vm<T: ResourceTracker>(
     use crate::bytecode::VM;
     HeapReader::with(
         heap,
-        &mut (interns, crate::io::PrintWriter::Disabled),
+        &mut (interns, crate::PrintWriter::Disabled),
         |reader, (interns, print)| VM::new(Vec::new(), reader, *interns, print.reborrow(), 120),
     )
 }

--- a/crates/monty/tests/heap_reader_compile_fail_cases/cases.rs
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/cases.rs
@@ -153,7 +153,7 @@ fn smuggle_vm<T: ResourceTracker>(
     use crate::bytecode::VM;
     HeapReader::with(
         heap,
-        &mut (interns, crate::PrintWriter::Disabled),
+        &mut (interns, monty_types::PrintWriter::Disabled),
         |reader, (interns, print)| VM::new(Vec::new(), reader, *interns, print.reborrow(), 120),
     )
 }

--- a/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_vm.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_vm.stderr
@@ -18,7 +18,7 @@ error: lifetime may not live long enough
 ...
 154 | /     HeapReader::with(
 155 | |         heap,
-156 | |         &mut (interns, crate::io::PrintWriter::Disabled),
+156 | |         &mut (interns, crate::PrintWriter::Disabled),
 157 | |         |reader, (interns, print)| VM::new(Vec::new(), reader, *interns, print.reborrow(), 120),
 158 | |     )
     | |_____^ returning this value requires that `'1` must outlive `'static`

--- a/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_vm.stderr
+++ b/crates/monty/tests/heap_reader_compile_fail_cases/smuggle_vm.stderr
@@ -18,7 +18,7 @@ error: lifetime may not live long enough
 ...
 154 | /     HeapReader::with(
 155 | |         heap,
-156 | |         &mut (interns, crate::PrintWriter::Disabled),
+156 | |         &mut (interns, monty_types::PrintWriter::Disabled),
 157 | |         |reader, (interns, print)| VM::new(Vec::new(), reader, *interns, print.reborrow(), 120),
 158 | |     )
     | |_____^ returning this value requires that `'1` must outlive `'static`

--- a/crates/monty/tests/inputs.rs
+++ b/crates/monty/tests/inputs.rs
@@ -3,7 +3,6 @@
 //! These tests verify that `MontyObject` inputs are correctly converted to `Object`
 //! and can be used in Python code execution.
 
-use indexmap::IndexMap;
 use monty::MontyRun;
 use monty_types::{CompileOptions, ExcType, MontyObject};
 
@@ -204,8 +203,7 @@ fn input_tuple() {
 
 #[test]
 fn input_dict() {
-    let mut map = IndexMap::new();
-    map.insert(MontyObject::String("a".to_string()), MontyObject::Int(1));
+    let map = vec![(MontyObject::String("a".to_string()), MontyObject::Int(1))];
 
     let ex = MontyRun::new(
         "x".to_owned(),
@@ -217,15 +215,15 @@ fn input_dict() {
     let result = ex.run_no_limits(vec![MontyObject::dict(map)]).unwrap();
 
     // Build expected map for comparison
-    let mut expected = IndexMap::new();
-    expected.insert(MontyObject::String("a".to_string()), MontyObject::Int(1));
-    assert_eq!(result, MontyObject::Dict(expected.into()));
+    assert_eq!(
+        result,
+        MontyObject::dict(vec![(MontyObject::String("a".to_string()), MontyObject::Int(1))])
+    );
 }
 
 #[test]
 fn input_dict_get() {
-    let mut map = IndexMap::new();
-    map.insert(MontyObject::String("key".to_string()), MontyObject::Int(42));
+    let map = vec![(MontyObject::String("key".to_string()), MontyObject::Int(42))];
 
     let ex = MontyRun::new(
         "x['key']".to_owned(),

--- a/crates/monty/tests/inputs.rs
+++ b/crates/monty/tests/inputs.rs
@@ -4,7 +4,8 @@
 //! and can be used in Python code execution.
 
 use indexmap::IndexMap;
-use monty::{CompileOptions, ExcType, MontyObject, MontyRun};
+use monty::MontyRun;
+use monty_types::{CompileOptions, ExcType, MontyObject};
 
 // === Immediate Value Tests ===
 

--- a/crates/monty/tests/json_error_data.rs
+++ b/crates/monty/tests/json_error_data.rs
@@ -4,7 +4,8 @@
 //! fallback. Host-facing payload behavior is invisible to `test_cases/`, so
 //! it is pinned here.
 
-use monty::{CompileOptions, JsonErrorData, MontyException, MontyRun};
+use monty::MontyRun;
+use monty_types::{CompileOptions, JsonErrorData, MontyException};
 
 /// Runs `code` and returns the resulting `MontyException`.
 fn run_exc(code: &str) -> MontyException {

--- a/crates/monty/tests/json_serde.rs
+++ b/crates/monty/tests/json_serde.rs
@@ -10,7 +10,8 @@
 //! structural values, not strings.
 
 use insta::assert_snapshot;
-use monty::{CompileOptions, ExcType, MontyObject, MontyRun};
+use monty::MontyRun;
+use monty_types::{CompileOptions, ExcType, MontyObject};
 
 /// Evaluate a Python snippet under Monty and return its final value.
 fn eval(code: &str) -> MontyObject {

--- a/crates/monty/tests/main.rs
+++ b/crates/monty/tests/main.rs
@@ -1,4 +1,5 @@
-use monty::{CompileOptions, MontyObject, MontyRun};
+use monty::MontyRun;
+use monty_types::{CompileOptions, MontyObject};
 
 /// Test we can reuse exec without borrow checker issues.
 #[test]

--- a/crates/monty/tests/math_module.rs
+++ b/crates/monty/tests/math_module.rs
@@ -1,4 +1,5 @@
-use monty::{CompileOptions, MontyObject, MontyRun};
+use monty::MontyRun;
+use monty_types::{CompileOptions, MontyObject};
 
 /// Helper to run a Python expression and return the result.
 fn run_expr(code: &str) -> MontyObject {

--- a/crates/monty/tests/module_dunders.rs
+++ b/crates/monty/tests/module_dunders.rs
@@ -17,7 +17,8 @@
 //!   time with `NotImplementedError` (CPython allows it, except `__debug__`
 //!   which it rejects with `SyntaxError`)
 
-use monty::{CompileOptions, DictPairs, ExcType, MontyObject, MontyRun};
+use monty::MontyRun;
+use monty_types::{CompileOptions, DictPairs, ExcType, MontyObject};
 
 /// Runs `code` to completion with no resource limits and returns the value of
 /// its final expression.

--- a/crates/monty/tests/name_lookup.rs
+++ b/crates/monty/tests/name_lookup.rs
@@ -11,14 +11,15 @@
 //! - Multiple distinct names each get their own lookup
 //! - Builtins bypass the `NameLookup` mechanism entirely
 
-use monty::{CompileOptions, MontyObject, MontyRun, NameLookupResult, NoLimitTracker, PrintWriter, RunProgress};
+use monty::{MontyRun, RunProgress};
+use monty_types::{CompileOptions, MontyException, MontyObject, NameLookupResult, NoLimitTracker, PrintWriter};
 
 /// Helper: drives execution through consecutive `NameLookup` yields,
 /// resolving each by calling `resolver(name)`.
 fn resolve_lookups_with(
     mut progress: RunProgress<NoLimitTracker>,
     resolver: impl Fn(&str) -> NameLookupResult,
-) -> Result<RunProgress<NoLimitTracker>, monty::MontyException> {
+) -> Result<RunProgress<NoLimitTracker>, MontyException> {
     while let RunProgress::NameLookup(lookup) = progress {
         let result = resolver(&lookup.name);
         progress = lookup.resume(result, PrintWriter::Stdout)?;
@@ -28,9 +29,7 @@ fn resolve_lookups_with(
 
 /// Helper: resolves all `NameLookup` yields as `Function` objects (the common case
 /// for external function calls).
-fn resolve_as_functions(
-    progress: RunProgress<NoLimitTracker>,
-) -> Result<RunProgress<NoLimitTracker>, monty::MontyException> {
+fn resolve_as_functions(progress: RunProgress<NoLimitTracker>) -> Result<RunProgress<NoLimitTracker>, MontyException> {
     resolve_lookups_with(progress, |name| {
         NameLookupResult::Value(MontyObject::Function {
             name: name.to_string(),

--- a/crates/monty/tests/os_tests.rs
+++ b/crates/monty/tests/os_tests.rs
@@ -4,9 +4,10 @@
 //! `RunProgress::OsCall` with the correct `OsFunction` variant and arguments,
 //! and that return values are correctly used by Python code.
 
-use monty::{
-    CompileOptions, FileMode, MontyDate, MontyDateTime, MontyFileHandle, MontyObject, MontyRun, NoLimitTracker,
-    PrintWriter, RunProgress, file_stat,
+use monty::{MontyRun, RunProgress};
+use monty_types::{
+    CompileOptions, FileMode, MontyDate, MontyDateTime, MontyFileHandle, MontyObject, NoLimitTracker, OsFunctionCall,
+    PrintWriter, file_stat,
 };
 
 /// Helper to run code and extract the OsCall progress.
@@ -32,39 +33,39 @@ fn run_to_oscall(code: &str) -> (&'static str, Vec<MontyObject>) {
 }
 
 /// Returns a `MontyObject` shaped like a plausible host response for `call`.
-fn mock_oscall_result(call: &monty::OsFunctionCall) -> MontyObject {
+fn mock_oscall_result(call: &OsFunctionCall) -> MontyObject {
     match call {
-        monty::OsFunctionCall::Exists(_)
-        | monty::OsFunctionCall::IsFile(_)
-        | monty::OsFunctionCall::IsDir(_)
-        | monty::OsFunctionCall::IsSymlink(_) => MontyObject::Bool(true),
-        monty::OsFunctionCall::ReadText(_) | monty::OsFunctionCall::Resolve(_) | monty::OsFunctionCall::Absolute(_) => {
+        OsFunctionCall::Exists(_)
+        | OsFunctionCall::IsFile(_)
+        | OsFunctionCall::IsDir(_)
+        | OsFunctionCall::IsSymlink(_) => MontyObject::Bool(true),
+        OsFunctionCall::ReadText(_) | OsFunctionCall::Resolve(_) | OsFunctionCall::Absolute(_) => {
             MontyObject::String("mock".to_owned())
         }
-        monty::OsFunctionCall::ReadBytes(_) => MontyObject::Bytes(vec![]),
-        monty::OsFunctionCall::Stat(_) => MontyObject::None,
-        monty::OsFunctionCall::Iterdir(_) => MontyObject::List(vec![]),
-        monty::OsFunctionCall::WriteText(_)
-        | monty::OsFunctionCall::WriteBytes(_)
-        | monty::OsFunctionCall::AppendText(_)
-        | monty::OsFunctionCall::AppendBytes(_)
-        | monty::OsFunctionCall::Mkdir(_)
-        | monty::OsFunctionCall::Unlink(_)
-        | monty::OsFunctionCall::Rmdir(_)
-        | monty::OsFunctionCall::Rename(_) => MontyObject::None,
-        monty::OsFunctionCall::Open(_) => MontyObject::FileHandle(MontyFileHandle {
+        OsFunctionCall::ReadBytes(_) => MontyObject::Bytes(vec![]),
+        OsFunctionCall::Stat(_) => MontyObject::None,
+        OsFunctionCall::Iterdir(_) => MontyObject::List(vec![]),
+        OsFunctionCall::WriteText(_)
+        | OsFunctionCall::WriteBytes(_)
+        | OsFunctionCall::AppendText(_)
+        | OsFunctionCall::AppendBytes(_)
+        | OsFunctionCall::Mkdir(_)
+        | OsFunctionCall::Unlink(_)
+        | OsFunctionCall::Rmdir(_)
+        | OsFunctionCall::Rename(_) => MontyObject::None,
+        OsFunctionCall::Open(_) => MontyObject::FileHandle(MontyFileHandle {
             path: "mock".to_owned(),
             mode: "r".parse::<FileMode>().unwrap(),
             position: 0,
         }),
-        monty::OsFunctionCall::Getenv(_) => MontyObject::String("mock_env_value".to_owned()),
-        monty::OsFunctionCall::GetEnviron => MontyObject::Dict(vec![].into()),
-        monty::OsFunctionCall::DateToday => MontyObject::Date(MontyDate {
+        OsFunctionCall::Getenv(_) => MontyObject::String("mock_env_value".to_owned()),
+        OsFunctionCall::GetEnviron => MontyObject::Dict(vec![].into()),
+        OsFunctionCall::DateToday => MontyObject::Date(MontyDate {
             year: 2023,
             month: 11,
             day: 14,
         }),
-        monty::OsFunctionCall::DateTimeNow(_) => MontyObject::DateTime(MontyDateTime {
+        OsFunctionCall::DateTimeNow(_) => MontyObject::DateTime(MontyDateTime {
             year: 2023,
             month: 11,
             day: 14,

--- a/crates/monty/tests/parse_errors.rs
+++ b/crates/monty/tests/parse_errors.rs
@@ -1,7 +1,8 @@
 use std::fmt::Write;
 
 use insta::assert_snapshot;
-use monty::{CompileOptions, ExcType, MontyException, MontyRun};
+use monty::MontyRun;
+use monty_types::{CompileOptions, ExcType, MontyException};
 
 /// Helper to extract the exception from a parse error.
 fn get_parse_err(code: impl Into<String>) -> MontyException {

--- a/crates/monty/tests/parse_large_literals.rs
+++ b/crates/monty/tests/parse_large_literals.rs
@@ -4,7 +4,8 @@
 //! at parse time to prevent the O(n^2) `BigInt::parse` from running. Non-decimal
 //! literals (hex, binary) and floats are unaffected.
 
-use monty::{CompileOptions, ExcType, MontyObject, MontyRun};
+use monty::MontyRun;
+use monty_types::{CompileOptions, ExcType, MontyObject};
 
 #[test]
 fn large_decimal_literal_rejected() {

--- a/crates/monty/tests/print_writer.rs
+++ b/crates/monty/tests/print_writer.rs
@@ -9,7 +9,8 @@
 //! `INSTA_UPDATE=always`).
 
 use insta::assert_snapshot;
-use monty::{CompileOptions, MontyRun, NoLimitTracker, PrintWriter};
+use monty::MontyRun;
+use monty_types::{CompileOptions, NoLimitTracker, PrintWriter};
 
 /// Run `code` under Monty with a string-collecting `PrintWriter` and return
 /// whatever was printed. Panics on parse/runtime errors — callers only care

--- a/crates/monty/tests/py_object.rs
+++ b/crates/monty/tests/py_object.rs
@@ -3,7 +3,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-use monty::{ExcType, MontyDate, MontyDateTime, MontyObject, MontyTimeDelta, MontyTimeZone};
+use monty_types::{DictPairs, ExcType, MontyDate, MontyDateTime, MontyObject, MontyTimeDelta, MontyTimeZone};
 
 /// Helper to compute a hash for a value.
 fn hash_of(obj: &MontyObject) -> u64 {
@@ -187,7 +187,7 @@ fn type_name() {
             name: "Foo".to_string(),
             type_id: 0,
             field_names: vec![],
-            attrs: monty::DictPairs::from(vec![]),
+            attrs: DictPairs::from(vec![]),
             frozen: false,
         }
         .type_name(),
@@ -311,7 +311,7 @@ fn is_truthy_dataclass() {
             name: "Foo".to_string(),
             type_id: 0,
             field_names: vec![],
-            attrs: monty::DictPairs::from(vec![]),
+            attrs: DictPairs::from(vec![]),
             frozen: false,
         }
         .is_truthy()

--- a/crates/monty/tests/regex.rs
+++ b/crates/monty/tests/regex.rs
@@ -9,7 +9,8 @@
 /// that grow unboundedly — a denial-of-service vector. Monty uses `fancy_regex`
 /// which enforces a default 1M-step backtrack limit, raising `re.PatternError`
 /// when exceeded. This is strictly better behavior for a sandbox.
-use monty::{CompileOptions, MontyRun};
+use monty::MontyRun;
+use monty_types::CompileOptions;
 
 /// Helper to run Python code and return the string result.
 fn run(code: &str) -> String {

--- a/crates/monty/tests/repl.rs
+++ b/crates/monty/tests/repl.rs
@@ -4,9 +4,10 @@
 //! only the newly fed snippet each time.
 
 use insta::assert_snapshot;
-use monty::{
-    CompileOptions, ExtFunctionResult, MontyException, MontyObject, MontyRepl, NoLimitTracker, PrintWriter,
-    ReplContinuationMode, ReplProgress, ReplStartError, ResourceTracker, detect_repl_continuation_mode,
+use monty::{MontyRepl, ReplContinuationMode, ReplProgress, ReplStartError, detect_repl_continuation_mode};
+use monty_types::{
+    CompileOptions, ExcType, ExtFunctionResult, MontyException, MontyObject, NoLimitTracker, PrintWriter,
+    ResourceTracker,
 };
 
 #[test]
@@ -356,7 +357,7 @@ fn repl_start_runtime_error_preserves_repl_state() {
         .feed_start("y = 20\nraise ValueError('boom')", vec![], PrintWriter::Stdout)
         .expect_err("expected ReplStartError");
     let ReplStartError { mut repl, error } = *err;
-    assert_eq!(error.exc_type(), monty::ExcType::ValueError);
+    assert_eq!(error.exc_type(), ExcType::ValueError);
     assert_eq!(error.message(), Some("boom"));
 
     // Variables from BEFORE the error snippet survive.
@@ -377,12 +378,12 @@ fn repl_start_runtime_error_during_external_call_preserves_repl_state() {
     let call = progress.into_function_call().expect("expected function call");
 
     // Resume with an exception from the external function.
-    let exc = monty::MontyException::new(monty::ExcType::RuntimeError, Some("ext failed".to_string()));
+    let exc = MontyException::new(ExcType::RuntimeError, Some("ext failed".to_string()));
     let err = call
         .resume(ExtFunctionResult::Error(exc), PrintWriter::Stdout)
         .expect_err("expected ReplStartError");
     let ReplStartError { mut repl, error } = *err;
-    assert_eq!(error.exc_type(), monty::ExcType::RuntimeError);
+    assert_eq!(error.exc_type(), ExcType::RuntimeError);
 
     // Variable from before the error is still accessible.
     assert_eq!(feed_run_print(&mut repl, "z").unwrap(), MontyObject::Int(99));

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -7,9 +7,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use monty::{
-    CompileOptions, ExcType, LimitedTracker, MontyObject, MontyRepl, MontyRun, NameLookupResult, PrintWriter,
-    ResourceLimits, RunProgress,
+use monty::{MontyRepl, MontyRun, RunProgress};
+use monty_types::{
+    CompileOptions, ExcType, LimitedTracker, MontyException, MontyObject, NameLookupResult, PrintWriter,
+    ResourceLimits, ResourceTracker,
 };
 
 /// Resolves consecutive `NameLookup` yields by providing a `Function` object for each name.
@@ -17,9 +18,7 @@ use monty::{
 /// External functions are no longer declared upfront. Instead, the VM yields `NameLookup`
 /// when it encounters an unresolved name. This helper resolves all such lookups until
 /// a different progress variant is reached.
-fn resolve_name_lookups<T: monty::ResourceTracker>(
-    mut progress: RunProgress<T>,
-) -> Result<RunProgress<T>, monty::MontyException> {
+fn resolve_name_lookups<T: ResourceTracker>(mut progress: RunProgress<T>) -> Result<RunProgress<T>, MontyException> {
     while let RunProgress::NameLookup(lookup) = progress {
         let name = lookup.name.clone();
         progress = lookup.resume(

--- a/crates/monty/tests/security.rs
+++ b/crates/monty/tests/security.rs
@@ -1,5 +1,6 @@
 use insta::assert_snapshot;
-use monty::{CompileOptions, MontyRun};
+use monty::MontyRun;
+use monty_types::CompileOptions;
 
 #[test]
 fn deeply_nested_parentheses_do_not_stack_overflow() {

--- a/crates/monty/tests/try_from.rs
+++ b/crates/monty/tests/try_from.rs
@@ -1,4 +1,5 @@
-use monty::{CompileOptions, MontyRun};
+use monty::MontyRun;
+use monty_types::CompileOptions;
 
 /// Tests for successful TryFrom conversions from Python values to Rust types.
 ///

--- a/crates/monty/tests/type_names.rs
+++ b/crates/monty/tests/type_names.rs
@@ -1,4 +1,4 @@
-use monty::{ExcType, MontyType};
+use monty_types::{ExcType, MontyType};
 use strum::IntoEnumIterator;
 
 /// `MontyType::from_type_name` must be the exact inverse of `Display`/`name()`


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Extracted shared boundary types into a new `monty-types` crate so hosts use `MontyObject`/exceptions/OS-calls/resource limits without linking the interpreter. `monty` no longer re-exports these types; host crates import from `monty-types` directly.

- **Refactors**
  - Added `crates/monty-types` with `MontyObject`/`MontyType`, `MontyException`/`ExcType` (+ stack frames), `BuiltinsFunctions`, `OsFunctionCall` + args, `ResourceLimits`/`ResourceTracker` (`NoLimitTracker`/`LimitedTracker`), `PrintStream`/`PrintWriter`, `FileMode`, `CompileOptions`, `NameLookupResult`/`ExtFunctionResult`, and CPython-compatible formatting helpers.
  - Interpreter-only behavior stays in internal extension traits (e.g. `ExcTypeExt`, `MontyObjectExt`); macros/VM code now reference `monty_types::ResourceTracker`.
  - Reordered files “newspaper style” and updated docs/READMEs to note hosts must depend on `monty-types`.

- **Dependencies**
  - `monty-fs`, `monty-pool`, `monty-proto` (default), `monty-python`, `monty-js`, fuzz/bench/datatest, and `monty-runtime` now depend on `monty-types` instead of `monty`.
  - Made `monty` optional in `monty-proto`; it links only behind the `worker` feature.
  - Promoted `chrono` and `strum` to workspace deps and removed `indexmap`.

<sup>Written for commit 33798f336a49224b22f87c92c676f474f1908af1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

