### PR TITLE
Support Path / Path and reflected str / Path in the / operator

### DIFF
--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -305,20 +305,31 @@ impl Path {
 
 /// Extracts a string from a Value for use as a path.
 fn extract_path_string<'a>(val: &Value, vm: &'a VM<'_>) -> RunResult<&'a str> {
+    value_as_path_str(val, vm.heap, vm.interns)
+        .ok_or_else(|| ExcType::type_error(format!("expected str or Path, got {}", val.py_type_name(vm))))
+}
+
+/// Extracts a path-like operand (`str` or `Path`) as a string slice, `None` otherwise.
+fn value_as_path_str<'a>(val: &Value, heap: &'a Heap, interns: &'a Interns) -> Option<&'a str> {
     match val {
-        Value::InternString(string_id) => Ok(vm.interns.get_str(*string_id)),
-        Value::Ref(heap_id) => match vm.heap.get(*heap_id) {
-            HeapData::Str(s) => Ok(s.as_str()),
-            HeapData::Path(p) => Ok(p.as_str()),
-            _ => Err(ExcType::type_error(format!(
-                "expected str or Path, got {}",
-                val.py_type_name(vm)
-            ))),
+        Value::InternString(string_id) => Some(interns.get_str(*string_id)),
+        Value::Ref(heap_id) => match heap.get(*heap_id) {
+            HeapData::Str(s) => Some(s.as_str()),
+            HeapData::Path(p) => Some(p.as_str()),
+            _ => None,
         },
-        _ => Err(ExcType::type_error(format!(
-            "expected str or Path, got {}",
-            val.py_type_name(vm)
-        ))),
+        _ => None,
+    }
+}
+
+/// Returns the `Path` behind `value` if it is a heap-allocated `Path`.
+fn value_as_path<'a>(value: &Value, heap: &'a Heap) -> Option<&'a Path> {
+    match value {
+        Value::Ref(id) => match heap.get(*id) {
+            HeapData::Path(p) => Some(p),
+            _ => None,
+        },
+        _ => None,
     }
 }
 
@@ -329,29 +340,28 @@ fn fold_joinpath(mut path: Path, parts: &[Value], vm: &VM<'_>) -> RunResult<Path
     Ok(path)
 }
 
-/// Handles the `/` operator for Path objects (path concatenation).
+/// Handles the `/` operator when either operand is a `Path` (path concatenation).
 ///
-/// In Python, `Path('/usr') / 'bin'` produces `Path('/usr/bin')`.
-pub(crate) fn path_div(path_id: HeapId, other: &Value, heap: &Heap, interns: &Interns) -> RunResult<Option<Value>> {
-    // Extract the right-hand side as a string
-    let other_str = match other {
-        Value::InternString(string_id) => interns.get_str(*string_id).to_owned(),
-        Value::Ref(other_id) => match heap.get(*other_id) {
-            HeapData::Str(s) => s.as_str().to_owned(),
-            HeapData::Path(p) => p.as_str().to_owned(),
-            _ => return Ok(None),
-        },
-        _ => return Ok(None),
+/// Covers both `Path / (str | Path)` and the reflected `str / Path` form,
+/// matching CPython's `PurePath.__truediv__` / `__rtruediv__`. Returns
+/// `Ok(None)` when neither combination applies so the caller can raise the
+/// standard unsupported-operand `TypeError`.
+pub(crate) fn path_div(lhs: &Value, rhs: &Value, heap: &Heap, interns: &Interns) -> RunResult<Option<Value>> {
+    let result = if let Some(path) = value_as_path(lhs, heap) {
+        // Path / (str | Path)
+        match value_as_path_str(rhs, heap, interns) {
+            Some(other) => path.joinpath(other),
+            None => return Ok(None),
+        }
+    } else if let Some(path) = value_as_path(rhs, heap) {
+        // str / Path — CPython's __rtruediv__: the left operand becomes the base
+        match value_as_path_str(lhs, heap, interns) {
+            Some(base) => Path::new(base.to_owned()).joinpath(path.as_str()),
+            None => return Ok(None),
+        }
+    } else {
+        return Ok(None);
     };
-
-    // Get the path string
-    let path_str = match heap.get(path_id) {
-        HeapData::Path(p) => p.as_str().to_owned(),
-        _ => return Ok(None),
-    };
-
-    // Perform path concatenation
-    let result = Path::new(path_str).joinpath(&other_str);
     Ok(Some(Value::Ref(heap.allocate(HeapData::Path(Path::new(result)))?)))
 }
 

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -993,7 +993,7 @@ impl<'h> PyTrait<'h> for Value {
                 }
                 _ => Ok(None),
             },
-            // LongInt / LongInt
+            // LongInt / LongInt, or Path concatenation with a heap str/Path operand
             (Self::Ref(id1), Self::Ref(id2)) => match (vm.heap.get(*id1), vm.heap.get(*id2)) {
                 (HeapData::LongInt(li1), HeapData::LongInt(li2)) => {
                     if li2.is_zero() {
@@ -1004,7 +1004,7 @@ impl<'h> PyTrait<'h> for Value {
                         Ok(Some(Self::Float(a_f64 / b_f64)))
                     }
                 }
-                _ => Ok(None),
+                _ => path::path_div(self, other, vm.heap, interns),
             },
             // LongInt / Float
             (Self::Ref(id), Self::Float(b)) => {
@@ -1089,15 +1089,8 @@ impl<'h> PyTrait<'h> for Value {
                     Err(ExcType::zero_division().into())
                 }
             }
-            _ => {
-                // Check for Path / (str or Path) - path concatenation
-                if let Self::Ref(id) = self
-                    && matches!(vm.heap.get(*id), HeapData::Path(_))
-                {
-                    return path::path_div(*id, other, vm.heap, interns);
-                }
-                Ok(None)
-            }
+            // Path / str and str / Path (path concatenation), otherwise unsupported
+            _ => path::path_div(self, other, vm.heap, interns),
         }
     }
 

--- a/crates/monty/test_cases/pathlib__pure.py
+++ b/crates/monty/test_cases/pathlib__pure.py
@@ -71,6 +71,57 @@ assert str(Path('/path/file').with_suffix('.txt')) == '/path/file.txt'
 assert str(Path('/usr') / 'local') == '/usr/local'
 assert str(Path('/usr') / 'local' / 'bin') == '/usr/local/bin'
 
+# Path / Path
+assert str(Path('/usr') / Path('bin')) == '/usr/bin'
+assert str(Path('/usr') / Path('/etc')) == '/etc'
+
+# Path / heap-allocated (non-interned) str
+heap_str = 'lo' + 'cal'
+assert str(Path('/usr') / heap_str) == '/usr/local'
+
+# str / Path (__rtruediv__)
+assert str('/usr' / Path('bin')) == '/usr/bin'
+assert str(heap_str / Path('bin')) == 'local/bin'
+assert str('/usr' / Path('/etc')) == '/etc'
+
+# absolute rhs replaces lhs
+assert str(Path('/usr') / '/etc') == '/etc'
+
+# empty and dot components
+assert str(Path('.') / 'a') == 'a'
+assert str(Path('/usr') / '') == '/usr'
+assert str(Path('/usr') / '.') == '/usr'
+assert str('' / Path('a')) == 'a'
+
+# augmented assignment
+aug = Path('/a')
+aug /= 'b'
+assert str(aug) == '/a/b'
+aug /= Path('c')
+assert str(aug) == '/a/b/c'
+
+# unsupported operand types raise TypeError matching CPython
+try:
+    Path('/usr') / 1
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "unsupported operand type(s) for /: 'PosixPath' and 'int'"
+try:
+    1 / Path('/usr')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "unsupported operand type(s) for /: 'int' and 'PosixPath'"
+try:
+    Path('/usr') / b'bin'
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "unsupported operand type(s) for /: 'PosixPath' and 'bytes'"
+try:
+    b'/usr' / Path('bin')
+    assert False, 'expected TypeError'
+except TypeError as e:
+    assert str(e) == "unsupported operand type(s) for /: 'bytes' and 'PosixPath'"
+
 # === as_posix method ===
 assert Path('/usr/bin').as_posix() == '/usr/bin'
 

--- a/limitations/pathlib.md
+++ b/limitations/pathlib.md
@@ -20,11 +20,11 @@ Implemented: `name`, `parent`, `stem`, `suffix`, `suffixes`, `parts`,
 `is_absolute()`, `joinpath(*other)`, `with_name(name)`, `with_stem(stem)`,
 `with_suffix(suffix)`, `as_posix()`, `__fspath__()`.
 
-The `/` operator works (`Path("a") / "b"` → `Path("a/b")`).
+The `/` operator works in both directions (`Path("a") / "b"`,
+`Path("a") / Path("b")`, `"a" / Path("b")`).
 
 Not implemented: `anchor`, `drive`, `root`, `relative_to`, `is_reserved`,
-`match`, `full_match`, `__truediv__` with a `Path` on the *left* of a str
-(but right-side str is fine), `with_segments`.
+`match`, `full_match`, `with_segments`.
 
 ## I/O methods (yield to host)
 


### PR DESCRIPTION
The / operator on Path only worked with an interned str on the right.
Path / Path and Path / <heap str> were intercepted by the LongInt/LongInt
match arm in py_div and fell through to TypeError, and the reflected
str / Path form (CPython's PurePath.__rtruediv__) was not handled at all.

path_div now takes both operand Values and handles either side being a
Path, mirroring CPython's __truediv__/__rtruediv__ semantics, and is
wired into both the (Ref, Ref) arm and the final catch-all of py_div.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018xSTpHcTbm3zJVd4vZD5pt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full path concatenation support with `/`: `Path / Path`, `Path / str` (interned or heap), and reflected `str / Path`, matching CPython `PurePath` behavior and fixing previous TypeErrors.

- **Bug Fixes**
  - Added `path_div(lhs, rhs)` to handle both `__truediv__` and `__rtruediv__` for `Path`.
  - Integrated into `py_div` `(Ref, Ref)` and fallback paths to avoid LongInt interception and to raise correct unsupported-operand errors.
  - Introduced `value_as_path_str`/`value_as_path` helpers; expanded tests (including augmented assignment) and updated `limitations/pathlib.md`.

<sup>Written for commit d674b7ab32a8f9c4dfc020c5dc5922b0383a4725. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

