### PR TITLE
Reject action-less open modes, fix mixed-indent traceback dedent

### DIFF
--- a/crates/monty-types/src/builtins.rs
+++ b/crates/monty-types/src/builtins.rs
@@ -26,6 +26,7 @@ use strum::{Display, EnumString, FromRepr, IntoStaticStr};
     serde::Deserialize,
 )]
 #[strum(serialize_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
 #[repr(u8)]
 pub enum BuiltinsFunctions {
     Abs,

--- a/crates/monty-types/src/file_mode.rs
+++ b/crates/monty-types/src/file_mode.rs
@@ -152,20 +152,13 @@ impl FileMode {
 /// text or binary form. Exclusive creation (`x`) is rejected for now because
 /// it needs a dedicated mount-table operation to be race-free.
 ///
-/// The `Err` payload is a CPython-matched message — empty input, an unknown
-/// mode character, duplicated `b`/`t`/`+`, conflicting binary+text flags, or
-/// more than one of the `r`/`w`/`a` actions.
+/// The `Err` payload is a CPython-matched message — an unknown mode
+/// character, duplicated `b`/`t`/`+`, conflicting binary+text flags, more
+/// than one of the `r`/`w`/`a` actions, or none at all (`''`, `'b'`, `'t'`).
 impl FromStr for FileMode {
     type Err = Cow<'static, str>;
 
     fn from_str(mode: &str) -> Result<Self, Self::Err> {
-        if mode.is_empty() {
-            // CPython's empty-mode error message, mirrored verbatim. Note: the
-            // duplicate-action message is different (lowercase, no `... and at most one
-            // plus` suffix) — see the `'r' | 'w' | 'a'` arm.
-            return Err("Must have exactly one of create/read/write/append mode and at most one plus".into());
-        }
-
         let mut action = None;
         let mut binary = false;
         let mut text = false;
@@ -174,6 +167,8 @@ impl FromStr for FileMode {
             match ch {
                 'r' | 'w' | 'a' => {
                     if action.replace(ch).is_some() {
+                        // CPython's duplicate-action message differs from the missing-action
+                        // one below (lowercase, no `... and at most one plus` suffix).
                         return Err("must have exactly one of create/read/write/append mode".into());
                     }
                 }
@@ -204,10 +199,13 @@ impl FromStr for FileMode {
             return Err("can't have text and binary mode at once".into());
         }
 
-        Ok(match action.unwrap_or('r') {
-            'w' => Self::Write(binary),
-            'a' => Self::Append(binary),
-            _ => Self::Read(binary),
-        })
+        // A mode with no `r`/`w`/`a` action (`''`, `'b'`, `'t'`) gets
+        // CPython's capitalized missing-action message, mirrored verbatim.
+        match action {
+            Some('w') => Ok(Self::Write(binary)),
+            Some('a') => Ok(Self::Append(binary)),
+            Some(_) => Ok(Self::Read(binary)),
+            None => Err("Must have exactly one of create/read/write/append mode and at most one plus".into()),
+        }
     }
 }

--- a/crates/monty/src/source_map.rs
+++ b/crates/monty/src/source_map.rs
@@ -103,13 +103,15 @@ impl<'s> SourceMap<'s> {
         } else {
             vec![self.line_text(start_line_idx), self.line_text(end_line_idx)]
         };
-        // Common leading-whitespace prefix across non-blank displayed lines.
+        // Common leading-whitespace prefix across non-blank displayed lines,
+        // comparing actual characters (not just lengths) so mixed tab/space
+        // indentation never strips mismatched whitespace.
         let dedent = displayed
             .iter()
             .filter(|line| !line.trim().is_empty())
-            .map(|line| line.len() - line.trim_start().len())
-            .min()
-            .unwrap_or(0);
+            .map(|line| &line[..line.len() - line.trim_start().len()])
+            .reduce(|a, b| common_prefix(a, b))
+            .map_or(0, str::len);
         let stripped = |line: &str| line.get(dedent..).unwrap_or("").to_owned();
         if total <= 3 {
             displayed
@@ -169,6 +171,20 @@ impl<'s> SourceMap<'s> {
         let line = &self.source[start..end];
         line.strip_suffix('\r').unwrap_or(line)
     }
+}
+
+/// Returns the longest common prefix of `a` and `b`, always cut on a char
+/// boundary. Used by [`SourceMap::multiline_preview`] to find the shared
+/// indentation of the displayed lines.
+fn common_prefix<'a>(a: &'a str, b: &str) -> &'a str {
+    let end = a
+        .char_indices()
+        .zip(b.chars())
+        .find(|&((_, ca), cb)| ca != cb)
+        // All zipped chars equal: the shorter string is the common prefix, and
+        // equal chars encode identically so its byte length indexes `a` safely.
+        .map_or(a.len().min(b.len()), |((i, _), _)| i);
+    &a[..end]
 }
 
 /// Crate-internal builders for [`StackFrame`] (which lives in `monty-types`):

--- a/crates/monty/test_cases/open__fs.py
+++ b/crates/monty/test_cases/open__fs.py
@@ -292,6 +292,24 @@ try:
 except ValueError as exc:
     assert str(exc) == "invalid mode: 'z'", f'unexpected unknown mode message: {exc}'
 
+# A `b`/`t` flag alone supplies no r/w/a action and must be rejected, not
+# silently treated as a read.
+try:
+    open(root / 'hello.txt', 'b')
+    assert False, 'expected action-less binary mode to fail'
+except ValueError as exc:
+    assert str(exc) == 'Must have exactly one of create/read/write/append mode and at most one plus', (
+        f'unexpected action-less mode message: {exc}'
+    )
+
+try:
+    open(root / 'hello.txt', 't')
+    assert False, 'expected action-less text mode to fail'
+except ValueError as exc:
+    assert str(exc) == 'Must have exactly one of create/read/write/append mode and at most one plus', (
+        f'unexpected action-less mode message: {exc}'
+    )
+
 # === Sized read ===
 # Set up a multi-line text fixture for the rest of these tests.
 (root / 'sized.txt').write_text('hello world')

--- a/crates/monty/tests/json_serde.rs
+++ b/crates/monty/tests/json_serde.rs
@@ -85,6 +85,19 @@ fn json_output_repr() {
 }
 
 #[test]
+fn json_output_builtin_function() {
+    // Builtin functions serialize by their lowercase Python name, matching
+    // the strum `Display`/wire representation.
+    assert_snapshot!(to_json(&eval("print")), @r#"{"BuiltinFunction":"print"}"#);
+}
+
+#[test]
+fn json_deserialize_builtin_function() {
+    let obj: MontyObject = serde_json::from_str(r#"{"BuiltinFunction":"print"}"#).unwrap();
+    assert_eq!(obj, eval("print"));
+}
+
+#[test]
 fn json_output_cycle_list() {
     // Cyclic references become MontyObject::Cycle on serialization.
     assert_snapshot!(

--- a/crates/monty/tests/main.rs
+++ b/crates/monty/tests/main.rs
@@ -83,6 +83,23 @@ fn subscript_augassign_matmul_reports_not_supported() {
     );
 }
 
+/// Multiline traceback previews dedent by the common leading-whitespace
+/// *prefix* of the displayed lines; with mixed tab/space indentation there is
+/// no common prefix, so lines keep their original indentation (matching
+/// CPython) rather than having unrelated whitespace blindly stripped. Kept as
+/// a Rust-side test because CPython adds caret anchors to the `in C` frame
+/// that Monty omits, so the comparative test-case suite cannot cover it.
+#[test]
+fn multiline_preview_mixed_indentation_not_dedented() {
+    let code = "if True:\n    class C:\n        x = (1 /\n\t0)";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let err = ex.run_no_limits(vec![]).unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Traceback (most recent call last):\n  File \"test.py\", line 2, in <module>\n        class C:\n            x = (1 /\n    \t0)\n  File \"test.py\", line 3, in C\n            x = (1 /\n    \t0)\nZeroDivisionError: division by zero"
+    );
+}
+
 /// A class whose `__init__` is bound to an external function cannot suspend:
 /// non-plain-function `__init__` runs synchronously via `evaluate_function`,
 /// which cannot yield to the host, so the call raises `NotImplementedError`

--- a/limitations/open.md
+++ b/limitations/open.md
@@ -39,9 +39,11 @@ further down.
   mount-table operation.
 - The mode string is normalized to a canonical form at parse time
   (`'rt'` → `'r'`, `'br'` → `'rb'`); the original raw input is not
-  preserved, and `file.mode` reports the canonical form. CPython instead
-  preserves and reports the string as passed: `open(p, 'rt').mode` is
-  `'rt'` in CPython but `'r'` in Monty.
+  preserved, and `file.mode` reports the canonical form. For *text* modes
+  this diverges from CPython, whose `TextIOWrapper` preserves the string
+  as passed: `open(p, 'rt').mode` is `'rt'` in CPython but `'r'` in Monty.
+  Binary modes match, because CPython's buffered classes normalize too
+  (`open(p, 'br').mode` is `'rb'` in both).
 
 ## `open()` arguments
 

--- a/limitations/open.md
+++ b/limitations/open.md
@@ -37,9 +37,11 @@ further down.
 - Exclusive creation mode (`x`) is rejected with `ValueError: exclusive
   creation mode is not supported`; it would need a dedicated race-free
   mount-table operation.
-- The mode string is normalized to CPython's canonical form
-  (`'rt'` → `'r'`, `'r+b'` → `'rb+'`); the original raw input is not
-  preserved.
+- The mode string is normalized to a canonical form at parse time
+  (`'rt'` → `'r'`, `'br'` → `'rb'`); the original raw input is not
+  preserved, and `file.mode` reports the canonical form. CPython instead
+  preserves and reports the string as passed: `open(p, 'rt').mode` is
+  `'rt'` in CPython but `'r'` in Monty.
 
 ## `open()` arguments
 


### PR DESCRIPTION
Follow-ups from the #592 review:

- `open(f, 'b')` / `open(f, 't')` no longer default to read mode; they now raise CPython's "Must have exactly one of create/read/write/append mode and at most one plus" ValueError.
- Document that `file.mode` reports the canonical mode string ('rt' -> 'r') where CPython preserves the raw input, in limitations/open.md.
- Multiline traceback previews dedent by the true common leading-whitespace prefix instead of the minimum whitespace length, so mixed tab/space indentation is no longer corrupted (matches CPython, which applies no dedent when there is no common prefix).
- `BuiltinsFunctions` serde now emits the documented lowercase variant names via `#[serde(rename_all = "lowercase")]`; snapshot-safe (postcard is index-based) and wire-safe (strum Display was already lowercase).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects action-less `open()` modes, fixes mixed-indent traceback dedent to match CPython, and standardizes builtin-function JSON names to lowercase. Docs clarify that `file.mode` normalization only diverges from CPython for text modes; binary modes match.

- **Bug Fixes**
  - `open(path, 'b'|'t'|'')` now raises ValueError: "Must have exactly one of create/read/write/append mode and at most one plus".
  - Multiline traceback previews dedent by the common leading-whitespace prefix; mixed tabs/spaces are preserved.
  - `BuiltinsFunctions` JSON serialization uses lowercase variant names; tests cover serialization and deserialization.

<sup>Written for commit 8b48a7cd0c5bb4ce91bf6c67fa4a2e23ab70d195. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

