### PR TITLE
move `py_set_attr` onto `PyTrait`

### DIFF
--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -1019,6 +1019,21 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         )
     }
 
+    fn py_set_attr(&mut self, name: &EitherStr, value: Value, vm: &mut VM<'h>) -> RunResult<()> {
+        heap_read_output_py_trait_forward!(
+            self,
+            |item| item.py_set_attr(name, value, vm),
+            else {
+                value.drop_with(vm);
+                let type_name = self.py_type(vm).name(vm.heap, vm.interns);
+                Err(ExcType::attribute_error_no_setattr(
+                    &type_name,
+                    name.as_str(vm.interns),
+                ))
+            }
+        )
+    }
+
     fn py_getattr(&self, attr: &EitherStr, vm: &mut VM<'h>) -> RunResult<Option<CallResult>> {
         heap_read_output_py_trait_forward!(
             self,

--- a/crates/monty/src/types/class.rs
+++ b/crates/monty/src/types/class.rs
@@ -7,7 +7,7 @@ use crate::{
     defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunResult},
     hash::{HashValue, identity_hash},
-    heap::{BorrowedHeapReadMut, DropWithContext, HeapId, HeapItem, HeapRead, heap_read_ref_as_field_mut},
+    heap::{BorrowedHeapReadMut, DropGuard, DropWithContext, HeapId, HeapItem, HeapRead, heap_read_ref_as_field_mut},
     types::str::allocate_string,
     value::{EitherStr, Value},
 };
@@ -80,7 +80,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Class> {
     }
 
     fn py_set_attr(&mut self, name: &EitherStr, value: Value, vm: &mut VM<'h>) -> RunResult<()> {
-        let old_value = self.set_attr(attribute_name_value(name, vm)?, value, vm)?;
+        let mut value_guard = DropGuard::new(value, vm);
+        let name = attribute_name_value(name, value_guard.ctx())?;
+        let (value, vm) = value_guard.into_parts();
+        let old_value = self.set_attr(name, value, vm)?;
         old_value.drop_with(vm);
         Ok(())
     }

--- a/crates/monty/src/types/class.rs
+++ b/crates/monty/src/types/class.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Write, mem};
 
-use super::{Dict, LazyHeapSet, PyTrait, Type};
+use super::{Dict, LazyHeapSet, PyTrait, Type, attribute_name_value};
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, VM},
@@ -77,6 +77,12 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Class> {
 
     fn py_len(&self, _vm: &VM<'h>) -> Option<usize> {
         None
+    }
+
+    fn py_set_attr(&mut self, name: &EitherStr, value: Value, vm: &mut VM<'h>) -> RunResult<()> {
+        let old_value = self.set_attr(attribute_name_value(name, vm)?, value, vm)?;
+        old_value.drop_with(vm);
+        Ok(())
     }
 
     fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -14,7 +14,7 @@ use crate::{
     exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
     hash::HashValue,
     heap::{
-        BorrowedHeapRead, BorrowedHeapReadMut, DropWithContext, HeapId, HeapItem, HeapRead, HeapReadOutput,
+        BorrowedHeapRead, BorrowedHeapReadMut, DropGuard, DropWithContext, HeapId, HeapItem, HeapRead, HeapReadOutput,
         heap_read_ref_as_field, heap_read_ref_as_field_mut,
     },
     intern::Interns,
@@ -159,7 +159,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
     }
 
     fn py_set_attr(&mut self, name: &EitherStr, value: Value, vm: &mut VM<'h>) -> RunResult<()> {
-        let old_value = self.set_attr(attribute_name_value(name, vm)?, value, vm)?;
+        let mut value_guard = DropGuard::new(value, vm);
+        let name = attribute_name_value(name, value_guard.ctx())?;
+        let (value, vm) = value_guard.into_parts();
+        let old_value = self.set_attr(name, value, vm)?;
         old_value.drop_with(vm);
         Ok(())
     }

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -6,7 +6,7 @@ use std::{
 
 use serde::ser::SerializeStruct;
 
-use super::{Dict, LazyHeapSet, PyTrait};
+use super::{Dict, LazyHeapSet, PyTrait, attribute_name_value};
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, VM},
@@ -14,8 +14,8 @@ use crate::{
     exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
     hash::HashValue,
     heap::{
-        BorrowedHeapRead, BorrowedHeapReadMut, HeapId, HeapItem, HeapRead, HeapReadOutput, heap_read_ref_as_field,
-        heap_read_ref_as_field_mut,
+        BorrowedHeapRead, BorrowedHeapReadMut, DropWithContext, HeapId, HeapItem, HeapRead, HeapReadOutput,
+        heap_read_ref_as_field, heap_read_ref_as_field_mut,
     },
     intern::Interns,
     types::Type,
@@ -156,6 +156,12 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
     fn py_len(&self, _vm: &VM<'h>) -> Option<usize> {
         // Dataclasses don't have a length
         None
+    }
+
+    fn py_set_attr(&mut self, name: &EitherStr, value: Value, vm: &mut VM<'h>) -> RunResult<()> {
+        let old_value = self.set_attr(attribute_name_value(name, vm)?, value, vm)?;
+        old_value.drop_with(vm);
+        Ok(())
     }
 
     fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -371,6 +371,16 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Deque> {
         Type::Deque
     }
 
+    fn py_set_attr(&mut self, name: &EitherStr, value: Value, vm: &mut VM<'h>) -> RunResult<()> {
+        value.drop_with(vm);
+        let type_name = self.py_type(vm).name(vm.heap, vm.interns);
+        if name.static_string() == Some(StaticStrings::Maxlen) {
+            Err(ExcType::attribute_error_not_writable("maxlen", &type_name))
+        } else {
+            Err(ExcType::attribute_error_no_setattr(&type_name, name.as_str(vm.interns)))
+        }
+    }
+
     fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
         let deque_id = self_id.expect("heap values have an id");
         let iterator = vm

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -1069,7 +1069,7 @@ impl<'h> HeapRead<'h, Dict> {
     /// previous factory for the caller to drop. Every other attribute — and any
     /// attribute on a plain dict — raises the generic no-setattr
     /// `AttributeError`. Consumes `value`.
-    pub(crate) fn set_default_factory_attr(
+    fn set_default_factory_attr(
         &mut self,
         attr: &EitherStr,
         value: Value,
@@ -1110,6 +1110,12 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
 
     fn py_type(&self, vm: &VM<'h>) -> Type {
         self.get(vm.heap).kind_type()
+    }
+
+    fn py_set_attr(&mut self, name: &EitherStr, value: Value, vm: &mut VM<'h>) -> RunResult<()> {
+        let old_value = self.set_default_factory_attr(name, value, vm)?;
+        old_value.drop_with(vm);
+        Ok(())
     }
 
     fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -9,7 +9,7 @@ use crate::{
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
     hash::{HashValue, identity_hash},
     heap::{
-        BorrowedHeapReadMut, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput,
+        BorrowedHeapReadMut, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput,
         heap_read_ref_as_field_mut,
     },
     intern::Interns,
@@ -93,7 +93,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Instance> {
     }
 
     fn py_set_attr(&mut self, name: &EitherStr, value: Value, vm: &mut VM<'h>) -> RunResult<()> {
-        let old_value = self.set_attr(attribute_name_value(name, vm)?, value, vm)?;
+        let mut value_guard = DropGuard::new(value, vm);
+        let name = attribute_name_value(name, value_guard.ctx())?;
+        let (value, vm) = value_guard.into_parts();
+        let old_value = self.set_attr(name, value, vm)?;
         old_value.drop_with(vm);
         Ok(())
     }

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, fmt::Write, mem};
 
-use super::{Dict, LazyHeapSet, PyTrait, Type};
+use super::{Dict, LazyHeapSet, PyTrait, Type, attribute_name_value};
 use crate::{
     args::{ArgValues, KwargsValues},
     builtins::Builtins,
@@ -90,6 +90,12 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Instance> {
 
     fn py_len(&self, _vm: &VM<'h>) -> Option<usize> {
         None
+    }
+
+    fn py_set_attr(&mut self, name: &EitherStr, value: Value, vm: &mut VM<'h>) -> RunResult<()> {
+        let old_value = self.set_attr(attribute_name_value(name, vm)?, value, vm)?;
+        old_value.drop_with(vm);
+        Ok(())
     }
 
     /// Always `NotImplemented` (`Ok(None)`), leaving the caller on identity: both

--- a/crates/monty/src/types/mod.rs
+++ b/crates/monty/src/types/mod.rs
@@ -54,7 +54,7 @@ pub(crate) use module::Module;
 pub(crate) use namedtuple::{NamedTuple, NamedTupleClass, construct_namedtuple};
 pub(crate) use path::Path;
 pub(crate) use property::Property;
-pub(crate) use py_trait::{AttrCallResult, CmpOrder, LazyHeapSet, PyTrait};
+pub(crate) use py_trait::{AttrCallResult, CmpOrder, LazyHeapSet, PyTrait, attribute_name_value};
 pub(crate) use range::{Range, RangeIterator};
 pub(crate) use re_match::ReMatch;
 pub(crate) use re_pattern::{BoundedCompileError, RePattern};

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -617,6 +617,16 @@ pub(crate) trait PyTrait<'h> {
         .into())
     }
 
+    /// Python attribute assignment, consuming `value` on both success and error.
+    ///
+    /// The default rejects assignment. Mutable attribute-bearing types override
+    /// this method and are responsible for releasing any replaced value.
+    fn py_set_attr(&mut self, name: &EitherStr, value: Value, vm: &mut VM<'h>) -> RunResult<()> {
+        value.drop_with(vm);
+        let type_name = self.py_type(vm).name(vm.heap, vm.interns);
+        Err(ExcType::attribute_error_no_setattr(&type_name, name.as_str(vm.interns)))
+    }
+
     /// Python attribute get operation (`__getattr__`), e.g., `obj.attr`.
     ///
     /// Returns the value associated with the attribute (owned), or `Ok(None)` if the type
@@ -682,6 +692,14 @@ pub(crate) trait PyTrait<'h> {
             &self.py_type(vm).name(vm.heap, vm.interns),
         ))
     }
+}
+
+/// Converts an attribute name into an owned dict key, preserving interned names.
+pub(crate) fn attribute_name_value(name: &EitherStr, vm: &VM<'_>) -> RunResult<Value> {
+    Ok(match name {
+        EitherStr::Interned(string_id) => Value::InternString(*string_id),
+        EitherStr::Heap(s) => allocate_string(s.as_str(), vm.heap)?,
+    })
 }
 
 /// Lazy wrapper around [`AHashSet`] that only allocates the set when needed.

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -1735,55 +1735,15 @@ impl Value {
         Err(ExcType::attribute_error(type_name, attr.as_str(vm.interns)))
     }
 
-    /// Sets an attribute on this value.
-    ///
-    /// Only Dataclass objects, user-defined class instances, and class objects
-    /// support attribute setting. Returns AttributeError for other types.
-    ///
-    /// Takes ownership of `value` and drops it on error.
-    /// On success, drops the old attribute value if one existed.
+    /// Sets an attribute, consuming `value` on both success and error.
     pub fn py_set_attr(&self, name: &EitherStr, value: Self, vm: &mut VM<'_>) -> RunResult<()> {
         if let Self::Ref(heap_id) = self {
-            let old_value = match vm.heap.read(*heap_id) {
-                HeapReadOutput::Dataclass(mut dc) => dc.set_attr(Self::attr_name_value(name, vm)?, value, vm)?,
-                HeapReadOutput::Instance(mut instance) => {
-                    instance.set_attr(Self::attr_name_value(name, vm)?, value, vm)?
-                }
-                HeapReadOutput::Class(mut class) => class.set_attr(Self::attr_name_value(name, vm)?, value, vm)?,
-                // `defaultdict.default_factory = ...`; every other dict attribute
-                // raises the generic no-setattr error inside this method.
-                HeapReadOutput::Dict(mut dict) => dict.set_default_factory_attr(name, value, vm)?,
-                other => {
-                    let type_ = other.py_type(vm);
-                    let type_name = type_.name(vm.heap, vm.interns);
-                    value.drop_with(vm);
-                    // `deque.maxlen` exists but is read-only, which CPython reports
-                    // differently from an attribute that isn't there at all.
-                    return if type_ == Type::Deque && name.static_string() == Some(StaticStrings::Maxlen) {
-                        Err(ExcType::attribute_error_not_writable("maxlen", &type_name))
-                    } else {
-                        Err(ExcType::attribute_error_no_setattr(&type_name, name.as_str(vm.interns)))
-                    };
-                }
-            };
-            old_value.drop_with(vm);
-            Ok(())
+            vm.heap.read(*heap_id).py_set_attr(name, value, vm)
         } else {
-            let type_name = self.py_type_name(vm);
             value.drop_with(vm);
+            let type_name = self.py_type_name(vm);
             Err(ExcType::attribute_error_no_setattr(&type_name, name.as_str(vm.interns)))
         }
-    }
-
-    /// Converts an attribute `name` into a dict-key `Value` for `set_attr` calls,
-    /// reusing the interned id when available.
-    fn attr_name_value(name: &EitherStr, vm: &VM<'_>) -> RunResult<Self> {
-        Ok(match name {
-            EitherStr::Interned(string_id) => Self::InternString(*string_id),
-            // TODO: should avoid needing to clone String via `EitherStr` - maybe
-            // `EitherStr` should store a `HeapRead<Str>`?
-            EitherStr::Heap(s) => allocate_string(s.as_str(), vm.heap)?,
-        })
     }
 
     /// Extracts an integer value from the Value.


### PR DESCRIPTION
Standard cleanup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move attribute assignment (`py_set_attr`) from `Value` to `PyTrait` so each heap type owns its write logic. Tightens error handling and ensures correct value dropping across types.

- **Refactors**
  - Added default `PyTrait::py_set_attr` that rejects assignment and consumes `value`.
  - Implemented overrides for Class, Instance, Dataclass, and Dict; Deque returns read-only error for `maxlen`.
  - `HeapReadOutput` now forwards `py_set_attr`, dropping `value` and returning a clear no-setattr error with the type name.
  - Introduced `attribute_name_value` and used `DropGuard` in setters to preserve interned names and ensure drops.
  - `Value::py_set_attr` now delegates to heap reads; removed `attr_name_value`; made Dict’s `set_default_factory_attr` private.

<sup>Written for commit 0ca552fe18160d43f0effd850c2b631f9a964b53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

