### PR TITLE
Populate class __annotations__ (stringized)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2008,8 +2008,10 @@ dependencies = [
  "num-traits",
  "postcard",
  "ruff_python_ast",
+ "ruff_python_codegen",
  "ruff_python_parser",
  "ruff_python_stdlib",
+ "ruff_source_file",
  "ruff_text_size",
  "serde",
  "serde_json",
@@ -3196,6 +3198,19 @@ dependencies = [
  "salsa",
  "thin-vec",
  "thiserror",
+]
+
+[[package]]
+name = "ruff_python_codegen"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1902d82ae0745be9d3d12a1aee4429acff987c768710dc38a6521eab05990ca0"
+dependencies = [
+ "ruff_python_ast",
+ "ruff_python_literal",
+ "ruff_python_parser",
+ "ruff_source_file",
+ "ruff_text_size",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.19-beta.4" }
 ruff_python_parser = "0.0.3"
 ruff_python_stdlib = "0.0.3"
 ruff_python_ast = "0.0.3"
+ruff_python_codegen = "0.0.3"
+ruff_source_file = "0.0.3"
 ruff_text_size = "0.0.3"
 ruff_db = { version="0.0.3" ,features = ["serde"] }
 # ty_python_semantic, ty_python_core and ty_vendored are only published at 0.0.2,

--- a/crates/monty/Cargo.toml
+++ b/crates/monty/Cargo.toml
@@ -22,6 +22,8 @@ monty-types = { workspace = true }
 ruff_python_parser = { workspace = true }
 ruff_python_stdlib = { workspace = true }
 ruff_python_ast = { workspace = true }
+ruff_python_codegen = { workspace = true }
+ruff_source_file = { workspace = true }
 ruff_text_size = { workspace = true }
 ahash = { workspace = true }
 itoa = { workspace = true }

--- a/crates/monty/src/lib.rs
+++ b/crates/monty/src/lib.rs
@@ -30,6 +30,7 @@ mod run_progress;
 mod sorting;
 mod source_map;
 mod string_builder;
+mod stringize;
 mod types;
 mod value;
 

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -7,17 +7,10 @@ use ruff_python_ast::{
     self as ast, BoolOp, CmpOp, ConversionFlag as RuffConversionFlag, ElifElseClause, Expr as AstExpr,
     InterpolatedStringElement, Keyword, Number, Operator as AstOperator, ParameterWithDefault, Stmt, UnaryOp,
     name::Name,
-    str::Quote,
     token::TokenKind,
-    visitor::{
-        Visitor,
-        transformer::{Transformer, walk_f_string},
-        walk_expr,
-    },
+    visitor::{Visitor, walk_expr},
 };
-use ruff_python_codegen::{Generator, Indentation};
 use ruff_python_parser::parse_module;
-use ruff_source_file::LineEnding;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::{
@@ -30,6 +23,7 @@ use crate::{
     fstring::{ConversionFlag, FStringPart, FormatSpec, ParsedFormatSpec, encode_format_spec},
     intern::{InternerBuilder, StringId},
     source_map::{SourceMap, StackFrameExt},
+    stringize::stringize_annotation,
     types::long_int::INT_MAX_STR_DIGITS,
     value::EitherStr,
 };
@@ -76,31 +70,6 @@ const SUPPORTED_FUTURES: [&str; 9] = [
 /// `__future__.all_feature_names`, since any name in neither list is reported as
 /// undefined.
 const UNSUPPORTED_FUTURES: [&str; 1] = ["barry_as_FLUFL"];
-
-/// Rewrites every string literal and f-string in an expression to single-quoted,
-/// matching how CPython's PEP 563 stringizer renders them (`x: "int"` gives
-/// `"'int'"`, `x: f"int"` gives `"f'int'"`).
-///
-/// Applied to class annotations before unparsing, because neither generator mode
-/// matches CPython alone — see [`Parser::parse_class_annotation`]. Nested
-/// literals are covered too, so `dict[str, "Foo"]` normalises throughout. Only
-/// the quote *style* changes; the generator still escapes as needed, so a
-/// literal containing a single quote keeps its double quotes rather than
-/// becoming invalid — again matching CPython.
-struct SingleQuoteStrings;
-
-impl Transformer for SingleQuoteStrings {
-    fn visit_string_literal(&self, string_literal: &mut ast::StringLiteral) {
-        string_literal.flags = string_literal.flags.with_quote_style(Quote::Single);
-    }
-
-    // F-strings carry their own flags, so they need normalising separately;
-    // walking the elements still reaches any plain literals nested in a spec.
-    fn visit_f_string(&self, f_string: &mut ast::FString) {
-        f_string.flags = f_string.flags.with_quote_style(Quote::Single);
-        walk_f_string(self, f_string);
-    }
-}
 
 /// A parameter in a function signature with optional default value.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -1045,21 +1014,11 @@ impl<'a> Parser<'a> {
     /// Builds the `'name': 'annotation'` pair for one annotated class-body name.
     ///
     /// The annotation is stringized rather than evaluated (see
-    /// `limitations/typing.md`), and is produced by *unparsing* the expression
-    /// rather than slicing the source. CPython's PEP 563 stringizer unparses too,
-    /// so this is what makes `x: dict[str,int]` yield `'dict[str, int]'` on both
-    /// — slicing would leak the original spacing, newlines and quote style.
+    /// `limitations/typing.md`); [`stringize_annotation`] owns rendering it back
+    /// to the text CPython would store.
     fn parse_class_annotation(&mut self, ident: Identifier, annotation: &mut AstExpr) -> DictItem {
         let ann_range = annotation.range();
-        // Neither generator mode matches CPython alone: `Mode::AstUnparse`
-        // normalises quotes but parenthesises tuple subscripts (`dict[(str,
-        // int)]`), while `Mode::Default` keeps subscripts but preserves the
-        // source quote style. So use `Default` and normalise the quotes first.
-        SingleQuoteStrings.visit_expr(annotation);
-        // `LineEnding::Lf` is pinned rather than defaulted: the default is
-        // platform-dependent, and Monty must stringize identically everywhere.
-        let unparsed = Generator::new(&Indentation::default(), LineEnding::Lf).expr(annotation);
-        let ann_id = self.interner.intern(&unparsed);
+        let ann_id = self.interner.intern(&stringize_annotation(annotation));
         DictItem::Pair(
             ExprLoc::new(ident.position, Expr::Literal(Literal::Str(ident.name_id))),
             ExprLoc::new(self.convert_range(ann_range), Expr::Literal(Literal::Str(ann_id))),

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -7,10 +7,13 @@ use ruff_python_ast::{
     self as ast, BoolOp, CmpOp, ConversionFlag as RuffConversionFlag, ElifElseClause, Expr as AstExpr,
     InterpolatedStringElement, Keyword, Number, Operator as AstOperator, ParameterWithDefault, Stmt, UnaryOp,
     name::Name,
+    str::Quote,
     token::TokenKind,
-    visitor::{Visitor, walk_expr},
+    visitor::{Visitor, transformer::Transformer, walk_expr},
 };
+use ruff_python_codegen::{Generator, Indentation};
 use ruff_python_parser::parse_module;
+use ruff_source_file::LineEnding;
 use ruff_text_size::{Ranged, TextRange, TextSize};
 
 use crate::{
@@ -37,6 +40,54 @@ pub const MAX_NESTING_DEPTH: u16 = 200;
 /// stack overflow while still catching the error before the recursion limit.
 #[cfg(debug_assertions)]
 pub const MAX_NESTING_DEPTH: u16 = 30;
+
+/// `from __future__ import ...` features whose semantics Monty already provides,
+/// so importing them is a no-op rather than an error.
+///
+/// All but the last became mandatory in Python 3.7 or earlier, so they are inert
+/// in CPython too — the imports survive only in code that once supported older
+/// versions. `annotations` is different in kind: it is still meaningful in
+/// CPython, and is a no-op here only because Monty stringizes annotations
+/// unconditionally (see `limitations/typing.md`), which is what it asks for.
+const SUPPORTED_FUTURES: [&str; 9] = [
+    "nested_scopes",
+    "generators",
+    "division",
+    "absolute_import",
+    "with_statement",
+    "print_function",
+    "unicode_literals",
+    "generator_stop",
+    "annotations",
+];
+
+/// `from __future__ import ...` features Monty does not implement, which are
+/// rejected rather than silently ignored — importing one asks for behaviour the
+/// sandbox will not deliver.
+///
+/// `barry_as_FLUFL` (PEP 401) makes `<>` the inequality operator and turns `!=`
+/// into a `SyntaxError`. Monty parses neither differently.
+///
+/// Together with [`SUPPORTED_FUTURES`] this must cover CPython's
+/// `__future__.all_feature_names`, since any name in neither list is reported as
+/// undefined.
+const UNSUPPORTED_FUTURES: [&str; 1] = ["barry_as_FLUFL"];
+
+/// Rewrites every string literal in an expression to single-quoted, matching how
+/// CPython's PEP 563 stringizer renders them (`x: "int"` gives `"'int'"`).
+///
+/// Applied to class annotations before unparsing, because neither generator mode
+/// matches CPython alone — see [`Parser::parse_class_annotation`]. Nested
+/// literals are covered too, so `dict[str, "Foo"]` normalises throughout. Only
+/// the quote *style* changes; the generator still escapes as needed, so a
+/// literal containing a single quote stays valid.
+struct SingleQuoteStrings;
+
+impl Transformer for SingleQuoteStrings {
+    fn visit_string_literal(&self, string_literal: &mut ast::StringLiteral) {
+        string_literal.flags = string_literal.flags.with_quote_style(Quote::Single);
+    }
+}
 
 /// A parameter in a function signature with optional default value.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -574,6 +625,43 @@ impl<'a> Parser<'a> {
                 ..
             }) => {
                 let position = self.convert_range(range);
+                // Compiler directives, not real imports, so they bind nothing and
+                // lower to a no-op — real-world modules then import cleanly. A
+                // feature Monty does not implement is rejected rather than
+                // ignored, so the import never quietly fails to do what it says.
+                //
+                // `level == 0` matters: `from .__future__ import x` is an ordinary
+                // relative import of a module that happens to share the name, and
+                // must fall through to the `ImportError` below.
+                if level == 0 && module.as_ref().is_some_and(|m| m.as_str() == "__future__") {
+                    return match names
+                        .iter()
+                        .find(|a| a.asname.is_some() || !SUPPORTED_FUTURES.contains(&a.name.id.as_str()))
+                    {
+                        Some(alias) if UNSUPPORTED_FUTURES.contains(&alias.name.id.as_str()) => {
+                            Err(ParseError::not_implemented(
+                                format!("the '{}' future feature", alias.name.id),
+                                self.convert_range(alias.range),
+                            ))
+                        }
+                        // Name checks come first so an aliased unknown feature is
+                        // reported as undefined, as CPython does.
+                        Some(alias) if !SUPPORTED_FUTURES.contains(&alias.name.id.as_str()) => Err(ParseError::syntax(
+                            format!("future feature {} is not defined", alias.name.id),
+                            self.convert_range(alias.range),
+                        )),
+                        // A known feature, so the alias is what selected it. An
+                        // alias asks to bind a name and a no-op binds nothing, so
+                        // accepting it would fail exactly the way this branch
+                        // exists to prevent — the `NameError` would surface later,
+                        // far from the import.
+                        Some(alias) => Err(ParseError::not_implemented(
+                            "aliasing a `__future__` feature",
+                            self.convert_range(alias.range),
+                        )),
+                        None => Ok(Node::Pass),
+                    };
+                }
                 // We only support absolute imports (level 0)
                 if level != 0 {
                     return Err(ParseError::import_error(
@@ -716,9 +804,10 @@ impl<'a> Parser<'a> {
     /// recorded in `members`, in source order, for namespace assembly.
     ///
     /// `pass` and `...` are ignored; a leading docstring becomes a `__doc__`
-    /// member. Class decorators are supported (enclosing scope, applied
-    /// bottom-up); inheritance, function/method decorators, and anything else in
-    /// the body are rejected as not-implemented, reserving the syntax for later.
+    /// member, and annotated names a stringized `__annotations__`. Class
+    /// decorators are supported (enclosing scope, applied bottom-up);
+    /// inheritance, function/method decorators, and anything else in the body
+    /// are rejected as not-implemented, reserving the syntax for later.
     fn parse_class_def(&mut self, class: ast::StmtClassDef) -> Result<ParseNode, ParseError> {
         let position = self.class_keyword_range(&class);
         // Parsed as ordinary expressions; the compiler emits the apply calls
@@ -746,6 +835,9 @@ impl<'a> Parser<'a> {
         // namespace dict from the body's locals.
         let mut body = Vec::new();
         let mut members = Vec::new();
+        // `(name, "source text")` pairs assembled into `__annotations__` below;
+        // always stringized (PEP 563). See `limitations/typing.md`.
+        let mut annotations: Vec<DictItem> = Vec::new();
 
         // CPython stores the class docstring as a real `__doc__` entry in the
         // class dict (`None` when absent), so synthesize a `__doc__ = <docstring
@@ -795,23 +887,37 @@ impl<'a> Parser<'a> {
                     let ident = self.identifier(id, *name_range);
                     self.parse_class_var(ident, *value, &mut members, &mut body)?;
                 }
-                // `name: T = <expr>` — an annotated class-level variable. A bare
-                // `name: T` (no value) is just an annotation and creates nothing.
+                // `name: T [= <expr>]` — an annotated class-level name. The
+                // annotation is recorded (stringized) in `__annotations__`; a
+                // value additionally makes it a class variable. A bare `name: T`
+                // records the annotation but binds no value (matching CPython).
                 Stmt::AnnAssign(ast::StmtAnnAssign {
-                    target, value, range, ..
+                    target,
+                    mut annotation,
+                    value,
+                    range,
+                    ..
                 }) => {
-                    if let Some(value) = value {
-                        let AstExpr::Name(ast::ExprName {
-                            id, range: name_range, ..
-                        }) = *target
-                        else {
-                            return Err(ParseError::not_implemented(
-                                "complex class variable targets (only `name = <expr>` is allowed)",
-                                self.convert_range(range),
-                            ));
-                        };
+                    if let AstExpr::Name(ast::ExprName {
+                        id, range: name_range, ..
+                    }) = *target
+                    {
                         let ident = self.identifier(&id, name_range);
-                        self.parse_class_var(ident, *value, &mut members, &mut body)?;
+                        annotations.push(self.parse_class_annotation(ident, &mut annotation));
+                        if let Some(value) = value {
+                            self.parse_class_var(ident, *value, &mut members, &mut body)?;
+                        }
+                    } else if value.is_some() {
+                        // Complex target with a value (`x.y: T = v`) is unsupported;
+                        // a bare complex annotation (`x.y: T`) stores nothing in
+                        // CPython either, so it is ignored. CPython does still
+                        // evaluate the target expression (`undefined.attr: T` raises
+                        // `NameError`) where Monty drops it — see
+                        // `limitations/typing.md`.
+                        return Err(ParseError::not_implemented(
+                            "complex class variable targets (only `name = <expr>` is allowed)",
+                            self.convert_range(range),
+                        ));
                     }
                 }
                 // `pass` and `...` (the common `class C: ...` stub idiom) are
@@ -846,6 +952,24 @@ impl<'a> Parser<'a> {
                 object: doc_value,
             },
         );
+
+        // Last statement so the values are assembled after all members exist.
+        // Always present (empty dict) to match `Cls.__annotations__ == {}`.
+        let annotations_target = Identifier::new(self.interner.intern("__annotations__"), position);
+        // Being last means this would silently clobber an explicit assignment in
+        // the body, losing its entries (CPython merges the two instead). Rejected
+        // rather than dropped quietly; the syntax is reserved for later.
+        if members.iter().any(|m| m.name_id == annotations_target.name_id) {
+            return Err(ParseError::not_implemented(
+                "assigning `__annotations__` in a class body",
+                position,
+            ));
+        }
+        members.push(annotations_target);
+        body.push(Node::Assign {
+            target: annotations_target,
+            object: ExprLoc::new(position, Expr::Dict(annotations)),
+        });
 
         // Wrap the body statements in a synthetic zero-arg function. The class
         // name's `name_id` is reused for nicer tracebacks; this function is never
@@ -897,6 +1021,30 @@ impl<'a> Parser<'a> {
             start_byte: start,
             end_byte: class.range.end().into(),
         }
+    }
+
+    /// Builds the `'name': 'annotation'` pair for one annotated class-body name.
+    ///
+    /// The annotation is stringized rather than evaluated (see
+    /// `limitations/typing.md`), and is produced by *unparsing* the expression
+    /// rather than slicing the source. CPython's PEP 563 stringizer unparses too,
+    /// so this is what makes `x: dict[str,int]` yield `'dict[str, int]'` on both
+    /// — slicing would leak the original spacing, newlines and quote style.
+    fn parse_class_annotation(&mut self, ident: Identifier, annotation: &mut AstExpr) -> DictItem {
+        let ann_range = annotation.range();
+        // Neither generator mode matches CPython alone: `Mode::AstUnparse`
+        // normalises quotes but parenthesises tuple subscripts (`dict[(str,
+        // int)]`), while `Mode::Default` keeps subscripts but preserves the
+        // source quote style. So use `Default` and normalise the quotes first.
+        SingleQuoteStrings.visit_expr(annotation);
+        // `LineEnding::Lf` is pinned rather than defaulted: the default is
+        // platform-dependent, and Monty must stringize identically everywhere.
+        let unparsed = Generator::new(&Indentation::default(), LineEnding::Lf).expr(annotation);
+        let ann_id = self.interner.intern(&unparsed);
+        DictItem::Pair(
+            ExprLoc::new(ident.position, Expr::Literal(Literal::Str(ident.name_id))),
+            ExprLoc::new(self.convert_range(ann_range), Expr::Literal(Literal::Str(ann_id))),
+        )
     }
 
     /// Parses a class-variable value and records the binding: rejects class-scope

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -9,7 +9,11 @@ use ruff_python_ast::{
     name::Name,
     str::Quote,
     token::TokenKind,
-    visitor::{Visitor, transformer::Transformer, walk_expr},
+    visitor::{
+        Visitor,
+        transformer::{Transformer, walk_f_string},
+        walk_expr,
+    },
 };
 use ruff_python_codegen::{Generator, Indentation};
 use ruff_python_parser::parse_module;
@@ -73,19 +77,28 @@ const SUPPORTED_FUTURES: [&str; 9] = [
 /// undefined.
 const UNSUPPORTED_FUTURES: [&str; 1] = ["barry_as_FLUFL"];
 
-/// Rewrites every string literal in an expression to single-quoted, matching how
-/// CPython's PEP 563 stringizer renders them (`x: "int"` gives `"'int'"`).
+/// Rewrites every string literal and f-string in an expression to single-quoted,
+/// matching how CPython's PEP 563 stringizer renders them (`x: "int"` gives
+/// `"'int'"`, `x: f"int"` gives `"f'int'"`).
 ///
 /// Applied to class annotations before unparsing, because neither generator mode
 /// matches CPython alone — see [`Parser::parse_class_annotation`]. Nested
 /// literals are covered too, so `dict[str, "Foo"]` normalises throughout. Only
 /// the quote *style* changes; the generator still escapes as needed, so a
-/// literal containing a single quote stays valid.
+/// literal containing a single quote keeps its double quotes rather than
+/// becoming invalid — again matching CPython.
 struct SingleQuoteStrings;
 
 impl Transformer for SingleQuoteStrings {
     fn visit_string_literal(&self, string_literal: &mut ast::StringLiteral) {
         string_literal.flags = string_literal.flags.with_quote_style(Quote::Single);
+    }
+
+    // F-strings carry their own flags, so they need normalising separately;
+    // walking the elements still reaches any plain literals nested in a spec.
+    fn visit_f_string(&self, f_string: &mut ast::FString) {
+        f_string.flags = f_string.flags.with_quote_style(Quote::Single);
+        walk_f_string(self, f_string);
     }
 }
 
@@ -956,20 +969,26 @@ impl<'a> Parser<'a> {
         // Last statement so the values are assembled after all members exist.
         // Always present (empty dict) to match `Cls.__annotations__ == {}`.
         let annotations_target = Identifier::new(self.interner.intern("__annotations__"), position);
-        // Being last means this would silently clobber an explicit assignment in
-        // the body, losing its entries (CPython merges the two instead). Rejected
-        // rather than dropped quietly; the syntax is reserved for later.
-        if members.iter().any(|m| m.name_id == annotations_target.name_id) {
+        let body_binds_annotations = members.iter().any(|m| m.name_id == annotations_target.name_id);
+        if body_binds_annotations && !annotations.is_empty() {
+            // Being last, the synthetic assignment would silently clobber the
+            // body's own binding and lose these entries. CPython merges instead —
+            // storing into whatever the name holds, which succeeds for a dict and
+            // raises `TypeError` otherwise. Rejected rather than dropped quietly.
             return Err(ParseError::not_implemented(
-                "assigning `__annotations__` in a class body",
+                "assigning `__annotations__` in a class body with annotated names",
                 position,
             ));
         }
-        members.push(annotations_target);
-        body.push(Node::Assign {
-            target: annotations_target,
-            object: ExprLoc::new(position, Expr::Dict(annotations)),
-        });
+        // With nothing to store, the body's own binding stands — synthesizing an
+        // empty dict over it would break class bodies CPython accepts.
+        if !body_binds_annotations {
+            members.push(annotations_target);
+            body.push(Node::Assign {
+                target: annotations_target,
+                object: ExprLoc::new(position, Expr::Dict(annotations)),
+            });
+        }
 
         // Wrap the body statements in a synthetic zero-arg function. The class
         // name's `name_id` is reused for nicer tracebacks; this function is never

--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -42,11 +42,9 @@ pub const MAX_NESTING_DEPTH: u16 = 30;
 /// `from __future__ import ...` features whose semantics Monty already provides,
 /// so importing them is a no-op rather than an error.
 ///
-/// All but the last became mandatory in Python 3.7 or earlier, so they are inert
-/// in CPython too — the imports survive only in code that once supported older
-/// versions. `annotations` is different in kind: it is still meaningful in
-/// CPython, and is a no-op here only because Monty stringizes annotations
-/// unconditionally (see `limitations/typing.md`), which is what it asks for.
+/// All but the last are inert in CPython too, having become mandatory by 3.7.
+/// `annotations` is still meaningful there, and a no-op here only because Monty
+/// stringizes unconditionally (see `limitations/typing.md`) — what it asks for.
 const SUPPORTED_FUTURES: [&str; 9] = [
     "nested_scopes",
     "generators",
@@ -59,16 +57,11 @@ const SUPPORTED_FUTURES: [&str; 9] = [
     "annotations",
 ];
 
-/// `from __future__ import ...` features Monty does not implement, which are
-/// rejected rather than silently ignored — importing one asks for behaviour the
-/// sandbox will not deliver.
-///
-/// `barry_as_FLUFL` (PEP 401) makes `<>` the inequality operator and turns `!=`
-/// into a `SyntaxError`. Monty parses neither differently.
-///
-/// Together with [`SUPPORTED_FUTURES`] this must cover CPython's
-/// `__future__.all_feature_names`, since any name in neither list is reported as
-/// undefined.
+/// `from __future__ import ...` features Monty does not implement, rejected
+/// rather than silently ignored. `barry_as_FLUFL` (PEP 401) makes `<>` the
+/// inequality operator and `!=` a `SyntaxError`; Monty parses neither
+/// differently. With [`SUPPORTED_FUTURES`] this must cover CPython's
+/// `all_feature_names` — a name in neither is reported as undefined.
 const UNSUPPORTED_FUTURES: [&str; 1] = ["barry_as_FLUFL"];
 
 /// A parameter in a function signature with optional default value.
@@ -607,14 +600,11 @@ impl<'a> Parser<'a> {
                 ..
             }) => {
                 let position = self.convert_range(range);
-                // Compiler directives, not real imports, so they bind nothing and
-                // lower to a no-op — real-world modules then import cleanly. A
-                // feature Monty does not implement is rejected rather than
-                // ignored, so the import never quietly fails to do what it says.
-                //
-                // `level == 0` matters: `from .__future__ import x` is an ordinary
-                // relative import of a module that happens to share the name, and
-                // must fall through to the `ImportError` below.
+                // Compiler directives, not real imports: they bind nothing and lower
+                // to a no-op, so real-world modules import cleanly. Anything Monty
+                // does not implement is rejected rather than quietly failing to do
+                // what it says. `level == 0` keeps `from .__future__ import x` an
+                // ordinary relative import, falling through to the `ImportError`.
                 if level == 0 && module.as_ref().is_some_and(|m| m.as_str() == "__future__") {
                     return match names
                         .iter()
@@ -940,10 +930,9 @@ impl<'a> Parser<'a> {
         let annotations_target = Identifier::new(self.interner.intern("__annotations__"), position);
         let body_binds_annotations = members.iter().any(|m| m.name_id == annotations_target.name_id);
         if body_binds_annotations && !annotations.is_empty() {
-            // Being last, the synthetic assignment would silently clobber the
-            // body's own binding and lose these entries. CPython merges instead —
-            // storing into whatever the name holds, which succeeds for a dict and
-            // raises `TypeError` otherwise. Rejected rather than dropped quietly.
+            // Being last, the synthetic assignment would clobber the body's own
+            // binding and lose these entries. CPython stores into whatever the name
+            // holds instead — merging into a dict, `TypeError` otherwise.
             return Err(ParseError::not_implemented(
                 "assigning `__annotations__` in a class body with annotated names",
                 position,

--- a/crates/monty/src/stringize.rs
+++ b/crates/monty/src/stringize.rs
@@ -10,7 +10,7 @@
 use ruff_python_ast::{
     self as ast, AtomicNodeIndex, Expr as AstExpr,
     str::{Quote, TripleQuotes},
-    str_prefix::StringLiteralPrefix,
+    str_prefix::{ByteStringPrefix, StringLiteralPrefix},
     visitor::transformer::{Transformer, walk_expr, walk_f_string},
 };
 use ruff_python_codegen::{Generator, Indentation};
@@ -38,6 +38,7 @@ pub(crate) fn stringize_annotation(annotation: &mut AstExpr) -> String {
 /// | `f"x" "y"`     | `f'x' 'y'`     | `f'xy'`             |
 /// | `r"raw\d"`     | `r'raw\d'`     | `'raw\\d'`          |
 /// | `"""triple"""` | `"""triple"""` | `'triple'`          |
+/// | `b"foo" b"bar"`| `b"foo" b"bar"`| `b'foobar'`         |
 struct CanonicalStringLiterals;
 
 impl Transformer for CanonicalStringLiterals {
@@ -46,6 +47,7 @@ impl Transformer for CanonicalStringLiterals {
     fn visit_expr(&self, expr: &mut AstExpr) {
         match expr {
             AstExpr::StringLiteral(s) => rebuild_string_literal(s),
+            AstExpr::BytesLiteral(b) => rebuild_bytes_literal(b),
             AstExpr::FString(f) if f.value.is_implicit_concatenated() => merge_f_string_parts(f),
             _ => {}
         }
@@ -96,6 +98,24 @@ fn rebuild_string_literal(expr: &mut ast::ExprStringLiteral) {
         flags: canonical_string_flags(expr.value.first_literal_flags()),
     };
     expr.value = ast::StringLiteralValue::single(canonical);
+}
+
+/// The `bytes` counterpart of [`rebuild_string_literal`], collapsing
+/// `b"foo" b"bar"` into `b'foobar'`.
+///
+/// Simpler than the `str` case only in the flags: `bytes` has no `u` prefix, so
+/// the canonical form keeps no prefix at all.
+fn rebuild_bytes_literal(expr: &mut ast::ExprBytesLiteral) {
+    let canonical = ast::BytesLiteral {
+        range: expr.range,
+        node_index: AtomicNodeIndex::default(),
+        value: expr.value.bytes().collect(),
+        flags: ast::BytesLiteralFlags::empty()
+            .with_prefix(ByteStringPrefix::Regular)
+            .with_quote_style(Quote::Single)
+            .with_triple_quotes(TripleQuotes::No),
+    };
+    expr.value = ast::BytesLiteralValue::single(canonical);
 }
 
 /// Collapses `f"x" "y"` into the single f-string `f'xy'`.

--- a/crates/monty/src/stringize.rs
+++ b/crates/monty/src/stringize.rs
@@ -57,29 +57,29 @@ pub(crate) fn stringize_annotation(annotation: &mut AstExpr) -> String {
 struct CanonicalStringLiterals;
 
 impl Transformer for CanonicalStringLiterals {
-    fn visit_string_literal(&self, string_literal: &mut ast::StringLiteral) {
-        string_literal.flags = canonical_string_flags(string_literal.flags);
+    // Rebuilding is unconditional rather than reserved for the spellings that
+    // happen to diverge: the value is the truth and the spelling is noise, so
+    // there is no "unaffected" case to preserve. One path, not a rule plus
+    // exceptions — which is also why the whole rewrite lives here rather than
+    // being split with `visit_string_literal`.
+    fn visit_expr(&self, expr: &mut AstExpr) {
+        match expr {
+            AstExpr::StringLiteral(s) => rebuild_string_literal(s),
+            AstExpr::FString(f) if f.value.is_implicit_concatenated() => merge_f_string_parts(f),
+            _ => {}
+        }
+        walk_expr(self, expr);
     }
 
-    // F-strings carry their own flags, so they need canonicalising separately;
-    // walking the elements still reaches any literals nested in a format spec.
+    // F-strings cannot be rebuilt from a value — the interpolations are live
+    // expressions — so only the flags are canonicalised. Walking the elements
+    // still reaches any literal nested in a format spec.
     fn visit_f_string(&self, f_string: &mut ast::FString) {
         f_string.flags = f_string
             .flags
             .with_quote_style(Quote::Single)
             .with_triple_quotes(TripleQuotes::No);
         walk_f_string(self, f_string);
-    }
-
-    // Concatenation is a property of the *expression*, not of any one part, so
-    // the merge happens here and the visits above then canonicalise the result.
-    fn visit_expr(&self, expr: &mut AstExpr) {
-        match expr {
-            AstExpr::StringLiteral(s) if s.value.is_implicit_concatenated() => merge_string_parts(s),
-            AstExpr::FString(f) if f.value.is_implicit_concatenated() => merge_f_string_parts(f),
-            _ => {}
-        }
-        walk_expr(self, expr);
     }
 }
 
@@ -88,10 +88,13 @@ impl Transformer for CanonicalStringLiterals {
 /// (`r"raw\d"` becomes `'raw\\d'`) since the generator re-escapes what the raw
 /// prefix used to cover.
 ///
-/// A `u` prefix is *kept*: CPython renders `u"x"` as `u'x'`, so canonical is not
-/// the same as bare. The quote style is a request, not a guarantee — the
-/// generator still switches to double quotes when the value contains a single
-/// one, which is what CPython does too.
+/// A `u` prefix is *kept*, so canonical is not the same as bare. That asymmetry
+/// is not a quirk to encode but a direct consequence of CPython's AST: `u` is the
+/// only prefix it retains (as `Constant.kind`, which its unparser re-emits),
+/// because raw-ness was already consumed by the parser and is not representable.
+///
+/// The quote style is a request, not a guarantee — the generator still switches
+/// to double quotes when the value contains a single one, matching CPython.
 fn canonical_string_flags(flags: ast::StringLiteralFlags) -> ast::StringLiteralFlags {
     let prefix = match flags.prefix() {
         StringLiteralPrefix::Unicode => StringLiteralPrefix::Unicode,
@@ -103,19 +106,23 @@ fn canonical_string_flags(flags: ast::StringLiteralFlags) -> ast::StringLiteralF
         .with_triple_quotes(TripleQuotes::No)
 }
 
-/// Collapses `"foo" "bar"` into the single literal `'foobar'`.
+/// Replaces a `str` literal with the single canonical literal for its value,
+/// which is what collapses `"foo" "bar"` into `'foobar'`.
 ///
-/// The parts' own flags are discarded in favour of the first part's, matching
-/// CPython: the concatenated *value* is what survives, and `visit_string_literal`
-/// canonicalises the flags immediately afterwards.
-fn merge_string_parts(expr: &mut ast::ExprStringLiteral) {
-    let merged = ast::StringLiteral {
+/// This is CPython's model rather than a translation of it. There, a literal
+/// reaches the unparser as a `Constant` holding a `str`, because the parser has
+/// already folded concatenation and processed the prefix — so it can simply
+/// write `repr(value)`. Ruff keeps the spelling (a formatter needs it), so the
+/// discard CPython's parser performed happens here instead.
+fn rebuild_string_literal(expr: &mut ast::ExprStringLiteral) {
+    let canonical = ast::StringLiteral {
         range: expr.range,
         node_index: AtomicNodeIndex::default(),
+        // `to_str` is the concatenation of every part, and the identity for one.
         value: expr.value.to_str().into(),
-        flags: expr.value.first_literal_flags(),
+        flags: canonical_string_flags(expr.value.first_literal_flags()),
     };
-    expr.value = ast::StringLiteralValue::single(merged);
+    expr.value = ast::StringLiteralValue::single(canonical);
 }
 
 /// Collapses `f"x" "y"` into the single f-string `f'xy'`.
@@ -126,7 +133,7 @@ fn merge_string_parts(expr: &mut ast::ExprStringLiteral) {
 /// one literal element; an f-string part contributes all of its own.
 fn merge_f_string_parts(expr: &mut ast::ExprFString) {
     let mut elements: Vec<ast::InterpolatedStringElement> = Vec::new();
-    // The first f-string part's flags stand for the whole, as above.
+    // The first f-string part's flags stand for the whole.
     let mut flags = None;
     for part in &expr.value {
         match part {

--- a/crates/monty/src/stringize.rs
+++ b/crates/monty/src/stringize.rs
@@ -1,0 +1,157 @@
+//! Rendering a ruff AST expression back to source text, the way CPython's
+//! PEP 563 stringizer does.
+//!
+//! The inverse of [`parse`](crate::parse): that module turns source into Monty's
+//! IR, this one turns a fragment of the AST back into the string a Python program
+//! would observe. Annotations are the only caller today — they are stored
+//! stringized rather than evaluated (see `limitations/typing.md`) — but the
+//! contract is "produce exactly what CPython's stringizer would", so any future
+//! stringization (function or module `__annotations__`) belongs here too.
+//!
+//! Unparsing rather than slicing the source is what makes `x: dict[str,int]`
+//! yield `'dict[str, int]'` on both interpreters; a slice would leak the original
+//! spacing, line breaks and quote style into the value.
+
+use ruff_python_ast::{
+    self as ast, AtomicNodeIndex, Expr as AstExpr,
+    str::{Quote, TripleQuotes},
+    str_prefix::StringLiteralPrefix,
+    visitor::transformer::{Transformer, walk_expr, walk_f_string},
+};
+use ruff_python_codegen::{Generator, Indentation};
+use ruff_source_file::LineEnding;
+
+/// Renders `annotation` to the text CPython's PEP 563 stringizer would produce.
+///
+/// Takes `&mut` because canonicalising the literals rewrites them in place; the
+/// expression is not otherwise used after stringization.
+///
+/// ```ignore
+/// stringize_annotation(&mut expr)  // `dict[str,"Foo"]` -> `dict[str, 'Foo']`
+/// ```
+pub(crate) fn stringize_annotation(annotation: &mut AstExpr) -> String {
+    // Neither generator mode matches CPython alone: `Mode::AstUnparse` normalises
+    // quotes but parenthesises tuple subscripts (`dict[(str, int)]`), while
+    // `Mode::Default` keeps subscripts but echoes the source literals. So use
+    // `Default` and canonicalise the literals first.
+    CanonicalStringLiterals.visit_expr(annotation);
+    // `LineEnding::Lf` is pinned rather than defaulted: the default is
+    // platform-dependent, and Monty must stringize identically everywhere.
+    Generator::new(&Indentation::default(), LineEnding::Lf).expr(annotation)
+}
+
+/// Rewrites the string literals in an expression into the single canonical form
+/// CPython's stringizer produces, so unparsing matches it.
+///
+/// The generator echoes each literal roughly as written — every implicitly
+/// concatenated part separately, prefixes and triple quotes intact — where
+/// CPython rebuilds *one* literal from the value. Descends the whole expression,
+/// so `dict[str, "Foo"]` is normalised at any depth.
+///
+/// | annotation     | without this   | with it (= CPython) |
+/// | -------------- | -------------- | ------------------- |
+/// | `"foo" "bar"`  | `'foo' 'bar'`  | `'foobar'`          |
+/// | `f"x" "y"`     | `f'x' 'y'`     | `f'xy'`             |
+/// | `r"raw\d"`     | `r'raw\d'`     | `'raw\\d'`          |
+/// | `"""triple"""` | `"""triple"""` | `'triple'`          |
+struct CanonicalStringLiterals;
+
+impl Transformer for CanonicalStringLiterals {
+    fn visit_string_literal(&self, string_literal: &mut ast::StringLiteral) {
+        string_literal.flags = canonical_string_flags(string_literal.flags);
+    }
+
+    // F-strings carry their own flags, so they need canonicalising separately;
+    // walking the elements still reaches any literals nested in a format spec.
+    fn visit_f_string(&self, f_string: &mut ast::FString) {
+        f_string.flags = f_string
+            .flags
+            .with_quote_style(Quote::Single)
+            .with_triple_quotes(TripleQuotes::No);
+        walk_f_string(self, f_string);
+    }
+
+    // Concatenation is a property of the *expression*, not of any one part, so
+    // the merge happens here and the visits above then canonicalise the result.
+    fn visit_expr(&self, expr: &mut AstExpr) {
+        match expr {
+            AstExpr::StringLiteral(s) if s.value.is_implicit_concatenated() => merge_string_parts(s),
+            AstExpr::FString(f) if f.value.is_implicit_concatenated() => merge_f_string_parts(f),
+            _ => {}
+        }
+        walk_expr(self, expr);
+    }
+}
+
+/// The flags CPython's stringizer effectively renders a `str` literal with:
+/// single-quoted and not triple-quoted, with a raw prefix folded into the value
+/// (`r"raw\d"` becomes `'raw\\d'`) since the generator re-escapes what the raw
+/// prefix used to cover.
+///
+/// A `u` prefix is *kept*: CPython renders `u"x"` as `u'x'`, so canonical is not
+/// the same as bare. The quote style is a request, not a guarantee — the
+/// generator still switches to double quotes when the value contains a single
+/// one, which is what CPython does too.
+fn canonical_string_flags(flags: ast::StringLiteralFlags) -> ast::StringLiteralFlags {
+    let prefix = match flags.prefix() {
+        StringLiteralPrefix::Unicode => StringLiteralPrefix::Unicode,
+        StringLiteralPrefix::Empty | StringLiteralPrefix::Raw { .. } => StringLiteralPrefix::Empty,
+    };
+    flags
+        .with_prefix(prefix)
+        .with_quote_style(Quote::Single)
+        .with_triple_quotes(TripleQuotes::No)
+}
+
+/// Collapses `"foo" "bar"` into the single literal `'foobar'`.
+///
+/// The parts' own flags are discarded in favour of the first part's, matching
+/// CPython: the concatenated *value* is what survives, and `visit_string_literal`
+/// canonicalises the flags immediately afterwards.
+fn merge_string_parts(expr: &mut ast::ExprStringLiteral) {
+    let merged = ast::StringLiteral {
+        range: expr.range,
+        node_index: AtomicNodeIndex::default(),
+        value: expr.value.to_str().into(),
+        flags: expr.value.first_literal_flags(),
+    };
+    expr.value = ast::StringLiteralValue::single(merged);
+}
+
+/// Collapses `f"x" "y"` into the single f-string `f'xy'`.
+///
+/// Unlike the `str` case the parts are not all the same kind — a concatenation
+/// mixes plain literals with f-strings — so the merge splices their *elements*
+/// into one element list rather than joining a string. A plain part contributes
+/// one literal element; an f-string part contributes all of its own.
+fn merge_f_string_parts(expr: &mut ast::ExprFString) {
+    let mut elements: Vec<ast::InterpolatedStringElement> = Vec::new();
+    // The first f-string part's flags stand for the whole, as above.
+    let mut flags = None;
+    for part in &expr.value {
+        match part {
+            ast::FStringPart::Literal(literal) => {
+                elements.push(ast::InterpolatedStringElement::Literal(
+                    ast::InterpolatedStringLiteralElement {
+                        range: literal.range,
+                        node_index: AtomicNodeIndex::default(),
+                        value: literal.value.clone(),
+                    },
+                ));
+            }
+            ast::FStringPart::FString(f_string) => {
+                flags = flags.or(Some(f_string.flags));
+                elements.extend(f_string.elements.iter().cloned());
+            }
+        }
+    }
+    // `is_implicit_concatenated` guarantees at least one f-string part, since a
+    // concatenation with none would not have parsed as an f-string.
+    let Some(flags) = flags else { return };
+    expr.value = ast::FStringValue::single(ast::FString {
+        range: expr.range,
+        node_index: AtomicNodeIndex::default(),
+        elements: elements.into(),
+        flags,
+    });
+}

--- a/crates/monty/src/stringize.rs
+++ b/crates/monty/src/stringize.rs
@@ -1,16 +1,11 @@
 //! Rendering a ruff AST expression back to source text, the way CPython's
 //! PEP 563 stringizer does.
 //!
-//! The inverse of [`parse`](crate::parse): that module turns source into Monty's
-//! IR, this one turns a fragment of the AST back into the string a Python program
-//! would observe. Annotations are the only caller today — they are stored
-//! stringized rather than evaluated (see `limitations/typing.md`) — but the
-//! contract is "produce exactly what CPython's stringizer would", so any future
-//! stringization (function or module `__annotations__`) belongs here too.
-//!
-//! Unparsing rather than slicing the source is what makes `x: dict[str,int]`
-//! yield `'dict[str, int]'` on both interpreters; a slice would leak the original
-//! spacing, line breaks and quote style into the value.
+//! The inverse of [`parse`](crate::parse). Class annotations are the only caller
+//! today (they are stored stringized, not evaluated — see
+//! `limitations/typing.md`), but the contract is "match CPython's stringizer", so
+//! any future stringization belongs here. Unparsing rather than slicing the
+//! source is what makes `x: dict[str,int]` yield `'dict[str, int]'` on both.
 
 use ruff_python_ast::{
     self as ast, AtomicNodeIndex, Expr as AstExpr,
@@ -23,30 +18,19 @@ use ruff_source_file::LineEnding;
 
 /// Renders `annotation` to the text CPython's PEP 563 stringizer would produce.
 ///
-/// Takes `&mut` because canonicalising the literals rewrites them in place; the
-/// expression is not otherwise used after stringization.
-///
-/// ```ignore
-/// stringize_annotation(&mut expr)  // `dict[str,"Foo"]` -> `dict[str, 'Foo']`
-/// ```
+/// Takes `&mut` because canonicalising the literals rewrites them in place.
 pub(crate) fn stringize_annotation(annotation: &mut AstExpr) -> String {
-    // Neither generator mode matches CPython alone: `Mode::AstUnparse` normalises
-    // quotes but parenthesises tuple subscripts (`dict[(str, int)]`), while
-    // `Mode::Default` keeps subscripts but echoes the source literals. So use
-    // `Default` and canonicalise the literals first.
+    // Neither generator mode matches CPython alone: `AstUnparse` normalises quotes
+    // but parenthesises tuple subscripts (`dict[(str, int)]`), `Default` keeps
+    // subscripts but echoes the source literals. So canonicalise, then `Default`.
     CanonicalStringLiterals.visit_expr(annotation);
-    // `LineEnding::Lf` is pinned rather than defaulted: the default is
-    // platform-dependent, and Monty must stringize identically everywhere.
+    // `Lf` is pinned because the default is platform-dependent, and Monty must
+    // stringize identically everywhere.
     Generator::new(&Indentation::default(), LineEnding::Lf).expr(annotation)
 }
 
-/// Rewrites the string literals in an expression into the single canonical form
-/// CPython's stringizer produces, so unparsing matches it.
-///
-/// The generator echoes each literal roughly as written — every implicitly
-/// concatenated part separately, prefixes and triple quotes intact — where
-/// CPython rebuilds *one* literal from the value. Descends the whole expression,
-/// so `dict[str, "Foo"]` is normalised at any depth.
+/// Rewrites string literals into the single canonical form CPython produces,
+/// since the generator otherwise echoes them roughly as written.
 ///
 /// | annotation     | without this   | with it (= CPython) |
 /// | -------------- | -------------- | ------------------- |
@@ -57,11 +41,8 @@ pub(crate) fn stringize_annotation(annotation: &mut AstExpr) -> String {
 struct CanonicalStringLiterals;
 
 impl Transformer for CanonicalStringLiterals {
-    // Rebuilding is unconditional rather than reserved for the spellings that
-    // happen to diverge: the value is the truth and the spelling is noise, so
-    // there is no "unaffected" case to preserve. One path, not a rule plus
-    // exceptions — which is also why the whole rewrite lives here rather than
-    // being split with `visit_string_literal`.
+    // Rebuilding is unconditional: the value is the truth and the spelling noise,
+    // so there is no unaffected case to preserve.
     fn visit_expr(&self, expr: &mut AstExpr) {
         match expr {
             AstExpr::StringLiteral(s) => rebuild_string_literal(s),
@@ -72,8 +53,7 @@ impl Transformer for CanonicalStringLiterals {
     }
 
     // F-strings cannot be rebuilt from a value — the interpolations are live
-    // expressions — so only the flags are canonicalised. Walking the elements
-    // still reaches any literal nested in a format spec.
+    // expressions — so only the flags are canonicalised.
     fn visit_f_string(&self, f_string: &mut ast::FString) {
         f_string.flags = f_string
             .flags
@@ -83,18 +63,13 @@ impl Transformer for CanonicalStringLiterals {
     }
 }
 
-/// The flags CPython's stringizer effectively renders a `str` literal with:
-/// single-quoted and not triple-quoted, with a raw prefix folded into the value
-/// (`r"raw\d"` becomes `'raw\\d'`) since the generator re-escapes what the raw
-/// prefix used to cover.
+/// The flags CPython effectively renders a `str` literal with: single-quoted, not
+/// triple-quoted, raw prefix folded into the value (the generator re-escapes what
+/// it covered). Quote style is a request — the generator still switches to double
+/// quotes when the value contains a single one, as CPython does.
 ///
-/// A `u` prefix is *kept*, so canonical is not the same as bare. That asymmetry
-/// is not a quirk to encode but a direct consequence of CPython's AST: `u` is the
-/// only prefix it retains (as `Constant.kind`, which its unparser re-emits),
-/// because raw-ness was already consumed by the parser and is not representable.
-///
-/// The quote style is a request, not a guarantee — the generator still switches
-/// to double quotes when the value contains a single one, matching CPython.
+/// `u` is kept because it is the only prefix CPython's AST retains (as
+/// `Constant.kind`); raw-ness is consumed by its parser and cannot come back.
 fn canonical_string_flags(flags: ast::StringLiteralFlags) -> ast::StringLiteralFlags {
     let prefix = match flags.prefix() {
         StringLiteralPrefix::Unicode => StringLiteralPrefix::Unicode,
@@ -106,19 +81,17 @@ fn canonical_string_flags(flags: ast::StringLiteralFlags) -> ast::StringLiteralF
         .with_triple_quotes(TripleQuotes::No)
 }
 
-/// Replaces a `str` literal with the single canonical literal for its value,
-/// which is what collapses `"foo" "bar"` into `'foobar'`.
+/// Replaces a `str` literal with the canonical literal for its value, collapsing
+/// `"foo" "bar"` into `'foobar'`.
 ///
-/// This is CPython's model rather than a translation of it. There, a literal
-/// reaches the unparser as a `Constant` holding a `str`, because the parser has
-/// already folded concatenation and processed the prefix — so it can simply
-/// write `repr(value)`. Ruff keeps the spelling (a formatter needs it), so the
-/// discard CPython's parser performed happens here instead.
+/// CPython needs no equivalent: its parser already folded concatenation and
+/// consumed the prefix, so its unparser just writes `repr(value)`. Ruff keeps the
+/// spelling — a formatter needs it — so the discard happens here.
 fn rebuild_string_literal(expr: &mut ast::ExprStringLiteral) {
     let canonical = ast::StringLiteral {
         range: expr.range,
         node_index: AtomicNodeIndex::default(),
-        // `to_str` is the concatenation of every part, and the identity for one.
+        // `to_str` concatenates every part, and is the identity for one.
         value: expr.value.to_str().into(),
         flags: canonical_string_flags(expr.value.first_literal_flags()),
     };
@@ -127,10 +100,9 @@ fn rebuild_string_literal(expr: &mut ast::ExprStringLiteral) {
 
 /// Collapses `f"x" "y"` into the single f-string `f'xy'`.
 ///
-/// Unlike the `str` case the parts are not all the same kind — a concatenation
-/// mixes plain literals with f-strings — so the merge splices their *elements*
-/// into one element list rather than joining a string. A plain part contributes
-/// one literal element; an f-string part contributes all of its own.
+/// Splices element lists rather than joining a string, because the parts are not
+/// all the same kind: a plain part contributes one literal element, an f-string
+/// part contributes all of its own.
 fn merge_f_string_parts(expr: &mut ast::ExprFString) {
     let mut elements: Vec<ast::InterpolatedStringElement> = Vec::new();
     // The first f-string part's flags stand for the whole.
@@ -152,8 +124,7 @@ fn merge_f_string_parts(expr: &mut ast::ExprFString) {
             }
         }
     }
-    // `is_implicit_concatenated` guarantees at least one f-string part, since a
-    // concatenation with none would not have parsed as an f-string.
+    // Unreachable: a concatenation with no f-string part would not parse as one.
     let Some(flags) = flags else { return };
     expr.value = ast::FStringValue::single(ast::FString {
         range: expr.range,

--- a/crates/monty/test_cases/class__annotations.py
+++ b/crates/monty/test_cases/class__annotations.py
@@ -123,9 +123,9 @@ assert type(c).__annotations__['x'] == 'int'
 
 
 # === What __annotations__ unlocks: a transformer discovering its own fields ===
-# It reads only the keys and their order, never the values, so it is unaffected
-# by stringization — as is CPython's own `@dataclass`, save for `ClassVar`/
-# `InitVar`, which it matches textually.
+# It reads only the keys and their order, never the values, so stringization
+# cannot affect it. CPython's `@dataclass` does inspect values, but falls back
+# to matching `ClassVar`/`InitVar` textually when they are strings.
 def mini_dataclass(cls):
     fields = list(cls.__annotations__)
 

--- a/crates/monty/test_cases/class__annotations.py
+++ b/crates/monty/test_cases/class__annotations.py
@@ -78,6 +78,31 @@ assert Quoted.__annotations__['d'] == "f'int'"
 assert Quoted.__annotations__['e'] == '"it\'s"'
 
 
+# === Literals are rebuilt canonically, not echoed part-by-part ===
+# CPython's stringizer renders one canonical literal per annotation, so
+# implicitly concatenated parts merge and a raw prefix folds into the value.
+# A `u` prefix survives, though — canonical is not the same as bare.
+class Literals:
+    a: 'foo' 'bar'  # fmt: skip
+    b: f"x" "y"  # fmt: skip
+    c: r'raw\d'
+    d: "a" r"b\n"  # fmt: skip
+    e: u'uni'  # fmt: skip
+    f: """triple"""  # fmt: skip
+    g: f'pre{1}post'
+    h: dict[str, 'A' 'B']  # fmt: skip
+
+
+assert Literals.__annotations__['a'] == "'foobar'"
+assert Literals.__annotations__['b'] == "f'xy'"
+assert Literals.__annotations__['c'] == "'raw\\\\d'"
+assert Literals.__annotations__['d'] == "'ab\\\\n'"
+assert Literals.__annotations__['e'] == "u'uni'"
+assert Literals.__annotations__['f'] == "'triple'"
+assert Literals.__annotations__['g'] == "f'pre{1}post'"
+assert Literals.__annotations__['h'] == "dict[str, 'AB']"
+
+
 # === Empty class: __annotations__ is an empty dict ===
 class E:
     p = 1

--- a/crates/monty/test_cases/class__annotations.py
+++ b/crates/monty/test_cases/class__annotations.py
@@ -96,6 +96,20 @@ assert Literals.__annotations__['g'] == "f'pre{1}post'"
 assert Literals.__annotations__['h'] == "dict[str, 'AB']"
 
 
+# === bytes literals canonicalize the same way, minus the `u` prefix ===
+class ByteLiterals:
+    a: b'foo'
+    b: b'foo' b'bar'  # fmt: skip
+    c: rb'raw\d'
+    d: b"""triple"""  # fmt: skip
+
+
+assert ByteLiterals.__annotations__['a'] == "b'foo'"
+assert ByteLiterals.__annotations__['b'] == "b'foobar'"
+assert ByteLiterals.__annotations__['c'] == "b'raw\\\\d'"
+assert ByteLiterals.__annotations__['d'] == "b'triple'"
+
+
 # === Empty class: __annotations__ is an empty dict ===
 class E:
     p = 1

--- a/crates/monty/test_cases/class__annotations.py
+++ b/crates/monty/test_cases/class__annotations.py
@@ -1,13 +1,10 @@
-# Monty stores class annotations in stringized form, unconditionally. Using
-# `from __future__ import annotations` makes CPython do the same, so these
-# asserts hold on both interpreters. Without the import, CPython 3.14 would
-# store the evaluated objects instead (PEP 649) — a documented divergence.
+# Monty stringizes class annotations unconditionally; the `__future__` import
+# makes CPython do the same, so these asserts hold on both. Without it CPython
+# 3.14 stores evaluated objects (PEP 649).
 #
-# Stringization is a known temporary divergence (see limitations/typing.md).
-# If Monty ever matches PEP 649, this file changes as follows: the `__future__`
-# import at the top goes away, and every assert comparing a value to a string
-# (`== 'int'`, `== 'list[int]'`, ...) becomes an identity check against the type
-# object. The asserts on annotation *keys* and their order stay as they are.
+# Stringization is a known temporary divergence (see limitations/typing.md). If
+# Monty ever matches PEP 649, the import goes away and every `== 'int'`-style
+# assert becomes an identity check; the key/order asserts stay.
 from __future__ import annotations
 
 
@@ -42,8 +39,7 @@ assert Container.__annotations__['mapping'] == 'dict[str, int]'
 
 
 # === Annotations are normalized, not captured as raw source text ===
-# Both interpreters stringize by unparsing the expression, so the original
-# spacing and line breaks are discarded rather than embedded in the value.
+# Both unparse the expression, so spacing and line breaks are discarded.
 class Spacing:
     a: list [ int ]  # fmt: skip
     b: dict[str,int]  # fmt: skip
@@ -65,9 +61,7 @@ class Quoted:
     c: dict[str, "Foo"]  # fmt: skip
     # f-strings carry their own quote flags, so they normalize separately.
     d: f"int"  # fmt: skip
-    # A literal containing a single quote keeps its double quotes rather than
-    # becoming invalid — the unparser's escape-minimizing choice wins over the
-    # normalization, on both interpreters.
+    # A single quote inside keeps the double quotes: escape-minimizing wins.
     e: "it's"  # fmt: skip
 
 
@@ -79,9 +73,8 @@ assert Quoted.__annotations__['e'] == '"it\'s"'
 
 
 # === Literals are rebuilt canonically, not echoed part-by-part ===
-# CPython's stringizer renders one canonical literal per annotation, so
-# implicitly concatenated parts merge and a raw prefix folds into the value.
-# A `u` prefix survives, though — canonical is not the same as bare.
+# Concatenated parts merge and a raw prefix folds into the value. A `u` prefix
+# survives, though — canonical is not the same as bare.
 class Literals:
     a: 'foo' 'bar'  # fmt: skip
     b: f"x" "y"  # fmt: skip
@@ -115,14 +108,10 @@ c = C()
 assert type(c).__annotations__['x'] == 'int'
 
 
-# === What __annotations__ unlocks: field discovery driven by the annotations ===
-# A class transformer written in sandboxed Python that discovers its own fields
-# — the pattern `@dataclass` automates.
-#
-# Note it reads only `list(cls.__annotations__)` — the keys and their order.
-# The annotation *values* are never inspected, so this transformer is unaffected
-# by whether they are strings or type objects. CPython's own `@dataclass` is the
-# same, save for recognising `ClassVar`/`InitVar`, which it matches textually.
+# === What __annotations__ unlocks: a transformer discovering its own fields ===
+# It reads only the keys and their order, never the values, so it is unaffected
+# by stringization — as is CPython's own `@dataclass`, save for `ClassVar`/
+# `InitVar`, which it matches textually.
 def mini_dataclass(cls):
     fields = list(cls.__annotations__)
 

--- a/crates/monty/test_cases/class__annotations.py
+++ b/crates/monty/test_cases/class__annotations.py
@@ -63,11 +63,19 @@ class Quoted:
     a: "int"  # fmt: skip
     b: 'int'
     c: dict[str, "Foo"]  # fmt: skip
+    # f-strings carry their own quote flags, so they normalize separately.
+    d: f"int"  # fmt: skip
+    # A literal containing a single quote keeps its double quotes rather than
+    # becoming invalid — the unparser's escape-minimizing choice wins over the
+    # normalization, on both interpreters.
+    e: "it's"  # fmt: skip
 
 
 assert Quoted.__annotations__['a'] == "'int'"
 assert Quoted.__annotations__['b'] == "'int'"
 assert Quoted.__annotations__['c'] == "dict[str, 'Foo']"
+assert Quoted.__annotations__['d'] == "f'int'"
+assert Quoted.__annotations__['e'] == '"it\'s"'
 
 
 # === Empty class: __annotations__ is an empty dict ===

--- a/crates/monty/test_cases/class__annotations.py
+++ b/crates/monty/test_cases/class__annotations.py
@@ -1,0 +1,121 @@
+# Monty stores class annotations in stringized form, unconditionally. Using
+# `from __future__ import annotations` makes CPython do the same, so these
+# asserts hold on both interpreters. Without the import, CPython 3.14 would
+# store the evaluated objects instead (PEP 649) — a documented divergence.
+#
+# Stringization is a known temporary divergence (see limitations/typing.md).
+# If Monty ever matches PEP 649, this file changes as follows: the `__future__`
+# import at the top goes away, and every assert comparing a value to a string
+# (`== 'int'`, `== 'list[int]'`, ...) becomes an identity check against the type
+# object. The asserts on annotation *keys* and their order stay as they are.
+from __future__ import annotations
+
+
+# === Ordered __annotations__, stringized, excluding unannotated names ===
+class C:
+    x: int
+    y: str = 'hi'
+    z = 5  # no annotation -> not a field
+    cv: ClassVar[int] = 0
+
+
+assert list(C.__annotations__.keys()) == ['x', 'y', 'cv']
+assert C.__annotations__['x'] == 'int'
+assert C.__annotations__['y'] == 'str'
+# Parameterized forms Monty cannot evaluate are preserved verbatim as text.
+assert C.__annotations__['cv'] == 'ClassVar[int]'
+assert 'z' not in C.__annotations__, 'unannotated class var is not in __annotations__'
+
+# === Annotated-with-value is also a real class variable ===
+assert C.y == 'hi'
+assert C.z == 5
+
+
+# === Parameterized types that Monty cannot evaluate are fine as strings ===
+class Container:
+    items: list[int]
+    mapping: dict[str, int]
+
+
+assert Container.__annotations__['items'] == 'list[int]'
+assert Container.__annotations__['mapping'] == 'dict[str, int]'
+
+
+# === Annotations are normalized, not captured as raw source text ===
+# Both interpreters stringize by unparsing the expression, so the original
+# spacing and line breaks are discarded rather than embedded in the value.
+class Spacing:
+    a: list [ int ]  # fmt: skip
+    b: dict[str,int]  # fmt: skip
+    c: dict[
+        str,
+        int,
+    ]
+
+
+assert Spacing.__annotations__['a'] == 'list[int]'
+assert Spacing.__annotations__['b'] == 'dict[str, int]'
+assert Spacing.__annotations__['c'] == 'dict[str, int]'
+
+
+# === String annotations normalize to single quotes, as CPython's does ===
+class Quoted:
+    a: "int"  # fmt: skip
+    b: 'int'
+    c: dict[str, "Foo"]  # fmt: skip
+
+
+assert Quoted.__annotations__['a'] == "'int'"
+assert Quoted.__annotations__['b'] == "'int'"
+assert Quoted.__annotations__['c'] == "dict[str, 'Foo']"
+
+
+# === Empty class: __annotations__ is an empty dict ===
+class E:
+    p = 1
+
+
+assert E.__annotations__ == {}
+
+# === Accessible via type(instance) too ===
+c = C()
+assert type(c).__annotations__['x'] == 'int'
+
+
+# === What __annotations__ unlocks: field discovery driven by the annotations ===
+# A class transformer written in sandboxed Python that discovers its own fields
+# — the pattern `@dataclass` automates.
+#
+# Note it reads only `list(cls.__annotations__)` — the keys and their order.
+# The annotation *values* are never inspected, so this transformer is unaffected
+# by whether they are strings or type objects. CPython's own `@dataclass` is the
+# same, save for recognising `ClassVar`/`InitVar`, which it matches textually.
+def mini_dataclass(cls):
+    fields = list(cls.__annotations__)
+
+    def __init__(self, *args, **kwargs):
+        for name, val in zip(fields, args):
+            setattr(self, name, val)
+        for name, val in kwargs.items():
+            setattr(self, name, val)
+
+    def __repr__(self):
+        inner = ', '.join(f'{n}={getattr(self, n)!r}' for n in fields)
+        return f'{cls.__name__}({inner})'
+
+    cls.__init__ = __init__
+    cls.__repr__ = __repr__
+    return cls
+
+
+@mini_dataclass
+class Point:
+    x: int
+    y: int
+
+
+p = Point(1, 2)
+assert p.x == 1
+assert p.y == 2
+assert repr(p) == 'Point(x=1, y=2)'
+assert repr(Point(x=5, y=6)) == 'Point(x=5, y=6)'

--- a/crates/monty/test_cases/import__future_unknown_feature.py
+++ b/crates/monty/test_cases/import__future_unknown_feature.py
@@ -1,0 +1,13 @@
+# `__future__` imports are accepted as no-ops, but only for real feature names,
+# so an eventual change to one of them (see limitations/typing.md) stays visible
+# only to code that asked for it.
+from __future__ import teleportation
+
+"""
+TRACEBACK:
+Traceback (most recent call last):
+  File "import__future_unknown_feature.py", line 4
+    from __future__ import teleportation
+                           ~~~~~~~~~~~~~
+SyntaxError: future feature teleportation is not defined
+"""

--- a/crates/monty/test_cases/import__relative_future_error.py
+++ b/crates/monty/test_cases/import__relative_future_error.py
@@ -1,0 +1,12 @@
+# `from __future__ import ...` is a compiler directive Monty accepts as a no-op,
+# but only in its absolute form: a relative import of a module that happens to
+# share the name is an ordinary import, and there is no package system.
+from .__future__ import annotations
+
+"""
+TRACEBACK:
+Traceback (most recent call last):
+  File "import__relative_future_error.py", line 4, in <module>
+    from .__future__ import annotations
+ImportError: attempted relative import with no known parent package
+"""

--- a/crates/monty/test_cases/refcount__class.py
+++ b/crates/monty/test_cases/refcount__class.py
@@ -6,4 +6,9 @@ class Foo:
 f = Foo()
 g = Foo()
 bm = f.m
-# ref-counts={'Foo': 3, 'f': 2, 'g': 1, 'bm': 1}
+# Every class carries a synthesized `__annotations__` dict (empty here), which
+# is a real heap object owned by the class namespace. Bind it so the strict
+# check — every live heap object must be reachable from a name — accounts for
+# it rather than seeing an unreferenced object.
+ann = Foo.__annotations__
+# ref-counts={'Foo': 3, 'f': 2, 'g': 1, 'bm': 1, 'ann': 2}

--- a/crates/monty/test_cases/refcount__with_class.py
+++ b/crates/monty/test_cases/refcount__with_class.py
@@ -25,4 +25,7 @@ with cm:
 # binding (refcount 2); `cm` and `bound` alias the one instance (refcount 2);
 # `CM` is held by the global plus the instance's class slot (refcount 2).
 survived = cm.last_exc
-# ref-counts={'CM': 2, 'cm': 2, 'bound': 2, 'survived': 2}
+# The class's synthesized `__annotations__` dict (empty here) is a heap object
+# owned by the class namespace, so bind it too — see `refcount__class.py`.
+ann = CM.__annotations__
+# ref-counts={'CM': 2, 'cm': 2, 'bound': 2, 'survived': 2, 'ann': 2}

--- a/crates/monty/tests/parse_errors.rs
+++ b/crates/monty/tests/parse_errors.rs
@@ -127,6 +127,70 @@ fn unknown_imports_compile_successfully_error_deferred_to_runtime() {
 }
 
 #[test]
+fn explicit_class_annotations_assignment_returns_not_implemented_error() {
+    // The synthesized `__annotations__` is the last class-body statement, so an
+    // explicit assignment would be silently clobbered and its entries lost.
+    // CPython merges the two; Monty rejects rather than dropping them quietly.
+    let err = get_parse_err("class C:\n    __annotations__ = {'a': 'b'}\n    x: int");
+    assert_eq!(err.exc_type(), ExcType::NotImplementedError);
+    assert_snapshot!(
+        err.message().unwrap(),
+        @"The monty syntax parser does not yet support assigning `__annotations__` in a class body"
+    );
+}
+
+#[test]
+fn supported_future_imports_compile_successfully() {
+    // `__future__` imports are compiler directives, not real imports. All but
+    // `annotations` became mandatory in Python 3.7 or earlier and so are inert
+    // in CPython too; `annotations` is a no-op because Monty already stringizes
+    // annotations. Rejecting any of them would break otherwise-valid code.
+    for feature in ["division", "print_function", "generator_stop", "annotations"] {
+        let code = format!("from __future__ import {feature}\nx = 1");
+        let result = MontyRun::new(code, "test.py", vec![], CompileOptions::default());
+        assert!(result.is_ok(), "`{feature}` should compile as a no-op");
+    }
+}
+
+#[test]
+fn unsupported_future_import_returns_not_implemented_error() {
+    // `barry_as_FLUFL` (PEP 401) is one of only two `__future__` features still
+    // meaningful in Python 3, and Monty does not implement it — it makes `<>`
+    // the inequality operator and `!=` a SyntaxError. Rejected rather than
+    // ignored, so the import cannot quietly fail to do what it says. CPython
+    // accepts it, so this is a deliberate divergence.
+    let err = get_parse_err("from __future__ import barry_as_FLUFL");
+    assert_eq!(err.exc_type(), ExcType::NotImplementedError);
+    assert_snapshot!(
+        err.message().unwrap(),
+        @"The monty syntax parser does not yet support the 'barry_as_FLUFL' future feature"
+    );
+}
+
+#[test]
+fn aliased_future_import_returns_not_implemented_error() {
+    // The no-op binds nothing, so accepting an alias would leave the name
+    // undefined and surface as a `NameError` far from the import. CPython binds
+    // a `__future__._Feature` object, so this is a deliberate divergence.
+    let err = get_parse_err("from __future__ import annotations as ann");
+    assert_eq!(err.exc_type(), ExcType::NotImplementedError);
+    assert_snapshot!(
+        err.message().unwrap(),
+        @"The monty syntax parser does not yet support aliasing a `__future__` feature"
+    );
+}
+
+#[test]
+fn undefined_future_import_returns_syntax_error() {
+    // A name that is not a `__future__` feature at all, matching CPython's
+    // message. See `test_cases/import__future_unknown_feature.py` for the
+    // dual-run traceback test.
+    let err = get_parse_err("from __future__ import teleportation");
+    assert_eq!(err.exc_type(), ExcType::SyntaxError);
+    assert_snapshot!(err.message().unwrap(), @"future feature teleportation is not defined");
+}
+
+#[test]
 fn async_with_statement_returns_not_implemented_error() {
     // Plain `with` is supported (see `test_cases/with__all.py`); only `async with`
     // is still rejected at parse time.

--- a/crates/monty/tests/parse_errors.rs
+++ b/crates/monty/tests/parse_errors.rs
@@ -135,8 +135,23 @@ fn explicit_class_annotations_assignment_returns_not_implemented_error() {
     assert_eq!(err.exc_type(), ExcType::NotImplementedError);
     assert_snapshot!(
         err.message().unwrap(),
-        @"The monty syntax parser does not yet support assigning `__annotations__` in a class body"
+        @"The monty syntax parser does not yet support assigning `__annotations__` in a class body with annotated names"
     );
+}
+
+#[test]
+fn class_binding_annotations_without_annotated_names_compiles() {
+    // With nothing to store, the body's own binding stands rather than being
+    // overwritten by a synthesized empty dict — CPython accepts both of these,
+    // so rejecting them would fail class bodies that are perfectly valid.
+    for body in [
+        "__annotations__ = {'a': 'b'}",
+        "def __annotations__(self):\n        return 1",
+    ] {
+        let code = format!("class C:\n    {body}\n");
+        let result = MontyRun::new(code, "test.py", vec![], CompileOptions::default());
+        assert!(result.is_ok(), "`{body}` should compile");
+    }
 }
 
 #[test]

--- a/limitations/classes.md
+++ b/limitations/classes.md
@@ -36,6 +36,8 @@ get/set (including `setattr(Foo, ...)` and function-attributes-become-methods),
 bound methods, class variables (arbitrary expressions, evaluated in a real
 suspendable class-body scope), **class decorators** (`@deco class Foo`), `__repr__`/`__str__`/`__enter__`/`__exit__`
 dispatch, `obj.__class__`, `Foo.__name__`, `Foo.__doc__`/`obj.__doc__`,
+`Foo.__annotations__` (ordered; values stringized and provisional — see
+[typing.md](typing.md)),
 `type(obj)`/`isinstance(obj, Foo)`, and the 3-arg `type()` constructor. The
 `__enter__`/`__exit__` divergences are in [with.md](with.md). Everything else
 below is where Monty differs from or does not implement CPython behaviour.
@@ -192,8 +194,8 @@ e.g. return a `dict` of the fields.
   attribute always raises the default `AttributeError` even when the class
   defines `__getattr__`, and attribute writes always go straight to the
   instance `__dict__`.
-- Introspection attributes other than `__name__`, `__doc__`, and
-  `obj.__class__`: `Foo.__dict__`, `obj.__dict__`, `Foo.__bases__`,
+- Introspection attributes other than `__name__`, `__doc__`, `__annotations__`
+  and `obj.__class__`: `Foo.__dict__`, `obj.__dict__`, `Foo.__bases__`,
   `Foo.__mro__`, `Foo.__qualname__`, `Foo.__module__`, and explicit
   `obj.__repr__()` / `obj.__str__()` calls when the class defines none — all
   raise `AttributeError`.
@@ -210,8 +212,11 @@ e.g. return a `dict` of the fields.
   (`f = lambda: (z := 1)`) binds in the lambda's own scope and works. A walrus
   in a comprehension in the class body is also rejected (CPython rejects that
   too, but as a `SyntaxError` with different wording). A walrus in an
-  *annotation* (`x: (y := int) = 5`) runs in Monty — annotations are ignored
-  generally — where CPython raises `SyntaxError`.
+  *annotation* (`x: (y := int) = 5`) runs in Monty — annotation expressions are
+  captured as source text (stringized) and never evaluated, so the walrus never
+  binds — where CPython raises `SyntaxError`. This one follows from annotations
+  never being evaluated, so it would change if they ever are (see
+  [typing.md](typing.md)).
 - `del obj.attr` (the `del` statement is unsupported generally).
 
 ## `FrozenInstanceError`

--- a/limitations/classes.md
+++ b/limitations/classes.md
@@ -182,8 +182,9 @@ e.g. return a `dict` of the fields.
 - Function and method decorators — `@classmethod`, `@staticmethod`, `@property`,
   and any decorator on a top-level `def` or a method (rejected at parse time).
   Class decorators are supported.
-- **Classes are barely introspectable**: `__dict__`, `__bases__`,
-  `__annotations__` and `dir()` are all unavailable (`cls.__name__` works).
+- **Classes are barely introspectable**: `__dict__`, `__bases__` and `dir()`
+  are all unavailable (`cls.__name__` and `cls.__annotations__` work — the
+  latter with stringized values, see [typing.md](typing.md)).
 - Dunder protocols other than `__init__`, `__repr__`, `__str__`,
   `__enter__`, and `__exit__`: `__new__`, `__call__`, `__iter__`,
   `__next__`, `__getitem__`, `__setitem__`, `__contains__`, `__add__`,

--- a/limitations/language.md
+++ b/limitations/language.md
@@ -68,6 +68,30 @@ unpacking form matches CPython exactly.
   system.
 - `__import__` is not defined.
 
+## `__future__` imports
+
+`from __future__ import ...` is a compiler directive, not a real import: it
+binds nothing and is accepted as a no-op. Of CPython's ten features, eight
+became mandatory in Python 3.7 or earlier and so are inert there too, and
+`annotations` is a no-op here because Monty already stringizes annotations
+(see [typing.md](typing.md)). Divergences:
+
+- **`barry_as_FLUFL`** (PEP 401) raises `NotImplementedError: "The monty
+  syntax parser does not yet support the 'barry_as_FLUFL' future feature"`.
+  CPython accepts it, making `<>` the inequality operator and `!=` a
+  `SyntaxError`; Monty parses neither differently, so the import is rejected
+  rather than silently ignored.
+- **Aliasing is rejected.** `from __future__ import annotations as ann` raises
+  `NotImplementedError: "The monty syntax parser does not yet support aliasing
+  a \`__future__\` feature"`. CPython binds `ann` to a `__future__._Feature`
+  object; a no-op would bind nothing and surface as a `NameError` far from the
+  import, so it is rejected at the import instead.
+- **Position is not enforced.** CPython requires `__future__` imports to
+  precede all other statements (`SyntaxError: "from __future__ imports must
+  occur at the beginning of the file"`); Monty accepts them anywhere.
+- `import __future__` (as opposed to `from __future__ import ...`) raises
+  `ModuleNotFoundError` — there is no `__future__` module object.
+
 ## Module-level dunder variables
 
 Monty has no module object and no `globals()` dict, but it exposes a fixed set

--- a/limitations/typing.md
+++ b/limitations/typing.md
@@ -47,11 +47,12 @@ This is a known temporary divergence; see `class__annotations.py`.
   Monty when the calling code uses `from __future__ import annotations`
   (PEP 563), which Monty's behaviour is otherwise equivalent to — except that
   Monty stringizes whether or not that import is present.
-- The blocker is that Monty has no generic types: `list[int]`,
-  `dict[str, int]` and `int | None` all raise
-  `TypeError: 'type' object is not subscriptable`, so evaluated annotations
-  would fail on the most common forms. Runtime `types.GenericAlias` and `|`
-  unions are the prerequisite for matching PEP 649.
+- The blocker is that Monty has no generic types: `list[int]` and
+  `dict[str, int]` raise `TypeError: 'type' object is not subscriptable`, and
+  `int | None` raises `TypeError: unsupported operand type(s) for |: 'type'
+  and 'NoneType'`, so evaluated annotations would fail on the most common
+  forms. Runtime `types.GenericAlias` and `|` unions are the prerequisite for
+  matching PEP 649.
 - **Treat the values as provisional.** Code reading `__annotations__` sees
   strings today and would see type objects after a PEP 649 migration; the
   *keys* and their order are stable either way.
@@ -60,9 +61,11 @@ This is a known temporary divergence; see `class__annotations.py`.
   still *evaluates the target expression* — `undefined.attr: int` raises
   `NameError` there and is silently dropped by Monty. With a value
   (`obj.attr: T = v`) Monty raises `NotImplementedError`.
-- Assigning **`__annotations__` explicitly** in a class body raises
-  `NotImplementedError`; CPython merges the explicit dict with the collected
-  annotations.
+- Binding **`__annotations__` explicitly** in a class body that *also* has
+  annotated names raises `NotImplementedError`. CPython instead stores the
+  collected annotations into whatever the name holds — merging into an explicit
+  `dict`, or raising `TypeError` if it holds something else. A class body that
+  binds the name but annotates nothing is accepted, and its binding stands.
 - **`from __future__ import annotations`** is accepted as a **no-op**, since it
   describes what Monty already does. See
   [language.md](language.md#__future__-imports) for the other features.

--- a/limitations/typing.md
+++ b/limitations/typing.md
@@ -21,9 +21,55 @@ anything.
   `assert_never`, `overload`, `final`, `runtime_checkable`, `NewType`,
   `NamedTuple`, `TypedDict`, `dataclass_transform`, `ParamSpec`,
   `Concatenate`, `Unpack`, `TypeAlias`, `TypeAliasType`, `LiteralString`.
-- Any introspection of annotations: `__annotations__` is not populated on
-  functions or modules, so libraries that read it (Pydantic, attrs,
-  inspect-based code) cannot run.
+- Annotation introspection on **functions and modules**: `__annotations__` is
+  not populated there. (Class `__annotations__` **is** populated — see below.)
+
+## Class annotations are stringized
+
+A class body's annotations **are** recorded, in order, on the class's
+`__annotations__` dict — but in **stringized** form, unconditionally. The values
+are the annotation expression rendered back to source, never evaluated. As in
+CPython's PEP 563 stringizer the expression is *unparsed* rather than sliced out
+of the file, so original spacing, line breaks and quote style are normalized
+away (`x: dict[str,int]` gives `'dict[str, int]'`):
+
+```python
+class C:
+    x: int
+    y: list[int]
+C.__annotations__        # {'x': 'int', 'y': 'list[int]'}  -- strings
+```
+
+This is a known temporary divergence; see `class__annotations.py`.
+
+- **Divergence from CPython 3.14's default** (PEP 649), where these are the
+  evaluated objects (`C.__annotations__['x'] is int`). CPython only agrees with
+  Monty when the calling code uses `from __future__ import annotations`
+  (PEP 563), which Monty's behaviour is otherwise equivalent to — except that
+  Monty stringizes whether or not that import is present.
+- The blocker is that Monty has no generic types: `list[int]`,
+  `dict[str, int]` and `int | None` all raise
+  `TypeError: 'type' object is not subscriptable`, so evaluated annotations
+  would fail on the most common forms. Runtime `types.GenericAlias` and `|`
+  unions are the prerequisite for matching PEP 649.
+- **Treat the values as provisional.** Code reading `__annotations__` sees
+  strings today and would see type objects after a PEP 649 migration; the
+  *keys* and their order are stable either way.
+- Only **simple `name: T` targets** are recorded, as in CPython. A bare
+  `obj.attr: T` contributes nothing to `__annotations__` on either, but CPython
+  still *evaluates the target expression* — `undefined.attr: int` raises
+  `NameError` there and is silently dropped by Monty. With a value
+  (`obj.attr: T = v`) Monty raises `NotImplementedError`.
+- Assigning **`__annotations__` explicitly** in a class body raises
+  `NotImplementedError`; CPython merges the explicit dict with the collected
+  annotations.
+- **`from __future__ import annotations`** is accepted as a **no-op**, since it
+  describes what Monty already does. See
+  [language.md](language.md#__future__-imports) for the other features.
+- Consequences: `get_type_hints()` (which would evaluate the strings) is still
+  not implemented, and code that reads `__annotations__` expecting type
+  *objects* sees strings. `@dataclass` is unaffected — it treats annotations as
+  strings, matching CPython's own handling of stringized annotations.
 
 If you need real type validation, do it on the *host* side around the
 sandbox boundary.

--- a/limitations/typing.md
+++ b/limitations/typing.md
@@ -71,8 +71,10 @@ This is a known temporary divergence; see `class__annotations.py`.
   [language.md](language.md#__future__-imports) for the other features.
 - Consequences: `get_type_hints()` (which would evaluate the strings) is still
   not implemented, and code that reads `__annotations__` expecting type
-  *objects* sees strings. `@dataclass` is unaffected — it treats annotations as
-  strings, matching CPython's own handling of stringized annotations.
+  *objects* sees strings. CPython 3.14's `@dataclass` reads evaluated objects
+  (`annotationlib.Format.FORWARDREF`), but keeps a string path for `ClassVar` /
+  `InitVar` so PEP 563 code still works — which is what makes stringized
+  annotations enough to build on.
 
 If you need real type validation, do it on the *host* side around the
 sandbox boundary.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ known-first-party = ["pydantic_monty"]
     # the other test cases: these tests exist to prove that double-quoted
     # annotations normalize to single quotes exactly as CPython's does.
     "Q000", # double quotes are the subject of the test, not a style slip
+    "F722", # `e: "it's"` is a string literal under test, not a forward reference
 ]
 
 "crates/monty-typeshed/vendor/typeshed/stdlib/**/*.pyi" = [
@@ -119,6 +120,9 @@ exclude = [
     "crates/monty-type-checking/tests/reveal_types.py",
     # duplicate parameter name test intentionally has a syntax error
     "crates/monty/test_cases/function__err_duplicate_param.py",
+    # annotation quote-normalization test: `e: "it's"` is a string literal under
+    # test, which pyright reads as a malformed forward reference
+    "crates/monty/test_cases/class__annotations.py",
     # break/continue outside loop tests intentionally test error handling
     "crates/monty/test_cases/loop__break_outside_error.py",
     "crates/monty/test_cases/loop__continue_outside_error.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,9 +84,17 @@ known-first-party = ["pydantic_monty"]
     "F841", # unused variable - needed for testing exception variable cleanup
     "F401", # Intentionally imports unknown typing constructs to test silent ignore behavior
     "F403", # star import test intentionally uses `from sys import *`
+    "F407", # unknown `__future__` feature - the point of the test is that it's a SyntaxError
     "E402", # Typing test file has multiple import sections to test different import patterns
     "E401", # Multiple imports on one line - needed for testing `import a, b` syntax
     "I001", # Import block unsorted - needed for testing `import a, b` syntax
+]
+
+"crates/monty/test_cases/class__annotations.py" = [
+    # Scoped to this file so the single-quote convention stays enforced across
+    # the other test cases: these tests exist to prove that double-quoted
+    # annotations normalize to single quotes exactly as CPython's does.
+    "Q000", # double quotes are the subject of the test, not a style slip
 ]
 
 "crates/monty-typeshed/vendor/typeshed/stdlib/**/*.pyi" = [


### PR DESCRIPTION
A class body's `x: T` annotations populate `__annotations__` as an ordered dict of stringized annotations.

**Stringized is interim.** PEP 563 never became CPython's default — PEP 649 did, in 3.14. The blocker isn't the annotation machinery, it's that Monty has no generic types: `list[int]` and `int | None` raise `TypeError`, so evaluated annotations would fail on the most common forms. Runtime `types.GenericAlias` is the prerequisite. Values are documented as provisional; keys and their order are stable either way — which is all a class transformer needs. CPython's own `@dataclass` does read the values, as evaluated objects, but keeps a string path for `ClassVar`/`InitVar` so PEP 563 code still works — so stringized annotations are enough to build on.

**Matching CPython.** Annotations are stringized by *unparsing* the expression, as CPython's stringizer does, rather than slicing source text — so spacing, line breaks and quote style don't leak into the value:

```python
class C:
    a: list [ int ]     # 'list[int]'
    b: dict[str,int]    # 'dict[str, int]'
    c: "int"            # "'int'"
```

**`__future__` imports** are handled as the compiler directives they are: honoured features are no-ops, in the absolute form only. Anything that would bind a name the no-op doesn't create is rejected rather than silently ignored — `barry_as_FLUFL` (PEP 401), and aliases such as `import annotations as ann`.

`test_cases/class__annotations.py` dual-runs green against CPython 3.14 and includes a worked `@mini_dataclass` that discovers its fields from `__annotations__`. Divergences are documented in `limitations/{typing,language,classes}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populates class `__annotations__` with ordered, CPython‑normalized, stringized annotations, and treats absolute `from __future__ import ...` as a no‑op. Stringization rebuilds string, bytes, and f-string literals canonically from their value to match CPython.

- **New Features**
  - Class annotations: build `__annotations__` in source order from `name: T`; values are strings from AST unparse with canonical literal normalization (merge adjacent string and f-string parts; fold raw/triple-quoted forms; prefer single quotes; keep the `u` prefix; apply to `bytes` literals too).
  - Behavior: `name: T = v` also creates a class variable; bare `name: T` does not bind a value; complex targets with a value are rejected; bare complex annotations are ignored; assigning `__annotations__` in a class body that also has annotated names is rejected; an empty dict is synthesized unless the body binds `__annotations__` itself.
  - `__future__`: absolute `from __future__ import x` is a no-op for supported features (including `annotations`); unknown features raise `SyntaxError`; `barry_as_FLUFL` and aliasing (`as ...`) raise `NotImplementedError`; relative `from .__future__ import ...` is treated as a normal import and errors accordingly.

- **Dependencies**
  - Add `ruff_python_codegen` and `ruff_source_file` to unparse and normalize annotations consistently.

<sup>Written for commit 950aa15a9c6252a82ed54516f520b4dcf082b250. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

