### PR TITLE
use same build profile for codspeed as release

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -35,8 +35,11 @@ jobs:
         with:
           python-version: '3.14'
 
+      # Pinned so a rust-cache hit can't silently keep serving an old binary
+      # (older versions lack `--profile` and build without the workspace's
+      # LTO settings, skewing benchmark numbers).
       - name: Install cargo-codspeed
-        run: cargo install cargo-codspeed
+        run: cargo install cargo-codspeed --version 5.0.1 --locked
 
       # The `pool` bench's workers run the `monty` CLI. Build it in RELEASE so
       # the workers are optimized (a debug interpreter would make the pool
@@ -49,9 +52,12 @@ jobs:
         run: cargo build -p monty-runtime --release
 
       # No `--bench` filter: build and run every monty-bench target (`main` +
-      # `pool`). CodSpeed runs all benches built into the package.
+      # `pool`). CodSpeed runs all benches built into the package. The
+      # `codspeed` profile (root Cargo.toml) is release codegen — fat LTO,
+      # one codegen unit — with symbols kept for CodSpeed's flamegraphs, so
+      # measurements reflect the optimization level users actually run.
       - name: Build benchmarks
-        run: cargo codspeed build -p monty-bench
+        run: cargo codspeed build -p monty-bench --profile codspeed
 
       - name: Run benchmarks
         uses: CodSpeedHQ/action@d872884a306dd4853acf0f584f4b706cf0cc72a2 # v4.13.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,14 @@ debug = true
 strip = false
 lto = false
 
+# CodSpeed benchmark builds: production codegen (fat LTO, single codegen unit
+# inherited from release) but with symbols kept so CodSpeed can build
+# flamegraphs — release's `strip = true` would discard them.
+[profile.codspeed]
+inherits = "release"
+debug = true
+strip = false
+
 [workspace.dependencies]
 # Internal crates. The `path` is used for local/workspace builds; the `version`
 # is required so the crates can be published to crates.io (`cargo publish`


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Align CodSpeed benchmark builds with the release profile so results reflect production optimizations, while keeping symbols for flamegraphs. Adds a `codspeed` Cargo profile and updates the workflow to use it.

- **Refactors**
  - Add `[profile.codspeed]` inheriting `release` with `debug = true` and `strip = false` to keep symbols; retains release-level codegen (fat LTO, single codegen unit).
  - Update CI to run `cargo codspeed build -p \`monty-bench\` --profile codspeed`.

- **Dependencies**
  - Pin `cargo-codspeed` to `5.0.1` with `--locked` to avoid outdated binaries that lack `--profile` support.

<sup>Written for commit f44247c26f7bc37581628dd850ed93056bcde7c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

