### PR TITLE
make benchmarks async properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,7 +602,9 @@ dependencies = [
  "codspeed",
  "codspeed-criterion-compat-walltime",
  "colored 2.2.0",
+ "futures",
  "regex",
+ "tokio",
 ]
 
 [[package]]
@@ -617,6 +619,7 @@ dependencies = [
  "clap",
  "codspeed",
  "criterion-plot",
+ "futures",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
@@ -629,6 +632,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -756,6 +760,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
+ "futures",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
@@ -768,6 +773,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 

--- a/crates/monty-bench/Cargo.toml
+++ b/crates/monty-bench/Cargo.toml
@@ -13,11 +13,11 @@ monty = { workspace = true, features = ["test-hooks"] }
 monty-types = { workspace = true }
 monty-pool = { workspace = true }
 monty-proto = { workspace = true }
-# The pool is async: benchmarks drive it via `Runtime::block_on`.
-tokio = { workspace = true, features = ["rt-multi-thread"] }
+# The pool benchmarks use Criterion's Tokio async executor.
+tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }
 pyo3 = { workspace = true, features = ["auto-initialize"] }
-codspeed-criterion-compat = "4.2.1"
-criterion = "0.5"
+codspeed-criterion-compat = { version = "4.2.1", features = ["async_tokio"] }
+criterion = { version = "0.5", features = ["async_tokio"] }
 
 [target.'cfg(unix)'.dependencies]
 pprof = { version = "0.15", features = ["flamegraph", "criterion"] }

--- a/crates/monty-bench/benches/pool.rs
+++ b/crates/monty-bench/benches/pool.rs
@@ -12,7 +12,7 @@ use std::{
     future::ready,
     path::{Path, PathBuf},
     process::Command,
-    sync::{Once, OnceLock},
+    sync::Once,
 };
 
 #[cfg(codspeed)]
@@ -23,7 +23,10 @@ use monty_pool::{Checkout, Pool, PoolConfig, PrintFuture, ReplConfig, ResumeValu
 use monty_types::{MontyObject, PrintStream};
 #[cfg(all(not(codspeed), unix))]
 use pprof::criterion::{Output, PProfProfiler};
-use tokio::runtime::{Builder, Runtime};
+use tokio::{
+    runtime::{Builder, Runtime},
+    sync::Mutex,
+};
 
 /// Locates (building once if needed) the `monty` CLI binary the workers run.
 /// Mirrors the resolution used by `monty-pool`'s integration tests: honour
@@ -53,23 +56,16 @@ fn monty_binary() -> PathBuf {
     path
 }
 
-/// The shared tokio runtime all benchmark iterations run on. One static
-/// runtime (rather than one per bench) so workers' process handles and pipe
-/// registrations outlive the individual `block_on` calls that use them.
+/// Creates the current-thread tokio runtime for one benchmark.
 ///
-/// Current-thread flavor: `block_on` then drives the io/timer drivers on the
-/// benchmark thread itself, so a turn's wakeup is a plain `epoll_wait` return
-/// rather than a cross-thread handoff from a worker thread. That measures the
-/// pool's own overhead, not the multi-thread scheduler's wakeup latency —
-/// matching the pre-async benches, which had no scheduler at all.
-fn runtime() -> &'static Runtime {
-    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
-    RUNTIME.get_or_init(|| {
-        Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("tokio runtime")
-    })
+/// This drives the I/O and timer drivers on the benchmark thread itself, so a
+/// turn's wakeup is a plain `epoll_wait` return rather than a cross-thread
+/// handoff.
+fn runtime() -> Runtime {
+    Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime")
 }
 
 /// Discards sandbox `print()` output — none of these benchmarks print.
@@ -111,18 +107,17 @@ async fn drive_answering_calls(session: &mut Checkout, mut event: TurnEvent) -> 
 /// spawns and tears down a worker, so this is dominated by process startup —
 /// the price paid once per fresh pool.
 fn pool_create_session_run(bench: &mut Bencher) {
+    let runtime = runtime();
     let binary = monty_binary();
-    bench.iter(|| {
-        runtime().block_on(async {
-            let pool = Pool::new(PoolConfig::subprocess(&binary)).await.unwrap();
-            let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
-            let event = session
-                .feed("1 + 1", vec![], vec![], false, &mut no_print)
-                .await
-                .unwrap();
-            black_box(expect_complete(event));
-            session.finish().await.unwrap();
-        });
+    bench.to_async(&runtime).iter(|| async {
+        let pool = Pool::new(PoolConfig::subprocess(&binary)).await.unwrap();
+        let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
+        let event = session
+            .feed("1 + 1", vec![], vec![], false, &mut no_print)
+            .await
+            .unwrap();
+        black_box(expect_complete(event));
+        session.finish().await.unwrap();
     });
 }
 
@@ -130,19 +125,18 @@ fn pool_create_session_run(bench: &mut Bencher) {
 /// per-session checkout handshake plus a trivial `1 + 1` feed — the overhead
 /// every request pays once the pool is warm.
 fn session_checkout_run(bench: &mut Bencher) {
-    let pool = runtime()
+    let runtime = runtime();
+    let pool = runtime
         .block_on(Pool::new(PoolConfig::subprocess(monty_binary())))
         .unwrap();
-    bench.iter(|| {
-        runtime().block_on(async {
-            let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
-            let event = session
-                .feed("1 + 1", vec![], vec![], false, &mut no_print)
-                .await
-                .unwrap();
-            black_box(expect_complete(event));
-            session.finish().await.unwrap();
-        });
+    bench.to_async(&runtime).iter(|| async {
+        let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
+        let event = session
+            .feed("1 + 1", vec![], vec![], false, &mut no_print)
+            .await
+            .unwrap();
+        black_box(expect_complete(event));
+        session.finish().await.unwrap();
     });
 }
 
@@ -159,20 +153,21 @@ for i in range(1000):
 /// protobuf channel on a single warm session. Reuses the session across
 /// iterations so only the messaging cost is measured, not checkout.
 fn ext_calls_1000(bench: &mut Bencher) {
-    let pool = runtime()
+    let runtime = runtime();
+    let pool = runtime
         .block_on(Pool::new(PoolConfig::subprocess(monty_binary())))
         .unwrap();
-    let mut session = runtime().block_on(pool.checkout(&ReplConfig::default())).unwrap();
-    bench.iter(|| {
-        runtime().block_on(async {
-            let event = session
-                .feed(EXT_CALL_LOOP, vec![], vec![], false, &mut no_print)
-                .await
-                .unwrap();
-            black_box(drive_answering_calls(&mut session, event).await);
-        });
+    let session = runtime.block_on(pool.checkout(&ReplConfig::default())).unwrap();
+    let session = Mutex::new(session);
+    bench.to_async(&runtime).iter(|| async {
+        let mut session = session.lock().await;
+        let event = session
+            .feed(EXT_CALL_LOOP, vec![], vec![], false, &mut no_print)
+            .await
+            .unwrap();
+        black_box(drive_answering_calls(&mut session, event).await);
     });
-    runtime().block_on(session.finish()).unwrap();
+    runtime.block_on(session.into_inner().finish()).unwrap();
 }
 
 /// Sums `amount * quantity` over every row of every external-call result —
@@ -220,38 +215,39 @@ fn make_rows() -> MontyObject {
 /// encode/decode and heap conversion of realistic tool results — the
 /// dominant wire cost for data-analysis agents.
 fn ext_call_rows(bench: &mut Bencher) {
+    let runtime = runtime();
     let rows = make_rows();
     // Expected sandbox result: 20 identical calls, each summing amount * quantity.
     let per_call: i64 = (0..100).map(|i| ((i * 37) % 500 + 1) * (i % 7 + 1)).sum();
     let expected = MontyObject::Int(per_call * 20);
-
-    let pool = runtime()
+    let pool = runtime
         .block_on(Pool::new(PoolConfig::subprocess(monty_binary())))
         .unwrap();
-    let mut session = runtime().block_on(pool.checkout(&ReplConfig::default())).unwrap();
-    bench.iter(|| {
-        runtime().block_on(async {
-            let mut event = session
-                .feed(EXT_ROWS_LOOP, vec![], vec![], false, &mut no_print)
-                .await
-                .unwrap();
-            let value = loop {
-                match event {
-                    TurnEvent::Complete(value) => break value,
-                    TurnEvent::FunctionCall { .. } => {
-                        event = session
-                            .resume(ResumeValue::Return(rows.clone()), &mut no_print)
-                            .await
-                            .unwrap();
-                    }
-                    other => panic!("expected Complete or FunctionCall, got {other:?}"),
+    let session = runtime.block_on(pool.checkout(&ReplConfig::default())).unwrap();
+    let session = Mutex::new(session);
+
+    bench.to_async(&runtime).iter(|| async {
+        let mut session = session.lock().await;
+        let mut event = session
+            .feed(EXT_ROWS_LOOP, vec![], vec![], false, &mut no_print)
+            .await
+            .unwrap();
+        let value = loop {
+            match event {
+                TurnEvent::Complete(value) => break value,
+                TurnEvent::FunctionCall { .. } => {
+                    event = session
+                        .resume(ResumeValue::Return(rows.clone()), &mut no_print)
+                        .await
+                        .unwrap();
                 }
-            };
-            assert_eq!(value, expected);
-            black_box(value);
-        });
+                other => panic!("expected Complete or FunctionCall, got {other:?}"),
+            }
+        };
+        assert_eq!(value, expected);
+        black_box(value);
     });
-    runtime().block_on(session.finish()).unwrap();
+    runtime.block_on(session.into_inner().finish()).unwrap();
 }
 
 /// Configures the pool benchmarks.


### PR DESCRIPTION
Use criterion features for async benchmarking.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches pool benchmarks to Criterion’s Tokio async executor for accurate async measurements. Replaces manual block_on and a static runtime with per-benchmark current-thread runtimes and `to_async`.

- **Refactors**
  - Enable `async_tokio` in `criterion` and `codspeed-criterion-compat`.
  - Use `bench.to_async(&runtime)` with a current-thread `tokio` runtime per benchmark.
  - Remove the global runtime; keep I/O and timers on the bench thread to avoid cross-thread scheduler noise.
  - Reuse a warm session across iterations with `tokio::sync::Mutex`.
  - Update deps: `tokio` adds `sync`; `criterion` pulls in `futures`.

<sup>Written for commit 2fc065ab2101d22ebecfe4ac02166b038cf6050f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

