### PR TITLE
Prep for v0.0.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,18 @@ jobs:
         with:
           persist-credentials: false
 
+      # The instrumented (llvm-cov) builds of every feature config don't fit on
+      # the runner's free disk when the rust-cache is cold: the job fills the
+      # disk mid-link, which also fails the cache save, so the next run is cold
+      # again. Drop the large preinstalled toolchains we never use (~25-30 GB)
+      # so cold runs fit and the cache can re-establish itself.
+      - name: free disk space
+        run: |
+          df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+          df -h /
+
       # no release versioning, see https://github.com/dtolnay/rust-toolchain/issues/180
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "monty"
-version = "0.0.19-beta.6"
+version = "0.0.19"
 dependencies = [
  "ahash",
  "chrono",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "monty-bench"
-version = "0.0.19-beta.6"
+version = "0.0.19"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "monty-datatest"
-version = "0.0.19-beta.6"
+version = "0.0.19"
 dependencies = [
  "ahash",
  "chrono",
@@ -2054,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "monty-fs"
-version = "0.0.19-beta.6"
+version = "0.0.19"
 dependencies = [
  "ahash",
  "monty-types",
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "monty-fuzz"
-version = "0.0.19-beta.6"
+version = "0.0.19"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -2073,7 +2073,7 @@ dependencies = [
 
 [[package]]
 name = "monty-js"
-version = "0.0.19-beta.6"
+version = "0.0.19"
 dependencies = [
  "monty-pool",
  "monty-type-checking",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "monty-macros"
-version = "0.0.19-beta.6"
+version = "0.0.19"
 dependencies = [
  "insta",
  "proc-macro2",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "monty-pool"
-version = "0.0.19-beta.6"
+version = "0.0.19"
 dependencies = [
  "monty-fs",
  "monty-proto",
@@ -2110,7 +2110,7 @@ dependencies = [
 
 [[package]]
 name = "monty-proto"
-version = "0.0.19-beta.6"
+version = "0.0.19"
 dependencies = [
  "monty",
  "monty-type-checking",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "monty-runtime"
-version = "0.0.19-beta.6"
+version = "0.0.19"
 dependencies = [
  "clap",
  "monty",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "monty-type-checking"
-version = "0.0.19-beta.6"
+version = "0.0.19"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "monty-types"
-version = "0.0.19-beta.6"
+version = "0.0.19"
 dependencies = [
  "chrono",
  "monty-macros",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "monty-typeshed"
-version = "0.0.19-beta.6"
+version = "0.0.19"
 dependencies = [
  "path-slash",
  "ruff_db",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "monty-wasm-runtime"
-version = "0.0.19-beta.6"
+version = "0.0.19"
 dependencies = [
  "monty-proto",
  "prost",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-monty"
-version = "0.0.19-beta.6"
+version = "0.0.19"
 dependencies = [
  "ahash",
  "monty-fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default-members = ["crates/monty-runtime"]
 
 [workspace.package]
 edition = "2024"
-version = "0.0.19-beta.6"
+version = "0.0.19"
 rust-version = "1.95"
 license = "MIT"
 authors = ["Samuel Colvin <samuel@pydantic.dev>"]
@@ -57,14 +57,14 @@ strip = false
 # rejects path-only dependencies). These versions MUST be kept in lockstep with
 # `workspace.package.version` above and bumped together on each release — see
 # RELEASING.md.
-monty = { path = "crates/monty", version = "0.0.19-beta.6" }
-monty-types = { path = "crates/monty-types", version = "0.0.19-beta.6" }
-monty-fs = { path = "crates/monty-fs", version = "0.0.19-beta.6" }
-monty-macros = { path = "crates/monty-macros", version = "0.0.19-beta.6" }
-monty-proto = { path = "crates/monty-proto", version = "0.0.19-beta.6" }
-monty-pool = { path = "crates/monty-pool", version = "0.0.19-beta.6" }
-monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.19-beta.6" }
-monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.19-beta.6" }
+monty = { path = "crates/monty", version = "0.0.19" }
+monty-types = { path = "crates/monty-types", version = "0.0.19" }
+monty-fs = { path = "crates/monty-fs", version = "0.0.19" }
+monty-macros = { path = "crates/monty-macros", version = "0.0.19" }
+monty-proto = { path = "crates/monty-proto", version = "0.0.19" }
+monty-pool = { path = "crates/monty-pool", version = "0.0.19" }
+monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.19" }
+monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.19" }
 # ruff, ty and related crates
 ruff_python_parser = "0.0.3"
 ruff_python_stdlib = "0.0.3"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,9 +16,9 @@ and sync `pydantic-monty`'s exact pin on `pydantic-monty-runtime` (via `crates/m
 ## 2. Commit and Push
 
 ```bash
-git checkout -b prepare-release-X.Y.Z
+git checkout -b prepare-release-vX.Y.Z
 git add .
-git commit -m "Bump version to X.Y.Z"
+git commit -m "Bump version to vX.Y.Z"
 git push
 ```
 

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.19-beta.6",
+  "version": "0.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pydantic/monty",
-      "version": "0.0.19-beta.6",
+      "version": "0.0.19",
       "license": "MIT",
       "devDependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.1",
@@ -29,11 +29,11 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@pydantic/monty-darwin-arm64": "0.0.19-beta.6",
-        "@pydantic/monty-darwin-x64": "0.0.19-beta.6",
-        "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.6",
-        "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.6",
-        "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.6"
+        "@pydantic/monty-darwin-arm64": "0.0.19",
+        "@pydantic/monty-darwin-x64": "0.0.19",
+        "@pydantic/monty-linux-arm64-gnu": "0.0.19",
+        "@pydantic/monty-linux-x64-gnu": "0.0.19",
+        "@pydantic/monty-win32-x64-msvc": "0.0.19"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2508,90 +2508,19 @@
       "license": "MIT"
     },
     "node_modules/@pydantic/monty-darwin-arm64": {
-      "version": "0.0.19-beta.6",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-arm64/-/monty-darwin-arm64-0.0.19-beta.6.tgz",
-      "integrity": "sha512-LBmIdkz+6KKlWvaR+1whP162ZBXTM+ONrjwVuz0+Ez3cyFukBKzvFsk5hrv25KWcpgiX5ftEdNs8JNAisXsBeQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-darwin-x64": {
-      "version": "0.0.19-beta.6",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-x64/-/monty-darwin-x64-0.0.19-beta.6.tgz",
-      "integrity": "sha512-AVQf1KtyO9RgptZ1cNAXUQIMYz+widVgxLe+j7pno/5iRjclQn3t6iKqTNxrzjGu84G9L/UZ9EcEHk86/3owQA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-linux-arm64-gnu": {
-      "version": "0.0.19-beta.6",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-arm64-gnu/-/monty-linux-arm64-gnu-0.0.19-beta.6.tgz",
-      "integrity": "sha512-LnyaaEuguQXaqng9Lux3htlaqD+366N90qxKYN4otF2yIHvVNXNhvcPhBy1iYzrl7pFuQJHJ6Ziv5tNCKh/28g==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-linux-x64-gnu": {
-      "version": "0.0.19-beta.6",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-x64-gnu/-/monty-linux-x64-gnu-0.0.19-beta.6.tgz",
-      "integrity": "sha512-EOLgKK3rPw17lL3bTbn7UvOM3ls/O0T64RcuP/otyxs7xbJTyBfbxs+ypXxsTRCoalINjoldKUuT7bAJUKQmRQ==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-win32-x64-msvc": {
-      "version": "0.0.19-beta.6",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-win32-x64-msvc/-/monty-win32-x64-msvc-0.0.19-beta.6.tgz",
-      "integrity": "sha512-vQ4VhsRMWaBS/Nq9oVvwns3hTPW2VkVgNMr1k+4TDTj4SlQVGLqXf6b0GADaUTnNDnqAKMhtj6EupiYOB+PpMg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",

--- a/crates/monty-js/package.json
+++ b/crates/monty-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.19-beta.6",
+  "version": "0.0.19",
   "type": "module",
   "description": "Sandboxed Python interpreter running in crash-isolated subprocess workers",
   "main": "dist/index.js",
@@ -91,10 +91,10 @@
     "arrowParens": "always"
   },
   "optionalDependencies": {
-    "@pydantic/monty-darwin-x64": "0.0.19-beta.6",
-    "@pydantic/monty-darwin-arm64": "0.0.19-beta.6",
-    "@pydantic/monty-linux-x64-gnu": "0.0.19-beta.6",
-    "@pydantic/monty-linux-arm64-gnu": "0.0.19-beta.6",
-    "@pydantic/monty-win32-x64-msvc": "0.0.19-beta.6"
+    "@pydantic/monty-darwin-x64": "0.0.19",
+    "@pydantic/monty-darwin-arm64": "0.0.19",
+    "@pydantic/monty-linux-x64-gnu": "0.0.19",
+    "@pydantic/monty-linux-arm64-gnu": "0.0.19",
+    "@pydantic/monty-win32-x64-msvc": "0.0.19"
   }
 }

--- a/crates/monty-python/pyproject.toml
+++ b/crates/monty-python/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     # ships the `monty` binary spawned as worker subprocesses; released in
     # lockstep with this package, so the pin is exact and kept in sync with the
     # workspace version by build.rs — don't edit it by hand
-    "pydantic-monty-runtime==0.0.19b.6",
+    "pydantic-monty-runtime==0.0.19",
 ]
 dynamic = ["license", "version"]
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepare the 0.0.19 release by removing the beta suffix and aligning versions across the Rust workspace, the JS package `@pydantic/monty` (and its platform packages), and the Python dependency `pydantic-monty-runtime==0.0.19`. Adds a CI step to free disk space in the Rust test job so instrumented builds succeed on cold caches, and updates RELEASING.md to use v‑prefixed branch names and commit messages.

<sup>Written for commit 29f78efe3e2ce9b7268cfe5737348d0923e3da90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

