### PR TITLE
Dispatch user-defined `__iter__` / `__next__` / `__contains__`

### DIFF
--- a/crates/monty-datatest/src/main.rs
+++ b/crates/monty-datatest/src/main.rs
@@ -1337,18 +1337,17 @@ fn try_run_test(path: &Path, code: &str, expectation: &Expectation, limits: Reso
                 let result = ex.run_ref_counts(vec![]);
                 match result {
                     Ok(monty::RefCountOutput {
-                        counts,
-                        unique_refs,
-                        heap_count,
-                        ..
+                        counts, unreachable, ..
                     }) => {
-                        // Strict matching: verify all heap objects are accounted for by variables
-                        if unique_refs != heap_count {
+                        // Strict matching: every live heap object must be reachable from a
+                        // named variable, transitively. Leftovers are leaks — a missed
+                        // `drop_with` — and are named here so the culprit is identifiable.
+                        if !unreachable.is_empty() {
                             return Err(TestFailure {
                                 test_name,
                                 kind: "Strict matching".to_string(),
-                                expected: format!("{heap_count} heap objects"),
-                                actual: format!("{unique_refs} referenced by variables, counts: {counts:?}"),
+                                expected: "no unreachable heap objects".to_string(),
+                                actual: format!("leaked {}: {}", unreachable.len(), unreachable.join(", ")),
                             });
                         }
                         if &counts != expected {

--- a/crates/monty/src/builtins/map.rs
+++ b/crates/monty/src/builtins/map.rs
@@ -8,7 +8,7 @@ use crate::{
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::{DropWithContext, HeapData},
-    types::{List, PyTrait, iter::checked_preallocation_hint},
+    types::{List, iter::checked_preallocation_hint},
     value::Value,
 };
 

--- a/crates/monty/src/bytecode/vm/collections.rs
+++ b/crates/monty/src/bytecode/vm/collections.rs
@@ -8,7 +8,7 @@ use crate::{
     intern::StringId,
     types::{
         Dict, List, PyTrait, Set, Slice, allocate_tuple, collect_iterable, collect_iterable_bounded,
-        slice::value_to_option_i64,
+        instance::instance_defines_iter, slice::value_to_option_i64,
     },
     value::{VALUE_SIZE, Value},
 };
@@ -109,7 +109,11 @@ impl VM<'_> {
 
         if !iterable.py_is_iterable(this) {
             let type_ = iterable.py_type_name(this);
-            return Err(ExcType::type_error_value_after_star(&type_));
+            return Err(if opts_out_of_iter(iterable, this) {
+                ExcType::type_error_not_iterable(&type_)
+            } else {
+                ExcType::type_error_value_after_star(&type_)
+            });
         }
         let copied_items: Vec<Value> = collect_iterable(iterable, this)?;
 
@@ -469,8 +473,7 @@ impl VM<'_> {
         defer_drop!(value, this);
 
         if !value.py_is_iterable(this) {
-            let type_name = value.py_type_name(this);
-            return Err(unpack_type_error(&type_name));
+            return Err(unpack_type_error(value, this));
         }
         // CPython's `UNPACK_SEQUENCE` special-cases exactly these three, so only
         // they can report a total in the "too many" message. It is deliberately
@@ -530,8 +533,7 @@ impl VM<'_> {
         let min_items = before + after;
 
         if !value.py_is_iterable(this) {
-            let type_name = value.py_type_name(this);
-            return Err(unpack_type_error(&type_name));
+            return Err(unpack_type_error(value, this));
         }
         // Drained in full: a starred target consumes everything, so unlike
         // `unpack_sequence` there is no bound to stop at — and therefore always
@@ -618,11 +620,30 @@ fn unpack_too_many_unknown_error(expected: usize) -> RunError {
     .into()
 }
 
-/// Creates a TypeError for attempting to unpack a non-iterable type.
-fn unpack_type_error(type_name: &str) -> RunError {
-    SimpleException::new_msg(
-        ExcType::TypeError,
-        format!("cannot unpack non-iterable {type_name} object"),
-    )
-    .into()
+/// Creates a TypeError for attempting to unpack a non-iterable value.
+///
+/// Takes the value rather than its name because the wording depends on *why* it
+/// is not iterable — see [`opts_out_of_iter`].
+fn unpack_type_error(value: &Value, vm: &VM<'_>) -> RunError {
+    let type_name = value.py_type_name(vm);
+    if opts_out_of_iter(value, vm) {
+        ExcType::type_error_not_iterable(&type_name)
+    } else {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("cannot unpack non-iterable {type_name} object"),
+        )
+        .into()
+    }
+}
+
+/// Whether a value already known to be non-iterable owes that to `__iter__ =
+/// None`, and so keeps the plain "not iterable" message at an unpacking site.
+///
+/// CPython substitutes site-specific wording ("cannot unpack non-iterable ...",
+/// "Value after * must be an iterable ...") only when the type has no `tp_iter`
+/// slot at all; a class opting out with `__iter__ = None` still fills the slot,
+/// so `slot_tp_iter`'s own error survives.
+fn opts_out_of_iter(value: &Value, vm: &VM<'_>) -> bool {
+    matches!(value, Value::Ref(id) if instance_defines_iter(*id, vm))
 }

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -1442,7 +1442,7 @@ impl<'h> VM<'h> {
                     };
                     let mut iter = self.heap.read(heap_id);
 
-                    match iter.py_next(self) {
+                    match iter.py_next(Some(heap_id), self) {
                         Ok(Some(value)) => self.push(value),
                         Ok(None) => {
                             // Drop the HeapRead before dec_ref to release the reader count

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -838,6 +838,18 @@ pub(crate) trait ExcTypeExt: Sized {
         .into()
     }
 
+    /// Creates a TypeError for a class opting out of `in` with
+    /// `__contains__ = None`.
+    ///
+    /// Matches CPython's `slot_sq_contains` format: `TypeError: '{type}' object
+    /// is not a container` — deliberately distinct from
+    /// [`type_error_not_container`], which covers a type that never had
+    /// `__contains__` at all.
+    #[must_use]
+    fn type_error_object_not_container(type_: &str) -> RunError {
+        SimpleException::new_msg(ExcType::TypeError, format!("'{type_}' object is not a container")).into()
+    }
+
     /// Creates a TypeError when `next()` receives a non-iterator.
     ///
     /// Matches CPython's format: `TypeError: '{type}' object is not an iterator`

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -824,12 +824,38 @@ pub(crate) trait ExcTypeExt: Sized {
         SimpleException::new_msg(ExcType::TypeError, format!("'{type_}' object is not iterable")).into()
     }
 
+    /// Creates a TypeError for the right operand of `in` / `not in` supporting
+    /// neither `__contains__` nor iteration.
+    ///
+    /// Matches CPython's format: `TypeError: argument of type '{type}' is not a
+    /// container or iterable`
+    #[must_use]
+    fn type_error_not_container(type_: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("argument of type '{type_}' is not a container or iterable"),
+        )
+        .into()
+    }
+
     /// Creates a TypeError when `next()` receives a non-iterator.
     ///
     /// Matches CPython's format: `TypeError: '{type}' object is not an iterator`
     #[must_use]
     fn type_error_not_iterator(type_: &str) -> RunError {
         SimpleException::new_msg(ExcType::TypeError, format!("'{type_}' object is not an iterator")).into()
+    }
+
+    /// Creates a TypeError for a user `__iter__` returning a non-iterator.
+    ///
+    /// Matches CPython's format: `TypeError: iter() returned non-iterator of type '{type}'`
+    #[must_use]
+    fn type_error_iter_returned_non_iterator(type_: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::TypeError,
+            format!("iter() returned non-iterator of type '{type_}'"),
+        )
+        .into()
     }
 
     /// Creates a TypeError for non-iterable type in PEP 448 `*value` literal unpack.
@@ -2153,6 +2179,17 @@ impl From<fmt::Error> for RunError {
 }
 
 impl RunError {
+    /// Whether this is a catchable `StopIteration`, i.e. a `__next__` reporting
+    /// exhaustion.
+    ///
+    /// Excluding `UncatchableExc` is defensive — it is only ever built from a
+    /// `ResourceError` — but spelled out so a future uncatchable variant cannot
+    /// read as "the iterator finished", letting sandboxed code absorb its own
+    /// limit breach.
+    pub(crate) fn is_stop_iteration(&self) -> bool {
+        matches!(self, Self::Exc(raise) if matches!(raise.exc.exc_type(), ExcType::StopIteration))
+    }
+
     /// Converts this runtime error to a `MontyException` for the public API.
     ///
     /// Internal errors are converted to `RuntimeError` exceptions with no traceback.

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -1315,50 +1315,6 @@ impl Heap {
 /// in `HeapId` space because freeing a slot requires consulting the free list,
 /// which is keyed by id.
 impl<'a> HeapReader<'a> {
-    /// Returns live heap entries unreachable from `roots`, with each entry's type
-    /// so callers holding `Interns` can name it ([`Type::name`]).
-    ///
-    /// `run_ref_counts` uses this to prove a test leaked nothing: an entry that
-    /// is alive but reachable from no named variable is a missed `drop_with`.
-    /// The walk is transitive, so an object owned by another object — a class's
-    /// `__annotations__`, a nested list, an instance attribute — is accounted
-    /// for by its owner and need not be bound to a name by the test itself.
-    ///
-    /// Unlike the cycle collector's [`mark_gray`](Self::mark_gray) this touches
-    /// no colors or refcounts, so it cannot perturb the state under test.
-    #[cfg(feature = "ref-count-return")]
-    pub(crate) fn unreachable_entries(&self, roots: impl IntoIterator<Item = HeapId>) -> Vec<(HeapId, Type)> {
-        let mut seen: HashSet<HeapId> = HashSet::new();
-        let mut work_stack: Vec<HeapId> = Vec::new();
-        for root in roots {
-            if seen.insert(root) {
-                work_stack.push(root);
-            }
-        }
-
-        // A root's subtree is live by construction, but `try_entry` keeps the
-        // walk total in case a test observes the heap mid-teardown.
-        while let Some(id) = work_stack.pop() {
-            let ptr = self.read_ptr(id);
-            if ptr.try_entry(self).is_none() {
-                continue;
-            }
-            for_each_child_id(ptr.data(self), |child_id| {
-                if seen.insert(child_id) {
-                    work_stack.push(child_id);
-                }
-            });
-        }
-
-        self.entries
-            .iter()
-            // The empty tuple singleton is an internal optimisation that is
-            // always live and never named, so it is not a leak. See `entry_count`.
-            .filter(|(id, _)| *id != EMPTY_TUPLE_ID && !seen.contains(id))
-            .map(|(id, _)| (id, self.read_ptr(id).data(self).py_type()))
-            .collect()
-    }
-
     /// Implementation of [`Heap::collect_cycles`]. Phase 1 (discover Purple
     /// roots and `mark_gray` their subtrees), Phase 2 (`scan`), and Phase 3
     /// (`collect_white`) run sequentially. After `scan` the `HeapPtr` work
@@ -1504,6 +1460,58 @@ impl<'a> HeapReader<'a> {
             };
             ptr = next_ptr;
         }
+    }
+}
+
+/// Leak detection for reference-counting tests.
+///
+/// Implemented on [`HeapReader`] because reading an entry's children needs
+/// [`HeapPtr::data`]. It borrows the cycle collector's [`for_each_child_id`] to
+/// walk edges but is not part of collection: nothing here mutates the heap, and
+/// it is reached only from `run_ref_counts`, never from [`Heap::collect_cycles`].
+#[cfg(feature = "ref-count-return")]
+impl HeapReader<'_> {
+    /// Returns live heap entries unreachable from `roots`, with each entry's type
+    /// so callers holding `Interns` can name it ([`Type::name`]).
+    ///
+    /// `run_ref_counts` uses this to prove a test leaked nothing: an entry that
+    /// is alive but reachable from no named variable is a missed `drop_with`.
+    /// The walk is transitive, so an object owned by another object — a class's
+    /// `__annotations__`, a nested list, an instance attribute — is accounted
+    /// for by its owner and need not be bound to a name by the test itself.
+    ///
+    /// Unlike the cycle collector's [`mark_gray`](Self::mark_gray) this touches
+    /// no colors or refcounts, so it cannot perturb the state under test.
+    pub(crate) fn unreachable_entries(&self, roots: impl IntoIterator<Item = HeapId>) -> Vec<(HeapId, Type)> {
+        let mut seen: HashSet<HeapId> = HashSet::new();
+        let mut work_stack: Vec<HeapId> = Vec::new();
+        for root in roots {
+            if seen.insert(root) {
+                work_stack.push(root);
+            }
+        }
+
+        // A root's subtree is live by construction, but `try_entry` keeps the
+        // walk total in case a test observes the heap mid-teardown.
+        while let Some(id) = work_stack.pop() {
+            let ptr = self.read_ptr(id);
+            if ptr.try_entry(self).is_none() {
+                continue;
+            }
+            for_each_child_id(ptr.data(self), |child_id| {
+                if seen.insert(child_id) {
+                    work_stack.push(child_id);
+                }
+            });
+        }
+
+        self.entries
+            .iter()
+            // The empty tuple singleton is an internal optimisation that is
+            // always live and never named, so it is not a leak. See `entry_count`.
+            .filter(|(id, _)| *id != EMPTY_TUPLE_ID && !seen.contains(id))
+            .map(|(id, _)| (id, self.read_ptr(id).data(self).py_type()))
+            .collect()
     }
 }
 

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "ref-count-return")]
+use std::collections::HashSet;
 use std::{
     cell::{Cell, UnsafeCell},
     collections::BTreeMap,
@@ -16,6 +18,8 @@ use serde::ser::SerializeStruct;
 // to resolve (used by the `defer_drop!` macros and throughout the codebase).
 pub(crate) use crate::heap_data::HeapData;
 pub(crate) use crate::heap_traits::{ContainsHeap, DropGuard, DropWithContext, HeapItem};
+#[cfg(feature = "ref-count-return")]
+use crate::types::Type;
 use crate::{
     asyncio::{Awaiter, Coroutine, ExternalFuture, ExternalFutureState, GatherFuture, GatherState},
     exception_private::SimpleException,
@@ -1311,6 +1315,50 @@ impl Heap {
 /// in `HeapId` space because freeing a slot requires consulting the free list,
 /// which is keyed by id.
 impl<'a> HeapReader<'a> {
+    /// Returns live heap entries unreachable from `roots`, with each entry's type
+    /// so callers holding `Interns` can name it ([`Type::name`]).
+    ///
+    /// `run_ref_counts` uses this to prove a test leaked nothing: an entry that
+    /// is alive but reachable from no named variable is a missed `drop_with`.
+    /// The walk is transitive, so an object owned by another object — a class's
+    /// `__annotations__`, a nested list, an instance attribute — is accounted
+    /// for by its owner and need not be bound to a name by the test itself.
+    ///
+    /// Unlike the cycle collector's [`mark_gray`](Self::mark_gray) this touches
+    /// no colors or refcounts, so it cannot perturb the state under test.
+    #[cfg(feature = "ref-count-return")]
+    pub(crate) fn unreachable_entries(&self, roots: impl IntoIterator<Item = HeapId>) -> Vec<(HeapId, Type)> {
+        let mut seen: HashSet<HeapId> = HashSet::new();
+        let mut work_stack: Vec<HeapId> = Vec::new();
+        for root in roots {
+            if seen.insert(root) {
+                work_stack.push(root);
+            }
+        }
+
+        // A root's subtree is live by construction, but `try_entry` keeps the
+        // walk total in case a test observes the heap mid-teardown.
+        while let Some(id) = work_stack.pop() {
+            let ptr = self.read_ptr(id);
+            if ptr.try_entry(self).is_none() {
+                continue;
+            }
+            for_each_child_id(ptr.data(self), |child_id| {
+                if seen.insert(child_id) {
+                    work_stack.push(child_id);
+                }
+            });
+        }
+
+        self.entries
+            .iter()
+            // The empty tuple singleton is an internal optimisation that is
+            // always live and never named, so it is not a leak. See `entry_count`.
+            .filter(|(id, _)| *id != EMPTY_TUPLE_ID && !seen.contains(id))
+            .map(|(id, _)| (id, self.read_ptr(id).data(self).py_type()))
+            .collect()
+    }
+
     /// Implementation of [`Heap::collect_cycles`]. Phase 1 (discover Purple
     /// roots and `mark_gray` their subtrees), Phase 2 (`scan`), and Phase 3
     /// (`collect_white`) run sequentially. After `scan` the `HeapPtr` work

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -704,6 +704,16 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         }
     }
 
+    fn py_is_iterator(&self, vm: &VM<'h>) -> bool {
+        match self {
+            // A user-defined class is an iterator only if it defines `__next__`.
+            Self::Instance(inst) => inst.py_is_iterator(vm),
+            // Every built-in iterator is identified by its type, so there is no
+            // list to keep in step with new iterator types here.
+            other => other.py_type(vm).is_iterator(),
+        }
+    }
+
     fn py_is_iterable(&self, vm: &VM<'h>) -> bool {
         heap_read_output_py_trait_forward!(self, |value| value.py_is_iterable(vm), else false)
     }
@@ -971,43 +981,43 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         }
     }
 
-    fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_next(&mut self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         match self {
-            Self::Str(value) => value.py_next(vm),
-            Self::Bytes(value) => value.py_next(vm),
-            Self::List(value) => value.py_next(vm),
-            Self::ListIterator(value) => value.py_next(vm),
-            Self::TupleIterator(value) => value.py_next(vm),
-            Self::StringIterator(value) => value.py_next(vm),
-            Self::BytesIterator(value) => value.py_next(vm),
-            Self::RangeIterator(value) => value.py_next(vm),
-            Self::DictKeyIterator(value) => value.py_next(vm),
-            Self::DictItemIterator(value) => value.py_next(vm),
-            Self::DictValueIterator(value) => value.py_next(vm),
-            Self::SetIterator(value) => value.py_next(vm),
-            Self::CallableIterator(value) => value.py_next(vm),
-            Self::Tuple(value) => value.py_next(vm),
-            Self::NamedTuple(value) => value.py_next(vm),
-            Self::Dict(value) => value.py_next(vm),
-            Self::DictKeysView(value) => value.py_next(vm),
-            Self::DictItemsView(value) => value.py_next(vm),
-            Self::DictValuesView(value) => value.py_next(vm),
-            Self::Set(value) => value.py_next(vm),
-            Self::FrozenSet(value) => value.py_next(vm),
-            Self::Range(value) => value.py_next(vm),
-            Self::Slice(value) => value.py_next(vm),
-            Self::Dataclass(value) => value.py_next(vm),
-            Self::Class(value) => value.py_next(vm),
-            Self::Instance(value) => value.py_next(vm),
-            Self::BoundMethod(value) => value.py_next(vm),
-            Self::Path(value) => value.py_next(vm),
-            Self::OpenFile(value) => value.py_next(vm),
-            Self::ReMatch(value) => value.py_next(vm),
-            Self::RePattern(value) => value.py_next(vm),
-            Self::Date(value) => value.py_next(vm),
-            Self::DateTime(value) => value.py_next(vm),
-            Self::TimeDelta(value) => value.py_next(vm),
-            Self::TimeZone(value) => value.py_next(vm),
+            Self::Str(value) => value.py_next(self_id, vm),
+            Self::Bytes(value) => value.py_next(self_id, vm),
+            Self::List(value) => value.py_next(self_id, vm),
+            Self::ListIterator(value) => value.py_next(self_id, vm),
+            Self::TupleIterator(value) => value.py_next(self_id, vm),
+            Self::StringIterator(value) => value.py_next(self_id, vm),
+            Self::BytesIterator(value) => value.py_next(self_id, vm),
+            Self::RangeIterator(value) => value.py_next(self_id, vm),
+            Self::DictKeyIterator(value) => value.py_next(self_id, vm),
+            Self::DictItemIterator(value) => value.py_next(self_id, vm),
+            Self::DictValueIterator(value) => value.py_next(self_id, vm),
+            Self::SetIterator(value) => value.py_next(self_id, vm),
+            Self::CallableIterator(value) => value.py_next(self_id, vm),
+            Self::Tuple(value) => value.py_next(self_id, vm),
+            Self::NamedTuple(value) => value.py_next(self_id, vm),
+            Self::Dict(value) => value.py_next(self_id, vm),
+            Self::DictKeysView(value) => value.py_next(self_id, vm),
+            Self::DictItemsView(value) => value.py_next(self_id, vm),
+            Self::DictValuesView(value) => value.py_next(self_id, vm),
+            Self::Set(value) => value.py_next(self_id, vm),
+            Self::FrozenSet(value) => value.py_next(self_id, vm),
+            Self::Range(value) => value.py_next(self_id, vm),
+            Self::Slice(value) => value.py_next(self_id, vm),
+            Self::Dataclass(value) => value.py_next(self_id, vm),
+            Self::Class(value) => value.py_next(self_id, vm),
+            Self::Instance(value) => value.py_next(self_id, vm),
+            Self::BoundMethod(value) => value.py_next(self_id, vm),
+            Self::Path(value) => value.py_next(self_id, vm),
+            Self::OpenFile(value) => value.py_next(self_id, vm),
+            Self::ReMatch(value) => value.py_next(self_id, vm),
+            Self::RePattern(value) => value.py_next(self_id, vm),
+            Self::Date(value) => value.py_next(self_id, vm),
+            Self::DateTime(value) => value.py_next(self_id, vm),
+            Self::TimeDelta(value) => value.py_next(self_id, vm),
+            Self::TimeZone(value) => value.py_next(self_id, vm),
             other => Err(ExcType::type_error_not_iterator(
                 &other.py_type(vm).name(vm.heap, vm.interns),
             )),

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -449,15 +449,13 @@ impl Executor {
     /// Executes the code and returns both the result and reference count data with a custom tracker,
     /// used for testing only.
     ///
-    /// This is used for testing reference counting behavior with a custom tracker. Returns:
-    /// - The execution result (`Exit`)
-    /// - Reference count data as a tuple of:
-    ///   - A map from variable names to their reference counts (only for heap-allocated values)
-    ///   - The number of unique heap value IDs referenced by variables
-    ///   - The total number of live heap values
+    /// This is used for testing reference counting behavior with a custom tracker. Returns
+    /// the execution result plus, in [`RefCountOutput`], a map from variable names to their
+    /// reference counts (heap-allocated values only), any live-but-unreachable heap entries,
+    /// and the total live heap population.
     ///
-    /// For strict matching validation, compare unique_refs_count with heap_entry_count.
-    /// If they're equal, all heap values are accounted for by named variables.
+    /// For strict-matching validation, assert that `unreachable` is empty: every live heap
+    /// object should be reachable from a named variable, so anything left over is a leak.
     ///
     /// Only available when the `ref-count-return` feature is enabled.
     #[cfg(feature = "ref-count-return")]
@@ -466,8 +464,6 @@ impl Executor {
         inputs: Vec<MontyObject>,
         resource_tracker: ResourceTracker,
     ) -> Result<RefCountOutput, MontyException> {
-        use std::collections::HashSet;
-
         let mut heap = Heap::new(self.namespace_size(), resource_tracker);
         let globals = self.empty_globals();
 
@@ -492,7 +488,7 @@ impl Executor {
             // Read refcounts BEFORE converting the return value, because
             // `frame_exit_to_object` drops the return value (decrementing its refcount).
             let mut counts = ahash::AHashMap::new();
-            let mut unique_ids = HashSet::new();
+            let mut roots = Vec::new();
 
             for (namespace_id, name_id) in executor.globals.iter() {
                 let idx = namespace_id.index();
@@ -500,10 +496,17 @@ impl Executor {
                     && let Value::Ref(id) = &globals[idx]
                 {
                     counts.insert(executor.interns.get_str(name_id).to_owned(), vm.heap.get_refcount(*id));
-                    unique_ids.insert(*id);
+                    roots.push(*id);
                 }
             }
-            let unique_refs = unique_ids.len();
+            // Named globals are the only roots: locals are gone once the module frame
+            // exits, so anything still live must hang off a name to not be a leak.
+            let unreachable: Vec<String> = vm
+                .heap
+                .unreachable_entries(roots)
+                .into_iter()
+                .map(|(id, ty)| format!("{} (id {})", ty.name(vm.heap, &executor.interns), id.index()))
+                .collect();
             let heap_count = vm.heap.entry_count();
 
             // Convert return value while VM is still alive (needs access to interns).
@@ -521,7 +524,7 @@ impl Executor {
             Ok(RefCountOutput {
                 py_object,
                 counts,
-                unique_refs,
+                unreachable,
                 heap_count,
                 allocations_since_gc,
             })
@@ -607,7 +610,11 @@ pub(crate) fn frame_exit_to_object(frame_exit_result: RunResult<FrameExit>, vm: 
 pub struct RefCountOutput {
     pub py_object: MontyObject,
     pub counts: ahash::AHashMap<String, usize>,
-    pub unique_refs: usize,
+    /// Live heap entries reachable from no named variable, described as
+    /// `"<type> (id N)"`. Non-empty means the run leaked: a missed `drop_with`
+    /// left an object alive that nothing can reach. Reachability is transitive,
+    /// so objects owned by another object are accounted for by their owner.
+    pub unreachable: Vec<String>,
     pub heap_count: usize,
     /// Number of GC-tracked allocations since the last cycle collection.
     ///

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -1868,10 +1868,18 @@ fn bytes_zfill<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h>)
 /// Implements Python's `bytes.join(iterable)` method.
 ///
 /// Joins elements of the iterable with the separator bytes.
-fn bytes_join<'h>(separator: &HeapRead<'h, [u8]>, iterable: Value, vm: &mut VM<'h>) -> RunResult<Value> {
-    let Ok(iter) = iterable.into_py_iter(vm) else {
+fn bytes_join<'h>(
+    separator: &HeapRead<'h, [u8]>,
+    iterable: Value,
+    vm: &mut VM<'h>,
+) -> RunResult<Value> {
+    // Checked up front: a user `__iter__` can raise anything, and rewriting that
+    // as "can only join an iterable" would hide it, resource errors included.
+    if !iterable.py_is_iterable(vm) {
+        iterable.drop_with(vm);
         return Err(ExcType::type_error_join_not_iterable());
-    };
+    }
+    let iter = iterable.into_py_iter(vm)?;
     defer_drop!(iter, vm);
     let mut iter = iter.read(vm);
 
@@ -2254,7 +2262,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, BytesIterator> {
         Ok(Value::Ref(self_id))
     }
 
-    fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_next(&mut self, _self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         let byte = {
             let iter = self.get(vm.heap);
             iter.as_slice(vm).get(iter.index).copied()

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -1868,11 +1868,7 @@ fn bytes_zfill<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h>)
 /// Implements Python's `bytes.join(iterable)` method.
 ///
 /// Joins elements of the iterable with the separator bytes.
-fn bytes_join<'h>(
-    separator: &HeapRead<'h, [u8]>,
-    iterable: Value,
-    vm: &mut VM<'h>,
-) -> RunResult<Value> {
+fn bytes_join<'h>(separator: &HeapRead<'h, [u8]>, iterable: Value, vm: &mut VM<'h>) -> RunResult<Value> {
     // Checked up front: a user `__iter__` can raise anything, and rewriting that
     // as "can only join an iterable" would hide it, resource errors included.
     if !iterable.py_is_iterable(vm) {

--- a/crates/monty/src/types/callable_iterator.rs
+++ b/crates/monty/src/types/callable_iterator.rs
@@ -67,6 +67,10 @@ impl HeapItem for CallableIterator {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, CallableIterator> {
+    fn py_is_iterator(&self, _: &VM<'h>) -> bool {
+        true
+    }
+
     fn py_is_iterable(&self, _: &VM<'h>) -> bool {
         true
     }
@@ -95,7 +99,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, CallableIterator> {
     /// `callable` re-enters Python and may reach this same iterator through a
     /// nested `next()`, which would alias the `UnsafeCell` if a borrow were held
     /// across it (`iter__reentrant.py` covers exactly that).
-    fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_next(&mut self, _: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         let resolved = {
             let this = self.get(vm.heap);
             if this.done {
@@ -132,14 +136,21 @@ impl<'h> PyTrait<'h> for HeapRead<'h, CallableIterator> {
     }
 }
 
-/// Calls `callable()` once, returning `None` when the result `==` `sentinel`.
+/// Calls `callable()` once, returning `None` when the result `==` `sentinel` or
+/// the call raises `StopIteration`.
 ///
 /// Takes both values by ownership: the caller has already cloned them out of the
 /// iterator so that no heap borrow is live across the re-entrant call.
 fn callable_next(callable: Value, sentinel: Value, vm: &mut VM<'_>) -> RunResult<Option<Value>> {
     defer_drop!(callable, vm);
     defer_drop!(sentinel, vm);
-    let result = vm.evaluate_function("iter(callable, sentinel)", callable, ArgValues::Empty)?;
+    let result = match vm.evaluate_function("iter(callable, sentinel)", callable, ArgValues::Empty) {
+        Ok(result) => result,
+        // CPython's `calliter_iternext` swallows `StopIteration` from the
+        // callable and reports exhaustion, exactly as for a `__next__`.
+        Err(e) if e.is_stop_iteration() => return Ok(None),
+        Err(e) => return Err(e),
+    };
     let mut result = DropGuard::new(result, vm);
     let (result_ref, vm) = result.as_parts_mut();
     if result_ref.py_eq(sentinel, vm)? {

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -1377,7 +1377,7 @@ macro_rules! impl_dict_iterator {
                 Ok(Value::Ref(self_id))
             }
 
-            fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+            fn py_next(&mut self, _self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
                 $next(self, vm)
             }
         }

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -415,11 +415,7 @@ pub(crate) fn instance_str(self_id: HeapId, vm: &mut VM<'_>) -> RunResult<Value>
 /// — so a `__contains__` returning a user object with a false `__bool__` /
 /// `__len__` diverges from CPython's `PyObject_IsTrue` (see
 /// `limitations/classes.md`).
-pub(crate) fn instance_contains(
-    self_id: HeapId,
-    item: &Value,
-    vm: &mut VM<'_>,
-) -> RunResult<Option<bool>> {
+pub(crate) fn instance_contains(self_id: HeapId, item: &Value, vm: &mut VM<'_>) -> RunResult<Option<bool>> {
     let class_id = instance_class(self_id, vm);
     if matches!(class_dunder(class_id, "__contains__", vm), Some(Value::None)) {
         return Err(ExcType::type_error_object_not_container(&class_name(
@@ -448,11 +444,7 @@ pub(crate) fn instance_contains(
 /// re-enters the VM on the *Rust* stack; `evaluate_function`'s re-entry guard
 /// bounds it with a catchable `RecursionError` — lower than CPython's depth for
 /// deep-but-finite chains, a documented divergence (`limitations/classes.md`).
-fn instance_call_str_dunder(
-    self_id: HeapId,
-    dunder: &'static str,
-    vm: &mut VM<'_>,
-) -> RunResult<Option<Value>> {
+fn instance_call_str_dunder(self_id: HeapId, dunder: &'static str, vm: &mut VM<'_>) -> RunResult<Option<Value>> {
     let Some(result) = instance_call_dunder_sync(self_id, dunder, None, vm)? else {
         return Ok(None);
     };

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -158,10 +158,13 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Instance> {
     fn py_is_iterable(&self, vm: &VM<'h>) -> bool {
         // CPython also accepts a `__getitem__`-only class here; Monty has no
         // such fallback, so it reports not-iterable (see limitations/classes.md).
-        class_defines(self.get(vm.heap).class, "__iter__", vm)
+        class_defines_not_none(self.get(vm.heap).class, "__iter__", vm)
     }
 
     fn py_is_iterator(&self, vm: &VM<'h>) -> bool {
+        // Plain existence, not [`class_defines_not_none`]: `__next__ = None` is
+        // not an opt-out in CPython — the class stays an iterator and calling it
+        // raises "'NoneType' object is not callable".
         class_defines(self.get(vm.heap).class, "__next__", vm)
     }
 
@@ -173,7 +176,16 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Instance> {
     /// the failure to the first `next()`.
     fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
         let self_id = self_id.expect("heap values have an id");
-        let Some(iterator) = instance_call_dunder_sync(self_id, "__iter__", None, vm)? else {
+        // `py_is_iterable` is the single source of truth for "does this class
+        // iterate", so an opted-out `__iter__ = None` reports not-iterable here
+        // instead of reaching the call and raising "'NoneType' object is not
+        // callable" — CPython's `slot_tp_iter` rejects it the same way.
+        let dispatched = if self.py_is_iterable(vm) {
+            instance_call_dunder_sync(self_id, "__iter__", None, vm)?
+        } else {
+            None
+        };
+        let Some(iterator) = dispatched else {
             return Err(ExcType::type_error_not_iterable(&class_name(
                 instance_class(self_id, vm),
                 vm.heap,
@@ -396,13 +408,24 @@ pub(crate) fn instance_str(self_id: HeapId, vm: &mut VM<'_>) -> RunResult<Value>
 ///
 /// `Ok(None)` means the class does not define it, leaving the caller to fall
 /// back to iteration — CPython checks `sq_contains` before `tp_iter`, so a
-/// class defining both is never iterated by `in`. The result is coerced with
-/// truthiness, matching CPython's `PyObject_IsTrue` on the slot result.
+/// class defining both is never iterated by `in`. `__contains__ = None` is an
+/// opt-out rather than an absence: it errors here instead of falling back.
+///
+/// The result is coerced with `py_bool`, which reports every instance as truthy
+/// — so a `__contains__` returning a user object with a false `__bool__` /
+/// `__len__` diverges from CPython's `PyObject_IsTrue` (see
+/// `limitations/classes.md`).
 pub(crate) fn instance_contains(
     self_id: HeapId,
     item: &Value,
     vm: &mut VM<'_>,
 ) -> RunResult<Option<bool>> {
+    let class_id = instance_class(self_id, vm);
+    if matches!(class_dunder(class_id, "__contains__", vm), Some(Value::None)) {
+        return Err(ExcType::type_error_object_not_container(&class_name(
+            class_id, vm.heap, vm.interns,
+        )));
+    }
     // The callee owns its argument, so the borrowed `item` is cloned;
     // `instance_call_dunder_sync` drops it again if there is no `__contains__`.
     let item = item.clone_with_heap(vm.heap);
@@ -487,16 +510,48 @@ fn instance_call_dunder_sync(
     vm.evaluate_function(dunder, func, args).map(Some)
 }
 
+/// Whether `self_id` is an instance whose class has an `__iter__` member —
+/// including a `None` one, which opts the class out of iteration.
+///
+/// The distinction is CPython's `tp_iter`-is-non-NULL test, which only the
+/// unpack error message needs (see `unpack_type_error`); everywhere else the
+/// question is [`HeapRead::py_is_iterable`].
+pub(crate) fn instance_defines_iter(self_id: HeapId, vm: &VM<'_>) -> bool {
+    match vm.heap.get(self_id) {
+        HeapData::Instance(inst) => class_defines(inst.class, "__iter__", vm),
+        _ => false,
+    }
+}
+
 /// Whether `class_id`'s namespace defines `dunder`, without cloning it out.
 ///
 /// Special-method lookup goes through the class only, never the instance
-/// `__dict__`, matching CPython's lookup for implicit invocations.
-/// [`class_member`] would `clone_with_heap` the value just to drop it again, so
-/// existence checks use this instead.
+/// `__dict__`, matching CPython's lookup for implicit invocations. A slot whose
+/// `None` value opts the class out of the protocol wants
+/// [`class_defines_not_none`] instead.
 fn class_defines(class_id: HeapId, dunder: &str, vm: &VM<'_>) -> bool {
+    class_dunder(class_id, dunder, vm).is_some()
+}
+
+/// Whether `class_id` defines `dunder` as something other than `None`.
+///
+/// `__iter__ = None` and `__contains__ = None` are explicit protocol opt-outs:
+/// CPython's `slot_tp_iter` / `slot_sq_contains` reject a `None` member with the
+/// same error as an absent one rather than calling it. This is per-slot, not
+/// general — `__next__ = None` keeps the class an iterator (see
+/// [`HeapRead::py_is_iterator`]), so use [`class_defines`] there.
+fn class_defines_not_none(class_id: HeapId, dunder: &str, vm: &VM<'_>) -> bool {
+    matches!(class_dunder(class_id, dunder, vm), Some(member) if !matches!(member, Value::None))
+}
+
+/// Borrows a dunder out of `class_id`'s namespace, or `None` if absent.
+///
+/// Backs the existence checks above without the `clone_with_heap` that
+/// [`class_member`] pays to hand out an owned value.
+fn class_dunder<'v>(class_id: HeapId, dunder: &str, vm: &'v VM<'_>) -> Option<&'v Value> {
     match vm.heap.get(class_id) {
-        HeapData::Class(class) => class.namespace().get_by_str(dunder, vm.heap, vm.interns).is_some(),
-        _ => false,
+        HeapData::Class(class) => class.namespace().get_by_str(dunder, vm.heap, vm.interns),
+        _ => None,
     }
 }
 

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -155,18 +155,68 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Instance> {
         ))
     }
 
+    fn py_is_iterable(&self, vm: &VM<'h>) -> bool {
+        // CPython also accepts a `__getitem__`-only class here; Monty has no
+        // such fallback, so it reports not-iterable (see limitations/classes.md).
+        class_defines(self.get(vm.heap).class, "__iter__", vm)
+    }
+
+    fn py_is_iterator(&self, vm: &VM<'h>) -> bool {
+        class_defines(self.get(vm.heap).class, "__next__", vm)
+    }
+
+    /// Dispatches the class's `__iter__` and returns its result unchanged.
+    ///
+    /// No wrapper is interposed, so a self-iterator satisfies `iter(obj) is obj`
+    /// exactly as in CPython. The result must itself be an iterator, mirroring
+    /// `PyObject_GetIter`'s `PyIter_Check` — raising here rather than deferring
+    /// the failure to the first `next()`.
+    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
+        let self_id = self_id.expect("heap values have an id");
+        let Some(iterator) = instance_call_dunder_sync(self_id, "__iter__", None, vm)? else {
+            return Err(ExcType::type_error_not_iterable(&class_name(
+                instance_class(self_id, vm),
+                vm.heap,
+                vm.interns,
+            )));
+        };
+        if iterator.py_is_iterator(vm) {
+            Ok(iterator)
+        } else {
+            let err = ExcType::type_error_iter_returned_non_iterator(&iterator.py_type_name(vm));
+            iterator.drop_with(vm);
+            Err(err)
+        }
+    }
+
+    /// Dispatches the class's `__next__`, turning `StopIteration` into exhaustion.
+    ///
+    /// Every other exception propagates, including an `UncatchableExc` from a
+    /// resource limit — see [`RunError::is_stop_iteration`]. No heap borrow is
+    /// held across the call: `__next__` runs Python, which may re-enter this
+    /// same instance through a nested `next()`.
+    fn py_next(&mut self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+        let self_id = self_id.expect("heap values have an id");
+        // The absent case doubles as the not-an-iterator check, halving the
+        // lookups — this runs for every item of every user iterator.
+        match instance_call_dunder_sync(self_id, "__next__", None, vm) {
+            Ok(Some(value)) => Ok(Some(value)),
+            Ok(None) => Err(ExcType::type_error_not_iterator(&class_name(
+                instance_class(self_id, vm),
+                vm.heap,
+                vm.interns,
+            ))),
+            Err(e) if e.is_stop_iteration() => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
     fn py_is_context_manager(&self, vm: &VM<'h>) -> bool {
         // CPython names `__exit__` in the protocol TypeError, so that is the
         // dunder the `BeforeWith` gate checks; a class with `__exit__` but no
         // `__enter__` passes the gate and gets the "missed __enter__ method"
         // error from `py_enter` instead — matching CPython's check order.
-        // Special-method lookup goes through the class only, never the
-        // instance `__dict__` (CPython looks these up on the type).
-        let class_id = self.get(vm.heap).class;
-        match vm.heap.get(class_id) {
-            HeapData::Class(class) => class.namespace().get_by_str("__exit__", vm.heap, vm.interns).is_some(),
-            _ => false,
-        }
+        class_defines(self.get(vm.heap).class, "__exit__", vm)
     }
 
     fn py_enter(&mut self, self_id: HeapId, vm: &mut VM<'h>) -> RunResult<CallResult> {
@@ -342,6 +392,29 @@ pub(crate) fn instance_str(self_id: HeapId, vm: &mut VM<'_>) -> RunResult<Value>
     }
 }
 
+/// Evaluates `item in instance` through the class's `__contains__`.
+///
+/// `Ok(None)` means the class does not define it, leaving the caller to fall
+/// back to iteration — CPython checks `sq_contains` before `tp_iter`, so a
+/// class defining both is never iterated by `in`. The result is coerced with
+/// truthiness, matching CPython's `PyObject_IsTrue` on the slot result.
+pub(crate) fn instance_contains(
+    self_id: HeapId,
+    item: &Value,
+    vm: &mut VM<'_>,
+) -> RunResult<Option<bool>> {
+    // The callee owns its argument, so the borrowed `item` is cloned;
+    // `instance_call_dunder_sync` drops it again if there is no `__contains__`.
+    let item = item.clone_with_heap(vm.heap);
+    match instance_call_dunder_sync(self_id, "__contains__", Some(item), vm)? {
+        Some(result) => {
+            defer_drop!(result, vm);
+            Ok(Some(result.py_bool(vm)))
+        }
+        None => Ok(None),
+    }
+}
+
 /// Calls a user-defined string dunder (`__repr__`/`__str__`) on the instance and
 /// validates that it returned a `str`.
 ///
@@ -352,22 +425,14 @@ pub(crate) fn instance_str(self_id: HeapId, vm: &mut VM<'_>) -> RunResult<Value>
 /// re-enters the VM on the *Rust* stack; `evaluate_function`'s re-entry guard
 /// bounds it with a catchable `RecursionError` — lower than CPython's depth for
 /// deep-but-finite chains, a documented divergence (`limitations/classes.md`).
-fn instance_call_str_dunder(self_id: HeapId, dunder: &'static str, vm: &mut VM<'_>) -> RunResult<Option<Value>> {
-    let class_id = instance_class(self_id, vm);
-    let Some(func) = class_member(class_id, dunder, vm) else {
+fn instance_call_str_dunder(
+    self_id: HeapId,
+    dunder: &'static str,
+    vm: &mut VM<'_>,
+) -> RunResult<Option<Value>> {
+    let Some(result) = instance_call_dunder_sync(self_id, dunder, None, vm)? else {
         return Ok(None);
     };
-    defer_drop!(func, vm);
-    // Only a plain function binds `self` as a descriptor (CPython's method
-    // lookup protocol, mirrored by `call_member_bound`); an already-bound
-    // method or other callable value is invoked with no extra argument.
-    let args = if is_method_value(func, vm) {
-        vm.heap.inc_ref(self_id);
-        ArgValues::One(Value::Ref(self_id))
-    } else {
-        ArgValues::Empty
-    };
-    let result = vm.evaluate_function(dunder, func, args)?;
     // CPython requires `__repr__`/`__str__` to return a `str`; reject any other
     // type with the same TypeError, dropping the offending return value.
     if result.is_str(vm.heap) {
@@ -379,6 +444,59 @@ fn instance_call_str_dunder(self_id: HeapId, dunder: &'static str, vm: &mut VM<'
         ));
         result.drop_with(vm);
         Err(exc)
+    }
+}
+
+/// Calls a zero- or one-argument dunder (`__repr__`, `__next__`,
+/// `__contains__`, ...) on the instance, binding `self` for a plain-function
+/// member. `Ok(None)` if the class does not define it — `arg` is dropped here
+/// in that case, so callers hand over ownership unconditionally.
+///
+/// Synchronous: the callee runs inside `evaluate_function` rather than as a
+/// pushed frame, so — unlike `__enter__` via [`call_member_bound`] — it cannot
+/// suspend on an external/OS call. That is forced by the callers' signatures,
+/// which must hand a `Value` straight back; see `limitations/classes.md`.
+fn instance_call_dunder_sync(
+    self_id: HeapId,
+    dunder: &'static str,
+    arg: Option<Value>,
+    vm: &mut VM<'_>,
+) -> RunResult<Option<Value>> {
+    let class_id = instance_class(self_id, vm);
+    let Some(func) = class_member(class_id, dunder, vm) else {
+        arg.drop_with(vm);
+        return Ok(None);
+    };
+    defer_drop!(func, vm);
+    // Only a plain function binds `self` as a descriptor (CPython's method
+    // lookup protocol, mirrored by `call_member_bound`); an already-bound
+    // method or other callable value is invoked without it.
+    let args = if is_method_value(func, vm) {
+        vm.heap.inc_ref(self_id);
+        let this = Value::Ref(self_id);
+        match arg {
+            Some(arg) => ArgValues::Two(this, arg),
+            None => ArgValues::One(this),
+        }
+    } else {
+        match arg {
+            Some(arg) => ArgValues::One(arg),
+            None => ArgValues::Empty,
+        }
+    };
+    vm.evaluate_function(dunder, func, args).map(Some)
+}
+
+/// Whether `class_id`'s namespace defines `dunder`, without cloning it out.
+///
+/// Special-method lookup goes through the class only, never the instance
+/// `__dict__`, matching CPython's lookup for implicit invocations.
+/// [`class_member`] would `clone_with_heap` the value just to drop it again, so
+/// existence checks use this instead.
+fn class_defines(class_id: HeapId, dunder: &str, vm: &VM<'_>) -> bool {
+    match vm.heap.get(class_id) {
+        HeapData::Class(class) => class.namespace().get_by_str(dunder, vm.heap, vm.interns).is_some(),
+        _ => false,
     }
 }
 

--- a/crates/monty/src/types/iter.rs
+++ b/crates/monty/src/types/iter.rs
@@ -164,7 +164,7 @@ pub fn iterator_next(iter_value: &Value, default: Option<Value>, vm: &mut VM<'_>
     let Value::Ref(iter_id) = iter_value else {
         return Err(ExcType::type_error_not_iterator(&iter_value.py_type_name(vm)));
     };
-    match vm.heap.read(*iter_id).py_next(vm)? {
+    match vm.heap.read(*iter_id).py_next(Some(*iter_id), vm)? {
         Some(item) => Ok(item),
         None => match default_guard.into_inner() {
             Some(default) => Ok(default),

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -952,6 +952,10 @@ impl HeapItem for ListIterator {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, ListIterator> {
+    fn py_is_iterator(&self, _: &VM<'h>) -> bool {
+        true
+    }
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -974,7 +978,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ListIterator> {
         Ok(Value::Ref(self_id))
     }
 
-    fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_next(&mut self, _: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         let (list_id, index) = {
             let iterator = self.get(vm.heap);
             (iterator.list, iterator.index)

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -586,6 +586,17 @@ pub(crate) trait PyTrait<'h> {
         false
     }
 
+    /// Whether `next()` can drive this object, the counterpart to
+    /// [`py_is_iterable`](PyTrait::py_is_iterable)'s "can `iter()` be called".
+    ///
+    /// Mirrors CPython's `PyIter_Check`, used by `PyObject_GetIter` to reject an
+    /// `__iter__` returning a non-iterator — the one caller here, in
+    /// `Instance::py_iter`. A type overriding `py_next` MUST return `true`, or
+    /// a user `__iter__` returning it is wrongly rejected.
+    fn py_is_iterator(&self, _vm: &VM<'h>) -> bool {
+        false
+    }
+
     /// Returns a Python iterator for this object (`__iter__`).
     fn py_iter(&self, _self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
         Err(ExcType::type_error_not_iterable(
@@ -594,7 +605,11 @@ pub(crate) trait PyTrait<'h> {
     }
 
     /// Advances this object using Python's iterator protocol (`__next__`).
-    fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    ///
+    /// `self_id` mirrors [`py_iter`](PyTrait::py_iter): a user-defined instance
+    /// needs its own id to bind `self` when calling `__next__`. Built-in
+    /// iterators hold their state inline and ignore it.
+    fn py_next(&mut self, _self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         Err(ExcType::type_error_not_iterator(
             &self.py_type(vm).name(vm.heap, vm.interns),
         ))

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -362,7 +362,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, RangeIterator> {
         Ok(Value::Ref(self_id))
     }
 
-    fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_next(&mut self, _self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         let iter = self.get_mut(vm.heap);
         if iter.remaining == 0 {
             Ok(None)

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -1610,7 +1610,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, SetIterator> {
         Ok(Value::Ref(self_id))
     }
 
-    fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_next(&mut self, _self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         let (source_id, index, expected_len, mutable) = {
             let iter = self.get(vm.heap);
             (

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -546,11 +546,7 @@ fn call_str_method_impl<'h>(
 ///
 /// # Errors
 /// Returns `TypeError` if the argument is not iterable or if any element is not a string.
-fn str_join<'h>(
-    separator: &HeapRead<'h, str>,
-    iterable: Value,
-    vm: &mut VM<'h>,
-) -> RunResult<Value> {
+fn str_join<'h>(separator: &HeapRead<'h, str>, iterable: Value, vm: &mut VM<'h>) -> RunResult<Value> {
     // Checked up front: a user `__iter__` can raise anything, and rewriting that
     // as "can only join an iterable" would hide it, resource errors included.
     if !iterable.py_is_iterable(vm) {

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -546,10 +546,18 @@ fn call_str_method_impl<'h>(
 ///
 /// # Errors
 /// Returns `TypeError` if the argument is not iterable or if any element is not a string.
-fn str_join<'h>(separator: &HeapRead<'h, str>, iterable: Value, vm: &mut VM<'h>) -> RunResult<Value> {
-    let Ok(iter) = iterable.into_py_iter(vm) else {
+fn str_join<'h>(
+    separator: &HeapRead<'h, str>,
+    iterable: Value,
+    vm: &mut VM<'h>,
+) -> RunResult<Value> {
+    // Checked up front: a user `__iter__` can raise anything, and rewriting that
+    // as "can only join an iterable" would hide it, resource errors included.
+    if !iterable.py_is_iterable(vm) {
+        iterable.drop_with(vm);
         return Err(ExcType::type_error_join_not_iterable());
-    };
+    }
+    let iter = iterable.into_py_iter(vm)?;
     defer_drop!(iter, vm);
     let mut iter = iter.read(vm);
 
@@ -2146,7 +2154,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, StringIterator> {
         Ok(Value::Ref(self_id))
     }
 
-    fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_next(&mut self, _self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         let next = self.get(vm.heap).as_str(vm).chars().next();
         if let Some(character) = next {
             let value = allocate_char(character, vm.heap)?;

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -672,7 +672,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TupleIterator> {
         Ok(Value::Ref(self_id))
     }
 
-    fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_next(&mut self, _self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         let (source_id, index) = {
             let iter = self.get(vm.heap);
             (iter.source_id(), iter.index)

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -1607,10 +1607,10 @@ impl Value {
                         None if self.py_is_iterable(vm) => self.contains_by_iteration(item, vm),
                         None => Err(ExcType::type_error_not_container(&self.py_type_name(vm))),
                     },
-                    // Any iterator is consumed until the item is found. Asking
-                    // `is_iterator()` covers the dedicated iterator types rather
-                    // than naming each one here.
-                    value if value.py_type(vm).is_iterator() => self.contains_by_iteration(item, vm),
+                    // Everything else with no `__contains__` of its own — the
+                    // iterators, and any future iterable heap type — is consumed
+                    // by iteration, as CPython falls back to `tp_iter`.
+                    _ if self.py_is_iterable(vm) => self.contains_by_iteration(item, vm),
                     _ => Err(ExcType::type_error_not_container(&self.py_type_name(vm))),
                 }
             }

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -25,7 +25,7 @@ use crate::{
     types::{
         Bytes, BytesIterator, CmpOrder, LazyHeapSet, LongInt, Property, PyTrait, StringIterator, Type,
         bytes::{bytes_repr_fmt, concat_bytes, get_byte_at_index, repeat_bytes},
-        instance::{instance_getattr, instance_repr, instance_str},
+        instance::{instance_contains, instance_getattr, instance_repr, instance_str},
         long_int::{
             bigint_cmp_f64, bigint_cmp_i64, bigint_eq_f64, bigint_eq_i64, check_bits_str_digits_limit, i64_cmp_f64,
             repeat_count, wide_i128_into_value,
@@ -94,7 +94,10 @@ pub(crate) enum ValueRead<'h, 'v> {
     Immediate(&'v Value),
     /// Heap values retain both their owner and the typed heap read handle.
     Heap {
-        _owner: &'v Value,
+        /// The `Value::Ref` this view was taken from. Keeps the entry alive for
+        /// the view's lifetime, and supplies the `HeapId` that `py_next` needs
+        /// to drive a user-defined `__next__`.
+        owner: &'v Value,
         value: HeapReadOutput<'h>,
     },
 }
@@ -108,7 +111,7 @@ impl<'h> ValueRead<'h, '_> {
         vm.heap.check_time()?;
         match self {
             Self::Immediate(value) => Err(ExcType::type_error_not_iterator(&value.py_type_name(vm))),
-            Self::Heap { value, .. } => value.py_next(vm),
+            Self::Heap { owner, value } => value.py_next(owner.ref_id(), vm),
         }
     }
 
@@ -1214,6 +1217,15 @@ impl<'h> PyTrait<'h> for Value {
         }
     }
 
+    fn py_is_iterator(&self, vm: &VM<'_>) -> bool {
+        // No immediate value is an iterator; interned `str`/`bytes` are iterable
+        // but, as in CPython, are not their own iterators.
+        match self {
+            Self::Ref(id) => vm.heap.read(*id).py_is_iterator(vm),
+            _ => false,
+        }
+    }
+
     fn py_is_iterable(&self, vm: &VM<'_>) -> bool {
         match self {
             // Interned string and bytes literals iterate without ever reaching
@@ -1236,9 +1248,9 @@ impl<'h> PyTrait<'h> for Value {
         }
     }
 
-    fn py_next(&mut self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
+    fn py_next(&mut self, _: Option<HeapId>, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
         if let Self::Ref(id) = self {
-            vm.heap.read(*id).py_next(vm)
+            vm.heap.read(*id).py_next(Some(*id), vm)
         } else {
             Err(ExcType::type_error_not_iterator(&self.py_type_name(vm)))
         }
@@ -1376,6 +1388,14 @@ impl Value {
         <Self as PyTrait<'_>>::py_iter(self, None, vm)
     }
 
+    /// Advances this value as an iterator, mirroring the inherent [`Value::py_iter`].
+    ///
+    /// The trait method's `self_id` is redundant for a `Value`, which already
+    /// carries its own `HeapId`, so callers use this and let the impl resolve it.
+    pub(crate) fn py_next(&mut self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
+        <Self as PyTrait<'_>>::py_next(self, None, vm)
+    }
+
     /// Converts an owned value into its Python iterator and releases the original reference.
     ///
     /// This is the ownership-preserving entry point for Rust consumers of the
@@ -1390,7 +1410,7 @@ impl Value {
     pub(crate) fn read<'h, 'v>(&'v self, vm: &VM<'h>) -> ValueRead<'h, 'v> {
         match self {
             Self::Ref(id) => ValueRead::Heap {
-                _owner: self,
+                owner: self,
                 value: vm.heap.read(*id),
             },
             _ => ValueRead::Immediate(self),
@@ -1476,6 +1496,9 @@ impl Value {
     /// - Dict: key lookup
     /// - Set/FrozenSet: element lookup
     /// - Str: substring search
+    /// - Instance: the class's `__contains__`, else iteration
+    ///
+    /// Anything else iterable is consumed until the item is found.
     pub fn py_contains(&self, item: &Self, vm: &mut VM<'_>) -> RunResult<bool> {
         match self {
             Self::Ref(heap_id) => {
@@ -1577,40 +1600,45 @@ impl Value {
                         };
                         Ok(range.contains(n))
                     }
-                    // An iterator is consumed until the item is found, as
-                    // CPython's `in` does for any iterable without `__contains__`.
-                    value if value.py_type(vm).is_iterator() => {
-                        let iter = self.py_iter(vm)?;
-                        defer_drop!(iter, vm);
-                        let mut iter = iter.read(vm);
-                        loop {
-                            let Some(el) = iter.py_next(vm)? else {
-                                break Ok(false);
-                            };
-                            let eq = item.py_eq(&el, vm);
-                            el.drop_with(vm);
-                            if eq? {
-                                break Ok(true);
-                            }
-                        }
-                    }
-                    _ => {
-                        let type_name = self.py_type_name(vm);
-                        Err(ExcType::type_error(format!(
-                            "argument of type '{type_name}' is not a container or iterable"
-                        )))
-                    }
+                    // `__contains__` first, iteration only as a fallback —
+                    // CPython's `sq_contains` precedes `tp_iter`.
+                    HeapReadOutput::Instance(_) => match instance_contains(*heap_id, item, vm)? {
+                        Some(found) => Ok(found),
+                        None if self.py_is_iterable(vm) => self.contains_by_iteration(item, vm),
+                        None => Err(ExcType::type_error_not_container(&self.py_type_name(vm))),
+                    },
+                    // Any iterator is consumed until the item is found. Asking
+                    // `is_iterator()` covers the dedicated iterator types rather
+                    // than naming each one here.
+                    value if value.py_type(vm).is_iterator() => self.contains_by_iteration(item, vm),
+                    _ => Err(ExcType::type_error_not_container(&self.py_type_name(vm))),
                 }
             }
             Self::InternString(string_id) => {
                 let container_str = vm.interns.get_str(*string_id);
                 str_contains(container_str, item, vm.heap, vm.interns)
             }
-            _ => {
-                let type_name = self.py_type_name(vm);
-                Err(ExcType::type_error(format!(
-                    "argument of type '{type_name}' is not a container or iterable"
-                )))
+            _ => Err(ExcType::type_error_not_container(&self.py_type_name(vm))),
+        }
+    }
+
+    /// Consumes `self` as an iterable, reporting whether `item` compares equal
+    /// to any element — the `in` fallback for anything without `__contains__`.
+    ///
+    /// Only called for values already known to be iterable, so it does not
+    /// re-check. An endless iterable runs until a resource limit fires.
+    fn contains_by_iteration(&self, item: &Self, vm: &mut VM<'_>) -> RunResult<bool> {
+        let iter = self.py_iter(vm)?;
+        defer_drop!(iter, vm);
+        let mut iter = iter.read(vm);
+        loop {
+            let Some(el) = iter.py_next(vm)? else {
+                break Ok(false);
+            };
+            let eq = item.py_eq(&el, vm);
+            el.drop_with(vm);
+            if eq? {
+                break Ok(true);
             }
         }
     }

--- a/crates/monty/test_cases/class__contains.py
+++ b/crates/monty/test_cases/class__contains.py
@@ -58,6 +58,49 @@ assert 1 not in NoneContains()
 assert isinstance(1 in NoneContains(), bool)
 
 
+class EmptyContainer:
+    def __contains__(self, item):
+        return []
+
+
+assert 1 not in EmptyContainer()
+
+
+# === __contains__ = None opts out of `in` entirely ===
+# The None is never called, and — unlike an absent __contains__ — there is no
+# fallback to iteration, so a class defining __iter__ too still raises.
+class OptOut:
+    __contains__ = None
+
+
+try:
+    1 in OptOut()
+    assert False, 'expected TypeError for an opted-out __contains__'
+except TypeError as e:
+    assert str(e) == "'OptOut' object is not a container"
+
+
+class OptOutIterable:
+    def __iter__(self):
+        return iter([1, 2])
+
+    __contains__ = None
+
+
+try:
+    1 in OptOutIterable()
+    assert False, 'expected TypeError rather than a fallback to iteration'
+except TypeError as e:
+    assert str(e) == "'OptOutIterable' object is not a container"
+try:
+    1 not in OptOutIterable()
+    assert False, 'expected TypeError from `not in` as well'
+except TypeError as e:
+    assert str(e) == "'OptOutIterable' object is not a container"
+# iteration itself is unaffected — only `in` is opted out
+assert list(OptOutIterable()) == [1, 2]
+
+
 # === __contains__ receives the item, and self when it is a plain function ===
 class Recorder:
     def __init__(self):

--- a/crates/monty/test_cases/class__contains.py
+++ b/crates/monty/test_cases/class__contains.py
@@ -1,0 +1,140 @@
+# A user class implementing `__contains__` decides `in` / `not in` itself.
+#
+# It takes precedence over `__iter__`, so a class defining both is never
+# iterated by `in`; a class defining neither is a TypeError.
+
+
+# === __contains__ alone: no __iter__ needed ===
+class Membership:
+    def __init__(self, allowed):
+        self.allowed = allowed
+
+    def __contains__(self, item):
+        return item in self.allowed
+
+
+m = Membership(['a', 'b'])
+assert 'a' in m
+assert 'z' not in m
+
+
+# === __contains__ takes precedence over __iter__ ===
+# The iteration answer and the __contains__ answer are deliberately opposite,
+# so this fails loudly if the fallback is reached.
+class Both:
+    def __iter__(self):
+        return iter([1, 2, 3])
+
+    def __contains__(self, item):
+        return item == 99
+
+
+b = Both()
+assert 99 in b
+assert 1 not in b
+# iteration itself is unaffected — only `in` consults __contains__
+assert list(b) == [1, 2, 3]
+assert [x for x in b] == [1, 2, 3]
+
+
+# === the result is coerced by truthiness, not required to be a bool ===
+class Truthy:
+    def __contains__(self, item):
+        return item
+
+
+assert 5 in Truthy()
+assert 0 not in Truthy()
+assert [0] in Truthy()
+assert [] not in Truthy()
+
+
+class NoneContains:
+    def __contains__(self, item):
+        return None
+
+
+assert 1 not in NoneContains()
+assert isinstance(1 in NoneContains(), bool)
+
+
+# === __contains__ receives the item, and self when it is a plain function ===
+class Recorder:
+    def __init__(self):
+        self.seen = []
+
+    def __contains__(self, item):
+        self.seen.append(item)
+        return False
+
+
+r = Recorder()
+assert 'x' not in r
+assert 'y' not in r
+assert r.seen == ['x', 'y']
+
+
+# === without __contains__, `in` still falls back to iteration ===
+class IterOnly:
+    def __iter__(self):
+        return iter(['p', 'q'])
+
+
+assert 'p' in IterOnly()
+assert 'z' not in IterOnly()
+
+
+# === exceptions from __contains__ propagate unchanged ===
+class Boom:
+    def __contains__(self, item):
+        raise ValueError('nope')
+
+
+try:
+    1 in Boom()
+    assert False, 'expected ValueError from __contains__'
+except ValueError as e:
+    assert str(e) == 'nope'
+try:
+    1 not in Boom()
+    assert False, 'expected ValueError from __contains__ via not in'
+except ValueError as e:
+    assert str(e) == 'nope'
+
+
+# === a non-callable __contains__ is a TypeError when `in` invokes it ===
+class NotCallable:
+    __contains__ = 42
+
+
+try:
+    1 in NotCallable()
+    assert False, 'expected TypeError for non-callable __contains__'
+except TypeError as e:
+    assert str(e) == "'int' object is not callable"
+
+
+# === __contains__ is looked up on the class, never the instance __dict__ ===
+class InstanceOnly:
+    def __init__(self):
+        self.__contains__ = lambda item: True
+
+
+try:
+    1 in InstanceOnly()
+    assert False, 'expected TypeError for instance-only __contains__'
+except TypeError as e:
+    assert str(e) == "argument of type 'InstanceOnly' is not a container or iterable"
+
+
+# === __contains__ may call back into `in` on itself ===
+class Nested:
+    def __init__(self, inner):
+        self.inner = inner
+
+    def __contains__(self, item):
+        return item in self.inner
+
+
+assert 1 in Nested(Nested([1, 2]))
+assert 3 not in Nested(Nested([1, 2]))

--- a/crates/monty/test_cases/iter__reentrant.py
+++ b/crates/monty/test_cases/iter__reentrant.py
@@ -21,3 +21,53 @@ def f():
 
 it = iter(f, 0)
 assert list(it) == [102]
+
+# === user iterator re-entering itself ===
+# `C.__next__` calls `next(it2)` on the very object being advanced, so the same
+# heap cell is reached twice. `py_next` copies `self_id` out and holds no borrow
+# across the call, which is what makes this safe.
+it2 = None
+
+
+class C:
+    def __init__(self):
+        self.d = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        self.d += 1
+        if self.d >= 3:
+            raise StopIteration
+        if self.d == 1:
+            return next(it2) + 100  # re-enter `it2` mid-advance
+        return self.d
+
+
+it2 = iter(C())
+assert list(it2) == [102]
+
+
+# === a user __next__ that mutates the instance while it is being iterated ===
+# `__next__` writes to `self.seen`, which takes a mutable borrow of the same
+# heap entry the iteration is driving.
+class Recorder:
+    def __init__(self):
+        self.i = 0
+        self.seen = []
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.i >= 3:
+            raise StopIteration
+        self.i += 1
+        self.seen.append(self.i)
+        return self.i
+
+
+rec = Recorder()
+assert list(rec) == [1, 2, 3]
+assert rec.seen == [1, 2, 3]

--- a/crates/monty/test_cases/iter__sentinel.py
+++ b/crates/monty/test_cases/iter__sentinel.py
@@ -20,6 +20,18 @@ assert list(iter(lambda: next(src), [1, 2])) == [[9]]
 # === immediate sentinel -> empty ===
 assert list(iter(lambda: 7, 7)) == []
 
+# === `in` consumes it, like any other iterator ===
+# It has no __contains__, so membership falls back to iteration and stops at the
+# match, leaving the rest of the iterator available.
+src3 = iter([1, 2, 3, 0])
+partial = iter(lambda: next(src3), 0)
+assert 2 in partial
+assert list(partial) == [3]
+src4 = iter([1, 2, 0])
+assert 99 not in iter(lambda: next(src4), 0)
+exhausted = iter(lambda: 7, 7)
+assert 7 not in exhausted
+
 
 # === callable exception propagates unchanged ===
 def boom():

--- a/crates/monty/test_cases/iter__sentinel.py
+++ b/crates/monty/test_cases/iter__sentinel.py
@@ -85,3 +85,20 @@ for x in ci2:
     collected.append(x)
 assert collected == [5, 6]
 assert next(ci2, 'STOPPED') == 'STOPPED'
+
+# === StopIteration from the callable ends iteration, as in CPython ===
+stop_calls = [0]
+
+
+def stops():
+    stop_calls[0] += 1
+    if stop_calls[0] >= 3:
+        raise StopIteration
+    return stop_calls[0]
+
+
+assert list(iter(stops, 99)) == [1, 2]
+stop_calls[0] = 0
+stop_it = iter(stops, 99)
+assert (next(stop_it), next(stop_it)) == (1, 2)
+assert next(stop_it, 'done') == 'done'

--- a/crates/monty/test_cases/iter__user_class.py
+++ b/crates/monty/test_cases/iter__user_class.py
@@ -1,0 +1,276 @@
+# A user class implementing the iterator protocol is iterable everywhere:
+# `for`, `list()`, `sum()`, comprehensions, `in`, unpacking and `next()`.
+#
+# `iter()` returns whatever `__iter__` returns, with no wrapper interposed, so
+# identity and type are preserved exactly as in CPython.
+
+
+# === self-iterator: __iter__ returns self ===
+class Countdown:
+    def __init__(self, n):
+        self.n = n
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.n <= 0:
+            raise StopIteration
+        self.n -= 1
+        return self.n + 1
+
+
+assert [x for x in Countdown(3)] == [3, 2, 1]
+assert list(Countdown(3)) == [3, 2, 1]
+assert sum(Countdown(4)) == 10
+assert tuple(Countdown(2)) == (2, 1)
+assert sorted(Countdown(3)) == [1, 2, 3]
+assert max(Countdown(3)) == 3
+assert set(Countdown(3)) == {1, 2, 3}
+
+collected = []
+for x in Countdown(2):
+    collected.append(x)
+assert collected == [2, 1]
+
+# === iter() interposes no wrapper ===
+c = Countdown(2)
+assert iter(c) is c
+assert type(iter(c)) is Countdown
+assert type(iter(c)).__name__ == 'Countdown'
+
+
+# === separate iterable and iterator; the container is re-iterable ===
+class MyRangeIter:
+    def __init__(self, hi):
+        self.i = 0
+        self.hi = hi
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.i >= self.hi:
+            raise StopIteration
+        self.i += 1
+        return self.i
+
+
+class MyRange:
+    def __init__(self, hi):
+        self.hi = hi
+
+    def __iter__(self):
+        return MyRangeIter(self.hi)
+
+
+r = MyRange(3)
+assert list(r) == [1, 2, 3]
+assert list(r) == [1, 2, 3]
+assert iter(r) is not r
+assert type(iter(r)) is MyRangeIter
+
+# === next() and next(default) ===
+c = Countdown(2)
+assert next(c) == 2
+assert next(c) == 1
+assert next(c, 'DONE') == 'DONE'
+
+
+# === __iter__ returning a builtin iterator (the common delegation pattern) ===
+class Wrap:
+    def __init__(self, items):
+        self._items = items
+
+    def __iter__(self):
+        return iter(self._items)
+
+
+assert list(Wrap([1, 2, 3])) == [1, 2, 3]
+assert sum(Wrap([1, 2, 3])) == 6
+w = Wrap([1, 2])
+assert (list(w), list(w)) == ([1, 2], [1, 2])
+assert list(Wrap('ab')) == ['a', 'b']
+assert list(Wrap({'k': 1})) == ['k']
+
+
+# `__iter__` may return any iterator type, including a `callable_iterator`,
+# which `py_is_iterator` has to accept alongside the generic and list ones.
+counter = [0]
+
+
+def bump():
+    counter[0] += 1
+    return counter[0]
+
+
+class WrapCallable:
+    def __iter__(self):
+        return iter(bump, 4)
+
+
+assert list(WrapCallable()) == [1, 2, 3]
+
+
+# === every consumption site reaches a user iterable ===
+class CD:
+    def __init__(self, n):
+        self.n = n
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.n <= 0:
+            raise StopIteration
+        self.n -= 1
+        return self.n + 1
+
+
+assert 2 in CD(3)
+assert 9 not in CD(3)
+assert [*CD(3)] == [3, 2, 1]
+assert (*CD(2),) == (2, 1)
+assert {*CD(2)} == {1, 2}
+a, b, d = CD(3)
+assert (a, b, d) == (3, 2, 1)
+head, *tail = CD(3)
+assert (head, tail) == (3, [2, 1])
+assert '-'.join(Wrap(['a', 'b'])) == 'a-b'
+assert b'-'.join(Wrap([b'a', b'b'])) == b'a-b'
+assert dict(Wrap([('k', 1)])) == {'k': 1}
+
+
+# === a user iterator is not latched: __next__ runs again after StopIteration ===
+class Resumable:
+    def __init__(self):
+        self.n = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        self.n += 1
+        if self.n >= 2:
+            raise StopIteration
+        return self.n
+
+
+res = Resumable()
+assert (list(res), list(res)) == ([1], [])
+
+
+# === __iter__ must return an iterator ===
+class BadIter:
+    def __iter__(self):
+        return 42
+
+
+try:
+    iter(BadIter())
+    assert False, 'expected TypeError for a non-iterator __iter__'
+except TypeError as e:
+    assert str(e) == "iter() returned non-iterator of type 'int'"
+
+
+class NoNext:
+    pass
+
+
+class ReturnsNoNext:
+    def __iter__(self):
+        return NoNext()
+
+
+try:
+    list(ReturnsNoNext())
+    assert False, 'expected TypeError for an __iter__ result without __next__'
+except TypeError as e:
+    assert str(e) == "iter() returned non-iterator of type 'NoNext'"
+
+
+# === __next__ without __iter__: next() works, iter() does not ===
+class NextOnly:
+    def __next__(self):
+        return 1
+
+
+assert next(NextOnly()) == 1
+try:
+    iter(NextOnly())
+    assert False, 'expected TypeError for a class with no __iter__'
+except TypeError as e:
+    assert str(e) == "'NextOnly' object is not iterable"
+
+
+# === a class with neither dunder keeps each site's own message ===
+class Plain:
+    pass
+
+
+try:
+    next(Plain())
+    assert False, 'expected TypeError for next() on a plain instance'
+except TypeError as e:
+    assert str(e) == "'Plain' object is not an iterator"
+try:
+    2 in Plain()
+    assert False, 'expected TypeError for `in` on a plain instance'
+except TypeError as e:
+    assert str(e) == "argument of type 'Plain' is not a container or iterable"
+try:
+    [*Plain()]
+    assert False, 'expected TypeError for `*` unpack of a plain instance'
+except TypeError as e:
+    assert str(e) == 'Value after * must be an iterable, not Plain'
+try:
+    _p, _q = Plain()
+    assert False, 'expected TypeError for unpacking a plain instance'
+except TypeError as e:
+    assert str(e) == 'cannot unpack non-iterable Plain object'
+try:
+    ''.join(Plain())
+    assert False, 'expected TypeError for join of a plain instance'
+except TypeError as e:
+    assert str(e) == 'can only join an iterable'
+
+
+# === exceptions from the dunders propagate unchanged ===
+class BoomIter:
+    def __iter__(self):
+        raise ValueError('boom')
+
+
+class BoomNext:
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        raise ValueError('kaboom')
+
+
+try:
+    list(BoomIter())
+    assert False, 'expected ValueError from __iter__'
+except ValueError as e:
+    assert str(e) == 'boom'
+try:
+    ''.join(BoomIter())
+    assert False, 'expected ValueError from __iter__ via join'
+except ValueError as e:
+    assert str(e) == 'boom'
+try:
+    list(BoomNext())
+    assert False, 'expected ValueError from __next__'
+except ValueError as e:
+    assert str(e) == 'kaboom'
+
+
+# === reversed() is not implied by the iterator protocol ===
+# CPython needs __reversed__, or __len__ + __getitem__; Monty dispatches
+# neither, so a user iterator is never reversible (see limitations/classes.md).
+try:
+    reversed(CD(2))
+    assert False, 'expected TypeError for reversed(user iterator)'
+except TypeError as e:
+    assert str(e) == "'CD' object is not reversible"

--- a/crates/monty/test_cases/iter__user_class.py
+++ b/crates/monty/test_cases/iter__user_class.py
@@ -235,6 +235,80 @@ except TypeError as e:
     assert str(e) == 'can only join an iterable'
 
 
+# === __iter__ = None opts out of the protocol ===
+# The None is never called: every site reports not-iterable, exactly as if
+# __iter__ were absent. The two unpacking sites keep the plain message rather
+# than their own wording, because the slot is filled (CPython's slot_tp_iter).
+class OptOut:
+    __iter__ = None
+
+
+try:
+    iter(OptOut())
+    assert False, 'expected TypeError for iter() of an opted-out class'
+except TypeError as e:
+    assert str(e) == "'OptOut' object is not iterable"
+try:
+    list(OptOut())
+    assert False, 'expected TypeError for list() of an opted-out class'
+except TypeError as e:
+    assert str(e) == "'OptOut' object is not iterable"
+try:
+    for _x in OptOut():
+        pass
+    assert False, 'expected TypeError for a for loop over an opted-out class'
+except TypeError as e:
+    assert str(e) == "'OptOut' object is not iterable"
+try:
+    sorted(OptOut())
+    assert False, 'expected TypeError for sorted() of an opted-out class'
+except TypeError as e:
+    assert str(e) == "'OptOut' object is not iterable"
+try:
+    _p, _q = OptOut()
+    assert False, 'expected TypeError for unpacking an opted-out class'
+except TypeError as e:
+    assert str(e) == "'OptOut' object is not iterable"
+try:
+    _head, *_tail = OptOut()
+    assert False, 'expected TypeError for starred unpacking of an opted-out class'
+except TypeError as e:
+    assert str(e) == "'OptOut' object is not iterable"
+try:
+    [*OptOut()]
+    assert False, 'expected TypeError for `*` unpack of an opted-out class'
+except TypeError as e:
+    assert str(e) == "'OptOut' object is not iterable"
+try:
+    ''.join(OptOut())
+    assert False, 'expected TypeError for join of an opted-out class'
+except TypeError as e:
+    assert str(e) == 'can only join an iterable'
+try:
+    2 in OptOut()
+    assert False, 'expected TypeError for `in` on an opted-out class'
+except TypeError as e:
+    assert str(e) == "argument of type 'OptOut' is not a container or iterable"
+
+
+# === __next__ = None is not an opt-out ===
+# Only __iter__ (and __contains__) treat None as absent, so this class stays an
+# iterator and the None is reached and called.
+class NoneNext:
+    def __iter__(self):
+        return self
+
+    __next__ = None
+
+
+assert iter(NoneNext()) is not None
+try:
+    list(NoneNext())
+    assert False, 'expected TypeError from calling a None __next__'
+except TypeError as e:
+    assert str(e) == "'NoneType' object is not callable"
+
+
 # === exceptions from the dunders propagate unchanged ===
 class BoomIter:
     def __iter__(self):

--- a/crates/monty/test_cases/refcount__class.py
+++ b/crates/monty/test_cases/refcount__class.py
@@ -6,9 +6,4 @@ class Foo:
 f = Foo()
 g = Foo()
 bm = f.m
-# Every class carries a synthesized `__annotations__` dict (empty here), which
-# is a real heap object owned by the class namespace. Bind it so the strict
-# check — every live heap object must be reachable from a name — accounts for
-# it rather than seeing an unreferenced object.
-ann = Foo.__annotations__
-# ref-counts={'Foo': 3, 'f': 2, 'g': 1, 'bm': 1, 'ann': 2}
+# ref-counts={'Foo': 3, 'f': 2, 'g': 1, 'bm': 1}

--- a/crates/monty/test_cases/refcount__user_contains.py
+++ b/crates/monty/test_cases/refcount__user_contains.py
@@ -1,7 +1,8 @@
 # `in` clones the needle to hand it to `__contains__`, which owns its argument,
-# and drops whatever the method returns. Neither may leak, on either path: when
-# the class defines `__contains__`, and when the clone has to be released again
-# because it does not and `in` falls back to iteration.
+# and drops whatever the method returns. Neither may leak, on any path: when the
+# class defines `__contains__`, when the clone has to be released again because
+# it does not and `in` falls back to iteration, and when `__contains__ = None`
+# opts the class out and `in` raises.
 class Always:
     def __contains__(self, item):
         return item
@@ -12,16 +13,26 @@ class IterOnly:
         return iter([1])
 
 
+class OptOut:
+    __contains__ = None
+
+
 needle = [1, 2]
 a = Always()
 i = IterOnly()
+o = OptOut()
 
 for _ in range(3):
     assert needle in a
     assert needle not in i
+    try:
+        needle in o
+        assert False, 'expected TypeError for an opted-out __contains__'
+    except TypeError:
+        pass
 
 needle
 # `needle` is 2 — its binding plus the trailing expression's returned value; a
 # leaked clone would push it to 5, one per loop iteration. The classes are 2:
 # the global name plus their instance's class slot.
-# ref-counts={'needle': 2, 'a': 1, 'i': 1, 'Always': 2, 'IterOnly': 2}
+# ref-counts={'needle': 2, 'a': 1, 'i': 1, 'o': 1, 'Always': 2, 'IterOnly': 2, 'OptOut': 2}

--- a/crates/monty/test_cases/refcount__user_contains.py
+++ b/crates/monty/test_cases/refcount__user_contains.py
@@ -1,0 +1,27 @@
+# `in` clones the needle to hand it to `__contains__`, which owns its argument,
+# and drops whatever the method returns. Neither may leak, on either path: when
+# the class defines `__contains__`, and when the clone has to be released again
+# because it does not and `in` falls back to iteration.
+class Always:
+    def __contains__(self, item):
+        return item
+
+
+class IterOnly:
+    def __iter__(self):
+        return iter([1])
+
+
+needle = [1, 2]
+a = Always()
+i = IterOnly()
+
+for _ in range(3):
+    assert needle in a
+    assert needle not in i
+
+needle
+# `needle` is 2 — its binding plus the trailing expression's returned value; a
+# leaked clone would push it to 5, one per loop iteration. The classes are 2:
+# the global name plus their instance's class slot.
+# ref-counts={'needle': 2, 'a': 1, 'i': 1, 'Always': 2, 'IterOnly': 2}

--- a/crates/monty/test_cases/refcount__user_iterator.py
+++ b/crates/monty/test_cases/refcount__user_iterator.py
@@ -1,0 +1,22 @@
+# A user iterator must not leak. `list(c)` drives `c` directly — no wrapper is
+# allocated to hold a reference to it — so once iteration finishes the instance
+# is back to just its own binding. `Countdown` is 2: the global name plus the
+# instance's class slot.
+class Countdown:
+    def __init__(self, n):
+        self.n = n
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.n <= 0:
+            raise StopIteration
+        self.n -= 1
+        return self.n + 1
+
+
+c = Countdown(3)
+out = list(c)
+out
+# ref-counts={'c': 1, 'out': 2, 'Countdown': 2}

--- a/crates/monty/test_cases/refcount__with_class.py
+++ b/crates/monty/test_cases/refcount__with_class.py
@@ -1,10 +1,8 @@
 # Reference counts stay balanced through the `with` machinery's pushed
 # frames: `BeforeWith` pushes the ctx and the `__enter__` frame binds self;
 # `WithExit`/`WithExceptStart` bind self plus the exception triple. The
-# suppressed exception survives through the attribute written by `__exit__`;
-# we bind it to `survived` at the end so the strict ref-count check (which
-# requires every live heap object to be reachable from a named variable)
-# accounts for it rather than seeing an unreferenced third heap object.
+# suppressed exception survives through the attribute written by `__exit__`,
+# which we assert by binding it to `survived` at the end.
 class CM:
     def __enter__(self):
         return self
@@ -25,7 +23,4 @@ with cm:
 # binding (refcount 2); `cm` and `bound` alias the one instance (refcount 2);
 # `CM` is held by the global plus the instance's class slot (refcount 2).
 survived = cm.last_exc
-# The class's synthesized `__annotations__` dict (empty here) is a heap object
-# owned by the class namespace, so bind it too — see `refcount__class.py`.
-ann = CM.__annotations__
-# ref-counts={'CM': 2, 'cm': 2, 'bound': 2, 'survived': 2, 'ann': 2}
+# ref-counts={'CM': 2, 'cm': 2, 'bound': 2, 'survived': 2}

--- a/crates/monty/tests/main.rs
+++ b/crates/monty/tests/main.rs
@@ -128,6 +128,33 @@ fn external_function_as_init_raises_not_implemented() {
     );
 }
 
+/// A user `__next__` calling an external function cannot suspend: like
+/// `__repr__`/`__str__` it runs synchronously via `evaluate_function`, so the
+/// call raises `NotImplementedError` (see `limitations/classes.md`). Rust-side
+/// for the same reason as `external_function_as_init_raises_not_implemented`:
+/// on CPython the external is a real function and the loop would succeed.
+#[test]
+fn external_function_in_next_raises_not_implemented() {
+    let code = "class Foo:\n    def __iter__(self):\n        return self\n\n    def __next__(self):\n        return ext_fn()\n\nfor _x in Foo():\n    pass";
+    let ex = MontyRun::new(
+        code.to_owned(),
+        "test.py",
+        vec!["ext_fn".to_owned()],
+        CompileOptions::default(),
+    )
+    .unwrap();
+    let err = ex
+        .run_no_limits(vec![MontyObject::Function {
+            name: "ext_fn".to_owned(),
+            docstring: None,
+        }])
+        .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Traceback (most recent call last):\n  File \"test.py\", line 8, in <module>\n    for _x in Foo():\n              ~~~~~\nNotImplementedError: __next__: external function 'ext_fn' is not yet supported in this context"
+    );
+}
+
 /// The 3-arg `type()` form rejects non-empty bases because Monty classes
 /// cannot inherit (documented in `limitations/classes.md`). Kept as a
 /// Rust-side test because CPython accepts bases, so the comparative

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -2516,3 +2516,34 @@ fn finditer_shares_subject_memory() {
         MontyObject::Int(4000)
     );
 }
+
+/// A resource limit hit *inside* a user `__next__` must terminate the run, not
+/// be mistaken for iterator exhaustion.
+///
+/// `py_next` turns a raised `StopIteration` into `Ok(None)` and propagates
+/// everything else, so the budget breach has to escape the loop. (It does not
+/// exercise `is_stop_iteration`'s `Exc`-only check, which is unreachable while
+/// resource errors are never typed `StopIteration` — see its docstring.)
+#[test]
+fn resource_limit_in_user_next_is_not_exhaustion() {
+    let code = r"
+class Spin:
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        x = 0
+        for i in range(100000000):
+            x = x + 1
+        return x
+
+for _v in Spin():
+    pass
+";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let limits = ResourceLimits::default().max_duration(Duration::from_millis(50));
+    let result = ex.run(vec![], ResourceTracker::new(limits), PrintWriter::Stdout);
+
+    let exc = result.expect_err("the time limit must terminate the run");
+    assert_eq!(exc.exc_type(), ExcType::TimeoutError);
+}

--- a/limitations/classes.md
+++ b/limitations/classes.md
@@ -206,6 +206,10 @@ e.g. return a `dict` of the fields.
   a `StopIteration` raised anywhere inside it ends the iteration — including one
   that propagates out of a nested call, where CPython's PEP 479 protections
   apply only to generators, which Monty does not have.
+- **A `__contains__` returning a user instance is always `True`.** The result is
+  coerced by Monty's truthiness, which reports every instance as truthy (see
+  above), where CPython's `PyObject_IsTrue` consults the returned object's
+  `__bool__`/`__len__`. Every other return type coerces as CPython does.
 - Attribute-access hooks are **never** dispatched: `__getattr__`,
   `__getattribute__`, `__setattr__`, `__delattr__`, and `__del__`. A missing
   attribute always raises the default `AttributeError` even when the class

--- a/limitations/classes.md
+++ b/limitations/classes.md
@@ -186,10 +186,26 @@ e.g. return a `dict` of the fields.
   are all unavailable (`cls.__name__` and `cls.__annotations__` work — the
   latter with stringized values, see [typing.md](typing.md)).
 - Dunder protocols other than `__init__`, `__repr__`, `__str__`,
-  `__enter__`, and `__exit__`: `__new__`, `__call__`, `__iter__`,
-  `__next__`, `__getitem__`, `__setitem__`, `__contains__`, `__add__`,
-  `__eq__`, `__hash__`, `__bool__`, etc. are not dispatched for
-  user-defined instances.
+  `__enter__`, `__exit__`, `__iter__`, `__next__`, and `__contains__`:
+  `__new__`, `__call__`, `__getitem__`, `__setitem__`, `__add__`, `__eq__`,
+  `__hash__`, `__bool__`, etc. are not dispatched for user-defined instances.
+- `__iter__` / `__next__` / `__contains__` **are** dispatched, but like
+  `__repr__`/`__str__` they run synchronously, so one that calls an external or
+  OS function cannot suspend and raises `NotImplementedError`. Two related
+  protocols are still not dispatched, so a class relying on either is not
+  iterable:
+  - the legacy `__getitem__`-only fallback — CPython iterates a class defining
+    `__getitem__` but not `__iter__` from index 0 until `IndexError`, while
+    Monty reports it as not iterable. (Note `monty -t` accepts `iter(obj)` for
+    such a class, so this fails only at runtime — see [iter.md](iter.md).)
+  - `__reversed__` — so `reversed(obj)` on any user instance raises
+    `TypeError: '{cls}' object is not reversible`. That matches CPython for a
+    class defining neither `__reversed__` nor `__len__` + `__getitem__`, and
+    diverges for one that does.
+- `__next__` is looked up on the class only, never the instance `__dict__`, and
+  a `StopIteration` raised anywhere inside it ends the iteration — including one
+  that propagates out of a nested call, where CPython's PEP 479 protections
+  apply only to generators, which Monty does not have.
 - Attribute-access hooks are **never** dispatched: `__getattr__`,
   `__getattribute__`, `__setattr__`, `__delattr__`, and `__del__`. A missing
   attribute always raises the default `AttributeError` even when the class

--- a/limitations/exceptions.md
+++ b/limitations/exceptions.md
@@ -96,8 +96,9 @@ before comparison, so traceback tests cannot catch it.
 
 An exception raised inside a Python callable that native code invokes
 *synchronously* — the `key=`/predicate/function argument of `map`, `filter`,
-`sorted`/`min`/`max`, and a user-defined `__iter__`/`__next__`/`__repr__`/`__str__`
-— omits the **calling** frame from its traceback; the callee frame is present.
+`sorted`/`min`/`max`, and a user-defined
+`__iter__`/`__next__`/`__contains__`/`__repr__`/`__str__` — omits the **calling**
+frame from its traceback; the callee frame is present.
 CPython shows both. This is a limitation of the re-entrant call path
 (`evaluate_function`), which does not splice the host call site into the
 traceback. The exception type and message are unaffected.

--- a/limitations/exceptions.md
+++ b/limitations/exceptions.md
@@ -93,3 +93,11 @@ Monty never emits CPython's `Did you mean: '...'?` suggestions on
 `NameError`/`AttributeError`. Note this divergence is invisible to the test
 suite: `scripts/run_traceback.py` strips the suggestions from CPython's output
 before comparison, so traceback tests cannot catch it.
+
+An exception raised inside a Python callable that native code invokes
+*synchronously* — the `key=`/predicate/function argument of `map`, `filter`,
+`sorted`/`min`/`max`, and a user-defined `__iter__`/`__next__`/`__repr__`/`__str__`
+— omits the **calling** frame from its traceback; the callee frame is present.
+CPython shows both. This is a limitation of the re-entrant call path
+(`evaluate_function`), which does not splice the host call site into the
+traceback. The exception type and message are unaffected.

--- a/limitations/iter.md
+++ b/limitations/iter.md
@@ -2,7 +2,6 @@
 
 - `iter(callable, sentinel)` runs `callable` synchronously, so one that calls an external/OS function cannot suspend and raises `NotImplementedError` — the same limitation as `map`/`filter`/`sorted(key=...)`.
 - `iter(callable, sentinel)` compares `result == sentinel`, where CPython compares `sentinel == result`; only observable if the two sides have asymmetric `__eq__`.
-- A `StopIteration` raised by `callable` propagates; CPython treats it as clean exhaustion and stops iterating.
 - A user instance defining `__call__` is rejected as not callable, since `__call__` is not dispatched (see [classes.md](classes.md)).
 - The vendored type stub is upstream typeshed's verbatim, so `-t` accepts `iter(obj)` for an object with only `__getitem__`; Monty has no `__getitem__` iteration fallback and raises `TypeError` at runtime.
 - Iterator `repr()` values omit CPython's process-local memory address, for example `<list_iterator object>` rather than `<list_iterator object at 0x...>`.

--- a/limitations/iter.md
+++ b/limitations/iter.md
@@ -2,7 +2,9 @@
 
 - `iter(callable, sentinel)` runs `callable` synchronously, so one that calls an external/OS function cannot suspend and raises `NotImplementedError` — the same limitation as `map`/`filter`/`sorted(key=...)`.
 - `iter(callable, sentinel)` compares `result == sentinel`, where CPython compares `sentinel == result`; only observable if the two sides have asymmetric `__eq__`.
+- A `StopIteration` raised by `callable` propagates; CPython treats it as clean exhaustion and stops iterating.
 - A user instance defining `__call__` is rejected as not callable, since `__call__` is not dispatched (see [classes.md](classes.md)).
 - The vendored type stub is upstream typeshed's verbatim, so `-t` accepts `iter(obj)` for an object with only `__getitem__`; Monty has no `__getitem__` iteration fallback and raises `TypeError` at runtime.
+- `-t` accepts `for x in obj` (though not `a, b = obj`) for a class that opts out of iteration with `__iter__ = None`, which raises `TypeError` at runtime as it does in CPython.
 - Iterator `repr()` values omit CPython's process-local memory address, for example `<list_iterator object>` rather than `<list_iterator object at 0x...>`.
 - Iterator-specific attributes such as `__length_hint__` are not exposed.


### PR DESCRIPTION
A class implementing the iterator protocol is now iterable everywhere — `for`,
`list()`/`sum()`/`sorted()`/`set()`, comprehensions, `in`, every unpacking form,
`join`, and `next()` — rather than raising `'C' object is not iterable`. The
type checker already accepted such a class, so this closes a `-t`-passes /
runtime-fails divergence rather than opening one.

`Instance` answers four `PyTrait` methods: `py_is_iterable`, `py_is_iterator`,
`py_iter` and `py_next`. The rest follows from #588 (every iteration callsite
routed through `py_iter`/`py_next`) and #589 (`py_is_iterable`). `MontyIter` is
untouched — once `py_iter` is overridden a user instance never reaches it.

Notable points:

- `py_iter` returns whatever `__iter__` returned, no wrapper interposed, so
  `iter(obj) is obj` holds for a self-iterator. The result must be an iterator,
  mirroring `PyObject_GetIter`'s `PyIter_Check` — that is what `py_is_iterator`
  is for.
- `py_next` gains `self_id: Option<HeapId>` because binding `self` needs the id
  and `HeapRead` does not carry one. `ValueRead::py_next` supplies it, so the
  ~30 builtin callers are untouched.
- `StopIteration` becomes exhaustion via `RunError::is_stop_iteration`, which
  matches only the catchable variant so a resource limit still propagates. The
  same helper fixes `iter(callable, sentinel)` — one bullet removed from
  `limitations/iter.md`.
- `str.join`/`bytes.join` rewrote any `into_py_iter` failure as `can only join
  an iterable`; now that a user `__iter__` can raise, they check
  `py_is_iterable` up front so `''.join(Boom())` surfaces the real error.

## `__contains__`

Dispatching `__iter__` would otherwise make a *wrong answer* reachable: `in`
never consulted `__contains__`, so a class defining both would silently return
the iteration answer where it previously raised. The last commit dispatches it
instead — `sq_contains` before `tp_iter`, with the result coerced by truthiness
as `PyObject_IsTrue` does.

`instance_call_dunder_sync` takes an optional argument to serve one-arg dunders,
and drops it itself when the class does not define the dunder, so no caller has
a path on which the clone can leak. The type checker needs nothing: `in` is an
operator, so it resolves against the class's own `__contains__` — verified with
a temporary probe in `good_types.py`, not assumed.

## Testing

`iter__user_class.py` covers every consumption site, both `__iter__` shapes and
each error path, byte-identical to CPython 3.14. `iter__reentrant.py` adds a
`__next__` that re-enters the object being advanced and one that mutates it
mid-iteration. `class__contains.py` covers precedence (the two answers are
deliberately opposite, so a fallback regression fails loudly), truthiness,
exception propagation, a non-callable `__contains__` and class-only lookup.

The two `refcount__*` cases prove nothing is retained; both were checked to
discriminate by breaking their expectations. Green under `memory-model-checks`
and `ref-count-return`. Suspension is a Rust-side test, since on CPython the
external is a real function and the call would succeed.

## Divergences

`limitations/classes.md`: `__iter__`/`__next__`/`__contains__` run
synchronously, so one calling an external/OS function raises
`NotImplementedError`; the `__getitem__`-only iteration fallback and
`__reversed__` remain undispatched. The `__contains__` entry is deleted rather
than reworded — the divergence is gone, not reshaped.
`limitations/exceptions.md`: a synchronously-invoked callable omits the calling
frame from its traceback — pre-existing, now also reachable here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds runtime dispatch for user-defined `__iter__`, `__next__`, and `__contains__` with CPython-accurate precedence, opt-outs, and error messages. Also upgrades refcount tests to detect real leaks via a transitive reachability walk.

- New Features
  - `in` calls `__contains__` first; `__contains__ = None` raises "'T' object is not a container". If absent, it iterates any iterable; non-containers raise "argument of type 'T' is not a container or iterable".
  - `__iter__ = None` opts out everywhere with "'T' object is not iterable". Unpacking and `*`-unpacking keep the plain wording for opted-out classes.
  - `iter(obj)` returns the user result unchanged. If it’s not an iterator, raise "iter() returned non-iterator of type 'T'" (via `py_is_iterator`).
  - `str.join`/`bytes.join` pre-check iterability so user `__iter__` errors surface. `__next__` is re-entrant-safe: `py_next(self_id, ...)` turns `StopIteration` into exhaustion; resource-limit errors propagate.

- Bug Fixes
  - `iter(callable, sentinel)` treats `StopIteration` from the callable as clean exhaustion.
  - `in` now falls back to iteration for any iterable (e.g. `callable_iterator`), not just a fixed set.
  - Unpacking errors distinguish opt-outs: opted-out classes keep "'T' object is not iterable" instead of site-specific wording.
  - Refcount strict check walks reachability from named globals; failures list unreachable heap objects by type/id, and tests no longer need extra bindings.

<sup>Written for commit 1380d9ca933dbaa1fb81f44b64495ee0d2c6c919. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

