### PR TITLE
release 0.0.19b6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "monty"
-version = "0.0.19-beta.5"
+version = "0.0.19-beta.6"
 dependencies = [
  "ahash",
  "chrono",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "monty-bench"
-version = "0.0.19-beta.5"
+version = "0.0.19-beta.6"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "monty-datatest"
-version = "0.0.19-beta.5"
+version = "0.0.19-beta.6"
 dependencies = [
  "ahash",
  "chrono",
@@ -2054,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "monty-fs"
-version = "0.0.19-beta.5"
+version = "0.0.19-beta.6"
 dependencies = [
  "ahash",
  "monty-types",
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "monty-fuzz"
-version = "0.0.19-beta.5"
+version = "0.0.19-beta.6"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -2073,7 +2073,7 @@ dependencies = [
 
 [[package]]
 name = "monty-js"
-version = "0.0.19-beta.5"
+version = "0.0.19-beta.6"
 dependencies = [
  "monty-pool",
  "monty-type-checking",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "monty-macros"
-version = "0.0.19-beta.5"
+version = "0.0.19-beta.6"
 dependencies = [
  "insta",
  "proc-macro2",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "monty-pool"
-version = "0.0.19-beta.5"
+version = "0.0.19-beta.6"
 dependencies = [
  "monty-fs",
  "monty-proto",
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "monty-proto"
-version = "0.0.19-beta.5"
+version = "0.0.19-beta.6"
 dependencies = [
  "monty",
  "monty-type-checking",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "monty-runtime"
-version = "0.0.19-beta.5"
+version = "0.0.19-beta.6"
 dependencies = [
  "clap",
  "monty",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "monty-type-checking"
-version = "0.0.19-beta.5"
+version = "0.0.19-beta.6"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "monty-types"
-version = "0.0.19-beta.5"
+version = "0.0.19-beta.6"
 dependencies = [
  "chrono",
  "monty-macros",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "monty-typeshed"
-version = "0.0.19-beta.5"
+version = "0.0.19-beta.6"
 dependencies = [
  "path-slash",
  "ruff_db",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "monty-wasm-runtime"
-version = "0.0.19-beta.5"
+version = "0.0.19-beta.6"
 dependencies = [
  "monty-proto",
  "prost",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-monty"
-version = "0.0.19-beta.5"
+version = "0.0.19-beta.6"
 dependencies = [
  "ahash",
  "monty-fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default-members = ["crates/monty-runtime"]
 
 [workspace.package]
 edition = "2024"
-version = "0.0.19-beta.5"
+version = "0.0.19-beta.6"
 rust-version = "1.95"
 license = "MIT"
 authors = ["Samuel Colvin <samuel@pydantic.dev>"]
@@ -49,14 +49,14 @@ lto = false
 # rejects path-only dependencies). These versions MUST be kept in lockstep with
 # `workspace.package.version` above and bumped together on each release — see
 # RELEASING.md.
-monty = { path = "crates/monty", version = "0.0.19-beta.5" }
-monty-types = { path = "crates/monty-types", version = "0.0.19-beta.5" }
-monty-fs = { path = "crates/monty-fs", version = "0.0.19-beta.5" }
-monty-macros = { path = "crates/monty-macros", version = "0.0.19-beta.5" }
-monty-proto = { path = "crates/monty-proto", version = "0.0.19-beta.5" }
-monty-pool = { path = "crates/monty-pool", version = "0.0.19-beta.5" }
-monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.19-beta.5" }
-monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.19-beta.5" }
+monty = { path = "crates/monty", version = "0.0.19-beta.6" }
+monty-types = { path = "crates/monty-types", version = "0.0.19-beta.6" }
+monty-fs = { path = "crates/monty-fs", version = "0.0.19-beta.6" }
+monty-macros = { path = "crates/monty-macros", version = "0.0.19-beta.6" }
+monty-proto = { path = "crates/monty-proto", version = "0.0.19-beta.6" }
+monty-pool = { path = "crates/monty-pool", version = "0.0.19-beta.6" }
+monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.19-beta.6" }
+monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.19-beta.6" }
 # ruff, ty and related crates
 ruff_python_parser = "0.0.3"
 ruff_python_stdlib = "0.0.3"

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.19-beta.5",
+  "version": "0.0.19-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pydantic/monty",
-      "version": "0.0.19-beta.5",
+      "version": "0.0.19-beta.6",
       "license": "MIT",
       "devDependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.1",
@@ -29,11 +29,11 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@pydantic/monty-darwin-arm64": "0.0.19-beta.5",
-        "@pydantic/monty-darwin-x64": "0.0.19-beta.5",
-        "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.5",
-        "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.5",
-        "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.5"
+        "@pydantic/monty-darwin-arm64": "0.0.19-beta.6",
+        "@pydantic/monty-darwin-x64": "0.0.19-beta.6",
+        "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.6",
+        "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.6",
+        "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.6"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2506,21 +2506,6 @@
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@pydantic/monty-darwin-arm64": {
-      "optional": true
-    },
-    "node_modules/@pydantic/monty-darwin-x64": {
-      "optional": true
-    },
-    "node_modules/@pydantic/monty-linux-arm64-gnu": {
-      "optional": true
-    },
-    "node_modules/@pydantic/monty-linux-x64-gnu": {
-      "optional": true
-    },
-    "node_modules/@pydantic/monty-win32-x64-msvc": {
-      "optional": true
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",

--- a/crates/monty-js/package.json
+++ b/crates/monty-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.19-beta.5",
+  "version": "0.0.19-beta.6",
   "type": "module",
   "description": "Sandboxed Python interpreter running in crash-isolated subprocess workers",
   "main": "dist/index.js",
@@ -91,10 +91,10 @@
     "arrowParens": "always"
   },
   "optionalDependencies": {
-    "@pydantic/monty-darwin-x64": "0.0.19-beta.5",
-    "@pydantic/monty-darwin-arm64": "0.0.19-beta.5",
-    "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.5",
-    "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.5",
-    "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.5"
+    "@pydantic/monty-darwin-x64": "0.0.19-beta.6",
+    "@pydantic/monty-darwin-arm64": "0.0.19-beta.6",
+    "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.6",
+    "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.6",
+    "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.6"
   }
 }

--- a/crates/monty-python/pyproject.toml
+++ b/crates/monty-python/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     # ships the `monty` binary spawned as worker subprocesses; released in
     # lockstep with this package, so the pin is exact and kept in sync with the
     # workspace version by build.rs — don't edit it by hand
-    "pydantic-monty-runtime==0.0.19b.5",
+    "pydantic-monty-runtime==0.0.19b.6",
 ]
 dynamic = ["license", "version"]
 


### PR DESCRIPTION
hopefully avoiding npm publish issue

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump all package versions to 0.0.19b6 and align JS optional dependencies to fix the npm publish issue.

- **Dependencies**
  - Update Rust workspace versions to `0.0.19-beta.6` in `Cargo.toml` and `Cargo.lock`.
  - Set `@pydantic/monty` to `0.0.19-beta.6` and align optional platform packages to `0.0.19-beta.6` in `package.json` and `package-lock.json`.
  - Pin `pydantic-monty-runtime==0.0.19b.6` in `crates/monty-python/pyproject.toml`.

<sup>Written for commit d5c1e1501dc49e97bbd24b07d0dca23a563d884c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

