### PR TITLE
Move `py_contains` onto `PyTrait`, fix `in` for bytes, add coverage

### DIFF
--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -572,21 +572,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
     /// Delegates to the types defining their own `in`; the rest keep the trait
     /// default (`None`), leaving `Value::py_contains` to iterate or raise.
     fn py_contains_impl(&self, self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        match self {
-            Self::Bytes(b) => b.py_contains_impl(self_id, item, vm),
-            Self::List(l) => l.py_contains_impl(self_id, item, vm),
-            Self::Tuple(t) => t.py_contains_impl(self_id, item, vm),
-            Self::Dict(d) => d.py_contains_impl(self_id, item, vm),
-            Self::DictKeysView(view) => view.py_contains_impl(self_id, item, vm),
-            Self::DictItemsView(view) => view.py_contains_impl(self_id, item, vm),
-            Self::DictValuesView(view) => view.py_contains_impl(self_id, item, vm),
-            Self::Set(s) => s.py_contains_impl(self_id, item, vm),
-            Self::FrozenSet(fs) => fs.py_contains_impl(self_id, item, vm),
-            Self::Str(s) => s.py_contains_impl(self_id, item, vm),
-            Self::Range(r) => r.py_contains_impl(self_id, item, vm),
-            Self::Instance(i) => i.py_contains_impl(self_id, item, vm),
-            _ => Ok(None),
-        }
+        heap_read_output_py_trait_forward!(self, |value| value.py_contains_impl(self_id, item, vm), else Ok(None))
     }
 
     fn py_bool(&self, vm: &mut VM<'h>) -> bool {

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -569,6 +569,26 @@ macro_rules! heap_read_output_py_trait_forward {
 }
 
 impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
+    /// Delegates to the types defining their own `in`; the rest keep the trait
+    /// default (`None`), leaving `Value::py_contains` to iterate or raise.
+    fn py_contains_impl(&self, self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        match self {
+            Self::Bytes(b) => b.py_contains_impl(self_id, item, vm),
+            Self::List(l) => l.py_contains_impl(self_id, item, vm),
+            Self::Tuple(t) => t.py_contains_impl(self_id, item, vm),
+            Self::Dict(d) => d.py_contains_impl(self_id, item, vm),
+            Self::DictKeysView(view) => view.py_contains_impl(self_id, item, vm),
+            Self::DictItemsView(view) => view.py_contains_impl(self_id, item, vm),
+            Self::DictValuesView(view) => view.py_contains_impl(self_id, item, vm),
+            Self::Set(s) => s.py_contains_impl(self_id, item, vm),
+            Self::FrozenSet(fs) => fs.py_contains_impl(self_id, item, vm),
+            Self::Str(s) => s.py_contains_impl(self_id, item, vm),
+            Self::Range(r) => r.py_contains_impl(self_id, item, vm),
+            Self::Instance(i) => i.py_contains_impl(self_id, item, vm),
+            _ => Ok(None),
+        }
+    }
+
     fn py_bool(&self, vm: &mut VM<'h>) -> bool {
         heap_read_output_py_trait_forward!(
             self,

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -279,6 +279,11 @@ impl ops::Deref for Bytes {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, Bytes> {
+    /// One-sided implementation of Python membership (`__contains__`).
+    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        bytes_contains(self.get(vm.heap).as_slice(), item, vm).map(Some)
+    }
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -2269,5 +2274,31 @@ impl<'h> PyTrait<'h> for HeapRead<'h, BytesIterator> {
         } else {
             Ok(None)
         }
+    }
+}
+
+/// Membership for `item in <bytes>`, shared by heap and interned containers.
+///
+/// CPython accepts a bytes-like probe (substring) or an integer (byte value);
+/// an integer outside `range(0, 256)` is a `ValueError`, anything else a `TypeError`.
+pub(crate) fn bytes_contains(container: &[u8], item: &Value, vm: &VM<'_>) -> RunResult<bool> {
+    let byte = match item {
+        Value::Int(i) => *i,
+        Value::Bool(b) => i64::from(*b),
+        // A bytes-like probe is a substring test.
+        Value::InternBytes(_) | Value::Ref(_) => {
+            let needle = extract_bytes_only(item, vm)?;
+            return Ok(container.windows(needle.len().max(1)).any(|w| w == needle) || needle.is_empty());
+        }
+        other => {
+            return Err(ExcType::type_error(format!(
+                "a bytes-like object is required, not '{}'",
+                other.py_type_name(vm)
+            )));
+        }
+    };
+    match u8::try_from(byte) {
+        Ok(b) => Ok(container.contains(&b)),
+        Err(_) => Err(ExcType::value_error("byte must be in range(0, 256)")),
     }
 }

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -2282,9 +2282,14 @@ impl<'h> PyTrait<'h> for HeapRead<'h, BytesIterator> {
 /// CPython accepts a bytes-like probe (substring) or an integer (byte value);
 /// an integer outside `range(0, 256)` is a `ValueError`, anything else a `TypeError`.
 pub(crate) fn bytes_contains(container: &[u8], item: &Value, vm: &VM<'_>) -> RunResult<bool> {
+    // `None` marks an integer probe that cannot be a byte, keeping the range
+    // error in one place. A `LongInt` never fits in a `u8` by construction — it
+    // exists precisely because the value overflowed `i64`.
     let byte = match item {
-        Value::Int(i) => *i,
-        Value::Bool(b) => i64::from(*b),
+        Value::Int(i) => Some(*i),
+        Value::Bool(b) => Some(i64::from(*b)),
+        Value::InternLongInt(_) => None,
+        Value::Ref(id) if matches!(vm.heap.get(*id), HeapData::LongInt(_)) => None,
         // A bytes-like probe is a substring test.
         Value::InternBytes(_) | Value::Ref(_) => {
             let needle = extract_bytes_only(item, vm)?;
@@ -2297,8 +2302,8 @@ pub(crate) fn bytes_contains(container: &[u8], item: &Value, vm: &VM<'_>) -> Run
             )));
         }
     };
-    match u8::try_from(byte) {
-        Ok(b) => Ok(container.contains(&b)),
-        Err(_) => Err(ExcType::value_error("byte must be in range(0, 256)")),
+    match byte.and_then(|b| u8::try_from(b).ok()) {
+        Some(b) => Ok(container.contains(&b)),
+        None => Err(ExcType::value_error("byte must be in range(0, 256)")),
     }
 }

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -797,6 +797,11 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
         true
     }
 
+    /// `in` on a dict tests its *keys*, matching CPython.
+    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        self.contains_key(item, vm).map(Some)
+    }
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::Dict
     }

--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -7,7 +7,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
-    heap::{DropGuard, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
+    heap::{ContainsHeap, DropGuard, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     types::{
         Dict, FrozenSet, LazyHeapSet, PyTrait, Set, Type, allocate_tuple,
@@ -158,6 +158,15 @@ impl DictView for DictKeysView {
 impl<'h> PyTrait<'h> for HeapRead<'h, DictKeysView> {
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
+    }
+
+    /// Delegates to the backing dict's key lookup.
+    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        let dict_id = self.get(vm.heap).dict_id();
+        let HeapReadOutput::Dict(dict) = vm.heap.read(dict_id) else {
+            panic!("dict_keys view must reference a dict");
+        };
+        dict.contains_key(item, vm).map(Some)
     }
 
     fn py_type(&self, _vm: &VM<'h>) -> Type {
@@ -424,6 +433,31 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictItemsView> {
         true
     }
 
+    /// Membership takes a `(key, value)` probe: look the key up, then compare
+    /// the stored value. A non-pair probe can never be a member.
+    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        let dict_id = self.get(vm.heap).dict_id();
+        let Some((key, value)) = cloned_items_view_candidate(item, vm) else {
+            return Ok(Some(false));
+        };
+        let mut key_guard = DropGuard::new(key, vm);
+        let (key, vm) = key_guard.as_parts_mut();
+        let mut value_guard = DropGuard::new(value, vm);
+        let (value, vm) = value_guard.as_parts_mut();
+        let HeapReadOutput::Dict(dict) = vm.heap.read(dict_id) else {
+            panic!("dict_items view must reference a dict");
+        };
+        match dict.dict_get(key, vm) {
+            Ok(Some(existing_value)) => {
+                let result = value.py_eq(&existing_value, vm);
+                existing_value.drop_with(vm);
+                result.map(Some)
+            }
+            Ok(None) => Ok(Some(false)),
+            Err(e) => Err(e),
+        }
+    }
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::DictItems
     }
@@ -561,6 +595,22 @@ impl<'h> HeapRead<'h, DictValuesView> {
 impl<'h> PyTrait<'h> for HeapRead<'h, DictValuesView> {
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
+    }
+
+    /// Values are not indexed, so this is a linear scan of the backing dict.
+    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        let dict_id = self.get(vm.heap).dict_id();
+        let HeapReadOutput::Dict(dict) = vm.heap.read(dict_id) else {
+            panic!("dict_values view must reference a dict");
+        };
+        let iter = dict.iter(vm)?;
+        defer_drop_mut!(iter, vm);
+        while let Some(value) = iter.next_value(vm)? {
+            if item.py_eq(value, vm)? {
+                return Ok(Some(true));
+            }
+        }
+        Ok(Some(false))
     }
 
     fn py_type(&self, _vm: &VM<'h>) -> Type {
@@ -819,4 +869,35 @@ fn sets_are_disjoint(left: &Set, right: &Set, vm: &mut VM<'_>) -> RunResult<bool
         }
     }
     Ok(true)
+}
+
+/// Extracts and clones the `(key, value)` probe accepted by `dict_items.__contains__`.
+///
+/// CPython treats only 2-tuples as valid probes for items-view membership. Monty
+/// also accepts namedtuples of length two so tuple-like runtime values behave
+/// sensibly even though namedtuples are not modeled as a true tuple subclass.
+pub(crate) fn cloned_items_view_candidate(item: &Value, heap: &impl ContainsHeap) -> Option<(Value, Value)> {
+    let Value::Ref(heap_id) = item else {
+        return None;
+    };
+
+    match heap.heap().get(*heap_id) {
+        HeapData::Tuple(tuple) => {
+            let items = tuple.as_slice();
+            if items.len() == 2 {
+                Some((items[0].clone_with_heap(heap), items[1].clone_with_heap(heap)))
+            } else {
+                None
+            }
+        }
+        HeapData::NamedTuple(namedtuple) => {
+            let items = namedtuple.as_vec();
+            if items.len() == 2 {
+                Some((items[0].clone_with_heap(heap), items[1].clone_with_heap(heap)))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
 }

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -77,6 +77,12 @@ impl<'h> HeapRead<'h, Instance> {
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, Instance> {
+    /// The class's `__contains__`, or `None` when it defines none — `in` then
+    /// falls back to iteration, matching CPython's `sq_contains` before `tp_iter`.
+    fn py_contains_impl(&self, self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        instance_contains(self_id, item, vm)
+    }
+
     fn py_type(&self, vm: &VM<'h>) -> Type {
         Type::Instance(self.get(vm.heap).class)
     }

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -368,6 +368,21 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
         true
     }
 
+    /// Linear search by equality, indexed so a user `__eq__` re-entering the
+    /// VM cannot invalidate the walk.
+    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        let len = self.get(vm.heap).len();
+        for i in 0..len {
+            let el = self.clone_item(i, vm);
+            let eq = item.py_eq(&el, vm);
+            el.drop_with(vm);
+            if eq? {
+                return Ok(Some(true));
+            }
+        }
+        Ok(Some(false))
+    }
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::List
     }

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -368,15 +368,14 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
         true
     }
 
-    /// Linear search by equality, indexed so a user `__eq__` re-entering the
-    /// VM cannot invalidate the walk.
+    /// Linear search by equality. `ListIter` re-reads the length on every step,
+    /// so a user `__eq__` re-entering the VM and shrinking the list halts the
+    /// walk cleanly instead of indexing out of bounds.
     fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let len = self.get(vm.heap).len();
-        for i in 0..len {
-            let el = self.clone_item(i, vm);
-            let eq = item.py_eq(&el, vm);
-            el.drop_with(vm);
-            if eq? {
+        let iter = self.iter(vm)?;
+        defer_drop_mut!(iter, vm);
+        while let Some(el) = iter.next(vm)? {
+            if item.py_eq(el, vm)? {
                 return Ok(Some(true));
             }
         }

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -166,6 +166,15 @@ pub(crate) trait PyTrait<'h> {
         Ok(None)
     }
 
+    /// One-sided implementation of Python membership (`__contains__`).
+    ///
+    /// `Ok(None)` means the type has no containment logic of its own, so
+    /// [`Value::py_contains`] falls back to iteration and then `TypeError`.
+    /// `self_id` is only needed by types that re-enter the VM (`Instance`).
+    fn py_contains_impl(&self, _self_id: HeapId, _item: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        Ok(None)
+    }
+
     /// One-sided Python equality comparison (`self == other` from `self`'s side).
     ///
     /// Mirrors CPython's `__eq__`/`tp_richcompare` protocol: returns

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -191,6 +191,30 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Range> {
         true
     }
 
+    /// O(1) containment: bounds plus step alignment, no iteration. Non-integral
+    /// items can never be members, matching CPython's fast path.
+    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        let range = self.get(vm.heap);
+        let n = match item {
+            Value::Int(i) => *i,
+            Value::Bool(b) => i64::from(*b),
+            Value::Float(f) => {
+                if f.fract() != 0.0 {
+                    return Ok(Some(false));
+                }
+                let int_val = f.trunc();
+                if int_val < i64::MIN as f64 || int_val > i64::MAX as f64 {
+                    return Ok(Some(false));
+                }
+                #[expect(clippy::cast_possible_truncation)]
+                let n = int_val as i64;
+                n
+            }
+            _ => return Ok(Some(false)),
+        };
+        Ok(Some(range.contains(n)))
+    }
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::Range
     }

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -985,6 +985,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Set> {
         true
     }
 
+    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        self.contains(item, vm).map(Some)
+    }
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::Set
     }
@@ -1298,6 +1302,10 @@ impl FrozenSet {
 impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
+    }
+
+    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        self.contains(item, vm).map(Some)
     }
 
     fn py_type(&self, _vm: &VM<'h>) -> Type {

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -17,7 +17,7 @@ use crate::{
     exception_private::{ExcType, ExcTypeExt, RunResult},
     hash::{HashValue, hash_python_str},
     heap::{DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, heap_read_ref_as_field},
-    intern::{StaticStrings, StringId},
+    intern::{Interns, StaticStrings, StringId},
     resource_checks::{check_repeat_size, check_replace_size},
     string_builder::StringBuilder,
     types::{
@@ -265,6 +265,12 @@ impl ops::Deref for Str {
 impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
+    }
+
+    /// Substring search; `in` on a str requires a str on the left.
+    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        let container = self.get(vm.heap).as_str();
+        str_contains(container, item, vm.heap, vm.interns).map(Some)
     }
 
     fn py_type(&self, _vm: &VM<'h>) -> Type {
@@ -2159,5 +2165,32 @@ impl<'h> PyTrait<'h> for HeapRead<'h, StringIterator> {
         } else {
             Ok(None)
         }
+    }
+}
+
+/// Helper for substring containment check in strings.
+///
+/// Called by `HeapRead<Str>::py_contains_impl` and, for interned strings, by
+/// `Value::py_contains`. A non-str probe reports its own type, as CPython does.
+pub(crate) fn str_contains(container_str: &str, item: &Value, heap: &Heap, interns: &Interns) -> RunResult<bool> {
+    match item {
+        Value::InternString(item_id) => {
+            let item_str = interns.get_str(*item_id);
+            Ok(container_str.contains(item_str))
+        }
+        Value::Ref(item_heap_id) => {
+            if let HeapData::Str(item_str) = heap.get(*item_heap_id) {
+                Ok(container_str.contains(item_str.as_str()))
+            } else {
+                Err(ExcType::type_error(format!(
+                    "'in <string>' requires string as left operand, not {}",
+                    item.py_type_name_heap(heap, interns)
+                )))
+            }
+        }
+        _ => Err(ExcType::type_error(format!(
+            "'in <string>' requires string as left operand, not {}",
+            item.py_type_name_heap(heap, interns)
+        ))),
     }
 }

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -286,6 +286,21 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         true
     }
 
+    /// Linear search by equality, indexed so a user `__eq__` re-entering the
+    /// VM cannot invalidate the walk.
+    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        let len = self.get(vm.heap).as_slice().len();
+        for i in 0..len {
+            let el = self.clone_item(i, vm);
+            let eq = item.py_eq(&el, vm);
+            el.drop_with(vm);
+            if eq? {
+                return Ok(Some(true));
+            }
+        }
+        Ok(Some(false))
+    }
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::Tuple
     }

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -286,15 +286,13 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         true
     }
 
-    /// Linear search by equality, indexed so a user `__eq__` re-entering the
-    /// VM cannot invalidate the walk.
+    /// Linear search by equality; `TupleIter` owns each yielded item, so a user
+    /// `__eq__` re-entering the VM cannot invalidate the walk.
     fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let len = self.get(vm.heap).as_slice().len();
-        for i in 0..len {
-            let el = self.clone_item(i, vm);
-            let eq = item.py_eq(&el, vm);
-            el.drop_with(vm);
-            if eq? {
+        let iter = self.iter(vm)?;
+        defer_drop_mut!(iter, vm);
+        while let Some(el) = iter.next(vm)? {
+            if item.py_eq(el, vm)? {
                 return Ok(Some(true));
             }
         }

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -13,25 +13,28 @@ use num_traits::FromPrimitive;
 use crate::{
     builtins::Builtins,
     bytecode::{CallResult, VM},
-    defer_drop, defer_drop_mut,
+    defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
     fstring::FormatFloat,
     hash::{HashValue, hash_one, hash_python_long_int},
-    heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapReadOutput},
+    heap::{ContainsHeap, DropWithContext, Heap, HeapData, HeapId, HeapReadOutput},
     identity::Identity,
     intern::{BytesId, FunctionId, Interns, LongIntId, StaticStrings, StringId},
     modules::ModuleFunctions,
     resource_checks::check_pow_size,
     types::{
         Bytes, BytesIterator, CmpOrder, LazyHeapSet, LongInt, Property, PyTrait, StringIterator, Type,
-        bytes::{bytes_repr_fmt, concat_bytes, get_byte_at_index, repeat_bytes},
-        instance::{instance_contains, instance_getattr, instance_repr, instance_str},
+        bytes::{bytes_contains, bytes_repr_fmt, concat_bytes, get_byte_at_index, repeat_bytes},
+        instance::{instance_getattr, instance_repr, instance_str},
         long_int::{
             bigint_cmp_f64, bigint_cmp_i64, bigint_eq_f64, bigint_eq_i64, check_bits_str_digits_limit, i64_cmp_f64,
             repeat_count, wide_i128_into_value,
         },
         slice::slice_collect_iterator,
-        str::{allocate_char, allocate_string, concat_allocate_str, get_char_at_index, repeat_str, string_repr_fmt},
+        str::{
+            allocate_char, allocate_string, concat_allocate_str, get_char_at_index, repeat_str, str_contains,
+            string_repr_fmt,
+        },
     },
 };
 
@@ -1488,135 +1491,27 @@ impl Value {
         }
     }
 
-    /// TODO this doesn't have many tests!!! also doesn't cover bytes
-    /// Checks if `item` is contained in `self` (the container).
+    /// Checks if `item` is contained in `self` (the container) — Python's `in`.
     ///
-    /// Implements Python's `in` operator for various container types:
-    /// - List/Tuple: linear search with equality
-    /// - Dict: key lookup
-    /// - Set/FrozenSet: element lookup
-    /// - Str: substring search
-    /// - Instance: the class's `__contains__`, else iteration
-    ///
-    /// Anything else iterable is consumed until the item is found.
+    /// Type-specific logic lives on each type's [`PyTrait::py_contains`]; this
+    /// resolves the value and applies CPython's protocol order: a type's own
+    /// containment first (`sq_contains`), then consuming it by iteration
+    /// (`tp_iter`), then `TypeError`.
     pub fn py_contains(&self, item: &Self, vm: &mut VM<'_>) -> RunResult<bool> {
         match self {
-            Self::Ref(heap_id) => {
-                let output = vm.heap.read(*heap_id);
-                match output {
-                    HeapReadOutput::List(list) => {
-                        let len = list.get(vm.heap).len();
-                        for i in 0..len {
-                            let el = list.clone_item(i, vm);
-                            let eq = item.py_eq(&el, vm);
-                            el.drop_with(vm);
-                            if eq? {
-                                return Ok(true);
-                            }
-                        }
-                        Ok(false)
-                    }
-                    HeapReadOutput::Tuple(tuple) => {
-                        let len = tuple.get(vm.heap).as_slice().len();
-                        for i in 0..len {
-                            let el = tuple.clone_item(i, vm);
-                            let eq = item.py_eq(&el, vm);
-                            el.drop_with(vm);
-                            if eq? {
-                                return Ok(true);
-                            }
-                        }
-                        Ok(false)
-                    }
-                    HeapReadOutput::Dict(dict) => dict.contains_key(item, vm),
-                    HeapReadOutput::DictKeysView(view) => {
-                        let dict_id = view.get(vm.heap).dict_id();
-                        let HeapReadOutput::Dict(dict) = vm.heap.read(dict_id) else {
-                            panic!("dict_keys view must reference a dict");
-                        };
-                        dict.contains_key(item, vm)
-                    }
-                    HeapReadOutput::DictItemsView(view) => {
-                        let dict_id = view.get(vm.heap).dict_id();
-                        let Some((key, value)) = cloned_items_view_candidate(item, vm) else {
-                            return Ok(false);
-                        };
-                        let mut key_guard = DropGuard::new(key, vm);
-                        let (key, vm) = key_guard.as_parts_mut();
-                        let mut value_guard = DropGuard::new(value, vm);
-                        let (value, vm) = value_guard.as_parts_mut();
-                        let HeapReadOutput::Dict(dict) = vm.heap.read(dict_id) else {
-                            panic!("dict_items view must reference a dict");
-                        };
-                        match dict.dict_get(key, vm) {
-                            Ok(Some(existing_value)) => {
-                                let result = value.py_eq(&existing_value, vm);
-                                existing_value.drop_with(vm);
-                                result
-                            }
-                            Ok(None) => Ok(false),
-                            Err(e) => Err(e),
-                        }
-                    }
-                    HeapReadOutput::DictValuesView(view) => {
-                        let dict_id = view.get(vm.heap).dict_id();
-                        let HeapReadOutput::Dict(dict) = vm.heap.read(dict_id) else {
-                            panic!("dict_values view must reference a dict");
-                        };
-                        let iter = dict.iter(vm)?;
-                        defer_drop_mut!(iter, vm);
-                        while let Some(value) = iter.next_value(vm)? {
-                            if item.py_eq(value, vm)? {
-                                return Ok(true);
-                            }
-                        }
-                        Ok(false)
-                    }
-                    HeapReadOutput::Set(set) => set.contains(item, vm),
-                    HeapReadOutput::FrozenSet(fset) => fset.contains(item, vm),
-                    HeapReadOutput::Str(s) => {
-                        let s_str = s.get(vm.heap).as_str();
-                        str_contains(s_str, item, vm.heap, vm.interns)
-                    }
-                    HeapReadOutput::Range(range) => {
-                        // Range containment is O(1) - check bounds and step alignment
-                        let range = range.get(vm.heap);
-                        let n = match item {
-                            Self::Int(i) => *i,
-                            Self::Bool(b) => i64::from(*b),
-                            Self::Float(f) => {
-                                if f.fract() != 0.0 {
-                                    return Ok(false);
-                                }
-                                let int_val = f.trunc();
-                                if int_val < i64::MIN as f64 || int_val > i64::MAX as f64 {
-                                    return Ok(false);
-                                }
-                                #[expect(clippy::cast_possible_truncation)]
-                                let n = int_val as i64;
-                                n
-                            }
-                            _ => return Ok(false),
-                        };
-                        Ok(range.contains(n))
-                    }
-                    // `__contains__` first, iteration only as a fallback —
-                    // CPython's `sq_contains` precedes `tp_iter`.
-                    HeapReadOutput::Instance(_) => match instance_contains(*heap_id, item, vm)? {
-                        Some(found) => Ok(found),
-                        None if self.py_is_iterable(vm) => self.contains_by_iteration(item, vm),
-                        None => Err(ExcType::type_error_not_container(&self.py_type_name(vm))),
-                    },
-                    // Everything else with no `__contains__` of its own — the
-                    // iterators, and any future iterable heap type — is consumed
-                    // by iteration, as CPython falls back to `tp_iter`.
-                    _ if self.py_is_iterable(vm) => self.contains_by_iteration(item, vm),
-                    _ => Err(ExcType::type_error_not_container(&self.py_type_name(vm))),
-                }
-            }
+            Self::Ref(heap_id) => match vm.heap.read(*heap_id).py_contains_impl(*heap_id, item, vm)? {
+                Some(found) => Ok(found),
+                None if self.py_is_iterable(vm) => self.contains_by_iteration(item, vm),
+                None => Err(ExcType::type_error_not_container(&self.py_type_name(vm))),
+            },
+            // Interned strings and bytes never reach the heap, so they answer here.
             Self::InternString(string_id) => {
                 let container_str = vm.interns.get_str(*string_id);
                 str_contains(container_str, item, vm.heap, vm.interns)
+            }
+            Self::InternBytes(bytes_id) => {
+                let container = vm.interns.get_bytes(*bytes_id);
+                bytes_contains(container, item, vm)
             }
             _ => Err(ExcType::type_error_not_container(&self.py_type_name(vm))),
         }
@@ -2364,58 +2259,6 @@ fn py_float_mod(a: f64, b: f64) -> f64 {
         r + b
     } else {
         r
-    }
-}
-
-/// Extracts and clones the `(key, value)` probe accepted by `dict_items.__contains__`.
-///
-/// CPython treats only 2-tuples as valid probes for items-view membership. Monty
-/// also accepts namedtuples of length two so tuple-like runtime values behave
-/// sensibly even though namedtuples are not modeled as a true tuple subclass.
-fn cloned_items_view_candidate(item: &Value, heap: &impl ContainsHeap) -> Option<(Value, Value)> {
-    let Value::Ref(heap_id) = item else {
-        return None;
-    };
-
-    match heap.heap().get(*heap_id) {
-        HeapData::Tuple(tuple) => {
-            let items = tuple.as_slice();
-            if items.len() == 2 {
-                Some((items[0].clone_with_heap(heap), items[1].clone_with_heap(heap)))
-            } else {
-                None
-            }
-        }
-        HeapData::NamedTuple(namedtuple) => {
-            let items = namedtuple.as_vec();
-            if items.len() == 2 {
-                Some((items[0].clone_with_heap(heap), items[1].clone_with_heap(heap)))
-            } else {
-                None
-            }
-        }
-        _ => None,
-    }
-}
-
-/// Helper for substring containment check in strings.
-///
-/// Called by `py_contains` when the container is a string.
-/// The item must also be a string (either interned or heap-allocated).
-fn str_contains(container_str: &str, item: &Value, heap: &Heap, interns: &Interns) -> RunResult<bool> {
-    match item {
-        Value::InternString(item_id) => {
-            let item_str = interns.get_str(*item_id);
-            Ok(container_str.contains(item_str))
-        }
-        Value::Ref(item_heap_id) => {
-            if let HeapData::Str(item_str) = heap.get(*item_heap_id) {
-                Ok(container_str.contains(item_str.as_str()))
-            } else {
-                Err(ExcType::type_error("'in <str>' requires string as left operand"))
-            }
-        }
-        _ => Err(ExcType::type_error("'in <str>' requires string as left operand")),
     }
 }
 

--- a/crates/monty/test_cases/bytes__ops.py
+++ b/crates/monty/test_cases/bytes__ops.py
@@ -236,6 +236,23 @@ try:
     assert False, 'expected ValueError for a negative byte'
 except ValueError as exc:
     assert str(exc) == 'byte must be in range(0, 256)'
+# Big integers are integer probes too, so they are out of range rather than TypeErrors.
+try:
+    2**100 in b'abc'
+    assert False, 'expected ValueError for a big int byte'
+except ValueError as exc:
+    assert str(exc) == 'byte must be in range(0, 256)'
+try:
+    -(2**100) in heap_bytes
+    assert False, 'expected ValueError for a negative big int byte'
+except ValueError as exc:
+    assert str(exc) == 'byte must be in range(0, 256)'
+big_base = 10
+try:
+    big_base**100 in heap_bytes
+    assert False, 'expected ValueError for a computed big int byte'
+except ValueError as exc:
+    assert str(exc) == 'byte must be in range(0, 256)'
 # Anything else is a TypeError -- being iterable does not make a valid probe.
 try:
     'a' in b'abc'

--- a/crates/monty/test_cases/bytes__ops.py
+++ b/crates/monty/test_cases/bytes__ops.py
@@ -207,3 +207,43 @@ try:
     assert False, 'expected TypeError'
 except TypeError as e:
     assert str(e) == "argument for bytes() given by name ('encoding') and position (2)"
+
+# === `in` / `not in` ===
+# A bytes-like probe is a substring test; the empty probe is always present.
+assert b'ab' in b'abc'
+assert b'abc' in b'abc'
+assert b'' in b'abc'
+assert b'x' not in b'abc'
+assert b'abcd' not in b'abc'
+# An integer probe tests a single byte value; bools are ints.
+assert 97 in b'abc'
+assert 99 in b'abc'
+assert 100 not in b'abc'
+assert True in b'\x01'
+# Concatenation yields heap bytes, exercising the non-interned container path.
+heap_bytes = b'ab' + b'c'
+assert b'ab' in heap_bytes
+assert 99 in heap_bytes
+assert b'x' not in heap_bytes
+# Out-of-range integers are a ValueError, not simply absent.
+try:
+    256 in b'abc'
+    assert False, 'expected ValueError for a byte above 255'
+except ValueError as exc:
+    assert str(exc) == 'byte must be in range(0, 256)'
+try:
+    -1 in b'abc'
+    assert False, 'expected ValueError for a negative byte'
+except ValueError as exc:
+    assert str(exc) == 'byte must be in range(0, 256)'
+# Anything else is a TypeError -- being iterable does not make a valid probe.
+try:
+    'a' in b'abc'
+    assert False, 'expected TypeError for a str probe'
+except TypeError as exc:
+    assert str(exc) == "a bytes-like object is required, not 'str'"
+try:
+    1.0 in b'abc'
+    assert False, 'expected TypeError for a float probe'
+except TypeError as exc:
+    assert str(exc) == "a bytes-like object is required, not 'float'"

--- a/crates/monty/test_cases/dict__ops.py
+++ b/crates/monty/test_cases/dict__ops.py
@@ -136,3 +136,10 @@ except TypeError as e:
 dup = {'k': [1], 'k': [2]}
 assert dup == {'k': [2]}
 assert len(dup) == 1
+
+# === `in` / `not in` ===
+# `in` on a dict tests its keys, never its values.
+membership = {'a': 1, 'b': 2}
+assert 'a' in membership
+assert 'z' not in membership
+assert 1 not in membership

--- a/crates/monty/test_cases/dict__views.py
+++ b/crates/monty/test_cases/dict__views.py
@@ -269,3 +269,14 @@ me_map = {'me': 1, 'you': 2, 'merve': 3}
 merve_set = {'merve', 'unknown'}
 common_ids = me_map.keys() & merve_set
 assert common_ids == {'merve'}
+
+# === `in` / `not in` on the views ===
+view_source = {'a': 1, 'b': 2}
+assert 'a' in view_source.keys()
+assert 'z' not in view_source.keys()
+assert 2 in view_source.values()
+assert 9 not in view_source.values()
+# An items probe must be a (key, value) pair; anything else is simply absent.
+assert ('a', 1) in view_source.items()
+assert ('a', 2) not in view_source.items()
+assert 'a' not in view_source.items()

--- a/crates/monty/test_cases/namedtuple__ops.py
+++ b/crates/monty/test_cases/namedtuple__ops.py
@@ -32,3 +32,9 @@ r = repr(vi)
 assert r.startswith('sys.version_info(major='), f'namedtuple repr starts with type name, {r!r}'
 assert ', minor=' in r, f'namedtuple repr has minor field, {r!r}'
 assert r.endswith(')'), f'namedtuple repr ends with paren, {r!r}'
+
+# === `in` / `not in` ===
+# `vi` is sys.version_info, this file's namedtuple fixture.
+assert vi.major in vi
+assert vi.minor in vi
+assert 9999 not in vi

--- a/crates/monty/test_cases/set__ops.py
+++ b/crates/monty/test_cases/set__ops.py
@@ -205,3 +205,8 @@ try:
     assert False, 'expected TypeError for non-iterable heap closure in set unpack'
 except TypeError:
     pass
+
+# === `in` / `not in` ===
+members = {1, 2, 3}
+assert 2 in members
+assert 9 not in members

--- a/crates/monty/test_cases/str__ops.py
+++ b/crates/monty/test_cases/str__ops.py
@@ -270,3 +270,15 @@ try:
     assert False, 'expected TypeError'
 except TypeError as e:
     assert str(e) == "argument for str() given by name ('encoding') and position (2)"
+
+# === `in` / `not in` ===
+assert 'bc' in 'abc'
+assert 'abc' in 'abc'
+assert '' in 'abc'
+assert 'x' not in 'abc'
+# Only a str is a valid probe; the error names the offending type.
+try:
+    1 in 'abc'
+    assert False, 'expected TypeError for a non-str probe'
+except TypeError as exc:
+    assert str(exc) == "'in <string>' requires string as left operand, not int"

--- a/crates/monty/test_cases/tuple__ops.py
+++ b/crates/monty/test_cases/tuple__ops.py
@@ -139,3 +139,11 @@ assert repr(()) == '()'
 assert repr((1,)) == '(1,)'
 assert repr((1, 2)) == '(1, 2)'
 assert repr((1, (2, 3))) == '(1, (2, 3))'
+
+# === `in` / `not in` ===
+tu = (1, 'two', 3)
+assert 1 in tu
+assert 'two' in tu
+assert 9 not in tu
+assert () == ()
+assert 2 in (1, (2, 3))[1]


### PR DESCRIPTION
- **Move `py_contains` onto `PyTrait`** as `py_contains_impl`, per davidhewitt's review on pydantic/monty#609. Each type owns its containment logic; `Value::py_contains` keeps only CPython's protocol order (`sq_contains`, then `tp_iter`, then `TypeError`). Follows the `py_*_impl` convention from #568.

- **Fix `in` for bytes.** `b'ab' in b'abc'` raised `TypeError` (interned literals were never dispatched) and heap bytes silently answered `False` (fell back to iteration, comparing a bytes probe against ints). Now supports both CPython probe shapes: bytes-like substring and integer byte value.

- **Add `in` coverage** for bytes, tuple, dict, set, str, namedtuple and the dict views — four of these had none. This surfaced one divergence, now fixed: the str probe error is `'in <string>' requires string as left operand, not int`, matching CPython.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves `py_contains` onto `PyTrait`, fixes `in` for bytes (including big‑int probes), and adds tests across core containers. Simplifies containment dispatch and aligns behavior with CPython.

- **Refactors**
  - Move `py_contains` to `PyTrait` as `py_contains_impl`; dispatch now forwards through the heap, and `List`/`Tuple` use their iterators for safe membership under re-entrancy.
  - `Value::py_contains` now only applies CPython order: `sq_contains` → `tp_iter` → `TypeError`.

- **Bug Fixes**
  - Bytes: support bytes-like substrings and integer byte probes for both interned and heap bytes; big-int probes raise `ValueError: byte must be in range(0, 256)`, non-bytes-like probes raise `TypeError`.
  - Align str probe error message and add `in` tests for bytes, tuple, dict, dict views, set, str, and namedtuple.

<sup>Written for commit 5fde597f192a7bce9e910ffe3a7e72b4847d7d43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

