### PR TITLE
Bound nesting of class-body expressions walked before parsing

### DIFF
--- a/crates/monty/src/parse.rs
+++ b/crates/monty/src/parse.rs
@@ -894,7 +894,7 @@ impl<'a> Parser<'a> {
                     }) = *target
                     {
                         let ident = self.identifier(&id, name_range);
-                        annotations.push(self.parse_class_annotation(ident, &mut annotation));
+                        annotations.push(self.parse_class_annotation(ident, &mut annotation)?);
                         if let Some(value) = value {
                             self.parse_class_var(ident, *value, &mut members, &mut body)?;
                         }
@@ -1024,13 +1024,17 @@ impl<'a> Parser<'a> {
     /// The annotation is stringized rather than evaluated (see
     /// `limitations/typing.md`); [`stringize_annotation`] owns rendering it back
     /// to the text CPython would store.
-    fn parse_class_annotation(&mut self, ident: Identifier, annotation: &mut AstExpr) -> DictItem {
+    ///
+    /// The annotation never reaches [`Parser::parse_expression`], so the depth
+    /// check guarding stringization's two recursive passes is made here.
+    fn parse_class_annotation(&mut self, ident: Identifier, annotation: &mut AstExpr) -> Result<DictItem, ParseError> {
+        self.check_expression_depth(annotation)?;
         let ann_range = annotation.range();
         let ann_id = self.interner.intern(&stringize_annotation(annotation));
-        DictItem::Pair(
+        Ok(DictItem::Pair(
             ExprLoc::new(ident.position, Expr::Literal(Literal::Str(ident.name_id))),
             ExprLoc::new(self.convert_range(ann_range), Expr::Literal(Literal::Str(ann_id))),
-        )
+        ))
     }
 
     /// Parses a class-variable value and records the binding: rejects class-scope
@@ -1059,7 +1063,10 @@ impl<'a> Parser<'a> {
     /// binding would be silently dropped — reject the syntax until class-scope
     /// walrus is implemented. A walrus inside a lambda *body* binds in the
     /// lambda's own scope and is allowed (see [`contains_class_scope_walrus`]).
+    /// The depth check comes first: the search recurses over the raw ruff AST,
+    /// which `parse_expression` has not yet bounded.
     fn reject_class_body_walrus(&self, expr: &AstExpr) -> Result<(), ParseError> {
+        self.check_expression_depth(expr)?;
         if contains_class_scope_walrus(expr) {
             Err(ParseError::not_implemented(
                 "assignment expressions (`:=`) in class bodies",
@@ -2143,6 +2150,51 @@ impl<'a> Parser<'a> {
         } else {
             let position = self.convert_range(get_range());
             Err(ParseError::syntax("Source is too deeply nested", position))
+        }
+    }
+
+    /// Rejects an expression nested deeper than the remaining budget, without
+    /// consuming any of it — for callers that walk a raw ruff expression
+    /// recursively *before* [`Parser::parse_expression`] can bound it.
+    ///
+    /// Ruff builds deeply nested ASTs from flat source (long attribute chains)
+    /// without recursing itself, so such a walk can overflow the host stack at
+    /// compile time. The check stops descending once the budget is exhausted, so
+    /// its own depth is bounded by [`MAX_NESTING_DEPTH`].
+    fn check_expression_depth(&self, expr: &AstExpr) -> Result<(), ParseError> {
+        /// Expression visitor that reports whether the walk ever ran out of budget.
+        struct DepthCheck {
+            remaining: u16,
+            too_deep: bool,
+        }
+        impl<'a> Visitor<'a> for DepthCheck {
+            fn visit_expr(&mut self, expr: &'a AstExpr) {
+                // Nothing is pruned (not even lambda bodies): the guarded walks
+                // reach everywhere, so the bound must too.
+                match self.remaining.checked_sub(1) {
+                    _ if self.too_deep => {}
+                    None => self.too_deep = true,
+                    Some(remaining) => {
+                        self.remaining = remaining;
+                        walk_expr(self, expr);
+                        self.remaining += 1;
+                    }
+                }
+            }
+        }
+
+        let mut check = DepthCheck {
+            remaining: self.depth_remaining,
+            too_deep: false,
+        };
+        check.visit_expr(expr);
+        if check.too_deep {
+            Err(ParseError::syntax(
+                "Source is too deeply nested",
+                self.convert_range(expr.range()),
+            ))
+        } else {
+            Ok(())
         }
     }
 }

--- a/crates/monty/tests/parse_errors.rs
+++ b/crates/monty/tests/parse_errors.rs
@@ -806,6 +806,52 @@ fn moderate_bool_op_chain_within_limit() {
     assert!(result.is_ok(), "moderate bool-op chain should succeed: {result:?}");
 }
 
+/// A flat-looking expression ruff parses without recursing, so only an explicit
+/// depth check stops a later recursive walk overflowing the host stack.
+fn deep_attribute_chain() -> String {
+    let mut chain = "a".to_owned();
+    for _ in 0..2_000 {
+        chain.push_str(".x");
+    }
+    chain
+}
+
+#[test]
+fn deeply_nested_class_annotation_exceeds_limit() {
+    // Stringized, never parsed, so `parse_expression`'s budget never sees it.
+    let code = format!("class C:\n    y: {}\n", deep_attribute_chain());
+    let err = get_parse_err(code);
+    assert_eq!(err.exc_type(), ExcType::SyntaxError);
+    assert_snapshot!(err.message().unwrap(), @"Source is too deeply nested");
+}
+
+#[test]
+fn deeply_nested_class_var_value_exceeds_limit() {
+    // The class-scope walrus search walks the value before it is parsed.
+    let code = format!("class C:\n    y = {}\n", deep_attribute_chain());
+    let err = get_parse_err(code);
+    assert_eq!(err.exc_type(), ExcType::SyntaxError);
+    assert_snapshot!(err.message().unwrap(), @"Source is too deeply nested");
+}
+
+#[test]
+fn deeply_nested_method_default_exceeds_limit() {
+    // Parameter defaults go through the same pre-parse walrus search.
+    let code = format!("class C:\n    def m(self, x={}): pass\n", deep_attribute_chain());
+    let err = get_parse_err(code);
+    assert_eq!(err.exc_type(), ExcType::SyntaxError);
+    assert_snapshot!(err.message().unwrap(), @"Source is too deeply nested");
+}
+
+#[test]
+fn moderate_class_annotation_within_limit() {
+    // The new checks must not reject annotations of ordinary depth.
+    let code = "class C:\n    y: dict[str, list[int]]\n    z: a.b.c = 1\n\
+                assert C.__annotations__ == {'y': 'dict[str, list[int]]', 'z': 'a.b.c'}\n";
+    let result = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default());
+    assert!(result.is_ok(), "ordinary class annotations should compile: {result:?}");
+}
+
 #[test]
 fn function_with_too_many_locals_and_except_as_returns_syntax_error() {
     let mut code = "def f():\n".to_owned();

--- a/limitations/language.md
+++ b/limitations/language.md
@@ -59,6 +59,7 @@ unpacking form matches CPython exactly.
 - AST nesting is capped at 200 levels (30 in debug builds); exceeding it raises `SyntaxError: Source is too deeply nested`.
 - The budget is shared across every nesting-producing construct (parens, calls, subscripts, attribute chains, operators, comprehensions, control-flow blocks, `with`, etc.), including the synthetic nesting from a flat multi-item `with` — see with.md.
 - The message differs from CPython, which uses construct-specific wording (`too many nested parentheses`, `too many statically nested blocks`, …).
+- Class-body annotations count against the budget even though they are stringized rather than evaluated (see typing.md), as do class-variable values and method parameter defaults — all three are walked before being parsed. CPython imposes no comparable limit on a stringized annotation.
 
 ## Imports
 


### PR DESCRIPTION
`stringize_annotation` and the class-body walrus search recurse over a raw ruff expression that `parse_expression` never bounds. Ruff builds deep ASTs from flat source without recursing, so `class C:\n    y: a.x.x...` (and the `y = ...` / `def m(self, x=...)` forms) aborted the process with a native stack overflow during `MontyRun::new` — a compile-time DoS on untrusted code.

Adds `Parser::check_expression_depth`, which measures nesting against the remaining budget without consuming it and stops descending at the limit, and calls it from both paths. All forms now raise `SyntaxError: Source is too deeply nested`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a compile-time stack overflow by bounding nesting in class-body expressions that are walked before parsing. Deeply nested annotations, class values, and method defaults now raise a `SyntaxError` instead of crashing.

- **Bug Fixes**
  - Added `Parser::check_expression_depth` to measure nesting without consuming the budget and stop at the limit.
  - Called the check for class annotations before stringization and in the class-body walrus search.
  - Long attribute chains in annotations, class variable values, and method parameter defaults now error with "Source is too deeply nested".
  - Added tests for deep chains and updated `limitations/language.md`.

<sup>Written for commit a49243612a8aff8282c357f99010b1c889526fac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

