### PR TITLE
Spike: open module-registry seam (illustrates #601)

### DIFF
--- a/crates/monty/src/bytecode/compiler.rs
+++ b/crates/monty/src/bytecode/compiler.rs
@@ -30,7 +30,7 @@ use crate::{
     fstring::{ConversionFlag, FStringPart, FormatSpec},
     function::Function,
     intern::{Interns, StringId},
-    modules::StandardLib,
+    modules::{StandardLib, registry},
     name_map::NameMap,
     parse::{CodeRange, ExceptHandler, Try},
     run::CompileOptions,
@@ -972,10 +972,14 @@ impl<'a> Compiler<'a> {
         let position = binding.position;
         self.code.set_location(position, None);
 
-        // Look up the module by name
-        if let Some(builtin_module) = StandardLib::from_string_id(module_name) {
-            // Known module - emit LoadModule
-            self.code.emit_u8(Opcode::LoadModule, builtin_module as u8)?;
+        // A module is known if it is in the open registry or the StandardLib
+        // enum. Both are static, so the compiler needs no registry borrow.
+        let known = registry::is_registered(self.interns.get_str(module_name))
+            || StandardLib::from_string_id(module_name).is_some();
+        if known {
+            // Known module - emit LoadModule carrying the module name (const-pool id).
+            let name_const = self.code.add_const(Value::InternString(module_name))?;
+            self.code.emit_u16(Opcode::LoadModule, name_const)?;
             // Store to the binding (respects Local/Global/Cell scope)
             self.compile_store(binding)?;
         } else {
@@ -1001,10 +1005,14 @@ impl<'a> Compiler<'a> {
     ) -> Result<(), CompileError> {
         self.code.set_location(position, None);
 
-        // Look up the module
-        if let Some(builtin_module) = StandardLib::from_string_id(module_name) {
-            // Known module - emit LoadModule
-            self.code.emit_u8(Opcode::LoadModule, builtin_module as u8)?;
+        // A module is known if it is in the open registry or the StandardLib
+        // enum. Both are static, so the compiler needs no registry borrow.
+        let known = registry::is_registered(self.interns.get_str(module_name))
+            || StandardLib::from_string_id(module_name).is_some();
+        if known {
+            // Known module - emit LoadModule carrying the module name (const-pool id).
+            let name_const = self.code.add_const(Value::InternString(module_name))?;
+            self.code.emit_u16(Opcode::LoadModule, name_const)?;
 
             // For each name to import
             for (i, (import_name, binding)) in names.iter().enumerate() {

--- a/crates/monty/src/bytecode/op.rs
+++ b/crates/monty/src/bytecode/op.rs
@@ -431,10 +431,12 @@ pub enum Opcode {
     Nop,
 
     // === Module Operations ===
-    /// Load a built-in module onto the stack. Operand: u8 module_id.
+    /// Load a built-in module onto the stack. Operand: u16 constant index for the module name.
     ///
-    /// The module_id maps to `BuiltinModule` (0=sys, 1=typing).
-    /// Creates the module on the heap and pushes a `Value::Ref` to it.
+    /// The operand indexes the constant pool at an `InternString` holding the
+    /// module name (the same encoding `RaiseImportError` uses). The VM resolves
+    /// it against the open module registry then `StandardLib`, creates the
+    /// module on the heap, and pushes a `Value::Ref` to it.
     LoadModule,
     /// Raises `ModuleNotFoundError` at runtime. Operand: u16 constant index for module name.
     ///
@@ -753,7 +755,7 @@ impl Opcode {
             (LoadSmallInt, Operand::I8(_)) => 1,
 
             // === Fixed-effect, U8 operand ===
-            (LoadLocal | LoadModule, Operand::U8(_)) => 1,
+            (LoadLocal, Operand::U8(_)) => 1,
             (StoreLocal, Operand::U8(_)) => -1,
             (DeleteLocal, Operand::U8(_)) => 0,
             // `ListAppend`/`SetAdd`/`DictSetItem` carry a u8 stack-depth operand
@@ -777,7 +779,7 @@ impl Opcode {
             (WithExceptStart, Operand::None) => 1,
 
             // === Fixed-effect, U16 operand ===
-            (LoadConst, Operand::U16(_)) => 1,
+            (LoadConst | LoadModule, Operand::U16(_)) => 1,
             (CompareModEq, Operand::U16(_)) => -1,
             (LoadLocalW | LoadGlobal | LoadCell, Operand::U16(_)) => 1,
             (StoreLocalW | StoreGlobal | StoreCell, Operand::U16(_)) => -1,

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -20,6 +20,7 @@ use crate::{
     heap::{ContainsHeap, DropGuard, DropWithContext, HeapData, HeapId},
     heap_data::CellValue,
     intern::{FunctionId, StaticStrings, StringId},
+    modules::registry,
     types::{Dict, Instance, PyTrait, Type, bytes::call_bytes_method, instance::class_name, str::call_str_method},
     value::{EitherStr, Value},
 };
@@ -481,6 +482,7 @@ impl VM<'_> {
         match callable {
             Value::Builtin(builtin) => builtin.call(self, args),
             Value::ModuleFunction(mf) => mf.call(self, args),
+            Value::RegistryFunction(id) => registry::call(*id, self, args),
             Value::ExtFunction(name_id) => {
                 // External function - return to caller to execute
                 Ok(CallResult::External(EitherStr::Interned(*name_id), args))

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -34,7 +34,7 @@ use crate::{
     heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapReadOutput, HeapReader},
     heap_data::{Closure, FunctionDefaults},
     intern::{FunctionId, Interns, StaticStrings, StringId},
-    modules::{StandardLib, json::JsonStringCache, re::RePatternCache},
+    modules::{StandardLib, json::JsonStringCache, re::RePatternCache, registry},
     object_bridge::MontyObjectExt,
     parse::CodeRange,
     types::{
@@ -1794,8 +1794,17 @@ impl<'h> VM<'h> {
                 }
                 // Module Operations
                 Opcode::LoadModule => {
-                    let module_id = cached_frame.fetch_u8();
-                    try_catch_sync!(self, cached_frame, self.load_module(module_id));
+                    // Operand is a u16 const-pool index at an InternString holding
+                    // the module name (written by compile_import/compile_import_from).
+                    let const_idx = cached_frame.fetch_u16();
+                    // As with `RaiseImportError` below, a non-InternString constant is
+                    // only possible via a corrupt snapshot; degrade to a catchable
+                    // error rather than panicking.
+                    let name_id = match cached_frame.code.constants().get(const_idx) {
+                        Value::InternString(id) => Ok(*id),
+                        _ => Err(ExcType::module_not_found_error("<unknown>")),
+                    };
+                    try_catch_sync!(self, cached_frame, name_id.and_then(|id| self.load_module(id)));
                 }
                 Opcode::RaiseImportError => {
                     // Fetch the module name from the constant pool and raise ModuleNotFoundError
@@ -1827,12 +1836,20 @@ impl<'h> VM<'h> {
         }
     }
 
-    /// Loads a built-in module and pushes it onto the stack.
-    fn load_module(&mut self, module_id: u8) -> RunResult<()> {
-        let module = StandardLib::from_repr(module_id).expect("unknown module id");
-
-        // Create the module on the heap using pre-interned strings
-        let heap_id = module.create(self)?;
+    /// Loads a built-in module by its interned name and pushes it onto the stack.
+    ///
+    /// Consults the open module registry first, then the `StandardLib` enum.
+    /// The compiler only emits `LoadModule` for names one of those accepts, so
+    /// the final error path is effectively unreachable but kept in step with the
+    /// `ModuleNotFoundError` that `RaiseImportError` raises for unknown names.
+    fn load_module(&mut self, name_id: StringId) -> RunResult<()> {
+        let heap_id = if let Some(descriptor) = registry::lookup(name_id, self.interns) {
+            registry::create_module(descriptor, self)?
+        } else if let Some(module) = StandardLib::from_string_id(name_id) {
+            module.create(self)?
+        } else {
+            return Err(ExcType::module_not_found_error(self.interns.get_str(name_id)));
+        };
         self.push(Value::Ref(heap_id));
         Ok(())
     }

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -795,6 +795,15 @@ pub(crate) trait ExcTypeExt: Sized {
         SimpleException::new_msg(ExcType::ValueError, msg).into()
     }
 
+    /// Creates a generic `RuntimeError` with a custom message.
+    ///
+    /// For internal-invariant failures that have no CPython analogue (e.g. a
+    /// corrupt registry id from a deserialized snapshot) — surfaced as a
+    /// catchable Python error rather than a panic.
+    fn runtime_error(msg: impl fmt::Display) -> RunError {
+        SimpleException::new_msg(ExcType::RuntimeError, msg).into()
+    }
+
     /// Creates a TypeError for bytes() constructor with invalid type.
     ///
     /// Matches CPython's format: `TypeError: cannot convert '{type}' object to bytes`

--- a/crates/monty/src/identity.rs
+++ b/crates/monty/src/identity.rs
@@ -13,7 +13,7 @@ use crate::{
     builtins::Builtins,
     bytecode::VM,
     heap::{Heap, HeapData},
-    modules::ModuleFunctions,
+    modules::{ModuleFunctions, registry::ModuleFuncId},
     types::{LongInt, Property},
     value::{Marker, Value},
 };
@@ -51,6 +51,8 @@ pub(crate) enum Identity<'a> {
     Builtin(Builtins),
     /// Identity of a standard-library function.
     ModuleFunction(ModuleFunctions),
+    /// Identity of a function from the open module registry.
+    RegistryFunction(ModuleFuncId),
     /// Identity of a sandbox-defined function.
     DefFunction(usize),
     /// Name-based identity retained for host-supplied callables.
@@ -78,6 +80,7 @@ impl<'a> Identity<'a> {
             Value::InternLongInt(id) => Self::InternLongInt(id.index()),
             Value::Builtin(builtin) => Self::Builtin(*builtin),
             Value::ModuleFunction(function) => Self::ModuleFunction(*function),
+            Value::RegistryFunction(id) => Self::RegistryFunction(*id),
             Value::DefFunction(id) => Self::DefFunction(id.index()),
             Value::ExtFunction(name) => Self::ExtFunction(vm.interns.get_str(*name)),
             Value::Marker(marker) => Self::Marker(*marker),
@@ -119,6 +122,7 @@ impl<'a> Identity<'a> {
             | Self::Heap(index) => u128::try_from(*index).expect("usize fits in u128"),
             Self::Builtin(value) => fixed_serde_payload(value),
             Self::ModuleFunction(value) => fixed_serde_payload(value),
+            Self::RegistryFunction(value) => fixed_serde_payload(value),
             Self::ExtFunction(name) if name.len() <= MAX_FIXED_BYTES => bytes_payload(name.as_bytes()),
             Self::ExtFunction(_) => return None,
             Self::Marker(value) => fixed_serde_payload(value),
@@ -146,6 +150,7 @@ impl<'a> Identity<'a> {
             Self::Marker(_) => 14,
             Self::Property(_) => 15,
             Self::Heap(_) => 16,
+            Self::RegistryFunction(_) => 17,
         }
     }
 }

--- a/crates/monty/src/modules/mod.rs
+++ b/crates/monty/src/modules/mod.rs
@@ -25,6 +25,8 @@ pub(crate) mod math;
 pub(crate) mod os;
 pub(crate) mod pathlib;
 pub(crate) mod re;
+pub(crate) mod registry;
+pub(crate) mod struct_;
 pub(crate) mod sys;
 pub(crate) mod typing;
 pub(crate) mod unicodedata;

--- a/crates/monty/src/modules/registry.rs
+++ b/crates/monty/src/modules/registry.rs
@@ -1,0 +1,151 @@
+//! Open, name-keyed registry of native stdlib modules.
+//!
+//! This is the extension seam that lets a new native module be added by
+//! appending a [`ModuleDescriptor`] literal (in the module's own file) plus a
+//! dispatch arm in [`call`], without editing the closed [`StandardLib`] /
+//! [`ModuleFunctions`] enums or adding [`crate::intern::StaticStrings`]
+//! variants. Module and function names are interned through the dynamic pool —
+//! [`crate::prepare`] seeds only the names of the modules a program actually
+//! imports (via [`descriptor_names`]), so neither the per-compile seeding cost
+//! nor the per-token `StaticStrings::from_str` probe grows as modules land.
+//!
+//! The registry is split in two:
+//! - [`ModuleDescriptor`] / [`REGISTRY`] hold only names and [`ModuleFuncId`]s
+//!   (no fn pointers) — plain data in a `static`.
+//! - [`call`] resolves an id to its function through a `match`, the simplest
+//!   dispatch shape; a fn-pointer table or trait-object registry could replace
+//!   the `match` later without touching any caller.
+//!
+//! [`StandardLib`]: super::StandardLib
+//! [`ModuleFunctions`]: super::ModuleFunctions
+
+use std::iter;
+
+use monty_types::ResourceError;
+
+use crate::{
+    args::ArgValues,
+    bytecode::{CallResult, VM},
+    exception_private::{ExcType, ExcTypeExt, RunResult},
+    heap::{HeapData, HeapId},
+    intern::{Interns, StringId},
+    modules::struct_,
+    types::Module,
+    value::Value,
+};
+
+/// Stable identifier for a function in the open module registry.
+///
+/// The numeric value is a permanent contract: it is stored in
+/// [`Value::RegistryFunction`] and folded into object identity
+/// (`crate::identity`), so both snapshots and `id()` depend on it. Entries may
+/// only be APPENDED to the dispatch `match` in [`call`], never reordered or
+/// removed — it is not a live `Vec` position.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub(crate) struct ModuleFuncId(pub(crate) u16);
+
+/// Static description of one registered module: its importable name and the
+/// `(attribute-name, id)` pairs installed into its namespace at import.
+///
+/// Holds only interned-name strings and [`ModuleFuncId`]s — plain data with no
+/// fn pointers, so it lives in a `static`.
+pub(crate) struct ModuleDescriptor {
+    /// The importable module name, e.g. `"struct"`.
+    pub name: &'static str,
+    /// Functions exposed as module attributes, in id order.
+    pub functions: &'static [(&'static str, ModuleFuncId)],
+}
+
+/// The registered modules. Appending an entry here (and a dispatch arm in
+/// [`call`]) is the entire surface for adding a native module.
+///
+/// Invariant: a descriptor's `name` must not collide with a [`StandardLib`]
+/// module name — `load_module` and the compiler gate both try the registry
+/// first, so a clash would silently shadow the built-in with no diagnostic.
+///
+/// [`StandardLib`]: super::StandardLib
+pub(crate) static REGISTRY: &[ModuleDescriptor] = &[struct_::DESCRIPTOR];
+
+/// One module's importable name plus every function name it exposes.
+///
+/// [`crate::prepare`] interns these into the dynamic string pool for each
+/// registered module a program imports, so [`create_module`] can resolve the
+/// module and all its function names at runtime — including functions the
+/// user's source never references by name.
+pub(crate) fn descriptor_names(desc: &ModuleDescriptor) -> impl Iterator<Item = &'static str> {
+    iter::once(desc.name).chain(desc.functions.iter().map(|(name, _)| *name))
+}
+
+/// Resolves a module name string to its descriptor, or `None` if it is not a
+/// registered module. The string-keyed core of [`lookup`] and [`is_registered`].
+pub(crate) fn lookup_by_name(name: &str) -> Option<&'static ModuleDescriptor> {
+    REGISTRY.iter().find(|m| m.name == name)
+}
+
+/// Resolves an (already-interned) module name id to its descriptor, or `None`
+/// if the name is not a registered module (caller falls back to [`StandardLib`]).
+///
+/// [`StandardLib`]: super::StandardLib
+pub(crate) fn lookup(name_id: StringId, interns: &Interns) -> Option<&'static ModuleDescriptor> {
+    lookup_by_name(interns.get_str(name_id))
+}
+
+/// Whether `name` is a registered module. Used by the compiler's import gate to
+/// decide between emitting `LoadModule` and `RaiseImportError`.
+pub(crate) fn is_registered(name: &str) -> bool {
+    lookup_by_name(name).is_some()
+}
+
+/// The attribute name a function id was registered under, for `repr`.
+pub(crate) fn function_name(id: ModuleFuncId) -> &'static str {
+    REGISTRY
+        .iter()
+        .flat_map(|m| m.functions)
+        .find(|(_, fid)| *fid == id)
+        .map_or("?", |(name, _)| *name)
+}
+
+/// Builds a registered module on the heap: a [`Module`] whose namespace maps
+/// each function name to a [`Value::RegistryFunction`].
+///
+/// # Panics
+///
+/// Panics if a registered name was not pre-interned by [`crate::prepare`]
+/// (see [`descriptor_names`]). Since prepare seeds exactly the modules a
+/// program imports, this only fires for a module reached without an import.
+pub(crate) fn create_module(desc: &ModuleDescriptor, vm: &mut VM<'_>) -> Result<HeapId, ResourceError> {
+    let module_name = name_id(desc.name, vm);
+    let mut module = Module::new(module_name);
+    for (attr, id) in desc.functions {
+        let attr_id = name_id(attr, vm);
+        module.set_attr(attr_id, Value::RegistryFunction(*id), vm);
+    }
+    vm.heap.allocate(HeapData::Module(module))
+}
+
+/// Dispatches a registry function call by id.
+///
+/// The dispatch `match` is the sole place a module's functions are referenced;
+/// adding a module means appending arms here in id order. Pure functions
+/// returning `Value` are wrapped in [`CallResult::Value`].
+pub(crate) fn call(id: ModuleFuncId, vm: &mut VM<'_>, args: ArgValues) -> RunResult<CallResult> {
+    match id.0 {
+        0 => struct_::calcsize(vm, args).map(CallResult::Value),
+        1 => struct_::pack(vm, args).map(CallResult::Value),
+        2 => struct_::unpack(vm, args).map(CallResult::Value),
+        // Only 0..=2 are ever produced by `create_module`; a higher id can only
+        // arrive from a corrupt/attacker-supplied deserialized snapshot, so
+        // return a catchable error rather than panicking the interpreter.
+        other => Err(ExcType::runtime_error(format!("invalid registry function id {other}"))),
+    }
+}
+
+/// Resolves a registered name to its interned [`StringId`].
+///
+/// Infallible in practice because [`crate::prepare`] seeds every registered
+/// name; the `expect` guards against a missed seeding step rather than user input.
+fn name_id(name: &str, vm: &VM<'_>) -> StringId {
+    vm.interns
+        .get_string_id_by_name(name)
+        .expect("registry module/function name must be pre-interned during prepare")
+}

--- a/crates/monty/src/modules/struct_.rs
+++ b/crates/monty/src/modules/struct_.rs
@@ -1,0 +1,359 @@
+//! Illustrative `struct` module for the module-registry spike.
+//!
+//! Deliberately minimal: just enough of `calcsize` / `pack` / `unpack` (a few
+//! standard-size numeric codes with a `<`/`>` byte-order prefix) to prove the
+//! registry seam flows end to end and produces/consumes the existing
+//! `bytes`/`tuple` heap types. This is NOT a production `struct` — errors map to
+//! `ValueError` and most of CPython's format language is absent. See
+//! `limitations/struct.md`.
+
+use std::mem;
+
+use monty_types::ResourceTracker;
+
+use crate::{
+    args::{ArgValues, FromArgs, StrArg},
+    bytecode::VM,
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
+    heap::{DropWithContext, HeapData},
+    modules::registry::{ModuleDescriptor, ModuleFuncId},
+    resource_checks::check_repeat_size,
+    types::{Bytes, allocate_tuple},
+    value::Value,
+};
+
+/// Registry descriptor for `struct`. Ids match the dispatch arms in
+/// [`super::registry::call`] and are append-only.
+pub(crate) const DESCRIPTOR: ModuleDescriptor = ModuleDescriptor {
+    name: "struct",
+    functions: &[
+        ("calcsize", ModuleFuncId(0)),
+        ("pack", ModuleFuncId(1)),
+        ("unpack", ModuleFuncId(2)),
+    ],
+};
+
+/// `struct.calcsize(format)` — packed byte size of `format`.
+pub(crate) fn calcsize(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
+    let CalcsizeArgs { format } = CalcsizeArgs::from_args(args, vm)?;
+    let parsed = parse(format.as_str(vm), vm.heap.tracker());
+    format.drop_with(vm);
+    let size = size_of(&parsed?.fields);
+    Ok(Value::Int(
+        i64::try_from(size).map_err(|_| ExcType::value_error("struct size too large"))?,
+    ))
+}
+
+/// `struct.pack(format, *values)` — pack `values` into `bytes`.
+pub(crate) fn pack(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
+    let PackArgs { format, values } = PackArgs::from_args(args, vm)?;
+    let parsed = parse(format.as_str(vm), vm.heap.tracker());
+    format.drop_with(vm);
+    let result = parsed.and_then(|fmt| pack_values(&fmt, &values, vm));
+    for value in values {
+        value.drop_with(vm);
+    }
+    result
+}
+
+/// `struct.unpack(format, buffer)` — unpack `buffer` into a tuple.
+pub(crate) fn unpack(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
+    let UnpackArgs { format, buffer } = UnpackArgs::from_args(args, vm)?;
+    let parsed = parse(format.as_str(vm), vm.heap.tracker());
+    format.drop_with(vm);
+    let result = parsed.and_then(|fmt| {
+        let bytes = buffer_bytes(&buffer, vm)?;
+        let size = size_of(&fmt.fields);
+        if bytes.len() != size {
+            return Err(ExcType::value_error(format!(
+                "unpack requires a buffer of {size} bytes"
+            )));
+        }
+        unpack_fields(&fmt, bytes, vm)
+    });
+    buffer.drop_with(vm);
+    result
+}
+
+/// `calcsize(format, /)`.
+#[derive(FromArgs)]
+#[from_args(name = "calcsize", style = unpack)]
+struct CalcsizeArgs {
+    #[from_args(pos_only)]
+    format: StrArg,
+}
+
+/// `pack(format, /, *values)`.
+#[derive(FromArgs)]
+#[from_args(name = "pack")]
+struct PackArgs {
+    #[from_args(pos_only)]
+    format: StrArg,
+    #[from_args(varargs)]
+    values: Vec<Value>,
+}
+
+/// `unpack(format, buffer, /)`.
+#[derive(FromArgs)]
+#[from_args(name = "unpack", style = unpack)]
+struct UnpackArgs {
+    #[from_args(pos_only)]
+    format: StrArg,
+    #[from_args(pos_only)]
+    buffer: Value,
+}
+
+/// A parsed format: byte order plus a sequence of `(code, repeat)` fields.
+struct Format {
+    big_endian: bool,
+    fields: Vec<Field>,
+}
+
+/// One format field: a code and its repeat count.
+#[derive(Clone, Copy)]
+struct Field {
+    code: u8,
+    count: usize,
+}
+
+/// Parses a `[<>=!]` prefix followed by `[count]code` items. Only the numeric
+/// codes `b B h H i I l L q f d` are supported; anything else is rejected.
+fn parse(fmt: &str, tracker: &ResourceTracker) -> RunResult<Format> {
+    // Each field consumes at least one code byte, so the field vector is bounded
+    // by the format length; charge for it up front, since a large (already
+    // tracked) format string would otherwise amplify ~size_of::<Field>()× into an
+    // untracked Vec.
+    check_repeat_size(mem::size_of::<Field>(), fmt.len(), tracker)?;
+    let bytes = fmt.as_bytes();
+    let native_big = cfg!(target_endian = "big");
+    let (big_endian, mut i) = match bytes.first() {
+        Some(b'<') => (false, 1),
+        Some(b'>' | b'!') => (true, 1),
+        Some(b'=') => (native_big, 1),
+        _ => (native_big, 0),
+    };
+    let mut fields = Vec::new();
+    while i < bytes.len() {
+        if bytes[i].is_ascii_whitespace() {
+            i += 1;
+            continue;
+        }
+        let mut count = 0usize;
+        let mut has_count = false;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            has_count = true;
+            count = count
+                .checked_mul(10)
+                .and_then(|c| c.checked_add(usize::from(bytes[i] - b'0')))
+                .ok_or_else(|| ExcType::value_error("overflow in item count"))?;
+            i += 1;
+        }
+        let Some(&code) = bytes.get(i) else {
+            return Err(ExcType::value_error("repeat count given without format specifier"));
+        };
+        i += 1;
+        if code_size(code).is_none() {
+            return Err(ExcType::value_error("bad char in struct format"));
+        }
+        fields.push(Field {
+            code,
+            count: if has_count { count } else { 1 },
+        });
+    }
+    Ok(Format { big_endian, fields })
+}
+
+/// Total packed size of the fields.
+fn size_of(fields: &[Field]) -> usize {
+    fields
+        .iter()
+        .map(|f| code_size(f.code).unwrap_or(0).saturating_mul(f.count))
+        .fold(0, usize::saturating_add)
+}
+
+/// Total number of packed items across all fields. Saturates so a format with
+/// huge repeat counts (`'9999999999999999999b9999999999999999999b'`) yields a
+/// rejected size/arity rather than an arithmetic-overflow panic.
+fn total_count(fields: &[Field]) -> usize {
+    fields.iter().map(|f| f.count).fold(0, usize::saturating_add)
+}
+
+/// Byte width of a code, or `None` if the code is unsupported.
+fn code_size(code: u8) -> Option<usize> {
+    match code {
+        b'b' | b'B' => Some(1),
+        b'h' | b'H' => Some(2),
+        b'i' | b'I' | b'l' | b'L' | b'f' => Some(4),
+        b'q' | b'd' => Some(8),
+        _ => None,
+    }
+}
+
+/// Packs `values` per `fmt` into a `bytes` object.
+fn pack_values(fmt: &Format, values: &[Value], vm: &mut VM<'_>) -> RunResult<Value> {
+    let expected = total_count(&fmt.fields);
+    if values.len() != expected {
+        return Err(ExcType::value_error(format!(
+            "pack expected {expected} items for packing (got {})",
+            values.len()
+        )));
+    }
+    let size = size_of(&fmt.fields);
+    // The output size comes from the format string, which can amplify a tiny
+    // input; charge the tracker before allocating the buffer.
+    check_repeat_size(size, 1, vm.heap.tracker())?;
+    let mut out = Vec::with_capacity(size);
+    let mut index = 0;
+    for field in &fmt.fields {
+        for _ in 0..field.count {
+            pack_one(&mut out, field.code, &values[index], fmt.big_endian)?;
+            index += 1;
+        }
+    }
+    let heap_id = vm.heap.allocate(HeapData::Bytes(Bytes::new(out)))?;
+    Ok(Value::Ref(heap_id))
+}
+
+/// Packs a single value for `code` into `out`.
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "the `f` code narrows f64 to f32 by design"
+)]
+fn pack_one(out: &mut Vec<u8>, code: u8, value: &Value, big_endian: bool) -> RunResult<()> {
+    if code == b'f' || code == b'd' {
+        let float = value_as_f64(value)?;
+        match code {
+            b'f' => put(out, &(float as f32).to_le_bytes(), big_endian),
+            _ => put(out, &float.to_le_bytes(), big_endian),
+        }
+    } else {
+        let int = value_as_i64(value)?;
+        let (min, max) = int_range(code);
+        if int < min || int > max {
+            return Err(ExcType::value_error(format!(
+                "'{}' format requires {min} <= number <= {max}",
+                char::from(code)
+            )));
+        }
+        let size = code_size(code).expect("validated code");
+        put(out, &int.to_le_bytes()[..size], big_endian);
+    }
+    Ok(())
+}
+
+/// Inclusive `[min, max]` for an integer code (all fit `i64` in this subset).
+fn int_range(code: u8) -> (i64, i64) {
+    match code {
+        b'b' => (-128, 127),
+        b'B' => (0, 255),
+        b'h' => (-32768, 32767),
+        b'H' => (0, 65535),
+        b'i' | b'l' => (-2_147_483_648, 2_147_483_647),
+        b'I' | b'L' => (0, 4_294_967_295),
+        _ => (i64::MIN, i64::MAX), // 'q'
+    }
+}
+
+/// Unpacks `buffer` (exactly `size_of(fields)` bytes) into a tuple.
+fn unpack_fields(fmt: &Format, buffer: &[u8], vm: &VM<'_>) -> RunResult<Value> {
+    // Building the output materialises one `Value` per unpacked field on the Rust
+    // heap before `allocate_tuple` charges anything; a buffer of 1-byte codes
+    // amplifies ~size_of::<Value>()× per input byte. Charge the tracker up front
+    // so the transient can't outrun the memory limit (mirrors `pack_values`).
+    let count = total_count(&fmt.fields);
+    check_repeat_size(mem::size_of::<Value>(), count, vm.heap.tracker())?;
+    let mut items = Vec::with_capacity(count);
+    let mut cursor = 0;
+    for field in &fmt.fields {
+        let size = code_size(field.code).expect("validated code");
+        for _ in 0..field.count {
+            items.push(read_one(&buffer[cursor..cursor + size], field.code, fmt.big_endian));
+            cursor += size;
+        }
+    }
+    allocate_tuple(items.into(), vm.heap).map_err(RunError::from)
+}
+
+/// Reads a single value of `code` from `bytes`.
+fn read_one(bytes: &[u8], code: u8, big_endian: bool) -> Value {
+    match code {
+        b'f' => {
+            let mut buf = [0u8; 4];
+            order_into(bytes, &mut buf, big_endian);
+            Value::Float(f64::from(f32::from_le_bytes(buf)))
+        }
+        b'd' => {
+            let mut buf = [0u8; 8];
+            order_into(bytes, &mut buf, big_endian);
+            Value::Float(f64::from_le_bytes(buf))
+        }
+        _ => {
+            let signed = matches!(code, b'b' | b'h' | b'i' | b'l' | b'q');
+            let size = bytes.len();
+            let mut buf = [0u8; 8];
+            order_into(bytes, &mut buf[..size], big_endian);
+            if signed && buf[size - 1] & 0x80 != 0 {
+                for byte in &mut buf[size..] {
+                    *byte = 0xff;
+                }
+            }
+            Value::Int(i64::from_le_bytes(buf))
+        }
+    }
+}
+
+/// Writes `le` (little-endian bytes) to `out`, reversing for big-endian.
+fn put(out: &mut Vec<u8>, le: &[u8], big_endian: bool) {
+    if big_endian {
+        out.extend(le.iter().rev());
+    } else {
+        out.extend_from_slice(le);
+    }
+}
+
+/// Copies `src` into `dst` in little-endian order (reversing a big-endian source).
+fn order_into(src: &[u8], dst: &mut [u8], big_endian: bool) {
+    if big_endian {
+        for (d, s) in dst.iter_mut().zip(src.iter().rev()) {
+            *d = *s;
+        }
+    } else {
+        dst.copy_from_slice(src);
+    }
+}
+
+/// Reads a Python `int`/`bool` as `i64`; errors otherwise (large ints outside
+/// `i64` are unsupported in this subset).
+fn value_as_i64(value: &Value) -> RunResult<i64> {
+    match value {
+        Value::Int(i) => Ok(*i),
+        Value::Bool(b) => Ok(i64::from(*b)),
+        _ => Err(ExcType::value_error("required argument is not an integer")),
+    }
+}
+
+/// Reads a Python `float`/`int`/`bool` as `f64`; errors otherwise.
+#[expect(
+    clippy::cast_precision_loss,
+    reason = "int-to-float widening matches CPython's struct"
+)]
+fn value_as_f64(value: &Value) -> RunResult<f64> {
+    match value {
+        Value::Float(f) => Ok(*f),
+        Value::Int(i) => Ok(*i as f64),
+        Value::Bool(b) => Ok(f64::from(u8::from(*b))),
+        _ => Err(ExcType::value_error("required argument is not a float")),
+    }
+}
+
+/// Borrows a `bytes` buffer, erroring on any other type.
+fn buffer_bytes<'a>(value: &'a Value, vm: &'a VM<'_>) -> RunResult<&'a [u8]> {
+    match value {
+        Value::InternBytes(id) => Ok(vm.interns.get_bytes(*id)),
+        Value::Ref(id) => match vm.heap.get(*id) {
+            HeapData::Bytes(b) => Ok(b.as_slice()),
+            _ => Err(ExcType::type_error("a bytes object is required")),
+        },
+        _ => Err(ExcType::type_error("a bytes object is required")),
+    }
+}

--- a/crates/monty/src/prepare.rs
+++ b/crates/monty/src/prepare.rs
@@ -11,6 +11,7 @@ use crate::{
     },
     fstring::{FStringPart, FormatSpec},
     intern::{InternerBuilder, StringId},
+    modules::registry::{self, ModuleDescriptor},
     name_map::{NameMap, namespace_overflow},
     namespace::NamespaceId,
     parse::{CodeRange, ExceptHandler, ParseError, ParseNode, ParseResult, ParsedSignature, RawFunctionDef, Try},
@@ -86,7 +87,7 @@ pub(crate) fn prepare_with_existing_names(
     parse_result: ParseResult,
     mut globals: NameMap,
 ) -> Result<PrepareResult, ParseError> {
-    let ParseResult { nodes, interner } = parse_result;
+    let ParseResult { nodes, mut interner } = parse_result;
     let mut prepared_nodes = Prepare::new_module(&mut globals, &interner).prepare_nodes(nodes)?;
 
     // In the root frame, the last expression is implicitly returned if it
@@ -98,6 +99,21 @@ pub(crate) fn prepare_with_existing_names(
         let new_expr_loc = expr_loc.clone();
         prepared_nodes.pop();
         prepared_nodes.push(Node::Return(Some(new_expr_loc)));
+    }
+
+    // Seed the dynamic string pool with the names of the registered modules this
+    // source actually imports, so `registry::create_module` can resolve their
+    // function names at runtime. Seeding only imported modules — rather than the
+    // whole registry — keeps per-compile cost proportional to what the program
+    // imports, not to how many modules are registered. Done after user strings
+    // are assigned (so no existing id shifts) and kept out of `StaticStrings` so
+    // the per-token `from_str` probe stays flat too.
+    let mut imported_modules: Vec<&'static ModuleDescriptor> = Vec::new();
+    collect_imported_registry_modules(&prepared_nodes, &interner, &mut imported_modules);
+    for desc in imported_modules {
+        for name in registry::descriptor_names(desc) {
+            interner.intern(name);
+        }
     }
 
     Ok(PrepareResult {
@@ -123,6 +139,63 @@ fn build_initial_globals(input_names: Vec<String>, interner: &mut InternerBuilde
         globals.ensure_slot(name_id, CodeRange::default())?;
     }
     Ok(globals)
+}
+
+/// Collects the descriptor of every registered module imported anywhere in
+/// `nodes`, deduplicated by name.
+///
+/// Walks nested bodies (function, class, loop, `try`, `with`) because an
+/// `import` can sit at any depth, and every reachable import must have its
+/// module's names seeded before the VM builds the module (see
+/// [`registry::create_module`]). Feeds the lazy seeding in
+/// [`prepare_with_existing_names`]: only imported modules are interned, so
+/// registering more modules does not slow preparation.
+fn collect_imported_registry_modules(
+    nodes: &[PreparedNode],
+    interner: &InternerBuilder,
+    out: &mut Vec<&'static ModuleDescriptor>,
+) {
+    for node in nodes {
+        match node {
+            Node::Import { names } => {
+                for import_name in names {
+                    push_registered(import_name.module_name, interner, out);
+                }
+            }
+            Node::ImportFrom { module_name, .. } => push_registered(*module_name, interner, out),
+            Node::For { body, or_else, .. } | Node::While { body, or_else, .. } | Node::If { body, or_else, .. } => {
+                collect_imported_registry_modules(body, interner, out);
+                collect_imported_registry_modules(or_else, interner, out);
+            }
+            Node::FunctionDef { def, .. } => collect_imported_registry_modules(&def.body, interner, out),
+            Node::ClassDef { body, .. } => collect_imported_registry_modules(&body.body, interner, out),
+            Node::Try(Try {
+                body,
+                handlers,
+                or_else,
+                finally,
+            }) => {
+                collect_imported_registry_modules(body, interner, out);
+                for handler in handlers {
+                    collect_imported_registry_modules(&handler.body, interner, out);
+                }
+                collect_imported_registry_modules(or_else, interner, out);
+                collect_imported_registry_modules(finally, interner, out);
+            }
+            Node::With { body, .. } => collect_imported_registry_modules(body, interner, out),
+            _ => {}
+        }
+    }
+}
+
+/// Pushes the descriptor for `module_name` onto `out` if it names a registered
+/// module not already collected. Utility for [`collect_imported_registry_modules`].
+fn push_registered(module_name: StringId, interner: &InternerBuilder, out: &mut Vec<&'static ModuleDescriptor>) {
+    if let Some(desc) = registry::lookup_by_name(interner.get_str(module_name))
+        && !out.iter().any(|d| d.name == desc.name)
+    {
+        out.push(desc);
+    }
 }
 
 /// State machine for the preparation phase that transforms parsed AST nodes into a prepared form.

--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -1165,7 +1165,11 @@ fn convert_args(args: Vec<MontyObject>, vm: &mut VM<'_>) -> Result<ArgValues, Mo
 /// `BoundMethod`, which are not what a host means by "a function it can invoke".
 fn is_callable(value: &Value, heap: &Heap) -> bool {
     match value {
-        Value::DefFunction(_) | Value::Builtin(_) | Value::ExtFunction(_) | Value::ModuleFunction(_) => true,
+        Value::DefFunction(_)
+        | Value::Builtin(_)
+        | Value::ExtFunction(_)
+        | Value::ModuleFunction(_)
+        | Value::RegistryFunction(_) => true,
         Value::Ref(id) => matches!(
             heap.get(*id),
             HeapData::Closure(_) | HeapData::FunctionDefaults(_) | HeapData::ExtFunction(_)

--- a/crates/monty/src/types/module.rs
+++ b/crates/monty/src/types/module.rs
@@ -98,7 +98,8 @@ impl<'h> HeapRead<'h, Module> {
     /// Calls an attribute as a function on this module.
     ///
     /// Modules don't have methods - they have callable attributes. This looks up
-    /// the attribute and calls it if it's a `ModuleFunction`.
+    /// the attribute and calls it via `vm.call_function`, which dispatches any
+    /// callable value (builtin, closed-`StandardLib`, or open-registry function).
     ///
     /// Returns `CallResult` because module functions may need OS operations
     /// (e.g., `os.getenv()`) that require host involvement.

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -22,7 +22,10 @@ use crate::{
     heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapReadOutput},
     identity::Identity,
     intern::{BytesId, FunctionId, Interns, LongIntId, StaticStrings, StringId},
-    modules::ModuleFunctions,
+    modules::{
+        ModuleFunctions,
+        registry::{self, ModuleFuncId},
+    },
     resource_checks::{check_div_size, check_lshift_size, check_mult_size, check_pow_size, check_repeat_size},
     types::{
         Bytes, CmpOrder, LazyHeapSet, List, LongInt, MontyIter, Property, PyTrait, Type, allocate_tuple,
@@ -88,6 +91,13 @@ pub(crate) enum Value {
 
     // Heap-allocated values (stored in arena)
     Ref(HeapId),
+
+    /// A function from a module in the open module registry ([`crate::modules::registry`]),
+    /// e.g. `struct.calcsize`. The [`ModuleFuncId`] indexes the registry's
+    /// dispatch table. Unlike [`Self::ModuleFunction`] (the closed `StandardLib`
+    /// enum path), this is the extensible path new native modules use. Holds no
+    /// heap reference, so clone/drop are trivial.
+    RegistryFunction(ModuleFuncId),
 
     /// Sentinel value indicating this Value was properly cleaned up via `drop_with`.
     /// Only exists when `memory-model-checks` feature is enabled. Used to verify reference counting
@@ -204,7 +214,7 @@ impl<'h> PyTrait<'h> for Value {
             Self::InternString(_) => Type::Str,
             Self::InternBytes(_) => Type::Bytes,
             Self::Builtin(c) => c.py_type(),
-            Self::ModuleFunction(_) => Type::BuiltinFunction,
+            Self::ModuleFunction(_) | Self::RegistryFunction(_) => Type::BuiltinFunction,
             Self::DefFunction(_) | Self::ExtFunction(_) => Type::Function,
             Self::Marker(m) => m.py_type(),
             Self::Property(_) => Type::Property,
@@ -255,6 +265,10 @@ impl<'h> PyTrait<'h> for Value {
             }),
             Self::ModuleFunction(mf) => Ok(match other {
                 Self::ModuleFunction(o) => Some(mf == o),
+                _ => None,
+            }),
+            Self::RegistryFunction(f) => Ok(match other {
+                Self::RegistryFunction(o) => Some(f == o),
                 _ => None,
             }),
             Self::DefFunction(f) => Ok(match other {
@@ -392,10 +406,10 @@ impl<'h> PyTrait<'h> for Value {
             Self::Float(f) => *f != 0.0,
             // InternLongInt is always truthy (if it were zero, it would fit in i64)
             Self::InternLongInt(_) => true,
-            Self::Builtin(_) | Self::ModuleFunction(_) => true, // Builtins are always truthy
+            Self::Builtin(_) | Self::ModuleFunction(_) | Self::RegistryFunction(_) => true, // Builtins are always truthy
             Self::DefFunction(_) | Self::ExtFunction(_) => true, // Functions are always truthy
-            Self::Marker(_) => true,                            // Markers are always truthy
-            Self::Property(_) => true,                          // Properties are always truthy
+            Self::Marker(_) => true,                             // Markers are always truthy
+            Self::Property(_) => true,                           // Properties are always truthy
             Self::InternString(string_id) => !vm.interns.get_str(*string_id).is_empty(),
             Self::InternBytes(bytes_id) => !vm.interns.get_bytes(*bytes_id).is_empty(),
             Self::Ref(id) => vm.heap.read(*id).py_bool(vm),
@@ -426,6 +440,16 @@ impl<'h> PyTrait<'h> for Value {
                 let py_id = self.id(vm).into_value(vm.heap)?;
                 defer_drop!(py_id, vm);
                 Ok(mf.py_repr_fmt(f, PythonIdDisplay::new(py_id, vm.heap))?)
+            }
+            Self::RegistryFunction(id) => {
+                let py_id = self.id(vm).into_value(vm.heap)?;
+                defer_drop!(py_id, vm);
+                Ok(write!(
+                    f,
+                    "<function {} at 0x{:x}>",
+                    registry::function_name(*id),
+                    PythonIdDisplay::new(py_id, vm.heap)
+                )?)
             }
             Self::DefFunction(f_id) => {
                 let py_id = self.id(vm).into_value(vm.heap)?;
@@ -1591,7 +1615,9 @@ impl Value {
             Self::InternString(_) => Type::Str,
             Self::InternBytes(_) => Type::Bytes,
             Self::Builtin(_) => Type::BuiltinFunction,
-            Self::ModuleFunction(_) | Self::DefFunction(_) | Self::ExtFunction(_) => Type::Function,
+            Self::ModuleFunction(_) | Self::RegistryFunction(_) | Self::DefFunction(_) | Self::ExtFunction(_) => {
+                Type::Function
+            }
             Self::Marker(_) => Type::SpecialForm,
             Self::Property(_) => Type::Property,
             Self::Ref(_) => Type::NoneType, // callers should resolve Ref via HeapData::py_type()
@@ -1741,6 +1767,7 @@ impl Value {
             Self::Undefined | Self::Ellipsis | Self::None => Ok(Some(hash_one(discriminant(self)))),
             Self::Builtin(b) => Ok(Some(hash_one(b))),
             Self::ModuleFunction(mf) => Ok(Some(hash_one(mf))),
+            Self::RegistryFunction(f) => Ok(Some(hash_one(f))),
             // Hash functions based on function ID
             Self::DefFunction(f_id) => Ok(Some(hash_one(f_id))),
             // Hash the function name's string contents so the inline path
@@ -2138,6 +2165,7 @@ impl Value {
             Self::Float(v) => Self::Float(*v),
             Self::Builtin(b) => Self::Builtin(*b),
             Self::ModuleFunction(mf) => Self::ModuleFunction(*mf),
+            Self::RegistryFunction(f) => Self::RegistryFunction(*f),
             Self::DefFunction(f) => Self::DefFunction(*f),
             Self::ExtFunction(f) => Self::ExtFunction(*f),
             Self::InternString(s) => Self::InternString(*s),
@@ -2272,7 +2300,11 @@ impl Value {
     /// `debug_assert!`s in dispatch's "not callable" arms.
     pub(crate) fn is_callable(&self, heap: &Heap) -> bool {
         match self {
-            Self::Builtin(_) | Self::ModuleFunction(_) | Self::ExtFunction(_) | Self::DefFunction(_) => true,
+            Self::Builtin(_)
+            | Self::ModuleFunction(_)
+            | Self::RegistryFunction(_)
+            | Self::ExtFunction(_)
+            | Self::DefFunction(_) => true,
             Self::Ref(id) => heap.get(*id).is_callable(),
             _ => false,
         }

--- a/crates/monty/test_cases/struct__ops.py
+++ b/crates/monty/test_cases/struct__ops.py
@@ -1,0 +1,46 @@
+import struct
+
+# === calcsize (standard sizes) ===
+assert struct.calcsize('>bBhHiIlLq') == 30
+assert struct.calcsize('>i') == 4
+assert struct.calcsize('<d') == 8
+assert struct.calcsize('>4i') == 16
+assert struct.calcsize('') == 0
+
+# === exact big/little-endian bytes ===
+assert struct.pack('>i', 1) == b'\x00\x00\x00\x01'
+assert struct.pack('<i', 1) == b'\x01\x00\x00\x00'
+assert struct.pack('>h', -1) == b'\xff\xff'
+assert struct.pack('>f', 1) == b'?\x80\x00\x00'  # int accepted for float code
+
+# === round-trips (pack then unpack) ===
+assert struct.unpack('>i', struct.pack('>i', -5)) == (-5,)
+assert struct.unpack('>4i', struct.pack('>4i', 1, 2, 3, 4)) == (1, 2, 3, 4)
+assert struct.unpack('>ihq', struct.pack('>ihq', 100, -2, 10**9)) == (100, -2, 10**9)
+assert struct.unpack('>f', struct.pack('>f', 1.5)) == (1.5,)
+assert struct.unpack('>d', struct.pack('>d', 3.14159)) == (3.14159,)
+
+
+# === import inside a function body (lazy name-seeding must reach nested imports) ===
+def _nested_calcsize():
+    import struct
+
+    return struct.calcsize('>i')
+
+
+assert _nested_calcsize() == 4
+
+# === errors: type diverges (ValueError in Monty, struct.error in CPython), so
+# catch broadly and don't assert the message ===
+try:
+    struct.pack('>b', 999)  # out of range for a signed byte
+    assert False, 'expected packing 999 into a signed byte to fail'
+except Exception:
+    pass
+
+# === a format with overflowing repeat counts is rejected, not panicked on ===
+try:
+    struct.pack('9999999999999999999b9999999999999999999b')
+    assert False, 'expected an oversized format to fail'
+except Exception:
+    pass

--- a/limitations/modules.md
+++ b/limitations/modules.md
@@ -15,6 +15,7 @@ and no way for sandboxed code to load additional modules.
 | `os`       | [os.md](os.md)                       |
 | `pathlib`  | [pathlib.md](pathlib.md)             |
 | `re`       | [re.md](re.md)                       |
+| `struct`   | [struct.md](struct.md)               |
 | `sys`      | [sys.md](sys.md)                     |
 | `typing`   | [typing.md](typing.md)               |
 
@@ -32,7 +33,7 @@ as a builtin, not via `collections`), `contextlib`, `copy`, `csv`,
 module is not importable), `decimal`, `enum`, `fractions`, `functools`,
 `hashlib`, `heapq`, `hmac`, `http`, `inspect`, `io`, `itertools`,
 `logging`, `multiprocessing`, `operator`, `pickle`, `queue`, `random`,
-`socket`, `string`, `struct`, `subprocess`, `tempfile`, `threading`,
+`socket`, `string`, `subprocess`, `tempfile`, `threading`,
 `time`, `traceback`, `unittest`, `urllib`, `uuid`, `warnings`, `weakref`,
 `zipfile`, `zlib`.
 

--- a/limitations/struct.md
+++ b/limitations/struct.md
@@ -1,0 +1,27 @@
+# `struct` module
+
+Monty's `struct` is an illustrative subset built to demonstrate the native
+module-registry seam, not a full implementation. It diverges from CPython in
+several deliberate ways.
+
+## Implemented
+
+Functions: `calcsize`, `pack`, `unpack`.
+
+Format codes: `b B h H i I l L q f d` (standard sizes), with a `<` / `>` / `!` /
+`=` byte-order prefix and optional repeat counts (e.g. `4i`).
+
+## Divergences from CPython
+
+- **Format/value errors are `ValueError`, not `struct.error`.** Monty raises
+  `ValueError` with its own messages where CPython raises `struct.error`; there
+  is no `struct.error` attribute, and the message text differs. (A non-`bytes`
+  buffer to `unpack` raises `TypeError`, which matches CPython.)
+- **Most of the format language is absent.** No `Q`, `n`, `N`, `P`, `e`, `s`,
+  `p`, `c`, `x`, and no `@` prefix — all raise `ValueError`. No native
+  sizes/alignment: a no-prefix format is treated as standard-size (unlike
+  CPython, where no prefix means native size/alignment). Large integers outside
+  the `i64` range are rejected. Unsupported codes raise `ValueError`.
+- **No `Struct` class, `iter_unpack`, `pack_into`, or `unpack_from`.**
+- **Only `bytes` input buffers** for `unpack` (`bytearray`/`memoryview` do not
+  exist in Monty).


### PR DESCRIPTION
Draft, not for merge. This is a spike to make the idea in #601 concrete,
since you said you were open to seeing what it looks like. The interesting
part is the seam; the module I used to exercise it is throwaway.

One self-contained commit; it builds clean and `struct__ops.py` passes on both
Monty and CPython.

## The idea

Today, adding a native stdlib module means editing the closed `StandardLib` /
`ModuleFunctions` enums and threading a new variant through every match that
references them. This replaces that with a name-keyed registry. Building the
seam is a one-time change to the core (the files in the reading order below).
After that, adding a pure-function module like this one is a registration in
two files (`modules/mod.rs` and `registry.rs`) plus the module's own file, with
no further core changes. A module that needed a new heap type would touch more,
which is the #568 question below.

The pieces:

- `modules/registry.rs`: a `static REGISTRY` of `ModuleDescriptor`s (plain
  data, no tracker generic) and a `registry::call` that dispatches by a
  stable `ModuleFuncId`. It's a plain match, no `dyn`, so it compiles under
  today's `VM<'h, T: ResourceTracker>`.
- Names are interned through the dynamic pool, not `StaticStrings`, so the
  per-token parse cost stays flat regardless of how many modules exist. And
  prepare interns only the modules a program actually imports, not the whole
  registry, so that cost tracks usage rather than registry size.
- One immediate `Value::RegistryFunction(ModuleFuncId)`: no heap ref, trivial
  clone/drop, no new `HeapData` variant. The scalar hot path is untouched,
  which I think is the #248 regression you flagged.
- `LoadModule` now carries a u16 const-pool name id (same shape as
  `RaiseImportError`). The import gate and `load_module` resolve registry
  first, then fall back to `StandardLib`.

## What I left open on purpose

- The `HeapData::Foreign` vs `Instance` convergence from #568. `struct` is
  pure functions over `bytes`/`tuple` and needs no new heap type, so the spike
  proves the registration/interning seam without prejudging that. It felt like
  a separate decision, happy to talk it through.
- dyn PyTrait. It's written against current main, so it still carries the
  `impl ResourceTracker` annotations #613 removes. If #613 lands first they drop
  to `VM<'h>` and the seam gets simpler; dropping the tracker generic is also
  what should make `dyn PyTrait` feasible. The registry shape is unchanged
  either way, only what an id resolves to (a runtime table instead of the
  match).

## About the `struct` module

Throwaway. `calcsize`/`pack`/`unpack` over a few numeric codes; format and
value errors are `ValueError` (buffer type errors stay `TypeError`), no
`struct.error`/`Struct`/`iter_unpack`/native sizes. It's there
only to run the seam end to end and show a module producing and consuming
existing heap types. Please don't review it for parity. Divergences are in
`limitations/struct.md`.

## Reading order

1. `modules/registry.rs` — the registry
2. `prepare.rs` — lazy per-import name interning
3. `bytecode/compiler.rs` `compile_import` — the "is X in scope" gate
4. `bytecode/vm/mod.rs` `load_module` + `vm/call.rs` — resolution and dispatch
5. `value.rs` — the one new variant

Everything is inside the `monty` crate (plus the `limitations/` docs). No host
crate, wire protocol, or binding changes.

Built with AI assistance (noted in the commit trailer). What I'm after is your
read on whether this is the shape you had in mind, not a merge review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces an open, name-keyed stdlib module registry so new native modules can be added via registration instead of editing closed enums; adds an illustrative `struct` module to exercise the seam end to end. Implements the extensibility direction discussed in #601 while keeping hot paths unchanged.

- **New Features**
  - Added `modules/registry.rs` with `ModuleDescriptor`, `ModuleFuncId`, `REGISTRY`, `lookup`/`is_registered`, `create_module`, `call` (append-only dispatch), plus `descriptor_names` and `function_name`.
  - New `Value::RegistryFunction` with VM call dispatch and `repr`; identity/serde and hashing support added.
  - Compiler emits `LoadModule` with a u16 const index for the module name; the import gate checks the registry first, then `StandardLib`.
  - `prepare` lazily interns names only for imported registry modules (walks nested imports).
  - Added minimal `struct` module (`calcsize`, `pack`, `unpack`) plus tests and docs under limitations.

- **Refactors**
  - `load_module` now resolves by interned name (registry-first, fallback to `StandardLib`); VM reads the name from the const pool at runtime.
  - Opcode `LoadModule` now uses a u16 const-pool operand; stack effects updated accordingly.
  - VM call path dispatches `RegistryFunction` via `registry::call`; module attribute calls use `vm.call_function`.
  - Added `ExcType::runtime_error` for invariant failures like invalid registry ids from snapshots; REPL/callability checks include `RegistryFunction`.

<sup>Written for commit d1b2fa9f58793dfa91c6601136839d937efbabc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

