### PR TITLE
tidy up max allocations remnants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -732,7 +732,7 @@ If you find yourself fighting the borrow checker around `clone_with_heap` or `al
 Reference counting alone cannot reclaim cycles. Monty uses **Bacon–Rajan trial deletion**
 (`Heap::collect_cycles` in `crates/monty/src/heap.rs`).
 
-**Resource limits**: When resource limits (allocations, memory, time) are exceeded, execution terminates with a `ResourceError`. No guarantees are made about the state of the heap or reference counts after a resource limit is exceeded. The heap may contain orphaned objects with incorrect refcounts. This is acceptable because resource exhaustion is a terminal error - the execution context should be discarded.
+**Resource limits**: When a memory or time limit is exceeded, execution terminates with a `ResourceError`. No guarantees are made about the state of the heap or reference counts after a resource limit is exceeded. The heap may contain orphaned objects with incorrect refcounts. This is acceptable because resource exhaustion is a terminal error - the execution context should be discarded.
 
 ## JavaScript Package (`@pydantic/monty`, `crates/monty-js/`)
 

--- a/crates/monty-runtime/README.md
+++ b/crates/monty-runtime/README.md
@@ -19,8 +19,8 @@ hello world
   before executing
 - `-m` / `--mount /host/path::/virtual/path[::mode[::write_limit_bytes]]` —
   mount a host directory into the sandbox (`ro`, `rw`, or `overlay`)
-- `--max-memory 10MB`, `--max-duration 0.5`, `--max-allocations`,
-  `--max-recursion-depth`, `--gc-interval` — sandbox resource limits
+- `--max-memory 10MB`, `--max-duration 0.5`, `--max-recursion-depth`,
+  `--gc-interval` — sandbox resource limits
 
 ## Worker mode
 

--- a/crates/monty-types/src/object.rs
+++ b/crates/monty-types/src/object.rs
@@ -974,7 +974,7 @@ impl Error for ConversionError {}
 ///
 /// This can occur when:
 /// - A `MontyObject` variant (like `Repr`) is only valid as an output, not an input
-/// - A resource limit (memory, allocations) is exceeded during conversion
+/// - A resource limit is exceeded during conversion
 #[derive(Debug, Clone)]
 pub enum InvalidInputError {
     /// The input type is not valid for conversion to a runtime Value.


### PR DESCRIPTION
followup to #611 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove remaining references to the removed allocations limit across docs and comments. Clarifies resource limits to memory and time only; no behavior changes.

- **Refactors**
  - Drop `--max-allocations` from `crates/monty-runtime/README.md` and align sandbox limit docs.
  - Update `CLAUDE.md` and `InvalidInputError` docs to refer to generic resource limits.

<sup>Written for commit f176152aab33786fdd9d9905909f7272039d4af0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

