### PR TITLE
Dispatch `__index__` for indexing, slicing and integer arguments

### DIFF
--- a/crates/monty/src/args/from_value.rs
+++ b/crates/monty/src/args/from_value.rs
@@ -236,15 +236,15 @@ impl FromValue for i64 {
     }
 }
 
-/// Replaces a user instance with the `int` its `__index__` returns, leaving
-/// every other value untouched.
+/// Replaces a value with the `int` the `__index__` protocol produces, leaving
+/// anything not `__index__`-able untouched.
 ///
 /// Runs before the fixed-width int impls match, so they only ever see real ints
-/// — the `PyNumber_Index` step CPython's `i`/`n` argument converters perform. A
-/// class without `__index__` is returned unchanged, so the caller still reports
-/// its own `WrongType`.
+/// — the `PyNumber_Index` step CPython's `i`/`n` argument converters perform. An
+/// int answers with an equal int, and a class without `__index__` is returned
+/// unchanged, so the caller still reports its own `WrongType`.
 fn resolve_index_dunder(value: Value, vm: &mut VM<'_>) -> Result<Value, FromValueFail> {
-    match value.try_index(vm) {
+    match value.py_index_impl(vm) {
         Ok(Some(index)) => {
             value.drop_with(vm);
             Ok(index)

--- a/crates/monty/src/args/from_value.rs
+++ b/crates/monty/src/args/from_value.rs
@@ -21,7 +21,7 @@ use crate::{
     bytecode::VM,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     heap::{ContainsHeap, DropWithContext, HeapData},
-    types::PyTrait,
+    types::{PyTrait, instance::instance_index},
     value::Value,
 };
 
@@ -186,10 +186,39 @@ impl FromValue for Value {
     }
 }
 
+/// Replaces a user instance with the `int` its `__index__` returns, leaving
+/// every other value untouched.
+///
+/// Runs before the fixed-width int impls match, so they only ever see real ints
+/// — the `PyNumber_Index` step CPython's `i`/`n` argument converters perform. A
+/// class without `__index__` is returned unchanged, so the caller still reports
+/// its own `WrongType`.
+fn resolve_index_dunder(value: Value, vm: &mut VM<'_>) -> Result<Value, FromValueFail> {
+    let Value::Ref(id) = &value else {
+        return Ok(value);
+    };
+    if !matches!(vm.heap.get(*id), HeapData::Instance(_)) {
+        return Ok(value);
+    }
+    let id = *id;
+    match instance_index(id, vm) {
+        Ok(Some(index)) => {
+            value.drop_with(vm);
+            Ok(index)
+        }
+        Ok(None) => Ok(value),
+        Err(err) => {
+            value.drop_with(vm);
+            Err(FromValueFail::Raise(err))
+        }
+    }
+}
+
 impl FromValue for i32 {
     const EXPECTED_TYPE_NAME: Option<&'static str> = Some("int");
 
     fn from_value(value: Value, vm: &mut VM<'_>) -> Result<Self, FromValueFail> {
+        let value = resolve_index_dunder(value, vm)?;
         let result = match value {
             Value::Bool(b) => Ok(Self::from(b)),
             // Overflow is a *value* failure: the argument is a genuine int,
@@ -219,6 +248,7 @@ impl FromValue for i64 {
     const EXPECTED_TYPE_NAME: Option<&'static str> = Some("int");
 
     fn from_value(value: Value, vm: &mut VM<'_>) -> Result<Self, FromValueFail> {
+        let value = resolve_index_dunder(value, vm)?;
         let result = match value {
             Value::Bool(b) => Ok(Self::from(b)),
             Value::Int(i) => Ok(i),

--- a/crates/monty/src/args/from_value.rs
+++ b/crates/monty/src/args/from_value.rs
@@ -21,7 +21,7 @@ use crate::{
     bytecode::VM,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     heap::{ContainsHeap, DropWithContext, HeapData},
-    types::{PyTrait, instance::instance_index},
+    types::PyTrait,
     value::Value,
 };
 
@@ -186,34 +186,6 @@ impl FromValue for Value {
     }
 }
 
-/// Replaces a user instance with the `int` its `__index__` returns, leaving
-/// every other value untouched.
-///
-/// Runs before the fixed-width int impls match, so they only ever see real ints
-/// — the `PyNumber_Index` step CPython's `i`/`n` argument converters perform. A
-/// class without `__index__` is returned unchanged, so the caller still reports
-/// its own `WrongType`.
-fn resolve_index_dunder(value: Value, vm: &mut VM<'_>) -> Result<Value, FromValueFail> {
-    let Value::Ref(id) = &value else {
-        return Ok(value);
-    };
-    if !matches!(vm.heap.get(*id), HeapData::Instance(_)) {
-        return Ok(value);
-    }
-    let id = *id;
-    match instance_index(id, vm) {
-        Ok(Some(index)) => {
-            value.drop_with(vm);
-            Ok(index)
-        }
-        Ok(None) => Ok(value),
-        Err(err) => {
-            value.drop_with(vm);
-            Err(FromValueFail::Raise(err))
-        }
-    }
-}
-
 impl FromValue for i32 {
     const EXPECTED_TYPE_NAME: Option<&'static str> = Some("int");
 
@@ -261,6 +233,27 @@ impl FromValue for i64 {
 
     fn type_error(got: &str) -> RunError {
         ExcType::type_error_not_integer(got)
+    }
+}
+
+/// Replaces a user instance with the `int` its `__index__` returns, leaving
+/// every other value untouched.
+///
+/// Runs before the fixed-width int impls match, so they only ever see real ints
+/// — the `PyNumber_Index` step CPython's `i`/`n` argument converters perform. A
+/// class without `__index__` is returned unchanged, so the caller still reports
+/// its own `WrongType`.
+fn resolve_index_dunder(value: Value, vm: &mut VM<'_>) -> Result<Value, FromValueFail> {
+    match value.try_index(vm) {
+        Ok(Some(index)) => {
+            value.drop_with(vm);
+            Ok(index)
+        }
+        Ok(None) => Ok(value),
+        Err(err) => {
+            value.drop_with(vm);
+            Err(FromValueFail::Raise(err))
+        }
     }
 }
 

--- a/crates/monty/src/bytecode/vm/collections.rs
+++ b/crates/monty/src/bytecode/vm/collections.rs
@@ -76,9 +76,9 @@ impl VM<'_> {
         let start_val = this.pop();
         defer_drop!(start_val, this);
 
-        let start = value_to_option_i64(start_val)?;
-        let stop = value_to_option_i64(stop_val)?;
-        let step = value_to_option_i64(step_val)?;
+        let start = value_to_option_i64(start_val, this)?;
+        let stop = value_to_option_i64(stop_val, this)?;
+        let step = value_to_option_i64(step_val, this)?;
 
         let slice = Slice::new(start, stop, step);
         let heap_id = this.heap.allocate(HeapData::Slice(slice));

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -78,6 +78,17 @@ macro_rules! try_catch_sync {
     };
 }
 
+/// Persists the cached frame IP before an operation that can execute Python.
+///
+/// A nested `run()` restores `instruction_ip` from the caller frame, so the
+/// caller must hold its resume IP for exceptions to find the right handler.
+macro_rules! try_catch_reentrant {
+    ($self:expr, $cached_frame:ident, $expr:expr) => {{
+        $self.current_frame_mut().ip = $cached_frame.ip;
+        try_catch_sync!($self, $cached_frame, $expr);
+    }};
+}
+
 /// Handles an exception and reloads cached frame state if caught.
 ///
 /// Use this in the main run loop where `cached_frame`
@@ -1317,7 +1328,8 @@ impl<'h> VM<'h> {
                     try_catch_sync!(self, cached_frame, self.build_fstring(count));
                 }
                 Opcode::BuildSlice => {
-                    try_catch_sync!(self, cached_frame, self.build_slice());
+                    // Bounds are coerced here, so a user `__index__` can run.
+                    try_catch_reentrant!(self, cached_frame, self.build_slice());
                 }
                 Opcode::ListExtend => {
                     try_catch_sync!(self, cached_frame, self.list_extend());
@@ -1359,6 +1371,9 @@ impl<'h> VM<'h> {
                 Opcode::BinarySubscr => {
                     let index = self.pop();
                     let obj = self.pop();
+                    // Sync IP before the call: a user `__index__` runs a nested
+                    // run() loop, which restores the frame IP from this frame.
+                    self.current_frame_mut().ip = cached_frame.ip;
                     let result = obj.py_getitem(&index, self);
                     obj.drop_with(self);
                     index.drop_with(self);
@@ -1512,9 +1527,13 @@ impl<'h> VM<'h> {
                     let (type_id, arg_count) = cached_frame.fetch_u8_u8();
                     let arg_count = arg_count as usize;
 
+                    // Sync IP before the call: `range(obj)`/`slice(obj)` coerce
+                    // their arguments, so a user `__index__` can push a frame
+                    // and run a nested run() loop.
+                    self.current_frame_mut().ip = cached_frame.ip;
+
                     match self.exec_call_builtin_type(type_id, arg_count) {
                         Ok(result) => self.push(result),
-                        // IP sync deferred to error path (no frame push possible)
                         Err(err) => catch_sync!(self, cached_frame, err),
                     }
                 }

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1286,6 +1286,20 @@ pub(crate) trait ExcTypeExt: Sized {
         SimpleException::new_msg(ExcType::IndexError, "cannot fit 'int' into an index-sized integer").into()
     }
 
+    /// [`Self::index_error_int_too_large`] for a value that supplied the index
+    /// through `__index__`.
+    ///
+    /// CPython names the object it asked, not the `int` it got back, so an
+    /// instance reports its own class here.
+    #[must_use]
+    fn index_error_cannot_fit(type_name: &str) -> RunError {
+        SimpleException::new_msg(
+            ExcType::IndexError,
+            format!("cannot fit '{type_name}' into an index-sized integer"),
+        )
+        .into()
+    }
+
     /// Creates an ImportError for when a name cannot be imported from a module.
     ///
     /// Matches CPython's format for built-in modules:

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -885,6 +885,10 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         heap_read_output_py_trait_forward!(self, |value| value.py_mod_impl(other, vm), else Ok(None))
     }
 
+    fn py_index_impl(&self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+        heap_read_output_py_trait_forward!(self, |value| value.py_index_impl(vm), else Ok(None))
+    }
+
     fn py_neg_impl(&self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         heap_read_output_py_trait_forward!(self, |value| value.py_neg_impl(vm), else Ok(None))
     }

--- a/crates/monty/src/modules/itertools.rs
+++ b/crates/monty/src/modules/itertools.rs
@@ -8,7 +8,7 @@
 use crate::{
     args::{ArgValues, FromArgs},
     bytecode::VM,
-    exception_private::{ExcType, ExcTypeExt, RunResult},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
     heap::{DropGuard, DropWithContext, HeapData, HeapId},
     intern::StaticStrings,
     modules::ModuleFunctions,
@@ -283,28 +283,28 @@ fn islice_bounds(
     first: &Value,
     second: Option<&Value>,
     third: Option<&Value>,
-    vm: &VM<'_>,
+    vm: &mut VM<'_>,
 ) -> RunResult<(usize, Option<usize>, usize)> {
     match second {
-        None => match islice_index(first, vm) {
+        None => match islice_index(first, vm)? {
             IsliceBound::Unbounded => Ok((0, None, 1)),
             IsliceBound::Index(stop) => Ok((0, Some(stop), 1)),
             IsliceBound::Invalid => Err(ExcType::islice_bad_stop()),
         },
         Some(second) => {
             // A `start` of `None` means "from the beginning", as in a slice.
-            let start = match islice_index(first, vm) {
+            let start = match islice_index(first, vm)? {
                 IsliceBound::Unbounded => 0,
                 IsliceBound::Index(start) => start,
                 IsliceBound::Invalid => return Err(ExcType::islice_bad_indices()),
             };
-            let stop = match islice_index(second, vm) {
+            let stop = match islice_index(second, vm)? {
                 IsliceBound::Unbounded => None,
                 IsliceBound::Index(stop) => Some(stop),
                 IsliceBound::Invalid => return Err(ExcType::islice_bad_indices()),
             };
             // A step of `None` is 1; zero and negatives are rejected outright.
-            let step = match third.map(|third| islice_index(third, vm)) {
+            let step = match third.map(|third| islice_index(third, vm)).transpose()? {
                 None | Some(IsliceBound::Unbounded) => 1,
                 Some(IsliceBound::Index(step)) if step > 0 => step,
                 Some(_) => return Err(ExcType::islice_bad_step()),
@@ -329,16 +329,19 @@ enum IsliceBound {
 
 /// Reads one `islice` bound; whether `Unbounded` is allowed is the caller's
 /// business, and differs per parameter.
-fn islice_index(value: &Value, vm: &VM<'_>) -> IsliceBound {
+fn islice_index(value: &Value, vm: &mut VM<'_>) -> RunResult<IsliceBound> {
     let index = match value {
-        Value::None => return IsliceBound::Unbounded,
+        Value::None => return Ok(IsliceBound::Unbounded),
         Value::Bool(b) => i64::from(*b),
+        // A raising `__index__` propagates; only a type mismatch is `Invalid`,
+        // which the caller words per parameter.
         other => match other.as_int(vm) {
             Ok(index) => index,
-            Err(_) => return IsliceBound::Invalid,
+            Err(RunError::Exc(_)) => return Ok(IsliceBound::Invalid),
+            Err(e) => return Err(e),
         },
     };
-    usize::try_from(index).map_or(IsliceBound::Invalid, IsliceBound::Index)
+    Ok(usize::try_from(index).map_or(IsliceBound::Invalid, IsliceBound::Index))
 }
 
 /// `itertools.chain(*iterables)` — each argument's items, back to back.

--- a/crates/monty/src/modules/itertools.rs
+++ b/crates/monty/src/modules/itertools.rs
@@ -173,7 +173,7 @@ fn normalize_bool(value: Value) -> Value {
 /// Negative counts clamp to zero (`repeat(x, -1)` is empty) and a `times` too
 /// large for a machine integer raises `OverflowError`, matching the conversion
 /// to `Py_ssize_t`. `bool` is accepted because it is an `int` subclass.
-fn repeat_times(value: &Value, vm: &VM<'_>) -> RunResult<usize> {
+fn repeat_times(value: &Value, vm: &mut VM<'_>) -> RunResult<usize> {
     let count = match value {
         Value::Bool(b) => i64::from(*b),
         other => other.as_int(vm)?,

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -905,29 +905,24 @@ fn parse_bytes_sub_args(
     let pos = args.into_pos_only(method, vm.heap)?;
     defer_drop!(pos, vm);
 
-    // `sub` is copied out before the bounds are read: `extract_bytes_only` borrows
-    // the heap, and reading a bound may run a user `__index__` that needs it
-    // mutably. Copying first keeps CPython's left-to-right argument order, which
-    // reordering the two would not.
-    let (sub, start, end) = match pos.as_slice() {
-        [sub_value] => {
-            let sub = extract_bytes_only(sub_value, vm)?.to_owned();
-            (sub, 0, len)
-        }
+    // The bounds convert before `sub` is inspected, as in CPython, whose parser
+    // runs the index converters and leaves the buffer check to the function body.
+    // A raising `__index__` bound then costs no copy; `pos` keeps `sub` alive.
+    let (sub_value, start, end) = match pos.as_slice() {
+        [sub_value] => (sub_value, 0, len),
         [sub_value, start_value] => {
-            let sub = extract_bytes_only(sub_value, vm)?.to_owned();
             let start = normalize_sequence_index(start_value.as_int(vm)?, len);
-            (sub, start, len)
+            (sub_value, start, len)
         }
         [sub_value, start_value, end_value] => {
-            let sub = extract_bytes_only(sub_value, vm)?.to_owned();
             let start = normalize_sequence_index(start_value.as_int(vm)?, len);
             let end = normalize_sequence_index(end_value.as_int(vm)?, len);
-            (sub, start, end)
+            (sub_value, start, end)
         }
         [] => return Err(ExcType::type_error_at_least(method, 1, 0)),
         _ => return Err(ExcType::type_error_at_most(method, 3, pos.len())),
     };
+    let sub = extract_bytes_only(sub_value, vm)?.to_owned();
 
     // Ensure start <= end to prevent slice panics (Python treats start > end as empty slice)
     Ok((sub, start, end.max(start)))
@@ -1380,11 +1375,13 @@ fn bytes_rsplit<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h>
 fn coerce_bytes_split_args(sep: Value, maxsplit: Value, vm: &mut VM<'_>) -> RunResult<(Option<Vec<u8>>, i64)> {
     defer_drop!(sep, vm);
     defer_drop!(maxsplit, vm);
+    // `maxsplit` converts first, as in CPython's clinic, which reads it while
+    // `sep` is still an unchecked object — a raising `__index__` costs no copy.
+    let maxsplit_int = maxsplit.as_int(vm)?;
     let sep = match sep {
         Value::None => None,
         _ => Some(extract_bytes_only(sep, vm)?.to_owned()),
     };
-    let maxsplit_int = maxsplit.as_int(vm)?;
     Ok((sep, maxsplit_int))
 }
 

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -905,18 +905,22 @@ fn parse_bytes_sub_args(
     let pos = args.into_pos_only(method, vm.heap)?;
     defer_drop!(pos, vm);
 
+    // `sub` is copied out before the bounds are read: `extract_bytes_only` borrows
+    // the heap, and reading a bound may run a user `__index__` that needs it
+    // mutably. Copying first keeps CPython's left-to-right argument order, which
+    // reordering the two would not.
     let (sub, start, end) = match pos.as_slice() {
         [sub_value] => {
-            let sub = extract_bytes_only(sub_value, vm)?;
+            let sub = extract_bytes_only(sub_value, vm)?.to_owned();
             (sub, 0, len)
         }
         [sub_value, start_value] => {
-            let sub = extract_bytes_only(sub_value, vm)?;
+            let sub = extract_bytes_only(sub_value, vm)?.to_owned();
             let start = normalize_sequence_index(start_value.as_int(vm)?, len);
             (sub, start, len)
         }
         [sub_value, start_value, end_value] => {
-            let sub = extract_bytes_only(sub_value, vm)?;
+            let sub = extract_bytes_only(sub_value, vm)?.to_owned();
             let start = normalize_sequence_index(start_value.as_int(vm)?, len);
             let end = normalize_sequence_index(end_value.as_int(vm)?, len);
             (sub, start, end)
@@ -926,7 +930,7 @@ fn parse_bytes_sub_args(
     };
 
     // Ensure start <= end to prevent slice panics (Python treats start > end as empty slice)
-    Ok((sub.to_owned(), start, end.max(start)))
+    Ok((sub, start, end.max(start)))
 }
 
 // =============================================================================
@@ -1926,31 +1930,41 @@ fn parse_bytes_justify_args(method: &str, args: ArgValues, vm: &mut VM<'_>) -> R
     let pos = args.into_pos_only(method, vm.heap)?;
     defer_drop!(pos, vm);
 
-    let extract_width = |v: &Value| -> RunResult<usize> {
-        let w = v.as_int(vm)?;
-        Ok(if w < 0 {
-            0
-        } else {
-            usize::try_from(w).unwrap_or(usize::MAX)
-        })
-    };
-
-    let extract_fill = |v: &Value| -> RunResult<u8> {
-        let fill_bytes = extract_bytes_only(v, vm)?;
-        if fill_bytes.len() != 1 {
-            return Err(ExcType::type_error(format!(
-                "{method}() argument 2 must be a byte string of length 1, not bytes of length {}",
-                fill_bytes.len()
-            )));
-        }
-        Ok(fill_bytes[0])
-    };
-
+    // Free functions rather than closures: `extract_width` needs `&mut VM` for a
+    // user `__index__`, which cannot coexist with a second closure capturing the
+    // same `vm` immutably.
     match pos.as_slice() {
-        [width_value] => Ok((extract_width(width_value)?, b' ')),
-        [width_value, fillbyte_value] => Ok((extract_width(width_value)?, extract_fill(fillbyte_value)?)),
+        [width_value] => Ok((extract_justify_width(width_value, vm)?, b' ')),
+        [width_value, fillbyte_value] => {
+            // Width first, so its error wins for `center('x', 'y')` as in CPython.
+            let width = extract_justify_width(width_value, vm)?;
+            Ok((width, extract_justify_fill(method, fillbyte_value, vm)?))
+        }
         [] => Err(ExcType::type_error_at_least(method, 1, 0)),
         _ => Err(ExcType::type_error_at_most(method, 2, pos.len())),
+    }
+}
+
+/// Reads a justify method's `width`, clamping negatives to zero as CPython does.
+fn extract_justify_width(value: &Value, vm: &mut VM<'_>) -> RunResult<usize> {
+    let width = value.as_int(vm)?;
+    Ok(if width < 0 {
+        0
+    } else {
+        usize::try_from(width).unwrap_or(usize::MAX)
+    })
+}
+
+/// Reads a justify method's `fillbyte`, which must be exactly one byte.
+fn extract_justify_fill(method: &str, value: &Value, vm: &VM<'_>) -> RunResult<u8> {
+    let fill_bytes = extract_bytes_only(value, vm)?;
+    if fill_bytes.len() == 1 {
+        Ok(fill_bytes[0])
+    } else {
+        Err(ExcType::type_error(format!(
+            "{method}() argument 2 must be a byte string of length 1, not bytes of length {}",
+            fill_bytes.len()
+        )))
     }
 }
 

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -128,6 +128,30 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Instance> {
         }
     }
 
+    /// Coerces the instance to an integer through the class's `__index__`.
+    ///
+    /// Validating the result here is both CPython's `__index__ returned non-int`
+    /// check and what stops a class whose `__index__` returns another such
+    /// instance from recursing — the caller converts a real int without
+    /// re-entering the protocol.
+    ///
+    /// Runs synchronously like the other dunders here, so an `__index__` that
+    /// calls an external/OS function raises rather than suspending.
+    fn py_index_impl(&self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+        let Some(result) = instance_call_dunder_sync(self.id(), "__index__", None, vm)? else {
+            return Ok(None);
+        };
+        if matches!(result, Value::Int(_) | Value::Bool(_) | Value::InternLongInt(_))
+            || matches!(&result, Value::Ref(id) if matches!(vm.heap.get(*id), HeapData::LongInt(_)))
+        {
+            Ok(Some(result))
+        } else {
+            let exc = ExcType::type_error(format!("__index__ returned non-int (type {})", result.py_type_name(vm)));
+            result.drop_with(vm);
+            Err(exc)
+        }
+    }
+
     fn py_type(&self, vm: &VM<'h>) -> Type {
         Type::Instance(self.get(vm.heap).class)
     }
@@ -507,36 +531,6 @@ pub(crate) fn instance_str(self_id: HeapId, vm: &mut VM<'_>) -> RunResult<Value>
     match instance_call_str_dunder(self_id, "__str__", vm)? {
         Some(s) => Ok(s),
         None => instance_repr(self_id, vm),
-    }
-}
-
-/// Coerces an instance to an integer through the class's `__index__`.
-///
-/// `Ok(None)` means the class does not define it, leaving the caller to raise
-/// its own `TypeError` — the message differs per consumer (`list indices must
-/// be integers`, `cannot be interpreted as an integer`, ...), so it is not
-/// raised here.
-///
-/// The returned value is validated to be a real `int` (`Int`/`Bool`/`LongInt`),
-/// which is both CPython's `__index__ returned non-int` check and what stops a
-/// class whose `__index__` returns another such instance from recursing: the
-/// caller can convert the result without re-entering this path. Out-of-range
-/// policy stays with the caller, since `as_int` and `as_index` differ on it.
-///
-/// Runs synchronously like the other dunders here, so an `__index__` that calls
-/// an external/OS function raises rather than suspending.
-pub(crate) fn instance_index(self_id: HeapId, vm: &mut VM<'_>) -> RunResult<Option<Value>> {
-    let Some(result) = instance_call_dunder_sync(self_id, "__index__", None, vm)? else {
-        return Ok(None);
-    };
-    if matches!(result, Value::Int(_) | Value::Bool(_) | Value::InternLongInt(_))
-        || matches!(&result, Value::Ref(id) if matches!(vm.heap.get(*id), HeapData::LongInt(_)))
-    {
-        Ok(Some(result))
-    } else {
-        let exc = ExcType::type_error(format!("__index__ returned non-int (type {})", result.py_type_name(vm)));
-        result.drop_with(vm);
-        Err(exc)
     }
 }
 

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -510,6 +510,36 @@ pub(crate) fn instance_str(self_id: HeapId, vm: &mut VM<'_>) -> RunResult<Value>
     }
 }
 
+/// Coerces an instance to an integer through the class's `__index__`.
+///
+/// `Ok(None)` means the class does not define it, leaving the caller to raise
+/// its own `TypeError` — the message differs per consumer (`list indices must
+/// be integers`, `cannot be interpreted as an integer`, ...), so it is not
+/// raised here.
+///
+/// The returned value is validated to be a real `int` (`Int`/`Bool`/`LongInt`),
+/// which is both CPython's `__index__ returned non-int` check and what stops a
+/// class whose `__index__` returns another such instance from recursing: the
+/// caller can convert the result without re-entering this path. Out-of-range
+/// policy stays with the caller, since `as_int` and `as_index` differ on it.
+///
+/// Runs synchronously like the other dunders here, so an `__index__` that calls
+/// an external/OS function raises rather than suspending.
+pub(crate) fn instance_index(self_id: HeapId, vm: &mut VM<'_>) -> RunResult<Option<Value>> {
+    let Some(result) = instance_call_dunder_sync(self_id, "__index__", None, vm)? else {
+        return Ok(None);
+    };
+    if matches!(result, Value::Int(_) | Value::Bool(_) | Value::InternLongInt(_))
+        || matches!(&result, Value::Ref(id) if matches!(vm.heap.get(*id), HeapData::LongInt(_)))
+    {
+        Ok(Some(result))
+    } else {
+        let exc = ExcType::type_error(format!("__index__ returned non-int (type {})", result.py_type_name(vm)));
+        result.drop_with(vm);
+        Err(exc)
+    }
+}
+
 /// Calls a user-defined string dunder (`__repr__`/`__str__`) on the instance and
 /// validates that it returned a `str`.
 ///

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -790,21 +790,21 @@ fn list_index<'h>(list: &HeapRead<'h, List>, args: ArgValues, vm: &mut VM<'h>) -
     let pos_args = args.into_pos_only("list.index", vm.heap)?;
     defer_drop!(pos_args, vm);
 
-    let len = list.get(vm.heap).items.len();
-    let (value, start, end) = match pos_args.as_slice() {
+    // Bounds are coerced before the length is read: `as_int` may dispatch a user
+    // `__index__` that mutates this list, and CPython normalizes against the
+    // length *after* argument parsing. Reading it first would resolve a negative
+    // bound against a stale length and search the wrong window.
+    let (value, start_arg, end_arg) = match pos_args.as_slice() {
         [] => return Err(ExcType::type_error_at_least("list.index", 1, 0)),
-        [value] => (value, 0, len),
-        [value, start_arg] => {
-            let start = normalize_sequence_index(start_arg.as_int(vm)?, len);
-            (value, start, len)
-        }
-        [value, start_arg, end_arg] => {
-            let start = normalize_sequence_index(start_arg.as_int(vm)?, len);
-            let end = normalize_sequence_index(end_arg.as_int(vm)?, len).max(start);
-            (value, start, end)
-        }
+        [value] => (value, None, None),
+        [value, start_arg] => (value, Some(start_arg.as_int(vm)?), None),
+        [value, start_arg, end_arg] => (value, Some(start_arg.as_int(vm)?), Some(end_arg.as_int(vm)?)),
         other => return Err(ExcType::type_error_at_most("list.index", 3, other.len())),
     };
+
+    let len = list.get(vm.heap).items.len();
+    let start = start_arg.map_or(0, |i| normalize_sequence_index(i, len));
+    let end = end_arg.map_or(len, |i| normalize_sequence_index(i, len)).max(start);
 
     // Search for the value in the specified range
     let iter = list.iter(vm)?;

--- a/crates/monty/src/types/long_int.rs
+++ b/crates/monty/src/types/long_int.rs
@@ -389,6 +389,12 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
         Ok(!self.get(vm.heap).is_zero())
     }
 
+    /// A `LongInt` *is* an int, so it indexes as itself — the caller narrows it
+    /// (or reports the overflow its own way).
+    fn py_index_impl(&self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+        Ok(Some(self.clone_value(vm.heap)))
+    }
+
     fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         Ok(eq_bigint(self.get(vm.heap).inner(), other, vm))
     }

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -274,6 +274,21 @@ pub(crate) trait PyTrait<'h> {
         self.py_repr(vm)
     }
 
+    /// Coerces this value to an `int` through the `__index__` protocol.
+    ///
+    /// `Ok(None)` — the default — means the type is not `__index__`-able, so
+    /// the caller raises its own `TypeError`; the wording differs per consumer
+    /// (`list indices must be integers`, `cannot be interpreted as an integer`,
+    /// `slice indices must be...`), which is why it is not raised here.
+    ///
+    /// The returned value is always a real `int` (`Int`/`Bool`/`LongInt`), so a
+    /// caller may narrow it — or recurse once through its own int arms — without
+    /// re-entering the protocol. Out-of-range policy stays with the caller,
+    /// since `as_int` and `as_index` disagree on it.
+    fn py_index_impl(&self, _vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+        Ok(None)
+    }
+
     /// Python unary minus (`__neg__`).
     ///
     /// `Ok(None)` — the default — means the type has no negation, so the VM

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -140,11 +140,20 @@ impl Slice {
 /// Returns Ok(None) for Value::None, Ok(Some(i)) for integers/bools, a user
 /// `__index__` result for instances, or Err(TypeError) for other types — which
 /// is what the "or have an `__index__` method" in the error message promises.
+///
+/// Ints too large for `i64` saturate to `i64::MIN`/`i64::MAX` instead of
+/// raising, matching CPython's clamping of slice bounds — unlike plain indexing,
+/// which raises `IndexError` on the same input.
 pub(crate) fn value_to_option_i64(value: &Value, vm: &mut VM<'_>) -> RunResult<Option<i64>> {
     match value {
         Value::None => Ok(None),
         Value::Int(i) => Ok(Some(*i)),
         Value::Bool(b) => Ok(Some(i64::from(*b))),
+        // Bounds beyond `i64` saturate rather than raise: CPython clamps slice
+        // bounds to the sequence, so `[1, 2, 3][10**30:]` is `[]`, not an error.
+        // This arm also catches an `__index__` that returns a `LongInt`, which
+        // the recursion below funnels back through here.
+        _ if let Some(index) = value.long_int_to_i64_saturating(vm) => Ok(Some(index)),
         _ => match value.try_index(vm)? {
             // Recurses exactly once: `try_index` validates an int result, so the
             // arms above take it on the way back in.

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -154,9 +154,9 @@ pub(crate) fn value_to_option_i64(value: &Value, vm: &mut VM<'_>) -> RunResult<O
         // This arm also catches an `__index__` that returns a `LongInt`, which
         // the recursion below funnels back through here.
         _ if let Some(index) = value.long_int_to_i64_saturating(vm) => Ok(Some(index)),
-        _ => match value.try_index(vm)? {
-            // Recurses exactly once: `try_index` validates an int result, so the
-            // arms above take it on the way back in.
+        _ => match value.py_index_impl(vm)? {
+            // Recurses exactly once: `py_index_impl` validates an int result, so
+            // the arms above take it on the way back in.
             Some(index) => {
                 defer_drop!(index, vm);
                 value_to_option_i64(index, vm)

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -19,7 +19,7 @@ use crate::{
     hash::HashValue,
     heap::{HeapData, HeapId, HeapItem, HeapObjectRead, HeapReadOutput},
     intern::StaticStrings,
-    types::{PyTrait, Type},
+    types::{PyTrait, Type, instance::instance_index},
     value::{EitherStr, Value},
 };
 
@@ -57,31 +57,30 @@ impl Slice {
     ///
     /// Each argument can be None to indicate "use default".
     pub fn init(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
-        let heap = &mut *vm.heap;
-        let pos_args = args.into_pos_only("slice", heap)?;
-        defer_drop!(pos_args, heap);
+        let pos_args = args.into_pos_only("slice", vm.heap)?;
+        defer_drop!(pos_args, vm);
 
         let slice = match pos_args.as_slice() {
             [] => return Err(ExcType::type_error_at_least("slice", 1, 0)),
             [first_arg] => {
-                let stop = value_to_option_i64(first_arg)?;
+                let stop = value_to_option_i64(first_arg, vm)?;
                 Self::new(None, stop, None)
             }
             [first_arg, second_arg] => {
-                let start = value_to_option_i64(first_arg)?;
-                let stop = value_to_option_i64(second_arg)?;
+                let start = value_to_option_i64(first_arg, vm)?;
+                let stop = value_to_option_i64(second_arg, vm)?;
                 Self::new(start, stop, None)
             }
             [first_arg, second_arg, third_arg] => {
-                let start = value_to_option_i64(first_arg)?;
-                let stop = value_to_option_i64(second_arg)?;
-                let step = value_to_option_i64(third_arg)?;
+                let start = value_to_option_i64(first_arg, vm)?;
+                let stop = value_to_option_i64(second_arg, vm)?;
+                let step = value_to_option_i64(third_arg, vm)?;
                 Self::new(start, stop, step)
             }
             _ => return Err(ExcType::type_error_at_most("slice", 3, pos_args.len())),
         };
 
-        Ok(Value::Ref(heap.allocate(HeapData::Slice(slice))))
+        Ok(Value::Ref(vm.heap.allocate(HeapData::Slice(slice))))
     }
 
     /// Computes concrete indices for a sequence of the given length.
@@ -138,13 +137,23 @@ impl Slice {
 /// Converts a Value to Option<i64>, treating None as None.
 ///
 /// Used for slice construction from both `slice()` builtin and `[start:stop:step]` syntax.
-/// Returns Ok(None) for Value::None, Ok(Some(i)) for integers/bools,
-/// or Err(TypeError) for other types.
-pub(crate) fn value_to_option_i64(value: &Value) -> RunResult<Option<i64>> {
+/// Returns Ok(None) for Value::None, Ok(Some(i)) for integers/bools, a user
+/// `__index__` result for instances, or Err(TypeError) for other types — which
+/// is what the "or have an `__index__` method" in the error message promises.
+pub(crate) fn value_to_option_i64(value: &Value, vm: &mut VM<'_>) -> RunResult<Option<i64>> {
     match value {
         Value::None => Ok(None),
         Value::Int(i) => Ok(Some(*i)),
         Value::Bool(b) => Ok(Some(i64::from(*b))),
+        Value::Ref(id) if matches!(vm.heap.get(*id), HeapData::Instance(_)) => {
+            let Some(index) = instance_index(*id, vm)? else {
+                return Err(ExcType::type_error_slice_indices());
+            };
+            // Recurses exactly once: `instance_index` validates an int result,
+            // so the arms above take it on the way back in.
+            defer_drop!(index, vm);
+            value_to_option_i64(index, vm)
+        }
         _ => Err(ExcType::type_error_slice_indices()),
     }
 }

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -19,7 +19,7 @@ use crate::{
     hash::HashValue,
     heap::{HeapData, HeapId, HeapItem, HeapObjectRead, HeapReadOutput},
     intern::StaticStrings,
-    types::{PyTrait, Type, instance::instance_index},
+    types::{PyTrait, Type},
     value::{EitherStr, Value},
 };
 
@@ -145,16 +145,15 @@ pub(crate) fn value_to_option_i64(value: &Value, vm: &mut VM<'_>) -> RunResult<O
         Value::None => Ok(None),
         Value::Int(i) => Ok(Some(*i)),
         Value::Bool(b) => Ok(Some(i64::from(*b))),
-        Value::Ref(id) if matches!(vm.heap.get(*id), HeapData::Instance(_)) => {
-            let Some(index) = instance_index(*id, vm)? else {
-                return Err(ExcType::type_error_slice_indices());
-            };
-            // Recurses exactly once: `instance_index` validates an int result,
-            // so the arms above take it on the way back in.
-            defer_drop!(index, vm);
-            value_to_option_i64(index, vm)
-        }
-        _ => Err(ExcType::type_error_slice_indices()),
+        _ => match value.try_index(vm)? {
+            // Recurses exactly once: `try_index` validates an int result, so the
+            // arms above take it on the way back in.
+            Some(index) => {
+                defer_drop!(index, vm);
+                value_to_option_i64(index, vm)
+            }
+            None => Err(ExcType::type_error_slice_indices()),
+        },
     }
 }
 

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -6,6 +6,7 @@ use std::{cell::Cell, fmt::Write, ops};
 /// operations like length and equality comparison.
 use monty_types::ResourceError;
 pub use monty_types::{StringRepr, string_repr_fmt};
+use num_traits::ToPrimitive;
 use ruff_python_stdlib::{identifiers::is_identifier, keyword::is_keyword};
 use smallvec::smallvec;
 
@@ -1205,13 +1206,24 @@ fn optional_index(value: &Value, default: usize, str_len: usize, vm: &mut VM<'_>
         Value::None => Ok(default),
         Value::Int(i) => Ok(normalize_sequence_index(*i, str_len)),
         Value::Bool(b) => Ok(normalize_sequence_index(i64::from(*b), str_len)),
+        // Both `LongInt` representations answer here. As well as sharing one
+        // error, this keeps an interned one out of the `_` arm below, whose
+        // recursion would otherwise hand it straight back to itself.
+        Value::InternLongInt(id) => {
+            let i = vm
+                .interns
+                .get_long_int(*id)
+                .to_i64()
+                .ok_or_else(|| ExcType::type_error("integer too large"))?;
+            Ok(normalize_sequence_index(i, str_len))
+        }
         Value::Ref(heap_id) if let HeapData::LongInt(li) = vm.heap.get(*heap_id) => {
             let i = li.to_i64().ok_or_else(|| ExcType::type_error("integer too large"))?;
             Ok(normalize_sequence_index(i, str_len))
         }
-        _ => match value.try_index(vm)? {
-            // Recurses exactly once: `try_index` validates an int result, so the
-            // arms above take it. Recursing rather than narrowing here keeps a
+        _ => match value.py_index_impl(vm)? {
+            // Recurses exactly once: `py_index_impl` validates an int result, so
+            // the arms above take it. Recursing rather than narrowing here keeps a
             // too-large result on the same path as a directly-passed `LongInt` —
             // which raises `TypeError: integer too large` where CPython clamps,
             // a pre-existing divergence this arm inherits rather than widens.

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -1181,6 +1181,18 @@ fn extract_int_arg(value: &Value, vm: &mut VM<'_>) -> RunResult<i64> {
     value.as_int(vm)
 }
 
+/// Extracts a C `int`-bounded integer, as CPython's clinic `int` converter does.
+///
+/// Distinct from [`extract_int_arg`], which is `ssize_t`-bounded: `str.expandtabs`
+/// declares `tabsize` as a C `int`, so `2**31` is an `OverflowError` there while
+/// an `ssize_t` argument still accepts it. Rejecting up front also keeps a large
+/// `tabsize` from reaching the space-building loop, where each tab amplifies into
+/// `tabsize` bytes.
+fn extract_c_int_arg(value: &Value, vm: &mut VM<'_>) -> RunResult<i32> {
+    let as_i64 = value.as_int_with_overflow(vm, ExcType::overflow_c_int)?;
+    i32::try_from(as_i64).map_err(|_| ExcType::overflow_c_int())
+}
+
 /// Extracts an optional slice index from a `Value`, treating `None` as `default`.
 ///
 /// Used by argument parsers where `None` means "use the default index" and
@@ -1874,21 +1886,21 @@ fn str_expandtabs<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h>) -
     let tabsize = match tabsize {
         None => 8,
         Some(val) => {
-            let result_int = extract_int_arg(&val, vm)?;
-            val.drop_with(vm.heap);
-            if result_int < 0 {
-                0
-            } else {
-                usize::try_from(result_int).unwrap_or(usize::MAX)
-            }
+            // `defer_drop!` rather than a trailing `drop_with`: the conversion
+            // raises for anything outside C `int`, and that `?` would otherwise
+            // leave `val`'s reference behind.
+            defer_drop!(val, vm);
+            // A negative tabsize expands to nothing, as CPython's `<= 0` test does.
+            usize::try_from(extract_c_int_arg(val, vm)?).unwrap_or(0)
         }
     };
 
     let s = s.get(vm.heap);
-    // `tabsize` is attacker-controlled (saturates to `usize::MAX`) and we don't
-    // know the result size up front, so use the unbounded builder — its 2×
-    // growth policy rejects the build at the first push that would exceed the
-    // memory limit, capping wasted intermediate allocation to `O(limit)`.
+    // `tabsize` is bounded by C `int` above, but a tab still amplifies into
+    // `tabsize` bytes and the result size is not known up front, so use the
+    // unbounded builder — its 2× growth policy rejects the build at the first
+    // push that would exceed the memory limit, capping wasted intermediate
+    // allocation to `O(limit)`.
     let mut builder = StringBuilder::new(&vm.heap.tracker);
     let mut column = 0;
 

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -25,6 +25,7 @@ use crate::{
     string_builder::StringBuilder,
     types::{
         LazyHeapSet, Type,
+        instance::instance_index,
         long_int::repeat_count,
         slice::{normalize_sequence_index, slice_collect_iterator},
     },
@@ -1172,19 +1173,13 @@ fn extract_string_arg(value: &Value, vm: &mut VM<'_>) -> RunResult<String> {
 }
 
 /// Extracts an integer from a Value, returning an error if not an integer.
+///
+/// Delegates rather than re-matching: [`Value::as_int`] is the one place that
+/// knows about `LongInt` and a user `__index__`, and its wording is CPython's
+/// (`'str' object cannot be interpreted as an integer`, `Python int too large
+/// to convert to C ssize_t`) where the hand-rolled version here was not.
 fn extract_int_arg(value: &Value, vm: &mut VM<'_>) -> RunResult<i64> {
-    match value {
-        Value::Int(i) => Ok(*i),
-        Value::Ref(heap_id) => {
-            if let HeapData::LongInt(li) = vm.heap.get(*heap_id) {
-                // Try to convert to i64
-                li.to_i64().ok_or_else(|| ExcType::type_error("integer too large"))
-            } else {
-                Err(ExcType::type_error("expected int"))
-            }
-        }
-        _ => Err(ExcType::type_error("expected int")),
-    }
+    value.as_int(vm)
 }
 
 /// Extracts an optional slice index from a `Value`, treating `None` as `default`.
@@ -1202,6 +1197,16 @@ fn optional_index(value: &Value, default: usize, str_len: usize, vm: &mut VM<'_>
         Value::Ref(heap_id) if let HeapData::LongInt(li) = vm.heap.get(*heap_id) => {
             let i = li.to_i64().ok_or_else(|| ExcType::type_error("integer too large"))?;
             Ok(normalize_sequence_index(i, str_len))
+        }
+        Value::Ref(heap_id) if matches!(vm.heap.get(*heap_id), HeapData::Instance(_)) => {
+            let Some(index) = instance_index(*heap_id, vm)? else {
+                return Err(ExcType::type_error_slice_indices());
+            };
+            // Recurses exactly once: `instance_index` validates an int result,
+            // so the arms above take it. Recursing rather than converting here
+            // keeps the too-large message identical for both routes.
+            defer_drop!(index, vm);
+            optional_index(index, default, str_len, vm)
         }
         _ => Err(ExcType::type_error_slice_indices()),
     }

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -25,7 +25,6 @@ use crate::{
     string_builder::StringBuilder,
     types::{
         LazyHeapSet, Type,
-        instance::instance_index,
         long_int::repeat_count,
         slice::{normalize_sequence_index, slice_collect_iterator},
     },
@@ -1198,17 +1197,18 @@ fn optional_index(value: &Value, default: usize, str_len: usize, vm: &mut VM<'_>
             let i = li.to_i64().ok_or_else(|| ExcType::type_error("integer too large"))?;
             Ok(normalize_sequence_index(i, str_len))
         }
-        Value::Ref(heap_id) if matches!(vm.heap.get(*heap_id), HeapData::Instance(_)) => {
-            let Some(index) = instance_index(*heap_id, vm)? else {
-                return Err(ExcType::type_error_slice_indices());
-            };
-            // Recurses exactly once: `instance_index` validates an int result,
-            // so the arms above take it. Recursing rather than converting here
-            // keeps the too-large message identical for both routes.
-            defer_drop!(index, vm);
-            optional_index(index, default, str_len, vm)
-        }
-        _ => Err(ExcType::type_error_slice_indices()),
+        _ => match value.try_index(vm)? {
+            // Recurses exactly once: `try_index` validates an int result, so the
+            // arms above take it. Recursing rather than narrowing here keeps a
+            // too-large result on the same path as a directly-passed `LongInt` —
+            // which raises `TypeError: integer too large` where CPython clamps,
+            // a pre-existing divergence this arm inherits rather than widens.
+            Some(index) => {
+                defer_drop!(index, vm);
+                optional_index(index, default, str_len, vm)
+            }
+            None => Err(ExcType::type_error_slice_indices()),
+        },
     }
 }
 

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -1782,6 +1782,18 @@ impl Value {
     /// automatically demotes i64-fitting values to `Value::Int`. However, this path could be
     /// reached via deserialization of crafted snapshot data.
     pub fn as_int(&self, vm: &mut VM<'_>) -> RunResult<i64> {
+        self.as_int_with_overflow(vm, ExcType::overflow_c_ssize_t)
+    }
+
+    /// [`Self::as_int`] with a caller-chosen overflow error.
+    ///
+    /// The width a value must fit is a property of the *consumer*, not of the
+    /// coercion: CPython's clinic `int` parameters (`str.expandtabs`'s
+    /// `tabsize`) report `... to C int` where an `ssize_t` parameter reports
+    /// `... to C ssize_t`, at every magnitude and through `__index__` alike.
+    /// Callers narrower than `i64` still range-check the result themselves —
+    /// this only makes the message theirs to choose.
+    pub(crate) fn as_int_with_overflow(&self, vm: &mut VM<'_>, on_overflow: fn() -> RunError) -> RunResult<i64> {
         match self {
             Self::Int(i) => Ok(*i),
             // `bool` is an `int` subclass in CPython, so it satisfies every
@@ -1789,13 +1801,13 @@ impl Value {
             // `try_index` below only dispatches for user instances.
             Self::Bool(b) => Ok(i64::from(*b)),
             Self::Ref(heap_id) if let HeapData::LongInt(li) = vm.heap.get(*heap_id) => {
-                li.to_i64().ok_or_else(ExcType::overflow_c_ssize_t)
+                li.to_i64().ok_or_else(on_overflow)
             }
             // Everything else is either `__index__`-able or a type error, and
             // `try_index` answers which without this arm inspecting the heap.
             _ => {
                 if let Some(index) = self.try_index(vm)? {
-                    Self::narrow_index_to_i64(index, vm, ExcType::overflow_c_ssize_t)
+                    Self::narrow_index_to_i64(index, vm, on_overflow)
                 } else {
                     let msg = format!("'{}' object cannot be interpreted as an integer", self.py_type_name(vm));
                     Err(SimpleException::new_msg(ExcType::TypeError, msg).into())

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -26,9 +26,7 @@ use crate::{
     types::{
         Bytes, BytesIterator, CmpOrder, LazyHeapSet, LongInt, Property, PyTrait, StringIterator, Type,
         bytes::{bytes_contains, bytes_repr_fmt, concat_bytes, get_byte_at_index, repeat_bytes},
-        instance::{
-            instance_dataclass_eq, instance_getattr, instance_index, instance_repr_fmt, instance_str, instance_user_eq,
-        },
+        instance::{instance_dataclass_eq, instance_getattr, instance_repr_fmt, instance_str, instance_user_eq},
         long_int::{
             bigint_cmp_f64, bigint_cmp_i64, bigint_eq_f64, bigint_eq_i64, check_bits_str_digits_limit, i64_cmp_f64,
             repeat_count, wide_i128_into_value,
@@ -602,6 +600,16 @@ impl<'h> PyTrait<'h> for Value {
             vm.heap.read(*id).py_cmp_op(other, op, vm)
         } else {
             Ok(None)
+        }
+    }
+
+    fn py_index_impl(&self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
+        match self {
+            // `bool` is an `int` subclass in CPython, so it satisfies the
+            // protocol directly rather than through a dunder.
+            Self::Int(_) | Self::Bool(_) | Self::InternLongInt(_) => Ok(Some(self.clone_with_heap(vm.heap))),
+            Self::Ref(id) => vm.heap.read(*id).py_index_impl(vm),
+            _ => Ok(None),
         }
     }
 
@@ -1795,18 +1803,14 @@ impl Value {
     /// this only makes the message theirs to choose.
     pub(crate) fn as_int_with_overflow(&self, vm: &mut VM<'_>, on_overflow: fn() -> RunError) -> RunResult<i64> {
         match self {
+            // Fast path for the common case; `py_index_impl` answers identically
+            // for a plain `int`, just via a clone the caller then drops.
             Self::Int(i) => Ok(*i),
-            // `bool` is an `int` subclass in CPython, so it satisfies every
-            // integer argument directly rather than via `__index__` — which
-            // `try_index` below only dispatches for user instances.
-            Self::Bool(b) => Ok(i64::from(*b)),
-            Self::Ref(heap_id) if let HeapData::LongInt(li) = vm.heap.get(*heap_id) => {
-                li.to_i64().ok_or_else(on_overflow)
-            }
-            // Everything else is either `__index__`-able or a type error, and
-            // `try_index` answers which without this arm inspecting the heap.
+            // Everything else is either `__index__`-able — `bool` and `LongInt`
+            // included, since both are ints — or a type error, and the protocol
+            // answers which without this arm inspecting the heap.
             _ => {
-                if let Some(index) = self.try_index(vm)? {
+                if let Some(index) = self.py_index_impl(vm)? {
                     Self::narrow_index_to_i64(index, vm, on_overflow)
                 } else {
                     let msg = format!("'{}' object cannot be interpreted as an integer", self.py_type_name(vm));
@@ -1832,15 +1836,13 @@ impl Value {
     pub fn as_index(&self, vm: &mut VM<'_>, container_type: Type) -> RunResult<i64> {
         match self {
             Self::Int(i) => Ok(*i),
-            Self::Bool(b) => Ok(i64::from(*b)),
-            Self::Ref(heap_id) if let HeapData::LongInt(li) = vm.heap.get(*heap_id) => {
-                li.to_i64().ok_or_else(ExcType::index_error_int_too_large)
-            }
             // Shaped like [`Self::as_int`]'s fallback, differing only in messages.
-            _ => match self.try_index(vm)? {
+            _ => match self.py_index_impl(vm)? {
                 Some(index) => {
                     // Resolved before narrowing because the closure cannot hold
-                    // `vm` while `narrow_index_to_i64` borrows it mutably.
+                    // `vm` while `narrow_index_to_i64` borrows it mutably. CPython
+                    // names the *original* object, so an over-large `__index__`
+                    // result reports the class, not the `int` it returned.
                     let name = self.py_type_name(vm).into_owned();
                     Self::narrow_index_to_i64(index, vm, move || ExcType::index_error_cannot_fit(&name))
                 }
@@ -1849,31 +1851,12 @@ impl Value {
         }
     }
 
-    /// Calls a user `__index__` when this is an instance whose class defines one.
-    ///
-    /// `Ok(None)` covers both "not an instance" and "no `__index__`", leaving the
-    /// caller to raise its own `TypeError` — the wording differs per consumer
-    /// (`list indices must be integers`, `cannot be interpreted as an integer`,
-    /// `slice indices must be…`), so it is not raised here.
-    ///
-    /// This is the single entry point to the protocol: consumers call it rather
-    /// than testing for `HeapData::Instance` themselves, so how a user class is
-    /// represented on the heap stays known only to this module and `instance.rs`.
-    /// The result is a validated int, so a caller may convert it — or recurse
-    /// once through its own int arms — without re-entering the dunder.
-    pub(crate) fn try_index(&self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
-        match self {
-            Self::Ref(id) if matches!(vm.heap.get(*id), HeapData::Instance(_)) => instance_index(*id, vm),
-            _ => Ok(None),
-        }
-    }
-
     /// Narrows an `__index__` result to `i64`, consuming it.
     ///
     /// Shared by [`Self::as_int`] and [`Self::as_index`], which disagree on the
     /// overflow message (`OverflowError` vs `IndexError`), hence `on_overflow`.
-    /// The value is already validated as an int by [`Self::try_index`], so the
-    /// non-int arms are unreachable.
+    /// The value is already validated as an int by [`PyTrait::py_index_impl`],
+    /// so the non-int arms are unreachable.
     fn narrow_index_to_i64(index: Self, vm: &mut VM<'_>, on_overflow: impl FnOnce() -> RunError) -> RunResult<i64> {
         let converted = match &index {
             Self::Int(i) => Ok(*i),
@@ -1881,9 +1864,9 @@ impl Value {
             Self::InternLongInt(id) => vm.interns.get_long_int(*id).to_i64().ok_or_else(on_overflow),
             Self::Ref(id) => match vm.heap.get(*id) {
                 HeapData::LongInt(li) => li.to_i64().ok_or_else(on_overflow),
-                _ => unreachable!("instance_index validated the result is an int"),
+                _ => unreachable!("py_index_impl validated the result is an int"),
             },
-            _ => unreachable!("instance_index validated the result is an int"),
+            _ => unreachable!("py_index_impl validated the result is an int"),
         };
         index.drop_with(vm);
         converted

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -1767,10 +1767,11 @@ impl Value {
 
     /// Extracts an integer value from the Value.
     ///
-    /// Accepts `Int` and `LongInt` (if it fits in i64), and falls back to a user
-    /// `__index__` — CPython's `PyNumber_Index`, which is what every "cannot be
-    /// interpreted as an integer" consumer uses. Returns a `TypeError` for other
-    /// types and an `OverflowError` if the value is too large.
+    /// Accepts `Int`, `Bool` (True=1, False=0) and `LongInt` (if it fits in
+    /// i64), and falls back to a user `__index__` — CPython's `PyNumber_Index`,
+    /// which is what every "cannot be interpreted as an integer" consumer uses.
+    /// Returns a `TypeError` for other types and an `OverflowError` if the value
+    /// is too large.
     ///
     /// Takes `&mut VM` because `__index__` re-enters the interpreter; it runs
     /// synchronously, so one calling an external/OS function raises rather than
@@ -1783,6 +1784,10 @@ impl Value {
     pub fn as_int(&self, vm: &mut VM<'_>) -> RunResult<i64> {
         match self {
             Self::Int(i) => Ok(*i),
+            // `bool` is an `int` subclass in CPython, so it satisfies every
+            // integer argument directly rather than via `__index__` — which
+            // `try_index` below only dispatches for user instances.
+            Self::Bool(b) => Ok(i64::from(*b)),
             Self::Ref(heap_id) if let HeapData::LongInt(li) = vm.heap.get(*heap_id) => {
                 li.to_i64().ok_or_else(ExcType::overflow_c_ssize_t)
             }

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -1881,6 +1881,26 @@ impl Value {
         }
     }
 
+    /// Saturating `i64` view of a `LongInt`-valued int (interned or
+    /// heap-allocated), for the consumers that clamp rather than raise on
+    /// overflow — slice bounds, where CPython clamps to the sequence so
+    /// `[1, 2, 3][10**30:]` is `[]` rather than an error.
+    ///
+    /// Returns `None` for every other value, `Int`/`Bool` included, so callers
+    /// keep their own fast paths for those. Do NOT use it for arguments that
+    /// must reject out-of-range ints — [`Self::as_int`] and [`Self::as_index`]
+    /// raise there instead.
+    pub(crate) fn long_int_to_i64_saturating(&self, vm: &VM<'_>) -> Option<i64> {
+        match self {
+            Self::InternLongInt(id) => Some(saturating_i64(vm.interns.get_long_int(*id))),
+            Self::Ref(id) => match vm.heap.get(*id) {
+                HeapData::LongInt(li) => Some(saturating_i64(li.inner())),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
     /// Performs Python `+` with reflected-operation fallback.
     pub(crate) fn py_add(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Self> {
         if let Some(result) = self.py_add_result(other, vm)? {
@@ -2421,6 +2441,18 @@ impl Marker {
         }
         Ok(())
     }
+}
+
+/// Clamps a `BigInt` to `i64`, pinning out-of-range values to the bound they
+/// overflowed past. Backs [`Value::long_int_to_i64_saturating`].
+fn saturating_i64(value: &BigInt) -> i64 {
+    value.to_i64().unwrap_or({
+        if value.sign() == Sign::Minus {
+            i64::MIN
+        } else {
+            i64::MAX
+        }
+    })
 }
 
 /// Extracts an immediate integer without promoting it to `BigInt`.

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -1783,25 +1783,18 @@ impl Value {
     pub fn as_int(&self, vm: &mut VM<'_>) -> RunResult<i64> {
         match self {
             Self::Int(i) => Ok(*i),
-            Self::Ref(heap_id) => {
-                // Both non-instance outcomes return from inside the `match`, so
-                // the entry's borrow ends before the `__index__` path below,
-                // which needs the heap mutably.
-                match vm.heap.get(*heap_id) {
-                    HeapData::LongInt(li) => return li.to_i64().ok_or_else(ExcType::overflow_c_ssize_t),
-                    HeapData::Instance(_) => {}
-                    _ => {
-                        let msg = format!("'{}' object cannot be interpreted as an integer", self.py_type_name(vm));
-                        return Err(SimpleException::new_msg(ExcType::TypeError, msg).into());
-                    }
-                }
-                let msg = format!("'{}' object cannot be interpreted as an integer", self.py_type_name(vm));
-                let on_missing = SimpleException::new_msg(ExcType::TypeError, msg).into();
-                Self::index_dunder_as_i64(*heap_id, vm, ExcType::overflow_c_ssize_t, on_missing)
+            Self::Ref(heap_id) if let HeapData::LongInt(li) = vm.heap.get(*heap_id) => {
+                li.to_i64().ok_or_else(ExcType::overflow_c_ssize_t)
             }
+            // Everything else is either `__index__`-able or a type error, and
+            // `try_index` answers which without this arm inspecting the heap.
             _ => {
-                let msg = format!("'{}' object cannot be interpreted as an integer", self.py_type_name(vm));
-                Err(SimpleException::new_msg(ExcType::TypeError, msg).into())
+                if let Some(index) = self.try_index(vm)? {
+                    Self::narrow_index_to_i64(index, vm, ExcType::overflow_c_ssize_t)
+                } else {
+                    let msg = format!("'{}' object cannot be interpreted as an integer", self.py_type_name(vm));
+                    Err(SimpleException::new_msg(ExcType::TypeError, msg).into())
+                }
             }
         }
     }
@@ -1823,38 +1816,43 @@ impl Value {
         match self {
             Self::Int(i) => Ok(*i),
             Self::Bool(b) => Ok(i64::from(*b)),
-            Self::Ref(heap_id) => {
-                // Shaped like [`Self::as_int`]'s arm, and for the same borrow reason.
-                match vm.heap.get(*heap_id) {
-                    HeapData::LongInt(li) => return li.to_i64().ok_or_else(ExcType::index_error_int_too_large),
-                    HeapData::Instance(_) => {}
-                    _ => return Err(ExcType::type_error_indices(container_type, &self.py_type_name(vm))),
-                }
-                let on_missing = ExcType::type_error_indices(container_type, &self.py_type_name(vm));
-                Self::index_dunder_as_i64(*heap_id, vm, ExcType::index_error_int_too_large, on_missing)
+            Self::Ref(heap_id) if let HeapData::LongInt(li) = vm.heap.get(*heap_id) => {
+                li.to_i64().ok_or_else(ExcType::index_error_int_too_large)
             }
-            _ => Err(ExcType::type_error_indices(container_type, &self.py_type_name(vm))),
+            // Shaped like [`Self::as_int`]'s fallback, differing only in messages.
+            _ => match self.try_index(vm)? {
+                Some(index) => Self::narrow_index_to_i64(index, vm, ExcType::index_error_int_too_large),
+                None => Err(ExcType::type_error_indices(container_type, &self.py_type_name(vm))),
+            },
         }
     }
 
-    /// Runs an instance's `__index__` and narrows the result to `i64`.
+    /// Calls a user `__index__` when this is an instance whose class defines one.
     ///
-    /// Shared by [`Self::as_int`] and [`Self::as_index`], which disagree on both
-    /// failure messages: `on_overflow` covers a result too wide for `i64`, and
-    /// `on_missing` the class not defining `__index__` at all. The result is
-    /// already validated as an int by `instance_index`, so this cannot recurse.
+    /// `Ok(None)` covers both "not an instance" and "no `__index__`", leaving the
+    /// caller to raise its own `TypeError` — the wording differs per consumer
+    /// (`list indices must be integers`, `cannot be interpreted as an integer`,
+    /// `slice indices must be…`), so it is not raised here.
     ///
-    /// `on_missing` is built eagerly rather than passed as a closure because
-    /// naming the type needs `vm`, which is handed over mutably here.
-    fn index_dunder_as_i64(
-        instance_id: HeapId,
-        vm: &mut VM<'_>,
-        on_overflow: impl FnOnce() -> RunError,
-        on_missing: RunError,
-    ) -> RunResult<i64> {
-        let Some(index) = instance_index(instance_id, vm)? else {
-            return Err(on_missing);
-        };
+    /// This is the single entry point to the protocol: consumers call it rather
+    /// than testing for `HeapData::Instance` themselves, so how a user class is
+    /// represented on the heap stays known only to this module and `instance.rs`.
+    /// The result is a validated int, so a caller may convert it — or recurse
+    /// once through its own int arms — without re-entering the dunder.
+    pub(crate) fn try_index(&self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
+        match self {
+            Self::Ref(id) if matches!(vm.heap.get(*id), HeapData::Instance(_)) => instance_index(*id, vm),
+            _ => Ok(None),
+        }
+    }
+
+    /// Narrows an `__index__` result to `i64`, consuming it.
+    ///
+    /// Shared by [`Self::as_int`] and [`Self::as_index`], which disagree on the
+    /// overflow message (`OverflowError` vs `IndexError`), hence `on_overflow`.
+    /// The value is already validated as an int by [`Self::try_index`], so the
+    /// non-int arms are unreachable.
+    fn narrow_index_to_i64(index: Self, vm: &mut VM<'_>, on_overflow: impl FnOnce() -> RunError) -> RunResult<i64> {
         let converted = match &index {
             Self::Int(i) => Ok(*i),
             Self::Bool(b) => Ok(i64::from(*b)),

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -1838,7 +1838,12 @@ impl Value {
             }
             // Shaped like [`Self::as_int`]'s fallback, differing only in messages.
             _ => match self.try_index(vm)? {
-                Some(index) => Self::narrow_index_to_i64(index, vm, ExcType::index_error_int_too_large),
+                Some(index) => {
+                    // Resolved before narrowing because the closure cannot hold
+                    // `vm` while `narrow_index_to_i64` borrows it mutably.
+                    let name = self.py_type_name(vm).into_owned();
+                    Self::narrow_index_to_i64(index, vm, move || ExcType::index_error_cannot_fit(&name))
+                }
                 None => Err(ExcType::type_error_indices(container_type, &self.py_type_name(vm))),
             },
         }

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -7,13 +7,13 @@ use std::{
 };
 
 use num_bigint::{BigInt, Sign};
-use num_traits::FromPrimitive;
+use num_traits::{FromPrimitive, ToPrimitive};
 
 use crate::{
     builtins::{Builtins, BuiltinsFunctions},
     bytecode::{CallResult, VM},
     defer_drop,
-    exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
+    exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     expressions::CmpOperator,
     fstring::FormatFloat,
     hash::{HashValue, hash_one, hash_python_long_int},
@@ -26,7 +26,9 @@ use crate::{
     types::{
         Bytes, BytesIterator, CmpOrder, LazyHeapSet, LongInt, Property, PyTrait, StringIterator, Type,
         bytes::{bytes_contains, bytes_repr_fmt, concat_bytes, get_byte_at_index, repeat_bytes},
-        instance::{instance_dataclass_eq, instance_getattr, instance_repr_fmt, instance_str, instance_user_eq},
+        instance::{
+            instance_dataclass_eq, instance_getattr, instance_index, instance_repr_fmt, instance_str, instance_user_eq,
+        },
         long_int::{
             bigint_cmp_f64, bigint_cmp_i64, bigint_eq_f64, bigint_eq_i64, check_bits_str_digits_limit, i64_cmp_f64,
             repeat_count, wide_i128_into_value,
@@ -1264,12 +1266,10 @@ impl<'h> PyTrait<'h> for Value {
                     return Ok(allocate_string(result_str, vm.heap));
                 }
 
-                // Handle interned string indexing, accepting Int and Bool
-                let index = match key {
-                    Self::Int(i) => *i,
-                    Self::Bool(b) => i64::from(*b),
-                    _ => return Err(ExcType::type_error_indices(Type::Str, &key.py_type_name(vm))),
-                };
+                // Shared with the heap-`str` path rather than re-matching here,
+                // so an interned literal accepts the same keys — `LongInt` and a
+                // user `__index__` included.
+                let index = key.as_index(vm, Type::Str)?;
 
                 let s = interns.get_str(*string_id);
                 let c = get_char_at_index(s, index).ok_or_else(ExcType::str_index_error)?;
@@ -1286,12 +1286,8 @@ impl<'h> PyTrait<'h> for Value {
                     return Ok(Self::Ref(heap_id));
                 }
 
-                // Handle interned bytes indexing - returns integer byte value
-                let index = match key {
-                    Self::Int(i) => *i,
-                    Self::Bool(b) => i64::from(*b),
-                    _ => return Err(ExcType::type_error_indices(Type::Bytes, &key.py_type_name(vm))),
-                };
+                // Shared with the heap-`bytes` path, as for `InternString` above.
+                let index = key.as_index(vm, Type::Bytes)?;
 
                 let bytes = interns.get_bytes(*bytes_id);
                 let byte = get_byte_at_index(bytes, index).ok_or_else(ExcType::bytes_index_error)?;
@@ -1771,23 +1767,37 @@ impl Value {
 
     /// Extracts an integer value from the Value.
     ///
-    /// Accepts `Int` and `LongInt` (if it fits in i64). Returns a `TypeError` for other types
-    /// and an `OverflowError` if the `LongInt` value is too large.
+    /// Accepts `Int` and `LongInt` (if it fits in i64), and falls back to a user
+    /// `__index__` — CPython's `PyNumber_Index`, which is what every "cannot be
+    /// interpreted as an integer" consumer uses. Returns a `TypeError` for other
+    /// types and an `OverflowError` if the value is too large.
+    ///
+    /// Takes `&mut VM` because `__index__` re-enters the interpreter; it runs
+    /// synchronously, so one calling an external/OS function raises rather than
+    /// suspending (see `limitations/classes.md`).
     ///
     /// Note: The LongInt-to-i64 conversion path is defensive code. In normal execution,
     /// heap-allocated `LongInt` values always exceed i64 range because `LongInt::into_value()`
     /// automatically demotes i64-fitting values to `Value::Int`. However, this path could be
     /// reached via deserialization of crafted snapshot data.
-    pub fn as_int(&self, vm: &VM<'_>) -> RunResult<i64> {
+    pub fn as_int(&self, vm: &mut VM<'_>) -> RunResult<i64> {
         match self {
             Self::Int(i) => Ok(*i),
             Self::Ref(heap_id) => {
-                if let HeapData::LongInt(li) = vm.heap.get(*heap_id) {
-                    li.to_i64().ok_or_else(ExcType::overflow_c_ssize_t)
-                } else {
-                    let msg = format!("'{}' object cannot be interpreted as an integer", self.py_type_name(vm));
-                    Err(SimpleException::new_msg(ExcType::TypeError, msg).into())
+                // Both non-instance outcomes return from inside the `match`, so
+                // the entry's borrow ends before the `__index__` path below,
+                // which needs the heap mutably.
+                match vm.heap.get(*heap_id) {
+                    HeapData::LongInt(li) => return li.to_i64().ok_or_else(ExcType::overflow_c_ssize_t),
+                    HeapData::Instance(_) => {}
+                    _ => {
+                        let msg = format!("'{}' object cannot be interpreted as an integer", self.py_type_name(vm));
+                        return Err(SimpleException::new_msg(ExcType::TypeError, msg).into());
+                    }
                 }
+                let msg = format!("'{}' object cannot be interpreted as an integer", self.py_type_name(vm));
+                let on_missing = SimpleException::new_msg(ExcType::TypeError, msg).into();
+                Self::index_dunder_as_i64(*heap_id, vm, ExcType::overflow_c_ssize_t, on_missing)
             }
             _ => {
                 let msg = format!("'{}' object cannot be interpreted as an integer", self.py_type_name(vm));
@@ -1798,27 +1808,65 @@ impl Value {
 
     /// Extracts an index value for sequence operations.
     ///
-    /// Accepts `Int`, `Bool` (True=1, False=0), and `LongInt` (if it fits in i64).
-    /// Returns a `TypeError` for other types with the container type name included.
-    /// Returns an `IndexError` if the `LongInt` value is too large to use as an index.
+    /// Accepts `Int`, `Bool` (True=1, False=0), and `LongInt` (if it fits in
+    /// i64), and falls back to a user `__index__` as CPython's subscript path
+    /// does. Returns a `TypeError` for other types with the container type name
+    /// included, and an `IndexError` if the value is too large to use as an index.
+    ///
+    /// Takes `&mut VM` for the same reason as [`Self::as_int`].
     ///
     /// Note: The LongInt-to-i64 conversion path is defensive code. In normal execution,
     /// heap-allocated `LongInt` values always exceed i64 range because `LongInt::into_value()`
     /// automatically demotes i64-fitting values to `Value::Int`. However, this path could be
     /// reached via deserialization of crafted snapshot data.
-    pub fn as_index(&self, vm: &VM<'_>, container_type: Type) -> RunResult<i64> {
+    pub fn as_index(&self, vm: &mut VM<'_>, container_type: Type) -> RunResult<i64> {
         match self {
             Self::Int(i) => Ok(*i),
             Self::Bool(b) => Ok(i64::from(*b)),
             Self::Ref(heap_id) => {
-                if let HeapData::LongInt(li) = vm.heap.get(*heap_id) {
-                    li.to_i64().ok_or_else(ExcType::index_error_int_too_large)
-                } else {
-                    Err(ExcType::type_error_indices(container_type, &self.py_type_name(vm)))
+                // Shaped like [`Self::as_int`]'s arm, and for the same borrow reason.
+                match vm.heap.get(*heap_id) {
+                    HeapData::LongInt(li) => return li.to_i64().ok_or_else(ExcType::index_error_int_too_large),
+                    HeapData::Instance(_) => {}
+                    _ => return Err(ExcType::type_error_indices(container_type, &self.py_type_name(vm))),
                 }
+                let on_missing = ExcType::type_error_indices(container_type, &self.py_type_name(vm));
+                Self::index_dunder_as_i64(*heap_id, vm, ExcType::index_error_int_too_large, on_missing)
             }
             _ => Err(ExcType::type_error_indices(container_type, &self.py_type_name(vm))),
         }
+    }
+
+    /// Runs an instance's `__index__` and narrows the result to `i64`.
+    ///
+    /// Shared by [`Self::as_int`] and [`Self::as_index`], which disagree on both
+    /// failure messages: `on_overflow` covers a result too wide for `i64`, and
+    /// `on_missing` the class not defining `__index__` at all. The result is
+    /// already validated as an int by `instance_index`, so this cannot recurse.
+    ///
+    /// `on_missing` is built eagerly rather than passed as a closure because
+    /// naming the type needs `vm`, which is handed over mutably here.
+    fn index_dunder_as_i64(
+        instance_id: HeapId,
+        vm: &mut VM<'_>,
+        on_overflow: impl FnOnce() -> RunError,
+        on_missing: RunError,
+    ) -> RunResult<i64> {
+        let Some(index) = instance_index(instance_id, vm)? else {
+            return Err(on_missing);
+        };
+        let converted = match &index {
+            Self::Int(i) => Ok(*i),
+            Self::Bool(b) => Ok(i64::from(*b)),
+            Self::InternLongInt(id) => vm.interns.get_long_int(*id).to_i64().ok_or_else(on_overflow),
+            Self::Ref(id) => match vm.heap.get(*id) {
+                HeapData::LongInt(li) => li.to_i64().ok_or_else(on_overflow),
+                _ => unreachable!("instance_index validated the result is an int"),
+            },
+            _ => unreachable!("instance_index validated the result is an int"),
+        };
+        index.drop_with(vm);
+        converted
     }
 
     /// True when this is a `LongInt`-valued int (interned or heap-allocated)
@@ -2499,14 +2547,14 @@ mod tests {
 
         let mut interns = create_test_interns();
         let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
-            let vm = VM::new(
+            let mut vm = VM::new(
                 Vec::new(),
                 reader,
                 interns,
                 PrintWriter::Disabled,
                 AssertMessageAnnotations::DEFAULT_MAX_BYTES.get(),
             );
-            value.as_index(&vm, Type::List)
+            value.as_index(&mut vm, Type::List)
         });
         assert_eq!(result.unwrap(), 42);
         value.drop_with(&mut heap);
@@ -2520,14 +2568,14 @@ mod tests {
 
         let mut interns = create_test_interns();
         let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
-            let vm = VM::new(
+            let mut vm = VM::new(
                 Vec::new(),
                 reader,
                 interns,
                 PrintWriter::Disabled,
                 AssertMessageAnnotations::DEFAULT_MAX_BYTES.get(),
             );
-            value.as_index(&vm, Type::List)
+            value.as_index(&mut vm, Type::List)
         });
         assert_eq!(result.unwrap(), -100);
         value.drop_with(&mut heap);
@@ -2543,14 +2591,14 @@ mod tests {
 
         let mut interns = create_test_interns();
         let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
-            let vm = VM::new(
+            let mut vm = VM::new(
                 Vec::new(),
                 reader,
                 interns,
                 PrintWriter::Disabled,
                 AssertMessageAnnotations::DEFAULT_MAX_BYTES.get(),
             );
-            value.as_index(&vm, Type::List)
+            value.as_index(&mut vm, Type::List)
         });
         assert!(result.is_err());
         value.drop_with(&mut heap);
@@ -2566,14 +2614,14 @@ mod tests {
 
         let mut interns = create_test_interns();
         let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
-            let vm = VM::new(
+            let mut vm = VM::new(
                 Vec::new(),
                 reader,
                 interns,
                 PrintWriter::Disabled,
                 AssertMessageAnnotations::DEFAULT_MAX_BYTES.get(),
             );
-            value.as_int(&vm)
+            value.as_int(&mut vm)
         });
         assert_eq!(result.unwrap(), 12345);
         value.drop_with(&mut heap);
@@ -2588,14 +2636,14 @@ mod tests {
 
         let mut interns = create_test_interns();
         let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
-            let vm = VM::new(
+            let mut vm = VM::new(
                 Vec::new(),
                 reader,
                 interns,
                 PrintWriter::Disabled,
                 AssertMessageAnnotations::DEFAULT_MAX_BYTES.get(),
             );
-            value.as_int(&vm)
+            value.as_int(&mut vm)
         });
         assert!(result.is_err());
         value.drop_with(&mut heap);
@@ -2609,14 +2657,14 @@ mod tests {
 
         let mut interns = create_test_interns();
         let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
-            let vm = VM::new(
+            let mut vm = VM::new(
                 Vec::new(),
                 reader,
                 interns,
                 PrintWriter::Disabled,
                 AssertMessageAnnotations::DEFAULT_MAX_BYTES.get(),
             );
-            value.as_index(&vm, Type::List)
+            value.as_index(&mut vm, Type::List)
         });
         assert_eq!(result.unwrap(), i64::MAX);
         value.drop_with(&mut heap);
@@ -2630,14 +2678,14 @@ mod tests {
 
         let mut interns = create_test_interns();
         let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
-            let vm = VM::new(
+            let mut vm = VM::new(
                 Vec::new(),
                 reader,
                 interns,
                 PrintWriter::Disabled,
                 AssertMessageAnnotations::DEFAULT_MAX_BYTES.get(),
             );
-            value.as_index(&vm, Type::List)
+            value.as_index(&mut vm, Type::List)
         });
         assert_eq!(result.unwrap(), i64::MIN);
         value.drop_with(&mut heap);
@@ -2652,14 +2700,14 @@ mod tests {
 
         let mut interns = create_test_interns();
         let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
-            let vm = VM::new(
+            let mut vm = VM::new(
                 Vec::new(),
                 reader,
                 interns,
                 PrintWriter::Disabled,
                 AssertMessageAnnotations::DEFAULT_MAX_BYTES.get(),
             );
-            value.as_index(&vm, Type::List)
+            value.as_index(&mut vm, Type::List)
         });
         assert!(result.is_err());
         value.drop_with(&mut heap);
@@ -2674,14 +2722,14 @@ mod tests {
 
         let mut interns = create_test_interns();
         let result = HeapReader::with(&mut heap, &mut interns, |reader, interns| {
-            let vm = VM::new(
+            let mut vm = VM::new(
                 Vec::new(),
                 reader,
                 interns,
                 PrintWriter::Disabled,
                 AssertMessageAnnotations::DEFAULT_MAX_BYTES.get(),
             );
-            value.as_index(&vm, Type::List)
+            value.as_index(&mut vm, Type::List)
         });
         assert!(result.is_err());
         value.drop_with(&mut heap);

--- a/crates/monty/test_cases/bool__ops.py
+++ b/crates/monty/test_cases/bool__ops.py
@@ -1,3 +1,5 @@
+import itertools
+
 # === Boolean 'and' operator ===
 # returns first falsy value, or last value if all truthy
 assert (5 and 3) == 3
@@ -34,3 +36,24 @@ assert type(True ^ False) == bool
 assert type(True & 1) == int
 assert type(1 | False) == int
 assert type(True ^ 1) == int
+
+# === bool is accepted wherever an integer argument is ===
+# `bool` is an `int` subclass in CPython, so every "cannot be interpreted as an
+# integer" consumer takes it directly.
+assert list(range(True)) == [0]
+assert list(range(False, True)) == [0]
+assert list(range(False, True, True)) == [0]
+assert 'x'.center(True) == 'x'
+assert 'x'.ljust(True) == 'x'
+assert 'x'.rjust(True) == 'x'
+assert 'abcabc'.find('b', True) == 1
+assert b'abcabc'.find(b'b', True) == 1
+assert 'a\tb'.expandtabs(True) == 'a b'
+assert list(itertools.repeat('x', True)) == ['x']
+assert round(1.234, True) == 1.2
+
+# The same holds for indexing and slicing, which take a separate path.
+assert [10, 20, 30][True] == 20
+assert [10, 20, 30][False] == 10
+assert [1, 2, 3, 4][True:] == [2, 3, 4]
+assert [1, 2, 3, 4][:True] == [1]

--- a/crates/monty/test_cases/class__index_dunder.py
+++ b/crates/monty/test_cases/class__index_dunder.py
@@ -144,3 +144,76 @@ try:
     assert False, 'expected an out-of-range index to raise'
 except IndexError as exc:
     assert str(exc) == 'list index out of range'
+
+# === a mutating __index__ resolves against the post-call list ===
+# `__index__` can run arbitrary code, so it may resize the very list being
+# indexed. Every length must be read *after* the dunder returns; reading it
+# first resolves a negative bound against a stale length.
+shrink_target = [9, 9, 9, 9, 9, 9, 9, 9, 7, 7]
+
+
+class ShrinkStart:
+    def __index__(self):
+        while len(shrink_target) > 3:
+            shrink_target.pop()
+        return -2
+
+
+# -2 normalizes against the post-call length 3, so the search starts at 1.
+assert shrink_target.index(9, ShrinkStart()) == 1
+assert shrink_target == [9, 9, 9]
+
+grow_target = [5, 6, 7, 8, 9, 10, 11, 12]
+
+
+class GrowStart:
+    def __index__(self):
+        grow_target.extend([99, 99, 99, 99, 99, 99, 99, 99])
+        return -3
+
+
+assert grow_target.index(99, GrowStart()) == 13
+
+end_target = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+
+class ShrinkEnd:
+    def __index__(self):
+        while len(end_target) > 4:
+            end_target.pop()
+        return -1
+
+
+# The window becomes [0, 3), so the 4 left at index 3 is out of range.
+try:
+    end_target.index(4, 0, ShrinkEnd())
+    assert False, 'expected the stale end bound to exclude the match'
+except ValueError as exc:
+    assert str(exc) == 'list.index(x): x not in list'
+
+# Subscripting reads the length after the dunder too.
+sub_target = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+
+class ShrinkSubscript:
+    def __index__(self):
+        sub_target.clear()
+        return 9
+
+
+try:
+    sub_target[ShrinkSubscript()]
+    assert False, 'expected the emptied list to raise IndexError'
+except IndexError as exc:
+    assert str(exc) == 'list index out of range'
+
+grow_sub = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+
+class GrowSubscript:
+    def __index__(self):
+        grow_sub.extend(range(100))
+        return 50
+
+
+assert grow_sub[GrowSubscript()] == 40

--- a/crates/monty/test_cases/class__index_dunder.py
+++ b/crates/monty/test_cases/class__index_dunder.py
@@ -1,0 +1,121 @@
+# `__index__` dispatch: a user class usable anywhere CPython accepts an index.
+import itertools
+
+
+class Idx:
+    def __index__(self):
+        return 2
+
+
+class Zero:
+    def __index__(self):
+        return 0
+
+
+class Negative:
+    def __index__(self):
+        return -1
+
+
+i = Idx()
+
+# === subscripting ===
+assert [10, 20, 30][i] == 30
+assert (7, 8, 9)[i] == 9
+assert 'abcdef'[i] == 'c'
+assert b'abcdef'[i] == 99
+assert range(10)[i] == 2
+assert [10, 20, 30][Negative()] == 30
+
+# Heap-allocated str/bytes take the same path as the interned literals above.
+built = 'abc' + 'def'
+assert built[i] == 'c'
+built_bytes = b'abc' + b'def'
+assert built_bytes[i] == 99
+
+# === slicing ===
+assert 'abcdef'[i:] == 'cdef'
+assert 'abcdef'[:i] == 'ab'
+assert 'abcdef'[::i] == 'ace'
+assert [1, 2, 3, 4][i:] == [3, 4]
+assert [1, 2, 3, 4][Zero() : i] == [1, 2]
+assert b'abcdef'[i:] == b'cdef'
+
+# === integer arguments ===
+# NB sequence repetition (`'ab' * Idx()`) is NOT covered — each `py_mul_impl`
+# owns its own coercion; see limitations/classes.md.
+assert list(range(i)) == [0, 1]
+assert list(range(Zero(), i)) == [0, 1]
+assert list(itertools.repeat('x', i)) == ['x', 'x']
+assert 'abcabc'.find('b', i) == 4
+assert b'abcabc'.find(b'b', i) == 4
+assert 'x'.center(Idx()) == 'x '
+
+# === a non-int return is rejected ===
+
+
+class BadReturn:
+    def __index__(self):
+        return 'nope'
+
+
+try:
+    [1, 2, 3][BadReturn()]
+    assert False, 'expected __index__ returning str to raise'
+except TypeError as exc:
+    assert str(exc) == '__index__ returned non-int (type str)'
+
+try:
+    'abc'[BadReturn() :]
+    assert False, 'expected __index__ returning str to raise in a slice'
+except TypeError as exc:
+    assert str(exc) == '__index__ returned non-int (type str)'
+
+# === a class without __index__ is still rejected ===
+
+
+class NoIndex:
+    pass
+
+
+try:
+    'abc'[NoIndex() :]
+    assert False, 'expected a class without __index__ to raise'
+except TypeError as exc:
+    assert str(exc) == 'slice indices must be integers or None or have an __index__ method'
+
+try:
+    range(NoIndex())
+    assert False, 'expected a class without __index__ to raise'
+except TypeError as exc:
+    assert str(exc) == "'NoIndex' object cannot be interpreted as an integer"
+
+# === a raising __index__ propagates ===
+
+
+class Boom:
+    def __index__(self):
+        raise ValueError('boom')
+
+
+try:
+    [1, 2, 3][Boom()]
+    assert False, 'expected a raising __index__ to propagate'
+except ValueError as exc:
+    assert str(exc) == 'boom'
+
+# === __index__ is looked up on the class, not the instance ===
+inst = NoIndex()
+inst.__index__ = lambda: 1
+try:
+    [1, 2, 3][inst]
+    assert False, 'expected an instance-dict __index__ to be ignored'
+except TypeError as exc:
+    assert str(exc) != ''
+
+# === out of range is an IndexError, not a coercion failure ===
+try:
+    [1, 2, 3][Idx().__index__() + 10]
+    assert False, 'expected an out-of-range index to raise'
+except IndexError as exc:
+    assert str(exc) == 'list index out of range'

--- a/crates/monty/test_cases/class__index_dunder.py
+++ b/crates/monty/test_cases/class__index_dunder.py
@@ -145,6 +145,51 @@ try:
 except IndexError as exc:
     assert str(exc) == 'list index out of range'
 
+# === an oversized __index__ return is a catchable IndexError ===
+# The dunder runs a nested interpreter loop, so the coercion's own error is
+# raised after that loop returns. It must still reach the enclosing handler,
+# including at module scope, and name the object asked for the index rather
+# than the `int` it returned.
+
+
+class WideIdx:
+    def __index__(self):
+        return 10**30
+
+
+wide_idx = WideIdx()
+try:
+    [1, 2, 3][wide_idx]
+    assert False, 'expected an oversized __index__ to raise'
+except IndexError as exc:
+    assert str(exc) == "cannot fit 'WideIdx' into an index-sized integer"
+
+# A plain int keeps CPython's `int` wording.
+try:
+    [1, 2, 3][10**30]
+    assert False, 'expected an oversized literal index to raise'
+except IndexError as exc:
+    assert str(exc) == "cannot fit 'int' into an index-sized integer"
+
+
+# The same coercion inside a function frame, which took a different path.
+def _wide_in_function():
+    try:
+        [1, 2, 3][WideIdx()]
+        return 'no raise'
+    except IndexError as exc:
+        return str(exc)
+
+
+assert _wide_in_function() == "cannot fit 'WideIdx' into an index-sized integer"
+
+# An integer argument coerced by a builtin call raises catchably too.
+try:
+    'x'.center(WideIdx())
+    assert False, 'expected an oversized width to raise'
+except OverflowError as exc:
+    assert str(exc) == 'Python int too large to convert to C ssize_t'
+
 # === a mutating __index__ resolves against the post-call list ===
 # `__index__` can run arbitrary code, so it may resize the very list being
 # indexed. Every length must be read *after* the dunder returns; reading it

--- a/crates/monty/test_cases/class__index_dunder.py
+++ b/crates/monty/test_cases/class__index_dunder.py
@@ -74,7 +74,28 @@ assert list(range(Zero(), i)) == [0, 1]
 assert list(itertools.repeat('x', i)) == ['x', 'x']
 assert 'abcabc'.find('b', i) == 4
 assert b'abcabc'.find(b'b', i) == 4
+assert b'a,b,c'.split(b',', i) == [b'a', b'b', b'c']
 assert 'x'.center(Idx()) == 'x '
+
+
+# The bytes methods convert their integer arguments before checking that the
+# first one is bytes-like, so a raising bound wins over the `str` TypeError.
+class BoundBoom:
+    def __index__(self):
+        raise RuntimeError('bound')
+
+
+try:
+    b'abc'.find('a', BoundBoom())
+    assert False, 'expected the bound to convert before the sub check'
+except RuntimeError as exc:
+    assert str(exc) == 'bound'
+
+try:
+    b'abc'.split('a', BoundBoom())
+    assert False, 'expected maxsplit to convert before the sep check'
+except RuntimeError as exc:
+    assert str(exc) == 'bound'
 
 # === a non-int return is rejected ===
 

--- a/crates/monty/test_cases/class__index_dunder.py
+++ b/crates/monty/test_cases/class__index_dunder.py
@@ -17,6 +17,16 @@ class Negative:
         return -1
 
 
+class BigIdx:
+    def __index__(self):
+        return 10**30
+
+
+class NegBigIdx:
+    def __index__(self):
+        return -(10**30)
+
+
 i = Idx()
 
 # === subscripting ===
@@ -40,6 +50,21 @@ assert 'abcdef'[::i] == 'ace'
 assert [1, 2, 3, 4][i:] == [3, 4]
 assert [1, 2, 3, 4][Zero() : i] == [1, 2]
 assert b'abcdef'[i:] == b'cdef'
+
+# === slice bounds beyond i64 clamp, they do not raise ===
+# Both a bare int literal and an `__index__` returning one land in the same
+# conversion; unlike plain indexing, slicing clamps instead of raising.
+assert [1, 2, 3][10**30 :] == []
+assert [1, 2, 3][: 10**30] == [1, 2, 3]
+assert [1, 2, 3][-(10**30) :] == [1, 2, 3]
+assert [1, 2, 3][BigIdx() :] == []
+assert [1, 2, 3][: BigIdx()] == [1, 2, 3]
+assert [1, 2, 3][NegBigIdx() :] == [1, 2, 3]
+assert [1, 2, 3][slice(BigIdx(), None)] == []
+assert 'abc'[BigIdx() :] == ''
+assert 'abc'[: BigIdx()] == 'abc'
+assert [1, 2, 3][:: 10**30] == [1]
+assert [1, 2, 3][:: -(10**30)] == [3]
 
 # === integer arguments ===
 # NB sequence repetition (`'ab' * Idx()`) is NOT covered — each `py_mul_impl`

--- a/crates/monty/test_cases/refcount__index_dunder.py
+++ b/crates/monty/test_cases/refcount__index_dunder.py
@@ -1,0 +1,38 @@
+# Refcount coverage for the `__index__` dispatch path.
+#
+# The dunder's return value is owned by the coercion, which must release it once
+# narrowed to an `i64`. Returning a `LongInt` (wider than a machine int, so it is
+# heap-allocated rather than inline) makes a missed release observable: nothing
+# else names the returned object.
+
+
+class WideIndex:
+    def __index__(self):
+        return 10**30 // 10**30 + 1
+
+
+class Boom:
+    def __index__(self):
+        raise ValueError('boom')
+
+
+wide = WideIndex()
+
+# Each of these allocates a fresh return value and must release it.
+assert [10, 20, 30][wide] == 30
+assert 'abcdef'[wide] == 'c'
+assert 'abcdef'[wide:] == 'cdef'
+assert list(range(wide)) == [0, 1]
+assert 'x'.center(wide) == 'x '
+
+# The raising path leaves the coercion through an early return, where a missed
+# release is easiest to introduce. The temporary receiver must be released too,
+# so a leak leaves an object nothing names.
+erroring = Boom()
+try:
+    [1, 2, 3][Boom()]
+except ValueError:
+    pass
+
+len('done')
+# ref-counts={'wide': 1, 'WideIndex': 2, 'Boom': 2, 'erroring': 1}

--- a/crates/monty/test_cases/refcount__index_dunder.py
+++ b/crates/monty/test_cases/refcount__index_dunder.py
@@ -1,14 +1,28 @@
 # Refcount coverage for the `__index__` dispatch path.
 #
 # The dunder's return value is owned by the coercion, which must release it once
-# narrowed to an `i64`. Returning a `LongInt` (wider than a machine int, so it is
-# heap-allocated rather than inline) makes a missed release observable: nothing
-# else names the returned object.
+# narrowed to an `i64`. Nothing else names that value, so a missed release shows
+# up as an unreachable heap object rather than as a wrong count.
+
+
+class NarrowIndex:
+    # The wide intermediates are released inside the dunder; the returned `2`
+    # fits a machine int, so it is inline and its release is a no-op.
+    def __index__(self):
+        return 10**30 // 10**30 + 1
+
+
+half = 10**15
 
 
 class WideIndex:
+    # Beyond `i64`, so the value cannot be inline (`into_value` only demotes what
+    # fits). Multiplied at runtime rather than written as a literal, which the
+    # compiler would fold and intern — an interned `LongInt` is not refcounted,
+    # so a missed release would leave nothing to observe. The coercion is handed
+    # this heap `LongInt` and must release it on the overflow path.
     def __index__(self):
-        return 10**30 // 10**30 + 1
+        return half * half
 
 
 class Boom:
@@ -16,14 +30,27 @@ class Boom:
         raise ValueError('boom')
 
 
-wide = WideIndex()
+narrow = NarrowIndex()
 
 # Each of these allocates a fresh return value and must release it.
-assert [10, 20, 30][wide] == 30
-assert 'abcdef'[wide] == 'c'
-assert 'abcdef'[wide:] == 'cdef'
-assert list(range(wide)) == [0, 1]
-assert 'x'.center(wide) == 'x '
+assert [10, 20, 30][narrow] == 30
+assert 'abcdef'[narrow] == 'c'
+assert 'abcdef'[narrow:] == 'cdef'
+assert list(range(narrow)) == [0, 1]
+assert 'x'.center(narrow) == 'x '
+
+# Indexing rejects the oversized return, so the release happens on the way out
+# through the error.
+wide = WideIndex()
+try:
+    [1, 2, 3][wide]
+    assert False, 'expected an out-of-range index to raise'
+except IndexError:
+    pass
+
+# A slice bound takes the same coercion but saturates instead of raising, so the
+# release happens on the success path too.
+assert [1, 2, 3][wide:] == []
 
 # The raising path leaves the coercion through an early return, where a missed
 # release is easiest to introduce. The temporary receiver must be released too,
@@ -35,4 +62,4 @@ except ValueError:
     pass
 
 len('done')
-# ref-counts={'wide': 1, 'WideIndex': 2, 'Boom': 2, 'erroring': 1}
+# ref-counts={'narrow': 1, 'NarrowIndex': 2, 'WideIndex': 2, 'wide': 1, 'Boom': 2, 'erroring': 1}

--- a/crates/monty/test_cases/refcount__str_arg_error_paths.py
+++ b/crates/monty/test_cases/refcount__str_arg_error_paths.py
@@ -1,0 +1,31 @@
+# Refcount coverage for `str` integer-argument error paths.
+#
+# `str.expandtabs` owns its `tabsize` argument and must release it even when the
+# C `int` range check rejects it -- that early return is where a missed release
+# is easiest to introduce. A `LongInt` argument is heap-allocated (wider than a
+# machine int), so a leak is observable rather than hidden in an inline value.
+
+
+class BigIndex:
+    def __index__(self):
+        return 10**30
+
+
+big = 10**30
+
+try:
+    '\thello'.expandtabs(big)
+    assert False, 'expected an out-of-range tabsize to overflow'
+except OverflowError:
+    pass
+
+# The same rejection reached through `__index__`, where the instance and the
+# value its dunder returns are both temporaries that must be released.
+try:
+    '\thello'.expandtabs(BigIndex())
+    assert False, 'expected an out-of-range __index__ tabsize to overflow'
+except OverflowError:
+    pass
+
+len('done')
+# ref-counts={'big': 1, 'BigIndex': 1}

--- a/crates/monty/test_cases/str__methods.py
+++ b/crates/monty/test_cases/str__methods.py
@@ -532,6 +532,28 @@ assert 'a\tb\tc'.expandtabs(0) == 'abc'
 
 # expandtabs() with negative tabsize (treated as 0)
 assert '\thello'.expandtabs(-1) == 'hello'
+assert '\thello'.expandtabs(-(2**31)) == 'hello'
+
+# expandtabs() takes a C int, so a tabsize outside i32 overflows rather than
+# being accepted -- at every magnitude, and through __index__ too.
+for bad_tabsize in (2**31, 2**63, 10**30, -(2**31) - 1):
+    try:
+        '\thello'.expandtabs(bad_tabsize)
+        assert False, 'expected an out-of-range tabsize to overflow'
+    except OverflowError as e:
+        assert str(e) == 'Python int too large to convert to C int'
+
+
+class BigTabsize:
+    def __index__(self):
+        return 2**31
+
+
+try:
+    '\thello'.expandtabs(BigTabsize())
+    assert False, 'expected an out-of-range __index__ tabsize to overflow'
+except OverflowError as e:
+    assert str(e) == 'Python int too large to convert to C int'
 
 # expandtabs() with newlines resetting column
 assert 'a\tb\nc\td'.expandtabs(4) == 'a   b\nc   d'

--- a/limitations/classes.md
+++ b/limitations/classes.md
@@ -96,10 +96,11 @@ order and error wording, but with these divergences:
   runs to completion synchronously, so it cannot yield to the host, and an
   external-function `__init__` raises `NotImplementedError` rather than
   suspending.
-- **`__eq__`/`__hash__` cannot suspend**: like `__repr__`/`__str__` they run to
-  completion synchronously, so one that calls an external/OS function raises
-  rather than yielding to the host. An exception raised by `__eq__` terminates
-  the run instead of being catchable by a `try` around the comparison.
+- **`__eq__`/`__hash__`/`__index__` cannot suspend**: like `__repr__`/`__str__`
+  they run to completion synchronously, so one that calls an external/OS
+  function raises rather than yielding to the host. An exception raised by
+  `__eq__` terminates the run instead of being catchable by a `try` around the
+  comparison.
 - **Ordering dunders are still not dispatched**; see the entry above.
   Instances are always truthy (no `__bool__`/`__len__` dispatch).
 - **Bound methods compare and hash by identity**: each `obj.method` access
@@ -192,10 +193,25 @@ first, e.g. return a `dict` of the fields.
   identifies which one raised.
 - Dunder protocols other than `__init__`, `__repr__`, `__str__`,
   `__enter__`, `__exit__`, `__iter__`, `__next__`, `__contains__`, `__eq__`,
-  and `__hash__`: `__new__`, `__call__`, `__getitem__`, `__setitem__`,
-  `__add__`, `__ne__`, `__bool__`, etc. are not dispatched for user-defined
-  instances. `__ne__` is always the negation of `__eq__`, as CPython derives it
-  by default, so a custom `__ne__` is ignored.
+  `__hash__`, and `__index__`: `__new__`, `__call__`, `__getitem__`,
+  `__setitem__`, `__add__`, `__ne__`, `__bool__`, etc. are not dispatched for
+  user-defined instances. `__ne__` is always the negation of `__eq__`, as
+  CPython derives it by default, so a custom `__ne__` is ignored.
+- **`__index__` is dispatched for indexing, but not for arithmetic
+  operators.** A class defining it works as a subscript (`seq[obj]`), as a
+  slice bound (`seq[obj:]`, `slice(obj)`), and as an integer argument
+  (`range(obj)`, `'x'.center(obj)`, `s.find(sub, obj)`). It is **not**
+  consulted by sequence repetition, so `'ab' * obj` and `[0] * obj` raise
+  `TypeError: unsupported operand type(s) for *` where CPython repeats — each
+  numeric operator carries its own coercion, which does not route through the
+  shared index path.
+- **`slice()` stores coerced bounds, not the objects passed.** CPython's
+  `slice()` keeps its arguments untouched and only calls `__index__` when the
+  slice is *used*, so `slice(obj).start` is `obj`; Monty coerces during
+  construction, so it is the resulting `int`. A bound whose `__index__` raises
+  therefore raises at `slice(...)` rather than at use, and one that is neither
+  `None`, an `int`, nor `__index__`-able is rejected up front instead of on
+  first use.
 - `__iter__` / `__next__` / `__contains__` **are** dispatched, but like
   `__repr__`/`__str__` they run synchronously, so one that calls an external or
   OS function cannot suspend and raises `NotImplementedError`. Two related

--- a/limitations/classes.md
+++ b/limitations/classes.md
@@ -212,6 +212,15 @@ first, e.g. return a `dict` of the fields.
   therefore raises at `slice(...)` rather than at use, and one that is neither
   `None`, an `int`, nor `__index__`-able is rejected up front instead of on
   first use.
+- **Slice bounds are stored saturated to `i64`.** Because bounds are coerced at
+  construction (above), one beyond `i64` is clamped to `i64::MIN`/`i64::MAX`
+  rather than kept exact: `slice(10**30).stop` is `9223372036854775807`, where
+  CPython reports `10**30`. *Slicing* with such a bound still matches CPython —
+  it clamps to the sequence either way, so `[1, 2, 3][10**30:]` is `[]` — the
+  divergence is only visible by reading the attribute back. This applies to
+  bounds written as literals and to those returned by `__index__` alike. Plain
+  indexing is unaffected: `[1, 2, 3][10**30]` raises `IndexError` as CPython
+  does.
 - `__iter__` / `__next__` / `__contains__` **are** dispatched, but like
   `__repr__`/`__str__` they run synchronously, so one that calls an external or
   OS function cannot suspend and raises `NotImplementedError`. Two related

--- a/limitations/classes.md
+++ b/limitations/classes.md
@@ -198,13 +198,16 @@ first, e.g. return a `dict` of the fields.
   user-defined instances. `__ne__` is always the negation of `__eq__`, as
   CPython derives it by default, so a custom `__ne__` is ignored.
 - **`__index__` is dispatched for indexing, but not for arithmetic
-  operators.** A class defining it works as a subscript (`seq[obj]`), as a
-  slice bound (`seq[obj:]`, `slice(obj)`), and as an integer argument
+  operators.** A class defining it works as a subscript *read* (`seq[obj]`), as
+  a slice bound (`seq[obj:]`, `slice(obj)`), and as an integer argument
   (`range(obj)`, `'x'.center(obj)`, `s.find(sub, obj)`). It is **not**
   consulted by sequence repetition, so `'ab' * obj` and `[0] * obj` raise
   `TypeError: unsupported operand type(s) for *` where CPython repeats — each
   numeric operator carries its own coercion, which does not route through the
   shared index path.
+- **Subscript assignment does not dispatch `__index__`.** `lst[obj] = x` raises
+  `TypeError: list indices must be integers or slices, not Foo` where CPython
+  coerces and assigns; only the read side takes the index path.
 - **`slice()` stores coerced bounds, not the objects passed.** CPython's
   `slice()` keeps its arguments untouched and only calls `__index__` when the
   slice is *used*, so `slice(obj).start` is `obj`; Monty coerces during


### PR DESCRIPTION
`__index__` is Python's "this object *is* an integer" protocol (PEP 357), called wherever an exact integer is required for a non-arithmetic purpose: sequence subscripts, slice bounds, `range()`, and integer arguments like `'x'.center(n)`. It is deliberately narrower than `__int__` — a lossy conversion that `float` also defines — which is why `seq[3.7]` is a `TypeError` while a class defining `__index__` indexes fine.

**The gap.** Raised by cubic on [pydantic/monty#635](https://github.com/pydantic/monty/pull/635) as an `islice` bug, but not `islice`-specific: Monty dispatched ten dunders, not `__index__`, so a class defining it was rejected everywhere CPython accepts an index, though the error messages already promised the protocol and `monty -t` already accepted the code.

**The fix.** `instance_index` joins the existing `instance_call_dunder_sync` dispatch and validates an int result; `as_int`/`as_index` now take `&mut VM`. Four hand-rolled int fast paths fold into them, picking up `LongInt` and correcting two `str` argument errors to match CPython.

**Not covered.** Sequence repetition (`'ab' * obj`) and `slice()` storing coerced bounds rather than the original object — both documented in `limitations/classes.md`.

**Testing.** New `class__index_dunder.py` / `refcount__index_dunder.py` cases dual-run against CPython; suite green under `ref-count-return` and `memory-model-checks`.

**Unrelated, pre-existing.** An exception raised in any sync dunder escapes `try`/`except` when the receiver is a variable (`1 in c`, but not `1 in C()`). Reproduces on clean `main`; not fixed here.

