### PR TITLE
fix `npm audit` warnings in `monty js`

### DIFF
--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -950,9 +950,9 @@
       "license": "Python-2.0"
     },
     "node_modules/@napi-rs/cli/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -4035,9 +4035,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
`make test-js` was yielding audit warnings, I thought might be a good idea to fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes npm audit warnings in `monty-js` by updating the lockfile to patched versions. Audit is now clean for `make test-js`; no runtime code changes.

- **Dependencies**
  - Bumped `js-yaml` from 4.2.0 to 4.3.0 (via `@napi-rs/cli`)
  - Bumped `shell-quote` from 1.8.4 to 1.10.0

<sup>Written for commit 29d337bd4baf2d7200a6791fc1cb6400b6a5f0e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

