### PR TITLE
Remove `ResourceError::Exception` and fix `check_replace_size` shrinking bypass

### DIFF
--- a/crates/monty-types/src/resource.rs
+++ b/crates/monty-types/src/resource.rs
@@ -14,7 +14,6 @@ use std::{cell::Cell, error::Error, fmt, time::Duration};
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use web_time::Instant;
 
-use crate::exceptions::MontyException;
 /// Threshold in bytes above which `check_large_result` is called.
 ///
 /// Operations that may produce results larger than this threshold (100KB) should call
@@ -26,6 +25,10 @@ pub const LARGE_RESULT_THRESHOLD: usize = 100_000;
 ///
 /// This allows the sandbox to enforce strict limits on allocation count,
 /// execution time, and memory usage.
+///
+/// All variants except `Recursion` are **uncatchable** inside the sandbox:
+/// untrusted code must never intercept resource enforcement. `Recursion`
+/// surfaces as a catchable `RecursionError`, matching CPython.
 #[derive(Debug, Clone)]
 pub enum ResourceError {
     /// Maximum number of allocations exceeded.
@@ -36,8 +39,6 @@ pub enum ResourceError {
     Memory { limit: usize, used: usize },
     /// Maximum recursion depth exceeded.
     Recursion { limit: usize, depth: usize },
-    /// Any other error, e.g. when propagating a python exception
-    Exception(MontyException),
 }
 
 impl fmt::Display for ResourceError {
@@ -54,9 +55,6 @@ impl fmt::Display for ResourceError {
             }
             Self::Recursion { .. } => {
                 write!(f, "maximum recursion depth exceeded")
-            }
-            Self::Exception(exc) => {
-                write!(f, "{exc}")
             }
         }
     }

--- a/crates/monty/src/bytecode/vm/exceptions.rs
+++ b/crates/monty/src/bytecode/vm/exceptions.rs
@@ -249,7 +249,7 @@ impl<T: ResourceTracker> VM<'_, T> {
         // Ensure exception has initial frame info
         error = self.attach_frame_to_error(error);
 
-        // For uncatchable exceptions (ResourceError like RecursionError),
+        // For terminal resource errors such as memory limits,
         // we still need to unwind the stack to collect all frames for the traceback
         if matches!(error, RunError::UncatchableExc(_) | RunError::Internal(_)) {
             return Some(self.unwind_for_traceback(error));
@@ -378,7 +378,7 @@ impl<T: ResourceTracker> VM<'_, T> {
 
     /// Unwinds the call stack to collect all frames for a traceback.
     ///
-    /// Used for uncatchable exceptions (like RecursionError) that can't be handled
+    /// Used for terminal resource errors that can't be handled
     /// but still need a complete traceback showing all active call frames.
     fn unwind_for_traceback(&mut self, mut error: RunError) -> RunError {
         // Pop frames and add caller frame info to the traceback

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1874,14 +1874,6 @@ impl SimpleException {
         f.write_char(')')
     }
 
-    pub(crate) fn with_frame(self, frame: RawStackFrame) -> ExceptionRaise {
-        ExceptionRaise {
-            exc: self,
-            frame: Some(frame),
-            hide_caret: false,
-        }
-    }
-
     pub(crate) fn with_position(self, position: CodeRange) -> ExceptionRaise {
         ExceptionRaise {
             exc: self,

--- a/crates/monty/src/resource_checks.rs
+++ b/crates/monty/src/resource_checks.rs
@@ -1,6 +1,6 @@
 use monty_types::{ExcType, LARGE_RESULT_THRESHOLD, ResourceError, ResourceTracker};
 
-use crate::exception_private::{ExceptionRaise, RawStackFrame, RunError, SimpleException};
+use crate::exception_private::{RunError, SimpleException};
 
 /// Pre-checks that an operation producing `item_len * count` bytes won't exceed resource limits.
 ///
@@ -71,7 +71,9 @@ pub fn check_div_size(dividend_bits: u64, tracker: &impl ResourceTracker) -> Res
 ///
 /// The upper bound on result size is: if `old` is non-empty, at most `input_len / old_len`
 /// replacements can occur, each producing `new_len` bytes instead of `old_len`. When `count`
-/// is specified, replacements are capped to that value.
+/// is specified, replacements are capped to that value. For shrinking replaces
+/// (`new_len < old_len`) matches only make the result smaller, so the worst case is zero
+/// matches: the full input copied into an untracked `String`/`Vec` — bound by `input_len`.
 pub fn check_replace_size(
     input_len: usize,
     old_len: usize,
@@ -79,21 +81,27 @@ pub fn check_replace_size(
     count: i64,
     tracker: &impl ResourceTracker,
 ) -> Result<(), ResourceError> {
-    // Empty pattern (old_len == 0): inserts before each element + after the last = input_len + 1
-    let max_replacements = input_len
-        .checked_div(old_len)
-        .unwrap_or_else(|| input_len.saturating_add(1));
-
-    let replacements = if count < 0 {
-        max_replacements
+    let estimated = if new_len < old_len {
+        // Shrinking replace: the max-matches formula below would *underestimate* the
+        // result (each match shrinks it), letting huge inputs skip the pre-check.
+        input_len
     } else {
-        max_replacements.min(usize::try_from(count).unwrap_or(usize::MAX))
-    };
+        // Empty pattern (old_len == 0): inserts before each element + after the last = input_len + 1
+        let max_replacements = input_len
+            .checked_div(old_len)
+            .unwrap_or_else(|| input_len.saturating_add(1));
 
-    // Result = input_len - (replacements * old_len) + (replacements * new_len)
-    let removed = replacements.saturating_mul(old_len);
-    let added = replacements.saturating_mul(new_len);
-    let estimated = input_len.saturating_sub(removed).saturating_add(added);
+        let replacements = if count < 0 {
+            max_replacements
+        } else {
+            max_replacements.min(usize::try_from(count).unwrap_or(usize::MAX))
+        };
+
+        // Result = input_len - (replacements * old_len) + (replacements * new_len)
+        let removed = replacements.saturating_mul(old_len);
+        let added = replacements.saturating_mul(new_len);
+        input_len.saturating_sub(removed).saturating_add(added)
+    };
 
     check_estimated_size(estimated, tracker)
 }
@@ -120,49 +128,42 @@ fn estimate_bits_to_bytes(bits: u64) -> usize {
     usize::try_from(bits.saturating_add(7) / 8).unwrap_or(usize::MAX)
 }
 
-/// Converts a resource error to a Python exception with optional stack frame.
-///
-/// Maps resource error types to Python exception types:
-/// - `Allocation` → `MemoryError`
-/// - `Memory` → `MemoryError`
-/// - `Time` → `TimeoutError`
-/// - `Recursion` → `RecursionError`
-pub(crate) fn resource_error_into_exception(err: ResourceError, frame: Option<RawStackFrame>) -> ExceptionRaise {
-    let (exc_type, msg) = match err {
-        ResourceError::Allocation { limit, count } => (
-            ExcType::MemoryError,
-            Some(format!("allocation limit exceeded: {count} > {limit}")),
-        ),
-        ResourceError::Memory { limit, used } => (
-            ExcType::MemoryError,
-            Some(format!("memory limit exceeded: {used} bytes > {limit} bytes")),
-        ),
-        ResourceError::Time { limit, elapsed } => (
-            ExcType::TimeoutError,
-            Some(format!("time limit exceeded: {elapsed:?} > {limit:?}")),
-        ),
-        ResourceError::Recursion { .. } => (
-            ExcType::RecursionError,
-            Some("maximum recursion depth exceeded".to_string()),
-        ),
-        ResourceError::Exception(exc) => (exc.exc_type(), exc.into_message()),
-    };
-    let exc = SimpleException::new(exc_type, msg);
-    match frame {
-        Some(f) => exc.with_frame(f),
-        None => exc.into(),
-    }
-}
-
+/// Converts a resource error to a Python exception, deciding type, message and
+/// catchability in a single lookup: `Allocation`/`Memory` → `MemoryError`,
+/// `Time` → `TimeoutError`, `Recursion` → `RecursionError`. Only
+/// `RecursionError` is catchable (matching CPython); the rest are uncatchable
+/// so untrusted code cannot suppress resource limit violations.
 impl From<ResourceError> for RunError {
     fn from(err: ResourceError) -> Self {
-        // RecursionError is catchable in CPython, so it must be catchable here too.
-        // Other resource errors (memory, time, allocation) remain uncatchable to prevent
-        // untrusted code from suppressing resource limit violations.
-        if matches!(err, ResourceError::Recursion { .. }) {
-            Self::Exc(resource_error_into_exception(err, None))
-        } else {
-            Self::UncatchableExc(resource_error_into_exception(err, None))
+        match err {
+            ResourceError::Allocation { limit, count } => Self::UncatchableExc(
+                SimpleException::new(
+                    ExcType::MemoryError,
+                    Some(format!("allocation limit exceeded: {count} > {limit}")),
+                )
+                .into(),
+            ),
+            ResourceError::Memory { limit, used } => Self::UncatchableExc(
+                SimpleException::new(
+                    ExcType::MemoryError,
+                    Some(format!("memory limit exceeded: {used} bytes > {limit} bytes")),
+                )
+                .into(),
+            ),
+            ResourceError::Time { limit, elapsed } => Self::UncatchableExc(
+                SimpleException::new(
+                    ExcType::TimeoutError,
+                    Some(format!("time limit exceeded: {elapsed:?} > {limit:?}")),
+                )
+                .into(),
+            ),
+            ResourceError::Recursion { .. } => Self::Exc(
+                SimpleException::new(
+                    ExcType::RecursionError,
+                    Some("maximum recursion depth exceeded".to_string()),
+                )
+                .into(),
+            ),
         }
     }
 }

--- a/crates/monty/src/resource_checks.rs
+++ b/crates/monty/src/resource_checks.rs
@@ -65,15 +65,9 @@ pub fn check_div_size(dividend_bits: u64, tracker: &impl ResourceTracker) -> Res
 
 /// Pre-checks that a string/bytes replace won't exceed resource limits before allocating.
 ///
-/// This prevents DoS via expressions like `('a' * 1000).replace('a', 'b' * 10_000_000)`
-/// where a small tracked input is amplified into a huge untracked Rust `String`/`Vec`
-/// by `String::replace()` before `allocate_string()` can check the result.
-///
-/// The upper bound on result size is: if `old` is non-empty, at most `input_len / old_len`
-/// replacements can occur, each producing `new_len` bytes instead of `old_len`. When `count`
-/// is specified, replacements are capped to that value. For shrinking replaces
-/// (`new_len < old_len`) matches only make the result smaller, so the worst case is zero
-/// matches: the full input copied into an untracked `String`/`Vec` — bound by `input_len`.
+/// Expanding replacements use the maximum possible match count. Shrinking
+/// replacements use `input_len`, since zero matches copies the full input into
+/// an otherwise untracked Rust `String` or `Vec`.
 pub fn check_replace_size(
     input_len: usize,
     old_len: usize,
@@ -82,8 +76,6 @@ pub fn check_replace_size(
     tracker: &impl ResourceTracker,
 ) -> Result<(), ResourceError> {
     let estimated = if new_len < old_len {
-        // Shrinking replace: the max-matches formula below would *underestimate* the
-        // result (each match shrinks it), letting huge inputs skip the pre-check.
         input_len
     } else {
         // Empty pattern (old_len == 0): inserts before each element + after the last = input_len + 1
@@ -128,42 +120,22 @@ fn estimate_bits_to_bytes(bits: u64) -> usize {
     usize::try_from(bits.saturating_add(7) / 8).unwrap_or(usize::MAX)
 }
 
-/// Converts a resource error to a Python exception, deciding type, message and
-/// catchability in a single lookup: `Allocation`/`Memory` → `MemoryError`,
-/// `Time` → `TimeoutError`, `Recursion` → `RecursionError`. Only
-/// `RecursionError` is catchable (matching CPython); the rest are uncatchable
-/// so untrusted code cannot suppress resource limit violations.
+/// Converts a resource error to its host-visible Python exception.
+///
+/// Recursion errors remain catchable for CPython compatibility; terminal
+/// memory and time errors cannot be suppressed by sandboxed code.
 impl From<ResourceError> for RunError {
     fn from(err: ResourceError) -> Self {
-        match err {
-            ResourceError::Allocation { limit, count } => Self::UncatchableExc(
-                SimpleException::new(
-                    ExcType::MemoryError,
-                    Some(format!("allocation limit exceeded: {count} > {limit}")),
-                )
-                .into(),
-            ),
-            ResourceError::Memory { limit, used } => Self::UncatchableExc(
-                SimpleException::new(
-                    ExcType::MemoryError,
-                    Some(format!("memory limit exceeded: {used} bytes > {limit} bytes")),
-                )
-                .into(),
-            ),
-            ResourceError::Time { limit, elapsed } => Self::UncatchableExc(
-                SimpleException::new(
-                    ExcType::TimeoutError,
-                    Some(format!("time limit exceeded: {elapsed:?} > {limit:?}")),
-                )
-                .into(),
-            ),
-            ResourceError::Recursion { .. } => Self::Exc(
-                SimpleException::new(
-                    ExcType::RecursionError,
-                    Some("maximum recursion depth exceeded".to_string()),
-                )
-                .into(),
-            ),
+        let (exc_type, catchable) = match &err {
+            ResourceError::Allocation { .. } | ResourceError::Memory { .. } => (ExcType::MemoryError, false),
+            ResourceError::Time { .. } => (ExcType::TimeoutError, false),
+            ResourceError::Recursion { .. } => (ExcType::RecursionError, true),
+        };
+        let exc = SimpleException::new_msg(exc_type, err).into();
+        if catchable {
+            Self::Exc(exc)
+        } else {
+            Self::UncatchableExc(exc)
         }
     }
 }

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -1764,6 +1764,34 @@ s.replace('', 'x' * 1000)
     assert_eq!(exc.exc_type(), ExcType::MemoryError);
 }
 
+/// Test that a shrinking `str.replace` is pre-checked against the full input size.
+///
+/// When `new` is shorter than `old`, the max-replacements formula estimates a result
+/// *smaller* than the input, but the true worst case (zero matches) copies the whole
+/// input into an untracked Rust `String` — the pre-check must bound by the input length.
+#[test]
+fn str_replace_shrinking_memory_limit() {
+    let code = r"
+s = 'ab' * 150000
+s.replace('ab', 'a')
+";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+
+    let limits = ResourceLimits::new().max_memory(500_000);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
+    assert!(
+        result.is_err(),
+        "shrinking str.replace of a large input should be pre-checked"
+    );
+    let exc = result.unwrap_err();
+    assert_eq!(exc.exc_type(), ExcType::MemoryError);
+    assert!(
+        exc.message().is_some_and(|m| m.contains("memory limit exceeded")),
+        "expected memory limit error, got: {exc}"
+    );
+}
+
 /// Test that `str.ljust` with huge width is rejected before allocation.
 ///
 /// Without the pre-check, `String::with_capacity(width)` would allocate

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -1764,16 +1764,12 @@ s.replace('', 'x' * 1000)
     assert_eq!(exc.exc_type(), ExcType::MemoryError);
 }
 
-/// Test that a shrinking `str.replace` is pre-checked against the full input size.
-///
-/// When `new` is shorter than `old`, the max-replacements formula estimates a result
-/// *smaller* than the input, but the true worst case (zero matches) copies the whole
-/// input into an untracked Rust `String` — the pre-check must bound by the input length.
+/// A non-matching shrinking `str.replace` is pre-checked against the full input.
 #[test]
 fn str_replace_shrinking_memory_limit() {
     let code = r"
 s = 'ab' * 150000
-s.replace('ab', 'a')
+s.replace('cd', 'a')
 ";
     let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
 
@@ -1786,9 +1782,33 @@ s.replace('ab', 'a')
     );
     let exc = result.unwrap_err();
     assert_eq!(exc.exc_type(), ExcType::MemoryError);
+    assert_eq!(
+        exc.message(),
+        Some("memory limit exceeded: 600024 bytes > 500000 bytes")
+    );
+}
+
+/// A non-matching shrinking `bytes.replace` is pre-checked against the full input.
+#[test]
+fn bytes_replace_shrinking_memory_limit() {
+    let code = r"
+s = b'ab' * 150000
+s.replace(b'cd', b'a')
+";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+
+    let limits = ResourceLimits::new().max_memory(500_000);
+    let result = ex.run(vec![], LimitedTracker::new(limits), PrintWriter::Stdout);
+
     assert!(
-        exc.message().is_some_and(|m| m.contains("memory limit exceeded")),
-        "expected memory limit error, got: {exc}"
+        result.is_err(),
+        "shrinking bytes.replace of a large input should be pre-checked"
+    );
+    let exc = result.unwrap_err();
+    assert_eq!(exc.exc_type(), ExcType::MemoryError);
+    assert_eq!(
+        exc.message(),
+        Some("memory limit exceeded: 600032 bytes > 500000 bytes")
     );
 }
 

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -1,9 +1,10 @@
 # Resource limits
 
 Monty enforces hard limits on memory, time, allocations, and recursion to
-keep untrusted code bounded. When a limit is exceeded, execution
-terminates with a `ResourceError` (visible to the *host*, not catchable
-inside the sandbox).
+keep untrusted code bounded. When a memory, time, or allocation limit is
+exceeded, execution terminates with a `ResourceError` (visible to the
+*host*, not catchable inside the sandbox). `RecursionError` is catchable,
+as in CPython.
 
 ## Memory / size limits
 

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -1,10 +1,10 @@
 # Resource limits
 
 Monty enforces hard limits on memory, time, allocations, and recursion to
-keep untrusted code bounded. When a memory, time, or allocation limit is
-exceeded, execution terminates with a `ResourceError` (visible to the
-*host*, not catchable inside the sandbox). `RecursionError` is catchable,
-as in CPython.
+keep untrusted code bounded. Memory and allocation limits surface to the host
+as terminal `MemoryError`s, while time limits surface as terminal
+`TimeoutError`s; sandboxed code cannot catch them. `RecursionError` is
+catchable, as in CPython.
 
 ## Memory / size limits
 
@@ -18,12 +18,13 @@ as in CPython.
   process RSS.
 - Operations whose result is bounded by simple arithmetic on input sizes
   are **pre-checked** before allocating: integer multiplication, left
-  shift, integer power, sequence repeat (`'x' * n`), padding (`str.ljust`,
-  `str.center`, `str.zfill`, `bytes.ljust`, …), and f-string formatting
+  shift, integer power, sequence repeat (`'x' * n`), replacement
+  (`str.replace`, `bytes.replace`), padding (`str.ljust`, `str.center`,
+  `str.zfill`, `bytes.ljust`, …), and f-string formatting
   (both dynamic width `f"{v:>{w}}"` and dynamic precision on float
   formats `f"{v:.{p}f}"` / `e` / `%`). The pre-check threshold is 100 KB —
-  anything that would estimate above that is rejected with `ResourceError`
-  rather than attempting the allocation.
+  estimates above that are checked against the remaining budget and rejected
+  with `MemoryError` before allocation when they would exceed it.
 - `bigint.pow(base, exp)` estimates result size as `bits(base) * exp` with
   a 4× safety multiplier to cover repeated-squaring intermediate values.
 
@@ -77,8 +78,9 @@ as in CPython.
 - `json.loads` rejects input nested deeper than 200 levels with
   `json.JSONDecodeError` (independent of the Python recursion limit).
 
-## After a ResourceError
+## After a terminal resource error
 
-When a resource limit fires, **no guarantees are made about heap state or
-reference counts**. The host should discard the VM rather than try to
-recover and continue running code in it.
+After a memory, allocation, or time limit fires, **no guarantees are made about
+heap state or reference counts**. The host should discard the VM rather than
+try to recover and continue running code in it. A caught `RecursionError` does
+not invalidate the VM and execution may continue inside the sandbox.


### PR DESCRIPTION
- Remove the ResourceError::Exception variant: its only user was the old in-process PySignalTracker (Ctrl+C propagation), gone since execution moved to subprocess pools. monty-types' resource module no longer depends on MontyException.
- Fold resource_error_into_exception into From<ResourceError> for RunError so exception type, message, and catchability are decided in one match; drop the never-used frame parameter and SimpleException::with_frame.
- check_replace_size: bound shrinking replaces (new_len < old_len) by input_len — the max-matches formula underestimates the zero-match worst case, letting huge inputs skip the pre-allocation check.
- Document that RecursionError is catchable (matching CPython) while other resource errors are not.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `ResourceError::Exception`, unified resource error → Python exception mapping in `From<ResourceError> for RunError`, and fixed string/bytes `replace` pre-check to block the zero‑match shrinking bypass. Only `RecursionError` is catchable; memory/time/allocation errors are terminal.

- **Bug Fixes**
  - Bound shrinking `str.replace`/`bytes.replace` by `input_len` so large inputs can’t skip pre-allocation checks; added tests for both types.

- **Refactors**
  - Removed `ResourceError::Exception`; `monty-types` no longer depends on `MontyException`. Dropped `resource_error_into_exception`, unused frame plumbing, and `SimpleException::with_frame`. Docs clarified that only `RecursionError` is catchable; other resource errors are uncatchable.

<sup>Written for commit ea917acf6670a70dca1267165f4ada10bc82e31e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

