### PR TITLE
cleanups to some drop branches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,7 +248,9 @@ while let Some(item) = iter.for_next(vm)? { ... }
 
 #### 2. `DropGuard` (when you need control over the value's fate)
 
-Use `DropGuard` directly when `defer_drop!` is too restrictive — specifically when you need to conditionally extract the value instead of dropping it. `DropGuard` provides `into_inner()` and `into_parts()` to reclaim ownership, while its `Drop` impl still guarantees cleanup on all other paths:
+Use `DropGuard` directly when `defer_drop!` is too restrictive — specifically when you need to conditionally extract the value instead of dropping it. `DropGuard` provides `into_inner()` and `into_parts()` to reclaim ownership, while its `Drop` impl still guarantees cleanup on all other paths.
+
+Do not use `DropGuard` when the value is never moved back out of it. A guard used only through `as_parts()` or `as_parts_mut()` must be replaced with `defer_drop!` or `defer_drop_mut!`; explicit guards are reserved for code that later calls `into_inner()` or `into_parts()`. This keeps the ownership intent visible and avoids unnecessary guard bookkeeping:
 
 ```rust
 // DropGuard needed here because on success we push lhs back onto the stack
@@ -266,14 +268,19 @@ if lhs.py_iadd(rhs, this.heap)? {
 
 #### 3. Manual `drop_with` (for trivially simple cases)
 
-For very simple cases with a single linear code path and no branching between acquiring and releasing the value, a direct `drop_with` call is fine:
+For very simple cases with a single linear code path and no branching between acquiring and releasing the value, a direct `drop_with` call is acceptable as long as it produces more concise code than `defer_drop!`:
 
 ```rust
 let iter = self.pop();
 iter.drop_with(self); // single path, no branching
 ```
 
-Avoid manual `drop_with` whenever there are multiple code paths (branching, `?`, `continue`, early returns) between acquiring and releasing the value — that is exactly where `defer_drop!` or `DropGuard` prevent leaks by guaranteeing cleanup on every path.
+`drop_with` should be used **only** when it is genuinely simpler than `defer_drop!` or `DropGuard`. The latter two are safer and more maintainable, especially in complex control flow. Multiple manual cleanup calls for the same owned value are a poor substitute for a guard.
+
+**Do not use `drop_with` if any of the following are true:**
+- The same value has `drop_with` called in multiple places (e.g. a loop with `continue` or `?` in the middle). This implies `defer_drop!` or `DropGuard` will be easier to read.
+- The explicit call to `drop_with` produces more lines of code than `defer_drop!` or `DropGuard` would. The latter often avoid rightward drift and make the cleanup logic easier.
+- The value is part of a container (e.g. `Vec<Value>`). Ideally the container itself implements `DropWithContext` and so `defer_drop` or `DropGuard` can be used on the whole container. Consider if a `DropWithContext` implementation for the container might be missing.
 
 ### Resource-tracked string construction (`StringBuilder`)
 
@@ -718,6 +725,18 @@ Heap-allocated values (`Value::Ref`) use manual reference counting. Key rules:
 - **Dropping**: Call `drop_with(ctx)` (the [`DropWithContext`] method) when discarding a `Value` that may be a `Ref`.
 
 Container types (`List`, `Tuple`, `Dict`) also have `clone_with_heap()` methods.
+
+### Raw `HeapId` ownership
+
+`HeapId` does not encode whether a reference is owned or borrowed. Locally owned IDs should typically be wrapped in `Value::Ref` immediately so `defer_drop!` and `DropGuard` can manage cleanup; a local raw `HeapId` should otherwise be presumed borrowed.
+
+Owned `HeapId` fields remain the preferred representation where a structure needs the raw ID, such as `ListIterator::list`. Such fields must be documented as owned and cleaned up exactly once:
+
+- Heap-stored `HeapItem` implementations must push every owned ID from `py_dec_ref_ids`; this is preferred to calling `Heap::dec_ref` directly because destruction uses the heap's iterative cleanup stack.
+- Non-`HeapItem` owners should release owned IDs through their `DropWithContext` implementation, where a direct `dec_ref` is acceptable.
+- Direct `dec_ref` in ordinary control flow is discouraged. As with `drop_with`, never scatter cleanup for the same owned reference across branches; use an owning `Value` and a guard instead.
+
+Raw ownership is also acceptable when immediately transferred into a documented owned field or across an API whose contract explicitly transfers ownership.
 
 **Mutability of the heap parameter is asymmetric** — do not assume the two methods take the same kind of borrow:
 

--- a/crates/monty/src/args/bind_native.rs
+++ b/crates/monty/src/args/bind_native.rs
@@ -36,8 +36,9 @@ use std::{mem, ptr};
 use crate::{
     args::{ArgPosIter, ArgValues, KwargsValues, KwargsValuesIter},
     bytecode::VM,
+    defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
-    heap::{ContainsHeap, DropGuard, DropWithContext},
+    heap::{ContainsHeap, DropWithContext},
     intern::{Interns, StringId},
     value::{EitherStr, Value},
 };
@@ -109,8 +110,7 @@ fn bind_slow<const N: usize>(
     // values already moved into `bound` are covered by the *caller's* guard
     // around the slots struct, so no error arm needs manual drops beyond
     // values it has already pulled out of an iterator.
-    let mut guard = DropGuard::new(state, vm);
-    let (state, vm) = guard.as_parts_mut();
+    defer_drop_mut!(state, vm);
 
     if spec.kwargs_not_supported_yet && state.kwargs.len() > 0 {
         return Err(ExcType::kwargs_not_implemented(spec.func_name));

--- a/crates/monty/src/args/bind_python.rs
+++ b/crates/monty/src/args/bind_python.rs
@@ -272,10 +272,8 @@ impl Signature {
         let keyword_args = keyword_args.into_iter();
         defer_drop_mut!(keyword_args, vm);
 
-        // Extract interns before guards since DropGuard borrows the full VM mutably
-        // but we only need mutable access to the heap portion.
-        let mut pos_iter_guard = DropGuard::new(pos_iter, vm);
-        let (pos_iter, vm) = pos_iter_guard.as_parts_mut();
+        // Keep unconsumed positional values guarded throughout binding.
+        defer_drop_mut!(pos_iter, vm);
 
         // Calculate how many positional params we have
         let pos_param_count = self.pos_arg_count();

--- a/crates/monty/src/builtins/min_max.rs
+++ b/crates/monty/src/builtins/min_max.rs
@@ -62,17 +62,8 @@ fn run_min_max(
     };
     defer_drop!(key_fn, vm);
 
-    // `default_value` is `Option<Value>` — we may consume it on the "empty
-    // iterable" path, or drop it on error paths. `DropGuard` ensures cleanup
-    // on every `?`-style early return.
-    let mut default_guard = DropGuard::new(default, vm);
-    let (default_value, vm) = default_guard.as_parts_mut();
-
-    // Wrap the remaining positional args in a guard so any unconsumed items
-    // are released on early error returns (e.g. the user-supplied `key`
-    // function raising mid-iteration).
-    let mut args_guard = DropGuard::new(args, vm);
-    let (args, vm) = args_guard.as_parts_mut();
+    defer_drop_mut!(default, vm);
+    defer_drop_mut!(args, vm);
 
     if args.is_empty() {
         return Err(SimpleException::new_msg(
@@ -91,7 +82,7 @@ fn run_min_max(
         let mut iter = iter.read(vm);
 
         let Some(result) = iter.py_next(vm)? else {
-            if let Some(default) = default_value.take() {
+            if let Some(default) = default.take() {
                 return Ok(default);
             }
             return Err(SimpleException::new_msg(
@@ -106,24 +97,18 @@ fn run_min_max(
             {
                 let (result, vm) = result_guard.as_parts_mut();
                 let result_key = evaluate_key(result.clone_with_heap(vm), key_fn, key_context, vm)?;
-                let mut result_key_guard = DropGuard::new(result_key, vm);
-                {
-                    let (result_key, vm) = result_key_guard.as_parts_mut();
+                defer_drop_mut!(result_key, vm);
 
-                    while let Some(item) = iter.py_next(vm)? {
-                        defer_drop_mut!(item, vm);
-                        let item_key = evaluate_key(item.clone_with_heap(vm), key_fn, key_context, vm)?;
-                        defer_drop_mut!(item_key, vm);
+                while let Some(item) = iter.py_next(vm)? {
+                    defer_drop_mut!(item, vm);
+                    let item_key = evaluate_key(item.clone_with_heap(vm), key_fn, key_context, vm)?;
+                    defer_drop_mut!(item_key, vm);
 
-                        if candidate_wins(result_key, item_key, is_min, vm)? {
-                            mem::swap(result, item);
-                            mem::swap(result_key, item_key);
-                        }
+                    if candidate_wins(result_key, item_key, is_min, vm)? {
+                        mem::swap(result, item);
+                        mem::swap(result_key, item_key);
                     }
                 }
-
-                let result_key = result_key_guard.into_inner();
-                result_key.drop_with(vm);
             }
             Ok(result_guard.into_inner())
         } else {
@@ -142,11 +127,9 @@ fn run_min_max(
         }
     } else {
         // Multiple arguments: compare them directly
-        if default_value.is_some() {
+        if default.is_some() {
             first_arg.drop_with(vm);
-            // `default_value` and `args` are owned by their respective guards
-            // — their Drop impls release the held values when the function
-            // returns.
+            // The deferred drops release `default` and remaining arguments.
             return Err(default_with_multiple_args(func_name));
         }
 
@@ -155,24 +138,18 @@ fn run_min_max(
             {
                 let (result, vm) = result_guard.as_parts_mut();
                 let result_key = evaluate_key(result.clone_with_heap(vm), key_fn, key_context, vm)?;
-                let mut result_key_guard = DropGuard::new(result_key, vm);
-                {
-                    let (result_key, vm) = result_key_guard.as_parts_mut();
+                defer_drop_mut!(result_key, vm);
 
-                    for item in args.drain(..) {
-                        defer_drop_mut!(item, vm);
-                        let item_key = evaluate_key(item.clone_with_heap(vm), key_fn, key_context, vm)?;
-                        defer_drop_mut!(item_key, vm);
+                for item in args.drain(..) {
+                    defer_drop_mut!(item, vm);
+                    let item_key = evaluate_key(item.clone_with_heap(vm), key_fn, key_context, vm)?;
+                    defer_drop_mut!(item_key, vm);
 
-                        if candidate_wins(result_key, item_key, is_min, vm)? {
-                            mem::swap(result, item);
-                            mem::swap(result_key, item_key);
-                        }
+                    if candidate_wins(result_key, item_key, is_min, vm)? {
+                        mem::swap(result, item);
+                        mem::swap(result_key, item_key);
                     }
                 }
-
-                let result_key = result_key_guard.into_inner();
-                result_key.drop_with(vm);
             }
             Ok(result_guard.into_inner())
         } else {

--- a/crates/monty/src/builtins/open.rs
+++ b/crates/monty/src/builtins/open.rs
@@ -17,7 +17,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
-    heap::{DropGuard, HeapData},
+    heap::HeapData,
     types::{PyTrait, file::FileMode},
     value::Value,
 };
@@ -45,8 +45,7 @@ pub(crate) fn builtin_open(vm: &mut VM<'_>, args: ArgValues) -> RunResult<CallRe
 
     // `file` and the unsupported kwargs are raw `Value`s; `mode` holds a
     // borrowed str — all need cleanup on every path.
-    let mut file = DropGuard::new(file, vm);
-    let (file, vm) = file.as_parts_mut();
+    defer_drop!(file, vm);
     defer_drop!(mode, vm);
     defer_drop!(buffering, vm);
     defer_drop!(encoding, vm);

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -19,7 +19,7 @@ use crate::{
         GatherState, TaskId, awaited_state_size,
     },
     bytecode::vm::scheduler::{Scheduler, SerializedTaskFrame, TaskState},
-    defer_drop,
+    defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     heap::{DropGuard, DropWithContext, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput, HeapReader},
     intern::FunctionId,
@@ -835,27 +835,25 @@ impl<'h> VM<'h> {
     ///   `set_state(t, Ready)` before switching, since the exception is
     ///   propagated by the `Err` return rather than the state check.)
     /// - `None` if the terminal task is gone.
-    fn deliver_awaiter_failure(&mut self, mut awaiter: Awaiter, error: RunError) -> Option<TaskId> {
+    fn deliver_awaiter_failure(&mut self, awaiter: Awaiter, error: RunError) -> Option<TaskId> {
+        let this = self;
+        defer_drop_mut!(awaiter, this);
         let target = loop {
-            match awaiter {
-                Awaiter::Task(t) => break t,
+            let next = match awaiter {
+                Awaiter::Task(t) => break *t,
                 Awaiter::GatherSlot { gather, .. } => {
-                    let HeapReadOutput::GatherFuture(mut outer) = self.heap.read(gather) else {
+                    let HeapReadOutput::GatherFuture(mut gather) = this.heap.read(*gather) else {
                         panic!("Awaiter::GatherSlot gather id is not a GatherFuture")
                     };
-                    let next = outer.fail(&mut self.scheduler, self.heap, &error);
-                    drop(outer);
-                    // Release the inc_ref the destructured awaiter owned on
-                    // `gather`; reassign to the next link in the chain.
-                    self.heap.dec_ref(gather);
-                    awaiter = next;
+                    gather.fail(&mut this.scheduler, this.heap, &error)
                 }
-            }
+            };
+            mem::replace(awaiter, next).drop_with(this);
         };
-        if !self.scheduler.has_task(target) {
+        if !this.scheduler.has_task(target) {
             return None;
         }
-        self.scheduler.fail_task(target, error, self.heap);
+        this.scheduler.fail_task(target, error, this.heap);
         Some(target)
     }
 

--- a/crates/monty/src/bytecode/vm/collections.rs
+++ b/crates/monty/src/bytecode/vm/collections.rs
@@ -115,27 +115,28 @@ impl VM<'_> {
                 ExcType::type_error_value_after_star(&type_)
             });
         }
-        let copied_items: Vec<Value> = collect_iterable(iterable, this)?;
 
-        // Check if any copied items are refs (for updating contains_refs)
-        let has_refs = copied_items.iter().any(|v| matches!(v, Value::Ref(_)));
+        {
+            let copied_items: Vec<Value> = collect_iterable(iterable, this)?;
+            defer_drop_mut!(copied_items, this);
 
-        // Check memory limit before growing the list
-        if let Value::Ref(_) = list_ref {
-            this.heap.track_growth(copied_items.len() * VALUE_SIZE)?;
-        }
+            // Check if any copied items are refs (for updating contains_refs)
+            let has_refs = copied_items.iter().any(|v| matches!(v, Value::Ref(_)));
 
-        // Extend the list
-        if let Value::Ref(id) = list_ref {
-            let HeapReadOutput::List(mut list) = this.heap.read(*id) else {
-                panic!("list_extend: expected List on heap");
-            };
-            let list = list.get_mut(this.heap);
-            // Update contains_refs before extending
-            if has_refs {
-                list.set_contains_refs();
+            // Extend the list
+            if let Value::Ref(id) = list_ref {
+                this.heap.track_growth(copied_items.len() * VALUE_SIZE)?;
+
+                let HeapReadOutput::List(mut list) = this.heap.read(*id) else {
+                    panic!("list_extend: expected List on heap");
+                };
+                let list = list.get_mut(this.heap);
+                // Update contains_refs before extending
+                if has_refs {
+                    list.set_contains_refs();
+                }
+                list.as_vec_mut().append(copied_items);
             }
-            list.as_vec_mut().extend(copied_items);
         }
 
         // Push list_ref back on the stack (don't drop it)
@@ -227,39 +228,43 @@ impl VM<'_> {
             return Err(RunError::internal("DictMerge: expected dict ref"));
         };
 
-        for (key, value) in copied_items {
-            // Validate key is a string (InternString or heap-allocated Str)
-            let is_string = match &key {
-                Value::InternString(_) => true,
-                Value::Ref(id) => matches!(this.heap.get(*id), HeapData::Str(_)),
-                _ => false,
-            };
-            if !is_string {
-                key.drop_with(this);
-                value.drop_with(this);
-                return Err(ExcType::type_error_kwargs_nonstring_key());
-            }
-
-            // Get the string key for error messages (needed before moving key into closure)
-            let key_str = match &key {
-                Value::InternString(id) => this.interns.get_str(*id).to_string(),
-                Value::Ref(id) => {
-                    if let HeapData::Str(s) = this.heap.get(*id) {
-                        s.as_str().to_string()
-                    } else {
-                        "<unknown>".to_string()
-                    }
+        {
+            let copied_items = copied_items.into_iter();
+            defer_drop_mut!(copied_items, this);
+            for (key, value) in copied_items {
+                // Validate key is a string (InternString or heap-allocated Str)
+                let is_string = match &key {
+                    Value::InternString(_) => true,
+                    Value::Ref(id) => matches!(this.heap.get(*id), HeapData::Str(_)),
+                    _ => false,
+                };
+                if !is_string {
+                    key.drop_with(this);
+                    value.drop_with(this);
+                    return Err(ExcType::type_error_kwargs_nonstring_key());
                 }
-                _ => "<unknown>".to_string(),
-            };
 
-            let HeapReadOutput::Dict(mut dict) = this.heap.read(dict_id) else {
-                unreachable!("DictMerge: entry is not a Dict")
-            };
+                // Get the string key for error messages (needed before moving key into closure)
+                let key_str = match &key {
+                    Value::InternString(id) => this.interns.get_str(*id).to_string(),
+                    Value::Ref(id) => {
+                        if let HeapData::Str(s) = this.heap.get(*id) {
+                            s.as_str().to_string()
+                        } else {
+                            "<unknown>".to_string()
+                        }
+                    }
+                    _ => "<unknown>".to_string(),
+                };
 
-            if let Some(old_value) = dict.set(key, value, this)? {
-                old_value.drop_with(this);
-                return Err(ExcType::type_error_multiple_values(func_name, &key_str));
+                let HeapReadOutput::Dict(mut dict) = this.heap.read(dict_id) else {
+                    unreachable!("DictMerge: entry is not a Dict")
+                };
+
+                if let Some(old_value) = dict.set(key, value, this)? {
+                    old_value.drop_with(this);
+                    return Err(ExcType::type_error_multiple_values(func_name, &key_str));
+                }
             }
         }
 
@@ -315,6 +320,8 @@ impl VM<'_> {
             unreachable!("DictUpdate: target is always a Ref — compiler invariant")
         };
 
+        let copied_items = copied_items.into_iter();
+        defer_drop_mut!(copied_items, this);
         for (key, value) in copied_items {
             let HeapReadOutput::Dict(mut dict) = this.heap.read(dict_id) else {
                 unreachable!("DictUpdate: heap entry is always a Dict — compiler invariant")
@@ -362,6 +369,8 @@ impl VM<'_> {
             unreachable!("SetExtend: target is always a Ref — compiler invariant")
         };
 
+        let copied_items = copied_items.into_iter();
+        defer_drop_mut!(copied_items, this);
         for item in copied_items {
             let HeapReadOutput::Set(mut set) = this.heap.read(set_id) else {
                 unreachable!("SetExtend: heap entry is always a Set — compiler invariant")
@@ -493,6 +502,7 @@ impl VM<'_> {
         // draining it — CPython stops consuming there too, which is why every
         // other type has no total to report.
         let items = collect_iterable_bounded(value, count + 1, this)?;
+        defer_drop_mut!(items, this);
         if items.len() != count {
             let err = if items.len() > count {
                 match total {
@@ -504,14 +514,11 @@ impl VM<'_> {
                 // length is known whether or not the type could report one.
                 unpack_size_error(count, items.len())
             };
-            for item in items {
-                item.drop_with(this);
-            }
             return Err(err);
         }
 
         // Push items in reverse order so first item is on top
-        for item in items.into_iter().rev() {
+        for item in items.drain(..).rev() {
             this.push(item);
         }
         Ok(())
@@ -538,15 +545,13 @@ impl VM<'_> {
         // Drained in full: a starred target consumes everything, so unlike
         // `unpack_sequence` there is no bound to stop at — and therefore always
         // a true total to report when there are too few values.
-        let items = collect_iterable(value, this)?;
+        let mut items_guard = DropGuard::new(collect_iterable(value, this)?, this);
+        let (items, _) = items_guard.as_parts();
         if items.len() < min_items {
-            let err = unpack_ex_too_few_error(min_items, items.len());
-            for item in items {
-                item.drop_with(this);
-            }
-            return Err(err);
+            return Err(unpack_ex_too_few_error(min_items, items.len()));
         }
 
+        let (items, this) = items_guard.into_parts();
         this.push_unpack_ex_results(items, before, after)
     }
 

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -30,8 +30,9 @@ use crate::{
         code::{Code, LocationEntry},
         op::{Opcode, decode_assert_flags},
     },
+    defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
-    heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapReadOutput, HeapReader},
+    heap::{ContainsHeap, DropWithContext, Heap, HeapData, HeapId, HeapReadOutput, HeapReader},
     heap_data::{CellValue, Closure, FunctionDefaults},
     intern::{FunctionId, Interns, StaticStrings, StringId},
     modules::{StandardLib, json::JsonStringCache, re::RePatternCache},
@@ -2367,8 +2368,8 @@ impl<'h> VM<'h> {
     fn store_cell(&mut self, cached_frame: &CachedFrame<'_>, slot: u16) {
         let value = self.pop();
         // The guard will clean up the new value if we panic, or the old value if we swap
-        let mut guard = DropGuard::new(value, self);
-        let (value, this) = guard.as_parts_mut();
+        let this = self;
+        defer_drop_mut!(value, this);
 
         let cell_id = this.cell_id_from_local(cached_frame, slot);
         let HeapReadOutput::Cell(mut cell) = this.heap.read(cell_id) else {

--- a/crates/monty/src/bytecode/vm/scheduler.rs
+++ b/crates/monty/src/bytecode/vm/scheduler.rs
@@ -97,12 +97,8 @@ pub(crate) struct Task {
 
 impl<C: ContainsHeap> DropWithContext<C> for Task {
     fn drop_with(mut self, heap: &mut C) {
-        for value in self.stack.drain(..) {
-            value.drop_with(heap);
-        }
-        for value in self.exception_stack.drain(..) {
-            value.drop_with(heap);
-        }
+        self.stack.drain(..).drop_with(heap);
+        self.exception_stack.drain(..).drop_with(heap);
         self.state.drop_with(heap);
         if let Some(coro_id) = self.coroutine_id.take() {
             heap.heap_mut().dec_ref(coro_id);

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -39,6 +39,10 @@ mod stable_heap;
 use stable_heap::StableHeap;
 
 /// Unique identifier for values stored inside the heap arena.
+///
+/// The ID does not encode ownership. Local IDs should normally be borrowed or
+/// wrapped immediately in `Value::Ref`; owned fields must document and release
+/// their reference through `HeapItem` or `DropWithContext` cleanup.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct HeapId(usize);
 
@@ -1049,6 +1053,12 @@ impl Heap {
     }
 
     /// Decrements the reference count and frees the value (plus children) once it hits zero.
+    ///
+    /// This is the low-level release operation for an owned raw `HeapId`. Ordinary
+    /// control flow should instead keep local ownership in `Value::Ref` and use
+    /// `defer_drop!` or `DropGuard`. Heap-stored owners declare child references in
+    /// `HeapItem::py_dec_ref_ids`; direct calls are appropriate in cleanup for other
+    /// structures that own raw IDs.
     ///
     /// Uses an iterative work stack instead of recursion to avoid Rust stack overflow
     /// when freeing deeply nested containers (e.g., a list nested 10,000 levels deep).

--- a/crates/monty/src/heap_traits.rs
+++ b/crates/monty/src/heap_traits.rs
@@ -40,14 +40,15 @@ pub(crate) trait HeapItem {
     /// separately when they are allocated.
     fn py_estimate_size(&self) -> usize;
 
-    /// Pushes any contained `HeapId`s onto the stack for reference counting.
+    /// Pushes every owned heap reference onto the iterative cleanup stack.
     ///
-    /// This is called during `dec_ref` to find nested heap references that
-    /// need their refcounts decremented when this value is freed.
+    /// Owned `HeapId` fields are valid in a `HeapItem`, but each must be documented
+    /// as owned and pushed exactly once here. Prefer this to calling `Heap::dec_ref`
+    /// directly; values containing references should delegate to their own
+    /// `py_dec_ref_ids` implementation.
     ///
-    /// When the `memory-model-checks` feature is enabled, this method also marks all
-    /// contained `Value`s as `Dereferenced` to prevent Drop panics. This
-    /// co-locates the cleanup logic with the reference collection logic.
+    /// With `memory-model-checks`, delegation also marks contained `Value`s as
+    /// `Dereferenced`, keeping that cleanup co-located with reference collection.
     fn py_dec_ref_ids(&mut self, stack: &mut Vec<HeapId>);
 }
 
@@ -85,6 +86,9 @@ impl ContainsHeap for Heap {
 /// cleanup automatically rather than inserting manual calls in every branch.
 pub(crate) trait DropWithContext<C: ?Sized> {
     /// Consume `self`, releasing every heap/VM reference it owns through `ctx`.
+    ///
+    /// Implementations owning raw `HeapId`s may call `Heap::dec_ref` here. Callers
+    /// should prefer a guard unless this is a simple, linear cleanup path.
     fn drop_with(self, ctx: &mut C);
 }
 

--- a/crates/monty/src/modules/asyncio.rs
+++ b/crates/monty/src/modules/asyncio.rs
@@ -103,42 +103,27 @@ pub(crate) fn gather(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let GatherArgs { awaitables } = GatherArgs::from_args(args, vm)?;
     defer_drop_mut!(awaitables, vm);
 
-    // Validate all positional args are awaitable and collect their heap ids.
-    // Both coroutines and external futures live on the heap; transfer
-    // ownership of each arg's HeapId into `items` and forget the `Value` so
-    // its `Drop` doesn't dec_ref the entry we just handed to the gather.
-    let mut items: Vec<HeapId> = Vec::new();
-
-    #[cfg_attr(not(feature = "memory-model-checks"), expect(unused_mut))]
-    for mut arg in awaitables.drain(..) {
-        let id = match &arg {
+    // Validate every argument before transferring any references to the gather,
+    // so an invalid later argument needs no raw-HeapId rollback.
+    for arg in awaitables.iter() {
+        if !matches!(
+            arg,
             Value::Ref(id)
                 if matches!(
                     vm.heap.get(*id),
                     HeapData::Coroutine(_) | HeapData::ExternalFuture(_) | HeapData::GatherFuture(_)
-                ) =>
-            {
-                Some(*id)
-            }
-            _ => None,
-        };
-
-        if let Some(id) = id {
-            items.push(id);
-            // Transfer ownership of the heap ref to the gather.
-            #[cfg(feature = "memory-model-checks")]
-            arg.dec_ref_forget();
-        } else {
-            arg.drop_with(vm.heap);
-            for id in items {
-                vm.heap.dec_ref(id);
-            }
+                )
+        ) {
             return Err(ExcType::type_error(
                 "An asyncio.Future, a coroutine or an awaitable is required",
             ));
         }
     }
 
+    let items = awaitables
+        .drain(..)
+        .map(|arg| arg.into_ref_id().expect("validated gather awaitable is heap-backed"))
+        .collect();
     let gather_future = GatherFuture::new(items);
     let id = vm.heap.allocate(HeapData::GatherFuture(gather_future))?;
     Ok(Value::Ref(id))

--- a/crates/monty/src/modules/json/dump.rs
+++ b/crates/monty/src/modules/json/dump.rs
@@ -13,7 +13,7 @@ use crate::{
     bytecode::{ContainsVM, VM},
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunResult},
-    heap::{ContainsHeap, DropGuard, Heap, HeapData, HeapId, HeapRead, HeapReadOutput},
+    heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapRead, HeapReadOutput},
     sorting::{apply_permutation, sort_indices},
     types::{Dict, PyTrait, long_int::check_bigint_str_digits_limit, str::allocate_string},
     value::Value,
@@ -142,22 +142,16 @@ pub(super) fn call_dumps(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let macro_args = JsonDumpsArgs::from_args(args, vm)?;
     let (obj, config) = JsonDumpsConfig::from_macro_args(macro_args, vm)?;
 
-    let mut obj_guard = DropGuard::new(obj, vm);
+    defer_drop!(obj, vm);
     let mut output = String::new();
     let mut active_containers = Vec::new();
-    {
-        let (obj, vm) = obj_guard.as_parts_mut();
-        let mut encoder = Encoder {
-            out: &mut output,
-            config: &config,
-            active_containers: &mut active_containers,
-            vm,
-        };
-        encoder.serialize_value(obj, 0)?;
-    }
-
-    let (obj, vm) = obj_guard.into_parts();
-    obj.drop_with(vm);
+    let mut encoder = Encoder {
+        out: &mut output,
+        config: &config,
+        active_containers: &mut active_containers,
+        vm,
+    };
+    encoder.serialize_value(obj, 0)?;
     Ok(allocate_string(output, vm.heap)?)
 }
 
@@ -207,8 +201,7 @@ fn apply_bool_flag(flags: u8, bit: u8, value: Value, vm: &mut VM<'_>) -> u8 {
 /// only pretty printing), and
 /// strings are repeated once per depth level exactly like CPython.
 fn parse_indent_value(value: Value, vm: &mut VM<'_>) -> RunResult<Option<String>> {
-    let mut value_guard = DropGuard::new(value, vm);
-    let (value, vm) = value_guard.as_parts_mut();
+    defer_drop!(value, vm);
 
     match value {
         Value::None => Ok(None),
@@ -246,8 +239,7 @@ fn spaces_from_indent_count(count: i64) -> RunResult<Option<String>> {
 /// `None` leaves the default separators intact. Otherwise the value must be a
 /// two-item list or tuple of strings representing the item and key separators.
 fn parse_separators_value(value: Value, vm: &mut VM<'_>) -> RunResult<Option<(String, String)>> {
-    let mut value_guard = DropGuard::new(value, vm);
-    let (value, vm) = value_guard.as_parts_mut();
+    defer_drop!(value, vm);
 
     if matches!(value, Value::None) {
         return Ok(None);
@@ -597,20 +589,15 @@ impl<'h> Encoder<'_, 'h> {
 fn sort_dict_entries(entries: &mut Vec<(Value, Value)>, vm: &mut VM<'_>) -> RunResult<()> {
     let mut indices: Vec<usize> = (0..entries.len()).collect();
     let compare_values: Vec<Value> = entries.iter().map(|(key, _)| key.clone_with_heap(vm)).collect();
-    let mut compare_values_guard = DropGuard::new(compare_values, vm);
-    let (compare_values, vm) = compare_values_guard.as_parts_mut();
+    defer_drop!(compare_values, vm);
     sort_indices(&mut indices, compare_values.as_slice(), false, vm)?;
     apply_permutation(entries.as_mut_slice(), &mut indices);
     Ok(())
 }
 
 /// Removes dict entries whose keys are not JSON-serializable, preserving order.
-///
-/// `skipkeys=True` must drop invalid entries without disturbing the relative
-/// order of the retained pairs. A two-pointer compaction avoids the repeated
-/// shifting cost of `Vec::remove(i)` while still cleaning up skipped `Value`
-/// references with `drop_with`.
 fn skip_disallowed_dict_keys(entries: &mut Vec<(Value, Value)>, vm: &mut VM<'_>) {
+    // Use two pointers to preserve relative order
     let mut write = 0;
     for read in 0..entries.len() {
         if is_json_key_allowed(&entries[read].0, vm) {
@@ -621,10 +608,8 @@ fn skip_disallowed_dict_keys(entries: &mut Vec<(Value, Value)>, vm: &mut VM<'_>)
         }
     }
 
-    for (key, value) in entries.drain(write..) {
-        key.drop_with(vm);
-        value.drop_with(vm);
-    }
+    // Drain the disallowed entries
+    entries.drain(write..).drop_with(vm);
 }
 
 /// Returns whether a value is an allowed JSON object key type.

--- a/crates/monty/src/modules/json/load.rs
+++ b/crates/monty/src/modules/json/load.rs
@@ -12,6 +12,7 @@ use super::JsonStringCache;
 use crate::{
     args::{ArgValues, FromArgs},
     bytecode::VM,
+    defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
     heap::{ContainsHeap, DropGuard, HeapData, HeapReader},
     types::{
@@ -71,9 +72,8 @@ const JSON_RECURSION_LIMIT: usize = 200;
 /// and will raise `TypeError` if passed.
 pub(super) fn call_loads(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     let JsonLoadsArgs { s } = JsonLoadsArgs::from_args(args, vm)?;
-    let mut data_guard = DropGuard::new(s, vm);
-    let (data, vm) = data_guard.as_parts_mut();
-    parse_json_input(data, vm)
+    defer_drop_mut!(s, vm);
+    parse_json_input(s, vm)
 }
 
 /// Argument shape for `json.loads(s)`.

--- a/crates/monty/src/modules/re.rs
+++ b/crates/monty/src/modules/re.rs
@@ -277,7 +277,9 @@ fn call_findall(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     defer_drop!(string, vm);
     let resolved = resolve_pattern(pattern, flags, vm)?;
     defer_drop!(resolved, vm);
-    resolved.get(vm.heap).findall(subject_str(string, vm)?, vm.heap)
+    let findall = resolved.get(vm.heap).prepare_findall();
+    let text = subject_str(string, vm)?.to_owned();
+    findall.run(&text, vm)
 }
 
 /// `re.sub(pattern, repl, string, count=0, flags=0)` — substitute matches with a replacement.

--- a/crates/monty/src/modules/re.rs
+++ b/crates/monty/src/modules/re.rs
@@ -277,9 +277,7 @@ fn call_findall(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     defer_drop!(string, vm);
     let resolved = resolve_pattern(pattern, flags, vm)?;
     defer_drop!(resolved, vm);
-    let findall = resolved.get(vm.heap).prepare_findall();
-    let text = subject_str(string, vm)?.to_owned();
-    findall.run(&text, vm)
+    resolved.get(vm.heap).findall(subject_str(string, vm)?, vm.heap)
 }
 
 /// `re.sub(pattern, repl, string, count=0, flags=0)` — substitute matches with a replacement.

--- a/crates/monty/src/modules/unicodedata.rs
+++ b/crates/monty/src/modules/unicodedata.rs
@@ -33,7 +33,7 @@ use crate::{
     bytecode::VM,
     defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
-    heap::{Heap, HeapData, HeapId},
+    heap::{DropGuard, Heap, HeapData, HeapId},
     intern::StaticStrings,
     modules::ModuleFunctions,
     string_builder::StringBuilder,
@@ -123,28 +123,14 @@ fn uni_name(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
         default: default_val,
     } = NameArgs::from_args(args, vm)?;
     defer_drop!(chr_val, vm);
-
-    // `default_val` is not covered by `defer_drop!` (it's an `Option` we may
-    // return by value), so drop it explicitly on every path that doesn't.
-    let c = match single_char(chr_val, "name", Some(1), vm) {
-        Ok(c) => c,
-        Err(e) => {
-            if let Some(d) = default_val {
-                d.drop_with(vm);
-            }
-            return Err(e);
-        }
-    };
+    let mut default_guard = DropGuard::new(default_val, vm);
+    let vm = default_guard.ctx();
+    let c = single_char(chr_val, "name", Some(1), vm)?;
 
     match unicode_names2::name(c) {
-        Some(name) => {
-            if let Some(d) = default_val {
-                d.drop_with(vm);
-            }
-            Ok(allocate_string(name.to_string(), vm.heap)?)
-        }
-        None => match default_val {
-            Some(d) => Ok(d),
+        Some(name) => Ok(allocate_string(name.to_string(), vm.heap)?),
+        None => match default_guard.into_inner() {
+            Some(default) => Ok(default),
             None => Err(SimpleException::new_msg(ExcType::ValueError, "no such name").into()),
         },
     }

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -523,9 +523,7 @@ impl Executor {
                 .map_err(|e| e.into_python_exception(&executor.interns, |_| Some(executor.code.as_str())))?;
 
             // Drop globals with proper ref counting
-            for value in globals {
-                value.drop_with(vm.heap);
-            }
+            globals.drop_with(vm.heap);
 
             let allocations_since_gc = vm.heap.get_allocations_since_gc();
 

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -126,17 +126,14 @@ impl<'h> HeapRead<'h, Dataclass> {
     /// Returns `FrozenInstanceError` if the dataclass is frozen.
     pub fn set_attr(&mut self, name: Value, value: Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         if self.get(vm.heap).frozen {
-            // Build the error message from the field name's repr (a heap `str`
-            // `Value`), dropping that temporary before dropping our own args.
+            defer_drop!(name, vm);
+            value.drop_with(vm);
             let name_repr = name.py_repr(vm)?;
             defer_drop!(name_repr, vm);
             let exc = SimpleException::new_msg(
                 ExcType::FrozenInstanceError,
                 format!("cannot assign to field {}", name_repr.to_str(vm)?),
             );
-            // Drop the values we were given ownership of
-            name.drop_with(vm);
-            value.drop_with(vm);
             return Err(exc.into());
         }
         self.attrs_mut().set(name, value, vm)

--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -440,10 +440,8 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictItemsView> {
         let Some((key, value)) = cloned_items_view_candidate(item, vm) else {
             return Ok(Some(false));
         };
-        let mut key_guard = DropGuard::new(key, vm);
-        let (key, vm) = key_guard.as_parts_mut();
-        let mut value_guard = DropGuard::new(value, vm);
-        let (value, vm) = value_guard.as_parts_mut();
+        defer_drop!(key, vm);
+        defer_drop!(value, vm);
         let HeapReadOutput::Dict(dict) = vm.heap.read(dict_id) else {
             panic!("dict_items view must reference a dict");
         };
@@ -843,8 +841,7 @@ fn apply_dict_view_sub(lhs: &Set, rhs: &Set, vm: &mut VM<'_>) -> RunResult<Set> 
 /// including one-shot iterator objects. Reusing the same collection path keeps
 /// binary operators and `isdisjoint(...)` consistent with each other.
 pub(crate) fn collect_iterable_to_set(value: Value, vm: &mut VM<'_>) -> Result<Set, RunError> {
-    let mut value_guard = DropGuard::new(value, vm);
-    let (value, vm) = value_guard.as_parts();
+    defer_drop!(value, vm);
     let iter = value.py_iter(vm)?;
     defer_drop!(iter, vm);
     let mut iter = iter.read(vm);

--- a/crates/monty/src/types/file.rs
+++ b/crates/monty/src/types/file.rs
@@ -74,6 +74,7 @@ use super::{
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, VM},
+    defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     heap::{DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
@@ -532,7 +533,7 @@ impl<'h> HeapRead<'h, OpenFile> {
         };
 
         if buffer_loaded {
-            return compute_slice(self_id, spec, vm).map(CallResult::Value);
+            return compute_slice(self, spec, vm).map(CallResult::Value);
         }
 
         // First buffered op: stash spec, yield to host for the full content.
@@ -560,20 +561,14 @@ impl<'h> HeapRead<'h, OpenFile> {
     /// itself, delivered to the host as a `MontyObject::FileHandle`.
     fn write(&mut self, self_id: HeapId, vm: &mut VM<'h>, args: ArgValues) -> RunResult<CallResult> {
         let data = args.get_one_arg("write", vm.heap)?;
+        defer_drop!(data, vm);
         let binary = self.get(vm.heap).mode.is_binary();
-        if let Err(err) = validate_write_data(&data, binary, vm) {
-            data.drop_with(vm);
-            return Err(err);
-        }
-        if let Err(err) = self.get(vm.heap).ensure_open() {
-            data.drop_with(vm);
-            return Err(err);
-        }
+        validate_write_data(data, binary, vm)?;
+        self.get(vm.heap).ensure_open()?;
         let (path, append, binary) = {
             let file = self.get(vm.heap);
             if !file.mode.writable() {
                 let message = if file.mode.is_binary() { "write" } else { "not writable" };
-                data.drop_with(vm);
                 return Err(unsupported_operation(message));
             }
             // `first_write_done` is flipped in `apply_write_position`, only once
@@ -591,8 +586,7 @@ impl<'h> HeapRead<'h, OpenFile> {
         // bytes vs str.
         let path = MontyPath::new(path);
         let call = if binary {
-            let bytes = extract_bytes_payload(&data, vm).expect("validate_write_data accepted a bytes-shaped value");
-            data.drop_with(vm);
+            let bytes = extract_bytes_payload(data, vm).expect("validate_write_data accepted a bytes-shaped value");
             let args = PathBytesDataArgs { path, data: bytes };
             if append {
                 OsFunctionCall::AppendBytes(args)
@@ -600,8 +594,7 @@ impl<'h> HeapRead<'h, OpenFile> {
                 OsFunctionCall::WriteBytes(args)
             }
         } else {
-            let text = extract_str_payload(&data, vm).expect("validate_write_data accepted a str-shaped value");
-            data.drop_with(vm);
+            let text = extract_str_payload(data, vm).expect("validate_write_data accepted a str-shaped value");
             let args = PathStringDataArgs { path, data: text };
             if append {
                 OsFunctionCall::AppendText(args)
@@ -727,60 +720,6 @@ fn inc_ref_for_pending_oscall(vm: &VM<'_>, file_id: HeapId) {
     vm.heap.inc_ref(file_id);
 }
 
-/// Materialises the host-returned `result` into a heap-resident `HeapId`
-/// suitable for the file's `buffer` slot.
-///
-/// The `OsFunction::ReadText` / `ReadBytes` host boundary returns one of
-/// `MontyObject::String` / `MontyObject::Bytes`, which `to_value` may turn
-/// into an interned `Value::InternString` / `Value::InternBytes` (notably
-/// for empty strings or single-char ASCII) instead of a `Value::Ref`. The
-/// file's `buffer` slot is `Option<HeapId>` and slicing assumes a
-/// heap-resident `Str` / `Bytes`, so interned variants are reallocated
-/// onto the heap here.
-///
-/// `result` is fully consumed: every path runs `drop_with` exactly
-/// once. The two `Value::Ref`-producing arms `inc_ref` the entry they
-/// hand back so the upcoming `drop_with`'s dec_ref balances out and
-/// the returned `HeapId` keeps the refcount it would have had without
-/// the dance. This avoids `mem::forget`, which clippy flags on the
-/// no-Drop release configuration.
-fn os_read_result_to_heap_id(result: Value, vm: &mut VM<'_>) -> RunResult<HeapId> {
-    // Match by reference: `Value` has a Drop impl under `memory-model-checks`,
-    // so we cannot destructure variants by move.
-    let id = match &result {
-        Value::Ref(id) => {
-            vm.heap.inc_ref(*id);
-            *id
-        }
-        Value::InternString(string_id) => {
-            let s = vm.interns.get_str(*string_id).to_owned();
-            // `allocate_string_no_interning` returns `Value::Ref` with
-            // refcount 1; inc_ref+drop_with below nets to zero and
-            // lets us drop the temporary Value cleanly.
-            let v = allocate_string_no_interning(s, vm.heap)?;
-            let Value::Ref(new_id) = &v else {
-                unreachable!("allocate_string_no_interning returns Value::Ref");
-            };
-            let new_id = *new_id;
-            vm.heap.inc_ref(new_id);
-            v.drop_with(vm);
-            new_id
-        }
-        Value::InternBytes(bytes_id) => {
-            let b = vm.interns.get_bytes(*bytes_id).to_vec();
-            vm.heap.allocate(HeapData::Bytes(Bytes::new(b)))?
-        }
-        _ => {
-            result.drop_with(vm);
-            return Err(RunError::internal(
-                "os_read_result_to_heap_id: OS result must be a string or bytes value",
-            ));
-        }
-    };
-    result.drop_with(vm);
-    Ok(id)
-}
-
 /// Stores the OS-returned full-file content into an [`OpenFile`]'s buffer and
 /// computes the slice that the originating call (`read(N)` / `readline()` /
 /// `readlines()` / `seek()`) should return.
@@ -797,76 +736,72 @@ fn os_read_result_to_heap_id(result: Value, vm: &mut VM<'_>) -> RunResult<HeapId
 ///   panic, so a host can recover.
 ///
 /// The file owns one inc_ref on `result` for its `buffer` slot. The caller's
-/// inc_ref on `file_id` (held by the in-flight OS call) is released here
-/// via the RAII [`DropGuard`] on `Value::Ref(file_id)`, so every error path
-/// drops the pin without explicit `dec_ref` boilerplate.
+/// inc_ref on `file_id` (held by the in-flight OS call) is released here.
 ///
 /// **Error handling**: `pending_read` is taken up-front so every subsequent
 /// error path leaves the file in a retry-safe state — a user-caught
 /// exception followed by a retry sees no stale slice spec.
 pub(crate) fn apply_buffer_store(file_id: HeapId, result: Value, vm: &mut VM<'_>) -> RunResult<Value> {
-    // The pin's dec_ref happens automatically on every path via the guard's
-    // Drop, so the early-return branches do not need explicit `dec_ref`s.
-    let mut pin = DropGuard::new(Value::Ref(file_id), vm);
+    // Ensure `file_id` is dec_ref'd on every path at end of this function.
+    let file = Value::Ref(file_id);
+    defer_drop!(file, vm);
 
-    // Stage 1: drain `pending_read` from the file. `result_guard` keeps the
-    // host-returned value alive across early-return branches; on the success
-    // path we hand ownership back via `into_inner`.
-    let (result, spec) = {
-        let (_, vm) = pin.as_parts_mut();
-        let mut result_guard = DropGuard::new(result, vm);
-        let (_, vm) = result_guard.as_parts_mut();
-
-        let HeapReadOutput::OpenFile(mut file) = vm.heap.read(file_id) else {
-            return Err(RunError::internal(
-                "apply_buffer_store: file_id does not point to an OpenFile",
-            ));
-        };
-        let spec = file.get_mut(vm.heap).pending_read.take();
-        drop(file);
-        let Some(spec) = spec else {
-            return Err(RunError::internal("apply_buffer_store: OpenFile has no pending_read"));
-        };
-        (result_guard.into_inner(), spec)
+    let HeapReadOutput::OpenFile(mut file) = vm.heap.read(file_id) else {
+        return Err(RunError::internal(
+            "apply_buffer_store: file_id does not point to an OpenFile",
+        ));
     };
 
-    // Stage 2: materialise the host result onto the heap. `result_guard` is
-    // no longer needed — the refcount now lives on `result_id`.
-    let (_, vm) = pin.as_parts_mut();
-    let result_id = os_read_result_to_heap_id(result, vm)?;
+    let mut result_guard = DropGuard::new(result, vm);
+    let (result, vm) = result_guard.as_parts_mut();
+
+    // Stage 1: drain `pending_read` from the file.
+    let Some(spec) = file.get_mut(vm.heap).pending_read.take() else {
+        return Err(RunError::internal("apply_buffer_store: OpenFile has no pending_read"));
+    };
+
+    // Stage 2: materialise the host result as an owned heap value.
+    match result {
+        Value::Ref(_) => {}
+        // promote interned strings to heap-resident Str
+        &mut Value::InternString(string_id) => {
+            let s = vm.interns.get_str(string_id).to_owned();
+            *result = allocate_string_no_interning(s, vm.heap)?;
+        }
+        // promote interned bytes to heap-resident Bytes
+        &mut Value::InternBytes(bytes_id) => {
+            let b = vm.interns.get_bytes(bytes_id).to_vec();
+            *result = Value::Ref(vm.heap.allocate(HeapData::Bytes(Bytes::new(b)))?);
+        }
+        _ => {
+            return Err(RunError::internal(
+                "apply_buffer_store: OS result must be a string or bytes value",
+            ));
+        }
+    }
 
     // Stage 3: install the buffer. Defensive: if it was already populated
-    // (e.g. a snapshot/restore race), drop the new content and slice from
-    // the existing one instead of stomping it.
-    let dec_result = {
-        let HeapReadOutput::OpenFile(mut file) = vm.heap.read(file_id) else {
-            vm.heap.dec_ref(result_id);
-            return Err(RunError::internal(
-                "apply_buffer_store: file_id does not point to an OpenFile",
-            ));
-        };
-        let f = file.get_mut(vm.heap);
-        if f.buffer.is_some() {
-            true
-        } else {
-            f.buffer = Some(result_id);
-            false
-        }
-    };
-    if dec_result {
-        vm.heap.dec_ref(result_id);
+    // (e.g. a snapshot/restore race), the guard drops the new content and we
+    // slice from the existing one instead of stomping it.
+    let (result, vm) = result_guard.into_parts();
+    let f = file.get_mut(vm.heap);
+    if f.buffer.is_none() {
+        let result_id = result
+            .into_ref_id()
+            .expect("OS read result was materialised on the heap");
+        f.buffer = Some(result_id);
+    } else {
+        result.drop_with(vm);
     }
 
     // Populate the cached buffer metadata so the upcoming `compute_slice`
     // call (and every later read) starts from a known byte position and
     // buffer length without re-scanning the buffer from char 0.
-    populate_buffer_meta(file_id, vm)?;
+    populate_buffer_meta(&mut file, vm)?;
 
-    // Compute the slice while the pin guard still keeps the file alive —
-    // otherwise `open(p).read(5)` (where no caller holds a separate
-    // reference) would risk a use-after-free if the pin's dec_ref ran first.
-    compute_slice(file_id, spec, vm)
-    // `pin` drops here, releasing the pending-file-effect refcount.
+    // Compute the slice while the guard still keeps the file alive — otherwise
+    // `open(p).read(5)` could release its last reference before slicing.
+    compute_slice(&mut file, spec, vm)
 }
 
 /// Applies a successful host write result to an [`OpenFile`]'s logical
@@ -877,11 +812,10 @@ pub(crate) fn apply_buffer_store(file_id: HeapId, result: Value, vm: &mut VM<'_>
 /// values returned by Monty's filesystem backends and CPython's `write()`.
 ///
 /// As with [`apply_buffer_store`], the pending-file-effect pin on `file_id`
-/// is released via the RAII [`DropGuard`] regardless of which path the
-/// function takes.
+/// is released by `defer_drop!` regardless of which path the function takes.
 pub(crate) fn apply_write_position(file_id: HeapId, result: Value, vm: &mut VM<'_>) -> RunResult<Value> {
-    let mut pin = DropGuard::new(Value::Ref(file_id), vm);
-    let (_, vm) = pin.as_parts_mut();
+    let pin = Value::Ref(file_id);
+    defer_drop!(pin, vm);
     let mut result_guard = DropGuard::new(result, vm);
     let (result_ref, vm) = result_guard.as_parts_mut();
 
@@ -923,26 +857,20 @@ pub(crate) fn apply_write_position(file_id: HeapId, result: Value, vm: &mut VM<'
 /// that's being returned, and allocates a fresh `Str`/`Bytes`/`List` for the
 /// result. All buffer reads go through the heap so the slice content is fully
 /// snapshot-safe.
-fn compute_slice(file_id: HeapId, spec: ReadSpec, vm: &mut VM<'_>) -> RunResult<Value> {
+fn compute_slice<'h>(file: &mut HeapRead<'h, OpenFile>, spec: ReadSpec, vm: &mut VM<'h>) -> RunResult<Value> {
     // Defensive: if `buffer` is loaded but `buffer_meta` is missing (e.g. a
     // restored snapshot from an older schema, or a future code path that
     // sets `buffer` directly), reconstruct the cache before slicing instead
     // of raising an internal error.
     let needs_meta = {
-        let HeapReadOutput::OpenFile(file) = vm.heap.read(file_id) else {
-            return Err(RunError::internal("compute_slice: not an OpenFile"));
-        };
         let f = file.get(vm.heap);
         f.buffer.is_some() && f.buffer_meta.is_none()
     };
     if needs_meta {
-        populate_buffer_meta(file_id, vm)?;
+        populate_buffer_meta(file, vm)?;
     }
 
     let (binary, buffer_id, position, byte_position, buffer_total) = {
-        let HeapReadOutput::OpenFile(file) = vm.heap.read(file_id) else {
-            return Err(RunError::internal("compute_slice: not an OpenFile"));
-        };
         let f = file.get(vm.heap);
         let buffer = f
             .buffer
@@ -957,9 +885,9 @@ fn compute_slice(file_id: HeapId, spec: ReadSpec, vm: &mut VM<'_>) -> RunResult<
     };
 
     if binary {
-        compute_slice_binary(file_id, buffer_id, position, buffer_total, spec, vm)
+        compute_slice_binary(file, buffer_id, position, buffer_total, spec, vm)
     } else {
-        compute_slice_text(file_id, buffer_id, position, byte_position, buffer_total, spec, vm)
+        compute_slice_text(file, buffer_id, position, byte_position, buffer_total, spec, vm)
     }
 }
 
@@ -976,14 +904,14 @@ fn compute_slice(file_id: HeapId, spec: ReadSpec, vm: &mut VM<'_>) -> RunResult<
 /// that borrow is still live; `Heap::allocate` is `&self` and the paged
 /// storage guarantees existing references stay valid across allocations, so
 /// the previous full-buffer `to_owned()` is gone.
-fn compute_slice_text(
-    file_id: HeapId,
+fn compute_slice_text<'h>(
+    file: &mut HeapRead<'h, OpenFile>,
     buffer_id: HeapId,
     position: usize,
     byte_position: usize,
     buffer_total: usize,
     spec: ReadSpec,
-    vm: &mut VM<'_>,
+    vm: &mut VM<'h>,
 ) -> RunResult<Value> {
     // Phase 1: read the buffer through an immutable heap borrow, compute the
     // slice, and allocate the result. `update_file_state` needs `&mut Heap`,
@@ -1065,7 +993,7 @@ fn compute_slice_text(
         }
     };
 
-    update_file_state(file_id, new_position, new_byte_position, eof, vm)?;
+    update_file_state(file, new_position, new_byte_position, eof, vm);
     Ok(value)
 }
 
@@ -1076,13 +1004,13 @@ fn compute_slice_text(
 /// returned slice is the only bytes that get cloned (previously the *entire*
 /// buffer was cloned on every call so the heap borrow could be released
 /// before `update_position_eof`).
-fn compute_slice_binary(
-    file_id: HeapId,
+fn compute_slice_binary<'h>(
+    file: &mut HeapRead<'h, OpenFile>,
     buffer_id: HeapId,
     position: usize,
     buffer_total: usize,
     spec: ReadSpec,
-    vm: &mut VM<'_>,
+    vm: &mut VM<'h>,
 ) -> RunResult<Value> {
     // `seek()` allows positioning past EOF; clamp here so the slice index
     // operations below never panic when `position > len`. The cap is per-call
@@ -1156,7 +1084,7 @@ fn compute_slice_binary(
 
     // Binary mode keeps `byte_position == min(position, buffer.len())` so
     // the cache stays consistent with the text-mode invariant.
-    update_file_state(file_id, new_position, new_position.min(buffer_total), eof, vm)?;
+    update_file_state(file, new_position, new_position.min(buffer_total), eof, vm);
     Ok(value)
 }
 
@@ -1215,24 +1143,19 @@ fn nth_char_byte_offset(s: &str, nth: usize) -> usize {
 /// borrow. All three values are `usize` for caller convenience; the widening
 /// to `u64` happens here at the single boundary so the slice code stays free
 /// of `as u64` casts that clippy would flag.
-fn update_file_state(
-    file_id: HeapId,
+fn update_file_state<'h>(
+    file: &mut HeapRead<'h, OpenFile>,
     new_position: usize,
     new_byte_position: usize,
     eof: bool,
-    vm: &mut VM<'_>,
-) -> RunResult<()> {
+    vm: &mut VM<'h>,
+) {
     // `usize > u64` is impossible on every platform we support, but
     // surfacing the conversion as an `expect` (rather than `as u64`) keeps
     // the assumption explicit and would survive a hypothetical wider-than-u64
     // target without silently truncating.
     let new_position = u64::try_from(new_position).expect("usize fits in u64");
     let new_byte_position = u64::try_from(new_byte_position).expect("usize fits in u64");
-    let HeapReadOutput::OpenFile(mut file) = vm.heap.read(file_id) else {
-        return Err(RunError::internal(
-            "update_file_state: file_id does not point to an OpenFile",
-        ));
-    };
     let f = file.get_mut(vm.heap);
     f.position = new_position;
     f.eof = eof;
@@ -1246,7 +1169,6 @@ fn update_file_state(
         buffer_total,
     });
     f.file_length = buffer_total;
-    Ok(())
 }
 
 /// Populates [`OpenFile::buffer_meta`] from the just-loaded buffer.
@@ -1257,16 +1179,9 @@ fn update_file_state(
 /// values derived from `buffer.len()` and `position`. The walk is O(buffer)
 /// for text but happens exactly once per file (the cache is then maintained
 /// incrementally by [`update_file_state`]).
-fn populate_buffer_meta(file_id: HeapId, vm: &mut VM<'_>) -> RunResult<()> {
-    // Pull what we need out of the file under a short scoped borrow so we
-    // can call `heap.get(buffer_id)` and `file.get_mut` separately without
-    // overlapping borrows.
+fn populate_buffer_meta<'h>(file: &mut HeapRead<'h, OpenFile>, vm: &mut VM<'h>) -> RunResult<()> {
+    // Pull what we need out of the file under a short scoped borrow
     let (buffer_id, position, binary, already_populated) = {
-        let HeapReadOutput::OpenFile(file) = vm.heap.read(file_id) else {
-            return Err(RunError::internal(
-                "populate_buffer_meta: file_id does not point to an OpenFile",
-            ));
-        };
         let f = file.get(vm.heap);
         let Some(buffer_id) = f.buffer else {
             return Err(RunError::internal("populate_buffer_meta: buffer must be loaded"));
@@ -1304,11 +1219,6 @@ fn populate_buffer_meta(file_id: HeapId, vm: &mut VM<'_>) -> RunResult<()> {
         }
     };
 
-    let HeapReadOutput::OpenFile(mut file) = vm.heap.read(file_id) else {
-        return Err(RunError::internal(
-            "populate_buffer_meta: file_id does not point to an OpenFile",
-        ));
-    };
     file.get_mut(vm.heap).buffer_meta = Some(meta);
     Ok(())
 }

--- a/crates/monty/src/types/file.rs
+++ b/crates/monty/src/types/file.rs
@@ -746,14 +746,14 @@ pub(crate) fn apply_buffer_store(file_id: HeapId, result: Value, vm: &mut VM<'_>
     let file = Value::Ref(file_id);
     defer_drop!(file, vm);
 
+    let mut result_guard = DropGuard::new(result, vm);
+    let (result, vm) = result_guard.as_parts_mut();
+
     let HeapReadOutput::OpenFile(mut file) = vm.heap.read(file_id) else {
         return Err(RunError::internal(
             "apply_buffer_store: file_id does not point to an OpenFile",
         ));
     };
-
-    let mut result_guard = DropGuard::new(result, vm);
-    let (result, vm) = result_guard.as_parts_mut();
 
     // Stage 1: drain `pending_read` from the file.
     let Some(spec) = file.get_mut(vm.heap).pending_read.take() else {

--- a/crates/monty/src/types/iter.rs
+++ b/crates/monty/src/types/iter.rs
@@ -58,8 +58,9 @@ pub(crate) fn checked_preallocation_hint(
     elem_size: usize,
     tracker: &ResourceTracker,
 ) -> Result<usize, ResourceError> {
+    let hint = hint.min(MAX_PREALLOCATION_HINT);
     check_estimated_size(hint.saturating_mul(elem_size), tracker)?;
-    Ok(hint.min(MAX_PREALLOCATION_HINT))
+    Ok(hint)
 }
 
 /// Adapts a retained Python iterator to Rust's `Iterator` with memory checks.

--- a/crates/monty/src/types/iter.rs
+++ b/crates/monty/src/types/iter.rs
@@ -49,14 +49,15 @@ struct IterArgs {
     sentinel: Option<Value>,
 }
 
+/// Largest iterator hint used to preallocate a native collection.
+const MAX_PREALLOCATION_HINT: usize = 65_536;
+
 /// Validates and clamps an iterator capacity hint before native allocation.
 pub(crate) fn checked_preallocation_hint(
     hint: usize,
     elem_size: usize,
     tracker: &ResourceTracker,
 ) -> Result<usize, ResourceError> {
-    const MAX_PREALLOCATION_HINT: usize = 65_536;
-
     check_estimated_size(hint.saturating_mul(elem_size), tracker)?;
     Ok(hint.min(MAX_PREALLOCATION_HINT))
 }
@@ -66,6 +67,7 @@ struct HeapedIterator<'this, 'h, I: CollectIter<'h>> {
     iter: &'this mut I,
     vm: &'this mut VM<'h>,
     error: &'this mut Option<RunError>,
+    preallocation_hint: usize,
     yielded: usize,
 }
 
@@ -95,7 +97,7 @@ impl<'h, I: CollectIter<'h>> Iterator for HeapedIterator<'_, 'h, I> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.iter.remaining(self.vm);
+        let remaining = self.iter.remaining(self.vm).min(self.preallocation_hint);
         (remaining, Some(remaining))
     }
 }
@@ -141,6 +143,7 @@ where
 {
     defer_drop!(iterator, vm);
     let mut iterator = iterator.read(vm);
+    let preallocation_hint = checked_preallocation_hint(iterator.iter_size_hint(vm), VALUE_SIZE, vm.heap.tracker())?;
     let mut values_guard = DropGuard::new(T::default(), vm);
     let (values, vm) = values_guard.as_parts_mut();
     let mut error = None;
@@ -148,6 +151,7 @@ where
         iter: &mut iterator,
         vm,
         error: &mut error,
+        preallocation_hint,
         yielded: 0,
     });
     if let Some(error) = error {

--- a/crates/monty/src/types/iter.rs
+++ b/crates/monty/src/types/iter.rs
@@ -9,8 +9,8 @@ use crate::{
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop,
-    exception_private::{ExcType, ExcTypeExt, RunResult},
-    heap::{DropGuard, HeapData},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
+    heap::{DropGuard, DropWithContext, HeapData},
     resource_checks::check_estimated_size,
     types::{PyTrait, callable_iterator::CallableIterator},
     value::{VALUE_SIZE, Value, ValueRead},
@@ -65,22 +65,30 @@ pub(crate) fn checked_preallocation_hint(
 struct HeapedIterator<'this, 'h, I: CollectIter<'h>> {
     iter: &'this mut I,
     vm: &'this mut VM<'h>,
+    error: &'this mut Option<RunError>,
     yielded: usize,
 }
 
 impl<'h, I: CollectIter<'h>> Iterator for HeapedIterator<'_, 'h, I> {
-    type Item = RunResult<Value>;
+    type Item = Value;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self.iter.next_value(self.vm) {
             Ok(None) => None,
-            Err(error) => Some(Err(error)),
+            Err(error) => {
+                *self.error = Some(error);
+                None
+            }
             Ok(Some(value)) => {
                 self.yielded += 1;
                 let estimated = self.yielded.saturating_mul(VALUE_SIZE);
                 match check_estimated_size(estimated, self.vm.heap.tracker()) {
-                    Ok(()) => Some(Ok(value)),
-                    Err(error) => Some(Err(error.into())),
+                    Ok(()) => Some(value),
+                    Err(error) => {
+                        *self.error = Some(error.into());
+                        value.drop_with(self.vm);
+                        None
+                    }
                 }
             }
         }
@@ -118,21 +126,35 @@ pub fn collect_iterable(value: &Value, vm: &mut VM<'_>) -> RunResult<Vec<Value>>
 }
 
 /// Collects every item yielded by an owned iterable into a target collection.
-pub(crate) fn collect_owned_iterable<T: FromIterator<Value>>(value: Value, vm: &mut VM<'_>) -> RunResult<T> {
+pub(crate) fn collect_owned_iterable<'h, T>(value: Value, vm: &mut VM<'h>) -> RunResult<T>
+where
+    T: Default + Extend<Value> + DropWithContext<VM<'h>>,
+{
     let iterator = value.into_py_iter(vm)?;
     collect_python_iterator(iterator, vm)
 }
 
 /// Drains an owned Python iterator with incremental allocation checks.
-fn collect_python_iterator<T: FromIterator<Value>>(iterator: Value, vm: &mut VM<'_>) -> RunResult<T> {
+fn collect_python_iterator<'h, T>(iterator: Value, vm: &mut VM<'h>) -> RunResult<T>
+where
+    T: Default + Extend<Value> + DropWithContext<VM<'h>>,
+{
     defer_drop!(iterator, vm);
     let mut iterator = iterator.read(vm);
-    HeapedIterator {
+    let mut values_guard = DropGuard::new(T::default(), vm);
+    let (values, vm) = values_guard.as_parts_mut();
+    let mut error = None;
+    values.extend(HeapedIterator {
         iter: &mut iterator,
         vm,
+        error: &mut error,
         yielded: 0,
+    });
+    if let Some(error) = error {
+        Err(error)
+    } else {
+        Ok(values_guard.into_inner())
     }
-    .collect()
 }
 
 /// Pulls at most `limit` items from an iterable, stopping early.
@@ -140,20 +162,15 @@ pub fn collect_iterable_bounded(value: &Value, limit: usize, vm: &mut VM<'_>) ->
     let iterator = value.py_iter(vm)?;
     defer_drop!(iterator, vm);
     let mut iterator = iterator.read(vm);
-    let mut items = Vec::new();
+    let mut items_guard = DropGuard::new(Vec::new(), vm);
+    let (items, vm) = items_guard.as_parts_mut();
     while items.len() < limit {
-        match iterator.py_next(vm) {
-            Ok(Some(value)) => items.push(value),
-            Ok(None) => break,
-            Err(error) => {
-                for item in items {
-                    item.drop_with(vm);
-                }
-                return Err(error);
-            }
+        match iterator.py_next(vm)? {
+            Some(value) => items.push(value),
+            None => break,
         }
     }
-    Ok(items)
+    Ok(items_guard.into_inner())
 }
 
 /// Implements Python's `next(iterator[, default])` semantics.

--- a/crates/monty/src/types/re_match.rs
+++ b/crates/monty/src/types/re_match.rs
@@ -18,7 +18,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunResult},
-    heap::{Heap, HeapData, HeapId, HeapItem, HeapRead},
+    heap::{DropGuard, Heap, HeapData, HeapId, HeapItem, HeapRead},
     intern::StaticStrings,
     types::{
         Dict, LazyHeapSet, PyTrait, Type, allocate_tuple,
@@ -454,18 +454,12 @@ fn call_group<'h>(m: &HeapRead<'h, ReMatch>, args: ArgValues, vm: &mut VM<'h>) -
         other => {
             let pos = other.into_pos_only("re.Match.group", vm.heap)?;
             defer_drop_mut!(pos, vm);
-            let mut elements = smallvec::smallvec![];
+            let mut elements_guard = DropGuard::new(smallvec::smallvec![], vm);
+            let (elements, vm) = elements_guard.as_parts_mut();
             for val in pos.as_slice() {
-                let result = resolve_group_arg(m.get(vm.heap), val, vm);
-                if result.is_err() {
-                    // Drop already-allocated elements
-                    for elem in elements {
-                        Value::drop_with(elem, vm);
-                    }
-                    return result;
-                }
-                elements.push(result?);
+                elements.push(resolve_group_arg(m.get(vm.heap), val, vm)?);
             }
+            let (elements, vm) = elements_guard.into_parts();
             Ok(allocate_tuple(elements, vm.heap)?)
         }
     }

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -20,7 +20,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
-    heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
+    heap::{DropGuard, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     modules::re::{ASCII, DOTALL, IGNORECASE, MULTILINE},
     resource_checks::check_estimated_size,
@@ -70,6 +70,52 @@ pub(crate) struct RePattern {
     /// unanchored still fits anchored). `None` = the engine's default limit. Not
     /// serialized — restored patterns recompile at the default limit.
     delegate_size_limit: Option<usize>,
+}
+
+/// Owned regex state for `findall`, detached from any heap borrow.
+pub(crate) struct FindallPattern {
+    compiled: Regex,
+}
+
+impl FindallPattern {
+    /// Returns all non-overlapping matches while guarding partial results.
+    pub fn run(&self, text: &str, vm: &mut VM<'_>) -> RunResult<Value> {
+        let cap_count = self.compiled.captures_len();
+        let mut results_guard = DropGuard::new(Vec::new(), vm);
+        let (results, vm) = results_guard.as_parts_mut();
+
+        match cap_count {
+            0 | 1 => {
+                for m in self.compiled.find_iter(text) {
+                    let val = m.map_err(ExcType::re_pattern_error)?.as_str();
+                    results.push(allocate_string(val, vm.heap)?);
+                }
+            }
+            2 => {
+                for caps in self.compiled.captures_iter(text) {
+                    let caps = caps.map_err(ExcType::re_pattern_error)?;
+                    let val = caps.get(1).map_or("", |m| m.as_str());
+                    results.push(allocate_string(val, vm.heap)?);
+                }
+            }
+            _ => {
+                for caps in self.compiled.captures_iter(text) {
+                    let caps = caps.map_err(ExcType::re_pattern_error)?;
+                    let mut elements_guard = DropGuard::new(SmallVec::<[Value; 3]>::new(), vm);
+                    let (elements, vm) = elements_guard.as_parts_mut();
+                    for cap in caps.iter().skip(1) {
+                        let val = cap.map_or("", |m| m.as_str());
+                        elements.push(allocate_string(val, vm.heap)?);
+                    }
+                    let (elements, vm) = elements_guard.into_parts();
+                    results.push(allocate_tuple(elements, vm.heap)?);
+                }
+            }
+        }
+
+        let (results, vm) = results_guard.into_parts();
+        Ok(Value::Ref(vm.heap.allocate(HeapData::List(List::new(results)))?))
+    }
 }
 
 impl PartialEq for RePattern {
@@ -224,48 +270,11 @@ impl RePattern {
         }
     }
 
-    /// `pattern.findall(string)` — return all non-overlapping matches.
-    ///
-    /// Follows CPython's semantics:
-    /// - No capture groups: returns a list of matched strings
-    /// - One capture group: returns a list of the group's matched strings
-    /// - Multiple capture groups: returns a list of tuples of matched strings
-    pub fn findall(&self, text: &str, heap: &Heap) -> RunResult<Value> {
-        let cap_count = self.compiled.captures_len();
-        let mut results = Vec::new();
-
-        match cap_count {
-            // No capture groups — return list of full match strings
-            0 | 1 => {
-                for m in self.compiled.find_iter(text) {
-                    let val = m.map_err(ExcType::re_pattern_error)?.as_str();
-                    results.push(allocate_string(val, heap)?);
-                }
-            }
-            // One capture group — return list of the group's strings
-            2 => {
-                for caps in self.compiled.captures_iter(text) {
-                    let caps = caps.map_err(ExcType::re_pattern_error)?;
-                    let val = caps.get(1).map_or("", |m| m.as_str());
-                    results.push(allocate_string(val, heap)?);
-                }
-            }
-            // Multiple capture groups — return list of tuples
-            _ => {
-                for caps in self.compiled.captures_iter(text) {
-                    let caps = caps.map_err(ExcType::re_pattern_error)?;
-                    let mut elements: SmallVec<[Value; 3]> = SmallVec::with_capacity(cap_count - 1);
-                    for cap in caps.iter().skip(1) {
-                        let val = cap.map_or("", |m| m.as_str());
-                        elements.push(allocate_string(val, heap)?);
-                    }
-                    results.push(allocate_tuple(elements, heap)?);
-                }
-            }
+    /// Detaches the compiled regex so `findall` can clean up partial results.
+    pub fn prepare_findall(&self) -> FindallPattern {
+        FindallPattern {
+            compiled: self.compiled.clone(),
         }
-
-        let list = List::new(results);
-        Ok(Value::Ref(heap.allocate(HeapData::List(list))?))
     }
 
     /// `pattern.sub(repl, string, count=0)` — substitute matches with a replacement.
@@ -439,8 +448,9 @@ impl<'h> PyTrait<'h> for HeapRead<'h, RePattern> {
             Some(StaticStrings::Findall) => {
                 let arg = args.get_one_arg("Pattern.findall", vm.heap)?;
                 defer_drop!(arg, vm);
-                let text = arg.to_str(vm)?;
-                self.get(vm.heap).findall(text, vm.heap)
+                let findall = self.get(vm.heap).prepare_findall();
+                let text = arg.to_str(vm)?.to_owned();
+                findall.run(&text, vm)
             }
             Some(StaticStrings::Sub) => call_pattern_sub(self, args, vm),
             Some(StaticStrings::Split) => call_pattern_split(self, args, vm),

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -20,7 +20,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
-    heap::{DropGuard, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
+    heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     modules::re::{ASCII, DOTALL, IGNORECASE, MULTILINE},
     resource_checks::check_estimated_size,
@@ -70,52 +70,6 @@ pub(crate) struct RePattern {
     /// unanchored still fits anchored). `None` = the engine's default limit. Not
     /// serialized — restored patterns recompile at the default limit.
     delegate_size_limit: Option<usize>,
-}
-
-/// Owned regex state for `findall`, detached from any heap borrow.
-pub(crate) struct FindallPattern {
-    compiled: Regex,
-}
-
-impl FindallPattern {
-    /// Returns all non-overlapping matches while guarding partial results.
-    pub fn run(&self, text: &str, vm: &mut VM<'_>) -> RunResult<Value> {
-        let cap_count = self.compiled.captures_len();
-        let mut results_guard = DropGuard::new(Vec::new(), vm);
-        let (results, vm) = results_guard.as_parts_mut();
-
-        match cap_count {
-            0 | 1 => {
-                for m in self.compiled.find_iter(text) {
-                    let val = m.map_err(ExcType::re_pattern_error)?.as_str();
-                    results.push(allocate_string(val, vm.heap)?);
-                }
-            }
-            2 => {
-                for caps in self.compiled.captures_iter(text) {
-                    let caps = caps.map_err(ExcType::re_pattern_error)?;
-                    let val = caps.get(1).map_or("", |m| m.as_str());
-                    results.push(allocate_string(val, vm.heap)?);
-                }
-            }
-            _ => {
-                for caps in self.compiled.captures_iter(text) {
-                    let caps = caps.map_err(ExcType::re_pattern_error)?;
-                    let mut elements_guard = DropGuard::new(SmallVec::<[Value; 3]>::new(), vm);
-                    let (elements, vm) = elements_guard.as_parts_mut();
-                    for cap in caps.iter().skip(1) {
-                        let val = cap.map_or("", |m| m.as_str());
-                        elements.push(allocate_string(val, vm.heap)?);
-                    }
-                    let (elements, vm) = elements_guard.into_parts();
-                    results.push(allocate_tuple(elements, vm.heap)?);
-                }
-            }
-        }
-
-        let (results, vm) = results_guard.into_parts();
-        Ok(Value::Ref(vm.heap.allocate(HeapData::List(List::new(results)))?))
-    }
 }
 
 impl PartialEq for RePattern {
@@ -270,11 +224,48 @@ impl RePattern {
         }
     }
 
-    /// Detaches the compiled regex so `findall` can clean up partial results.
-    pub fn prepare_findall(&self) -> FindallPattern {
-        FindallPattern {
-            compiled: self.compiled.clone(),
+    /// `pattern.findall(string)` — return all non-overlapping matches.
+    ///
+    /// Follows CPython's semantics:
+    /// - No capture groups: returns a list of matched strings
+    /// - One capture group: returns a list of the group's matched strings
+    /// - Multiple capture groups: returns a list of tuples of matched strings
+    pub fn findall(&self, text: &str, heap: &Heap) -> RunResult<Value> {
+        let cap_count = self.compiled.captures_len();
+        let mut results = Vec::new();
+
+        match cap_count {
+            // No capture groups — return list of full match strings
+            0 | 1 => {
+                for m in self.compiled.find_iter(text) {
+                    let val = m.map_err(ExcType::re_pattern_error)?.as_str();
+                    results.push(allocate_string(val, heap)?);
+                }
+            }
+            // One capture group — return list of the group's strings
+            2 => {
+                for caps in self.compiled.captures_iter(text) {
+                    let caps = caps.map_err(ExcType::re_pattern_error)?;
+                    let val = caps.get(1).map_or("", |m| m.as_str());
+                    results.push(allocate_string(val, heap)?);
+                }
+            }
+            // Multiple capture groups — return list of tuples
+            _ => {
+                for caps in self.compiled.captures_iter(text) {
+                    let caps = caps.map_err(ExcType::re_pattern_error)?;
+                    let mut elements: SmallVec<[Value; 3]> = SmallVec::with_capacity(cap_count - 1);
+                    for cap in caps.iter().skip(1) {
+                        let val = cap.map_or("", |m| m.as_str());
+                        elements.push(allocate_string(val, heap)?);
+                    }
+                    results.push(allocate_tuple(elements, heap)?);
+                }
+            }
         }
+
+        let list = List::new(results);
+        Ok(Value::Ref(heap.allocate(HeapData::List(list))?))
     }
 
     /// `pattern.sub(repl, string, count=0)` — substitute matches with a replacement.
@@ -448,9 +439,8 @@ impl<'h> PyTrait<'h> for HeapRead<'h, RePattern> {
             Some(StaticStrings::Findall) => {
                 let arg = args.get_one_arg("Pattern.findall", vm.heap)?;
                 defer_drop!(arg, vm);
-                let findall = self.get(vm.heap).prepare_findall();
-                let text = arg.to_str(vm)?.to_owned();
-                findall.run(&text, vm)
+                let text = arg.to_str(vm)?;
+                self.get(vm.heap).findall(text, vm.heap)
             }
             Some(StaticStrings::Sub) => call_pattern_sub(self, args, vm),
             Some(StaticStrings::Split) => call_pattern_split(self, args, vm),

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -1676,8 +1676,7 @@ fn unhashable_type_name(value: &Value, vm: &mut VM<'_>) -> RunResult<String> {
             HeapData::NamedTuple(namedtuple) => namedtuple.as_vec()[index].clone_with_heap(vm.heap),
             _ => unreachable!("tuple-like heap value changed type"),
         };
-        let mut item_guard = DropGuard::new(item, vm);
-        let (item, vm) = item_guard.as_parts_mut();
+        defer_drop!(item, vm);
         if item.py_hash(vm)?.is_none() {
             return unhashable_type_name(item, vm);
         }

--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -580,18 +580,14 @@ fn int_convert(x: &Value, vm: &mut VM<'_>) -> RunResult<Value> {
 /// lands in the range error, not `OverflowError`; non-integers raise
 /// `TypeError` before the range is checked.
 fn int_base(base: Value, vm: &mut VM<'_>) -> RunResult<u32> {
-    let n = match &base {
+    defer_drop!(base, vm);
+    let n = match base {
         Value::Bool(b) => i64::from(*b),
         Value::Int(i) => *i,
         // Clamped by PyNumber_AsSsize_t: any i64-overflowing int is out of range.
-        _ if is_long_int(&base, vm) => i64::MAX,
-        _ => {
-            let err = ExcType::type_error_not_integer(&base.py_type_name(vm));
-            base.drop_with(vm);
-            return Err(err);
-        }
+        _ if is_long_int(base, vm) => i64::MAX,
+        _ => return Err(ExcType::type_error_not_integer(&base.py_type_name(vm))),
     };
-    base.drop_with(vm);
     match u32::try_from(n) {
         Ok(0) => Ok(0),
         Ok(b @ 2..=36) => Ok(b),

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -1348,6 +1348,23 @@ impl Value {
         }
     }
 
+    /// Consumes this Value as a reference, returning the contained HeapId otherwise returns None.
+    ///
+    /// The caller is responsible for ensuring the `HeapId` is properly decref'd.
+    pub fn into_ref_id(self) -> Option<HeapId> {
+        match self {
+            Self::Ref(id) => {
+                #[cfg(feature = "memory-model-checks")]
+                {
+                    // Mark the value as dereferenced to prevent double-free
+                    mem::forget(self);
+                }
+                Some(id)
+            }
+            _ => None,
+        }
+    }
+
     /// Returns the module name if this value is a module, otherwise returns "<unknown>".
     ///
     /// Used for error messages in `from module import name` when the name doesn't exist.
@@ -1920,7 +1937,9 @@ impl Value {
     ///
     /// # Important
     /// This method MUST be called before overwriting a namespace slot or discarding
-    /// a value to prevent memory leaks.
+    /// a value to prevent memory leaks. Call it directly only on a simple, linear
+    /// cleanup path; use `defer_drop!` or `DropGuard` when any branch or `?` could
+    /// bypass cleanup.
     #[cfg(not(feature = "memory-model-checks"))]
     #[inline]
     pub fn drop_with(self, heap: &mut impl ContainsHeap) {


### PR DESCRIPTION
Hoping that better prompting and examples can make claude reduce the amount of spaghetti it generates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies drop/cleanup across VM and stdlib with `defer_drop!`/`defer_drop_mut!`, documents raw `HeapId` ownership, and removes leak/double‑drop paths across iterators, JSON, asyncio, regex, file I/O, dict/set/list ops, globals, and error paths. Also clamps iterator preallocation and per‑yield growth to prevent capacity overflows.

- **Refactors**
  - Tighten `CLAUDE.md` guidance: prefer `defer_drop!`/`defer_drop_mut!`, use `DropGuard` only when extracting; clarify raw `HeapId` ownership; require `HeapItem::py_dec_ref_ids` to push every owned ID.
  - Add `Value::into_ref_id()` and use it for ownership transfer in `asyncio.gather` and file buffer storage; validate awaitables before transfer.
  - Replace ad‑hoc guards with `defer_drop` in arg binding, `min`/`max`, `open`, JSON dump/load helpers, dict views, iter utilities, and VM ops (e.g. `store_cell`); use `.drain(...).drop_with(...)` for stacks and containers (scheduler, globals, JSON key filtering).
  - File I/O: promote interned read results to heap-backed values; `compute_slice`, `update_file_state`, and `populate_buffer_meta` now operate on a `HeapRead<OpenFile>`; pending file pins use `defer_drop!`; simplify write position updates.

- **Bug Fixes**
  - Guard partial results on error in iterator collection (bounded too), JSON key sorting/filtering, `re.Match.group`, unpack ops, and `min`/`max`.
  - Remove leak/double‑drop paths in `open()`, list/dict/set extend/update, task scheduler drops, awaiter failure delivery, globals cleanup, `unicodedata.name` default handling, dataclass attribute errors, and `int` base parsing.
  - Improve memory tracking when growing collections; cap iterator preallocation hints and clamp per‑yield growth; apply container‑level `.drop_with(...)` consistently.

<sup>Written for commit e0e195e53d5f16b38603a2b7aaace97e5bbc3ec4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

