### PR TITLE
fix npm publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1186,7 +1186,7 @@ jobs:
             echo "Publishing pre-release with 'next' tag"
             TAG_ARG=(--tag next)
           fi
-          for tarball in package-tarballs/monty-{darwin,linux,win32}-*.tgz; do
+          for tarball in ./package-tarballs/monty-{darwin,linux,win32}-*.tgz; do
             npm publish "$tarball" --provenance --access public "${TAG_ARG[@]}"
           done
-          npm publish package-tarballs/monty-main.tgz --provenance --access public "${TAG_ARG[@]}"
+          npm publish ./package-tarballs/monty-main.tgz --provenance --access public "${TAG_ARG[@]}"


### PR DESCRIPTION
npm expects local paths to either start with `/` or `./` according to https://docs.npmjs.com/cli/v11/using-npm/package-spec#tarballs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `npm` publish step in CI by adding `./` to tarball paths so `npm` accepts them as local files. This unblocks publishing for all platform builds and the main tarball.

<sup>Written for commit eeb9b94e6688ec7d0831129e27e6078e86a2d466. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

