### PR TITLE
Count the module's pending result in the strict ref-count check

### DIFF
--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -502,8 +502,13 @@ impl Executor {
                     roots.push(*id);
                 }
             }
-            // Named globals are the only roots: locals are gone once the module frame
-            // exits, so anything still live must hang off a name to not be a leak.
+            // The module's result is a root too: it is still owned by the pending
+            // `FrameExit::Return` here, since `frame_exit_to_object` below is what drops it.
+            if let Ok(FrameExit::Return(Value::Ref(id))) = &frame_exit_result {
+                roots.push(*id);
+            }
+            // Those are the only roots: locals are gone once the module frame exits, so
+            // anything still live must hang off a name or the result to not be a leak.
             let unreachable: Vec<String> = vm
                 .heap
                 .unreachable_entries(roots)

--- a/crates/monty/test_cases/refcount__unbound_result.py
+++ b/crates/monty/test_cases/refcount__unbound_result.py
@@ -1,0 +1,7 @@
+# The module's trailing expression is an unbound heap value. It is still owned by
+# the pending frame exit when ref-counts are read, so the strict check must treat
+# it as accounted for — otherwise it is falsely reported as an unreferenced heap
+# object. `a` is 2 here: its own binding plus the returned list's reference to it.
+a = [1]
+[a, 2]
+# ref-counts={'a': 2}


### PR DESCRIPTION
A module whose trailing expression is an unbound heap value (e.g. `[2, 3]`) still owns that value via the pending `FrameExit::Return` when refcounts are read — `frame_exit_to_object` drops it afterwards. The strict check roots its reachability walk at the named globals only, so that live value was reported as a leak, unfixable except by binding it to a throwaway name.

Fix: add the pending result as a root of the walk. Covered by `refcount__unbound_result.py`.

Noticed in #609, now merged; the bug predates that branch and is independent of it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix strict ref-count check to include the module’s pending result as a root, so unbound trailing expressions aren’t falsely flagged as leaks. Adds a test to cover this case and nested references.

- **Bug Fixes**
  - Include the pending `FrameExit::Return` result in the reachability roots before `frame_exit_to_object` runs.
  - Add `refcount__unbound_result.py` to verify the result and its nested reference are accounted.

<sup>Written for commit cbe7598b72127c5a6145dada89e0c1de70edd8f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

