### PR TITLE
stop uninstalling workspace in `make install-py`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ endif
 
 .PHONY: install-py
 install-py: .uv ## Install python dependencies
-	# --only-dev to avoid building the python package, use make dev-py for that
-	uv sync --all-packages --only-dev
+	# --only-dev avoids building the python packages; --inexact preserves builds installed by make dev-py
+	uv sync --all-packages --only-dev --inexact
 
 .PHONY: install-js
 install-js: ## Install JS package dependencies


### PR DESCRIPTION
I noticed that `make install-py` was uninstalling the local project.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `make install-py` to preserve local workspace builds by adding `--inexact` to `uv sync`, preventing the local project from being uninstalled.
Now runs `uv sync --all-packages --only-dev --inexact` so builds installed via `make dev-py` are kept.

<sup>Written for commit 0bf9ebd30ecf5aaf8921d1ef0c954f34311322d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

