### PR TITLE
make `dev-py` install python dev deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install: .cargo install-py install-js ## Install the package, dependencies, and 
 	uvx prek install --install-hooks
 
 .PHONY: dev-py
-dev-py: ## Install the python package for development
+dev-py: install-py ## Install the python package for development
 	uv run maturin develop --uv -m crates/monty-runtime/Cargo.toml
 	uv run maturin develop --uv -m crates/monty-python/Cargo.toml
 


### PR DESCRIPTION
Followup to #595

I keep hitting issues with pre-commit not having the right python deps; this should sort it automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `dev-py` depend on `install-py` so Python dev deps are installed and `pre-commit` hooks run without missing packages.

<sup>Written for commit ec296b4bb3dc869fa5a77885b36a5a7a138d3db1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

