### PR TITLE
Fix remaining `py_contains` issues from the #625 review

### DIFF
--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -449,7 +449,8 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictItemsView> {
         };
         match dict.dict_get(key, vm) {
             Ok(Some(existing_value)) => {
-                let result = value.py_eq(&existing_value, vm);
+                // Stored value on the left, as CPython's `dictitems_contains` does.
+                let result = existing_value.py_eq(value, vm);
                 existing_value.drop_with(vm);
                 result.map(Some)
             }
@@ -606,7 +607,8 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictValuesView> {
         let iter = dict.iter(vm)?;
         defer_drop_mut!(iter, vm);
         while let Some(value) = iter.next_value(vm)? {
-            if item.py_eq(value, vm)? {
+            // Stored value on the left, matching CPython's iteration fallback.
+            if value.py_eq(item, vm)? {
                 return Ok(Some(true));
             }
         }

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -368,14 +368,15 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
         true
     }
 
-    /// Linear search by equality. `ListIter` re-reads the length on every step,
-    /// so a user `__eq__` re-entering the VM and shrinking the list halts the
-    /// walk cleanly instead of indexing out of bounds.
+    /// Linear search by equality, stored element on the left of `==` as CPython's
+    /// `list_contains` does. `ListIter` re-reads the length on every step, so a
+    /// user `__eq__` re-entering the VM and shrinking the list halts the walk
+    /// cleanly instead of indexing out of bounds.
     fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let iter = self.iter(vm)?;
         defer_drop_mut!(iter, vm);
         while let Some(el) = iter.next(vm)? {
-            if item.py_eq(el, vm)? {
+            if el.py_eq(item, vm)? {
                 return Ok(Some(true));
             }
         }

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -267,6 +267,21 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
         true
     }
 
+    /// Linear search by equality like [`Tuple`](super::Tuple) — a namedtuple is a
+    /// tuple subclass in CPython and inherits `tuplecontains`. Without this, `in`
+    /// falls back to iteration and allocates a heap `TupleIterator`, which can
+    /// trip the allocation limit on a tight heap.
+    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        let iter = self.iter(vm)?;
+        defer_drop_mut!(iter, vm);
+        while let Some(el) = iter.next(vm)? {
+            if el.py_eq(item, vm)? {
+                return Ok(Some(true));
+            }
+        }
+        Ok(Some(false))
+    }
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::NamedTuple
     }

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -203,7 +203,9 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Range> {
                     return Ok(Some(false));
                 }
                 let int_val = f.trunc();
-                if int_val < i64::MIN as f64 || int_val > i64::MAX as f64 {
+                // Exclusive upper bound: `i64::MAX as f64` rounds up to 2^63, which
+                // `int_val as i64` would saturate back down to `i64::MAX`.
+                if int_val < i64::MIN as f64 || int_val >= i64::MAX as f64 {
                     return Ok(Some(false));
                 }
                 #[expect(clippy::cast_possible_truncation)]

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -286,13 +286,14 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         true
     }
 
-    /// Linear search by equality; `TupleIter` owns each yielded item, so a user
+    /// Linear search by equality, stored element on the left of `==` as CPython's
+    /// `tuplecontains` does. `TupleIter` owns each yielded item, so a user
     /// `__eq__` re-entering the VM cannot invalidate the walk.
     fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let iter = self.iter(vm)?;
         defer_drop_mut!(iter, vm);
         while let Some(el) = iter.next(vm)? {
-            if item.py_eq(el, vm)? {
+            if el.py_eq(item, vm)? {
                 return Ok(Some(true));
             }
         }

--- a/crates/monty/test_cases/dict__views.py
+++ b/crates/monty/test_cases/dict__views.py
@@ -280,3 +280,32 @@ assert 9 not in view_source.values()
 assert ('a', 1) in view_source.items()
 assert ('a', 2) not in view_source.items()
 assert 'a' not in view_source.items()
+
+# The values view is a linear scan comparing by value.
+nested_view = {'a': [1, 2], 'b': (3, 4), 'c': 1}
+assert [1, 2] in nested_view.values()
+assert (3, 4) in nested_view.values()
+assert [1, 3] not in nested_view.values()
+assert 1.0 in nested_view.values()
+assert True in nested_view.values()
+assert None not in nested_view.values()
+# Duplicate values are found once each.
+dupe_view = {'a': 1, 'b': 1}
+assert 1 in dupe_view.values()
+assert 2 not in dupe_view.values()
+# The items view looks the key up, then compares the stored value.
+assert ('a', [1, 2]) in nested_view.items()
+assert ('a', [1, 3]) not in nested_view.items()
+assert ('z', [1, 2]) not in nested_view.items()
+assert ('c', True) in nested_view.items()
+assert ('c', 1.0) in nested_view.items()
+# Probes that are not a 2-item pair can never be members.
+assert ('a', [1, 2], 'extra') not in nested_view.items()
+assert ('a',) not in nested_view.items()
+assert ['a', [1, 2]] not in nested_view.items()
+# Keys view membership rejects an unhashable probe, as dict lookup does.
+try:
+    [1] in nested_view.keys()
+    assert False, 'expected TypeError for an unhashable keys probe'
+except TypeError as exc:
+    assert str(exc) == "cannot use 'list' as a dict key (unhashable type: 'list')"

--- a/crates/monty/test_cases/list__ops.py
+++ b/crates/monty/test_cases/list__ops.py
@@ -590,3 +590,18 @@ def _tracking_index2():
 _tracking_obj2()[_tracking_index2()] += 7
 assert _eval_log == ['obj', 'idx'], f'eval-once order with persistent list: {_eval_log}'
 assert _result_list == [10, 20, 37], f'augmented assign via function: {_result_list}'
+
+
+# === `in` / `not in` ===
+lst_in = [1, 'two', 3]
+assert 1 in lst_in
+assert 'two' in lst_in
+assert 9 not in lst_in
+# Nested containers compare by value, exercising the recursive `py_eq` path.
+assert [2, 3] in [1, [2, 3]]
+assert [2, 4] not in [1, [2, 3]]
+assert True in [1, 2]
+assert 1.0 in [1, 2]
+assert (2, 3) in [1, (2, 3)]
+assert None in [None]
+assert 1 not in []

--- a/crates/monty/test_cases/namedtuple__ops.py
+++ b/crates/monty/test_cases/namedtuple__ops.py
@@ -38,3 +38,13 @@ assert r.endswith(')'), f'namedtuple repr ends with paren, {r!r}'
 assert vi.major in vi
 assert vi.minor in vi
 assert 9999 not in vi
+# Membership uses tuple-style containment, allocating no iterator.
+assert vi.micro in vi
+assert 'not-a-field-value' not in vi
+# The str field exercises the non-integer comparison path.
+assert vi.releaselevel in vi
+assert vi.serial in vi
+# A probe that is a container is compared by value, not unpacked.
+assert None not in vi
+assert (vi.major, vi.minor) not in vi
+assert [vi.major] not in vi

--- a/crates/monty/test_cases/range__ops.py
+++ b/crates/monty/test_cases/range__ops.py
@@ -274,3 +274,19 @@ assert hash(range(0, 1, 1)) == hash(range(0, 2, 2))
 assert hash(range(0, 0)) == hash(range(5, 5))
 assert hash(range(0, 4, 2)) == hash(range(0, 3, 2))
 assert {range(0, 1, 1): 'a'}[range(0, 2, 2)] == 'a'
+
+# A float probe at the i64 boundary must not saturate into the range: 2**63 has
+# no i64 representation, so a naive bounds check truncates it onto the first member.
+big_desc = range(2**63 - 1, 2**63 - 4, -1)
+assert len(big_desc) == 3
+assert (2**63 - 1) in big_desc
+assert 2.0**63 not in big_desc
+assert 9223372036854775808.0 not in big_desc
+# Bools are ints, so they follow the integer fast path.
+assert True in range(3)
+assert False in range(3)
+assert True not in range(2, 5)
+# Other non-numeric probes are absent rather than a TypeError.
+assert None not in range(5)
+assert (1,) not in range(5)
+assert [1] not in range(5)

--- a/crates/monty/test_cases/tuple__ops.py
+++ b/crates/monty/test_cases/tuple__ops.py
@@ -147,3 +147,10 @@ assert 'two' in tu
 assert 9 not in tu
 assert () == ()
 assert 2 in (1, (2, 3))[1]
+# Members compare by value, across types where Python considers them equal.
+assert True in (1, 2)
+assert 1.0 in (1, 2)
+assert (2, 3) in (1, (2, 3))
+assert [2, 3] in (1, [2, 3])
+assert None in (None,)
+assert 1 not in ()

--- a/limitations/classes.md
+++ b/limitations/classes.md
@@ -101,6 +101,9 @@ order and error wording, but with these divergences:
 - **Equality and hashing are identity-only**: a user `__eq__`/`__hash__` is
   not dispatched. `a == b` is true only when `a is b`; instances hash by
   identity. Instances are always truthy (no `__bool__`/`__len__` dispatch).
+  This extends to membership: `obj in container` compares the elements of a
+  list/tuple/namedtuple/`dict.values()` by identity, so an instance whose
+  `__eq__` would match in CPython is reported absent.
 - **Bound methods compare and hash by identity**: each `obj.method` access
   creates a fresh object, so `obj.method == obj.method` is `False` and two
   accesses hash differently. CPython compares/hashes bound methods by


### PR DESCRIPTION
Addresses the unrelated cubic findings left open on pydantic/monty#625.

1. **namedtuple containment.** `x in <namedtuple>` fell through to the iteration fallback, allocating a heap `TupleIterator` that can trip the allocation limit on a tight heap. Namedtuples are tuple subclasses in CPython and inherit `tuplecontains`, so they get the same linear search, over the stack-borrowed `NamedTupleIter`.

2. **range float upper bound.** `int_val > i64::MAX as f64` never rejected 2^63, because `i64::MAX as f64` rounds *up* to 2^63; the cast then saturated back to `i64::MAX`, reporting a false member for a range containing `i64::MAX`. The bound is now exclusive, covered by `range(2**63 - 1, 2**63 - 4, -1)`.

3. **`dict.items()` `==` operand order.** CPython's `dictitems_contains` puts the *stored* value on the left of `==`, so an asymmetric `__eq__` on that side decides the result; the probe was on the left.

4. **`dict.values()` `==` operand order.** The same inversion in the values-view iteration fallback. `list_contains` and `tuplecontains` carry it too — cubic did not flag those, but they are swapped here so all four sites agree with CPython.

The operand-order changes in 3 and 4 are hardening, not observable today: equality is identity-only and `py_eq` never re-enters the VM, so no user `__eq__` runs during containment (documented in `limitations/classes.md`, updated here). They cannot carry a test for that reason. Everything else does, alongside broader membership coverage: cross-type numeric equality, nested containers, non-pair and over-long items probes, unhashable keys probes, duplicate values, and a namedtuple str field.

1086/1086 test cases pass under both Monty and CPython 3.14; clippy and lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes remaining `py_contains` issues from the #625 review. Aligns membership checks with CPython, prevents a 64-bit float boundary false positive, and avoids extra allocation for namedtuple membership; adds tests and updates docs.

- **Bug Fixes**
  - Namedtuple: use tuple-style linear contains; no heap iterator allocation.
  - Range: make float upper bound exclusive; `2**63` no longer appears in ranges around `i64::MAX`.
  - Dict views: compare with the stored value on the left in `items()` and `values()` to match CPython.
  - List/Tuple: same operand order change for `in` to match CPython semantics.

<sup>Written for commit 0eaf41b0f0ae618e6cce1a792bdd274492c0b166. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

