### PR TITLE
switch hasher from `DefaultHasher` to `ahash`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,10 +76,24 @@ Possible security risks to consider:
 * subprocess/shell execution - os.system, subprocess, etc.
 * import system abuse - importing modules with side effects or accessing `__import__`
 * external function/callback misuse - callbacks run in host environment
-* deserialization attacks - loading untrusted serialized Monty/snapshot data
 * regex/string DoS - catastrophic backtracking or operations bypassing limits
 * information leakage via timing or error messages
 * Python/Javascript/Rust APIs that accidentally allow developers to expose their host to monty code
+
+### Dumps/snapshots are a TRUSTED boundary
+
+Serialized dumps (`ReplRun`/`RunSnapshot`/`RunProgress` `dump()`/`load()`) are
+NOT part of the sandbox threat model: the host is ALWAYS responsible for
+signing dumps it produces and verifying them before loading. Do not add
+validation passes, depth guards, or other hardening motivated by malformed or
+malicious dump content, and do not weigh hostile-dump scenarios in design
+trade-offs — loading an unverified dump is a host bug, like calling any other
+`unsafe`-adjacent API wrong.
+
+This is distinct from the boundaries that DO stay untrusted:
+* wire frames from a (possibly compromised) worker child — parents must
+  validate everything and never panic (see the subprocess isolation section)
+* code running inside the sandbox, always
 
 ## Filesystem Mounts (`crates/monty-fs/`)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2458,6 +2458,7 @@ dependencies = [
 name = "monty-proto"
 version = "0.0.19"
 dependencies = [
+ "ahash",
  "monty",
  "monty-type-checking",
  "monty-types",

--- a/crates/monty-proto/Cargo.toml
+++ b/crates/monty-proto/Cargo.toml
@@ -25,6 +25,8 @@ prost = { workspace = true }
 monty-type-checking = { workspace = true, optional = true }
 # Optional: powers the `python` feature's Python ↔ MontyObject conversion layer
 pyo3 = { workspace = true, optional = true, features = ["num-bigint"] }
+# Optional: hasher for the `python` feature's frozen-dataclass `__hash__`
+ahash = { workspace = true, optional = true }
 # generation-only dependencies (see src/bin/generate.rs); exact pins so the
 # checked-in generated code is reproducible across contributors and CI
 prost-build = { version = "=0.14.4", optional = true }
@@ -37,7 +39,7 @@ generate = ["dep:prost-build", "dep:protox"]
 # Enables the `python` module: PyO3-based conversions between Python objects
 # and `MontyObject`/`MontyException`. Off by default so pure-Rust consumers
 # (monty-pool, monty-runtime) never build or link against libpython.
-python = ["dep:pyo3"]
+python = ["dep:pyo3", "dep:ahash"]
 # Enables the `worker` module: the child-side Child state machine that drives
 # the interpreter. Off by default so host-side consumers (monty-pool, the
 # bindings) never link the interpreter itself.

--- a/crates/monty-proto/src/python/dataclass.rs
+++ b/crates/monty-proto/src/python/dataclass.rs
@@ -5,11 +5,9 @@
 //! - Converting `MontyObject::Dataclass` back to Python via `PyUnknownDataclass`
 //! - `PyUnknownDataclass`: A Python class that mimics dataclass behavior
 
-use std::{
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
-};
+use std::hash::{Hash, Hasher};
 
+use ahash::AHasher;
 use monty_types::{DictPairs, MontyObject};
 use pyo3::{
     Bound,
@@ -394,7 +392,7 @@ impl PyUnknownDataclass {
             return Err(PyTypeError::new_err("unhashable type: 'UnknownDataclass'"));
         }
 
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = AHasher::default();
 
         let attrs = self.attrs.bind(py);
         for field_name in &self.field_names {

--- a/crates/monty/src/dump_format.rs
+++ b/crates/monty/src/dump_format.rs
@@ -11,7 +11,10 @@ const MAGIC: &[u8; 6] = b"MONTY\0";
 ///
 /// Bump this whenever a serialized discriminant can shift, so older dumps are
 /// rejected instead of decoding as their neighbour.
-pub(crate) const VERSION: u16 = 4;
+///
+/// Version 5: dict/set entries no longer serialize per-entry hashes (rebuilt
+/// lazily on load), so dumps are stable across platforms and hasher changes.
+pub(crate) const VERSION: u16 = 5;
 
 /// Number of bytes before the postcard payload.
 const HEADER_LEN: usize = MAGIC.len() + size_of::<u16>() + size_of::<u8>();

--- a/crates/monty/src/hash.rs
+++ b/crates/monty/src/hash.rs
@@ -3,12 +3,12 @@
 //! Defines:
 //!
 //! * [`HashValue`] — a verified Python hash. Construction goes through
-//!   [`HashValue::from_raw`]; storing or comparing hashes anywhere in the
+//!   [`HashValue::new`]; storing or comparing hashes anywhere in the
 //!   runtime should use this type rather than a bare `u64` so the invariant
 //!   is enforced by the type system.
 //!
 //!   Internally backed by a [`NonZero<u64>`] holding the **bit-inverse** of
-//!   the raw hash. The inversion is invisible to callers (`from_raw` /
+//!   the raw hash. The inversion is invisible to callers (`new` /
 //!   `get` translate at the boundary) but means `Option<HashValue>` is
 //!   niche-packed into 8 bytes — `None` is the bit pattern `0`, the inverse
 //!   of the reserved `u64::MAX` sentinel.
@@ -41,20 +41,22 @@ use crate::{heap::HeapId, intern::StaticStrings};
 ///
 /// Internally a [`NonZero<u64>`] holding the bit-inverse of the raw hash, so
 /// `Option<HashValue>` niche-packs into 8 bytes. Construct via
-/// [`HashValue::from_raw`]; extract via [`HashValue::get`] (both translate
+/// [`HashValue::new`]; extract via [`HashValue::raw`] (both translate
 /// the inversion at the boundary).
 ///
 /// The bit-inversion is purely an implementation detail of the niche
-/// packing — none of the public traits leak it. [`Hash`], [`fmt::Debug`],
-/// [`serde::Serialize`] and [`serde::Deserialize`] all hand-translate to/from
-/// the raw `u64` form, so:
+/// packing — none of the public traits leak it. [`Hash`] and [`fmt::Debug`]
+/// hand-translate to/from the raw `u64` form, so:
 ///
 /// * Composite hashes that fold a `HashValue` see the same bytes `get()`
 ///   returns (independent of storage layout — a future change to e.g.
 ///   `NonMaxU64` would leave tuple/dict hashes invariant).
 /// * Debug output shows the raw hash (`HashValue(5)`, not the inverted bits).
-/// * Snapshots store the raw hash, so the wire format is decoupled from the
-///   niche-packing representation.
+///
+/// Deliberately NOT `Serialize`/`Deserialize`: hashes are hasher- and
+/// build-specific derived data and must never cross the serialization
+/// boundary — dumps stay hash-free and every build recomputes with its own
+/// hasher (dict/set indices rebuild lazily, caches refill on first use).
 ///
 /// Stored in interner hash tables, returned by `Value::py_hash`, and used
 /// wherever a known-good hash needs to be passed around.
@@ -104,23 +106,6 @@ impl fmt::Debug for HashValue {
     /// output matches `get()`.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("HashValue").field(&self.raw()).finish()
-    }
-}
-
-impl serde::Serialize for HashValue {
-    /// Emits the raw hash so the wire format is decoupled from the
-    /// niche-packing representation.
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.raw().serialize(serializer)
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for HashValue {
-    /// Reads a raw `u64` and reconstructs via [`HashValue::from_raw`], so
-    /// even a pathological wire value of `u64::MAX` is handled by the same
-    /// sentinel-collision path as fresh hashes.
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Ok(Self::new(u64::deserialize(deserializer)?))
     }
 }
 

--- a/crates/monty/src/hash.rs
+++ b/crates/monty/src/hash.rs
@@ -24,13 +24,13 @@
 //!   time for any non-trivial program).
 
 use std::{
-    collections::hash_map::DefaultHasher,
     fmt,
     hash::{Hash, Hasher},
     num::NonZero,
     sync::atomic::{AtomicU64, Ordering},
 };
 
+use ahash::AHasher;
 use num_bigint::BigInt;
 use num_traits::ToPrimitive;
 use strum::EnumCount;
@@ -124,14 +124,17 @@ impl<'de> serde::Deserialize<'de> for HashValue {
     }
 }
 
-/// Hashes any `Hash` value with a fresh [`DefaultHasher`].
+/// Hashes any `Hash` value with a fresh [`AHasher`].
 ///
 /// Keeps the hasher boilerplate in one place for the cold `Value::py_hash` arms
 /// (builtins, functions, markers, singletons), so the hot arms (int/str/ref)
 /// never pay for constructing a hasher they don't use.
+///
+/// `AHasher::default()` uses fixed keys, so hashes are deterministic within a
+/// build — required because dict snapshots store raw entry hashes.
 #[inline]
 pub(crate) fn hash_one(value: impl Hash) -> HashValue {
-    let mut hasher = DefaultHasher::new();
+    let mut hasher = AHasher::default();
     value.hash(&mut hasher);
     HashValue::new(hasher.finish())
 }
@@ -140,7 +143,7 @@ pub(crate) fn hash_one(value: impl Hash) -> HashValue {
 ///
 /// The canonical hash for objects that compare by identity — user classes,
 /// instances, bound methods, and cells (CPython's default for objects without
-/// a user `__hash__`). Keeps the `DefaultHasher` boilerplate in one place.
+/// a user `__hash__`). Keeps the hasher boilerplate in one place.
 #[inline]
 pub(crate) fn identity_hash(id: HeapId) -> HashValue {
     hash_one(id)
@@ -153,7 +156,7 @@ pub(crate) fn identity_hash(id: HeapId) -> HashValue {
 /// for dict-key consistency.
 #[inline]
 pub(crate) fn hash_python_str(s: &str) -> HashValue {
-    let mut hasher = DefaultHasher::new();
+    let mut hasher = AHasher::default();
     s.hash(&mut hasher);
     HashValue::new(hasher.finish())
 }
@@ -164,7 +167,7 @@ pub(crate) fn hash_python_str(s: &str) -> HashValue {
 /// and the interned bytes table.
 #[inline]
 pub(crate) fn hash_python_bytes(b: &[u8]) -> HashValue {
-    let mut hasher = DefaultHasher::new();
+    let mut hasher = AHasher::default();
     b.hash(&mut hasher);
     HashValue::new(hasher.finish())
 }
@@ -173,7 +176,7 @@ pub(crate) fn hash_python_bytes(b: &[u8]) -> HashValue {
 ///
 /// For values that fit in `i64`, returns `i.cast_unsigned()` so that
 /// `hash(LongInt(5)) == hash(Value::Int(5))`. For larger values, falls back
-/// to hashing `(sign, little-endian bytes)` via [`DefaultHasher`].
+/// to hashing `(sign, little-endian bytes)` via [`AHasher`].
 ///
 /// Used by heap `LongInt::py_hash` and by `Interns::long_int_hash` so that
 /// interned and heap-allocated long ints with equal value hash identically.
@@ -182,7 +185,7 @@ pub(crate) fn hash_python_long_int(bi: &BigInt) -> HashValue {
     if let Some(i) = bi.to_i64() {
         HashValue::new(i.cast_unsigned())
     } else {
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = AHasher::default();
         let (sign, bytes) = bi.to_bytes_le();
         sign.hash(&mut hasher);
         bytes.hash(&mut hasher);

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -189,10 +189,11 @@ pub(crate) enum HeapData {
 }
 
 // `HeapData` is memcpy'd on every allocate and free, so its inline size is paid on
-// the hottest heap paths. `Dict` — far too hot to box — sets the 72-byte payload
-// ceiling (currently tag-free thanks to niche packing); if this assertion fails a
-// variant has outgrown it and should be boxed (or, for `Dict` itself, slimmed down).
-const _: () = assert!(mem::size_of::<HeapData>() <= 80);
+// the hottest heap paths. `Dict` — far too hot to box — sets the payload ceiling;
+// if this assertion fails a variant has outgrown it and should be boxed (or, for
+// `Dict` itself, slimmed down). `Dict`'s lazy-rebuild `RefCell` currently costs it
+// both the borrow flag and (via `UnsafeCell`) niche packing of the tag: 72 -> 88.
+const _: () = assert!(mem::size_of::<HeapData>() <= 88);
 
 impl HeapData {
     /// Returns whether this heap data type can participate in reference cycles.

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -189,11 +189,10 @@ pub(crate) enum HeapData {
 }
 
 // `HeapData` is memcpy'd on every allocate and free, so its inline size is paid on
-// the hottest heap paths. `Dict` — far too hot to box — sets the payload ceiling;
-// if this assertion fails a variant has outgrown it and should be boxed (or, for
-// `Dict` itself, slimmed down). `Dict`'s lazy-rebuild `RefCell` currently costs it
-// both the borrow flag and (via `UnsafeCell`) niche packing of the tag: 72 -> 88.
-const _: () = assert!(mem::size_of::<HeapData>() <= 88);
+// the hottest heap paths. `Dict` — far too hot to box — sets the 72-byte payload
+// ceiling (currently tag-free thanks to niche packing); if this assertion fails a
+// variant has outgrown it and should be boxed (or, for `Dict` itself, slimmed down).
+const _: () = assert!(mem::size_of::<HeapData>() <= 80);
 
 impl HeapData {
     /// Returns whether this heap data type can participate in reference cycles.
@@ -541,7 +540,7 @@ pub(crate) fn heap_subscript(id: HeapId, key: &Value, vm: &mut VM<'_>) -> RunRes
         // dict — and `dec_ref` asserts that an entry has no active readers when it
         // is freed.
         let found = {
-            let HeapReadOutput::Dict(dict) = vm.heap.read(id) else {
+            let HeapReadOutput::Dict(mut dict) = vm.heap.read(id) else {
                 unreachable!("a defaultdict is a dict");
             };
             dict.dict_get(key, vm)?
@@ -551,14 +550,15 @@ pub(crate) fn heap_subscript(id: HeapId, key: &Value, vm: &mut VM<'_>) -> RunRes
             None => defaultdict_missing(id, key, vm),
         }
     } else {
-        vm.heap.read(id).py_getitem(key, vm)
+        let mut this = vm.heap.read(id);
+        this.py_getitem(key, vm)
     }
 }
 
 impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
     /// Delegates to the types defining their own `in`; the rest keep the trait
     /// default (`None`), leaving `Value::py_contains` to iterate or raise.
-    fn py_contains_impl(&self, self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_contains_impl(&mut self, self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         heap_read_output_py_trait_forward!(self, |value| value.py_contains_impl(self_id, item, vm), else Ok(None))
     }
 
@@ -587,7 +587,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         heap_read_output_py_trait_forward!(self, |value| value.py_radd_impl(other, vm), else Ok(None))
     }
 
-    fn py_rsub_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_rsub_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         heap_read_output_py_trait_forward!(self, |value| value.py_rsub_impl(other, vm), else Ok(None))
     }
 
@@ -635,27 +635,27 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         heap_read_output_py_trait_forward!(self, |value| value.py_rpow_impl(other, modulus, vm), else Ok(None))
     }
 
-    fn py_and_impl(&self, other: &Value, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_and_impl(&mut self, other: &Value, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         heap_read_output_py_trait_forward!(self, |value| value.py_and_impl(other, vm, self_id), else Ok(None))
     }
 
-    fn py_rand_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_rand_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         heap_read_output_py_trait_forward!(self, |value| value.py_rand_impl(other, vm), else Ok(None))
     }
 
-    fn py_or_impl(&self, other: &Value, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_or_impl(&mut self, other: &Value, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         heap_read_output_py_trait_forward!(self, |value| value.py_or_impl(other, vm, self_id), else Ok(None))
     }
 
-    fn py_ror_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_ror_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         heap_read_output_py_trait_forward!(self, |value| value.py_ror_impl(other, vm), else Ok(None))
     }
 
-    fn py_xor_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_xor_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         heap_read_output_py_trait_forward!(self, |value| value.py_xor_impl(other, vm), else Ok(None))
     }
 
-    fn py_rxor_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_rxor_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         heap_read_output_py_trait_forward!(self, |value| value.py_rxor_impl(other, vm), else Ok(None))
     }
 
@@ -760,7 +760,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         heap_read_output_py_trait_forward!(self, |value| value.py_len(vm), else None)
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         heap_read_output_py_trait_forward!(
             self,
             |value| value.py_eq_impl(other, vm),
@@ -874,7 +874,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         heap_read_output_py_trait_forward!(self, |value| value.py_add_impl(other, vm, self_id), else Ok(None))
     }
 
-    fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_sub_impl(&mut self, other: &Value, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         heap_read_output_py_trait_forward!(self, |value| value.py_sub_impl(other, vm, self_id), else Ok(None))
     }
 
@@ -916,7 +916,7 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         heap_read_output_py_trait_forward!(self, |value| value.py_cmp_op(other, op, vm, self_id), else Ok(None))
     }
 
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
+    fn py_getitem(&mut self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
         heap_read_output_py_trait_forward!(
             self,
             |value| value.py_getitem(key, vm),

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -1,11 +1,11 @@
 use std::{
-    collections::hash_map::DefaultHasher,
     fmt::Write,
     hash::{Hash, Hasher},
     mem,
     ops::Deref,
 };
 
+use ahash::AHasher;
 use monty_types::ExcType;
 
 use crate::{
@@ -798,12 +798,12 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
             else {
                 match self {
                     Self::Closure(c) => {
-                        let mut hasher = DefaultHasher::new();
+                        let mut hasher = AHasher::default();
                         c.get(vm.heap).func_id.hash(&mut hasher);
                         Ok(Some(HashValue::new(hasher.finish())))
                     }
                     Self::FunctionDefaults(fd) => {
-                        let mut hasher = DefaultHasher::new();
+                        let mut hasher = AHasher::default();
                         fd.get(vm.heap).func_id.hash(&mut hasher);
                         Ok(Some(HashValue::new(hasher.finish())))
                     }

--- a/crates/monty/src/modules/collections/counter.rs
+++ b/crates/monty/src/modules/collections/counter.rs
@@ -860,7 +860,7 @@ fn counter_require_mapping(rhs: &Value, vm: &mut VM<'_>) -> RunResult<HeapId> {
 
 /// Returns the count for `key` in the Counter `id`, or `None` if absent.
 fn counter_lookup(id: HeapId, key: &Value, vm: &mut VM<'_>) -> RunResult<Option<Value>> {
-    let HeapReadOutput::Dict(dict) = vm.heap.read(id) else {
+    let HeapReadOutput::Dict(mut dict) = vm.heap.read(id) else {
         unreachable!("counter_lookup on a non-dict heap entry");
     };
     dict.dict_get(key, vm)

--- a/crates/monty/src/modules/dataclasses/field.rs
+++ b/crates/monty/src/modules/dataclasses/field.rs
@@ -86,7 +86,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DataclassField> {
         None
     }
 
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         // `Field` defines no `__eq__`, so it compares by identity, which
         // `Value::py_eq_impl` resolves before ever reaching here.
         Ok(None)

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -281,7 +281,7 @@ impl ops::Deref for Bytes {
 
 impl<'h> PyTrait<'h> for HeapRead<'h, Bytes> {
     /// One-sided implementation of Python membership (`__contains__`).
-    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_contains_impl(&mut self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         bytes_contains(self.get(vm.heap).as_slice(), item, vm).map(Some)
     }
 
@@ -301,7 +301,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Bytes> {
         Some(self.get(vm.heap).0.len())
     }
 
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
+    fn py_getitem(&mut self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
         // Check for slice first (Value::Ref pointing to HeapData::Slice)
         if let Value::Ref(id) = key
             && let HeapData::Slice(slice) = vm.heap.get(*id)
@@ -321,7 +321,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Bytes> {
         Ok(Value::Int(i64::from(byte)))
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         // Heap bytes equal interned or heap bytes with the same content.
         Ok(eq_bytes(self.get(vm.heap).as_slice(), other, vm))
     }
@@ -2375,7 +2375,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, BytesIterator> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
         Ok(None)
     }
 

--- a/crates/monty/src/types/callable_iterator.rs
+++ b/crates/monty/src/types/callable_iterator.rs
@@ -79,7 +79,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, CallableIterator> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
         Ok(None)
     }
 

--- a/crates/monty/src/types/class.rs
+++ b/crates/monty/src/types/class.rs
@@ -88,7 +88,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Class> {
         Ok(())
     }
 
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         // Classes return `NotImplemented`; rich equality's final identity
         // fallback makes a class equal only to itself.
         Ok(None)

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -167,15 +167,15 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
         Ok(())
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::Dataclass(other)) = other.read_heap(vm) else {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        let Some(HeapReadOutput::Dataclass(mut other)) = other.read_heap(vm) else {
             return Ok(None);
         };
         // Dataclasses are equal only if they are the same class and have equal attrs.
         if self.get(vm.heap).type_id() != other.get(vm.heap).type_id() {
             return Ok(Some(false));
         }
-        Ok(Some(self.attrs().eq_dict(&other.attrs(), vm)?))
+        Ok(Some(self.attrs().eq_dict(&mut other.attrs_mut(), vm)?))
     }
 
     /// Hashes a frozen dataclass by its class name and the values of declared fields.

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -1,8 +1,9 @@
 use std::{
     fmt::Write,
-    hash::{DefaultHasher, Hash, Hasher},
+    hash::{Hash, Hasher},
 };
 
+use ahash::AHasher;
 use serde::ser::SerializeStruct;
 
 use super::{Dict, LazyHeapSet, PyTrait, attribute_name_value};
@@ -187,7 +188,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
         }
         let mut guard = vm.recursion_guard()?;
         let vm = &mut *guard;
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = AHasher::default();
         // Hash the class name
         self.get(vm.heap).name.hash(&mut hasher);
         // Hash each declared field (name, value) pair in order

--- a/crates/monty/src/types/date.rs
+++ b/crates/monty/src/types/date.rs
@@ -189,7 +189,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Date> {
         None
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let Some(HeapReadOutput::Date(other)) = other.read_heap(vm) else {
             return Ok(None);
         };
@@ -226,7 +226,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Date> {
         Ok(py_add(*self.get(vm.heap), *other.get(vm.heap), vm.heap))
     }
 
-    fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_sub_impl(&mut self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         match other.read_heap(vm) {
             Some(HeapReadOutput::Date(other)) => Ok(py_sub_date(*self.get(vm.heap), *other.get(vm.heap), vm.heap)),
             Some(HeapReadOutput::TimeDelta(other)) => {

--- a/crates/monty/src/types/date.rs
+++ b/crates/monty/src/types/date.rs
@@ -3,11 +3,7 @@
 //! Monty stores dates with `chrono::NaiveDate` and keeps CPython-compatible
 //! constructor validation and arithmetic behavior.
 
-use std::{
-    collections::hash_map::DefaultHasher,
-    fmt::{self, Write},
-    hash::{Hash, Hasher},
-};
+use std::fmt::{self, Write};
 
 use chrono::{Datelike, NaiveDate, format::StrftimeItems};
 use monty_types::OsFunctionCall;
@@ -17,7 +13,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
-    hash::HashValue,
+    hash::{HashValue, hash_one},
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     types::{
@@ -201,9 +197,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Date> {
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
-        let mut hasher = DefaultHasher::new();
-        self.get(vm.heap).hash(&mut hasher);
-        Ok(Some(HashValue::new(hasher.finish())))
+        Ok(Some(hash_one(self.get(vm.heap))))
     }
 
     fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -760,7 +760,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
         None
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let Some(HeapReadOutput::DateTime(other)) = other.read_heap(vm) else {
             return Ok(None);
         };
@@ -852,7 +852,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
         Ok(py_add(&value, &other, vm.heap))
     }
 
-    fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_sub_impl(&mut self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         match other.read_heap(vm) {
             Some(HeapReadOutput::DateTime(other)) => {
                 let value = self.get(vm.heap).clone();

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -4,7 +4,6 @@
 //! constructor rules, aware/naive comparison semantics, and arithmetic on top.
 
 use std::{
-    collections::hash_map::DefaultHasher,
     fmt::Write,
     hash::{Hash, Hasher},
 };
@@ -19,7 +18,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
-    hash::HashValue,
+    hash::{HashValue, hash_one},
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     types::{
@@ -777,9 +776,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
-        let mut hasher = DefaultHasher::new();
-        self.get(vm.heap).hash(&mut hasher);
-        Ok(Some(HashValue::new(hasher.finish())))
+        Ok(Some(hash_one(self.get(vm.heap))))
     }
 
     fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -331,7 +331,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Deque> {
     }
 
     /// `in` walks the deque comparing each item by `==`, like `list`.
-    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_contains_impl(&mut self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let len = self.get(vm.heap).len();
         for i in 0..len {
             let el = self
@@ -379,7 +379,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Deque> {
         Ok(self.get(vm.heap).len() > 0)
     }
 
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
+    fn py_getitem(&mut self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
         let idx = self.resolve_index(key, vm)?;
         Ok(self.get(vm.heap).items[idx].clone_with_heap(vm))
     }
@@ -397,7 +397,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Deque> {
         Ok(())
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         // A deque only ever equals another deque — unlike NamedTuple/tuple, there
         // is no cross-type equality with list. `maxlen` is not part of equality.
         let Some(HeapReadOutput::Deque(other)) = other.read_heap(vm) else {
@@ -642,7 +642,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DequeIterator> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
         Ok(None)
     }
 

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -1,4 +1,8 @@
-use std::{fmt::Write, mem, slice, vec};
+use std::{
+    cell::{Cell, RefCell},
+    fmt::Write,
+    mem, slice, vec,
+};
 
 use hashbrown::HashTable;
 use serde::ser::SerializeStruct;
@@ -63,8 +67,14 @@ use crate::{
 /// improving GC performance for dicts of primitives.
 #[derive(Debug, Default)]
 pub(crate) struct Dict {
-    /// indices mapping from the entry hash to its index.
-    indices: HashTable<usize>,
+    /// Indices mapping from the entry hash to its index. Derived data: never
+    /// serialized, rebuilt lazily after deserialize (see [`Dict::indices_stale`]).
+    /// `RefCell` so the rebuild can run behind `&self` heap handles.
+    indices: RefCell<HashTable<usize>>,
+    /// True when `indices`/entry hashes need a rebuild (set only by
+    /// deserialize). A `Cell<bool>` so the hot-path staleness check is a
+    /// plain byte load instead of a `RefCell` borrow cycle.
+    stale: Cell<bool>,
     /// entries is a dense vec maintaining entry order.
     entries: Vec<DictEntry>,
     /// True if any key or value in the dict is a `Value::Ref`. Used to skip iteration
@@ -138,8 +148,12 @@ impl DictKind {
 struct DictEntry {
     key: Value,
     value: Value,
-    /// the hash is needed here for correct use of insert_unique
-    hash: u64,
+    /// The key's hash, needed for correct use of `insert_unique`. Skipped on
+    /// serde — hashes are hasher/build-specific so they never cross the wire;
+    /// recomputed together with `indices` by `ensure_indices`. `Cell` so the
+    /// lazy rebuild can run behind `&self` heap handles.
+    #[serde(skip)]
+    hash: Cell<u64>,
 }
 
 impl Dict {
@@ -151,7 +165,8 @@ impl Dict {
 
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            indices: HashTable::with_capacity(capacity),
+            indices: RefCell::new(HashTable::with_capacity(capacity)),
+            stale: Cell::new(false),
             entries: Vec::with_capacity(capacity),
             contains_refs: false,
             kind: DictKind::plain(),
@@ -274,6 +289,16 @@ impl Dict {
         self.contains_refs
     }
 
+    /// True when `indices` (and the per-entry hash cells) must be rebuilt —
+    /// i.e. this dict was just deserialized (hashes never cross the wire).
+    ///
+    /// Rebuild via `ensure_indices` wherever a VM is available; VM-less
+    /// readers must fall back to a linear scan.
+    #[inline]
+    fn indices_stale(&self) -> bool {
+        self.stale.get()
+    }
+
     /// Creates a dict from a vector of (key, value) pairs.
     ///
     /// Assumes the caller is transferring ownership of all keys and values in the pairs.
@@ -305,6 +330,9 @@ impl Dict {
     /// and are released here if the insertion exceeds the memory limit.
     pub fn set_json_string_key(&mut self, key: Value, value: Value, vm: &mut VM<'_>) -> RunResult<Option<Value>> {
         debug_assert!(json_key_string_slice(&key, vm.heap, vm.interns).is_some());
+        // Only called on dicts under construction by the JSON decoder, which
+        // are never deserialized-stale.
+        debug_assert!(!self.indices_stale());
 
         if matches!(key, Value::Ref(_)) || matches!(value, Value::Ref(_)) {
             self.contains_refs = true;
@@ -316,7 +344,11 @@ impl Dict {
             .raw();
         let opt_index = self.find_json_string_key_index(hash, &key, vm.heap, vm.interns);
 
-        let entry = DictEntry { key, value, hash };
+        let entry = DictEntry {
+            key,
+            value,
+            hash: Cell::new(hash),
+        };
         if let Some(index) = opt_index {
             let old_entry = mem::replace(&mut self.entries[index], entry);
             old_entry.key.drop_with(vm);
@@ -324,7 +356,9 @@ impl Dict {
         } else {
             let index = self.entries.len();
             self.entries.push(entry);
-            self.indices.insert_unique(hash, index, |&i| self.entries[i].hash);
+            self.indices
+                .borrow_mut()
+                .insert_unique(hash, index, |&i| self.entries[i].hash.get());
             Ok(None)
         }
     }
@@ -336,9 +370,10 @@ impl Dict {
     fn find_json_string_key_index(&self, hash: u64, key: &Value, heap: &Heap, interns: &Interns) -> Option<usize> {
         let key_str = json_key_string_slice(key, heap, interns).expect("json object keys are always string values");
         self.indices
+            .borrow()
             .find(hash, |&idx| {
                 let entry = &self.entries[idx];
-                entry.hash == hash && json_key_equals_str(&entry.key, key_str, heap, interns)
+                entry.hash.get() == hash && json_key_equals_str(&entry.key, key_str, heap, interns)
             })
             .copied()
     }
@@ -461,28 +496,34 @@ impl Dict {
     ///
     /// This is an O(1) lookup that doesn't require mutable heap access.
     /// Only works for string keys - returns None if the key is not found.
+    ///
+    /// This is the one keyed lookup with no VM in scope, so it cannot rebuild
+    /// stale indices after a deserialize — it degrades to a linear scan until
+    /// some VM-bearing operation rebuilds them.
     pub fn get_by_str(&self, key_str: &str, heap: &Heap, interns: &Interns) -> Option<&Value> {
-        // Use the canonical string hash so the lookup matches stored entry
-        // hashes exactly, including the `u64::MAX` sentinel remapping.
-        let hash = hash_python_str(key_str).raw();
-
-        // Find entry with matching hash and key
-        self.indices
-            .find(hash, |&idx| {
-                let entry_key = &self.entries[idx].key;
-                match entry_key {
-                    Value::InternString(id) => interns.get_str(*id) == key_str,
-                    Value::Ref(id) => {
-                        if let HeapData::Str(s) = heap.get(*id) {
-                            s.as_str() == key_str
-                        } else {
-                            false
-                        }
-                    }
-                    _ => false,
+        let key_eq = |key: &Value| match key {
+            Value::InternString(id) => interns.get_str(*id) == key_str,
+            Value::Ref(id) => {
+                if let HeapData::Str(s) = heap.get(*id) {
+                    s.as_str() == key_str
+                } else {
+                    false
                 }
-            })
-            .map(|&idx| &self.entries[idx].value)
+            }
+            _ => false,
+        };
+
+        if self.indices_stale() {
+            self.entries.iter().find(|e| key_eq(&e.key)).map(|e| &e.value)
+        } else {
+            // Use the canonical string hash so the lookup matches stored entry
+            // hashes exactly, including the `u64::MAX` sentinel remapping.
+            let hash = hash_python_str(key_str).raw();
+            self.indices
+                .borrow()
+                .find(hash, |&idx| key_eq(&self.entries[idx].key))
+                .map(|&idx| &self.entries[idx].value)
+        }
     }
 
     /// Sets a key-value pair in the dict.
@@ -528,7 +569,11 @@ impl<'h> HeapRead<'h, Dict> {
             }
         };
 
-        let entry = DictEntry { key, value, hash };
+        let entry = DictEntry {
+            key,
+            value,
+            hash: Cell::new(hash),
+        };
         if let Some(index) = opt_index {
             // Key exists, replace in place to preserve insertion order
             let old_entry = mem::replace(&mut self.get_mut(vm.heap).entries[index], entry);
@@ -542,7 +587,8 @@ impl<'h> HeapRead<'h, Dict> {
             let index = this.entries.len();
             this.entries.push(entry);
             this.indices
-                .insert_unique(hash, index, |index| this.entries[*index].hash);
+                .borrow_mut()
+                .insert_unique(hash, index, |index| this.entries[*index].hash.get());
             Ok(None)
         }
     }
@@ -563,9 +609,10 @@ impl<'h> HeapRead<'h, Dict> {
             let entry = self.get_mut(vm.heap).entries.remove(index);
             // Remove from index table and rebuild (same as dict_popitem)
             let this = self.get_mut(vm.heap);
-            this.indices.clear();
+            let mut indices = this.indices.borrow_mut();
+            indices.clear();
             for (idx, e) in this.entries.iter().enumerate() {
-                this.indices.insert_unique(e.hash, idx, |&i| this.entries[i].hash);
+                indices.insert_unique(e.hash.get(), idx, |&i| this.entries[i].hash.get());
             }
             Ok(Some((entry.key, entry.value)))
         } else {
@@ -670,6 +717,7 @@ struct DictInitArgs {
 
 impl<'h> HeapRead<'h, Dict> {
     fn find_index_hash(&self, key: &Value, vm: &mut VM<'h>) -> RunResult<(Option<usize>, u64)> {
+        self.ensure_indices(vm)?;
         let hash = key
             .py_hash(vm)?
             .ok_or_else(|| ExcType::type_error_unhashable_dict_key(&key.py_type_name(vm)))?
@@ -682,8 +730,8 @@ impl<'h> HeapRead<'h, Dict> {
         // Collect candidate indices during the lookup to avoid borrow tracker issues
         let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
         let this = self.get(vm.heap);
-        this.indices.find(hash, |v| {
-            if this.entries[*v].hash == hash {
+        this.indices.borrow().find(hash, |v| {
+            if this.entries[*v].hash.get() == hash {
                 candidates.push(*v);
             }
             false
@@ -698,6 +746,40 @@ impl<'h> HeapRead<'h, Dict> {
         }
 
         Ok((None, hash))
+    }
+
+    /// Rebuilds the per-entry hash cells and the `indices` table if they are
+    /// stale (i.e. this dict was just deserialized — hashes never cross the
+    /// serialization boundary, each build recomputes with its own hasher).
+    ///
+    /// Must be called before consulting `indices` from any VM-bearing path.
+    /// No-op for dicts constructed in this process.
+    fn ensure_indices(&self, vm: &mut VM<'h>) -> RunResult<()> {
+        if !self.get(vm.heap).indices_stale() {
+            return Ok(());
+        }
+        // Phase 1: recompute each key's hash. Keys are cloned out (and
+        // defer-dropped) because `py_hash` needs `&mut VM` and may read the
+        // heap (tuple keys, frozen dataclasses), so no dict borrow can be
+        // held across it.
+        let len = self.get(vm.heap).entries.len();
+        for i in 0..len {
+            let key = self.get(vm.heap).entries[i].key.clone_with_heap(vm.heap);
+            defer_drop!(key, vm);
+            let hash = key
+                .py_hash(vm)?
+                .expect("deserialized dict keys were hashable when inserted")
+                .raw();
+            self.get(vm.heap).entries[i].hash.set(hash);
+        }
+        // Phase 2: rebuild the index table from the fresh hashes.
+        let this = self.get(vm.heap);
+        let mut indices = this.indices.borrow_mut();
+        for (idx, e) in this.entries.iter().enumerate() {
+            indices.insert_unique(e.hash.get(), idx, |&i| this.entries[i].hash.get());
+        }
+        this.stale.set(false);
+        Ok(())
     }
 
     /// Checks whether the dict contains a given key.
@@ -1535,7 +1617,7 @@ impl<C: ContainsHeap> DropWithContext<C> for DictEntry {
 ///
 /// Removes all items from the dict.
 fn dict_clear<'h>(dict: &mut HeapRead<'h, Dict>, vm: &mut VM<'h>) {
-    dict.get_mut(vm.heap).indices.clear();
+    dict.get_mut(vm.heap).indices.borrow_mut().clear();
     mem::take(&mut dict.get_mut(vm.heap).entries).drop_with(vm.heap);
     // Note: contains_refs stays true even if all refs removed, per conservative GC strategy
 }
@@ -1720,6 +1802,8 @@ fn dict_setdefault<'h>(dict: &mut HeapRead<'h, Dict>, args: ArgValues, vm: &mut 
 /// Removes and returns the last inserted key-value pair as a tuple.
 /// Raises KeyError if the dict is empty.
 fn dict_popitem<'h>(dict: &mut HeapRead<'h, Dict>, vm: &mut VM<'h>) -> RunResult<Value> {
+    // The rebuild below reads per-entry hashes, so they must be fresh.
+    dict.ensure_indices(vm)?;
     let this = dict.get_mut(vm.heap);
     if this.is_empty() {
         return Err(ExcType::key_error_popitem_empty_dict());
@@ -1733,9 +1817,12 @@ fn dict_popitem<'h>(dict: &mut HeapRead<'h, Dict>, vm: &mut VM<'h>) -> RunResult
     // (This is simpler than trying to find and remove the specific hash entry)
     // TODO: This O(n) rebuild could be optimized by finding and removing the
     // specific hash entry directly from the hashbrown table.
-    this.indices.clear();
-    for (idx, e) in this.entries.iter().enumerate() {
-        this.indices.insert_unique(e.hash, idx, |&i| this.entries[i].hash);
+    {
+        let mut indices = this.indices.borrow_mut();
+        indices.clear();
+        for (idx, e) in this.entries.iter().enumerate() {
+            indices.insert_unique(e.hash.get(), idx, |&i| this.entries[i].hash.get());
+        }
     }
 
     // Create tuple (key, value)
@@ -1743,7 +1830,9 @@ fn dict_popitem<'h>(dict: &mut HeapRead<'h, Dict>, vm: &mut VM<'h>) -> RunResult
 }
 
 // Custom serde implementation for Dict.
-// Serializes entries, contains_refs, and kind; rebuilds the indices hash table on deserialize.
+// Serializes entries, contains_refs and kind only — hashes and the indices table
+// are hasher/build-specific derived data, rebuilt lazily by `ensure_indices` on
+// first keyed access (so dumps stay stable across platforms and hasher changes).
 impl serde::Serialize for Dict {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut state = serializer.serialize_struct("Dict", 3)?;
@@ -1763,13 +1852,11 @@ impl<'de> serde::Deserialize<'de> for Dict {
             kind: DictKind,
         }
         let fields = DictFields::deserialize(deserializer)?;
-        // Rebuild the indices hash table from the entries
-        let mut indices = HashTable::with_capacity(fields.entries.len());
-        for (idx, entry) in fields.entries.iter().enumerate() {
-            indices.insert_unique(entry.hash, idx, |&i| fields.entries[i].hash);
-        }
+        // `stale` marks the empty indices (and zeroed entry hashes) for the
+        // lazy rebuild on first keyed access.
         Ok(Self {
-            indices,
+            indices: RefCell::new(HashTable::new()),
+            stale: Cell::new(!fields.entries.is_empty()),
             entries: fields.entries,
             contains_refs: fields.contains_refs,
             kind: fields.kind,

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -1,9 +1,4 @@
-use std::{
-    collections::hash_map::DefaultHasher,
-    fmt::Write,
-    hash::{Hash, Hasher},
-    mem, slice, vec,
-};
+use std::{fmt::Write, mem, slice, vec};
 
 use hashbrown::HashTable;
 use serde::ser::SerializeStruct;
@@ -16,6 +11,7 @@ use crate::{
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunResult},
     expressions::CmpOperator,
+    hash::hash_python_str,
     heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     modules::collections::{
@@ -466,10 +462,9 @@ impl Dict {
     /// This is an O(1) lookup that doesn't require mutable heap access.
     /// Only works for string keys - returns None if the key is not found.
     pub fn get_by_str(&self, key_str: &str, heap: &Heap, interns: &Interns) -> Option<&Value> {
-        // Compute hash for the string key
-        let mut hasher = DefaultHasher::new();
-        key_str.hash(&mut hasher);
-        let hash = hasher.finish();
+        // Use the canonical string hash so the lookup matches stored entry
+        // hashes exactly, including the `u64::MAX` sentinel remapping.
+        let hash = hash_python_str(key_str).raw();
 
         // Find entry with matching hash and key
         self.indices

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -1,8 +1,4 @@
-use std::{
-    cell::{Cell, RefCell},
-    fmt::Write,
-    mem, slice, vec,
-};
+use std::{fmt::Write, mem, slice, vec};
 
 use hashbrown::HashTable;
 use serde::ser::SerializeStruct;
@@ -68,13 +64,11 @@ use crate::{
 #[derive(Debug, Default)]
 pub(crate) struct Dict {
     /// Indices mapping from the entry hash to its index. Derived data: never
-    /// serialized, rebuilt lazily after deserialize (see [`Dict::indices_stale`]).
-    /// `RefCell` so the rebuild can run behind `&self` heap handles.
-    indices: RefCell<HashTable<usize>>,
+    /// serialized, rebuilt lazily after deserialize by `ensure_indices`.
+    indices: HashTable<usize>,
     /// True when `indices`/entry hashes need a rebuild (set only by
-    /// deserialize). A `Cell<bool>` so the hot-path staleness check is a
-    /// plain byte load instead of a `RefCell` borrow cycle.
-    stale: Cell<bool>,
+    /// deserialize, cleared by `ensure_indices`).
+    stale: bool,
     /// entries is a dense vec maintaining entry order.
     entries: Vec<DictEntry>,
     /// True if any key or value in the dict is a `Value::Ref`. Used to skip iteration
@@ -150,10 +144,9 @@ struct DictEntry {
     value: Value,
     /// The key's hash, needed for correct use of `insert_unique`. Skipped on
     /// serde — hashes are hasher/build-specific so they never cross the wire;
-    /// recomputed together with `indices` by `ensure_indices`. `Cell` so the
-    /// lazy rebuild can run behind `&self` heap handles.
+    /// recomputed together with `indices` by `ensure_indices`.
     #[serde(skip)]
-    hash: Cell<u64>,
+    hash: u64,
 }
 
 impl Dict {
@@ -165,8 +158,8 @@ impl Dict {
 
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            indices: RefCell::new(HashTable::with_capacity(capacity)),
-            stale: Cell::new(false),
+            indices: HashTable::with_capacity(capacity),
+            stale: false,
             entries: Vec::with_capacity(capacity),
             contains_refs: false,
             kind: DictKind::plain(),
@@ -296,7 +289,7 @@ impl Dict {
     /// readers must fall back to a linear scan.
     #[inline]
     fn indices_stale(&self) -> bool {
-        self.stale.get()
+        self.stale
     }
 
     /// Creates a dict from a vector of (key, value) pairs.
@@ -344,11 +337,7 @@ impl Dict {
             .raw();
         let opt_index = self.find_json_string_key_index(hash, &key, vm.heap, vm.interns);
 
-        let entry = DictEntry {
-            key,
-            value,
-            hash: Cell::new(hash),
-        };
+        let entry = DictEntry { key, value, hash };
         if let Some(index) = opt_index {
             let old_entry = mem::replace(&mut self.entries[index], entry);
             old_entry.key.drop_with(vm);
@@ -356,9 +345,7 @@ impl Dict {
         } else {
             let index = self.entries.len();
             self.entries.push(entry);
-            self.indices
-                .borrow_mut()
-                .insert_unique(hash, index, |&i| self.entries[i].hash.get());
+            self.indices.insert_unique(hash, index, |&i| self.entries[i].hash);
             Ok(None)
         }
     }
@@ -370,10 +357,9 @@ impl Dict {
     fn find_json_string_key_index(&self, hash: u64, key: &Value, heap: &Heap, interns: &Interns) -> Option<usize> {
         let key_str = json_key_string_slice(key, heap, interns).expect("json object keys are always string values");
         self.indices
-            .borrow()
             .find(hash, |&idx| {
                 let entry = &self.entries[idx];
-                entry.hash.get() == hash && json_key_equals_str(&entry.key, key_str, heap, interns)
+                entry.hash == hash && json_key_equals_str(&entry.key, key_str, heap, interns)
             })
             .copied()
     }
@@ -413,8 +399,9 @@ impl<'h> HeapRead<'h, Dict> {
     /// Element-wise equality against another dict (matching keys and values).
     ///
     /// Shared by `Dict::py_eq_impl` and `Dataclass::py_eq_impl` (which compares
-    /// the dataclasses' attribute dicts).
-    pub(crate) fn eq_dict(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<bool> {
+    /// the dataclasses' attribute dicts). `other` is `&mut` because its
+    /// indices are consulted (and may lazily rebuild); `self` is only iterated.
+    pub(crate) fn eq_dict(&self, other: &mut Self, vm: &mut VM<'h>) -> RunResult<bool> {
         if self.get(vm.heap).len() != other.get(vm.heap).len() {
             return Ok(false);
         }
@@ -442,21 +429,28 @@ impl<'h> HeapRead<'h, Dict> {
     /// `Counter.__eq__` returns `NotImplemented` and the comparison falls back
     /// to [`eq_dict`](Self::eq_dict), where a zero count *is* a real entry — so
     /// `Counter(a=1, b=0) == {'a': 1}` stays `False`.
-    pub(crate) fn eq_counter(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<bool> {
+    ///
+    /// Both sides are `&mut` because each is probed by key (and may lazily
+    /// rebuild its indices) while the other is iterated.
+    pub(crate) fn eq_counter(&mut self, other: &mut Self, vm: &mut VM<'h>) -> RunResult<bool> {
         // Every count in `self` must match the other side's, missing reading as 0.
-        let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
-        while let Some((key, value)) = iter.next(vm)? {
-            let other_value = other.dict_get(key, vm)?;
-            let eq = match &other_value {
-                Some(other_value) => value.py_eq(other_value, vm),
-                None => value.py_eq(&Value::Int(0), vm),
-            };
-            if let Some(other_value) = other_value {
-                other_value.drop_with(vm);
-            }
-            if !eq? {
-                return Ok(false);
+        // Scoped so the iterator's borrow of `self` ends before the second pass
+        // probes `self` by key.
+        {
+            let iter = self.iter(vm)?;
+            defer_drop_mut!(iter, vm);
+            while let Some((key, value)) = iter.next(vm)? {
+                let other_value = other.dict_get(key, vm)?;
+                let eq = match &other_value {
+                    Some(other_value) => value.py_eq(other_value, vm),
+                    None => value.py_eq(&Value::Int(0), vm),
+                };
+                if let Some(other_value) = other_value {
+                    other_value.drop_with(vm);
+                }
+                if !eq? {
+                    return Ok(false);
+                }
             }
         }
 
@@ -481,7 +475,7 @@ impl<'h> HeapRead<'h, Dict> {
     ///
     /// Returns Ok(Some(value)) if key exists, Ok(None) if key doesn't exist.
     /// Returns Err if key is unhashable.
-    pub(crate) fn dict_get<'a>(&'a self, key: &Value, vm: &'a mut VM<'h>) -> RunResult<Option<Value>> {
+    pub(crate) fn dict_get<'a>(&'a mut self, key: &Value, vm: &'a mut VM<'h>) -> RunResult<Option<Value>> {
         let (opt_index, _hash) = self.find_index_hash(key, vm)?;
         if let Some(index) = opt_index {
             Ok(Some(self.get(vm.heap).entries[index].value.clone_with_heap(vm.heap)))
@@ -520,7 +514,6 @@ impl Dict {
             // hashes exactly, including the `u64::MAX` sentinel remapping.
             let hash = hash_python_str(key_str).raw();
             self.indices
-                .borrow()
                 .find(hash, |&idx| key_eq(&self.entries[idx].key))
                 .map(|&idx| &self.entries[idx].value)
         }
@@ -569,11 +562,7 @@ impl<'h> HeapRead<'h, Dict> {
             }
         };
 
-        let entry = DictEntry {
-            key,
-            value,
-            hash: Cell::new(hash),
-        };
+        let entry = DictEntry { key, value, hash };
         if let Some(index) = opt_index {
             // Key exists, replace in place to preserve insertion order
             let old_entry = mem::replace(&mut self.get_mut(vm.heap).entries[index], entry);
@@ -587,8 +576,7 @@ impl<'h> HeapRead<'h, Dict> {
             let index = this.entries.len();
             this.entries.push(entry);
             this.indices
-                .borrow_mut()
-                .insert_unique(hash, index, |index| this.entries[*index].hash.get());
+                .insert_unique(hash, index, |index| this.entries[*index].hash);
             Ok(None)
         }
     }
@@ -609,10 +597,10 @@ impl<'h> HeapRead<'h, Dict> {
             let entry = self.get_mut(vm.heap).entries.remove(index);
             // Remove from index table and rebuild (same as dict_popitem)
             let this = self.get_mut(vm.heap);
-            let mut indices = this.indices.borrow_mut();
+            let (indices, entries) = (&mut this.indices, &this.entries);
             indices.clear();
-            for (idx, e) in this.entries.iter().enumerate() {
-                indices.insert_unique(e.hash.get(), idx, |&i| this.entries[i].hash.get());
+            for (idx, e) in entries.iter().enumerate() {
+                indices.insert_unique(e.hash, idx, |&i| entries[i].hash);
             }
             Ok(Some((entry.key, entry.value)))
         } else {
@@ -716,7 +704,7 @@ struct DictInitArgs {
 }
 
 impl<'h> HeapRead<'h, Dict> {
-    fn find_index_hash(&self, key: &Value, vm: &mut VM<'h>) -> RunResult<(Option<usize>, u64)> {
+    fn find_index_hash(&mut self, key: &Value, vm: &mut VM<'h>) -> RunResult<(Option<usize>, u64)> {
         self.ensure_indices(vm)?;
         let hash = key
             .py_hash(vm)?
@@ -730,8 +718,8 @@ impl<'h> HeapRead<'h, Dict> {
         // Collect candidate indices during the lookup to avoid borrow tracker issues
         let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
         let this = self.get(vm.heap);
-        this.indices.borrow().find(hash, |v| {
-            if this.entries[*v].hash.get() == hash {
+        this.indices.find(hash, |v| {
+            if this.entries[*v].hash == hash {
                 candidates.push(*v);
             }
             false
@@ -748,13 +736,13 @@ impl<'h> HeapRead<'h, Dict> {
         Ok((None, hash))
     }
 
-    /// Rebuilds the per-entry hash cells and the `indices` table if they are
+    /// Rebuilds the per-entry hashes and the `indices` table if they are
     /// stale (i.e. this dict was just deserialized — hashes never cross the
     /// serialization boundary, each build recomputes with its own hasher).
     ///
     /// Must be called before consulting `indices` from any VM-bearing path.
     /// No-op for dicts constructed in this process.
-    fn ensure_indices(&self, vm: &mut VM<'h>) -> RunResult<()> {
+    fn ensure_indices(&mut self, vm: &mut VM<'h>) -> RunResult<()> {
         if !self.get(vm.heap).indices_stale() {
             return Ok(());
         }
@@ -770,20 +758,20 @@ impl<'h> HeapRead<'h, Dict> {
                 .py_hash(vm)?
                 .expect("deserialized dict keys were hashable when inserted")
                 .raw();
-            self.get(vm.heap).entries[i].hash.set(hash);
+            self.get_mut(vm.heap).entries[i].hash = hash;
         }
         // Phase 2: rebuild the index table from the fresh hashes.
-        let this = self.get(vm.heap);
-        let mut indices = this.indices.borrow_mut();
-        for (idx, e) in this.entries.iter().enumerate() {
-            indices.insert_unique(e.hash.get(), idx, |&i| this.entries[i].hash.get());
+        let this = self.get_mut(vm.heap);
+        let (indices, entries) = (&mut this.indices, &this.entries);
+        for (idx, e) in entries.iter().enumerate() {
+            indices.insert_unique(e.hash, idx, |&i| entries[i].hash);
         }
-        this.stale.set(false);
+        this.stale = false;
         Ok(())
     }
 
     /// Checks whether the dict contains a given key.
-    pub(crate) fn contains_key(&self, key: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
+    pub(crate) fn contains_key(&mut self, key: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
         let (opt_index, _hash) = self.find_index_hash(key, vm)?;
         Ok(opt_index.is_some())
     }
@@ -1200,7 +1188,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
     }
 
     /// `in` on a dict tests its *keys*, matching CPython.
-    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_contains_impl(&mut self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         self.contains_key(item, vm).map(Some)
     }
 
@@ -1226,16 +1214,16 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
         Some(self.get(vm.heap).len())
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         match other.read_heap(vm) {
-            Some(HeapReadOutput::Dict(other)) => {
+            Some(HeapReadOutput::Dict(mut other)) => {
                 // Two Counters compare as multisets (zero counts ignored); any
                 // other pairing is plain dict equality.
                 let both_counters = self.get(vm.heap).is_counter() && other.get(vm.heap).is_counter();
                 if both_counters {
-                    Ok(Some(self.eq_counter(&other, vm)?))
+                    Ok(Some(self.eq_counter(&mut other, vm)?))
                 } else {
-                    Ok(Some(self.eq_dict(&other, vm)?))
+                    Ok(Some(self.eq_dict(&mut other, vm)?))
                 }
             }
             _ => Ok(None),
@@ -1283,15 +1271,15 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
         self.counter_binary(other, CounterOp::Add, vm, self_id)
     }
 
-    fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_sub_impl(&mut self, other: &Value, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         self.counter_binary(other, CounterOp::Sub, vm, self_id)
     }
 
-    fn py_and_impl(&self, other: &Value, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_and_impl(&mut self, other: &Value, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         self.counter_binary(other, CounterOp::And, vm, self_id)
     }
 
-    fn py_or_impl(&self, other: &Value, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_or_impl(&mut self, other: &Value, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         self.counter_binary(other, CounterOp::Or, vm, self_id)
     }
 
@@ -1357,7 +1345,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
     /// A Counter reads a missing key as `0` *without* inserting it. A
     /// defaultdict's miss inserts `factory()` instead, which re-enters the VM
     /// and so cannot happen behind this `&self` — see `heap_data::heap_subscript`.
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
+    fn py_getitem(&mut self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
         match self.dict_get(key, vm)? {
             Some(value) => Ok(value),
             None if self.get(vm.heap).is_counter() => Ok(Value::Int(0)),
@@ -1617,7 +1605,7 @@ impl<C: ContainsHeap> DropWithContext<C> for DictEntry {
 ///
 /// Removes all items from the dict.
 fn dict_clear<'h>(dict: &mut HeapRead<'h, Dict>, vm: &mut VM<'h>) {
-    dict.get_mut(vm.heap).indices.borrow_mut().clear();
+    dict.get_mut(vm.heap).indices.clear();
     mem::take(&mut dict.get_mut(vm.heap).entries).drop_with(vm.heap);
     // Note: contains_refs stays true even if all refs removed, per conservative GC strategy
 }
@@ -1817,12 +1805,10 @@ fn dict_popitem<'h>(dict: &mut HeapRead<'h, Dict>, vm: &mut VM<'h>) -> RunResult
     // (This is simpler than trying to find and remove the specific hash entry)
     // TODO: This O(n) rebuild could be optimized by finding and removing the
     // specific hash entry directly from the hashbrown table.
-    {
-        let mut indices = this.indices.borrow_mut();
-        indices.clear();
-        for (idx, e) in this.entries.iter().enumerate() {
-            indices.insert_unique(e.hash.get(), idx, |&i| this.entries[i].hash.get());
-        }
+    let (indices, entries) = (&mut this.indices, &this.entries);
+    indices.clear();
+    for (idx, e) in entries.iter().enumerate() {
+        indices.insert_unique(e.hash, idx, |&i| entries[i].hash);
     }
 
     // Create tuple (key, value)
@@ -1855,8 +1841,8 @@ impl<'de> serde::Deserialize<'de> for Dict {
         // `stale` marks the empty indices (and zeroed entry hashes) for the
         // lazy rebuild on first keyed access.
         Ok(Self {
-            indices: RefCell::new(HashTable::new()),
-            stale: Cell::new(!fields.entries.is_empty()),
+            indices: HashTable::new(),
+            stale: !fields.entries.is_empty(),
             entries: fields.entries,
             contains_refs: fields.contains_refs,
             kind: fields.kind,
@@ -1987,7 +1973,7 @@ macro_rules! impl_dict_iterator {
                 None
             }
 
-            fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
+            fn py_eq_impl(&mut self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
                 Ok(None)
             }
 

--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -69,7 +69,7 @@ impl<'h> HeapRead<'h, DictKeysView> {
     }
 
     /// Compares this keys view to a mutable set using set membership semantics.
-    pub(crate) fn eq_set(&self, other: &HeapRead<'h, Set>, vm: &mut VM<'h>) -> RunResult<bool> {
+    pub(crate) fn eq_set(&self, other: &mut HeapRead<'h, Set>, vm: &mut VM<'h>) -> RunResult<bool> {
         dict_keys_eq_set_like(
             &self.dict(vm),
             other.get(vm.heap).len(),
@@ -79,7 +79,7 @@ impl<'h> HeapRead<'h, DictKeysView> {
     }
 
     /// Compares this keys view to a frozenset using set membership semantics.
-    pub(crate) fn eq_frozenset(&self, other: &HeapRead<'h, FrozenSet>, vm: &mut VM<'h>) -> RunResult<bool> {
+    pub(crate) fn eq_frozenset(&self, other: &mut HeapRead<'h, FrozenSet>, vm: &mut VM<'h>) -> RunResult<bool> {
         dict_keys_eq_set_like(
             &self.dict(vm),
             other.get(vm.heap).len(),
@@ -114,7 +114,7 @@ impl<'h> HeapRead<'h, DictKeysView> {
         let capacity = Set::preallocation_capacity(other.len(), vm.heap.tracker())?;
         let mut result_guard = DropGuard::new(Set::with_capacity(capacity), vm);
         let (result, vm) = result_guard.as_parts_mut();
-        let dict = self.dict(vm);
+        let mut dict = self.dict(vm);
         for key in other.iter() {
             if dict.contains_key(key, vm)? {
                 result.add(key.clone_with_heap(vm), vm)?;
@@ -129,12 +129,12 @@ impl<'h> HeapRead<'h, DictKeysView> {
         &self,
         other: &Value,
         vm: &mut VM<'h>,
-        operation: impl FnOnce(&Set, &Set, &mut VM<'_>) -> RunResult<Set>,
+        operation: impl FnOnce(&mut Set, &mut Set, &mut VM<'_>) -> RunResult<Set>,
     ) -> RunResult<Option<Value>> {
         let lhs = collect_iterable_to_set(other.clone_with_heap(vm), vm)?;
-        defer_drop!(lhs, vm);
+        defer_drop_mut!(lhs, vm);
         let rhs = self.to_set(vm)?;
-        defer_drop!(rhs, vm);
+        defer_drop_mut!(rhs, vm);
         let result = operation(lhs, rhs, vm)?;
         Ok(Some(Value::Ref(vm.heap.allocate(HeapData::Set(result)))))
     }
@@ -142,9 +142,9 @@ impl<'h> HeapRead<'h, DictKeysView> {
     /// Implements `dict_keys.isdisjoint(iterable)` with CPython's iterable semantics.
     pub(crate) fn isdisjoint_from_value(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
         let self_set = self.to_set(vm)?;
-        defer_drop!(self_set, vm);
+        defer_drop_mut!(self_set, vm);
         let other_set = collect_iterable_to_set(other.clone_with_heap(vm), vm)?;
-        defer_drop!(other_set, vm);
+        defer_drop_mut!(other_set, vm);
         sets_are_disjoint(self_set, other_set, vm)
     }
 }
@@ -161,9 +161,9 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictKeysView> {
     }
 
     /// Delegates to the backing dict's key lookup.
-    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_contains_impl(&mut self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let dict_id = self.get(vm.heap).dict_id();
-        let HeapReadOutput::Dict(dict) = vm.heap.read(dict_id) else {
+        let HeapReadOutput::Dict(mut dict) = vm.heap.read(dict_id) else {
             panic!("dict_keys view must reference a dict");
         };
         dict.contains_key(item, vm).map(Some)
@@ -186,14 +186,14 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictKeysView> {
         Some(self.get(vm.heap).dict(vm.heap).len())
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         match other.read_heap(vm) {
             Some(HeapReadOutput::DictKeysView(other)) => {
                 if self.get(vm.heap).dict_id == other.get(vm.heap).dict_id {
                     return Ok(Some(true));
                 }
                 let left = self.dict(vm);
-                let right = other.dict(vm);
+                let mut right = other.dict(vm);
                 dict_keys_eq_set_like(
                     &left,
                     right.get(vm.heap).len(),
@@ -202,41 +202,41 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictKeysView> {
                 )
                 .map(Some)
             }
-            Some(HeapReadOutput::Set(other)) => Ok(Some(self.eq_set(&other, vm)?)),
-            Some(HeapReadOutput::FrozenSet(other)) => Ok(Some(self.eq_frozenset(&other, vm)?)),
+            Some(HeapReadOutput::Set(mut other)) => Ok(Some(self.eq_set(&mut other, vm)?)),
+            Some(HeapReadOutput::FrozenSet(mut other)) => Ok(Some(self.eq_frozenset(&mut other, vm)?)),
             _ => Ok(None),
         }
     }
 
-    fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_sub_impl(&mut self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         dict_view_binary_op_value(self.to_set(vm)?, other, vm, apply_dict_view_sub)
     }
 
-    fn py_and_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_and_impl(&mut self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         self.intersection(other, vm)
     }
 
-    fn py_or_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_or_impl(&mut self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         dict_view_binary_op_value(self.to_set(vm)?, other, vm, apply_dict_view_or)
     }
 
-    fn py_xor_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_xor_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         dict_view_binary_op_value(self.to_set(vm)?, other, vm, apply_dict_view_xor)
     }
 
-    fn py_rsub_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_rsub_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         self.reflected_binary_op(other, vm, apply_dict_view_sub)
     }
 
-    fn py_rand_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_rand_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         self.intersection(other, vm)
     }
 
-    fn py_ror_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_ror_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         self.reflected_binary_op(other, vm, apply_dict_view_or)
     }
 
-    fn py_rxor_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_rxor_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         self.reflected_binary_op(other, vm, apply_dict_view_xor)
     }
 
@@ -303,7 +303,7 @@ impl<'h> HeapRead<'h, DictItemsView> {
     }
 
     /// Compares this items view to a mutable set using set membership semantics.
-    pub(crate) fn eq_set(&self, other: &HeapRead<'h, Set>, vm: &mut VM<'h>) -> RunResult<bool> {
+    pub(crate) fn eq_set(&self, other: &mut HeapRead<'h, Set>, vm: &mut VM<'h>) -> RunResult<bool> {
         dict_items_eq_set_like(
             &self.dict(vm),
             other.get(vm.heap).len(),
@@ -313,7 +313,7 @@ impl<'h> HeapRead<'h, DictItemsView> {
     }
 
     /// Compares this items view to a frozenset using set membership semantics.
-    pub(crate) fn eq_frozenset(&self, other: &HeapRead<'h, FrozenSet>, vm: &mut VM<'h>) -> RunResult<bool> {
+    pub(crate) fn eq_frozenset(&self, other: &mut HeapRead<'h, FrozenSet>, vm: &mut VM<'h>) -> RunResult<bool> {
         dict_items_eq_set_like(
             &self.dict(vm),
             other.get(vm.heap).len(),
@@ -343,12 +343,12 @@ impl<'h> HeapRead<'h, DictItemsView> {
     /// Intersects live items with an arbitrary iterable.
     fn intersection(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         let other = collect_iterable_to_set(other.clone_with_heap(vm), vm)?;
-        defer_drop!(other, vm);
+        defer_drop_mut!(other, vm);
         let result = if other.is_empty() {
             Set::new()
         } else if self.items_are_hashable(vm)? {
             let items = self.to_set(vm)?;
-            defer_drop!(items, vm);
+            defer_drop_mut!(items, vm);
             apply_dict_view_and(items, other, vm)?
         } else {
             self.intersect_unhashable_items(other, vm)?
@@ -402,12 +402,12 @@ impl<'h> HeapRead<'h, DictItemsView> {
         &self,
         other: &Value,
         vm: &mut VM<'h>,
-        operation: impl FnOnce(&Set, &Set, &mut VM<'_>) -> RunResult<Set>,
+        operation: impl FnOnce(&mut Set, &mut Set, &mut VM<'_>) -> RunResult<Set>,
     ) -> RunResult<Option<Value>> {
         let lhs = collect_iterable_to_set(other.clone_with_heap(vm), vm)?;
-        defer_drop!(lhs, vm);
+        defer_drop_mut!(lhs, vm);
         let rhs = self.to_set(vm)?;
-        defer_drop!(rhs, vm);
+        defer_drop_mut!(rhs, vm);
         let result = operation(lhs, rhs, vm)?;
         Ok(Some(Value::Ref(vm.heap.allocate(HeapData::Set(result)))))
     }
@@ -415,9 +415,9 @@ impl<'h> HeapRead<'h, DictItemsView> {
     /// Implements `dict_items.isdisjoint(iterable)` with CPython's iterable semantics.
     pub(crate) fn isdisjoint_from_value(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
         let self_set = self.to_set(vm)?;
-        defer_drop!(self_set, vm);
+        defer_drop_mut!(self_set, vm);
         let other_set = collect_iterable_to_set(other.clone_with_heap(vm), vm)?;
-        defer_drop!(other_set, vm);
+        defer_drop_mut!(other_set, vm);
         sets_are_disjoint(self_set, other_set, vm)
     }
 }
@@ -435,14 +435,14 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictItemsView> {
 
     /// Membership takes a `(key, value)` probe: look the key up, then compare
     /// the stored value. A non-pair probe can never be a member.
-    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_contains_impl(&mut self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let dict_id = self.get(vm.heap).dict_id();
         let Some((key, value)) = cloned_items_view_candidate(item, vm) else {
             return Ok(Some(false));
         };
         defer_drop!(key, vm);
         defer_drop!(value, vm);
-        let HeapReadOutput::Dict(dict) = vm.heap.read(dict_id) else {
+        let HeapReadOutput::Dict(mut dict) = vm.heap.read(dict_id) else {
             panic!("dict_items view must reference a dict");
         };
         match dict.dict_get(key, vm) {
@@ -474,51 +474,51 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictItemsView> {
         Some(self.get(vm.heap).dict(vm.heap).len())
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         match other.read_heap(vm) {
             Some(HeapReadOutput::DictItemsView(other)) => {
                 if self.get(vm.heap).dict_id == other.get(vm.heap).dict_id {
                     return Ok(Some(true));
                 }
                 let left = self.dict(vm);
-                let right = other.dict(vm);
-                Ok(Some(left.eq_dict(&right, vm)?))
+                let mut right = other.dict(vm);
+                Ok(Some(left.eq_dict(&mut right, vm)?))
             }
-            Some(HeapReadOutput::Set(other)) => Ok(Some(self.eq_set(&other, vm)?)),
-            Some(HeapReadOutput::FrozenSet(other)) => Ok(Some(self.eq_frozenset(&other, vm)?)),
+            Some(HeapReadOutput::Set(mut other)) => Ok(Some(self.eq_set(&mut other, vm)?)),
+            Some(HeapReadOutput::FrozenSet(mut other)) => Ok(Some(self.eq_frozenset(&mut other, vm)?)),
             _ => Ok(None),
         }
     }
 
-    fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_sub_impl(&mut self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         dict_view_binary_op_value(self.to_set(vm)?, other, vm, apply_dict_view_sub)
     }
 
-    fn py_and_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_and_impl(&mut self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         self.intersection(other, vm)
     }
 
-    fn py_or_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_or_impl(&mut self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         dict_view_binary_op_value(self.to_set(vm)?, other, vm, apply_dict_view_or)
     }
 
-    fn py_xor_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_xor_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         dict_view_binary_op_value(self.to_set(vm)?, other, vm, apply_dict_view_xor)
     }
 
-    fn py_rsub_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_rsub_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         self.reflected_binary_op(other, vm, apply_dict_view_sub)
     }
 
-    fn py_rand_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_rand_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         self.intersection(other, vm)
     }
 
-    fn py_ror_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_ror_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         self.reflected_binary_op(other, vm, apply_dict_view_or)
     }
 
-    fn py_rxor_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_rxor_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         self.reflected_binary_op(other, vm, apply_dict_view_xor)
     }
 
@@ -597,7 +597,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictValuesView> {
     }
 
     /// Values are not indexed, so this is a linear scan of the backing dict.
-    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_contains_impl(&mut self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let dict_id = self.get(vm.heap).dict_id();
         let HeapReadOutput::Dict(dict) = vm.heap.read(dict_id) else {
             panic!("dict_values view must reference a dict");
@@ -630,7 +630,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictValuesView> {
         Some(self.get(vm.heap).dict(vm.heap).len())
     }
 
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         // `dict_values` views use identity equality (handled before the heap read).
         Ok(None)
     }
@@ -768,11 +768,11 @@ fn dict_view_binary_op_value(
     lhs_set: Set,
     rhs: &Value,
     vm: &mut VM<'_>,
-    operation: impl FnOnce(&Set, &Set, &mut VM<'_>) -> RunResult<Set>,
+    operation: impl FnOnce(&mut Set, &mut Set, &mut VM<'_>) -> RunResult<Set>,
 ) -> RunResult<Option<Value>> {
-    defer_drop!(lhs_set, vm);
+    defer_drop_mut!(lhs_set, vm);
     let rhs_set = collect_iterable_to_set(rhs.clone_with_heap(vm), vm)?;
-    defer_drop!(rhs_set, vm);
+    defer_drop_mut!(rhs_set, vm);
 
     let result = operation(lhs_set, rhs_set, vm)?;
     let result_id = vm.heap.allocate(HeapData::Set(result));
@@ -780,13 +780,13 @@ fn dict_view_binary_op_value(
 }
 
 /// Computes dictionary-view intersection.
-fn apply_dict_view_and(lhs: &Set, rhs: &Set, vm: &mut VM<'_>) -> RunResult<Set> {
+fn apply_dict_view_and(lhs: &mut Set, rhs: &mut Set, vm: &mut VM<'_>) -> RunResult<Set> {
     let capacity = Set::preallocation_capacity(lhs.len().min(rhs.len()), vm.heap.tracker())?;
     let mut result_guard = DropGuard::new(Set::with_capacity(capacity), vm);
     let (result, vm) = result_guard.as_parts_mut();
     let (smaller, larger) = if lhs.len() <= rhs.len() { (lhs, rhs) } else { (rhs, lhs) };
     for value in smaller.iter() {
-        if vm.heap.protect(larger).contains(value, vm)? {
+        if vm.heap.protect_mut(larger).contains(value, vm)? {
             result.add(value.clone_with_heap(vm), vm)?;
         }
     }
@@ -794,7 +794,7 @@ fn apply_dict_view_and(lhs: &Set, rhs: &Set, vm: &mut VM<'_>) -> RunResult<Set> 
 }
 
 /// Computes dictionary-view union.
-fn apply_dict_view_or(lhs: &Set, rhs: &Set, vm: &mut VM<'_>) -> RunResult<Set> {
+fn apply_dict_view_or(lhs: &mut Set, rhs: &mut Set, vm: &mut VM<'_>) -> RunResult<Set> {
     let capacity = Set::preallocation_capacity(lhs.len().saturating_add(rhs.len()), vm.heap.tracker())?;
     let mut result_guard = DropGuard::new(Set::with_capacity(capacity), vm);
     let (result, vm) = result_guard.as_parts_mut();
@@ -805,17 +805,17 @@ fn apply_dict_view_or(lhs: &Set, rhs: &Set, vm: &mut VM<'_>) -> RunResult<Set> {
 }
 
 /// Computes dictionary-view symmetric difference.
-fn apply_dict_view_xor(lhs: &Set, rhs: &Set, vm: &mut VM<'_>) -> RunResult<Set> {
+fn apply_dict_view_xor(lhs: &mut Set, rhs: &mut Set, vm: &mut VM<'_>) -> RunResult<Set> {
     let capacity = Set::preallocation_capacity(lhs.len().saturating_add(rhs.len()), vm.heap.tracker())?;
     let mut result_guard = DropGuard::new(Set::with_capacity(capacity), vm);
     let (result, vm) = result_guard.as_parts_mut();
     for value in lhs.iter() {
-        if !vm.heap.protect(rhs).contains(value, vm)? {
+        if !vm.heap.protect_mut(rhs).contains(value, vm)? {
             result.add(value.clone_with_heap(vm), vm)?;
         }
     }
     for value in rhs.iter() {
-        if !vm.heap.protect(lhs).contains(value, vm)? {
+        if !vm.heap.protect_mut(lhs).contains(value, vm)? {
             result.add(value.clone_with_heap(vm), vm)?;
         }
     }
@@ -823,12 +823,12 @@ fn apply_dict_view_xor(lhs: &Set, rhs: &Set, vm: &mut VM<'_>) -> RunResult<Set> 
 }
 
 /// Computes dictionary-view difference.
-fn apply_dict_view_sub(lhs: &Set, rhs: &Set, vm: &mut VM<'_>) -> RunResult<Set> {
+fn apply_dict_view_sub(lhs: &mut Set, rhs: &mut Set, vm: &mut VM<'_>) -> RunResult<Set> {
     let capacity = Set::preallocation_capacity(lhs.len(), vm.heap.tracker())?;
     let mut result_guard = DropGuard::new(Set::with_capacity(capacity), vm);
     let (result, vm) = result_guard.as_parts_mut();
     for value in lhs.iter() {
-        if !vm.heap.protect(rhs).contains(value, vm)? {
+        if !vm.heap.protect_mut(rhs).contains(value, vm)? {
             result.add(value.clone_with_heap(vm), vm)?;
         }
     }
@@ -855,7 +855,7 @@ pub(crate) fn collect_iterable_to_set(value: Value, vm: &mut VM<'_>) -> Result<S
 }
 
 /// Returns whether two temporary sets have no elements in common.
-fn sets_are_disjoint(left: &Set, right: &Set, vm: &mut VM<'_>) -> RunResult<bool> {
+fn sets_are_disjoint(left: &mut Set, right: &mut Set, vm: &mut VM<'_>) -> RunResult<bool> {
     let (smaller, larger) = if left.len() <= right.len() {
         (left, right)
     } else {
@@ -863,7 +863,7 @@ fn sets_are_disjoint(left: &Set, right: &Set, vm: &mut VM<'_>) -> RunResult<bool
     };
 
     for value in smaller.iter() {
-        if vm.heap.protect(larger).contains(value, vm)? {
+        if vm.heap.protect_mut(larger).contains(value, vm)? {
             return Ok(false);
         }
     }

--- a/crates/monty/src/types/file.rs
+++ b/crates/monty/src/types/file.rs
@@ -308,7 +308,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, OpenFile> {
         None
     }
 
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         // File objects use identity equality (handled before the heap read).
         Ok(None)
     }

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -80,7 +80,7 @@ impl<'h> HeapRead<'h, Instance> {
 impl<'h> PyTrait<'h> for HeapRead<'h, Instance> {
     /// The class's `__contains__`, or `None` when it defines none — `in` then
     /// falls back to iteration, matching CPython's `sq_contains` before `tp_iter`.
-    fn py_contains_impl(&self, self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_contains_impl(&mut self, self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         instance_contains(self_id, item, vm)
     }
 
@@ -103,7 +103,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Instance> {
 
     /// Returns `NotImplemented`; comparisons dispatch at the `Value` level because
     /// user and synthesized dataclass equality require the instance's `HeapId`.
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         Ok(None)
     }
 
@@ -339,7 +339,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, BoundMethod> {
         None
     }
 
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         Ok(None)
     }
 

--- a/crates/monty/src/types/itertools/mod.rs
+++ b/crates/monty/src/types/itertools/mod.rs
@@ -176,7 +176,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ItertoolsIter> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
         Ok(None)
     }
 

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -369,7 +369,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
     /// `list_contains` does. `ListIter` re-reads the length on every step, so a
     /// user `__eq__` re-entering the VM and shrinking the list halts the walk
     /// cleanly instead of indexing out of bounds.
-    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_contains_impl(&mut self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let iter = self.iter(vm)?;
         defer_drop_mut!(iter, vm);
         while let Some(el) = iter.next(vm)? {
@@ -388,7 +388,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
         Some(self.get(vm.heap).items.len())
     }
 
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
+    fn py_getitem(&mut self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
         // Check for slice first (Value::Ref pointing to HeapData::Slice)
         if let Value::Ref(id) = key
             && let HeapData::Slice(slice) = vm.heap.get(*id)
@@ -467,7 +467,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
         Ok(())
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let Some(HeapReadOutput::List(other)) = other.read_heap(vm) else {
             return Ok(None);
         };
@@ -977,7 +977,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ListIterator> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
         Ok(None)
     }
 

--- a/crates/monty/src/types/long_int.rs
+++ b/crates/monty/src/types/long_int.rs
@@ -388,7 +388,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, LongInt> {
         Ok(!self.get(vm.heap).is_zero())
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         Ok(eq_bigint(self.get(vm.heap).inner(), other, vm))
     }
 
@@ -441,7 +441,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, LongInt> {
         }))
     }
 
-    fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_sub_impl(&mut self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         let lhs = self.get(vm.heap);
         let result = match other {
             Value::Int(rhs) => lhs.inner() - rhs,
@@ -453,7 +453,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, LongInt> {
         Ok(Some(LongInt::new(result).into_value(vm.heap)))
     }
 
-    fn py_rsub_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_rsub_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         let rhs = self.get(vm.heap);
         let result = match other {
             Value::Int(lhs) => BigInt::from(*lhs) - rhs.inner(),
@@ -611,27 +611,27 @@ impl<'h> PyTrait<'h> for HeapRead<'h, LongInt> {
         }
     }
 
-    fn py_and_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_and_impl(&mut self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         Ok(self.bitwise_value(other, vm, |lhs, rhs| lhs & rhs))
     }
 
-    fn py_rand_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_rand_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         Ok(self.bitwise_value(other, vm, |lhs, rhs| rhs & lhs))
     }
 
-    fn py_or_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_or_impl(&mut self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         Ok(self.bitwise_value(other, vm, |lhs, rhs| lhs | rhs))
     }
 
-    fn py_ror_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_ror_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         Ok(self.bitwise_value(other, vm, |lhs, rhs| rhs | lhs))
     }
 
-    fn py_xor_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_xor_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         Ok(self.bitwise_value(other, vm, |lhs, rhs| lhs ^ rhs))
     }
 
-    fn py_rxor_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_rxor_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         Ok(self.bitwise_value(other, vm, |lhs, rhs| rhs ^ lhs))
     }
 

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -8,7 +8,6 @@ use std::{
 };
 
 use ahash::AHasher;
-
 /// Python named tuple type, combining tuple-like indexing with named attribute access.
 ///
 /// Named tuples are like regular tuples but with field names, providing two ways
@@ -343,7 +342,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
     /// tuple subclass in CPython and inherits `tuplecontains`. Without this, `in`
     /// falls back to iteration and allocates a heap `TupleIterator`, which can
     /// trip the allocation limit on a tight heap.
-    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_contains_impl(&mut self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let iter = self.iter(vm)?;
         defer_drop_mut!(iter, vm);
         while let Some(el) = iter.next(vm)? {
@@ -369,7 +368,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
         Some(self.get(vm.heap).len())
     }
 
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
+    fn py_getitem(&mut self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
         // A slice degrades to a plain tuple, as in CPython — the field names
         // describe the original instance only, so they cannot survive a slice.
         if let Value::Ref(key_id) = key
@@ -445,7 +444,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
         self.py_mul_impl(other, vm)
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         // A namedtuple equals another namedtuple element-wise, and also equals a
         // plain tuple with the same elements (class name is ignored). Both
         // directions of the tuple case are covered here, so `Tuple::py_eq_impl`
@@ -844,7 +843,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTupleClass> {
         None
     }
 
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         // Class objects compare by identity, resolved before reaching here.
         Ok(None)
     }

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -1,12 +1,13 @@
 use std::{
     cell::Cell,
     cmp::Ordering,
-    collections::hash_map::DefaultHasher,
     fmt::Write,
     hash::{Hash, Hasher},
     iter::once,
     mem,
 };
+
+use ahash::AHasher;
 
 /// Python named tuple type, combining tuple-like indexing with named attribute access.
 ///
@@ -478,7 +479,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
         if let Some(cached) = self.get(vm.heap).cached_hash.get() {
             return Ok(Some(cached));
         }
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = AHasher::default();
         let iter = self.iter(vm)?;
         defer_drop_mut!(iter, vm);
         while let Some(item) = iter.next(vm)? {

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -440,7 +440,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Path> {
         None
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let Some(HeapReadOutput::Path(other)) = other.read_heap(vm) else {
             return Ok(None);
         };

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -4,12 +4,7 @@
 //! (require `OsAccess` implementation). Pure methods are handled directly by the VM,
 //! while filesystem methods yield external function calls for the host to resolve.
 
-use std::{
-    cell::Cell,
-    collections::hash_map::DefaultHasher,
-    fmt::Write,
-    hash::{Hash, Hasher},
-};
+use std::{cell::Cell, fmt::Write};
 
 use monty_types::MontyPath;
 use smallvec::SmallVec;
@@ -20,7 +15,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
-    hash::HashValue,
+    hash::{HashValue, hash_one},
     heap::{DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     os_dispatch::{build_path_os_call, is_path_os_method},
@@ -457,9 +452,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Path> {
         if let Some(cached) = p.cached_hash.get() {
             return Ok(Some(cached));
         }
-        let mut hasher = DefaultHasher::new();
-        p.as_str().hash(&mut hasher);
-        let hash = HashValue::new(hasher.finish());
+        let hash = hash_one(p.as_str());
         p.cached_hash.set(Some(hash));
         Ok(Some(hash))
     }

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -172,7 +172,9 @@ pub(crate) trait PyTrait<'h> {
     /// `Ok(None)` means the type has no containment logic of its own, so
     /// [`Value::py_contains`] falls back to iteration and then `TypeError`.
     /// `self_id` is only needed by types that re-enter the VM (`Instance`).
-    fn py_contains_impl(&self, _self_id: HeapId, _item: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    /// `&mut self` so dict/set lookups can lazily rebuild indices after a
+    /// dump/load (hashes are never serialized).
+    fn py_contains_impl(&mut self, _self_id: HeapId, _item: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         Ok(None)
     }
 
@@ -193,7 +195,10 @@ pub(crate) trait PyTrait<'h> {
     /// Heap-backed implementations receive `self_id`; immediate values receive
     /// `None`. Recursion depth is tracked via `vm.recursion_guard()`; returns
     /// `Err(ResourceError::Recursion)` if maximum depth is exceeded.
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>>;
+    ///
+    /// `&mut self` so dict/set comparisons can lazily rebuild indices after a
+    /// dump/load (hashes are never serialized).
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>>;
 
     /// Python comparison (`<`, `>`, etc.).
     ///
@@ -319,12 +324,12 @@ pub(crate) trait PyTrait<'h> {
 
     /// One-sided implementation of Python subtraction (`__sub__`).
     /// `self_id` carries this value's heap id, as for [`py_add_impl`](Self::py_add_impl).
-    fn py_sub_impl(&self, _other: &Value, _vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_sub_impl(&mut self, _other: &Value, _vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         Ok(None)
     }
 
     /// Reflected implementation of Python subtraction (`__rsub__`).
-    fn py_rsub_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_rsub_impl(&mut self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         Ok(None)
     }
 
@@ -390,33 +395,33 @@ pub(crate) trait PyTrait<'h> {
 
     /// One-sided implementation of Python bitwise AND (`__and__`).
     /// `self_id` carries this value's heap id, as for [`py_add_impl`](Self::py_add_impl).
-    fn py_and_impl(&self, _other: &Value, _vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_and_impl(&mut self, _other: &Value, _vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         Ok(None)
     }
 
     /// Reflected implementation of Python bitwise AND (`__rand__`).
-    fn py_rand_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_rand_impl(&mut self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         Ok(None)
     }
 
     /// One-sided implementation of Python bitwise OR (`__or__`).
     /// `self_id` carries this value's heap id, as for [`py_add_impl`](Self::py_add_impl).
-    fn py_or_impl(&self, _other: &Value, _vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_or_impl(&mut self, _other: &Value, _vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         Ok(None)
     }
 
     /// Reflected implementation of Python bitwise OR (`__ror__`).
-    fn py_ror_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_ror_impl(&mut self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         Ok(None)
     }
 
     /// One-sided implementation of Python bitwise XOR (`__xor__`).
-    fn py_xor_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_xor_impl(&mut self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         Ok(None)
     }
 
     /// Reflected implementation of Python bitwise XOR (`__rxor__`).
-    fn py_rxor_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_rxor_impl(&mut self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         Ok(None)
     }
 
@@ -593,7 +598,7 @@ pub(crate) trait PyTrait<'h> {
     /// and access to interned string content.
     ///
     /// Default implementation returns TypeError.
-    fn py_getitem(&self, _key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
+    fn py_getitem(&mut self, _key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
         Err(ExcType::type_error_not_sub(&self.py_type(vm).name(vm.heap, vm.interns)))
     }
 

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -192,7 +192,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Range> {
 
     /// O(1) containment: bounds plus step alignment, no iteration. Non-integral
     /// items can never be members, matching CPython's fast path.
-    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_contains_impl(&mut self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let range = self.get(vm.heap);
         let n = match item {
             Value::Int(i) => *i,
@@ -228,7 +228,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Range> {
         Some(self.get(vm.heap).len())
     }
 
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
+    fn py_getitem(&mut self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
         // Check for slice first (Value::Ref pointing to HeapData::Slice)
         if let Value::Ref(id) = key
             && let HeapData::Slice(slice) = vm.heap.get(*id)
@@ -265,7 +265,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Range> {
         Ok(Value::Int(offset_i64))
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let Some(HeapReadOutput::Range(other)) = other.read_heap(vm) else {
             return Ok(None);
         };
@@ -369,7 +369,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, RangeIterator> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
         Ok(None)
     }
 

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -4,11 +4,11 @@
 //! with configurable start, stop, and step values.
 
 use std::{
-    collections::hash_map::DefaultHasher,
     fmt::Write,
     hash::{Hash, Hasher},
 };
 
+use ahash::AHasher;
 use num_integer::div_ceil;
 
 use crate::{
@@ -297,7 +297,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Range> {
         // and `range(0, 2, 2)`.
         let r = self.get(vm.heap);
         let len = r.len();
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = AHasher::default();
         len.hash(&mut hasher);
         if len > 0 {
             r.start.hash(&mut hasher);

--- a/crates/monty/src/types/re_match.rs
+++ b/crates/monty/src/types/re_match.rs
@@ -318,7 +318,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
         None
     }
 
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         // Match objects use identity equality (handled before the heap read).
         Ok(None)
     }
@@ -387,7 +387,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
         Ok(CallResult::Value(result))
     }
 
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
+    fn py_getitem(&mut self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
         match key {
             Value::Int(n) => self.get(vm.heap).get_group(*n, vm.heap),
             Value::Bool(b) => self.get(vm.heap).get_group(i64::from(*b), vm.heap),

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -368,7 +368,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, RePattern> {
         None
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let Some(HeapReadOutput::RePattern(other)) = other.read_heap(vm) else {
             return Ok(None);
         };

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -1,8 +1,4 @@
-use std::{
-    cell::{Cell, RefCell},
-    fmt::Write,
-    mem,
-};
+use std::{cell::Cell, fmt::Write, mem};
 
 use hashbrown::HashTable;
 use monty_types::{ResourceError, ResourceTracker};
@@ -30,10 +26,9 @@ struct SetEntry {
     pub(crate) value: Value,
     /// Cached hash for efficient lookup and reinsertion. Skipped on serde —
     /// hashes are hasher/build-specific so they never cross the wire;
-    /// recomputed together with `indices` by `ensure_indices`. `Cell` so the
-    /// lazy rebuild can run behind `&self` heap handles.
+    /// recomputed together with `indices` by `ensure_indices`.
     #[serde(skip)]
-    pub(crate) hash: Cell<u64>,
+    pub(crate) hash: u64,
 }
 
 /// Internal storage shared between Set and FrozenSet.
@@ -44,13 +39,11 @@ struct SetEntry {
 #[derive(Debug, Default)]
 pub(crate) struct SetStorage {
     /// Maps hash to index in entries vector. Derived data: never serialized,
-    /// rebuilt lazily (see [`SetStorage::indices_stale`]). `RefCell` so the
-    /// rebuild can run behind `&self` heap handles.
-    indices: RefCell<HashTable<usize>>,
+    /// rebuilt lazily by `ensure_indices`.
+    indices: HashTable<usize>,
     /// True when `indices`/entry hashes need a rebuild (set by deserialize
-    /// and `from_entries`). A `Cell<bool>` so the hot-path staleness check
-    /// is a plain byte load instead of a `RefCell` borrow cycle.
-    stale: Cell<bool>,
+    /// and `from_entries`, cleared by `ensure_indices`).
+    stale: bool,
     /// Dense vector of entries maintaining insertion order.
     entries: Vec<SetEntry>,
 }
@@ -64,8 +57,8 @@ impl SetStorage {
     /// Creates a new set storage with pre-allocated capacity.
     fn with_capacity(capacity: usize) -> Self {
         Self {
-            indices: RefCell::new(HashTable::with_capacity(capacity)),
-            stale: Cell::new(false),
+            indices: HashTable::with_capacity(capacity),
+            stale: false,
             entries: Vec::with_capacity(capacity),
         }
     }
@@ -75,7 +68,7 @@ impl SetStorage {
     /// Rebuild via `ensure_indices` before consulting `indices`.
     #[inline]
     fn indices_stale(&self) -> bool {
-        self.stale.get()
+        self.stale
     }
 
     /// Creates a SetStorage from a vector of values (assumed already deduplicated,
@@ -87,15 +80,9 @@ impl SetStorage {
     /// The caller is responsible for handling reference counting.
     fn from_entries(values: Vec<Value>) -> Self {
         Self {
-            indices: RefCell::new(HashTable::new()),
-            stale: Cell::new(!values.is_empty()),
-            entries: values
-                .into_iter()
-                .map(|value| SetEntry {
-                    value,
-                    hash: Cell::new(0),
-                })
-                .collect(),
+            indices: HashTable::new(),
+            stale: !values.is_empty(),
+            entries: values.into_iter().map(|value| SetEntry { value, hash: 0 }).collect(),
         }
     }
 
@@ -125,7 +112,7 @@ impl SetStorage {
     fn add(&mut self, value: Value, vm: &mut VM<'_>) -> RunResult<bool> {
         // Detached storages can be stale too (clones of / conversions from a
         // freshly deserialized set), so rebuild before consulting `indices`.
-        vm.heap.protect(&*self).ensure_indices(vm)?;
+        self.ensure_indices_detached(vm)?;
         let mut value_guard = DropGuard::new(value, vm);
         let (value, vm) = value_guard.as_parts_mut();
         let hash = set_element_hash(value, vm)?;
@@ -133,7 +120,6 @@ impl SetStorage {
         // Check if value already exists.
         let existing = self
             .indices
-            .borrow()
             .find(hash, |&idx| value.py_eq(&self.entries[idx].value, vm).unwrap_or(false))
             .copied();
 
@@ -142,15 +128,31 @@ impl SetStorage {
         } else {
             let index = self.entries.len();
             let value = value_guard.into_inner();
-            self.entries.push(SetEntry {
-                value,
-                hash: Cell::new(hash),
-            });
-            self.indices
-                .borrow_mut()
-                .insert_unique(hash, index, |&idx| self.entries[idx].hash.get());
+            self.entries.push(SetEntry { value, hash });
+            self.indices.insert_unique(hash, index, |&idx| self.entries[idx].hash);
             Ok(true)
         }
+    }
+
+    /// Detached-storage counterpart of `HeapRead::ensure_indices`.
+    ///
+    /// Only callable where `self` is disjoint from the VM (storages under
+    /// construction or extracted copies) — the borrow checker enforces that,
+    /// which is why this cannot serve heap-resident storages.
+    fn ensure_indices_detached(&mut self, vm: &mut VM<'_>) -> RunResult<()> {
+        if !self.indices_stale() {
+            return Ok(());
+        }
+        for i in 0..self.entries.len() {
+            let hash = set_element_hash(&self.entries[i].value, vm)?;
+            self.entries[i].hash = hash;
+        }
+        let (indices, entries) = (&mut self.indices, &self.entries);
+        for (idx, e) in entries.iter().enumerate() {
+            indices.insert_unique(e.hash, idx, |&i| entries[i].hash);
+        }
+        self.stale = false;
+        Ok(())
     }
 }
 
@@ -166,8 +168,8 @@ impl<'h> HeapRead<'h, SetStorage> {
         // Collect candidates by hash
         let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
         let storage = &self.get(vm.heap);
-        storage.indices.borrow().find(hash, |&idx| {
-            if storage.entries[idx].hash.get() == hash {
+        storage.indices.find(hash, |&idx| {
+            if storage.entries[idx].hash == hash {
                 candidates.push(idx);
             }
             false
@@ -191,12 +193,10 @@ impl<'h> HeapRead<'h, SetStorage> {
         // Remove via short-lived mutable borrow
         let storage = self.get_mut(vm.heap);
         let removed_entry = storage.entries.remove(index);
-        {
-            let mut indices = storage.indices.borrow_mut();
-            indices.clear();
-            for (idx, e) in storage.entries.iter().enumerate() {
-                indices.insert_unique(e.hash.get(), idx, |&i| storage.entries[i].hash.get());
-            }
+        let (indices, entries) = (&mut storage.indices, &storage.entries);
+        indices.clear();
+        for (idx, e) in entries.iter().enumerate() {
+            indices.insert_unique(e.hash, idx, |&i| entries[i].hash);
         }
 
         removed_entry.value.drop_with(vm);
@@ -228,8 +228,7 @@ impl<'h> HeapRead<'h, SetStorage> {
         // Remove from hash table
         storage
             .indices
-            .borrow_mut()
-            .find_entry(entry.hash.get(), |&idx| idx == storage.entries.len())
+            .find_entry(entry.hash, |&idx| idx == storage.entries.len())
             .expect("entry must exist")
             .remove();
 
@@ -239,7 +238,7 @@ impl<'h> HeapRead<'h, SetStorage> {
     /// Removes all elements from the set.
     fn clear(&mut self, vm: &mut VM<'h>) {
         let entries = mem::take(&mut self.get_mut(vm.heap).entries);
-        self.get_mut(vm.heap).indices.borrow_mut().clear();
+        self.get_mut(vm.heap).indices.clear();
         entries.drop_with(vm);
     }
 }
@@ -251,14 +250,14 @@ impl SetStorage {
     /// equally stale clone (rebuilt lazily) and a fresh source a fresh one.
     fn clone_with_heap(&self, heap: &impl ContainsHeap) -> Self {
         Self {
-            indices: RefCell::new(self.indices.borrow().clone()),
-            stale: self.stale.clone(),
+            indices: self.indices.clone(),
+            stale: self.stale,
             entries: self
                 .entries
                 .iter()
                 .map(|entry| SetEntry {
                     value: entry.value.clone_with_heap(heap),
-                    hash: entry.hash.clone(),
+                    hash: entry.hash,
                 })
                 .collect(),
         }
@@ -267,15 +266,15 @@ impl SetStorage {
 
 impl<'h> HeapRead<'h, SetStorage> {
     /// Checks if the set contains a value.
-    pub fn contains(&self, value: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
+    pub fn contains(&mut self, value: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
         self.ensure_indices(vm)?;
         let hash = set_element_hash(value, vm)?;
 
         // Collect candidates by hash
         let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
         let storage = &self.get(vm.heap);
-        storage.indices.borrow().find(hash, |&idx| {
-            if storage.entries[idx].hash.get() == hash {
+        storage.indices.find(hash, |&idx| {
+            if storage.entries[idx].hash == hash {
                 candidates.push(idx);
             }
             false
@@ -293,14 +292,14 @@ impl<'h> HeapRead<'h, SetStorage> {
         Ok(false)
     }
 
-    /// Rebuilds the per-entry hash cells and the `indices` table if they are
+    /// Rebuilds the per-entry hashes and the `indices` table if they are
     /// stale — either because this storage was just deserialized or because it
     /// was built by `from_entries` (hashes never cross storage boundaries or
     /// the wire; each storage computes its own).
     ///
     /// Must be called before consulting `indices`. Works for heap-resident
-    /// and `Heap::protect`-wrapped detached storages alike. No-op when fresh.
-    fn ensure_indices(&self, vm: &mut VM<'h>) -> RunResult<()> {
+    /// and `Heap::protect_mut`-wrapped detached storages alike. No-op when fresh.
+    fn ensure_indices(&mut self, vm: &mut VM<'h>) -> RunResult<()> {
         if !self.get(vm.heap).indices_stale() {
             return Ok(());
         }
@@ -312,15 +311,15 @@ impl<'h> HeapRead<'h, SetStorage> {
             let value = self.get(vm.heap).entries[i].value.clone_with_heap(vm.heap);
             defer_drop!(value, vm);
             let hash = set_element_hash(value, vm)?;
-            self.get(vm.heap).entries[i].hash.set(hash);
+            self.get_mut(vm.heap).entries[i].hash = hash;
         }
         // Phase 2: rebuild the index table from the fresh hashes.
-        let storage = self.get(vm.heap);
-        let mut indices = storage.indices.borrow_mut();
-        for (idx, e) in storage.entries.iter().enumerate() {
-            indices.insert_unique(e.hash.get(), idx, |&i| storage.entries[i].hash.get());
+        let storage = self.get_mut(vm.heap);
+        let (indices, entries) = (&mut storage.indices, &storage.entries);
+        for (idx, e) in entries.iter().enumerate() {
+            indices.insert_unique(e.hash, idx, |&i| entries[i].hash);
         }
-        storage.stale.set(false);
+        storage.stale = false;
         Ok(())
     }
 }
@@ -352,7 +351,7 @@ impl SetStorage {
 
 impl<'h> HeapRead<'h, SetStorage> {
     /// Compares two sets for equality.
-    fn eq(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<bool> {
+    fn eq(&self, other: &mut Self, vm: &mut VM<'h>) -> RunResult<bool> {
         if self.get(vm.heap).len() != other.get(vm.heap).len() {
             return Ok(false);
         }
@@ -457,9 +456,9 @@ impl<'h, C: ContainsVM<'h>> DropWithContext<C> for SetIter<'_, 'h> {
 
 impl SetStorage {
     /// Returns true if this set is a subset of other.
-    fn is_subset(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<bool> {
+    fn is_subset(&self, other: &mut Self, vm: &mut VM<'_>) -> RunResult<bool> {
         for entry in &self.entries {
-            if !vm.heap.protect(other).contains(&entry.value, vm)? {
+            if !vm.heap.protect_mut(other).contains(&entry.value, vm)? {
                 return Ok(false);
             }
         }
@@ -467,12 +466,12 @@ impl SetStorage {
     }
 
     /// Returns true if this set is a superset of other.
-    fn is_superset(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<bool> {
+    fn is_superset(&mut self, other: &Self, vm: &mut VM<'_>) -> RunResult<bool> {
         other.is_subset(self, vm)
     }
 
     /// Returns true if this set has no elements in common with other.
-    fn is_disjoint(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<bool> {
+    fn is_disjoint(&mut self, other: &mut Self, vm: &mut VM<'_>) -> RunResult<bool> {
         // Iterate over the smaller set for efficiency
         let (smaller, larger) = if self.len() <= other.len() {
             (self, other)
@@ -481,7 +480,7 @@ impl SetStorage {
         };
 
         for entry in &smaller.entries {
-            if vm.heap.protect(larger).contains(&entry.value, vm)? {
+            if vm.heap.protect_mut(larger).contains(&entry.value, vm)? {
                 return Ok(false);
             }
         }
@@ -503,7 +502,7 @@ impl<'h> HeapRead<'h, SetStorage> {
     }
 
     /// Returns a new set containing elements in both sets (intersection).
-    fn intersection(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<SetStorage> {
+    fn intersection(&mut self, other: &mut Self, vm: &mut VM<'h>) -> RunResult<SetStorage> {
         let mut result_guard = DropGuard::new(SetStorage::new(), vm);
         let (result, vm) = result_guard.as_parts_mut();
         // Iterate over the smaller set for efficiency
@@ -527,7 +526,7 @@ impl<'h> HeapRead<'h, SetStorage> {
     }
 
     /// Returns a new set containing elements in self but not in other (difference).
-    fn difference(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<SetStorage> {
+    fn difference(&self, other: &mut Self, vm: &mut VM<'h>) -> RunResult<SetStorage> {
         let mut result_guard = DropGuard::new(SetStorage::new(), vm);
         let (result, vm) = result_guard.as_parts_mut();
         let len = self.get(vm.heap).len();
@@ -544,7 +543,7 @@ impl<'h> HeapRead<'h, SetStorage> {
     }
 
     /// Returns a new set containing elements in either set but not both (symmetric difference).
-    fn symmetric_difference(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<SetStorage> {
+    fn symmetric_difference(&mut self, other: &mut Self, vm: &mut VM<'h>) -> RunResult<SetStorage> {
         let mut result_guard = DropGuard::new(SetStorage::new(), vm);
         let (result, vm) = result_guard.as_parts_mut();
 
@@ -782,7 +781,7 @@ impl<'h> HeapRead<'h, Set> {
     /// Uses a two-phase lookup (collect candidates, then compare) to avoid
     /// holding a borrow on the set storage during `py_eq` calls.
     pub fn add(&mut self, value: Value, vm: &mut VM<'h>) -> RunResult<bool> {
-        self.storage().ensure_indices(vm)?;
+        self.storage_mut().ensure_indices(vm)?;
         let mut value_guard = DropGuard::new(value, vm);
         let (value, vm) = value_guard.as_parts();
         let hash = set_element_hash(value, vm)?;
@@ -790,8 +789,8 @@ impl<'h> HeapRead<'h, Set> {
         // Collect candidate indices to avoid borrow conflict between set storage and py_eq
         let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
         let storage = &self.get(vm.heap).0;
-        storage.indices.borrow().find(hash, |&idx| {
-            if storage.entries[idx].hash.get() == hash {
+        storage.indices.find(hash, |&idx| {
+            if storage.entries[idx].hash == hash {
                 candidates.push(idx);
             }
             false
@@ -809,19 +808,15 @@ impl<'h> HeapRead<'h, Set> {
         let (value, vm) = value_guard.into_parts();
         let storage = &mut self.get_mut(vm.heap).0;
         let index = storage.entries.len();
-        storage.entries.push(SetEntry {
-            value,
-            hash: Cell::new(hash),
-        });
+        storage.entries.push(SetEntry { value, hash });
         storage
             .indices
-            .borrow_mut()
-            .insert_unique(hash, index, |&idx| storage.entries[idx].hash.get());
+            .insert_unique(hash, index, |&idx| storage.entries[idx].hash);
         Ok(true)
     }
 
-    pub(crate) fn contains(&self, value: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
-        self.storage().contains(value, vm)
+    pub(crate) fn contains(&mut self, value: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
+        self.storage_mut().contains(value, vm)
     }
 
     /// `set.update(iterable)` via HeapRead.
@@ -858,16 +853,16 @@ impl<'h> HeapRead<'h, Set> {
     /// Set algebra operations (union, intersection, difference, symmetric_difference)
     /// via HeapRead. Clones self's storage once, then calls the existing `SetStorage`
     /// methods on the standalone copy.
-    fn set_algebra(&self, other: Value, op: SetAlgebra, vm: &mut VM<'h>) -> RunResult<Value> {
+    fn set_algebra(&mut self, other: Value, op: SetAlgebra, vm: &mut VM<'h>) -> RunResult<Value> {
         let other_storage = Set::get_storage_from_value(other, vm)?;
-        defer_drop!(other_storage, vm);
-        let other_storage = vm.heap.protect(other_storage);
+        defer_drop_mut!(other_storage, vm);
+        let mut other_storage = vm.heap.protect_mut(other_storage);
 
         let result = match op {
             SetAlgebra::Union => self.storage().union(&other_storage, vm)?,
-            SetAlgebra::Intersection => self.storage().intersection(&other_storage, vm)?,
-            SetAlgebra::Difference => self.storage().difference(&other_storage, vm)?,
-            SetAlgebra::SymmetricDifference => self.storage().symmetric_difference(&other_storage, vm)?,
+            SetAlgebra::Intersection => self.storage_mut().intersection(&mut other_storage, vm)?,
+            SetAlgebra::Difference => self.storage().difference(&mut other_storage, vm)?,
+            SetAlgebra::SymmetricDifference => self.storage_mut().symmetric_difference(&mut other_storage, vm)?,
         };
 
         let heap_id = vm.heap.allocate(HeapData::Set(Set(result)));
@@ -893,10 +888,10 @@ impl<'h> HeapRead<'h, Set> {
             let temp = Set::from_iterable(other.clone_with_heap(vm), vm)?;
             temp.0
         };
-        defer_drop!(other_storage, vm);
+        defer_drop_mut!(other_storage, vm);
 
         let self_storage = self.get(vm.heap).0.clone_with_heap(vm.heap);
-        defer_drop!(self_storage, vm);
+        defer_drop_mut!(self_storage, vm);
 
         match op {
             SetComparison::Subset => self_storage.is_subset(other_storage, vm),
@@ -944,8 +939,8 @@ impl<C: ContainsHeap> DropWithContext<C> for FrozenSet {
 impl<'h> HeapRead<'h, FrozenSet> {
     /// Checks if the frozenset contains a value, using the candidate collection pattern
     /// to avoid holding a borrow on the storage during `py_eq` calls.
-    pub(crate) fn contains(&self, value: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
-        self.storage().contains(value, vm)
+    pub(crate) fn contains(&mut self, value: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
+        self.storage_mut().contains(value, vm)
     }
 
     /// Binary set operation via HeapRead. Creates a new frozenset from the result.
@@ -953,58 +948,62 @@ impl<'h> HeapRead<'h, FrozenSet> {
     /// Clones self's storage entries to release the heap borrow before calling
     /// the set operations (which need `&mut VM` for hashing and equality checks).
     /// Applies set sub when the other value is a set operand.
-    fn sub_value(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<FrozenSet>> {
+    fn sub_value(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<FrozenSet>> {
         let Some(other_storage) = get_storage_from_set_operand(other, vm)? else {
             return Ok(None);
         };
-        defer_drop!(other_storage, vm);
-        let other_storage = vm.heap.protect(other_storage);
-        Ok(Some(FrozenSet::wrap(self.storage().difference(&other_storage, vm)?)))
+        defer_drop_mut!(other_storage, vm);
+        let mut other_storage = vm.heap.protect_mut(other_storage);
+        Ok(Some(FrozenSet::wrap(
+            self.storage().difference(&mut other_storage, vm)?,
+        )))
     }
 
     /// Applies set and when the other value is a set operand.
-    fn and_value(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<FrozenSet>> {
+    fn and_value(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<FrozenSet>> {
         let Some(other_storage) = get_storage_from_set_operand(other, vm)? else {
             return Ok(None);
         };
-        defer_drop!(other_storage, vm);
-        let other_storage = vm.heap.protect(other_storage);
-        Ok(Some(FrozenSet::wrap(self.storage().intersection(&other_storage, vm)?)))
+        defer_drop_mut!(other_storage, vm);
+        let mut other_storage = vm.heap.protect_mut(other_storage);
+        Ok(Some(FrozenSet::wrap(
+            self.storage_mut().intersection(&mut other_storage, vm)?,
+        )))
     }
 
     /// Applies set or when the other value is a set operand.
-    fn or_value(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<FrozenSet>> {
+    fn or_value(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<FrozenSet>> {
         let Some(other_storage) = get_storage_from_set_operand(other, vm)? else {
             return Ok(None);
         };
-        defer_drop!(other_storage, vm);
-        let other_storage = vm.heap.protect(other_storage);
+        defer_drop_mut!(other_storage, vm);
+        let other_storage = vm.heap.protect_mut(other_storage);
         Ok(Some(FrozenSet::wrap(self.storage().union(&other_storage, vm)?)))
     }
 
     /// Applies set xor when the other value is a set operand.
-    fn xor_value(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<FrozenSet>> {
+    fn xor_value(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<FrozenSet>> {
         let Some(other_storage) = get_storage_from_set_operand(other, vm)? else {
             return Ok(None);
         };
-        defer_drop!(other_storage, vm);
-        let other_storage = vm.heap.protect(other_storage);
+        defer_drop_mut!(other_storage, vm);
+        let mut other_storage = vm.heap.protect_mut(other_storage);
         Ok(Some(FrozenSet::wrap(
-            self.storage().symmetric_difference(&other_storage, vm)?,
+            self.storage_mut().symmetric_difference(&mut other_storage, vm)?,
         )))
     }
 
     /// Set algebra operations for frozenset via HeapRead.
-    fn set_algebra(&self, other: Value, op: SetAlgebra, vm: &mut VM<'h>) -> RunResult<Value> {
+    fn set_algebra(&mut self, other: Value, op: SetAlgebra, vm: &mut VM<'h>) -> RunResult<Value> {
         let other_storage = Set::get_storage_from_value(other, vm)?;
-        defer_drop!(other_storage, vm);
-        let other_storage = vm.heap.protect(other_storage);
+        defer_drop_mut!(other_storage, vm);
+        let mut other_storage = vm.heap.protect_mut(other_storage);
 
         let result = match op {
             SetAlgebra::Union => self.storage().union(&other_storage, vm)?,
-            SetAlgebra::Intersection => self.storage().intersection(&other_storage, vm)?,
-            SetAlgebra::Difference => self.storage().difference(&other_storage, vm)?,
-            SetAlgebra::SymmetricDifference => self.storage().symmetric_difference(&other_storage, vm)?,
+            SetAlgebra::Intersection => self.storage_mut().intersection(&mut other_storage, vm)?,
+            SetAlgebra::Difference => self.storage().difference(&mut other_storage, vm)?,
+            SetAlgebra::SymmetricDifference => self.storage_mut().symmetric_difference(&mut other_storage, vm)?,
         };
 
         let heap_id = vm.heap.allocate(HeapData::FrozenSet(FrozenSet::wrap(result)));
@@ -1028,10 +1027,10 @@ impl<'h> HeapRead<'h, FrozenSet> {
             let temp = Set::from_iterable(other.clone_with_heap(vm), vm)?;
             temp.0
         };
-        defer_drop!(other_storage, vm);
+        defer_drop_mut!(other_storage, vm);
 
         let self_storage = self.get(vm.heap).storage.clone_with_heap(vm.heap);
-        defer_drop!(self_storage, vm);
+        defer_drop_mut!(self_storage, vm);
 
         match op {
             SetComparison::Subset => self_storage.is_subset(other_storage, vm),
@@ -1042,6 +1041,10 @@ impl<'h> HeapRead<'h, FrozenSet> {
 
     fn storage(&self) -> BorrowedHeapRead<'_, 'h, SetStorage> {
         heap_read_ref_as_field!(self, FrozenSet, storage)
+    }
+
+    fn storage_mut(&mut self) -> BorrowedHeapReadMut<'_, 'h, SetStorage> {
+        heap_read_ref_as_field_mut!(self, FrozenSet, storage)
     }
 }
 
@@ -1056,7 +1059,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Set> {
         true
     }
 
-    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_contains_impl(&mut self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         self.contains(item, vm).map(Some)
     }
 
@@ -1076,13 +1079,13 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Set> {
         Some(self.get(vm.heap).len())
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         // `set` and `frozenset` compare equal by their members, regardless of
         // mutability. `set == dict_keys`/`dict_items` is handled by the reflected
         // pass via the dict-view impls.
         match other.read_heap(vm) {
-            Some(HeapReadOutput::Set(other)) => Ok(Some(self.storage().eq(&other.storage(), vm)?)),
-            Some(HeapReadOutput::FrozenSet(other)) => Ok(Some(self.storage().eq(&other.storage(), vm)?)),
+            Some(HeapReadOutput::Set(mut other)) => Ok(Some(self.storage().eq(&mut other.storage_mut(), vm)?)),
+            Some(HeapReadOutput::FrozenSet(mut other)) => Ok(Some(self.storage().eq(&mut other.storage_mut(), vm)?)),
             _ => Ok(None),
         }
     }
@@ -1091,7 +1094,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Set> {
         Ok(!self.get(vm.heap).is_empty())
     }
 
-    fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_sub_impl(&mut self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         let Some(result) = self.sub_value(other, vm)? else {
             return Ok(None);
         };
@@ -1099,7 +1102,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Set> {
         Ok(Some(Value::Ref(result_id)))
     }
 
-    fn py_and_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_and_impl(&mut self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         let Some(result) = self.and_value(other, vm)? else {
             return Ok(None);
         };
@@ -1107,7 +1110,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Set> {
         Ok(Some(Value::Ref(result_id)))
     }
 
-    fn py_or_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_or_impl(&mut self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         let Some(result) = self.or_value(other, vm)? else {
             return Ok(None);
         };
@@ -1115,7 +1118,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Set> {
         Ok(Some(Value::Ref(result_id)))
     }
 
-    fn py_xor_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_xor_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         let Some(result) = self.xor_value(other, vm)? else {
             return Ok(None);
         };
@@ -1222,43 +1225,45 @@ impl<'h> HeapRead<'h, Set> {
     /// `dict_keys`, and `dict_items`) so the VM can raise the standard
     /// unsupported-operands `TypeError`.
     /// Applies set sub when the other value is a set operand.
-    fn sub_value(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Set>> {
+    fn sub_value(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Set>> {
         let Some(other_storage) = get_storage_from_set_operand(other, vm)? else {
             return Ok(None);
         };
-        defer_drop!(other_storage, vm);
-        let other_storage = vm.heap.protect(other_storage);
-        Ok(Some(Set(self.storage().difference(&other_storage, vm)?)))
+        defer_drop_mut!(other_storage, vm);
+        let mut other_storage = vm.heap.protect_mut(other_storage);
+        Ok(Some(Set(self.storage().difference(&mut other_storage, vm)?)))
     }
 
     /// Applies set and when the other value is a set operand.
-    fn and_value(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Set>> {
+    fn and_value(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Set>> {
         let Some(other_storage) = get_storage_from_set_operand(other, vm)? else {
             return Ok(None);
         };
-        defer_drop!(other_storage, vm);
-        let other_storage = vm.heap.protect(other_storage);
-        Ok(Some(Set(self.storage().intersection(&other_storage, vm)?)))
+        defer_drop_mut!(other_storage, vm);
+        let mut other_storage = vm.heap.protect_mut(other_storage);
+        Ok(Some(Set(self.storage_mut().intersection(&mut other_storage, vm)?)))
     }
 
     /// Applies set or when the other value is a set operand.
-    fn or_value(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Set>> {
+    fn or_value(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Set>> {
         let Some(other_storage) = get_storage_from_set_operand(other, vm)? else {
             return Ok(None);
         };
-        defer_drop!(other_storage, vm);
-        let other_storage = vm.heap.protect(other_storage);
+        defer_drop_mut!(other_storage, vm);
+        let other_storage = vm.heap.protect_mut(other_storage);
         Ok(Some(Set(self.storage().union(&other_storage, vm)?)))
     }
 
     /// Applies set xor when the other value is a set operand.
-    fn xor_value(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Set>> {
+    fn xor_value(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Set>> {
         let Some(other_storage) = get_storage_from_set_operand(other, vm)? else {
             return Ok(None);
         };
-        defer_drop!(other_storage, vm);
-        let other_storage = vm.heap.protect(other_storage);
-        Ok(Some(Set(self.storage().symmetric_difference(&other_storage, vm)?)))
+        defer_drop_mut!(other_storage, vm);
+        let mut other_storage = vm.heap.protect_mut(other_storage);
+        Ok(Some(Set(self
+            .storage_mut()
+            .symmetric_difference(&mut other_storage, vm)?)))
     }
 }
 
@@ -1375,7 +1380,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
         true
     }
 
-    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_contains_impl(&mut self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         self.contains(item, vm).map(Some)
     }
 
@@ -1395,13 +1400,13 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
         Some(self.get(vm.heap).len())
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         // `frozenset` and `set` compare equal by their members, regardless of
         // mutability. `frozenset == dict_keys`/`dict_items` is handled by the
         // reflected pass via the dict-view impls.
         match other.read_heap(vm) {
-            Some(HeapReadOutput::FrozenSet(other)) => Ok(Some(self.storage().eq(&other.storage(), vm)?)),
-            Some(HeapReadOutput::Set(other)) => Ok(Some(self.storage().eq(&other.storage(), vm)?)),
+            Some(HeapReadOutput::FrozenSet(mut other)) => Ok(Some(self.storage().eq(&mut other.storage_mut(), vm)?)),
+            Some(HeapReadOutput::Set(mut other)) => Ok(Some(self.storage().eq(&mut other.storage_mut(), vm)?)),
             _ => Ok(None),
         }
     }
@@ -1431,7 +1436,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
         Ok(!self.get(vm.heap).is_empty())
     }
 
-    fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_sub_impl(&mut self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         let Some(result) = self.sub_value(other, vm)? else {
             return Ok(None);
         };
@@ -1439,7 +1444,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
         Ok(Some(Value::Ref(result_id)))
     }
 
-    fn py_and_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_and_impl(&mut self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         let Some(result) = self.and_value(other, vm)? else {
             return Ok(None);
         };
@@ -1447,7 +1452,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
         Ok(Some(Value::Ref(result_id)))
     }
 
-    fn py_or_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_or_impl(&mut self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         let Some(result) = self.or_value(other, vm)? else {
             return Ok(None);
         };
@@ -1455,7 +1460,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
         Ok(Some(Value::Ref(result_id)))
     }
 
-    fn py_xor_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_xor_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         let Some(result) = self.xor_value(other, vm)? else {
             return Ok(None);
         };
@@ -1573,8 +1578,8 @@ impl<'de> serde::Deserialize<'de> for SetStorage {
         // `stale` marks the empty indices (and zeroed entry hashes) for the
         // lazy rebuild on first keyed access.
         Ok(Self {
-            indices: RefCell::new(HashTable::new()),
-            stale: Cell::new(!entries.is_empty()),
+            indices: HashTable::new(),
+            stale: !entries.is_empty(),
             entries,
         })
     }
@@ -1678,7 +1683,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, SetIterator> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
         Ok(None)
     }
 

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -1,4 +1,8 @@
-use std::{cell::Cell, fmt::Write, mem};
+use std::{
+    cell::{Cell, RefCell},
+    fmt::Write,
+    mem,
+};
 
 use hashbrown::HashTable;
 use monty_types::{ResourceError, ResourceTracker};
@@ -24,8 +28,12 @@ use crate::{
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct SetEntry {
     pub(crate) value: Value,
-    /// Cached hash for efficient lookup and reinsertion.
-    pub(crate) hash: u64,
+    /// Cached hash for efficient lookup and reinsertion. Skipped on serde —
+    /// hashes are hasher/build-specific so they never cross the wire;
+    /// recomputed together with `indices` by `ensure_indices`. `Cell` so the
+    /// lazy rebuild can run behind `&self` heap handles.
+    #[serde(skip)]
+    pub(crate) hash: Cell<u64>,
 }
 
 /// Internal storage shared between Set and FrozenSet.
@@ -35,8 +43,14 @@ struct SetEntry {
 /// The hash table maps value hashes to indices in the entries vector.
 #[derive(Debug, Default)]
 pub(crate) struct SetStorage {
-    /// Maps hash to index in entries vector.
-    indices: HashTable<usize>,
+    /// Maps hash to index in entries vector. Derived data: never serialized,
+    /// rebuilt lazily (see [`SetStorage::indices_stale`]). `RefCell` so the
+    /// rebuild can run behind `&self` heap handles.
+    indices: RefCell<HashTable<usize>>,
+    /// True when `indices`/entry hashes need a rebuild (set by deserialize
+    /// and `from_entries`). A `Cell<bool>` so the hot-path staleness check
+    /// is a plain byte load instead of a `RefCell` borrow cycle.
+    stale: Cell<bool>,
     /// Dense vector of entries maintaining insertion order.
     entries: Vec<SetEntry>,
 }
@@ -50,31 +64,44 @@ impl SetStorage {
     /// Creates a new set storage with pre-allocated capacity.
     fn with_capacity(capacity: usize) -> Self {
         Self {
-            indices: HashTable::with_capacity(capacity),
+            indices: RefCell::new(HashTable::with_capacity(capacity)),
+            stale: Cell::new(false),
             entries: Vec::with_capacity(capacity),
         }
     }
 
-    /// Creates a SetStorage from a vector of (value, hash) pairs.
-    ///
-    /// This is used to avoid borrow conflicts when we need to copy another set's
-    /// contents and then perform operations requiring mutable heap access.
-    /// The caller is responsible for handling reference counting.
-    fn from_entries(entries: Vec<(Value, u64)>) -> Self {
-        let mut storage = Self::with_capacity(entries.len());
-        for (idx, (value, hash)) in entries.into_iter().enumerate() {
-            storage.entries.push(SetEntry { value, hash });
-            storage.indices.insert_unique(hash, idx, |&i| storage.entries[i].hash);
-        }
-        storage
+    /// True when `indices` (and the per-entry hash cells) must be rebuilt —
+    /// set by deserialization and [`SetStorage::from_entries`].
+    /// Rebuild via `ensure_indices` before consulting `indices`.
+    #[inline]
+    fn indices_stale(&self) -> bool {
+        self.stale.get()
     }
 
-    /// Clones entries with proper reference counting.
-    fn clone_entries(&self, heap: &impl ContainsHeap) -> Vec<(Value, u64)> {
-        self.entries
-            .iter()
-            .map(|e| (e.value.clone_with_heap(heap), e.hash))
-            .collect()
+    /// Creates a SetStorage from a vector of values (assumed already deduplicated,
+    /// e.g. cloned from another set's entries).
+    ///
+    /// The storage is born with stale indices — hashes are recomputed by
+    /// `ensure_indices` on first keyed use. Never carrying hashes between
+    /// storages keeps a single source of truth for them.
+    /// The caller is responsible for handling reference counting.
+    fn from_entries(values: Vec<Value>) -> Self {
+        Self {
+            indices: RefCell::new(HashTable::new()),
+            stale: Cell::new(!values.is_empty()),
+            entries: values
+                .into_iter()
+                .map(|value| SetEntry {
+                    value,
+                    hash: Cell::new(0),
+                })
+                .collect(),
+        }
+    }
+
+    /// Clones the element values with proper reference counting.
+    fn clone_entries(&self, heap: &impl ContainsHeap) -> Vec<Value> {
+        self.entries.iter().map(|e| e.value.clone_with_heap(heap)).collect()
     }
 
     /// Returns the number of elements in the set.
@@ -96,6 +123,9 @@ impl SetStorage {
     /// The caller transfers ownership of `value`. If the value is already in
     /// the set, it will be dropped.
     fn add(&mut self, value: Value, vm: &mut VM<'_>) -> RunResult<bool> {
+        // Detached storages can be stale too (clones of / conversions from a
+        // freshly deserialized set), so rebuild before consulting `indices`.
+        vm.heap.protect(&*self).ensure_indices(vm)?;
         let mut value_guard = DropGuard::new(value, vm);
         let (value, vm) = value_guard.as_parts_mut();
         let hash = set_element_hash(value, vm)?;
@@ -103,15 +133,22 @@ impl SetStorage {
         // Check if value already exists.
         let existing = self
             .indices
-            .find(hash, |&idx| value.py_eq(&self.entries[idx].value, vm).unwrap_or(false));
+            .borrow()
+            .find(hash, |&idx| value.py_eq(&self.entries[idx].value, vm).unwrap_or(false))
+            .copied();
 
         if existing.is_some() {
             Ok(false)
         } else {
             let index = self.entries.len();
             let value = value_guard.into_inner();
-            self.entries.push(SetEntry { value, hash });
-            self.indices.insert_unique(hash, index, |&idx| self.entries[idx].hash);
+            self.entries.push(SetEntry {
+                value,
+                hash: Cell::new(hash),
+            });
+            self.indices
+                .borrow_mut()
+                .insert_unique(hash, index, |&idx| self.entries[idx].hash.get());
             Ok(true)
         }
     }
@@ -123,13 +160,14 @@ impl<'h> HeapRead<'h, SetStorage> {
     /// Returns `Ok(true)` if the element was removed, `Ok(false)` if not found.
     /// Returns `Err` if the key is unhashable.
     fn remove(&mut self, value: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
+        self.ensure_indices(vm)?;
         let hash = set_element_hash(value, vm)?;
 
         // Collect candidates by hash
         let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
         let storage = &self.get(vm.heap);
-        storage.indices.find(hash, |&idx| {
-            if storage.entries[idx].hash == hash {
+        storage.indices.borrow().find(hash, |&idx| {
+            if storage.entries[idx].hash.get() == hash {
                 candidates.push(idx);
             }
             false
@@ -153,9 +191,12 @@ impl<'h> HeapRead<'h, SetStorage> {
         // Remove via short-lived mutable borrow
         let storage = self.get_mut(vm.heap);
         let removed_entry = storage.entries.remove(index);
-        storage.indices.clear();
-        for (idx, e) in storage.entries.iter().enumerate() {
-            storage.indices.insert_unique(e.hash, idx, |&i| storage.entries[i].hash);
+        {
+            let mut indices = storage.indices.borrow_mut();
+            indices.clear();
+            for (idx, e) in storage.entries.iter().enumerate() {
+                indices.insert_unique(e.hash.get(), idx, |&i| storage.entries[i].hash.get());
+            }
         }
 
         removed_entry.value.drop_with(vm);
@@ -174,6 +215,8 @@ impl<'h> HeapRead<'h, SetStorage> {
     ///
     /// Returns `Err(KeyError)` if the set is empty.
     fn pop(&mut self, vm: &mut VM<'h>) -> RunResult<Value> {
+        // The hash-table removal below reads the entry's hash, so it must be fresh.
+        self.ensure_indices(vm)?;
         if self.get(vm.heap).is_empty() {
             return Err(ExcType::key_error_pop_empty_set());
         }
@@ -185,7 +228,8 @@ impl<'h> HeapRead<'h, SetStorage> {
         // Remove from hash table
         storage
             .indices
-            .find_entry(entry.hash, |&idx| idx == storage.entries.len())
+            .borrow_mut()
+            .find_entry(entry.hash.get(), |&idx| idx == storage.entries.len())
             .expect("entry must exist")
             .remove();
 
@@ -195,22 +239,26 @@ impl<'h> HeapRead<'h, SetStorage> {
     /// Removes all elements from the set.
     fn clear(&mut self, vm: &mut VM<'h>) {
         let entries = mem::take(&mut self.get_mut(vm.heap).entries);
-        self.get_mut(vm.heap).indices.clear();
+        self.get_mut(vm.heap).indices.borrow_mut().clear();
         entries.drop_with(vm);
     }
 }
 
 impl SetStorage {
     /// Creates a deep clone with proper reference counting.
+    ///
+    /// Clones the indices and hash cells as-is, so a stale source produces an
+    /// equally stale clone (rebuilt lazily) and a fresh source a fresh one.
     fn clone_with_heap(&self, heap: &impl ContainsHeap) -> Self {
         Self {
-            indices: self.indices.clone(),
+            indices: RefCell::new(self.indices.borrow().clone()),
+            stale: self.stale.clone(),
             entries: self
                 .entries
                 .iter()
                 .map(|entry| SetEntry {
                     value: entry.value.clone_with_heap(heap),
-                    hash: entry.hash,
+                    hash: entry.hash.clone(),
                 })
                 .collect(),
         }
@@ -220,13 +268,14 @@ impl SetStorage {
 impl<'h> HeapRead<'h, SetStorage> {
     /// Checks if the set contains a value.
     pub fn contains(&self, value: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
+        self.ensure_indices(vm)?;
         let hash = set_element_hash(value, vm)?;
 
         // Collect candidates by hash
         let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
         let storage = &self.get(vm.heap);
-        storage.indices.find(hash, |&idx| {
-            if storage.entries[idx].hash == hash {
+        storage.indices.borrow().find(hash, |&idx| {
+            if storage.entries[idx].hash.get() == hash {
                 candidates.push(idx);
             }
             false
@@ -242,6 +291,37 @@ impl<'h> HeapRead<'h, SetStorage> {
         }
 
         Ok(false)
+    }
+
+    /// Rebuilds the per-entry hash cells and the `indices` table if they are
+    /// stale — either because this storage was just deserialized or because it
+    /// was built by `from_entries` (hashes never cross storage boundaries or
+    /// the wire; each storage computes its own).
+    ///
+    /// Must be called before consulting `indices`. Works for heap-resident
+    /// and `Heap::protect`-wrapped detached storages alike. No-op when fresh.
+    fn ensure_indices(&self, vm: &mut VM<'h>) -> RunResult<()> {
+        if !self.get(vm.heap).indices_stale() {
+            return Ok(());
+        }
+        // Phase 1: recompute each element's hash. Elements are cloned out (and
+        // defer-dropped) because hashing needs `&mut VM` and may read the heap
+        // (tuples, frozensets), so no storage borrow can be held across it.
+        let len = self.get(vm.heap).entries.len();
+        for i in 0..len {
+            let value = self.get(vm.heap).entries[i].value.clone_with_heap(vm.heap);
+            defer_drop!(value, vm);
+            let hash = set_element_hash(value, vm)?;
+            self.get(vm.heap).entries[i].hash.set(hash);
+        }
+        // Phase 2: rebuild the index table from the fresh hashes.
+        let storage = self.get(vm.heap);
+        let mut indices = storage.indices.borrow_mut();
+        for (idx, e) in storage.entries.iter().enumerate() {
+            indices.insert_unique(e.hash.get(), idx, |&i| storage.entries[i].hash.get());
+        }
+        storage.stale.set(false);
+        Ok(())
     }
 }
 
@@ -702,6 +782,7 @@ impl<'h> HeapRead<'h, Set> {
     /// Uses a two-phase lookup (collect candidates, then compare) to avoid
     /// holding a borrow on the set storage during `py_eq` calls.
     pub fn add(&mut self, value: Value, vm: &mut VM<'h>) -> RunResult<bool> {
+        self.storage().ensure_indices(vm)?;
         let mut value_guard = DropGuard::new(value, vm);
         let (value, vm) = value_guard.as_parts();
         let hash = set_element_hash(value, vm)?;
@@ -709,8 +790,8 @@ impl<'h> HeapRead<'h, Set> {
         // Collect candidate indices to avoid borrow conflict between set storage and py_eq
         let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
         let storage = &self.get(vm.heap).0;
-        storage.indices.find(hash, |&idx| {
-            if storage.entries[idx].hash == hash {
+        storage.indices.borrow().find(hash, |&idx| {
+            if storage.entries[idx].hash.get() == hash {
                 candidates.push(idx);
             }
             false
@@ -728,10 +809,14 @@ impl<'h> HeapRead<'h, Set> {
         let (value, vm) = value_guard.into_parts();
         let storage = &mut self.get_mut(vm.heap).0;
         let index = storage.entries.len();
-        storage.entries.push(SetEntry { value, hash });
+        storage.entries.push(SetEntry {
+            value,
+            hash: Cell::new(hash),
+        });
         storage
             .indices
-            .insert_unique(hash, index, |&idx| storage.entries[idx].hash);
+            .borrow_mut()
+            .insert_unique(hash, index, |&idx| storage.entries[idx].hash.get());
         Ok(true)
     }
 
@@ -755,7 +840,7 @@ impl<'h> HeapRead<'h, Set> {
 
         if let Some(entries) = entries_opt {
             other.drop_with(vm);
-            for (value, _hash) in entries {
+            for value in entries {
                 self.add(value, vm)?;
             }
             return Ok(());
@@ -1472,7 +1557,9 @@ fn get_storage_from_set_operand(value: &Value, vm: &mut VM<'_>) -> RunResult<Opt
 }
 
 // Custom serde implementations for SetStorage, Set, and FrozenSet.
-// Only serialize entries; rebuild the indices hash table on deserialize.
+// Only element values are serialized — hashes and the indices table are
+// hasher/build-specific derived data, rebuilt lazily by `ensure_indices` on
+// first keyed access (so dumps stay stable across platforms and hasher changes).
 
 impl serde::Serialize for SetStorage {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
@@ -1483,12 +1570,13 @@ impl serde::Serialize for SetStorage {
 impl<'de> serde::Deserialize<'de> for SetStorage {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let entries: Vec<SetEntry> = serde::Deserialize::deserialize(deserializer)?;
-        // Rebuild the indices hash table from the entries
-        let mut indices = HashTable::with_capacity(entries.len());
-        for (idx, entry) in entries.iter().enumerate() {
-            indices.insert_unique(entry.hash, idx, |&i| entries[i].hash);
-        }
-        Ok(Self { indices, entries })
+        // `stale` marks the empty indices (and zeroed entry hashes) for the
+        // lazy rebuild on first keyed access.
+        Ok(Self {
+            indices: RefCell::new(HashTable::new()),
+            stale: Cell::new(!entries.is_empty()),
+            entries,
+        })
     }
 }
 

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -39,11 +39,8 @@ struct SetEntry {
 #[derive(Debug, Default)]
 pub(crate) struct SetStorage {
     /// Maps hash to index in entries vector. Derived data: never serialized,
-    /// rebuilt lazily by `ensure_indices`.
+    /// rebuilt lazily by `ensure_indices` (empty with entries present ⇒ stale).
     indices: HashTable<usize>,
-    /// True when `indices`/entry hashes need a rebuild (set by deserialize
-    /// and `from_entries`, cleared by `ensure_indices`).
-    stale: bool,
     /// Dense vector of entries maintaining insertion order.
     entries: Vec<SetEntry>,
 }
@@ -58,17 +55,20 @@ impl SetStorage {
     fn with_capacity(capacity: usize) -> Self {
         Self {
             indices: HashTable::with_capacity(capacity),
-            stale: false,
             entries: Vec::with_capacity(capacity),
         }
     }
 
-    /// True when `indices` (and the per-entry hash cells) must be rebuilt —
-    /// set by deserialization and [`SetStorage::from_entries`].
-    /// Rebuild via `ensure_indices` before consulting `indices`.
+    /// True when `indices` (and the per-entry hashes) must be rebuilt — after
+    /// deserialization or [`SetStorage::from_entries`], both of which leave the
+    /// table empty while entries remain.
+    ///
+    /// Derived, not flagged: a `stale` bool would pad `SetStorage` by 8 bytes,
+    /// costing `HeapData` its niche. Only `remove` empties a built table, and it
+    /// refills it under the same `&mut`.
     #[inline]
     fn indices_stale(&self) -> bool {
-        self.stale
+        self.indices.is_empty() && !self.entries.is_empty()
     }
 
     /// Creates a SetStorage from a vector of values (assumed already deduplicated,
@@ -81,7 +81,6 @@ impl SetStorage {
     fn from_entries(values: Vec<Value>) -> Self {
         Self {
             indices: HashTable::new(),
-            stale: !values.is_empty(),
             entries: values.into_iter().map(|value| SetEntry { value, hash: 0 }).collect(),
         }
     }
@@ -151,7 +150,6 @@ impl SetStorage {
         for (idx, e) in entries.iter().enumerate() {
             indices.insert_unique(e.hash, idx, |&i| entries[i].hash);
         }
-        self.stale = false;
         Ok(())
     }
 }
@@ -251,7 +249,6 @@ impl SetStorage {
     fn clone_with_heap(&self, heap: &impl ContainsHeap) -> Self {
         Self {
             indices: self.indices.clone(),
-            stale: self.stale,
             entries: self
                 .entries
                 .iter()
@@ -319,7 +316,6 @@ impl<'h> HeapRead<'h, SetStorage> {
         for (idx, e) in entries.iter().enumerate() {
             indices.insert_unique(e.hash, idx, |&i| entries[i].hash);
         }
-        storage.stale = false;
         Ok(())
     }
 }
@@ -1575,11 +1571,8 @@ impl serde::Serialize for SetStorage {
 impl<'de> serde::Deserialize<'de> for SetStorage {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let entries: Vec<SetEntry> = serde::Deserialize::deserialize(deserializer)?;
-        // `stale` marks the empty indices (and zeroed entry hashes) for the
-        // lazy rebuild on first keyed access.
         Ok(Self {
             indices: HashTable::new(),
-            stale: !entries.is_empty(),
             entries,
         })
     }

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -162,7 +162,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Slice> {
         None
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let Some(HeapReadOutput::Slice(other)) = other.read_heap(vm) else {
             return Ok(None);
         };

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -3,12 +3,7 @@
 //! Provides a slice object representing start:stop:step indices for sequence slicing.
 //! Each field is optional (None in Python), where None means "use the default for that field".
 
-use std::{
-    collections::hash_map::DefaultHasher,
-    fmt,
-    fmt::Write,
-    hash::{Hash, Hasher},
-};
+use std::{fmt, fmt::Write};
 
 use super::LazyHeapSet;
 use crate::{
@@ -16,7 +11,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunResult},
-    hash::HashValue,
+    hash::{HashValue, hash_one},
     heap::{HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     types::{PyTrait, Type},
@@ -177,9 +172,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Slice> {
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
-        let mut hasher = DefaultHasher::new();
-        self.get(vm.heap).hash(&mut hasher);
-        Ok(Some(HashValue::new(hasher.finish())))
+        Ok(Some(hash_one(self.get(vm.heap))))
     }
 
     fn py_bool(&self, _vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -267,7 +267,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
     }
 
     /// Substring search; `in` on a str requires a str on the left.
-    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_contains_impl(&mut self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let container = self.get(vm.heap).as_str();
         str_contains(container, item, vm.heap, vm.interns).map(Some)
     }
@@ -289,7 +289,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
         Some(self.get(vm.heap).0.chars().count())
     }
 
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
+    fn py_getitem(&mut self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
         // Check for slice first (Value::Ref pointing to HeapData::Slice)
         if let Value::Ref(id) = key
             && let HeapData::Slice(slice) = vm.heap.get(*id)
@@ -306,7 +306,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
         Ok(allocate_char(c, vm.heap))
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         // A heap string equals an interned or heap string with the same content.
         Ok(eq_str(self.get(vm.heap).as_str(), other, vm))
     }
@@ -2119,7 +2119,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, StringIterator> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
         Ok(None)
     }
 

--- a/crates/monty/src/types/timedelta.rs
+++ b/crates/monty/src/types/timedelta.rs
@@ -4,12 +4,7 @@
 //! normalized `(days, seconds, microseconds)` semantics for constructors, arithmetic,
 //! and formatting.
 
-use std::{
-    cmp::Ordering,
-    collections::hash_map::DefaultHasher,
-    fmt::Write,
-    hash::{Hash, Hasher},
-};
+use std::{cmp::Ordering, fmt::Write};
 
 use chrono::TimeDelta as ChronoTimeDelta;
 
@@ -17,7 +12,7 @@ use crate::{
     args::{ArgValues, FromArgs, FromValue, FromValueFail, is_long_int},
     bytecode::{CallResult, VM},
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
-    hash::HashValue,
+    hash::{HashValue, hash_one},
     heap::{HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     types::{CmpOrder, LazyHeapSet, PyTrait, Type, date, datetime, str::allocate_string},
@@ -315,9 +310,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeDelta> {
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
-        let mut hasher = DefaultHasher::new();
-        self.get(vm.heap).hash(&mut hasher);
-        Ok(Some(HashValue::new(hasher.finish())))
+        Ok(Some(hash_one(self.get(vm.heap))))
     }
 
     fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {

--- a/crates/monty/src/types/timedelta.rs
+++ b/crates/monty/src/types/timedelta.rs
@@ -300,7 +300,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeDelta> {
         None
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let Some(HeapReadOutput::TimeDelta(other)) = other.read_heap(vm) else {
             return Ok(None);
         };
@@ -385,7 +385,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeDelta> {
         }
     }
 
-    fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_sub_impl(&mut self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         let Some(HeapReadOutput::TimeDelta(other)) = other.read_heap(vm) else {
             return Ok(None);
         };

--- a/crates/monty/src/types/timezone.rs
+++ b/crates/monty/src/types/timezone.rs
@@ -224,7 +224,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeZone> {
         None
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let Some(HeapReadOutput::TimeZone(other)) = other.read_heap(vm) else {
             return Ok(None);
         };

--- a/crates/monty/src/types/timezone.rs
+++ b/crates/monty/src/types/timezone.rs
@@ -3,7 +3,6 @@
 //! Phase 1 intentionally supports only fixed offsets (no DST or IANA database).
 
 use std::{
-    collections::hash_map::DefaultHasher,
     fmt::Write,
     hash::{Hash, Hasher},
 };
@@ -13,7 +12,7 @@ use crate::{
     bytecode::VM,
     defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
-    hash::HashValue,
+    hash::{HashValue, hash_one},
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::Interns,
     types::{
@@ -235,9 +234,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeZone> {
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
-        let mut hasher = DefaultHasher::new();
-        self.get(vm.heap).hash(&mut hasher);
-        Ok(Some(HashValue::new(hasher.finish())))
+        Ok(Some(hash_one(self.get(vm.heap))))
     }
 
     fn py_bool(&self, _vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -287,7 +287,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
     /// Linear search by equality, stored element on the left of `==` as CPython's
     /// `tuplecontains` does. `TupleIter` owns each yielded item, so a user
     /// `__eq__` re-entering the VM cannot invalidate the walk.
-    fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_contains_impl(&mut self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         let iter = self.iter(vm)?;
         defer_drop_mut!(iter, vm);
         while let Some(el) = iter.next(vm)? {
@@ -310,7 +310,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         Some(self.get(vm.heap).items.len())
     }
 
-    fn py_getitem(&self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
+    fn py_getitem(&mut self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
         // Check for slice first (Value::Ref pointing to HeapData::Slice)
         if let Value::Ref(key_id) = key
             && let HeapData::Slice(slice_obj) = vm.heap.get(*key_id)
@@ -334,7 +334,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         Ok(self.clone_item(idx, vm))
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         // A tuple equals another tuple; `tuple == namedtuple` is handled by the
         // reflected pass via `NamedTuple::py_eq_impl`.
         let Some(HeapReadOutput::Tuple(other)) = other.read_heap(vm) else {
@@ -666,7 +666,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TupleIterator> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
+    fn py_eq_impl(&mut self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
         Ok(None)
     }
 

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -1,12 +1,12 @@
 use std::{
     cell::Cell,
     cmp::Ordering,
-    collections::hash_map::DefaultHasher,
     fmt::Write,
     hash::{Hash, Hasher},
     mem,
 };
 
+use ahash::AHasher;
 /// Python tuple type using `SmallVec` for inline storage of small tuples.
 ///
 /// This type provides Python tuple semantics. Tuples are immutable sequences
@@ -368,7 +368,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         if let Some(cached) = self.get(vm.heap).cached_hash.get() {
             return Ok(Some(cached));
         }
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = AHasher::default();
         let iter = self.iter(vm)?;
         defer_drop_mut!(iter, vm);
         while let Some(item) = iter.next(vm)? {

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -260,58 +260,9 @@ impl<'h> PyTrait<'h> for Value {
         }
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'_>) -> RunResult<Option<bool>> {
-        match self {
-            // `Undefined` is a sentinel and is never equal to anything.
-            Self::Undefined => Ok(Some(false)),
-
-            Self::None => Ok(matches!(other, Self::None).then_some(true)),
-            Self::Ellipsis => Ok(matches!(other, Self::Ellipsis).then_some(true)),
-            Self::NotImplemented => Ok(matches!(other, Self::NotImplemented).then_some(true)),
-            Self::Bool(b) => Ok(eq_i64(i64::from(*b), other, vm)),
-            Self::Int(a) => Ok(eq_i64(*a, other, vm)),
-            Self::Float(f) => Ok(eq_f64(*f, other, vm)),
-            // `InternLongInt` is normally materialised to a heap `LongInt` before
-            // it can be compared, but handle it directly so equality never
-            // silently diverges if one reaches here.
-            Self::InternLongInt(id) => Ok(eq_bigint(vm.interns.get_long_int(*id), other, vm)),
-            Self::InternString(id) => Ok(match other {
-                // Interned strings are deduplicated, so equal ids ⇔ equal content.
-                Self::InternString(o) => Some(id == o),
-                _ => eq_str(vm.interns.get_str(*id), other, vm),
-            }),
-            Self::InternBytes(id) => Ok(match other {
-                // Fast path for the same interned bytes; otherwise compare content
-                // (interned bytes are not deduplicated, unlike strings).
-                Self::InternBytes(o) if id == o => Some(true),
-                _ => eq_bytes(vm.interns.get_bytes(*id), other, vm),
-            }),
-            Self::Builtin(b) => Ok(match other {
-                Self::Builtin(o) => Some(b == o),
-                _ => None,
-            }),
-            Self::ModuleFunction(mf) => Ok(match other {
-                Self::ModuleFunction(o) => Some(mf == o),
-                _ => None,
-            }),
-            Self::DefFunction(f) => Ok(match other {
-                Self::DefFunction(o) => Some(f == o),
-                _ => None,
-            }),
-            Self::Marker(m) => Ok(match other {
-                Self::Marker(o) => Some(m == o),
-                _ => None,
-            }),
-            Self::Property(p) => Ok(match other {
-                Self::Property(o) => Some(p == o),
-                _ => None,
-            }),
-            Self::Ref(id) => vm.heap.read(*id).py_eq_impl(other, vm),
-            #[cfg(feature = "memory-model-checks")]
-            Self::Dereferenced => panic!("Cannot access Dereferenced object"),
-        }
+    fn py_eq_impl(&mut self, other: &Value, vm: &mut VM<'_>) -> RunResult<Option<bool>> {
+        self.py_eq_one_sided(other, vm)
     }
-
     fn py_cmp(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<CmpOrder> {
         let interns = vm.interns;
         // py_cmp handles numbers, strings, bytes, tuples, and lists.
@@ -676,33 +627,13 @@ impl<'h> PyTrait<'h> for Value {
     }
 
     /// One-sided implementation of Python `-`.
-    fn py_sub_impl(&self, other: &Self, vm: &mut VM<'_>, _self_id: Option<HeapId>) -> RunResult<Option<Self>> {
-        match (self, other) {
-            // Int - Int with overflow detection
-            (Self::Int(a), Self::Int(b)) => {
-                if let Some(result) = a.checked_sub(*b) {
-                    Ok(Some(Self::Int(result)))
-                } else {
-                    Ok(Some(wide_i128_into_value(i128::from(*a) - i128::from(*b), vm.heap)))
-                }
-            }
-            // Float - Float
-            (Self::Float(a), Self::Float(b)) => Ok(Some(Self::Float(a - b))),
-            // Int - Float and Float - Int
-            (Self::Int(a), Self::Float(b)) => Ok(Some(Self::Float(*a as f64 - b))),
-            (Self::Float(a), Self::Int(b)) => Ok(Some(Self::Float(a - *b as f64))),
-            (Self::Ref(id), _) => vm.heap.read(*id).py_sub_impl(other, vm, Some(*id)),
-            _ => Ok(None),
-        }
+    fn py_sub_impl(&mut self, other: &Self, vm: &mut VM<'_>, _self_id: Option<HeapId>) -> RunResult<Option<Self>> {
+        self.py_sub_impl_one_sided(other, vm)
     }
 
     /// Reflected implementation of Python `-`.
-    fn py_rsub_impl(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
-        if let Self::Ref(id) = self {
-            vm.heap.read(*id).py_rsub_impl(other, vm)
-        } else {
-            Ok(None)
-        }
+    fn py_rsub_impl(&mut self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
+        self.py_rsub_impl_one_sided(other, vm)
     }
 
     /// One-sided implementation of Python `*`.
@@ -1119,69 +1050,33 @@ impl<'h> PyTrait<'h> for Value {
     }
 
     /// One-sided implementation of Python `&`.
-    fn py_and_impl(&self, other: &Self, vm: &mut VM<'_>, _self_id: Option<HeapId>) -> RunResult<Option<Self>> {
-        if let (Self::Bool(lhs), Self::Bool(rhs)) = (self, other) {
-            Ok(Some(Self::Bool(*lhs && *rhs)))
-        } else if let (Some(lhs), Some(rhs)) = (immediate_int(self), immediate_int(other)) {
-            Ok(Some(Self::Int(lhs & rhs)))
-        } else if let Self::Ref(id) = self {
-            vm.heap.read(*id).py_and_impl(other, vm, Some(*id))
-        } else {
-            Ok(None)
-        }
+    fn py_and_impl(&mut self, other: &Self, vm: &mut VM<'_>, _self_id: Option<HeapId>) -> RunResult<Option<Self>> {
+        self.py_and_impl_one_sided(other, vm)
     }
 
     /// Reflected implementation of Python `&`.
-    fn py_rand_impl(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
-        if let Self::Ref(id) = self {
-            vm.heap.read(*id).py_rand_impl(other, vm)
-        } else {
-            Ok(None)
-        }
+    fn py_rand_impl(&mut self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
+        self.py_rand_impl_one_sided(other, vm)
     }
 
     /// One-sided implementation of Python `|`.
-    fn py_or_impl(&self, other: &Self, vm: &mut VM<'_>, _self_id: Option<HeapId>) -> RunResult<Option<Self>> {
-        if let (Self::Bool(lhs), Self::Bool(rhs)) = (self, other) {
-            Ok(Some(Self::Bool(*lhs || *rhs)))
-        } else if let (Some(lhs), Some(rhs)) = (immediate_int(self), immediate_int(other)) {
-            Ok(Some(Self::Int(lhs | rhs)))
-        } else if let Self::Ref(id) = self {
-            vm.heap.read(*id).py_or_impl(other, vm, Some(*id))
-        } else {
-            Ok(None)
-        }
+    fn py_or_impl(&mut self, other: &Self, vm: &mut VM<'_>, _self_id: Option<HeapId>) -> RunResult<Option<Self>> {
+        self.py_or_impl_one_sided(other, vm)
     }
 
     /// Reflected implementation of Python `|`.
-    fn py_ror_impl(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
-        if let Self::Ref(id) = self {
-            vm.heap.read(*id).py_ror_impl(other, vm)
-        } else {
-            Ok(None)
-        }
+    fn py_ror_impl(&mut self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
+        self.py_ror_impl_one_sided(other, vm)
     }
 
     /// One-sided implementation of Python `^`.
-    fn py_xor_impl(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
-        if let (Self::Bool(lhs), Self::Bool(rhs)) = (self, other) {
-            Ok(Some(Self::Bool(*lhs ^ *rhs)))
-        } else if let (Some(lhs), Some(rhs)) = (immediate_int(self), immediate_int(other)) {
-            Ok(Some(Self::Int(lhs ^ rhs)))
-        } else if let Self::Ref(id) = self {
-            vm.heap.read(*id).py_xor_impl(other, vm)
-        } else {
-            Ok(None)
-        }
+    fn py_xor_impl(&mut self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
+        self.py_xor_impl_one_sided(other, vm)
     }
 
     /// Reflected implementation of Python `^`.
-    fn py_rxor_impl(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
-        if let Self::Ref(id) = self {
-            vm.heap.read(*id).py_rxor_impl(other, vm)
-        } else {
-            Ok(None)
-        }
+    fn py_rxor_impl(&mut self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
+        self.py_rxor_impl_one_sided(other, vm)
     }
 
     /// One-sided implementation of Python `<<`.
@@ -1247,57 +1142,8 @@ impl<'h> PyTrait<'h> for Value {
         Ok(None)
     }
 
-    fn py_getitem(&self, key: &Self, vm: &mut VM<'_>) -> RunResult<Self> {
-        let interns = vm.interns;
-        match self {
-            // `heap_subscript` owns the one case a heap read cannot: a
-            // defaultdict miss, which calls its factory and re-enters the VM.
-            Self::Ref(id) => heap_subscript(*id, key, vm),
-            Self::InternString(string_id) => {
-                // Check for slice first
-                if let Self::Ref(key_id) = key
-                    && let HeapData::Slice(slice_obj) = vm.heap.get(*key_id)
-                {
-                    let s = interns.get_str(*string_id);
-                    let result_str: Box<str> = slice_collect_iterator(vm, slice_obj, s.chars(), |c| c)?;
-                    return Ok(allocate_string(result_str, vm.heap));
-                }
-
-                // Handle interned string indexing, accepting Int and Bool
-                let index = match key {
-                    Self::Int(i) => *i,
-                    Self::Bool(b) => i64::from(*b),
-                    _ => return Err(ExcType::type_error_indices(Type::Str, &key.py_type_name(vm))),
-                };
-
-                let s = interns.get_str(*string_id);
-                let c = get_char_at_index(s, index).ok_or_else(ExcType::str_index_error)?;
-                Ok(allocate_char(c, vm.heap))
-            }
-            Self::InternBytes(bytes_id) => {
-                // Check for slice first
-                if let Self::Ref(key_id) = key
-                    && let HeapData::Slice(slice_obj) = vm.heap.get(*key_id)
-                {
-                    let bytes = interns.get_bytes(*bytes_id);
-                    let result_bytes = slice_collect_iterator(vm, slice_obj, bytes.iter(), |b| *b)?;
-                    let heap_id = vm.heap.allocate(HeapData::Bytes(Bytes::new(result_bytes)));
-                    return Ok(Self::Ref(heap_id));
-                }
-
-                // Handle interned bytes indexing - returns integer byte value
-                let index = match key {
-                    Self::Int(i) => *i,
-                    Self::Bool(b) => i64::from(*b),
-                    _ => return Err(ExcType::type_error_indices(Type::Bytes, &key.py_type_name(vm))),
-                };
-
-                let bytes = interns.get_bytes(*bytes_id);
-                let byte = get_byte_at_index(bytes, index).ok_or_else(ExcType::bytes_index_error)?;
-                Ok(Self::Int(i64::from(byte)))
-            }
-            _ => Err(ExcType::type_error_not_sub(&self.py_type_name(vm))),
-        }
+    fn py_getitem(&mut self, key: &Self, vm: &mut VM<'_>) -> RunResult<Self> {
+        Self::py_getitem(self, key, vm)
     }
 
     fn py_setitem(&mut self, key: Self, value: Self, vm: &mut VM<'_>) -> RunResult<()> {
@@ -1505,6 +1351,207 @@ impl Value {
         matches!(self, Self::NotImplemented)
     }
 
+    /// One-sided `==` for values (the body behind [`PyTrait::py_eq_impl`]).
+    ///
+    /// Inherent and `&self` because a `Value` itself is never mutated by
+    /// comparison — only heap containers need the trait's `&mut self` (lazy
+    /// index rebuilds); the `Ref` arm binds a mutable heap handle for that.
+    fn py_eq_one_sided(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<bool>> {
+        match self {
+            // `Undefined` is a sentinel and is never equal to anything.
+            Self::Undefined => Ok(Some(false)),
+
+            Self::None => Ok(matches!(other, Self::None).then_some(true)),
+            Self::Ellipsis => Ok(matches!(other, Self::Ellipsis).then_some(true)),
+            Self::NotImplemented => Ok(matches!(other, Self::NotImplemented).then_some(true)),
+            Self::Bool(b) => Ok(eq_i64(i64::from(*b), other, vm)),
+            Self::Int(a) => Ok(eq_i64(*a, other, vm)),
+            Self::Float(f) => Ok(eq_f64(*f, other, vm)),
+            // `InternLongInt` is normally materialised to a heap `LongInt` before
+            // it can be compared, but handle it directly so equality never
+            // silently diverges if one reaches here.
+            Self::InternLongInt(id) => Ok(eq_bigint(vm.interns.get_long_int(*id), other, vm)),
+            Self::InternString(id) => Ok(match other {
+                // Interned strings are deduplicated, so equal ids ⇔ equal content.
+                Self::InternString(o) => Some(id == o),
+                _ => eq_str(vm.interns.get_str(*id), other, vm),
+            }),
+            Self::InternBytes(id) => Ok(match other {
+                // Fast path for the same interned bytes; otherwise compare content
+                // (interned bytes are not deduplicated, unlike strings).
+                Self::InternBytes(o) if id == o => Some(true),
+                _ => eq_bytes(vm.interns.get_bytes(*id), other, vm),
+            }),
+            Self::Builtin(b) => Ok(match other {
+                Self::Builtin(o) => Some(b == o),
+                _ => None,
+            }),
+            Self::ModuleFunction(mf) => Ok(match other {
+                Self::ModuleFunction(o) => Some(mf == o),
+                _ => None,
+            }),
+            Self::DefFunction(f) => Ok(match other {
+                Self::DefFunction(o) => Some(f == o),
+                _ => None,
+            }),
+            Self::Marker(m) => Ok(match other {
+                Self::Marker(o) => Some(m == o),
+                _ => None,
+            }),
+            Self::Property(p) => Ok(match other {
+                Self::Property(o) => Some(p == o),
+                _ => None,
+            }),
+            Self::Ref(id) => {
+                let mut this = vm.heap.read(*id);
+                this.py_eq_impl(other, vm)
+            }
+            #[cfg(feature = "memory-model-checks")]
+            Self::Dereferenced => panic!("Cannot access Dereferenced object"),
+        }
+    }
+
+    pub(crate) fn py_getitem(&self, key: &Self, vm: &mut VM<'_>) -> RunResult<Self> {
+        let interns = vm.interns;
+        match self {
+            // `heap_subscript` owns the one case a heap read cannot: a
+            // defaultdict miss, which calls its factory and re-enters the VM.
+            Self::Ref(id) => heap_subscript(*id, key, vm),
+            Self::InternString(string_id) => {
+                // Check for slice first
+                if let Self::Ref(key_id) = key
+                    && let HeapData::Slice(slice_obj) = vm.heap.get(*key_id)
+                {
+                    let s = interns.get_str(*string_id);
+                    let result_str: Box<str> = slice_collect_iterator(vm, slice_obj, s.chars(), |c| c)?;
+                    return Ok(allocate_string(result_str, vm.heap));
+                }
+
+                // Handle interned string indexing, accepting Int and Bool
+                let index = match key {
+                    Self::Int(i) => *i,
+                    Self::Bool(b) => i64::from(*b),
+                    _ => return Err(ExcType::type_error_indices(Type::Str, &key.py_type_name(vm))),
+                };
+
+                let s = interns.get_str(*string_id);
+                let c = get_char_at_index(s, index).ok_or_else(ExcType::str_index_error)?;
+                Ok(allocate_char(c, vm.heap))
+            }
+            Self::InternBytes(bytes_id) => {
+                // Check for slice first
+                if let Self::Ref(key_id) = key
+                    && let HeapData::Slice(slice_obj) = vm.heap.get(*key_id)
+                {
+                    let bytes = interns.get_bytes(*bytes_id);
+                    let result_bytes = slice_collect_iterator(vm, slice_obj, bytes.iter(), |b| *b)?;
+                    let heap_id = vm.heap.allocate(HeapData::Bytes(Bytes::new(result_bytes)));
+                    return Ok(Self::Ref(heap_id));
+                }
+
+                // Handle interned bytes indexing - returns integer byte value
+                let index = match key {
+                    Self::Int(i) => *i,
+                    Self::Bool(b) => i64::from(*b),
+                    _ => return Err(ExcType::type_error_indices(Type::Bytes, &key.py_type_name(vm))),
+                };
+
+                let bytes = interns.get_bytes(*bytes_id);
+                let byte = get_byte_at_index(bytes, index).ok_or_else(ExcType::bytes_index_error)?;
+                Ok(Self::Int(i64::from(byte)))
+            }
+            _ => Err(ExcType::type_error_not_sub(&self.py_type_name(vm))),
+        }
+    }
+
+    fn py_sub_impl_one_sided(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
+        match (self, other) {
+            // Int - Int with overflow detection
+            (Self::Int(a), Self::Int(b)) => {
+                if let Some(result) = a.checked_sub(*b) {
+                    Ok(Some(Self::Int(result)))
+                } else {
+                    Ok(Some(wide_i128_into_value(i128::from(*a) - i128::from(*b), vm.heap)))
+                }
+            }
+            // Float - Float
+            (Self::Float(a), Self::Float(b)) => Ok(Some(Self::Float(a - b))),
+            // Int - Float and Float - Int
+            (Self::Int(a), Self::Float(b)) => Ok(Some(Self::Float(*a as f64 - b))),
+            (Self::Float(a), Self::Int(b)) => Ok(Some(Self::Float(a - *b as f64))),
+            (Self::Ref(id), _) => vm.heap.read(*id).py_sub_impl(other, vm, Some(*id)),
+            _ => Ok(None),
+        }
+    }
+
+    fn py_rsub_impl_one_sided(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
+        if let Self::Ref(id) = self {
+            vm.heap.read(*id).py_rsub_impl(other, vm)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn py_and_impl_one_sided(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
+        if let (Self::Bool(lhs), Self::Bool(rhs)) = (self, other) {
+            Ok(Some(Self::Bool(*lhs && *rhs)))
+        } else if let (Some(lhs), Some(rhs)) = (immediate_int(self), immediate_int(other)) {
+            Ok(Some(Self::Int(lhs & rhs)))
+        } else if let Self::Ref(id) = self {
+            vm.heap.read(*id).py_and_impl(other, vm, Some(*id))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn py_rand_impl_one_sided(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
+        if let Self::Ref(id) = self {
+            vm.heap.read(*id).py_rand_impl(other, vm)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn py_or_impl_one_sided(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
+        if let (Self::Bool(lhs), Self::Bool(rhs)) = (self, other) {
+            Ok(Some(Self::Bool(*lhs || *rhs)))
+        } else if let (Some(lhs), Some(rhs)) = (immediate_int(self), immediate_int(other)) {
+            Ok(Some(Self::Int(lhs | rhs)))
+        } else if let Self::Ref(id) = self {
+            vm.heap.read(*id).py_or_impl(other, vm, Some(*id))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn py_ror_impl_one_sided(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
+        if let Self::Ref(id) = self {
+            vm.heap.read(*id).py_ror_impl(other, vm)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn py_xor_impl_one_sided(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
+        if let (Self::Bool(lhs), Self::Bool(rhs)) = (self, other) {
+            Ok(Some(Self::Bool(*lhs ^ *rhs)))
+        } else if let (Some(lhs), Some(rhs)) = (immediate_int(self), immediate_int(other)) {
+            Ok(Some(Self::Int(lhs ^ rhs)))
+        } else if let Self::Ref(id) = self {
+            vm.heap.read(*id).py_xor_impl(other, vm)
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn py_rxor_impl_one_sided(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
+        if let Self::Ref(id) = self {
+            vm.heap.read(*id).py_rxor_impl(other, vm)
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Equality as containers perform it: identity before user equality.
     pub fn py_eq(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<bool> {
         if self.is(other) {
@@ -1553,7 +1600,7 @@ impl Value {
             } else {
                 Ok(Self::NotImplemented)
             }
-        } else if let Some(result) = self.py_eq_impl(other, vm)? {
+        } else if let Some(result) = self.py_eq_one_sided(other, vm)? {
             Ok(Self::Bool(result))
         } else {
             Ok(Self::NotImplemented)
@@ -1675,11 +1722,14 @@ impl Value {
     /// (`tp_iter`), then `TypeError`.
     pub fn py_contains(&self, item: &Self, vm: &mut VM<'_>) -> RunResult<bool> {
         match self {
-            Self::Ref(heap_id) => match vm.heap.read(*heap_id).py_contains_impl(*heap_id, item, vm)? {
-                Some(found) => Ok(found),
-                None if self.py_is_iterable(vm) => self.contains_by_iteration(item, vm),
-                None => Err(ExcType::type_error_not_container(&self.py_type_name(vm))),
-            },
+            Self::Ref(heap_id) => {
+                let mut this = vm.heap.read(*heap_id);
+                match this.py_contains_impl(*heap_id, item, vm)? {
+                    Some(found) => Ok(found),
+                    None if self.py_is_iterable(vm) => self.contains_by_iteration(item, vm),
+                    None => Err(ExcType::type_error_not_container(&self.py_type_name(vm))),
+                }
+            }
             // Interned strings and bytes never reach the heap, so they answer here.
             Self::InternString(string_id) => {
                 let container_str = vm.interns.get_str(*string_id);
@@ -1858,8 +1908,8 @@ impl Value {
         self.binary_op(
             other,
             vm,
-            |vm| self.py_sub_impl(other, vm, self.ref_id()),
-            |vm| other.py_rsub_impl(self, vm),
+            |vm| self.py_sub_impl_one_sided(other, vm),
+            |vm| other.py_rsub_impl_one_sided(self, vm),
             "-",
         )
     }
@@ -1935,8 +1985,8 @@ impl Value {
         self.binary_op(
             other,
             vm,
-            |vm| self.py_and_impl(other, vm, self.ref_id()),
-            |vm| other.py_rand_impl(self, vm),
+            |vm| self.py_and_impl_one_sided(other, vm),
+            |vm| other.py_rand_impl_one_sided(self, vm),
             "&",
         )
     }
@@ -1946,8 +1996,8 @@ impl Value {
         self.binary_op(
             other,
             vm,
-            |vm| self.py_or_impl(other, vm, self.ref_id()),
-            |vm| other.py_ror_impl(self, vm),
+            |vm| self.py_or_impl_one_sided(other, vm),
+            |vm| other.py_ror_impl_one_sided(self, vm),
             "|",
         )
     }
@@ -1957,8 +2007,8 @@ impl Value {
         self.binary_op(
             other,
             vm,
-            |vm| self.py_xor_impl(other, vm),
-            |vm| other.py_rxor_impl(self, vm),
+            |vm| self.py_xor_impl_one_sided(other, vm),
+            |vm| other.py_rxor_impl_one_sided(self, vm),
             "^",
         )
     }

--- a/crates/monty/tests/binary_serde.rs
+++ b/crates/monty/tests/binary_serde.rs
@@ -25,7 +25,7 @@ fn resolve_name_lookups(mut progress: RunProgress) -> Result<RunProgress, MontyE
 fn dump_header_rejects_incompatible_data() {
     let runner = MontyRun::new("1 + 2".to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
     let bytes = runner.dump().unwrap();
-    assert_eq!(&bytes[..9], b"MONTY\0\x04\x00\x00");
+    assert_eq!(&bytes[..9], b"MONTY\0\x05\x00\x00");
 
     let legacy = postcard::to_allocvec(&runner).unwrap();
     assert_eq!(
@@ -285,6 +285,81 @@ ext_fn(0)
     // itertools-specific (a plain `x = [1, 2]` global does it too).
     let original = progress.into_function_call().expect("should be at function call");
     assert_eq!(original.function_name, "ext_fn");
+    let from_original = original.resume(MontyObject::Int(0), PrintWriter::Stdout).unwrap();
+    assert_eq!(from_original.into_complete().unwrap(), expected);
+
+    let loaded: RunProgress = RunProgress::load(&bytes).unwrap();
+    let call = loaded.into_function_call().expect("should be at function call");
+    let from_loaded = call.resume(MontyObject::Int(0), PrintWriter::Stdout).unwrap();
+    assert_eq!(from_loaded.into_complete().unwrap(), expected);
+}
+
+/// Dicts and sets survive a dump/load even though their hashes and index
+/// tables are never serialized: lookups after restore trigger the lazy
+/// `ensure_indices` rebuild, and instance-attribute access exercises the
+/// VM-less `get_by_str` linear fallback. Covers str/int/tuple keys, both set
+/// types, post-restore mutation, equality, and set algebra.
+#[test]
+fn run_progress_dump_load_rebuilds_dict_and_set_indices() {
+    let code = r"
+class C:
+    def __init__(self):
+        self.x = 1
+        self.y = 2
+
+obj = C()
+d = {'a': 1, 2: 'two', (3, 'x'): 4}
+s = {1, 'two', (3, 'x')}
+fs = frozenset([7, 'eight'])
+ext_fn(0)
+d['new'] = 5
+s.add(99)
+[
+    d['a'], d[2], d[(3, 'x')], d['new'],
+    (3, 'x') in s, 'two' in s, 42 in s, 99 in s,
+    7 in fs, 'eight' in fs, 8 in fs,
+    d.pop(2),
+    len(d), len(s),
+    d == {'a': 1, (3, 'x'): 4, 'new': 5},
+    s | {100} == {1, 'two', (3, 'x'), 99, 100},
+    obj.x + obj.y,
+    list(d)[0],
+]
+"
+    .to_owned();
+    let runner = MontyRun::new(code, "test.py", vec![], CompileOptions::default()).unwrap();
+
+    // Suspend at `ext_fn` with the containers live on the heap.
+    let progress = runner
+        .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
+        .unwrap();
+    let progress = resolve_name_lookups(progress).unwrap();
+    let bytes = progress.dump().unwrap();
+
+    let expected = MontyObject::List(vec![
+        MontyObject::Int(1),
+        MontyObject::String("two".to_owned()),
+        MontyObject::Int(4),
+        MontyObject::Int(5),
+        MontyObject::Bool(true),
+        MontyObject::Bool(true),
+        MontyObject::Bool(false),
+        MontyObject::Bool(true),
+        MontyObject::Bool(true),
+        MontyObject::Bool(true),
+        MontyObject::Bool(false),
+        MontyObject::String("two".to_owned()),
+        MontyObject::Int(3),
+        MontyObject::Int(4),
+        MontyObject::Bool(true),
+        MontyObject::Bool(true),
+        MontyObject::Int(3),
+        MontyObject::String("a".to_owned()),
+    ]);
+
+    // Resume both (an unresumed `RunProgress` leaves its globals' refs
+    // unreleased, aborting under `memory-model-checks`).
+    let original = progress.into_function_call().expect("should be at function call");
     let from_original = original.resume(MontyObject::Int(0), PrintWriter::Stdout).unwrap();
     assert_eq!(from_original.into_complete().unwrap(), expected);
 

--- a/crates/monty/tests/py_object.rs
+++ b/crates/monty/tests/py_object.rs
@@ -1,13 +1,11 @@
-use std::{
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
-};
+use std::hash::{Hash, Hasher};
 
+use ahash::AHasher;
 use monty_types::{DictPairs, ExcType, MontyDate, MontyDateTime, MontyObject, MontyTimeDelta, MontyTimeZone};
 
 /// Helper to compute a hash for a value.
 fn hash_of(obj: &MontyObject) -> u64 {
-    let mut hasher = DefaultHasher::new();
+    let mut hasher = AHasher::default();
     obj.hash(&mut hasher);
     hasher.finish()
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch hashing to `ahash` and stop serializing dict/set entry hashes for portability. Dict/set indices now rebuild lazily on first keyed use; dump format bumped to v5.

- **Refactors**
  - Replaced `DefaultHasher` with `AHasher::default()` and added helpers (`hash_one`, `hash_python_str`/`bytes`); updated tuple/namedtuple/range/slice/date/datetime/timedelta/path/timezone, and Python bindings (frozen dataclass hashing in `monty-proto`).
  - Dict/Set: no per-entry hashes in dumps; indices are derived and rebuilt by `ensure_indices(..)`; VM-less `Dict::get_by_str` linearly scans until a keyed op refreshes indices; detached copies use `SetStorage::ensure_indices_detached`; removed interior mutability (PyTrait methods now take `&mut self` where needed); deleted `HashValue` Serialize/Deserialize; docs clarify dumps/snapshots are a trusted boundary.

- **Dependencies**
  - Added optional `ahash` to `monty-proto`’s `python` feature; updated `Cargo.lock`.

<sup>Written for commit 185e7087ae8a487b5a34ee6d965a70fc39adef1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

