### PR TITLE
Enforce resource timeouts during bytes containment

### DIFF
--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -2293,7 +2293,16 @@ pub(crate) fn bytes_contains(container: &[u8], item: &Value, vm: &VM<'_>) -> Run
         // A bytes-like probe is a substring test.
         Value::InternBytes(_) | Value::Ref(_) => {
             let needle = extract_bytes_only(item, vm)?;
-            return Ok(container.windows(needle.len().max(1)).any(|w| w == needle) || needle.is_empty());
+            if needle.is_empty() {
+                return Ok(true);
+            }
+            for window in container.windows(needle.len()) {
+                vm.heap.check_time()?;
+                if window == needle {
+                    return Ok(true);
+                }
+            }
+            return Ok(false);
         }
         other => {
             return Err(ExcType::type_error(format!(

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -1577,7 +1577,13 @@ fn timeout_in_bounded_deque_repeat() {
         "deque(maxlen=10**9) * 10**9",
     );
 }
+
 /// Test that bytes substring membership checks the time limit during its native search loop.
+///
+/// The needle only mismatches on its last byte, so every window costs a full 50KB
+/// compare — without the in-loop `check_time()` the search runs to completion and
+/// returns `False`, since nothing else polls the clock between the `in` and the end
+/// of the program.
 #[test]
 fn timeout_in_bytes_contains() {
     let run = MontyRun::new(
@@ -1592,14 +1598,20 @@ fn timeout_in_bytes_contains() {
     needle[49_999] = b'b';
     let limits = ResourceLimits::default().max_duration(Duration::from_millis(1));
 
+    let start = Instant::now();
     let result = run.run(
         vec![haystack, MontyObject::Bytes(needle)],
         ResourceTracker::new(limits),
         PrintWriter::Stdout,
     );
+    let elapsed = start.elapsed();
 
     let exc = result.expect_err("bytes membership must hit the time limit");
     assert_eq!(exc.exc_type(), ExcType::TimeoutError);
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "should terminate promptly, took {elapsed:?}"
+    );
 }
 
 /// Test that `sorted(range(huge))` respects the time limit.

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -1609,7 +1609,7 @@ fn timeout_in_bytes_contains() {
     let exc = result.expect_err("bytes membership must hit the time limit");
     assert_eq!(exc.exc_type(), ExcType::TimeoutError);
     assert!(
-        elapsed < Duration::from_secs(2),
+        elapsed < Duration::from_millis(200),
         "should terminate promptly, took {elapsed:?}"
     );
 }

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -1543,8 +1543,9 @@ fn assert_timeout_in_builtin(code: &str, label: &str) {
         ExcType::TimeoutError,
         "{label}: expected TimeoutError, got: {exc}"
     );
+    // 100ms budget + 400ms slack; worst measured overrun is ~110ms, spent tearing down the partial result.
     assert!(
-        elapsed < Duration::from_secs(2),
+        elapsed < Duration::from_millis(500),
         "{label}: should terminate promptly, took {elapsed:?}"
     );
 }

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -1577,6 +1577,30 @@ fn timeout_in_bounded_deque_repeat() {
         "deque(maxlen=10**9) * 10**9",
     );
 }
+/// Test that bytes substring membership checks the time limit during its native search loop.
+#[test]
+fn timeout_in_bytes_contains() {
+    let run = MontyRun::new(
+        "needle in haystack".to_owned(),
+        "test.py",
+        vec!["haystack".to_owned(), "needle".to_owned()],
+        CompileOptions::default(),
+    )
+    .unwrap();
+    let haystack = MontyObject::Bytes(vec![b'a'; 1_000_000]);
+    let mut needle = vec![b'a'; 50_000];
+    needle[49_999] = b'b';
+    let limits = ResourceLimits::default().max_duration(Duration::from_millis(1));
+
+    let result = run.run(
+        vec![haystack, MontyObject::Bytes(needle)],
+        ResourceTracker::new(limits),
+        PrintWriter::Stdout,
+    );
+
+    let exc = result.expect_err("bytes membership must hit the time limit");
+    assert_eq!(exc.exc_type(), ExcType::TimeoutError);
+}
 
 /// Test that `sorted(range(huge))` respects the time limit.
 ///


### PR DESCRIPTION
### Motivation
- The bytes membership implementation used a native `windows().any(|w| w == needle)` substring scan with no `vm.heap.check_time()` calls, allowing attacker-controlled bytes probes to consume native CPU time and bypass Monty’s in-process execution time limits.

### Description
- Replace the unchecked `windows().any(...)` path with an explicit `for window in container.windows(needle.len())` loop that calls `vm.heap.check_time()?` on each iteration and returns immediately on match.
- Preserve Python semantics for empty-needle probes (returns true) and existing integer-byte probe behavior.
- Add a regression test `timeout_in_bytes_contains` in `crates/monty/tests/resource_limits.rs` that runs a large near-matching needle/haystack under a short `max_duration` and asserts a `TimeoutError` is raised.
- Run formatting/linting as part of validation.

### Testing
- `cargo fmt --all -- --check` passed.
- `cargo test -p monty --test resource_limits timeout_in_bytes_contains` passed.
- `cargo run -p monty-datatest bytes__ops` passed.
- `cargo clippy -p monty --tests -- -D warnings` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6863dd6c5483308f036ca7b99ad95b)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce VM timeouts during bytes substring membership so large scans can’t bypass execution limits. Tighten test bounds to catch slow termination.

- **Bug Fixes**
  - Replace `windows().any(...)` with a loop that calls `vm.heap.check_time()?` each step and returns on match.
  - Preserve semantics: empty needle is true; non-match is false; integer–byte probes unchanged.
  - Add `timeout_in_bytes_contains`: 1 ms `max_duration`, expect `TimeoutError`, and assert elapsed < 200 ms.
  - Tighten shared builtin timeout bound in `assert_timeout_in_builtin` from 2 s to 500 ms.

<sup>Written for commit e936787b862743febc3972b617f2e26aa6b517d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

