### PR TITLE
Make bytes substring search linear and interruptible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,6 +2002,7 @@ dependencies = [
  "itoa",
  "jiter",
  "libm",
+ "memchr",
  "monty-macros",
  "monty-types",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,9 @@ unicode-general-category = "1"
 # or lead CPython's, affecting only recently (re)assigned code points.
 unicode_names2 = "1"
 unicode-normalization = "0.1"
+# Linear-time substring search over `[u8]`, which std only provides for `str`.
+# Already linked transitively via ruff/fancy-regex; this just names it directly.
+memchr = "2.7"
 # bigint and related crates
 num-bigint = { version = "0.4", features = ["serde"] }
 num-traits = "0.2"

--- a/crates/monty/Cargo.toml
+++ b/crates/monty/Cargo.toml
@@ -38,6 +38,7 @@ num-integer = { workspace = true }
 unicode-general-category = { workspace = true }
 unicode_names2 = { workspace = true }
 unicode-normalization = { workspace = true }
+memchr = { workspace = true }
 smallvec = { version = "1.13", features = ["serde"] }
 fancy-regex = "0.17.0"
 libm = "0.2"

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -1428,6 +1428,11 @@ fn bytes_split_by_seq<'a>(bytes: &'a [u8], sep: &[u8], heap: &Heap) -> Result<Ve
 
 /// Splits bytes by a separator sequence, returning at most n parts.
 fn bytes_splitn_by_seq<'a>(bytes: &'a [u8], sep: &[u8], n: usize, heap: &Heap) -> Result<Vec<&'a [u8]>, ResourceError> {
+    // `maxsplit=0` (`n == 1`) permits no splits, so return before `finder_for`
+    // preprocesses the separator — that runs ahead of any `check_time()`.
+    if n <= 1 {
+        return Ok(vec![bytes]);
+    }
     let Some(finder) = finder_for(sep, bytes) else {
         return Ok(vec![bytes]);
     };
@@ -1456,6 +1461,11 @@ fn bytes_rsplitn_by_seq<'a>(
     n: usize,
     heap: &Heap,
 ) -> Result<Vec<&'a [u8]>, ResourceError> {
+    // `maxsplit=0` (`n == 1`) permits no splits, so return before `rfinder_for`
+    // preprocesses the separator — that runs ahead of any `check_time()`.
+    if n <= 1 {
+        return Ok(vec![bytes]);
+    }
     let Some(finder) = rfinder_for(sep, bytes) else {
         return Ok(vec![bytes]);
     };
@@ -1781,6 +1791,11 @@ fn bytes_replace_all(bytes: &[u8], old: &[u8], new: &[u8], heap: &Heap) -> Resul
 /// Checks the time limit periodically to enforce `max_duration` during
 /// potentially long replacement operations on large byte sequences.
 fn bytes_replace_n(bytes: &[u8], old: &[u8], new: &[u8], n: usize, heap: &Heap) -> Result<Vec<u8>, ResourceError> {
+    // `count=0` permits no replacements, so return before `finder_for`
+    // preprocesses `old` — that runs ahead of any `check_time()`.
+    if n == 0 {
+        return Ok(bytes.to_vec());
+    }
     if old.is_empty() {
         // Empty pattern: insert new before each byte (up to n times)
         let mut result = Vec::new();

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -1782,8 +1782,18 @@ fn bytes_replace_all(bytes: &[u8], old: &[u8], new: &[u8], heap: &Heap) -> Resul
         result.extend_from_slice(&bytes[start..]);
         Ok(result)
     } else {
-        Ok(bytes.to_vec())
+        replace_nothing(bytes, heap)
     }
+}
+
+/// Copies `bytes` unchanged, for a `replace` that cannot match anything.
+///
+/// Polls before copying: the callers reaching here skip the scan loop, and
+/// with it the `check_time()` it would have run first, so without this a
+/// no-match `replace` over a large input would never touch the clock.
+fn replace_nothing(bytes: &[u8], heap: &Heap) -> Result<Vec<u8>, ResourceError> {
+    heap.check_time()?;
+    Ok(bytes.to_vec())
 }
 
 /// Replaces at most n occurrences of `old` with `new` in bytes.
@@ -1794,7 +1804,7 @@ fn bytes_replace_n(bytes: &[u8], old: &[u8], new: &[u8], n: usize, heap: &Heap) 
     // `count=0` permits no replacements, so return before `finder_for`
     // preprocesses `old` — that runs ahead of any `check_time()`.
     if n == 0 {
-        return Ok(bytes.to_vec());
+        return replace_nothing(bytes, heap);
     }
     if old.is_empty() {
         // Empty pattern: insert new before each byte (up to n times)
@@ -1830,7 +1840,7 @@ fn bytes_replace_n(bytes: &[u8], old: &[u8], new: &[u8], n: usize, heap: &Heap) 
         result.extend_from_slice(&bytes[start..]);
         Ok(result)
     } else {
-        Ok(bytes.to_vec())
+        replace_nothing(bytes, heap)
     }
 }
 

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -572,10 +572,30 @@ const SCAN_CHUNK: usize = 64 * 1024;
 /// Finds the first occurrence of `needle` in `haystack`.
 ///
 /// Callers must handle the empty needle: it would spin [`count_non_overlapping`].
-/// Repeated scans for the same needle should build one [`Finder`] and call
-/// [`find_with`] instead — see its docstring.
+/// Repeated scans for the same needle should build one [`Finder`] via
+/// [`finder_for`] and call [`find_with`] instead — see their docstrings.
 fn find_subsequence(haystack: &[u8], needle: &[u8], heap: &Heap) -> Result<Option<usize>, ResourceError> {
-    find_with(&Finder::new(needle), haystack, heap)
+    match finder_for(needle, haystack) {
+        Some(finder) => find_with(&finder, haystack, heap),
+        None => Ok(None),
+    }
+}
+
+/// Builds a forward finder, or `None` when `needle` cannot fit in `haystack`.
+///
+/// [`Finder::new`] runs Two-Way preprocessing over the whole needle *before*
+/// [`find_with`] reaches its first `check_time()`, so a host-supplied needle
+/// longer than the haystack would burn unpolled time on a search that provably
+/// cannot match. Every finder must be built through this or [`rfinder_for`].
+fn finder_for<'n>(needle: &'n [u8], haystack: &[u8]) -> Option<Finder<'n>> {
+    (needle.len() <= haystack.len()).then(|| Finder::new(needle))
+}
+
+/// Builds a reverse finder, or `None` when `needle` cannot fit in `haystack`.
+///
+/// The mirror of [`finder_for`], with the same preprocessing rationale.
+fn rfinder_for<'n>(needle: &'n [u8], haystack: &[u8]) -> Option<FinderRev<'n>> {
+    (needle.len() <= haystack.len()).then(|| FinderRev::new(needle))
 }
 
 /// Finds the first occurrence of `finder`'s needle in `haystack`.
@@ -612,7 +632,10 @@ fn find_with(finder: &Finder<'_>, haystack: &[u8], heap: &Heap) -> Result<Option
 ///
 /// The mirror of [`find_subsequence`]; [`rfind_with`] is the reusable form.
 fn rfind_subsequence(haystack: &[u8], needle: &[u8], heap: &Heap) -> Result<Option<usize>, ResourceError> {
-    rfind_with(&FinderRev::new(needle), haystack, heap)
+    match rfinder_for(needle, haystack) {
+        Some(finder) => rfind_with(&finder, haystack, heap),
+        None => Ok(None),
+    }
 }
 
 /// Finds the last occurrence of `finder`'s needle in `haystack`.
@@ -637,7 +660,9 @@ fn rfind_with(finder: &FinderRev<'_>, haystack: &[u8], heap: &Heap) -> Result<Op
 
 /// Counts non-overlapping occurrences of `needle` in `haystack`.
 fn count_non_overlapping(haystack: &[u8], needle: &[u8], heap: &Heap) -> Result<usize, ResourceError> {
-    let finder = Finder::new(needle);
+    let Some(finder) = finder_for(needle, haystack) else {
+        return Ok(0);
+    };
     let mut count = 0;
     let mut pos = 0;
     while let Some(found) = find_with(&finder, &haystack[pos..], heap)? {
@@ -1386,7 +1411,9 @@ struct BytesRsplitArgs {
 
 /// Splits bytes by a separator sequence.
 fn bytes_split_by_seq<'a>(bytes: &'a [u8], sep: &[u8], heap: &Heap) -> Result<Vec<&'a [u8]>, ResourceError> {
-    let finder = Finder::new(sep);
+    let Some(finder) = finder_for(sep, bytes) else {
+        return Ok(vec![bytes]);
+    };
     let mut parts = Vec::new();
     let mut start = 0;
 
@@ -1401,7 +1428,9 @@ fn bytes_split_by_seq<'a>(bytes: &'a [u8], sep: &[u8], heap: &Heap) -> Result<Ve
 
 /// Splits bytes by a separator sequence, returning at most n parts.
 fn bytes_splitn_by_seq<'a>(bytes: &'a [u8], sep: &[u8], n: usize, heap: &Heap) -> Result<Vec<&'a [u8]>, ResourceError> {
-    let finder = Finder::new(sep);
+    let Some(finder) = finder_for(sep, bytes) else {
+        return Ok(vec![bytes]);
+    };
     let mut parts = Vec::new();
     let mut start = 0;
     let mut count = 0;
@@ -1427,7 +1456,9 @@ fn bytes_rsplitn_by_seq<'a>(
     n: usize,
     heap: &Heap,
 ) -> Result<Vec<&'a [u8]>, ResourceError> {
-    let finder = FinderRev::new(sep);
+    let Some(finder) = rfinder_for(sep, bytes) else {
+        return Ok(vec![bytes]);
+    };
     let mut parts = Vec::new();
     let mut end = bytes.len();
     let mut count = 0;
@@ -1729,8 +1760,7 @@ fn bytes_replace_all(bytes: &[u8], old: &[u8], new: &[u8], heap: &Heap) -> Resul
         }
         result.extend_from_slice(new);
         Ok(result)
-    } else {
-        let finder = Finder::new(old);
+    } else if let Some(finder) = finder_for(old, bytes) {
         let mut result = Vec::new();
         let mut start = 0;
         while let Some(pos) = find_with(&finder, &bytes[start..], heap)? {
@@ -1741,6 +1771,8 @@ fn bytes_replace_all(bytes: &[u8], old: &[u8], new: &[u8], heap: &Heap) -> Resul
         }
         result.extend_from_slice(&bytes[start..]);
         Ok(result)
+    } else {
+        Ok(bytes.to_vec())
     }
 }
 
@@ -1765,8 +1797,7 @@ fn bytes_replace_n(bytes: &[u8], old: &[u8], new: &[u8], n: usize, heap: &Heap) 
             result.extend_from_slice(new);
         }
         Ok(result)
-    } else {
-        let finder = Finder::new(old);
+    } else if let Some(finder) = finder_for(old, bytes) {
         let mut result = Vec::new();
         let mut start = 0;
         let mut count = 0;
@@ -1783,6 +1814,8 @@ fn bytes_replace_n(bytes: &[u8], old: &[u8], new: &[u8], n: usize, heap: &Heap) 
         }
         result.extend_from_slice(&bytes[start..]);
         Ok(result)
+    } else {
+        Ok(bytes.to_vec())
     }
 }
 

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -571,19 +571,34 @@ const SCAN_CHUNK: usize = 64 * 1024;
 
 /// Finds the first occurrence of `needle` in `haystack`.
 ///
+/// Callers must handle the empty needle: it would spin [`count_non_overlapping`].
+/// Repeated scans for the same needle should build one [`Finder`] and call
+/// [`find_with`] instead — see its docstring.
+fn find_subsequence(haystack: &[u8], needle: &[u8], heap: &Heap) -> Result<Option<usize>, ResourceError> {
+    find_with(&Finder::new(needle), haystack, heap)
+}
+
+/// Finds the first occurrence of `finder`'s needle in `haystack`.
+///
 /// Chunks overlap by `needle.len() - 1` so boundary-straddling matches are
 /// found; the stride never drops below the needle length so that overlap cannot
-/// dominate. Callers must handle the empty needle: it would spin
-/// [`count_non_overlapping`].
-fn find_subsequence(haystack: &[u8], needle: &[u8], heap: &Heap) -> Result<Option<usize>, ResourceError> {
-    debug_assert!(!needle.is_empty(), "callers must handle the empty needle");
-    let finder = Finder::new(needle);
-    let stride = SCAN_CHUNK.max(needle.len());
+/// dominate. Above that floor a chunk spans up to `2 * needle.len()`, so a long
+/// needle widens the `max_duration` overshoot — unavoidable, since a window
+/// shorter than the needle cannot hold a match. See
+/// `limitations/resource_limits.md`.
+///
+/// Takes the [`Finder`] by reference because constructing one runs Two-Way
+/// preprocessing over the needle; callers scanning in a loop (counting,
+/// splitting, replacing) build it once rather than per match.
+fn find_with(finder: &Finder<'_>, haystack: &[u8], heap: &Heap) -> Result<Option<usize>, ResourceError> {
+    let needle_len = finder.needle().len();
+    debug_assert!(needle_len > 0, "callers must handle the empty needle");
+    let stride = SCAN_CHUNK.max(needle_len);
     let mut start = 0;
     while start < haystack.len() {
         heap.check_time()?;
         let end = start
-            .saturating_add(stride + needle.len().saturating_sub(1))
+            .saturating_add(stride + needle_len.saturating_sub(1))
             .min(haystack.len());
         if let Some(pos) = finder.find(&haystack[start..end]) {
             return Ok(Some(start + pos));
@@ -595,15 +610,23 @@ fn find_subsequence(haystack: &[u8], needle: &[u8], heap: &Heap) -> Result<Optio
 
 /// Finds the last occurrence of `needle` in `haystack`.
 ///
-/// The mirror of [`find_subsequence`], walking chunks from the end.
+/// The mirror of [`find_subsequence`]; [`rfind_with`] is the reusable form.
 fn rfind_subsequence(haystack: &[u8], needle: &[u8], heap: &Heap) -> Result<Option<usize>, ResourceError> {
-    debug_assert!(!needle.is_empty(), "callers must handle the empty needle");
-    let finder = FinderRev::new(needle);
-    let stride = SCAN_CHUNK.max(needle.len());
+    rfind_with(&FinderRev::new(needle), haystack, heap)
+}
+
+/// Finds the last occurrence of `finder`'s needle in `haystack`.
+///
+/// The mirror of [`find_with`], walking chunks from the end; the same
+/// preprocessing-reuse rationale applies.
+fn rfind_with(finder: &FinderRev<'_>, haystack: &[u8], heap: &Heap) -> Result<Option<usize>, ResourceError> {
+    let needle_len = finder.needle().len();
+    debug_assert!(needle_len > 0, "callers must handle the empty needle");
+    let stride = SCAN_CHUNK.max(needle_len);
     let mut end = haystack.len();
     while end > 0 {
         heap.check_time()?;
-        let start = end.saturating_sub(stride + needle.len().saturating_sub(1));
+        let start = end.saturating_sub(stride + needle_len.saturating_sub(1));
         if let Some(pos) = finder.rfind(&haystack[start..end]) {
             return Ok(Some(start + pos));
         }
@@ -614,9 +637,10 @@ fn rfind_subsequence(haystack: &[u8], needle: &[u8], heap: &Heap) -> Result<Opti
 
 /// Counts non-overlapping occurrences of `needle` in `haystack`.
 fn count_non_overlapping(haystack: &[u8], needle: &[u8], heap: &Heap) -> Result<usize, ResourceError> {
+    let finder = Finder::new(needle);
     let mut count = 0;
     let mut pos = 0;
-    while let Some(found) = find_subsequence(&haystack[pos..], needle, heap)? {
+    while let Some(found) = find_with(&finder, &haystack[pos..], heap)? {
         count += 1;
         pos += found + needle.len();
     }
@@ -1362,10 +1386,11 @@ struct BytesRsplitArgs {
 
 /// Splits bytes by a separator sequence.
 fn bytes_split_by_seq<'a>(bytes: &'a [u8], sep: &[u8], heap: &Heap) -> Result<Vec<&'a [u8]>, ResourceError> {
+    let finder = Finder::new(sep);
     let mut parts = Vec::new();
     let mut start = 0;
 
-    while let Some(pos) = find_subsequence(&bytes[start..], sep, heap)? {
+    while let Some(pos) = find_with(&finder, &bytes[start..], heap)? {
         parts.push(&bytes[start..start + pos]);
         start = start + pos + sep.len();
     }
@@ -1376,12 +1401,13 @@ fn bytes_split_by_seq<'a>(bytes: &'a [u8], sep: &[u8], heap: &Heap) -> Result<Ve
 
 /// Splits bytes by a separator sequence, returning at most n parts.
 fn bytes_splitn_by_seq<'a>(bytes: &'a [u8], sep: &[u8], n: usize, heap: &Heap) -> Result<Vec<&'a [u8]>, ResourceError> {
+    let finder = Finder::new(sep);
     let mut parts = Vec::new();
     let mut start = 0;
     let mut count = 0;
 
     while count + 1 < n {
-        if let Some(pos) = find_subsequence(&bytes[start..], sep, heap)? {
+        if let Some(pos) = find_with(&finder, &bytes[start..], heap)? {
             parts.push(&bytes[start..start + pos]);
             start = start + pos + sep.len();
             count += 1;
@@ -1401,12 +1427,13 @@ fn bytes_rsplitn_by_seq<'a>(
     n: usize,
     heap: &Heap,
 ) -> Result<Vec<&'a [u8]>, ResourceError> {
+    let finder = FinderRev::new(sep);
     let mut parts = Vec::new();
     let mut end = bytes.len();
     let mut count = 0;
 
     while count + 1 < n {
-        if let Some(pos) = rfind_subsequence(&bytes[..end], sep, heap)? {
+        if let Some(pos) = rfind_with(&finder, &bytes[..end], heap)? {
             parts.push(&bytes[pos + sep.len()..end]);
             end = pos;
             count += 1;
@@ -1703,9 +1730,10 @@ fn bytes_replace_all(bytes: &[u8], old: &[u8], new: &[u8], heap: &Heap) -> Resul
         result.extend_from_slice(new);
         Ok(result)
     } else {
+        let finder = Finder::new(old);
         let mut result = Vec::new();
         let mut start = 0;
-        while let Some(pos) = find_subsequence(&bytes[start..], old, heap)? {
+        while let Some(pos) = find_with(&finder, &bytes[start..], heap)? {
             heap.check_time()?;
             result.extend_from_slice(&bytes[start..start + pos]);
             result.extend_from_slice(new);
@@ -1738,12 +1766,13 @@ fn bytes_replace_n(bytes: &[u8], old: &[u8], new: &[u8], n: usize, heap: &Heap) 
         }
         Ok(result)
     } else {
+        let finder = Finder::new(old);
         let mut result = Vec::new();
         let mut start = 0;
         let mut count = 0;
         while count < n {
             heap.check_time()?;
-            if let Some(pos) = find_subsequence(&bytes[start..], old, heap)? {
+            if let Some(pos) = find_with(&finder, &bytes[start..], heap)? {
                 result.extend_from_slice(&bytes[start..start + pos]);
                 result.extend_from_slice(new);
                 start = start + pos + old.len();

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -67,6 +67,7 @@ use std::{cell::Cell, ffi::c_int, fmt::Write, mem, ops, str};
 /// - `expandtabs(tabsize=8)` - Tab expansion
 /// - `translate(table[, delete])` - Character translation
 /// - `maketrans(frm, to)` - Create translation table (staticmethod)
+use memchr::memmem::{Finder, FinderRev};
 use monty_types::ResourceError;
 pub use monty_types::{bytes_repr, bytes_repr_fmt};
 use smallvec::smallvec;
@@ -557,6 +558,71 @@ struct BytesDecodeArgs {
     errors: Option<StrArg>,
 }
 
+// =============================================================================
+// Substring scanning
+// =============================================================================
+//
+// Every `bytes` substring operation funnels through the scanners below. A scan
+// runs inside one bytecode instruction, so the VM's per-instruction
+// `check_time()` cannot preempt it — hence the chunked polling.
+
+/// Bytes scanned between `check_time()` polls.
+const SCAN_CHUNK: usize = 64 * 1024;
+
+/// Finds the first occurrence of `needle` in `haystack`.
+///
+/// Chunks overlap by `needle.len() - 1` so boundary-straddling matches are
+/// found; the stride never drops below the needle length so that overlap cannot
+/// dominate. Callers must handle the empty needle: it would spin
+/// [`count_non_overlapping`].
+fn find_subsequence(haystack: &[u8], needle: &[u8], heap: &Heap) -> Result<Option<usize>, ResourceError> {
+    debug_assert!(!needle.is_empty(), "callers must handle the empty needle");
+    let finder = Finder::new(needle);
+    let stride = SCAN_CHUNK.max(needle.len());
+    let mut start = 0;
+    while start < haystack.len() {
+        heap.check_time()?;
+        let end = start
+            .saturating_add(stride + needle.len().saturating_sub(1))
+            .min(haystack.len());
+        if let Some(pos) = finder.find(&haystack[start..end]) {
+            return Ok(Some(start + pos));
+        }
+        start += stride;
+    }
+    Ok(None)
+}
+
+/// Finds the last occurrence of `needle` in `haystack`.
+///
+/// The mirror of [`find_subsequence`], walking chunks from the end.
+fn rfind_subsequence(haystack: &[u8], needle: &[u8], heap: &Heap) -> Result<Option<usize>, ResourceError> {
+    debug_assert!(!needle.is_empty(), "callers must handle the empty needle");
+    let finder = FinderRev::new(needle);
+    let stride = SCAN_CHUNK.max(needle.len());
+    let mut end = haystack.len();
+    while end > 0 {
+        heap.check_time()?;
+        let start = end.saturating_sub(stride + needle.len().saturating_sub(1));
+        if let Some(pos) = finder.rfind(&haystack[start..end]) {
+            return Ok(Some(start + pos));
+        }
+        end = end.saturating_sub(stride);
+    }
+    Ok(None)
+}
+
+/// Counts non-overlapping occurrences of `needle` in `haystack`.
+fn count_non_overlapping(haystack: &[u8], needle: &[u8], heap: &Heap) -> Result<usize, ResourceError> {
+    let mut count = 0;
+    let mut pos = 0;
+    while let Some(found) = find_subsequence(&haystack[pos..], needle, heap)? {
+        count += 1;
+        pos += found + needle.len();
+    }
+    Ok(count)
+}
+
 /// Implements Python's `bytes.count(sub[, start[, end]])` method.
 ///
 /// Returns the number of non-overlapping occurrences of the subsequence.
@@ -569,26 +635,11 @@ fn bytes_count<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h>)
         // Empty subsequence: count positions between each byte plus 1
         slice.len() + 1
     } else {
-        count_non_overlapping(slice, &sub)
+        count_non_overlapping(slice, &sub, vm.heap)?
     };
 
     let count_i64 = i64::try_from(count).expect("count exceeds i64::MAX");
     Ok(Value::Int(count_i64))
-}
-
-/// Counts non-overlapping occurrences of needle in haystack.
-fn count_non_overlapping(haystack: &[u8], needle: &[u8]) -> usize {
-    let mut count = 0;
-    let mut pos = 0;
-    while pos + needle.len() <= haystack.len() {
-        if &haystack[pos..pos + needle.len()] == needle {
-            count += 1;
-            pos += needle.len();
-        } else {
-            pos += 1;
-        }
-    }
-    count
 }
 
 /// Implements Python's `bytes.find(sub[, start[, end]])` method.
@@ -603,7 +654,7 @@ fn bytes_find<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h>) 
         // Empty subsequence: always found at start position
         Some(0)
     } else {
-        find_subsequence(slice, &sub)
+        find_subsequence(slice, &sub, vm.heap)?
     };
 
     let idx = match result {
@@ -611,11 +662,6 @@ fn bytes_find<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h>) 
         None => -1,
     };
     Ok(Value::Int(idx))
-}
-
-/// Finds the first occurrence of needle in haystack.
-fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack.windows(needle.len()).position(|window| window == needle)
 }
 
 /// Implements Python's `bytes.index(sub[, start[, end]])` method.
@@ -630,7 +676,7 @@ fn bytes_index<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h>)
         // Empty subsequence: always found at start position
         Some(0)
     } else {
-        find_subsequence(slice, &sub)
+        find_subsequence(slice, &sub, vm.heap)?
     };
 
     match result {
@@ -1030,7 +1076,7 @@ fn bytes_rfind<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h>)
         // Empty subsequence: always found at end position
         Some(slice.len())
     } else {
-        rfind_subsequence(slice, &sub)
+        rfind_subsequence(slice, &sub, vm.heap)?
     };
 
     let idx = match result {
@@ -1038,14 +1084,6 @@ fn bytes_rfind<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h>)
         None => -1,
     };
     Ok(Value::Int(idx))
-}
-
-/// Finds the last occurrence of needle in haystack.
-fn rfind_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    if needle.len() > haystack.len() {
-        return None;
-    }
-    haystack.windows(needle.len()).rposition(|window| window == needle)
 }
 
 /// Implements Python's `bytes.rindex(sub[, start[, end]])` method.
@@ -1059,7 +1097,7 @@ fn bytes_rindex<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h>
     let result = if sub.is_empty() {
         Some(slice.len())
     } else {
-        rfind_subsequence(slice, &sub)
+        rfind_subsequence(slice, &sub, vm.heap)?
     };
 
     match result {
@@ -1216,10 +1254,10 @@ fn bytes_split<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h>)
                 return Err(ExcType::value_error_empty_separator());
             }
             if maxsplit < 0 {
-                bytes_split_by_seq(bytes, sep)
+                bytes_split_by_seq(bytes, sep, vm.heap)?
             } else {
                 let max = usize::try_from(maxsplit).unwrap_or(usize::MAX);
-                bytes_splitn_by_seq(bytes, sep, max + 1)
+                bytes_splitn_by_seq(bytes, sep, max + 1, vm.heap)?
             }
         }
         None => {
@@ -1257,10 +1295,10 @@ fn bytes_rsplit<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h>
                 return Err(ExcType::value_error_empty_separator());
             }
             if maxsplit < 0 {
-                bytes_split_by_seq(bytes, sep)
+                bytes_split_by_seq(bytes, sep, vm.heap)?
             } else {
                 let max = usize::try_from(maxsplit).unwrap_or(usize::MAX);
-                bytes_rsplitn_by_seq(bytes, sep, max + 1)
+                bytes_rsplitn_by_seq(bytes, sep, max + 1, vm.heap)?
             }
         }
         None => {
@@ -1323,27 +1361,27 @@ struct BytesRsplitArgs {
 }
 
 /// Splits bytes by a separator sequence.
-fn bytes_split_by_seq<'a>(bytes: &'a [u8], sep: &[u8]) -> Vec<&'a [u8]> {
+fn bytes_split_by_seq<'a>(bytes: &'a [u8], sep: &[u8], heap: &Heap) -> Result<Vec<&'a [u8]>, ResourceError> {
     let mut parts = Vec::new();
     let mut start = 0;
 
-    while let Some(pos) = find_subsequence(&bytes[start..], sep) {
+    while let Some(pos) = find_subsequence(&bytes[start..], sep, heap)? {
         parts.push(&bytes[start..start + pos]);
         start = start + pos + sep.len();
     }
     parts.push(&bytes[start..]);
 
-    parts
+    Ok(parts)
 }
 
 /// Splits bytes by a separator sequence, returning at most n parts.
-fn bytes_splitn_by_seq<'a>(bytes: &'a [u8], sep: &[u8], n: usize) -> Vec<&'a [u8]> {
+fn bytes_splitn_by_seq<'a>(bytes: &'a [u8], sep: &[u8], n: usize, heap: &Heap) -> Result<Vec<&'a [u8]>, ResourceError> {
     let mut parts = Vec::new();
     let mut start = 0;
     let mut count = 0;
 
     while count + 1 < n {
-        if let Some(pos) = find_subsequence(&bytes[start..], sep) {
+        if let Some(pos) = find_subsequence(&bytes[start..], sep, heap)? {
             parts.push(&bytes[start..start + pos]);
             start = start + pos + sep.len();
             count += 1;
@@ -1353,17 +1391,22 @@ fn bytes_splitn_by_seq<'a>(bytes: &'a [u8], sep: &[u8], n: usize) -> Vec<&'a [u8
     }
     parts.push(&bytes[start..]);
 
-    parts
+    Ok(parts)
 }
 
 /// Splits bytes by a separator sequence from the right, returning at most n parts.
-fn bytes_rsplitn_by_seq<'a>(bytes: &'a [u8], sep: &[u8], n: usize) -> Vec<&'a [u8]> {
+fn bytes_rsplitn_by_seq<'a>(
+    bytes: &'a [u8],
+    sep: &[u8],
+    n: usize,
+    heap: &Heap,
+) -> Result<Vec<&'a [u8]>, ResourceError> {
     let mut parts = Vec::new();
     let mut end = bytes.len();
     let mut count = 0;
 
     while count + 1 < n {
-        if let Some(pos) = rfind_subsequence(&bytes[..end], sep) {
+        if let Some(pos) = rfind_subsequence(&bytes[..end], sep, heap)? {
             parts.push(&bytes[pos + sep.len()..end]);
             end = pos;
             count += 1;
@@ -1374,7 +1417,7 @@ fn bytes_rsplitn_by_seq<'a>(bytes: &'a [u8], sep: &[u8], n: usize) -> Vec<&'a [u
     parts.push(&bytes[..end]);
     parts.reverse();
 
-    parts
+    Ok(parts)
 }
 
 /// Splits bytes by ASCII whitespace, filtering empty parts.
@@ -1554,7 +1597,7 @@ fn bytes_partition<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<
     }
 
     let bytes = bytes.get(vm.heap);
-    let (before, sep_found, after) = match find_subsequence(bytes, sep) {
+    let (before, sep_found, after) = match find_subsequence(bytes, sep, vm.heap)? {
         Some(pos) => (bytes[..pos].to_vec(), sep.to_vec(), bytes[pos + sep.len()..].to_vec()),
         None => (bytes.to_vec(), Vec::new(), Vec::new()),
     };
@@ -1582,7 +1625,7 @@ fn bytes_rpartition<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM
     }
 
     let bytes = bytes.get(vm.heap);
-    let (before, sep_found, after) = match rfind_subsequence(bytes, sep) {
+    let (before, sep_found, after) = match rfind_subsequence(bytes, sep, vm.heap)? {
         Some(pos) => (bytes[..pos].to_vec(), sep.to_vec(), bytes[pos + sep.len()..].to_vec()),
         None => (Vec::new(), Vec::new(), bytes.to_vec()),
     };
@@ -1662,7 +1705,7 @@ fn bytes_replace_all(bytes: &[u8], old: &[u8], new: &[u8], heap: &Heap) -> Resul
     } else {
         let mut result = Vec::new();
         let mut start = 0;
-        while let Some(pos) = find_subsequence(&bytes[start..], old) {
+        while let Some(pos) = find_subsequence(&bytes[start..], old, heap)? {
             heap.check_time()?;
             result.extend_from_slice(&bytes[start..start + pos]);
             result.extend_from_slice(new);
@@ -1700,7 +1743,7 @@ fn bytes_replace_n(bytes: &[u8], old: &[u8], new: &[u8], n: usize, heap: &Heap) 
         let mut count = 0;
         while count < n {
             heap.check_time()?;
-            if let Some(pos) = find_subsequence(&bytes[start..], old) {
+            if let Some(pos) = find_subsequence(&bytes[start..], old, heap)? {
                 result.extend_from_slice(&bytes[start..start + pos]);
                 result.extend_from_slice(new);
                 start = start + pos + old.len();
@@ -2293,7 +2336,8 @@ pub(crate) fn bytes_contains(container: &[u8], item: &Value, vm: &VM<'_>) -> Run
         // A bytes-like probe is a substring test.
         Value::InternBytes(_) | Value::Ref(_) => {
             let needle = extract_bytes_only(item, vm)?;
-            return Ok(container.windows(needle.len().max(1)).any(|w| w == needle) || needle.is_empty());
+            // An empty needle is in everything, and `find_subsequence` rejects it.
+            return Ok(needle.is_empty() || find_subsequence(container, needle, vm.heap)?.is_some());
         }
         other => {
             return Err(ExcType::type_error(format!(

--- a/crates/monty/test_cases/bytes__methods.py
+++ b/crates/monty/test_cases/bytes__methods.py
@@ -540,3 +540,45 @@ except AttributeError as e:
     msg = str(e)
     assert 'bytes' in msg, f'error should mention bytes, got: {e}'
     assert 'nonexistent' in msg, f'error should mention method name, got: {e}'
+
+# === Large-haystack substring searches ===
+# The native scanner walks large haystacks in chunks; matches straddling a
+# chunk boundary must still be found, at whole-haystack offsets.
+needle = b'a' * 64 + b'b'
+tail = b'c' * 200
+for offset in (65_500, 65_535, 65_536, 65_537, 131_000, 131_072):
+    head = b'a' * offset
+    hay = head + needle + tail
+    assert hay.find(needle) == offset
+    assert hay.rfind(needle) == offset
+    assert hay.index(needle) == offset
+    assert hay.rindex(needle) == offset
+    assert needle in hay
+    assert hay.count(needle) == 1
+    assert hay.partition(needle) == (head, needle, tail)
+    assert hay.rpartition(needle) == (head, needle, tail)
+    assert hay.split(needle) == [head, tail]
+    assert hay.rsplit(needle) == [head, tail]
+    assert hay.replace(needle, b'-') == head + b'-' + tail
+
+# matches on both sides of a chunk boundary
+hay2 = b'x' * 65_530 + b'|' + b'y' * 20 + b'|' + b'z' * 10
+assert hay2.count(b'|') == 2
+assert hay2.find(b'|') == 65_530
+assert hay2.rfind(b'|') == 65_551
+assert hay2.split(b'|') == [b'x' * 65_530, b'y' * 20, b'z' * 10]
+
+# needle longer than the scanner's chunk stride
+long_needle = b'n' * 70_000
+hay3 = b'm' * 1000 + long_needle + b'm' * 1000
+assert hay3.find(long_needle) == 1000
+assert hay3.rfind(long_needle) == 1000
+assert long_needle in hay3
+assert hay3.count(long_needle) == 1
+
+# near-match probe at a size where a quadratic scan would stall
+missing = b'a' * 99 + b'b'
+assert (b'a' * 200_000).find(missing) == -1
+assert (b'a' * 200_000).rfind(missing) == -1
+assert (missing in b'a' * 200_000) is False
+assert (b'a' * 200_000).count(missing) == 0

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -1565,6 +1565,101 @@ fn timeout_in_list_constructor() {
     assert_timeout_in_builtin("list(range(10**18))", "list(range(10**18))");
 }
 
+/// Covers all four substring scanners; `index`/`rindex` share theirs with
+/// `find`/`rfind`.
+const BYTES_SEARCH_EXPRS: &[&str] = &[
+    "needle in haystack",
+    "haystack.find(needle)",
+    "haystack.rfind(needle)",
+    "haystack.count(needle)",
+    "haystack.split(needle)",
+    "haystack.rsplit(needle)",
+    "haystack.replace(needle, b'')",
+    "haystack.partition(needle)",
+    "haystack.rpartition(needle)",
+];
+
+/// Runs `expr` with `haystack`/`needle` bound, under `limits`.
+fn run_bytes_search(expr: &str, haystack: Vec<u8>, needle: Vec<u8>, limits: ResourceLimits) -> BytesSearchOutcome {
+    let run = MontyRun::new(
+        expr.to_owned(),
+        "test.py",
+        vec!["haystack".to_owned(), "needle".to_owned()],
+        CompileOptions::default(),
+    )
+    .unwrap();
+
+    let start = Instant::now();
+    let result = run.run(
+        vec![MontyObject::Bytes(haystack), MontyObject::Bytes(needle)],
+        ResourceTracker::new(limits),
+        PrintWriter::Stdout,
+    );
+    BytesSearchOutcome {
+        elapsed: start.elapsed(),
+        result,
+    }
+}
+
+/// What a `bytes` search returned, and how long it took.
+struct BytesSearchOutcome {
+    elapsed: Duration,
+    result: Result<MontyObject, MontyException>,
+}
+
+/// Worst case for a naive `windows()` scan: every offset compares the full
+/// needle before failing on its last byte.
+fn near_match_inputs(haystack_len: usize, needle_len: usize) -> (Vec<u8>, Vec<u8>) {
+    let mut needle = vec![b'a'; needle_len];
+    *needle.last_mut().unwrap() = b'b';
+    (vec![b'a'; haystack_len], needle)
+}
+
+/// Near-matching probes must not blow up quadratically.
+///
+/// A naive scan takes ~800ms on these inputs, a linear one microseconds; the
+/// generous budget keeps the timing assertion robust on loaded CI.
+#[test]
+fn bytes_search_is_not_quadratic() {
+    for expr in BYTES_SEARCH_EXPRS {
+        let (haystack, needle) = near_match_inputs(1_000_000, 50_000);
+        let outcome = run_bytes_search(expr, haystack, needle, ResourceLimits::default());
+
+        assert!(
+            outcome.result.is_ok(),
+            "{expr}: expected success, got {:?}",
+            outcome.result
+        );
+        assert!(
+            outcome.elapsed < Duration::from_millis(300),
+            "{expr}: took {:?}, expected a linear scan",
+            outcome.elapsed
+        );
+    }
+}
+
+/// Bytes searches must remain interruptible by the time limit.
+///
+/// The haystack is large enough that even a linear scan outlives the budget.
+#[test]
+fn timeout_in_bytes_search() {
+    for expr in BYTES_SEARCH_EXPRS {
+        let (haystack, needle) = near_match_inputs(64 * 1024 * 1024, 4096);
+        let limits = ResourceLimits::default().max_duration(Duration::from_millis(1));
+        let outcome = run_bytes_search(expr, haystack, needle, limits);
+
+        let exc = outcome
+            .result
+            .expect_err(&format!("{expr}: expected the time limit to fire"));
+        assert_eq!(exc.exc_type(), ExcType::TimeoutError, "{expr}");
+        assert!(
+            outcome.elapsed < Duration::from_secs(2),
+            "{expr}: should terminate promptly, took {:?}",
+            outcome.elapsed
+        );
+    }
+}
+
 /// Test that a bounded `deque * n` repetition respects the time limit mid-build.
 ///
 /// `repeat_deque` clones into a Rust-side loop that polls `check_time()`. Beyond

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -70,7 +70,9 @@ catch them. `RecursionError` is catchable, as in CPython.
   `replace` and their variants) poll the clock every 64KiB, or every two
   lengths of the searched-for sequence if that is longer. Searching for a
   sequence over 64KiB therefore overshoots `max_duration` in proportion to
-  its length; `max_memory` bounds how long it can get.
+  its length, and `max_memory` does not bound that length: it caps sequences
+  built at runtime, but a `bytes` literal is interned when the source is
+  parsed and never counted against it.
 - The budget covers cumulative **execution time**, not wall-clock time:
   the clock runs only while the interpreter executes bytecode, and is
   paused while execution is suspended waiting on the host (external

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -62,6 +62,10 @@ catch them. `RecursionError` is catchable, as in CPython.
 
 - The host can set a `max_duration` budget; if exceeded the VM stops on
   the next bytecode boundary with `ResourceError`.
+- Enforcement is polled, not preemptive: a single bytecode instruction may
+  run a long native operation (a `bytes` substring scan, a sort, an iterator
+  drain), and those poll the clock at a coarse granularity. A run can
+  therefore overshoot `max_duration` slightly before stopping.
 - The budget covers cumulative **execution time**, not wall-clock time:
   the clock runs only while the interpreter executes bytecode, and is
   paused while execution is suspended waiting on the host (external

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -65,7 +65,12 @@ catch them. `RecursionError` is catchable, as in CPython.
 - Enforcement is polled, not preemptive: a single bytecode instruction may
   run a long native operation (a `bytes` substring scan, a sort, an iterator
   drain), and those poll the clock at a coarse granularity. A run can
-  therefore overshoot `max_duration` slightly before stopping.
+  therefore overshoot `max_duration` before stopping.
+- `bytes` substring operations (`in`, `find`, `count`, `split`, `partition`,
+  `replace` and their variants) poll the clock every 64KiB, or every two
+  lengths of the searched-for sequence if that is longer. Searching for a
+  sequence over 64KiB therefore overshoots `max_duration` in proportion to
+  its length; `max_memory` bounds how long it can get.
 - The budget covers cumulative **execution time**, not wall-clock time:
   the clock runs only while the interpreter executes bytecode, and is
   paused while execution is suspended waiting on the host (external

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -66,13 +66,18 @@ catch them. `RecursionError` is catchable, as in CPython.
   run a long native operation (a `bytes` substring scan, a sort, an iterator
   drain), and those poll the clock at a coarse granularity. A run can
   therefore overshoot `max_duration` before stopping.
-- `bytes` substring operations (`in`, `find`, `count`, `split`, `partition`,
-  `replace` and their variants) poll the clock every 64KiB, or every two
-  lengths of the searched-for sequence if that is longer. Searching for a
+- `bytes` operations that search for a sub-sequence (`in` with a bytes-like
+  probe, `find`, `count`, `split`, `partition`, `replace` and their
+  variants) poll the clock every 64KiB, or every two lengths of the
+  searched-for sequence if that is longer. Searching for a
   sequence over 64KiB therefore overshoots `max_duration` in proportion to
   its length, and `max_memory` does not bound that length: it caps sequences
   built at runtime, but a `bytes` literal is interned when the source is
   parsed and never counted against it.
+- The neighbouring `bytes` operations that scan without a sub-sequence are
+  **not** polled and run to completion however large the input: `in` with an
+  integer probe (a single-byte scan) and `split()`/`rsplit()` left to their
+  default `sep=None` (whitespace splitting).
 - The budget covers cumulative **execution time**, not wall-clock time:
   the clock runs only while the interpreter executes bytecode, and is
   paused while execution is suspended waiting on the host (external


### PR DESCRIPTION
Alternative to #642, which fixed one of four copies of the same scan.

## Motivation

Every `bytes` substring operation carried its own naive `windows()` scan: `bytes_contains` (serving `in`), `find_subsequence` (`find`/`index`/`split`/`partition`/`replace`), `rfind_subsequence` (`rfind`/`rindex`/`rsplit`/`rpartition`) and `count_non_overlapping` (`count`).

Two problems, present in all four:

1. **O(haystack × needle).** A haystack of `b'a' * 1_000_000` and a needle of `b'a' * 49_999 + b'b'` makes every offset compare a 49,999-byte prefix before failing — ~47 billion byte comparisons from a 1MB input.
2. **No `check_time()`.** The scan runs inside a single bytecode instruction, so the VM's per-instruction check cannot preempt it (see `heap.rs:908-918`). `max_duration` is not enforced while it runs.

#642 addresses (2) for `in` only. The other three copies are untouched, so `haystack.find(needle)` reproduces the original overrun unchanged; it also costs ~44% on the benign path, since polling every 10 byte-offsets means an `Instant::elapsed()` per 10 bytes.

## Description

Collapse all four copies onto two shared scanners built on `memchr::memmem` (O(n+m)), walking the haystack in 64KiB chunks with a `check_time()` poll per chunk. `bytes_contains` now calls `find_subsequence(...).is_some()` rather than rolling its own.

Chunking still matters with a linear search: `max_memory` defaults to `None`, so a single scan over an arbitrarily large haystack would otherwise remain uninterruptible. Chunks overlap by `needle.len() - 1` so boundary-straddling matches are found, and the stride never drops below the needle length so overlap cannot dominate for long needles.

`memchr` is already in the tree via ruff/`fancy-regex` — and already runs on attacker-controlled data, since `fancy-regex` backs the sandbox's `re` module — so this is a direct pin of a crate monty already links, not new surface.

## Results

| | `main` | #642 | this |
|---|---|---|---|
| pathological `in`, 1ms limit | 808ms, `Ok` | 1ms, `TimeoutError` | 1ms, `TimeoutError` |
| pathological `.find`/`.count`/`.split`/`.replace`/`.partition` | ~800ms, `Ok` | ~800ms, `Ok` | interrupted promptly |
| benign 200 × `b'zz' in <1MB>` | 488ms | 704ms | **9.2ms** |

## Testing

Tests written first, red confirmed before the fix:

- `bytes_search_is_not_quadratic` — nine affected expressions on near-matching input must finish under 300ms. Red at 808ms; now 0.08s in debug.
- `timeout_in_bytes_search` — 64MB haystack under a 1ms limit must raise `TimeoutError` promptly, covering the chunked polling.
- `bytes__methods.py` — chunk-boundary parity cases (offsets 65,500–131,072, needles longer than the stride, multi-match splits). Pass before *and* after on Monty and CPython — the no-regression guard.

Full suite green: 119 resource-limit tests, 1118 test cases, `make lint-rs` / `make lint-py` clean. `limitations/resource_limits.md` gains a bullet noting time enforcement is polled and can overshoot.

**For review:** the linearity test asserts wall-clock time, the only way to observe complexity. Sized at ~100x margin over expected and 3x under the broken value, but it could in principle flake on a badly overloaded runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces naive `bytes` substring scans with linear, interruptible search using `memchr::memmem`, fixing a timeout bypass and speeding up common cases. Also skips unneeded preprocessing, reuses finders, and enforces time limits even when `replace` is a no-op.

- **Bug Fixes**
  - Enforces time limits during large sub-sequence scans by polling `check_time()` per chunk (64KiB stride; for long needles, stride grows to the needle length). Applies to sub-sequence forms of `in`, find/index, rfind/rindex, count, split/rsplit with a separator, partition/rpartition, and replace. Integer `in` and whitespace split/rsplit (`sep=None`) are not polled.
  - Polls before a no-match `replace` copy (pattern longer than the haystack or `count=0`) so large copies don’t bypass the time limit.
  - Avoids unpolled Two-Way preprocessing by skipping `Finder` setup when the needle cannot fit in the haystack, and by early-returning for no-op limits (`split(..., 0)`, `rsplit(..., 0)`, `replace(..., 0)`).
  - Documents that polling can overshoot (and grows with needle length) and that `max_memory` does not bound this, since large `bytes` literals are not charged.

- **Refactors**
  - Consolidates four O(haystack × needle) scans into shared forward/reverse scanners built on `memchr::memmem` with overlapped chunking; builds and reuses `Finder`/`FinderRev` once per operation.
  - Routes `in` (bytes-like) through the shared find scanner and preserves empty-needle semantics in callers.
  - Adds tests for linearity, timeouts, and chunk-boundary matches; adds a direct dependency on `memchr`.

<sup>Written for commit ed34367b30257aad2260df0a8942903efb38cdb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

