### PR TITLE
Apply new drop standards to the collections code

### DIFF
--- a/crates/monty/src/modules/collections/counter.rs
+++ b/crates/monty/src/modules/collections/counter.rs
@@ -14,7 +14,7 @@ use smallvec::smallvec;
 use crate::{
     args::{ArgValues, KwargsValues},
     bytecode::VM,
-    defer_drop_mut,
+    defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::{DropGuard, DropWithContext, HeapData, HeapId, HeapReadOutput},
     resource_checks::check_repeat_size,
@@ -253,25 +253,19 @@ fn counter_merge_mapping(
         };
         dict.get(vm.heap).is_empty()
     };
-    let mut pairs = pairs.into_iter();
-    while let Some((key, count)) = pairs.next() {
+    // A merge can fail on an unhashable key or a non-numeric count; the guard
+    // releases the pairs it never reached.
+    let pairs = pairs.into_iter();
+    defer_drop_mut!(pairs, vm);
+    for (key, count) in pairs.by_ref() {
         // The fast path stores `count` itself, while a bump only reads it — so
         // that branch owns the release.
-        let outcome = if is_empty && !subtract {
-            counter_set(dict_id, key, count, vm)
+        if is_empty && !subtract {
+            counter_set(dict_id, key, count, vm)?;
         } else {
             let outcome = counter_bump(dict_id, key, &count, subtract, true, vm);
             count.drop_with(vm);
-            outcome
-        };
-        if let Err(e) = outcome {
-            // A merge can fail on an unhashable key or a non-numeric count —
-            // drop the pairs we have not consumed yet.
-            for (key, count) in pairs {
-                key.drop_with(vm);
-                count.drop_with(vm);
-            }
-            return Err(e);
+            outcome?;
         }
     }
     Ok(())
@@ -307,12 +301,8 @@ pub(crate) fn counter_update_method(
     // CPython names the specific method (with the `Counter.` qualifier) here.
     let name = if subtract { "Counter.subtract" } else { "Counter.update" };
     if total > 1 {
-        if let Some(source) = source {
-            source.drop_with(vm);
-        }
-        for extra in pos {
-            extra.drop_with(vm);
-        }
+        source.drop_with(vm);
+        pos.drop_with(vm);
         kwargs.drop_with(vm);
         return Err(ExcType::type_error_too_many_positional_range(name, 1, 2, total + 1, 0));
     }
@@ -365,9 +355,7 @@ pub(crate) fn counter_order(counts: Vec<Value>, vm: &mut VM<'_>) -> RunResult<Ve
             }
         }
     });
-    for count in counts {
-        count.drop_with(vm);
-    }
+    counts.drop_with(vm);
     match failure {
         Some(e) => Err(e),
         None => Ok(order),
@@ -554,76 +542,51 @@ fn counter_binary_extreme(
     op: ExtremeOp,
     vm: &mut VM<'_>,
 ) -> RunResult<()> {
-    let mut l_pairs = counter_snapshot(l_id, vm).into_iter();
-    let outcome = loop {
-        let Some((key, count)) = l_pairs.next() else {
-            break Ok(());
-        };
-        let other = match counter_lookup(r_id, &key, vm) {
-            Ok(existing) => existing.unwrap_or(Value::Int(0)),
-            Err(e) => {
-                key.drop_with(vm);
-                count.drop_with(vm);
-                break Err(e);
-            }
-        };
+    // Two guards cover every failure below, so each one is a plain `?`: the outer
+    // releases the entries the loop never reached, the inner the one in flight.
+    let l_pairs = counter_snapshot(l_id, vm).into_iter();
+    defer_drop_mut!(l_pairs, vm);
+    for entry in l_pairs.by_ref() {
+        let mut entry = DropGuard::new(entry, vm);
+        let ((key, count), vm) = entry.as_parts_mut();
+        let other = counter_lookup(r_id, key, vm)?.unwrap_or(Value::Int(0));
+        let mut other = DropGuard::new(other, vm);
+        let (other_count, vm) = other.as_parts_mut();
         // `count < other`: `|` keeps `count` when it is *not* smaller, `&` keeps
         // it when it *is* smaller. The loser is released.
-        let picked = match count_holds(&count, &other, CountCmp::Lt, vm) {
-            Ok(count_is_smaller) => {
-                let keep_count = match op {
-                    ExtremeOp::Max => !count_is_smaller,
-                    ExtremeOp::Min => count_is_smaller,
-                };
-                if keep_count {
-                    other.drop_with(vm);
-                    count
-                } else {
-                    count.drop_with(vm);
-                    other
-                }
-            }
-            Err(e) => {
-                count.drop_with(vm);
-                other.drop_with(vm);
-                key.drop_with(vm);
-                break Err(e);
-            }
+        let count_is_smaller = count_holds(count, other_count, CountCmp::Lt, vm)?;
+        let keep_count = match op {
+            ExtremeOp::Max => !count_is_smaller,
+            ExtremeOp::Min => count_is_smaller,
         };
-        if let Err(e) = counter_set(result_id, key, picked, vm) {
-            break Err(e);
-        }
-    };
-    drain_pairs(l_pairs, vm);
-    outcome?;
+        let other = other.into_inner();
+        let ((key, count), vm) = entry.into_parts();
+        let picked = if keep_count {
+            other.drop_with(vm);
+            count
+        } else {
+            count.drop_with(vm);
+            other
+        };
+        // `counter_set` consumes both, releasing them itself if the store fails.
+        counter_set(result_id, key, picked, vm)?;
+    }
 
     if matches!(op, ExtremeOp::Max) {
-        let mut r_pairs = counter_snapshot(r_id, vm).into_iter();
-        let outcome = loop {
-            let Some((key, count)) = r_pairs.next() else {
-                break Ok(());
-            };
-            match counter_lookup(l_id, &key, vm) {
-                // Shared keys were already resolved in the left pass.
-                Ok(Some(existing)) => {
-                    existing.drop_with(vm);
-                    key.drop_with(vm);
-                    count.drop_with(vm);
-                }
-                Ok(None) => {
-                    if let Err(e) = counter_set(result_id, key, count, vm) {
-                        break Err(e);
-                    }
-                }
-                Err(e) => {
-                    key.drop_with(vm);
-                    count.drop_with(vm);
-                    break Err(e);
-                }
+        let r_pairs = counter_snapshot(r_id, vm).into_iter();
+        defer_drop_mut!(r_pairs, vm);
+        for entry in r_pairs.by_ref() {
+            let mut entry = DropGuard::new(entry, vm);
+            let ((key, _), vm) = entry.as_parts_mut();
+            // Shared keys were already resolved in the left pass, so the guard
+            // releases this entry; only a right-only key reaches the result.
+            if let Some(existing) = counter_lookup(l_id, key, vm)? {
+                existing.drop_with(vm);
+            } else {
+                let ((key, count), vm) = entry.into_parts();
+                counter_set(result_id, key, count, vm)?;
             }
-        };
-        drain_pairs(r_pairs, vm);
-        outcome?;
+        }
     }
     Ok(())
 }
@@ -662,58 +625,40 @@ pub(crate) fn counter_compare(l_id: HeapId, r_id: HeapId, cmp: CounterCmp, vm: &
     // tracks whether every compared pair matched, which the strict forms need.
     let mut holds = true;
     let mut equal = true;
-    // `counter_union_counts` hands back owned pairs the caller must drop. Iterate
-    // by hand so a short-circuit (`!holds`) or a failing comparison still drains
-    // the un-compared remainder — a bare `for` loop drops them via plain `Drop`,
-    // which never debits the heap refcount, leaking every remaining pair.
-    let mut pairs = counter_union_counts(l_id, r_id, vm)?.into_iter();
-    while let Some((l, r)) = pairs.next() {
+    // `counter_union_counts` hands back owned pairs the caller must drop. The
+    // guard covers every exit — a short-circuit (`!holds`), a failing comparison,
+    // and normal exhaustion — releasing whatever the loop never compared.
+    let pairs = counter_union_counts(l_id, r_id, vm)?.into_iter();
+    defer_drop_mut!(pairs, vm);
+    for pair in pairs.by_ref() {
+        defer_drop!(pair, vm);
+        let (l, r) = pair;
         // One `py_cmp` yields both the loose check and the equality the strict
         // forms need. A `NaN` pair is unordered: the loose comparison fails (as
         // in CPython, `nan <= x` is false) and the pair counts as not-equal.
-        match l.py_cmp(&r, vm) {
-            Ok(CmpOrder::Ordered(Ordering::Equal)) => {}
-            Ok(CmpOrder::Ordered(ordering)) => {
+        match l.py_cmp(r, vm)? {
+            CmpOrder::Ordered(Ordering::Equal) => {}
+            CmpOrder::Ordered(ordering) => {
                 holds &= op.holds(ordering);
                 equal = false;
             }
-            Ok(CmpOrder::Unordered) => {
+            CmpOrder::Unordered => {
                 holds = false;
                 equal = false;
             }
-            Ok(CmpOrder::Incomparable) => {
-                let e = ExcType::type_error_ordering(op.symbol(), &l.py_type_name(vm), &r.py_type_name(vm));
-                l.drop_with(vm);
-                r.drop_with(vm);
-                drain_pairs(pairs, vm);
-                return Err(e);
-            }
-            Err(e) => {
-                l.drop_with(vm);
-                r.drop_with(vm);
-                drain_pairs(pairs, vm);
-                return Err(e);
+            CmpOrder::Incomparable => {
+                return Err(ExcType::type_error_ordering(
+                    op.symbol(),
+                    &l.py_type_name(vm),
+                    &r.py_type_name(vm),
+                ));
             }
         }
-        l.drop_with(vm);
-        r.drop_with(vm);
         if !holds {
             break;
         }
     }
-    // Release any pairs left after an early `break` (a no-op once exhausted).
-    drain_pairs(pairs, vm);
     Ok(holds && (!strict || !equal))
-}
-
-/// Drops every remaining `(Value, Value)` pair from an iterator, debiting the
-/// heap refcount each holds. Used to release the un-consumed tail after an early
-/// exit, where a plain `Drop` of the iterator would leak (it never sees the VM).
-fn drain_pairs(pairs: impl Iterator<Item = (Value, Value)>, vm: &mut VM<'_>) {
-    for (a, b) in pairs {
-        a.drop_with(vm);
-        b.drop_with(vm);
-    }
 }
 
 /// Pairs up the counts of two Counters over the union of their keys, with a
@@ -722,47 +667,37 @@ fn drain_pairs(pairs: impl Iterator<Item = (Value, Value)>, vm: &mut VM<'_>) {
 /// Returns owned clones so the caller can run comparisons that need `&mut VM`.
 /// Every returned pair must be dropped by the caller.
 fn counter_union_counts(l_id: HeapId, r_id: HeapId, vm: &mut VM<'_>) -> RunResult<Vec<(Value, Value)>> {
-    let mut pairs = Vec::new();
+    // Three guards, so a failing lookup is a plain `?`: the pairs accumulated so
+    // far, the entries not yet visited, and the entry in flight all get released.
+    let mut pairs = DropGuard::new(Vec::new(), vm);
     // Left keys against their right counterparts, then the right-only keys.
     for (keys_id, other_id, flip) in [(l_id, r_id, false), (r_id, l_id, true)] {
-        let mut entries = counter_snapshot(keys_id, vm).into_iter();
-        let outcome = loop {
-            let Some((key, count)) = entries.next() else {
-                break Ok(());
-            };
-            let other = match counter_lookup(other_id, &key, vm) {
-                Ok(other) => other,
-                Err(e) => {
-                    key.drop_with(vm);
-                    count.drop_with(vm);
-                    break Err(e);
-                }
-            };
+        let (collected, vm) = pairs.as_parts_mut();
+        let entries = counter_snapshot(keys_id, vm).into_iter();
+        defer_drop_mut!(entries, vm);
+        for entry in entries.by_ref() {
+            let mut entry = DropGuard::new(entry, vm);
+            let ((key, _), vm) = entry.as_parts_mut();
+            let other = counter_lookup(other_id, key, vm)?;
             // On the second pass only keys absent from the left are new; the
-            // shared ones were already paired, so skip them.
+            // shared ones were already paired, so skip them (the guard releases
+            // the entry); otherwise the count moves into `collected`.
             match (flip, other) {
-                (true, Some(other)) => {
-                    other.drop_with(vm);
-                    count.drop_with(vm);
+                (true, Some(other)) => other.drop_with(vm),
+                (true, None) => {
+                    let ((key, count), vm) = entry.into_parts();
+                    key.drop_with(vm);
+                    collected.push((Value::Int(0), count));
                 }
-                (true, None) => pairs.push((Value::Int(0), count)),
-                (false, other) => pairs.push((count, other.unwrap_or(Value::Int(0)))),
+                (false, other) => {
+                    let ((key, count), vm) = entry.into_parts();
+                    key.drop_with(vm);
+                    collected.push((count, other.unwrap_or(Value::Int(0))));
+                }
             }
-            key.drop_with(vm);
-        };
-        for (key, count) in entries {
-            key.drop_with(vm);
-            count.drop_with(vm);
-        }
-        if let Err(e) = outcome {
-            for (l, r) in pairs {
-                l.drop_with(vm);
-                r.drop_with(vm);
-            }
-            return Err(e);
         }
     }
-    Ok(pairs)
+    Ok(pairs.into_inner())
 }
 
 /// Applies a `Counter` algebra operator **in place**, mutating `l_id`.
@@ -789,99 +724,51 @@ pub(crate) fn counter_inplace_op(l_id: HeapId, rhs: &Value, op: CounterOp, vm: &
         //     self[elem] = other_count` — walks *other*, so new keys can appear.
         CounterOp::Or => {
             let r_id = counter_require_mapping(rhs, vm)?;
-            let mut r_pairs = counter_snapshot(r_id, vm).into_iter();
-            let outcome = loop {
-                let Some((key, other_count)) = r_pairs.next() else {
-                    break Ok(());
-                };
+            let r_pairs = counter_snapshot(r_id, vm).into_iter();
+            defer_drop_mut!(r_pairs, vm);
+            for entry in r_pairs.by_ref() {
+                let mut entry = DropGuard::new(entry, vm);
+                let ((key, other_count), vm) = entry.as_parts_mut();
                 // A key absent from `self` reads as 0 (`self[elem]`).
-                let count = match counter_lookup(l_id, &key, vm) {
-                    Ok(existing) => existing.unwrap_or(Value::Int(0)),
-                    Err(e) => {
-                        key.drop_with(vm);
-                        other_count.drop_with(vm);
-                        break Err(e);
-                    }
-                };
+                let count = counter_lookup(l_id, key, vm)?.unwrap_or(Value::Int(0));
                 // `other_count > self[elem]`: other first, so the TypeError names it first.
-                let bigger = match count_holds(&other_count, &count, CountCmp::Gt, vm) {
-                    Ok(true) => {
-                        count.drop_with(vm);
-                        Some(other_count)
-                    }
-                    Ok(false) => {
-                        count.drop_with(vm);
-                        other_count.drop_with(vm);
-                        None
-                    }
-                    Err(e) => {
-                        count.drop_with(vm);
-                        other_count.drop_with(vm);
-                        key.drop_with(vm);
-                        break Err(e);
-                    }
-                };
-                match bigger {
-                    Some(bigger) => {
-                        if let Err(e) = counter_set(l_id, key, bigger, vm) {
-                            break Err(e);
-                        }
-                    }
-                    None => key.drop_with(vm),
+                let bigger = count_holds(other_count, &count, CountCmp::Gt, vm);
+                count.drop_with(vm);
+                // A count that is not bigger leaves `self` alone, and the guard
+                // releases the entry — as it does if the comparison raised.
+                if bigger? {
+                    let ((key, other_count), vm) = entry.into_parts();
+                    counter_set(l_id, key, other_count, vm)?;
                 }
-            };
-            drain_pairs(r_pairs, vm);
-            outcome?;
+            }
         }
         // `for elem, count in self.items(): if other[elem] < count:
         //     self[elem] = other[elem]` — walks *self*, subscripting `other`.
         CounterOp::And => {
-            let mut pairs = counter_snapshot(l_id, vm).into_iter();
-            let outcome = loop {
-                let Some((key, count)) = pairs.next() else {
-                    break Ok(());
-                };
+            let pairs = counter_snapshot(l_id, vm).into_iter();
+            defer_drop_mut!(pairs, vm);
+            for entry in pairs.by_ref() {
+                let mut entry = DropGuard::new(entry, vm);
+                let ((key, count), vm) = entry.as_parts_mut();
                 // `other[elem]` is a real subscript: a Counter yields 0 for a
                 // missing key, a plain dict raises `KeyError`, and a non-mapping
                 // raises its subscript error — exactly CPython's `__iand__`. An
                 // empty `self` never reaches here, so `c &= 5` is a no-op then.
-                let other_count = match rhs.py_getitem(&key, vm) {
-                    Ok(existing) => existing,
-                    Err(e) => {
-                        key.drop_with(vm);
-                        count.drop_with(vm);
-                        break Err(e);
-                    }
-                };
+                let other_count = rhs.py_getitem(key, vm)?;
+                let mut other_count = DropGuard::new(other_count, vm);
+                let (other, vm) = other_count.as_parts_mut();
                 // `other[elem] < count`: other first, matching CPython's wording.
-                let smaller = match count_holds(&other_count, &count, CountCmp::Lt, vm) {
-                    Ok(true) => {
-                        count.drop_with(vm);
-                        Some(other_count)
-                    }
-                    Ok(false) => {
-                        other_count.drop_with(vm);
-                        count.drop_with(vm);
-                        None
-                    }
-                    Err(e) => {
-                        other_count.drop_with(vm);
-                        count.drop_with(vm);
-                        key.drop_with(vm);
-                        break Err(e);
-                    }
-                };
-                match smaller {
-                    Some(smaller) => {
-                        if let Err(e) = counter_set(l_id, key, smaller, vm) {
-                            break Err(e);
-                        }
-                    }
-                    None => key.drop_with(vm),
+                let is_smaller = count_holds(other, count, CountCmp::Lt, vm)?;
+                // Only the smaller of the two survives; the guards release the
+                // loser, the whole entry when nothing changes, and both if the
+                // comparison raised.
+                if is_smaller {
+                    let smaller = other_count.into_inner();
+                    let ((key, count), vm) = entry.into_parts();
+                    count.drop_with(vm);
+                    counter_set(l_id, key, smaller, vm)?;
                 }
-            };
-            drain_pairs(pairs, vm);
-            outcome?;
+            }
         }
     }
     counter_retain_positive(l_id, vm)
@@ -900,51 +787,37 @@ pub(crate) fn counter_unary_op(id: HeapId, negate: bool, vm: &mut VM<'_>) -> Run
     // early-returns would otherwise leak.
     let mut result_guard = DropGuard::new(Value::Ref(result_id), vm);
     let vm = result_guard.ctx();
-    let mut pairs = counter_snapshot(id, vm).into_iter();
-    let outcome = loop {
-        let Some((k, c)) = pairs.next() else {
-            break Ok(());
-        };
-        // `-c` filters on `count < 0` first (reporting `<` for an unorderable
-        // count, dropping a NaN), then stores `0 - count`. `+c` copies the count
-        // through and lets the trailing `retain_positive` apply the `> 0` strip.
-        let stored = if negate {
-            match count_holds(&c, &Value::Int(0), CountCmp::Lt, vm) {
-                Ok(true) => {
-                    let negated = count_arith(&Value::Int(0), &c, true, vm);
-                    c.drop_with(vm);
-                    match negated {
-                        Ok(negated) => Some(negated),
-                        Err(e) => {
-                            k.drop_with(vm);
-                            break Err(e);
-                        }
-                    }
+    // Scoped so the iterator guard releases its borrow of `result_guard` before
+    // the result is handed back.
+    {
+        let pairs = counter_snapshot(id, vm).into_iter();
+        defer_drop_mut!(pairs, vm);
+        for entry in pairs.by_ref() {
+            let mut entry = DropGuard::new(entry, vm);
+            let ((_, count), vm) = entry.as_parts_mut();
+            // `-c` filters on `count < 0` first (reporting `<` for an unorderable
+            // count, dropping a NaN), then stores `0 - count`. `+c` copies the count
+            // through and lets the trailing `retain_positive` apply the `> 0` strip.
+            let negated = if negate {
+                if !count_holds(count, &Value::Int(0), CountCmp::Lt, vm)? {
+                    // Not negative, so nothing is stored; the guard releases the entry.
+                    continue;
                 }
-                Ok(false) => {
-                    c.drop_with(vm);
-                    None
+                Some(count_arith(&Value::Int(0), count, true, vm)?)
+            } else {
+                None
+            };
+            let ((key, count), vm) = entry.into_parts();
+            let stored = match negated {
+                Some(negated) => {
+                    count.drop_with(vm);
+                    negated
                 }
-                Err(e) => {
-                    c.drop_with(vm);
-                    k.drop_with(vm);
-                    break Err(e);
-                }
-            }
-        } else {
-            Some(c)
-        };
-        match stored {
-            Some(count) => {
-                if let Err(e) = counter_set(result_id, k, count, vm) {
-                    break Err(e);
-                }
-            }
-            None => k.drop_with(vm),
+                None => count,
+            };
+            counter_set(result_id, key, stored, vm)?;
         }
-    };
-    drain_pairs(pairs, vm);
-    outcome?;
+    }
     counter_retain_positive(result_id, vm)?;
     Ok(result_guard.into_inner())
 }
@@ -952,15 +825,13 @@ pub(crate) fn counter_unary_op(id: HeapId, negate: bool, vm: &mut VM<'_>) -> Run
 /// Folds a batch of `(key, delta)` pairs into the Counter `id`, releasing any
 /// pairs left unconsumed when a bump fails.
 fn counter_bump_all(id: HeapId, pairs: Vec<(Value, Value)>, subtract: bool, vm: &mut VM<'_>) -> RunResult<()> {
-    let mut pairs = pairs.into_iter();
-    while let Some((key, delta)) = pairs.next() {
+    let pairs = pairs.into_iter();
+    defer_drop_mut!(pairs, vm);
+    for (key, delta) in pairs.by_ref() {
         // `counter_bump` borrows the delta, so each one is released here.
         let outcome = counter_bump(id, key, &delta, subtract, false, vm);
         delta.drop_with(vm);
-        if let Err(e) = outcome {
-            drain_pairs(pairs, vm);
-            return Err(e);
-        }
+        outcome?;
     }
     Ok(())
 }
@@ -1008,43 +879,36 @@ fn counter_set(id: HeapId, key: Value, count: Value, vm: &mut VM<'_>) -> RunResu
 
 /// Removes every entry whose count is not strictly positive from the Counter `id`.
 fn counter_retain_positive(id: HeapId, vm: &mut VM<'_>) -> RunResult<()> {
-    let entries: Vec<(Value, Value)> = counter_snapshot(id, vm);
-    let mut remove: Vec<Value> = Vec::new();
-    let mut entries = entries.into_iter();
-    let outcome = loop {
-        let Some((key, count)) = entries.next() else {
-            break Ok(());
-        };
-        let positive = count_is_positive(&count, vm);
-        count.drop_with(vm);
-        match positive {
-            Ok(true) => key.drop_with(vm),
-            Ok(false) => remove.push(key),
-            Err(e) => {
-                key.drop_with(vm);
-                break Err(e);
+    // The keys to remove are collected first: the scan clones them out of the
+    // dict, so popping while iterating is not possible. Both guards release what
+    // they still hold if a count comparison — or a `pop` hashing a key — raises.
+    let mut remove = DropGuard::new(Vec::new(), vm);
+    {
+        let (remove, vm) = remove.as_parts_mut();
+        let entries = counter_snapshot(id, vm).into_iter();
+        defer_drop_mut!(entries, vm);
+        for entry in entries.by_ref() {
+            let mut entry = DropGuard::new(entry, vm);
+            let ((_, count), vm) = entry.as_parts_mut();
+            let positive = count_is_positive(count, vm)?;
+            if !positive {
+                let ((key, count), vm) = entry.into_parts();
+                count.drop_with(vm);
+                remove.push(key);
             }
         }
-    };
-    for (key, count) in entries {
-        key.drop_with(vm);
-        count.drop_with(vm);
     }
-    if let Err(e) = outcome {
-        for key in remove {
-            key.drop_with(vm);
-        }
-        return Err(e);
-    }
-    for key in remove {
+    let (remove, vm) = remove.into_parts();
+    let remove = remove.into_iter();
+    defer_drop_mut!(remove, vm);
+    for key in remove.by_ref() {
+        defer_drop!(key, vm);
         let HeapReadOutput::Dict(mut dict) = vm.heap.read(id) else {
             unreachable!("counter_retain_positive on a non-dict heap entry");
         };
-        if let Some((old_key, old_val)) = dict.pop(&key, vm)? {
-            old_key.drop_with(vm);
-            old_val.drop_with(vm);
+        if let Some(old) = dict.pop(key, vm)? {
+            old.drop_with(vm);
         }
-        key.drop_with(vm);
     }
     Ok(())
 }

--- a/crates/monty/src/modules/collections/mod.rs
+++ b/crates/monty/src/modules/collections/mod.rs
@@ -30,7 +30,7 @@ use crate::{
     args::{ArgValues, FromArgs},
     builtins::Builtins,
     bytecode::VM,
-    defer_drop,
+    defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::{DropWithContext, HeapData, HeapId, HeapReadOutput},
     intern::StaticStrings,
@@ -99,12 +99,8 @@ pub(crate) fn counter_init(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value>
 
     // Counter accepts at most one positional (the iterable/mapping).
     if total > 1 {
-        if let Some(source) = source {
-            source.drop_with(vm);
-        }
-        for extra in pos {
-            extra.drop_with(vm);
-        }
+        source.drop_with(vm);
+        pos.drop_with(vm);
         kwargs.drop_with(vm);
         return Err(ExcType::type_error_too_many_positional_range(
             "Counter.__init__",
@@ -144,9 +140,7 @@ pub(crate) fn defaultdict_init(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Va
         Some(value) if value.is_callable(vm.heap) => Some(value),
         Some(value) => {
             value.drop_with(vm);
-            for extra in pos {
-                extra.drop_with(vm);
-            }
+            pos.drop_with(vm);
             kwargs.drop_with(vm);
             return Err(ExcType::type_error("first argument must be callable or None"));
         }
@@ -242,9 +236,7 @@ fn namedtuple(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     // Collect defaults (rightmost fields), then validate the count.
     let default_values = collect_defaults(defaults, vm)?;
     if default_values.len() > names.len() {
-        for v in default_values {
-            v.drop_with(vm);
-        }
+        default_values.drop_with(vm);
         return Err(ExcType::type_error("Got more default values than field names"));
     }
 
@@ -276,29 +268,15 @@ fn parse_field_names(field_names: &Value, vm: &mut VM<'_>) -> RunResult<Vec<Stri
     } else {
         let items = collect_owned_iterable::<Vec<Value>>(field_names.clone_with_heap(vm.heap), vm)?;
         let mut names = Vec::with_capacity(items.len());
-        // Drain by hand so a failing `str()` (a field's `__str__` raising)
-        // releases the current item *and* the un-iterated remainder — a bare
-        // `?` inside a `for` loop would leak both.
-        let mut iter = items.into_iter();
-        while let Some(item) = iter.next() {
-            let as_str = match item.py_str(vm) {
-                Ok(as_str) => as_str,
-                Err(e) => {
-                    item.drop_with(vm);
-                    iter.drop_with(vm);
-                    return Err(e);
-                }
-            };
-            let owned = as_str.to_str(vm).map(str::to_owned);
-            as_str.drop_with(vm);
-            item.drop_with(vm);
-            match owned {
-                Ok(name) => names.push(name),
-                Err(e) => {
-                    iter.drop_with(vm);
-                    return Err(e);
-                }
-            }
+        // A failing `str()` (a field's `__str__` raising) must release the
+        // current item *and* the un-iterated remainder; the guards cover both.
+        let iter = items.into_iter();
+        defer_drop_mut!(iter, vm);
+        for item in iter.by_ref() {
+            defer_drop!(item, vm);
+            let as_str = item.py_str(vm)?;
+            defer_drop!(as_str, vm);
+            names.push(as_str.to_str(vm)?.to_owned());
         }
         Ok(names)
     }

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -6,7 +6,7 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
-    heap::{DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
+    heap::{DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     resource_checks::check_repeat_size,
     types::{LazyHeapSet, Type, list::repr_sequence_fmt, long_int::repeat_count},
@@ -180,35 +180,26 @@ impl Deque {
         let DequeArgs { iterable, maxlen } = DequeArgs::from_args(args, vm)?;
 
         // `maxlen` is validated before the iterable is consumed (CPython order), so
-        // both failing branches must release the already-bound `iterable`. An
-        // explicit `None` is unbounded; a big int out of range is `OverflowError`.
+        // the guard releases the already-bound `iterable` on every failing branch.
+        // An explicit `None` is unbounded; a big int out of range is `OverflowError`.
+        let mut iterable = DropGuard::new(iterable, vm);
         let raw_maxlen = if let Value::None = maxlen {
             None
         } else {
+            let vm = iterable.ctx();
             let parsed = read_ssize(&maxlen, vm, ExcType::overflow_c_ssize_t);
             maxlen.drop_with(vm);
             match parsed {
                 Some(Ok(i)) => Some(i),
-                Some(Err(e)) => {
-                    iterable.drop_with(vm);
-                    return Err(e);
-                }
-                None => {
-                    iterable.drop_with(vm);
-                    return Err(ExcType::type_error_integer_required());
-                }
+                Some(Err(e)) => return Err(e),
+                None => return Err(ExcType::type_error_integer_required()),
             }
         };
-        let maxlen = match raw_maxlen.map(check_maxlen).transpose() {
-            Ok(maxlen) => maxlen,
-            Err(e) => {
-                iterable.drop_with(vm);
-                return Err(e);
-            }
-        };
+        let maxlen = raw_maxlen.map(check_maxlen).transpose()?;
 
         // An omitted iterable is empty; an explicit `None` falls through to
         // `collect_owned_iterable`, raising `'NoneType' object is not iterable`.
+        let (iterable, vm) = iterable.into_parts();
         let items = match iterable {
             None => Vec::new(),
             Some(v) => collect_owned_iterable(v, vm)?,
@@ -216,9 +207,7 @@ impl Deque {
 
         let (deque, evicted) = Self::new(items, maxlen);
         // Items dropped by the maxlen truncation still hold their refcounts.
-        for value in evicted {
-            value.drop_with(vm);
-        }
+        evicted.drop_with(vm);
         let heap_id = vm.heap.allocate(HeapData::Deque(deque))?;
         Ok(Value::Ref(heap_id))
     }
@@ -492,9 +481,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Deque> {
         let mut items = self.clone_all_items(vm);
         items.extend(other.clone_all_items(vm));
         let (deque, evicted) = Deque::new(items, maxlen);
-        for value in evicted {
-            value.drop_with(vm.heap);
-        }
+        evicted.drop_with(vm.heap);
         let id = vm.heap.allocate(HeapData::Deque(deque))?;
         Ok(Some(Value::Ref(id)))
     }
@@ -749,9 +736,7 @@ fn call_deque_method<'h>(
             }
             this.bump_state();
             let items: Vec<Value> = this.items.drain(..).collect();
-            for value in items {
-                value.drop_with(vm);
-            }
+            items.drop_with(vm);
             Ok(Value::None)
         }
         StaticStrings::Copy => {
@@ -759,9 +744,7 @@ fn call_deque_method<'h>(
             let maxlen = deque.get(vm.heap).maxlen();
             let items = deque.clone_all_items(vm);
             let (new_deque, evicted) = Deque::new(items, maxlen);
-            for value in evicted {
-                value.drop_with(vm);
-            }
+            evicted.drop_with(vm);
             let id = vm.heap.allocate(HeapData::Deque(new_deque))?;
             Ok(Value::Ref(id))
         }
@@ -796,16 +779,12 @@ fn call_deque_method<'h>(
 /// `deque.rotate([n=1])` — rotates right by `n` (left if negative), wrapping.
 fn rotate<'h>(deque: &mut HeapRead<'h, Deque>, args: ArgValues, vm: &mut VM<'h>) -> RunResult<Value> {
     let RotateArgs { n } = RotateArgs::from_args(args, vm)?;
+    defer_drop!(n, vm);
     // A big int is a valid rotation count; only one out of `i64` range is an
     // `OverflowError`, matching CPython's `PyNumber_AsSsize_t`.
-    let parsed = read_ssize(&n, vm, ExcType::overflow_c_ssize_t);
-    let n = if let Some(res) = parsed {
-        n.drop_with(vm);
-        res?
-    } else {
-        let name = n.py_type_name(vm);
-        n.drop_with(vm);
-        return Err(ExcType::type_error_not_an_integer(&name));
+    let n = match read_ssize(n, vm, ExcType::overflow_c_ssize_t) {
+        Some(res) => res?,
+        None => return Err(ExcType::type_error_not_an_integer(&n.py_type_name(vm))),
     };
     let this = deque.get_mut(vm.heap);
     let len = this.items.len();
@@ -830,13 +809,17 @@ fn insert<'h>(deque: &mut HeapRead<'h, Deque>, args: ArgValues, vm: &mut VM<'h>)
         item,
     } = InsertArgs::from_args(args, vm)?;
     defer_drop!(index_value, vm);
+    // Every failing branch below releases `item` through the guard — including
+    // the `track_growth` limit, where a plain `Drop` would leak its refcount.
+    // The insert at the end takes it back out.
+    let mut item_guard = DropGuard::new(item, vm);
+    let vm = item_guard.ctx();
 
     // CPython checks fullness before touching the index.
     let this = deque.get(vm.heap);
     if let Some(max) = this.maxlen()
         && this.len() >= max
     {
-        item.drop_with(vm);
         return Err(ExcType::index_error_deque_full());
     }
 
@@ -844,15 +827,8 @@ fn insert<'h>(deque: &mut HeapRead<'h, Deque>, args: ArgValues, vm: &mut VM<'h>)
     // `OverflowError` (CPython's `PyNumber_AsSsize_t`), not a type error.
     let raw = match read_ssize(index_value, vm, ExcType::overflow_c_ssize_t) {
         Some(Ok(i)) => i,
-        Some(Err(e)) => {
-            item.drop_with(vm);
-            return Err(e);
-        }
-        None => {
-            let name = index_value.py_type_name(vm);
-            item.drop_with(vm);
-            return Err(ExcType::type_error_not_an_integer(&name));
-        }
+        Some(Err(e)) => return Err(e),
+        None => return Err(ExcType::type_error_not_an_integer(&index_value.py_type_name(vm))),
     };
 
     // insert() clamps rather than raising, like list.insert.
@@ -861,6 +837,7 @@ fn insert<'h>(deque: &mut HeapRead<'h, Deque>, args: ArgValues, vm: &mut VM<'h>)
     let idx = usize::try_from(normalized).expect("index clamped non-negative");
 
     vm.heap.track_growth(VALUE_SIZE)?;
+    let (item, vm) = item_guard.into_parts();
     if matches!(item, Value::Ref(_)) {
         deque.get_mut(vm.heap).contains_refs = true;
     }
@@ -1060,33 +1037,29 @@ fn repeat_deque(source: Vec<Value>, maxlen: Option<usize>, count: usize, vm: &mu
         check_repeat_size(mem::size_of::<Value>(), kept, vm.heap.tracker())?;
         // `Vec::new()` (not `with_capacity(kept)`): the check above is the real
         // guard, and reserving an attacker-sized capacity would itself abort.
-        let mut result = Vec::new();
+        // The guard releases the clones built so far if the time poll trips.
+        let mut result = DropGuard::new(Vec::new(), vm);
         if kept > 0 {
             let start = (len - kept % len) % len;
             for i in 0..kept {
-                result.push(source[(start + i % len) % len].clone_with_heap(vm.heap));
-                // Poll once per notional copy; on a timeout, release the clones
-                // built so far rather than leaking them through the plain `Drop`.
-                if i % len == 0
-                    && let Err(e) = vm.heap.check_time()
-                {
-                    result.drop_with(vm);
-                    return Err(e.into());
+                let (items, vm) = result.as_parts_mut();
+                items.push(source[(start + i % len) % len].clone_with_heap(vm.heap));
+                // Poll once per notional copy.
+                if i % len == 0 {
+                    vm.heap.check_time()?;
                 }
             }
         }
-        result
+        result.into_inner()
     } else {
         check_repeat_size(len.saturating_mul(mem::size_of::<Value>()), count, vm.heap.tracker())?;
-        let mut result = Vec::with_capacity(len * count);
+        let mut result = DropGuard::new(Vec::with_capacity(len * count), vm);
         for _ in 0..count {
-            result.extend(source.iter().map(|v| v.clone_with_heap(vm.heap)));
-            if let Err(e) = vm.heap.check_time() {
-                result.drop_with(vm);
-                return Err(e.into());
-            }
+            let (items, vm) = result.as_parts_mut();
+            items.extend(source.iter().map(|v| v.clone_with_heap(vm.heap)));
+            vm.heap.check_time()?;
         }
-        result
+        result.into_inner()
     };
     // We already trimmed to at most `maxlen`, so `Deque::new` evicts nothing and
     // no refcounts need releasing — `debug_assert` guards that invariant.

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -738,13 +738,9 @@ impl<'h> HeapRead<'h, NamedTuple> {
         let (pos, kwargs) = args.into_parts();
         let n_pos = pos.len();
         if n_pos > 0 {
-            for v in pos {
-                v.drop_with(vm);
-            }
+            pos.drop_with(vm);
             kwargs.drop_with(vm);
-            for v in items {
-                v.drop_with(vm);
-            }
+            items.drop_with(vm);
             return Err(ExcType::type_error(format!(
                 "_replace() takes 1 positional argument but {} were given",
                 n_pos + 1
@@ -763,9 +759,7 @@ impl<'h> HeapRead<'h, NamedTuple> {
             }
         }
         if !unexpected.is_empty() {
-            for v in items {
-                v.drop_with(vm);
-            }
+            items.drop_with(vm);
             return Err(ExcType::type_error(format!(
                 "Got unexpected field names: {}",
                 py_list_repr(&unexpected)
@@ -1019,9 +1013,8 @@ pub(crate) fn cmp_item_seqs(a: Vec<Value>, b: Vec<Value>, vm: &mut VM<'_>) -> Ru
             }
         }
     }
-    for value in a.into_iter().chain(b) {
-        value.drop_with(vm);
-    }
+    a.drop_with(vm);
+    b.drop_with(vm);
     // All compared pairs were equal, so the shorter sequence sorts first.
     result.unwrap_or_else(|| Ok(CmpOrder::Ordered(a_len.cmp(&b_len))))
 }
@@ -1112,13 +1105,9 @@ pub(crate) fn construct_namedtuple(class_id: HeapId, vm: &mut VM<'_>, args: ArgV
     // Too many positionals. `__new__(cls, ...)` counts `cls`, so the limit and
     // the count both include it (the `+ 1`s).
     if n_pos > n {
-        for v in pos {
-            v.drop_with(vm);
-        }
+        pos.drop_with(vm);
         kwargs.drop_with(vm);
-        for v in defaults {
-            v.drop_with(vm);
-        }
+        defaults.drop_with(vm);
         return Err(ExcType::type_error_too_many_positional_range(
             &func_name,
             n + 1,
@@ -1177,12 +1166,9 @@ pub(crate) fn construct_namedtuple(class_id: HeapId, vm: &mut VM<'_>, args: ArgV
     }
 
     if let Some(err) = first_err {
-        for v in leftover {
-            v.drop_with(vm);
-        }
-        for v in slots.into_iter().flatten() {
-            v.drop_with(vm);
-        }
+        leftover.drop_with(vm);
+        // `Vec<Option<Value>>` releases through the `Vec` and `Option` impls.
+        slots.drop_with(vm);
         return Err(err);
     }
 
@@ -1213,9 +1199,7 @@ fn make_from_iterable(
     let items = collect_owned_iterable::<Vec<Value>>(iterable, vm)?;
     if items.len() != n {
         let got = items.len();
-        for v in items {
-            v.drop_with(vm);
-        }
+        items.drop_with(vm);
         return Err(ExcType::type_error(format!("Expected {n} arguments, got {got}")));
     }
     build_namedtuple(name, field_names, items, class_id, vm)


### PR DESCRIPTION
Follow-up cleanup to #608 applying the #633 drop rules:

- `for v in … { v.drop_with(vm) }` loops replaced by one `drop_with` on the
  container's own `DropWithContext` impl
- Values released from several branches now held by a `DropGuard`, or
  `defer_drop!` / `defer_drop_mut!` where nothing is extracted, so each failure
  is a plain `?`
- The `loop` / `break Err(e)` / `outcome?` scaffolding that manual draining
  forced on the Counter folds dissolves with it
- `counter.rs`'s `drain_pairs` helper deleted — it reimplemented the `IntoIter<U>`
  and `(U, V)` impls
- One behaviour change: `deque.insert` no longer leaks its item when
  `track_growth` trips a memory limit between binding and inserting

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the #633 drop-branch rules across `collections` to simplify cleanup and prevent refcount leaks. Also fixes a leak in `deque.insert` when a growth check fails.

- **Refactors**
  - Replace per-item drops with container `.drop_with` on `Vec`/iterators, and remove `counter.rs`’s `drain_pairs`.
  - Use `DropGuard`, `defer_drop!`, and `defer_drop_mut!` to release values on all error paths and make failures a plain `?`.
  - Simplifies Counter folds and namedtuple parsing logic without behavior changes.

- **Bug Fixes**
  - `deque.insert`: item is no longer leaked if `vm.heap.track_growth` trips a memory limit.

<sup>Written for commit f63013bca131f5a30034ec1898886257abb0401a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

