### PR TITLE
OpenTelemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +213,12 @@ checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
 dependencies = [
  "critical-section",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attribute-derive"
@@ -214,7 +231,7 @@ dependencies = [
  "manyhow",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -230,7 +247,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "quote-use",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -277,6 +294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,9 +334,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
@@ -538,7 +561,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -664,6 +687,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,6 +734,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -911,7 +954,7 @@ checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -922,7 +965,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -950,7 +993,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1011,6 +1054,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,7 +1080,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1162,6 +1215,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,7 +1291,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1280,7 +1342,7 @@ checksum = "1da24fbda09ec01bca7cfa1797c0e520e75123bccb01dcdf9041f8aa65183bc2"
 dependencies = [
  "attribute-derive",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1314,8 +1376,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1326,8 +1390,22 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1463,10 +1541,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1520,6 +1679,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
 name = "icu_properties"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1552,6 +1731,27 @@ dependencies = [
  "zerofrom",
  "zerotrie",
  "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -1628,6 +1828,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is-macro"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,7 +1842,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1702,6 +1908,55 @@ dependencies = [
  "num-traits",
  "pyo3",
  "smallvec",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1793,7 +2048,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "libc",
  "redox_syscall 0.7.0",
 ]
@@ -1838,6 +2093,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "logfire"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b60ab073230edf8760a3565c315d6b058c74093070ca4168b78c230a0facb734"
+dependencies = [
+ "chrono",
+ "env_filter",
+ "futures-util",
+ "log",
+ "logfire-core",
+ "nu-ansi-term",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "rand 0.10.1",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "logfire-core"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345c70b7197595007b1b9a4d71b25ee8f646759732995b4984adbf666f43e4b4"
+
+[[package]]
 name = "logos"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,7 +2152,7 @@ dependencies = [
  "quote",
  "regex-syntax",
  "rustc_version",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1882,7 +2166,7 @@ dependencies = [
  "quote",
  "regex-automata",
  "regex-syntax",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1904,6 +2188,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "manyhow"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,7 +2202,7 @@ dependencies = [
  "manyhow-macros",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1924,6 +2214,15 @@ dependencies = [
  "proc-macro-utils",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -1975,7 +2274,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2110,7 +2409,7 @@ dependencies = [
  "insta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2118,14 +2417,22 @@ name = "monty-pool"
 version = "0.0.19"
 dependencies = [
  "futures-util",
+ "logfire",
  "monty-fs",
  "monty-proto",
  "monty-types",
+ "num-traits",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "rustls",
+ "serde",
+ "serde_json",
  "tempfile",
  "tokio",
  "tokio-tungstenite",
+ "tracing",
  "tungstenite",
+ "uuid",
 ]
 
 [[package]]
@@ -2221,7 +2528,7 @@ version = "3.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "909805cbad4d569e69b80e101290fe72e92b9742ba9e333b0c1e83b22fb7447b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "ctor",
  "futures",
  "napi-build",
@@ -2248,7 +2555,7 @@ dependencies = [
  "napi-derive-backend",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2261,7 +2568,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "semver",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2299,7 +2606,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2311,7 +2618,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2322,6 +2629,15 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-bigint"
@@ -2396,6 +2712,84 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "ordermap"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,6 +2855,12 @@ dependencies = [
  "password-hash",
  "sha2",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
@@ -2640,7 +3040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2688,7 +3088,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.114",
  "tempfile",
 ]
 
@@ -2702,7 +3102,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2829,7 +3229,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2842,7 +3242,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2861,6 +3261,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.1",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2891,7 +3348,7 @@ dependencies = [
  "proc-macro-utils",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2899,6 +3356,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -2944,6 +3407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -2992,6 +3456,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3017,7 +3490,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3026,7 +3499,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3057,6 +3530,41 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "rgb"
@@ -3166,7 +3674,7 @@ dependencies = [
  "quote",
  "regex",
  "ruff_python_trivia",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3204,7 +3712,7 @@ checksum = "a10ab966362319801f5e85ce5c6aeac69f0cf50936a31e888f5d004e9279f337"
 dependencies = [
  "aho-corasick",
  "arrayvec",
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "compact_str",
  "get-size2",
  "is-macro",
@@ -3237,7 +3745,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af3e1f868fa58adc12d1fa3ce1b29c6098aa4b101739d9589cbde9fec239af59"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "icu_properties",
  "itertools 0.15.0",
  "ruff_python_ast",
@@ -3249,7 +3757,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3b8436fb010636ea79ce545acc3e391296ef4e804f7cef336dd5f9c8a4aa3a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bstr",
  "compact_str",
  "get-size2",
@@ -3271,7 +3779,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c8860927bf42efdabb31ccb2ac9b8f98ee43897b45536f8023e217b158e49a4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "unicode-ident",
 ]
 
@@ -3348,7 +3856,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3371,13 +3879,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -3403,7 +3951,7 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1e066dc922e513bda599c6ccb5f3bb2b0ea5870a579448f2622993f0a9a2f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -3466,7 +4014,7 @@ checksum = "76bc78ffaf65b1a9175818592c5130aa10b1bb245a905722fd4db87cea8a8457"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -3480,10 +4028,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3518,7 +4098,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3566,6 +4146,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3586,6 +4175,22 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -3723,7 +4328,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3735,7 +4340,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3785,6 +4390,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3792,7 +4417,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3843,7 +4468,16 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3924,7 +4558,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3934,6 +4568,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -3993,6 +4638,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4011,7 +4701,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4021,7 +4711,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
@@ -4085,7 +4827,7 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10d09fb9d592f581b1d9891cc35482f14e16a7f385e264dfddc5b1c53dc2853d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "bitvec",
  "get-size2",
  "hashbrown 0.17.0",
@@ -4114,7 +4856,7 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7ef2038b6e20d8200137e7d02efd225a8c8fd66bb5fd9e66cb631296ca341be"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.1",
  "compact_str",
  "drop_bomb",
  "get-size2",
@@ -4278,6 +5020,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4301,9 +5055,16 @@ version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
+ "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"
@@ -4319,6 +5080,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -4350,6 +5120,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4368,7 +5151,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -4399,6 +5182,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4471,7 +5263,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4482,7 +5274,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4726,7 +5518,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -4747,7 +5539,7 @@ checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4767,7 +5559,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -4807,7 +5599,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -318,12 +318,22 @@ const pool = await Monty.create({
   durationLimitGrace: 1, // maxDurationSecs backstop grace (seconds, null disables)
   maxCheckoutsPerWorker: 100, // recycle workers after this many sessions
   binaryPath: '/path/to/monty', // explicit binary (default: auto-resolved)
+  logfireToken: 'pylf_v1_...', // record sessions to Logfire (default: no telemetry)
 })
 ```
 
 The `monty` binary resolves from: explicit `binaryPath` → the `MONTY_BIN`
 environment variable → the installed platform package → `PATH` → a cargo
 workspace `target/` build (development).
+
+With `logfireToken` set, the pool reports every session it serves to
+[Logfire](https://pydantic.dev/logfire): one span per checkout, with a nested
+span per protocol turn carrying the code fed, its inputs, external call
+arguments and results, exceptions and `print` output. Session dumps and
+restores are recorded by size only. Recording happens in the host process (the
+native pool sees the whole conversation with each worker); the workers receive
+no token and run no exporter. The `/wasm` worker pool has no equivalent — its
+pool is pure TypeScript with no exporter.
 
 ## Value Conversion
 

--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -330,10 +330,10 @@ With `logfireToken` set, the pool reports every session it serves to
 [Logfire](https://pydantic.dev/logfire): one span per checkout, with a nested
 span per protocol turn carrying the code fed, its inputs, external call
 arguments and results, exceptions and `print` output. Session dumps and
-restores are recorded by size only. Recording happens in the host process (the
-native pool sees the whole conversation with each worker); the workers receive
-no token and run no exporter. The `/wasm` worker pool has no equivalent — its
-pool is pure TypeScript with no exporter.
+restores are recorded by size only. Recording happens in the host process,
+which sees the whole conversation with each worker; the workers get no token.
+The `/wasm` worker pool has no equivalent — it is pure TypeScript with no
+exporter.
 
 ## Value Conversion
 

--- a/crates/monty-js/__test__/pool.spec.ts
+++ b/crates/monty-js/__test__/pool.spec.ts
@@ -63,8 +63,7 @@ test('maxCheckoutsPerWorker recycles the worker', async (ctx) => {
 
 test('logfireToken pool round-trips', async (ctx) => {
   skipIfBrowser(ctx)
-  // a syntactically valid but fake token: the pool records every turn, and
-  // the failing background export never affects execution
+  // a well-formed but fake token: recording runs, and the failing background export never affects execution
   await using pool = await Monty.create({ logfireToken: 'pylf_v1_us_0000000000000000000000' })
   await using session = await pool.checkout()
   t.is(await session.feedRun('1 + 2'), 3)

--- a/crates/monty-js/__test__/pool.spec.ts
+++ b/crates/monty-js/__test__/pool.spec.ts
@@ -61,6 +61,15 @@ test('maxCheckoutsPerWorker recycles the worker', async (ctx) => {
   await second.close()
 })
 
+test('logfireToken pool round-trips', async (ctx) => {
+  skipIfBrowser(ctx)
+  // a syntactically valid but fake token: the pool records every turn, and
+  // the failing background export never affects execution
+  await using pool = await Monty.create({ logfireToken: 'pylf_v1_us_0000000000000000000000' })
+  await using session = await pool.checkout()
+  t.is(await session.feedRun('1 + 2'), 3)
+})
+
 test('concurrent sessions run in distinct workers', async (ctx) => {
   skipIfBrowser(ctx)
   await using pool = await Monty.create()

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -2508,19 +2508,90 @@
       "license": "MIT"
     },
     "node_modules/@pydantic/monty-darwin-arm64": {
-      "optional": true
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-arm64/-/monty-darwin-arm64-0.0.19.tgz",
+      "integrity": "sha512-lVBvwAnStWUtSUw/AFcnqFNgUTvbGgyXxLW8ECUWKn3o1iWJLLsuYbhyn+qYmB1F+vZVZqP/tY7CYeoiIO0c/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@pydantic/monty-darwin-x64": {
-      "optional": true
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-x64/-/monty-darwin-x64-0.0.19.tgz",
+      "integrity": "sha512-0zvFDj8CHoE7m2AOJ9MQCgb+7nldjvNdAjUqvM1EjZYKJnenVt/egYZdrjOOjEyEAxsSMoae6mgPvk3DorFfgg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@pydantic/monty-linux-arm64-gnu": {
-      "optional": true
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-arm64-gnu/-/monty-linux-arm64-gnu-0.0.19.tgz",
+      "integrity": "sha512-dXsOAaKWdPsNyJOYwOo2bWjBnnLmM05G8wQJXOM1pMomqD8g0DhK4z5LypJHLg/I280AHL6Nd08+Oi39axbu7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@pydantic/monty-linux-x64-gnu": {
-      "optional": true
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-x64-gnu/-/monty-linux-x64-gnu-0.0.19.tgz",
+      "integrity": "sha512-h1hx2YAOBFUqXXI7sMBTHwi4JdWHUT4r+MuiXW7xbarPwkaRlsnq7iHbT+goHoG9qj8hIQxJnb7GD/eyDVauiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@pydantic/monty-win32-x64-msvc": {
-      "optional": true
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-win32-x64-msvc/-/monty-win32-x64-msvc-0.0.19.tgz",
+      "integrity": "sha512-Z4ZFK7cwoY5+FLmfNeREnx0v6IChnLdOcVqHxxCV3QrVfzq1gfZ7bJFs57AQy+XpbHI39f5ZKooC8uY+mHyfuw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -98,8 +98,8 @@ pub struct NativePoolOptions {
     pub duration_limit_grace_ms: Option<f64>,
     /// Recycle a worker after serving this many checkouts.
     pub max_checkouts_per_worker: Option<u32>,
-    /// Logfire write token; when set, the pool records every session it
-    /// serves from the host process. Absent: no telemetry and no exporter.
+    /// Logfire write token; when set, the pool records every session it serves
+    /// from the host process. The workers get no token and run no exporter.
     pub logfire_token: Option<String>,
 }
 

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -98,6 +98,9 @@ pub struct NativePoolOptions {
     pub duration_limit_grace_ms: Option<f64>,
     /// Recycle a worker after serving this many checkouts.
     pub max_checkouts_per_worker: Option<u32>,
+    /// Logfire write token; when set, the pool records every session it
+    /// serves from the host process. Absent: no telemetry and no exporter.
+    pub logfire_token: Option<String>,
 }
 
 /// Session options for `checkout()`.
@@ -155,6 +158,7 @@ impl NativePool {
         config.request_timeout = options.request_timeout_ms.map(duration_from_ms).transpose()?;
         config.duration_limit_grace = options.duration_limit_grace_ms.map(duration_from_ms).transpose()?;
         config.max_checkouts_per_worker = options.max_checkouts_per_worker;
+        config.logfire_token = options.logfire_token;
         if config.max_processes < 1 {
             return Err(invalid("maxProcesses must be at least 1"));
         }

--- a/crates/monty-js/ts/pool.ts
+++ b/crates/monty-js/ts/pool.ts
@@ -45,9 +45,8 @@ export interface MontyOptions {
   /** Recycle a worker (kill and replace) after serving this many sessions. */
   maxCheckoutsPerWorker?: number
   /**
-   * Logfire write token. When set, the pool records every session to Logfire
-   * from the host process; workers receive no token, and any OTel setup of
-   * your own application is untouched.
+   * Logfire write token. When set, the pool records every session from the host
+   * process; workers get no token and your app's own OTel setup is untouched.
    */
   logfireToken?: string
 }

--- a/crates/monty-js/ts/pool.ts
+++ b/crates/monty-js/ts/pool.ts
@@ -44,6 +44,12 @@ export interface MontyOptions {
   durationLimitGrace?: number | null
   /** Recycle a worker (kill and replace) after serving this many sessions. */
   maxCheckoutsPerWorker?: number
+  /**
+   * Logfire write token. When set, the pool records every session to Logfire
+   * from the host process; workers receive no token, and any OTel setup of
+   * your own application is untouched.
+   */
+  logfireToken?: string
 }
 
 /** Options for [`Monty.checkout`], mirroring `pydantic_monty`. */
@@ -106,6 +112,7 @@ export class Monty {
         ? { durationLimitGraceMs: (options.durationLimitGrace ?? 1) * 1000 }
         : {}),
       ...(options.maxCheckoutsPerWorker !== undefined ? { maxCheckoutsPerWorker: options.maxCheckoutsPerWorker } : {}),
+      ...(options.logfireToken !== undefined ? { logfireToken: options.logfireToken } : {}),
     })
     await native.start()
     return new Monty(native)

--- a/crates/monty-pool/Cargo.toml
+++ b/crates/monty-pool/Cargo.toml
@@ -44,8 +44,8 @@ serde_json = { workspace = true }
 # (`service.instance.id`, `process.pid`); versions must match logfire's.
 opentelemetry = "0.32"
 opentelemetry_sdk = "0.32"
-# Only for the span/level types logfire's own API exposes; all recording goes
-# through the `logfire::` macros.
+# Only for the span/level types logfire's API exposes; recording goes through
+# the `logfire::` macros.
 tracing = "0.1"
 # The pool's own `service.instance.id`: v7 so the ids sort by pool start.
 uuid = { version = "1", features = ["v7"] }

--- a/crates/monty-pool/Cargo.toml
+++ b/crates/monty-pool/Cargo.toml
@@ -32,12 +32,31 @@ futures-util = { workspace = true }
 # Pulled in only so the pool can install a process-level rustls `CryptoProvider`
 # before the first `wss://` dial (see `install_crypto_provider` in worker.rs).
 rustls = { workspace = true }
+# Telemetry for pools created with a `logfire_token`, configured in local mode
+# so the host application's own tracing/OTel setup is untouched. `data-dir` is
+# off: the pool must never read `.logfire/logfire_credentials.json` from its cwd.
+logfire = { version = "0.11", default-features = false, features = ["export-http-protobuf"] }
+# telemetry_json's logfire-style value encoding
+num-traits = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+# Resource attributes logfire's own builder does not cover
+# (`service.instance.id`, `process.pid`); versions must match logfire's.
+opentelemetry = "0.32"
+opentelemetry_sdk = "0.32"
+# Only for the span/level types logfire's own API exposes; all recording goes
+# through the `logfire::` macros.
+tracing = "0.1"
+# The pool's own `service.instance.id`: v7 so the ids sort by pool start.
+uuid = { version = "1", features = ["v7"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 # The mock WebSocket child servers in tests stay synchronous, on plain threads.
 tungstenite = { workspace = true }
+# In-memory exporters for the telemetry recorder's structural tests.
+opentelemetry_sdk = { version = "0.32", features = ["testing"] }
 
 [lints]
 workspace = true

--- a/crates/monty-pool/README.md
+++ b/crates/monty-pool/README.md
@@ -86,20 +86,19 @@ session remain alive and usable.
 ## Observability
 
 Setting `PoolConfig::logfire_token` records every session the pool serves to
-[Logfire](https://pydantic.dev/logfire), from the host process — the pool builds every request
-and decodes every event anyway, so the whole conversation is observable without instrumenting
-the workers (they receive no token and run no exporter, and recording works on both
-transports). Each checkout becomes one session span; each feed is a nested span held across
-suspension round-trips, with a child span per suspension whose duration is the host round-trip.
-Fed code, inputs, call arguments and results, exceptions and `print` output are recorded in
-full — values are encoded the way the Python logfire SDK encodes attributes, capped at 64KB
-per value — while `Load`/`Dump` snapshot blobs are recorded by size only.
+[Logfire](https://pydantic.dev/logfire). Recording happens in the host process, which builds
+every request and decodes every event anyway, so both transports are covered and the workers
+stay uninstrumented — they receive no token and run no exporter. Each checkout becomes one
+session span; each feed is a nested span held across suspension round-trips, with a child span
+per suspension whose duration is the host round-trip. Fed code, inputs, call arguments and
+results, exceptions and `print` output are recorded in full — values encoded the way the
+Python logfire SDK encodes attributes, capped at 64KB per value — while `Load`/`Dump` snapshot
+blobs are recorded by size only.
 
 Logfire is configured in *local* mode: the host application's own `tracing`/OTel setup is
 untouched and several pools can coexist. `Pool::close` flushes the exporter (a pool merely
-dropped may lose its last, not-yet-exported batch of spans). As in any logfire-instrumented
-process, a `RUST_LOG` directive in the host environment filters what is recorded (everything
-here is emitted at INFO).
+dropped may lose its last batch of spans). As in any logfire-instrumented process, a `RUST_LOG`
+directive filters what is recorded — everything here is emitted at INFO.
 
 ## Transports
 

--- a/crates/monty-pool/README.md
+++ b/crates/monty-pool/README.md
@@ -83,6 +83,24 @@ and restored later — including on a different worker or machine — with `Chec
 Runtime errors inside the sandbox (`PoolError::Runtime`) are not crashes: the worker and its
 session remain alive and usable.
 
+## Observability
+
+Setting `PoolConfig::logfire_token` records every session the pool serves to
+[Logfire](https://pydantic.dev/logfire), from the host process — the pool builds every request
+and decodes every event anyway, so the whole conversation is observable without instrumenting
+the workers (they receive no token and run no exporter, and recording works on both
+transports). Each checkout becomes one session span; each feed is a nested span held across
+suspension round-trips, with a child span per suspension whose duration is the host round-trip.
+Fed code, inputs, call arguments and results, exceptions and `print` output are recorded in
+full — values are encoded the way the Python logfire SDK encodes attributes, capped at 64KB
+per value — while `Load`/`Dump` snapshot blobs are recorded by size only.
+
+Logfire is configured in *local* mode: the host application's own `tracing`/OTel setup is
+untouched and several pools can coexist. `Pool::close` flushes the exporter (a pool merely
+dropped may lose its last, not-yet-exported batch of spans). As in any logfire-instrumented
+process, a `RUST_LOG` directive in the host environment filters what is recorded (everything
+here is emitted at INFO).
+
 ## Transports
 
 - **Subprocess** (`PoolConfig::subprocess`) — spawn local `monty subprocess` children over

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -43,7 +43,10 @@ impl MontyTransport {
 }
 
 /// Configuration for a [`Pool`].
-#[derive(Debug, Clone)]
+///
+/// `Debug` is hand-written to redact [`Self::logfire_token`] — a write
+/// credential must not end up in a host's diagnostic log.
+#[derive(Clone)]
 pub struct PoolConfig {
     /// Workers spawned eagerly at pool creation and kept warm. Forced to 0 for
     /// the [`MontyTransport::Websocket`] transport (connections are made
@@ -80,6 +83,21 @@ pub struct PoolConfig {
     /// setup is untouched; [`Pool::close`] flushes the exporter (a pool
     /// merely dropped may lose its last, not-yet-exported batch of spans).
     pub logfire_token: Option<String>,
+}
+
+impl fmt::Debug for PoolConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PoolConfig")
+            .field("min_processes", &self.min_processes)
+            .field("max_processes", &self.max_processes)
+            .field("transport", &self.transport)
+            .field("checkout_timeout", &self.checkout_timeout)
+            .field("request_timeout", &self.request_timeout)
+            .field("duration_limit_grace", &self.duration_limit_grace)
+            .field("max_checkouts_per_worker", &self.max_checkouts_per_worker)
+            .field("logfire_token", &self.logfire_token.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
 }
 
 impl PoolConfig {

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -76,12 +76,11 @@ pub struct PoolConfig {
     /// Recycle (kill and respawn) a worker after this many checkouts, to
     /// bound the impact of any slow leak in a long-lived child.
     pub max_checkouts_per_worker: Option<u32>,
-    /// Logfire write token. When set, the pool records every session it
-    /// serves to [Logfire](https://pydantic.dev/logfire) from the host
-    /// process — workers receive no token and run no exporter. Configured in
-    /// logfire's local mode, so the host application's own tracing/OTel
-    /// setup is untouched; [`Pool::close`] flushes the exporter (a pool
-    /// merely dropped may lose its last, not-yet-exported batch of spans).
+    /// Logfire write token. When set, the pool records every session it serves
+    /// to [Logfire](https://pydantic.dev/logfire) from the host process —
+    /// workers receive no token. Logfire is configured in local mode, so the
+    /// host's own tracing/OTel setup is untouched, and [`Pool::close`] flushes
+    /// the exporter (a pool merely dropped may lose its last batch of spans).
     pub logfire_token: Option<String>,
 }
 

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -2,6 +2,8 @@
 
 mod checkout;
 mod pool;
+mod telemetry;
+mod telemetry_json;
 mod worker;
 
 use std::{borrow::Cow, error, fmt, io, num::NonZero, path::PathBuf, process::ExitStatus, thread, time::Duration};
@@ -71,6 +73,13 @@ pub struct PoolConfig {
     /// Recycle (kill and respawn) a worker after this many checkouts, to
     /// bound the impact of any slow leak in a long-lived child.
     pub max_checkouts_per_worker: Option<u32>,
+    /// Logfire write token. When set, the pool records every session it
+    /// serves to [Logfire](https://pydantic.dev/logfire) from the host
+    /// process — workers receive no token and run no exporter. Configured in
+    /// logfire's local mode, so the host application's own tracing/OTel
+    /// setup is untouched; [`Pool::close`] flushes the exporter (a pool
+    /// merely dropped may lose its last, not-yet-exported batch of spans).
+    pub logfire_token: Option<String>,
 }
 
 impl PoolConfig {
@@ -99,6 +108,7 @@ impl PoolConfig {
             request_timeout: None,
             duration_limit_grace: Some(Duration::from_secs(1)),
             max_checkouts_per_worker: None,
+            logfire_token: None,
         }
     }
 }
@@ -138,6 +148,9 @@ pub enum PoolError {
     Exhausted,
     /// A worker process could not be spawned.
     Spawn(String),
+    /// The pool's logfire telemetry could not be configured
+    /// ([`PoolConfig::logfire_token`]); the pool was not created.
+    Telemetry(String),
     /// The checkout was already finished or its worker already discarded.
     Finished,
     /// The remote worker's connection dropped without a turn-ending event
@@ -207,6 +220,7 @@ impl fmt::Display for PoolError {
             Self::Typing(diagnostics) => write!(f, "type checking failed:\n{diagnostics}"),
             Self::Exhausted => f.write_str("no monty worker became available within the checkout timeout"),
             Self::Spawn(msg) => write!(f, "failed to spawn monty worker: {msg}"),
+            Self::Telemetry(msg) => write!(f, "failed to configure logfire telemetry: {msg}"),
             Self::Finished => f.write_str("this checkout has already been finished"),
             Self::Disconnected { context } => write!(f, "monty worker connection closed while {context}"),
             Self::Shutdown { dump } => match dump {

--- a/crates/monty-pool/src/pool.rs
+++ b/crates/monty-pool/src/pool.rs
@@ -8,15 +8,18 @@ use std::{
 };
 
 use futures_util::future::join_all;
+use logfire::Logfire;
 use monty_proto::pb;
 use tokio::{
     sync::Notify,
+    task::spawn_blocking,
     time::{Instant, timeout_at},
 };
 
 use crate::{
     PoolConfig, PoolError,
     checkout::{Checkout, ReplConfig, request},
+    telemetry,
     worker::Worker,
 };
 
@@ -44,6 +47,10 @@ pub(crate) struct PoolInner {
     /// Signalled whenever a worker returns to the idle queue or capacity is
     /// released, waking blocked `checkout` calls.
     available: Notify,
+    /// The pool's logfire (`PoolConfig::logfire_token`), which every worker's
+    /// recorder holds a clone of. `None`: telemetry is off. [`Pool::close`]
+    /// shuts it down, flushing the exporter.
+    logfire: Option<Logfire>,
 }
 
 struct PoolState {
@@ -63,12 +70,18 @@ impl Pool {
                 config.min_processes, config.max_processes
             )));
         }
+        let logfire = config
+            .logfire_token
+            .clone()
+            .map(telemetry::init)
+            .transpose()
+            .map_err(|err| PoolError::Telemetry(err.to_string()))?;
         // Only the subprocess transport pre-warms workers; WebSocket connections
         // are made per-checkout (its `min_processes` is 0).
         let mut idle = Vec::with_capacity(config.min_processes);
         if !config.transport.is_websocket() {
             for _ in 0..config.min_processes {
-                idle.push(Worker::new(&config).await?);
+                idle.push(Worker::new(&config, logfire.as_ref()).await?);
             }
         }
         let total = idle.len();
@@ -77,6 +90,7 @@ impl Pool {
                 config,
                 state: Mutex::new(PoolState { idle, total }),
                 available: Notify::new(),
+                logfire,
             }),
         })
     }
@@ -120,6 +134,14 @@ impl Pool {
             worker.reap_or_kill(SHUTDOWN_EXIT_GRACE).await;
         }))
         .await;
+        // Flush and stop the telemetry exporter, off the async runtime —
+        // `shutdown` blocks until the exporter confirms. Errors are swallowed:
+        // they are export failures (e.g. a bad token) teardown cannot fix, and
+        // a second `close` reports "already shut down". A pool merely dropped
+        // skips this and may lose its last, not-yet-exported batch of spans.
+        if let Some(logfire) = self.inner.logfire.clone() {
+            let _ = spawn_blocking(move || logfire.shutdown()).await;
+        }
     }
 
     /// Number of idle workers right now (diagnostics/tests only — the value
@@ -185,7 +207,7 @@ impl PoolInner {
                 // guard the reserved slot: a failed — or cancelled, for the
                 // WebSocket dial — spawn must release it or the pool shrinks
                 let capacity = CapacityGuard::new(self);
-                let worker = Worker::new(&self.config).await?;
+                let worker = Worker::new(&self.config, self.logfire.as_ref()).await?;
                 capacity.disarm();
                 return Ok(worker);
             }

--- a/crates/monty-pool/src/pool.rs
+++ b/crates/monty-pool/src/pool.rs
@@ -110,6 +110,10 @@ impl Pool {
     ///
     /// Optional: dropping the pool kills idle workers instead, which is just
     /// as safe — this only trades a SIGKILL for a clean protocol goodbye.
+    ///
+    /// This also shuts the telemetry exporter down, so it is the last thing a
+    /// pool should be asked to do: what sessions still checked out here go on
+    /// to record is dropped rather than exported.
     pub async fn close(&self) {
         // Pair each removed worker with a capacity guard immediately: if this
         // future is dropped mid-close, every unreaped worker is killed by its

--- a/crates/monty-pool/src/pool.rs
+++ b/crates/monty-pool/src/pool.rs
@@ -47,9 +47,8 @@ pub(crate) struct PoolInner {
     /// Signalled whenever a worker returns to the idle queue or capacity is
     /// released, waking blocked `checkout` calls.
     available: Notify,
-    /// The pool's logfire (`PoolConfig::logfire_token`), which every worker's
-    /// recorder holds a clone of. `None`: telemetry is off. [`Pool::close`]
-    /// shuts it down, flushing the exporter.
+    /// The pool's logfire (`PoolConfig::logfire_token`), cloned into every
+    /// worker's recorder; `None` when telemetry is off.
     logfire: Option<Logfire>,
 }
 
@@ -111,9 +110,9 @@ impl Pool {
     /// Optional: dropping the pool kills idle workers instead, which is just
     /// as safe — this only trades a SIGKILL for a clean protocol goodbye.
     ///
-    /// This also shuts the telemetry exporter down, so it is the last thing a
-    /// pool should be asked to do: what sessions still checked out here go on
-    /// to record is dropped rather than exported.
+    /// This also shuts the telemetry exporter down, so it must be the last
+    /// thing asked of a pool: whatever a still-checked-out session records
+    /// afterwards is dropped rather than exported.
     pub async fn close(&self) {
         // Pair each removed worker with a capacity guard immediately: if this
         // future is dropped mid-close, every unreaped worker is killed by its
@@ -138,11 +137,10 @@ impl Pool {
             worker.reap_or_kill(SHUTDOWN_EXIT_GRACE).await;
         }))
         .await;
-        // Flush and stop the telemetry exporter, off the async runtime —
-        // `shutdown` blocks until the exporter confirms. Errors are swallowed:
-        // they are export failures (e.g. a bad token) teardown cannot fix, and
-        // a second `close` reports "already shut down". A pool merely dropped
-        // skips this and may lose its last, not-yet-exported batch of spans.
+        // Flush and stop the exporter off the async runtime — `shutdown`
+        // blocks until the exporter confirms. Errors are swallowed: they are
+        // export failures (e.g. a bad token) teardown cannot fix, and a second
+        // `close` reports "already shut down".
         if let Some(logfire) = self.inner.logfire.clone() {
             let _ = spawn_blocking(move || logfire.shutdown()).await;
         }

--- a/crates/monty-pool/src/pool.rs
+++ b/crates/monty-pool/src/pool.rs
@@ -47,9 +47,9 @@ pub(crate) struct PoolInner {
     /// Signalled whenever a worker returns to the idle queue or capacity is
     /// released, waking blocked `checkout` calls.
     available: Notify,
-    /// The pool's logfire (`PoolConfig::logfire_token`), cloned into every
+    /// The pool's logfire (`PoolConfig::logfire_token`), shared with every
     /// worker's recorder; `None` when telemetry is off.
-    logfire: Option<Logfire>,
+    logfire: Option<Arc<Logfire>>,
 }
 
 struct PoolState {
@@ -74,7 +74,8 @@ impl Pool {
             .clone()
             .map(telemetry::init)
             .transpose()
-            .map_err(|err| PoolError::Telemetry(err.to_string()))?;
+            .map_err(|err| PoolError::Telemetry(err.to_string()))?
+            .map(Arc::new);
         // Only the subprocess transport pre-warms workers; WebSocket connections
         // are made per-checkout (its `min_processes` is 0).
         let mut idle = Vec::with_capacity(config.min_processes);

--- a/crates/monty-pool/src/telemetry.rs
+++ b/crates/monty-pool/src/telemetry.rs
@@ -132,6 +132,9 @@ impl Recorder {
                     parent: self.context_span(),
                     "load",
                     state_bytes = l.state.len(),
+                    // filled in by the reply, which announces the name the
+                    // restored session runs under
+                    script_name = Empty,
                 ));
             }
             // ends the session: closing the spans is the whole record, since
@@ -196,7 +199,14 @@ impl Recorder {
             }
             Some(pb::parent_request::Kind::Dump(_)) => {
                 self.dump_turn = true;
-                self.turn = Some(logfire::span!(parent: self.context_span(), "dump"));
+                self.turn = Some(logfire::span!(
+                    parent: self.context_span(),
+                    "dump",
+                    // filled in by the `DumpResult` reply
+                    state_bytes = Empty,
+                    total_execution_micros = Empty,
+                    max_duration_micros = Empty,
+                ));
             }
             // no span of its own: the session is normally already reset, and
             // a lone "shutdown" span would start a whole trace for a worker
@@ -221,9 +231,9 @@ impl Recorder {
         let micros = event.total_execution_micros;
         let max_duration = event.max_duration_micros;
         // only a `Load` reply carries this: the session span already exists with
-        // the `Configure` name, so the dump's name goes on the load turn
-        if let Some(script_name) = &event.restored_script_name {
-            logfire::info!(parent: self.context_span(), "restored {script_name}", script_name = script_name);
+        // the `Configure` name, so the dump's name goes on the load span
+        if let (Some(script_name), Some(load)) = (&event.restored_script_name, &self.turn) {
+            load.record("script_name", script_name.as_str());
         }
         match &event.kind {
             Some(pb::child_event::Kind::Print(p)) => {
@@ -307,14 +317,15 @@ impl Recorder {
                 );
                 self.end_feed();
             }
+            // the dump span carries its own result, and closes on it
             Some(pb::child_event::Kind::DumpResult(d)) => {
-                logfire::info!(
-                    parent: self.context_span(),
-                    "dump result",
-                    state_bytes = d.state.len(),
-                    total_execution_micros = micros,
-                    max_duration_micros = max_duration,
-                );
+                if let Some(dump) = &self.turn {
+                    dump.record("state_bytes", int_attr(d.state.len()));
+                    dump.record("total_execution_micros", int_attr(micros));
+                    if let Some(max_duration) = max_duration {
+                        dump.record("max_duration_micros", int_attr(max_duration));
+                    }
+                }
                 self.turn = None;
             }
             // only a serving relay sends this (a WebSocket worker's server is
@@ -353,9 +364,9 @@ impl Recorder {
                 if let Some(value) = value {
                     feed.record("output", &value, cut);
                 }
-                feed.span.record("total_execution_micros", micros_attr(micros));
+                feed.span.record("total_execution_micros", int_attr(micros));
                 if let Some(max_duration) = max_duration {
-                    feed.span.record("max_duration_micros", micros_attr(max_duration));
+                    feed.span.record("max_duration_micros", int_attr(max_duration));
                 }
             }
             None => logfire::info!(
@@ -769,10 +780,10 @@ fn record_attr(span: &Span, field: &'static str, value: &OtelValue) {
     };
 }
 
-/// A microsecond count as the i64 `tracing` records integers as; saturating,
-/// since it has no u64 (an unsigned one would land as a debug string).
-fn micros_attr(micros: u64) -> i64 {
-    i64::try_from(micros).unwrap_or(i64::MAX)
+/// An unsigned count as the i64 `tracing` records integers as; saturating,
+/// since `tracing` has no u64 (one would land as a debug string instead).
+fn int_attr(count: impl TryInto<i64>) -> i64 {
+    count.try_into().unwrap_or(i64::MAX)
 }
 
 /// [`attr_value`] for an optional field: an absent value renders as an absent
@@ -987,6 +998,42 @@ mod tests {
             .collect();
         assert_eq!(flags.len(), 1);
         assert_eq!(flags[0].value, true.into());
+    }
+
+    /// A `Load` and a `Dump` report their result on their own span, so a
+    /// housekeeping turn is one span with nothing hanging off it.
+    #[test]
+    fn housekeeping_turns_report_on_their_span() {
+        let (logfire, spans, logs) = test_logfire();
+        let mut recorder = Recorder::new(Some(logfire), None);
+
+        recorder.begin_turn(&request(pb::parent_request::Kind::Load(pb::Load { state: vec![0; 8] })));
+        recorder.event(&pb::ChildEvent {
+            kind: Some(pb::child_event::Kind::Ok(pb::Ok {})),
+            total_execution_micros: 42,
+            max_duration_micros: None,
+            restored_script_name: Some("dumped.py".to_owned()),
+        });
+        recorder.begin_turn(&request(pb::parent_request::Kind::Dump(pb::Dump {})));
+        recorder.event(&event(pb::child_event::Kind::DumpResult(pb::DumpResult {
+            state: vec![0; 16],
+        })));
+
+        let spans = spans.get_finished_spans().unwrap();
+        let attr = |name: &str, key: &str| {
+            spans
+                .iter()
+                .find(|s| s.name == name)
+                .unwrap()
+                .attributes
+                .iter()
+                .find(|kv| kv.key.as_str() == key)
+                .map(|kv| kv.value.clone())
+        };
+        assert_eq!(attr("load", "script_name"), Some("dumped.py".into()));
+        assert_eq!(attr("dump", "state_bytes"), Some(16.into()));
+        assert_eq!(attr("dump", "total_execution_micros"), Some(42.into()));
+        assert!(logs.get_emitted_logs().unwrap().is_empty());
     }
 
     /// A feed restored mid-suspension has no feed span of its own, so its

--- a/crates/monty-pool/src/telemetry.rs
+++ b/crates/monty-pool/src/telemetry.rs
@@ -19,15 +19,14 @@ use monty_proto::{WireFunctionCall, WireObject, pb, pb::os_call::Call};
 use monty_types::{MontyObject, bytes_repr};
 use opentelemetry::{KeyValue, Value as OtelValue};
 use opentelemetry_sdk::Resource;
-use tracing::{Span, level_filters::LevelFilter};
+use tracing::{Span, field::Empty, level_filters::LevelFilter};
 use uuid::Uuid;
 
 use crate::telemetry_json::{
     nonfinite_str, serialize_capped, serialize_dict_capped, serialize_named_capped, serialize_seq_capped,
 };
 
-/// Configures a pool-scoped logfire with `token` and records that the pool
-/// started.
+/// Configures a pool-scoped logfire with `token`.
 ///
 /// Local mode (see the module docs) makes the returned [`Logfire`] the only
 /// handle: the pool must keep it alive and `shutdown` it to flush the exporter.
@@ -50,8 +49,6 @@ pub(crate) fn init(token: String) -> Result<Logfire, ConfigureError> {
         .with_default_level_filter(LevelFilter::INFO)
         .with_advanced_options(AdvancedOptions::default().with_resource(resource))
         .finish()?;
-    let _guard = set_local_logfire(logfire.clone());
-    logfire::info!("monty pool started");
     Ok(logfire)
 }
 
@@ -72,10 +69,10 @@ pub(crate) struct Recorder {
     turn: Option<Span>,
     /// The span of the suspension the feed is blocked on, closed when the
     /// answering `Resume*` is sent so its duration is the host round-trip.
-    pending: Option<Span>,
+    pending: Option<OpenSpan>,
     /// The in-flight feed's span, held across suspension round-trips so the
     /// whole feed is one span. Closed by the turn-ending event.
-    feed: Option<Span>,
+    feed: Option<OpenSpan>,
     /// The session span every turn nests inside; `Configure` opens it and
     /// `Reset` closes it.
     session: Option<Span>,
@@ -159,38 +156,33 @@ impl Recorder {
                 // worker rejects; close the stale spans so nesting stays sane
                 self.pending = None;
                 self.feed = None;
-                self.feed = Some(logfire::span!(
+                let cut = code_cut | inputs_cut;
+                let span = logfire::span!(
                     parent: self.context_span(),
-                    "feed",
+                    "run code",
                     code = &code,
                     code.language = "python",
                     inputs = inputs,
                     skip_type_check = f.skip_type_check,
-                    length_limit_exceeded = (code_cut | inputs_cut).then_some(true),
-                ));
-            }
-            // the resume family opens no span: it records the host's answer
-            // inside the pending suspension span, then closes it
-            Some(pb::parent_request::Kind::ResumeCall(r)) => {
-                let pending = self.take_pending();
-                let (result, cut) = render_ext_result(r.result.as_ref());
-                logfire::info!(
-                    parent: pending,
-                    "call result",
-                    call_id = r.call_id,
-                    result = result,
                     length_limit_exceeded = cut.then_some(true),
+                    // declared empty here, filled in by the `Complete` event
+                    // that closes this span
+                    output = Empty,
+                    total_execution_micros = Empty,
+                    max_duration_micros = Empty,
                 );
+                self.feed = Some(OpenSpan::new(span, cut));
+            }
+            // the resume family opens no span: the host's answer is an
+            // attribute of the suspension span it closes, so a round-trip
+            // reads as one span rather than a span plus a child record
+            Some(pb::parent_request::Kind::ResumeCall(r)) => {
+                let (result, cut) = render_ext_result(r.result.as_ref());
+                self.close_pending("return_value", &result, cut);
             }
             Some(pb::parent_request::Kind::ResumeNameLookup(r)) => {
-                let pending = self.take_pending();
                 let (result, cut) = render_name_lookup(r.kind.as_ref());
-                logfire::info!(
-                    parent: pending,
-                    "name lookup result",
-                    result = result,
-                    length_limit_exceeded = cut.then_some(true),
-                );
+                self.close_pending("value", &result, cut);
             }
             Some(pb::parent_request::Kind::ResumeFutures(r)) => {
                 let pending = self.take_pending();
@@ -246,9 +238,9 @@ impl Recorder {
             }
             Some(pb::child_event::Kind::FunctionCall(c)) => {
                 let (args, kwargs, cut) = render_call_arguments(c);
-                self.pending = Some(logfire::span!(
+                let span = logfire::span!(
                     parent: self.context_span(),
-                    "function call {function_name}",
+                    "call {function_name}",
                     function_name = &c.function_name,
                     args = args,
                     kwargs = kwargs,
@@ -257,39 +249,40 @@ impl Recorder {
                     length_limit_exceeded = cut.then_some(true),
                     total_execution_micros = micros,
                     max_duration_micros = max_duration,
-                ));
+                    // filled in by the answering `ResumeCall`
+                    return_value = Empty,
+                );
+                self.pending = Some(OpenSpan::new(span, cut));
             }
             Some(pb::child_event::Kind::OsCall(c)) => {
                 self.pending = Some(os_call_span(c, micros, max_duration, &self.context_span()));
             }
             Some(pb::child_event::Kind::NameLookup(n)) => {
-                self.pending = Some(logfire::span!(
+                let span = logfire::span!(
                     parent: self.context_span(),
                     "name lookup {name}",
                     name = &n.name,
                     total_execution_micros = micros,
                     max_duration_micros = max_duration,
-                ));
+                    // filled in by the answering `ResumeNameLookup`
+                    value = Empty,
+                    length_limit_exceeded = Empty,
+                );
+                self.pending = Some(OpenSpan::new(span, false));
             }
             Some(pb::child_event::Kind::ResolveFutures(r)) => {
-                self.pending = Some(logfire::span!(
+                let span = logfire::span!(
                     parent: self.context_span(),
                     "resolve futures",
                     pending_call_ids = render_call_ids(&r.pending_call_ids),
                     total_execution_micros = micros,
                     max_duration_micros = max_duration,
-                ));
+                );
+                self.pending = Some(OpenSpan::new(span, false));
             }
             Some(pb::child_event::Kind::Complete(c)) => {
                 let (value, cut) = optional_attr(c.value.as_ref());
-                logfire::info!(
-                    parent: self.context_span(),
-                    "complete",
-                    value = value,
-                    length_limit_exceeded = cut.then_some(true),
-                    total_execution_micros = micros,
-                    max_duration_micros = max_duration,
-                );
+                self.record_complete(value, cut, micros, max_duration);
                 self.end_feed();
             }
             Some(pb::child_event::Kind::Error(e)) => {
@@ -347,22 +340,59 @@ impl Recorder {
         }
     }
 
+    /// Records a completed run's result on the feed span itself, so the run
+    /// reads as one span rather than a span plus a child record.
+    ///
+    /// A restored suspension has no feed span (its `Load` turn stands in for
+    /// one), so its completion is recorded as an event instead.
+    fn record_complete(&mut self, value: Option<OtelValue>, cut: bool, micros: u64, max_duration: Option<u64>) {
+        // taking the span closes it here rather than in the `end_feed` the
+        // caller runs next, which would close it a moment later anyway
+        match self.feed.take() {
+            Some(mut feed) => {
+                if let Some(value) = value {
+                    feed.record("output", &value, cut);
+                }
+                feed.span.record("total_execution_micros", micros_attr(micros));
+                if let Some(max_duration) = max_duration {
+                    feed.span.record("max_duration_micros", micros_attr(max_duration));
+                }
+            }
+            None => logfire::info!(
+                parent: self.context_span(),
+                "complete",
+                output = value,
+                length_limit_exceeded = cut.then_some(true),
+                total_execution_micros = micros,
+                max_duration_micros = max_duration,
+            ),
+        }
+    }
+
     /// The innermost open span, used as the explicit parent for new spans and
     /// records; [`Span::none`] (a root record) when nothing is open.
     fn context_span(&self) -> Span {
         self.turn
             .as_ref()
-            .or(self.pending.as_ref())
-            .or(self.feed.as_ref())
+            .or(self.pending.as_ref().map(OpenSpan::span))
+            .or(self.feed.as_ref().map(OpenSpan::span))
             .or(self.session.as_ref())
             .cloned()
             .unwrap_or_else(Span::none)
     }
 
-    /// Takes the pending suspension span so the resume answer can be recorded
+    /// Records the host's answer on the suspension span it answers, then
+    /// closes that span by dropping it.
+    fn close_pending(&mut self, field: &'static str, value: &OtelValue, cut: bool) {
+        if let Some(mut pending) = self.pending.take() {
+            pending.record(field, value, cut);
+        }
+    }
+
+    /// Takes the pending suspension span so a resume answer can be recorded
     /// inside it before the caller drops it, closing it.
     fn take_pending(&mut self) -> Span {
-        self.pending.take().unwrap_or_else(Span::none)
+        self.pending.take().map_or_else(Span::none, |pending| pending.span)
     }
 
     /// Closes the feed-scoped spans after a turn-ending
@@ -372,6 +402,38 @@ impl Recorder {
         self.turn = None;
         self.pending = None;
         self.feed = None;
+    }
+}
+
+/// An open span plus whether it already carries `length_limit_exceeded`.
+///
+/// The spans that gain an attribute after they open — a suspension's answer, a
+/// run's return value — may need to flag a cut the span was opened without.
+/// A key recorded twice is exported twice, so the flag has to be remembered.
+struct OpenSpan {
+    span: Span,
+    cut: bool,
+}
+
+impl OpenSpan {
+    /// Holds a span already flagged (or not) by the values it was opened with.
+    const fn new(span: Span, cut: bool) -> Self {
+        Self { span, cut }
+    }
+
+    const fn span(&self) -> &Span {
+        &self.span
+    }
+
+    /// Records `value` on the span, flagging a cut it does not already carry.
+    /// The field must have been declared when the span was opened (as
+    /// [`Empty`] at the latest) or `tracing` drops it silently.
+    fn record(&mut self, field: &'static str, value: &OtelValue, cut: bool) {
+        record_attr(&self.span, field, value);
+        if cut && !self.cut {
+            self.span.record("length_limit_exceeded", true);
+            self.cut = true;
+        }
     }
 }
 
@@ -479,8 +541,11 @@ fn render_call_ids(ids: &[u32]) -> Option<String> {
 /// Each call shape gets its own macro invocation because the attribute set is
 /// baked into the span's `logfire.json_schema` at compile time — a union-shaped
 /// call would surface every unused argument as `null` in the UI.
-fn os_call_span(os_call: &pb::OsCall, micros: u64, max_duration: Option<u64>, parent: &Span) -> Span {
+fn os_call_span(os_call: &pb::OsCall, micros: u64, max_duration: Option<u64>, parent: &Span) -> OpenSpan {
     let call_id = os_call.call_id;
+    // set by the arms whose arguments can be cut; recorded once below, so that
+    // the answering `ResumeCall` can tell whether the flag is already there
+    let mut args_cut = false;
     /// One span with only the given `args.*` attributes plus the shared tail.
     macro_rules! os_call {
         ($function:expr $(, $($key:ident).+ = $value:expr)* $(,)?) => {
@@ -492,10 +557,13 @@ fn os_call_span(os_call: &pb::OsCall, micros: u64, max_duration: Option<u64>, pa
                 call_id = call_id,
                 total_execution_micros = micros,
                 max_duration_micros = max_duration,
+                // filled in by the answering `ResumeCall`
+                return_value = Empty,
+                length_limit_exceeded = Empty,
             )
         };
     }
-    match os_call.call.as_ref() {
+    let span = match os_call.call.as_ref() {
         Some(Call::Exists(p)) => os_call!("exists", args.path = p),
         Some(Call::IsFile(p)) => os_call!("is_file", args.path = p),
         Some(Call::IsDir(p)) => os_call!("is_dir", args.path = p),
@@ -510,39 +578,23 @@ fn os_call_span(os_call: &pb::OsCall, micros: u64, max_duration: Option<u64>, pa
         Some(Call::Rmdir(p)) => os_call!("rmdir", args.path = p),
         Some(Call::WriteText(w)) => {
             let (data, cut) = truncate_str(&w.data);
-            os_call!(
-                "write_text",
-                args.path = &w.path,
-                args.data = data,
-                length_limit_exceeded = cut.then_some(true)
-            )
+            args_cut = cut;
+            os_call!("write_text", args.path = &w.path, args.data = data)
         }
         Some(Call::AppendText(w)) => {
             let (data, cut) = truncate_str(&w.data);
-            os_call!(
-                "append_text",
-                args.path = &w.path,
-                args.data = data,
-                length_limit_exceeded = cut.then_some(true)
-            )
+            args_cut = cut;
+            os_call!("append_text", args.path = &w.path, args.data = data)
         }
         Some(Call::WriteBytes(w)) => {
             let (data, cut) = bytes_attr(&w.data);
-            os_call!(
-                "write_bytes",
-                args.path = &w.path,
-                args.data = data,
-                length_limit_exceeded = cut.then_some(true)
-            )
+            args_cut = cut;
+            os_call!("write_bytes", args.path = &w.path, args.data = data)
         }
         Some(Call::AppendBytes(w)) => {
             let (data, cut) = bytes_attr(&w.data);
-            os_call!(
-                "append_bytes",
-                args.path = &w.path,
-                args.data = data,
-                length_limit_exceeded = cut.then_some(true)
-            )
+            args_cut = cut;
+            os_call!("append_bytes", args.path = &w.path, args.data = data)
         }
         Some(Call::Open(o)) => os_call!("open", args.path = &o.path, args.mode = &o.mode),
         Some(Call::Mkdir(m)) => os_call!(
@@ -558,12 +610,8 @@ fn os_call_span(os_call: &pb::OsCall, micros: u64, max_duration: Option<u64>, pa
         Some(Call::Getenv(g)) => {
             let (default, cut) = optional_attr(g.default.as_ref());
             let default = default.map(|v| v.as_str().into_owned());
-            os_call!(
-                "getenv",
-                args.key = &g.key,
-                args.default = default,
-                length_limit_exceeded = cut.then_some(true)
-            )
+            args_cut = cut;
+            os_call!("getenv", args.key = &g.key, args.default = default)
         }
         Some(Call::GetEnviron(_)) => os_call!("get_environ"),
         Some(Call::DateToday(_)) => os_call!("date_today"),
@@ -580,7 +628,11 @@ fn os_call_span(os_call: &pb::OsCall, micros: u64, max_duration: Option<u64>, pa
             }
         }
         None => os_call!(MISSING),
+    };
+    if args_cut {
+        span.record("length_limit_exceeded", true);
     }
+    OpenSpan::new(span, args_cut)
 }
 
 /// Renders an exception as `Type: message`.
@@ -704,6 +756,25 @@ fn attr_value(value: &WireObject) -> (OtelValue, bool) {
     }
 }
 
+/// Records `value` on an already-open span, keeping its native attribute type:
+/// [`Span::record`] takes statically typed `tracing` values, so the dynamic
+/// [`OtelValue`] has to be matched out.
+fn record_attr(span: &Span, field: &'static str, value: &OtelValue) {
+    match value {
+        OtelValue::Bool(b) => span.record(field, *b),
+        OtelValue::I64(i) => span.record(field, *i),
+        OtelValue::F64(f) => span.record(field, *f),
+        // `attr_value` never yields an array; `as_str` renders one anyway
+        other => span.record(field, other.as_str().as_ref()),
+    };
+}
+
+/// A microsecond count as the i64 `tracing` records integers as; saturating,
+/// since it has no u64 (an unsigned one would land as a debug string).
+fn micros_attr(micros: u64) -> i64 {
+    i64::try_from(micros).unwrap_or(i64::MAX)
+}
+
 /// [`attr_value`] for an optional field: an absent value renders as an absent
 /// attribute, not as [`MISSING`].
 fn optional_attr(value: Option<&WireObject>) -> (Option<OtelValue>, bool) {
@@ -760,7 +831,7 @@ fn print_stream(stream: i32) -> &'static str {
 #[cfg(test)]
 mod tests {
     use logfire::{Logfire, config::AdvancedOptions};
-    use monty_proto::{WireFunctionCall, pb};
+    use monty_proto::{WireFunctionCall, pb, pb::os_call::Call};
     use monty_types::MontyObject;
     use opentelemetry::{logs::AnyValue, trace::SpanId};
     use opentelemetry_sdk::{
@@ -842,33 +913,100 @@ mod tests {
         // spans are exported innermost-first as they close
         let spans = spans.get_finished_spans().unwrap();
         let names: Vec<&str> = spans.iter().map(|s| s.name.as_ref()).collect();
-        assert_eq!(
-            names,
-            ["function call {function_name}", "feed", "session {script_name}"]
-        );
+        assert_eq!(names, ["call {function_name}", "run code", "session {script_name}"]);
         let by_name = |name: &str| -> &SpanData { spans.iter().find(|s| s.name == name).unwrap() };
         let session = by_name("session {script_name}");
-        let feed = by_name("feed");
-        let call = by_name("function call {function_name}");
+        let feed = by_name("run code");
+        let call = by_name("call {function_name}");
         assert_eq!(session.parent_span_id, SpanId::INVALID);
         assert_eq!(feed.parent_span_id, session.span_context.span_id());
         assert_eq!(call.parent_span_id, feed.span_context.span_id());
-        let worker_pid = session.attributes.iter().find(|kv| kv.key.as_str() == "worker_pid");
-        assert_eq!(worker_pid.unwrap().value, 4321.into());
-
-        // the resume answer lands in the suspension span, completion in the feed
-        let logs = logs.get_emitted_logs().unwrap();
-        let parent_of = |name: &str| {
-            logs.iter()
-                .find(|l| l.record.event_name() == Some(name))
-                .unwrap()
-                .record
-                .trace_context()
-                .unwrap()
-                .span_id
+        let attr = |span: &SpanData, key: &str| {
+            span.attributes
+                .iter()
+                .find(|kv| kv.key.as_str() == key)
+                .map(|kv| kv.value.clone())
         };
-        assert_eq!(parent_of("call result"), call.span_context.span_id());
-        assert_eq!(parent_of("complete"), feed.span_context.span_id());
+        assert_eq!(attr(session, "worker_pid"), Some(4321.into()));
+        // the run's result and the host's answer to the suspension are
+        // attributes of their own spans, typed as the values were, rather
+        // than child records — which leaves this session with no records at all
+        assert_eq!(attr(feed, "output"), Some(4.into()));
+        assert_eq!(attr(feed, "total_execution_micros"), Some(42.into()));
+        assert_eq!(attr(call, "return_value"), Some(4.into()));
+        assert!(logs.get_emitted_logs().unwrap().is_empty());
+    }
+
+    /// A suspension's answer is an attribute of the span it closes, and a cut
+    /// answer flags `length_limit_exceeded` only once — the os call below is
+    /// opened with the flag already set by its own oversize argument, and a
+    /// key recorded twice would be exported twice.
+    #[test]
+    fn suspension_answers_land_on_their_span() {
+        let (logfire, spans, _logs) = test_logfire();
+        let mut recorder = Recorder::new(Some(logfire), None);
+        let long = "x".repeat(ATTR_SIZE_LIMIT * 2);
+
+        recorder.event(&event(pb::child_event::Kind::NameLookup(pb::NameLookup {
+            name: "fetch".to_owned(),
+        })));
+        recorder.begin_turn(&request(pb::parent_request::Kind::ResumeNameLookup(
+            pb::ResumeNameLookup {
+                kind: Some(pb::resume_name_lookup::Kind::Value(
+                    MontyObject::String("<function>".to_owned()).into(),
+                )),
+            },
+        )));
+        recorder.event(&event(pb::child_event::Kind::OsCall(pb::OsCall {
+            call_id: 1,
+            call: Some(Call::WriteText(pb::os_call::TextWrite {
+                path: "/mnt/data/f.txt".to_owned(),
+                data: long.clone(),
+            })),
+        })));
+        recorder.begin_turn(&request(pb::parent_request::Kind::ResumeCall(pb::ResumeCall {
+            call_id: 1,
+            result: Some(pb::ExtFunctionResult {
+                kind: Some(pb::ext_function_result::Kind::ReturnValue(
+                    MontyObject::String(long).into(),
+                )),
+            }),
+        })));
+
+        let spans = spans.get_finished_spans().unwrap();
+        let by_name = |name: &str| -> &SpanData { spans.iter().find(|s| s.name == name).unwrap() };
+        let lookup = by_name("name lookup {name}");
+        let value = lookup.attributes.iter().find(|kv| kv.key.as_str() == "value");
+        assert_eq!(value.unwrap().value, "<function>".into());
+
+        let os_call = by_name("os call {function}");
+        let flags: Vec<_> = os_call
+            .attributes
+            .iter()
+            .filter(|kv| kv.key.as_str() == "length_limit_exceeded")
+            .collect();
+        assert_eq!(flags.len(), 1);
+        assert_eq!(flags[0].value, true.into());
+    }
+
+    /// A feed restored mid-suspension has no feed span of its own, so its
+    /// completion keeps the record it would otherwise be an attribute of.
+    #[test]
+    fn completion_without_a_feed_span_is_recorded() {
+        let (logfire, _spans, logs) = test_logfire();
+        let mut recorder = Recorder::new(Some(logfire), None);
+        recorder.event(&event(pb::child_event::Kind::Complete(pb::Complete {
+            value: Some(MontyObject::Int(7).into()),
+        })));
+
+        let logs = logs.get_emitted_logs().unwrap();
+        let record = &logs.first().unwrap().record;
+        assert_eq!(record.event_name(), Some("complete"));
+        let value = record
+            .attributes_iter()
+            .find(|(k, _)| k.as_str() == "output")
+            .map(|(_, v)| v.clone());
+        assert_eq!(value, Some(AnyValue::Int(7)));
     }
 
     /// Every attribute a host or the sandbox can make arbitrarily long is

--- a/crates/monty-pool/src/telemetry.rs
+++ b/crates/monty-pool/src/telemetry.rs
@@ -1,28 +1,16 @@
 //! Logfire instrumentation of the pool's protocol conversations.
 //!
-//! The pool records every worker's wire traffic from the host side: it builds
-//! each `ParentRequest` and decodes each `ChildEvent` anyway, so the whole
-//! conversation is observable without instrumenting the sandbox itself. A
-//! worker serves one REPL session per checkout, so the trace is shaped the
-//! same way: `Configure` opens a session span carrying its arguments and
-//! `Reset` closes it. Each `Feed` opens a span held across suspension
-//! round-trips, so the whole logical feed is one span: every suspension
-//! (external function call, os call, name lookup, future resolution) becomes
-//! a child span closed when the pool's `Resume*` answer is sent — its
-//! duration is the host round-trip — and the turn-ending
-//! `Complete`/`Error`/`TypingError` event closes the feed span. Housekeeping
-//! requests (`Load`, `Dump`, ...) are plain turn spans of their own.
-//! Everything the protocol carries is recorded verbatim — code, inputs, call
-//! arguments, results, exceptions — except the opaque `Load`/`Dump` snapshot
-//! blobs, which are recorded as a byte count.
+//! The pool builds every `ParentRequest` and decodes every `ChildEvent`
+//! anyway, so the sandbox needs no instrumenting. The trace mirrors the
+//! protocol: `Configure` opens a session span `Reset` closes, `Feed` opens a
+//! span held across suspensions, and each suspension is a child span the
+//! answering `Resume*` closes — its duration is the host round-trip.
 //!
-//! Logfire is configured in *local* mode: nothing global is touched, so the
-//! host application keeps its own `tracing`/OTel setup and several pools can
-//! coexist in one process. The flip side is that every recording call must
-//! scope the pool's own logfire in via [`set_local_logfire`], and spans must
-//! be parented explicitly (`parent:`) rather than by thread-local entering —
-//! a checkout's turns can run on different threads, so an entered-span stack
-//! would both be wrong and make [`crate::Checkout`] `!Send`.
+//! Logfire runs in *local* mode, leaving the host's own tracing/OTel setup
+//! alone, so every recording call must scope the pool's logfire in via
+//! [`set_local_logfire`] and spans are parented explicitly rather than
+//! entered — a checkout's turns can run on different threads, so an
+//! entered-span stack would be wrong and make [`crate::Checkout`] `!Send`.
 
 use std::process;
 
@@ -41,16 +29,13 @@ use crate::telemetry_json::{
 /// Configures a pool-scoped logfire with `token` and records that the pool
 /// started.
 ///
-/// Local mode (see the module docs) means the returned [`Logfire`] is the
-/// only handle on this configuration: the pool must keep it alive and call
-/// `shutdown` on teardown to flush the exporter. The pool identifies itself
-/// with a fresh `service.instance.id` (UUIDv7, so ids sort by pool start)
-/// plus the host `process.pid`. `RUST_LOG` in the host environment filters
-/// what is recorded, as in any logfire-instrumented process; the default
-/// level is INFO, which everything recorded here is emitted at.
+/// Local mode (see the module docs) makes the returned [`Logfire`] the only
+/// handle: the pool must keep it alive and `shutdown` it to flush the exporter.
+/// Everything here is recorded at INFO, so `RUST_LOG` can filter it out.
 pub(crate) fn init(token: String) -> Result<Logfire, ConfigureError> {
-    // `builder_empty` so this adds only these two attributes: logfire fills
-    // in service name/version and the sdk resource itself
+    // `builder_empty` so this adds only these two attributes: logfire fills in
+    // service name/version and the sdk resource itself. UUIDv7 so instance ids
+    // sort by pool start.
     let resource = Resource::builder_empty()
         .with_attributes([
             KeyValue::new("service.instance.id", Uuid::now_v7().to_string()),
@@ -72,16 +57,10 @@ pub(crate) fn init(token: String) -> Result<Logfire, ConfigureError> {
 
 /// Records one worker's protocol turns to the pool's logfire.
 ///
-/// Lives on the [`crate::worker::Worker`], which sees every request sent and
-/// every event received — the same vantage point the child's own loop would
-/// have. A disabled recorder (pool without a `logfire_token`) makes every
-/// method a no-op and, crucially, skips rendering values to strings, so the
-/// worker is written the same way whether or not telemetry is on.
-///
-/// Spans are plain [`Span`] handles closed by dropping them (never entered —
-/// see the module docs), so a worker that dies mid-turn closes everything
-/// still open when it is dropped, and the spans survive the crash — they were
-/// never inside the crashed process.
+/// Lives on the [`crate::worker::Worker`], which sees every request and event.
+/// A disabled recorder (no `logfire_token`) is a no-op that skips rendering
+/// values at all, so the worker is written the same way either way. Spans close
+/// by being dropped, so a worker that dies mid-turn still closes its own.
 pub(crate) struct Recorder {
     /// `None` disables the recorder entirely.
     logfire: Option<Logfire>,
@@ -91,22 +70,17 @@ pub(crate) struct Recorder {
     /// The span of a housekeeping turn (`Load`, `Dump`, ...), closed by the
     /// turn-ending event. Innermost: a `Dump` can run mid-suspension.
     turn: Option<Span>,
-    /// The span of the suspension the feed is blocked on (external function
-    /// call, os call, name lookup, future resolution). Opened by the
-    /// suspension event, closed when the answering `Resume*` is sent, so its
-    /// duration is the host round-trip.
+    /// The span of the suspension the feed is blocked on, closed when the
+    /// answering `Resume*` is sent so its duration is the host round-trip.
     pending: Option<Span>,
-    /// The span of the in-flight feed, held across suspension round-trips so
-    /// the whole logical feed is one span. Opened by `Feed`, closed by the
-    /// turn-ending `Complete`/`Error`/`TypingError` event.
+    /// The in-flight feed's span, held across suspension round-trips so the
+    /// whole feed is one span. Closed by the turn-ending event.
     feed: Option<Span>,
-    /// The session span every turn nests inside. `Configure` opens it,
-    /// `Reset` closes it, and dropping the recorder closes one left open by
-    /// a crash or shutdown.
+    /// The session span every turn nests inside; `Configure` opens it and
+    /// `Reset` closes it.
     session: Option<Span>,
-    /// Whether the current turn is a `Dump`: an `Error` reply to one (e.g. an
-    /// oversize dump) leaves the feed suspended and resumable, so it must
-    /// close only the dump span, not the feed.
+    /// Whether the current turn is a `Dump`: an `Error` reply to one leaves
+    /// the feed suspended and resumable, so it closes only the dump span.
     dump_turn: bool,
 }
 
@@ -124,13 +98,8 @@ impl Recorder {
         }
     }
 
-    /// Starts recording one turn, called after the request frame is written
-    /// (a rejected oversize frame never reaches the worker, so it records
-    /// nothing): opens the session span on `Configure`, the feed span on
-    /// `Feed`, or a turn span for the housekeeping requests. `Resume*`
-    /// requests open no span — they record the host's answer inside the
-    /// pending suspension span and close it, so a feed reads as one span with
-    /// a child span per suspension.
+    /// Starts recording one turn; called once the frame is on the wire, so a
+    /// rejected oversize frame records nothing.
     pub(crate) fn begin_turn(&mut self, request: &pb::ParentRequest) {
         let Some(logfire) = &self.logfire else { return };
         let _guard = set_local_logfire(logfire.clone());
@@ -139,8 +108,7 @@ impl Recorder {
         self.turn = None;
         self.dump_turn = false;
         match &request.kind {
-            // Configure opens the session span rather than a turn span; a
-            // stale session (impossible via the checkout state machine, but
+            // a stale session (impossible via the checkout state machine, but
             // cheap to be safe against) is closed by the overwrite
             Some(pb::parent_request::Kind::Configure(c)) => {
                 self.pending = None;
@@ -157,7 +125,7 @@ impl Recorder {
                     max_memory_bytes = limits.and_then(|l| l.max_memory_bytes),
                     gc_interval = limits.and_then(|l| l.gc_interval),
                     max_recursion_depth = limits.and_then(|l| l.max_recursion_depth),
-                    // i64: a u32 has no typed `tracing` value and would be
+                    // i64: `tracing` has no typed u32 value, so a u32 would be
                     // recorded as its debug string
                     worker_pid = self.worker_pid.map(i64::from),
                 ));
@@ -169,9 +137,9 @@ impl Recorder {
                     state_bytes = l.state.len(),
                 ));
             }
-            // ends the session: closing the spans is the whole record, and
-            // the bare `Ok` it is answered with would say nothing. A reset
-            // can land mid-suspension in principle, so close innermost-first.
+            // ends the session: closing the spans is the whole record, since
+            // the bare `Ok` it is answered with would say nothing. A reset can
+            // land mid-suspension, so close innermost-first.
             Some(pb::parent_request::Kind::Reset(_)) => {
                 self.pending = None;
                 self.feed = None;
@@ -201,8 +169,8 @@ impl Recorder {
                     length_limit_exceeded = (code_cut | inputs_cut).then_some(true),
                 ));
             }
-            // the resume family: record the host's answer inside the pending
-            // suspension span, then close it — its duration is the host time
+            // the resume family opens no span: it records the host's answer
+            // inside the pending suspension span, then closes it
             Some(pb::parent_request::Kind::ResumeCall(r)) => {
                 let pending = self.take_pending();
                 let (result, cut) = render_ext_result(r.result.as_ref());
@@ -251,23 +219,17 @@ impl Recorder {
         }
     }
 
-    /// Records one event received from the worker.
-    ///
-    /// The suspension events open the pending span the matching `Resume*`
-    /// closes; the turn-ending events close the feed and/or housekeeping turn
-    /// spans. `DumpResult` records only its snapshot size, for the reason
-    /// given in the module docs.
+    /// Records one event from the worker: suspension events open the pending
+    /// span, turn-ending events close the feed and turn spans.
     pub(crate) fn event(&mut self, event: &pb::ChildEvent) {
         let Some(logfire) = &self.logfire else { return };
         let _guard = set_local_logfire(logfire.clone());
-        // carried by every turn-ending event; recording the budget alongside
-        // keeps `Load`-restored sessions (whose limits come from the dump, not
-        // the session span's Configure) showing what the time is measured against
+        // the budget travels with the elapsed time so `Load`-restored sessions,
+        // whose limits come from the dump, show what it is measured against
         let micros = event.total_execution_micros;
         let max_duration = event.max_duration_micros;
-        // only a `Load` reply carries this: the session span was opened by the
-        // preceding `Configure`, so the script name the dump restored — the one
-        // the session actually runs under — is recorded on the load turn instead
+        // only a `Load` reply carries this: the session span already exists with
+        // the `Configure` name, so the dump's name goes on the load turn
         if let Some(script_name) = &event.restored_script_name {
             logfire::info!(parent: self.context_span(), "restored {script_name}", script_name = script_name);
         }
@@ -332,9 +294,8 @@ impl Recorder {
             }
             Some(pb::child_event::Kind::Error(e)) => {
                 record_error(e, micros, max_duration, &self.context_span());
-                // an error reply to `Dump` (e.g. an oversize dump) does not
-                // end the in-flight feed — the worker stays suspended and
-                // resumable — so it closes only the dump span
+                // an error reply to `Dump` leaves the feed suspended and
+                // resumable, so it closes only the dump span
                 if self.dump_turn {
                     self.turn = None;
                 } else {
@@ -364,9 +325,9 @@ impl Recorder {
                 self.turn = None;
             }
             // only a serving relay sends this (a WebSocket worker's server is
-            // shutting down); its final state dump is an opaque blob,
-            // recorded by size, absent when there was no session or the dump
-            // failed. The worker is discarded right after, closing its spans.
+            // shutting down); its final state dump is absent when there was no
+            // session or the dump failed. The worker is discarded right after,
+            // closing its spans.
             Some(pb::child_event::Kind::Shutdown(s)) => {
                 logfire::info!(
                     parent: self.context_span(),
@@ -399,7 +360,7 @@ impl Recorder {
     }
 
     /// Takes the pending suspension span so the resume answer can be recorded
-    /// inside it before it closes (by dropping) at the end of the caller.
+    /// inside it before the caller drops it, closing it.
     fn take_pending(&mut self) -> Span {
         self.pending.take().unwrap_or_else(Span::none)
     }
@@ -418,10 +379,9 @@ impl Recorder {
 /// worker rejects such frames; telemetry still has to render something.
 const MISSING: &str = "<missing>";
 
-/// Renders a feed's named inputs as one JSON object of name → encoded value;
-/// the bool reports a cut at [`ATTR_SIZE_LIMIT`]. The values are borrowed, not
-/// cloned: a feed's inputs can be a large object graph, and only 64 KiB of the
-/// encoding survives.
+/// Renders a feed's named inputs as one JSON object; the bool reports a cut at
+/// [`ATTR_SIZE_LIMIT`]. Values are borrowed, never cloned — inputs can be a
+/// large graph of which only the cap survives.
 fn render_inputs(inputs: &[pb::NamedValue]) -> (Option<String>, bool) {
     if inputs.is_empty() {
         return (None, false);
@@ -439,10 +399,9 @@ fn render_inputs(inputs: &[pb::NamedValue]) -> (Option<String>, bool) {
     (Some(json), cut)
 }
 
-/// Renders a suspended call's positional arguments as a JSON list and its
-/// keyword arguments as a JSON object; either is absent when empty. The
-/// arguments are borrowed, not cloned, for the reason given in
-/// [`render_inputs`].
+/// Renders a call's positional arguments as a JSON list and its keyword
+/// arguments as a JSON object, either absent when empty; borrowed for the
+/// reason given in [`render_inputs`].
 fn render_call_arguments(call: &WireFunctionCall) -> (Option<String>, Option<String>, bool) {
     let mut any_cut = false;
     let args = (!call.args.is_empty()).then(|| {
@@ -513,15 +472,13 @@ fn render_call_ids(ids: &[u32]) -> Option<String> {
     (!ids.is_empty()).then(|| serde_json::to_string(ids).unwrap_or_default())
 }
 
-/// Opens the span for one os call suspension: the function name plus each of
-/// its arguments as a standalone `args.*` attribute named after the proto
-/// field (strings as strings, numbers as numbers, bools as bools; `bytes`
-/// data as its Python repr). Every path is a virtual sandbox path. The span
-/// stays open until the pool's answer closes it.
+/// Opens the span for one os call suspension: the function name plus each
+/// argument as an `args.*` attribute named after its proto field. Every path
+/// is a virtual sandbox path.
 ///
 /// Each call shape gets its own macro invocation because the attribute set is
-/// baked into the span's `logfire.json_schema` at compile time — a single
-/// union-shaped call would surface every unused argument as `null` in the UI.
+/// baked into the span's `logfire.json_schema` at compile time — a union-shaped
+/// call would surface every unused argument as `null` in the UI.
 fn os_call_span(os_call: &pb::OsCall, micros: u64, max_duration: Option<u64>, parent: &Span) -> Span {
     let call_id = os_call.call_id;
     /// One span with only the given `args.*` attributes plus the shared tail.
@@ -595,9 +552,9 @@ fn os_call_span(os_call: &pb::OsCall, micros: u64, max_duration: Option<u64>, pa
             args.exist_ok = m.exist_ok
         ),
         Some(Call::Rename(r)) => os_call!("rename", args.src = &r.src, args.dst = &r.dst),
-        // a getenv with no default is recorded with `args.default = null`,
-        // matching the `None` that `os.getenv` defaults to in Python; span
-        // attributes cannot carry a dynamic typed value, so it is stringified
+        // no default is recorded as `args.default = null`, matching Python's
+        // `os.getenv`; a span attribute cannot carry a dynamically typed
+        // value, so the default is stringified
         Some(Call::Getenv(g)) => {
             let (default, cut) = optional_attr(g.default.as_ref());
             let default = default.map(|v| v.as_str().into_owned());
@@ -653,13 +610,10 @@ fn render_traceback(frames: &[pb::StackFrame]) -> (Option<String>, bool) {
     (Some(traceback), cut)
 }
 
-/// Records an `Error` event: exception type, message, traceback, and — for
-/// the exception types carrying a structured payload — each payload field as
-/// a standalone `exc_data.*` attribute, including the offending input (it is
-/// the value being debugged).
-///
-/// Like [`os_call_span`], each payload shape gets its own macro invocation
-/// so records don't surface the other shape's attributes as `null`.
+/// Records an `Error` event: exception type, message, traceback, and each
+/// field of a structured payload as an `exc_data.*` attribute — including the
+/// offending input, the value being debugged. One macro invocation per payload
+/// shape, for the reason given in [`os_call_span`].
 fn record_error(error: &pb::Error, micros: u64, max_duration: Option<u64>, parent: &Span) {
     let exc = error.exception.as_ref();
     let exc_type = exc.map_or_else(|| MISSING.to_owned(), |e| e.exc_type.clone());
@@ -763,12 +717,9 @@ fn unzip<T>(pair: Option<(T, bool)>) -> (Option<T>, bool) {
 }
 
 /// A bytes value as logfire renders bytes: the repr's escaped content without
-/// the b'' wrapper, as raw text capped at [`ATTR_SIZE_LIMIT`].
-///
-/// Only the leading [`ATTR_SIZE_LIMIT`] bytes are escaped: every byte escapes
-/// to at least one character, so that is already enough to fill the cap, and
-/// escaping the rest would quadruple a payload as big as a `write_bytes` call
-/// allows just to throw it away.
+/// the b'' wrapper, capped at [`ATTR_SIZE_LIMIT`]. Only that many input bytes
+/// are escaped — each escapes to at least one character, so the rest would
+/// inflate a whole `write_bytes` payload just to throw it away.
 fn bytes_attr(b: &[u8]) -> (String, bool) {
     let head = &b[..b.len().min(ATTR_SIZE_LIMIT)];
     let repr = bytes_repr(head);
@@ -849,12 +800,9 @@ mod tests {
         }
     }
 
-    /// Drives one whole session — configure, feed, a suspension round-trip,
-    /// completion, reset — and checks the exported span tree: the suspension
-    /// span is a child of the feed span, the feed span of the session span,
-    /// the session span a root; and the resume/complete log records land
-    /// inside the right spans. This is what proves the explicit-parent
-    /// plumbing (spans are never entered — see the module docs) holds up.
+    /// Drives a whole session and checks the exported spans nest and the log
+    /// records land in the right ones — this is what proves the explicit-parent
+    /// plumbing (see the module docs) holds up.
     #[test]
     fn one_feed_produces_a_nested_span_tree() {
         let (logfire, spans, logs) = test_logfire();
@@ -905,8 +853,6 @@ mod tests {
         assert_eq!(session.parent_span_id, SpanId::INVALID);
         assert_eq!(feed.parent_span_id, session.span_context.span_id());
         assert_eq!(call.parent_span_id, feed.span_context.span_id());
-        // the worker's identity is a session attribute (the child-side
-        // recorder used to carry it as a per-process resource attribute)
         let worker_pid = session.attributes.iter().find(|kv| kv.key.as_str() == "worker_pid");
         assert_eq!(worker_pid.unwrap().value, 4321.into());
 
@@ -926,9 +872,7 @@ mod tests {
     }
 
     /// Every attribute a host or the sandbox can make arbitrarily long is
-    /// capped and flagged — including the ones reached through an
-    /// `ExtFunctionResult` or a structured exception payload, and including a
-    /// `bytes` payload, which is escaped only as far as the cap can keep.
+    /// capped and flagged, including those inside an `ExtFunctionResult`.
     #[test]
     fn oversize_attributes_are_capped_and_flagged() {
         let long = "x".repeat(ATTR_SIZE_LIMIT * 2);
@@ -958,8 +902,8 @@ mod tests {
         assert_eq!(bytes_attr(b"hi\xff"), ("hi\\xff".to_owned(), false));
     }
 
-    /// The `Error` event's structured payload fields are capped too — the
-    /// codec name of a `UnicodeDecodeError` is whatever the sandbox passed.
+    /// The `Error` event's structured `exc_data.*` payload fields are capped
+    /// and flagged too.
     #[test]
     fn oversize_error_payload_is_capped() {
         let (logfire, _spans, logs) = test_logfire();

--- a/crates/monty-pool/src/telemetry.rs
+++ b/crates/monty-pool/src/telemetry.rs
@@ -34,7 +34,9 @@ use opentelemetry_sdk::Resource;
 use tracing::{Span, level_filters::LevelFilter};
 use uuid::Uuid;
 
-use crate::telemetry_json::{nonfinite_str, serialize_capped};
+use crate::telemetry_json::{
+    nonfinite_str, serialize_capped, serialize_dict_capped, serialize_named_capped, serialize_seq_capped,
+};
 
 /// Configures a pool-scoped logfire with `token` and records that the pool
 /// started.
@@ -263,6 +265,12 @@ impl Recorder {
         // the session span's Configure) showing what the time is measured against
         let micros = event.total_execution_micros;
         let max_duration = event.max_duration_micros;
+        // only a `Load` reply carries this: the session span was opened by the
+        // preceding `Configure`, so the script name the dump restored — the one
+        // the session actually runs under — is recorded on the load turn instead
+        if let Some(script_name) = &event.restored_script_name {
+            logfire::info!(parent: self.context_span(), "restored {script_name}", script_name = script_name);
+        }
         match &event.kind {
             Some(pb::child_event::Kind::Print(p)) => {
                 let (text, cut) = truncate_str(&p.text);
@@ -411,36 +419,39 @@ impl Recorder {
 const MISSING: &str = "<missing>";
 
 /// Renders a feed's named inputs as one JSON object of name → encoded value;
-/// the bool reports a cut at [`ATTR_SIZE_LIMIT`]. The inputs are cloned into
-/// a dict to encode them; only run when telemetry is enabled.
+/// the bool reports a cut at [`ATTR_SIZE_LIMIT`]. The values are borrowed, not
+/// cloned: a feed's inputs can be a large object graph, and only 64 KiB of the
+/// encoding survives.
 fn render_inputs(inputs: &[pb::NamedValue]) -> (Option<String>, bool) {
     if inputs.is_empty() {
         return (None, false);
     }
-    let pairs = inputs
+    // one placeholder, borrowed by every value the frame left out
+    let missing = MontyObject::Repr(MISSING.to_owned());
+    let pairs: Vec<(&str, &MontyObject)> = inputs
         .iter()
         .map(|i| {
-            let value = i.value.as_ref().and_then(|v| v.0.clone());
-            let value = value.unwrap_or_else(|| MontyObject::Repr(MISSING.to_owned()));
-            (MontyObject::String(i.name.clone()), value)
+            let value = i.value.as_ref().and_then(|v| v.0.as_ref()).unwrap_or(&missing);
+            (i.name.as_str(), value)
         })
-        .collect::<Vec<_>>();
-    let (json, cut) = serialize_capped(&MontyObject::dict(pairs), ATTR_SIZE_LIMIT);
+        .collect();
+    let (json, cut) = serialize_named_capped(&pairs, ATTR_SIZE_LIMIT);
     (Some(json), cut)
 }
 
 /// Renders a suspended call's positional arguments as a JSON list and its
 /// keyword arguments as a JSON object; either is absent when empty. The
-/// arguments are cloned to encode them; only run when telemetry is enabled.
+/// arguments are borrowed, not cloned, for the reason given in
+/// [`render_inputs`].
 fn render_call_arguments(call: &WireFunctionCall) -> (Option<String>, Option<String>, bool) {
     let mut any_cut = false;
     let args = (!call.args.is_empty()).then(|| {
-        let (json, cut) = serialize_capped(&MontyObject::List(call.args.clone()), ATTR_SIZE_LIMIT);
+        let (json, cut) = serialize_seq_capped(&call.args, ATTR_SIZE_LIMIT);
         any_cut |= cut;
         json
     });
     let kwargs = (!call.kwargs.is_empty()).then(|| {
-        let (json, cut) = serialize_capped(&MontyObject::dict(call.kwargs.clone()), ATTR_SIZE_LIMIT);
+        let (json, cut) = serialize_dict_capped(&call.kwargs, ATTR_SIZE_LIMIT);
         any_cut |= cut;
         json
     });
@@ -453,9 +464,16 @@ fn render_call_arguments(call: &WireFunctionCall) -> (Option<String>, Option<Str
 fn render_ext_result(result: Option<&pb::ExtFunctionResult>) -> (OtelValue, bool) {
     match result.and_then(|r| r.kind.as_ref()) {
         Some(pb::ext_function_result::Kind::ReturnValue(v)) => attr_value(v),
-        Some(pb::ext_function_result::Kind::Error(e)) => (format!("raise {}", render_exception(e)).into(), false),
+        // the host writes both of these, so both need the cap
+        Some(pb::ext_function_result::Kind::Error(e)) => {
+            let (text, cut) = truncate_str(&format!("raise {}", render_exception(e)));
+            (text.into(), cut)
+        }
         Some(pb::ext_function_result::Kind::Future(id)) => (format!("future {id}").into(), false),
-        Some(pb::ext_function_result::Kind::NotFound(name)) => (format!("not found: {name}").into(), false),
+        Some(pb::ext_function_result::Kind::NotFound(name)) => {
+            let (text, cut) = truncate_str(&format!("not found: {name}"));
+            (text.into(), cut)
+        }
         Some(pb::ext_function_result::Kind::NotHandled(_)) => ("not handled".into(), false),
         None => (MISSING.into(), false),
     }
@@ -673,20 +691,25 @@ fn record_error(error: &pb::Error, micros: u64, max_duration: Option<u64>, paren
                 Some(pb::unicode_error_data::Object::ObjectStr(s)) => truncate_str(s),
                 None => (MISSING.to_owned(), false),
             };
+            // the codec name is whatever the sandbox passed to `decode`, so it
+            // needs the cap as much as the object does
+            let (encoding, encoding_cut) = truncate_str(&u.encoding);
+            let (reason, reason_cut) = truncate_str(&u.reason);
             error_event!(
-                base_cut | object_cut,
-                exc_data.encoding = &u.encoding,
+                base_cut | object_cut | encoding_cut | reason_cut,
+                exc_data.encoding = encoding,
                 exc_data.object = object,
                 exc_data.start = u.start,
                 exc_data.end = u.end,
-                exc_data.reason = &u.reason,
+                exc_data.reason = reason,
             );
         }
         Some(pb::exc_data::Kind::Json(j)) => {
             let (doc, doc_cut) = unzip(j.doc.as_deref().map(truncate_str));
+            let (msg, msg_cut) = truncate_str(&j.msg);
             error_event!(
-                base_cut | doc_cut,
-                exc_data.msg = &j.msg,
+                base_cut | doc_cut | msg_cut,
+                exc_data.msg = msg,
                 exc_data.doc = doc,
                 exc_data.pos = j.pos,
                 exc_data.lineno = j.lineno,
@@ -741,9 +764,16 @@ fn unzip<T>(pair: Option<(T, bool)>) -> (Option<T>, bool) {
 
 /// A bytes value as logfire renders bytes: the repr's escaped content without
 /// the b'' wrapper, as raw text capped at [`ATTR_SIZE_LIMIT`].
+///
+/// Only the leading [`ATTR_SIZE_LIMIT`] bytes are escaped: every byte escapes
+/// to at least one character, so that is already enough to fill the cap, and
+/// escaping the rest would quadruple a payload as big as a `write_bytes` call
+/// allows just to throw it away.
 fn bytes_attr(b: &[u8]) -> (String, bool) {
-    let repr = bytes_repr(b);
-    truncate_str(&repr[2..repr.len() - 1])
+    let head = &b[..b.len().min(ATTR_SIZE_LIMIT)];
+    let repr = bytes_repr(head);
+    let (text, cut) = truncate_str(&repr[2..repr.len() - 1]);
+    (text, cut | (head.len() < b.len()))
 }
 
 /// Renders strings as a JSON list, absent when empty.
@@ -781,13 +811,13 @@ mod tests {
     use logfire::{Logfire, config::AdvancedOptions};
     use monty_proto::{WireFunctionCall, pb};
     use monty_types::MontyObject;
-    use opentelemetry::trace::SpanId;
+    use opentelemetry::{logs::AnyValue, trace::SpanId};
     use opentelemetry_sdk::{
         logs::{InMemoryLogExporter, SimpleLogProcessor},
         trace::{InMemorySpanExporter, SimpleSpanProcessor, SpanData},
     };
 
-    use super::Recorder;
+    use super::{ATTR_SIZE_LIMIT, Recorder, bytes_attr, render_ext_result};
 
     /// A local logfire capturing spans and logs in memory instead of exporting.
     fn test_logfire() -> (Logfire, InMemorySpanExporter, InMemoryLogExporter) {
@@ -893,6 +923,77 @@ mod tests {
         };
         assert_eq!(parent_of("call result"), call.span_context.span_id());
         assert_eq!(parent_of("complete"), feed.span_context.span_id());
+    }
+
+    /// Every attribute a host or the sandbox can make arbitrarily long is
+    /// capped and flagged — including the ones reached through an
+    /// `ExtFunctionResult` or a structured exception payload, and including a
+    /// `bytes` payload, which is escaped only as far as the cap can keep.
+    #[test]
+    fn oversize_attributes_are_capped_and_flagged() {
+        let long = "x".repeat(ATTR_SIZE_LIMIT * 2);
+        let result = pb::ExtFunctionResult {
+            kind: Some(pb::ext_function_result::Kind::Error(pb::RaisedException {
+                exc_type: "ValueError".to_owned(),
+                message: Some(long.clone()),
+                traceback: vec![],
+                data: None,
+            })),
+        };
+        let (value, cut) = render_ext_result(Some(&result));
+        assert!(cut);
+        assert_eq!(value.as_str().len(), ATTR_SIZE_LIMIT);
+
+        let (name, cut) = render_ext_result(Some(&pb::ExtFunctionResult {
+            kind: Some(pb::ext_function_result::Kind::NotFound(long)),
+        }));
+        assert!(cut);
+        assert_eq!(name.as_str().len(), ATTR_SIZE_LIMIT);
+
+        // a payload one byte past the cap: the escaped head fills it exactly,
+        // so only the dropped input marks it as cut
+        let (text, cut) = bytes_attr(&vec![b'a'; ATTR_SIZE_LIMIT + 1]);
+        assert!(cut);
+        assert_eq!(text.len(), ATTR_SIZE_LIMIT);
+        assert_eq!(bytes_attr(b"hi\xff"), ("hi\\xff".to_owned(), false));
+    }
+
+    /// The `Error` event's structured payload fields are capped too — the
+    /// codec name of a `UnicodeDecodeError` is whatever the sandbox passed.
+    #[test]
+    fn oversize_error_payload_is_capped() {
+        let (logfire, _spans, logs) = test_logfire();
+        let mut recorder = Recorder::new(Some(logfire), None);
+        recorder.event(&event(pb::child_event::Kind::Error(pb::Error {
+            exception: Some(pb::RaisedException {
+                exc_type: "UnicodeDecodeError".to_owned(),
+                message: None,
+                traceback: vec![],
+                data: Some(pb::ExcData {
+                    kind: Some(pb::exc_data::Kind::Unicode(pb::UnicodeErrorData {
+                        encoding: "u".repeat(ATTR_SIZE_LIMIT * 2),
+                        object: None,
+                        start: 0,
+                        end: 1,
+                        reason: "bad".to_owned(),
+                    })),
+                }),
+            }),
+        })));
+
+        let logs = logs.get_emitted_logs().unwrap();
+        let record = &logs.first().unwrap().record;
+        let attr = |key: &str| {
+            record
+                .attributes_iter()
+                .find(|(k, _)| k.as_str() == key)
+                .map(|(_, v)| v.clone())
+        };
+        let Some(AnyValue::String(encoding)) = attr("exc_data.encoding") else {
+            panic!("expected a string encoding attribute");
+        };
+        assert_eq!(encoding.as_str().len(), ATTR_SIZE_LIMIT);
+        assert_eq!(attr("length_limit_exceeded"), Some(AnyValue::Boolean(true)));
     }
 
     /// A disabled recorder (pool without a token) records nothing and holds

--- a/crates/monty-pool/src/telemetry.rs
+++ b/crates/monty-pool/src/telemetry.rs
@@ -12,7 +12,7 @@
 //! entered — a checkout's turns can run on different threads, so an
 //! entered-span stack would be wrong and make [`crate::Checkout`] `!Send`.
 
-use std::process;
+use std::{process, sync::Arc};
 
 use logfire::{ConfigureError, Logfire, config::AdvancedOptions, set_local_logfire};
 use monty_proto::{WireFunctionCall, WireObject, pb, pb::os_call::Call};
@@ -59,8 +59,10 @@ pub(crate) fn init(token: String) -> Result<Logfire, ConfigureError> {
 /// values at all, so the worker is written the same way either way. Spans close
 /// by being dropped, so a worker that dies mid-turn still closes its own.
 pub(crate) struct Recorder {
-    /// `None` disables the recorder entirely.
-    logfire: Option<Logfire>,
+    /// `None` disables the recorder entirely. Behind an [`Arc`] because
+    /// [`Logfire`] is ~2 KiB and this lives on every [`crate::worker::Worker`],
+    /// which is moved on each checkout and release.
+    logfire: Option<Arc<Logfire>>,
     /// OS pid of the worker, recorded on its session spans (`None` for a
     /// remote WebSocket worker).
     worker_pid: Option<u32>,
@@ -83,7 +85,7 @@ pub(crate) struct Recorder {
 
 impl Recorder {
     /// A recorder for one worker; `logfire = None` records nothing.
-    pub(crate) const fn new(logfire: Option<Logfire>, worker_pid: Option<u32>) -> Self {
+    pub(crate) const fn new(logfire: Option<Arc<Logfire>>, worker_pid: Option<u32>) -> Self {
         Self {
             logfire,
             worker_pid,
@@ -99,7 +101,7 @@ impl Recorder {
     /// rejected oversize frame records nothing.
     pub(crate) fn begin_turn(&mut self, request: &pb::ParentRequest) {
         let Some(logfire) = &self.logfire else { return };
-        let _guard = set_local_logfire(logfire.clone());
+        let _guard = set_local_logfire(logfire.as_ref().clone());
         // a turn span whose ending event never arrived (worker died mid-turn,
         // undecodable reply) closes here rather than leaking open
         self.turn = None;
@@ -225,7 +227,7 @@ impl Recorder {
     /// span, turn-ending events close the feed and turn spans.
     pub(crate) fn event(&mut self, event: &pb::ChildEvent) {
         let Some(logfire) = &self.logfire else { return };
-        let _guard = set_local_logfire(logfire.clone());
+        let _guard = set_local_logfire(logfire.as_ref().clone());
         // the budget travels with the elapsed time so `Load`-restored sessions,
         // whose limits come from the dump, show what it is measured against
         let micros = event.total_execution_micros;
@@ -841,6 +843,8 @@ fn print_stream(stream: i32) -> &'static str {
 // recording is a side effect of the worker, not part of the pool's public API
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use logfire::{Logfire, config::AdvancedOptions};
     use monty_proto::{WireFunctionCall, pb, pb::os_call::Call};
     use monty_types::MontyObject;
@@ -888,7 +892,7 @@ mod tests {
     #[test]
     fn one_feed_produces_a_nested_span_tree() {
         let (logfire, spans, logs) = test_logfire();
-        let mut recorder = Recorder::new(Some(logfire), Some(4321));
+        let mut recorder = Recorder::new(Some(Arc::new(logfire)), Some(4321));
 
         recorder.begin_turn(&request(pb::parent_request::Kind::Configure(pb::Configure {
             script_name: "main.py".to_owned(),
@@ -955,7 +959,7 @@ mod tests {
     #[test]
     fn suspension_answers_land_on_their_span() {
         let (logfire, spans, _logs) = test_logfire();
-        let mut recorder = Recorder::new(Some(logfire), None);
+        let mut recorder = Recorder::new(Some(Arc::new(logfire)), None);
         let long = "x".repeat(ATTR_SIZE_LIMIT * 2);
 
         recorder.event(&event(pb::child_event::Kind::NameLookup(pb::NameLookup {
@@ -1005,7 +1009,7 @@ mod tests {
     #[test]
     fn housekeeping_turns_report_on_their_span() {
         let (logfire, spans, logs) = test_logfire();
-        let mut recorder = Recorder::new(Some(logfire), None);
+        let mut recorder = Recorder::new(Some(Arc::new(logfire)), None);
 
         recorder.begin_turn(&request(pb::parent_request::Kind::Load(pb::Load { state: vec![0; 8] })));
         recorder.event(&pb::ChildEvent {
@@ -1041,7 +1045,7 @@ mod tests {
     #[test]
     fn completion_without_a_feed_span_is_recorded() {
         let (logfire, _spans, logs) = test_logfire();
-        let mut recorder = Recorder::new(Some(logfire), None);
+        let mut recorder = Recorder::new(Some(Arc::new(logfire)), None);
         recorder.event(&event(pb::child_event::Kind::Complete(pb::Complete {
             value: Some(MontyObject::Int(7).into()),
         })));
@@ -1092,7 +1096,7 @@ mod tests {
     #[test]
     fn oversize_error_payload_is_capped() {
         let (logfire, _spans, logs) = test_logfire();
-        let mut recorder = Recorder::new(Some(logfire), None);
+        let mut recorder = Recorder::new(Some(Arc::new(logfire)), None);
         recorder.event(&event(pb::child_event::Kind::Error(pb::Error {
             exception: Some(pb::RaisedException {
                 exc_type: "UnicodeDecodeError".to_owned(),

--- a/crates/monty-pool/src/telemetry.rs
+++ b/crates/monty-pool/src/telemetry.rs
@@ -1,0 +1,911 @@
+//! Logfire instrumentation of the pool's protocol conversations.
+//!
+//! The pool records every worker's wire traffic from the host side: it builds
+//! each `ParentRequest` and decodes each `ChildEvent` anyway, so the whole
+//! conversation is observable without instrumenting the sandbox itself. A
+//! worker serves one REPL session per checkout, so the trace is shaped the
+//! same way: `Configure` opens a session span carrying its arguments and
+//! `Reset` closes it. Each `Feed` opens a span held across suspension
+//! round-trips, so the whole logical feed is one span: every suspension
+//! (external function call, os call, name lookup, future resolution) becomes
+//! a child span closed when the pool's `Resume*` answer is sent — its
+//! duration is the host round-trip — and the turn-ending
+//! `Complete`/`Error`/`TypingError` event closes the feed span. Housekeeping
+//! requests (`Load`, `Dump`, ...) are plain turn spans of their own.
+//! Everything the protocol carries is recorded verbatim — code, inputs, call
+//! arguments, results, exceptions — except the opaque `Load`/`Dump` snapshot
+//! blobs, which are recorded as a byte count.
+//!
+//! Logfire is configured in *local* mode: nothing global is touched, so the
+//! host application keeps its own `tracing`/OTel setup and several pools can
+//! coexist in one process. The flip side is that every recording call must
+//! scope the pool's own logfire in via [`set_local_logfire`], and spans must
+//! be parented explicitly (`parent:`) rather than by thread-local entering —
+//! a checkout's turns can run on different threads, so an entered-span stack
+//! would both be wrong and make [`crate::Checkout`] `!Send`.
+
+use std::process;
+
+use logfire::{ConfigureError, Logfire, config::AdvancedOptions, set_local_logfire};
+use monty_proto::{WireFunctionCall, WireObject, pb, pb::os_call::Call};
+use monty_types::{MontyObject, bytes_repr};
+use opentelemetry::{KeyValue, Value as OtelValue};
+use opentelemetry_sdk::Resource;
+use tracing::{Span, level_filters::LevelFilter};
+use uuid::Uuid;
+
+use crate::telemetry_json::{nonfinite_str, serialize_capped};
+
+/// Configures a pool-scoped logfire with `token` and records that the pool
+/// started.
+///
+/// Local mode (see the module docs) means the returned [`Logfire`] is the
+/// only handle on this configuration: the pool must keep it alive and call
+/// `shutdown` on teardown to flush the exporter. The pool identifies itself
+/// with a fresh `service.instance.id` (UUIDv7, so ids sort by pool start)
+/// plus the host `process.pid`. `RUST_LOG` in the host environment filters
+/// what is recorded, as in any logfire-instrumented process; the default
+/// level is INFO, which everything recorded here is emitted at.
+pub(crate) fn init(token: String) -> Result<Logfire, ConfigureError> {
+    // `builder_empty` so this adds only these two attributes: logfire fills
+    // in service name/version and the sdk resource itself
+    let resource = Resource::builder_empty()
+        .with_attributes([
+            KeyValue::new("service.instance.id", Uuid::now_v7().to_string()),
+            KeyValue::new("process.pid", i64::from(process::id())),
+        ])
+        .build();
+    let logfire = logfire::configure()
+        .local()
+        .with_token(token)
+        .with_service_name("monty")
+        .with_service_version(env!("CARGO_PKG_VERSION"))
+        .with_default_level_filter(LevelFilter::INFO)
+        .with_advanced_options(AdvancedOptions::default().with_resource(resource))
+        .finish()?;
+    let _guard = set_local_logfire(logfire.clone());
+    logfire::info!("monty pool started");
+    Ok(logfire)
+}
+
+/// Records one worker's protocol turns to the pool's logfire.
+///
+/// Lives on the [`crate::worker::Worker`], which sees every request sent and
+/// every event received — the same vantage point the child's own loop would
+/// have. A disabled recorder (pool without a `logfire_token`) makes every
+/// method a no-op and, crucially, skips rendering values to strings, so the
+/// worker is written the same way whether or not telemetry is on.
+///
+/// Spans are plain [`Span`] handles closed by dropping them (never entered —
+/// see the module docs), so a worker that dies mid-turn closes everything
+/// still open when it is dropped, and the spans survive the crash — they were
+/// never inside the crashed process.
+pub(crate) struct Recorder {
+    /// `None` disables the recorder entirely.
+    logfire: Option<Logfire>,
+    /// OS pid of the worker, recorded on its session spans (`None` for a
+    /// remote WebSocket worker).
+    worker_pid: Option<u32>,
+    /// The span of a housekeeping turn (`Load`, `Dump`, ...), closed by the
+    /// turn-ending event. Innermost: a `Dump` can run mid-suspension.
+    turn: Option<Span>,
+    /// The span of the suspension the feed is blocked on (external function
+    /// call, os call, name lookup, future resolution). Opened by the
+    /// suspension event, closed when the answering `Resume*` is sent, so its
+    /// duration is the host round-trip.
+    pending: Option<Span>,
+    /// The span of the in-flight feed, held across suspension round-trips so
+    /// the whole logical feed is one span. Opened by `Feed`, closed by the
+    /// turn-ending `Complete`/`Error`/`TypingError` event.
+    feed: Option<Span>,
+    /// The session span every turn nests inside. `Configure` opens it,
+    /// `Reset` closes it, and dropping the recorder closes one left open by
+    /// a crash or shutdown.
+    session: Option<Span>,
+    /// Whether the current turn is a `Dump`: an `Error` reply to one (e.g. an
+    /// oversize dump) leaves the feed suspended and resumable, so it must
+    /// close only the dump span, not the feed.
+    dump_turn: bool,
+}
+
+impl Recorder {
+    /// A recorder for one worker; `logfire = None` records nothing.
+    pub(crate) const fn new(logfire: Option<Logfire>, worker_pid: Option<u32>) -> Self {
+        Self {
+            logfire,
+            worker_pid,
+            turn: None,
+            pending: None,
+            feed: None,
+            session: None,
+            dump_turn: false,
+        }
+    }
+
+    /// Starts recording one turn, called after the request frame is written
+    /// (a rejected oversize frame never reaches the worker, so it records
+    /// nothing): opens the session span on `Configure`, the feed span on
+    /// `Feed`, or a turn span for the housekeeping requests. `Resume*`
+    /// requests open no span — they record the host's answer inside the
+    /// pending suspension span and close it, so a feed reads as one span with
+    /// a child span per suspension.
+    pub(crate) fn begin_turn(&mut self, request: &pb::ParentRequest) {
+        let Some(logfire) = &self.logfire else { return };
+        let _guard = set_local_logfire(logfire.clone());
+        // a turn span whose ending event never arrived (worker died mid-turn,
+        // undecodable reply) closes here rather than leaking open
+        self.turn = None;
+        self.dump_turn = false;
+        match &request.kind {
+            // Configure opens the session span rather than a turn span; a
+            // stale session (impossible via the checkout state machine, but
+            // cheap to be safe against) is closed by the overwrite
+            Some(pb::parent_request::Kind::Configure(c)) => {
+                self.pending = None;
+                self.feed = None;
+                let limits = c.limits.as_ref();
+                self.session = Some(logfire::span!(
+                    "session {script_name}",
+                    script_name = &c.script_name,
+                    monty_version = &c.monty_version,
+                    type_check = c.type_check,
+                    type_check_stubs = c.type_check_stubs.as_ref(),
+                    assert_message_annotations = c.assert_message_annotations,
+                    max_duration_micros = limits.and_then(|l| l.max_duration_micros),
+                    max_memory_bytes = limits.and_then(|l| l.max_memory_bytes),
+                    gc_interval = limits.and_then(|l| l.gc_interval),
+                    max_recursion_depth = limits.and_then(|l| l.max_recursion_depth),
+                    // i64: a u32 has no typed `tracing` value and would be
+                    // recorded as its debug string
+                    worker_pid = self.worker_pid.map(i64::from),
+                ));
+            }
+            Some(pb::parent_request::Kind::Load(l)) => {
+                self.turn = Some(logfire::span!(
+                    parent: self.context_span(),
+                    "load",
+                    state_bytes = l.state.len(),
+                ));
+            }
+            // ends the session: closing the spans is the whole record, and
+            // the bare `Ok` it is answered with would say nothing. A reset
+            // can land mid-suspension in principle, so close innermost-first.
+            Some(pb::parent_request::Kind::Reset(_)) => {
+                self.pending = None;
+                self.feed = None;
+                self.session = None;
+            }
+            Some(pb::parent_request::Kind::InstallDependencies(d)) => {
+                self.turn = Some(logfire::span!(
+                    parent: self.context_span(),
+                    "install dependencies",
+                    requirements = render_str_list(&d.requirements),
+                ));
+            }
+            Some(pb::parent_request::Kind::Feed(f)) => {
+                let (code, code_cut) = truncate_str(&f.code);
+                let (inputs, inputs_cut) = render_inputs(&f.inputs);
+                // a feed while one is open is a checkout-level error the
+                // worker rejects; close the stale spans so nesting stays sane
+                self.pending = None;
+                self.feed = None;
+                self.feed = Some(logfire::span!(
+                    parent: self.context_span(),
+                    "feed",
+                    code = &code,
+                    code.language = "python",
+                    inputs = inputs,
+                    skip_type_check = f.skip_type_check,
+                    length_limit_exceeded = (code_cut | inputs_cut).then_some(true),
+                ));
+            }
+            // the resume family: record the host's answer inside the pending
+            // suspension span, then close it — its duration is the host time
+            Some(pb::parent_request::Kind::ResumeCall(r)) => {
+                let pending = self.take_pending();
+                let (result, cut) = render_ext_result(r.result.as_ref());
+                logfire::info!(
+                    parent: pending,
+                    "call result",
+                    call_id = r.call_id,
+                    result = result,
+                    length_limit_exceeded = cut.then_some(true),
+                );
+            }
+            Some(pb::parent_request::Kind::ResumeNameLookup(r)) => {
+                let pending = self.take_pending();
+                let (result, cut) = render_name_lookup(r.kind.as_ref());
+                logfire::info!(
+                    parent: pending,
+                    "name lookup result",
+                    result = result,
+                    length_limit_exceeded = cut.then_some(true),
+                );
+            }
+            Some(pb::parent_request::Kind::ResumeFutures(r)) => {
+                let pending = self.take_pending();
+                let (results, cut) = render_future_results(&r.results);
+                logfire::info!(
+                    parent: pending,
+                    "future results",
+                    results = results,
+                    length_limit_exceeded = cut.then_some(true),
+                );
+            }
+            Some(pb::parent_request::Kind::Dump(_)) => {
+                self.dump_turn = true;
+                self.turn = Some(logfire::span!(parent: self.context_span(), "dump"));
+            }
+            // no span of its own: the session is normally already reset, and
+            // a lone "shutdown" span would start a whole trace for a worker
+            // exiting; closing whatever is open is the record
+            Some(pb::parent_request::Kind::Shutdown(_)) => {
+                self.pending = None;
+                self.feed = None;
+                self.session = None;
+            }
+            // `checkout::request` always sets a kind
+            None => {}
+        }
+    }
+
+    /// Records one event received from the worker.
+    ///
+    /// The suspension events open the pending span the matching `Resume*`
+    /// closes; the turn-ending events close the feed and/or housekeeping turn
+    /// spans. `DumpResult` records only its snapshot size, for the reason
+    /// given in the module docs.
+    pub(crate) fn event(&mut self, event: &pb::ChildEvent) {
+        let Some(logfire) = &self.logfire else { return };
+        let _guard = set_local_logfire(logfire.clone());
+        // carried by every turn-ending event; recording the budget alongside
+        // keeps `Load`-restored sessions (whose limits come from the dump, not
+        // the session span's Configure) showing what the time is measured against
+        let micros = event.total_execution_micros;
+        let max_duration = event.max_duration_micros;
+        match &event.kind {
+            Some(pb::child_event::Kind::Print(p)) => {
+                let (text, cut) = truncate_str(&p.text);
+                logfire::info!(
+                    parent: self.context_span(),
+                    "print {stream}",
+                    stream = print_stream(p.stream),
+                    text = text,
+                    length_limit_exceeded = cut.then_some(true),
+                );
+            }
+            Some(pb::child_event::Kind::FunctionCall(c)) => {
+                let (args, kwargs, cut) = render_call_arguments(c);
+                self.pending = Some(logfire::span!(
+                    parent: self.context_span(),
+                    "function call {function_name}",
+                    function_name = &c.function_name,
+                    args = args,
+                    kwargs = kwargs,
+                    call_id = c.call_id,
+                    method_call = c.method_call,
+                    length_limit_exceeded = cut.then_some(true),
+                    total_execution_micros = micros,
+                    max_duration_micros = max_duration,
+                ));
+            }
+            Some(pb::child_event::Kind::OsCall(c)) => {
+                self.pending = Some(os_call_span(c, micros, max_duration, &self.context_span()));
+            }
+            Some(pb::child_event::Kind::NameLookup(n)) => {
+                self.pending = Some(logfire::span!(
+                    parent: self.context_span(),
+                    "name lookup {name}",
+                    name = &n.name,
+                    total_execution_micros = micros,
+                    max_duration_micros = max_duration,
+                ));
+            }
+            Some(pb::child_event::Kind::ResolveFutures(r)) => {
+                self.pending = Some(logfire::span!(
+                    parent: self.context_span(),
+                    "resolve futures",
+                    pending_call_ids = render_call_ids(&r.pending_call_ids),
+                    total_execution_micros = micros,
+                    max_duration_micros = max_duration,
+                ));
+            }
+            Some(pb::child_event::Kind::Complete(c)) => {
+                let (value, cut) = optional_attr(c.value.as_ref());
+                logfire::info!(
+                    parent: self.context_span(),
+                    "complete",
+                    value = value,
+                    length_limit_exceeded = cut.then_some(true),
+                    total_execution_micros = micros,
+                    max_duration_micros = max_duration,
+                );
+                self.end_feed();
+            }
+            Some(pb::child_event::Kind::Error(e)) => {
+                record_error(e, micros, max_duration, &self.context_span());
+                // an error reply to `Dump` (e.g. an oversize dump) does not
+                // end the in-flight feed — the worker stays suspended and
+                // resumable — so it closes only the dump span
+                if self.dump_turn {
+                    self.turn = None;
+                } else {
+                    self.end_feed();
+                }
+            }
+            Some(pb::child_event::Kind::TypingError(t)) => {
+                let (diagnostics, cut) = truncate_str(&t.diagnostics);
+                logfire::error!(
+                    parent: self.context_span(),
+                    "typing error",
+                    diagnostics = diagnostics,
+                    length_limit_exceeded = cut.then_some(true),
+                    total_execution_micros = micros,
+                    max_duration_micros = max_duration,
+                );
+                self.end_feed();
+            }
+            Some(pb::child_event::Kind::DumpResult(d)) => {
+                logfire::info!(
+                    parent: self.context_span(),
+                    "dump result",
+                    state_bytes = d.state.len(),
+                    total_execution_micros = micros,
+                    max_duration_micros = max_duration,
+                );
+                self.turn = None;
+            }
+            // only a serving relay sends this (a WebSocket worker's server is
+            // shutting down); its final state dump is an opaque blob,
+            // recorded by size, absent when there was no session or the dump
+            // failed. The worker is discarded right after, closing its spans.
+            Some(pb::child_event::Kind::Shutdown(s)) => {
+                logfire::info!(
+                    parent: self.context_span(),
+                    "shutdown",
+                    state_bytes = s.dump.as_ref().map(Vec::len),
+                    total_execution_micros = micros,
+                    max_duration_micros = max_duration,
+                );
+            }
+            // a bare acknowledgement ending a housekeeping turn; the turn
+            // span itself is the record
+            Some(pb::child_event::Kind::Ok(_)) => self.turn = None,
+            Some(pb::child_event::Kind::FatalError(f)) => {
+                logfire::error!(parent: self.context_span(), "fatal error", message = &f.message);
+            }
+            None => logfire::error!(parent: self.context_span(), "event with no kind"),
+        }
+    }
+
+    /// The innermost open span, used as the explicit parent for new spans and
+    /// records; [`Span::none`] (a root record) when nothing is open.
+    fn context_span(&self) -> Span {
+        self.turn
+            .as_ref()
+            .or(self.pending.as_ref())
+            .or(self.feed.as_ref())
+            .or(self.session.as_ref())
+            .cloned()
+            .unwrap_or_else(Span::none)
+    }
+
+    /// Takes the pending suspension span so the resume answer can be recorded
+    /// inside it before it closes (by dropping) at the end of the caller.
+    fn take_pending(&mut self) -> Span {
+        self.pending.take().unwrap_or_else(Span::none)
+    }
+
+    /// Closes the feed-scoped spans after a turn-ending
+    /// `Complete`/`Error`/`TypingError` event; innermost-first, and a no-op
+    /// for the housekeeping turns those events can also end.
+    fn end_feed(&mut self) {
+        self.turn = None;
+        self.pending = None;
+        self.feed = None;
+    }
+}
+
+/// Placeholder for a field the protocol requires but the frame omitted. The
+/// worker rejects such frames; telemetry still has to render something.
+const MISSING: &str = "<missing>";
+
+/// Renders a feed's named inputs as one JSON object of name → encoded value;
+/// the bool reports a cut at [`ATTR_SIZE_LIMIT`]. The inputs are cloned into
+/// a dict to encode them; only run when telemetry is enabled.
+fn render_inputs(inputs: &[pb::NamedValue]) -> (Option<String>, bool) {
+    if inputs.is_empty() {
+        return (None, false);
+    }
+    let pairs = inputs
+        .iter()
+        .map(|i| {
+            let value = i.value.as_ref().and_then(|v| v.0.clone());
+            let value = value.unwrap_or_else(|| MontyObject::Repr(MISSING.to_owned()));
+            (MontyObject::String(i.name.clone()), value)
+        })
+        .collect::<Vec<_>>();
+    let (json, cut) = serialize_capped(&MontyObject::dict(pairs), ATTR_SIZE_LIMIT);
+    (Some(json), cut)
+}
+
+/// Renders a suspended call's positional arguments as a JSON list and its
+/// keyword arguments as a JSON object; either is absent when empty. The
+/// arguments are cloned to encode them; only run when telemetry is enabled.
+fn render_call_arguments(call: &WireFunctionCall) -> (Option<String>, Option<String>, bool) {
+    let mut any_cut = false;
+    let args = (!call.args.is_empty()).then(|| {
+        let (json, cut) = serialize_capped(&MontyObject::List(call.args.clone()), ATTR_SIZE_LIMIT);
+        any_cut |= cut;
+        json
+    });
+    let kwargs = (!call.kwargs.is_empty()).then(|| {
+        let (json, cut) = serialize_capped(&MontyObject::dict(call.kwargs.clone()), ATTR_SIZE_LIMIT);
+        any_cut |= cut;
+        json
+    });
+    (args, kwargs, any_cut)
+}
+
+/// Renders the pool's answer to a `FunctionCall` / `OsCall` suspension: a
+/// returned value in its typed [`attr_value`] form, every other outcome
+/// descriptively. The bool reports a cut at [`ATTR_SIZE_LIMIT`].
+fn render_ext_result(result: Option<&pb::ExtFunctionResult>) -> (OtelValue, bool) {
+    match result.and_then(|r| r.kind.as_ref()) {
+        Some(pb::ext_function_result::Kind::ReturnValue(v)) => attr_value(v),
+        Some(pb::ext_function_result::Kind::Error(e)) => (format!("raise {}", render_exception(e)).into(), false),
+        Some(pb::ext_function_result::Kind::Future(id)) => (format!("future {id}").into(), false),
+        Some(pb::ext_function_result::Kind::NotFound(name)) => (format!("not found: {name}").into(), false),
+        Some(pb::ext_function_result::Kind::NotHandled(_)) => ("not handled".into(), false),
+        None => (MISSING.into(), false),
+    }
+}
+
+/// Renders the pool's answer to a `NameLookup` suspension; the bool reports
+/// a cut at [`ATTR_SIZE_LIMIT`].
+fn render_name_lookup(kind: Option<&pb::resume_name_lookup::Kind>) -> (OtelValue, bool) {
+    match kind {
+        Some(pb::resume_name_lookup::Kind::Value(v)) => attr_value(v),
+        Some(pb::resume_name_lookup::Kind::Undefined(_)) => ("undefined".into(), false),
+        None => (MISSING.into(), false),
+    }
+}
+
+/// Renders resolved futures as `call_id: result, ...`; the bool reports a cut
+/// of any result — or of the joined output — at [`ATTR_SIZE_LIMIT`].
+fn render_future_results(results: &[pb::FutureResult]) -> (Option<String>, bool) {
+    if results.is_empty() {
+        return (None, false);
+    }
+    let mut any_cut = false;
+    let entries: Vec<String> = results
+        .iter()
+        .map(|r| {
+            let (result, cut) = render_ext_result(r.result.as_ref());
+            any_cut |= cut;
+            format!("{}: {result}", r.call_id)
+        })
+        .collect();
+    let (joined, cut) = truncate_str(&entries.join(", "));
+    (Some(joined), any_cut | cut)
+}
+
+/// Renders the ids a `ResolveFutures` suspension is blocked on as a JSON list.
+fn render_call_ids(ids: &[u32]) -> Option<String> {
+    (!ids.is_empty()).then(|| serde_json::to_string(ids).unwrap_or_default())
+}
+
+/// Opens the span for one os call suspension: the function name plus each of
+/// its arguments as a standalone `args.*` attribute named after the proto
+/// field (strings as strings, numbers as numbers, bools as bools; `bytes`
+/// data as its Python repr). Every path is a virtual sandbox path. The span
+/// stays open until the pool's answer closes it.
+///
+/// Each call shape gets its own macro invocation because the attribute set is
+/// baked into the span's `logfire.json_schema` at compile time — a single
+/// union-shaped call would surface every unused argument as `null` in the UI.
+fn os_call_span(os_call: &pb::OsCall, micros: u64, max_duration: Option<u64>, parent: &Span) -> Span {
+    let call_id = os_call.call_id;
+    /// One span with only the given `args.*` attributes plus the shared tail.
+    macro_rules! os_call {
+        ($function:expr $(, $($key:ident).+ = $value:expr)* $(,)?) => {
+            logfire::span!(
+                parent: parent,
+                "os call {function}",
+                function = $function,
+                $($($key).+ = $value,)*
+                call_id = call_id,
+                total_execution_micros = micros,
+                max_duration_micros = max_duration,
+            )
+        };
+    }
+    match os_call.call.as_ref() {
+        Some(Call::Exists(p)) => os_call!("exists", args.path = p),
+        Some(Call::IsFile(p)) => os_call!("is_file", args.path = p),
+        Some(Call::IsDir(p)) => os_call!("is_dir", args.path = p),
+        Some(Call::IsSymlink(p)) => os_call!("is_symlink", args.path = p),
+        Some(Call::ReadText(p)) => os_call!("read_text", args.path = p),
+        Some(Call::ReadBytes(p)) => os_call!("read_bytes", args.path = p),
+        Some(Call::Stat(p)) => os_call!("stat", args.path = p),
+        Some(Call::Iterdir(p)) => os_call!("iterdir", args.path = p),
+        Some(Call::Resolve(p)) => os_call!("resolve", args.path = p),
+        Some(Call::Absolute(p)) => os_call!("absolute", args.path = p),
+        Some(Call::Unlink(p)) => os_call!("unlink", args.path = p),
+        Some(Call::Rmdir(p)) => os_call!("rmdir", args.path = p),
+        Some(Call::WriteText(w)) => {
+            let (data, cut) = truncate_str(&w.data);
+            os_call!(
+                "write_text",
+                args.path = &w.path,
+                args.data = data,
+                length_limit_exceeded = cut.then_some(true)
+            )
+        }
+        Some(Call::AppendText(w)) => {
+            let (data, cut) = truncate_str(&w.data);
+            os_call!(
+                "append_text",
+                args.path = &w.path,
+                args.data = data,
+                length_limit_exceeded = cut.then_some(true)
+            )
+        }
+        Some(Call::WriteBytes(w)) => {
+            let (data, cut) = bytes_attr(&w.data);
+            os_call!(
+                "write_bytes",
+                args.path = &w.path,
+                args.data = data,
+                length_limit_exceeded = cut.then_some(true)
+            )
+        }
+        Some(Call::AppendBytes(w)) => {
+            let (data, cut) = bytes_attr(&w.data);
+            os_call!(
+                "append_bytes",
+                args.path = &w.path,
+                args.data = data,
+                length_limit_exceeded = cut.then_some(true)
+            )
+        }
+        Some(Call::Open(o)) => os_call!("open", args.path = &o.path, args.mode = &o.mode),
+        Some(Call::Mkdir(m)) => os_call!(
+            "mkdir",
+            args.path = &m.path,
+            args.parents = m.parents,
+            args.exist_ok = m.exist_ok
+        ),
+        Some(Call::Rename(r)) => os_call!("rename", args.src = &r.src, args.dst = &r.dst),
+        // a getenv with no default is recorded with `args.default = null`,
+        // matching the `None` that `os.getenv` defaults to in Python; span
+        // attributes cannot carry a dynamic typed value, so it is stringified
+        Some(Call::Getenv(g)) => {
+            let (default, cut) = optional_attr(g.default.as_ref());
+            let default = default.map(|v| v.as_str().into_owned());
+            os_call!(
+                "getenv",
+                args.key = &g.key,
+                args.default = default,
+                length_limit_exceeded = cut.then_some(true)
+            )
+        }
+        Some(Call::GetEnviron(_)) => os_call!("get_environ"),
+        Some(Call::DateToday(_)) => os_call!("date_today"),
+        // a null tz name marks a fixed-offset timezone; a naive call has no args
+        Some(Call::DateTimeNow(n)) => {
+            if let Some(tz) = &n.tz {
+                os_call!(
+                    "date_time_now",
+                    args.tz_offset_seconds = tz.offset_seconds,
+                    args.tz_name = tz.name.as_ref()
+                )
+            } else {
+                os_call!("date_time_now")
+            }
+        }
+        None => os_call!(MISSING),
+    }
+}
+
+/// Renders an exception as `Type: message`.
+fn render_exception(exc: &pb::RaisedException) -> String {
+    match &exc.message {
+        Some(message) => format!("{}: {message}", exc.exc_type),
+        None => exc.exc_type.clone(),
+    }
+}
+
+/// Renders a traceback as one newline-separated string of `file:line in
+/// frame` entries, outermost first; the bool reports a cut at
+/// [`ATTR_SIZE_LIMIT`].
+fn render_traceback(frames: &[pb::StackFrame]) -> (Option<String>, bool) {
+    if frames.is_empty() {
+        return (None, false);
+    }
+    let entries: Vec<String> = frames
+        .iter()
+        .map(|f| {
+            let line = f.start.as_ref().map_or(0, |loc| loc.line);
+            let name = f.frame_name.as_deref().unwrap_or("<module>");
+            format!("{}:{line} in {name}", f.filename)
+        })
+        .collect();
+    let (traceback, cut) = truncate_str(&entries.join("\n"));
+    (Some(traceback), cut)
+}
+
+/// Records an `Error` event: exception type, message, traceback, and — for
+/// the exception types carrying a structured payload — each payload field as
+/// a standalone `exc_data.*` attribute, including the offending input (it is
+/// the value being debugged).
+///
+/// Like [`os_call_span`], each payload shape gets its own macro invocation
+/// so records don't surface the other shape's attributes as `null`.
+fn record_error(error: &pb::Error, micros: u64, max_duration: Option<u64>, parent: &Span) {
+    let exc = error.exception.as_ref();
+    let exc_type = exc.map_or_else(|| MISSING.to_owned(), |e| e.exc_type.clone());
+    let (message, message_cut) = unzip(exc.and_then(|e| e.message.as_deref()).map(truncate_str));
+    let (traceback, traceback_cut) = render_traceback(exc.map_or(&[], |e| &e.traceback));
+    let base_cut = message_cut | traceback_cut;
+    /// One error record with the given cut flag and `exc_data.*` attributes
+    /// plus the shared fields.
+    macro_rules! error_event {
+        ($cut:expr $(, $($key:ident).+ = $value:expr)* $(,)?) => {
+            logfire::error!(
+                // reborrowed because the macro takes the parent by reference
+                parent: *parent,
+                "error {exc_type}",
+                exc_type = &exc_type,
+                exc_message = message,
+                traceback = traceback,
+                $($($key).+ = $value,)*
+                length_limit_exceeded = ($cut).then_some(true),
+                total_execution_micros = micros,
+                max_duration_micros = max_duration,
+            )
+        };
+    }
+    match exc.and_then(|e| e.data.as_ref()).and_then(|d| d.kind.as_ref()) {
+        Some(pb::exc_data::Kind::Unicode(u)) => {
+            let (object, object_cut) = match &u.object {
+                Some(pb::unicode_error_data::Object::ObjectBytes(b)) => bytes_attr(b),
+                Some(pb::unicode_error_data::Object::ObjectStr(s)) => truncate_str(s),
+                None => (MISSING.to_owned(), false),
+            };
+            error_event!(
+                base_cut | object_cut,
+                exc_data.encoding = &u.encoding,
+                exc_data.object = object,
+                exc_data.start = u.start,
+                exc_data.end = u.end,
+                exc_data.reason = &u.reason,
+            );
+        }
+        Some(pb::exc_data::Kind::Json(j)) => {
+            let (doc, doc_cut) = unzip(j.doc.as_deref().map(truncate_str));
+            error_event!(
+                base_cut | doc_cut,
+                exc_data.msg = &j.msg,
+                exc_data.doc = doc,
+                exc_data.pos = j.pos,
+                exc_data.lineno = j.lineno,
+                exc_data.colno = j.colno,
+            );
+        }
+        None => error_event!(base_cut),
+    }
+}
+
+/// Byte cap for one value attribute; bigger values are cut off, and the
+/// record gets a `length_limit_exceeded` attribute saying so.
+const ATTR_SIZE_LIMIT: usize = 64 * 1024;
+
+/// Renders a wire value as a typed OTel attribute: scalars keep their native
+/// attribute type, everything else becomes logfire-style JSON text. The bool
+/// is true when [`ATTR_SIZE_LIMIT`] cut the output short.
+fn attr_value(value: &WireObject) -> (OtelValue, bool) {
+    match value.0.as_ref() {
+        Some(MontyObject::Bool(b)) => ((*b).into(), false),
+        Some(MontyObject::Int(i)) => ((*i).into(), false),
+        Some(MontyObject::Float(f)) if f.is_finite() => ((*f).into(), false),
+        // Python `str()` of the non-finite floats JSON cannot carry
+        Some(MontyObject::Float(f)) => (nonfinite_str(*f).into(), false),
+        Some(MontyObject::String(s)) => {
+            let (text, cut) = truncate_str(s);
+            (text.into(), cut)
+        }
+        Some(MontyObject::Bytes(b)) => {
+            let (text, cut) = bytes_attr(b);
+            (text.into(), cut)
+        }
+        Some(other) => {
+            let (json, cut) = serialize_capped(other, ATTR_SIZE_LIMIT);
+            (json.into(), cut)
+        }
+        None => (MISSING.into(), false),
+    }
+}
+
+/// [`attr_value`] for an optional field: an absent value renders as an absent
+/// attribute, not as [`MISSING`].
+fn optional_attr(value: Option<&WireObject>) -> (Option<OtelValue>, bool) {
+    unzip(value.map(attr_value))
+}
+
+/// Splits an optional `(value, cut)` pair into the optional value and the cut
+/// flag, so an absent attribute contributes no `length_limit_exceeded`.
+fn unzip<T>(pair: Option<(T, bool)>) -> (Option<T>, bool) {
+    pair.map_or((None, false), |(value, cut)| (Some(value), cut))
+}
+
+/// A bytes value as logfire renders bytes: the repr's escaped content without
+/// the b'' wrapper, as raw text capped at [`ATTR_SIZE_LIMIT`].
+fn bytes_attr(b: &[u8]) -> (String, bool) {
+    let repr = bytes_repr(b);
+    truncate_str(&repr[2..repr.len() - 1])
+}
+
+/// Renders strings as a JSON list, absent when empty.
+fn render_str_list(items: &[String]) -> Option<String> {
+    (!items.is_empty()).then(|| serde_json::to_string(items).unwrap_or_default())
+}
+
+/// Truncates a raw string attribute to [`ATTR_SIZE_LIMIT`] bytes on a char
+/// boundary; the bool reports whether anything was cut off.
+fn truncate_str(s: &str) -> (String, bool) {
+    if s.len() <= ATTR_SIZE_LIMIT {
+        (s.to_owned(), false)
+    } else {
+        let mut end = ATTR_SIZE_LIMIT;
+        while !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        (s[..end].to_owned(), true)
+    }
+}
+
+/// The human name of a `PrintStream` enum value, for the print event's message.
+fn print_stream(stream: i32) -> &'static str {
+    match pb::PrintStream::try_from(stream) {
+        Ok(pb::PrintStream::Stdout) => "stdout",
+        Ok(pb::PrintStream::Stderr) => "stderr",
+        _ => "unspecified",
+    }
+}
+
+// tests live here rather than in `tests/` because `Recorder` is crate-private:
+// recording is a side effect of the worker, not part of the pool's public API
+#[cfg(test)]
+mod tests {
+    use logfire::{Logfire, config::AdvancedOptions};
+    use monty_proto::{WireFunctionCall, pb};
+    use monty_types::MontyObject;
+    use opentelemetry::trace::SpanId;
+    use opentelemetry_sdk::{
+        logs::{InMemoryLogExporter, SimpleLogProcessor},
+        trace::{InMemorySpanExporter, SimpleSpanProcessor, SpanData},
+    };
+
+    use super::Recorder;
+
+    /// A local logfire capturing spans and logs in memory instead of exporting.
+    fn test_logfire() -> (Logfire, InMemorySpanExporter, InMemoryLogExporter) {
+        let spans = InMemorySpanExporter::default();
+        let logs = InMemoryLogExporter::default();
+        let logfire = logfire::configure()
+            .local()
+            .send_to_logfire(false)
+            .with_additional_span_processor(SimpleSpanProcessor::new(spans.clone()))
+            .with_advanced_options(AdvancedOptions::default().with_log_processor(SimpleLogProcessor::new(logs.clone())))
+            .finish()
+            .unwrap();
+        (logfire, spans, logs)
+    }
+
+    fn request(kind: pb::parent_request::Kind) -> pb::ParentRequest {
+        pb::ParentRequest {
+            kind: Some(kind),
+            trace_parent: None,
+        }
+    }
+
+    fn event(kind: pb::child_event::Kind) -> pb::ChildEvent {
+        pb::ChildEvent {
+            kind: Some(kind),
+            total_execution_micros: 42,
+            max_duration_micros: None,
+            restored_script_name: None,
+        }
+    }
+
+    /// Drives one whole session — configure, feed, a suspension round-trip,
+    /// completion, reset — and checks the exported span tree: the suspension
+    /// span is a child of the feed span, the feed span of the session span,
+    /// the session span a root; and the resume/complete log records land
+    /// inside the right spans. This is what proves the explicit-parent
+    /// plumbing (spans are never entered — see the module docs) holds up.
+    #[test]
+    fn one_feed_produces_a_nested_span_tree() {
+        let (logfire, spans, logs) = test_logfire();
+        let mut recorder = Recorder::new(Some(logfire), Some(4321));
+
+        recorder.begin_turn(&request(pb::parent_request::Kind::Configure(pb::Configure {
+            script_name: "main.py".to_owned(),
+            limits: None,
+            type_check: false,
+            type_check_stubs: None,
+            monty_version: "0.0.1".to_owned(),
+            assert_message_annotations: None,
+        })));
+        recorder.begin_turn(&request(pb::parent_request::Kind::Feed(pb::Feed {
+            code: "double(2)".to_owned(),
+            inputs: vec![],
+            skip_type_check: false,
+        })));
+        recorder.event(&event(pb::child_event::Kind::FunctionCall(WireFunctionCall {
+            function_name: "double".to_owned(),
+            args: vec![MontyObject::Int(2)],
+            kwargs: vec![],
+            call_id: 1,
+            method_call: false,
+        })));
+        recorder.begin_turn(&request(pb::parent_request::Kind::ResumeCall(pb::ResumeCall {
+            call_id: 1,
+            result: Some(pb::ExtFunctionResult {
+                kind: Some(pb::ext_function_result::Kind::ReturnValue(MontyObject::Int(4).into())),
+            }),
+        })));
+        recorder.event(&event(pb::child_event::Kind::Complete(pb::Complete {
+            value: Some(MontyObject::Int(4).into()),
+        })));
+        recorder.begin_turn(&request(pb::parent_request::Kind::Reset(pb::Reset {})));
+
+        // spans are exported innermost-first as they close
+        let spans = spans.get_finished_spans().unwrap();
+        let names: Vec<&str> = spans.iter().map(|s| s.name.as_ref()).collect();
+        assert_eq!(
+            names,
+            ["function call {function_name}", "feed", "session {script_name}"]
+        );
+        let by_name = |name: &str| -> &SpanData { spans.iter().find(|s| s.name == name).unwrap() };
+        let session = by_name("session {script_name}");
+        let feed = by_name("feed");
+        let call = by_name("function call {function_name}");
+        assert_eq!(session.parent_span_id, SpanId::INVALID);
+        assert_eq!(feed.parent_span_id, session.span_context.span_id());
+        assert_eq!(call.parent_span_id, feed.span_context.span_id());
+        // the worker's identity is a session attribute (the child-side
+        // recorder used to carry it as a per-process resource attribute)
+        let worker_pid = session.attributes.iter().find(|kv| kv.key.as_str() == "worker_pid");
+        assert_eq!(worker_pid.unwrap().value, 4321.into());
+
+        // the resume answer lands in the suspension span, completion in the feed
+        let logs = logs.get_emitted_logs().unwrap();
+        let parent_of = |name: &str| {
+            logs.iter()
+                .find(|l| l.record.event_name() == Some(name))
+                .unwrap()
+                .record
+                .trace_context()
+                .unwrap()
+                .span_id
+        };
+        assert_eq!(parent_of("call result"), call.span_context.span_id());
+        assert_eq!(parent_of("complete"), feed.span_context.span_id());
+    }
+
+    /// A disabled recorder (pool without a token) records nothing and holds
+    /// no spans, whatever passes through it.
+    #[test]
+    fn disabled_recorder_is_inert() {
+        let mut recorder = Recorder::new(None, None);
+        recorder.begin_turn(&request(pb::parent_request::Kind::Feed(pb::Feed {
+            code: "1".to_owned(),
+            inputs: vec![],
+            skip_type_check: false,
+        })));
+        recorder.event(&event(pb::child_event::Kind::Complete(pb::Complete { value: None })));
+        assert!(recorder.session.is_none() && recorder.feed.is_none() && recorder.pending.is_none());
+    }
+}

--- a/crates/monty-pool/src/telemetry_json.rs
+++ b/crates/monty-pool/src/telemetry_json.rs
@@ -11,6 +11,7 @@
 //! become their digit string rather than a raw JSON number.
 
 use std::{
+    collections::HashMap,
     fmt::Write as _,
     io::{self, Write},
 };
@@ -24,8 +25,32 @@ use serde::ser::{Serialize, SerializeMap, Serializer};
 /// serialization short — the partial output is then no longer valid JSON, and
 /// the caller should mark it as truncated.
 pub(crate) fn serialize_capped(value: &MontyObject, limit: usize) -> (String, bool) {
+    capped(&JsonEncoded { value, limit }, limit)
+}
+
+/// [`serialize_capped`] for a list of values, borrowing them rather than
+/// cloning them into a [`MontyObject::List`].
+pub(crate) fn serialize_seq_capped(items: &[MontyObject], limit: usize) -> (String, bool) {
+    capped(&JsonSeq { items, limit }, limit)
+}
+
+/// [`serialize_capped`] for dict pairs (non-string keys rendered by their
+/// repr), borrowing them rather than cloning them into a [`MontyObject::Dict`].
+pub(crate) fn serialize_dict_capped(pairs: &[(MontyObject, MontyObject)], limit: usize) -> (String, bool) {
+    capped(&JsonDict { pairs, limit }, limit)
+}
+
+/// [`serialize_capped`] for named values as a JSON object, borrowing them
+/// rather than cloning them into a dict.
+pub(crate) fn serialize_named_capped(pairs: &[(&str, &MontyObject)], limit: usize) -> (String, bool) {
+    capped(&JsonNamed { pairs, limit }, limit)
+}
+
+/// Serializes into a [`CappedWriter`]; the bool reports the cap cutting
+/// serialization short.
+fn capped(value: &impl Serialize, limit: usize) -> (String, bool) {
     let mut writer = CappedWriter { buf: Vec::new(), limit };
-    let cut = serde_json::to_writer(&mut writer, &JsonEncoded(value)).is_err();
+    let cut = serde_json::to_writer(&mut writer, value).is_err();
     // the buffer holds whole serializer writes, so it is valid UTF-8;
     // from_utf8_lossy just avoids a panic path
     (String::from_utf8_lossy(&writer.buf).into_owned(), cut)
@@ -55,11 +80,28 @@ impl Write for CappedWriter {
 
 /// Serializes a [`MontyObject`] with the logfire value mapping (rather than
 /// the tagged-enum encoding of the derived `Serialize`, which is for the wire).
-struct JsonEncoded<'a>(&'a MontyObject);
+///
+/// `limit` is the caller's byte cap, carried down the value tree so a huge
+/// `bytes` leaf is escaped only as far as the cap can keep — the writer alone
+/// cannot help, since it sees the escaped string only once it is built.
+struct JsonEncoded<'a> {
+    value: &'a MontyObject,
+    limit: usize,
+}
+
+impl<'a> JsonEncoded<'a> {
+    /// The same encoder for a nested value.
+    const fn nested(&self, value: &'a MontyObject) -> Self {
+        Self {
+            value,
+            limit: self.limit,
+        }
+    }
+}
 
 impl Serialize for JsonEncoded<'_> {
     fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
-        match self.0 {
+        match self.value {
             MontyObject::None => s.serialize_unit(),
             MontyObject::Bool(b) => s.serialize_bool(*b),
             MontyObject::Int(i) => s.serialize_i64(*i),
@@ -72,49 +114,49 @@ impl Serialize for JsonEncoded<'_> {
             MontyObject::Float(f) if f.is_finite() => s.serialize_f64(*f),
             MontyObject::Float(f) => s.serialize_str(nonfinite_str(*f)),
             MontyObject::String(v) => s.serialize_str(v),
-            // like logfire: the repr's escaped content without the b'' wrapper
+            // like logfire: the repr's escaped content without the b'' wrapper.
+            // Escaping stops at `limit` bytes of input: every byte escapes to
+            // at least one character, so the rest could only produce output the
+            // cap discards — after quadrupling a huge payload to build it
             MontyObject::Bytes(b) => {
-                let repr = bytes_repr(b);
+                let repr = bytes_repr(&b[..b.len().min(self.limit)]);
                 s.serialize_str(&repr[2..repr.len() - 1])
             }
             MontyObject::List(items)
             | MontyObject::Tuple(items)
             | MontyObject::Set(items)
-            | MontyObject::FrozenSet(items) => s.collect_seq(items.iter().map(JsonEncoded)),
+            | MontyObject::FrozenSet(items) => s.collect_seq(items.iter().map(|v| self.nested(v))),
             // a namedtuple is a tuple in Python, so logfire encodes the values
             // as an array and drops the field names
-            MontyObject::NamedTuple { values, .. } => s.collect_seq(values.iter().map(JsonEncoded)),
+            MontyObject::NamedTuple { values, .. } => s.collect_seq(values.iter().map(|v| self.nested(v))),
             MontyObject::Dict(pairs) => {
-                let mut map = s.serialize_map(Some(pairs.len()))?;
-                for (key, value) in pairs {
-                    match key {
-                        MontyObject::String(k) => map.serialize_entry(k, &JsonEncoded(value))?,
-                        other => map.serialize_entry(&other.py_repr(), &JsonEncoded(value))?,
-                    }
-                }
-                map.end()
+                serialize_pairs(pairs.into_iter().map(|(k, v)| (k, v)), pairs.len(), self.limit, s)
             }
             // like logfire dataclasses: an object of the declared fields only
             MontyObject::Dataclass { field_names, attrs, .. } => {
+                // indexed once: scanning `attrs` per field is quadratic, and
+                // both sides are as long as the sandbox's source made them
+                let mut by_name: HashMap<&str, &MontyObject> = HashMap::with_capacity(attrs.len());
+                for (key, value) in attrs {
+                    if let MontyObject::String(k) = key {
+                        by_name.entry(k.as_str()).or_insert(value);
+                    }
+                }
                 let mut map = s.serialize_map(Some(field_names.len()))?;
                 for name in field_names {
-                    let value = attrs
-                        .into_iter()
-                        .find(|(key, _)| matches!(key, MontyObject::String(k) if k == name));
-                    if let Some((_, value)) = value {
-                        map.serialize_entry(name, &JsonEncoded(value))?;
+                    if let Some(value) = by_name.get(name.as_str()) {
+                        map.serialize_entry(name, &self.nested(value))?;
                     }
                 }
                 map.end()
             }
             MontyObject::Date(d) => s.collect_str(&format_args!("{:04}-{:02}-{:02}", d.year, d.month, d.day)),
             MontyObject::DateTime(dt) => s.serialize_str(&datetime_isoformat(dt)),
-            MontyObject::TimeDelta(td) => {
-                let micros =
-                    (i64::from(td.days) * 86_400 + i64::from(td.seconds)) * 1_000_000 + i64::from(td.microseconds);
-                #[expect(clippy::cast_precision_loss)]
-                s.serialize_f64(micros as f64 / 1e6)
-            }
+            // total seconds, accumulated in f64 throughout: an extreme `days`
+            // overflows the microseconds of the same sum in i64
+            MontyObject::TimeDelta(td) => s.serialize_f64(
+                f64::from(td.days).mul_add(86_400.0, f64::from(td.seconds)) + f64::from(td.microseconds) / 1e6,
+            ),
             // like logfire: `str(exc)`, which in Python is the message alone
             MontyObject::Exception { arg, .. } => s.serialize_str(arg.as_deref().unwrap_or_default()),
             MontyObject::Path(p) => s.serialize_str(p),
@@ -124,6 +166,75 @@ impl Serialize for JsonEncoded<'_> {
             other => s.serialize_str(&other.py_repr()),
         }
     }
+}
+
+/// Encodes borrowed values as a JSON array, for a caller holding the items
+/// but no [`MontyObject`] container to point [`JsonEncoded`] at.
+struct JsonSeq<'a> {
+    items: &'a [MontyObject],
+    limit: usize,
+}
+
+impl Serialize for JsonSeq<'_> {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        s.collect_seq(self.items.iter().map(|value| JsonEncoded {
+            value,
+            limit: self.limit,
+        }))
+    }
+}
+
+/// [`JsonSeq`] for dict pairs: a JSON object keyed like [`MontyObject::Dict`].
+struct JsonDict<'a> {
+    pairs: &'a [(MontyObject, MontyObject)],
+    limit: usize,
+}
+
+impl Serialize for JsonDict<'_> {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        serialize_pairs(self.pairs.iter().map(|(k, v)| (k, v)), self.pairs.len(), self.limit, s)
+    }
+}
+
+/// [`JsonSeq`] for named values: a JSON object of `name` → encoded value.
+struct JsonNamed<'a> {
+    pairs: &'a [(&'a str, &'a MontyObject)],
+    limit: usize,
+}
+
+impl Serialize for JsonNamed<'_> {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        let mut map = s.serialize_map(Some(self.pairs.len()))?;
+        for (name, value) in self.pairs {
+            map.serialize_entry(
+                name,
+                &JsonEncoded {
+                    value,
+                    limit: self.limit,
+                },
+            )?;
+        }
+        map.end()
+    }
+}
+
+/// Serializes key/value pairs as a JSON object, string keys verbatim and
+/// everything else by its Python repr (JSON has no non-string keys).
+fn serialize_pairs<'a, S: Serializer>(
+    pairs: impl Iterator<Item = (&'a MontyObject, &'a MontyObject)>,
+    len: usize,
+    limit: usize,
+    s: S,
+) -> Result<S::Ok, S::Error> {
+    let mut map = s.serialize_map(Some(len))?;
+    for (key, value) in pairs {
+        let value = JsonEncoded { value, limit };
+        match key {
+            MontyObject::String(k) => map.serialize_entry(k, &value)?,
+            other => map.serialize_entry(&other.py_repr(), &value)?,
+        }
+    }
+    map.end()
 }
 
 /// Python's `str()` of the float values JSON has no representation for.
@@ -164,7 +275,7 @@ fn datetime_isoformat(dt: &MontyDateTime) -> String {
 mod tests {
     use monty_types::{DictPairs, ExcType, MontyDate, MontyDateTime, MontyObject, MontyTimeDelta};
 
-    use super::serialize_capped;
+    use super::{serialize_capped, serialize_dict_capped, serialize_named_capped, serialize_seq_capped};
 
     /// Shorthand: encode with a byte cap nothing here reaches.
     fn json(obj: &MontyObject) -> String {
@@ -267,6 +378,18 @@ mod tests {
         assert_eq!(json(&delta), "86401.5");
     }
 
+    /// The extreme end of Python's `timedelta` range overflows an i64 of
+    /// microseconds, so the total is accumulated in f64 instead.
+    #[test]
+    fn huge_timedelta_does_not_overflow() {
+        let delta = MontyObject::TimeDelta(MontyTimeDelta {
+            days: i32::MAX,
+            seconds: 86_399,
+            microseconds: 999_999,
+        });
+        assert_eq!(json(&delta), "185542587187200.0");
+    }
+
     #[test]
     fn exception_is_its_message() {
         let exc = MontyObject::Exception {
@@ -325,5 +448,45 @@ mod tests {
         assert!(cut);
         assert!(s.len() <= 20);
         assert!(s.starts_with("[0,1,"));
+    }
+
+    /// A `bytes` leaf is escaped only as far as the byte cap can keep, so a
+    /// huge payload is never quadrupled into a repr that is then thrown away.
+    #[test]
+    fn oversize_bytes_are_capped_before_escaping() {
+        let value = MontyObject::List(vec![MontyObject::Bytes(vec![0xff; 10_000]), MontyObject::Int(1)]);
+        let (s, cut) = serialize_capped(&value, 64);
+        assert!(cut);
+        assert!(s.len() <= 64);
+        // a payload the cap can hold is still encoded in full
+        let value = MontyObject::Bytes(vec![0xff; 4]);
+        assert_eq!(json(&value), r#""\\xff\\xff\\xff\\xff""#);
+    }
+
+    /// The borrowed-value encoders (used so telemetry never deep-clones a
+    /// feed's inputs or a call's arguments) match their owned counterparts.
+    #[test]
+    fn borrowed_values_encode_like_owned_ones() {
+        let items = vec![MontyObject::Int(1), MontyObject::String("x".to_owned())];
+        assert_eq!(
+            serialize_seq_capped(&items, usize::MAX),
+            (r#"[1,"x"]"#.to_owned(), false)
+        );
+
+        let pairs = vec![
+            (MontyObject::String("a".to_owned()), MontyObject::Int(1)),
+            (MontyObject::Int(2), MontyObject::None),
+        ];
+        assert_eq!(
+            serialize_dict_capped(&pairs, usize::MAX),
+            (r#"{"a":1,"2":null}"#.to_owned(), false)
+        );
+
+        let one = MontyObject::Int(1);
+        let two = MontyObject::List(vec![MontyObject::Bool(true)]);
+        assert_eq!(
+            serialize_named_capped(&[("x", &one), ("y", &two)], usize::MAX),
+            (r#"{"x":1,"y":[true]}"#.to_owned(), false)
+        );
     }
 }

--- a/crates/monty-pool/src/telemetry_json.rs
+++ b/crates/monty-pool/src/telemetry_json.rs
@@ -1,0 +1,329 @@
+//! Logfire-style JSON encoding of [`MontyObject`]s for telemetry attributes.
+//!
+//! Mirrors the Python logfire JSON encoder (`logfire/_internal/json_encoder.py`):
+//! containers become JSON arrays/objects, dates use isoformat, timedeltas their
+//! total seconds, and opaque objects fall back to their `repr`. Output is
+//! capped at a byte limit so a huge value cannot blow up the telemetry
+//! pipeline; the caller is told when the cap cut serialization short.
+//!
+//! Known divergences from the Python encoder: sets are encoded in storage
+//! order (Python sorts them when comparable), and integers beyond `i128`
+//! become their digit string rather than a raw JSON number.
+
+use std::{
+    fmt::Write as _,
+    io::{self, Write},
+};
+
+use monty_types::{MontyDateTime, MontyObject, bytes_repr};
+use num_traits::ToPrimitive;
+use serde::ser::{Serialize, SerializeMap, Serializer};
+
+/// Serializes `value` to logfire-style JSON (see the module docs for the
+/// format), capped at `limit` bytes. The bool is true when the cap cut
+/// serialization short — the partial output is then no longer valid JSON, and
+/// the caller should mark it as truncated.
+pub(crate) fn serialize_capped(value: &MontyObject, limit: usize) -> (String, bool) {
+    let mut writer = CappedWriter { buf: Vec::new(), limit };
+    let cut = serde_json::to_writer(&mut writer, &JsonEncoded(value)).is_err();
+    // the buffer holds whole serializer writes, so it is valid UTF-8;
+    // from_utf8_lossy just avoids a panic path
+    (String::from_utf8_lossy(&writer.buf).into_owned(), cut)
+}
+
+/// An in-memory writer that rejects any write taking it past `limit` bytes,
+/// aborting serialization instead of building an unbounded string.
+struct CappedWriter {
+    buf: Vec<u8>,
+    limit: usize,
+}
+
+impl Write for CappedWriter {
+    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+        if self.buf.len() + data.len() > self.limit {
+            Err(io::Error::other("byte limit reached"))
+        } else {
+            self.buf.extend_from_slice(data);
+            Ok(data.len())
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Serializes a [`MontyObject`] with the logfire value mapping (rather than
+/// the tagged-enum encoding of the derived `Serialize`, which is for the wire).
+struct JsonEncoded<'a>(&'a MontyObject);
+
+impl Serialize for JsonEncoded<'_> {
+    fn serialize<S: Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        match self.0 {
+            MontyObject::None => s.serialize_unit(),
+            MontyObject::Bool(b) => s.serialize_bool(*b),
+            MontyObject::Int(i) => s.serialize_i64(*i),
+            // beyond i128 (vanishingly rare) the digits become a string, as a
+            // raw JSON number would need serde_json's arbitrary-precision mode
+            MontyObject::BigInt(b) => match b.to_i128() {
+                Some(i) => s.serialize_i128(i),
+                None => s.collect_str(b),
+            },
+            MontyObject::Float(f) if f.is_finite() => s.serialize_f64(*f),
+            MontyObject::Float(f) => s.serialize_str(nonfinite_str(*f)),
+            MontyObject::String(v) => s.serialize_str(v),
+            // like logfire: the repr's escaped content without the b'' wrapper
+            MontyObject::Bytes(b) => {
+                let repr = bytes_repr(b);
+                s.serialize_str(&repr[2..repr.len() - 1])
+            }
+            MontyObject::List(items)
+            | MontyObject::Tuple(items)
+            | MontyObject::Set(items)
+            | MontyObject::FrozenSet(items) => s.collect_seq(items.iter().map(JsonEncoded)),
+            // a namedtuple is a tuple in Python, so logfire encodes the values
+            // as an array and drops the field names
+            MontyObject::NamedTuple { values, .. } => s.collect_seq(values.iter().map(JsonEncoded)),
+            MontyObject::Dict(pairs) => {
+                let mut map = s.serialize_map(Some(pairs.len()))?;
+                for (key, value) in pairs {
+                    match key {
+                        MontyObject::String(k) => map.serialize_entry(k, &JsonEncoded(value))?,
+                        other => map.serialize_entry(&other.py_repr(), &JsonEncoded(value))?,
+                    }
+                }
+                map.end()
+            }
+            // like logfire dataclasses: an object of the declared fields only
+            MontyObject::Dataclass { field_names, attrs, .. } => {
+                let mut map = s.serialize_map(Some(field_names.len()))?;
+                for name in field_names {
+                    let value = attrs
+                        .into_iter()
+                        .find(|(key, _)| matches!(key, MontyObject::String(k) if k == name));
+                    if let Some((_, value)) = value {
+                        map.serialize_entry(name, &JsonEncoded(value))?;
+                    }
+                }
+                map.end()
+            }
+            MontyObject::Date(d) => s.collect_str(&format_args!("{:04}-{:02}-{:02}", d.year, d.month, d.day)),
+            MontyObject::DateTime(dt) => s.serialize_str(&datetime_isoformat(dt)),
+            MontyObject::TimeDelta(td) => {
+                let micros =
+                    (i64::from(td.days) * 86_400 + i64::from(td.seconds)) * 1_000_000 + i64::from(td.microseconds);
+                #[expect(clippy::cast_precision_loss)]
+                s.serialize_f64(micros as f64 / 1e6)
+            }
+            // like logfire: `str(exc)`, which in Python is the message alone
+            MontyObject::Exception { arg, .. } => s.serialize_str(arg.as_deref().unwrap_or_default()),
+            MontyObject::Path(p) => s.serialize_str(p),
+            MontyObject::Cycle(..) => s.serialize_str("<circular reference>"),
+            MontyObject::Repr(r) => s.serialize_str(r),
+            // everything left is opaque: fall back to its repr, like logfire
+            other => s.serialize_str(&other.py_repr()),
+        }
+    }
+}
+
+/// Python's `str()` of the float values JSON has no representation for.
+pub(crate) fn nonfinite_str(f: f64) -> &'static str {
+    if f.is_nan() {
+        "nan"
+    } else if f > 0.0 {
+        "inf"
+    } else {
+        "-inf"
+    }
+}
+
+/// Python `datetime.isoformat()`: microseconds only when non-zero, and the
+/// UTC offset (when aware) as `±HH:MM`, extended with `:SS` when needed.
+fn datetime_isoformat(dt: &MontyDateTime) -> String {
+    let mut iso = format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}",
+        dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second
+    );
+    if dt.microsecond != 0 {
+        let _ = write!(iso, ".{:06}", dt.microsecond);
+    }
+    if let Some(offset) = dt.offset_seconds {
+        let sign = if offset < 0 { '-' } else { '+' };
+        let abs = offset.unsigned_abs();
+        let _ = write!(iso, "{sign}{:02}:{:02}", abs / 3600, (abs % 3600) / 60);
+        if abs % 60 != 0 {
+            let _ = write!(iso, ":{:02}", abs % 60);
+        }
+    }
+    iso
+}
+
+// tests live here rather than in `tests/` because `serialize_capped` is
+// crate-private: telemetry encoding is not part of the pool's public API
+#[cfg(test)]
+mod tests {
+    use monty_types::{DictPairs, ExcType, MontyDate, MontyDateTime, MontyObject, MontyTimeDelta};
+
+    use super::serialize_capped;
+
+    /// Shorthand: encode with a byte cap nothing here reaches.
+    fn json(obj: &MontyObject) -> String {
+        let (json, cut) = serialize_capped(obj, usize::MAX);
+        assert!(!cut);
+        json
+    }
+
+    #[test]
+    fn scalars_encode_as_json_scalars() {
+        assert_eq!(json(&MontyObject::Bool(true)), "true");
+        assert_eq!(json(&MontyObject::Int(-42)), "-42");
+        assert_eq!(json(&MontyObject::Float(1.5)), "1.5");
+        assert_eq!(json(&MontyObject::String("hello".to_owned())), r#""hello""#);
+        assert_eq!(json(&MontyObject::None), "null");
+    }
+
+    #[test]
+    fn nonfinite_floats_become_python_str() {
+        assert_eq!(json(&MontyObject::Float(f64::INFINITY)), r#""inf""#);
+        assert_eq!(json(&MontyObject::Float(f64::NEG_INFINITY)), r#""-inf""#);
+        assert_eq!(json(&MontyObject::Float(f64::NAN)), r#""nan""#);
+    }
+
+    #[test]
+    fn containers_become_json() {
+        let list = MontyObject::List(vec![
+            MontyObject::Int(1),
+            MontyObject::String("x".to_owned()),
+            MontyObject::None,
+            MontyObject::Float(f64::NAN),
+        ]);
+        assert_eq!(json(&list), r#"[1,"x",null,"nan"]"#);
+
+        let tuple = MontyObject::Tuple(vec![MontyObject::Bool(false), MontyObject::Float(2.5)]);
+        assert_eq!(json(&tuple), "[false,2.5]");
+
+        let nested = MontyObject::List(vec![MontyObject::List(vec![MontyObject::Int(1)])]);
+        assert_eq!(json(&nested), "[[1]]");
+    }
+
+    #[test]
+    fn dict_keys_are_strings_or_reprs() {
+        let dict = MontyObject::dict(vec![
+            (MontyObject::String("a".to_owned()), MontyObject::Int(1)),
+            (MontyObject::Int(2), MontyObject::String("b".to_owned())),
+        ]);
+        assert_eq!(json(&dict), r#"{"a":1,"2":"b"}"#);
+    }
+
+    #[test]
+    fn bytes_use_repr_content() {
+        let bytes = MontyObject::Bytes(b"hi\xff".to_vec());
+        assert_eq!(json(&bytes), r#""hi\\xff""#);
+    }
+
+    #[test]
+    fn dates_use_isoformat() {
+        let date = MontyObject::Date(MontyDate {
+            year: 2024,
+            month: 3,
+            day: 7,
+        });
+        assert_eq!(json(&date), r#""2024-03-07""#);
+
+        let naive = MontyObject::DateTime(MontyDateTime {
+            year: 2024,
+            month: 3,
+            day: 7,
+            hour: 1,
+            minute: 2,
+            second: 3,
+            microsecond: 0,
+            offset_seconds: None,
+            timezone_name: None,
+        });
+        assert_eq!(json(&naive), r#""2024-03-07T01:02:03""#);
+
+        let aware = MontyObject::DateTime(MontyDateTime {
+            year: 2024,
+            month: 3,
+            day: 7,
+            hour: 1,
+            minute: 2,
+            second: 3,
+            microsecond: 450,
+            offset_seconds: Some(-5 * 3600),
+            timezone_name: None,
+        });
+        assert_eq!(json(&aware), r#""2024-03-07T01:02:03.000450-05:00""#);
+    }
+
+    #[test]
+    fn timedelta_is_total_seconds() {
+        let delta = MontyObject::TimeDelta(MontyTimeDelta {
+            days: 1,
+            seconds: 1,
+            microseconds: 500_000,
+        });
+        assert_eq!(json(&delta), "86401.5");
+    }
+
+    #[test]
+    fn exception_is_its_message() {
+        let exc = MontyObject::Exception {
+            exc_type: ExcType::ValueError,
+            arg: Some("boom".to_owned()),
+        };
+        assert_eq!(json(&exc), r#""boom""#);
+    }
+
+    #[test]
+    fn namedtuple_is_a_plain_array() {
+        let nt = MontyObject::NamedTuple {
+            type_name: "Point".to_owned(),
+            field_names: vec!["x".to_owned(), "y".to_owned()],
+            values: vec![MontyObject::Int(1), MontyObject::Int(2)],
+        };
+        assert_eq!(json(&nt), "[1,2]");
+    }
+
+    #[test]
+    fn dataclass_is_an_object_of_declared_fields() {
+        let dc = MontyObject::Dataclass {
+            name: "Point".to_owned(),
+            type_id: 1,
+            field_names: vec!["x".to_owned(), "y".to_owned()],
+            attrs: DictPairs::from(vec![
+                (MontyObject::String("x".to_owned()), MontyObject::Int(1)),
+                (MontyObject::String("y".to_owned()), MontyObject::Int(2)),
+                (MontyObject::String("extra".to_owned()), MontyObject::Int(9)),
+            ]),
+            frozen: false,
+        };
+        assert_eq!(json(&dc), r#"{"x":1,"y":2}"#);
+    }
+
+    #[test]
+    fn opaque_values_fall_back_to_repr() {
+        assert_eq!(json(&MontyObject::Ellipsis), r#""Ellipsis""#);
+        assert_eq!(json(&MontyObject::Path("/mnt/data".to_owned())), r#""/mnt/data""#);
+        assert_eq!(
+            json(&MontyObject::Cycle(0, "[...]".to_owned())),
+            r#""<circular reference>""#
+        );
+    }
+
+    #[test]
+    fn big_ints_encode_as_numbers() {
+        let big = MontyObject::BigInt("123456789012345678901234567890".parse().unwrap());
+        assert_eq!(json(&big), "123456789012345678901234567890");
+    }
+
+    #[test]
+    fn oversize_output_is_cut_off_and_flagged() {
+        let value = MontyObject::List((0..1000).map(MontyObject::Int).collect());
+        let (s, cut) = serialize_capped(&value, 20);
+        assert!(cut);
+        assert!(s.len() <= 20);
+        assert!(s.starts_with("[0,1,"));
+    }
+}

--- a/crates/monty-pool/src/telemetry_json.rs
+++ b/crates/monty-pool/src/telemetry_json.rs
@@ -2,13 +2,12 @@
 //!
 //! Mirrors the Python logfire JSON encoder (`logfire/_internal/json_encoder.py`):
 //! containers become JSON arrays/objects, dates use isoformat, timedeltas their
-//! total seconds, and opaque objects fall back to their `repr`. Output is
-//! capped at a byte limit so a huge value cannot blow up the telemetry
-//! pipeline; the caller is told when the cap cut serialization short.
+//! total seconds, and opaque objects fall back to their `repr`. Output is capped
+//! at a byte limit so a huge value cannot blow up the telemetry pipeline.
 //!
-//! Known divergences from the Python encoder: sets are encoded in storage
-//! order (Python sorts them when comparable), and integers beyond `i128`
-//! become their digit string rather than a raw JSON number.
+//! Divergences from the Python encoder: sets are encoded in storage order
+//! (Python sorts them when comparable), and integers beyond `i128` become their
+//! digit string rather than a raw JSON number.
 
 use std::{
     collections::HashMap,
@@ -20,28 +19,27 @@ use monty_types::{MontyDateTime, MontyObject, bytes_repr};
 use num_traits::ToPrimitive;
 use serde::ser::{Serialize, SerializeMap, Serializer};
 
-/// Serializes `value` to logfire-style JSON (see the module docs for the
-/// format), capped at `limit` bytes. The bool is true when the cap cut
-/// serialization short — the partial output is then no longer valid JSON, and
-/// the caller should mark it as truncated.
+/// Serializes `value` to logfire-style JSON (see the module docs), capped at
+/// `limit` bytes. The bool is true when the cap cut serialization short — the
+/// partial output is then no longer valid JSON, so the caller should mark it
+/// truncated.
 pub(crate) fn serialize_capped(value: &MontyObject, limit: usize) -> (String, bool) {
     capped(&JsonEncoded { value, limit }, limit)
 }
 
-/// [`serialize_capped`] for a list of values, borrowing them rather than
-/// cloning them into a [`MontyObject::List`].
+/// [`serialize_capped`] for a borrowed list; this and the two variants below
+/// exist to avoid cloning values into an owned [`MontyObject`] container.
 pub(crate) fn serialize_seq_capped(items: &[MontyObject], limit: usize) -> (String, bool) {
     capped(&JsonSeq { items, limit }, limit)
 }
 
-/// [`serialize_capped`] for dict pairs (non-string keys rendered by their
-/// repr), borrowing them rather than cloning them into a [`MontyObject::Dict`].
+/// [`serialize_capped`] for borrowed dict pairs; non-string keys render as
+/// their repr.
 pub(crate) fn serialize_dict_capped(pairs: &[(MontyObject, MontyObject)], limit: usize) -> (String, bool) {
     capped(&JsonDict { pairs, limit }, limit)
 }
 
-/// [`serialize_capped`] for named values as a JSON object, borrowing them
-/// rather than cloning them into a dict.
+/// [`serialize_capped`] for borrowed name → value pairs, as a JSON object.
 pub(crate) fn serialize_named_capped(pairs: &[(&str, &MontyObject)], limit: usize) -> (String, bool) {
     capped(&JsonNamed { pairs, limit }, limit)
 }
@@ -81,16 +79,16 @@ impl Write for CappedWriter {
 /// Serializes a [`MontyObject`] with the logfire value mapping (rather than
 /// the tagged-enum encoding of the derived `Serialize`, which is for the wire).
 ///
-/// `limit` is the caller's byte cap, carried down the value tree so a huge
-/// `bytes` leaf is escaped only as far as the cap can keep — the writer alone
-/// cannot help, since it sees the escaped string only once it is built.
+/// `limit` is carried down the value tree so a huge `bytes` leaf is escaped
+/// only as far as the cap can keep — the writer alone cannot help, since it
+/// sees the escaped string only once it is built.
 struct JsonEncoded<'a> {
     value: &'a MontyObject,
     limit: usize,
 }
 
 impl<'a> JsonEncoded<'a> {
-    /// The same encoder for a nested value.
+    /// An encoder for a child value, carrying `limit` down the tree.
     const fn nested(&self, value: &'a MontyObject) -> Self {
         Self {
             value,
@@ -105,8 +103,8 @@ impl Serialize for JsonEncoded<'_> {
             MontyObject::None => s.serialize_unit(),
             MontyObject::Bool(b) => s.serialize_bool(*b),
             MontyObject::Int(i) => s.serialize_i64(*i),
-            // beyond i128 (vanishingly rare) the digits become a string, as a
-            // raw JSON number would need serde_json's arbitrary-precision mode
+            // beyond i128 the digits become a string: a raw JSON number would
+            // need serde_json's arbitrary-precision mode
             MontyObject::BigInt(b) => match b.to_i128() {
                 Some(i) => s.serialize_i128(i),
                 None => s.collect_str(b),
@@ -115,9 +113,9 @@ impl Serialize for JsonEncoded<'_> {
             MontyObject::Float(f) => s.serialize_str(nonfinite_str(*f)),
             MontyObject::String(v) => s.serialize_str(v),
             // like logfire: the repr's escaped content without the b'' wrapper.
-            // Escaping stops at `limit` bytes of input: every byte escapes to
-            // at least one character, so the rest could only produce output the
-            // cap discards — after quadrupling a huge payload to build it
+            // Escaping stops at `limit` input bytes — each escapes to at least
+            // one character, so the rest would only inflate a huge payload to
+            // produce output the cap discards
             MontyObject::Bytes(b) => {
                 let repr = bytes_repr(&b[..b.len().min(self.limit)]);
                 s.serialize_str(&repr[2..repr.len() - 1])
@@ -168,8 +166,8 @@ impl Serialize for JsonEncoded<'_> {
     }
 }
 
-/// Encodes borrowed values as a JSON array, for a caller holding the items
-/// but no [`MontyObject`] container to point [`JsonEncoded`] at.
+/// [`JsonEncoded`] for borrowed items with no owning [`MontyObject`]
+/// container: a JSON array.
 struct JsonSeq<'a> {
     items: &'a [MontyObject],
     limit: usize,
@@ -269,8 +267,8 @@ fn datetime_isoformat(dt: &MontyDateTime) -> String {
     iso
 }
 
-// tests live here rather than in `tests/` because `serialize_capped` is
-// crate-private: telemetry encoding is not part of the pool's public API
+// tests live here because the encoders are crate-private: telemetry encoding
+// is not part of the pool's public API
 #[cfg(test)]
 mod tests {
     use monty_types::{DictPairs, ExcType, MontyDate, MontyDateTime, MontyObject, MontyTimeDelta};

--- a/crates/monty-pool/src/worker.rs
+++ b/crates/monty-pool/src/worker.rs
@@ -51,9 +51,8 @@ pub(crate) struct Worker {
     /// Checkouts this worker has served, for `max_checkouts_per_worker`.
     pub(crate) checkouts_served: u32,
     /// Records this worker's protocol turns to the pool's logfire (a no-op
-    /// recorder when the pool has no `logfire_token`). Lives here because the
-    /// worker sees every request sent and every event received — the whole
-    /// conversation — regardless of which checkout drives it.
+    /// when the pool has no `logfire_token`). It lives here because the worker
+    /// sees the whole conversation, whichever checkout drives it.
     recorder: Recorder,
 }
 
@@ -85,8 +84,8 @@ struct WebSocketWorker {
 }
 
 impl Worker {
-    /// Creates a worker for `config`'s transport; `logfire`, when present, is
-    /// the pool's telemetry the worker's turns are recorded to.
+    /// Creates a worker for `config`'s transport, recording its turns to the
+    /// pool's `logfire` when telemetry is on.
     pub(crate) async fn new(config: &PoolConfig, logfire: Option<&Logfire>) -> Result<Self, PoolError> {
         match &config.transport {
             MontyTransport::Subprocess(binary_path) => Self::subprocess(binary_path, logfire),
@@ -197,8 +196,7 @@ impl Worker {
             }
         };
         // record only requests that hit the wire: a rejected oversize frame
-        // never reached the worker, so the turn (and any pending suspension)
-        // is still exactly where it was
+        // leaves the turn (and any pending suspension) exactly where it was
         if result.is_ok() {
             self.recorder.begin_turn(request);
         }
@@ -241,8 +239,8 @@ impl Worker {
                 decode_event(&data)
             }
         }?;
-        // recorded only after a complete decode, so a `recv` future dropped
-        // mid-frame (deadline race) records nothing — cancel-safety intact
+        // only after a complete decode, so a `recv` future dropped mid-frame
+        // (deadline race) records nothing — cancel-safety intact
         self.recorder.event(&event);
         Ok(event)
     }

--- a/crates/monty-pool/src/worker.rs
+++ b/crates/monty-pool/src/worker.rs
@@ -22,6 +22,7 @@ use std::{
 };
 
 use futures_util::{SinkExt, StreamExt};
+use logfire::Logfire;
 use monty_proto::{FrameError, MAX_FRAME_LEN, decode_frame, encode_framed_into, encode_to_capped_vec, pb};
 use rustls::crypto::aws_lc_rs::default_provider;
 use tokio::{
@@ -37,7 +38,7 @@ use tokio_tungstenite::{
     tungstenite::{Error as WsError, Message, protocol::WebSocketConfig},
 };
 
-use crate::{MontyTransport, PoolConfig, PoolError};
+use crate::{MontyTransport, PoolConfig, PoolError, telemetry::Recorder};
 
 /// The async WebSocket stream type for a remote worker.
 type WsStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
@@ -49,6 +50,11 @@ pub(crate) struct Worker {
     kind: WorkerKind,
     /// Checkouts this worker has served, for `max_checkouts_per_worker`.
     pub(crate) checkouts_served: u32,
+    /// Records this worker's protocol turns to the pool's logfire (a no-op
+    /// recorder when the pool has no `logfire_token`). Lives here because the
+    /// worker sees every request sent and every event received — the whole
+    /// conversation — regardless of which checkout drives it.
+    recorder: Recorder,
 }
 
 /// The two transports a worker can speak the protocol over. Both variants are
@@ -79,13 +85,15 @@ struct WebSocketWorker {
 }
 
 impl Worker {
-    pub(crate) async fn new(config: &PoolConfig) -> Result<Self, PoolError> {
+    /// Creates a worker for `config`'s transport; `logfire`, when present, is
+    /// the pool's telemetry the worker's turns are recorded to.
+    pub(crate) async fn new(config: &PoolConfig, logfire: Option<&Logfire>) -> Result<Self, PoolError> {
         match &config.transport {
-            MontyTransport::Subprocess(binary_path) => Self::subprocess(binary_path),
+            MontyTransport::Subprocess(binary_path) => Self::subprocess(binary_path, logfire),
             // Bound the dial by `request_timeout` (see `websocket`); a missing
             // one falls back to a generous fixed budget.
             MontyTransport::Websocket(url) => {
-                Self::websocket(url, config.request_timeout.unwrap_or(DEFAULT_DIAL_TIMEOUT)).await
+                Self::websocket(url, config.request_timeout.unwrap_or(DEFAULT_DIAL_TIMEOUT), logfire).await
             }
         }
     }
@@ -95,7 +103,7 @@ impl Worker {
     /// There is no spawn-time handshake: a wrong or broken binary surfaces as
     /// an error on the first request the worker serves (typically the
     /// `Configure` of its first checkout).
-    fn subprocess(binary_path: &PathBuf) -> Result<Self, PoolError> {
+    fn subprocess(binary_path: &PathBuf, logfire: Option<&Logfire>) -> Result<Self, PoolError> {
         let mut command = Command::new(binary_path);
         command
             .arg("subprocess")
@@ -120,6 +128,7 @@ impl Worker {
 
         let stdin = child.stdin.take().expect("piped stdin");
         let stdout = child.stdout.take().expect("piped stdout");
+        let recorder = Recorder::new(logfire.cloned(), child.id());
         Ok(Self {
             kind: WorkerKind::Subprocess(Box::new(SubprocessWorker {
                 child,
@@ -128,6 +137,7 @@ impl Worker {
                 send_buf: Vec::with_capacity(SEND_BUF_CAPACITY),
             })),
             checkouts_served: 0,
+            recorder,
         })
     }
 
@@ -139,7 +149,7 @@ impl Worker {
     /// hung dial would otherwise stall the checkout forever. Frame/message
     /// limits are raised to monty's [`MAX_FRAME_LEN`] so the transport never
     /// rejects a frame the protocol itself would accept.
-    async fn websocket(url: &str, dial_timeout: Duration) -> Result<Self, PoolError> {
+    async fn websocket(url: &str, dial_timeout: Duration, logfire: Option<&Logfire>) -> Result<Self, PoolError> {
         install_crypto_provider();
         let ws_config = WebSocketConfig::default()
             .max_frame_size(Some(MAX_FRAME_LEN as usize))
@@ -152,6 +162,8 @@ impl Worker {
         Ok(Self {
             kind: WorkerKind::WebSocket(Box::new(WebSocketWorker { stream: Some(stream) })),
             checkouts_served: 0,
+            // remote worker: there is no local pid to record
+            recorder: Recorder::new(logfire.cloned(), None),
         })
     }
 
@@ -160,7 +172,7 @@ impl Worker {
     /// oversize frame is rejected *before* any I/O so the stream stays synced
     /// (see `Checkout::request_turn`).
     pub(crate) async fn send(&mut self, request: &pb::ParentRequest) -> Result<(), FrameError> {
-        match &mut self.kind {
+        let result = match &mut self.kind {
             WorkerKind::Subprocess(w) => {
                 // prefix + body in one reused buffer: a single write syscall
                 // per request, no per-frame allocation, and a pipe write needs
@@ -183,7 +195,14 @@ impl Worker {
                     None => Err(FrameError::Truncated),
                 }
             }
+        };
+        // record only requests that hit the wire: a rejected oversize frame
+        // never reached the worker, so the turn (and any pending suspension)
+        // is still exactly where it was
+        if result.is_ok() {
+            self.recorder.begin_turn(request);
         }
+        result
     }
 
     /// Receives one event. EOF/close is an error here because within a
@@ -193,7 +212,7 @@ impl Worker {
     /// module docs), which is what lets `Checkout` race a turn against its
     /// deadline.
     pub(crate) async fn recv(&mut self) -> Result<pb::ChildEvent, FrameError> {
-        match &mut self.kind {
+        let event = match &mut self.kind {
             WorkerKind::Subprocess(w) => match w.recv.recv().await? {
                 Some(event) => Ok(event),
                 None => Err(FrameError::Truncated), // clean EOF mid-checkout is still a vanished peer
@@ -221,7 +240,11 @@ impl Worker {
                 };
                 decode_event(&data)
             }
-        }
+        }?;
+        // recorded only after a complete decode, so a `recv` future dropped
+        // mid-frame (deadline race) records nothing — cancel-safety intact
+        self.recorder.event(&event);
+        Ok(event)
     }
 
     /// The OS process id, when the worker is a local subprocess (`None` for a

--- a/crates/monty-pool/src/worker.rs
+++ b/crates/monty-pool/src/worker.rs
@@ -17,7 +17,7 @@ use std::{
     env,
     path::PathBuf,
     process::{ExitStatus, Stdio},
-    sync::Once,
+    sync::{Arc, Once},
     time::Duration,
 };
 
@@ -52,8 +52,9 @@ pub(crate) struct Worker {
     pub(crate) checkouts_served: u32,
     /// Records this worker's protocol turns to the pool's logfire (a no-op
     /// when the pool has no `logfire_token`). It lives here because the worker
-    /// sees the whole conversation, whichever checkout drives it.
-    recorder: Recorder,
+    /// sees the whole conversation, whichever checkout drives it — boxed to
+    /// keep a `Worker` pointer-sized, since checkout and release move it.
+    recorder: Box<Recorder>,
 }
 
 /// The two transports a worker can speak the protocol over. Both variants are
@@ -86,7 +87,7 @@ struct WebSocketWorker {
 impl Worker {
     /// Creates a worker for `config`'s transport, recording its turns to the
     /// pool's `logfire` when telemetry is on.
-    pub(crate) async fn new(config: &PoolConfig, logfire: Option<&Logfire>) -> Result<Self, PoolError> {
+    pub(crate) async fn new(config: &PoolConfig, logfire: Option<&Arc<Logfire>>) -> Result<Self, PoolError> {
         match &config.transport {
             MontyTransport::Subprocess(binary_path) => Self::subprocess(binary_path, logfire),
             // Bound the dial by `request_timeout` (see `websocket`); a missing
@@ -102,7 +103,7 @@ impl Worker {
     /// There is no spawn-time handshake: a wrong or broken binary surfaces as
     /// an error on the first request the worker serves (typically the
     /// `Configure` of its first checkout).
-    fn subprocess(binary_path: &PathBuf, logfire: Option<&Logfire>) -> Result<Self, PoolError> {
+    fn subprocess(binary_path: &PathBuf, logfire: Option<&Arc<Logfire>>) -> Result<Self, PoolError> {
         let mut command = Command::new(binary_path);
         command
             .arg("subprocess")
@@ -127,7 +128,7 @@ impl Worker {
 
         let stdin = child.stdin.take().expect("piped stdin");
         let stdout = child.stdout.take().expect("piped stdout");
-        let recorder = Recorder::new(logfire.cloned(), child.id());
+        let recorder = Box::new(Recorder::new(logfire.cloned(), child.id()));
         Ok(Self {
             kind: WorkerKind::Subprocess(Box::new(SubprocessWorker {
                 child,
@@ -148,7 +149,7 @@ impl Worker {
     /// hung dial would otherwise stall the checkout forever. Frame/message
     /// limits are raised to monty's [`MAX_FRAME_LEN`] so the transport never
     /// rejects a frame the protocol itself would accept.
-    async fn websocket(url: &str, dial_timeout: Duration, logfire: Option<&Logfire>) -> Result<Self, PoolError> {
+    async fn websocket(url: &str, dial_timeout: Duration, logfire: Option<&Arc<Logfire>>) -> Result<Self, PoolError> {
         install_crypto_provider();
         let ws_config = WebSocketConfig::default()
             .max_frame_size(Some(MAX_FRAME_LEN as usize))
@@ -162,7 +163,7 @@ impl Worker {
             kind: WorkerKind::WebSocket(Box::new(WebSocketWorker { stream: Some(stream) })),
             checkouts_served: 0,
             // remote worker: there is no local pid to record
-            recorder: Recorder::new(logfire.cloned(), None),
+            recorder: Box::new(Recorder::new(logfire.cloned(), None)),
         })
     }
 

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -1263,6 +1263,38 @@ async fn workers_are_recycled_after_max_checkouts() {
 }
 
 #[tokio::test]
+async fn logfire_token_pool_round_trips() {
+    let mut config = config();
+    // a syntactically valid but fake token: the pool configures its local
+    // logfire and records every turn, while the background exporter's
+    // failures never affect execution
+    config.logfire_token = Some("pylf_v1_us_0000000000000000000000".to_owned());
+    // recycle after every checkout so a replacement worker's recorder is
+    // exercised too
+    config.max_checkouts_per_worker = Some(1);
+    let pool = Pool::new(config).await.unwrap();
+
+    let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
+    let event = session
+        .feed("1 + 2", vec![], vec![], false, &mut no_print)
+        .await
+        .unwrap();
+    assert_eq!(expect_complete(event), MontyObject::Int(3));
+    session.finish().await.unwrap();
+
+    let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
+    let event = session
+        .feed("2 + 2", vec![], vec![], false, &mut no_print)
+        .await
+        .unwrap();
+    assert_eq!(expect_complete(event), MontyObject::Int(4));
+    session.finish().await.unwrap();
+
+    // flushes the exporter (its failures against the fake token are swallowed)
+    pool.close().await;
+}
+
+#[tokio::test]
 async fn concurrent_checkouts_run_in_parallel() {
     let mut config = config();
     config.min_processes = 2;

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -1265,12 +1265,10 @@ async fn workers_are_recycled_after_max_checkouts() {
 #[tokio::test]
 async fn logfire_token_pool_round_trips() {
     let mut config = config();
-    // a syntactically valid but fake token: the pool configures its local
-    // logfire and records every turn, while the background exporter's
-    // failures never affect execution
+    // a syntactically valid but fake token: the pool records every turn, while
+    // the background exporter's failures never affect execution
     config.logfire_token = Some("pylf_v1_us_0000000000000000000000".to_owned());
-    // recycle after every checkout so a replacement worker's recorder is
-    // exercised too
+    // recycle after every checkout, so a replacement worker's recorder runs too
     config.max_checkouts_per_worker = Some(1);
     let pool = Pool::new(config).await.unwrap();
 

--- a/crates/monty-python/README.md
+++ b/crates/monty-python/README.md
@@ -230,6 +230,25 @@ with Monty() as pool:
             ...  # the worker died; the pool already replaced it
 ```
 
+### Observability
+
+Passing a [Logfire](https://pydantic.dev/logfire) write token instruments the
+pool. Each checkout becomes one session span, with a nested span per turn
+recording the code fed, its inputs, external call arguments and results,
+exceptions and `print` output. Session dumps and restores are recorded by size
+only. Without the token nothing is recorded and no exporter runs. Recording
+happens in the host process (the pool sees the whole conversation with each
+worker); the workers themselves receive no token and run no exporter, and any
+logfire/OTel setup of your own application is untouched.
+
+```python test="skip"
+from pydantic_monty import Monty
+
+with Monty(logfire_token='pylf_v1_...') as pool:
+    with pool.checkout() as session:
+        session.feed_run('1 + 1')
+```
+
 See `limitations/pool-architecture.md` in the repository for the behavioural
 details of subprocess execution (host-side mounts, buffered print
 callbacks, session dumps).

--- a/crates/monty-python/README.md
+++ b/crates/monty-python/README.md
@@ -233,13 +233,14 @@ with Monty() as pool:
 ### Observability
 
 Passing a [Logfire](https://pydantic.dev/logfire) write token instruments the
-pool. Each checkout becomes one session span, with a nested span per turn
+pool: each checkout becomes one session span, with a nested span per turn
 recording the code fed, its inputs, external call arguments and results,
 exceptions and `print` output. Session dumps and restores are recorded by size
-only. Without the token nothing is recorded and no exporter runs. Recording
-happens in the host process (the pool sees the whole conversation with each
-worker); the workers themselves receive no token and run no exporter, and any
-logfire/OTel setup of your own application is untouched.
+only. Without a token nothing is recorded and no exporter runs.
+
+Recording happens in the host process, which sees the whole conversation with
+each worker; the workers get no token, and your application's own logfire/OTel
+setup is untouched.
 
 ```python test="skip"
 from pydantic_monty import Monty

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -376,6 +376,7 @@ class Monty:
         checkout_timeout: float | None = None,
         request_timeout: float | None = None,
         max_checkouts_per_worker: int | None = None,
+        logfire_token: str | None = None,
     ) -> Self:
         """
         Configure a worker pool; the workers are spawned by `with`.
@@ -394,6 +395,10 @@ class Monty:
                 exceeds it is killed and the call raises `MontyCrashedError`
                 with `timed_out=True`. Backstops the sandbox `limits`.
             max_checkouts_per_worker: Recycle a worker after this many sessions.
+            logfire_token: Logfire write token. When set, the pool records
+                every session to Logfire from the host process; workers
+                receive no token, and any logfire/OTel setup of your own
+                application is untouched.
         """
 
     def __enter__(self) -> Self: ...
@@ -657,6 +662,7 @@ class AsyncMonty:
         checkout_timeout: float | None = None,
         request_timeout: float | None = None,
         max_checkouts_per_worker: int | None = None,
+        logfire_token: str | None = None,
     ) -> Self:
         """
         Configure a worker pool; the workers are spawned by `async with`.

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -396,9 +396,8 @@ class Monty:
                 with `timed_out=True`. Backstops the sandbox `limits`.
             max_checkouts_per_worker: Recycle a worker after this many sessions.
             logfire_token: Logfire write token. When set, the pool records
-                every session to Logfire from the host process; workers
-                receive no token, and any logfire/OTel setup of your own
-                application is untouched.
+                every session from the host process; the workers get no token
+                and your application's own logfire/OTel setup is untouched.
         """
 
     def __enter__(self) -> Self: ...

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -115,7 +115,9 @@ impl PyMonty {
         checkout_timeout = None,
         request_timeout = None,
         max_checkouts_per_worker = None,
+        logfire_token = None,
     ))]
+    #[expect(clippy::too_many_arguments)]
     fn new(
         py: Python<'_>,
         binary_path: Option<PathBuf>,
@@ -124,6 +126,7 @@ impl PyMonty {
         checkout_timeout: Option<f64>,
         request_timeout: Option<f64>,
         max_checkouts_per_worker: Option<u32>,
+        logfire_token: Option<String>,
     ) -> PyResult<Self> {
         Ok(Self {
             config: parse_pool_config(
@@ -134,6 +137,7 @@ impl PyMonty {
                 checkout_timeout,
                 request_timeout,
                 max_checkouts_per_worker,
+                logfire_token,
             )?,
             pool: Arc::new(Mutex::new(None)),
         })
@@ -474,7 +478,9 @@ impl PyAsyncMonty {
         checkout_timeout = None,
         request_timeout = None,
         max_checkouts_per_worker = None,
+        logfire_token = None,
     ))]
+    #[expect(clippy::too_many_arguments)]
     fn new(
         py: Python<'_>,
         binary_path: Option<PathBuf>,
@@ -483,6 +489,7 @@ impl PyAsyncMonty {
         checkout_timeout: Option<f64>,
         request_timeout: Option<f64>,
         max_checkouts_per_worker: Option<u32>,
+        logfire_token: Option<String>,
     ) -> PyResult<Self> {
         Ok(Self {
             config: parse_pool_config(
@@ -493,6 +500,7 @@ impl PyAsyncMonty {
                 checkout_timeout,
                 request_timeout,
                 max_checkouts_per_worker,
+                logfire_token,
             )?,
             pool: Arc::new(Mutex::new(None)),
         })
@@ -912,6 +920,7 @@ impl PyAsyncMontySession {
 /// Builds the subprocess-transport `monty-pool` config from the (shared)
 /// `Monty`/`AsyncMonty` constructor arguments, resolving the binary via
 /// `pydantic_monty._binary` when not given explicitly.
+#[expect(clippy::too_many_arguments)]
 fn parse_pool_config(
     py: Python<'_>,
     binary_path: Option<PathBuf>,
@@ -920,6 +929,7 @@ fn parse_pool_config(
     checkout_timeout: Option<f64>,
     request_timeout: Option<f64>,
     max_checkouts_per_worker: Option<u32>,
+    logfire_token: Option<String>,
 ) -> PyResult<PoolConfig> {
     let binary_path = match binary_path {
         Some(path) => path,
@@ -937,6 +947,7 @@ fn parse_pool_config(
     config.checkout_timeout = checkout_timeout.map(duration_from_secs).transpose()?;
     config.request_timeout = request_timeout.map(duration_from_secs).transpose()?;
     config.max_checkouts_per_worker = max_checkouts_per_worker;
+    config.logfire_token = logfire_token;
     Ok(config)
 }
 
@@ -1718,7 +1729,9 @@ pub(crate) fn pool_err_to_py(py: Python<'_>, err: PoolError) -> PyErr {
         PoolError::Disconnected { .. } => MontyDisconnectError::new_err(py, message),
         PoolError::Shutdown { dump } => MontyShutdown::new_err(py, message, dump),
         PoolError::Exhausted => PyTimeoutError::new_err(message),
-        PoolError::Protocol(_) | PoolError::Spawn(_) | PoolError::Finished => PyRuntimeError::new_err(message),
+        PoolError::Protocol(_) | PoolError::Spawn(_) | PoolError::Telemetry(_) | PoolError::Finished => {
+            PyRuntimeError::new_err(message)
+        }
     }
 }
 

--- a/crates/monty-python/tests/test_pool.py
+++ b/crates/monty-python/tests/test_pool.py
@@ -167,6 +167,14 @@ result
     assert result == snapshot('Max argument depth exceeded')
 
 
+def test_logfire_token_pool_round_trips():
+    # a syntactically valid but fake token: the pool records every turn, and
+    # the failing background export never affects execution
+    with Monty(logfire_token='pylf_v1_us_0000000000000000000000') as pool:
+        with pool.checkout() as session:
+            assert session.feed_run('1 + 2') == snapshot(3)
+
+
 # === async variants ===
 
 
@@ -223,3 +231,9 @@ async def test_async_pool_not_entered():
     assert exc_info.value.args[0] == snapshot(
         'the pool is not active — enter the Monty / AsyncMonty context manager first'
     )
+
+
+async def test_async_logfire_token_pool_round_trips():
+    async with AsyncMonty(logfire_token='pylf_v1_us_0000000000000000000000') as pool:
+        async with pool.checkout() as session:
+            assert await session.feed_run('1 + 2') == snapshot(3)

--- a/crates/monty-python/tests/test_pool.py
+++ b/crates/monty-python/tests/test_pool.py
@@ -168,8 +168,7 @@ result
 
 
 def test_logfire_token_pool_round_trips():
-    # a syntactically valid but fake token: the pool records every turn, and
-    # the failing background export never affects execution
+    # a well-formed but fake token: recording runs, and the failing background export never affects execution
     with Monty(logfire_token='pylf_v1_us_0000000000000000000000') as pool:
         with pool.checkout() as session:
             assert session.feed_run('1 + 2') == snapshot(3)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add opt-in `logfire`/OTel tracing recorded in the host `monty-pool` instead of the subprocess. Also share the `logfire` handle via `Arc` to shrink `Worker` size and remove a checkout memcpy slowdown, with no behavior change.

- **New Features**
  - Host-side Logfire: one session span per checkout; one feed span per `Feed` with a child per suspension/host round-trip; includes `total_execution_micros`/`max_duration_micros`; sets `service.instance.id`/`process.pid`; adds `worker_pid`; covers WebSocket transport.
  - Attributes: logfire‑style JSON with a 64 KiB cap per value (nested included) and truncation flags; bytes escaping capped to the first 64 KiB; records fed code, inputs, function `args`/`kwargs`, and typed OS call `args.*`; `Dump`/`Load` and filesystem writes record sizes only; `Load` records the adopted script name.
  - Bindings/tests/docs: `Monty(..., logfire_token=...)`, `AsyncMonty(..., logfire_token=...)`, and `Monty.create({ logfireToken })`; docs add Observability sections; JS locks published `@pydantic/monty-<platform>` packages; round‑trip tests use a fake token to validate recording without affecting execution.

- **Refactors**
  - Telemetry moved from the worker to the host with a per‑worker `Recorder`; events recorded only after full decode (recv is cancel‑safe); Logfire scoped via `set_local_logfire` with explicit parent spans; reduced verbosity and excess child spans.
  - `Pool::close` flushes the exporter off the runtime; mid‑feed `Dump` errors no longer close the feed span; worker identity moved to a `worker_pid` session attribute; new `PoolError::Telemetry`; `PoolConfig::Debug` redacts `logfire_token`; background export failures never affect execution.
  - Performance: share the `Logfire` via `Arc` and box the recorder instead of embedding it in `Worker`, keeping `Worker` small and eliminating the checkout memcpy regression.

<sup>Written for commit d2dbfda1380a1a28ea77cd154cac378448843153. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

