### PR TITLE
Re-validate cached overlay host paths on every read

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,8 @@ Key rules:
 - Avoid `#[cfg(unix)]`-only code in the main crate — all features must work on all platforms
 - Tests in `crates/*/tests/` should be cross-platform; use helper functions for
   OS-specific APIs like symlink creation (see `symlink_file`/`symlink_dir` in
-  `crates/monty-fs/tests/fs_security.rs`)
+  `crates/monty-fs/tests/common/mod.rs`, shared via `mod common;` — each
+  `tests/*.rs` is its own crate, so helpers used by more than one belong there)
 - CI runs `cargo test -p monty --features memory-model-checks` and `cargo test -p monty-fs`
   on Linux, macOS, and Windows
 

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -24,7 +24,7 @@ use super::{
     overlay_state::{ENTRY_MEMORY_USAGE, OverlayEntry, OverlayFile, OverlayFileRef, OverlayState},
     path_security::{
         ResolveMode, normalize_virtual_path, reject_drive_or_unc_segments, reject_escaping_symlink,
-        reject_overlong_path, resolve_path, strip_mount_prefix,
+        reject_overlong_path, resolve_path, revalidate_cached_host_path, strip_mount_prefix,
     },
 };
 
@@ -279,7 +279,8 @@ fn read_text(
             Ok(MontyObject::String(bytes_to_utf8(file.content.clone())?))
         }
         Some(OverlayEntry::RealFileRef(file_ref)) => {
-            read_text_fs(&file_ref.host_path, vpath, available_memory(state, ctx)?)
+            let host_path = revalidate_cached_host_path(&file_ref.host_path, ctx.mount_host, vpath)?;
+            read_text_fs(&host_path, vpath, available_memory(state, ctx)?)
         }
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
@@ -305,7 +306,8 @@ fn read_bytes(
             Ok(MontyObject::Bytes(file.content.clone()))
         }
         Some(OverlayEntry::RealFileRef(file_ref)) => {
-            read_bytes_fs(&file_ref.host_path, vpath, available_memory(state, ctx)?)
+            let host_path = revalidate_cached_host_path(&file_ref.host_path, ctx.mount_host, vpath)?;
+            read_bytes_fs(&host_path, vpath, available_memory(state, ctx)?)
         }
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
@@ -450,7 +452,10 @@ fn existing_file_len(
     match state.get(relative) {
         Some(OverlayEntry::File(file)) => Ok(file.content.len()),
         Some(OverlayEntry::Deleted) => Ok(0),
-        Some(OverlayEntry::RealFileRef(file_ref)) => file_len(&file_ref.host_path, vpath),
+        Some(OverlayEntry::RealFileRef(file_ref)) => {
+            let host_path = revalidate_cached_host_path(&file_ref.host_path, ctx.mount_host, vpath)?;
+            file_len(&host_path, vpath)
+        }
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
         }
@@ -486,10 +491,13 @@ fn existing_file_bytes(
             Ok(file.content.clone())
         }
         Some(OverlayEntry::Deleted) => Ok(Vec::new()),
-        Some(OverlayEntry::RealFileRef(file_ref)) => match read_bytes_fs(&file_ref.host_path, vpath, budget)? {
-            MontyObject::Bytes(bytes) => Ok(bytes),
-            _ => unreachable!("read_bytes_fs should return bytes"),
-        },
+        Some(OverlayEntry::RealFileRef(file_ref)) => {
+            let host_path = revalidate_cached_host_path(&file_ref.host_path, ctx.mount_host, vpath)?;
+            match read_bytes_fs(&host_path, vpath, budget)? {
+                MontyObject::Bytes(bytes) => Ok(bytes),
+                _ => unreachable!("read_bytes_fs should return bytes"),
+            }
+        }
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
         }

--- a/crates/monty-fs/src/path_security.rs
+++ b/crates/monty-fs/src/path_security.rs
@@ -443,6 +443,25 @@ pub(super) fn reject_escaping_symlink(
     check_boundary(&canonical, &canonical_mount, virtual_path)
 }
 
+/// Re-validates a cached overlay host path against the mount boundary,
+/// returning the canonical path to read from.
+///
+/// `RealFileRef` caches a path validated once at rename time, so a host-side
+/// process sharing the mount can re-point it before the read. Read the
+/// returned path, not the cached one, so the check and the open cannot
+/// disagree about which file they mean.
+pub(super) fn revalidate_cached_host_path(
+    host_path: &Path,
+    mount_host_path: &Path,
+    virtual_path: &str,
+) -> Result<PathBuf, MountError> {
+    let canonical = fs::canonicalize(host_path).map_err(|e| MountError::Io(e, virtual_path.to_owned()))?;
+    let canonical_mount = fs::canonicalize(mount_host_path).map_err(|e| MountError::Io(e, virtual_path.to_owned()))?;
+
+    check_boundary(&canonical, &canonical_mount, virtual_path)?;
+    Ok(canonical)
+}
+
 /// Ensures a host path stays within the mount boundary, component-wise.
 ///
 /// Applied to canonicalized paths as the authoritative check, and to lexically

--- a/crates/monty-fs/src/path_security.rs
+++ b/crates/monty-fs/src/path_security.rs
@@ -434,10 +434,8 @@ pub(super) fn reject_escaping_symlink(
         target
     };
 
-    // Canonicalize the resolved target and check it against the mount root
-    // canonicalized at mount time — re-canonicalizing here would resolve a
-    // mount root a host process had since replaced with an escaping symlink,
-    // and so accept its target as in-bounds.
+    // Check against the root canonicalized at mount time: re-canonicalizing
+    // would follow a mount root since replaced with an escaping symlink.
     let canonical = fs::canonicalize(&resolved).map_err(|_| MountError::PathEscape {
         virtual_path: virtual_path.to_owned(),
     })?;
@@ -453,9 +451,8 @@ pub(super) fn reject_escaping_symlink(
 /// returned path, not the cached one, so the check and the open cannot
 /// disagree about which file they mean.
 ///
-/// `mount_host_path` must be the mount root canonicalized at mount time
-/// (`MountContext::mount_host`); canonicalizing it here instead would follow
-/// a mount root swapped for an escaping symlink and admit its target.
+/// `mount_host_path` must be the root canonicalized at mount time
+/// (`MountContext::mount_host`) — see `reject_escaping_symlink`.
 pub(super) fn revalidate_cached_host_path(
     host_path: &Path,
     mount_host_path: &Path,

--- a/crates/monty-fs/src/path_security.rs
+++ b/crates/monty-fs/src/path_security.rs
@@ -434,13 +434,15 @@ pub(super) fn reject_escaping_symlink(
         target
     };
 
-    // Canonicalize the resolved target and check the boundary.
+    // Canonicalize the resolved target and check it against the mount root
+    // canonicalized at mount time — re-canonicalizing here would resolve a
+    // mount root a host process had since replaced with an escaping symlink,
+    // and so accept its target as in-bounds.
     let canonical = fs::canonicalize(&resolved).map_err(|_| MountError::PathEscape {
         virtual_path: virtual_path.to_owned(),
     })?;
-    let canonical_mount = fs::canonicalize(mount_host_path).map_err(|e| MountError::Io(e, virtual_path.to_owned()))?;
 
-    check_boundary(&canonical, &canonical_mount, virtual_path)
+    check_boundary(&canonical, mount_host_path, virtual_path)
 }
 
 /// Re-validates a cached overlay host path against the mount boundary,
@@ -450,15 +452,18 @@ pub(super) fn reject_escaping_symlink(
 /// process sharing the mount can re-point it before the read. Read the
 /// returned path, not the cached one, so the check and the open cannot
 /// disagree about which file they mean.
+///
+/// `mount_host_path` must be the mount root canonicalized at mount time
+/// (`MountContext::mount_host`); canonicalizing it here instead would follow
+/// a mount root swapped for an escaping symlink and admit its target.
 pub(super) fn revalidate_cached_host_path(
     host_path: &Path,
     mount_host_path: &Path,
     virtual_path: &str,
 ) -> Result<PathBuf, MountError> {
     let canonical = fs::canonicalize(host_path).map_err(|e| MountError::Io(e, virtual_path.to_owned()))?;
-    let canonical_mount = fs::canonicalize(mount_host_path).map_err(|e| MountError::Io(e, virtual_path.to_owned()))?;
 
-    check_boundary(&canonical, &canonical_mount, virtual_path)?;
+    check_boundary(&canonical, mount_host_path, virtual_path)?;
     Ok(canonical)
 }
 

--- a/crates/monty-fs/tests/common/mod.rs
+++ b/crates/monty-fs/tests/common/mod.rs
@@ -1,0 +1,39 @@
+//! Helpers shared across the `monty-fs` integration tests.
+//!
+//! Each `tests/*.rs` file compiles as its own crate, so anything used by more
+//! than one of them lives here rather than being copied. Symlink creation is
+//! the main case: the std API differs by platform, and mount-boundary tests
+//! need symlinks on every platform CI runs.
+
+use std::path::Path;
+
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
+#[cfg(windows)]
+use std::os::windows::fs::{symlink_dir as win_symlink_dir, symlink_file as win_symlink_file};
+
+/// Cross-platform symlink to a file.
+///
+/// On Unix uses `std::os::unix::fs::symlink`, on Windows uses
+/// `std::os::windows::fs::symlink_file`, which needs Developer Mode or an
+/// elevated shell.
+pub fn symlink_file(original: impl AsRef<Path>, link: impl AsRef<Path>) {
+    #[cfg(unix)]
+    symlink(original.as_ref(), link.as_ref()).expect("failed to create file symlink");
+    #[cfg(windows)]
+    win_symlink_file(original.as_ref(), link.as_ref())
+        .expect("failed to create file symlink (enable Windows Developer Mode or run elevated)");
+}
+
+/// Cross-platform symlink to a directory.
+///
+/// On Unix uses `std::os::unix::fs::symlink`, on Windows uses
+/// `std::os::windows::fs::symlink_dir`, which needs Developer Mode or an
+/// elevated shell.
+pub fn symlink_dir(original: impl AsRef<Path>, link: impl AsRef<Path>) {
+    #[cfg(unix)]
+    symlink(original.as_ref(), link.as_ref()).expect("failed to create directory symlink");
+    #[cfg(windows)]
+    win_symlink_dir(original.as_ref(), link.as_ref())
+        .expect("failed to create directory symlink (enable Windows Developer Mode or run elevated)");
+}

--- a/crates/monty-fs/tests/common/mod.rs
+++ b/crates/monty-fs/tests/common/mod.rs
@@ -1,9 +1,7 @@
 //! Helpers shared across the `monty-fs` integration tests.
 //!
-//! Each `tests/*.rs` file compiles as its own crate, so anything used by more
-//! than one of them lives here rather than being copied. Symlink creation is
-//! the main case: the std API differs by platform, and mount-boundary tests
-//! need symlinks on every platform CI runs.
+//! Each `tests/*.rs` compiles as its own crate, so anything used by more than
+//! one of them lives here rather than being copied.
 
 #[cfg(unix)]
 use std::os::unix::fs::symlink;
@@ -11,11 +9,7 @@ use std::os::unix::fs::symlink;
 use std::os::windows::fs::{symlink_dir as win_symlink_dir, symlink_file as win_symlink_file};
 use std::path::Path;
 
-/// Cross-platform symlink to a file.
-///
-/// On Unix uses `std::os::unix::fs::symlink`, on Windows uses
-/// `std::os::windows::fs::symlink_file`, which needs Developer Mode or an
-/// elevated shell.
+/// Cross-platform symlink to a file. Windows needs Developer Mode or elevation.
 pub fn symlink_file(original: impl AsRef<Path>, link: impl AsRef<Path>) {
     #[cfg(unix)]
     symlink(original.as_ref(), link.as_ref()).expect("failed to create file symlink");
@@ -24,11 +18,7 @@ pub fn symlink_file(original: impl AsRef<Path>, link: impl AsRef<Path>) {
         .expect("failed to create file symlink (enable Windows Developer Mode or run elevated)");
 }
 
-/// Cross-platform symlink to a directory.
-///
-/// On Unix uses `std::os::unix::fs::symlink`, on Windows uses
-/// `std::os::windows::fs::symlink_dir`, which needs Developer Mode or an
-/// elevated shell.
+/// Cross-platform symlink to a directory. Windows needs Developer Mode or elevation.
 pub fn symlink_dir(original: impl AsRef<Path>, link: impl AsRef<Path>) {
     #[cfg(unix)]
     symlink(original.as_ref(), link.as_ref()).expect("failed to create directory symlink");

--- a/crates/monty-fs/tests/common/mod.rs
+++ b/crates/monty-fs/tests/common/mod.rs
@@ -5,12 +5,11 @@
 //! the main case: the std API differs by platform, and mount-boundary tests
 //! need symlinks on every platform CI runs.
 
-use std::path::Path;
-
 #[cfg(unix)]
 use std::os::unix::fs::symlink;
 #[cfg(windows)]
 use std::os::windows::fs::{symlink_dir as win_symlink_dir, symlink_file as win_symlink_file};
+use std::path::Path;
 
 /// Cross-platform symlink to a file.
 ///

--- a/crates/monty-fs/tests/fs.rs
+++ b/crates/monty-fs/tests/fs.rs
@@ -4,11 +4,7 @@
 //! ReadOnly, OverlayMemory) and all supported filesystem
 //! operations. Uses real temporary directories to verify correct behavior.
 
-#[cfg(unix)]
-use std::os::unix::fs::symlink as unix_symlink;
-#[cfg(windows)]
-use std::os::windows::fs::symlink_file as win_symlink_file;
-use std::{fs, path::Path};
+use std::fs;
 
 use monty_fs::{DEFAULT_MEMORY_USAGE_LIMIT, Mount, MountCallOutcome, MountError, MountMode, MountTable, OverlayState};
 use monty_types::{
@@ -16,6 +12,11 @@ use monty_types::{
     RenameCallArgs, UnicodeErrorData, UnicodeErrorObject,
 };
 use tempfile::TempDir;
+
+// Only `symlink_file` is needed here; `symlink_dir` is dead in this crate.
+#[expect(dead_code, reason = "shared helper module; not every test crate uses all of it")]
+mod common;
+use common::symlink_file;
 
 // =============================================================================
 // Helpers
@@ -118,18 +119,6 @@ fn rename(src: &str, dst: &str) -> OsFunctionCall {
         src: src.into(),
         dst: dst.into(),
     })
-}
-
-/// Creates a file symlink, handling platform differences.
-///
-/// On Unix, uses `std::os::unix::fs::symlink`. On Windows, uses
-/// `std::os::windows::fs::symlink_file`.
-fn symlink_file(original: impl AsRef<Path>, link: impl AsRef<Path>) {
-    #[cfg(unix)]
-    unix_symlink(original.as_ref(), link.as_ref()).unwrap();
-
-    #[cfg(windows)]
-    win_symlink_file(original.as_ref(), link.as_ref()).unwrap();
 }
 
 /// Asserts an exception has the expected type and message.

--- a/crates/monty-fs/tests/fs_security.rs
+++ b/crates/monty-fs/tests/fs_security.rs
@@ -6,9 +6,7 @@
 
 #[cfg(unix)]
 use std::os::unix::fs::symlink;
-#[cfg(windows)]
-use std::os::windows::fs::{symlink_dir as win_symlink_dir, symlink_file as win_symlink_file};
-use std::{fmt, fs, path::Path};
+use std::{fmt, fs};
 
 use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable, OverlayState};
 use monty_types::{
@@ -16,6 +14,9 @@ use monty_types::{
     PathStringDataArgs,
 };
 use tempfile::TempDir;
+
+mod common;
+use common::{symlink_dir, symlink_file};
 
 // =============================================================================
 // Helpers
@@ -196,28 +197,6 @@ fn all_modes() -> Vec<(&'static str, MountMode)> {
         ("ReadOnly", MountMode::ReadOnly),
         ("OverlayMemory", MountMode::OverlayMemory(OverlayState::new())),
     ]
-}
-
-/// Cross-platform symlink to a file.
-///
-/// On Unix uses `std::os::unix::fs::symlink`, on Windows uses
-/// `std::os::windows::fs::symlink_file`.
-fn symlink_file(original: impl AsRef<Path>, link: impl AsRef<Path>) {
-    #[cfg(unix)]
-    symlink(original.as_ref(), link.as_ref()).unwrap();
-    #[cfg(windows)]
-    win_symlink_file(original.as_ref(), link.as_ref()).unwrap();
-}
-
-/// Cross-platform symlink to a directory.
-///
-/// On Unix uses `std::os::unix::fs::symlink`, on Windows uses
-/// `std::os::windows::fs::symlink_dir`.
-fn symlink_dir(original: impl AsRef<Path>, link: impl AsRef<Path>) {
-    #[cfg(unix)]
-    symlink(original.as_ref(), link.as_ref()).unwrap();
-    #[cfg(windows)]
-    win_symlink_dir(original.as_ref(), link.as_ref()).unwrap();
 }
 
 // =============================================================================

--- a/crates/monty-fs/tests/overlay_stale_ref.rs
+++ b/crates/monty-fs/tests/overlay_stale_ref.rs
@@ -3,18 +3,29 @@
 //! host path with no boundary check — it was validated once, at rename time.
 //! These tests cover the gaps the rename-time guards (`reject_escaping_symlink`,
 //! the symlink skip in `collect_real_descendants`) leave open.
+//!
+//! Every read path that dereferences a `RealFileRef` must re-validate it, so
+//! each is exercised here: `read_text`, `read_bytes`, and the `existing_file_len`
+//! / `existing_file_bytes` pair an append goes through.
 
 #[cfg(unix)]
 use std::os::unix::fs::symlink as unix_symlink;
 #[cfg(windows)]
-use std::os::windows::fs::symlink_file as win_symlink_file;
+use std::os::windows::fs::{symlink_dir as win_symlink_dir, symlink_file as win_symlink_file};
 #[cfg(windows)]
 use std::process::Command;
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable, OverlayState};
-use monty_types::{MontyObject, OsFunctionCall, RenameCallArgs};
+use monty_types::{MontyObject, OsFunctionCall, PathStringDataArgs, RenameCallArgs};
 use tempfile::TempDir;
+
+/// Marker written to the out-of-mount file; its appearance in any result is
+/// the disclosure these tests guard against.
+const SECRET: &str = "SECRET-HOST-CONTENT";
 
 /// Mounts `host` at `/mnt` in `OverlayMemory` mode — the only mode that builds
 /// `RealFileRef` entries.
@@ -53,59 +64,162 @@ fn symlink_file(original: &Path, link: &Path) {
     win_symlink_file(original, link).expect("failed to create symlink (enable Windows Developer Mode or run elevated)");
 }
 
-/// Variant 1 — the cached host path is re-pointed outside the mount after the
-/// rename-time check has already passed. Sandboxed code cannot create that
-/// symlink itself, so this models a host process sharing the mount.
+/// Creates a directory symlink, handling platform differences.
+#[cfg(unix)]
+fn symlink_dir(original: &Path, link: &Path) {
+    unix_symlink(original, link).expect("failed to create directory symlink");
+}
+
+/// Creates a directory symlink, handling platform differences.
+#[cfg(windows)]
+fn symlink_dir(original: &Path, link: &Path) {
+    win_symlink_dir(original, link)
+        .expect("failed to create directory symlink (enable Windows Developer Mode or run elevated)");
+}
+
+/// A mount holding one cached `RealFileRef` at `/mnt/moved.txt` that a
+/// host-side actor has since re-pointed at an out-of-mount secret.
+///
+/// Owns its temp dirs so they outlive the dispatch. Sandboxed code cannot
+/// create that symlink itself, so this models a host process sharing the mount.
+struct StaleRef {
+    mounts: MountTable,
+    _mount_dir: TempDir,
+    _outside_dir: TempDir,
+    /// The out-of-mount file whose contents must never surface.
+    secret: PathBuf,
+}
+
+impl StaleRef {
+    /// Caches the ref via a rename, then stales it by swapping the backing file
+    /// for a symlink out of the mount.
+    fn new() -> Self {
+        let mount_dir = TempDir::new().unwrap();
+        let outside_dir = TempDir::new().unwrap();
+
+        let secret = outside_dir.path().join("secret.txt");
+        fs::write(&secret, SECRET).unwrap();
+
+        fs::create_dir_all(mount_dir.path().join("inner")).unwrap();
+        let real_file = mount_dir.path().join("inner/file.txt");
+        fs::write(&real_file, "public").unwrap();
+
+        let mut mounts = mount_overlay(mount_dir.path());
+
+        // Caches a RealFileRef whose host_path is `real_file` — validated, in bounds.
+        dispatch(&mut mounts, rename_call("/mnt/inner/file.txt", "/mnt/moved.txt")).expect("rename should succeed");
+
+        // The host-side actor re-points it out of the mount, staling the cache.
+        fs::remove_file(&real_file).unwrap();
+        symlink_file(&secret, &real_file);
+
+        Self {
+            mounts,
+            _mount_dir: mount_dir,
+            _outside_dir: outside_dir,
+            secret,
+        }
+    }
+
+    /// Dispatches `call` and asserts it neither succeeded nor leaked. The read
+    /// paths raise `PathEscape`; append additionally refuses before writing.
+    fn assert_rejected(&mut self, call: OsFunctionCall) {
+        let outcome = dispatch(&mut self.mounts, call);
+        let leaked = match &outcome {
+            Ok(MontyObject::String(s)) => s.contains(SECRET),
+            Ok(MontyObject::Bytes(b)) => b.windows(SECRET.len()).any(|w| w == SECRET.as_bytes()),
+            _ => false,
+        };
+        assert!(
+            !leaked,
+            "HOST FILE DISCLOSURE: dereferencing a stale overlay ref returned the contents of {}",
+            self.secret.display()
+        );
+        assert!(
+            matches!(outcome, Err(MountError::PathEscape { .. })),
+            "expected PathEscape, got {outcome:?}"
+        );
+    }
+}
+
+/// `read_text` must re-validate the cached ref rather than trust it.
 #[test]
-fn stale_ref_is_revalidated_on_read() {
-    let mount_dir = TempDir::new().unwrap();
-    let outside_dir = TempDir::new().unwrap();
+fn stale_ref_is_revalidated_on_read_text() {
+    StaleRef::new().assert_rejected(OsFunctionCall::ReadText("/mnt/moved.txt".into()));
+}
 
-    let secret = outside_dir.path().join("secret.txt");
-    fs::write(&secret, "SECRET-HOST-CONTENT").unwrap();
+/// `read_bytes` shares the `RealFileRef` shortcut and must re-validate too.
+#[test]
+fn stale_ref_is_revalidated_on_read_bytes() {
+    StaleRef::new().assert_rejected(OsFunctionCall::ReadBytes("/mnt/moved.txt".into()));
+}
 
-    fs::create_dir_all(mount_dir.path().join("inner")).unwrap();
-    let real_file = mount_dir.path().join("inner/file.txt");
-    fs::write(&real_file, "public").unwrap();
+/// Appending to a `RealFileRef` reads the backing file to materialize it into
+/// the overlay (`existing_file_len`, then `existing_file_bytes`), so it must
+/// re-validate on both — otherwise the secret is copied into overlay state and
+/// readable from there afterwards.
+#[test]
+fn stale_ref_is_revalidated_on_append() {
+    let mut scenario = StaleRef::new();
+    scenario.assert_rejected(OsFunctionCall::AppendText(PathStringDataArgs {
+        path: "/mnt/moved.txt".into(),
+        data: "appended".to_owned(),
+    }));
 
-    let mut mt = mount_overlay(mount_dir.path());
+    // An append that slipped through would leave the secret in overlay state,
+    // where a later read serves it from memory without touching the host.
+    scenario.assert_rejected(OsFunctionCall::ReadText("/mnt/moved.txt".into()));
+}
 
-    // Caches a RealFileRef whose host_path is `real_file` — validated, in bounds.
+/// The mount root itself is swapped for a symlink out of the mount after the
+/// ref was cached. The boundary check must compare against the root
+/// canonicalized at mount time; re-canonicalizing it here would follow the swap
+/// and admit everything beneath the attacker's directory.
+#[test]
+fn stale_ref_is_rejected_when_mount_root_is_swapped() {
+    let base = TempDir::new().unwrap();
+    let mount_path = base.path().join("mount");
+    let elsewhere = base.path().join("elsewhere");
+    fs::create_dir_all(mount_path.join("inner")).unwrap();
+    fs::create_dir_all(elsewhere.join("inner")).unwrap();
+    fs::write(mount_path.join("inner/file.txt"), "public").unwrap();
+    fs::write(elsewhere.join("inner/file.txt"), SECRET).unwrap();
+
+    let mut mt = mount_overlay(&mount_path);
     dispatch(&mut mt, rename_call("/mnt/inner/file.txt", "/mnt/moved.txt")).expect("rename should succeed");
 
-    // The host-side actor re-points it out of the mount, staling the cache.
-    fs::remove_file(&real_file).unwrap();
-    symlink_file(&secret, &real_file);
+    // Swap the whole mount root for a link to `elsewhere`, so the cached ref's
+    // path resolves under a directory that was never mounted.
+    fs::rename(&mount_path, base.path().join("mount_old")).unwrap();
+    symlink_dir(&elsewhere, &mount_path);
 
     let outcome = dispatch(&mut mt, OsFunctionCall::ReadText("/mnt/moved.txt".into()));
-    println!("[variant 1] read of stale ref: {outcome:?}");
-
-    let leaked = matches!(&outcome, Ok(MontyObject::String(s)) if s.contains("SECRET-HOST-CONTENT"));
-    println!("[variant 1] LEAKED?          : {leaked}");
-
+    let leaked = matches!(&outcome, Ok(MontyObject::String(s)) if s.contains(SECRET));
     assert!(
         !leaked,
-        "HOST FILE DISCLOSURE: reading a stale overlay ref returned the contents of {}",
-        secret.display()
+        "HOST FILE DISCLOSURE: swapping the mount root defeated the check"
+    );
+    assert!(
+        matches!(outcome, Err(MountError::PathEscape { .. })),
+        "expected PathEscape, got {outcome:?}"
     );
 }
 
 /// Control — the same escaping symlink read through the normal resolution path
-/// is rejected, so variant 1's leak is specific to the `RealFileRef` shortcut.
+/// is rejected, so the leak above is specific to the `RealFileRef` shortcut.
 #[test]
 fn direct_read_through_escaping_symlink_is_rejected() {
     let mount_dir = TempDir::new().unwrap();
     let outside_dir = TempDir::new().unwrap();
 
     let secret = outside_dir.path().join("secret.txt");
-    fs::write(&secret, "SECRET-HOST-CONTENT").unwrap();
+    fs::write(&secret, SECRET).unwrap();
     symlink_file(&secret, &mount_dir.path().join("link.txt"));
 
     let mut mt = mount_overlay(mount_dir.path());
     let outcome = dispatch(&mut mt, OsFunctionCall::ReadText("/mnt/link.txt".into()));
-    println!("[control] direct read via symlink: {outcome:?}");
 
-    let leaked = matches!(&outcome, Ok(MontyObject::String(s)) if s.contains("SECRET-HOST-CONTENT"));
+    let leaked = matches!(&outcome, Ok(MontyObject::String(s)) if s.contains(SECRET));
     assert!(!leaked, "control failed: the ordinary resolution path also leaks");
 }
 
@@ -128,26 +242,23 @@ fn junction_is_classified_as_symlink() {
     assert!(fs::symlink_metadata(&junction).unwrap().file_type().is_symlink());
 }
 
-/// Variant 1b — renaming an escaping symlink into the overlay must be refused
-/// outright, so a regression in `reject_escaping_symlink` is caught here too.
+/// Renaming an escaping symlink into the overlay must be refused outright, so
+/// `reject_escaping_symlink` is exercised rather than left to the read-time
+/// check standing behind it.
 #[test]
 fn renaming_escaping_symlink_into_overlay_is_rejected() {
     let mount_dir = TempDir::new().unwrap();
     let outside_dir = TempDir::new().unwrap();
 
     let secret = outside_dir.path().join("secret.txt");
-    fs::write(&secret, "SECRET-HOST-CONTENT").unwrap();
+    fs::write(&secret, SECRET).unwrap();
     symlink_file(&secret, &mount_dir.path().join("link.txt"));
 
     let mut mt = mount_overlay(mount_dir.path());
     let rename_outcome = dispatch(&mut mt, rename_call("/mnt/link.txt", "/mnt/captured.txt"));
-    println!("[variant 1b] rename outcome: {rename_outcome:?}");
 
-    // A refusal ends the attack here; if it succeeded, the read is what leaks.
-    if rename_outcome.is_ok() {
-        let read_outcome = dispatch(&mut mt, OsFunctionCall::ReadText("/mnt/captured.txt".into()));
-        println!("[variant 1b] read outcome  : {read_outcome:?}");
-        let leaked = matches!(&read_outcome, Ok(MontyObject::String(s)) if s.contains("SECRET-HOST-CONTENT"));
-        assert!(!leaked, "HOST FILE DISCLOSURE via renamed escaping symlink");
-    }
+    assert!(
+        matches!(rename_outcome, Err(MountError::PathEscape { .. })),
+        "expected the rename to be refused with PathEscape, got {rename_outcome:?}"
+    );
 }

--- a/crates/monty-fs/tests/overlay_stale_ref.rs
+++ b/crates/monty-fs/tests/overlay_stale_ref.rs
@@ -8,10 +8,6 @@
 //! each is exercised here: `read_text`, `read_bytes`, and the `existing_file_len`
 //! / `existing_file_bytes` pair an append goes through.
 
-#[cfg(unix)]
-use std::os::unix::fs::symlink as unix_symlink;
-#[cfg(windows)]
-use std::os::windows::fs::{symlink_dir as win_symlink_dir, symlink_file as win_symlink_file};
 #[cfg(windows)]
 use std::process::Command;
 use std::{
@@ -22,6 +18,9 @@ use std::{
 use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable, OverlayState};
 use monty_types::{MontyObject, OsFunctionCall, PathStringDataArgs, RenameCallArgs};
 use tempfile::TempDir;
+
+mod common;
+use common::{symlink_dir, symlink_file};
 
 /// Marker written to the out-of-mount file; its appearance in any result is
 /// the disclosure these tests guard against.
@@ -50,31 +49,6 @@ fn rename_call(src: &str, dst: &str) -> OsFunctionCall {
         src: src.into(),
         dst: dst.into(),
     })
-}
-
-/// Creates a file symlink, handling platform differences.
-#[cfg(unix)]
-fn symlink_file(original: &Path, link: &Path) {
-    unix_symlink(original, link).expect("failed to create symlink");
-}
-
-/// Creates a file symlink, handling platform differences.
-#[cfg(windows)]
-fn symlink_file(original: &Path, link: &Path) {
-    win_symlink_file(original, link).expect("failed to create symlink (enable Windows Developer Mode or run elevated)");
-}
-
-/// Creates a directory symlink, handling platform differences.
-#[cfg(unix)]
-fn symlink_dir(original: &Path, link: &Path) {
-    unix_symlink(original, link).expect("failed to create directory symlink");
-}
-
-/// Creates a directory symlink, handling platform differences.
-#[cfg(windows)]
-fn symlink_dir(original: &Path, link: &Path) {
-    win_symlink_dir(original, link)
-        .expect("failed to create directory symlink (enable Windows Developer Mode or run elevated)");
 }
 
 /// A mount holding one cached `RealFileRef` at `/mnt/moved.txt` that a
@@ -214,7 +188,7 @@ fn direct_read_through_escaping_symlink_is_rejected() {
 
     let secret = outside_dir.path().join("secret.txt");
     fs::write(&secret, SECRET).unwrap();
-    symlink_file(&secret, &mount_dir.path().join("link.txt"));
+    symlink_file(&secret, mount_dir.path().join("link.txt"));
 
     let mut mt = mount_overlay(mount_dir.path());
     let outcome = dispatch(&mut mt, OsFunctionCall::ReadText("/mnt/link.txt".into()));
@@ -252,7 +226,7 @@ fn renaming_escaping_symlink_into_overlay_is_rejected() {
 
     let secret = outside_dir.path().join("secret.txt");
     fs::write(&secret, SECRET).unwrap();
-    symlink_file(&secret, &mount_dir.path().join("link.txt"));
+    symlink_file(&secret, mount_dir.path().join("link.txt"));
 
     let mut mt = mount_overlay(mount_dir.path());
     let rename_outcome = dispatch(&mut mt, rename_call("/mnt/link.txt", "/mnt/captured.txt"));

--- a/crates/monty-fs/tests/overlay_stale_ref.rs
+++ b/crates/monty-fs/tests/overlay_stale_ref.rs
@@ -1,0 +1,153 @@
+//! Renaming a real host file inside an `OverlayMemory` mount records a
+//! `RealFileRef` rather than copying the bytes, and reads followed that cached
+//! host path with no boundary check — it was validated once, at rename time.
+//! These tests cover the gaps the rename-time guards (`reject_escaping_symlink`,
+//! the symlink skip in `collect_real_descendants`) leave open.
+
+#[cfg(unix)]
+use std::os::unix::fs::symlink as unix_symlink;
+#[cfg(windows)]
+use std::os::windows::fs::symlink_file as win_symlink_file;
+#[cfg(windows)]
+use std::process::Command;
+use std::{fs, path::Path};
+
+use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable, OverlayState};
+use monty_types::{MontyObject, OsFunctionCall, RenameCallArgs};
+use tempfile::TempDir;
+
+/// Mounts `host` at `/mnt` in `OverlayMemory` mode — the only mode that builds
+/// `RealFileRef` entries.
+fn mount_overlay(host: &Path) -> MountTable {
+    let mut mt = MountTable::new();
+    mt.mount("/mnt", host, MountMode::OverlayMemory(OverlayState::new()), None)
+        .expect("failed to configure mount");
+    mt
+}
+
+/// Dispatches a call, panicking if the mount table declines to handle it.
+fn dispatch(mt: &mut MountTable, call: OsFunctionCall) -> Result<MontyObject, MountError> {
+    match mt.handle_os_call(call) {
+        MountCallOutcome::Handled(result) => result,
+        MountCallOutcome::NotHandled(call) => panic!("mount table returned NotHandled: {call:?}"),
+    }
+}
+
+/// The OS call `os.rename(src, dst)` produces.
+fn rename_call(src: &str, dst: &str) -> OsFunctionCall {
+    OsFunctionCall::Rename(RenameCallArgs {
+        src: src.into(),
+        dst: dst.into(),
+    })
+}
+
+/// Creates a file symlink, handling platform differences.
+#[cfg(unix)]
+fn symlink_file(original: &Path, link: &Path) {
+    unix_symlink(original, link).expect("failed to create symlink");
+}
+
+/// Creates a file symlink, handling platform differences.
+#[cfg(windows)]
+fn symlink_file(original: &Path, link: &Path) {
+    win_symlink_file(original, link).expect("failed to create symlink (enable Windows Developer Mode or run elevated)");
+}
+
+/// Variant 1 — the cached host path is re-pointed outside the mount after the
+/// rename-time check has already passed. Sandboxed code cannot create that
+/// symlink itself, so this models a host process sharing the mount.
+#[test]
+fn stale_ref_is_revalidated_on_read() {
+    let mount_dir = TempDir::new().unwrap();
+    let outside_dir = TempDir::new().unwrap();
+
+    let secret = outside_dir.path().join("secret.txt");
+    fs::write(&secret, "SECRET-HOST-CONTENT").unwrap();
+
+    fs::create_dir_all(mount_dir.path().join("inner")).unwrap();
+    let real_file = mount_dir.path().join("inner/file.txt");
+    fs::write(&real_file, "public").unwrap();
+
+    let mut mt = mount_overlay(mount_dir.path());
+
+    // Caches a RealFileRef whose host_path is `real_file` — validated, in bounds.
+    dispatch(&mut mt, rename_call("/mnt/inner/file.txt", "/mnt/moved.txt")).expect("rename should succeed");
+
+    // The host-side actor re-points it out of the mount, staling the cache.
+    fs::remove_file(&real_file).unwrap();
+    symlink_file(&secret, &real_file);
+
+    let outcome = dispatch(&mut mt, OsFunctionCall::ReadText("/mnt/moved.txt".into()));
+    println!("[variant 1] read of stale ref: {outcome:?}");
+
+    let leaked = matches!(&outcome, Ok(MontyObject::String(s)) if s.contains("SECRET-HOST-CONTENT"));
+    println!("[variant 1] LEAKED?          : {leaked}");
+
+    assert!(
+        !leaked,
+        "HOST FILE DISCLOSURE: reading a stale overlay ref returned the contents of {}",
+        secret.display()
+    );
+}
+
+/// Control — the same escaping symlink read through the normal resolution path
+/// is rejected, so variant 1's leak is specific to the `RealFileRef` shortcut.
+#[test]
+fn direct_read_through_escaping_symlink_is_rejected() {
+    let mount_dir = TempDir::new().unwrap();
+    let outside_dir = TempDir::new().unwrap();
+
+    let secret = outside_dir.path().join("secret.txt");
+    fs::write(&secret, "SECRET-HOST-CONTENT").unwrap();
+    symlink_file(&secret, &mount_dir.path().join("link.txt"));
+
+    let mut mt = mount_overlay(mount_dir.path());
+    let outcome = dispatch(&mut mt, OsFunctionCall::ReadText("/mnt/link.txt".into()));
+    println!("[control] direct read via symlink: {outcome:?}");
+
+    let leaked = matches!(&outcome, Ok(MontyObject::String(s)) if s.contains("SECRET-HOST-CONTENT"));
+    assert!(!leaked, "control failed: the ordinary resolution path also leaks");
+}
+
+/// The premise `collect_real_descendants`' capture-time skip rests on: std must
+/// classify a Windows directory junction as a symlink for its `is_symlink()`
+/// filter to catch one. If this flips, revisit that skip.
+#[cfg(windows)]
+#[test]
+fn junction_is_classified_as_symlink() {
+    let dir = TempDir::new().unwrap();
+    let (target, junction) = (dir.path().join("t"), dir.path().join("jn"));
+    fs::create_dir(&target).unwrap();
+    let status = Command::new("cmd")
+        .args(["/C", "mklink", "/J"])
+        .arg(&junction)
+        .arg(&target)
+        .status()
+        .unwrap();
+    assert!(status.success(), "mklink /J failed: {status:?}");
+    assert!(fs::symlink_metadata(&junction).unwrap().file_type().is_symlink());
+}
+
+/// Variant 1b — renaming an escaping symlink into the overlay must be refused
+/// outright, so a regression in `reject_escaping_symlink` is caught here too.
+#[test]
+fn renaming_escaping_symlink_into_overlay_is_rejected() {
+    let mount_dir = TempDir::new().unwrap();
+    let outside_dir = TempDir::new().unwrap();
+
+    let secret = outside_dir.path().join("secret.txt");
+    fs::write(&secret, "SECRET-HOST-CONTENT").unwrap();
+    symlink_file(&secret, &mount_dir.path().join("link.txt"));
+
+    let mut mt = mount_overlay(mount_dir.path());
+    let rename_outcome = dispatch(&mut mt, rename_call("/mnt/link.txt", "/mnt/captured.txt"));
+    println!("[variant 1b] rename outcome: {rename_outcome:?}");
+
+    // A refusal ends the attack here; if it succeeded, the read is what leaks.
+    if rename_outcome.is_ok() {
+        let read_outcome = dispatch(&mut mt, OsFunctionCall::ReadText("/mnt/captured.txt".into()));
+        println!("[variant 1b] read outcome  : {read_outcome:?}");
+        let leaked = matches!(&read_outcome, Ok(MontyObject::String(s)) if s.contains("SECRET-HOST-CONTENT"));
+        assert!(!leaked, "HOST FILE DISCLOSURE via renamed escaping symlink");
+    }
+}

--- a/crates/monty-fs/tests/overlay_stale_ref.rs
+++ b/crates/monty-fs/tests/overlay_stale_ref.rs
@@ -1,12 +1,7 @@
-//! Renaming a real host file inside an `OverlayMemory` mount records a
-//! `RealFileRef` rather than copying the bytes, and reads followed that cached
-//! host path with no boundary check — it was validated once, at rename time.
-//! These tests cover the gaps the rename-time guards (`reject_escaping_symlink`,
-//! the symlink skip in `collect_real_descendants`) leave open.
-//!
-//! Every read path that dereferences a `RealFileRef` must re-validate it, so
-//! each is exercised here: `read_text`, `read_bytes`, and the `existing_file_len`
-//! / `existing_file_bytes` pair an append goes through.
+//! An `OverlayMemory` rename records a `RealFileRef` instead of copying the
+//! bytes, and reads followed that cached host path unchecked. Every path that
+//! dereferences one is exercised here: `read_text`, `read_bytes`, and the
+//! `existing_file_len` / `existing_file_bytes` pair an append goes through.
 
 #[cfg(windows)]
 use std::process::Command;
@@ -52,10 +47,9 @@ fn rename_call(src: &str, dst: &str) -> OsFunctionCall {
 }
 
 /// A mount holding one cached `RealFileRef` at `/mnt/moved.txt` that a
-/// host-side actor has since re-pointed at an out-of-mount secret.
-///
-/// Owns its temp dirs so they outlive the dispatch. Sandboxed code cannot
-/// create that symlink itself, so this models a host process sharing the mount.
+/// host-side actor has since re-pointed at an out-of-mount secret. Sandboxed
+/// code cannot create that symlink itself; this models a host process sharing
+/// the mount. Owns its temp dirs so they outlive the dispatch.
 struct StaleRef {
     mounts: MountTable,
     _mount_dir: TempDir,
@@ -95,8 +89,7 @@ impl StaleRef {
         }
     }
 
-    /// Dispatches `call` and asserts it neither succeeded nor leaked. The read
-    /// paths raise `PathEscape`; append additionally refuses before writing.
+    /// Asserts `call` neither succeeded nor leaked the secret.
     fn assert_rejected(&mut self, call: OsFunctionCall) {
         let outcome = dispatch(&mut self.mounts, call);
         let leaked = match &outcome {
@@ -128,10 +121,9 @@ fn stale_ref_is_revalidated_on_read_bytes() {
     StaleRef::new().assert_rejected(OsFunctionCall::ReadBytes("/mnt/moved.txt".into()));
 }
 
-/// Appending to a `RealFileRef` reads the backing file to materialize it into
-/// the overlay (`existing_file_len`, then `existing_file_bytes`), so it must
-/// re-validate on both — otherwise the secret is copied into overlay state and
-/// readable from there afterwards.
+/// Appending materializes the backing file into the overlay via
+/// `existing_file_len` then `existing_file_bytes`, so both must re-validate —
+/// otherwise the secret lands in overlay state and reads back from memory.
 #[test]
 fn stale_ref_is_revalidated_on_append() {
     let mut scenario = StaleRef::new();
@@ -145,10 +137,9 @@ fn stale_ref_is_revalidated_on_append() {
     scenario.assert_rejected(OsFunctionCall::ReadText("/mnt/moved.txt".into()));
 }
 
-/// The mount root itself is swapped for a symlink out of the mount after the
-/// ref was cached. The boundary check must compare against the root
-/// canonicalized at mount time; re-canonicalizing it here would follow the swap
-/// and admit everything beneath the attacker's directory.
+/// Swapping the mount root for an escaping symlink after the ref was cached:
+/// the check must compare against the root canonicalized at mount time, since
+/// re-canonicalizing here would follow the swap.
 #[test]
 fn stale_ref_is_rejected_when_mount_root_is_swapped() {
     let base = TempDir::new().unwrap();
@@ -197,9 +188,8 @@ fn direct_read_through_escaping_symlink_is_rejected() {
     assert!(!leaked, "control failed: the ordinary resolution path also leaks");
 }
 
-/// The premise `collect_real_descendants`' capture-time skip rests on: std must
-/// classify a Windows directory junction as a symlink for its `is_symlink()`
-/// filter to catch one. If this flips, revisit that skip.
+/// `collect_real_descendants`' capture-time skip relies on std classifying a
+/// Windows junction as a symlink. If this flips, revisit that skip.
 #[cfg(windows)]
 #[test]
 fn junction_is_classified_as_symlink() {
@@ -216,9 +206,8 @@ fn junction_is_classified_as_symlink() {
     assert!(fs::symlink_metadata(&junction).unwrap().file_type().is_symlink());
 }
 
-/// Renaming an escaping symlink into the overlay must be refused outright, so
-/// `reject_escaping_symlink` is exercised rather than left to the read-time
-/// check standing behind it.
+/// Renaming an escaping symlink in must be refused outright, so
+/// `reject_escaping_symlink` is exercised rather than the read-time check behind it.
 #[test]
 fn renaming_escaping_symlink_into_overlay_is_rejected() {
     let mount_dir = TempDir::new().unwrap();

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -78,6 +78,11 @@ The host enforces these invariants on every path operation:
   Unix — `a\b.txt`, `a:b.txt` — are refused there too, since Windows would
   read them as drive-relative. Colons elsewhere are fine (`note:2026.txt`).
 - Symlinks pointing outside the mount are rejected on resolution.
+- `OverlayMemory` renames of real files keep a reference to the backing host
+  path rather than copying it. That path is re-checked against the mount on
+  every read, so if a host-side process replaces it with a symlink out of the
+  mount after the rename, the read raises `PermissionError` — where CPython
+  would follow the new symlink and return its contents.
 - Null bytes in any path component are rejected (`ValueError`).
 - Resolved paths returned to the sandbox (e.g. via `Path.resolve()`) are
   virtual paths, never host paths.


### PR DESCRIPTION
`OverlayMemory` renames store a `RealFileRef` holding the backing host path instead of copying bytes; reads went straight to it, validated once at rename time then trusted. Fixed by re-checking it against the mount on every read, and reading from the path that check returned rather than the cached one.

Three notes on scope:

- **Not a standalone escape** — needs a second actor mutating the mount between rename and read. This takes the trusted window from indefinite to milliseconds, but does not close it entirely.
- **Pre-existing symlinks already blocked** — controls pin the leak to the cached-ref shortcut.
- **Windows junction** — asserts that `file_type().is_symlink()` catches junctions, the premise `collect_real_descendants`' capture-time skip rests on.

**CI:** the junction test is `#[cfg(windows)]`, so only the Windows leg of `cargo test -p monty-fs` builds and runs it.

Based on VERIA-2.

Note: this solution takes the trusted window for a filename from indefinite to milliseconds, but the same exploit still potentially exists.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks stale `RealFileRef` escapes by re-validating cached host paths on every `OverlayMemory` read and comparing against the mount root captured at mount time. All reads now open the canonical, re-checked path.

- **Bug Fixes**
  - Added `revalidate_cached_host_path` and read from its canonical path in `read_text`, `read_bytes`, `existing_file_len`, and `existing_file_bytes`.
  - Updated `reject_escaping_symlink` to compare against `MountContext::mount_host` (captured at mount time), closing the mount-root-swap hole and removing a redundant canonicalize.

- **Tests/Docs**
  - Added coverage for `read_bytes`, the append path (`existing_file_len`/`existing_file_bytes`), a mount-root-swap regression, control symlink rejection, and Windows junction classification.
  - Shared cross-platform symlink helpers via `tests/common`; migrated `fs.rs`. Updated filesystem limitations; trimmed comments; fixed nightly rustfmt import grouping.

<sup>Written for commit 4ab62d1ed2adc7796c68548354eb348020605c2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



