### PR TITLE
Track iterator types for GC so their cycles can't evade collection

### DIFF
--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -171,37 +171,53 @@ impl HeapData {
     ///
     /// This optimization allows programs that allocate many leaf objects (like strings)
     /// to avoid triggering unnecessary GC cycles.
+    ///
+    /// Matched exhaustively so new variants must choose.
     #[inline]
     pub(crate) fn is_gc_tracked(&self) -> bool {
-        matches!(
-            self,
+        match self {
             Self::List(_)
-                | Self::Tuple(_)
-                | Self::NamedTuple(_)
-                | Self::Dict(_)
-                | Self::DictKeysView(_)
-                | Self::DictItemsView(_)
-                | Self::DictValuesView(_)
-                | Self::Set(_)
-                | Self::FrozenSet(_)
-                | Self::Closure(_)
-                | Self::FunctionDefaults(_)
-                | Self::Cell(_)
-                | Self::Dataclass(_)
-                | Self::Class(_)
-                | Self::Instance(_)
-                | Self::BoundMethod(_)
-                | Self::Iter(_)
-                | Self::Module(_)
-                | Self::Coroutine(_)
-                | Self::GatherFuture(_)
-                | Self::ExternalFuture(_)
-        )
-        // `OpenFile` is deliberately *not* listed here: its single heap
-        // reference (`buffer`) only ever points to `Str` / `Bytes`, neither of
-        // which is GC-tracked, so an `OpenFile` cannot participate in a
-        // reference cycle. Add it back if `OpenFile` ever gains a field that
-        // can hold a container value (e.g. a user-provided callback).
+            | Self::Tuple(_)
+            | Self::NamedTuple(_)
+            | Self::Dict(_)
+            | Self::DictKeysView(_)
+            | Self::DictItemsView(_)
+            | Self::DictValuesView(_)
+            | Self::Set(_)
+            | Self::FrozenSet(_)
+            | Self::Closure(_)
+            | Self::FunctionDefaults(_)
+            | Self::Cell(_)
+            | Self::Dataclass(_)
+            | Self::Class(_)
+            | Self::Instance(_)
+            | Self::BoundMethod(_)
+            | Self::Iter(_)
+            | Self::ListIterator(_)
+            | Self::CallableIterator(_)
+            | Self::Module(_)
+            | Self::Coroutine(_)
+            | Self::GatherFuture(_)
+            | Self::ExternalFuture(_) => true,
+            // Leaf types, plus three whose heap refs can only point at leaves and so
+            // cannot close a cycle: `OpenFile` (→ Str/Bytes), `ReMatch` (→ Str),
+            // `DateTime` (→ TimeZone). Move up if any gains a container-valued field.
+            Self::Str(_)
+            | Self::Bytes(_)
+            | Self::Range(_)
+            | Self::Slice(_)
+            | Self::Exception(_)
+            | Self::LongInt(_)
+            | Self::Path(_)
+            | Self::OpenFile(_)
+            | Self::RePattern(_)
+            | Self::ReMatch(_)
+            | Self::ExtFunction(_)
+            | Self::Date(_)
+            | Self::DateTime(_)
+            | Self::TimeDelta(_)
+            | Self::TimeZone(_) => false,
+        }
     }
 
     /// Whether calling a `Ref` to this heap data would succeed at dispatch.

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -104,6 +104,56 @@ len(result)
     );
 }
 
+/// Cycles through `callable_iterator` / `list_iterator` must be collected even
+/// when the iterator is the last external reference dropped.
+#[test]
+#[cfg(feature = "ref-count-return")]
+fn gc_collects_iterator_cycles_rooted_by_the_iterator() {
+    let code = r"
+class Src:
+    def step(self):
+        return 1
+
+roots = []
+for i in range(2000):
+    o = Src()
+    it = iter(o.step, 0)
+    o.it = it         # cycle: instance -> attrs -> callable_iterator -> bound method
+    roots.append(it)  # ... rooted ONLY through the iterator
+
+    a = []
+    li = iter(a)
+    a.append(li)      # cycle: list -> list_iterator
+    roots.append(li)  # ... likewise rooted only through the iterator
+
+# Dropping `roots` decrements every cycle member exactly once, and the only
+# member holding a surviving refcount at that point is the iterator.
+roots = None
+
+# Churn so the collector keeps firing afterwards; the cycles above must be
+# reclaimed by one of these passes.
+for i in range(2000):
+    d = {}
+    d['self'] = d
+
+result = 'done'
+result
+";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+
+    // Small interval so a collection fires while the cycles are still rooted,
+    // clearing the `Purple` flags earlier decrements left on the other members.
+    let tracker = ResourceTracker::new(ResourceLimits::default().gc_interval(500));
+    let output = ex.run_ref_counts_with_tracker(vec![], tracker).expect("should succeed");
+
+    // 7 survive here; untracked iterators leak the 4000 cycles instead (~9995).
+    assert!(
+        output.heap_count < 20,
+        "GC should collect iterator-rooted cycles: {} heap objects (expected < 20)",
+        output.heap_count
+    );
+}
+
 /// Test that GC properly collects self-referencing list cycles.
 ///
 /// Each iteration's `a.append(a)` produces a self-referencing list; the next


### PR DESCRIPTION
## The bug

`ListIterator` and `CallableIterator` hold owned references to arbitrary user objects, but neither was listed in `HeapData::is_gc_tracked`. This means that they did not properly participate in cyclic GC checking.

Also changed the `is_gc_tracked` match to be exhaustive so that newly added HeapDate types in future are not missed.

Developed with TDD - failing test case now passes.