### PR TITLE
Shrink `HeapData` from 160 to 80 bytes by boxing large variants

### DIFF
--- a/crates/monty/src/builtins/type_.rs
+++ b/crates/monty/src/builtins/type_.rs
@@ -161,6 +161,6 @@ fn create_class(
 
     let class_id = vm
         .heap
-        .allocate(HeapData::Class(Class::new(class_name, namespace_dict)))?;
+        .allocate(HeapData::Class(Box::new(Class::new(class_name, namespace_dict))))?;
     Ok(Value::Ref(class_id))
 }

--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -889,7 +889,7 @@ impl<'h> VM<'h> {
     pub fn add_pending_call(&mut self, call_id: CallId) -> RunResult<()> {
         let future_id = self
             .heap
-            .allocate(HeapData::ExternalFuture(ExternalFuture::new_pending(call_id)))?;
+            .allocate(HeapData::ExternalFuture(Box::new(ExternalFuture::new_pending(call_id))))?;
         self.scheduler.add_pending_external(call_id, future_id, self.heap);
         self.push(Value::Ref(future_id));
         Ok(())

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -945,7 +945,7 @@ impl VM<'_> {
         // Allocate the instance. On allocation failure drop the args we own.
         let instance_id = match self
             .heap
-            .allocate(HeapData::Instance(Instance::new(class_id, Dict::new())))
+            .allocate(HeapData::Instance(Box::new(Instance::new(class_id, Dict::new()))))
         {
             Ok(id) => id,
             Err(e) => {

--- a/crates/monty/src/dump_format.rs
+++ b/crates/monty/src/dump_format.rs
@@ -11,7 +11,7 @@ const MAGIC: &[u8; 6] = b"MONTY\0";
 ///
 /// Bump this whenever a serialized discriminant can shift, so older dumps are
 /// rejected instead of decoding as their neighbour.
-pub(crate) const VERSION: u16 = 2;
+pub(crate) const VERSION: u16 = 3;
 
 /// Number of bytes before the postcard payload.
 const HEADER_LEN: usize = MAGIC.len() + size_of::<u16>() + size_of::<u8>();

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -583,15 +583,34 @@ impl<'a> HeapPtr<'a> {
         }
 
         /// Like `heap_read` but for `Box<T>` fields inside `HeapData` variants.
+        ///
+        /// The `&Box<T>` is only used to locate the box field inside the enum; the
+        /// inner pointer is *loaded out of* that field rather than derived by
+        /// dereferencing the box. Dereferencing (`boxed.as_ref()`) would create a
+        /// shared `&T` whose `SharedReadOnly` provenance makes later
+        /// `HeapRead::get_mut` writes UB; the loaded pointer instead carries the
+        /// box's own stored (writeable) provenance.
         #[expect(
             clippy::borrowed_box,
             reason = "We intentionally take &Box<T> to signal this is for boxed HeapData variants; &T would lose that context"
         )]
-        fn heap_read_boxed<'a, T>(boxed: &Box<T>, readers: NonNull<Cell<usize>>) -> HeapRead<'a, T> {
+        fn heap_read_boxed<'a, T>(
+            base: *mut HeapData,
+            boxed: &Box<T>,
+            readers: NonNull<Cell<usize>>,
+        ) -> HeapRead<'a, T> {
+            let base_addr = base as usize;
+            let field_addr = ptr::from_ref(boxed) as usize;
+            let offset = field_addr - base_addr;
+            // SAFETY: `offset` locates the live `Box<T>` field within the enum, and the
+            // pointer to it is derived from the `UnsafeCell`'s `*mut` (not from `&Box<T>`),
+            // preserving `SharedReadWrite` permission for the load below. `Box<T>` with
+            // `T: Sized` is guaranteed to be represented as a single non-null pointer, so
+            // loading the field as `*mut T` yields the box's data pointer together with
+            // the read/write provenance it was stored with.
+            let value = unsafe { NonNull::new_unchecked(base.byte_add(offset).cast::<*mut T>().read()) };
             HeapRead {
-                // SAFETY: The Box's allocation is valid for reads/writes as long as the
-                // HeapData containing it is alive.
-                value: unsafe { NonNull::new_unchecked(ptr::from_ref(boxed.as_ref()).cast_mut()) },
+                value,
                 readers,
                 borrow: PhantomData,
             }
@@ -615,8 +634,10 @@ impl<'a> HeapPtr<'a> {
             HeapData::List(list) => HeapReadOutput::List(heap_read(base, list, readers)),
             HeapData::Deque(deque) => HeapReadOutput::Deque(heap_read(base, deque, readers)),
             HeapData::Tuple(tuple) => HeapReadOutput::Tuple(heap_read(base, tuple, readers)),
-            HeapData::NamedTuple(named_tuple) => HeapReadOutput::NamedTuple(heap_read(base, named_tuple, readers)),
-            HeapData::NamedTupleClass(class) => HeapReadOutput::NamedTupleClass(heap_read(base, class, readers)),
+            HeapData::NamedTuple(named_tuple) => {
+                HeapReadOutput::NamedTuple(heap_read_boxed(base, named_tuple, readers))
+            }
+            HeapData::NamedTupleClass(class) => HeapReadOutput::NamedTupleClass(heap_read_boxed(base, class, readers)),
             HeapData::Dict(dict) => HeapReadOutput::Dict(heap_read(base, dict, readers)),
             HeapData::DictItemsView(v) => HeapReadOutput::DictItemsView(heap_read(base, v, readers)),
             HeapData::DictKeysView(v) => HeapReadOutput::DictKeysView(heap_read(base, v, readers)),
@@ -634,8 +655,8 @@ impl<'a> HeapPtr<'a> {
             HeapData::Exception(simple_exception) => {
                 HeapReadOutput::Exception(heap_read(base, simple_exception, readers))
             }
-            HeapData::Dataclass(dataclass) => HeapReadOutput::Dataclass(heap_read(base, dataclass, readers)),
-            HeapData::Class(class) => HeapReadOutput::Class(heap_read(base, class, readers)),
+            HeapData::Dataclass(dataclass) => HeapReadOutput::Dataclass(heap_read_boxed(base, dataclass, readers)),
+            HeapData::Class(class) => HeapReadOutput::Class(heap_read_boxed(base, class, readers)),
             HeapData::Instance(instance) => HeapReadOutput::Instance(heap_read(base, instance, readers)),
             HeapData::BoundMethod(bound_method) => HeapReadOutput::BoundMethod(heap_read(base, bound_method, readers)),
             HeapData::DataclassField(field) => HeapReadOutput::DataclassField(heap_read(base, field, readers)),
@@ -655,15 +676,15 @@ impl<'a> HeapPtr<'a> {
             HeapData::Module(module) => HeapReadOutput::Module(heap_read(base, module, readers)),
             HeapData::Coroutine(coroutine) => HeapReadOutput::Coroutine(heap_read(base, coroutine, readers)),
             HeapData::GatherFuture(gather_future) => {
-                HeapReadOutput::GatherFuture(heap_read(base, gather_future, readers))
+                HeapReadOutput::GatherFuture(heap_read_boxed(base, gather_future, readers))
             }
             HeapData::ExternalFuture(external_future) => {
-                HeapReadOutput::ExternalFuture(heap_read(base, external_future, readers))
+                HeapReadOutput::ExternalFuture(heap_read_boxed(base, external_future, readers))
             }
             HeapData::Path(path) => HeapReadOutput::Path(heap_read(base, path, readers)),
-            HeapData::OpenFile(file) => HeapReadOutput::OpenFile(heap_read(base, file, readers)),
-            HeapData::RePattern(re_pattern) => HeapReadOutput::RePattern(heap_read_boxed(re_pattern, readers)),
-            HeapData::ReMatch(re_match) => HeapReadOutput::ReMatch(heap_read(base, re_match, readers)),
+            HeapData::OpenFile(file) => HeapReadOutput::OpenFile(heap_read_boxed(base, file, readers)),
+            HeapData::RePattern(re_pattern) => HeapReadOutput::RePattern(heap_read_boxed(base, re_pattern, readers)),
+            HeapData::ReMatch(re_match) => HeapReadOutput::ReMatch(heap_read_boxed(base, re_match, readers)),
             HeapData::Date(d) => HeapReadOutput::Date(heap_read(base, d, readers)),
             HeapData::DateTime(d) => HeapReadOutput::DateTime(heap_read(base, d, readers)),
             HeapData::TimeDelta(d) => HeapReadOutput::TimeDelta(heap_read(base, d, readers)),

--- a/crates/monty/src/heap.rs
+++ b/crates/monty/src/heap.rs
@@ -657,7 +657,7 @@ impl<'a> HeapPtr<'a> {
             }
             HeapData::Dataclass(dataclass) => HeapReadOutput::Dataclass(heap_read_boxed(base, dataclass, readers)),
             HeapData::Class(class) => HeapReadOutput::Class(heap_read_boxed(base, class, readers)),
-            HeapData::Instance(instance) => HeapReadOutput::Instance(heap_read(base, instance, readers)),
+            HeapData::Instance(instance) => HeapReadOutput::Instance(heap_read_boxed(base, instance, readers)),
             HeapData::BoundMethod(bound_method) => HeapReadOutput::BoundMethod(heap_read(base, bound_method, readers)),
             HeapData::DataclassField(field) => HeapReadOutput::DataclassField(heap_read(base, field, readers)),
             HeapData::ListIterator(iter) => HeapReadOutput::ListIterator(heap_read(base, iter, readers)),
@@ -673,7 +673,7 @@ impl<'a> HeapPtr<'a> {
             HeapData::CallableIterator(c) => HeapReadOutput::CallableIterator(heap_read(base, c, readers)),
             HeapData::Itertools(i) => HeapReadOutput::Itertools(heap_read(base, i, readers)),
             HeapData::LongInt(l) => HeapReadOutput::LongInt(heap_read(base, l, readers)),
-            HeapData::Module(module) => HeapReadOutput::Module(heap_read(base, module, readers)),
+            HeapData::Module(module) => HeapReadOutput::Module(heap_read_boxed(base, module, readers)),
             HeapData::Coroutine(coroutine) => HeapReadOutput::Coroutine(heap_read(base, coroutine, readers)),
             HeapData::GatherFuture(gather_future) => {
                 HeapReadOutput::GatherFuture(heap_read_boxed(base, gather_future, readers))

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -31,6 +31,11 @@ use crate::{
 
 /// HeapData captures every runtime value that must live in the arena.
 ///
+/// The enum is moved by value on every heap allocate and free, so its inline
+/// size is a direct memcpy cost on those hot paths. Variants larger than
+/// [`Tuple`]/[`Dict`] (the largest hot variants) are therefore `Box`ed — see the size
+/// assertion below the enum before adding or growing a variant.
+///
 /// Each variant wraps a type that implements `PyTrait`, providing
 /// Python-compatible operations. The trait is manually implemented to dispatch
 /// to the appropriate variant's implementation.
@@ -42,9 +47,9 @@ pub(crate) enum HeapData {
     /// `collections.deque` — a double-ended queue with an optional `maxlen`.
     Deque(Deque),
     Tuple(Tuple),
-    NamedTuple(NamedTuple),
+    NamedTuple(Box<NamedTuple>),
     /// A `collections.namedtuple` class object (the callable that builds instances).
-    NamedTupleClass(NamedTupleClass),
+    NamedTupleClass(Box<NamedTupleClass>),
     Dict(Dict),
     DictKeysView(DictKeysView),
     DictItemsView(DictItemsView),
@@ -79,12 +84,12 @@ pub(crate) enum HeapData {
     ///
     /// Contains a class name, a Dict of field name -> value mappings, and a set
     /// of method names that trigger external function calls when invoked.
-    Dataclass(Dataclass),
+    Dataclass(Box<Dataclass>),
     /// A user-defined class object created by `class Foo: ...`.
     ///
     /// Holds the class name and a namespace of methods + class variables. Its own
     /// `HeapId` is the type identity used by `type()`/`isinstance`.
-    Class(Class),
+    Class(Box<Class>),
     /// An instance of a user-defined class.
     ///
     /// Holds a reference to its `Class` and an `attrs` dict (the instance `__dict__`).
@@ -136,13 +141,13 @@ pub(crate) enum HeapData {
     /// A gather() result tracking multiple coroutines/tasks.
     ///
     /// Created by asyncio.gather() and spawns tasks when awaited.
-    GatherFuture(GatherFuture),
+    GatherFuture(Box<GatherFuture>),
     /// An external future driven by the host.
     ///
     /// Created when the host returns `ExtFunctionResult::Future(call_id)`.
     /// Holds its own state machine (`Pending`/`Resolved`/`Failed`) so
     /// re-await yields cached results, matching CPython's Future semantics.
-    ExternalFuture(ExternalFuture),
+    ExternalFuture(Box<ExternalFuture>),
     /// A filesystem path from `pathlib.Path`.
     ///
     /// Stored on the heap to provide Python-compatible path operations.
@@ -153,7 +158,7 @@ pub(crate) enum HeapData {
     ///
     /// The object stores only virtual path and mode state.  Reads and writes are
     /// full-file OS calls; no native file descriptor is kept while Monty runs.
-    OpenFile(OpenFile),
+    OpenFile(Box<OpenFile>),
     /// A compiled regex pattern from `re.compile()`.
     ///
     /// Contains the original pattern string, flags, and compiled regex engine.
@@ -163,7 +168,7 @@ pub(crate) enum HeapData {
     ///
     /// Contains the matched text, capture groups, positions, and input string.
     /// Leaf type: no heap references, not GC-tracked.
-    ReMatch(ReMatch),
+    ReMatch(Box<ReMatch>),
     /// Reference to an external function supplied by the host or synthesized for a call.
     ExtFunction(ExtFunction),
     /// A `datetime.date` value stored with `chrono::NaiveDate`.
@@ -182,6 +187,12 @@ pub(crate) enum HeapData {
     /// dispatches on which adaptor it is.
     Itertools(ItertoolsIter),
 }
+
+// `HeapData` is memcpy'd on every allocate and free, so its inline size is paid on
+// the hottest heap paths. `Tuple` (inline `SmallVec` storage) and `Dict` — both far
+// too hot to box — set the 80-byte payload ceiling (96 with the discriminant); if
+// this assertion fails a variant has outgrown them and should be boxed.
+const _: () = assert!(mem::size_of::<HeapData>() <= 96);
 
 impl HeapData {
     /// Returns whether this heap data type can participate in reference cycles.

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -33,7 +33,7 @@ use crate::{
 ///
 /// The enum is moved by value on every heap allocate and free, so its inline
 /// size is a direct memcpy cost on those hot paths. Variants larger than
-/// [`Tuple`]/[`Dict`] (the largest hot variants) are therefore `Box`ed — see the size
+/// [`Dict`] (the largest hot variant) are therefore `Box`ed — see the size
 /// assertion below the enum before adding or growing a variant.
 ///
 /// Each variant wraps a type that implements `PyTrait`, providing
@@ -93,7 +93,7 @@ pub(crate) enum HeapData {
     /// An instance of a user-defined class.
     ///
     /// Holds a reference to its `Class` and an `attrs` dict (the instance `__dict__`).
-    Instance(Instance),
+    Instance(Box<Instance>),
     /// A method bound to an instance, produced by `obj.method` without calling it.
     BoundMethod(BoundMethod),
     /// One `dataclasses.Field` of a `@dataclass`, held by the class's
@@ -132,7 +132,7 @@ pub(crate) enum HeapData {
     ///
     /// Modules have a name and a dictionary of attributes. They are created by
     /// import statements and can have refs to other heap values in their attributes.
-    Module(Module),
+    Module(Box<Module>),
     /// A coroutine object from an async function call.
     ///
     /// Contains pre-bound arguments and captured cells, ready to be awaited.
@@ -189,10 +189,10 @@ pub(crate) enum HeapData {
 }
 
 // `HeapData` is memcpy'd on every allocate and free, so its inline size is paid on
-// the hottest heap paths. `Tuple` (inline `SmallVec` storage) and `Dict` — both far
-// too hot to box — set the 80-byte payload ceiling (96 with the discriminant); if
-// this assertion fails a variant has outgrown them and should be boxed.
-const _: () = assert!(mem::size_of::<HeapData>() <= 96);
+// the hottest heap paths. `Dict` — far too hot to box — sets the 72-byte payload
+// ceiling (currently tag-free thanks to niche packing); if this assertion fails a
+// variant has outgrown it and should be boxed (or, for `Dict` itself, slimmed down).
+const _: () = assert!(mem::size_of::<HeapData>() <= 80);
 
 impl HeapData {
     /// Returns whether this heap data type can participate in reference cycles.

--- a/crates/monty/src/modules/asyncio.rs
+++ b/crates/monty/src/modules/asyncio.rs
@@ -125,7 +125,7 @@ pub(crate) fn gather(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
         .map(|arg| arg.into_ref_id().expect("validated gather awaitable is heap-backed"))
         .collect();
     let gather_future = GatherFuture::new(items);
-    let id = vm.heap.allocate(HeapData::GatherFuture(gather_future))?;
+    let id = vm.heap.allocate(HeapData::GatherFuture(Box::new(gather_future)))?;
     Ok(Value::Ref(id))
 }
 

--- a/crates/monty/src/modules/asyncio.rs
+++ b/crates/monty/src/modules/asyncio.rs
@@ -54,7 +54,7 @@ pub fn create_module(vm: &mut VM<'_>) -> Result<HeapId, ResourceError> {
         vm,
     );
 
-    vm.heap.allocate(HeapData::Module(module))
+    vm.heap.allocate(HeapData::Module(Box::new(module)))
 }
 pub(super) fn call(vm: &mut VM<'_>, functions: AsyncioFunctions, args: ArgValues) -> RunResult<CallResult> {
     match functions {

--- a/crates/monty/src/modules/collections/counter.rs
+++ b/crates/monty/src/modules/collections/counter.rs
@@ -1,6 +1,6 @@
 //! Runtime behaviour for `collections.Counter`.
 //!
-//! A Counter is a `dict` tagged with [`DictKind::Counter`](crate::types::DictKind);
+//! A Counter is a `dict` tagged with a `Counter` [`DictKind`](crate::types::DictKind);
 //! everything here operates on that dict through the VM by [`HeapId`] rather than
 //! on `Dict`'s internals, which is why it lives beside the module surface instead
 //! of in `types/dict.rs`. The dict method surface is inherited as-is — only the

--- a/crates/monty/src/modules/collections/defaultdict.rs
+++ b/crates/monty/src/modules/collections/defaultdict.rs
@@ -1,6 +1,6 @@
 //! Runtime behaviour for `collections.defaultdict`.
 //!
-//! A defaultdict is a `dict` tagged with [`DictKind::Default`](crate::types::DictKind),
+//! A defaultdict is a `dict` tagged with a defaultdict [`DictKind`](crate::types::DictKind),
 //! carrying its `default_factory`. The only behavioural addition is the
 //! missing-key hook below; everything else is the inherited dict surface.
 

--- a/crates/monty/src/modules/collections/mod.rs
+++ b/crates/monty/src/modules/collections/mod.rs
@@ -69,7 +69,7 @@ pub fn create_module(vm: &mut VM<'_>) -> Result<HeapId, ResourceError> {
         vm,
     );
 
-    vm.heap.allocate(HeapData::Module(module))
+    vm.heap.allocate(HeapData::Module(Box::new(module)))
 }
 
 /// The callable functions exposed by the `collections` module.

--- a/crates/monty/src/modules/collections/mod.rs
+++ b/crates/monty/src/modules/collections/mod.rs
@@ -257,7 +257,9 @@ fn namedtuple(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
 
     let field_names: Vec<EitherStr> = names.into_iter().map(EitherStr::Heap).collect();
     let class = NamedTupleClass::new(type_name, field_names, default_values, module);
-    Ok(Value::Ref(vm.heap.allocate(HeapData::NamedTupleClass(class))?))
+    Ok(Value::Ref(
+        vm.heap.allocate(HeapData::NamedTupleClass(Box::new(class)))?,
+    ))
 }
 
 /// Parses the `field_names` argument into owned strings.

--- a/crates/monty/src/modules/collections/mod.rs
+++ b/crates/monty/src/modules/collections/mod.rs
@@ -36,6 +36,7 @@ use crate::{
     intern::StaticStrings,
     types::{
         Dict, Module, NamedTupleClass, PyTrait, Type,
+        dict::DictKind,
         iter::collect_owned_iterable,
         str::{StringRepr, str_isidentifier},
     },
@@ -169,6 +170,17 @@ pub(crate) fn defaultdict_init(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Va
             return Err(e);
         }
     };
+
+    // The dict is already on the heap, so its `py_estimate_size` was charged
+    // without the boxed kind state — charge that box before installing it,
+    // otherwise the refund at free time exceeds what was tracked.
+    if let Err(error) = vm.heap.track_growth(DictKind::SPECIAL_SIZE) {
+        if let Some(factory) = factory {
+            factory.drop_with(vm);
+        }
+        dict_value.drop_with(vm);
+        return Err(error.into());
+    }
 
     let Value::Ref(dict_id) = dict_value else {
         unreachable!("Dict::init returns a dict ref");

--- a/crates/monty/src/modules/dataclasses.rs
+++ b/crates/monty/src/modules/dataclasses.rs
@@ -54,7 +54,7 @@ pub fn create_module(vm: &mut VM<'_>) -> Result<HeapId, ResourceError> {
         Value::ModuleFunction(ModuleFunctions::Dataclasses(DataclassesFunctions::IsDataclass)),
         vm,
     );
-    vm.heap.allocate(HeapData::Module(module))
+    vm.heap.allocate(HeapData::Module(Box::new(module)))
 }
 
 /// Dispatches a `dataclasses` module function call.

--- a/crates/monty/src/modules/datetime.rs
+++ b/crates/monty/src/modules/datetime.rs
@@ -47,5 +47,5 @@ pub fn create_module(vm: &mut VM<'_>) -> Result<HeapId, ResourceError> {
         vm,
     );
 
-    vm.heap.allocate(HeapData::Module(module))
+    vm.heap.allocate(HeapData::Module(Box::new(module)))
 }

--- a/crates/monty/src/modules/gc.rs
+++ b/crates/monty/src/modules/gc.rs
@@ -53,7 +53,7 @@ pub fn create_module(vm: &mut VM<'_>) -> Result<HeapId, ResourceError> {
     ] {
         module.set_attr(name, Value::ModuleFunction(ModuleFunctions::Gc(function)), vm);
     }
-    vm.heap.allocate(HeapData::Module(module))
+    vm.heap.allocate(HeapData::Module(Box::new(module)))
 }
 
 /// Dispatches a `gc` module function call.

--- a/crates/monty/src/modules/itertools.rs
+++ b/crates/monty/src/modules/itertools.rs
@@ -46,7 +46,7 @@ pub fn create_module(vm: &mut VM<'_>) -> Result<HeapId, ResourceError> {
         module.set_attr(*name, Value::ModuleFunction(ModuleFunctions::Itertools(*func)), vm);
     }
 
-    vm.heap.allocate(HeapData::Module(module))
+    vm.heap.allocate(HeapData::Module(Box::new(module)))
 }
 
 /// Dispatches a call to an `itertools` module function.

--- a/crates/monty/src/modules/json/mod.rs
+++ b/crates/monty/src/modules/json/mod.rs
@@ -65,7 +65,7 @@ pub fn create_module(vm: &mut VM<'_>) -> Result<HeapId, ResourceError> {
         Value::Builtin(Builtins::ExcType(ExcType::JsonDecodeError)),
         vm,
     );
-    vm.heap.allocate(HeapData::Module(module))
+    vm.heap.allocate(HeapData::Module(Box::new(module)))
 }
 
 /// Dispatches a `json` module function call.

--- a/crates/monty/src/modules/math.rs
+++ b/crates/monty/src/modules/math.rs
@@ -196,7 +196,7 @@ pub fn create_module(vm: &mut VM<'_>) -> Result<HeapId, ResourceError> {
     module.set_attr(StaticStrings::MathInf, Value::Float(f64::INFINITY), vm);
     module.set_attr(StaticStrings::MathNan, Value::Float(f64::NAN), vm);
 
-    vm.heap.allocate(HeapData::Module(module))
+    vm.heap.allocate(HeapData::Module(Box::new(module)))
 }
 
 /// Static mapping of attribute names to math functions for module creation.

--- a/crates/monty/src/modules/os.rs
+++ b/crates/monty/src/modules/os.rs
@@ -99,7 +99,7 @@ pub fn create_module(vm: &mut VM<'_>) -> Result<HeapId, ResourceError> {
     for (attr, value) in attrs {
         module.set_attr(attr, value, vm);
     }
-    vm.heap.allocate(HeapData::Module(module))
+    vm.heap.allocate(HeapData::Module(Box::new(module)))
 }
 
 /// Dispatches a call to an os module function.

--- a/crates/monty/src/modules/pathlib.rs
+++ b/crates/monty/src/modules/pathlib.rs
@@ -30,5 +30,5 @@ pub fn create_module(vm: &mut VM<'_>) -> Result<HeapId, ResourceError> {
     // pathlib.Path - the Path class (callable to create Path instances)
     module.set_attr(StaticStrings::PathClass, Value::Builtin(Builtins::Type(Type::Path)), vm);
 
-    vm.heap.allocate(HeapData::Module(module))
+    vm.heap.allocate(HeapData::Module(Box::new(module)))
 }

--- a/crates/monty/src/modules/re.rs
+++ b/crates/monty/src/modules/re.rs
@@ -180,7 +180,7 @@ pub fn create_module(vm: &mut VM<'_>) -> Result<HeapId, ResourceError> {
         vm,
     );
 
-    vm.heap.allocate(HeapData::Module(module))
+    vm.heap.allocate(HeapData::Module(Box::new(module)))
 }
 
 /// Dispatches a call to a `re` module function. Always `CallResult::Value` — regex

--- a/crates/monty/src/modules/sys.rs
+++ b/crates/monty/src/modules/sys.rs
@@ -91,7 +91,7 @@ pub fn create_module(vm: &mut VM<'_>) -> Result<HeapId, ResourceError> {
         vm,
     );
 
-    vm.heap.allocate(HeapData::Module(module))
+    vm.heap.allocate(HeapData::Module(Box::new(module)))
 }
 
 /// Dispatches a `sys` module function call.

--- a/crates/monty/src/modules/sys.rs
+++ b/crates/monty/src/modules/sys.rs
@@ -79,7 +79,7 @@ pub fn create_module(vm: &mut VM<'_>) -> Result<HeapId, ResourceError> {
             Value::Int(0),
         ],
     );
-    let version_info_id = vm.heap.allocate(HeapData::NamedTuple(version_info))?;
+    let version_info_id = vm.heap.allocate(HeapData::NamedTuple(Box::new(version_info)))?;
     module.set_attr(StaticStrings::VersionInfo, Value::Ref(version_info_id), vm);
 
     // Test-only callables — see the module-level docs and the

--- a/crates/monty/src/modules/typing.rs
+++ b/crates/monty/src/modules/typing.rs
@@ -35,7 +35,7 @@ pub fn create_module(vm: &mut VM<'_>) -> Result<HeapId, ResourceError> {
         module.set_attr(*ss, Value::Marker(Marker(*ss)), vm);
     }
 
-    vm.heap.allocate(HeapData::Module(module))
+    vm.heap.allocate(HeapData::Module(Box::new(module)))
 }
 
 /// Typing marker attributes exported by this module.

--- a/crates/monty/src/modules/unicodedata.rs
+++ b/crates/monty/src/modules/unicodedata.rs
@@ -85,7 +85,7 @@ pub fn create_module(vm: &mut VM<'_>) -> Result<HeapId, ResourceError> {
     let version = allocate_string(UNIDATA_VERSION, vm.heap)?;
     module.set_attr(StaticStrings::UnidataVersion, version, vm);
 
-    vm.heap.allocate(HeapData::Module(module))
+    vm.heap.allocate(HeapData::Module(Box::new(module)))
 }
 
 /// Dispatches a call to a `unicodedata` module function.

--- a/crates/monty/src/object_bridge.rs
+++ b/crates/monty/src/object_bridge.rs
@@ -108,7 +108,7 @@ impl MontyObjectExt for MontyObject {
                 let values = convert_values(values, vm)?;
                 let field_name_strs: Vec<EitherStr> = field_names.into_iter().map(Into::into).collect();
                 let nt = NamedTuple::new(type_name, field_name_strs, values);
-                Ok(Value::Ref(vm.heap.allocate(HeapData::NamedTuple(nt))?))
+                Ok(Value::Ref(vm.heap.allocate(HeapData::NamedTuple(Box::new(nt)))?))
             }
             Self::Dict(map) => {
                 let pairs = convert_pairs(map, vm)?;
@@ -195,12 +195,12 @@ impl MontyObjectExt for MontyObject {
                 let dict = Dict::from_pairs(pairs, vm)
                     .map_err(|_| InvalidInputError::invalid_type("unhashable dataclass attr keys"))?;
                 let dc = Dataclass::new(name, type_id, field_names, dict, frozen);
-                Ok(Value::Ref(vm.heap.allocate(HeapData::Dataclass(dc))?))
+                Ok(Value::Ref(vm.heap.allocate(HeapData::Dataclass(Box::new(dc)))?))
             }
             Self::Path(s) => Ok(Value::Ref(vm.heap.allocate(HeapData::Path(Path::new(s)))?)),
             Self::FileHandle(handle) => {
                 let file = OpenFile::with_state(handle.path, handle.mode, handle.position);
-                Ok(Value::Ref(vm.heap.allocate(HeapData::OpenFile(file))?))
+                Ok(Value::Ref(vm.heap.allocate(HeapData::OpenFile(Box::new(file)))?))
             }
             Self::Type(t) => match t.to_internal() {
                 Some(ty) => Ok(Value::Builtin(Builtins::Type(ty))),

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -84,6 +84,12 @@ pub(crate) struct Dict {
 
 /// Distinguishes a plain `dict` from a `collections.defaultdict` or `Counter`.
 ///
+/// Stored as one word: a plain `dict` (the overwhelmingly common case) is
+/// `None`, and the special kinds box a [`DictSpecial`]. `Dict` is embedded
+/// inline in `Instance` and `Module`, so every byte here is paid by the
+/// `HeapData` size ceiling (see the assertion in `heap_data.rs`) — an unboxed
+/// factory `Value` would push the whole heap arena's entry size up.
+///
 /// The real solution is inheritance, as CPython does it: both are genuine
 /// `dict` subclasses there (`class Counter(dict)`; `defaultdict`'s C struct
 /// embeds a `PyDictObject` and adds a `default_factory`), so they get the dict
@@ -92,14 +98,17 @@ pub(crate) struct Dict {
 /// hence the `type(x) is Counter` divergence in `limitations/collections.md`.
 /// Workable in the meantime; revisit once inheritance exists.
 ///
-/// The `Default(Some(_))` factory is a heap reference the dict owns — released
-/// in [`Dict::py_dec_ref_ids`] / `DropWithContext` and reported to the cycle
+/// The defaultdict factory is a heap reference the dict owns — released in
+/// [`Dict::py_dec_ref_ids`] / `DropWithContext` and reported to the cycle
 /// collector alongside the entries, so those two paths MUST stay in sync.
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
-pub(crate) enum DictKind {
-    /// A plain `dict`.
-    #[default]
-    Plain,
+pub(crate) struct DictKind(Option<Box<DictSpecial>>);
+
+/// Boxed state for the non-plain [`DictKind`]s. Private to this module —
+/// everything outside speaks through `DictKind`'s constructors and `Dict`'s
+/// accessors (`is_defaultdict`, `default_factory`, `kind_type`, ...).
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+enum DictSpecial {
     /// A `collections.defaultdict`; the optional `default_factory` is invoked
     /// on a missing-key access. `None` means missing keys raise `KeyError`.
     Default(Option<Value>),
@@ -107,6 +116,26 @@ pub(crate) enum DictKind {
     /// inserting), and it adds `most_common`/`elements`/arithmetic on top of
     /// the dict surface.
     Counter,
+}
+
+impl DictKind {
+    /// A plain `dict` — no allocation.
+    #[must_use]
+    pub fn plain() -> Self {
+        Self(None)
+    }
+
+    /// A `defaultdict` kind, taking ownership of the factory reference.
+    #[must_use]
+    pub fn defaultdict(factory: Option<Value>) -> Self {
+        Self(Some(Box::new(DictSpecial::Default(factory))))
+    }
+
+    /// A `Counter` kind.
+    #[must_use]
+    pub fn counter() -> Self {
+        Self(Some(Box::new(DictSpecial::Counter)))
+    }
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -129,7 +158,7 @@ impl Dict {
             indices: HashTable::with_capacity(capacity),
             entries: Vec::with_capacity(capacity),
             contains_refs: false,
-            kind: DictKind::Plain,
+            kind: DictKind::plain(),
         }
     }
 
@@ -140,24 +169,24 @@ impl Dict {
         if matches!(factory, Some(Value::Ref(_))) {
             self.contains_refs = true;
         }
-        self.kind = DictKind::Default(factory);
+        self.kind = DictKind::defaultdict(factory);
     }
 
     /// Returns whether this dict is a `defaultdict`.
     #[must_use]
     pub fn is_defaultdict(&self) -> bool {
-        matches!(self.kind, DictKind::Default(_))
+        matches!(self.kind.0.as_deref(), Some(DictSpecial::Default(_)))
     }
 
     /// Marks this dict as a `collections.Counter`.
     pub fn make_counter(&mut self) {
-        self.kind = DictKind::Counter;
+        self.kind = DictKind::counter();
     }
 
     /// Returns whether this dict is a `Counter`.
     #[must_use]
     pub fn is_counter(&self) -> bool {
-        matches!(self.kind, DictKind::Counter)
+        matches!(self.kind.0.as_deref(), Some(DictSpecial::Counter))
     }
 
     /// Clones this dict's kind for a derived dict, taking a counted reference to
@@ -169,17 +198,19 @@ impl Dict {
     /// is_defaultdict()` chain silently degrades a `Counter` to a plain dict.
     #[must_use]
     pub fn cloned_kind(&self, heap: &impl ContainsHeap) -> DictKind {
-        match &self.kind {
-            DictKind::Plain => DictKind::Plain,
-            DictKind::Default(factory) => DictKind::Default(factory.as_ref().map(|f| f.clone_with_heap(heap))),
-            DictKind::Counter => DictKind::Counter,
+        match self.kind.0.as_deref() {
+            None => DictKind::plain(),
+            Some(DictSpecial::Default(factory)) => {
+                DictKind::defaultdict(factory.as_ref().map(|f| f.clone_with_heap(heap)))
+            }
+            Some(DictSpecial::Counter) => DictKind::counter(),
         }
     }
 
     /// Adopts a kind produced by [`cloned_kind`], taking ownership of any
     /// factory reference it carries.
     pub fn set_kind(&mut self, kind: DictKind) {
-        if matches!(kind, DictKind::Default(Some(Value::Ref(_)))) {
+        if matches!(kind.0.as_deref(), Some(DictSpecial::Default(Some(Value::Ref(_))))) {
             self.contains_refs = true;
         }
         self.kind = kind;
@@ -189,10 +220,10 @@ impl Dict {
     /// `Counter`).
     #[must_use]
     pub fn kind_type(&self) -> Type {
-        match self.kind {
-            DictKind::Plain => Type::Dict,
-            DictKind::Default(_) => Type::DefaultDict,
-            DictKind::Counter => Type::Counter,
+        match self.kind.0.as_deref() {
+            None => Type::Dict,
+            Some(DictSpecial::Default(_)) => Type::DefaultDict,
+            Some(DictSpecial::Counter) => Type::Counter,
         }
     }
 
@@ -207,9 +238,9 @@ impl Dict {
     /// factory-less defaultdict.
     #[must_use]
     pub fn default_factory(&self) -> Option<&Value> {
-        match &self.kind {
-            DictKind::Default(factory) => factory.as_ref(),
-            DictKind::Plain | DictKind::Counter => None,
+        match self.kind.0.as_deref() {
+            Some(DictSpecial::Default(factory)) => factory.as_ref(),
+            None | Some(DictSpecial::Counter) => None,
         }
     }
 
@@ -222,10 +253,10 @@ impl Dict {
         }
         // The `default_factory =` setter only calls this on an existing
         // defaultdict; the other arms are defensive.
-        match &mut self.kind {
-            DictKind::Default(slot) => mem::replace(slot, factory),
-            DictKind::Plain | DictKind::Counter => {
-                self.kind = DictKind::Default(factory);
+        match self.kind.0.as_deref_mut() {
+            Some(DictSpecial::Default(slot)) => mem::replace(slot, factory),
+            None | Some(DictSpecial::Counter) => {
+                self.kind = DictKind::defaultdict(factory);
                 None
             }
         }
@@ -1371,9 +1402,9 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
             // no factory (the zero-arg constructor); Counter is rejected above.
             StaticStrings::Fromkeys => {
                 let kind = if self.get(vm.heap).is_defaultdict() {
-                    DictKind::Default(None)
+                    DictKind::defaultdict(None)
                 } else {
-                    DictKind::Plain
+                    DictKind::plain()
                 };
                 dict_fromkeys(args, kind, vm)
             }
@@ -1464,7 +1495,7 @@ impl HeapItem for Dict {
     fn py_dec_ref_ids(&mut self, stack: &mut Vec<HeapId>) {
         // Release the default_factory (a defaultdict with a heap-ref factory, e.g.
         // a lambda). MUST be reported here and in `for_each_child_id` identically.
-        if let DictKind::Default(Some(factory)) = &mut self.kind
+        if let Some(DictSpecial::Default(Some(factory))) = self.kind.0.as_deref_mut()
             && let Value::Ref(id) = factory
         {
             stack.push(*id);
@@ -1499,7 +1530,9 @@ impl<C: ContainsHeap> DropWithContext<C> for Dict {
 
 impl<C: ContainsHeap> DropWithContext<C> for DictKind {
     fn drop_with(self, heap: &mut C) {
-        if let Self::Default(Some(factory)) = self {
+        if let Some(special) = self.0
+            && let DictSpecial::Default(Some(factory)) = *special
+        {
             factory.drop_with(heap);
         }
     }

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -136,6 +136,18 @@ impl DictKind {
     pub fn counter() -> Self {
         Self(Some(Box::new(DictSpecial::Counter)))
     }
+
+    /// Bytes the boxed [`DictSpecial`] adds on top of `size_of::<Dict>()`.
+    ///
+    /// Code that turns an *already allocated* dict special must charge this
+    /// with [`Heap::track_growth`], because [`Dict::py_estimate_size`] adds it
+    /// unconditionally and the refund at free time reads the current size.
+    pub const SPECIAL_SIZE: usize = mem::size_of::<DictSpecial>();
+
+    /// Heap bytes owned by this kind beyond the `DictKind` word itself.
+    fn estimate_size(&self) -> usize {
+        if self.0.is_some() { Self::SPECIAL_SIZE } else { 0 }
+    }
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -165,6 +177,9 @@ impl Dict {
     /// Marks this dict as a `defaultdict` with the given factory (a callable or
     /// `None`), taking ownership of the factory reference. Called once at
     /// construction; the factory joins the dict's `contains_refs` accounting.
+    ///
+    /// If the dict is already on the heap, the caller must first charge
+    /// [`DictKind::SPECIAL_SIZE`] with [`Heap::track_growth`].
     pub fn make_defaultdict(&mut self, factory: Option<Value>) {
         if matches!(factory, Some(Value::Ref(_))) {
             self.contains_refs = true;
@@ -179,6 +194,9 @@ impl Dict {
     }
 
     /// Marks this dict as a `collections.Counter`.
+    ///
+    /// Same tracker contract as [`Dict::make_defaultdict`]: charge
+    /// [`DictKind::SPECIAL_SIZE`] first if the dict is already allocated.
     pub fn make_counter(&mut self) {
         self.kind = DictKind::counter();
     }
@@ -1488,8 +1506,9 @@ impl<'h> HeapRead<'h, Dict> {
 
 impl HeapItem for Dict {
     fn py_estimate_size(&self) -> usize {
-        // Dict size: struct overhead + entries (2 Values per entry for key+value)
-        mem::size_of::<Self>() + self.len() * 2 * VALUE_SIZE
+        // Dict size: struct overhead + the boxed kind state (defaultdict/Counter)
+        // + entries (2 Values per entry for key+value)
+        mem::size_of::<Self>() + self.kind.estimate_size() + self.len() * 2 * VALUE_SIZE
     }
 
     fn py_dec_ref_ids(&mut self, stack: &mut Vec<HeapId>) {

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -1231,7 +1231,7 @@ pub(crate) fn build_namedtuple(
     vm: &mut VM<'_>,
 ) -> RunResult<Value> {
     let nt = NamedTuple::with_class(name, field_names, items, class_id);
-    let id = vm.heap.allocate(HeapData::NamedTuple(nt))?;
+    let id = vm.heap.allocate(HeapData::NamedTuple(Box::new(nt)))?;
     // The instance owns a reference to its class object (see `py_dec_ref_ids`).
     if let Some(cid) = class_id {
         vm.heap.inc_ref(cid);

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -188,7 +188,7 @@ impl RePattern {
         heap: &Heap,
     ) -> RunResult<Value> {
         let m = ReMatch::from_captures(caps, subject.clone_with_heap(heap), all_ascii, &self.compiled);
-        Ok(Value::Ref(heap.allocate(HeapData::ReMatch(m))?))
+        Ok(Value::Ref(heap.allocate(HeapData::ReMatch(Box::new(m)))?))
     }
 
     /// `pattern.search(string)` — find first match anywhere in the string.

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -27,6 +27,7 @@ use crate::{
     types::{
         LazyHeapSet, List, PyTrait, ReMatch, Type, allocate_tuple,
         str::{allocate_string, string_repr_fmt},
+        tuple::TupleVec,
     },
     value::{EitherStr, Value},
 };
@@ -263,7 +264,7 @@ impl RePattern {
             _ => {
                 for caps in self.compiled.captures_iter(text) {
                     let caps = caps.map_err(ExcType::re_pattern_error)?;
-                    let mut elements: SmallVec<[Value; 3]> = SmallVec::with_capacity(cap_count - 1);
+                    let mut elements: TupleVec = SmallVec::with_capacity(cap_count - 1);
                     for cap in caps.iter().skip(1) {
                         let val = cap.map_or("", |m| m.as_str());
                         elements.push(allocate_string(val, heap)?);

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -47,14 +47,14 @@ use crate::{
 
 /// Inline capacity for small tuples. Tuples with 2 or fewer elements avoid
 /// heap allocation for the items storage.
-const TUPLE_INLINE_CAPACITY: usize = 3;
+const TUPLE_INLINE_CAPACITY: usize = 2;
 
 /// Storage type for tuple items. Uses SmallVec to inline small tuples.
 pub(crate) type TupleVec = SmallVec<[Value; TUPLE_INLINE_CAPACITY]>;
 
 /// Python tuple value stored on the heap.
 ///
-/// Uses `SmallVec<[Value; 3]>` internally to avoid separate heap allocation
+/// Uses `SmallVec<[Value; 2]>` internally to avoid separate heap allocation
 /// for tuples with 3 or fewer elements. This is a significant optimization
 /// since small tuples are very common (enumerate, dict items, returns, etc.).
 ///

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -55,7 +55,7 @@ pub(crate) type TupleVec = SmallVec<[Value; TUPLE_INLINE_CAPACITY]>;
 /// Python tuple value stored on the heap.
 ///
 /// Uses `SmallVec<[Value; 2]>` internally to avoid separate heap allocation
-/// for tuples with 3 or fewer elements. This is a significant optimization
+/// for tuples with 2 or fewer elements. This is a significant optimization
 /// since small tuples are very common (enumerate, dict items, returns, etc.).
 ///
 /// # Reference Counting
@@ -86,7 +86,7 @@ impl Tuple {
     /// Automatically computes the `contains_refs` flag by checking if any value
     /// is a `Value::Ref`. Since tuples are immutable, this flag never changes.
     ///
-    /// For tuples with 3 or fewer elements, the items are stored inline in the
+    /// For tuples with 2 or fewer elements, the items are stored inline in the
     /// SmallVec without additional heap allocation.
     ///
     /// Note: This does NOT increment reference counts - the caller must
@@ -151,7 +151,7 @@ impl From<Tuple> for TupleVec {
 ///
 /// This is the preferred way to allocate tuples as it provides:
 /// - Empty tuple interning: `() is ()` returns `True`
-/// - SmallVec optimization for small tuples (≤3 elements)
+/// - SmallVec optimization for small tuples (≤2 elements)
 ///
 /// # Example Usage
 /// ```ignore
@@ -165,7 +165,7 @@ pub fn allocate_tuple(items: SmallVec<[Value; TUPLE_INLINE_CAPACITY]>, heap: &He
     if items.is_empty() {
         Ok(heap.get_empty_tuple())
     } else {
-        // Allocate a new tuple (SmallVec will inline if ≤3 elements)
+        // Allocate a new tuple (SmallVec will inline if ≤2 elements)
         let heap_id = heap.allocate(HeapData::Tuple(Tuple::new(items)))?;
         Ok(Value::Ref(heap_id))
     }

--- a/crates/monty/src/types/type.rs
+++ b/crates/monty/src/types/type.rs
@@ -404,12 +404,12 @@ impl Type {
         match (self, method_id) {
             // Type-level `dict.fromkeys(...)`, so the result is a plain dict.
             (Self::Dict, m) if m == StaticStrings::Fromkeys => {
-                dict_fromkeys(args, DictKind::Plain, vm).map(AttrCallResult::Value)
+                dict_fromkeys(args, DictKind::plain(), vm).map(AttrCallResult::Value)
             }
             // `defaultdict.fromkeys(...)` builds `cls()`, i.e. a defaultdict with no
             // factory — matching CPython's inherited `dict.fromkeys` classmethod.
             (Self::DefaultDict, m) if m == StaticStrings::Fromkeys => {
-                dict_fromkeys(args, DictKind::Default(None), vm).map(AttrCallResult::Value)
+                dict_fromkeys(args, DictKind::defaultdict(None), vm).map(AttrCallResult::Value)
             }
             // Counter deliberately disables the inherited classmethod.
             (Self::Counter, m) if m == StaticStrings::Fromkeys => {

--- a/crates/monty/tests/binary_serde.rs
+++ b/crates/monty/tests/binary_serde.rs
@@ -25,7 +25,7 @@ fn resolve_name_lookups(mut progress: RunProgress) -> Result<RunProgress, MontyE
 fn dump_header_rejects_incompatible_data() {
     let runner = MontyRun::new("1 + 2".to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
     let bytes = runner.dump().unwrap();
-    assert_eq!(&bytes[..9], b"MONTY\0\x02\x00\x00");
+    assert_eq!(&bytes[..9], b"MONTY\0\x03\x00\x00");
 
     let legacy = postcard::to_allocvec(&runner).unwrap();
     assert_eq!(


### PR DESCRIPTION
HeapData is memcpy'd on every heap allocate and free, so its inline size is paid on the hottest heap paths — flamegraphs showed this memcpy at 16-19% of allocation-heavy benchmarks. Box the seven variants larger than Tuple (NamedTuple, Dataclass, Class, GatherFuture, ExternalFuture, OpenFile, ReMatch), halving HeapData to 80 bytes and HeapEntry to 104. A const assertion now enforces the 80-byte ceiling.

Also fix a latent soundness bug in heap_read_boxed: it derived its pointer by dereferencing the box (a SharedReadOnly `&T` then cast_mut), which is UB once the pointee is written via HeapRead::get_mut — Miri flags it on dataclass mutation. The helper now loads the box's data pointer out of the enum field via the UnsafeCell-derived base pointer, preserving the box's write provenance. Verified with cargo miri test -p monty --lib plus miri runs of dataclass/class/gather/open test cases.


Claude-Session: https://claude.ai/code/session_01CwNzqmKLdfWo4h6DTUkz5X

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shrinks `HeapData` to 72B (down from 160B) by boxing large variants and compacting `DictKind`, cutting memcpy on hot allocate/free paths. Keeps the `heap_read_boxed` soundness fix and bumps dump schema to reject incompatible dumps.

- **Performance**
  - Boxed `NamedTuple`, `NamedTupleClass`, `Dataclass`, `Class`, `Instance`, `Module`, `GatherFuture`, `ExternalFuture`, `OpenFile`, `ReMatch`.
  - `DictKind` compacted behind `Option<Box<...>>`, shrinking `Dict`; accounting updated (`Dict::py_estimate_size`, `defaultdict_init` charges boxed kind); `HeapEntry` now 96B; const assert enforces `HeapData` ≤ 80B.
  - `Tuple` inline capacity is 2 (was 3); updated `re_pattern` to use `TupleVec`.

- **Bug Fixes and Compatibility**
  - `heap_read_boxed` now loads the box’s data pointer from the enum field via the `UnsafeCell`-derived base pointer, preserving write provenance (Miri-verified).
  - Dump schema `VERSION` bumped to 3 to reject pre-change `defaultdict`/`Counter` dumps.

<sup>Written for commit c88dcbad15608d85e73351dba539ca9bd68b12c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

