### PR TITLE
Bound native dataclass equality by the recursion-depth limit

### DIFF
--- a/crates/monty/src/modules/dataclasses.rs
+++ b/crates/monty/src/modules/dataclasses.rs
@@ -561,6 +561,11 @@ pub(crate) fn dataclass_eq(
     if !matches!(vm.heap.get(other_id), HeapData::Instance(inst) if inst.class() == class_id) {
         return Ok(None);
     }
+    // Charge a recursion level: two distinct cyclic dataclasses (`a.x = a;
+    // b.x = b; a == b`) re-enter here per level and would otherwise overflow
+    // the host stack.
+    let mut depth = vm.recursion_guard()?;
+    let vm = &mut *depth;
     for name_id in field_names {
         let field_name = vm.interns.get_str(*name_id).to_owned();
         // Each read is guarded before the next runs, so the second failing

--- a/crates/monty/src/modules/dataclasses.rs
+++ b/crates/monty/src/modules/dataclasses.rs
@@ -564,8 +564,8 @@ pub(crate) fn dataclass_eq(
     // Charge a recursion level: two distinct cyclic dataclasses (`a.x = a;
     // b.x = b; a == b`) re-enter here per level and would otherwise overflow
     // the host stack.
-    let mut depth = vm.recursion_guard()?;
-    let vm = &mut *depth;
+    let mut guard = vm.recursion_guard()?;
+    let vm = &mut *guard;
     for name_id in field_names {
         let field_name = vm.interns.get_str(*name_id).to_owned();
         // Each read is guarded before the next runs, so the second failing

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -419,8 +419,8 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Deque> {
         // Charge a recursion level: two distinct cyclic deques (`a.append(a);
         // b.append(b); a == b`) re-enter here per level and would otherwise
         // overflow the host stack. A deque walks by index, so it charges directly.
-        let mut depth = vm.recursion_guard()?;
-        let vm = &mut *depth;
+        let mut guard = vm.recursion_guard()?;
+        let vm = &mut *guard;
         for i in 0..len {
             let a = self.get(vm.heap).items[i].clone_with_heap(vm.heap);
             defer_drop!(a, vm);
@@ -442,8 +442,8 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Deque> {
     fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {
         let self_len = self.get(vm.heap).len();
         let other_len = other.get(vm.heap).len();
-        let mut depth = vm.recursion_guard()?;
-        let vm = &mut *depth;
+        let mut guard = vm.recursion_guard()?;
+        let vm = &mut *guard;
         for i in 0..self_len.min(other_len) {
             let a = self.get(vm.heap).items[i].clone_with_heap(vm.heap);
             defer_drop!(a, vm);

--- a/crates/monty/test_cases/dataclass__repr_eq.py
+++ b/crates/monty/test_cases/dataclass__repr_eq.py
@@ -146,7 +146,9 @@ assert repr(left) == 'Node(x=Node(x=...))'
 
 # Comparing two *distinct* cyclic dataclasses re-enters the field walk once per
 # level; CPython raises RecursionError, and Monty must bound it rather than
-# overflowing the host stack.
+# overflowing the host stack. Only the type is asserted, never the message:
+# CPython picks between its depth counter ('maximum recursion depth exceeded')
+# and its C-stack guard ('Stack overflow (used N kB) in comparison') by platform.
 cyc_a = Node(None)
 cyc_b = Node(None)
 cyc_a.x = cyc_a
@@ -154,14 +156,14 @@ cyc_b.x = cyc_b
 try:
     cyc_a == cyc_b
     assert False, 'expected RecursionError from cyclic dataclass equality'
-except RecursionError as e:
-    assert str(e) == 'maximum recursion depth exceeded'
+except RecursionError:
+    pass
 # Mutually cyclic dataclasses recurse the same way.
 try:
     left == cyc_a
     assert False, 'expected RecursionError from mutually cyclic dataclasses'
-except RecursionError as e:
-    assert str(e) == 'maximum recursion depth exceeded'
+except RecursionError:
+    pass
 # A cycle reached through a container recurses through that container's guard,
 # whichever container it is.
 box_a = Node(None)
@@ -171,8 +173,8 @@ box_b.x = [box_b]
 try:
     box_a == box_b
     assert False, 'expected RecursionError from a cycle through a list field'
-except RecursionError as e:
-    assert str(e) == 'maximum recursion depth exceeded'
+except RecursionError:
+    pass
 
 dict_a = Node(None)
 dict_b = Node(None)
@@ -181,8 +183,8 @@ dict_b.x = {'k': dict_b}
 try:
     dict_a == dict_b
     assert False, 'expected RecursionError from a cycle through a dict field'
-except RecursionError as e:
-    assert str(e) == 'maximum recursion depth exceeded'
+except RecursionError:
+    pass
 
 tuple_a = Node(None)
 tuple_b = Node(None)
@@ -191,8 +193,8 @@ tuple_b.x = (tuple_b,)
 try:
     tuple_a == tuple_b
     assert False, 'expected RecursionError from a cycle through a tuple field'
-except RecursionError as e:
-    assert str(e) == 'maximum recursion depth exceeded'
+except RecursionError:
+    pass
 # The identity shortcut still resolves a cyclic dataclass against itself.
 assert cyc_a == cyc_a
 # The guard releases its level on the way out, so later comparisons still run.

--- a/crates/monty/test_cases/dataclass__repr_eq.py
+++ b/crates/monty/test_cases/dataclass__repr_eq.py
@@ -154,15 +154,16 @@ cyc_b.x = cyc_b
 try:
     cyc_a == cyc_b
     assert False, 'expected RecursionError from cyclic dataclass equality'
-except RecursionError:
-    pass
+except RecursionError as e:
+    assert str(e) == 'maximum recursion depth exceeded'
 # Mutually cyclic dataclasses recurse the same way.
 try:
     left == cyc_a
     assert False, 'expected RecursionError from mutually cyclic dataclasses'
-except RecursionError:
-    pass
-# A cycle reached through a container recurses through that container's guard.
+except RecursionError as e:
+    assert str(e) == 'maximum recursion depth exceeded'
+# A cycle reached through a container recurses through that container's guard,
+# whichever container it is.
 box_a = Node(None)
 box_b = Node(None)
 box_a.x = [box_a]
@@ -170,10 +171,32 @@ box_b.x = [box_b]
 try:
     box_a == box_b
     assert False, 'expected RecursionError from a cycle through a list field'
-except RecursionError:
-    pass
+except RecursionError as e:
+    assert str(e) == 'maximum recursion depth exceeded'
+
+dict_a = Node(None)
+dict_b = Node(None)
+dict_a.x = {'k': dict_a}
+dict_b.x = {'k': dict_b}
+try:
+    dict_a == dict_b
+    assert False, 'expected RecursionError from a cycle through a dict field'
+except RecursionError as e:
+    assert str(e) == 'maximum recursion depth exceeded'
+
+tuple_a = Node(None)
+tuple_b = Node(None)
+tuple_a.x = (tuple_a,)
+tuple_b.x = (tuple_b,)
+try:
+    tuple_a == tuple_b
+    assert False, 'expected RecursionError from a cycle through a tuple field'
+except RecursionError as e:
+    assert str(e) == 'maximum recursion depth exceeded'
 # The identity shortcut still resolves a cyclic dataclass against itself.
 assert cyc_a == cyc_a
+# The guard releases its level on the way out, so later comparisons still run.
+assert Node(1) == Node(1)
 
 # The comparison chain short-circuits, so an earlier unequal field is reported
 # before the uninitialized one is ever read; and identity wins outright, since

--- a/crates/monty/test_cases/dataclass__repr_eq.py
+++ b/crates/monty/test_cases/dataclass__repr_eq.py
@@ -144,6 +144,37 @@ left.x = right
 right.x = left
 assert repr(left) == 'Node(x=Node(x=...))'
 
+# Comparing two *distinct* cyclic dataclasses re-enters the field walk once per
+# level; CPython raises RecursionError, and Monty must bound it rather than
+# overflowing the host stack.
+cyc_a = Node(None)
+cyc_b = Node(None)
+cyc_a.x = cyc_a
+cyc_b.x = cyc_b
+try:
+    cyc_a == cyc_b
+    assert False, 'expected RecursionError from cyclic dataclass equality'
+except RecursionError:
+    pass
+# Mutually cyclic dataclasses recurse the same way.
+try:
+    left == cyc_a
+    assert False, 'expected RecursionError from mutually cyclic dataclasses'
+except RecursionError:
+    pass
+# A cycle reached through a container recurses through that container's guard.
+box_a = Node(None)
+box_b = Node(None)
+box_a.x = [box_a]
+box_b.x = [box_b]
+try:
+    box_a == box_b
+    assert False, 'expected RecursionError from a cycle through a list field'
+except RecursionError:
+    pass
+# The identity shortcut still resolves a cyclic dataclass against itself.
+assert cyc_a == cyc_a
+
 # The comparison chain short-circuits, so an earlier unequal field is reported
 # before the uninitialized one is ever read; and identity wins outright, since
 # CPython's generated `__eq__` opens with `self is other`.


### PR DESCRIPTION
Native `@dataclass` equality compares each field with `py_eq_operator`, which dispatches back into `dataclass_eq` for a dataclass-valued field. Two distinct cyclic instances (`a.x = a; b.x = b; a == b`) re-enter that walk once per level with nothing bounding it, so `max_recursion_depth` is never consulted and the host stack overflows — an abort, not a catchable error. Reachable from plain sandboxed code, so in-process embedders get a reliable DoS; the subprocess pool contains it to one worker but a crash-replace loop is cheap to drive.

Charges a recursion level in `dataclass_eq` via the existing `vm.recursion_guard()`, placed after the class/identity early-outs so non-recursive comparisons pay nothing — the same treatment `deque::py_eq_impl` already gets. CPython raises `RecursionError` here too, so this is also the parity-correct outcome. `dataclass_repr_fmt` was already cycle-guarded via `LazyHeapSet`, and native `@dataclass` rejects `frozen`/`order`, so there's no synthesized `__hash__` or ordering left unguarded.

Reported by a Codex security review against 35626eb. No `limitations/` entry: the directory is divergences-only and this restores parity, matching the precedent set when `deque` got the same guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard dataclass equality with the VM recursion limit to raise RecursionError instead of overflowing the host stack when comparing cyclic `@dataclass` instances. Matches CPython and prevents a sandbox DoS.

- **Bug Fixes**
  - Charge recursion in `dataclass_eq` via `vm.recursion_guard()` after class/identity fast paths; non-recursive comparisons are unchanged.
  - Tests assert `RecursionError` (type only) for distinct and mutually cyclic dataclasses and for cycles via list, dict, and tuple fields; also verify the guard releases its level (later `Node(1) == Node(1)` passes) and that identity comparisons return `True`.

- **Refactors**
  - Rename recursion guard bindings to `guard` in `deque` equality and ordering for consistency; no behavior change.

<sup>Written for commit ad4c6da9eb259d67c4f7a8b7a2fb4454c708c016. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

