### PR TITLE
 move richcmp to use a vtable

### DIFF
--- a/crates/monty/src/builtins/min_max.rs
+++ b/crates/monty/src/builtins/min_max.rs
@@ -1,14 +1,14 @@
 //! Implementation of the min() and max() builtin functions.
 
-use std::{cmp::Ordering, mem};
+use std::mem;
 
 use crate::{
     args::{ArgValues, FromArgs},
     bytecode::VM,
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
+    exception_private::{ExcType, RunError, RunResult, SimpleException},
     heap::DropGuard,
-    types::{CmpOrder, PyTrait},
+    types::RichCmpOp,
     value::Value,
 };
 
@@ -217,16 +217,8 @@ fn evaluate_key(item: Value, key_fn: &Value, key_context: &'static str, vm: &mut
 /// while `max()` replaces it when the new candidate compares larger. Equal values
 /// keep the existing winner so ties preserve the first-seen item, matching CPython.
 fn candidate_wins(current: &Value, candidate: &Value, is_min: bool, vm: &mut VM<'_>) -> RunResult<bool> {
-    let ordering = match candidate.py_cmp(current, vm)? {
-        CmpOrder::Ordered(ordering) => ordering,
-        // A `NaN` candidate (or `NaN`-carrying container) is neither smaller nor
-        // larger, so it never displaces the incumbent — matching CPython, where
-        // `min`/`max` only swap on a strict `<`/`>` and `NaN` yields neither.
-        CmpOrder::Unordered => return Ok(false),
-        CmpOrder::Incomparable => return Err(ord_not_supported(candidate, current, is_min, vm)),
-    };
-
-    Ok((is_min && ordering == Ordering::Less) || (!is_min && ordering == Ordering::Greater))
+    let op = if is_min { RichCmpOp::Lt } else { RichCmpOp::Gt };
+    candidate.py_rich_compare_bool(current, op, vm)
 }
 
 /// Creates the CPython-compatible error for `default=` with multiple positional args.
@@ -237,12 +229,4 @@ fn default_with_multiple_args(func_name: &str) -> RunError {
         format!("Cannot specify a default for {func_name}() with multiple positional arguments"),
     )
     .into()
-}
-
-#[cold]
-fn ord_not_supported(left: &Value, right: &Value, is_min: bool, vm: &VM<'_>) -> RunError {
-    let left_type = left.py_type_name(vm);
-    let right_type = right.py_type_name(vm);
-    let operator = if is_min { "<" } else { ">" };
-    ExcType::type_error_ordering(operator, &left_type, &right_type)
 }

--- a/crates/monty/src/bytecode/vm/compare.rs
+++ b/crates/monty/src/bytecode/vm/compare.rs
@@ -3,97 +3,52 @@
 use super::VM;
 use crate::{
     defer_drop,
-    exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
+    exception_private::{RunError, RunResult},
     expressions::CmpOperator,
-    types::{CmpOrder, PyTrait},
+    types::RichCmpOp,
     value::Value,
 };
 
 impl VM<'_> {
     /// Evaluates a comparison as a boolean without consuming its operands.
     ///
-    /// Shared by fused asserts and comparison helpers that need truth rather
-    /// than the arbitrary value a direct `==` expression may produce.
+    /// Fused asserts use this path because they need the truth of an expression,
+    /// rather than the arbitrary value returned by a direct rich comparison.
     #[inline]
     pub(super) fn cmp_values(&mut self, op: CmpOperator, lhs: &Value, rhs: &Value) -> RunResult<bool> {
-        match op {
-            CmpOperator::Eq | CmpOperator::NotEq => {
-                let result = lhs.py_rich_eq(rhs, self)?;
-                let is_equal = result.py_bool(self);
-                result.drop_with(self);
-                let is_equal = is_equal?;
-                Ok(if op == CmpOperator::NotEq { !is_equal } else { is_equal })
+        if let Some(op) = RichCmpOp::from_cmp_operator(op) {
+            lhs.py_rich_compare_bool(rhs, op, self)
+        } else {
+            match op {
+                CmpOperator::Is => Ok(lhs.is(rhs)),
+                CmpOperator::IsNot => Ok(!lhs.is(rhs)),
+                // `in` tests membership of the left operand in the right one.
+                CmpOperator::In => rhs.py_contains(lhs, self),
+                CmpOperator::NotIn => Ok(!rhs.py_contains(lhs, self)?),
+                _ => unreachable!("rich comparisons handled above"),
             }
-            CmpOperator::Is => Ok(lhs.is(rhs)),
-            CmpOperator::IsNot => Ok(!lhs.is(rhs)),
-            // `in` tests membership of the *left* operand in the right one.
-            CmpOperator::In => rhs.py_contains(lhs, self),
-            CmpOperator::NotIn => Ok(!rhs.py_contains(lhs, self)?),
-            CmpOperator::Lt | CmpOperator::LtE | CmpOperator::Gt | CmpOperator::GtE => self.cmp_ordering(op, lhs, rhs),
         }
     }
 
-    /// Executes direct `==`, preserving an arbitrary value returned by `__eq__`.
-    pub(super) fn compare_eq(&mut self) -> Result<(), RunError> {
+    /// Pops two operands and pushes their arbitrary rich-comparison result.
+    fn compare_rich_op<const OP: u8>(&mut self) -> Result<(), RunError> {
+        const { assert!(CmpOperator::from_repr(OP).is_some(), "invalid CmpOperator operand") };
+        let cmp_op = CmpOperator::from_repr(OP).expect("invalid CmpOperator operand");
+        let op = RichCmpOp::from_cmp_operator(cmp_op).expect("compare_rich_op requires a rich comparison");
         let this = self;
+
         let rhs = this.pop();
         defer_drop!(rhs, this);
         let lhs = this.pop();
         defer_drop!(lhs, this);
 
-        let result = lhs.py_rich_eq(rhs, this)?;
+        let result = lhs.py_rich_compare(rhs, op, this)?;
         this.push(result);
         Ok(())
     }
 
-    /// Executes direct `!=`; user `__ne__` dispatch is not yet supported.
-    pub(super) fn compare_ne(&mut self) -> Result<(), RunError> {
-        let this = self;
-        let rhs = this.pop();
-        defer_drop!(rhs, this);
-        let lhs = this.pop();
-        defer_drop!(lhs, this);
-
-        let result = lhs.py_rich_eq(rhs, this)?;
-        defer_drop!(result, this);
-        let is_not_equal = !result.py_bool(this)?;
-        this.push(Value::Bool(is_not_equal));
-        Ok(())
-    }
-
-    /// Evaluates an ordering comparison, preserving CPython's behavior for
-    /// unordered values such as `NaN` and incomparable operand types.
-    #[inline]
-    fn cmp_ordering(&mut self, op: CmpOperator, lhs: &Value, rhs: &Value) -> RunResult<bool> {
-        // A type whose ordering no `CmpOrder` describes (a `Counter` compares as
-        // a multiset) answers the operator itself. Hooked in here rather than at
-        // the opcode so the fused-assert path, which calls `cmp_values` directly,
-        // gets the same semantics.
-        if let Some(result) = lhs.py_cmp_op(rhs, op, self)? {
-            return Ok(result);
-        }
-        match lhs.py_cmp(rhs, self)? {
-            CmpOrder::Ordered(ordering) => Ok(match op {
-                CmpOperator::Lt => ordering.is_lt(),
-                CmpOperator::LtE => ordering.is_le(),
-                CmpOperator::Gt => ordering.is_gt(),
-                CmpOperator::GtE => ordering.is_ge(),
-                // `cmp_values` calls this only for ordering operators.
-                _ => unreachable!("cmp_ordering reached with a non-ordering operator"),
-            }),
-            CmpOrder::Unordered => Ok(false),
-            CmpOrder::Incomparable => {
-                let left_type = lhs.py_type_name(self);
-                let right_type = rhs.py_type_name(self);
-                Err(ExcType::type_error_ordering(op.as_str(), &left_type, &right_type))
-            }
-        }
-    }
-
-    /// Pops both operands and pushes a boolean comparison result.
-    /// The const operator lets dispatch specialize the implementation per opcode.
-    fn compare_op<const OP: u8>(&mut self) -> Result<(), RunError> {
-        // Rejects a bad `OP` at compile time, which makes the `else` dead.
+    /// Pops two operands and pushes a boolean identity or containment result.
+    fn compare_bool_op<const OP: u8>(&mut self) -> Result<(), RunError> {
         const { assert!(CmpOperator::from_repr(OP).is_some(), "invalid CmpOperator operand") };
         let op = CmpOperator::from_repr(OP).expect("invalid CmpOperator operand");
         let this = self;
@@ -109,24 +64,42 @@ impl VM<'_> {
     }
 }
 
-/// Defines a specialized entry point for each boolean comparison opcode.
-macro_rules! compare_opcodes {
+/// Defines specialized entry points for rich-comparison opcodes.
+macro_rules! rich_compare_opcodes {
     ($($name:ident => $op:ident,)*) => {
         impl VM<'_> {
             $(
                 pub(super) fn $name(&mut self) -> Result<(), RunError> {
-                    self.compare_op::<{ CmpOperator::$op.as_operand() }>()
+                    self.compare_rich_op::<{ CmpOperator::$op.as_operand() }>()
                 }
             )*
         }
     };
 }
 
-compare_opcodes! {
+rich_compare_opcodes! {
+    compare_eq => Eq,
+    compare_ne => NotEq,
     compare_lt => Lt,
     compare_le => LtE,
     compare_gt => Gt,
     compare_ge => GtE,
+}
+
+/// Defines specialized entry points for non-rich comparison opcodes.
+macro_rules! bool_compare_opcodes {
+    ($($name:ident => $op:ident,)*) => {
+        impl VM<'_> {
+            $(
+                pub(super) fn $name(&mut self) -> Result<(), RunError> {
+                    self.compare_bool_op::<{ CmpOperator::$op.as_operand() }>()
+                }
+            )*
+        }
+    };
+}
+
+bool_compare_opcodes! {
     compare_is => Is,
     compare_is_not => IsNot,
     compare_in => In,

--- a/crates/monty/src/bytecode/vm/compare.rs
+++ b/crates/monty/src/bytecode/vm/compare.rs
@@ -3,97 +3,52 @@
 use super::VM;
 use crate::{
     defer_drop,
-    exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
+    exception_private::{RunError, RunResult},
     expressions::CmpOperator,
-    types::{CmpOrder, PyTrait},
+    types::RichCmpOp,
     value::Value,
 };
 
 impl VM<'_> {
     /// Evaluates a comparison as a boolean without consuming its operands.
     ///
-    /// Shared by fused asserts and comparison helpers that need truth rather
-    /// than the arbitrary value a direct `==` expression may produce.
+    /// Fused asserts use this path because they need the truth of an expression,
+    /// rather than the arbitrary value returned by a direct rich comparison.
     #[inline]
     pub(super) fn cmp_values(&mut self, op: CmpOperator, lhs: &Value, rhs: &Value) -> RunResult<bool> {
-        match op {
-            CmpOperator::Eq | CmpOperator::NotEq => {
-                let result = lhs.py_rich_eq(rhs, self)?;
-                let is_equal = result.py_bool(self);
-                result.drop_with(self);
-                let is_equal = is_equal?;
-                Ok(if op == CmpOperator::NotEq { !is_equal } else { is_equal })
+        if let Some(op) = RichCmpOp::from_cmp_operator(op) {
+            lhs.py_rich_compare_bool(rhs, op, self)
+        } else {
+            match op {
+                CmpOperator::Is => Ok(lhs.is(rhs)),
+                CmpOperator::IsNot => Ok(!lhs.is(rhs)),
+                // `in` tests membership of the left operand in the right one.
+                CmpOperator::In => rhs.py_contains(lhs, self),
+                CmpOperator::NotIn => Ok(!rhs.py_contains(lhs, self)?),
+                _ => unreachable!("rich comparisons handled above"),
             }
-            CmpOperator::Is => Ok(lhs.is(rhs)),
-            CmpOperator::IsNot => Ok(!lhs.is(rhs)),
-            // `in` tests membership of the *left* operand in the right one.
-            CmpOperator::In => rhs.py_contains(lhs, self),
-            CmpOperator::NotIn => Ok(!rhs.py_contains(lhs, self)?),
-            CmpOperator::Lt | CmpOperator::LtE | CmpOperator::Gt | CmpOperator::GtE => self.cmp_ordering(op, lhs, rhs),
         }
     }
 
-    /// Executes direct `==`, preserving an arbitrary value returned by `__eq__`.
-    pub(super) fn compare_eq(&mut self) -> Result<(), RunError> {
+    /// Pops two operands and pushes their arbitrary rich-comparison result.
+    fn compare_rich_op<const OP: u8>(&mut self) -> Result<(), RunError> {
+        const { assert!(CmpOperator::from_repr(OP).is_some(), "invalid CmpOperator operand") };
+        let cmp_op = CmpOperator::from_repr(OP).expect("invalid CmpOperator operand");
+        let op = RichCmpOp::from_cmp_operator(cmp_op).expect("compare_rich_op requires a rich comparison");
         let this = self;
+
         let rhs = this.pop();
         defer_drop!(rhs, this);
         let lhs = this.pop();
         defer_drop!(lhs, this);
 
-        let result = lhs.py_rich_eq(rhs, this)?;
+        let result = lhs.py_rich_compare(rhs, op, this)?;
         this.push(result);
         Ok(())
     }
 
-    /// Executes direct `!=`; user `__ne__` dispatch is not yet supported.
-    pub(super) fn compare_ne(&mut self) -> Result<(), RunError> {
-        let this = self;
-        let rhs = this.pop();
-        defer_drop!(rhs, this);
-        let lhs = this.pop();
-        defer_drop!(lhs, this);
-
-        let result = lhs.py_rich_eq(rhs, this)?;
-        defer_drop!(result, this);
-        let is_not_equal = !result.py_bool(this)?;
-        this.push(Value::Bool(is_not_equal));
-        Ok(())
-    }
-
-    /// Evaluates an ordering comparison, preserving CPython's behavior for
-    /// unordered values such as `NaN` and incomparable operand types.
-    #[inline]
-    fn cmp_ordering(&mut self, op: CmpOperator, lhs: &Value, rhs: &Value) -> RunResult<bool> {
-        // A type whose ordering no `CmpOrder` describes (a `Counter` compares as
-        // a multiset) answers the operator itself. Hooked in here rather than at
-        // the opcode so the fused-assert path, which calls `cmp_values` directly,
-        // gets the same semantics.
-        if let Some(result) = lhs.py_cmp_op(rhs, op, self, lhs.ref_id())? {
-            return Ok(result);
-        }
-        match lhs.py_cmp(rhs, self)? {
-            CmpOrder::Ordered(ordering) => Ok(match op {
-                CmpOperator::Lt => ordering.is_lt(),
-                CmpOperator::LtE => ordering.is_le(),
-                CmpOperator::Gt => ordering.is_gt(),
-                CmpOperator::GtE => ordering.is_ge(),
-                // `cmp_values` calls this only for ordering operators.
-                _ => unreachable!("cmp_ordering reached with a non-ordering operator"),
-            }),
-            CmpOrder::Unordered => Ok(false),
-            CmpOrder::Incomparable => {
-                let left_type = lhs.py_type_name(self);
-                let right_type = rhs.py_type_name(self);
-                Err(ExcType::type_error_ordering(op.as_str(), &left_type, &right_type))
-            }
-        }
-    }
-
-    /// Pops both operands and pushes a boolean comparison result.
-    /// The const operator lets dispatch specialize the implementation per opcode.
-    fn compare_op<const OP: u8>(&mut self) -> Result<(), RunError> {
-        // Rejects a bad `OP` at compile time, which makes the `else` dead.
+    /// Pops two operands and pushes a boolean identity or containment result.
+    fn compare_bool_op<const OP: u8>(&mut self) -> Result<(), RunError> {
         const { assert!(CmpOperator::from_repr(OP).is_some(), "invalid CmpOperator operand") };
         let op = CmpOperator::from_repr(OP).expect("invalid CmpOperator operand");
         let this = self;
@@ -109,24 +64,42 @@ impl VM<'_> {
     }
 }
 
-/// Defines a specialized entry point for each boolean comparison opcode.
-macro_rules! compare_opcodes {
+/// Defines specialized entry points for rich-comparison opcodes.
+macro_rules! rich_compare_opcodes {
     ($($name:ident => $op:ident,)*) => {
         impl VM<'_> {
             $(
                 pub(super) fn $name(&mut self) -> Result<(), RunError> {
-                    self.compare_op::<{ CmpOperator::$op.as_operand() }>()
+                    self.compare_rich_op::<{ CmpOperator::$op.as_operand() }>()
                 }
             )*
         }
     };
 }
 
-compare_opcodes! {
+rich_compare_opcodes! {
+    compare_eq => Eq,
+    compare_ne => NotEq,
     compare_lt => Lt,
     compare_le => LtE,
     compare_gt => Gt,
     compare_ge => GtE,
+}
+
+/// Defines specialized entry points for non-rich comparison opcodes.
+macro_rules! bool_compare_opcodes {
+    ($($name:ident => $op:ident,)*) => {
+        impl VM<'_> {
+            $(
+                pub(super) fn $name(&mut self) -> Result<(), RunError> {
+                    self.compare_bool_op::<{ CmpOperator::$op.as_operand() }>()
+                }
+            )*
+        }
+    };
+}
+
+bool_compare_opcodes! {
     compare_is => Is,
     compare_is_not => IsNot,
     compare_in => In,

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -13,7 +13,6 @@ use crate::{
     asyncio::{Awaiter, Coroutine, ExternalFuture, ExternalFutureState, GatherFuture, GatherState},
     bytecode::{CallResult, VM},
     exception_private::{ExcTypeExt, RunError, RunResult, SimpleException},
-    expressions::CmpOperator,
     hash::{HashValue, identity_hash},
     heap::{DropWithContext, HeapId, HeapItem, HeapReadOutput},
     intern::FunctionId,
@@ -25,9 +24,9 @@ use crate::{
         BoundMethod, Bytes, BytesIterator, Class, Dataclass, Deque, Dict, DictItemIterator, DictItemsView,
         DictKeyIterator, DictKeysView, DictValueIterator, DictValuesView, ExtFunction, FrozenSet, Instance,
         ItertoolsIter, LazyHeapSet, List, LongInt, Module, NamedTuple, NamedTupleClass, OpenFile, Path, PyTrait, Range,
-        RangeIterator, ReMatch, RePattern, Set, SetIterator, Slice, Str, StringIterator, Tuple, TupleIterator, Type,
-        callable_iterator::CallableIterator, date, datetime, deque::DequeIterator, list::ListIterator,
-        str::allocate_string, timedelta, timezone,
+        RangeIterator, ReMatch, RePattern, RichCmpOp, Set, SetIterator, Slice, Str, StringIterator, Tuple,
+        TupleIterator, Type, callable_iterator::CallableIterator, date, datetime, deque::DequeIterator,
+        list::ListIterator, str::allocate_string, timedelta, timezone,
     },
     value::{EitherStr, Value},
 };
@@ -793,6 +792,26 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         )
     }
 
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        heap_read_output_py_trait_forward!(
+            self,
+            |value| value.py_rich_compare_impl(other, op, vm, self_id),
+            else {
+                if op.is_equality() {
+                    Ok(op.equality_result(self.py_eq_impl(other, vm)?))
+                } else {
+                    Ok(Value::NotImplemented)
+                }
+            }
+        )
+    }
+
     /// Dispatches hashing to per-type `PyTrait` implementations where possible.
     fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         heap_read_output_py_trait_forward!(
@@ -907,10 +926,6 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
 
     fn py_ior_impl(&mut self, other: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
         heap_read_output_py_trait_forward!(self, |value| value.py_ior_impl(other, vm), else Ok(false))
-    }
-
-    fn py_cmp_op(&self, other: &Value, op: CmpOperator, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        heap_read_output_py_trait_forward!(self, |value| value.py_cmp_op(other, op, vm), else Ok(None))
     }
 
     fn py_getitem(&self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -24,9 +24,9 @@ use crate::{
         BoundMethod, Bytes, BytesIterator, Class, Dataclass, Deque, Dict, DictItemIterator, DictItemsView,
         DictKeyIterator, DictKeysView, DictValueIterator, DictValuesView, ExtFunction, FrozenSet, Instance,
         ItertoolsIter, LazyHeapSet, List, LongInt, Module, NamedTuple, NamedTupleClass, OpenFile, Path, PyTrait, Range,
-        RangeIterator, ReMatch, RePattern, RichCmpOp, Set, SetIterator, Slice, Str, StringIterator, Tuple,
-        TupleIterator, Type, callable_iterator::CallableIterator, date, datetime, deque::DequeIterator,
-        list::ListIterator, str::allocate_string, timedelta, timezone,
+        RangeIterator, ReMatch, RePattern, RichCmpOp, RichCmpVtable, Set, SetIterator, Slice, Str, StringIterator,
+        Tuple, TupleIterator, Type, callable_iterator::CallableIterator, date, datetime, deque::DequeIterator,
+        invoke_rich_cmp_slot, list::ListIterator, str::allocate_string, timedelta, timezone,
     },
     value::{EitherStr, Value},
 };
@@ -562,7 +562,52 @@ pub(crate) fn heap_subscript(id: HeapId, key: &Value, vm: &mut VM<'_>) -> RunRes
     }
 }
 
+impl<'h> HeapReadOutput<'h> {
+    /// Dispatches rich comparison through the concrete heap variant's vtable.
+    fn rich_compare(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Value> {
+        heap_read_output_py_trait_forward!(
+            self,
+            |value| invoke_rich_cmp_slot(value, other, op, vm, self_id),
+            else {
+                if op.is_equality() {
+                    Ok(op.equality_result(self.fallback_eq(other, vm)))
+                } else {
+                    Ok(Value::NotImplemented)
+                }
+            }
+        )
+    }
+
+    /// Implements equality for heap variants without their own `PyTrait` implementation.
+    fn fallback_eq(&self, other: &Value, vm: &VM<'h>) -> Option<bool> {
+        match self {
+            Self::Closure(a) => match other.read_heap(vm) {
+                Some(Self::Closure(b)) => {
+                    let a = a.get(vm.heap);
+                    let b = b.get(vm.heap);
+                    Some(a.func_id == b.func_id && a.cells == b.cells)
+                }
+                _ => None,
+            },
+            Self::FunctionDefaults(a) => match other.read_heap(vm) {
+                Some(Self::FunctionDefaults(b)) => Some(a.get(vm.heap).func_id == b.get(vm.heap).func_id),
+                _ => None,
+            },
+            Self::ExtFunction(_)
+            | Self::Cell(_)
+            | Self::Exception(_)
+            | Self::Module(_)
+            | Self::Coroutine(_)
+            | Self::GatherFuture(_)
+            | Self::ExternalFuture(_) => None,
+            _ => unreachable!("concrete heap variants dispatch their own rich-comparison slots"),
+        }
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     /// Delegates to the types defining their own `in`; the rest keep the trait
     /// default (`None`), leaving `Value::py_contains` to iterate or raise.
     fn py_contains_impl(&self, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
@@ -759,57 +804,6 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
 
     fn py_len(&self, vm: &VM<'h>) -> Option<usize> {
         heap_read_output_py_trait_forward!(self, |value| value.py_len(vm), else None)
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        heap_read_output_py_trait_forward!(
-            self,
-            |value| value.py_eq_impl(other, vm),
-            else {
-                match self {
-                    Self::Closure(a) => Ok(match other.read_heap(vm) {
-                        Some(Self::Closure(b)) => {
-                            let a = a.get(vm.heap);
-                            let b = b.get(vm.heap);
-                            Some(a.func_id == b.func_id && a.cells == b.cells)
-                        }
-                        _ => None,
-                    }),
-                    Self::FunctionDefaults(a) => Ok(match other.read_heap(vm) {
-                        Some(Self::FunctionDefaults(b)) => Some(a.get(vm.heap).func_id == b.get(vm.heap).func_id),
-                        _ => None,
-                    }),
-                    Self::ExtFunction(_)
-                    | Self::Cell(_)
-                    | Self::Exception(_)
-                    | Self::Module(_)
-                    | Self::Coroutine(_)
-                    | Self::GatherFuture(_)
-                    | Self::ExternalFuture(_) => Ok(None),
-                    _ => unreachable!("py-trait variants handled by heap_read_output_py_trait_forward"),
-                }
-            }
-        )
-    }
-
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        heap_read_output_py_trait_forward!(
-            self,
-            |value| value.py_rich_compare_impl(other, op, vm, self_id),
-            else {
-                if op.is_equality() {
-                    Ok(op.equality_result(self.py_eq_impl(other, vm)?))
-                } else {
-                    Ok(Value::NotImplemented)
-                }
-            }
-        )
     }
 
     /// Dispatches hashing to per-type `PyTrait` implementations where possible.

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -564,10 +564,10 @@ pub(crate) fn heap_subscript(id: HeapId, key: &Value, vm: &mut VM<'_>) -> RunRes
 
 impl<'h> HeapReadOutput<'h> {
     /// Dispatches rich comparison through the concrete heap variant's vtable.
-    fn rich_compare(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Value> {
+    fn rich_compare(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         heap_read_output_py_trait_forward!(
             self,
-            |value| invoke_rich_cmp_slot(value, other, op, vm, self_id),
+            |value| invoke_rich_cmp_slot(value, other, op, vm),
             else {
                 if op.is_equality() {
                     Ok(op.equality_result(self.fallback_eq(other, vm)))

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -13,7 +13,6 @@ use crate::{
     asyncio::{Awaiter, Coroutine, ExternalFuture, ExternalFutureState, GatherFuture, GatherState, awaited_state_size},
     bytecode::{CallResult, VM},
     exception_private::{ExcTypeExt, RunError, RunResult, SimpleException},
-    expressions::CmpOperator,
     hash::{HashValue, identity_hash},
     heap::{DropWithContext, HeapId, HeapItem, HeapReadOutput},
     intern::FunctionId,
@@ -22,9 +21,9 @@ use crate::{
         BoundMethod, Bytes, BytesIterator, Class, Dataclass, Deque, Dict, DictItemIterator, DictItemsView,
         DictKeyIterator, DictKeysView, DictValueIterator, DictValuesView, ExtFunction, FrozenSet, Instance,
         ItertoolsIter, LazyHeapSet, List, LongInt, Module, NamedTuple, NamedTupleClass, OpenFile, Path, PyTrait, Range,
-        RangeIterator, ReMatch, RePattern, Set, SetIterator, Slice, Str, StringIterator, Tuple, TupleIterator, Type,
-        callable_iterator::CallableIterator, date, datetime, deque::DequeIterator, list::ListIterator,
-        str::allocate_string, timedelta, timezone,
+        RangeIterator, ReMatch, RePattern, RichCmpOp, Set, SetIterator, Slice, Str, StringIterator, Tuple,
+        TupleIterator, Type, callable_iterator::CallableIterator, date, datetime, deque::DequeIterator,
+        list::ListIterator, str::allocate_string, timedelta, timezone,
     },
     value::{EitherStr, Value},
 };
@@ -883,6 +882,26 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
         )
     }
 
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        heap_read_output_py_trait_forward!(
+            self,
+            |value| value.py_rich_compare_impl(other, op, vm, self_id),
+            else {
+                if op.is_equality() {
+                    Ok(op.equality_result(self.py_eq_impl(other, vm)?))
+                } else {
+                    Ok(Value::NotImplemented)
+                }
+            }
+        )
+    }
+
     /// Dispatches hashing to per-type `PyTrait` implementations where possible.
     fn py_hash(&self, self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         heap_read_output_py_trait_forward!(
@@ -996,16 +1015,6 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
 
     fn py_ior_impl(&mut self, other: &Value, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<bool> {
         heap_read_output_py_trait_forward!(self, |value| value.py_ior_impl(other, vm, self_id), else Ok(false))
-    }
-
-    fn py_cmp_op(
-        &self,
-        other: &Value,
-        op: CmpOperator,
-        vm: &mut VM<'h>,
-        self_id: Option<HeapId>,
-    ) -> RunResult<Option<bool>> {
-        heap_read_output_py_trait_forward!(self, |value| value.py_cmp_op(other, op, vm, self_id), else Ok(None))
     }
 
     fn py_getitem(&self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {

--- a/crates/monty/src/heap_data.rs
+++ b/crates/monty/src/heap_data.rs
@@ -21,9 +21,9 @@ use crate::{
         BoundMethod, Bytes, BytesIterator, Class, Dataclass, Deque, Dict, DictItemIterator, DictItemsView,
         DictKeyIterator, DictKeysView, DictValueIterator, DictValuesView, ExtFunction, FrozenSet, Instance,
         ItertoolsIter, LazyHeapSet, List, LongInt, Module, NamedTuple, NamedTupleClass, OpenFile, Path, PyTrait, Range,
-        RangeIterator, ReMatch, RePattern, RichCmpOp, Set, SetIterator, Slice, Str, StringIterator, Tuple,
-        TupleIterator, Type, callable_iterator::CallableIterator, date, datetime, deque::DequeIterator,
-        list::ListIterator, str::allocate_string, timedelta, timezone,
+        RangeIterator, ReMatch, RePattern, RichCmpOp, RichCmpVtable, Set, SetIterator, Slice, Str, StringIterator,
+        Tuple, TupleIterator, Type, callable_iterator::CallableIterator, date, datetime, deque::DequeIterator,
+        invoke_rich_cmp_slot, list::ListIterator, str::allocate_string, timedelta, timezone,
     },
     value::{EitherStr, Value},
 };
@@ -646,7 +646,52 @@ pub(crate) fn heap_subscript(id: HeapId, key: &Value, vm: &mut VM<'_>) -> RunRes
     }
 }
 
+impl<'h> HeapReadOutput<'h> {
+    /// Dispatches rich comparison through the concrete heap variant's vtable.
+    fn rich_compare(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Value> {
+        heap_read_output_py_trait_forward!(
+            self,
+            |value| invoke_rich_cmp_slot(value, other, op, vm, self_id),
+            else {
+                if op.is_equality() {
+                    Ok(op.equality_result(self.fallback_eq(other, vm)))
+                } else {
+                    Ok(Value::NotImplemented)
+                }
+            }
+        )
+    }
+
+    /// Implements equality for heap variants without their own `PyTrait` implementation.
+    fn fallback_eq(&self, other: &Value, vm: &VM<'h>) -> Option<bool> {
+        match self {
+            Self::Closure(a) => match other.read_heap(vm) {
+                Some(Self::Closure(b)) => {
+                    let a = a.get(vm.heap);
+                    let b = b.get(vm.heap);
+                    Some(a.func_id == b.func_id && a.cells == b.cells)
+                }
+                _ => None,
+            },
+            Self::FunctionDefaults(a) => match other.read_heap(vm) {
+                Some(Self::FunctionDefaults(b)) => Some(a.get(vm.heap).func_id == b.get(vm.heap).func_id),
+                _ => None,
+            },
+            Self::ExtFunction(_)
+            | Self::Cell(_)
+            | Self::Exception(_)
+            | Self::Module(_)
+            | Self::Coroutine(_)
+            | Self::GatherFuture(_)
+            | Self::ExternalFuture(_) => None,
+            _ => unreachable!("concrete heap variants dispatch their own rich-comparison slots"),
+        }
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     /// Delegates to the types defining their own `in`; the rest keep the trait
     /// default (`None`), leaving `Value::py_contains` to iterate or raise.
     fn py_contains_impl(&self, self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
@@ -849,57 +894,6 @@ impl<'h> PyTrait<'h> for HeapReadOutput<'h> {
 
     fn py_len(&self, vm: &VM<'h>) -> Option<usize> {
         heap_read_output_py_trait_forward!(self, |value| value.py_len(vm), else None)
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        heap_read_output_py_trait_forward!(
-            self,
-            |value| value.py_eq_impl(other, vm),
-            else {
-                match self {
-                    Self::Closure(a) => Ok(match other.read_heap(vm) {
-                        Some(Self::Closure(b)) => {
-                            let a = a.get(vm.heap);
-                            let b = b.get(vm.heap);
-                            Some(a.func_id == b.func_id && a.cells == b.cells)
-                        }
-                        _ => None,
-                    }),
-                    Self::FunctionDefaults(a) => Ok(match other.read_heap(vm) {
-                        Some(Self::FunctionDefaults(b)) => Some(a.get(vm.heap).func_id == b.get(vm.heap).func_id),
-                        _ => None,
-                    }),
-                    Self::ExtFunction(_)
-                    | Self::Cell(_)
-                    | Self::Exception(_)
-                    | Self::Module(_)
-                    | Self::Coroutine(_)
-                    | Self::GatherFuture(_)
-                    | Self::ExternalFuture(_) => Ok(None),
-                    _ => unreachable!("py-trait variants handled by heap_read_output_py_trait_forward"),
-                }
-            }
-        )
-    }
-
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        heap_read_output_py_trait_forward!(
-            self,
-            |value| value.py_rich_compare_impl(other, op, vm, self_id),
-            else {
-                if op.is_equality() {
-                    Ok(op.equality_result(self.py_eq_impl(other, vm)?))
-                } else {
-                    Ok(Value::NotImplemented)
-                }
-            }
-        )
     }
 
     /// Dispatches hashing to per-type `PyTrait` implementations where possible.

--- a/crates/monty/src/modules/collections/counter.rs
+++ b/crates/monty/src/modules/collections/counter.rs
@@ -7,7 +7,7 @@
 //! missing-key read (`0`, no insert), `most_common`/`elements`/`total`/`update`/
 //! `subtract`, and the `+ - & |` algebra are added on top.
 
-use std::{cmp::Ordering, mem};
+use std::mem;
 
 use smallvec::smallvec;
 
@@ -18,7 +18,8 @@ use crate::{
     exception_private::{ExcType, ExcTypeExt, RunResult},
     heap::{DropGuard, DropWithContext, HeapData, HeapId, HeapReadOutput},
     resource_checks::check_repeat_size,
-    types::{Dict, List, PyTrait, allocate_tuple, iter::collect_owned_iterable, py_trait::CmpOrder},
+    sorting::sort_indices,
+    types::{Dict, List, PyTrait, RichCmpOp, allocate_tuple, iter::collect_owned_iterable},
     value::{VALUE_SIZE, Value},
 };
 
@@ -54,61 +55,20 @@ enum CountCmp {
 }
 
 impl CountCmp {
-    /// The operator symbol CPython names in the `TypeError`.
-    fn symbol(self) -> &'static str {
+    /// Converts the algebra's comparison choice into the runtime protocol op.
+    fn rich_op(self) -> RichCmpOp {
         match self {
-            Self::Le => "<=",
-            Self::Lt => "<",
-            Self::Ge => ">=",
-            Self::Gt => ">",
-        }
-    }
-
-    /// Whether `lhs <op> rhs` holds given the three-way `ordering` of the pair.
-    fn holds(self, ordering: Ordering) -> bool {
-        match self {
-            Self::Le => ordering != Ordering::Greater,
-            Self::Lt => ordering == Ordering::Less,
-            Self::Ge => ordering != Ordering::Less,
-            Self::Gt => ordering == Ordering::Greater,
+            Self::Le => RichCmpOp::Le,
+            Self::Lt => RichCmpOp::Lt,
+            Self::Ge => RichCmpOp::Ge,
+            Self::Gt => RichCmpOp::Gt,
         }
     }
 }
 
-/// Evaluates `lhs <op> rhs` between two counts, raising CPython's operator-
-/// specific `TypeError` when the pair has no ordering at all.
-///
-/// `NaN` makes a pair *unordered* rather than incomparable, and every IEEE
-/// ordering comparison against `NaN` is false — so `nan <= nan` is `false`, which
-/// is exactly what CPython's element-wise `Counter` comparisons observe.
+/// Evaluates the requested Python ordering operation between two counts.
 fn count_holds(lhs: &Value, rhs: &Value, op: CountCmp, vm: &mut VM<'_>) -> RunResult<bool> {
-    match lhs.py_cmp(rhs, vm)? {
-        CmpOrder::Ordered(ordering) => Ok(op.holds(ordering)),
-        CmpOrder::Unordered => Ok(false),
-        CmpOrder::Incomparable => Err(ExcType::type_error_ordering(
-            op.symbol(),
-            &lhs.py_type_name(vm),
-            &rhs.py_type_name(vm),
-        )),
-    }
-}
-
-/// Orders two counts for *sorting* (`most_common`, Counter repr), raising the
-/// sort's `<` `TypeError` when they are incomparable.
-///
-/// Unlike the algebra's [`count_holds`], a `NaN` pair is treated as **equal**
-/// here: Python's `sorted`/`heapq` never raise on `NaN`, they just leave it
-/// wherever the (ill-defined for `NaN`) ordering happens to place it.
-fn count_sort_cmp(lhs: &Value, rhs: &Value, vm: &mut VM<'_>) -> RunResult<Ordering> {
-    match lhs.py_cmp(rhs, vm)? {
-        CmpOrder::Ordered(ordering) => Ok(ordering),
-        CmpOrder::Unordered => Ok(Ordering::Equal),
-        CmpOrder::Incomparable => Err(ExcType::type_error_ordering(
-            "<",
-            &lhs.py_type_name(vm),
-            &rhs.py_type_name(vm),
-        )),
-    }
+    lhs.py_rich_compare_bool(rhs, op.rich_op(), vm)
 }
 
 /// Whether a count is strictly greater than zero (the `Counter` algebra keeps
@@ -339,27 +299,9 @@ pub(crate) fn counter_total(dict_id: HeapId, vm: &mut VM<'_>) -> RunResult<Value
 /// Consumes `counts`.
 pub(crate) fn counter_order(counts: Vec<Value>, vm: &mut VM<'_>) -> RunResult<Vec<usize>> {
     let mut order: Vec<usize> = (0..counts.len()).collect();
-    // `sort_by` needs an infallible comparator, so a comparison error is stashed
-    // and reported once the sort finishes; the ordering it produces in that case
-    // is discarded.
-    let mut failure = None;
-    order.sort_by(|&a, &b| {
-        if failure.is_some() {
-            return Ordering::Equal;
-        }
-        match count_sort_cmp(&counts[b], &counts[a], vm) {
-            Ok(ordering) => ordering,
-            Err(e) => {
-                failure = Some(e);
-                Ordering::Equal
-            }
-        }
-    });
-    counts.drop_with(vm);
-    match failure {
-        Some(e) => Err(e),
-        None => Ok(order),
-    }
+    defer_drop!(counts, vm);
+    sort_indices(&mut order, counts, true, vm)?;
+    Ok(order)
 }
 
 /// Snapshots a Counter's counts as owned clones, releasing the heap borrow so
@@ -621,44 +563,25 @@ pub(crate) fn counter_compare(l_id: HeapId, r_id: HeapId, cmp: CounterCmp, vm: &
         CounterCmp::Ge => (CountCmp::Ge, false),
         CounterCmp::Gt => (CountCmp::Ge, true),
     };
-    // `holds` is false as soon as any pair breaks the loose ordering; `equal`
-    // tracks whether every compared pair matched, which the strict forms need.
-    let mut holds = true;
+    // Strict comparisons additionally need count equality after the loose
+    // relation holds for every key.
     let mut equal = true;
     // `counter_union_counts` hands back owned pairs the caller must drop. The
-    // guard covers every exit — a short-circuit (`!holds`), a failing comparison,
+    // guard covers every exit — a failed loose comparison, an exception,
     // and normal exhaustion — releasing whatever the loop never compared.
     let pairs = counter_union_counts(l_id, r_id, vm)?.into_iter();
     defer_drop_mut!(pairs, vm);
     for pair in pairs.by_ref() {
         defer_drop!(pair, vm);
         let (l, r) = pair;
-        // One `py_cmp` yields both the loose check and the equality the strict
-        // forms need. A `NaN` pair is unordered: the loose comparison fails (as
-        // in CPython, `nan <= x` is false) and the pair counts as not-equal.
-        match l.py_cmp(r, vm)? {
-            CmpOrder::Ordered(Ordering::Equal) => {}
-            CmpOrder::Ordered(ordering) => {
-                holds &= op.holds(ordering);
-                equal = false;
-            }
-            CmpOrder::Unordered => {
-                holds = false;
-                equal = false;
-            }
-            CmpOrder::Incomparable => {
-                return Err(ExcType::type_error_ordering(
-                    op.symbol(),
-                    &l.py_type_name(vm),
-                    &r.py_type_name(vm),
-                ));
-            }
+        if !count_holds(l, r, op, vm)? {
+            return Ok(false);
         }
-        if !holds {
-            break;
+        if strict && !l.py_eq(r, vm)? {
+            equal = false;
         }
     }
-    Ok(holds && (!strict || !equal))
+    Ok(!strict || !equal)
 }
 
 /// Pairs up the counts of two Counters over the union of their keys, with a

--- a/crates/monty/src/modules/dataclasses/field.rs
+++ b/crates/monty/src/modules/dataclasses/field.rs
@@ -86,8 +86,8 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, DataclassField> {
         None
     }
 
-    fn py_hash(&self, self_id: HeapId, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
-        Ok(Some(identity_hash(self_id)))
+    fn py_hash(&self, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+        Ok(Some(identity_hash(self.id())))
     }
 
     /// CPython's `Field.__repr__`, attribute for attribute. The two spellings

--- a/crates/monty/src/modules/dataclasses/field.rs
+++ b/crates/monty/src/modules/dataclasses/field.rs
@@ -86,14 +86,8 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, DataclassField> {
         None
     }
 
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // `Field` defines no `__eq__`, so it compares by identity, which
-        // `Value::py_eq_impl` resolves before ever reaching here.
-        Ok(None)
-    }
-
-    fn py_hash(&self, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
-        Ok(Some(identity_hash(self.id())))
+    fn py_hash(&self, self_id: HeapId, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+        Ok(Some(identity_hash(self_id)))
     }
 
     /// CPython's `Field.__repr__`, attribute for attribute. The two spellings

--- a/crates/monty/src/modules/dataclasses/field.rs
+++ b/crates/monty/src/modules/dataclasses/field.rs
@@ -86,12 +86,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DataclassField> {
         None
     }
 
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // `Field` defines no `__eq__`, so it compares by identity, which
-        // `Value::py_eq_impl` resolves before ever reaching here.
-        Ok(None)
-    }
-
     fn py_hash(&self, self_id: HeapId, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         Ok(Some(identity_hash(self_id)))
     }

--- a/crates/monty/src/modules/dataclasses/options.rs
+++ b/crates/monty/src/modules/dataclasses/options.rs
@@ -44,12 +44,6 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, DataclassParams> {
         None
     }
 
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // `_DataclassParams` defines no `__eq__`, so it compares by identity,
-        // which `Value::py_eq_impl` resolves before ever reaching here.
-        Ok(None)
-    }
-
     fn py_hash(&self, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         Ok(Some(identity_hash(self.id())))
     }

--- a/crates/monty/src/sorting.rs
+++ b/crates/monty/src/sorting.rs
@@ -8,14 +8,12 @@
 //! This module provides [`sort_indices`] for the comparison step and
 //! [`apply_permutation`] for the in-place rearrangement step.
 
-use std::cmp::Ordering;
-
 use crate::{
     args::{ArgValues, FromArgs, LaxBool},
     bytecode::VM,
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
-    types::{CmpOrder, PyTrait},
+    exception_private::{RunError, RunResult},
+    types::RichCmpOp,
     value::Value,
 };
 
@@ -77,33 +75,81 @@ pub fn sort_values(values: &mut [Value], key_fn: Option<&Value>, reverse: bool, 
 
         Ok(())
     } else {
-        // With no key function can sort directly on the original array
-        let mut sort_result: RunResult<()> = Ok(());
-        let mut n = 0usize;
-        values.sort_by(|a, b| {
-            n += 1;
-            compare_values(n, a, b, reverse, &mut sort_result, vm)
-        });
-        sort_result
+        let mut indices = (0..values.len()).collect::<Vec<_>>();
+        sort_indices(&mut indices, values, reverse, vm)?;
+        apply_permutation(values, &mut indices);
+        Ok(())
     }
 }
 
 /// Sorts a vector of indices by comparing items at those positions.
 ///
-/// Compares `values[a]` vs `values[b]` using `py_cmp`, optionally reversing
-/// the ordering. If any comparison fails (type error or runtime error), the
-/// sort finishes early and the error is returned.
+/// Compares `values[a] < values[b]`, swapping operands for reverse order.
+/// If any comparison fails, the sort finishes early and returns the error.
 ///
 /// The `values` slice is typically either the items themselves (no key function)
 /// or the pre-computed key values.
 pub fn sort_indices(indices: &mut [usize], values: &[Value], reverse: bool, vm: &mut VM<'_>) -> Result<(), RunError> {
-    let mut sort_result: RunResult<()> = Ok(());
-    let mut n = 0usize;
-    indices.sort_by(|&a, &b| {
-        n += 1;
-        compare_values(n, &values[a], &values[b], reverse, &mut sort_result, vm)
-    });
-    sort_result
+    let mut scratch = indices.to_vec();
+    let mut width = 1;
+    while width < indices.len() {
+        let stride = width.saturating_mul(2);
+        for start in (0..indices.len()).step_by(stride) {
+            let mid = start.saturating_add(width).min(indices.len());
+            let end = start.saturating_add(stride).min(indices.len());
+            merge_indices(indices, &mut scratch, values, start, mid, end, reverse, vm)?;
+        }
+        indices.copy_from_slice(&scratch);
+        width = stride;
+    }
+    Ok(())
+}
+
+/// Stably merges adjacent sorted index ranges using Python's `<` predicate.
+///
+/// The right item moves first only when it is strictly less than the left;
+/// equality and partial-order ties retain their original order.
+#[expect(clippy::too_many_arguments)]
+fn merge_indices(
+    indices: &[usize],
+    scratch: &mut [usize],
+    values: &[Value],
+    start: usize,
+    mid: usize,
+    end: usize,
+    reverse: bool,
+    vm: &mut VM<'_>,
+) -> RunResult<()> {
+    let (mut left, mut right) = (start, mid);
+    for destination in &mut scratch[start..end] {
+        let take_right = if left == mid {
+            true
+        } else if right == end {
+            false
+        } else {
+            comes_before(&values[indices[right]], &values[indices[left]], reverse, vm)?
+        };
+        *destination = if take_right {
+            let index = indices[right];
+            right += 1;
+            index
+        } else {
+            let index = indices[left];
+            left += 1;
+            index
+        };
+    }
+    Ok(())
+}
+
+/// Tests whether `lhs` precedes `rhs` in the requested sort direction.
+fn comes_before(lhs: &Value, rhs: &Value, reverse: bool, vm: &mut VM<'_>) -> RunResult<bool> {
+    vm.heap.check_time()?;
+    if reverse {
+        rhs.py_rich_compare_bool(lhs, RichCmpOp::Lt, vm)
+    } else {
+        lhs.py_rich_compare_bool(rhs, RichCmpOp::Lt, vm)
+    }
 }
 
 /// Rearranges `items` in-place according to a permutation of indices.
@@ -133,39 +179,4 @@ pub fn apply_permutation<T>(items: &mut [T], indices: &mut [usize]) {
             current = target;
         }
     }
-}
-
-/// Helper for the sort functions which compares two values, handling any exceptions and timeouts.
-/// `n` is the caller's running comparison count, keying the amortized time check.
-fn compare_values(
-    n: usize,
-    a: &Value,
-    b: &Value,
-    reverse: bool,
-    sort_result: &mut RunResult<()>,
-    vm: &mut VM<'_>,
-) -> Ordering {
-    if sort_result.is_err() {
-        // short-circuit if we've already encountered an error in a previous comparison
-        return Ordering::Equal;
-    }
-    if let Err(e) = vm.heap.tracker.check_time_every(n) {
-        *sort_result = Err(e.into());
-        return Ordering::Equal;
-    }
-    let err = match a.py_cmp(b, vm) {
-        Ok(CmpOrder::Ordered(ord)) => return if reverse { ord.reverse() } else { ord },
-        // A `NaN` (or `NaN`-carrying container) has no ordering but must not
-        // raise: CPython's `sorted`/`list.sort` leave such elements wherever the
-        // comparisons happen to place them. Treat it as "equal" — no swap.
-        Ok(CmpOrder::Unordered) => return Ordering::Equal,
-        Ok(CmpOrder::Incomparable) => ExcType::type_error(format!(
-            "'<' not supported between instances of '{}' and '{}'",
-            a.py_type_name(vm),
-            b.py_type_name(vm)
-        )),
-        Err(e) => e,
-    };
-    *sort_result = Err(err);
-    Ordering::Equal
 }

--- a/crates/monty/src/sorting.rs
+++ b/crates/monty/src/sorting.rs
@@ -93,8 +93,9 @@ pub fn sort_values(values: &mut [Value], key_fn: Option<&Value>, reverse: bool, 
 /// The `values` slice is typically either the items themselves (no key function)
 /// or the pre-computed key values.
 pub fn sort_indices(indices: &mut [usize], values: &[Value], reverse: bool, vm: &mut VM<'_>) -> Result<(), RunError> {
+    let mut comparisons = 0;
     if indices.len() <= INSERTION_SORT_THRESHOLD {
-        return insertion_sort_indices(indices, values, reverse, vm);
+        return insertion_sort_indices(indices, values, reverse, &mut comparisons, vm);
     }
 
     let mut scratch = indices.to_vec();
@@ -104,7 +105,17 @@ pub fn sort_indices(indices: &mut [usize], values: &[Value], reverse: bool, vm: 
         for start in (0..indices.len()).step_by(stride) {
             let mid = start.saturating_add(width).min(indices.len());
             let end = start.saturating_add(stride).min(indices.len());
-            merge_indices(indices, &mut scratch, values, start, mid, end, reverse, vm)?;
+            merge_indices(
+                indices,
+                &mut scratch,
+                values,
+                start,
+                mid,
+                end,
+                reverse,
+                &mut comparisons,
+                vm,
+            )?;
         }
         indices.copy_from_slice(&scratch);
         width = stride;
@@ -113,10 +124,24 @@ pub fn sort_indices(indices: &mut [usize], values: &[Value], reverse: bool, vm: 
 }
 
 /// Stably insertion-sorts a small index buffer using Python's `<` predicate.
-fn insertion_sort_indices(indices: &mut [usize], values: &[Value], reverse: bool, vm: &mut VM<'_>) -> RunResult<()> {
+fn insertion_sort_indices(
+    indices: &mut [usize],
+    values: &[Value],
+    reverse: bool,
+    comparisons: &mut usize,
+    vm: &mut VM<'_>,
+) -> RunResult<()> {
     for unsorted in 1..indices.len() {
         let mut current = unsorted;
-        while current > 0 && comes_before(&values[indices[current]], &values[indices[current - 1]], reverse, vm)? {
+        while current > 0
+            && comes_before(
+                &values[indices[current]],
+                &values[indices[current - 1]],
+                reverse,
+                comparisons,
+                vm,
+            )?
+        {
             indices.swap(current, current - 1);
             current -= 1;
         }
@@ -137,6 +162,7 @@ fn merge_indices(
     mid: usize,
     end: usize,
     reverse: bool,
+    comparisons: &mut usize,
     vm: &mut VM<'_>,
 ) -> RunResult<()> {
     let (mut left, mut right) = (start, mid);
@@ -146,7 +172,13 @@ fn merge_indices(
         } else if right == end {
             false
         } else {
-            comes_before(&values[indices[right]], &values[indices[left]], reverse, vm)?
+            comes_before(
+                &values[indices[right]],
+                &values[indices[left]],
+                reverse,
+                comparisons,
+                vm,
+            )?
         };
         *destination = if take_right {
             let index = indices[right];
@@ -162,8 +194,9 @@ fn merge_indices(
 }
 
 /// Tests whether `lhs` precedes `rhs` in the requested sort direction.
-fn comes_before(lhs: &Value, rhs: &Value, reverse: bool, vm: &mut VM<'_>) -> RunResult<bool> {
-    vm.heap.check_time()?;
+fn comes_before(lhs: &Value, rhs: &Value, reverse: bool, comparisons: &mut usize, vm: &mut VM<'_>) -> RunResult<bool> {
+    *comparisons += 1;
+    vm.heap.tracker.check_time_every(*comparisons)?;
     if reverse {
         rhs.py_rich_compare_bool(lhs, RichCmpOp::Lt, vm)
     } else {

--- a/crates/monty/src/sorting.rs
+++ b/crates/monty/src/sorting.rs
@@ -8,6 +8,8 @@
 //! This module provides [`sort_indices`] for the comparison step and
 //! [`apply_permutation`] for the in-place rearrangement step.
 
+use smallvec::SmallVec;
+
 use crate::{
     args::{ArgValues, FromArgs, LaxBool},
     bytecode::VM,
@@ -16,6 +18,9 @@ use crate::{
     types::RichCmpOp,
     value::Value,
 };
+
+/// Maximum index-buffer length sorted without a scratch allocation.
+const INSERTION_SORT_THRESHOLD: usize = 8;
 
 /// Argument shape for `list.sort(*, key=None, reverse=False)` and, by
 /// extension, the kwargs accepted by the `sorted()` builtin. Both fields
@@ -52,12 +57,15 @@ pub fn parse_and_sort(items: &mut [Value], args: ArgValues, vm: &mut VM<'_>) -> 
 
 /// Sorts a vector of values, with optional key function.
 pub fn sort_values(values: &mut [Value], key_fn: Option<&Value>, reverse: bool, vm: &mut VM<'_>) -> RunResult<()> {
-    if let Some(f) = key_fn {
+    let keys = Vec::new();
+
+    defer_drop_mut!(keys, vm);
+    let mut indices = (0..values.len()).collect::<SmallVec<[usize; INSERTION_SORT_THRESHOLD]>>();
+
+    let compare_values = if let Some(f) = key_fn {
         // Sort by key function: compute all the keys, sort an index buffer, then
         // rearrange the original values in-place according to the sorted indices.
-        let mut indices = (0..values.len()).collect::<Vec<_>>();
-        let keys: Vec<Value> = Vec::with_capacity(values.len());
-        defer_drop_mut!(keys, vm);
+        keys.reserve(values.len());
 
         // Each key call re-enters `run()` with a fresh dispatch countdown, so a
         // short key reaches no checkpoint: this is the pass's only clock poll.
@@ -67,19 +75,14 @@ pub fn sort_values(values: &mut [Value], key_fn: Option<&Value>, reverse: bool, 
             keys.push(vm.evaluate_function("sorted() key argument", f, ArgValues::One(item))?);
         }
 
-        // 2. Sort indices by comparing key values (or values themselves if no key)
-        sort_indices(&mut indices, keys, reverse, vm)?;
-
-        // 3. Rearrange values in-place in the detached buffer.
-        apply_permutation(values, &mut indices);
-
-        Ok(())
+        keys.as_slice()
     } else {
-        let mut indices = (0..values.len()).collect::<Vec<_>>();
-        sort_indices(&mut indices, values, reverse, vm)?;
-        apply_permutation(values, &mut indices);
-        Ok(())
-    }
+        &*values
+    };
+
+    sort_indices(&mut indices, compare_values, reverse, vm)?;
+    apply_permutation(values, &mut indices);
+    Ok(())
 }
 
 /// Sorts a vector of indices by comparing items at those positions.
@@ -90,6 +93,10 @@ pub fn sort_values(values: &mut [Value], key_fn: Option<&Value>, reverse: bool, 
 /// The `values` slice is typically either the items themselves (no key function)
 /// or the pre-computed key values.
 pub fn sort_indices(indices: &mut [usize], values: &[Value], reverse: bool, vm: &mut VM<'_>) -> Result<(), RunError> {
+    if indices.len() <= INSERTION_SORT_THRESHOLD {
+        return insertion_sort_indices(indices, values, reverse, vm);
+    }
+
     let mut scratch = indices.to_vec();
     let mut width = 1;
     while width < indices.len() {
@@ -101,6 +108,18 @@ pub fn sort_indices(indices: &mut [usize], values: &[Value], reverse: bool, vm: 
         }
         indices.copy_from_slice(&scratch);
         width = stride;
+    }
+    Ok(())
+}
+
+/// Stably insertion-sorts a small index buffer using Python's `<` predicate.
+fn insertion_sort_indices(indices: &mut [usize], values: &[Value], reverse: bool, vm: &mut VM<'_>) -> RunResult<()> {
+    for unsorted in 1..indices.len() {
+        let mut current = unsorted;
+        while current > 0 && comes_before(&values[indices[current]], &values[indices[current - 1]], reverse, vm)? {
+            indices.swap(current, current - 1);
+            current -= 1;
+        }
     }
     Ok(())
 }

--- a/crates/monty/src/sorting.rs
+++ b/crates/monty/src/sorting.rs
@@ -8,14 +8,12 @@
 //! This module provides [`sort_indices`] for the comparison step and
 //! [`apply_permutation`] for the in-place rearrangement step.
 
-use std::cmp::Ordering;
-
 use crate::{
     args::{ArgValues, FromArgs, LaxBool},
     bytecode::VM,
     defer_drop, defer_drop_mut,
-    exception_private::{ExcType, ExcTypeExt, RunError, RunResult},
-    types::{CmpOrder, PyTrait},
+    exception_private::{RunError, RunResult},
+    types::RichCmpOp,
     value::Value,
 };
 
@@ -74,25 +72,81 @@ pub fn sort_values(values: &mut [Value], key_fn: Option<&Value>, reverse: bool, 
 
         Ok(())
     } else {
-        // With no key function can sort directly on the original array
-        let mut sort_result: RunResult<()> = Ok(());
-        values.sort_by(|a, b| compare_values(a, b, reverse, &mut sort_result, vm));
-        sort_result
+        let mut indices = (0..values.len()).collect::<Vec<_>>();
+        sort_indices(&mut indices, values, reverse, vm)?;
+        apply_permutation(values, &mut indices);
+        Ok(())
     }
 }
 
 /// Sorts a vector of indices by comparing items at those positions.
 ///
-/// Compares `values[a]` vs `values[b]` using `py_cmp`, optionally reversing
-/// the ordering. If any comparison fails (type error or runtime error), the
-/// sort finishes early and the error is returned.
+/// Compares `values[a] < values[b]`, swapping operands for reverse order.
+/// If any comparison fails, the sort finishes early and returns the error.
 ///
 /// The `values` slice is typically either the items themselves (no key function)
 /// or the pre-computed key values.
 pub fn sort_indices(indices: &mut [usize], values: &[Value], reverse: bool, vm: &mut VM<'_>) -> Result<(), RunError> {
-    let mut sort_result: RunResult<()> = Ok(());
-    indices.sort_by(|&a, &b| compare_values(&values[a], &values[b], reverse, &mut sort_result, vm));
-    sort_result
+    let mut scratch = indices.to_vec();
+    let mut width = 1;
+    while width < indices.len() {
+        let stride = width.saturating_mul(2);
+        for start in (0..indices.len()).step_by(stride) {
+            let mid = start.saturating_add(width).min(indices.len());
+            let end = start.saturating_add(stride).min(indices.len());
+            merge_indices(indices, &mut scratch, values, start, mid, end, reverse, vm)?;
+        }
+        indices.copy_from_slice(&scratch);
+        width = stride;
+    }
+    Ok(())
+}
+
+/// Stably merges adjacent sorted index ranges using Python's `<` predicate.
+///
+/// The right item moves first only when it is strictly less than the left;
+/// equality and partial-order ties retain their original order.
+#[expect(clippy::too_many_arguments)]
+fn merge_indices(
+    indices: &[usize],
+    scratch: &mut [usize],
+    values: &[Value],
+    start: usize,
+    mid: usize,
+    end: usize,
+    reverse: bool,
+    vm: &mut VM<'_>,
+) -> RunResult<()> {
+    let (mut left, mut right) = (start, mid);
+    for destination in &mut scratch[start..end] {
+        let take_right = if left == mid {
+            true
+        } else if right == end {
+            false
+        } else {
+            comes_before(&values[indices[right]], &values[indices[left]], reverse, vm)?
+        };
+        *destination = if take_right {
+            let index = indices[right];
+            right += 1;
+            index
+        } else {
+            let index = indices[left];
+            left += 1;
+            index
+        };
+    }
+    Ok(())
+}
+
+/// Tests whether `lhs` precedes `rhs` in the requested sort direction.
+fn comes_before(lhs: &Value, rhs: &Value, reverse: bool, vm: &mut VM<'_>) -> RunResult<bool> {
+    vm.heap.check_time()?;
+    if reverse {
+        rhs.py_rich_compare_bool(lhs, RichCmpOp::Lt, vm)
+    } else {
+        lhs.py_rich_compare_bool(rhs, RichCmpOp::Lt, vm)
+    }
 }
 
 /// Rearranges `items` in-place according to a permutation of indices.
@@ -122,31 +176,4 @@ pub fn apply_permutation<T>(items: &mut [T], indices: &mut [usize]) {
             current = target;
         }
     }
-}
-
-/// Helper for the sort functions which compares two values, handling any exceptions and timeouts.
-fn compare_values(a: &Value, b: &Value, reverse: bool, sort_result: &mut RunResult<()>, vm: &mut VM<'_>) -> Ordering {
-    if sort_result.is_err() {
-        // short-circuit if we've already encountered an error in a previous comparison
-        return Ordering::Equal;
-    }
-    if let Err(e) = vm.heap.check_time() {
-        *sort_result = Err(e.into());
-        return Ordering::Equal;
-    }
-    let err = match a.py_cmp(b, vm) {
-        Ok(CmpOrder::Ordered(ord)) => return if reverse { ord.reverse() } else { ord },
-        // A `NaN` (or `NaN`-carrying container) has no ordering but must not
-        // raise: CPython's `sorted`/`list.sort` leave such elements wherever the
-        // comparisons happen to place them. Treat it as "equal" — no swap.
-        Ok(CmpOrder::Unordered) => return Ordering::Equal,
-        Ok(CmpOrder::Incomparable) => ExcType::type_error(format!(
-            "'<' not supported between instances of '{}' and '{}'",
-            a.py_type_name(vm),
-            b.py_type_name(vm)
-        )),
-        Err(e) => e,
-    };
-    *sort_result = Err(err);
-    Ordering::Equal
 }

--- a/crates/monty/src/sorting.rs
+++ b/crates/monty/src/sorting.rs
@@ -8,6 +8,8 @@
 //! This module provides [`sort_indices`] for the comparison step and
 //! [`apply_permutation`] for the in-place rearrangement step.
 
+use smallvec::SmallVec;
+
 use crate::{
     args::{ArgValues, FromArgs, LaxBool},
     bytecode::VM,
@@ -16,6 +18,9 @@ use crate::{
     types::RichCmpOp,
     value::Value,
 };
+
+/// Maximum index-buffer length sorted without a scratch allocation.
+const INSERTION_SORT_THRESHOLD: usize = 8;
 
 /// Argument shape for `list.sort(*, key=None, reverse=False)` and, by
 /// extension, the kwargs accepted by the `sorted()` builtin. Both fields
@@ -52,31 +57,29 @@ pub fn parse_and_sort(items: &mut [Value], args: ArgValues, vm: &mut VM<'_>) -> 
 
 /// Sorts a vector of values, with optional key function.
 pub fn sort_values(values: &mut [Value], key_fn: Option<&Value>, reverse: bool, vm: &mut VM<'_>) -> RunResult<()> {
-    if let Some(f) = key_fn {
+    let keys = Vec::new();
+
+    defer_drop_mut!(keys, vm);
+    let mut indices = (0..values.len()).collect::<SmallVec<[usize; INSERTION_SORT_THRESHOLD]>>();
+
+    let compare_values = if let Some(f) = key_fn {
         // Sort by key function: compute all the keys, sort an index buffer, then
         // rearrange the original values in-place according to the sorted indices.
-        let mut indices = (0..values.len()).collect::<Vec<_>>();
-        let keys: Vec<Value> = Vec::with_capacity(values.len());
-        defer_drop_mut!(keys, vm);
+        keys.reserve(values.len());
 
         for item in values.iter() {
             let item = item.clone_with_heap(vm);
             keys.push(vm.evaluate_function("sorted() key argument", f, ArgValues::One(item))?);
         }
 
-        // 2. Sort indices by comparing key values (or values themselves if no key)
-        sort_indices(&mut indices, keys, reverse, vm)?;
-
-        // 3. Rearrange values in-place in the detached buffer.
-        apply_permutation(values, &mut indices);
-
-        Ok(())
+        keys.as_slice()
     } else {
-        let mut indices = (0..values.len()).collect::<Vec<_>>();
-        sort_indices(&mut indices, values, reverse, vm)?;
-        apply_permutation(values, &mut indices);
-        Ok(())
-    }
+        &*values
+    };
+
+    sort_indices(&mut indices, compare_values, reverse, vm)?;
+    apply_permutation(values, &mut indices);
+    Ok(())
 }
 
 /// Sorts a vector of indices by comparing items at those positions.
@@ -87,6 +90,10 @@ pub fn sort_values(values: &mut [Value], key_fn: Option<&Value>, reverse: bool, 
 /// The `values` slice is typically either the items themselves (no key function)
 /// or the pre-computed key values.
 pub fn sort_indices(indices: &mut [usize], values: &[Value], reverse: bool, vm: &mut VM<'_>) -> Result<(), RunError> {
+    if indices.len() <= INSERTION_SORT_THRESHOLD {
+        return insertion_sort_indices(indices, values, reverse, vm);
+    }
+
     let mut scratch = indices.to_vec();
     let mut width = 1;
     while width < indices.len() {
@@ -98,6 +105,18 @@ pub fn sort_indices(indices: &mut [usize], values: &[Value], reverse: bool, vm: 
         }
         indices.copy_from_slice(&scratch);
         width = stride;
+    }
+    Ok(())
+}
+
+/// Stably insertion-sorts a small index buffer using Python's `<` predicate.
+fn insertion_sort_indices(indices: &mut [usize], values: &[Value], reverse: bool, vm: &mut VM<'_>) -> RunResult<()> {
+    for unsorted in 1..indices.len() {
+        let mut current = unsorted;
+        while current > 0 && comes_before(&values[indices[current]], &values[indices[current - 1]], reverse, vm)? {
+            indices.swap(current, current - 1);
+            current -= 1;
+        }
     }
     Ok(())
 }

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -72,7 +72,7 @@ use monty_types::ResourceError;
 pub use monty_types::{bytes_repr, bytes_repr_fmt};
 use smallvec::smallvec;
 
-use super::{LazyHeapSet, PyTrait, RichCmpOp, Type};
+use super::{LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, Type};
 use crate::{
     args::{ArgValues, FromArgs, StrArg},
     bytecode::{CallResult, VM},
@@ -284,7 +284,31 @@ impl ops::Deref for Bytes {
     }
 }
 
+impl<'h> HeapObjectRead<'h, Bytes> {
+    /// Compares bytes content across interned and heap representations.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_compare(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(eq_bytes(self.get(vm.heap).as_slice(), other, vm)));
+        }
+        let other = match other {
+            Value::InternBytes(id) => vm.interns.get_bytes(*id),
+            Value::Ref(id) if let HeapData::Bytes(other) = vm.heap.get(*id) => other.as_slice(),
+            _ => return Ok(Value::NotImplemented),
+        };
+        Ok(Value::Bool(op.holds(self.get(vm.heap).as_slice().cmp(other))))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, Bytes> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     /// One-sided implementation of Python membership (`__contains__`).
     fn py_contains_impl(&self, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         bytes_contains(self.get(vm.heap).as_slice(), item, vm).map(Some)
@@ -326,12 +350,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Bytes> {
         Ok(Value::Int(i64::from(byte)))
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // Heap bytes equal interned or heap bytes with the same content.
-        Ok(eq_bytes(self.get(vm.heap).as_slice(), other, vm))
-    }
-
-    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let b = self.get(vm.heap);
         if let Some(cached) = b.1.get() {
             return Ok(Some(cached));
@@ -342,24 +361,6 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Bytes> {
         let hash = hash_python_bytes(b.as_slice());
         b.1.set(Some(hash));
         Ok(Some(hash))
-    }
-
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let other = match other {
-            Value::InternBytes(id) => vm.interns.get_bytes(*id),
-            Value::Ref(id) if let HeapData::Bytes(other) = vm.heap.get(*id) => other.as_slice(),
-            _ => return Ok(Value::NotImplemented),
-        };
-        Ok(Value::Bool(op.holds(self.get(vm.heap).as_slice().cmp(other))))
     }
 
     fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {
@@ -2390,12 +2391,10 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, BytesIterator> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
-    }
-
-    fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
-        Ok(self.clone_value(vm.heap))
+    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
+        let self_id = self_id.expect("heap values have an id");
+        vm.heap.inc_ref(self_id);
+        Ok(Value::Ref(self_id))
     }
 
     fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -287,13 +287,7 @@ impl ops::Deref for Bytes {
 impl<'h> HeapObjectRead<'h, Bytes> {
     /// Compares bytes content across interned and heap representations.
     #[expect(clippy::unnecessary_wraps)]
-    fn rich_compare(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
+    fn rich_compare(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         if op.is_equality() {
             return Ok(op.equality_result(eq_bytes(self.get(vm.heap).as_slice(), other, vm)));
         }
@@ -350,7 +344,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Bytes> {
         Ok(Value::Int(i64::from(byte)))
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let b = self.get(vm.heap);
         if let Some(cached) = b.1.get() {
             return Ok(Some(cached));
@@ -2391,10 +2385,8 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, BytesIterator> {
         None
     }
 
-    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
-        let self_id = self_id.expect("heap values have an id");
-        vm.heap.inc_ref(self_id);
-        Ok(Value::Ref(self_id))
+    fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
+        Ok(self.clone_value(vm.heap))
     }
 
     fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -72,7 +72,7 @@ use monty_types::ResourceError;
 pub use monty_types::{bytes_repr, bytes_repr_fmt};
 use smallvec::smallvec;
 
-use super::{CmpOrder, LazyHeapSet, PyTrait, Type};
+use super::{LazyHeapSet, PyTrait, RichCmpOp, Type};
 use crate::{
     args::{ArgValues, FromArgs, StrArg},
     bytecode::{CallResult, VM},
@@ -344,8 +344,22 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Bytes> {
         Ok(Some(hash))
     }
 
-    fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {
-        Ok(CmpOrder::Ordered(self.get(vm.heap).0.cmp(&other.get(vm.heap).0)))
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let other = match other {
+            Value::InternBytes(id) => vm.interns.get_bytes(*id),
+            Value::Ref(id) if let HeapData::Bytes(other) = vm.heap.get(*id) => other.as_slice(),
+            _ => return Ok(Value::NotImplemented),
+        };
+        Ok(Value::Bool(op.holds(self.get(vm.heap).as_slice().cmp(other))))
     }
 
     fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -71,7 +71,7 @@ use monty_types::ResourceError;
 pub use monty_types::{bytes_repr, bytes_repr_fmt};
 use smallvec::smallvec;
 
-use super::{LazyHeapSet, PyTrait, RichCmpOp, Type};
+use super::{LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, Type};
 use crate::{
     args::{ArgValues, FromArgs, StrArg},
     bytecode::{CallResult, VM},
@@ -278,7 +278,31 @@ impl ops::Deref for Bytes {
     }
 }
 
+impl<'h> HeapRead<'h, Bytes> {
+    /// Compares bytes content across interned and heap representations.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_compare(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(eq_bytes(self.get(vm.heap).as_slice(), other, vm)));
+        }
+        let other = match other {
+            Value::InternBytes(id) => vm.interns.get_bytes(*id),
+            Value::Ref(id) if let HeapData::Bytes(other) = vm.heap.get(*id) => other.as_slice(),
+            _ => return Ok(Value::NotImplemented),
+        };
+        Ok(Value::Bool(op.holds(self.get(vm.heap).as_slice().cmp(other))))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapRead<'h, Bytes> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     /// One-sided implementation of Python membership (`__contains__`).
     fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         bytes_contains(self.get(vm.heap).as_slice(), item, vm).map(Some)
@@ -320,11 +344,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Bytes> {
         Ok(Value::Int(i64::from(byte)))
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // Heap bytes equal interned or heap bytes with the same content.
-        Ok(eq_bytes(self.get(vm.heap).as_slice(), other, vm))
-    }
-
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let b = self.get(vm.heap);
         if let Some(cached) = b.1.get() {
@@ -336,24 +355,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Bytes> {
         let hash = hash_python_bytes(b.as_slice());
         b.1.set(Some(hash));
         Ok(Some(hash))
-    }
-
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let other = match other {
-            Value::InternBytes(id) => vm.interns.get_bytes(*id),
-            Value::Ref(id) if let HeapData::Bytes(other) = vm.heap.get(*id) => other.as_slice(),
-            _ => return Ok(Value::NotImplemented),
-        };
-        Ok(Value::Bool(op.holds(self.get(vm.heap).as_slice().cmp(other))))
     }
 
     fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {
@@ -2265,10 +2266,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, BytesIterator> {
 
     fn py_len(&self, _: &VM<'h>) -> Option<usize> {
         None
-    }
-
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
     }
 
     fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -71,7 +71,7 @@ use monty_types::ResourceError;
 pub use monty_types::{bytes_repr, bytes_repr_fmt};
 use smallvec::smallvec;
 
-use super::{CmpOrder, LazyHeapSet, PyTrait, Type};
+use super::{LazyHeapSet, PyTrait, RichCmpOp, Type};
 use crate::{
     args::{ArgValues, FromArgs, StrArg},
     bytecode::{CallResult, VM},
@@ -338,8 +338,22 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Bytes> {
         Ok(Some(hash))
     }
 
-    fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {
-        Ok(CmpOrder::Ordered(self.get(vm.heap).0.cmp(&other.get(vm.heap).0)))
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let other = match other {
+            Value::InternBytes(id) => vm.interns.get_bytes(*id),
+            Value::Ref(id) if let HeapData::Bytes(other) = vm.heap.get(*id) => other.as_slice(),
+            _ => return Ok(Value::NotImplemented),
+        };
+        Ok(Value::Bool(op.holds(self.get(vm.heap).as_slice().cmp(other))))
     }
 
     fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/callable_iterator.rs
+++ b/crates/monty/src/types/callable_iterator.rs
@@ -79,12 +79,10 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, CallableIterator> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
-    }
-
-    fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
-        Ok(self.clone_value(vm.heap))
+    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
+        let self_id = self_id.expect("heap values have an id");
+        vm.heap.inc_ref(self_id);
+        Ok(Value::Ref(self_id))
     }
 
     /// Calls `callable()` and yields the result unless it `==` `sentinel`.

--- a/crates/monty/src/types/callable_iterator.rs
+++ b/crates/monty/src/types/callable_iterator.rs
@@ -79,10 +79,8 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, CallableIterator> {
         None
     }
 
-    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
-        let self_id = self_id.expect("heap values have an id");
-        vm.heap.inc_ref(self_id);
-        Ok(Value::Ref(self_id))
+    fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
+        Ok(self.clone_value(vm.heap))
     }
 
     /// Calls `callable()` and yields the result unless it `==` `sentinel`.

--- a/crates/monty/src/types/callable_iterator.rs
+++ b/crates/monty/src/types/callable_iterator.rs
@@ -83,10 +83,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, CallableIterator> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
-    }
-
     fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
         let self_id = self_id.expect("heap values have an id");
         vm.heap.inc_ref(self_id);

--- a/crates/monty/src/types/class.rs
+++ b/crates/monty/src/types/class.rs
@@ -148,13 +148,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Class> {
         Ok(())
     }
 
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // Classes return `NotImplemented`; rich equality's final identity
-        // fallback makes a class equal only to itself.
-        Ok(None)
-    }
-
-    fn py_hash(&self, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, self_id: HeapId, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         // Class objects hash by identity (like CPython type objects).
         Ok(Some(identity_hash(self.id())))
     }

--- a/crates/monty/src/types/class.rs
+++ b/crates/monty/src/types/class.rs
@@ -148,7 +148,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Class> {
         Ok(())
     }
 
-    fn py_hash(&self, self_id: HeapId, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         // Class objects hash by identity (like CPython type objects).
         Ok(Some(identity_hash(self.id())))
     }

--- a/crates/monty/src/types/class.rs
+++ b/crates/monty/src/types/class.rs
@@ -88,12 +88,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Class> {
         Ok(())
     }
 
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // Classes return `NotImplemented`; rich equality's final identity
-        // fallback makes a class equal only to itself.
-        Ok(None)
-    }
-
     fn py_hash(&self, self_id: HeapId, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         // Class objects hash by identity (like CPython type objects).
         Ok(Some(identity_hash(self_id)))

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -5,7 +5,7 @@ use std::{
 
 use serde::ser::SerializeStruct;
 
-use super::{Dict, LazyHeapSet, PyTrait, attribute_name_value};
+use super::{Dict, LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, attribute_name_value};
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, VM},
@@ -147,7 +147,21 @@ impl<'h> HeapRead<'h, Dataclass> {
     }
 }
 
+impl<'h> HeapObjectRead<'h, Dataclass> {
+    /// Compares host dataclasses by class and attributes.
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let Some(HeapReadOutput::Dataclass(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        let equal =
+            self.get(vm.heap).type_id() == other.get(vm.heap).type_id() && self.attrs().eq_dict(&other.attrs(), vm)?;
+        Ok(op.equality_result(Some(equal)))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, Dataclass> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::Dataclass
     }
@@ -164,17 +178,6 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Dataclass> {
         let old_value = self.set_attr(name, value, vm)?;
         old_value.drop_with(vm);
         Ok(())
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::Dataclass(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        // Dataclasses are equal only if they are the same class and have equal attrs.
-        if self.get(vm.heap).type_id() != other.get(vm.heap).type_id() {
-            return Ok(Some(false));
-        }
-        Ok(Some(self.attrs().eq_dict(&other.attrs(), vm)?))
     }
 
     /// Hashes a frozen dataclass by its class name and the values of declared fields.

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -149,7 +149,7 @@ impl<'h> HeapRead<'h, Dataclass> {
 
 impl<'h> HeapObjectRead<'h, Dataclass> {
     /// Compares host dataclasses by class and attributes.
-    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         let Some(HeapReadOutput::Dataclass(other)) = other.read_heap(vm) else {
             return Ok(Value::NotImplemented);
         };

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -6,7 +6,7 @@ use std::{
 
 use serde::ser::SerializeStruct;
 
-use super::{Dict, LazyHeapSet, PyTrait, attribute_name_value};
+use super::{Dict, LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, attribute_name_value};
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, VM},
@@ -148,7 +148,21 @@ impl<'h> HeapRead<'h, Dataclass> {
     }
 }
 
+impl<'h> HeapRead<'h, Dataclass> {
+    /// Compares host dataclasses by class and attributes.
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let Some(HeapReadOutput::Dataclass(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        let equal =
+            self.get(vm.heap).type_id() == other.get(vm.heap).type_id() && self.attrs().eq_dict(&other.attrs(), vm)?;
+        Ok(op.equality_result(Some(equal)))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::Dataclass
     }
@@ -165,17 +179,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dataclass> {
         let old_value = self.set_attr(name, value, vm)?;
         old_value.drop_with(vm);
         Ok(())
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::Dataclass(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        // Dataclasses are equal only if they are the same class and have equal attrs.
-        if self.get(vm.heap).type_id() != other.get(vm.heap).type_id() {
-            return Ok(Some(false));
-        }
-        Ok(Some(self.attrs().eq_dict(&other.attrs(), vm)?))
     }
 
     /// Hashes a frozen dataclass by its class name and the values of declared fields.

--- a/crates/monty/src/types/date.rs
+++ b/crates/monty/src/types/date.rs
@@ -185,13 +185,7 @@ impl HeapItem for Date {
 impl<'h> HeapObjectRead<'h, Date> {
     /// Compares dates without exposing representation-specific methods to dispatch.
     #[expect(clippy::unnecessary_wraps)]
-    fn rich_compare(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
+    fn rich_compare(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         let Some(HeapReadOutput::Date(other)) = other.read_heap(vm) else {
             return Ok(Value::NotImplemented);
         };
@@ -212,7 +206,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Date> {
         None
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(HashValue::new(hasher.finish())))

--- a/crates/monty/src/types/date.rs
+++ b/crates/monty/src/types/date.rs
@@ -21,7 +21,7 @@ use crate::{
     heap::{Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     types::{
-        AttrCallResult, CmpOrder, LazyHeapSet, PyTrait, TimeDelta, Type,
+        AttrCallResult, LazyHeapSet, PyTrait, RichCmpOp, TimeDelta, Type,
         str::{allocate_string, allocate_string_no_interning},
         timedelta,
     },
@@ -206,8 +206,20 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Date> {
         Ok(Some(HashValue::new(hasher.finish())))
     }
 
-    fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {
-        Ok(CmpOrder::from_total(self.get(vm.heap).partial_cmp(other.get(vm.heap))))
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let Some(HeapReadOutput::Date(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        Ok(Value::Bool(op.holds(self.get(vm.heap).cmp(other.get(vm.heap)))))
     }
 
     fn py_bool(&self, _vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/date.rs
+++ b/crates/monty/src/types/date.rs
@@ -21,7 +21,7 @@ use crate::{
     heap::{Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     types::{
-        AttrCallResult, LazyHeapSet, PyTrait, RichCmpOp, TimeDelta, Type,
+        AttrCallResult, LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, TimeDelta, Type,
         str::{allocate_string, allocate_string_no_interning},
         timedelta,
     },
@@ -182,9 +182,28 @@ impl HeapItem for Date {
     fn py_dec_ref_ids(&mut self, _stack: &mut Vec<HeapId>) {}
 }
 
+impl<'h> HeapObjectRead<'h, Date> {
+    /// Compares dates without exposing representation-specific methods to dispatch.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_compare(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        let Some(HeapReadOutput::Date(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        Ok(Value::Bool(op.holds(self.get(vm.heap).cmp(other.get(vm.heap)))))
+    }
+}
+
 /// `HeapRead`-based dispatch for `Date`, enabling the `HeapReadOutput` enum to
 /// delegate `PyTrait` calls to heap-resident dates.
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, Date> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::Date
     }
@@ -193,33 +212,10 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Date> {
         None
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::Date(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        Ok(Some(*self.get(vm.heap) == *other.get(vm.heap)))
-    }
-
-    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(HashValue::new(hasher.finish())))
-    }
-
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let Some(HeapReadOutput::Date(other)) = other.read_heap(vm) else {
-            return Ok(Value::NotImplemented);
-        };
-        Ok(Value::Bool(op.holds(self.get(vm.heap).cmp(other.get(vm.heap)))))
     }
 
     fn py_bool(&self, _vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/date.rs
+++ b/crates/monty/src/types/date.rs
@@ -22,7 +22,7 @@ use crate::{
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     types::{
-        AttrCallResult, LazyHeapSet, PyTrait, RichCmpOp, TimeDelta, Type,
+        AttrCallResult, LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, TimeDelta, Type,
         str::{allocate_string, allocate_string_no_interning},
         timedelta,
     },
@@ -187,9 +187,28 @@ impl HeapItem for Date {
     fn py_dec_ref_ids(&mut self, _stack: &mut Vec<HeapId>) {}
 }
 
+impl<'h> HeapRead<'h, Date> {
+    /// Compares dates without exposing representation-specific methods to dispatch.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_compare(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        let Some(HeapReadOutput::Date(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        Ok(Value::Bool(op.holds(self.get(vm.heap).cmp(other.get(vm.heap)))))
+    }
+}
+
 /// `HeapRead`-based dispatch for `Date`, enabling the `HeapReadOutput` enum to
 /// delegate `PyTrait` calls to heap-resident dates.
 impl<'h> PyTrait<'h> for HeapRead<'h, Date> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::Date
     }
@@ -198,33 +217,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Date> {
         None
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::Date(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        Ok(Some(*self.get(vm.heap) == *other.get(vm.heap)))
-    }
-
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(HashValue::new(hasher.finish())))
-    }
-
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let Some(HeapReadOutput::Date(other)) = other.read_heap(vm) else {
-            return Ok(Value::NotImplemented);
-        };
-        Ok(Value::Bool(op.holds(self.get(vm.heap).cmp(other.get(vm.heap)))))
     }
 
     fn py_bool(&self, _vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/date.rs
+++ b/crates/monty/src/types/date.rs
@@ -22,7 +22,7 @@ use crate::{
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     types::{
-        AttrCallResult, CmpOrder, LazyHeapSet, PyTrait, TimeDelta, Type,
+        AttrCallResult, LazyHeapSet, PyTrait, RichCmpOp, TimeDelta, Type,
         str::{allocate_string, allocate_string_no_interning},
         timedelta,
     },
@@ -211,8 +211,20 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Date> {
         Ok(Some(HashValue::new(hasher.finish())))
     }
 
-    fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {
-        Ok(CmpOrder::from_total(self.get(vm.heap).partial_cmp(other.get(vm.heap))))
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let Some(HeapReadOutput::Date(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        Ok(Value::Bool(op.holds(self.get(vm.heap).cmp(other.get(vm.heap)))))
     }
 
     fn py_bool(&self, _vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -23,7 +23,7 @@ use crate::{
     heap::{Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     types::{
-        AttrCallResult, CmpOrder, LazyHeapSet, PyTrait, TimeDelta, TimeZone, Type,
+        AttrCallResult, LazyHeapSet, PyTrait, RichCmpOp, TimeDelta, TimeZone, Type,
         date::{self, StrftimeArgs},
         str::{StringRepr, allocate_string, allocate_string_no_interning},
         timedelta, timezone,
@@ -782,19 +782,30 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, DateTime> {
         Ok(Some(HashValue::new(hasher.finish())))
     }
 
-    fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let Some(HeapReadOutput::DateTime(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
         let a = self.get(vm.heap);
         let b = other.get(vm.heap);
         if is_aware(a) != is_aware(b) {
-            // Comparing offset-naive and offset-aware datetimes has no ordering
-            // in CPython (it raises `TypeError`), so report it as incomparable.
-            return Ok(CmpOrder::Incomparable);
+            return Ok(Value::NotImplemented);
         }
-        // Both sides compare on an integer microsecond count — always ordered.
-        if is_aware(a) {
-            return Ok(CmpOrder::Ordered(utc_micros(a).cmp(&utc_micros(b))));
-        }
-        Ok(CmpOrder::Ordered(local_micros(a).cmp(&local_micros(b))))
+        let ordering = if is_aware(a) {
+            utc_micros(a).cmp(&utc_micros(b))
+        } else {
+            local_micros(a).cmp(&local_micros(b))
+        };
+        Ok(Value::Bool(op.holds(ordering)))
     }
 
     fn py_bool(&self, _vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -753,13 +753,7 @@ impl HeapItem for DateTime {
 impl<'h> HeapObjectRead<'h, DateTime> {
     /// Compares datetimes while preserving aware/naive equality semantics.
     #[expect(clippy::unnecessary_wraps)]
-    fn rich_compare(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
+    fn rich_compare(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         let Some(HeapReadOutput::DateTime(other)) = other.read_heap(vm) else {
             return Ok(Value::NotImplemented);
         };
@@ -794,7 +788,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, DateTime> {
         None
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(HashValue::new(hasher.finish())))

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -23,7 +23,7 @@ use crate::{
     heap::{Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     types::{
-        AttrCallResult, LazyHeapSet, PyTrait, RichCmpOp, TimeDelta, TimeZone, Type,
+        AttrCallResult, LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, TimeDelta, TimeZone, Type,
         date::{self, StrftimeArgs},
         str::{StringRepr, allocate_string, allocate_string_no_interning},
         timedelta, timezone,
@@ -750,9 +750,42 @@ impl HeapItem for DateTime {
     }
 }
 
+impl<'h> HeapObjectRead<'h, DateTime> {
+    /// Compares datetimes while preserving aware/naive equality semantics.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_compare(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        let Some(HeapReadOutput::DateTime(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        let a = self.get(vm.heap);
+        let b = other.get(vm.heap);
+        if is_aware(a) != is_aware(b) {
+            return Ok(if op.is_equality() {
+                Value::Bool(op == RichCmpOp::Ne)
+            } else {
+                Value::NotImplemented
+            });
+        }
+        let ordering = if is_aware(a) {
+            utc_micros(a).cmp(&utc_micros(b))
+        } else {
+            local_micros(a).cmp(&local_micros(b))
+        };
+        Ok(Value::Bool(op.holds(ordering)))
+    }
+}
+
 /// `HeapRead`-based dispatch for `DateTime`, enabling the `HeapReadOutput` enum to
 /// delegate `PyTrait` calls to heap-resident datetimes.
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, DateTime> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::DateTime
     }
@@ -761,51 +794,10 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, DateTime> {
         None
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::DateTime(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        let a = self.get(vm.heap);
-        let b = other.get(vm.heap);
-        Ok(Some(if is_aware(a) != is_aware(b) {
-            false
-        } else if is_aware(a) {
-            utc_micros(a) == utc_micros(b)
-        } else {
-            local_micros(a) == local_micros(b)
-        }))
-    }
-
-    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(HashValue::new(hasher.finish())))
-    }
-
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let Some(HeapReadOutput::DateTime(other)) = other.read_heap(vm) else {
-            return Ok(Value::NotImplemented);
-        };
-        let a = self.get(vm.heap);
-        let b = other.get(vm.heap);
-        if is_aware(a) != is_aware(b) {
-            return Ok(Value::NotImplemented);
-        }
-        let ordering = if is_aware(a) {
-            utc_micros(a).cmp(&utc_micros(b))
-        } else {
-            local_micros(a).cmp(&local_micros(b))
-        };
-        Ok(Value::Bool(op.holds(ordering)))
     }
 
     fn py_bool(&self, _vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -24,7 +24,7 @@ use crate::{
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     types::{
-        AttrCallResult, CmpOrder, LazyHeapSet, PyTrait, TimeDelta, TimeZone, Type,
+        AttrCallResult, LazyHeapSet, PyTrait, RichCmpOp, TimeDelta, TimeZone, Type,
         date::{self, StrftimeArgs},
         str::{StringRepr, allocate_string, allocate_string_no_interning},
         timedelta, timezone,
@@ -822,19 +822,30 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
         Ok(Some(HashValue::new(hasher.finish())))
     }
 
-    fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let Some(HeapReadOutput::DateTime(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
         let a = self.get(vm.heap);
         let b = other.get(vm.heap);
         if is_aware(a) != is_aware(b) {
-            // Comparing offset-naive and offset-aware datetimes has no ordering
-            // in CPython (it raises `TypeError`), so report it as incomparable.
-            return Ok(CmpOrder::Incomparable);
+            return Ok(Value::NotImplemented);
         }
-        // Both sides compare on an integer microsecond count — always ordered.
-        if is_aware(a) {
-            return Ok(CmpOrder::Ordered(utc_micros(a).cmp(&utc_micros(b))));
-        }
-        Ok(CmpOrder::Ordered(local_micros(a).cmp(&local_micros(b))))
+        let ordering = if is_aware(a) {
+            utc_micros(a).cmp(&utc_micros(b))
+        } else {
+            local_micros(a).cmp(&local_micros(b))
+        };
+        Ok(Value::Bool(op.holds(ordering)))
     }
 
     fn py_bool(&self, _vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/datetime.rs
+++ b/crates/monty/src/types/datetime.rs
@@ -24,7 +24,7 @@ use crate::{
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     types::{
-        AttrCallResult, LazyHeapSet, PyTrait, RichCmpOp, TimeDelta, TimeZone, Type,
+        AttrCallResult, LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, TimeDelta, TimeZone, Type,
         date::{self, StrftimeArgs},
         str::{StringRepr, allocate_string, allocate_string_no_interning},
         timedelta, timezone,
@@ -790,9 +790,42 @@ impl HeapItem for DateTime {
     }
 }
 
+impl<'h> HeapRead<'h, DateTime> {
+    /// Compares datetimes while preserving aware/naive equality semantics.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_compare(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        let Some(HeapReadOutput::DateTime(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        let a = self.get(vm.heap);
+        let b = other.get(vm.heap);
+        if is_aware(a) != is_aware(b) {
+            return Ok(if op.is_equality() {
+                Value::Bool(op == RichCmpOp::Ne)
+            } else {
+                Value::NotImplemented
+            });
+        }
+        let ordering = if is_aware(a) {
+            utc_micros(a).cmp(&utc_micros(b))
+        } else {
+            local_micros(a).cmp(&local_micros(b))
+        };
+        Ok(Value::Bool(op.holds(ordering)))
+    }
+}
+
 /// `HeapRead`-based dispatch for `DateTime`, enabling the `HeapReadOutput` enum to
 /// delegate `PyTrait` calls to heap-resident datetimes.
 impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::DateTime
     }
@@ -801,51 +834,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DateTime> {
         None
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::DateTime(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        let a = self.get(vm.heap);
-        let b = other.get(vm.heap);
-        Ok(Some(if is_aware(a) != is_aware(b) {
-            false
-        } else if is_aware(a) {
-            utc_micros(a) == utc_micros(b)
-        } else {
-            local_micros(a) == local_micros(b)
-        }))
-    }
-
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(HashValue::new(hasher.finish())))
-    }
-
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let Some(HeapReadOutput::DateTime(other)) = other.read_heap(vm) else {
-            return Ok(Value::NotImplemented);
-        };
-        let a = self.get(vm.heap);
-        let b = other.get(vm.heap);
-        if is_aware(a) != is_aware(b) {
-            return Ok(Value::NotImplemented);
-        }
-        let ordering = if is_aware(a) {
-            utc_micros(a).cmp(&utc_micros(b))
-        } else {
-            local_micros(a).cmp(&local_micros(b))
-        };
-        Ok(Value::Bool(op.holds(ordering)))
     }
 
     fn py_bool(&self, _vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -1,6 +1,6 @@
 use std::{collections::VecDeque, fmt::Write, mem};
 
-use super::{PyTrait, RichCmpOp, iter::collect_owned_iterable};
+use super::{PyTrait, RichCmpOp, RichCmpVtable, iter::collect_owned_iterable};
 use crate::{
     args::{ArgValues, FromArgs},
     bytecode::{CallResult, VM},
@@ -330,7 +330,66 @@ fn evict_back_if_full(deque: &mut Deque) -> Option<Value> {
     }
 }
 
+impl<'h> HeapObjectRead<'h, Deque> {
+    /// Compares only deque items; `maxlen` is not part of equality.
+    ///
+    /// A recursion guard bounds comparisons between distinct cyclic deques.
+    fn eq_bool(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        let Some(HeapReadOutput::Deque(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
+        let len = self.get(vm.heap).len();
+        if len != other.get(vm.heap).len() {
+            return Ok(Some(false));
+        }
+        let mut guard = vm.recursion_guard()?;
+        let vm = &mut *guard;
+        for i in 0..len {
+            let a = self.get(vm.heap).items[i].clone_with_heap(vm.heap);
+            defer_drop!(a, vm);
+            let b = other.get(vm.heap).items[i].clone_with_heap(vm.heap);
+            defer_drop!(b, vm);
+            if !a.py_eq(b, vm)? {
+                return Ok(Some(false));
+            }
+        }
+        Ok(Some(true))
+    }
+
+    /// Lexicographically compares two deques while bounding recursive contents.
+    fn rich_compare(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.eq_bool(other, vm)?));
+        }
+        let Some(HeapReadOutput::Deque(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        let self_len = self.get(vm.heap).len();
+        let other_len = other.get(vm.heap).len();
+        let mut guard = vm.recursion_guard()?;
+        let vm = &mut *guard;
+        for i in 0..self_len.min(other_len) {
+            let a = self.get(vm.heap).items[i].clone_with_heap(vm.heap);
+            defer_drop!(a, vm);
+            let b = other.get(vm.heap).items[i].clone_with_heap(vm.heap);
+            defer_drop!(b, vm);
+            if !a.py_lex_eq(b, vm)? {
+                return a.py_rich_compare(b, op, vm);
+            }
+        }
+        Ok(Value::Bool(op.holds(self_len.cmp(&other_len))))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, Deque> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -400,63 +459,6 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Deque> {
         // The guard drops whatever `value` holds after the swap — i.e. the old item.
         mem::swap(&mut self.get_mut(vm.heap).items[idx], value);
         Ok(())
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // A deque only ever equals another deque — unlike NamedTuple/tuple, there
-        // is no cross-type equality with list. `maxlen` is not part of equality.
-        let Some(HeapReadOutput::Deque(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        let len = self.get(vm.heap).len();
-        if len != other.get(vm.heap).len() {
-            return Ok(Some(false));
-        }
-        // Charge a recursion level: two distinct cyclic deques (`a.append(a);
-        // b.append(b); a == b`) re-enter here per level and would otherwise
-        // overflow the host stack. A deque walks by index, so it charges directly.
-        let mut guard = vm.recursion_guard()?;
-        let vm = &mut *guard;
-        for i in 0..len {
-            let a = self.get(vm.heap).items[i].clone_with_heap(vm.heap);
-            defer_drop!(a, vm);
-            let b = other.get(vm.heap).items[i].clone_with_heap(vm.heap);
-            defer_drop!(b, vm);
-            if !a.py_eq(b, vm)? {
-                return Ok(Some(false));
-            }
-        }
-        Ok(Some(true))
-    }
-
-    /// Lexicographically compares two deques while bounding recursive contents.
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let Some(HeapReadOutput::Deque(other)) = other.read_heap(vm) else {
-            return Ok(Value::NotImplemented);
-        };
-        let self_len = self.get(vm.heap).len();
-        let other_len = other.get(vm.heap).len();
-        let mut guard = vm.recursion_guard()?;
-        let vm = &mut *guard;
-        for i in 0..self_len.min(other_len) {
-            let a = self.get(vm.heap).items[i].clone_with_heap(vm.heap);
-            defer_drop!(a, vm);
-            let b = other.get(vm.heap).items[i].clone_with_heap(vm.heap);
-            defer_drop!(b, vm);
-            if !a.py_lex_eq(b, vm)? {
-                return a.py_rich_compare(b, op, vm);
-            }
-        }
-        Ok(Value::Bool(op.holds(self_len.cmp(&other_len))))
     }
 
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, heap_ids: &mut LazyHeapSet) -> RunResult<()> {
@@ -646,12 +648,10 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, DequeIterator> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
-    }
-
-    fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
-        Ok(self.clone_value(vm.heap))
+    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
+        let self_id = self_id.expect("heap values have an id");
+        vm.heap.inc_ref(self_id);
+        Ok(Value::Ref(self_id))
     }
 
     fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -357,13 +357,7 @@ impl<'h> HeapObjectRead<'h, Deque> {
     }
 
     /// Lexicographically compares two deques while bounding recursive contents.
-    fn rich_compare(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
+    fn rich_compare(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         if op.is_equality() {
             return Ok(op.equality_result(self.eq_bool(other, vm)?));
         }
@@ -648,10 +642,8 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, DequeIterator> {
         None
     }
 
-    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
-        let self_id = self_id.expect("heap values have an id");
-        vm.heap.inc_ref(self_id);
-        Ok(Value::Ref(self_id))
+    fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
+        Ok(self.clone_value(vm.heap))
     }
 
     fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -1,6 +1,6 @@
-use std::{cmp::Ordering, collections::VecDeque, fmt::Write, mem};
+use std::{collections::VecDeque, fmt::Write, mem};
 
-use super::{CmpOrder, PyTrait, iter::collect_owned_iterable};
+use super::{PyTrait, RichCmpOp, iter::collect_owned_iterable};
 use crate::{
     args::{ArgValues, FromArgs},
     bytecode::{CallResult, VM},
@@ -429,13 +429,20 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Deque> {
         Ok(Some(true))
     }
 
-    /// Lexicographic ordering, deque-vs-deque only.
-    ///
-    /// The trait takes `&Self`, so the dispatcher has already rejected other
-    /// types with "'<' not supported between instances of ...". Charges a
-    /// recursion level for the same reason [`py_eq_impl`](Self::py_eq_impl)
-    /// does — nested deques recurse through here.
-    fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {
+    /// Lexicographically compares two deques while bounding recursive contents.
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let Some(HeapReadOutput::Deque(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
         let self_len = self.get(vm.heap).len();
         let other_len = other.get(vm.heap).len();
         let mut guard = vm.recursion_guard()?;
@@ -445,24 +452,11 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Deque> {
             defer_drop!(a, vm);
             let b = other.get(vm.heap).items[i].clone_with_heap(vm.heap);
             defer_drop!(b, vm);
-            match a.py_cmp(b, vm)? {
-                CmpOrder::Ordered(Ordering::Equal) => {}
-                CmpOrder::Ordered(ord) => return Ok(CmpOrder::Ordered(ord)),
-                // A `NaN` element is never `==`-equal, so it is the first
-                // differing pair and the deque is unordered (yields `False`).
-                CmpOrder::Unordered => return Ok(CmpOrder::Unordered),
-                // CPython checks `__eq__` first and only orders non-equal pairs,
-                // so equal-but-unorderable elements (e.g. `None == None`) don't
-                // block the comparison — mirror list/tuple.
-                CmpOrder::Incomparable => {
-                    if !a.py_eq(b, vm)? {
-                        return Ok(CmpOrder::Incomparable);
-                    }
-                }
+            if !a.py_lex_eq(b, vm)? {
+                return a.py_rich_compare(b, op, vm);
             }
         }
-        // All shared items equal — the shorter deque sorts first.
-        Ok(CmpOrder::Ordered(self_len.cmp(&other_len)))
+        Ok(Value::Bool(op.holds(self_len.cmp(&other_len))))
     }
 
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, heap_ids: &mut LazyHeapSet) -> RunResult<()> {

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -1,6 +1,6 @@
-use std::{cmp::Ordering, collections::VecDeque, fmt::Write, mem};
+use std::{collections::VecDeque, fmt::Write, mem};
 
-use super::{CmpOrder, PyTrait, iter::collect_owned_iterable};
+use super::{PyTrait, RichCmpOp, iter::collect_owned_iterable};
 use crate::{
     args::{ArgValues, FromArgs},
     bytecode::{CallResult, VM},
@@ -432,13 +432,20 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Deque> {
         Ok(Some(true))
     }
 
-    /// Lexicographic ordering, deque-vs-deque only.
-    ///
-    /// The trait takes `&Self`, so the dispatcher has already rejected other
-    /// types with "'<' not supported between instances of ...". Charges a
-    /// recursion level for the same reason [`py_eq_impl`](Self::py_eq_impl)
-    /// does — nested deques recurse through here.
-    fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {
+    /// Lexicographically compares two deques while bounding recursive contents.
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let Some(HeapReadOutput::Deque(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
         let self_len = self.get(vm.heap).len();
         let other_len = other.get(vm.heap).len();
         let mut guard = vm.recursion_guard()?;
@@ -448,24 +455,11 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Deque> {
             defer_drop!(a, vm);
             let b = other.get(vm.heap).items[i].clone_with_heap(vm.heap);
             defer_drop!(b, vm);
-            match a.py_cmp(b, vm)? {
-                CmpOrder::Ordered(Ordering::Equal) => {}
-                CmpOrder::Ordered(ord) => return Ok(CmpOrder::Ordered(ord)),
-                // A `NaN` element is never `==`-equal, so it is the first
-                // differing pair and the deque is unordered (yields `False`).
-                CmpOrder::Unordered => return Ok(CmpOrder::Unordered),
-                // CPython checks `__eq__` first and only orders non-equal pairs,
-                // so equal-but-unorderable elements (e.g. `None == None`) don't
-                // block the comparison — mirror list/tuple.
-                CmpOrder::Incomparable => {
-                    if !a.py_eq(b, vm)? {
-                        return Ok(CmpOrder::Incomparable);
-                    }
-                }
+            if !a.py_lex_eq(b, vm)? {
+                return a.py_rich_compare(b, op, vm);
             }
         }
-        // All shared items equal — the shorter deque sorts first.
-        Ok(CmpOrder::Ordered(self_len.cmp(&other_len)))
+        Ok(Value::Bool(op.holds(self_len.cmp(&other_len))))
     }
 
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, heap_ids: &mut LazyHeapSet) -> RunResult<()> {

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -1,6 +1,6 @@
 use std::{collections::VecDeque, fmt::Write, mem};
 
-use super::{PyTrait, RichCmpOp, iter::collect_owned_iterable};
+use super::{PyTrait, RichCmpOp, RichCmpVtable, iter::collect_owned_iterable};
 use crate::{
     args::{ArgValues, FromArgs},
     bytecode::{CallResult, VM},
@@ -333,7 +333,66 @@ fn evict_back_if_full(deque: &mut Deque) -> Option<Value> {
     }
 }
 
+impl<'h> HeapRead<'h, Deque> {
+    /// Compares only deque items; `maxlen` is not part of equality.
+    ///
+    /// A recursion guard bounds comparisons between distinct cyclic deques.
+    fn eq_bool(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        let Some(HeapReadOutput::Deque(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
+        let len = self.get(vm.heap).len();
+        if len != other.get(vm.heap).len() {
+            return Ok(Some(false));
+        }
+        let mut guard = vm.recursion_guard()?;
+        let vm = &mut *guard;
+        for i in 0..len {
+            let a = self.get(vm.heap).items[i].clone_with_heap(vm.heap);
+            defer_drop!(a, vm);
+            let b = other.get(vm.heap).items[i].clone_with_heap(vm.heap);
+            defer_drop!(b, vm);
+            if !a.py_eq(b, vm)? {
+                return Ok(Some(false));
+            }
+        }
+        Ok(Some(true))
+    }
+
+    /// Lexicographically compares two deques while bounding recursive contents.
+    fn rich_compare(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.eq_bool(other, vm)?));
+        }
+        let Some(HeapReadOutput::Deque(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        let self_len = self.get(vm.heap).len();
+        let other_len = other.get(vm.heap).len();
+        let mut guard = vm.recursion_guard()?;
+        let vm = &mut *guard;
+        for i in 0..self_len.min(other_len) {
+            let a = self.get(vm.heap).items[i].clone_with_heap(vm.heap);
+            defer_drop!(a, vm);
+            let b = other.get(vm.heap).items[i].clone_with_heap(vm.heap);
+            defer_drop!(b, vm);
+            if !a.py_lex_eq(b, vm)? {
+                return a.py_rich_compare(b, op, vm);
+            }
+        }
+        Ok(Value::Bool(op.holds(self_len.cmp(&other_len))))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapRead<'h, Deque> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -403,63 +462,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Deque> {
         // The guard drops whatever `value` holds after the swap — i.e. the old item.
         mem::swap(&mut self.get_mut(vm.heap).items[idx], value);
         Ok(())
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // A deque only ever equals another deque — unlike NamedTuple/tuple, there
-        // is no cross-type equality with list. `maxlen` is not part of equality.
-        let Some(HeapReadOutput::Deque(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        let len = self.get(vm.heap).len();
-        if len != other.get(vm.heap).len() {
-            return Ok(Some(false));
-        }
-        // Charge a recursion level: two distinct cyclic deques (`a.append(a);
-        // b.append(b); a == b`) re-enter here per level and would otherwise
-        // overflow the host stack. A deque walks by index, so it charges directly.
-        let mut guard = vm.recursion_guard()?;
-        let vm = &mut *guard;
-        for i in 0..len {
-            let a = self.get(vm.heap).items[i].clone_with_heap(vm.heap);
-            defer_drop!(a, vm);
-            let b = other.get(vm.heap).items[i].clone_with_heap(vm.heap);
-            defer_drop!(b, vm);
-            if !a.py_eq(b, vm)? {
-                return Ok(Some(false));
-            }
-        }
-        Ok(Some(true))
-    }
-
-    /// Lexicographically compares two deques while bounding recursive contents.
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let Some(HeapReadOutput::Deque(other)) = other.read_heap(vm) else {
-            return Ok(Value::NotImplemented);
-        };
-        let self_len = self.get(vm.heap).len();
-        let other_len = other.get(vm.heap).len();
-        let mut guard = vm.recursion_guard()?;
-        let vm = &mut *guard;
-        for i in 0..self_len.min(other_len) {
-            let a = self.get(vm.heap).items[i].clone_with_heap(vm.heap);
-            defer_drop!(a, vm);
-            let b = other.get(vm.heap).items[i].clone_with_heap(vm.heap);
-            defer_drop!(b, vm);
-            if !a.py_lex_eq(b, vm)? {
-                return a.py_rich_compare(b, op, vm);
-            }
-        }
-        Ok(Value::Bool(op.holds(self_len.cmp(&other_len))))
     }
 
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, heap_ids: &mut LazyHeapSet) -> RunResult<()> {
@@ -650,10 +652,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DequeIterator> {
 
     fn py_len(&self, _: &VM<'h>) -> Option<usize> {
         None
-    }
-
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
     }
 
     fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -11,13 +11,17 @@ use smallvec::{SmallVec, smallvec};
 
 use super::{
     DictItemsView, DictKeysView, DictValuesView, LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, allocate_tuple,
+    list::repr_check_time,
 };
 use crate::{
     args::{ArgValues, FromArgs, KwargsValues},
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunResult},
-    heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapRead, HeapReadOutput},
+    heap::{
+        ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapRead,
+        HeapReadOutput,
+    },
     intern::{Interns, StaticStrings},
     modules::collections::{
         counter::{
@@ -1149,7 +1153,7 @@ impl<'h> HeapObjectRead<'h, Dict> {
     }
 
     /// Two Counters compare as multisets; ordinary dicts decline ordering.
-    fn rich_compare(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Value> {
+    fn rich_compare(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         if op.is_equality() {
             return Ok(op.equality_result(self.eq_bool(other, vm)?));
         }
@@ -1160,16 +1164,14 @@ impl<'h> HeapObjectRead<'h, Dict> {
             RichCmpOp::Ge => CounterCmp::Ge,
             RichCmpOp::Eq | RichCmpOp::Ne => unreachable!("equality handled above"),
         };
-        match (self_id, other.ref_id()) {
-            (Some(lhs), Some(rhs)) if self.both_counters(rhs, vm) => {
-                Ok(Value::Bool(counter_compare(lhs, rhs, cmp, vm)?))
-            }
+        match other.ref_id() {
+            Some(rhs) if self.both_counters(rhs, vm) => Ok(Value::Bool(counter_compare(self.id(), rhs, cmp, vm)?)),
             _ => Ok(Value::NotImplemented),
         }
     }
 }
 
-/// `PyTrait` implementation for `HeapRead<'h, Dict>`.
+/// `PyTrait` implementation for a heap-backed `Dict` object.
 ///
 /// All methods access the dict data through short-lived borrows from the heap via
 /// `self.get(vm.heap)`, and mutation methods use `self.get_mut(vm.heap)`. This avoids
@@ -1208,8 +1210,8 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Dict> {
         Ok(!self.get(vm.heap).is_empty())
     }
 
-    fn py_neg_impl(&self, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Option<Value>> {
-        self.counter_unary(true, vm, self_id)
+    fn py_neg_impl(&self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+        self.counter_unary(true, vm, self.id())
     }
 
     fn py_pos_impl(&self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
@@ -1919,10 +1921,8 @@ macro_rules! impl_dict_iterator {
                 None
             }
 
-            fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
-                let self_id = self_id.expect("heap values have an id");
-                vm.heap.inc_ref(self_id);
-                Ok(Value::Ref(self_id))
+            fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
+                Ok(self.clone_value(vm.heap))
             }
 
             fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -9,17 +9,13 @@ use hashbrown::HashTable;
 use serde::ser::SerializeStruct;
 use smallvec::{SmallVec, smallvec};
 
-use super::{DictItemsView, DictKeysView, DictValuesView, LazyHeapSet, PyTrait, allocate_tuple, list::repr_check_time};
+use super::{DictItemsView, DictKeysView, DictValuesView, LazyHeapSet, PyTrait, RichCmpOp, allocate_tuple};
 use crate::{
     args::{ArgValues, FromArgs, KwargsValues},
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunResult},
-    expressions::CmpOperator,
-    heap::{
-        ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapRead,
-        HeapReadOutput,
-    },
+    heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     modules::collections::{
         counter::{
@@ -1187,24 +1183,29 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Dict> {
         Ok(!self.get(vm.heap).is_empty())
     }
 
-    /// Two Counters compare as multisets; every other pairing defers to `py_cmp`,
-    /// which has no dict ordering and so raises `TypeError` — CPython's
-    /// `Counter.__lt__` likewise returns `NotImplemented` for a non-Counter,
-    /// which is why `Counter(a=1) < {'a': 2}` never becomes a dict comparison.
-    fn py_cmp_op(&self, other: &Value, op: CmpOperator, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+    /// Two Counters compare as multisets; ordinary dicts decline ordering.
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
         let cmp = match op {
-            CmpOperator::Lt => CounterCmp::Lt,
-            CmpOperator::LtE => CounterCmp::Le,
-            CmpOperator::Gt => CounterCmp::Gt,
-            CmpOperator::GtE => CounterCmp::Ge,
-            // Only the four ordering operators reach `py_cmp_op`.
-            _ => return Ok(None),
+            RichCmpOp::Lt => CounterCmp::Lt,
+            RichCmpOp::Le => CounterCmp::Le,
+            RichCmpOp::Gt => CounterCmp::Gt,
+            RichCmpOp::Ge => CounterCmp::Ge,
+            RichCmpOp::Eq | RichCmpOp::Ne => unreachable!("equality handled above"),
         };
-        match other.ref_id() {
-            Some(other_id) if self.both_counters(other_id, vm) => {
-                Ok(Some(counter_compare(self.id(), other_id, cmp, vm)?))
+        match (self_id, other.ref_id()) {
+            (Some(lhs), Some(rhs)) if self.both_counters(rhs, vm) => {
+                Ok(Value::Bool(counter_compare(lhs, rhs, cmp, vm)?))
             }
-            _ => Ok(None),
+            _ => Ok(Value::NotImplemented),
         }
     }
 

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -9,13 +9,15 @@ use hashbrown::HashTable;
 use serde::ser::SerializeStruct;
 use smallvec::{SmallVec, smallvec};
 
-use super::{DictItemsView, DictKeysView, DictValuesView, LazyHeapSet, PyTrait, RichCmpOp, allocate_tuple};
+use super::{
+    DictItemsView, DictKeysView, DictValuesView, LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, allocate_tuple,
+};
 use crate::{
     args::{ArgValues, FromArgs, KwargsValues},
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunResult},
-    heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
+    heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     modules::collections::{
         counter::{
@@ -373,7 +375,7 @@ fn json_key_equals_str(key: &Value, expected: &str, heap: &Heap, interns: &Inter
 impl<'h> HeapRead<'h, Dict> {
     /// Element-wise equality against another dict (matching keys and values).
     ///
-    /// Shared by `Dict::py_eq_impl` and `Dataclass::py_eq_impl` (which compares
+    /// Shared by dict and host-dataclass rich equality (the latter compares
     /// the dataclasses' attribute dicts).
     pub(crate) fn eq_dict(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<bool> {
         if self.get(vm.heap).len() != other.get(vm.heap).len() {
@@ -1130,12 +1132,51 @@ impl<'h> HeapRead<'h, Dict> {
     }
 }
 
-/// `PyTrait` implementation for a heap-backed `Dict` object.
+impl<'h> HeapObjectRead<'h, Dict> {
+    /// Compares dicts by mapping contents, with Counter's zero-count semantics.
+    fn eq_bool(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        match other.read_heap(vm) {
+            Some(HeapReadOutput::Dict(other)) => {
+                let both_counters = self.get(vm.heap).is_counter() && other.get(vm.heap).is_counter();
+                if both_counters {
+                    Ok(Some(self.eq_counter(&other, vm)?))
+                } else {
+                    Ok(Some(self.eq_dict(&other, vm)?))
+                }
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Two Counters compare as multisets; ordinary dicts decline ordering.
+    fn rich_compare(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.eq_bool(other, vm)?));
+        }
+        let cmp = match op {
+            RichCmpOp::Lt => CounterCmp::Lt,
+            RichCmpOp::Le => CounterCmp::Le,
+            RichCmpOp::Gt => CounterCmp::Gt,
+            RichCmpOp::Ge => CounterCmp::Ge,
+            RichCmpOp::Eq | RichCmpOp::Ne => unreachable!("equality handled above"),
+        };
+        match (self_id, other.ref_id()) {
+            (Some(lhs), Some(rhs)) if self.both_counters(rhs, vm) => {
+                Ok(Value::Bool(counter_compare(lhs, rhs, cmp, vm)?))
+            }
+            _ => Ok(Value::NotImplemented),
+        }
+    }
+}
+
+/// `PyTrait` implementation for `HeapRead<'h, Dict>`.
 ///
 /// All methods access the dict data through short-lived borrows from the heap via
 /// `self.get(vm.heap)`, and mutation methods use `self.get_mut(vm.heap)`. This avoids
 /// taking the dict out of the heap, enabling self-referential operations like `d.update(d)`.
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, Dict> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -1163,54 +1204,12 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Dict> {
         Some(self.get(vm.heap).len())
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        match other.read_heap(vm) {
-            Some(HeapReadOutput::Dict(other)) => {
-                // Two Counters compare as multisets (zero counts ignored); any
-                // other pairing is plain dict equality.
-                let both_counters = self.get(vm.heap).is_counter() && other.get(vm.heap).is_counter();
-                if both_counters {
-                    Ok(Some(self.eq_counter(&other, vm)?))
-                } else {
-                    Ok(Some(self.eq_dict(&other, vm)?))
-                }
-            }
-            _ => Ok(None),
-        }
-    }
-
     fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {
         Ok(!self.get(vm.heap).is_empty())
     }
 
-    /// Two Counters compare as multisets; ordinary dicts decline ordering.
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let cmp = match op {
-            RichCmpOp::Lt => CounterCmp::Lt,
-            RichCmpOp::Le => CounterCmp::Le,
-            RichCmpOp::Gt => CounterCmp::Gt,
-            RichCmpOp::Ge => CounterCmp::Ge,
-            RichCmpOp::Eq | RichCmpOp::Ne => unreachable!("equality handled above"),
-        };
-        match (self_id, other.ref_id()) {
-            (Some(lhs), Some(rhs)) if self.both_counters(rhs, vm) => {
-                Ok(Value::Bool(counter_compare(lhs, rhs, cmp, vm)?))
-            }
-            _ => Ok(Value::NotImplemented),
-        }
-    }
-
-    fn py_neg_impl(&self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
-        self.counter_unary(true, vm, self.id())
+    fn py_neg_impl(&self, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+        self.counter_unary(true, vm, self_id)
     }
 
     fn py_pos_impl(&self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
@@ -1920,12 +1919,10 @@ macro_rules! impl_dict_iterator {
                 None
             }
 
-            fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-                Ok(None)
-            }
-
-            fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
-                Ok(self.clone_value(vm.heap))
+            fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
+                let self_id = self_id.expect("heap values have an id");
+                vm.heap.inc_ref(self_id);
+                Ok(Value::Ref(self_id))
             }
 
             fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -9,7 +9,9 @@ use hashbrown::HashTable;
 use serde::ser::SerializeStruct;
 use smallvec::{SmallVec, smallvec};
 
-use super::{DictItemsView, DictKeysView, DictValuesView, LazyHeapSet, PyTrait, RichCmpOp, allocate_tuple};
+use super::{
+    DictItemsView, DictKeysView, DictValuesView, LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, allocate_tuple,
+};
 use crate::{
     args::{ArgValues, FromArgs, KwargsValues},
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
@@ -402,7 +404,7 @@ fn json_key_equals_str(key: &Value, expected: &str, heap: &Heap, interns: &Inter
 impl<'h> HeapRead<'h, Dict> {
     /// Element-wise equality against another dict (matching keys and values).
     ///
-    /// Shared by `Dict::py_eq_impl` and `Dataclass::py_eq_impl` (which compares
+    /// Shared by dict and host-dataclass rich equality (the latter compares
     /// the dataclasses' attribute dicts).
     pub(crate) fn eq_dict(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<bool> {
         if self.get(vm.heap).len() != other.get(vm.heap).len() {
@@ -1141,12 +1143,51 @@ impl<'h> HeapRead<'h, Dict> {
     }
 }
 
+impl<'h> HeapRead<'h, Dict> {
+    /// Compares dicts by mapping contents, with Counter's zero-count semantics.
+    fn eq_bool(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        match other.read_heap(vm) {
+            Some(HeapReadOutput::Dict(other)) => {
+                let both_counters = self.get(vm.heap).is_counter() && other.get(vm.heap).is_counter();
+                if both_counters {
+                    Ok(Some(self.eq_counter(&other, vm)?))
+                } else {
+                    Ok(Some(self.eq_dict(&other, vm)?))
+                }
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Two Counters compare as multisets; ordinary dicts decline ordering.
+    fn rich_compare(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.eq_bool(other, vm)?));
+        }
+        let cmp = match op {
+            RichCmpOp::Lt => CounterCmp::Lt,
+            RichCmpOp::Le => CounterCmp::Le,
+            RichCmpOp::Gt => CounterCmp::Gt,
+            RichCmpOp::Ge => CounterCmp::Ge,
+            RichCmpOp::Eq | RichCmpOp::Ne => unreachable!("equality handled above"),
+        };
+        match (self_id, other.ref_id()) {
+            (Some(lhs), Some(rhs)) if self.both_counters(rhs, vm) => {
+                Ok(Value::Bool(counter_compare(lhs, rhs, cmp, vm)?))
+            }
+            _ => Ok(Value::NotImplemented),
+        }
+    }
+}
+
 /// `PyTrait` implementation for `HeapRead<'h, Dict>`.
 ///
 /// All methods access the dict data through short-lived borrows from the heap via
 /// `self.get(vm.heap)`, and mutation methods use `self.get_mut(vm.heap)`. This avoids
 /// taking the dict out of the heap, enabling self-referential operations like `d.update(d)`.
 impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -1174,50 +1215,8 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
         Some(self.get(vm.heap).len())
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        match other.read_heap(vm) {
-            Some(HeapReadOutput::Dict(other)) => {
-                // Two Counters compare as multisets (zero counts ignored); any
-                // other pairing is plain dict equality.
-                let both_counters = self.get(vm.heap).is_counter() && other.get(vm.heap).is_counter();
-                if both_counters {
-                    Ok(Some(self.eq_counter(&other, vm)?))
-                } else {
-                    Ok(Some(self.eq_dict(&other, vm)?))
-                }
-            }
-            _ => Ok(None),
-        }
-    }
-
     fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {
         Ok(!self.get(vm.heap).is_empty())
-    }
-
-    /// Two Counters compare as multisets; ordinary dicts decline ordering.
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let cmp = match op {
-            RichCmpOp::Lt => CounterCmp::Lt,
-            RichCmpOp::Le => CounterCmp::Le,
-            RichCmpOp::Gt => CounterCmp::Gt,
-            RichCmpOp::Ge => CounterCmp::Ge,
-            RichCmpOp::Eq | RichCmpOp::Ne => unreachable!("equality handled above"),
-        };
-        match (self_id, other.ref_id()) {
-            (Some(lhs), Some(rhs)) if self.both_counters(rhs, vm) => {
-                Ok(Value::Bool(counter_compare(lhs, rhs, cmp, vm)?))
-            }
-            _ => Ok(Value::NotImplemented),
-        }
     }
 
     fn py_neg_impl(&self, vm: &mut VM<'h>, self_id: Option<HeapId>) -> RunResult<Option<Value>> {
@@ -1941,10 +1940,6 @@ macro_rules! impl_dict_iterator {
 
             fn py_len(&self, _: &VM<'h>) -> Option<usize> {
                 None
-            }
-
-            fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-                Ok(None)
             }
 
             fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -9,13 +9,12 @@ use hashbrown::HashTable;
 use serde::ser::SerializeStruct;
 use smallvec::{SmallVec, smallvec};
 
-use super::{DictItemsView, DictKeysView, DictValuesView, LazyHeapSet, PyTrait, allocate_tuple};
+use super::{DictItemsView, DictKeysView, DictValuesView, LazyHeapSet, PyTrait, RichCmpOp, allocate_tuple};
 use crate::{
     args::{ArgValues, FromArgs, KwargsValues},
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunResult},
-    expressions::CmpOperator,
     heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     modules::collections::{
@@ -1195,28 +1194,29 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Dict> {
         Ok(!self.get(vm.heap).is_empty())
     }
 
-    /// Two Counters compare as multisets; every other pairing defers to `py_cmp`,
-    /// which has no dict ordering and so raises `TypeError` — CPython's
-    /// `Counter.__lt__` likewise returns `NotImplemented` for a non-Counter,
-    /// which is why `Counter(a=1) < {'a': 2}` never becomes a dict comparison.
-    fn py_cmp_op(
+    /// Two Counters compare as multisets; ordinary dicts decline ordering.
+    fn py_rich_compare_impl(
         &self,
         other: &Value,
-        op: CmpOperator,
+        op: RichCmpOp,
         vm: &mut VM<'h>,
         self_id: Option<HeapId>,
-    ) -> RunResult<Option<bool>> {
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
         let cmp = match op {
-            CmpOperator::Lt => CounterCmp::Lt,
-            CmpOperator::LtE => CounterCmp::Le,
-            CmpOperator::Gt => CounterCmp::Gt,
-            CmpOperator::GtE => CounterCmp::Ge,
-            // Only the four ordering operators reach `py_cmp_op`.
-            _ => return Ok(None),
+            RichCmpOp::Lt => CounterCmp::Lt,
+            RichCmpOp::Le => CounterCmp::Le,
+            RichCmpOp::Gt => CounterCmp::Gt,
+            RichCmpOp::Ge => CounterCmp::Ge,
+            RichCmpOp::Eq | RichCmpOp::Ne => unreachable!("equality handled above"),
         };
         match (self_id, other.ref_id()) {
-            (Some(l), Some(r)) if self.both_counters(r, vm) => Ok(Some(counter_compare(l, r, cmp, vm)?)),
-            _ => Ok(None),
+            (Some(lhs), Some(rhs)) if self.both_counters(rhs, vm) => {
+                Ok(Value::Bool(counter_compare(lhs, rhs, cmp, vm)?))
+            }
+            _ => Ok(Value::NotImplemented),
         }
     }
 

--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -10,7 +10,7 @@ use crate::{
     heap::{ContainsHeap, DropGuard, Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     types::{
-        Dict, FrozenSet, LazyHeapSet, PyTrait, Set, Type, allocate_tuple,
+        Dict, FrozenSet, LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, Set, Type, allocate_tuple,
         dict::{DictItemIterator, DictKeyIterator, DictValueIterator},
         iter::checked_preallocation_hint,
     },
@@ -155,7 +155,35 @@ impl DictView for DictKeysView {
     }
 }
 
+impl<'h> HeapObjectRead<'h, DictKeysView> {
+    /// Compares key views with other set-like values.
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let equal = match other.read_heap(vm) {
+            Some(HeapReadOutput::DictKeysView(other)) => {
+                if self.get(vm.heap).dict_id == other.get(vm.heap).dict_id {
+                    Some(true)
+                } else {
+                    let left = self.dict(vm);
+                    let right = other.dict(vm);
+                    Some(dict_keys_eq_set_like(
+                        &left,
+                        right.get(vm.heap).len(),
+                        |key, vm| right.contains_key(key, vm),
+                        vm,
+                    )?)
+                }
+            }
+            Some(HeapReadOutput::Set(other)) => Some(self.eq_set(&other, vm)?),
+            Some(HeapReadOutput::FrozenSet(other)) => Some(self.eq_frozenset(&other, vm)?),
+            _ => None,
+        };
+        Ok(op.equality_result(equal))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, DictKeysView> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -186,29 +214,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, DictKeysView> {
         Some(self.get(vm.heap).dict(vm.heap).len())
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        match other.read_heap(vm) {
-            Some(HeapReadOutput::DictKeysView(other)) => {
-                if self.get(vm.heap).dict_id == other.get(vm.heap).dict_id {
-                    return Ok(Some(true));
-                }
-                let left = self.dict(vm);
-                let right = other.dict(vm);
-                dict_keys_eq_set_like(
-                    &left,
-                    right.get(vm.heap).len(),
-                    |key, vm| right.contains_key(key, vm),
-                    vm,
-                )
-                .map(Some)
-            }
-            Some(HeapReadOutput::Set(other)) => Ok(Some(self.eq_set(&other, vm)?)),
-            Some(HeapReadOutput::FrozenSet(other)) => Ok(Some(self.eq_frozenset(&other, vm)?)),
-            _ => Ok(None),
-        }
-    }
-
-    fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         dict_view_binary_op_value(self.to_set(vm)?, other, vm, apply_dict_view_sub)
     }
 
@@ -422,7 +428,30 @@ impl DictView for DictItemsView {
     }
 }
 
+impl<'h> HeapObjectRead<'h, DictItemsView> {
+    /// Compares item views with other set-like values.
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let equal = match other.read_heap(vm) {
+            Some(HeapReadOutput::DictItemsView(other)) => {
+                if self.get(vm.heap).dict_id == other.get(vm.heap).dict_id {
+                    Some(true)
+                } else {
+                    let left = self.dict(vm);
+                    let right = other.dict(vm);
+                    Some(left.eq_dict(&right, vm)?)
+                }
+            }
+            Some(HeapReadOutput::Set(other)) => Some(self.eq_set(&other, vm)?),
+            Some(HeapReadOutput::FrozenSet(other)) => Some(self.eq_frozenset(&other, vm)?),
+            _ => None,
+        };
+        Ok(op.equality_result(equal))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, DictItemsView> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -468,23 +497,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, DictItemsView> {
         Some(self.get(vm.heap).dict(vm.heap).len())
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        match other.read_heap(vm) {
-            Some(HeapReadOutput::DictItemsView(other)) => {
-                if self.get(vm.heap).dict_id == other.get(vm.heap).dict_id {
-                    return Ok(Some(true));
-                }
-                let left = self.dict(vm);
-                let right = other.dict(vm);
-                Ok(Some(left.eq_dict(&right, vm)?))
-            }
-            Some(HeapReadOutput::Set(other)) => Ok(Some(self.eq_set(&other, vm)?)),
-            Some(HeapReadOutput::FrozenSet(other)) => Ok(Some(self.eq_frozenset(&other, vm)?)),
-            _ => Ok(None),
-        }
-    }
-
-    fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         dict_view_binary_op_value(self.to_set(vm)?, other, vm, apply_dict_view_sub)
     }
 
@@ -616,11 +629,6 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, DictValuesView> {
 
     fn py_len(&self, vm: &VM<'h>) -> Option<usize> {
         Some(self.get(vm.heap).dict(vm.heap).len())
-    }
-
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // `dict_values` views use identity equality (handled before the heap read).
-        Ok(None)
     }
 
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, heap_ids: &mut LazyHeapSet) -> RunResult<()> {

--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -157,7 +157,7 @@ impl DictView for DictKeysView {
 
 impl<'h> HeapObjectRead<'h, DictKeysView> {
     /// Compares key views with other set-like values.
-    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         let equal = match other.read_heap(vm) {
             Some(HeapReadOutput::DictKeysView(other)) => {
                 if self.get(vm.heap).dict_id == other.get(vm.heap).dict_id {
@@ -214,7 +214,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, DictKeysView> {
         Some(self.get(vm.heap).dict(vm.heap).len())
     }
 
-    fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         dict_view_binary_op_value(self.to_set(vm)?, other, vm, apply_dict_view_sub)
     }
 
@@ -430,7 +430,7 @@ impl DictView for DictItemsView {
 
 impl<'h> HeapObjectRead<'h, DictItemsView> {
     /// Compares item views with other set-like values.
-    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         let equal = match other.read_heap(vm) {
             Some(HeapReadOutput::DictItemsView(other)) => {
                 if self.get(vm.heap).dict_id == other.get(vm.heap).dict_id {
@@ -497,7 +497,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, DictItemsView> {
         Some(self.get(vm.heap).dict(vm.heap).len())
     }
 
-    fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         dict_view_binary_op_value(self.to_set(vm)?, other, vm, apply_dict_view_sub)
     }
 

--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -10,7 +10,7 @@ use crate::{
     heap::{ContainsHeap, DropGuard, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     types::{
-        Dict, FrozenSet, LazyHeapSet, PyTrait, Set, Type, allocate_tuple,
+        Dict, FrozenSet, LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, Set, Type, allocate_tuple,
         dict::{DictItemIterator, DictKeyIterator, DictValueIterator},
         iter::checked_preallocation_hint,
     },
@@ -155,7 +155,35 @@ impl DictView for DictKeysView {
     }
 }
 
+impl<'h> HeapRead<'h, DictKeysView> {
+    /// Compares key views with other set-like values.
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let equal = match other.read_heap(vm) {
+            Some(HeapReadOutput::DictKeysView(other)) => {
+                if self.get(vm.heap).dict_id == other.get(vm.heap).dict_id {
+                    Some(true)
+                } else {
+                    let left = self.dict(vm);
+                    let right = other.dict(vm);
+                    Some(dict_keys_eq_set_like(
+                        &left,
+                        right.get(vm.heap).len(),
+                        |key, vm| right.contains_key(key, vm),
+                        vm,
+                    )?)
+                }
+            }
+            Some(HeapReadOutput::Set(other)) => Some(self.eq_set(&other, vm)?),
+            Some(HeapReadOutput::FrozenSet(other)) => Some(self.eq_frozenset(&other, vm)?),
+            _ => None,
+        };
+        Ok(op.equality_result(equal))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapRead<'h, DictKeysView> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -180,28 +208,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictKeysView> {
 
     fn py_len(&self, vm: &VM<'h>) -> Option<usize> {
         Some(self.get(vm.heap).dict(vm.heap).len())
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        match other.read_heap(vm) {
-            Some(HeapReadOutput::DictKeysView(other)) => {
-                if self.get(vm.heap).dict_id == other.get(vm.heap).dict_id {
-                    return Ok(Some(true));
-                }
-                let left = self.dict(vm);
-                let right = other.dict(vm);
-                dict_keys_eq_set_like(
-                    &left,
-                    right.get(vm.heap).len(),
-                    |key, vm| right.contains_key(key, vm),
-                    vm,
-                )
-                .map(Some)
-            }
-            Some(HeapReadOutput::Set(other)) => Ok(Some(self.eq_set(&other, vm)?)),
-            Some(HeapReadOutput::FrozenSet(other)) => Ok(Some(self.eq_frozenset(&other, vm)?)),
-            _ => Ok(None),
-        }
     }
 
     fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
@@ -428,7 +434,30 @@ impl DictView for DictItemsView {
     }
 }
 
+impl<'h> HeapRead<'h, DictItemsView> {
+    /// Compares item views with other set-like values.
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let equal = match other.read_heap(vm) {
+            Some(HeapReadOutput::DictItemsView(other)) => {
+                if self.get(vm.heap).dict_id == other.get(vm.heap).dict_id {
+                    Some(true)
+                } else {
+                    let left = self.dict(vm);
+                    let right = other.dict(vm);
+                    Some(left.eq_dict(&right, vm)?)
+                }
+            }
+            Some(HeapReadOutput::Set(other)) => Some(self.eq_set(&other, vm)?),
+            Some(HeapReadOutput::FrozenSet(other)) => Some(self.eq_frozenset(&other, vm)?),
+            _ => None,
+        };
+        Ok(op.equality_result(equal))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapRead<'h, DictItemsView> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -468,22 +497,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictItemsView> {
 
     fn py_len(&self, vm: &VM<'h>) -> Option<usize> {
         Some(self.get(vm.heap).dict(vm.heap).len())
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        match other.read_heap(vm) {
-            Some(HeapReadOutput::DictItemsView(other)) => {
-                if self.get(vm.heap).dict_id == other.get(vm.heap).dict_id {
-                    return Ok(Some(true));
-                }
-                let left = self.dict(vm);
-                let right = other.dict(vm);
-                Ok(Some(left.eq_dict(&right, vm)?))
-            }
-            Some(HeapReadOutput::Set(other)) => Ok(Some(self.eq_set(&other, vm)?)),
-            Some(HeapReadOutput::FrozenSet(other)) => Ok(Some(self.eq_frozenset(&other, vm)?)),
-            _ => Ok(None),
-        }
     }
 
     fn py_sub_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
@@ -624,11 +637,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, DictValuesView> {
 
     fn py_len(&self, vm: &VM<'h>) -> Option<usize> {
         Some(self.get(vm.heap).dict(vm.heap).len())
-    }
-
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // `dict_values` views use identity equality (handled before the heap read).
-        Ok(None)
     }
 
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, heap_ids: &mut LazyHeapSet) -> RunResult<()> {

--- a/crates/monty/src/types/file.rs
+++ b/crates/monty/src/types/file.rs
@@ -308,11 +308,6 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, OpenFile> {
         None
     }
 
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // File objects use identity equality (handled before the heap read).
-        Ok(None)
-    }
-
     fn py_bool(&self, _vm: &mut VM<'h>) -> RunResult<bool> {
         Ok(true)
     }

--- a/crates/monty/src/types/file.rs
+++ b/crates/monty/src/types/file.rs
@@ -312,11 +312,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, OpenFile> {
         None
     }
 
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // File objects use identity equality (handled before the heap read).
-        Ok(None)
-    }
-
     fn py_bool(&self, _vm: &mut VM<'h>) -> RunResult<bool> {
         Ok(true)
     }

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, fmt::Write};
 
-use super::{Dict, LazyHeapSet, PyTrait, Type, attribute_name_value};
+use super::{Dict, LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, Type, attribute_name_value};
 use crate::{
     args::{ArgValues, KwargsValues},
     builtins::Builtins,
@@ -65,7 +65,7 @@ pub(crate) struct BoundMethod {
     pub func: Value,
 }
 
-impl<'h> HeapRead<'h, Instance> {
+impl<'h> HeapObjectRead<'h, Instance> {
     fn attrs_mut(&mut self) -> BorrowedHeapReadMut<'_, 'h, Dict> {
         heap_read_ref_as_field_mut!(self, Instance, attrs)
     }
@@ -99,33 +99,30 @@ impl<'h> HeapRead<'h, Instance> {
     pub fn set_attr_unchecked(&mut self, name: Value, value: Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         self.attrs_mut().set(name, value, vm)
     }
+
+    /// Resolves and invokes the class special method for one rich comparison.
+    ///
+    /// Missing `__ne__` derives from `__eq__`; any other missing method declines
+    /// the operation. Lookup occurs immediately before invocation so mutations
+    /// made by the left comparison are visible to reflected dispatch.
+    fn rich_compare(
+        _receiver: &Self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        instance_rich_compare(self_id.expect("heap values have an id"), other, op, vm)
+    }
 }
 
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, Instance> {
-    /// Evaluates `item in self` through the class's `__contains__`.
-    ///
-    /// `None` leaves the caller to fall back to iteration. An explicit
-    /// `__contains__ = None` instead reports that the object is not a container.
-    /// Results use `py_bool`, whose handling of user objects is documented in
-    /// `limitations/classes.md`.
-    fn py_contains_impl(&self, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let class_id = self.get(vm.heap).class();
-        if matches!(class_dunder(class_id, "__contains__", vm), Some(Value::None)) {
-            Err(ExcType::type_error_object_not_container(&class_name(
-                class_id, vm.heap, vm.interns,
-            )))
-        } else {
-            // The callee owns its argument, so the borrowed `item` is cloned;
-            // `instance_call_dunder_sync` drops it again if there is no `__contains__`.
-            let item = item.clone_with_heap(vm.heap);
-            match instance_call_dunder_sync(self.id(), "__contains__", Some(item), vm)? {
-                Some(result) => {
-                    defer_drop!(result, vm);
-                    Ok(Some(result.py_bool(vm)?))
-                }
-                None => Ok(None),
-            }
-        }
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
+    /// The class's `__contains__`, or `None` when it defines none — `in` then
+    /// falls back to iteration, matching CPython's `sq_contains` before `tp_iter`.
+    fn py_contains_impl(&self, self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        instance_contains(self_id, item, vm)
     }
 
     fn py_type(&self, vm: &VM<'h>) -> Type {
@@ -143,12 +140,6 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Instance> {
         let old_value = self.set_attr(name, value, vm)?;
         old_value.drop_with(vm);
         Ok(())
-    }
-
-    /// Returns `NotImplemented`; comparisons dispatch at the `Value` level because
-    /// user and synthesized dataclass equality require the instance's `HeapId`.
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
     }
 
     /// Hashes an instance, following CPython's precedence.
@@ -381,11 +372,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, BoundMethod> {
         None
     }
 
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
-    }
-
-    fn py_hash(&self, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, self_id: HeapId, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         // Bound methods hash by identity, consistent with their identity-only
         // equality (CPython hashes by `(instance, func)` — see limitations/classes.md).
         Ok(Some(identity_hash(self.id())))
@@ -643,28 +630,61 @@ fn instance_class(self_id: HeapId, vm: &VM<'_>) -> HeapId {
     }
 }
 
-/// Dispatches a user-defined `__eq__`, or `Ok(None)` when it is absent.
+/// Runs one side of rich comparison for a user instance.
+fn instance_rich_compare(self_id: HeapId, other: &Value, op: RichCmpOp, vm: &mut VM<'_>) -> RunResult<Value> {
+    if let Some(result) = instance_user_rich_compare(self_id, other, op, vm)? {
+        Ok(result)
+    } else {
+        match op {
+            RichCmpOp::Eq => {
+                if matches!(other, Value::Ref(other_id) if self_id == *other_id) {
+                    Ok(Value::Bool(true))
+                } else if let Some(equal) = instance_dataclass_eq(self_id, other, vm)? {
+                    Ok(Value::Bool(equal))
+                } else {
+                    Ok(Value::NotImplemented)
+                }
+            }
+            RichCmpOp::Ne => {
+                let result = instance_rich_compare(self_id, other, RichCmpOp::Eq, vm)?;
+                if result.is_not_implemented() {
+                    Ok(result)
+                } else {
+                    defer_drop!(result, vm);
+                    Ok(Value::Bool(!result.py_bool(vm)?))
+                }
+            }
+            _ => Ok(Value::NotImplemented),
+        }
+    }
+}
+
+/// Dispatches one user-defined rich-comparison method, or reports its absence.
 ///
-/// The user's value is preserved so direct equality can return it unchanged;
-/// callers interpret `NotImplemented` according to their comparison mode.
-pub(crate) fn instance_user_eq(self_id: HeapId, other: &Value, vm: &mut VM<'_>) -> RunResult<Option<Value>> {
-    if !matches!(vm.heap.get(self_id), HeapData::Instance(_)) {
-        return Ok(None);
+/// The user's value, including `NotImplemented`, is preserved for the bilateral
+/// protocol driver. The borrowed other operand is cloned because the call owns
+/// its arguments.
+fn instance_user_rich_compare(
+    self_id: HeapId,
+    other: &Value,
+    op: RichCmpOp,
+    vm: &mut VM<'_>,
+) -> RunResult<Option<Value>> {
+    let dunder = op.dunder();
+    if class_defines(instance_class(self_id, vm), dunder, vm) {
+        let other = other.clone_with_heap(vm.heap);
+        instance_call_dunder_sync(self_id, dunder, Some(other), vm)
+    } else {
+        Ok(None)
     }
-    let class_id = instance_class(self_id, vm);
-    if !class_defines(class_id, "__eq__", vm) {
-        return Ok(None);
-    }
-    let other = other.clone_with_heap(vm.heap);
-    instance_call_dunder_sync(self_id, "__eq__", Some(other), vm)
 }
 
 /// Dispatches the synthesized field-wise `__eq__` of a dataclass instance, or
 /// `Ok(None)` when `self_id` is not one — or is one declared `eq=False` — which
 /// leaves the caller on identity.
 ///
-/// Not in `HeapObjectRead<Instance>::py_eq_impl` because fields are read as
-/// `self.field` is (see [`instance_attr`]), which needs the instance's `HeapId`.
+/// Kept outside the native instance slot because fields are read as `self.field`
+/// is (see [`instance_attr`]), which needs the instance's `HeapId`.
 pub(crate) fn instance_dataclass_eq(self_id: HeapId, other: &Value, vm: &mut VM<'_>) -> RunResult<Option<bool>> {
     if !matches!(vm.heap.get(self_id), HeapData::Instance(_)) {
         return Ok(None);

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -65,7 +65,7 @@ pub(crate) struct BoundMethod {
     pub func: Value,
 }
 
-impl<'h> HeapObjectRead<'h, Instance> {
+impl<'h> HeapRead<'h, Instance> {
     fn attrs_mut(&mut self) -> BorrowedHeapReadMut<'_, 'h, Dict> {
         heap_read_ref_as_field_mut!(self, Instance, attrs)
     }
@@ -99,30 +99,43 @@ impl<'h> HeapObjectRead<'h, Instance> {
     pub fn set_attr_unchecked(&mut self, name: Value, value: Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         self.attrs_mut().set(name, value, vm)
     }
+}
 
-    /// Resolves and invokes the class special method for one rich comparison.
-    ///
-    /// Missing `__ne__` derives from `__eq__`; any other missing method declines
-    /// the operation. Lookup occurs immediately before invocation so mutations
-    /// made by the left comparison are visible to reflected dispatch.
-    fn rich_compare(
-        _receiver: &Self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        instance_rich_compare(self_id.expect("heap values have an id"), other, op, vm)
-    }
+/// Resolves and invokes the class special method for one rich comparison.
+///
+/// Missing `__ne__` derives from `__eq__`; any other missing method declines
+/// the operation. Lookup occurs immediately before invocation so mutations
+/// made by the left comparison are visible to reflected dispatch.
+fn instance_rich_compare_slot(
+    receiver: &HeapObjectRead<'_, Instance>,
+    other: &Value,
+    op: RichCmpOp,
+    vm: &mut VM<'_>,
+) -> RunResult<Value> {
+    instance_rich_compare(receiver.id(), other, op, vm)
 }
 
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, Instance> {
-    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(instance_rich_compare_slot);
 
     /// The class's `__contains__`, or `None` when it defines none — `in` then
     /// falls back to iteration, matching CPython's `sq_contains` before `tp_iter`.
-    fn py_contains_impl(&self, self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        instance_contains(self_id, item, vm)
+    fn py_contains_impl(&self, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        let class_id = self.get(vm.heap).class();
+        if matches!(class_dunder(class_id, "__contains__", vm), Some(Value::None)) {
+            Err(ExcType::type_error_object_not_container(&class_name(
+                class_id, vm.heap, vm.interns,
+            )))
+        } else {
+            let item = item.clone_with_heap(vm.heap);
+            match instance_call_dunder_sync(self.id(), "__contains__", Some(item), vm)? {
+                Some(result) => {
+                    defer_drop!(result, vm);
+                    Ok(Some(result.py_bool(vm)?))
+                }
+                None => Ok(None),
+            }
+        }
     }
 
     fn py_type(&self, vm: &VM<'h>) -> Type {
@@ -372,7 +385,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, BoundMethod> {
         None
     }
 
-    fn py_hash(&self, self_id: HeapId, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         // Bound methods hash by identity, consistent with their identity-only
         // equality (CPython hashes by `(instance, func)` — see limitations/classes.md).
         Ok(Some(identity_hash(self.id())))

--- a/crates/monty/src/types/instance.rs
+++ b/crates/monty/src/types/instance.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, fmt::Write, mem};
 
-use super::{Dict, LazyHeapSet, PyTrait, Type, attribute_name_value};
+use super::{Dict, LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, Type, attribute_name_value};
 use crate::{
     args::{ArgValues, KwargsValues},
     builtins::Builtins,
@@ -75,9 +75,26 @@ impl<'h> HeapRead<'h, Instance> {
     pub fn set_attr(&mut self, name: Value, value: Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         self.attrs_mut().set(name, value, vm)
     }
+
+    /// Resolves and invokes the class special method for one rich comparison.
+    ///
+    /// Missing `__ne__` derives from `__eq__`; any other missing method declines
+    /// the operation. Lookup occurs immediately before invocation so mutations
+    /// made by the left comparison are visible to reflected dispatch.
+    fn rich_compare(
+        _receiver: &Self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        instance_rich_compare(self_id.expect("heap values have an id"), other, op, vm)
+    }
 }
 
 impl<'h> PyTrait<'h> for HeapRead<'h, Instance> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     /// The class's `__contains__`, or `None` when it defines none — `in` then
     /// falls back to iteration, matching CPython's `sq_contains` before `tp_iter`.
     fn py_contains_impl(&self, self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
@@ -99,12 +116,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Instance> {
         let old_value = self.set_attr(name, value, vm)?;
         old_value.drop_with(vm);
         Ok(())
-    }
-
-    /// Returns `NotImplemented`; comparisons dispatch at the `Value` level because
-    /// user and synthesized dataclass equality require the instance's `HeapId`.
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
     }
 
     /// Hashes an instance, following CPython's precedence.
@@ -341,10 +352,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, BoundMethod> {
 
     fn py_len(&self, _vm: &VM<'h>) -> Option<usize> {
         None
-    }
-
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
     }
 
     fn py_hash(&self, self_id: HeapId, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
@@ -637,27 +644,60 @@ fn instance_class(self_id: HeapId, vm: &VM<'_>) -> HeapId {
     }
 }
 
-/// Dispatches a user-defined `__eq__`, or `Ok(None)` when it is absent.
+/// Runs one side of rich comparison for a user instance.
+fn instance_rich_compare(self_id: HeapId, other: &Value, op: RichCmpOp, vm: &mut VM<'_>) -> RunResult<Value> {
+    if let Some(result) = instance_user_rich_compare(self_id, other, op, vm)? {
+        Ok(result)
+    } else {
+        match op {
+            RichCmpOp::Eq => {
+                if matches!(other, Value::Ref(other_id) if self_id == *other_id) {
+                    Ok(Value::Bool(true))
+                } else if let Some(equal) = instance_dataclass_eq(self_id, other, vm)? {
+                    Ok(Value::Bool(equal))
+                } else {
+                    Ok(Value::NotImplemented)
+                }
+            }
+            RichCmpOp::Ne => {
+                let result = instance_rich_compare(self_id, other, RichCmpOp::Eq, vm)?;
+                if result.is_not_implemented() {
+                    Ok(result)
+                } else {
+                    defer_drop!(result, vm);
+                    Ok(Value::Bool(!result.py_bool(vm)?))
+                }
+            }
+            _ => Ok(Value::NotImplemented),
+        }
+    }
+}
+
+/// Dispatches one user-defined rich-comparison method, or reports its absence.
 ///
-/// The user's value is preserved so direct equality can return it unchanged;
-/// callers interpret `NotImplemented` according to their comparison mode.
-pub(crate) fn instance_user_eq(self_id: HeapId, other: &Value, vm: &mut VM<'_>) -> RunResult<Option<Value>> {
-    if !matches!(vm.heap.get(self_id), HeapData::Instance(_)) {
-        return Ok(None);
+/// The user's value, including `NotImplemented`, is preserved for the bilateral
+/// protocol driver. The borrowed other operand is cloned because the call owns
+/// its arguments.
+fn instance_user_rich_compare(
+    self_id: HeapId,
+    other: &Value,
+    op: RichCmpOp,
+    vm: &mut VM<'_>,
+) -> RunResult<Option<Value>> {
+    let dunder = op.dunder();
+    if class_defines(instance_class(self_id, vm), dunder, vm) {
+        let other = other.clone_with_heap(vm.heap);
+        instance_call_dunder_sync(self_id, dunder, Some(other), vm)
+    } else {
+        Ok(None)
     }
-    let class_id = instance_class(self_id, vm);
-    if !class_defines(class_id, "__eq__", vm) {
-        return Ok(None);
-    }
-    let other = other.clone_with_heap(vm.heap);
-    instance_call_dunder_sync(self_id, "__eq__", Some(other), vm)
 }
 
 /// Dispatches the synthesized field-wise `__eq__` of a dataclass instance, or
 /// `Ok(None)` when `self_id` is not one, which leaves the caller on identity.
 ///
-/// Not in `HeapRead<Instance>::py_eq_impl` because fields are read as
-/// `self.field` is (see [`instance_attr`]), which needs the instance's `HeapId`.
+/// Kept outside the native instance slot because fields are read as `self.field`
+/// is (see [`instance_attr`]), which needs the instance's `HeapId`.
 pub(crate) fn instance_dataclass_eq(self_id: HeapId, other: &Value, vm: &mut VM<'_>) -> RunResult<Option<bool>> {
     if !matches!(vm.heap.get(self_id), HeapData::Instance(_)) {
         return Ok(None);

--- a/crates/monty/src/types/itertools/mod.rs
+++ b/crates/monty/src/types/itertools/mod.rs
@@ -230,10 +230,8 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, ItertoolsIter> {
         None
     }
 
-    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
-        let self_id = self_id.expect("heap values have an id");
-        vm.heap.inc_ref(self_id);
-        Ok(Value::Ref(self_id))
+    fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
+        Ok(self.clone_value(vm.heap))
     }
 
     fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/itertools/mod.rs
+++ b/crates/monty/src/types/itertools/mod.rs
@@ -230,12 +230,10 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, ItertoolsIter> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
-    }
-
-    fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
-        Ok(self.clone_value(vm.heap))
+    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
+        let self_id = self_id.expect("heap values have an id");
+        vm.heap.inc_ref(self_id);
+        Ok(Value::Ref(self_id))
     }
 
     fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/itertools/mod.rs
+++ b/crates/monty/src/types/itertools/mod.rs
@@ -195,10 +195,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ItertoolsIter> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
-    }
-
     fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
         let self_id = self_id.expect("heap values have an id");
         vm.heap.inc_ref(self_id);

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -3,7 +3,7 @@ use std::{fmt::Write, mem};
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
-use super::{PyTrait, RichCmpOp, iter::collect_owned_iterable};
+use super::{PyTrait, RichCmpOp, RichCmpVtable, iter::collect_owned_iterable};
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
@@ -324,7 +324,67 @@ impl<'h, C: ContainsVM<'h>> DropWithContext<C> for ListIter<'_, 'h> {
     }
 }
 
+impl<'h> HeapObjectRead<'h, List> {
+    /// Compares list elements for the equality slots.
+    fn eq_bool(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        let Some(HeapReadOutput::List(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
+        if self.get(vm.heap).items.len() != other.get(vm.heap).items.len() {
+            return Ok(Some(false));
+        }
+        let iter = self.iter(vm)?;
+        defer_drop_mut!(iter, vm);
+        while let Some((i, a)) = iter.next_with_index(vm)? {
+            let b = other.clone_item(i, vm);
+            defer_drop!(b, vm);
+            if !a.py_eq(b, vm)? {
+                return Ok(Some(false));
+            }
+        }
+        Ok(Some(true))
+    }
+
+    /// Compares lists lexicographically while bounding nested-container depth.
+    ///
+    /// Equality identifies the shared prefix; the first unequal pair receives
+    /// the original operator and may return any Python value. Lengths decide
+    /// only when every shared element compares equal.
+    fn rich_compare(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.eq_bool(other, vm)?));
+        }
+        let Some(HeapReadOutput::List(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        let a_len = self.get(vm.heap).items.len();
+        let b_len = other.get(vm.heap).items.len();
+        let min_len = a_len.min(b_len);
+        let iter = self.iter(vm)?;
+        defer_drop_mut!(iter, vm);
+        while let Some((i, av)) = iter.next_with_index(vm)? {
+            if i >= min_len {
+                break;
+            }
+            let bv = other.clone_item(i, vm);
+            defer_drop!(bv, vm);
+            if !av.py_lex_eq(bv, vm)? {
+                return av.py_rich_compare(bv, op, vm);
+            }
+        }
+        Ok(Value::Bool(op.holds(a_len.cmp(&b_len))))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, List> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -433,61 +493,6 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, List> {
         mem::swap(&mut self.get_mut(vm.heap).items[idx], value);
 
         Ok(())
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::List(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        if self.get(vm.heap).items.len() != other.get(vm.heap).items.len() {
-            return Ok(Some(false));
-        }
-        let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
-        while let Some((i, a)) = iter.next_with_index(vm)? {
-            let b = other.clone_item(i, vm);
-            defer_drop!(b, vm);
-            if !a.py_eq(b, vm)? {
-                return Ok(Some(false));
-            }
-        }
-        Ok(Some(true))
-    }
-
-    /// Compares lists lexicographically while bounding nested-container depth.
-    ///
-    /// Equality identifies the shared prefix; the first unequal pair receives
-    /// the original operator and may return any Python value. Lengths decide
-    /// only when every shared element compares equal.
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let Some(HeapReadOutput::List(other)) = other.read_heap(vm) else {
-            return Ok(Value::NotImplemented);
-        };
-        let a_len = self.get(vm.heap).items.len();
-        let b_len = other.get(vm.heap).items.len();
-        let min_len = a_len.min(b_len);
-        let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
-        while let Some((i, av)) = iter.next_with_index(vm)? {
-            if i >= min_len {
-                break;
-            }
-            let bv = other.clone_item(i, vm);
-            defer_drop!(bv, vm);
-            if !av.py_lex_eq(bv, vm)? {
-                return av.py_rich_compare(bv, op, vm);
-            }
-        }
-        Ok(Value::Bool(op.holds(a_len.cmp(&b_len))))
     }
 
     fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {
@@ -1022,12 +1027,10 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, ListIterator> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
-    }
-
-    fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
-        Ok(self.clone_value(vm.heap))
+    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
+        let self_id = self_id.expect("heap values have an id");
+        vm.heap.inc_ref(self_id);
+        Ok(Value::Ref(self_id))
     }
 
     fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -350,13 +350,7 @@ impl<'h> HeapObjectRead<'h, List> {
     /// Equality identifies the shared prefix; the first unequal pair receives
     /// the original operator and may return any Python value. Lengths decide
     /// only when every shared element compares equal.
-    fn rich_compare(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
+    fn rich_compare(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         if op.is_equality() {
             return Ok(op.equality_result(self.eq_bool(other, vm)?));
         }
@@ -410,10 +404,6 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, List> {
 
     fn py_len(&self, vm: &VM<'h>) -> Option<usize> {
         Some(self.get(vm.heap).items.len())
-    }
-
-    fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {
-        HeapRead::py_cmp(self, other, vm)
     }
 
     fn py_getitem(&self, key: &Value, vm: &mut VM<'h>) -> RunResult<Value> {
@@ -1027,10 +1017,8 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, ListIterator> {
         None
     }
 
-    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
-        let self_id = self_id.expect("heap values have an id");
-        vm.heap.inc_ref(self_id);
-        Ok(Value::Ref(self_id))
+    fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
+        Ok(self.clone_value(vm.heap))
     }
 
     fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -1,9 +1,9 @@
-use std::{cmp::Ordering, fmt::Write, mem};
+use std::{fmt::Write, mem};
 
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
-use super::{CmpOrder, PyTrait, iter::collect_owned_iterable};
+use super::{PyTrait, RichCmpOp, iter::collect_owned_iterable};
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
@@ -206,45 +206,6 @@ impl<'h> HeapRead<'h, List> {
         self.get(vm.heap).items[index].clone_with_heap(vm.heap)
     }
 
-    /// Lexicographic comparison for lists — the ordering behind `<`/`<=`/`>`/`>=`.
-    ///
-    /// Element-by-element left-to-right; the first non-equal pair decides. If all
-    /// compared elements are equal, the shorter list is less (`[1] < [1, 2]`).
-    /// The first differing pair's [`CmpOrder`] propagates: a `NaN` element makes
-    /// the list [`CmpOrder::Unordered`] (`[nan] < [1]` is `False`), a
-    /// type-mismatched element makes it [`CmpOrder::Incomparable`] (`[1] < ['a']`
-    /// raises `TypeError`). Mirrors [`Tuple::py_cmp`](super::Tuple) — the
-    /// `ListIter` holds the recursion token that bounds nested-container depth.
-    pub(crate) fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {
-        let a_len = self.get(vm.heap).items.len();
-        let b_len = other.get(vm.heap).items.len();
-        let min_len = a_len.min(b_len);
-        let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
-        while let Some((i, av)) = iter.next_with_index(vm)? {
-            if i >= min_len {
-                break;
-            }
-            let bv = other.clone_item(i, vm);
-            defer_drop!(bv, vm);
-            match av.py_cmp(bv, vm)? {
-                CmpOrder::Ordered(Ordering::Equal) => {}
-                CmpOrder::Ordered(ord) => return Ok(CmpOrder::Ordered(ord)),
-                // A `NaN` element is never `==`-equal, so it is the first
-                // differing pair and the list is unordered (yields `False`).
-                CmpOrder::Unordered => return Ok(CmpOrder::Unordered),
-                // CPython checks `__eq__` first and only orders non-equal pairs, so
-                // equal-but-unorderable elements (e.g. `None == None`) don't block.
-                CmpOrder::Incomparable => {
-                    if !av.py_eq(bv, vm)? {
-                        return Ok(CmpOrder::Incomparable);
-                    }
-                }
-            }
-        }
-        Ok(CmpOrder::Ordered(a_len.cmp(&b_len)))
-    }
-
     /// Clones all items from this list with proper refcount management.
     ///
     /// Preflights the slot bytes so an over-budget clone raises a graceful
@@ -292,7 +253,7 @@ impl<'h> HeapRead<'h, List> {
 /// [`defer_drop_mut!`] so the token (and any in-flight item) is released on
 /// every exit path (success, early `return`, error via `?`). The token is
 /// intentionally non-optional — every iteration of a Python container can
-/// transitively trigger `py_eq` / `py_hash` / `py_repr` / `py_cmp` /
+/// transitively trigger equality / hashing / repr / rich comparison /
 /// dict-or-set membership, all of which recurse on cyclic structures.
 ///
 /// **Mutation safety.** The list length is re-read on every call to `next`,
@@ -491,6 +452,42 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, List> {
             }
         }
         Ok(Some(true))
+    }
+
+    /// Compares lists lexicographically while bounding nested-container depth.
+    ///
+    /// Equality identifies the shared prefix; the first unequal pair receives
+    /// the original operator and may return any Python value. Lengths decide
+    /// only when every shared element compares equal.
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let Some(HeapReadOutput::List(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        let a_len = self.get(vm.heap).items.len();
+        let b_len = other.get(vm.heap).items.len();
+        let min_len = a_len.min(b_len);
+        let iter = self.iter(vm)?;
+        defer_drop_mut!(iter, vm);
+        while let Some((i, av)) = iter.next_with_index(vm)? {
+            if i >= min_len {
+                break;
+            }
+            let bv = other.clone_item(i, vm);
+            defer_drop!(bv, vm);
+            if !av.py_lex_eq(bv, vm)? {
+                return av.py_rich_compare(bv, op, vm);
+            }
+        }
+        Ok(Value::Bool(op.holds(a_len.cmp(&b_len))))
     }
 
     fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -4,7 +4,7 @@ use monty_types::ResourceError;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
-use super::{PyTrait, RichCmpOp, iter::collect_owned_iterable};
+use super::{PyTrait, RichCmpOp, RichCmpVtable, iter::collect_owned_iterable};
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
@@ -324,7 +324,67 @@ impl<'h, C: ContainsVM<'h>> DropWithContext<C> for ListIter<'_, 'h> {
     }
 }
 
+impl<'h> HeapRead<'h, List> {
+    /// Compares list elements for the equality slots.
+    fn eq_bool(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        let Some(HeapReadOutput::List(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
+        if self.get(vm.heap).items.len() != other.get(vm.heap).items.len() {
+            return Ok(Some(false));
+        }
+        let iter = self.iter(vm)?;
+        defer_drop_mut!(iter, vm);
+        while let Some((i, a)) = iter.next_with_index(vm)? {
+            let b = other.clone_item(i, vm);
+            defer_drop!(b, vm);
+            if !a.py_eq(b, vm)? {
+                return Ok(Some(false));
+            }
+        }
+        Ok(Some(true))
+    }
+
+    /// Compares lists lexicographically while bounding nested-container depth.
+    ///
+    /// Equality identifies the shared prefix; the first unequal pair receives
+    /// the original operator and may return any Python value. Lengths decide
+    /// only when every shared element compares equal.
+    fn rich_compare(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.eq_bool(other, vm)?));
+        }
+        let Some(HeapReadOutput::List(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        let a_len = self.get(vm.heap).items.len();
+        let b_len = other.get(vm.heap).items.len();
+        let min_len = a_len.min(b_len);
+        let iter = self.iter(vm)?;
+        defer_drop_mut!(iter, vm);
+        while let Some((i, av)) = iter.next_with_index(vm)? {
+            if i >= min_len {
+                break;
+            }
+            let bv = other.clone_item(i, vm);
+            defer_drop!(bv, vm);
+            if !av.py_lex_eq(bv, vm)? {
+                return av.py_rich_compare(bv, op, vm);
+            }
+        }
+        Ok(Value::Bool(op.holds(a_len.cmp(&b_len))))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapRead<'h, List> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -429,61 +489,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
         mem::swap(&mut self.get_mut(vm.heap).items[idx], value);
 
         Ok(())
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::List(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        if self.get(vm.heap).items.len() != other.get(vm.heap).items.len() {
-            return Ok(Some(false));
-        }
-        let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
-        while let Some((i, a)) = iter.next_with_index(vm)? {
-            let b = other.clone_item(i, vm);
-            defer_drop!(b, vm);
-            if !a.py_eq(b, vm)? {
-                return Ok(Some(false));
-            }
-        }
-        Ok(Some(true))
-    }
-
-    /// Compares lists lexicographically while bounding nested-container depth.
-    ///
-    /// Equality identifies the shared prefix; the first unequal pair receives
-    /// the original operator and may return any Python value. Lengths decide
-    /// only when every shared element compares equal.
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let Some(HeapReadOutput::List(other)) = other.read_heap(vm) else {
-            return Ok(Value::NotImplemented);
-        };
-        let a_len = self.get(vm.heap).items.len();
-        let b_len = other.get(vm.heap).items.len();
-        let min_len = a_len.min(b_len);
-        let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
-        while let Some((i, av)) = iter.next_with_index(vm)? {
-            if i >= min_len {
-                break;
-            }
-            let bv = other.clone_item(i, vm);
-            defer_drop!(bv, vm);
-            if !av.py_lex_eq(bv, vm)? {
-                return av.py_rich_compare(bv, op, vm);
-            }
-        }
-        Ok(Value::Bool(op.holds(a_len.cmp(&b_len))))
     }
 
     fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {
@@ -978,10 +983,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ListIterator> {
 
     fn py_len(&self, _: &VM<'h>) -> Option<usize> {
         None
-    }
-
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
     }
 
     fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -1,10 +1,10 @@
-use std::{cmp::Ordering, fmt::Write, mem};
+use std::{fmt::Write, mem};
 
 use monty_types::ResourceError;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
-use super::{CmpOrder, PyTrait, iter::collect_owned_iterable};
+use super::{PyTrait, RichCmpOp, iter::collect_owned_iterable};
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
@@ -210,45 +210,6 @@ impl<'h> HeapRead<'h, List> {
         self.get(vm.heap).items[index].clone_with_heap(vm.heap)
     }
 
-    /// Lexicographic comparison for lists — the ordering behind `<`/`<=`/`>`/`>=`.
-    ///
-    /// Element-by-element left-to-right; the first non-equal pair decides. If all
-    /// compared elements are equal, the shorter list is less (`[1] < [1, 2]`).
-    /// The first differing pair's [`CmpOrder`] propagates: a `NaN` element makes
-    /// the list [`CmpOrder::Unordered`] (`[nan] < [1]` is `False`), a
-    /// type-mismatched element makes it [`CmpOrder::Incomparable`] (`[1] < ['a']`
-    /// raises `TypeError`). Mirrors [`Tuple::py_cmp`](super::Tuple) — the
-    /// `ListIter` holds the recursion token that bounds nested-container depth.
-    pub(crate) fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {
-        let a_len = self.get(vm.heap).items.len();
-        let b_len = other.get(vm.heap).items.len();
-        let min_len = a_len.min(b_len);
-        let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
-        while let Some((i, av)) = iter.next_with_index(vm)? {
-            if i >= min_len {
-                break;
-            }
-            let bv = other.clone_item(i, vm);
-            defer_drop!(bv, vm);
-            match av.py_cmp(bv, vm)? {
-                CmpOrder::Ordered(Ordering::Equal) => {}
-                CmpOrder::Ordered(ord) => return Ok(CmpOrder::Ordered(ord)),
-                // A `NaN` element is never `==`-equal, so it is the first
-                // differing pair and the list is unordered (yields `False`).
-                CmpOrder::Unordered => return Ok(CmpOrder::Unordered),
-                // CPython checks `__eq__` first and only orders non-equal pairs, so
-                // equal-but-unorderable elements (e.g. `None == None`) don't block.
-                CmpOrder::Incomparable => {
-                    if !av.py_eq(bv, vm)? {
-                        return Ok(CmpOrder::Incomparable);
-                    }
-                }
-            }
-        }
-        Ok(CmpOrder::Ordered(a_len.cmp(&b_len)))
-    }
-
     /// Clones all items from this list with proper refcount management.
     fn clone_all_items(&self, vm: &mut VM<'h>) -> Vec<Value> {
         let len = self.get(vm.heap).items.len();
@@ -292,7 +253,7 @@ impl<'h> HeapRead<'h, List> {
 /// [`defer_drop_mut!`] so the token (and any in-flight item) is released on
 /// every exit path (success, early `return`, error via `?`). The token is
 /// intentionally non-optional — every iteration of a Python container can
-/// transitively trigger `py_eq` / `py_hash` / `py_repr` / `py_cmp` /
+/// transitively trigger equality / hashing / repr / rich comparison /
 /// dict-or-set membership, all of which recurse on cyclic structures.
 ///
 /// **Mutation safety.** The list length is re-read on every call to `next`,
@@ -487,6 +448,42 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
             }
         }
         Ok(Some(true))
+    }
+
+    /// Compares lists lexicographically while bounding nested-container depth.
+    ///
+    /// Equality identifies the shared prefix; the first unequal pair receives
+    /// the original operator and may return any Python value. Lengths decide
+    /// only when every shared element compares equal.
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let Some(HeapReadOutput::List(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        let a_len = self.get(vm.heap).items.len();
+        let b_len = other.get(vm.heap).items.len();
+        let min_len = a_len.min(b_len);
+        let iter = self.iter(vm)?;
+        defer_drop_mut!(iter, vm);
+        while let Some((i, av)) = iter.next_with_index(vm)? {
+            if i >= min_len {
+                break;
+            }
+            let bv = other.clone_item(i, vm);
+            defer_drop!(bv, vm);
+            if !av.py_lex_eq(bv, vm)? {
+                return av.py_rich_compare(bv, op, vm);
+            }
+        }
+        Ok(Value::Bool(op.holds(a_len.cmp(&b_len))))
     }
 
     fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/long_int.rs
+++ b/crates/monty/src/types/long_int.rs
@@ -377,13 +377,7 @@ fn int_max_str_digits_threshold() -> &'static BigInt {
 impl<'h> HeapObjectRead<'h, LongInt> {
     /// Compares arbitrary-precision integers with every numeric representation.
     #[expect(clippy::unnecessary_wraps)]
-    fn rich_compare(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
+    fn rich_compare(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         if op.is_equality() {
             return Ok(op.equality_result(eq_bigint(self.get(vm.heap).inner(), other, vm)));
         }
@@ -417,7 +411,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
         Ok(!self.get(vm.heap).is_zero())
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         Ok(Some(self.get(vm.heap).hash()))
     }
 

--- a/crates/monty/src/types/long_int.rs
+++ b/crates/monty/src/types/long_int.rs
@@ -26,7 +26,7 @@ use crate::{
     hash::{HashValue, hash_python_long_int},
     heap::{Heap, HeapData, HeapObjectRead, HeapRead},
     resource_checks::{check_div_size, check_lshift_size, check_mult_size, check_pow_size},
-    types::{LazyHeapSet, PyTrait, Type, str::allocate_string},
+    types::{LazyHeapSet, PyTrait, RichCmpOp, Type, str::allocate_string},
     value::{Value, eq_bigint},
 };
 
@@ -393,7 +393,29 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
         Ok(eq_bigint(self.get(vm.heap).inner(), other, vm))
     }
 
-    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let lhs = self.get(vm.heap);
+        let ordering = match other {
+            Value::Bool(rhs) => Some(bigint_cmp_i64(lhs.inner(), i64::from(*rhs))),
+            Value::Int(rhs) => Some(bigint_cmp_i64(lhs.inner(), *rhs)),
+            Value::Float(rhs) => lhs.partial_cmp_f64(*rhs),
+            Value::InternLongInt(rhs) => Some(lhs.inner().cmp(vm.interns.get_long_int(*rhs))),
+            Value::Ref(id) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => Some(lhs.inner().cmp(rhs.inner())),
+            _ => return Ok(Value::NotImplemented),
+        };
+        Ok(Value::Bool(ordering.is_some_and(|ordering| op.holds(ordering))))
+    }
+
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         Ok(Some(self.get(vm.heap).hash()))
     }
 

--- a/crates/monty/src/types/long_int.rs
+++ b/crates/monty/src/types/long_int.rs
@@ -26,7 +26,7 @@ use crate::{
     hash::{HashValue, hash_python_long_int},
     heap::{Heap, HeapData, HeapObjectRead, HeapRead},
     resource_checks::{check_div_size, check_lshift_size, check_mult_size, check_pow_size},
-    types::{LazyHeapSet, PyTrait, RichCmpOp, Type, str::allocate_string},
+    types::{LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, Type, str::allocate_string},
     value::{Value, eq_bigint},
 };
 
@@ -374,26 +374,10 @@ fn int_max_str_digits_threshold() -> &'static BigInt {
     })
 }
 
-// === Trait Implementations ===
-
-impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
-    fn py_type(&self, _vm: &VM<'h>) -> Type {
-        Type::Int
-    }
-
-    fn py_len(&self, _vm: &VM<'h>) -> Option<usize> {
-        None
-    }
-
-    fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {
-        Ok(!self.get(vm.heap).is_zero())
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(eq_bigint(self.get(vm.heap).inner(), other, vm))
-    }
-
-    fn py_rich_compare_impl(
+impl<'h> HeapObjectRead<'h, LongInt> {
+    /// Compares arbitrary-precision integers with every numeric representation.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_compare(
         &self,
         other: &Value,
         op: RichCmpOp,
@@ -401,7 +385,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
         _self_id: Option<HeapId>,
     ) -> RunResult<Value> {
         if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+            return Ok(op.equality_result(eq_bigint(self.get(vm.heap).inner(), other, vm)));
         }
         let lhs = self.get(vm.heap);
         let ordering = match other {
@@ -413,6 +397,24 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
             _ => return Ok(Value::NotImplemented),
         };
         Ok(Value::Bool(ordering.is_some_and(|ordering| op.holds(ordering))))
+    }
+}
+
+// === Trait Implementations ===
+
+impl<'h> PyTrait<'h> for HeapObjectRead<'h, LongInt> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
+    fn py_type(&self, _vm: &VM<'h>) -> Type {
+        Type::Int
+    }
+
+    fn py_len(&self, _vm: &VM<'h>) -> Option<usize> {
+        None
+    }
+
+    fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {
+        Ok(!self.get(vm.heap).is_zero())
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {

--- a/crates/monty/src/types/long_int.rs
+++ b/crates/monty/src/types/long_int.rs
@@ -28,7 +28,7 @@ use crate::{
     hash::{HashValue, hash_python_long_int},
     heap::{Heap, HeapData, HeapId, HeapRead},
     resource_checks::{check_div_size, check_lshift_size, check_mult_size, check_pow_size},
-    types::{LazyHeapSet, PyTrait, RichCmpOp, Type, str::allocate_string},
+    types::{LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, Type, str::allocate_string},
     value::{Value, eq_bigint},
 };
 
@@ -390,26 +390,10 @@ fn int_max_str_digits_threshold() -> &'static BigInt {
     })
 }
 
-// === Trait Implementations ===
-
-impl<'h> PyTrait<'h> for HeapRead<'h, LongInt> {
-    fn py_type(&self, _vm: &VM<'h>) -> Type {
-        Type::Int
-    }
-
-    fn py_len(&self, _vm: &VM<'h>) -> Option<usize> {
-        None
-    }
-
-    fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {
-        Ok(!self.get(vm.heap).is_zero())
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(eq_bigint(self.get(vm.heap).inner(), other, vm))
-    }
-
-    fn py_rich_compare_impl(
+impl<'h> HeapRead<'h, LongInt> {
+    /// Compares arbitrary-precision integers with every numeric representation.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_compare(
         &self,
         other: &Value,
         op: RichCmpOp,
@@ -417,7 +401,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, LongInt> {
         _self_id: Option<HeapId>,
     ) -> RunResult<Value> {
         if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+            return Ok(op.equality_result(eq_bigint(self.get(vm.heap).inner(), other, vm)));
         }
         let lhs = self.get(vm.heap);
         let ordering = match other {
@@ -429,6 +413,24 @@ impl<'h> PyTrait<'h> for HeapRead<'h, LongInt> {
             _ => return Ok(Value::NotImplemented),
         };
         Ok(Value::Bool(ordering.is_some_and(|ordering| op.holds(ordering))))
+    }
+}
+
+// === Trait Implementations ===
+
+impl<'h> PyTrait<'h> for HeapRead<'h, LongInt> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
+    fn py_type(&self, _vm: &VM<'h>) -> Type {
+        Type::Int
+    }
+
+    fn py_len(&self, _vm: &VM<'h>) -> Option<usize> {
+        None
+    }
+
+    fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {
+        Ok(!self.get(vm.heap).is_zero())
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {

--- a/crates/monty/src/types/long_int.rs
+++ b/crates/monty/src/types/long_int.rs
@@ -28,7 +28,7 @@ use crate::{
     hash::{HashValue, hash_python_long_int},
     heap::{Heap, HeapData, HeapId, HeapRead},
     resource_checks::{check_div_size, check_lshift_size, check_mult_size, check_pow_size},
-    types::{LazyHeapSet, PyTrait, Type, str::allocate_string},
+    types::{LazyHeapSet, PyTrait, RichCmpOp, Type, str::allocate_string},
     value::{Value, eq_bigint},
 };
 
@@ -407,6 +407,28 @@ impl<'h> PyTrait<'h> for HeapRead<'h, LongInt> {
 
     fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         Ok(eq_bigint(self.get(vm.heap).inner(), other, vm))
+    }
+
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let lhs = self.get(vm.heap);
+        let ordering = match other {
+            Value::Bool(rhs) => Some(bigint_cmp_i64(lhs.inner(), i64::from(*rhs))),
+            Value::Int(rhs) => Some(bigint_cmp_i64(lhs.inner(), *rhs)),
+            Value::Float(rhs) => lhs.partial_cmp_f64(*rhs),
+            Value::InternLongInt(rhs) => Some(lhs.inner().cmp(vm.interns.get_long_int(*rhs))),
+            Value::Ref(id) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => Some(lhs.inner().cmp(rhs.inner())),
+            _ => return Ok(Value::NotImplemented),
+        };
+        Ok(Value::Bool(ordering.is_some_and(|ordering| op.holds(ordering))))
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {

--- a/crates/monty/src/types/mod.rs
+++ b/crates/monty/src/types/mod.rs
@@ -54,7 +54,9 @@ pub(crate) use module::Module;
 pub(crate) use namedtuple::{NamedTuple, NamedTupleClass, construct_namedtuple};
 pub(crate) use path::Path;
 pub(crate) use property::Property;
-pub(crate) use py_trait::{AttrCallResult, LazyHeapSet, PyTrait, RichCmpOp, attribute_name_value};
+pub(crate) use py_trait::{
+    AttrCallResult, LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, attribute_name_value, invoke_rich_cmp_slot,
+};
 pub(crate) use range::{Range, RangeIterator};
 pub(crate) use re_match::ReMatch;
 pub(crate) use re_pattern::{BoundedCompileError, RePattern};

--- a/crates/monty/src/types/mod.rs
+++ b/crates/monty/src/types/mod.rs
@@ -54,7 +54,7 @@ pub(crate) use module::Module;
 pub(crate) use namedtuple::{NamedTuple, NamedTupleClass, construct_namedtuple};
 pub(crate) use path::Path;
 pub(crate) use property::Property;
-pub(crate) use py_trait::{AttrCallResult, CmpOrder, LazyHeapSet, PyTrait, attribute_name_value};
+pub(crate) use py_trait::{AttrCallResult, LazyHeapSet, PyTrait, RichCmpOp, attribute_name_value};
 pub(crate) use range::{Range, RangeIterator};
 pub(crate) use re_match::ReMatch;
 pub(crate) use re_pattern::{BoundedCompileError, RePattern};

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -26,7 +26,7 @@ use std::{
 /// named access improves usability and readability.
 use smallvec::SmallVec;
 
-use super::{PyTrait, RichCmpOp, tuple::TupleIterator};
+use super::{PyTrait, RichCmpOp, RichCmpVtable, tuple::TupleIterator};
 use crate::{
     args::{ArgValues, KwargsValues},
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
@@ -327,9 +327,55 @@ impl<'h, C: ContainsVM<'h>> DropWithContext<C> for NamedTupleIter<'_, 'h> {
     }
 }
 
-/// `PyTrait` implementation for `HeapObjectRead<NamedTuple>`, providing all Python
-/// operations on heap-allocated named tuples via short-lived borrow patterns.
+impl<'h> HeapObjectRead<'h, NamedTuple> {
+    /// Compares a named tuple with tuple-like values for the equality slots.
+    fn eq_bool(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        match other.read_heap(vm) {
+            Some(HeapReadOutput::NamedTuple(other)) => {
+                if self.get(vm.heap).len() != other.get(vm.heap).len() {
+                    return Ok(Some(false));
+                }
+                let iter = self.iter(vm)?;
+                defer_drop_mut!(iter, vm);
+                while let Some((i, a)) = iter.next_with_index(vm)? {
+                    let b = other.clone_item(i, vm);
+                    defer_drop!(b, vm);
+                    if !a.py_eq(b, vm)? {
+                        return Ok(Some(false));
+                    }
+                }
+                Ok(Some(true))
+            }
+            Some(HeapReadOutput::Tuple(other)) => Ok(Some(self.eq_tuple(&other, vm)?)),
+            _ => Ok(None),
+        }
+    }
+
+    /// Compares named tuples by their elements, including against plain tuples.
+    fn rich_compare(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.eq_bool(other, vm)?));
+        }
+        let other_items = match other.read_heap(vm) {
+            Some(HeapReadOutput::NamedTuple(other)) => other.cloned_items(vm),
+            Some(HeapReadOutput::Tuple(other)) => other.cloned_items(vm),
+            _ => return Ok(Value::NotImplemented),
+        };
+        rich_compare_item_seqs(self.cloned_items(vm), other_items, op, vm)
+    }
+}
+
+/// `PyTrait` implementation for `HeapRead<NamedTuple>`, providing all Python operations
+/// on heap-allocated named tuples via short-lived borrow patterns.
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, NamedTuple> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -435,51 +481,6 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, NamedTuple> {
 
     fn py_rmul_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         self.py_mul_impl(other, vm)
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // A namedtuple equals another namedtuple element-wise, and also equals a
-        // plain tuple with the same elements (class name is ignored). Both
-        // directions of the tuple case are covered here, so `Tuple::py_eq_impl`
-        // need not know about namedtuples.
-        match other.read_heap(vm) {
-            Some(HeapReadOutput::NamedTuple(other)) => {
-                if self.get(vm.heap).len() != other.get(vm.heap).len() {
-                    return Ok(Some(false));
-                }
-                let iter = self.iter(vm)?;
-                defer_drop_mut!(iter, vm);
-                while let Some((i, a)) = iter.next_with_index(vm)? {
-                    let b = other.clone_item(i, vm);
-                    defer_drop!(b, vm);
-                    if !a.py_eq(b, vm)? {
-                        return Ok(Some(false));
-                    }
-                }
-                Ok(Some(true))
-            }
-            Some(HeapReadOutput::Tuple(other)) => Ok(Some(self.eq_tuple(&other, vm)?)),
-            _ => Ok(None),
-        }
-    }
-
-    /// Compares named tuples by their elements, including against plain tuples.
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let other_items = match other.read_heap(vm) {
-            Some(HeapReadOutput::NamedTuple(other)) => other.cloned_items(vm),
-            Some(HeapReadOutput::Tuple(other)) => other.cloned_items(vm),
-            _ => return Ok(Value::NotImplemented),
-        };
-        rich_compare_item_seqs(self.cloned_items(vm), other_items, op, vm)
     }
 
     /// Hashes by element only (not by class name), matching `Tuple::py_hash`
@@ -849,13 +850,8 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, NamedTupleClass> {
         None
     }
 
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // Class objects compare by identity, resolved before reaching here.
-        Ok(None)
-    }
-
-    fn py_hash(&self, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
-        Ok(Some(identity_hash(self.id())))
+    fn py_hash(&self, self_id: HeapId, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+        Ok(Some(identity_hash(self_id)))
     }
 
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, _heap_ids: &mut LazyHeapSet) -> RunResult<()> {

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -1,6 +1,5 @@
 use std::{
     cell::Cell,
-    cmp::Ordering,
     collections::hash_map::DefaultHasher,
     fmt::Write,
     hash::{Hash, Hasher},
@@ -27,7 +26,7 @@ use std::{
 /// named access improves usability and readability.
 use smallvec::SmallVec;
 
-use super::{CmpOrder, PyTrait, tuple::TupleIterator};
+use super::{PyTrait, RichCmpOp, tuple::TupleIterator};
 use crate::{
     args::{ArgValues, KwargsValues},
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
@@ -223,11 +222,8 @@ impl<'h> HeapRead<'h, NamedTuple> {
         self.get(vm.heap).items[index].clone_with_heap(vm)
     }
 
-    /// Clones every item, for the orderings in [`cmp_item_seqs`].
-    ///
-    /// Preflights the slot bytes so an over-budget clone raises a graceful
-    /// `MemoryError` instead of bursting past the allocator's hard limit.
-    pub(crate) fn cloned_items(&self, vm: &mut VM<'h>) -> RunResult<Vec<Value>> {
+    /// Clones every item for [`rich_compare_item_seqs`].
+    pub(crate) fn cloned_items(&self, vm: &mut VM<'h>) -> Vec<Value> {
         let len = self.get(vm.heap).len();
         vm.heap.tracker.check_allocation(len.saturating_mul(VALUE_SIZE))?;
         Ok((0..len).map(|i| self.clone_item(i, vm)).collect())
@@ -465,6 +461,25 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, NamedTuple> {
             Some(HeapReadOutput::Tuple(other)) => Ok(Some(self.eq_tuple(&other, vm)?)),
             _ => Ok(None),
         }
+    }
+
+    /// Compares named tuples by their elements, including against plain tuples.
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let other_items = match other.read_heap(vm) {
+            Some(HeapReadOutput::NamedTuple(other)) => other.cloned_items(vm),
+            Some(HeapReadOutput::Tuple(other)) => other.cloned_items(vm),
+            _ => return Ok(Value::NotImplemented),
+        };
+        rich_compare_item_seqs(self.cloned_items(vm), other_items, op, vm)
     }
 
     /// Hashes by element only (not by class name), matching `Tuple::py_hash`
@@ -941,78 +956,21 @@ impl HeapItem for NamedTupleClass {
 // Construction and shared helpers.
 // ============================================================================
 
-/// Lexicographic ordering between two cloned item sequences.
+/// Rich-compares two cloned tuple-like item sequences lexicographically.
 ///
-/// A namedtuple is a tuple subclass, so it orders element-wise against another
-/// namedtuple *or* a plain tuple, with the shorter sequence sorting first when
-/// it is a prefix of the longer. The class and field names take no part, so two
-/// different namedtuple classes compare purely by value (matching CPython).
-///
-/// Takes both sides already cloned — the comparison needs `&mut VM`, which the
-/// caller cannot hold alongside two live `HeapRead`s. Both vectors are consumed
-/// and their items dropped.
-///
-/// Element-level results propagate exactly as in [`Tuple::py_cmp`]: a `NaN`
-/// yields [`CmpOrder::Unordered`] rather than an error, while a genuinely
-/// type-mismatched pair yields [`CmpOrder::Incomparable`].
-///
-/// Charges one recursion level: unlike equality/repr, ordering does not walk a
-/// token-bearing `NamedTupleIter` (it compares detached item vecs), so nested
-/// namedtuples (`a < b` where each wraps the last) would otherwise recurse
-/// through here per level and overflow the host stack instead of raising
-/// `RecursionError`. A [`RecursionToken`] rather than a `recursion_guard()` is
-/// used because both vecs are still owned on the failure path — the token does
-/// not borrow the VM, so they can be dropped before returning the error.
-pub(crate) fn cmp_item_seqs(a: Vec<Value>, b: Vec<Value>, vm: &mut VM<'_>) -> RunResult<CmpOrder> {
-    let token = match vm.recursion_token() {
-        Ok(token) => token,
-        Err(err) => {
-            a.drop_with(vm);
-            b.drop_with(vm);
-            return Err(err.into());
-        }
-    };
-
+/// Takes owned vectors because the comparison needs `&mut VM`, which cannot be
+/// held alongside both source `HeapRead`s. Guards release every cloned item on
+/// success, comparison failure, or an exception.
+pub(crate) fn rich_compare_item_seqs(a: Vec<Value>, b: Vec<Value>, op: RichCmpOp, vm: &mut VM<'_>) -> RunResult<Value> {
     let (a_len, b_len) = (a.len(), b.len());
-    let mut result = None;
+    defer_drop!(a, vm);
+    defer_drop!(b, vm);
     for (av, bv) in a.iter().zip(b.iter()) {
-        match av.py_cmp(bv, vm) {
-            Ok(CmpOrder::Ordered(Ordering::Equal)) => {}
-            Ok(CmpOrder::Ordered(ord)) => {
-                result = Some(Ok(CmpOrder::Ordered(ord)));
-                break;
-            }
-            Ok(CmpOrder::Unordered) => {
-                result = Some(Ok(CmpOrder::Unordered));
-                break;
-            }
-            Ok(CmpOrder::Incomparable) => {
-                // CPython checks `__eq__` first and only orders non-equal pairs,
-                // so equal-but-unorderable elements (e.g. `None == None`) do not
-                // block the comparison.
-                match av.py_eq(bv, vm) {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        result = Some(Ok(CmpOrder::Incomparable));
-                        break;
-                    }
-                    Err(e) => {
-                        result = Some(Err(e));
-                        break;
-                    }
-                }
-            }
-            Err(e) => {
-                result = Some(Err(e));
-                break;
-            }
+        if !av.py_lex_eq(bv, vm)? {
+            return av.py_rich_compare(bv, op, vm);
         }
     }
-    a.drop_with(vm);
-    b.drop_with(vm);
-    token.drop_with(vm);
-    // All compared pairs were equal, so the shorter sequence sorts first.
-    result.unwrap_or_else(|| Ok(CmpOrder::Ordered(a_len.cmp(&b_len))))
+    Ok(Value::Bool(op.holds(a_len.cmp(&b_len))))
 }
 
 /// Clones the items of a tuple-like value (`tuple` or `namedtuple`) into an

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -223,7 +223,7 @@ impl<'h> HeapRead<'h, NamedTuple> {
     }
 
     /// Clones every item for [`rich_compare_item_seqs`].
-    pub(crate) fn cloned_items(&self, vm: &mut VM<'h>) -> Vec<Value> {
+    pub(crate) fn cloned_items(&self, vm: &mut VM<'h>) -> RunResult<Vec<Value>> {
         let len = self.get(vm.heap).len();
         vm.heap.tracker.check_allocation(len.saturating_mul(VALUE_SIZE))?;
         Ok((0..len).map(|i| self.clone_item(i, vm)).collect())
@@ -352,13 +352,7 @@ impl<'h> HeapObjectRead<'h, NamedTuple> {
     }
 
     /// Compares named tuples by their elements, including against plain tuples.
-    fn rich_compare(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
+    fn rich_compare(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         if op.is_equality() {
             return Ok(op.equality_result(self.eq_bool(other, vm)?));
         }
@@ -367,11 +361,11 @@ impl<'h> HeapObjectRead<'h, NamedTuple> {
             Some(HeapReadOutput::Tuple(other)) => other.cloned_items(vm),
             _ => return Ok(Value::NotImplemented),
         };
-        rich_compare_item_seqs(self.cloned_items(vm), other_items, op, vm)
+        rich_compare_item_seqs(self.cloned_items(vm)?, other_items?, op, vm)
     }
 }
 
-/// `PyTrait` implementation for `HeapRead<NamedTuple>`, providing all Python operations
+/// `PyTrait` implementation for `HeapObjectRead<NamedTuple>`, providing all Python operations
 /// on heap-allocated named tuples via short-lived borrow patterns.
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, NamedTuple> {
     const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
@@ -850,8 +844,8 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, NamedTupleClass> {
         None
     }
 
-    fn py_hash(&self, self_id: HeapId, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
-        Ok(Some(identity_hash(self_id)))
+    fn py_hash(&self, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+        Ok(Some(identity_hash(self.id())))
     }
 
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, _heap_ids: &mut LazyHeapSet) -> RunResult<()> {

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -26,7 +26,7 @@ use std::{
 /// named access improves usability and readability.
 use smallvec::SmallVec;
 
-use super::{PyTrait, RichCmpOp, tuple::TupleIterator};
+use super::{PyTrait, RichCmpOp, RichCmpVtable, tuple::TupleIterator};
 use crate::{
     args::{ArgValues, KwargsValues},
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
@@ -326,9 +326,55 @@ impl<'h, C: ContainsVM<'h>> DropWithContext<C> for NamedTupleIter<'_, 'h> {
     }
 }
 
+impl<'h> HeapRead<'h, NamedTuple> {
+    /// Compares a named tuple with tuple-like values for the equality slots.
+    fn eq_bool(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        match other.read_heap(vm) {
+            Some(HeapReadOutput::NamedTuple(other)) => {
+                if self.get(vm.heap).len() != other.get(vm.heap).len() {
+                    return Ok(Some(false));
+                }
+                let iter = self.iter(vm)?;
+                defer_drop_mut!(iter, vm);
+                while let Some((i, a)) = iter.next_with_index(vm)? {
+                    let b = other.clone_item(i, vm);
+                    defer_drop!(b, vm);
+                    if !a.py_eq(b, vm)? {
+                        return Ok(Some(false));
+                    }
+                }
+                Ok(Some(true))
+            }
+            Some(HeapReadOutput::Tuple(other)) => Ok(Some(self.eq_tuple(&other, vm)?)),
+            _ => Ok(None),
+        }
+    }
+
+    /// Compares named tuples by their elements, including against plain tuples.
+    fn rich_compare(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.eq_bool(other, vm)?));
+        }
+        let other_items = match other.read_heap(vm) {
+            Some(HeapReadOutput::NamedTuple(other)) => other.cloned_items(vm),
+            Some(HeapReadOutput::Tuple(other)) => other.cloned_items(vm),
+            _ => return Ok(Value::NotImplemented),
+        };
+        rich_compare_item_seqs(self.cloned_items(vm), other_items, op, vm)
+    }
+}
+
 /// `PyTrait` implementation for `HeapRead<NamedTuple>`, providing all Python operations
 /// on heap-allocated named tuples via short-lived borrow patterns.
 impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -434,51 +480,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
 
     fn py_rmul_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         self.py_mul_impl(other, vm)
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // A namedtuple equals another namedtuple element-wise, and also equals a
-        // plain tuple with the same elements (class name is ignored). Both
-        // directions of the tuple case are covered here, so `Tuple::py_eq_impl`
-        // need not know about namedtuples.
-        match other.read_heap(vm) {
-            Some(HeapReadOutput::NamedTuple(other)) => {
-                if self.get(vm.heap).len() != other.get(vm.heap).len() {
-                    return Ok(Some(false));
-                }
-                let iter = self.iter(vm)?;
-                defer_drop_mut!(iter, vm);
-                while let Some((i, a)) = iter.next_with_index(vm)? {
-                    let b = other.clone_item(i, vm);
-                    defer_drop!(b, vm);
-                    if !a.py_eq(b, vm)? {
-                        return Ok(Some(false));
-                    }
-                }
-                Ok(Some(true))
-            }
-            Some(HeapReadOutput::Tuple(other)) => Ok(Some(self.eq_tuple(&other, vm)?)),
-            _ => Ok(None),
-        }
-    }
-
-    /// Compares named tuples by their elements, including against plain tuples.
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let other_items = match other.read_heap(vm) {
-            Some(HeapReadOutput::NamedTuple(other)) => other.cloned_items(vm),
-            Some(HeapReadOutput::Tuple(other)) => other.cloned_items(vm),
-            _ => return Ok(Value::NotImplemented),
-        };
-        rich_compare_item_seqs(self.cloned_items(vm), other_items, op, vm)
     }
 
     /// Hashes by element only (not by class name), matching `Tuple::py_hash`
@@ -859,11 +860,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTupleClass> {
 
     fn py_len(&self, _vm: &VM<'h>) -> Option<usize> {
         None
-    }
-
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // Class objects compare by identity, resolved before reaching here.
-        Ok(None)
     }
 
     fn py_hash(&self, self_id: HeapId, _vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -1,6 +1,5 @@
 use std::{
     cell::Cell,
-    cmp::Ordering,
     collections::hash_map::DefaultHasher,
     fmt::Write,
     hash::{Hash, Hasher},
@@ -27,7 +26,7 @@ use std::{
 /// named access improves usability and readability.
 use smallvec::SmallVec;
 
-use super::{CmpOrder, PyTrait, tuple::TupleIterator};
+use super::{PyTrait, RichCmpOp, tuple::TupleIterator};
 use crate::{
     args::{ArgValues, KwargsValues},
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
@@ -223,7 +222,7 @@ impl<'h> HeapRead<'h, NamedTuple> {
         self.get(vm.heap).items[index].clone_with_heap(vm)
     }
 
-    /// Clones every item, for the orderings in [`cmp_item_seqs`].
+    /// Clones every item for [`rich_compare_item_seqs`].
     pub(crate) fn cloned_items(&self, vm: &mut VM<'h>) -> Vec<Value> {
         let len = self.get(vm.heap).len();
         (0..len).map(|i| self.clone_item(i, vm)).collect()
@@ -461,6 +460,25 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
             Some(HeapReadOutput::Tuple(other)) => Ok(Some(self.eq_tuple(&other, vm)?)),
             _ => Ok(None),
         }
+    }
+
+    /// Compares named tuples by their elements, including against plain tuples.
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let other_items = match other.read_heap(vm) {
+            Some(HeapReadOutput::NamedTuple(other)) => other.cloned_items(vm),
+            Some(HeapReadOutput::Tuple(other)) => other.cloned_items(vm),
+            _ => return Ok(Value::NotImplemented),
+        };
+        rich_compare_item_seqs(self.cloned_items(vm), other_items, op, vm)
     }
 
     /// Hashes by element only (not by class name), matching `Tuple::py_hash`
@@ -963,60 +981,21 @@ impl HeapItem for NamedTupleClass {
 // Construction and shared helpers.
 // ============================================================================
 
-/// Lexicographic ordering between two cloned item sequences.
+/// Rich-compares two cloned tuple-like item sequences lexicographically.
 ///
-/// A namedtuple is a tuple subclass, so it orders element-wise against another
-/// namedtuple *or* a plain tuple, with the shorter sequence sorting first when
-/// it is a prefix of the longer. The class and field names take no part, so two
-/// different namedtuple classes compare purely by value (matching CPython).
-///
-/// Takes both sides already cloned — the comparison needs `&mut VM`, which the
-/// caller cannot hold alongside two live `HeapRead`s. Both vectors are consumed
-/// and their items dropped.
-///
-/// Element-level results propagate exactly as in [`Tuple::py_cmp`]: a `NaN`
-/// yields [`CmpOrder::Unordered`] rather than an error, while a genuinely
-/// type-mismatched pair yields [`CmpOrder::Incomparable`].
-pub(crate) fn cmp_item_seqs(a: Vec<Value>, b: Vec<Value>, vm: &mut VM<'_>) -> RunResult<CmpOrder> {
+/// Takes owned vectors because the comparison needs `&mut VM`, which cannot be
+/// held alongside both source `HeapRead`s. Guards release every cloned item on
+/// success, comparison failure, or an exception.
+pub(crate) fn rich_compare_item_seqs(a: Vec<Value>, b: Vec<Value>, op: RichCmpOp, vm: &mut VM<'_>) -> RunResult<Value> {
     let (a_len, b_len) = (a.len(), b.len());
-    let mut result = None;
+    defer_drop!(a, vm);
+    defer_drop!(b, vm);
     for (av, bv) in a.iter().zip(b.iter()) {
-        match av.py_cmp(bv, vm) {
-            Ok(CmpOrder::Ordered(Ordering::Equal)) => {}
-            Ok(CmpOrder::Ordered(ord)) => {
-                result = Some(Ok(CmpOrder::Ordered(ord)));
-                break;
-            }
-            Ok(CmpOrder::Unordered) => {
-                result = Some(Ok(CmpOrder::Unordered));
-                break;
-            }
-            Ok(CmpOrder::Incomparable) => {
-                // CPython checks `__eq__` first and only orders non-equal pairs,
-                // so equal-but-unorderable elements (e.g. `None == None`) do not
-                // block the comparison.
-                match av.py_eq(bv, vm) {
-                    Ok(true) => {}
-                    Ok(false) => {
-                        result = Some(Ok(CmpOrder::Incomparable));
-                        break;
-                    }
-                    Err(e) => {
-                        result = Some(Err(e));
-                        break;
-                    }
-                }
-            }
-            Err(e) => {
-                result = Some(Err(e));
-                break;
-            }
+        if !av.py_lex_eq(bv, vm)? {
+            return av.py_rich_compare(bv, op, vm);
         }
     }
-    a.drop_with(vm);
-    b.drop_with(vm);
-    // All compared pairs were equal, so the shorter sequence sorts first.
-    result.unwrap_or_else(|| Ok(CmpOrder::Ordered(a_len.cmp(&b_len))))
+    Ok(Value::Bool(op.holds(a_len.cmp(&b_len))))
 }
 
 /// Clones the items of a tuple-like value (`tuple` or `namedtuple`) into an

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -438,7 +438,7 @@ impl Path {
 impl<'h> HeapObjectRead<'h, Path> {
     /// Compares normalized virtual paths.
     #[expect(clippy::unnecessary_wraps)]
-    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         let Some(HeapReadOutput::Path(other)) = other.read_heap(vm) else {
             return Ok(Value::NotImplemented);
         };
@@ -458,7 +458,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Path> {
         None
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let p = self.get(vm.heap);
         if let Some(cached) = p.cached_hash.get() {
             return Ok(Some(cached));

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -24,7 +24,7 @@ use crate::{
     heap::{DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     os_dispatch::{build_path_os_call, is_path_os_method},
-    types::{LazyHeapSet, List, PyTrait, Type, allocate_tuple, str::allocate_string},
+    types::{LazyHeapSet, List, PyTrait, RichCmpOp, RichCmpVtable, Type, allocate_tuple, str::allocate_string},
     value::{EitherStr, Value},
 };
 
@@ -435,7 +435,20 @@ impl Path {
     }
 }
 
+impl<'h> HeapObjectRead<'h, Path> {
+    /// Compares normalized virtual paths.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let Some(HeapReadOutput::Path(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        Ok(op.equality_result(Some(self.get(vm.heap).path == other.get(vm.heap).path)))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, Path> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::Path
     }
@@ -445,14 +458,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Path> {
         None
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::Path(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        Ok(Some(self.get(vm.heap).path == other.get(vm.heap).path))
-    }
-
-    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let p = self.get(vm.heap);
         if let Some(cached) = p.cached_hash.get() {
             return Ok(Some(cached));

--- a/crates/monty/src/types/path.rs
+++ b/crates/monty/src/types/path.rs
@@ -25,7 +25,7 @@ use crate::{
     heap::{DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::{Interns, StaticStrings},
     os_dispatch::{build_path_os_call, is_path_os_method},
-    types::{LazyHeapSet, List, PyTrait, Type, allocate_tuple, str::allocate_string},
+    types::{LazyHeapSet, List, PyTrait, RichCmpOp, RichCmpVtable, Type, allocate_tuple, str::allocate_string},
     value::{EitherStr, Value},
 };
 
@@ -440,7 +440,20 @@ impl Path {
     }
 }
 
+impl<'h> HeapRead<'h, Path> {
+    /// Compares normalized virtual paths.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let Some(HeapReadOutput::Path(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        Ok(op.equality_result(Some(self.get(vm.heap).path == other.get(vm.heap).path)))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapRead<'h, Path> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::Path
     }
@@ -448,13 +461,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Path> {
     fn py_len(&self, _vm: &VM<'h>) -> Option<usize> {
         // Paths don't have a length in Python
         None
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::Path(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        Ok(Some(self.get(vm.heap).path == other.get(vm.heap).path))
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -163,7 +163,7 @@ impl RichCmpOp {
 }
 
 /// A native implementation of one rich-comparison slot.
-pub(crate) type RichCmpFn<'h, T> = fn(&T, &Value, RichCmpOp, &mut VM<'h>, Option<HeapId>) -> RunResult<Value>;
+pub(crate) type RichCmpFn<'h, T> = fn(&T, &Value, RichCmpOp, &mut VM<'h>) -> RunResult<Value>;
 
 /// Static rich-comparison slots exposed by a Rust value implementation.
 ///
@@ -237,10 +237,9 @@ pub(crate) fn invoke_rich_cmp_slot<'h>(
     other: &Value,
     op: RichCmpOp,
     vm: &mut VM<'h>,
-    self_id: Option<HeapId>,
 ) -> RunResult<Value> {
     if let Some(compare) = <_ as PyTrait<'h>>::RICH_COMPARE.get(op) {
-        compare(receiver, other, op, vm, self_id)
+        compare(receiver, other, op, vm)
     } else {
         Ok(Value::NotImplemented)
     }
@@ -258,9 +257,9 @@ pub(crate) fn invoke_rich_cmp_slot<'h>(
 /// Methods take the concrete [`VM`]/`Heap` types, which own the resource
 /// tracker enforcing time/memory/recursion limits.
 ///
-/// The lifetime `'h` is the heap borrow lifetime. For concrete types (e.g. `Dict`,
-/// `List`) this is unused and should be `'_`. For `HeapRead<'h, T>` implementers
-/// the lifetime connects the read handle to the VM's heap reference.
+/// The lifetime `'h` connects [`crate::heap::HeapObjectRead`] implementations
+/// to the VM's heap reference; immediate [`Value`] implementations use it only
+/// through the VM argument.
 pub(crate) trait PyTrait<'h>: Sized {
     /// Native rich-comparison methods supplied by this type.
     const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::EMPTY;

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -65,58 +65,87 @@ impl From<AttrCallResult> for CallResult {
     }
 }
 
-/// Outcome of an ordering comparison ([`PyTrait::py_cmp`] / [`Value::py_cmp`]).
+/// One of Python's six rich-comparison operations.
 ///
-/// A plain `Option<Ordering>` conflated two very different "no ordering" cases;
-/// this enum splits them so callers reproduce CPython exactly:
-///
-/// - [`Ordered`](Self::Ordered) — a definite `<` / `==` / `>` result.
-/// - [`Unordered`](Self::Unordered) — the operands *are* valid comparison
-///   partners but have no ordering because a `NaN` is involved (directly, or as
-///   the first differing element of a list/tuple). CPython's ordering operators
-///   (`<`, `<=`, `>`, `>=`) all yield `False` here rather than raising, and
-///   `sorted`/`min`/`max` treat it as "no swap".
-/// - [`Incomparable`](Self::Incomparable) — the operand types (or the types of
-///   their first differing elements) have no defined ordering at all; ordering
-///   operators raise `TypeError`.
-///
-/// Collapsing `Unordered` into `Incomparable` is exactly the bug that made
-/// `float('nan') < 1` raise instead of returning `False`.
+/// Identity and containment operators use separate protocols and deliberately
+/// cannot reach [`PyTrait::py_rich_compare_impl`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum CmpOrder {
-    /// A definite ordering between the two operands.
-    Ordered(Ordering),
-    /// Valid partners, but unordered because a `NaN` is involved.
-    Unordered,
-    /// The operand types have no defined ordering.
-    Incomparable,
+pub(crate) enum RichCmpOp {
+    /// Less than (`<`).
+    Lt,
+    /// Less than or equal (`<=`).
+    Le,
+    /// Equal (`==`).
+    Eq,
+    /// Not equal (`!=`).
+    Ne,
+    /// Greater than (`>`).
+    Gt,
+    /// Greater than or equal (`>=`).
+    Ge,
 }
 
-impl CmpOrder {
-    /// Maps an `Option<Ordering>` from a numeric comparison helper, where `None`
-    /// can *only* mean a `NaN` operand (`f64::partial_cmp`, `i64_cmp_f64`,
-    /// `bigint_cmp_f64`, and `LongInt::partial_cmp_f64` all return `None`
-    /// exclusively for `NaN`). `None` therefore becomes [`Unordered`], never
-    /// [`Incomparable`].
-    ///
-    /// [`Unordered`]: Self::Unordered
-    /// [`Incomparable`]: Self::Incomparable
-    pub(crate) fn from_numeric(ordering: Option<Ordering>) -> Self {
-        match ordering {
-            Some(ordering) => Self::Ordered(ordering),
-            None => Self::Unordered,
+impl RichCmpOp {
+    /// Converts a source comparison operator when it is a rich comparison.
+    pub(crate) fn from_cmp_operator(op: CmpOperator) -> Option<Self> {
+        match op {
+            CmpOperator::Lt => Some(Self::Lt),
+            CmpOperator::LtE => Some(Self::Le),
+            CmpOperator::Eq => Some(Self::Eq),
+            CmpOperator::NotEq => Some(Self::Ne),
+            CmpOperator::Gt => Some(Self::Gt),
+            CmpOperator::GtE => Some(Self::Ge),
+            CmpOperator::Is | CmpOperator::IsNot | CmpOperator::In | CmpOperator::NotIn => None,
         }
     }
 
-    /// Maps an `Option<Ordering>` from a *total*-order comparison (strings,
-    /// bytes, dates, timedeltas), where `None` never arises from a valid pair —
-    /// so `None` means the types don't compare at all ([`Incomparable`]).
-    ///
-    /// [`Incomparable`]: Self::Incomparable
-    pub(crate) fn from_total(ordering: Option<Ordering>) -> Self {
-        match ordering {
-            Some(ordering) => Self::Ordered(ordering),
-            None => Self::Incomparable,
+    /// Returns the operation tried on the right operand after `NotImplemented`.
+    pub(crate) fn reflected(self) -> Self {
+        match self {
+            Self::Lt => Self::Gt,
+            Self::Le => Self::Ge,
+            Self::Eq => Self::Eq,
+            Self::Ne => Self::Ne,
+            Self::Gt => Self::Lt,
+            Self::Ge => Self::Le,
+        }
+    }
+
+    /// Whether this operation belongs to the equality pair.
+    pub(crate) fn is_equality(self) -> bool {
+        matches!(self, Self::Eq | Self::Ne)
+    }
+
+    /// Evaluates this operation against an existing total ordering.
+    pub(crate) fn holds(self, ordering: Ordering) -> bool {
+        match self {
+            Self::Lt => ordering.is_lt(),
+            Self::Le => ordering.is_le(),
+            Self::Eq => ordering.is_eq(),
+            Self::Ne => !ordering.is_eq(),
+            Self::Gt => ordering.is_gt(),
+            Self::Ge => ordering.is_ge(),
+        }
+    }
+
+    /// Converts one-sided boolean equality into a rich-comparison result.
+    pub(crate) fn equality_result(self, equal: Option<bool>) -> Value {
+        debug_assert!(self.is_equality());
+        match equal {
+            Some(equal) => Value::Bool(if self == Self::Ne { !equal } else { equal }),
+            None => Value::NotImplemented,
+        }
+    }
+
+    /// Returns the spelling used in ordering `TypeError` messages.
+    pub(crate) fn symbol(self) -> &'static str {
+        match self {
+            Self::Lt => "<",
+            Self::Le => "<=",
+            Self::Eq => "==",
+            Self::Ne => "!=",
+            Self::Gt => ">",
+            Self::Ge => ">=",
         }
     }
 }
@@ -175,10 +204,8 @@ pub(crate) trait PyTrait<'h> {
     /// One-sided equality normalized for identity-or-equality operations.
     ///
     /// Returns `Some(bool)` when this type handles `other`, or `None` for
-    /// `NotImplemented`. User instances truth-test arbitrary `__eq__` results
-    /// here, while [`Value::py_rich_eq`] uses a separate path to preserve them.
-    /// This mirrors the `NotImplemented` half of [`py_cmp`](Self::py_cmp)'s
-    /// [`CmpOrder::Incomparable`].
+    /// `NotImplemented`. User instances preserve arbitrary `__eq__` results in
+    /// [`py_rich_compare_impl`](Self::py_rich_compare_impl) instead.
     ///
     /// Cross-type equality (e.g. `int`/`float`, `namedtuple`/`tuple`,
     /// `dict_keys`/`set`) is handled here in-situ: each type inspects `other`
@@ -190,36 +217,24 @@ pub(crate) trait PyTrait<'h> {
     /// `Err(ResourceError::Recursion)` if maximum depth is exceeded.
     fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>>;
 
-    /// Python comparison (`<`, `>`, etc.).
+    /// Runs one side of Python's rich-comparison protocol.
     ///
-    /// For containers, this performs element-wise comparison using the heap
-    /// to resolve nested references. Takes `&mut VM` to allow lazy hash
-    /// computation for dict key lookups and access to interned string content.
-    ///
-    /// Recursion depth is tracked via `vm.recursion_guard()`.
-    ///
-    /// Returns a [`CmpOrder`] distinguishing a definite ordering, a
-    /// `NaN`-driven unordered-but-valid result (ordering operators yield
-    /// `False`), and a genuine type mismatch (ordering operators raise
-    /// `TypeError`) — see [`CmpOrder`] for why the distinction matters. The
-    /// default is [`CmpOrder::Incomparable`] (the type has no ordering).
-    /// Returns `Err(ResourceError::Recursion)` if maximum depth is exceeded.
-    fn py_cmp(&self, _other: &Self, _vm: &mut VM<'h>) -> RunResult<CmpOrder> {
-        Ok(CmpOrder::Incomparable)
-    }
-
-    /// Answers a single ordering operator (`<` `<=` `>` `>=`) for types that a
-    /// [`CmpOrder`] cannot describe, taking precedence over [`py_cmp`](Self::py_cmp).
-    ///
-    /// A `Counter` compares as a multiset, where `<=` and `>=` are independent
-    /// containment tests (neither need hold) and each operator names *itself* in
-    /// the `TypeError` an unorderable count raises — so the answer depends on
-    /// which operator was written, which a single `CmpOrder` cannot carry.
-    ///
-    /// Only the four ordering operators reach here. `Ok(None)` — the default —
-    /// defers to `py_cmp`.
-    fn py_cmp_op(&self, _other: &Value, _op: CmpOperator, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
+    /// Any Python value is a valid handled result. [`Value::NotImplemented`]
+    /// asks the caller to try the reflected operation on `other`; the default
+    /// adapts existing boolean equality implementations and declines ordering.
+    /// `self_id` lets ID-dependent heap types such as Counters re-enter the VM.
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            Ok(op.equality_result(self.py_eq_impl(other, vm)?))
+        } else {
+            Ok(Value::NotImplemented)
+        }
     }
 
     /// Returns the truthiness of the value following Python semantics.

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -68,7 +68,7 @@ impl From<AttrCallResult> for CallResult {
 /// One of Python's six rich-comparison operations.
 ///
 /// Identity and containment operators use separate protocols and deliberately
-/// cannot reach [`PyTrait::py_rich_compare_impl`].
+/// cannot reach the rich-comparison vtable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RichCmpOp {
     /// Less than (`<`).
@@ -116,6 +116,18 @@ impl RichCmpOp {
         matches!(self, Self::Eq | Self::Ne)
     }
 
+    /// Returns the special method implementing this operation on an instance.
+    pub(crate) fn dunder(self) -> &'static str {
+        match self {
+            Self::Lt => "__lt__",
+            Self::Le => "__le__",
+            Self::Eq => "__eq__",
+            Self::Ne => "__ne__",
+            Self::Gt => "__gt__",
+            Self::Ge => "__ge__",
+        }
+    }
+
     /// Evaluates this operation against an existing total ordering.
     pub(crate) fn holds(self, ordering: Ordering) -> bool {
         match self {
@@ -150,7 +162,91 @@ impl RichCmpOp {
     }
 }
 
-/// Common operations for Python values.
+/// A native implementation of one rich-comparison slot.
+pub(crate) type RichCmpFn<'h, T> = fn(&T, &Value, RichCmpOp, &mut VM<'h>, Option<HeapId>) -> RunResult<Value>;
+
+/// Static rich-comparison slots exposed by a Rust value implementation.
+///
+/// A missing pointer means the type does not define that operation. Multiple
+/// slots may share one function when their type checks and comparison work are
+/// common; the operation is passed to the function for that purpose.
+pub(crate) struct RichCmpVtable<'h, T> {
+    /// Native `<` implementation, if defined.
+    lt: Option<RichCmpFn<'h, T>>,
+    /// Native `<=` implementation, if defined.
+    le: Option<RichCmpFn<'h, T>>,
+    /// Native `==` implementation, if defined.
+    eq: Option<RichCmpFn<'h, T>>,
+    /// Native `!=` implementation, if defined.
+    ne: Option<RichCmpFn<'h, T>>,
+    /// Native `>` implementation, if defined.
+    gt: Option<RichCmpFn<'h, T>>,
+    /// Native `>=` implementation, if defined.
+    ge: Option<RichCmpFn<'h, T>>,
+}
+
+impl<'h, T> RichCmpVtable<'h, T> {
+    /// A type with no native rich-comparison methods.
+    pub(crate) const EMPTY: Self = Self::new(None, None, None, None, None, None);
+
+    /// Creates an arbitrary combination of rich-comparison slots.
+    pub(crate) const fn new(
+        lt: Option<RichCmpFn<'h, T>>,
+        le: Option<RichCmpFn<'h, T>>,
+        eq: Option<RichCmpFn<'h, T>>,
+        ne: Option<RichCmpFn<'h, T>>,
+        gt: Option<RichCmpFn<'h, T>>,
+        ge: Option<RichCmpFn<'h, T>>,
+    ) -> Self {
+        Self { lt, le, eq, ne, gt, ge }
+    }
+
+    /// Exposes only equality, deriving `!=` through the same implementation.
+    pub(crate) const fn equality(compare: RichCmpFn<'h, T>) -> Self {
+        Self::new(None, None, Some(compare), Some(compare), None, None)
+    }
+
+    /// Exposes all six operations through one shared implementation.
+    pub(crate) const fn all(compare: RichCmpFn<'h, T>) -> Self {
+        Self::new(
+            Some(compare),
+            Some(compare),
+            Some(compare),
+            Some(compare),
+            Some(compare),
+            Some(compare),
+        )
+    }
+
+    /// Resolves the native function for one operation.
+    fn get(&self, op: RichCmpOp) -> Option<RichCmpFn<'h, T>> {
+        match op {
+            RichCmpOp::Lt => self.lt,
+            RichCmpOp::Le => self.le,
+            RichCmpOp::Eq => self.eq,
+            RichCmpOp::Ne => self.ne,
+            RichCmpOp::Gt => self.gt,
+            RichCmpOp::Ge => self.ge,
+        }
+    }
+}
+
+/// Invokes one statically resolved rich-comparison slot.
+pub(crate) fn invoke_rich_cmp_slot<'h>(
+    receiver: &impl PyTrait<'h>,
+    other: &Value,
+    op: RichCmpOp,
+    vm: &mut VM<'h>,
+    self_id: Option<HeapId>,
+) -> RunResult<Value> {
+    if let Some(compare) = <_ as PyTrait<'h>>::RICH_COMPARE.get(op) {
+        compare(receiver, other, op, vm, self_id)
+    } else {
+        Ok(Value::NotImplemented)
+    }
+}
+
+/// Common operations for heap-allocated Python values.
 ///
 /// Implementers should provide Python-compatible semantics for all operations.
 /// Most methods take a `&VM` or `&mut VM` reference to access the heap and interned
@@ -162,10 +258,13 @@ impl RichCmpOp {
 /// Methods take the concrete [`VM`]/`Heap` types, which own the resource
 /// tracker enforcing time/memory/recursion limits.
 ///
-/// The lifetime `'h` connects [`crate::heap::HeapObjectRead`] implementations
-/// to the VM's heap reference; immediate [`Value`] implementations use it only
-/// through the VM argument.
-pub(crate) trait PyTrait<'h> {
+/// The lifetime `'h` is the heap borrow lifetime. For concrete types (e.g. `Dict`,
+/// `List`) this is unused and should be `'_`. For `HeapRead<'h, T>` implementers
+/// the lifetime connects the read handle to the VM's heap reference.
+pub(crate) trait PyTrait<'h>: Sized {
+    /// Native rich-comparison methods supplied by this type.
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::EMPTY;
+
     /// Returns the Python type name for this value (e.g., "list", "str").
     ///
     /// Used for error messages and the `type()` builtin.
@@ -199,42 +298,6 @@ pub(crate) trait PyTrait<'h> {
     /// [`Value::py_contains`] falls back to iteration and then `TypeError`.
     fn py_contains_impl(&self, _item: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         Ok(None)
-    }
-
-    /// One-sided equality normalized for identity-or-equality operations.
-    ///
-    /// Returns `Some(bool)` when this type handles `other`, or `None` for
-    /// `NotImplemented`. User instances preserve arbitrary `__eq__` results in
-    /// [`py_rich_compare_impl`](Self::py_rich_compare_impl) instead.
-    ///
-    /// Cross-type equality (e.g. `int`/`float`, `namedtuple`/`tuple`,
-    /// `dict_keys`/`set`) is handled here in-situ: each type inspects `other`
-    /// directly. For containers this performs element-wise comparison using the
-    /// heap to resolve nested references; `&mut VM` allows lazy hash computation
-    /// for dict key lookups and access to interned string content.
-    ///
-    /// Recursion depth is tracked via `vm.recursion_guard()`; returns
-    /// `Err(ResourceError::Recursion)` if maximum depth is exceeded.
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>>;
-
-    /// Runs one side of Python's rich-comparison protocol.
-    ///
-    /// Any Python value is a valid handled result. [`Value::NotImplemented`]
-    /// asks the caller to try the reflected operation on `other`; the default
-    /// adapts existing boolean equality implementations and declines ordering.
-    /// `self_id` lets ID-dependent heap types such as Counters re-enter the VM.
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            Ok(op.equality_result(self.py_eq_impl(other, vm)?))
-        } else {
-            Ok(Value::NotImplemented)
-        }
     }
 
     /// Returns the truthiness of the value following Python semantics.

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -68,7 +68,7 @@ impl From<AttrCallResult> for CallResult {
 /// One of Python's six rich-comparison operations.
 ///
 /// Identity and containment operators use separate protocols and deliberately
-/// cannot reach [`PyTrait::py_rich_compare_impl`].
+/// cannot reach the rich-comparison vtable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RichCmpOp {
     /// Less than (`<`).
@@ -116,6 +116,18 @@ impl RichCmpOp {
         matches!(self, Self::Eq | Self::Ne)
     }
 
+    /// Returns the special method implementing this operation on an instance.
+    pub(crate) fn dunder(self) -> &'static str {
+        match self {
+            Self::Lt => "__lt__",
+            Self::Le => "__le__",
+            Self::Eq => "__eq__",
+            Self::Ne => "__ne__",
+            Self::Gt => "__gt__",
+            Self::Ge => "__ge__",
+        }
+    }
+
     /// Evaluates this operation against an existing total ordering.
     pub(crate) fn holds(self, ordering: Ordering) -> bool {
         match self {
@@ -150,6 +162,90 @@ impl RichCmpOp {
     }
 }
 
+/// A native implementation of one rich-comparison slot.
+pub(crate) type RichCmpFn<'h, T> = fn(&T, &Value, RichCmpOp, &mut VM<'h>, Option<HeapId>) -> RunResult<Value>;
+
+/// Static rich-comparison slots exposed by a Rust value implementation.
+///
+/// A missing pointer means the type does not define that operation. Multiple
+/// slots may share one function when their type checks and comparison work are
+/// common; the operation is passed to the function for that purpose.
+pub(crate) struct RichCmpVtable<'h, T> {
+    /// Native `<` implementation, if defined.
+    lt: Option<RichCmpFn<'h, T>>,
+    /// Native `<=` implementation, if defined.
+    le: Option<RichCmpFn<'h, T>>,
+    /// Native `==` implementation, if defined.
+    eq: Option<RichCmpFn<'h, T>>,
+    /// Native `!=` implementation, if defined.
+    ne: Option<RichCmpFn<'h, T>>,
+    /// Native `>` implementation, if defined.
+    gt: Option<RichCmpFn<'h, T>>,
+    /// Native `>=` implementation, if defined.
+    ge: Option<RichCmpFn<'h, T>>,
+}
+
+impl<'h, T> RichCmpVtable<'h, T> {
+    /// A type with no native rich-comparison methods.
+    pub(crate) const EMPTY: Self = Self::new(None, None, None, None, None, None);
+
+    /// Creates an arbitrary combination of rich-comparison slots.
+    pub(crate) const fn new(
+        lt: Option<RichCmpFn<'h, T>>,
+        le: Option<RichCmpFn<'h, T>>,
+        eq: Option<RichCmpFn<'h, T>>,
+        ne: Option<RichCmpFn<'h, T>>,
+        gt: Option<RichCmpFn<'h, T>>,
+        ge: Option<RichCmpFn<'h, T>>,
+    ) -> Self {
+        Self { lt, le, eq, ne, gt, ge }
+    }
+
+    /// Exposes only equality, deriving `!=` through the same implementation.
+    pub(crate) const fn equality(compare: RichCmpFn<'h, T>) -> Self {
+        Self::new(None, None, Some(compare), Some(compare), None, None)
+    }
+
+    /// Exposes all six operations through one shared implementation.
+    pub(crate) const fn all(compare: RichCmpFn<'h, T>) -> Self {
+        Self::new(
+            Some(compare),
+            Some(compare),
+            Some(compare),
+            Some(compare),
+            Some(compare),
+            Some(compare),
+        )
+    }
+
+    /// Resolves the native function for one operation.
+    fn get(&self, op: RichCmpOp) -> Option<RichCmpFn<'h, T>> {
+        match op {
+            RichCmpOp::Lt => self.lt,
+            RichCmpOp::Le => self.le,
+            RichCmpOp::Eq => self.eq,
+            RichCmpOp::Ne => self.ne,
+            RichCmpOp::Gt => self.gt,
+            RichCmpOp::Ge => self.ge,
+        }
+    }
+}
+
+/// Invokes one statically resolved rich-comparison slot.
+pub(crate) fn invoke_rich_cmp_slot<'h>(
+    receiver: &impl PyTrait<'h>,
+    other: &Value,
+    op: RichCmpOp,
+    vm: &mut VM<'h>,
+    self_id: Option<HeapId>,
+) -> RunResult<Value> {
+    if let Some(compare) = <_ as PyTrait<'h>>::RICH_COMPARE.get(op) {
+        compare(receiver, other, op, vm, self_id)
+    } else {
+        Ok(Value::NotImplemented)
+    }
+}
+
 /// Common operations for heap-allocated Python values.
 ///
 /// Implementers should provide Python-compatible semantics for all operations.
@@ -165,7 +261,10 @@ impl RichCmpOp {
 /// The lifetime `'h` is the heap borrow lifetime. For concrete types (e.g. `Dict`,
 /// `List`) this is unused and should be `'_`. For `HeapRead<'h, T>` implementers
 /// the lifetime connects the read handle to the VM's heap reference.
-pub(crate) trait PyTrait<'h> {
+pub(crate) trait PyTrait<'h>: Sized {
+    /// Native rich-comparison methods supplied by this type.
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::EMPTY;
+
     /// Returns the Python type name for this value (e.g., "list", "str").
     ///
     /// Used for error messages and the `type()` builtin.
@@ -203,42 +302,6 @@ pub(crate) trait PyTrait<'h> {
     /// `self_id` is only needed by types that re-enter the VM (`Instance`).
     fn py_contains_impl(&self, _self_id: HeapId, _item: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
         Ok(None)
-    }
-
-    /// One-sided equality normalized for identity-or-equality operations.
-    ///
-    /// Returns `Some(bool)` when this type handles `other`, or `None` for
-    /// `NotImplemented`. User instances preserve arbitrary `__eq__` results in
-    /// [`py_rich_compare_impl`](Self::py_rich_compare_impl) instead.
-    ///
-    /// Cross-type equality (e.g. `int`/`float`, `namedtuple`/`tuple`,
-    /// `dict_keys`/`set`) is handled here in-situ: each type inspects `other`
-    /// directly. For containers this performs element-wise comparison using the
-    /// heap to resolve nested references; `&mut VM` allows lazy hash computation
-    /// for dict key lookups and access to interned string content.
-    ///
-    /// Recursion depth is tracked via `vm.recursion_guard()`; returns
-    /// `Err(ResourceError::Recursion)` if maximum depth is exceeded.
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>>;
-
-    /// Runs one side of Python's rich-comparison protocol.
-    ///
-    /// Any Python value is a valid handled result. [`Value::NotImplemented`]
-    /// asks the caller to try the reflected operation on `other`; the default
-    /// adapts existing boolean equality implementations and declines ordering.
-    /// `self_id` lets ID-dependent heap types such as Counters re-enter the VM.
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            Ok(op.equality_result(self.py_eq_impl(other, vm)?))
-        } else {
-            Ok(Value::NotImplemented)
-        }
     }
 
     /// Returns the truthiness of the value following Python semantics.

--- a/crates/monty/src/types/py_trait.rs
+++ b/crates/monty/src/types/py_trait.rs
@@ -65,58 +65,87 @@ impl From<AttrCallResult> for CallResult {
     }
 }
 
-/// Outcome of an ordering comparison ([`PyTrait::py_cmp`] / [`Value::py_cmp`]).
+/// One of Python's six rich-comparison operations.
 ///
-/// A plain `Option<Ordering>` conflated two very different "no ordering" cases;
-/// this enum splits them so callers reproduce CPython exactly:
-///
-/// - [`Ordered`](Self::Ordered) — a definite `<` / `==` / `>` result.
-/// - [`Unordered`](Self::Unordered) — the operands *are* valid comparison
-///   partners but have no ordering because a `NaN` is involved (directly, or as
-///   the first differing element of a list/tuple). CPython's ordering operators
-///   (`<`, `<=`, `>`, `>=`) all yield `False` here rather than raising, and
-///   `sorted`/`min`/`max` treat it as "no swap".
-/// - [`Incomparable`](Self::Incomparable) — the operand types (or the types of
-///   their first differing elements) have no defined ordering at all; ordering
-///   operators raise `TypeError`.
-///
-/// Collapsing `Unordered` into `Incomparable` is exactly the bug that made
-/// `float('nan') < 1` raise instead of returning `False`.
+/// Identity and containment operators use separate protocols and deliberately
+/// cannot reach [`PyTrait::py_rich_compare_impl`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum CmpOrder {
-    /// A definite ordering between the two operands.
-    Ordered(Ordering),
-    /// Valid partners, but unordered because a `NaN` is involved.
-    Unordered,
-    /// The operand types have no defined ordering.
-    Incomparable,
+pub(crate) enum RichCmpOp {
+    /// Less than (`<`).
+    Lt,
+    /// Less than or equal (`<=`).
+    Le,
+    /// Equal (`==`).
+    Eq,
+    /// Not equal (`!=`).
+    Ne,
+    /// Greater than (`>`).
+    Gt,
+    /// Greater than or equal (`>=`).
+    Ge,
 }
 
-impl CmpOrder {
-    /// Maps an `Option<Ordering>` from a numeric comparison helper, where `None`
-    /// can *only* mean a `NaN` operand (`f64::partial_cmp`, `i64_cmp_f64`,
-    /// `bigint_cmp_f64`, and `LongInt::partial_cmp_f64` all return `None`
-    /// exclusively for `NaN`). `None` therefore becomes [`Unordered`], never
-    /// [`Incomparable`].
-    ///
-    /// [`Unordered`]: Self::Unordered
-    /// [`Incomparable`]: Self::Incomparable
-    pub(crate) fn from_numeric(ordering: Option<Ordering>) -> Self {
-        match ordering {
-            Some(ordering) => Self::Ordered(ordering),
-            None => Self::Unordered,
+impl RichCmpOp {
+    /// Converts a source comparison operator when it is a rich comparison.
+    pub(crate) fn from_cmp_operator(op: CmpOperator) -> Option<Self> {
+        match op {
+            CmpOperator::Lt => Some(Self::Lt),
+            CmpOperator::LtE => Some(Self::Le),
+            CmpOperator::Eq => Some(Self::Eq),
+            CmpOperator::NotEq => Some(Self::Ne),
+            CmpOperator::Gt => Some(Self::Gt),
+            CmpOperator::GtE => Some(Self::Ge),
+            CmpOperator::Is | CmpOperator::IsNot | CmpOperator::In | CmpOperator::NotIn => None,
         }
     }
 
-    /// Maps an `Option<Ordering>` from a *total*-order comparison (strings,
-    /// bytes, dates, timedeltas), where `None` never arises from a valid pair —
-    /// so `None` means the types don't compare at all ([`Incomparable`]).
-    ///
-    /// [`Incomparable`]: Self::Incomparable
-    pub(crate) fn from_total(ordering: Option<Ordering>) -> Self {
-        match ordering {
-            Some(ordering) => Self::Ordered(ordering),
-            None => Self::Incomparable,
+    /// Returns the operation tried on the right operand after `NotImplemented`.
+    pub(crate) fn reflected(self) -> Self {
+        match self {
+            Self::Lt => Self::Gt,
+            Self::Le => Self::Ge,
+            Self::Eq => Self::Eq,
+            Self::Ne => Self::Ne,
+            Self::Gt => Self::Lt,
+            Self::Ge => Self::Le,
+        }
+    }
+
+    /// Whether this operation belongs to the equality pair.
+    pub(crate) fn is_equality(self) -> bool {
+        matches!(self, Self::Eq | Self::Ne)
+    }
+
+    /// Evaluates this operation against an existing total ordering.
+    pub(crate) fn holds(self, ordering: Ordering) -> bool {
+        match self {
+            Self::Lt => ordering.is_lt(),
+            Self::Le => ordering.is_le(),
+            Self::Eq => ordering.is_eq(),
+            Self::Ne => !ordering.is_eq(),
+            Self::Gt => ordering.is_gt(),
+            Self::Ge => ordering.is_ge(),
+        }
+    }
+
+    /// Converts one-sided boolean equality into a rich-comparison result.
+    pub(crate) fn equality_result(self, equal: Option<bool>) -> Value {
+        debug_assert!(self.is_equality());
+        match equal {
+            Some(equal) => Value::Bool(if self == Self::Ne { !equal } else { equal }),
+            None => Value::NotImplemented,
+        }
+    }
+
+    /// Returns the spelling used in ordering `TypeError` messages.
+    pub(crate) fn symbol(self) -> &'static str {
+        match self {
+            Self::Lt => "<",
+            Self::Le => "<=",
+            Self::Eq => "==",
+            Self::Ne => "!=",
+            Self::Gt => ">",
+            Self::Ge => ">=",
         }
     }
 }
@@ -179,10 +208,8 @@ pub(crate) trait PyTrait<'h> {
     /// One-sided equality normalized for identity-or-equality operations.
     ///
     /// Returns `Some(bool)` when this type handles `other`, or `None` for
-    /// `NotImplemented`. User instances truth-test arbitrary `__eq__` results
-    /// here, while [`Value::py_rich_eq`] uses a separate path to preserve them.
-    /// This mirrors the `NotImplemented` half of [`py_cmp`](Self::py_cmp)'s
-    /// [`CmpOrder::Incomparable`].
+    /// `NotImplemented`. User instances preserve arbitrary `__eq__` results in
+    /// [`py_rich_compare_impl`](Self::py_rich_compare_impl) instead.
     ///
     /// Cross-type equality (e.g. `int`/`float`, `namedtuple`/`tuple`,
     /// `dict_keys`/`set`) is handled here in-situ: each type inspects `other`
@@ -190,48 +217,28 @@ pub(crate) trait PyTrait<'h> {
     /// heap to resolve nested references; `&mut VM` allows lazy hash computation
     /// for dict key lookups and access to interned string content.
     ///
-    /// Heap-backed implementations receive `self_id`; immediate values receive
-    /// `None`. Recursion depth is tracked via `vm.recursion_guard()`; returns
+    /// Recursion depth is tracked via `vm.recursion_guard()`; returns
     /// `Err(ResourceError::Recursion)` if maximum depth is exceeded.
     fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>>;
 
-    /// Python comparison (`<`, `>`, etc.).
+    /// Runs one side of Python's rich-comparison protocol.
     ///
-    /// For containers, this performs element-wise comparison using the heap
-    /// to resolve nested references. Takes `&mut VM` to allow lazy hash
-    /// computation for dict key lookups and access to interned string content.
-    ///
-    /// Recursion depth is tracked via `vm.recursion_guard()`.
-    ///
-    /// Returns a [`CmpOrder`] distinguishing a definite ordering, a
-    /// `NaN`-driven unordered-but-valid result (ordering operators yield
-    /// `False`), and a genuine type mismatch (ordering operators raise
-    /// `TypeError`) — see [`CmpOrder`] for why the distinction matters. The
-    /// default is [`CmpOrder::Incomparable`] (the type has no ordering).
-    /// Returns `Err(ResourceError::Recursion)` if maximum depth is exceeded.
-    fn py_cmp(&self, _other: &Self, _vm: &mut VM<'h>) -> RunResult<CmpOrder> {
-        Ok(CmpOrder::Incomparable)
-    }
-
-    /// Answers a single ordering operator (`<` `<=` `>` `>=`) for types that a
-    /// [`CmpOrder`] cannot describe, taking precedence over [`py_cmp`](Self::py_cmp).
-    ///
-    /// A `Counter` compares as a multiset, where `<=` and `>=` are independent
-    /// containment tests (neither need hold) and each operator names *itself* in
-    /// the `TypeError` an unorderable count raises — so the answer depends on
-    /// which operator was written, which a single `CmpOrder` cannot carry.
-    /// `self_id` is this value's heap id, as for [`py_add_impl`](Self::py_add_impl).
-    ///
-    /// Only the four ordering operators reach here. `Ok(None)` — the default —
-    /// defers to `py_cmp`.
-    fn py_cmp_op(
+    /// Any Python value is a valid handled result. [`Value::NotImplemented`]
+    /// asks the caller to try the reflected operation on `other`; the default
+    /// adapts existing boolean equality implementations and declines ordering.
+    /// `self_id` lets ID-dependent heap types such as Counters re-enter the VM.
+    fn py_rich_compare_impl(
         &self,
-        _other: &Value,
-        _op: CmpOperator,
-        _vm: &mut VM<'h>,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
         _self_id: Option<HeapId>,
-    ) -> RunResult<Option<bool>> {
-        Ok(None)
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            Ok(op.equality_result(self.py_eq_impl(other, vm)?))
+        } else {
+            Ok(Value::NotImplemented)
+        }
     }
 
     /// Returns the truthiness of the value following Python semantics.

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -17,7 +17,7 @@ use crate::{
     defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunResult},
     hash::HashValue,
-    heap::{Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapRead, HeapReadOutput},
+    heap::{Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapReadOutput},
     types::{LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, Type},
     value::Value,
 };
@@ -188,7 +188,7 @@ impl Default for Range {
 impl<'h> HeapObjectRead<'h, Range> {
     /// Compares ranges by the sequence they produce rather than raw parameters.
     #[expect(clippy::unnecessary_wraps)]
-    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         let Some(HeapReadOutput::Range(other)) = other.read_heap(vm) else {
             return Ok(Value::NotImplemented);
         };
@@ -282,7 +282,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Range> {
         Ok(Value::Int(offset_i64))
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         // Ranges are equal by the sequence they produce, so the hash must depend
         // only on what equality compares: length, then start (if non-empty), then
         // step (only if length > 1). Hashing the raw `start`/`stop`/`step` fields
@@ -362,10 +362,8 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, RangeIterator> {
         None
     }
 
-    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
-        let self_id = self_id.expect("heap values have an id");
-        vm.heap.inc_ref(self_id);
-        Ok(Value::Ref(self_id))
+    fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
+        Ok(self.clone_value(vm.heap))
     }
 
     fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -17,8 +17,8 @@ use crate::{
     defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunResult},
     hash::HashValue,
-    heap::{Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapReadOutput},
-    types::{LazyHeapSet, PyTrait, Type},
+    heap::{Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapRead, HeapReadOutput},
+    types::{LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, Type},
     value::Value,
 };
 
@@ -185,7 +185,24 @@ impl Default for Range {
     }
 }
 
+impl<'h> HeapObjectRead<'h, Range> {
+    /// Compares ranges by the sequence they produce rather than raw parameters.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let Some(HeapReadOutput::Range(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        let a = self.get(vm.heap);
+        let b = other.get(vm.heap);
+        let len = a.len();
+        let equal = len == b.len() && (len == 0 || (a.start == b.start && (len == 1 || a.step == b.step)));
+        Ok(op.equality_result(Some(equal)))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, Range> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -265,31 +282,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Range> {
         Ok(Value::Int(offset_i64))
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::Range(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        let a = self.get(vm.heap);
-        let b = other.get(vm.heap);
-        // Compare ranges by their actual sequences, not parameters.
-        // Two ranges are equal if they produce the same elements.
-        let len1 = a.len();
-        let len2 = b.len();
-        Ok(Some(if len1 != len2 {
-            false
-        } else if len1 == 0 {
-            true // Both empty
-        } else if len1 == 1 {
-            // Single-element ranges are equal when their one element matches,
-            // regardless of step (e.g. range(0, 1, 1) == range(0, 2, 2)).
-            a.start == b.start
-        } else {
-            // Same length (>1) - compare first element and step.
-            a.start == b.start && a.step == b.step
-        }))
-    }
-
-    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         // Ranges are equal by the sequence they produce, so the hash must depend
         // only on what equality compares: length, then start (if non-empty), then
         // step (only if length > 1). Hashing the raw `start`/`stop`/`step` fields
@@ -369,12 +362,10 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, RangeIterator> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
-    }
-
-    fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
-        Ok(self.clone_value(vm.heap))
+    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
+        let self_id = self_id.expect("heap values have an id");
+        vm.heap.inc_ref(self_id);
+        Ok(Value::Ref(self_id))
     }
 
     fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/range.rs
+++ b/crates/monty/src/types/range.rs
@@ -19,7 +19,7 @@ use crate::{
     exception_private::{ExcType, ExcTypeExt, RunResult},
     hash::HashValue,
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
-    types::{LazyHeapSet, PyTrait, Type},
+    types::{LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, Type},
     value::Value,
 };
 
@@ -186,7 +186,24 @@ impl Default for Range {
     }
 }
 
+impl<'h> HeapRead<'h, Range> {
+    /// Compares ranges by the sequence they produce rather than raw parameters.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let Some(HeapReadOutput::Range(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        let a = self.get(vm.heap);
+        let b = other.get(vm.heap);
+        let len = a.len();
+        let equal = len == b.len() && (len == 0 || (a.start == b.start && (len == 1 || a.step == b.step)));
+        Ok(op.equality_result(Some(equal)))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapRead<'h, Range> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -264,30 +281,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Range> {
         let offset = i128::from(range.start) + (normalized * i128::from(range.step));
         let offset_i64 = i64::try_from(offset).map_err(|_| ExcType::overflow_c_ssize_t())?;
         Ok(Value::Int(offset_i64))
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::Range(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        let a = self.get(vm.heap);
-        let b = other.get(vm.heap);
-        // Compare ranges by their actual sequences, not parameters.
-        // Two ranges are equal if they produce the same elements.
-        let len1 = a.len();
-        let len2 = b.len();
-        Ok(Some(if len1 != len2 {
-            false
-        } else if len1 == 0 {
-            true // Both empty
-        } else if len1 == 1 {
-            // Single-element ranges are equal when their one element matches,
-            // regardless of step (e.g. range(0, 1, 1) == range(0, 2, 2)).
-            a.start == b.start
-        } else {
-            // Same length (>1) - compare first element and step.
-            a.start == b.start && a.step == b.step
-        }))
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
@@ -376,10 +369,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, RangeIterator> {
 
     fn py_len(&self, _: &VM<'h>) -> Option<usize> {
         None
-    }
-
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
     }
 
     fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {

--- a/crates/monty/src/types/re_match.rs
+++ b/crates/monty/src/types/re_match.rs
@@ -318,11 +318,6 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, ReMatch> {
         None
     }
 
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // Match objects use identity equality (handled before the heap read).
-        Ok(None)
-    }
-
     fn py_bool(&self, _vm: &mut VM<'h>) -> RunResult<bool> {
         // Match objects are always truthy
         Ok(true)

--- a/crates/monty/src/types/re_match.rs
+++ b/crates/monty/src/types/re_match.rs
@@ -318,11 +318,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ReMatch> {
         None
     }
 
-    fn py_eq_impl(&self, _other: &Value, _vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // Match objects use identity equality (handled before the heap read).
-        Ok(None)
-    }
-
     fn py_bool(&self, _vm: &mut VM<'h>) -> RunResult<bool> {
         // Match objects are always truthy
         Ok(true)

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -362,7 +362,7 @@ impl RePattern {
 impl<'h> HeapObjectRead<'h, RePattern> {
     /// Compares compiled patterns by source and flags.
     #[expect(clippy::unnecessary_wraps)]
-    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         let Some(HeapReadOutput::RePattern(other)) = other.read_heap(vm) else {
             return Ok(Value::NotImplemented);
         };

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -25,7 +25,7 @@ use crate::{
     modules::re::{ASCII, DOTALL, IGNORECASE, MULTILINE},
     resource_checks::check_estimated_size,
     types::{
-        LazyHeapSet, List, PyTrait, ReMatch, Type, allocate_tuple,
+        LazyHeapSet, List, PyTrait, ReMatch, RichCmpOp, RichCmpVtable, Type, allocate_tuple,
         str::{allocate_string, string_repr_fmt},
         tuple::TupleVec,
     },
@@ -359,20 +359,26 @@ impl RePattern {
     }
 }
 
+impl<'h> HeapObjectRead<'h, RePattern> {
+    /// Compares compiled patterns by source and flags.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let Some(HeapReadOutput::RePattern(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        Ok(op.equality_result(Some(self.get(vm.heap) == other.get(vm.heap))))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, RePattern> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::RePattern
     }
 
     fn py_len(&self, _vm: &VM<'h>) -> Option<usize> {
         None
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::RePattern(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        Ok(Some(self.get(vm.heap) == other.get(vm.heap)))
     }
 
     fn py_bool(&self, _vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -25,7 +25,7 @@ use crate::{
     modules::re::{ASCII, DOTALL, IGNORECASE, MULTILINE},
     resource_checks::check_estimated_size,
     types::{
-        LazyHeapSet, List, PyTrait, ReMatch, Type, allocate_tuple,
+        LazyHeapSet, List, PyTrait, ReMatch, RichCmpOp, RichCmpVtable, Type, allocate_tuple,
         str::{allocate_string, string_repr_fmt},
         tuple::TupleVec,
     },
@@ -365,20 +365,26 @@ impl RePattern {
     }
 }
 
+impl<'h> HeapRead<'h, RePattern> {
+    /// Compares compiled patterns by source and flags.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let Some(HeapReadOutput::RePattern(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        Ok(op.equality_result(Some(self.get(vm.heap) == other.get(vm.heap))))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapRead<'h, RePattern> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::RePattern
     }
 
     fn py_len(&self, _vm: &VM<'h>) -> Option<usize> {
         None
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::RePattern(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        Ok(Some(self.get(vm.heap) == other.get(vm.heap)))
     }
 
     fn py_bool(&self, _vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -4,7 +4,7 @@ use hashbrown::HashTable;
 use monty_types::{ResourceError, ResourceTracker};
 use smallvec::SmallVec;
 
-use super::{PyTrait, iter::checked_preallocation_hint};
+use super::{PyTrait, RichCmpOp, RichCmpVtable, iter::checked_preallocation_hint};
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
@@ -961,7 +961,21 @@ impl<C: ContainsHeap> DropWithContext<C> for SetEntry {
     }
 }
 
+impl<'h> HeapObjectRead<'h, Set> {
+    /// Compares sets and frozensets by their members.
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let equal = match other.read_heap(vm) {
+            Some(HeapReadOutput::Set(other)) => Some(self.storage().eq(&other.storage(), vm)?),
+            Some(HeapReadOutput::FrozenSet(other)) => Some(self.storage().eq(&other.storage(), vm)?),
+            _ => None,
+        };
+        Ok(op.equality_result(equal))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, Set> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -980,17 +994,6 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Set> {
 
     fn py_len(&self, vm: &VM<'h>) -> Option<usize> {
         Some(self.get(vm.heap).len())
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // `set` and `frozenset` compare equal by their members, regardless of
-        // mutability. `set == dict_keys`/`dict_items` is handled by the reflected
-        // pass via the dict-view impls.
-        match other.read_heap(vm) {
-            Some(HeapReadOutput::Set(other)) => Ok(Some(self.storage().eq(&other.storage(), vm)?)),
-            Some(HeapReadOutput::FrozenSet(other)) => Ok(Some(self.storage().eq(&other.storage(), vm)?)),
-            _ => Ok(None),
-        }
     }
 
     fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {
@@ -1270,7 +1273,21 @@ impl FrozenSet {
     }
 }
 
+impl<'h> HeapObjectRead<'h, FrozenSet> {
+    /// Compares frozensets and sets by their members.
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let equal = match other.read_heap(vm) {
+            Some(HeapReadOutput::FrozenSet(other)) => Some(self.storage().eq(&other.storage(), vm)?),
+            Some(HeapReadOutput::Set(other)) => Some(self.storage().eq(&other.storage(), vm)?),
+            _ => None,
+        };
+        Ok(op.equality_result(equal))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, FrozenSet> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -1289,17 +1306,6 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, FrozenSet> {
 
     fn py_len(&self, vm: &VM<'h>) -> Option<usize> {
         Some(self.get(vm.heap).len())
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // `frozenset` and `set` compare equal by their members, regardless of
-        // mutability. `frozenset == dict_keys`/`dict_items` is handled by the
-        // reflected pass via the dict-view impls.
-        match other.read_heap(vm) {
-            Some(HeapReadOutput::FrozenSet(other)) => Ok(Some(self.storage().eq(&other.storage(), vm)?)),
-            Some(HeapReadOutput::Set(other)) => Ok(Some(self.storage().eq(&other.storage(), vm)?)),
-            _ => Ok(None),
-        }
     }
 
     /// Hashes the frozenset by XORing all element hashes.
@@ -1565,12 +1571,10 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, SetIterator> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
-    }
-
-    fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
-        Ok(self.clone_value(vm.heap))
+    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
+        let self_id = self_id.expect("heap values have an id");
+        vm.heap.inc_ref(self_id);
+        Ok(Value::Ref(self_id))
     }
 
     fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -963,7 +963,7 @@ impl<C: ContainsHeap> DropWithContext<C> for SetEntry {
 
 impl<'h> HeapObjectRead<'h, Set> {
     /// Compares sets and frozensets by their members.
-    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         let equal = match other.read_heap(vm) {
             Some(HeapReadOutput::Set(other)) => Some(self.storage().eq(&other.storage(), vm)?),
             Some(HeapReadOutput::FrozenSet(other)) => Some(self.storage().eq(&other.storage(), vm)?),
@@ -1275,7 +1275,7 @@ impl FrozenSet {
 
 impl<'h> HeapObjectRead<'h, FrozenSet> {
     /// Compares frozensets and sets by their members.
-    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         let equal = match other.read_heap(vm) {
             Some(HeapReadOutput::FrozenSet(other)) => Some(self.storage().eq(&other.storage(), vm)?),
             Some(HeapReadOutput::Set(other)) => Some(self.storage().eq(&other.storage(), vm)?),
@@ -1571,10 +1571,8 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, SetIterator> {
         None
     }
 
-    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
-        let self_id = self_id.expect("heap values have an id");
-        vm.heap.inc_ref(self_id);
-        Ok(Value::Ref(self_id))
+    fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
+        Ok(self.clone_value(vm.heap))
     }
 
     fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -4,7 +4,7 @@ use hashbrown::HashTable;
 use monty_types::{ResourceError, ResourceTracker};
 use smallvec::SmallVec;
 
-use super::{PyTrait, iter::checked_preallocation_hint};
+use super::{PyTrait, RichCmpOp, RichCmpVtable, iter::checked_preallocation_hint};
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
@@ -980,7 +980,21 @@ impl<C: ContainsHeap> DropWithContext<C> for SetEntry {
     }
 }
 
+impl<'h> HeapRead<'h, Set> {
+    /// Compares sets and frozensets by their members.
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let equal = match other.read_heap(vm) {
+            Some(HeapReadOutput::Set(other)) => Some(self.storage().eq(&other.storage(), vm)?),
+            Some(HeapReadOutput::FrozenSet(other)) => Some(self.storage().eq(&other.storage(), vm)?),
+            _ => None,
+        };
+        Ok(op.equality_result(equal))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapRead<'h, Set> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -999,17 +1013,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Set> {
 
     fn py_len(&self, vm: &VM<'h>) -> Option<usize> {
         Some(self.get(vm.heap).len())
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // `set` and `frozenset` compare equal by their members, regardless of
-        // mutability. `set == dict_keys`/`dict_items` is handled by the reflected
-        // pass via the dict-view impls.
-        match other.read_heap(vm) {
-            Some(HeapReadOutput::Set(other)) => Ok(Some(self.storage().eq(&other.storage(), vm)?)),
-            Some(HeapReadOutput::FrozenSet(other)) => Ok(Some(self.storage().eq(&other.storage(), vm)?)),
-            _ => Ok(None),
-        }
     }
 
     fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {
@@ -1299,7 +1302,21 @@ impl FrozenSet {
     }
 }
 
+impl<'h> HeapRead<'h, FrozenSet> {
+    /// Compares frozensets and sets by their members.
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let equal = match other.read_heap(vm) {
+            Some(HeapReadOutput::FrozenSet(other)) => Some(self.storage().eq(&other.storage(), vm)?),
+            Some(HeapReadOutput::Set(other)) => Some(self.storage().eq(&other.storage(), vm)?),
+            _ => None,
+        };
+        Ok(op.equality_result(equal))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -1318,17 +1335,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, FrozenSet> {
 
     fn py_len(&self, vm: &VM<'h>) -> Option<usize> {
         Some(self.get(vm.heap).len())
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // `frozenset` and `set` compare equal by their members, regardless of
-        // mutability. `frozenset == dict_keys`/`dict_items` is handled by the
-        // reflected pass via the dict-view impls.
-        match other.read_heap(vm) {
-            Some(HeapReadOutput::FrozenSet(other)) => Ok(Some(self.storage().eq(&other.storage(), vm)?)),
-            Some(HeapReadOutput::Set(other)) => Ok(Some(self.storage().eq(&other.storage(), vm)?)),
-            _ => Ok(None),
-        }
     }
 
     /// Hashes the frozenset by XORing all element hashes.
@@ -1606,10 +1612,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, SetIterator> {
 
     fn py_len(&self, _: &VM<'h>) -> Option<usize> {
         None
-    }
-
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
     }
 
     fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -160,7 +160,7 @@ fn normalize_index(index: i64, length: i64, lower: i64, upper: i64) -> i64 {
 impl<'h> HeapObjectRead<'h, Slice> {
     /// Compares the three normalized slice components.
     #[expect(clippy::unnecessary_wraps)]
-    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         let Some(HeapReadOutput::Slice(other)) = other.read_heap(vm) else {
             return Ok(Value::NotImplemented);
         };
@@ -182,7 +182,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Slice> {
         None
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(HashValue::new(hasher.finish())))

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -19,7 +19,7 @@ use crate::{
     hash::HashValue,
     heap::{HeapData, HeapId, HeapItem, HeapObjectRead, HeapReadOutput},
     intern::StaticStrings,
-    types::{PyTrait, Type},
+    types::{PyTrait, RichCmpOp, RichCmpVtable, Type},
     value::{EitherStr, Value},
 };
 
@@ -157,7 +157,22 @@ fn normalize_index(index: i64, length: i64, lower: i64, upper: i64) -> i64 {
     normalized.clamp(lower, upper)
 }
 
+impl<'h> HeapObjectRead<'h, Slice> {
+    /// Compares the three normalized slice components.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let Some(HeapReadOutput::Slice(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        let a = self.get(vm.heap);
+        let b = other.get(vm.heap);
+        Ok(op.equality_result(Some(a.start == b.start && a.stop == b.stop && a.step == b.step)))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, Slice> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::Slice
     }
@@ -167,16 +182,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Slice> {
         None
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::Slice(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        let a = self.get(vm.heap);
-        let b = other.get(vm.heap);
-        Ok(Some(a.start == b.start && a.stop == b.stop && a.step == b.step))
-    }
-
-    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(HashValue::new(hasher.finish())))

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -20,7 +20,7 @@ use crate::{
     hash::HashValue,
     heap::{HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
-    types::{PyTrait, Type},
+    types::{PyTrait, RichCmpOp, RichCmpVtable, Type},
     value::{EitherStr, Value},
 };
 
@@ -158,7 +158,22 @@ fn normalize_index(index: i64, length: i64, lower: i64, upper: i64) -> i64 {
     normalized.clamp(lower, upper)
 }
 
+impl<'h> HeapRead<'h, Slice> {
+    /// Compares the three normalized slice components.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let Some(HeapReadOutput::Slice(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        let a = self.get(vm.heap);
+        let b = other.get(vm.heap);
+        Ok(op.equality_result(Some(a.start == b.start && a.stop == b.stop && a.step == b.step)))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapRead<'h, Slice> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::Slice
     }
@@ -166,15 +181,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Slice> {
     fn py_len(&self, _vm: &VM<'h>) -> Option<usize> {
         // Slices don't have a length in Python
         None
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::Slice(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        let a = self.get(vm.heap);
-        let b = other.get(vm.heap);
-        Ok(Some(a.start == b.start && a.stop == b.stop && a.step == b.step))
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -266,13 +266,7 @@ impl ops::Deref for Str {
 impl<'h> HeapObjectRead<'h, Str> {
     /// Compares string content across interned and heap representations.
     #[expect(clippy::unnecessary_wraps)]
-    fn rich_compare(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
+    fn rich_compare(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         if op.is_equality() {
             return Ok(op.equality_result(eq_str(self.get(vm.heap).as_str(), other, vm)));
         }
@@ -332,7 +326,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Str> {
         Ok(allocate_char(c, vm.heap))
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let s = self.get(vm.heap);
         if let Some(cached) = s.1.get() {
             return Ok(Some(cached));
@@ -2130,10 +2124,8 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, StringIterator> {
         None
     }
 
-    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
-        let self_id = self_id.expect("heap values have an id");
-        vm.heap.inc_ref(self_id);
-        Ok(Value::Ref(self_id))
+    fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
+        Ok(self.clone_value(vm.heap))
     }
 
     fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -9,7 +9,7 @@ pub use monty_types::{StringRepr, string_repr_fmt};
 use ruff_python_stdlib::{identifiers::is_identifier, keyword::is_keyword};
 use smallvec::smallvec;
 
-use super::{Bytes, CmpOrder, PyTrait};
+use super::{Bytes, PyTrait, RichCmpOp};
 use crate::{
     args::{ArgValues, FromArgs, StrArg},
     bytecode::{CallResult, VM},
@@ -330,8 +330,22 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Str> {
         Ok(!self.get(vm.heap).0.is_empty())
     }
 
-    fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {
-        Ok(CmpOrder::Ordered(self.get(vm.heap).0.cmp(&other.get(vm.heap).0)))
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let other = match other {
+            Value::InternString(id) => vm.interns.get_str(*id),
+            Value::Ref(id) if let HeapData::Str(other) = vm.heap.get(*id) => other.as_str(),
+            _ => return Ok(Value::NotImplemented),
+        };
+        Ok(Value::Bool(op.holds(self.get(vm.heap).as_str().cmp(other))))
     }
 
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, _heap_ids: &mut LazyHeapSet) -> RunResult<()> {

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -9,7 +9,7 @@ pub use monty_types::{StringRepr, string_repr_fmt};
 use ruff_python_stdlib::{identifiers::is_identifier, keyword::is_keyword};
 use smallvec::smallvec;
 
-use super::{Bytes, PyTrait, RichCmpOp};
+use super::{Bytes, PyTrait, RichCmpOp, RichCmpVtable};
 use crate::{
     args::{ArgValues, FromArgs, StrArg},
     bytecode::{CallResult, VM},
@@ -263,7 +263,31 @@ impl ops::Deref for Str {
     }
 }
 
+impl<'h> HeapObjectRead<'h, Str> {
+    /// Compares string content across interned and heap representations.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_compare(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(eq_str(self.get(vm.heap).as_str(), other, vm)));
+        }
+        let other = match other {
+            Value::InternString(id) => vm.interns.get_str(*id),
+            Value::Ref(id) if let HeapData::Str(other) = vm.heap.get(*id) => other.as_str(),
+            _ => return Ok(Value::NotImplemented),
+        };
+        Ok(Value::Bool(op.holds(self.get(vm.heap).as_str().cmp(other))))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, Str> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -308,12 +332,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Str> {
         Ok(allocate_char(c, vm.heap))
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // A heap string equals an interned or heap string with the same content.
-        Ok(eq_str(self.get(vm.heap).as_str(), other, vm))
-    }
-
-    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let s = self.get(vm.heap);
         if let Some(cached) = s.1.get() {
             return Ok(Some(cached));
@@ -328,24 +347,6 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Str> {
 
     fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {
         Ok(!self.get(vm.heap).0.is_empty())
-    }
-
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let other = match other {
-            Value::InternString(id) => vm.interns.get_str(*id),
-            Value::Ref(id) if let HeapData::Str(other) = vm.heap.get(*id) => other.as_str(),
-            _ => return Ok(Value::NotImplemented),
-        };
-        Ok(Value::Bool(op.holds(self.get(vm.heap).as_str().cmp(other))))
     }
 
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, _heap_ids: &mut LazyHeapSet) -> RunResult<()> {
@@ -2129,12 +2130,10 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, StringIterator> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
-    }
-
-    fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
-        Ok(self.clone_value(vm.heap))
+    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
+        let self_id = self_id.expect("heap values have an id");
+        vm.heap.inc_ref(self_id);
+        Ok(Value::Ref(self_id))
     }
 
     fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -9,7 +9,7 @@ pub use monty_types::{StringRepr, string_repr_fmt};
 use ruff_python_stdlib::{identifiers::is_identifier, keyword::is_keyword};
 use smallvec::smallvec;
 
-use super::{Bytes, CmpOrder, PyTrait};
+use super::{Bytes, PyTrait, RichCmpOp};
 use crate::{
     args::{ArgValues, FromArgs, StrArg},
     bytecode::{CallResult, VM},
@@ -330,8 +330,22 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
         Ok(!self.get(vm.heap).0.is_empty())
     }
 
-    fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {
-        Ok(CmpOrder::Ordered(self.get(vm.heap).0.cmp(&other.get(vm.heap).0)))
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let other = match other {
+            Value::InternString(id) => vm.interns.get_str(*id),
+            Value::Ref(id) if let HeapData::Str(other) = vm.heap.get(*id) => other.as_str(),
+            _ => return Ok(Value::NotImplemented),
+        };
+        Ok(Value::Bool(op.holds(self.get(vm.heap).as_str().cmp(other))))
     }
 
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, _heap_ids: &mut LazyHeapSet) -> RunResult<()> {

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -9,7 +9,7 @@ pub use monty_types::{StringRepr, string_repr_fmt};
 use ruff_python_stdlib::{identifiers::is_identifier, keyword::is_keyword};
 use smallvec::smallvec;
 
-use super::{Bytes, PyTrait, RichCmpOp};
+use super::{Bytes, PyTrait, RichCmpOp, RichCmpVtable};
 use crate::{
     args::{ArgValues, FromArgs, StrArg},
     bytecode::{CallResult, VM},
@@ -263,7 +263,31 @@ impl ops::Deref for Str {
     }
 }
 
+impl<'h> HeapRead<'h, Str> {
+    /// Compares string content across interned and heap representations.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_compare(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(eq_str(self.get(vm.heap).as_str(), other, vm)));
+        }
+        let other = match other {
+            Value::InternString(id) => vm.interns.get_str(*id),
+            Value::Ref(id) if let HeapData::Str(other) = vm.heap.get(*id) => other.as_str(),
+            _ => return Ok(Value::NotImplemented),
+        };
+        Ok(Value::Bool(op.holds(self.get(vm.heap).as_str().cmp(other))))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -308,11 +332,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
         Ok(allocate_char(c, vm.heap)?)
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // A heap string equals an interned or heap string with the same content.
-        Ok(eq_str(self.get(vm.heap).as_str(), other, vm))
-    }
-
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let s = self.get(vm.heap);
         if let Some(cached) = s.1.get() {
@@ -328,24 +347,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Str> {
 
     fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {
         Ok(!self.get(vm.heap).0.is_empty())
-    }
-
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let other = match other {
-            Value::InternString(id) => vm.interns.get_str(*id),
-            Value::Ref(id) if let HeapData::Str(other) = vm.heap.get(*id) => other.as_str(),
-            _ => return Ok(Value::NotImplemented),
-        };
-        Ok(Value::Bool(op.holds(self.get(vm.heap).as_str().cmp(other))))
     }
 
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, _heap_ids: &mut LazyHeapSet) -> RunResult<()> {
@@ -2141,10 +2142,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, StringIterator> {
 
     fn py_len(&self, _: &VM<'h>) -> Option<usize> {
         None
-    }
-
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
     }
 
     fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {

--- a/crates/monty/src/types/timedelta.rs
+++ b/crates/monty/src/types/timedelta.rs
@@ -297,13 +297,7 @@ impl HeapItem for TimeDelta {
 impl<'h> HeapObjectRead<'h, TimeDelta> {
     /// Compares normalized durations by total microseconds.
     #[expect(clippy::unnecessary_wraps)]
-    fn rich_compare(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
+    fn rich_compare(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         let Some(HeapReadOutput::TimeDelta(other)) = other.read_heap(vm) else {
             return Ok(Value::NotImplemented);
         };
@@ -325,7 +319,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, TimeDelta> {
         None
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(HashValue::new(hasher.finish())))

--- a/crates/monty/src/types/timedelta.rs
+++ b/crates/monty/src/types/timedelta.rs
@@ -20,7 +20,7 @@ use crate::{
     hash::HashValue,
     heap::{HeapData, HeapId, HeapItem, HeapObjectRead, HeapReadOutput},
     intern::StaticStrings,
-    types::{CmpOrder, LazyHeapSet, PyTrait, Type, date, datetime, str::allocate_string},
+    types::{LazyHeapSet, PyTrait, RichCmpOp, Type, date, datetime, str::allocate_string},
     value::{EitherStr, Value},
 };
 
@@ -320,10 +320,21 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, TimeDelta> {
         Ok(Some(HashValue::new(hasher.finish())))
     }
 
-    fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {
-        Ok(CmpOrder::Ordered(
-            total_microseconds(self.get(vm.heap)).cmp(&total_microseconds(other.get(vm.heap))),
-        ))
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let Some(HeapReadOutput::TimeDelta(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        let ordering = total_microseconds(self.get(vm.heap)).cmp(&total_microseconds(other.get(vm.heap)));
+        Ok(Value::Bool(op.holds(ordering)))
     }
 
     fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/timedelta.rs
+++ b/crates/monty/src/types/timedelta.rs
@@ -20,7 +20,7 @@ use crate::{
     hash::HashValue,
     heap::{HeapData, HeapId, HeapItem, HeapObjectRead, HeapReadOutput},
     intern::StaticStrings,
-    types::{LazyHeapSet, PyTrait, RichCmpOp, Type, date, datetime, str::allocate_string},
+    types::{LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, Type, date, datetime, str::allocate_string},
     value::{EitherStr, Value},
 };
 
@@ -294,9 +294,29 @@ impl HeapItem for TimeDelta {
     fn py_dec_ref_ids(&mut self, _stack: &mut Vec<HeapId>) {}
 }
 
+impl<'h> HeapObjectRead<'h, TimeDelta> {
+    /// Compares normalized durations by total microseconds.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_compare(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        let Some(HeapReadOutput::TimeDelta(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        let ordering = total_microseconds(self.get(vm.heap)).cmp(&total_microseconds(other.get(vm.heap)));
+        Ok(Value::Bool(op.holds(ordering)))
+    }
+}
+
 /// `HeapRead`-based dispatch for `TimeDelta`, enabling the `HeapReadOutput` enum to
 /// delegate `PyTrait` calls to heap-resident timedeltas.
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, TimeDelta> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::TimeDelta
     }
@@ -305,36 +325,10 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, TimeDelta> {
         None
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::TimeDelta(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        Ok(Some(
-            total_microseconds(self.get(vm.heap)) == total_microseconds(other.get(vm.heap)),
-        ))
-    }
-
-    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(HashValue::new(hasher.finish())))
-    }
-
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let Some(HeapReadOutput::TimeDelta(other)) = other.read_heap(vm) else {
-            return Ok(Value::NotImplemented);
-        };
-        let ordering = total_microseconds(self.get(vm.heap)).cmp(&total_microseconds(other.get(vm.heap)));
-        Ok(Value::Bool(op.holds(ordering)))
     }
 
     fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/timedelta.rs
+++ b/crates/monty/src/types/timedelta.rs
@@ -21,7 +21,7 @@ use crate::{
     hash::HashValue,
     heap::{HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
-    types::{LazyHeapSet, PyTrait, RichCmpOp, Type, date, datetime, str::allocate_string},
+    types::{LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, Type, date, datetime, str::allocate_string},
     value::{EitherStr, Value},
 };
 
@@ -299,9 +299,29 @@ impl HeapItem for TimeDelta {
     fn py_dec_ref_ids(&mut self, _stack: &mut Vec<HeapId>) {}
 }
 
+impl<'h> HeapRead<'h, TimeDelta> {
+    /// Compares normalized durations by total microseconds.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_compare(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        let Some(HeapReadOutput::TimeDelta(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        let ordering = total_microseconds(self.get(vm.heap)).cmp(&total_microseconds(other.get(vm.heap)));
+        Ok(Value::Bool(op.holds(ordering)))
+    }
+}
+
 /// `HeapRead`-based dispatch for `TimeDelta`, enabling the `HeapReadOutput` enum to
 /// delegate `PyTrait` calls to heap-resident timedeltas.
 impl<'h> PyTrait<'h> for HeapRead<'h, TimeDelta> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::TimeDelta
     }
@@ -310,36 +330,10 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeDelta> {
         None
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::TimeDelta(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        Ok(Some(
-            total_microseconds(self.get(vm.heap)) == total_microseconds(other.get(vm.heap)),
-        ))
-    }
-
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(HashValue::new(hasher.finish())))
-    }
-
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let Some(HeapReadOutput::TimeDelta(other)) = other.read_heap(vm) else {
-            return Ok(Value::NotImplemented);
-        };
-        let ordering = total_microseconds(self.get(vm.heap)).cmp(&total_microseconds(other.get(vm.heap)));
-        Ok(Value::Bool(op.holds(ordering)))
     }
 
     fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/timedelta.rs
+++ b/crates/monty/src/types/timedelta.rs
@@ -21,7 +21,7 @@ use crate::{
     hash::HashValue,
     heap::{HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
-    types::{CmpOrder, LazyHeapSet, PyTrait, Type, date, datetime, str::allocate_string},
+    types::{LazyHeapSet, PyTrait, RichCmpOp, Type, date, datetime, str::allocate_string},
     value::{EitherStr, Value},
 };
 
@@ -325,10 +325,21 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TimeDelta> {
         Ok(Some(HashValue::new(hasher.finish())))
     }
 
-    fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {
-        Ok(CmpOrder::Ordered(
-            total_microseconds(self.get(vm.heap)).cmp(&total_microseconds(other.get(vm.heap))),
-        ))
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let Some(HeapReadOutput::TimeDelta(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        let ordering = total_microseconds(self.get(vm.heap)).cmp(&total_microseconds(other.get(vm.heap)));
+        Ok(Value::Bool(op.holds(ordering)))
     }
 
     fn py_bool(&self, vm: &mut VM<'h>) -> RunResult<bool> {

--- a/crates/monty/src/types/timezone.rs
+++ b/crates/monty/src/types/timezone.rs
@@ -217,7 +217,7 @@ impl HeapItem for TimeZone {
 impl<'h> HeapObjectRead<'h, TimeZone> {
     /// Compares fixed-offset timezones by UTC offset.
     #[expect(clippy::unnecessary_wraps)]
-    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         let Some(HeapReadOutput::TimeZone(other)) = other.read_heap(vm) else {
             return Ok(Value::NotImplemented);
         };
@@ -240,7 +240,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, TimeZone> {
         None
     }
 
-    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(HashValue::new(hasher.finish())))

--- a/crates/monty/src/types/timezone.rs
+++ b/crates/monty/src/types/timezone.rs
@@ -17,7 +17,7 @@ use crate::{
     heap::{Heap, HeapData, HeapId, HeapItem, HeapObjectRead, HeapReadOutput},
     intern::Interns,
     types::{
-        LazyHeapSet, PyTrait, Type,
+        LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, Type,
         str::{StringRepr, allocate_string},
         timedelta,
         timedelta::{MICROSECONDS_PER_SECOND, SECONDS_PER_HOUR, SECONDS_PER_MINUTE},
@@ -214,9 +214,24 @@ impl HeapItem for TimeZone {
     fn py_dec_ref_ids(&mut self, _stack: &mut Vec<HeapId>) {}
 }
 
+impl<'h> HeapObjectRead<'h, TimeZone> {
+    /// Compares fixed-offset timezones by UTC offset.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let Some(HeapReadOutput::TimeZone(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        Ok(op.equality_result(Some(
+            self.get(vm.heap).offset_seconds == other.get(vm.heap).offset_seconds,
+        )))
+    }
+}
+
 /// `HeapRead`-based dispatch for `TimeZone`, enabling the `HeapReadOutput` enum to
 /// delegate `PyTrait` calls to heap-resident timezone objects.
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, TimeZone> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::TimeZone
     }
@@ -225,16 +240,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, TimeZone> {
         None
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::TimeZone(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        Ok(Some(
-            self.get(vm.heap).offset_seconds == other.get(vm.heap).offset_seconds,
-        ))
-    }
-
-    fn py_hash(&self, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
+    fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {
         let mut hasher = DefaultHasher::new();
         self.get(vm.heap).hash(&mut hasher);
         Ok(Some(HashValue::new(hasher.finish())))

--- a/crates/monty/src/types/timezone.rs
+++ b/crates/monty/src/types/timezone.rs
@@ -18,7 +18,7 @@ use crate::{
     heap::{Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::Interns,
     types::{
-        LazyHeapSet, PyTrait, Type,
+        LazyHeapSet, PyTrait, RichCmpOp, RichCmpVtable, Type,
         str::{StringRepr, allocate_string},
         timedelta,
         timedelta::{MICROSECONDS_PER_SECOND, SECONDS_PER_HOUR, SECONDS_PER_MINUTE},
@@ -219,24 +219,30 @@ impl HeapItem for TimeZone {
     fn py_dec_ref_ids(&mut self, _stack: &mut Vec<HeapId>) {}
 }
 
+impl<'h> HeapRead<'h, TimeZone> {
+    /// Compares fixed-offset timezones by UTC offset.
+    #[expect(clippy::unnecessary_wraps)]
+    fn rich_eq(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Value> {
+        let Some(HeapReadOutput::TimeZone(other)) = other.read_heap(vm) else {
+            return Ok(Value::NotImplemented);
+        };
+        Ok(op.equality_result(Some(
+            self.get(vm.heap).offset_seconds == other.get(vm.heap).offset_seconds,
+        )))
+    }
+}
+
 /// `HeapRead`-based dispatch for `TimeZone`, enabling the `HeapReadOutput` enum to
 /// delegate `PyTrait` calls to heap-resident timezone objects.
 impl<'h> PyTrait<'h> for HeapRead<'h, TimeZone> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::equality(Self::rich_eq);
+
     fn py_type(&self, _vm: &VM<'h>) -> Type {
         Type::TimeZone
     }
 
     fn py_len(&self, _vm: &VM<'h>) -> Option<usize> {
         None
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let Some(HeapReadOutput::TimeZone(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        Ok(Some(
-            self.get(vm.heap).offset_seconds == other.get(vm.heap).offset_seconds,
-        ))
     }
 
     fn py_hash(&self, _self_id: HeapId, vm: &mut VM<'h>) -> RunResult<Option<HashValue>> {

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -24,7 +24,7 @@ use std::{
 /// All tuple methods from Python's builtins are implemented.
 use smallvec::SmallVec;
 
-use super::{PyTrait, RichCmpOp, iter::collect_owned_iterable};
+use super::{PyTrait, RichCmpOp, RichCmpVtable, iter::collect_owned_iterable};
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
@@ -279,7 +279,73 @@ impl<'h, C: ContainsVM<'h>> DropWithContext<C> for TupleIter<'_, 'h> {
     }
 }
 
+impl<'h> HeapObjectRead<'h, Tuple> {
+    /// Compares tuple elements for the equality slots.
+    fn eq_bool(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        let Some(HeapReadOutput::Tuple(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
+        if self.get(vm.heap).items.len() != other.get(vm.heap).items.len() {
+            return Ok(Some(false));
+        }
+        let iter = self.iter(vm)?;
+        defer_drop_mut!(iter, vm);
+        while let Some((i, a)) = iter.next_with_index(vm)? {
+            let b = other.clone_item(i, vm);
+            defer_drop!(b, vm);
+            if !a.py_eq(b, vm)? {
+                return Ok(Some(false));
+            }
+        }
+        Ok(Some(true))
+    }
+
+    /// Compares tuples lexicographically, including against named tuples.
+    ///
+    /// Equality identifies the shared prefix; the first unequal pair receives
+    /// the original operator and may return any Python value. Lengths decide
+    /// only when every shared element compares equal.
+    fn rich_compare(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.eq_bool(other, vm)?));
+        }
+        let other = match other.read_heap(vm) {
+            Some(HeapReadOutput::Tuple(other)) => other,
+            Some(HeapReadOutput::NamedTuple(other)) => {
+                let (a, b) = (self.cloned_items(vm), other.cloned_items(vm));
+                return rich_compare_item_seqs(a, b, op, vm);
+            }
+            _ => return Ok(Value::NotImplemented),
+        };
+
+        let a_len = self.get(vm.heap).items.len();
+        let b_len = other.get(vm.heap).items.len();
+        let min_len = a_len.min(b_len);
+        let iter = self.iter(vm)?;
+        defer_drop_mut!(iter, vm);
+        while let Some((i, av)) = iter.next_with_index(vm)? {
+            if i >= min_len {
+                break;
+            }
+            let bv = other.clone_item(i, vm);
+            defer_drop!(bv, vm);
+            if !av.py_lex_eq(bv, vm)? {
+                return av.py_rich_compare(bv, op, vm);
+            }
+        }
+        Ok(Value::Bool(op.holds(a_len.cmp(&b_len))))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapObjectRead<'h, Tuple> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -334,27 +400,6 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Tuple> {
         Ok(self.clone_item(idx, vm))
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // A tuple equals another tuple; `tuple == namedtuple` is handled by the
-        // reflected pass via `NamedTuple::py_eq_impl`.
-        let Some(HeapReadOutput::Tuple(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        if self.get(vm.heap).items.len() != other.get(vm.heap).items.len() {
-            return Ok(Some(false));
-        }
-        let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
-        while let Some((i, a)) = iter.next_with_index(vm)? {
-            let b = other.clone_item(i, vm);
-            defer_drop!(b, vm);
-            if !a.py_eq(b, vm)? {
-                return Ok(Some(false));
-            }
-        }
-        Ok(Some(true))
-    }
-
     /// Hashes the tuple as the combined hash of its elements.
     ///
     /// Identical to `NamedTuple::py_hash`, so a `Tuple` and a `NamedTuple` with
@@ -382,49 +427,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Tuple> {
         Ok(Some(hash))
     }
 
-    /// Compares tuples lexicographically, including against named tuples.
-    ///
-    /// Equality identifies the shared prefix; the first unequal pair receives
-    /// the original operator and may return any Python value. Lengths decide
-    /// only when every shared element compares equal.
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let other = match other.read_heap(vm) {
-            Some(HeapReadOutput::Tuple(other)) => other,
-            Some(HeapReadOutput::NamedTuple(other)) => {
-                let (a, b) = (self.cloned_items(vm), other.cloned_items(vm));
-                return rich_compare_item_seqs(a, b, op, vm);
-            }
-            _ => return Ok(Value::NotImplemented),
-        };
-
-        let a_len = self.get(vm.heap).items.len();
-        let b_len = other.get(vm.heap).items.len();
-        let min_len = a_len.min(b_len);
-        let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
-        while let Some((i, av)) = iter.next_with_index(vm)? {
-            if i >= min_len {
-                break;
-            }
-            let bv = other.clone_item(i, vm);
-            defer_drop!(bv, vm);
-            if !av.py_lex_eq(bv, vm)? {
-                return av.py_rich_compare(bv, op, vm);
-            }
-        }
-        Ok(Value::Bool(op.holds(a_len.cmp(&b_len))))
-    }
-
-    fn py_add_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
+    fn py_add_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
         let Some(HeapReadOutput::Tuple(other)) = other.read_heap(vm) else {
             return Ok(None);
         };
@@ -654,12 +657,10 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, TupleIterator> {
         None
     }
 
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
-    }
-
-    fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
-        Ok(self.clone_value(vm.heap))
+    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
+        let self_id = self_id.expect("heap values have an id");
+        vm.heap.inc_ref(self_id);
+        Ok(Value::Ref(self_id))
     }
 
     fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -1,6 +1,5 @@
 use std::{
     cell::Cell,
-    cmp::Ordering,
     collections::hash_map::DefaultHasher,
     fmt::Write,
     hash::{Hash, Hasher},
@@ -25,7 +24,7 @@ use std::{
 /// All tuple methods from Python's builtins are implemented.
 use smallvec::SmallVec;
 
-use super::{CmpOrder, PyTrait, iter::collect_owned_iterable};
+use super::{PyTrait, RichCmpOp, iter::collect_owned_iterable};
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
@@ -39,6 +38,7 @@ use crate::{
         LazyHeapSet, Type,
         list::repr_sequence_fmt,
         long_int::repeat_count,
+        namedtuple::rich_compare_item_seqs,
         slice::{normalize_sequence_index, slice_collect_iterator},
     },
     value::{EitherStr, VALUE_SIZE, Value},
@@ -166,9 +166,9 @@ impl<'h> HeapRead<'h, Tuple> {
     }
 
     /// Clones every item into a plain `Vec`, for the namedtuple orderings in
-    /// [`cmp_item_seqs`](crate::types::namedtuple::cmp_item_seqs).
-    pub(crate) fn cloned_items(&self, vm: &mut VM<'h>) -> RunResult<Vec<Value>> {
-        Ok(self.clone_all_items(vm)?.into_vec())
+    /// [`rich_compare_item_seqs`](crate::types::namedtuple::rich_compare_item_seqs).
+    pub(crate) fn cloned_items(&self, vm: &mut VM<'h>) -> Vec<Value> {
+        self.clone_all_items(vm).into_vec()
     }
 
     /// Clones all items from this tuple with proper refcount management.
@@ -382,19 +382,30 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Tuple> {
         Ok(Some(hash))
     }
 
-    /// Lexicographic comparison for tuples.
+    /// Compares tuples lexicographically, including against named tuples.
     ///
-    /// Compares element-by-element left-to-right. The first non-equal pair
-    /// determines the result. If all compared elements are equal, the shorter
-    /// tuple is considered less than the longer one — matching Python semantics:
-    /// `(1, 2) < (1, 2, 3)` is `True`.
-    ///
-    /// The result of the first differing pair propagates directly: a `NaN`
-    /// element yields [`CmpOrder::Unordered`] (`(nan,) < (1,)` is `False`, not a
-    /// `TypeError`), while a type-mismatched element yields
-    /// [`CmpOrder::Incomparable`] (`(1,) < ('a',)` raises) — this element-level
-    /// distinction is exactly why [`CmpOrder`] exists.
-    fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {
+    /// Equality identifies the shared prefix; the first unequal pair receives
+    /// the original operator and may return any Python value. Lengths decide
+    /// only when every shared element compares equal.
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let other = match other.read_heap(vm) {
+            Some(HeapReadOutput::Tuple(other)) => other,
+            Some(HeapReadOutput::NamedTuple(other)) => {
+                let (a, b) = (self.cloned_items(vm), other.cloned_items(vm));
+                return rich_compare_item_seqs(a, b, op, vm);
+            }
+            _ => return Ok(Value::NotImplemented),
+        };
+
         let a_len = self.get(vm.heap).items.len();
         let b_len = other.get(vm.heap).items.len();
         let min_len = a_len.min(b_len);
@@ -402,32 +413,15 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Tuple> {
         defer_drop_mut!(iter, vm);
         while let Some((i, av)) = iter.next_with_index(vm)? {
             if i >= min_len {
-                // `self` was longer than `other`; remaining items don't
-                // participate in element-wise comparison.
                 break;
             }
             let bv = other.clone_item(i, vm);
             defer_drop!(bv, vm);
-            match av.py_cmp(bv, vm)? {
-                CmpOrder::Ordered(Ordering::Equal) => {}
-                CmpOrder::Ordered(ord) => return Ok(CmpOrder::Ordered(ord)),
-                // A `NaN` element: elements are never `==`-equal to a `NaN`, so
-                // this is the first differing pair and the tuple is unordered.
-                CmpOrder::Unordered => return Ok(CmpOrder::Unordered),
-                CmpOrder::Incomparable => {
-                    // The elements don't support ordering. CPython checks
-                    // `__eq__` first and only calls `__lt__` for non-equal
-                    // pairs, so equal-but-unorderable elements (e.g.
-                    // `None == None`) are treated as equal and don't block the
-                    // comparison; a genuinely differing pair makes the tuple
-                    // incomparable.
-                    if !av.py_eq(bv, vm)? {
-                        return Ok(CmpOrder::Incomparable);
-                    }
-                }
+            if !av.py_lex_eq(bv, vm)? {
+                return av.py_rich_compare(bv, op, vm);
             }
         }
-        Ok(CmpOrder::Ordered(a_len.cmp(&b_len)))
+        Ok(Value::Bool(op.holds(a_len.cmp(&b_len))))
     }
 
     fn py_add_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -167,8 +167,8 @@ impl<'h> HeapRead<'h, Tuple> {
 
     /// Clones every item into a plain `Vec`, for the namedtuple orderings in
     /// [`rich_compare_item_seqs`](crate::types::namedtuple::rich_compare_item_seqs).
-    pub(crate) fn cloned_items(&self, vm: &mut VM<'h>) -> Vec<Value> {
-        self.clone_all_items(vm).into_vec()
+    pub(crate) fn cloned_items(&self, vm: &mut VM<'h>) -> RunResult<Vec<Value>> {
+        Ok(self.clone_all_items(vm)?.into_vec())
     }
 
     /// Clones all items from this tuple with proper refcount management.
@@ -305,20 +305,14 @@ impl<'h> HeapObjectRead<'h, Tuple> {
     /// Equality identifies the shared prefix; the first unequal pair receives
     /// the original operator and may return any Python value. Lengths decide
     /// only when every shared element compares equal.
-    fn rich_compare(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
+    fn rich_compare(&self, other: &Value, op: RichCmpOp, vm: &mut VM<'h>) -> RunResult<Value> {
         if op.is_equality() {
             return Ok(op.equality_result(self.eq_bool(other, vm)?));
         }
         let other = match other.read_heap(vm) {
             Some(HeapReadOutput::Tuple(other)) => other,
             Some(HeapReadOutput::NamedTuple(other)) => {
-                let (a, b) = (self.cloned_items(vm), other.cloned_items(vm));
+                let (a, b) = (self.cloned_items(vm)?, other.cloned_items(vm)?);
                 return rich_compare_item_seqs(a, b, op, vm);
             }
             _ => return Ok(Value::NotImplemented),
@@ -427,7 +421,7 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, Tuple> {
         Ok(Some(hash))
     }
 
-    fn py_add_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
+    fn py_add_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         let Some(HeapReadOutput::Tuple(other)) = other.read_heap(vm) else {
             return Ok(None);
         };
@@ -657,10 +651,8 @@ impl<'h> PyTrait<'h> for HeapObjectRead<'h, TupleIterator> {
         None
     }
 
-    fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {
-        let self_id = self_id.expect("heap values have an id");
-        vm.heap.inc_ref(self_id);
-        Ok(Value::Ref(self_id))
+    fn py_iter(&self, vm: &mut VM<'h>) -> RunResult<Value> {
+        Ok(self.clone_value(vm.heap))
     }
 
     fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -25,7 +25,7 @@ use std::{
 use monty_types::ResourceError;
 use smallvec::SmallVec;
 
-use super::{PyTrait, RichCmpOp, iter::collect_owned_iterable};
+use super::{PyTrait, RichCmpOp, RichCmpVtable, iter::collect_owned_iterable};
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
@@ -287,7 +287,73 @@ impl<'h, C: ContainsVM<'h>> DropWithContext<C> for TupleIter<'_, 'h> {
     }
 }
 
+impl<'h> HeapRead<'h, Tuple> {
+    /// Compares tuple elements for the equality slots.
+    fn eq_bool(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
+        let Some(HeapReadOutput::Tuple(other)) = other.read_heap(vm) else {
+            return Ok(None);
+        };
+        if self.get(vm.heap).items.len() != other.get(vm.heap).items.len() {
+            return Ok(Some(false));
+        }
+        let iter = self.iter(vm)?;
+        defer_drop_mut!(iter, vm);
+        while let Some((i, a)) = iter.next_with_index(vm)? {
+            let b = other.clone_item(i, vm);
+            defer_drop!(b, vm);
+            if !a.py_eq(b, vm)? {
+                return Ok(Some(false));
+            }
+        }
+        Ok(Some(true))
+    }
+
+    /// Compares tuples lexicographically, including against named tuples.
+    ///
+    /// Equality identifies the shared prefix; the first unequal pair receives
+    /// the original operator and may return any Python value. Lengths decide
+    /// only when every shared element compares equal.
+    fn rich_compare(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.eq_bool(other, vm)?));
+        }
+        let other = match other.read_heap(vm) {
+            Some(HeapReadOutput::Tuple(other)) => other,
+            Some(HeapReadOutput::NamedTuple(other)) => {
+                let (a, b) = (self.cloned_items(vm), other.cloned_items(vm));
+                return rich_compare_item_seqs(a, b, op, vm);
+            }
+            _ => return Ok(Value::NotImplemented),
+        };
+
+        let a_len = self.get(vm.heap).items.len();
+        let b_len = other.get(vm.heap).items.len();
+        let min_len = a_len.min(b_len);
+        let iter = self.iter(vm)?;
+        defer_drop_mut!(iter, vm);
+        while let Some((i, av)) = iter.next_with_index(vm)? {
+            if i >= min_len {
+                break;
+            }
+            let bv = other.clone_item(i, vm);
+            defer_drop!(bv, vm);
+            if !av.py_lex_eq(bv, vm)? {
+                return av.py_rich_compare(bv, op, vm);
+            }
+        }
+        Ok(Value::Bool(op.holds(a_len.cmp(&b_len))))
+    }
+}
+
 impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
     fn py_is_iterable(&self, _vm: &VM<'h>) -> bool {
         true
     }
@@ -342,27 +408,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         Ok(self.clone_item(idx, vm))
     }
 
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        // A tuple equals another tuple; `tuple == namedtuple` is handled by the
-        // reflected pass via `NamedTuple::py_eq_impl`.
-        let Some(HeapReadOutput::Tuple(other)) = other.read_heap(vm) else {
-            return Ok(None);
-        };
-        if self.get(vm.heap).items.len() != other.get(vm.heap).items.len() {
-            return Ok(Some(false));
-        }
-        let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
-        while let Some((i, a)) = iter.next_with_index(vm)? {
-            let b = other.clone_item(i, vm);
-            defer_drop!(b, vm);
-            if !a.py_eq(b, vm)? {
-                return Ok(Some(false));
-            }
-        }
-        Ok(Some(true))
-    }
-
     /// Hashes the tuple as the combined hash of its elements.
     ///
     /// Identical to `NamedTuple::py_hash`, so a `Tuple` and a `NamedTuple` with
@@ -388,48 +433,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         let hash = HashValue::new(hasher.finish());
         self.get(vm.heap).cached_hash.set(Some(hash));
         Ok(Some(hash))
-    }
-
-    /// Compares tuples lexicographically, including against named tuples.
-    ///
-    /// Equality identifies the shared prefix; the first unequal pair receives
-    /// the original operator and may return any Python value. Lengths decide
-    /// only when every shared element compares equal.
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'h>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
-        if op.is_equality() {
-            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
-        }
-        let other = match other.read_heap(vm) {
-            Some(HeapReadOutput::Tuple(other)) => other,
-            Some(HeapReadOutput::NamedTuple(other)) => {
-                let (a, b) = (self.cloned_items(vm), other.cloned_items(vm));
-                return rich_compare_item_seqs(a, b, op, vm);
-            }
-            _ => return Ok(Value::NotImplemented),
-        };
-
-        let a_len = self.get(vm.heap).items.len();
-        let b_len = other.get(vm.heap).items.len();
-        let min_len = a_len.min(b_len);
-        let iter = self.iter(vm)?;
-        defer_drop_mut!(iter, vm);
-        while let Some((i, av)) = iter.next_with_index(vm)? {
-            if i >= min_len {
-                break;
-            }
-            let bv = other.clone_item(i, vm);
-            defer_drop!(bv, vm);
-            if !av.py_lex_eq(bv, vm)? {
-                return av.py_rich_compare(bv, op, vm);
-            }
-        }
-        Ok(Value::Bool(op.holds(a_len.cmp(&b_len))))
     }
 
     fn py_add_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
@@ -674,10 +677,6 @@ impl<'h> PyTrait<'h> for HeapRead<'h, TupleIterator> {
 
     fn py_len(&self, _: &VM<'h>) -> Option<usize> {
         None
-    }
-
-    fn py_eq_impl(&self, _: &Value, _: &mut VM<'h>) -> RunResult<Option<bool>> {
-        Ok(None)
     }
 
     fn py_iter(&self, self_id: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Value> {

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -1,6 +1,5 @@
 use std::{
     cell::Cell,
-    cmp::Ordering,
     collections::hash_map::DefaultHasher,
     fmt::Write,
     hash::{Hash, Hasher},
@@ -26,7 +25,7 @@ use std::{
 use monty_types::ResourceError;
 use smallvec::SmallVec;
 
-use super::{CmpOrder, PyTrait, iter::collect_owned_iterable};
+use super::{PyTrait, RichCmpOp, iter::collect_owned_iterable};
 use crate::{
     args::ArgValues,
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
@@ -40,6 +39,7 @@ use crate::{
         LazyHeapSet, Type,
         list::repr_sequence_fmt,
         long_int::repeat_count,
+        namedtuple::rich_compare_item_seqs,
         slice::{normalize_sequence_index, slice_collect_iterator},
     },
     value::{EitherStr, Value},
@@ -179,7 +179,7 @@ impl<'h> HeapRead<'h, Tuple> {
 
     /// Clones all items from this tuple with proper refcount management.
     /// Clones every item into a plain `Vec`, for the namedtuple orderings in
-    /// [`cmp_item_seqs`](crate::types::namedtuple::cmp_item_seqs).
+    /// [`rich_compare_item_seqs`](crate::types::namedtuple::rich_compare_item_seqs).
     pub(crate) fn cloned_items(&self, vm: &mut VM<'h>) -> Vec<Value> {
         self.clone_all_items(vm).into_vec()
     }
@@ -390,19 +390,30 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         Ok(Some(hash))
     }
 
-    /// Lexicographic comparison for tuples.
+    /// Compares tuples lexicographically, including against named tuples.
     ///
-    /// Compares element-by-element left-to-right. The first non-equal pair
-    /// determines the result. If all compared elements are equal, the shorter
-    /// tuple is considered less than the longer one — matching Python semantics:
-    /// `(1, 2) < (1, 2, 3)` is `True`.
-    ///
-    /// The result of the first differing pair propagates directly: a `NaN`
-    /// element yields [`CmpOrder::Unordered`] (`(nan,) < (1,)` is `False`, not a
-    /// `TypeError`), while a type-mismatched element yields
-    /// [`CmpOrder::Incomparable`] (`(1,) < ('a',)` raises) — this element-level
-    /// distinction is exactly why [`CmpOrder`] exists.
-    fn py_cmp(&self, other: &Self, vm: &mut VM<'h>) -> RunResult<CmpOrder> {
+    /// Equality identifies the shared prefix; the first unequal pair receives
+    /// the original operator and may return any Python value. Lengths decide
+    /// only when every shared element compares equal.
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'h>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            return Ok(op.equality_result(self.py_eq_impl(other, vm)?));
+        }
+        let other = match other.read_heap(vm) {
+            Some(HeapReadOutput::Tuple(other)) => other,
+            Some(HeapReadOutput::NamedTuple(other)) => {
+                let (a, b) = (self.cloned_items(vm), other.cloned_items(vm));
+                return rich_compare_item_seqs(a, b, op, vm);
+            }
+            _ => return Ok(Value::NotImplemented),
+        };
+
         let a_len = self.get(vm.heap).items.len();
         let b_len = other.get(vm.heap).items.len();
         let min_len = a_len.min(b_len);
@@ -410,32 +421,15 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         defer_drop_mut!(iter, vm);
         while let Some((i, av)) = iter.next_with_index(vm)? {
             if i >= min_len {
-                // `self` was longer than `other`; remaining items don't
-                // participate in element-wise comparison.
                 break;
             }
             let bv = other.clone_item(i, vm);
             defer_drop!(bv, vm);
-            match av.py_cmp(bv, vm)? {
-                CmpOrder::Ordered(Ordering::Equal) => {}
-                CmpOrder::Ordered(ord) => return Ok(CmpOrder::Ordered(ord)),
-                // A `NaN` element: elements are never `==`-equal to a `NaN`, so
-                // this is the first differing pair and the tuple is unordered.
-                CmpOrder::Unordered => return Ok(CmpOrder::Unordered),
-                CmpOrder::Incomparable => {
-                    // The elements don't support ordering. CPython checks
-                    // `__eq__` first and only calls `__lt__` for non-equal
-                    // pairs, so equal-but-unorderable elements (e.g.
-                    // `None == None`) are treated as equal and don't block the
-                    // comparison; a genuinely differing pair makes the tuple
-                    // incomparable.
-                    if !av.py_eq(bv, vm)? {
-                        return Ok(CmpOrder::Incomparable);
-                    }
-                }
+            if !av.py_lex_eq(bv, vm)? {
+                return av.py_rich_compare(bv, op, vm);
             }
         }
-        Ok(CmpOrder::Ordered(a_len.cmp(&b_len)))
+        Ok(Value::Bool(op.holds(a_len.cmp(&b_len))))
     }
 
     fn py_add_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -23,9 +23,10 @@ use crate::{
     modules::ModuleFunctions,
     resource_checks::check_pow_size,
     types::{
-        Bytes, BytesIterator, LazyHeapSet, LongInt, Property, PyTrait, RichCmpOp, StringIterator, Type,
+        Bytes, BytesIterator, LazyHeapSet, LongInt, Property, PyTrait, RichCmpOp, RichCmpVtable, StringIterator, Type,
         bytes::{bytes_contains, bytes_repr_fmt, concat_bytes, get_byte_at_index, repeat_bytes},
-        instance::{instance_dataclass_eq, instance_getattr, instance_repr_fmt, instance_str, instance_user_eq},
+        instance::{instance_getattr, instance_repr_fmt, instance_str},
+        invoke_rich_cmp_slot,
         long_int::{
             bigint_cmp_f64, bigint_cmp_i64, bigint_eq_f64, bigint_eq_i64, check_bits_str_digits_limit, i64_cmp_f64,
             repeat_count, wide_i128_into_value,
@@ -232,110 +233,17 @@ impl From<bool> for Value {
     }
 }
 
-impl<'h> PyTrait<'h> for Value {
-    fn py_type(&self, vm: &VM<'_>) -> Type {
-        match self {
-            Self::Undefined => panic!("Cannot get type of undefined value"),
-            Self::Ellipsis => Type::Ellipsis,
-            Self::NotImplemented => Type::NotImplementedType,
-            Self::None => Type::NoneType,
-            Self::Bool(_) => Type::Bool,
-            Self::Int(_) | Self::InternLongInt(_) => Type::Int,
-            Self::Float(_) => Type::Float,
-            Self::InternString(_) => Type::Str,
-            Self::InternBytes(_) => Type::Bytes,
-            Self::Builtin(c) => c.py_type(),
-            Self::ModuleFunction(_) => Type::BuiltinFunction,
-            Self::DefFunction(_) => Type::Function,
-            Self::Marker(m) => m.py_type(),
-            Self::Property(_) => Type::Property,
-            Self::Ref(id) => vm.heap.read(*id).py_type(vm),
-            #[cfg(feature = "memory-model-checks")]
-            Self::Dereferenced => panic!("Cannot access Dereferenced object"),
+impl Value {
+    /// Compares immediate values and delegates heap values through their slot tables.
+    fn rich_compare(&self, other: &Self, op: RichCmpOp, vm: &mut VM<'_>, _self_id: Option<HeapId>) -> RunResult<Self> {
+        if let Self::Ref(id) = self {
+            return invoke_rich_cmp_slot(&vm.heap.read(*id), other, op, vm, Some(*id));
         }
-    }
-
-    fn py_len(&self, vm: &VM<'_>) -> Option<usize> {
-        match self {
-            // Count Unicode characters, not bytes, to match Python semantics
-            Self::InternString(string_id) => Some(vm.interns.get_str(*string_id).chars().count()),
-            Self::InternBytes(bytes_id) => Some(vm.interns.get_bytes(*bytes_id).len()),
-            Self::Ref(id) => vm.heap.read(*id).py_len(vm),
-            _ => None,
-        }
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'_>) -> RunResult<Option<bool>> {
-        match self {
-            // `Undefined` is a sentinel and is never equal to anything.
-            Self::Undefined => Ok(Some(false)),
-
-            Self::None => Ok(matches!(other, Self::None).then_some(true)),
-            Self::Ellipsis => Ok(matches!(other, Self::Ellipsis).then_some(true)),
-            Self::NotImplemented => Ok(matches!(other, Self::NotImplemented).then_some(true)),
-            Self::Bool(b) => Ok(eq_i64(i64::from(*b), other, vm)),
-            Self::Int(a) => Ok(eq_i64(*a, other, vm)),
-            Self::Float(f) => Ok(eq_f64(*f, other, vm)),
-            // `InternLongInt` is normally materialised to a heap `LongInt` before
-            // it can be compared, but handle it directly so equality never
-            // silently diverges if one reaches here.
-            Self::InternLongInt(id) => Ok(eq_bigint(vm.interns.get_long_int(*id), other, vm)),
-            Self::InternString(id) => Ok(match other {
-                // Interned strings are deduplicated, so equal ids ⇔ equal content.
-                Self::InternString(o) => Some(id == o),
-                _ => eq_str(vm.interns.get_str(*id), other, vm),
-            }),
-            Self::InternBytes(id) => Ok(match other {
-                // Fast path for the same interned bytes; otherwise compare content
-                // (interned bytes are not deduplicated, unlike strings).
-                Self::InternBytes(o) if id == o => Some(true),
-                _ => eq_bytes(vm.interns.get_bytes(*id), other, vm),
-            }),
-            Self::Builtin(b) => Ok(match other {
-                Self::Builtin(o) => Some(b == o),
-                _ => None,
-            }),
-            Self::ModuleFunction(mf) => Ok(match other {
-                Self::ModuleFunction(o) => Some(mf == o),
-                _ => None,
-            }),
-            Self::DefFunction(f) => Ok(match other {
-                Self::DefFunction(o) => Some(f == o),
-                _ => None,
-            }),
-            Self::Marker(m) => Ok(match other {
-                Self::Marker(o) => Some(m == o),
-                _ => None,
-            }),
-            Self::Property(p) => Ok(match other {
-                Self::Property(o) => Some(p == o),
-                _ => None,
-            }),
-            Self::Ref(id) => vm.heap.read(*id).py_eq_impl(other, vm),
-            #[cfg(feature = "memory-model-checks")]
-            Self::Dereferenced => panic!("Cannot access Dereferenced object"),
-        }
-    }
-
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'_>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
         if op.is_equality() {
-            let result = self.py_rich_eq_one_side(other, vm)?;
-            if op == RichCmpOp::Eq || result.is_not_implemented() {
-                return Ok(result);
-            }
-            defer_drop!(result, vm);
-            return Ok(Self::Bool(!result.py_bool(vm)?));
+            return Ok(op.equality_result(self.eq_bool(other, vm)));
         }
 
         let interns = vm.interns;
-        // Immediate representations compare here; heap-backed left operands
-        // delegate to their concrete `PyTrait` implementation below.
         let ordering = match (self, other) {
             (Self::Int(lhs), Self::Int(rhs)) => Some(lhs.cmp(rhs)),
             (Self::Float(lhs), Self::Float(rhs)) => {
@@ -343,7 +251,6 @@ impl<'h> PyTrait<'h> for Value {
                     lhs.partial_cmp(rhs).is_some_and(|ordering| op.holds(ordering)),
                 ));
             }
-            // Int/float ordering is exact (no rounding of either operand).
             (Self::Int(lhs), Self::Float(rhs)) => {
                 return Ok(Self::Bool(
                     i64_cmp_f64(*lhs, *rhs).is_some_and(|ordering| op.holds(ordering)),
@@ -375,13 +282,11 @@ impl<'h> PyTrait<'h> for Value {
             (Self::InternLongInt(lhs), Self::InternLongInt(rhs)) => {
                 Some(interns.get_long_int(*lhs).cmp(interns.get_long_int(*rhs)))
             }
-            // Bool promotion is bounded to two calls: Bool becomes Int, which
-            // either matches an immediate arm or delegates to a heap type.
             (Self::Bool(lhs), _) => {
-                return Self::Int(i64::from(*lhs)).py_rich_compare_impl(other, op, vm, None);
+                return Self::Int(i64::from(*lhs)).rich_compare(other, op, vm, None);
             }
             (_, Self::Bool(rhs)) => {
-                return self.py_rich_compare_impl(&Self::Int(i64::from(*rhs)), op, vm, None);
+                return self.rich_compare(&Self::Int(i64::from(*rhs)), op, vm, None);
             }
             (Self::Int(lhs), Self::Ref(id)) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => {
                 Some(bigint_cmp_i64(rhs.inner(), *lhs).reverse())
@@ -408,13 +313,93 @@ impl<'h> PyTrait<'h> for Value {
             (Self::InternBytes(lhs), Self::Ref(id)) if let HeapData::Bytes(rhs) = vm.heap.get(*id) => {
                 Some(interns.get_bytes(*lhs).cmp(rhs.as_slice()))
             }
-            (Self::Ref(id), _) => return vm.heap.read(*id).py_rich_compare_impl(other, op, vm, Some(*id)),
             _ => None,
         };
         Ok(match ordering {
             Some(ordering) => Self::Bool(op.holds(ordering)),
             None => Self::NotImplemented,
         })
+    }
+
+    /// Implements equality for immediate representations without protocol dispatch.
+    fn eq_bool(&self, other: &Self, vm: &VM<'_>) -> Option<bool> {
+        match self {
+            Self::Undefined => Some(false),
+            Self::None => matches!(other, Self::None).then_some(true),
+            Self::Ellipsis => matches!(other, Self::Ellipsis).then_some(true),
+            Self::NotImplemented => matches!(other, Self::NotImplemented).then_some(true),
+            Self::Bool(value) => eq_i64(i64::from(*value), other, vm),
+            Self::Int(value) => eq_i64(*value, other, vm),
+            Self::Float(value) => eq_f64(*value, other, vm),
+            Self::InternLongInt(id) => eq_bigint(vm.interns.get_long_int(*id), other, vm),
+            Self::InternString(id) => match other {
+                Self::InternString(other_id) => Some(id == other_id),
+                _ => eq_str(vm.interns.get_str(*id), other, vm),
+            },
+            Self::InternBytes(id) => match other {
+                Self::InternBytes(other_id) if id == other_id => Some(true),
+                _ => eq_bytes(vm.interns.get_bytes(*id), other, vm),
+            },
+            Self::Builtin(value) => match other {
+                Self::Builtin(other_value) => Some(value == other_value),
+                _ => None,
+            },
+            Self::ModuleFunction(value) => match other {
+                Self::ModuleFunction(other_value) => Some(value == other_value),
+                _ => None,
+            },
+            Self::DefFunction(value) => match other {
+                Self::DefFunction(other_value) => Some(value == other_value),
+                _ => None,
+            },
+            Self::Marker(value) => match other {
+                Self::Marker(other_value) => Some(value == other_value),
+                _ => None,
+            },
+            Self::Property(value) => match other {
+                Self::Property(other_value) => Some(value == other_value),
+                _ => None,
+            },
+            Self::Ref(_) => unreachable!("heap values delegate before immediate equality"),
+            #[cfg(feature = "memory-model-checks")]
+            Self::Dereferenced => panic!("Cannot access Dereferenced object"),
+        }
+    }
+}
+
+impl<'h> PyTrait<'h> for Value {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
+    fn py_type(&self, vm: &VM<'_>) -> Type {
+        match self {
+            Self::Undefined => panic!("Cannot get type of undefined value"),
+            Self::Ellipsis => Type::Ellipsis,
+            Self::NotImplemented => Type::NotImplementedType,
+            Self::None => Type::NoneType,
+            Self::Bool(_) => Type::Bool,
+            Self::Int(_) | Self::InternLongInt(_) => Type::Int,
+            Self::Float(_) => Type::Float,
+            Self::InternString(_) => Type::Str,
+            Self::InternBytes(_) => Type::Bytes,
+            Self::Builtin(c) => c.py_type(),
+            Self::ModuleFunction(_) => Type::BuiltinFunction,
+            Self::DefFunction(_) => Type::Function,
+            Self::Marker(m) => m.py_type(),
+            Self::Property(_) => Type::Property,
+            Self::Ref(id) => vm.heap.read(*id).py_type(vm),
+            #[cfg(feature = "memory-model-checks")]
+            Self::Dereferenced => panic!("Cannot access Dereferenced object"),
+        }
+    }
+
+    fn py_len(&self, vm: &VM<'_>) -> Option<usize> {
+        match self {
+            // Count Unicode characters, not bytes, to match Python semantics
+            Self::InternString(string_id) => Some(vm.interns.get_str(*string_id).chars().count()),
+            Self::InternBytes(bytes_id) => Some(vm.interns.get_bytes(*bytes_id).len()),
+            Self::Ref(id) => vm.heap.read(*id).py_len(vm),
+            _ => None,
+        }
     }
 
     fn py_bool(&self, vm: &mut VM<'_>) -> RunResult<bool> {
@@ -1519,12 +1504,12 @@ impl Value {
     /// The left operand is tried first, followed by the reflected operation on
     /// the right. Equality falls back to identity; unsupported ordering raises.
     pub(crate) fn py_rich_compare(&self, other: &Self, op: RichCmpOp, vm: &mut VM<'_>) -> RunResult<Self> {
-        let lhs_result = self.py_rich_compare_impl(other, op, vm, self.ref_id())?;
+        let lhs_result = invoke_rich_cmp_slot(self, other, op, vm, self.ref_id())?;
         if !lhs_result.is_not_implemented() {
             return Ok(lhs_result);
         }
 
-        let rhs_result = other.py_rich_compare_impl(self, op.reflected(), vm, other.ref_id())?;
+        let rhs_result = invoke_rich_cmp_slot(other, self, op.reflected(), vm, other.ref_id())?;
         if !rhs_result.is_not_implemented() {
             return Ok(rhs_result);
         }
@@ -1545,27 +1530,6 @@ impl Value {
         let result = self.py_rich_compare(other, op, vm)?;
         defer_drop!(result, vm);
         result.py_bool(vm)
-    }
-
-    /// Runs one side of rich equality, preserving arbitrary user results.
-    fn py_rich_eq_one_side(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Self> {
-        if let Self::Ref(id) = self
-            && matches!(vm.heap.get(*id), HeapData::Instance(_))
-        {
-            if let Some(result) = instance_user_eq(*id, other, vm)? {
-                Ok(result)
-            } else if self.is(other) {
-                Ok(Self::Bool(true))
-            } else if let Some(result) = instance_dataclass_eq(*id, other, vm)? {
-                Ok(Self::Bool(result))
-            } else {
-                Ok(Self::NotImplemented)
-            }
-        } else if let Some(result) = self.py_eq_impl(other, vm)? {
-            Ok(Self::Bool(result))
-        } else {
-            Ok(Self::NotImplemented)
-        }
     }
 
     /// Returns an iterator for this value using its type-specific protocol when available.
@@ -1602,7 +1566,7 @@ impl Value {
     /// Reads the heap entry this value references, or `None` if it is not a
     /// heap reference.
     ///
-    /// Used by per-type [`PyTrait::py_eq_impl`] impls to resolve the other operand
+    /// Used by per-type rich-comparison callbacks to resolve the other operand
     /// to a heap object of their own type, returning `NotImplemented` otherwise.
     pub(crate) fn read_heap<'a>(&self, vm: &VM<'a>) -> Option<HeapReadOutput<'a>> {
         match self {
@@ -2198,8 +2162,8 @@ impl Value {
 // or a heap object) against an arbitrary `other: &Value`, resolving `other`'s
 // representation as needed. They return `None` (NotImplemented) when `other`
 // is not a compatible Python type, so the reflected comparison can run. These
-// are shared by `Value::py_eq_impl` (inline operands) and
-// `HeapReadOutput::py_eq_impl` (heap operands) so the interned-vs-heap and
+// are shared by immediate and heap rich-comparison callbacks so the
+// interned-vs-heap and
 // numeric-tower logic lives once.
 // ---------------------------------------------------------------------------
 

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -14,7 +14,6 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
-    expressions::CmpOperator,
     fstring::FormatFloat,
     hash::{HashValue, hash_one, hash_python_long_int},
     heap::{ContainsHeap, DropWithContext, Heap, HeapData, HeapId, HeapReadOutput},
@@ -24,14 +23,13 @@ use crate::{
     modules::ModuleFunctions,
     resource_checks::check_pow_size,
     types::{
-        Bytes, BytesIterator, CmpOrder, LazyHeapSet, LongInt, Property, PyTrait, StringIterator, Type,
+        Bytes, BytesIterator, LazyHeapSet, LongInt, Property, PyTrait, RichCmpOp, StringIterator, Type,
         bytes::{bytes_contains, bytes_repr_fmt, concat_bytes, get_byte_at_index, repeat_bytes},
         instance::{instance_dataclass_eq, instance_getattr, instance_repr_fmt, instance_str, instance_user_eq},
         long_int::{
             bigint_cmp_f64, bigint_cmp_i64, bigint_eq_f64, bigint_eq_i64, check_bits_str_digits_limit, i64_cmp_f64,
             repeat_count, wide_i128_into_value,
         },
-        namedtuple::cmp_item_seqs,
         slice::slice_collect_iterator,
         str::{
             allocate_char, allocate_string, concat_allocate_str, get_char_at_index, repeat_str, str_contains,
@@ -319,115 +317,104 @@ impl<'h> PyTrait<'h> for Value {
         }
     }
 
-    fn py_cmp(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<CmpOrder> {
-        let interns = vm.interns;
-        // py_cmp handles numbers, strings, bytes, tuples, and lists.
-        // Recursion depth tracking for tuples/lists is handled by their iterators.
-        //
-        // `from_numeric` maps a `None` from a numeric helper to
-        // `CmpOrder::Unordered` (only `NaN` yields `None` there), while
-        // `from_total` maps `None` from a total-order comparison to
-        // `CmpOrder::Incomparable`. Any operand pair with no comparison at all
-        // falls through to the `Incomparable` catch-alls below.
-        match (self, other) {
-            (Self::Int(s), Self::Int(o)) => Ok(CmpOrder::Ordered(s.cmp(o))),
-            (Self::Float(s), Self::Float(o)) => Ok(CmpOrder::from_numeric(s.partial_cmp(o))),
-            // Int/float ordering is exact (no rounding of either operand).
-            (Self::Int(s), Self::Float(o)) => Ok(CmpOrder::from_numeric(i64_cmp_f64(*s, *o))),
-            (Self::Float(s), Self::Int(o)) => Ok(CmpOrder::from_numeric(i64_cmp_f64(*o, *s).map(Ordering::reverse))),
-            (Self::Int(a), Self::InternLongInt(b)) => Ok(CmpOrder::Ordered(
-                bigint_cmp_i64(interns.get_long_int(*b), *a).reverse(),
-            )),
-            (Self::InternLongInt(a), Self::Int(b)) => {
-                Ok(CmpOrder::Ordered(bigint_cmp_i64(interns.get_long_int(*a), *b)))
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'_>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            let result = self.py_rich_eq_one_side(other, vm)?;
+            if op == RichCmpOp::Eq || result.is_not_implemented() {
+                return Ok(result);
             }
-            (Self::Float(a), Self::InternLongInt(b)) => Ok(CmpOrder::from_numeric(
-                bigint_cmp_f64(interns.get_long_int(*b), *a).map(Ordering::reverse),
-            )),
-            (Self::InternLongInt(a), Self::Float(b)) => {
-                Ok(CmpOrder::from_numeric(bigint_cmp_f64(interns.get_long_int(*a), *b)))
-            }
-            (Self::InternLongInt(a), Self::InternLongInt(b)) => Ok(CmpOrder::Ordered(
-                interns.get_long_int(*a).cmp(interns.get_long_int(*b)),
-            )),
-            // Bool promotion: convert to Int and re-dispatch. Recursion is bounded
-            // to at most 2 levels (Bool→Int, then Int matches directly above).
-            (Self::Bool(s), _) => Self::Int(i64::from(*s)).py_cmp(other, vm),
-            (_, Self::Bool(s)) => self.py_cmp(&Self::Int(i64::from(*s)), vm),
-            // Int vs LongInt comparison
-            (Self::Int(a), Self::Ref(id)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
-                Ok(CmpOrder::Ordered(bigint_cmp_i64(li.inner(), *a).reverse()))
-            }
-            (Self::InternLongInt(a), Self::Ref(id)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
-                Ok(CmpOrder::Ordered(interns.get_long_int(*a).cmp(li.inner())))
-            }
-            // LongInt vs Int comparison
-            (Self::Ref(id), Self::Int(b)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
-                Ok(CmpOrder::Ordered(bigint_cmp_i64(li.inner(), *b)))
-            }
-            (Self::Ref(id), Self::InternLongInt(b)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
-                Ok(CmpOrder::Ordered(li.inner().cmp(interns.get_long_int(*b))))
-            }
-            // Float vs LongInt comparison (exact, no precision loss)
-            (Self::Float(s), Self::Ref(id)) if let HeapData::LongInt(li) = vm.heap.get(*id) => Ok(
-                CmpOrder::from_numeric(bigint_cmp_f64(li.inner(), *s).map(Ordering::reverse)),
-            ),
-            // LongInt vs Float comparison (exact, no precision loss)
-            (Self::Ref(id), Self::Float(o)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
-                Ok(CmpOrder::from_numeric(li.partial_cmp_f64(*o)))
-            }
-            // Ref vs Ref comparison: handles LongInt, Str, Tuple, and List
-            (Self::Ref(id1), Self::Ref(id2)) => match (vm.heap.read(*id1), vm.heap.read(*id2)) {
-                (HeapReadOutput::LongInt(a), HeapReadOutput::LongInt(b)) => {
-                    Ok(CmpOrder::Ordered(a.get(vm.heap).inner().cmp(b.get(vm.heap).inner())))
-                }
-                (HeapReadOutput::Str(a), HeapReadOutput::Str(b)) => {
-                    Ok(CmpOrder::Ordered(a.get(vm.heap).as_str().cmp(b.get(vm.heap).as_str())))
-                }
-                (HeapReadOutput::Tuple(a), HeapReadOutput::Tuple(b)) => a.py_cmp(&b, vm),
-                // A namedtuple orders like the tuple it subclasses, including
-                // against a plain tuple in either direction. Both sides are
-                // cloned first because the comparison needs `&mut VM`, which
-                // cannot coexist with two live `HeapRead`s.
-                (HeapReadOutput::NamedTuple(a), HeapReadOutput::NamedTuple(b)) => {
-                    let (a, b) = (a.cloned_items(vm)?, b.cloned_items(vm)?);
-                    cmp_item_seqs(a, b, vm)
-                }
-                (HeapReadOutput::NamedTuple(a), HeapReadOutput::Tuple(b)) => {
-                    let (a, b) = (a.cloned_items(vm)?, b.cloned_items(vm)?);
-                    cmp_item_seqs(a, b, vm)
-                }
-                (HeapReadOutput::Tuple(a), HeapReadOutput::NamedTuple(b)) => {
-                    let (a, b) = (a.cloned_items(vm)?, b.cloned_items(vm)?);
-                    cmp_item_seqs(a, b, vm)
-                }
-                (HeapReadOutput::List(a), HeapReadOutput::List(b)) => a.py_cmp(&b, vm),
-                (HeapReadOutput::Deque(a), HeapReadOutput::Deque(b)) => a.py_cmp(&b, vm),
-                (HeapReadOutput::Date(a), HeapReadOutput::Date(b)) => {
-                    Ok(CmpOrder::from_total(a.get(vm.heap).partial_cmp(b.get(vm.heap))))
-                }
-                (HeapReadOutput::DateTime(a), HeapReadOutput::DateTime(b)) => a.py_cmp(&b, vm),
-                (HeapReadOutput::TimeDelta(a), HeapReadOutput::TimeDelta(b)) => {
-                    Ok(CmpOrder::from_total(a.get(vm.heap).partial_cmp(b.get(vm.heap))))
-                }
-                _ => Ok(CmpOrder::Incomparable),
-            },
-            // Interned string comparisons
-            (Self::InternString(s1), Self::InternString(s2)) => {
-                Ok(CmpOrder::Ordered(interns.get_str(*s1).cmp(interns.get_str(*s2))))
-            }
-            // Cross-type string comparisons: interned vs heap-allocated
-            (Self::InternString(s1), Self::Ref(id2)) if let HeapData::Str(s2) = vm.heap.get(*id2) => {
-                Ok(CmpOrder::Ordered(interns.get_str(*s1).cmp(s2.as_str())))
-            }
-            (Self::Ref(id1), Self::InternString(s2)) if let HeapData::Str(s1) = vm.heap.get(*id1) => {
-                Ok(CmpOrder::Ordered(s1.as_str().cmp(interns.get_str(*s2))))
-            }
-            (Self::InternBytes(b1), Self::InternBytes(b2)) => {
-                Ok(CmpOrder::Ordered(interns.get_bytes(*b1).cmp(interns.get_bytes(*b2))))
-            }
-            _ => Ok(CmpOrder::Incomparable),
+            defer_drop!(result, vm);
+            return Ok(Self::Bool(!result.py_bool(vm)?));
         }
+
+        let interns = vm.interns;
+        // Immediate representations compare here; heap-backed left operands
+        // delegate to their concrete `PyTrait` implementation below.
+        let ordering = match (self, other) {
+            (Self::Int(lhs), Self::Int(rhs)) => Some(lhs.cmp(rhs)),
+            (Self::Float(lhs), Self::Float(rhs)) => {
+                return Ok(Self::Bool(
+                    lhs.partial_cmp(rhs).is_some_and(|ordering| op.holds(ordering)),
+                ));
+            }
+            // Int/float ordering is exact (no rounding of either operand).
+            (Self::Int(lhs), Self::Float(rhs)) => {
+                return Ok(Self::Bool(
+                    i64_cmp_f64(*lhs, *rhs).is_some_and(|ordering| op.holds(ordering)),
+                ));
+            }
+            (Self::Float(lhs), Self::Int(rhs)) => {
+                return Ok(Self::Bool(
+                    i64_cmp_f64(*rhs, *lhs)
+                        .map(Ordering::reverse)
+                        .is_some_and(|ordering| op.holds(ordering)),
+                ));
+            }
+            (Self::Int(lhs), Self::InternLongInt(rhs)) => {
+                Some(bigint_cmp_i64(interns.get_long_int(*rhs), *lhs).reverse())
+            }
+            (Self::InternLongInt(lhs), Self::Int(rhs)) => Some(bigint_cmp_i64(interns.get_long_int(*lhs), *rhs)),
+            (Self::Float(lhs), Self::InternLongInt(rhs)) => {
+                return Ok(Self::Bool(
+                    bigint_cmp_f64(interns.get_long_int(*rhs), *lhs)
+                        .map(Ordering::reverse)
+                        .is_some_and(|ordering| op.holds(ordering)),
+                ));
+            }
+            (Self::InternLongInt(lhs), Self::Float(rhs)) => {
+                return Ok(Self::Bool(
+                    bigint_cmp_f64(interns.get_long_int(*lhs), *rhs).is_some_and(|ordering| op.holds(ordering)),
+                ));
+            }
+            (Self::InternLongInt(lhs), Self::InternLongInt(rhs)) => {
+                Some(interns.get_long_int(*lhs).cmp(interns.get_long_int(*rhs)))
+            }
+            // Bool promotion is bounded to two calls: Bool becomes Int, which
+            // either matches an immediate arm or delegates to a heap type.
+            (Self::Bool(lhs), _) => {
+                return Self::Int(i64::from(*lhs)).py_rich_compare_impl(other, op, vm, None);
+            }
+            (_, Self::Bool(rhs)) => {
+                return self.py_rich_compare_impl(&Self::Int(i64::from(*rhs)), op, vm, None);
+            }
+            (Self::Int(lhs), Self::Ref(id)) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => {
+                Some(bigint_cmp_i64(rhs.inner(), *lhs).reverse())
+            }
+            (Self::InternLongInt(lhs), Self::Ref(id)) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => {
+                Some(interns.get_long_int(*lhs).cmp(rhs.inner()))
+            }
+            (Self::Float(lhs), Self::Ref(id)) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => {
+                return Ok(Self::Bool(
+                    bigint_cmp_f64(rhs.inner(), *lhs)
+                        .map(Ordering::reverse)
+                        .is_some_and(|ordering| op.holds(ordering)),
+                ));
+            }
+            (Self::InternString(lhs), Self::InternString(rhs)) => {
+                Some(interns.get_str(*lhs).cmp(interns.get_str(*rhs)))
+            }
+            (Self::InternString(lhs), Self::Ref(id)) if let HeapData::Str(rhs) = vm.heap.get(*id) => {
+                Some(interns.get_str(*lhs).cmp(rhs.as_str()))
+            }
+            (Self::InternBytes(lhs), Self::InternBytes(rhs)) => {
+                Some(interns.get_bytes(*lhs).cmp(interns.get_bytes(*rhs)))
+            }
+            (Self::InternBytes(lhs), Self::Ref(id)) if let HeapData::Bytes(rhs) = vm.heap.get(*id) => {
+                Some(interns.get_bytes(*lhs).cmp(rhs.as_slice()))
+            }
+            (Self::Ref(id), _) => return vm.heap.read(*id).py_rich_compare_impl(other, op, vm, Some(*id)),
+            _ => None,
+        };
+        Ok(match ordering {
+            Some(ordering) => Self::Bool(op.holds(ordering)),
+            None => Self::NotImplemented,
+        })
     }
 
     fn py_bool(&self, vm: &mut VM<'_>) -> RunResult<bool> {
@@ -595,15 +582,7 @@ impl<'h> PyTrait<'h> for Value {
         }
     }
 
-    fn py_cmp_op(&self, other: &Self, op: CmpOperator, vm: &mut VM<'_>) -> RunResult<Option<bool>> {
-        if let Self::Ref(id) = self {
-            vm.heap.read(*id).py_cmp_op(other, op, vm)
-        } else {
-            Ok(None)
-        }
-    }
-
-    fn py_neg_impl(&self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
+    fn py_neg_impl(&self, vm: &mut VM<'_>, _self_id: Option<HeapId>) -> RunResult<Option<Self>> {
         match self {
             // `checked_neg` catches `i64::MIN`, whose negation only fits a LongInt.
             Self::Int(n) => match n.checked_neg() {
@@ -1517,31 +1496,59 @@ impl Value {
 
     /// Python's `==` operator normalized to a boolean.
     pub fn py_eq_operator(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<bool> {
-        let result = self.py_rich_eq(other, vm)?;
-        defer_drop!(result, vm);
-        result.py_bool(vm)
+        self.py_rich_compare_bool(other, RichCmpOp::Eq, vm)
     }
 
-    /// Direct Python `==`, preserving any arbitrary value returned by `__eq__`.
+    /// Equality used to identify the shared prefix of ordered sequences.
     ///
-    /// Tries the left operand, then reflected equality when it returns
-    /// `NotImplemented`; identity is only the final fallback after both decline.
-    pub(crate) fn py_rich_eq(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Self> {
-        let lhs_result = self.py_rich_eq_impl(other, vm)?;
+    /// Heap identity is observable and shortcuts equality as CPython does.
+    /// Immediate values have no allocation identity, so they use direct `==`;
+    /// notably, a `NaN` remains unequal and makes the sequence unordered.
+    pub(crate) fn py_lex_eq(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<bool> {
+        if let (Self::Ref(lhs), Self::Ref(rhs)) = (self, other)
+            && lhs == rhs
+        {
+            Ok(true)
+        } else {
+            self.py_eq_operator(other, vm)
+        }
+    }
+
+    /// Runs Python's reflected rich-comparison protocol.
+    ///
+    /// The left operand is tried first, followed by the reflected operation on
+    /// the right. Equality falls back to identity; unsupported ordering raises.
+    pub(crate) fn py_rich_compare(&self, other: &Self, op: RichCmpOp, vm: &mut VM<'_>) -> RunResult<Self> {
+        let lhs_result = self.py_rich_compare_impl(other, op, vm, self.ref_id())?;
         if !lhs_result.is_not_implemented() {
             return Ok(lhs_result);
         }
 
-        let rhs_result = other.py_rich_eq_impl(self, vm)?;
+        let rhs_result = other.py_rich_compare_impl(self, op.reflected(), vm, other.ref_id())?;
         if !rhs_result.is_not_implemented() {
             return Ok(rhs_result);
         }
 
-        Ok(Self::Bool(self.is(other)))
+        match op {
+            RichCmpOp::Eq => Ok(Self::Bool(self.is(other))),
+            RichCmpOp::Ne => Ok(Self::Bool(!self.is(other))),
+            _ => Err(ExcType::type_error_ordering(
+                op.symbol(),
+                &self.py_type_name(vm),
+                &other.py_type_name(vm),
+            )),
+        }
     }
 
-    /// Runs one side of rich equality, using `NotImplemented` to request reflected dispatch.
-    fn py_rich_eq_impl(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Self> {
+    /// Truth-tests a rich-comparison result without an identity shortcut.
+    pub(crate) fn py_rich_compare_bool(&self, other: &Self, op: RichCmpOp, vm: &mut VM<'_>) -> RunResult<bool> {
+        let result = self.py_rich_compare(other, op, vm)?;
+        defer_drop!(result, vm);
+        result.py_bool(vm)
+    }
+
+    /// Runs one side of rich equality, preserving arbitrary user results.
+    fn py_rich_eq_one_side(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Self> {
         if let Self::Ref(id) = self
             && matches!(vm.heap.get(*id), HeapData::Instance(_))
         {

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -1527,9 +1527,38 @@ impl Value {
 
     /// Truth-tests a rich-comparison result without an identity shortcut.
     pub(crate) fn py_rich_compare_bool(&self, other: &Self, op: RichCmpOp, vm: &mut VM<'_>) -> RunResult<bool> {
+        if let Some(result) = self.rich_compare_bool_fast(other, op) {
+            return Ok(result);
+        }
         let result = self.py_rich_compare(other, op, vm)?;
+        // A native slot answers with a plain `bool`; only a user-defined method
+        // can hand back an object that needs the truth-test protocol.
+        if let Self::Bool(result) = result {
+            return Ok(result);
+        }
         defer_drop!(result, vm);
         result.py_bool(vm)
+    }
+
+    /// Answers the comparisons that dominate sorting without slot dispatch.
+    ///
+    /// `sorted()`, `min()`/`max()` and container equality compare plain `int`s
+    /// (and `float`s) far more often than anything else, and each of those
+    /// comparisons otherwise walks the reflected protocol, builds an
+    /// intermediate [`Value`] and truth-tests it. Both arms below produce
+    /// exactly what [`Self::rich_compare`] would, so the slow path stays the
+    /// single source of truth for everything else.
+    #[inline]
+    fn rich_compare_bool_fast(&self, other: &Self, op: RichCmpOp) -> Option<bool> {
+        match (self, other) {
+            (Self::Int(lhs), Self::Int(rhs)) => Some(op.holds(lhs.cmp(rhs))),
+            // A `NaN` is unordered rather than unequal, so `==`/`!=` keep to the
+            // general path where that distinction is made.
+            (Self::Float(lhs), Self::Float(rhs)) if !op.is_equality() => {
+                Some(lhs.partial_cmp(rhs).is_some_and(|ordering| op.holds(ordering)))
+            }
+            _ => None,
+        }
     }
 
     /// Returns an iterator for this value using its type-specific protocol when available.

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -235,9 +235,9 @@ impl From<bool> for Value {
 
 impl Value {
     /// Compares immediate values and delegates heap values through their slot tables.
-    fn rich_compare(&self, other: &Self, op: RichCmpOp, vm: &mut VM<'_>, _self_id: Option<HeapId>) -> RunResult<Self> {
+    fn rich_compare(&self, other: &Self, op: RichCmpOp, vm: &mut VM<'_>) -> RunResult<Self> {
         if let Self::Ref(id) = self {
-            return invoke_rich_cmp_slot(&vm.heap.read(*id), other, op, vm, Some(*id));
+            return invoke_rich_cmp_slot(&vm.heap.read(*id), other, op, vm);
         }
         if op.is_equality() {
             return Ok(op.equality_result(self.eq_bool(other, vm)));
@@ -283,10 +283,10 @@ impl Value {
                 Some(interns.get_long_int(*lhs).cmp(interns.get_long_int(*rhs)))
             }
             (Self::Bool(lhs), _) => {
-                return Self::Int(i64::from(*lhs)).rich_compare(other, op, vm, None);
+                return Self::Int(i64::from(*lhs)).rich_compare(other, op, vm);
             }
             (_, Self::Bool(rhs)) => {
-                return self.rich_compare(&Self::Int(i64::from(*rhs)), op, vm, None);
+                return self.rich_compare(&Self::Int(i64::from(*rhs)), op, vm);
             }
             (Self::Int(lhs), Self::Ref(id)) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => {
                 Some(bigint_cmp_i64(rhs.inner(), *lhs).reverse())
@@ -567,7 +567,7 @@ impl<'h> PyTrait<'h> for Value {
         }
     }
 
-    fn py_neg_impl(&self, vm: &mut VM<'_>, _self_id: Option<HeapId>) -> RunResult<Option<Self>> {
+    fn py_neg_impl(&self, vm: &mut VM<'_>) -> RunResult<Option<Self>> {
         match self {
             // `checked_neg` catches `i64::MIN`, whose negation only fits a LongInt.
             Self::Int(n) => match n.checked_neg() {
@@ -1504,12 +1504,12 @@ impl Value {
     /// The left operand is tried first, followed by the reflected operation on
     /// the right. Equality falls back to identity; unsupported ordering raises.
     pub(crate) fn py_rich_compare(&self, other: &Self, op: RichCmpOp, vm: &mut VM<'_>) -> RunResult<Self> {
-        let lhs_result = invoke_rich_cmp_slot(self, other, op, vm, self.ref_id())?;
+        let lhs_result = invoke_rich_cmp_slot(self, other, op, vm)?;
         if !lhs_result.is_not_implemented() {
             return Ok(lhs_result);
         }
 
-        let rhs_result = invoke_rich_cmp_slot(other, self, op.reflected(), vm, other.ref_id())?;
+        let rhs_result = invoke_rich_cmp_slot(other, self, op.reflected(), vm)?;
         if !rhs_result.is_not_implemented() {
             return Ok(rhs_result);
         }

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -23,9 +23,10 @@ use crate::{
     modules::ModuleFunctions,
     resource_checks::check_pow_size,
     types::{
-        Bytes, BytesIterator, LazyHeapSet, LongInt, Property, PyTrait, RichCmpOp, StringIterator, Type,
+        Bytes, BytesIterator, LazyHeapSet, LongInt, Property, PyTrait, RichCmpOp, RichCmpVtable, StringIterator, Type,
         bytes::{bytes_contains, bytes_repr_fmt, concat_bytes, get_byte_at_index, repeat_bytes},
-        instance::{instance_dataclass_eq, instance_getattr, instance_repr_fmt, instance_str, instance_user_eq},
+        instance::{instance_getattr, instance_repr_fmt, instance_str},
+        invoke_rich_cmp_slot,
         long_int::{
             bigint_cmp_f64, bigint_cmp_i64, bigint_eq_f64, bigint_eq_i64, check_bits_str_digits_limit, i64_cmp_f64,
             repeat_count, wide_i128_into_value,
@@ -226,110 +227,17 @@ impl From<bool> for Value {
     }
 }
 
-impl<'h> PyTrait<'h> for Value {
-    fn py_type(&self, vm: &VM<'_>) -> Type {
-        match self {
-            Self::Undefined => panic!("Cannot get type of undefined value"),
-            Self::Ellipsis => Type::Ellipsis,
-            Self::NotImplemented => Type::NotImplementedType,
-            Self::None => Type::NoneType,
-            Self::Bool(_) => Type::Bool,
-            Self::Int(_) | Self::InternLongInt(_) => Type::Int,
-            Self::Float(_) => Type::Float,
-            Self::InternString(_) => Type::Str,
-            Self::InternBytes(_) => Type::Bytes,
-            Self::Builtin(c) => c.py_type(),
-            Self::ModuleFunction(_) => Type::BuiltinFunction,
-            Self::DefFunction(_) => Type::Function,
-            Self::Marker(m) => m.py_type(),
-            Self::Property(_) => Type::Property,
-            Self::Ref(id) => vm.heap.read(*id).py_type(vm),
-            #[cfg(feature = "memory-model-checks")]
-            Self::Dereferenced => panic!("Cannot access Dereferenced object"),
+impl Value {
+    /// Compares immediate values and delegates heap values through their slot tables.
+    fn rich_compare(&self, other: &Self, op: RichCmpOp, vm: &mut VM<'_>, _self_id: Option<HeapId>) -> RunResult<Self> {
+        if let Self::Ref(id) = self {
+            return invoke_rich_cmp_slot(&vm.heap.read(*id), other, op, vm, Some(*id));
         }
-    }
-
-    fn py_len(&self, vm: &VM<'_>) -> Option<usize> {
-        match self {
-            // Count Unicode characters, not bytes, to match Python semantics
-            Self::InternString(string_id) => Some(vm.interns.get_str(*string_id).chars().count()),
-            Self::InternBytes(bytes_id) => Some(vm.interns.get_bytes(*bytes_id).len()),
-            Self::Ref(id) => vm.heap.read(*id).py_len(vm),
-            _ => None,
-        }
-    }
-
-    fn py_eq_impl(&self, other: &Value, vm: &mut VM<'_>) -> RunResult<Option<bool>> {
-        match self {
-            // `Undefined` is a sentinel and is never equal to anything.
-            Self::Undefined => Ok(Some(false)),
-
-            Self::None => Ok(matches!(other, Self::None).then_some(true)),
-            Self::Ellipsis => Ok(matches!(other, Self::Ellipsis).then_some(true)),
-            Self::NotImplemented => Ok(matches!(other, Self::NotImplemented).then_some(true)),
-            Self::Bool(b) => Ok(eq_i64(i64::from(*b), other, vm)),
-            Self::Int(a) => Ok(eq_i64(*a, other, vm)),
-            Self::Float(f) => Ok(eq_f64(*f, other, vm)),
-            // `InternLongInt` is normally materialised to a heap `LongInt` before
-            // it can be compared, but handle it directly so equality never
-            // silently diverges if one reaches here.
-            Self::InternLongInt(id) => Ok(eq_bigint(vm.interns.get_long_int(*id), other, vm)),
-            Self::InternString(id) => Ok(match other {
-                // Interned strings are deduplicated, so equal ids ⇔ equal content.
-                Self::InternString(o) => Some(id == o),
-                _ => eq_str(vm.interns.get_str(*id), other, vm),
-            }),
-            Self::InternBytes(id) => Ok(match other {
-                // Fast path for the same interned bytes; otherwise compare content
-                // (interned bytes are not deduplicated, unlike strings).
-                Self::InternBytes(o) if id == o => Some(true),
-                _ => eq_bytes(vm.interns.get_bytes(*id), other, vm),
-            }),
-            Self::Builtin(b) => Ok(match other {
-                Self::Builtin(o) => Some(b == o),
-                _ => None,
-            }),
-            Self::ModuleFunction(mf) => Ok(match other {
-                Self::ModuleFunction(o) => Some(mf == o),
-                _ => None,
-            }),
-            Self::DefFunction(f) => Ok(match other {
-                Self::DefFunction(o) => Some(f == o),
-                _ => None,
-            }),
-            Self::Marker(m) => Ok(match other {
-                Self::Marker(o) => Some(m == o),
-                _ => None,
-            }),
-            Self::Property(p) => Ok(match other {
-                Self::Property(o) => Some(p == o),
-                _ => None,
-            }),
-            Self::Ref(id) => vm.heap.read(*id).py_eq_impl(other, vm),
-            #[cfg(feature = "memory-model-checks")]
-            Self::Dereferenced => panic!("Cannot access Dereferenced object"),
-        }
-    }
-
-    fn py_rich_compare_impl(
-        &self,
-        other: &Value,
-        op: RichCmpOp,
-        vm: &mut VM<'_>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Value> {
         if op.is_equality() {
-            let result = self.py_rich_eq_one_side(other, vm)?;
-            if op == RichCmpOp::Eq || result.is_not_implemented() {
-                return Ok(result);
-            }
-            defer_drop!(result, vm);
-            return Ok(Self::Bool(!result.py_bool(vm)?));
+            return Ok(op.equality_result(self.eq_bool(other, vm)));
         }
 
         let interns = vm.interns;
-        // Immediate representations compare here; heap-backed left operands
-        // delegate to their concrete `PyTrait` implementation below.
         let ordering = match (self, other) {
             (Self::Int(lhs), Self::Int(rhs)) => Some(lhs.cmp(rhs)),
             (Self::Float(lhs), Self::Float(rhs)) => {
@@ -337,7 +245,6 @@ impl<'h> PyTrait<'h> for Value {
                     lhs.partial_cmp(rhs).is_some_and(|ordering| op.holds(ordering)),
                 ));
             }
-            // Int/float ordering is exact (no rounding of either operand).
             (Self::Int(lhs), Self::Float(rhs)) => {
                 return Ok(Self::Bool(
                     i64_cmp_f64(*lhs, *rhs).is_some_and(|ordering| op.holds(ordering)),
@@ -369,13 +276,11 @@ impl<'h> PyTrait<'h> for Value {
             (Self::InternLongInt(lhs), Self::InternLongInt(rhs)) => {
                 Some(interns.get_long_int(*lhs).cmp(interns.get_long_int(*rhs)))
             }
-            // Bool promotion is bounded to two calls: Bool becomes Int, which
-            // either matches an immediate arm or delegates to a heap type.
             (Self::Bool(lhs), _) => {
-                return Self::Int(i64::from(*lhs)).py_rich_compare_impl(other, op, vm, None);
+                return Self::Int(i64::from(*lhs)).rich_compare(other, op, vm, None);
             }
             (_, Self::Bool(rhs)) => {
-                return self.py_rich_compare_impl(&Self::Int(i64::from(*rhs)), op, vm, None);
+                return self.rich_compare(&Self::Int(i64::from(*rhs)), op, vm, None);
             }
             (Self::Int(lhs), Self::Ref(id)) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => {
                 Some(bigint_cmp_i64(rhs.inner(), *lhs).reverse())
@@ -402,13 +307,93 @@ impl<'h> PyTrait<'h> for Value {
             (Self::InternBytes(lhs), Self::Ref(id)) if let HeapData::Bytes(rhs) = vm.heap.get(*id) => {
                 Some(interns.get_bytes(*lhs).cmp(rhs.as_slice()))
             }
-            (Self::Ref(id), _) => return vm.heap.read(*id).py_rich_compare_impl(other, op, vm, Some(*id)),
             _ => None,
         };
         Ok(match ordering {
             Some(ordering) => Self::Bool(op.holds(ordering)),
             None => Self::NotImplemented,
         })
+    }
+
+    /// Implements equality for immediate representations without protocol dispatch.
+    fn eq_bool(&self, other: &Self, vm: &VM<'_>) -> Option<bool> {
+        match self {
+            Self::Undefined => Some(false),
+            Self::None => matches!(other, Self::None).then_some(true),
+            Self::Ellipsis => matches!(other, Self::Ellipsis).then_some(true),
+            Self::NotImplemented => matches!(other, Self::NotImplemented).then_some(true),
+            Self::Bool(value) => eq_i64(i64::from(*value), other, vm),
+            Self::Int(value) => eq_i64(*value, other, vm),
+            Self::Float(value) => eq_f64(*value, other, vm),
+            Self::InternLongInt(id) => eq_bigint(vm.interns.get_long_int(*id), other, vm),
+            Self::InternString(id) => match other {
+                Self::InternString(other_id) => Some(id == other_id),
+                _ => eq_str(vm.interns.get_str(*id), other, vm),
+            },
+            Self::InternBytes(id) => match other {
+                Self::InternBytes(other_id) if id == other_id => Some(true),
+                _ => eq_bytes(vm.interns.get_bytes(*id), other, vm),
+            },
+            Self::Builtin(value) => match other {
+                Self::Builtin(other_value) => Some(value == other_value),
+                _ => None,
+            },
+            Self::ModuleFunction(value) => match other {
+                Self::ModuleFunction(other_value) => Some(value == other_value),
+                _ => None,
+            },
+            Self::DefFunction(value) => match other {
+                Self::DefFunction(other_value) => Some(value == other_value),
+                _ => None,
+            },
+            Self::Marker(value) => match other {
+                Self::Marker(other_value) => Some(value == other_value),
+                _ => None,
+            },
+            Self::Property(value) => match other {
+                Self::Property(other_value) => Some(value == other_value),
+                _ => None,
+            },
+            Self::Ref(_) => unreachable!("heap values delegate before immediate equality"),
+            #[cfg(feature = "memory-model-checks")]
+            Self::Dereferenced => panic!("Cannot access Dereferenced object"),
+        }
+    }
+}
+
+impl<'h> PyTrait<'h> for Value {
+    const RICH_COMPARE: RichCmpVtable<'h, Self> = RichCmpVtable::all(Self::rich_compare);
+
+    fn py_type(&self, vm: &VM<'_>) -> Type {
+        match self {
+            Self::Undefined => panic!("Cannot get type of undefined value"),
+            Self::Ellipsis => Type::Ellipsis,
+            Self::NotImplemented => Type::NotImplementedType,
+            Self::None => Type::NoneType,
+            Self::Bool(_) => Type::Bool,
+            Self::Int(_) | Self::InternLongInt(_) => Type::Int,
+            Self::Float(_) => Type::Float,
+            Self::InternString(_) => Type::Str,
+            Self::InternBytes(_) => Type::Bytes,
+            Self::Builtin(c) => c.py_type(),
+            Self::ModuleFunction(_) => Type::BuiltinFunction,
+            Self::DefFunction(_) => Type::Function,
+            Self::Marker(m) => m.py_type(),
+            Self::Property(_) => Type::Property,
+            Self::Ref(id) => vm.heap.read(*id).py_type(vm),
+            #[cfg(feature = "memory-model-checks")]
+            Self::Dereferenced => panic!("Cannot access Dereferenced object"),
+        }
+    }
+
+    fn py_len(&self, vm: &VM<'_>) -> Option<usize> {
+        match self {
+            // Count Unicode characters, not bytes, to match Python semantics
+            Self::InternString(string_id) => Some(vm.interns.get_str(*string_id).chars().count()),
+            Self::InternBytes(bytes_id) => Some(vm.interns.get_bytes(*bytes_id).len()),
+            Self::Ref(id) => vm.heap.read(*id).py_len(vm),
+            _ => None,
+        }
     }
 
     fn py_bool(&self, vm: &mut VM<'_>) -> RunResult<bool> {
@@ -1513,12 +1498,12 @@ impl Value {
     /// The left operand is tried first, followed by the reflected operation on
     /// the right. Equality falls back to identity; unsupported ordering raises.
     pub(crate) fn py_rich_compare(&self, other: &Self, op: RichCmpOp, vm: &mut VM<'_>) -> RunResult<Self> {
-        let lhs_result = self.py_rich_compare_impl(other, op, vm, self.ref_id())?;
+        let lhs_result = invoke_rich_cmp_slot(self, other, op, vm, self.ref_id())?;
         if !lhs_result.is_not_implemented() {
             return Ok(lhs_result);
         }
 
-        let rhs_result = other.py_rich_compare_impl(self, op.reflected(), vm, other.ref_id())?;
+        let rhs_result = invoke_rich_cmp_slot(other, self, op.reflected(), vm, other.ref_id())?;
         if !rhs_result.is_not_implemented() {
             return Ok(rhs_result);
         }
@@ -1539,27 +1524,6 @@ impl Value {
         let result = self.py_rich_compare(other, op, vm)?;
         defer_drop!(result, vm);
         result.py_bool(vm)
-    }
-
-    /// Runs one side of rich equality, preserving arbitrary user results.
-    fn py_rich_eq_one_side(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Self> {
-        if let Self::Ref(id) = self
-            && matches!(vm.heap.get(*id), HeapData::Instance(_))
-        {
-            if let Some(result) = instance_user_eq(*id, other, vm)? {
-                Ok(result)
-            } else if self.is(other) {
-                Ok(Self::Bool(true))
-            } else if let Some(result) = instance_dataclass_eq(*id, other, vm)? {
-                Ok(Self::Bool(result))
-            } else {
-                Ok(Self::NotImplemented)
-            }
-        } else if let Some(result) = self.py_eq_impl(other, vm)? {
-            Ok(Self::Bool(result))
-        } else {
-            Ok(Self::NotImplemented)
-        }
     }
 
     /// Returns an iterator for this value using its type-specific protocol when available.
@@ -1599,7 +1563,7 @@ impl Value {
     /// Reads the heap entry this value references, or `None` if it is not a
     /// heap reference.
     ///
-    /// Used by per-type [`PyTrait::py_eq_impl`] impls to resolve the other operand
+    /// Used by per-type rich-comparison callbacks to resolve the other operand
     /// to a heap object of their own type, returning `NotImplemented` otherwise.
     pub(crate) fn read_heap<'a>(&self, vm: &VM<'a>) -> Option<HeapReadOutput<'a>> {
         match self {
@@ -2190,8 +2154,8 @@ impl Value {
 // or a heap object) against an arbitrary `other: &Value`, resolving `other`'s
 // representation as needed. They return `None` (NotImplemented) when `other`
 // is not a compatible Python type, so the reflected comparison can run. These
-// are shared by `Value::py_eq_impl` (inline operands) and
-// `HeapReadOutput::py_eq_impl` (heap operands) so the interned-vs-heap and
+// are shared by immediate and heap rich-comparison callbacks so the
+// interned-vs-heap and
 // numeric-tower logic lives once.
 // ---------------------------------------------------------------------------
 

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -14,7 +14,6 @@ use crate::{
     bytecode::{CallResult, VM},
     defer_drop,
     exception_private::{ExcType, ExcTypeExt, RunResult, SimpleException},
-    expressions::CmpOperator,
     fstring::FormatFloat,
     hash::{HashValue, hash_one, hash_python_long_int},
     heap::{ContainsHeap, DropWithContext, Heap, HeapData, HeapId, HeapReadOutput},
@@ -24,14 +23,13 @@ use crate::{
     modules::ModuleFunctions,
     resource_checks::check_pow_size,
     types::{
-        Bytes, BytesIterator, CmpOrder, LazyHeapSet, LongInt, Property, PyTrait, StringIterator, Type,
+        Bytes, BytesIterator, LazyHeapSet, LongInt, Property, PyTrait, RichCmpOp, StringIterator, Type,
         bytes::{bytes_contains, bytes_repr_fmt, concat_bytes, get_byte_at_index, repeat_bytes},
         instance::{instance_dataclass_eq, instance_getattr, instance_repr_fmt, instance_str, instance_user_eq},
         long_int::{
             bigint_cmp_f64, bigint_cmp_i64, bigint_eq_f64, bigint_eq_i64, check_bits_str_digits_limit, i64_cmp_f64,
             repeat_count, wide_i128_into_value,
         },
-        namedtuple::cmp_item_seqs,
         slice::slice_collect_iterator,
         str::{
             allocate_char, allocate_string, concat_allocate_str, get_char_at_index, repeat_str, str_contains,
@@ -313,115 +311,104 @@ impl<'h> PyTrait<'h> for Value {
         }
     }
 
-    fn py_cmp(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<CmpOrder> {
-        let interns = vm.interns;
-        // py_cmp handles numbers, strings, bytes, tuples, and lists.
-        // Recursion depth tracking for tuples/lists is handled by their iterators.
-        //
-        // `from_numeric` maps a `None` from a numeric helper to
-        // `CmpOrder::Unordered` (only `NaN` yields `None` there), while
-        // `from_total` maps `None` from a total-order comparison to
-        // `CmpOrder::Incomparable`. Any operand pair with no comparison at all
-        // falls through to the `Incomparable` catch-alls below.
-        match (self, other) {
-            (Self::Int(s), Self::Int(o)) => Ok(CmpOrder::Ordered(s.cmp(o))),
-            (Self::Float(s), Self::Float(o)) => Ok(CmpOrder::from_numeric(s.partial_cmp(o))),
-            // Int/float ordering is exact (no rounding of either operand).
-            (Self::Int(s), Self::Float(o)) => Ok(CmpOrder::from_numeric(i64_cmp_f64(*s, *o))),
-            (Self::Float(s), Self::Int(o)) => Ok(CmpOrder::from_numeric(i64_cmp_f64(*o, *s).map(Ordering::reverse))),
-            (Self::Int(a), Self::InternLongInt(b)) => Ok(CmpOrder::Ordered(
-                bigint_cmp_i64(interns.get_long_int(*b), *a).reverse(),
-            )),
-            (Self::InternLongInt(a), Self::Int(b)) => {
-                Ok(CmpOrder::Ordered(bigint_cmp_i64(interns.get_long_int(*a), *b)))
+    fn py_rich_compare_impl(
+        &self,
+        other: &Value,
+        op: RichCmpOp,
+        vm: &mut VM<'_>,
+        _self_id: Option<HeapId>,
+    ) -> RunResult<Value> {
+        if op.is_equality() {
+            let result = self.py_rich_eq_one_side(other, vm)?;
+            if op == RichCmpOp::Eq || result.is_not_implemented() {
+                return Ok(result);
             }
-            (Self::Float(a), Self::InternLongInt(b)) => Ok(CmpOrder::from_numeric(
-                bigint_cmp_f64(interns.get_long_int(*b), *a).map(Ordering::reverse),
-            )),
-            (Self::InternLongInt(a), Self::Float(b)) => {
-                Ok(CmpOrder::from_numeric(bigint_cmp_f64(interns.get_long_int(*a), *b)))
-            }
-            (Self::InternLongInt(a), Self::InternLongInt(b)) => Ok(CmpOrder::Ordered(
-                interns.get_long_int(*a).cmp(interns.get_long_int(*b)),
-            )),
-            // Bool promotion: convert to Int and re-dispatch. Recursion is bounded
-            // to at most 2 levels (Bool→Int, then Int matches directly above).
-            (Self::Bool(s), _) => Self::Int(i64::from(*s)).py_cmp(other, vm),
-            (_, Self::Bool(s)) => self.py_cmp(&Self::Int(i64::from(*s)), vm),
-            // Int vs LongInt comparison
-            (Self::Int(a), Self::Ref(id)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
-                Ok(CmpOrder::Ordered(bigint_cmp_i64(li.inner(), *a).reverse()))
-            }
-            (Self::InternLongInt(a), Self::Ref(id)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
-                Ok(CmpOrder::Ordered(interns.get_long_int(*a).cmp(li.inner())))
-            }
-            // LongInt vs Int comparison
-            (Self::Ref(id), Self::Int(b)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
-                Ok(CmpOrder::Ordered(bigint_cmp_i64(li.inner(), *b)))
-            }
-            (Self::Ref(id), Self::InternLongInt(b)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
-                Ok(CmpOrder::Ordered(li.inner().cmp(interns.get_long_int(*b))))
-            }
-            // Float vs LongInt comparison (exact, no precision loss)
-            (Self::Float(s), Self::Ref(id)) if let HeapData::LongInt(li) = vm.heap.get(*id) => Ok(
-                CmpOrder::from_numeric(bigint_cmp_f64(li.inner(), *s).map(Ordering::reverse)),
-            ),
-            // LongInt vs Float comparison (exact, no precision loss)
-            (Self::Ref(id), Self::Float(o)) if let HeapData::LongInt(li) = vm.heap.get(*id) => {
-                Ok(CmpOrder::from_numeric(li.partial_cmp_f64(*o)))
-            }
-            // Ref vs Ref comparison: handles LongInt, Str, Tuple, and List
-            (Self::Ref(id1), Self::Ref(id2)) => match (vm.heap.read(*id1), vm.heap.read(*id2)) {
-                (HeapReadOutput::LongInt(a), HeapReadOutput::LongInt(b)) => {
-                    Ok(CmpOrder::Ordered(a.get(vm.heap).inner().cmp(b.get(vm.heap).inner())))
-                }
-                (HeapReadOutput::Str(a), HeapReadOutput::Str(b)) => {
-                    Ok(CmpOrder::Ordered(a.get(vm.heap).as_str().cmp(b.get(vm.heap).as_str())))
-                }
-                (HeapReadOutput::Tuple(a), HeapReadOutput::Tuple(b)) => a.py_cmp(&b, vm),
-                // A namedtuple orders like the tuple it subclasses, including
-                // against a plain tuple in either direction. Both sides are
-                // cloned first because the comparison needs `&mut VM`, which
-                // cannot coexist with two live `HeapRead`s.
-                (HeapReadOutput::NamedTuple(a), HeapReadOutput::NamedTuple(b)) => {
-                    let (a, b) = (a.cloned_items(vm), b.cloned_items(vm));
-                    cmp_item_seqs(a, b, vm)
-                }
-                (HeapReadOutput::NamedTuple(a), HeapReadOutput::Tuple(b)) => {
-                    let (a, b) = (a.cloned_items(vm), b.cloned_items(vm));
-                    cmp_item_seqs(a, b, vm)
-                }
-                (HeapReadOutput::Tuple(a), HeapReadOutput::NamedTuple(b)) => {
-                    let (a, b) = (a.cloned_items(vm), b.cloned_items(vm));
-                    cmp_item_seqs(a, b, vm)
-                }
-                (HeapReadOutput::List(a), HeapReadOutput::List(b)) => a.py_cmp(&b, vm),
-                (HeapReadOutput::Deque(a), HeapReadOutput::Deque(b)) => a.py_cmp(&b, vm),
-                (HeapReadOutput::Date(a), HeapReadOutput::Date(b)) => {
-                    Ok(CmpOrder::from_total(a.get(vm.heap).partial_cmp(b.get(vm.heap))))
-                }
-                (HeapReadOutput::DateTime(a), HeapReadOutput::DateTime(b)) => a.py_cmp(&b, vm),
-                (HeapReadOutput::TimeDelta(a), HeapReadOutput::TimeDelta(b)) => {
-                    Ok(CmpOrder::from_total(a.get(vm.heap).partial_cmp(b.get(vm.heap))))
-                }
-                _ => Ok(CmpOrder::Incomparable),
-            },
-            // Interned string comparisons
-            (Self::InternString(s1), Self::InternString(s2)) => {
-                Ok(CmpOrder::Ordered(interns.get_str(*s1).cmp(interns.get_str(*s2))))
-            }
-            // Cross-type string comparisons: interned vs heap-allocated
-            (Self::InternString(s1), Self::Ref(id2)) if let HeapData::Str(s2) = vm.heap.get(*id2) => {
-                Ok(CmpOrder::Ordered(interns.get_str(*s1).cmp(s2.as_str())))
-            }
-            (Self::Ref(id1), Self::InternString(s2)) if let HeapData::Str(s1) = vm.heap.get(*id1) => {
-                Ok(CmpOrder::Ordered(s1.as_str().cmp(interns.get_str(*s2))))
-            }
-            (Self::InternBytes(b1), Self::InternBytes(b2)) => {
-                Ok(CmpOrder::Ordered(interns.get_bytes(*b1).cmp(interns.get_bytes(*b2))))
-            }
-            _ => Ok(CmpOrder::Incomparable),
+            defer_drop!(result, vm);
+            return Ok(Self::Bool(!result.py_bool(vm)?));
         }
+
+        let interns = vm.interns;
+        // Immediate representations compare here; heap-backed left operands
+        // delegate to their concrete `PyTrait` implementation below.
+        let ordering = match (self, other) {
+            (Self::Int(lhs), Self::Int(rhs)) => Some(lhs.cmp(rhs)),
+            (Self::Float(lhs), Self::Float(rhs)) => {
+                return Ok(Self::Bool(
+                    lhs.partial_cmp(rhs).is_some_and(|ordering| op.holds(ordering)),
+                ));
+            }
+            // Int/float ordering is exact (no rounding of either operand).
+            (Self::Int(lhs), Self::Float(rhs)) => {
+                return Ok(Self::Bool(
+                    i64_cmp_f64(*lhs, *rhs).is_some_and(|ordering| op.holds(ordering)),
+                ));
+            }
+            (Self::Float(lhs), Self::Int(rhs)) => {
+                return Ok(Self::Bool(
+                    i64_cmp_f64(*rhs, *lhs)
+                        .map(Ordering::reverse)
+                        .is_some_and(|ordering| op.holds(ordering)),
+                ));
+            }
+            (Self::Int(lhs), Self::InternLongInt(rhs)) => {
+                Some(bigint_cmp_i64(interns.get_long_int(*rhs), *lhs).reverse())
+            }
+            (Self::InternLongInt(lhs), Self::Int(rhs)) => Some(bigint_cmp_i64(interns.get_long_int(*lhs), *rhs)),
+            (Self::Float(lhs), Self::InternLongInt(rhs)) => {
+                return Ok(Self::Bool(
+                    bigint_cmp_f64(interns.get_long_int(*rhs), *lhs)
+                        .map(Ordering::reverse)
+                        .is_some_and(|ordering| op.holds(ordering)),
+                ));
+            }
+            (Self::InternLongInt(lhs), Self::Float(rhs)) => {
+                return Ok(Self::Bool(
+                    bigint_cmp_f64(interns.get_long_int(*lhs), *rhs).is_some_and(|ordering| op.holds(ordering)),
+                ));
+            }
+            (Self::InternLongInt(lhs), Self::InternLongInt(rhs)) => {
+                Some(interns.get_long_int(*lhs).cmp(interns.get_long_int(*rhs)))
+            }
+            // Bool promotion is bounded to two calls: Bool becomes Int, which
+            // either matches an immediate arm or delegates to a heap type.
+            (Self::Bool(lhs), _) => {
+                return Self::Int(i64::from(*lhs)).py_rich_compare_impl(other, op, vm, None);
+            }
+            (_, Self::Bool(rhs)) => {
+                return self.py_rich_compare_impl(&Self::Int(i64::from(*rhs)), op, vm, None);
+            }
+            (Self::Int(lhs), Self::Ref(id)) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => {
+                Some(bigint_cmp_i64(rhs.inner(), *lhs).reverse())
+            }
+            (Self::InternLongInt(lhs), Self::Ref(id)) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => {
+                Some(interns.get_long_int(*lhs).cmp(rhs.inner()))
+            }
+            (Self::Float(lhs), Self::Ref(id)) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => {
+                return Ok(Self::Bool(
+                    bigint_cmp_f64(rhs.inner(), *lhs)
+                        .map(Ordering::reverse)
+                        .is_some_and(|ordering| op.holds(ordering)),
+                ));
+            }
+            (Self::InternString(lhs), Self::InternString(rhs)) => {
+                Some(interns.get_str(*lhs).cmp(interns.get_str(*rhs)))
+            }
+            (Self::InternString(lhs), Self::Ref(id)) if let HeapData::Str(rhs) = vm.heap.get(*id) => {
+                Some(interns.get_str(*lhs).cmp(rhs.as_str()))
+            }
+            (Self::InternBytes(lhs), Self::InternBytes(rhs)) => {
+                Some(interns.get_bytes(*lhs).cmp(interns.get_bytes(*rhs)))
+            }
+            (Self::InternBytes(lhs), Self::Ref(id)) if let HeapData::Bytes(rhs) = vm.heap.get(*id) => {
+                Some(interns.get_bytes(*lhs).cmp(rhs.as_slice()))
+            }
+            (Self::Ref(id), _) => return vm.heap.read(*id).py_rich_compare_impl(other, op, vm, Some(*id)),
+            _ => None,
+        };
+        Ok(match ordering {
+            Some(ordering) => Self::Bool(op.holds(ordering)),
+            None => Self::NotImplemented,
+        })
     }
 
     fn py_bool(&self, vm: &mut VM<'_>) -> RunResult<bool> {
@@ -586,20 +573,6 @@ impl<'h> PyTrait<'h> for Value {
             vm.heap.read(*id).py_ior_impl(other, vm, Some(*id))
         } else {
             Ok(false)
-        }
-    }
-
-    fn py_cmp_op(
-        &self,
-        other: &Self,
-        op: CmpOperator,
-        vm: &mut VM<'_>,
-        _self_id: Option<HeapId>,
-    ) -> RunResult<Option<bool>> {
-        if let Self::Ref(id) = self {
-            vm.heap.read(*id).py_cmp_op(other, op, vm, Some(*id))
-        } else {
-            Ok(None)
         }
     }
 
@@ -1517,31 +1490,59 @@ impl Value {
 
     /// Python's `==` operator normalized to a boolean.
     pub fn py_eq_operator(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<bool> {
-        let result = self.py_rich_eq(other, vm)?;
-        defer_drop!(result, vm);
-        result.py_bool(vm)
+        self.py_rich_compare_bool(other, RichCmpOp::Eq, vm)
     }
 
-    /// Direct Python `==`, preserving any arbitrary value returned by `__eq__`.
+    /// Equality used to identify the shared prefix of ordered sequences.
     ///
-    /// Tries the left operand, then reflected equality when it returns
-    /// `NotImplemented`; identity is only the final fallback after both decline.
-    pub(crate) fn py_rich_eq(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Self> {
-        let lhs_result = self.py_rich_eq_impl(other, vm)?;
+    /// Heap identity is observable and shortcuts equality as CPython does.
+    /// Immediate values have no allocation identity, so they use direct `==`;
+    /// notably, a `NaN` remains unequal and makes the sequence unordered.
+    pub(crate) fn py_lex_eq(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<bool> {
+        if let (Self::Ref(lhs), Self::Ref(rhs)) = (self, other)
+            && lhs == rhs
+        {
+            Ok(true)
+        } else {
+            self.py_eq_operator(other, vm)
+        }
+    }
+
+    /// Runs Python's reflected rich-comparison protocol.
+    ///
+    /// The left operand is tried first, followed by the reflected operation on
+    /// the right. Equality falls back to identity; unsupported ordering raises.
+    pub(crate) fn py_rich_compare(&self, other: &Self, op: RichCmpOp, vm: &mut VM<'_>) -> RunResult<Self> {
+        let lhs_result = self.py_rich_compare_impl(other, op, vm, self.ref_id())?;
         if !lhs_result.is_not_implemented() {
             return Ok(lhs_result);
         }
 
-        let rhs_result = other.py_rich_eq_impl(self, vm)?;
+        let rhs_result = other.py_rich_compare_impl(self, op.reflected(), vm, other.ref_id())?;
         if !rhs_result.is_not_implemented() {
             return Ok(rhs_result);
         }
 
-        Ok(Self::Bool(self.is(other)))
+        match op {
+            RichCmpOp::Eq => Ok(Self::Bool(self.is(other))),
+            RichCmpOp::Ne => Ok(Self::Bool(!self.is(other))),
+            _ => Err(ExcType::type_error_ordering(
+                op.symbol(),
+                &self.py_type_name(vm),
+                &other.py_type_name(vm),
+            )),
+        }
     }
 
-    /// Runs one side of rich equality, using `NotImplemented` to request reflected dispatch.
-    fn py_rich_eq_impl(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Self> {
+    /// Truth-tests a rich-comparison result without an identity shortcut.
+    pub(crate) fn py_rich_compare_bool(&self, other: &Self, op: RichCmpOp, vm: &mut VM<'_>) -> RunResult<bool> {
+        let result = self.py_rich_compare(other, op, vm)?;
+        defer_drop!(result, vm);
+        result.py_bool(vm)
+    }
+
+    /// Runs one side of rich equality, preserving arbitrary user results.
+    fn py_rich_eq_one_side(&self, other: &Self, vm: &mut VM<'_>) -> RunResult<Self> {
         if let Self::Ref(id) = self
             && matches!(vm.heap.get(*id), HeapData::Instance(_))
         {

--- a/crates/monty/test_cases/bytes__ops.py
+++ b/crates/monty/test_cases/bytes__ops.py
@@ -85,6 +85,14 @@ assert b'abc' > b'ab'
 assert b'\x00' < b'\xff'
 assert b'\xfe' < b'\xff'
 
+# Literals are interned while bytes() results are heap allocated.
+heap_abc = bytes(b'abc')
+heap_abd = bytes(b'abd')
+assert b'abc' < heap_abd
+assert heap_abc < b'abd'
+assert heap_abc < heap_abd
+assert heap_abc <= b'abc'
+
 # Sorting
 assert sorted([b'c', b'a', b'b']) == [b'a', b'b', b'c']
 assert sorted([b'bb', b'a', b'ba']) == [b'a', b'ba', b'bb']

--- a/crates/monty/test_cases/class__basic.py
+++ b/crates/monty/test_cases/class__basic.py
@@ -183,6 +183,133 @@ self_result_eq = SelfResultEq()
 assert (self_result_eq == 1) is self_result_eq, 'direct equality preserves a self result'
 assert self_result_eq in [1], 'container membership truth-tests a self result'
 
+# === Rich ordering methods ===
+
+
+class OrderedValue:
+    def __init__(self, value):
+        self.value = value
+
+    def __lt__(self, other):
+        if not isinstance(other, OrderedValue):
+            return NotImplemented
+        return self.value < other.value
+
+    def __le__(self, other):
+        if not isinstance(other, OrderedValue):
+            return NotImplemented
+        return self.value <= other.value
+
+    def __gt__(self, other):
+        if not isinstance(other, OrderedValue):
+            return NotImplemented
+        return self.value > other.value
+
+    def __ge__(self, other):
+        if not isinstance(other, OrderedValue):
+            return NotImplemented
+        return self.value >= other.value
+
+
+low = OrderedValue(1)
+high = OrderedValue(2)
+assert (low < high) is True
+assert (low <= high) is True
+assert (high > low) is True
+assert (high >= low) is True
+assert sorted([high, low]) == [low, high]
+assert min(high, low) is low
+assert max(low, high) is high
+
+
+class LeftOrdering:
+    def __lt__(self, other):
+        return NotImplemented
+
+
+class ReflectedOrdering:
+    def __lt__(self, other):
+        return 'reflected lt'
+
+    def __le__(self, other):
+        return 'reflected le'
+
+    def __gt__(self, other):
+        return 'reflected gt'
+
+    def __ge__(self, other):
+        return 'reflected ge'
+
+
+assert (LeftOrdering() < ReflectedOrdering()) == 'reflected gt'
+assert (LeftOrdering() <= ReflectedOrdering()) == 'reflected ge'
+assert (LeftOrdering() > ReflectedOrdering()) == 'reflected lt'
+assert (LeftOrdering() >= ReflectedOrdering()) == 'reflected le'
+assert (1 < ReflectedOrdering()) == 'reflected gt'
+
+
+class MutableReflectedOrdering:
+    def __gt__(self, other):
+        return 'old result'
+
+
+def replacement_gt(self, other):
+    return 'new result'
+
+
+class MutatingLeftOrdering:
+    def __lt__(self, other):
+        setattr(MutableReflectedOrdering, '__gt__', replacement_gt)
+        return NotImplemented
+
+
+assert (MutatingLeftOrdering() < MutableReflectedOrdering()) == 'new result'
+
+
+class DisabledOrdering:
+    __lt__ = None
+
+
+try:
+    DisabledOrdering() < DisabledOrdering()
+    assert False, 'expected a None ordering method to fail'
+except TypeError as exc:
+    assert str(exc) == "'NoneType' object is not callable"
+
+
+class HeapOrderingResult:
+    def __lt__(self, other):
+        return []
+
+
+heap_ordering_result = HeapOrderingResult() < HeapOrderingResult()
+assert heap_ordering_result == []
+assert ([HeapOrderingResult()] < [HeapOrderingResult()]) == []
+
+
+class CustomNe:
+    def __eq__(self, other):
+        return True
+
+    def __ne__(self, other):
+        return 'custom ne'
+
+
+assert (CustomNe() != CustomNe()) == 'custom ne'
+
+
+class DeclinedNe:
+    def __eq__(self, other):
+        return True
+
+    def __ne__(self, other):
+        return NotImplemented
+
+
+declined_ne = DeclinedNe()
+assert (declined_ne != DeclinedNe()) is True
+assert (declined_ne != declined_ne) is False
+
 # === Instances are always truthy ===
 assert bool(p) is True
 if q:

--- a/crates/monty/test_cases/collections__counter.py
+++ b/crates/monty/test_cases/collections__counter.py
@@ -120,6 +120,13 @@ assert (Counter(a=1) < Counter(a=1)) is False, '< is false when equal'
 assert (Counter(a=3) >= Counter(a=1, b=1)) is False, '>= fails on a key present only on the right'
 assert (Counter(a=2) > Counter(a=1)) is True, '> is >= and not equal'
 
+# Sorting and extrema use the same operator-specific partial ordering.
+small_counter = Counter(a=1)
+large_counter = Counter(a=2)
+assert sorted([large_counter, small_counter]) == [small_counter, large_counter]
+assert min(large_counter, small_counter) is small_counter
+assert max(small_counter, large_counter) is large_counter
+
 # === NaN counts follow IEEE: every ordering comparison is false, and NaN != NaN ===
 nan = float('nan')
 assert (Counter(a=nan) <= Counter(a=nan)) is False, 'nan <= nan is false'

--- a/crates/monty/test_cases/compare__mixed_types.py
+++ b/crates/monty/test_cases/compare__mixed_types.py
@@ -224,11 +224,8 @@ assert not ([1, nan] < [1, 2]), 'nan as second element is unordered'
 try:
     [nan] < ['a']
     assert False, 'expected list with float/str element mismatch to raise'
-except TypeError:
-    # Both raise TypeError; only the message text diverges (Monty names the
-    # outer 'list'/'list', CPython the inner 'float'/'str') — see
-    # limitations/language.md, so the exact message is not asserted here.
-    pass
+except TypeError as exc:
+    assert str(exc) == "'<' not supported between instances of 'float' and 'str'"
 
 # === sorted / min / max with NaN do not raise ===
 # NaN compares as neither less nor greater, so it never triggers a swap; CPython

--- a/crates/monty/test_cases/datetime__core.py
+++ b/crates/monty/test_cases/datetime__core.py
@@ -967,7 +967,7 @@ assert repr(aware_rep_result) == 'datetime.datetime(2025, 6, 15, 12, 30, tzinfo=
 assert bool(datetime.date(2024, 1, 1))
 assert bool(datetime.date(1, 1, 1))
 
-# === date ordering comparisons (date.rs py_cmp) ===
+# === date ordering comparisons ===
 
 assert datetime.date(2024, 1, 1) < datetime.date(2024, 1, 2)
 assert datetime.date(2024, 1, 2) > datetime.date(2024, 1, 1)
@@ -1162,7 +1162,7 @@ assert str(datetime.timedelta(seconds=1, microseconds=500)) == '0:00:01.000500'
 assert str(datetime.timedelta(microseconds=1)) == '0:00:00.000001'
 assert str(datetime.timedelta(days=1, microseconds=123456)) == '1 day, 0:00:00.123456'
 
-# === timedelta ordering comparisons (timedelta.rs py_cmp) ===
+# === timedelta ordering comparisons ===
 
 assert datetime.timedelta(days=1) < datetime.timedelta(days=2)
 assert datetime.timedelta(days=2) > datetime.timedelta(days=1)

--- a/crates/monty/test_cases/str__ops.py
+++ b/crates/monty/test_cases/str__ops.py
@@ -155,6 +155,14 @@ assert 'z' < 'é'
 assert '日' < '本'
 assert '😀' < '😁'
 
+# Literals are interned while multi-character join results are heap allocated.
+heap_abc = ''.join(['a', 'b', 'c'])
+heap_abd = ''.join(['a', 'b', 'd'])
+assert 'abc' < heap_abd
+assert heap_abc < 'abd'
+assert heap_abc < heap_abd
+assert heap_abc <= 'abc'
+
 # Sorting
 assert sorted('cba') == ['a', 'b', 'c']
 assert sorted(['b', 'c', 'a']) == ['a', 'b', 'c']

--- a/limitations/classes.md
+++ b/limitations/classes.md
@@ -1,10 +1,10 @@
 # Classes
 
 Sandboxed Python code in Monty can define simple classes. A `class`
-statement with instance methods, `__init__`, `__eq__`, `__repr__`/`__str__`,
-and class variables works. The class body has a real scope (like CPython's
-class-body code object), so class variables may be arbitrary expressions
-and may reference earlier class variables:
+statement with instance methods, `__init__`, rich comparison methods,
+`__repr__`/`__str__`, and class variables works. The class body has a real scope
+(like CPython's class-body code object), so class variables may be arbitrary
+expressions and may reference earlier class variables:
 
 ```python
 class Foo:
@@ -28,18 +28,21 @@ methods dispatch back to the host (see `test_cases/dataclass__basic.py`).
 
 ## Supported surface
 
-Listed to bound what the divergences below apply to. Working,
-CPython-matching features: instance methods, `__init__` (full parameter
-shapes), instance and class attribute get/set (including `setattr(Foo, ...)`
-and function-attributes-become-methods), bound methods, class variables
-(arbitrary expressions, evaluated in a real suspendable class-body scope),
-**class decorators** (`@deco class Foo`),
-`__repr__`/`__str__`/`__enter__`/`__exit__`/`__eq__`/`__hash__` dispatch,
-`obj.__class__`, `Foo.__name__`, `Foo.__doc__`/`obj.__doc__`,
-`Foo.__annotations__` (ordered; values stringized and provisional, see
-./typing.md), `type(obj)`/`isinstance(obj, Foo)`, and the 3-arg
-`type()` constructor. The `__enter__`/`__exit__` divergences are in
-./with.md.
+Per the `limitations/` convention this file documents only *divergences* from
+CPython; the supported surface is summarized here just to bound what the
+divergences below apply to. Working, CPython-matching features: instance
+methods, `__init__` (full parameter shapes), instance and class attribute
+get/set (including `setattr(Foo, ...)` and function-attributes-become-methods),
+bound methods, class variables (arbitrary expressions, evaluated in a real
+suspendable class-body scope), **class decorators** (`@deco class Foo`),
+`__repr__`/`__str__`/`__enter__`/`__exit__`, all six rich comparison
+methods, `__hash__` dispatch, `obj.__class__`, `Foo.__name__`,
+`Foo.__doc__`/`obj.__doc__`,
+`Foo.__annotations__` (ordered; values stringized and provisional — see
+[typing.md](typing.md)), `type(obj)`/`isinstance(obj, Foo)`, and the 3-arg
+`type()` constructor. The
+`__enter__`/`__exit__` divergences are in [with.md](with.md). Everything else
+below is where Monty differs from or does not implement CPython behaviour.
 
 ## Dynamic class creation — `type(name, bases, dict)`
 
@@ -80,11 +83,6 @@ order and error wording, but with these divergences:
 - **Bound methods report `function`, not `method`.** `type(obj.method)` is
   `<class 'function'>` where CPython says `<class 'method'>`; Monty has no
   dedicated `method` type.
-- **Ordering comparisons on instances raise, but a user `__lt__`/`__gt__`/… is
-  not dispatched.** `a < b` on instances of a class with no comparison dunders
-  raises `TypeError: '<' not supported between instances of 'Foo' and 'Foo'`
-  (matching CPython). A class that *defines* `__lt__` etc. still raises: those
-  dunders are not dispatched (see the not-dispatched dunder list below).
 - **`__repr__`/`__str__` cannot suspend**: they are run to completion
   synchronously, so a `__repr__`/`__str__` that calls an external/OS function
   raises rather than yielding to the host. `__init__` and regular methods
@@ -96,12 +94,12 @@ order and error wording, but with these divergences:
   runs to completion synchronously, so it cannot yield to the host, and an
   external-function `__init__` raises `NotImplementedError` rather than
   suspending.
-- **`__eq__`/`__hash__` cannot suspend**: like `__repr__`/`__str__` they run to
-  completion synchronously, so one that calls an external/OS function raises
-  rather than yielding to the host. An exception raised by `__eq__` terminates
-  the run instead of being catchable by a `try` around the comparison.
-- **Ordering dunders are still not dispatched**; see the entry above.
-  Instances are always truthy (no `__bool__`/`__len__` dispatch).
+- **Rich comparison methods and `__hash__` cannot suspend**: like
+  `__repr__`/`__str__` they run to completion synchronously, so one that calls
+  an external/OS function raises rather than yielding to the host. An exception
+  raised by a comparison method terminates the run instead of being catchable
+  by a `try` around the comparison.
+- **Instances are always truthy**: `__bool__` and `__len__` are not dispatched.
 - **Bound methods compare and hash by identity**: each `obj.method` access
   creates a fresh object, so `obj.method == obj.method` is `False` and two
   accesses hash differently. CPython compares/hashes bound methods by
@@ -191,11 +189,10 @@ first, e.g. return a `dict` of the fields.
   Every decorator in a stack reports that same location; only the callee frame
   identifies which one raised.
 - Dunder protocols other than `__init__`, `__repr__`, `__str__`,
-  `__enter__`, `__exit__`, `__iter__`, `__next__`, `__contains__`, `__eq__`,
-  and `__hash__`: `__new__`, `__call__`, `__getitem__`, `__setitem__`,
-  `__add__`, `__ne__`, `__bool__`, etc. are not dispatched for user-defined
-  instances. `__ne__` is always the negation of `__eq__`, as CPython derives it
-  by default, so a custom `__ne__` is ignored.
+  `__enter__`, `__exit__`, `__iter__`, `__next__`, `__contains__`, the six rich
+  comparisons, and `__hash__`: `__new__`, `__call__`, `__getitem__`,
+  `__setitem__`, `__add__`, `__bool__`, etc. are not dispatched for user-defined
+  instances.
 - `__iter__` / `__next__` / `__contains__` **are** dispatched, but like
   `__repr__`/`__str__` they run synchronously, so one that calls an external or
   OS function cannot suspend and raises `NotImplementedError`. Two related

--- a/limitations/classes.md
+++ b/limitations/classes.md
@@ -1,10 +1,10 @@
 # Classes
 
 Sandboxed Python code in Monty can define simple classes. A `class`
-statement with instance methods, `__init__`, `__eq__`, `__repr__`/`__str__`,
-and class variables works. The class body has a real scope (like CPython's
-class-body code object), so class variables may be arbitrary expressions
-and may reference earlier class variables:
+statement with instance methods, `__init__`, rich comparison methods,
+`__repr__`/`__str__`, and class variables works. The class body has a real scope
+(like CPython's class-body code object), so class variables may be arbitrary
+expressions and may reference earlier class variables:
 
 ```python
 class Foo:
@@ -35,8 +35,9 @@ methods, `__init__` (full parameter shapes), instance and class attribute
 get/set (including `setattr(Foo, ...)` and function-attributes-become-methods),
 bound methods, class variables (arbitrary expressions, evaluated in a real
 suspendable class-body scope), **class decorators** (`@deco class Foo`),
-`__repr__`/`__str__`/`__enter__`/`__exit__`/`__eq__`/`__hash__` dispatch,
-`obj.__class__`, `Foo.__name__`, `Foo.__doc__`/`obj.__doc__`,
+`__repr__`/`__str__`/`__enter__`/`__exit__`, all six rich comparison
+methods, `__hash__` dispatch, `obj.__class__`, `Foo.__name__`,
+`Foo.__doc__`/`obj.__doc__`,
 `Foo.__annotations__` (ordered; values stringized and provisional — see
 [typing.md](typing.md)), `type(obj)`/`isinstance(obj, Foo)`, and the 3-arg
 `type()` constructor. The
@@ -83,11 +84,6 @@ order and error wording, but with these divergences:
 - **Bound methods report `function`, not `method`.** `type(obj.method)` is
   `<class 'function'>` where CPython says `<class 'method'>` — Monty has no
   dedicated `method` type.
-- **Ordering comparisons on instances raise, but a user `__lt__`/`__gt__`/… is
-  not dispatched.** `a < b` on instances of a class with no comparison dunders
-  raises `TypeError: '<' not supported between instances of 'Foo' and 'Foo'`
-  (matching CPython). A class that *defines* `__lt__` etc. still raises — those
-  dunders are not dispatched (see the not-dispatched dunder list below).
 - **`__repr__`/`__str__` cannot suspend**: they are run to completion
   synchronously, so a `__repr__`/`__str__` that calls an external/OS function
   raises rather than yielding to the host. `__init__` and regular methods
@@ -99,12 +95,12 @@ order and error wording, but with these divergences:
   runs to completion synchronously, so it cannot yield to the host, and an
   external-function `__init__` raises `NotImplementedError` rather than
   suspending.
-- **`__eq__`/`__hash__` cannot suspend**: like `__repr__`/`__str__` they run to
-  completion synchronously, so one that calls an external/OS function raises
-  rather than yielding to the host. An exception raised by `__eq__` terminates
-  the run instead of being catchable by a `try` around the comparison.
-- **Ordering dunders are still not dispatched** — see the entry above.
-  Instances are always truthy (no `__bool__`/`__len__` dispatch).
+- **Rich comparison methods and `__hash__` cannot suspend**: like
+  `__repr__`/`__str__` they run to completion synchronously, so one that calls
+  an external/OS function raises rather than yielding to the host. An exception
+  raised by a comparison method terminates the run instead of being catchable
+  by a `try` around the comparison.
+- **Instances are always truthy**: `__bool__` and `__len__` are not dispatched.
 - **Bound methods compare and hash by identity**: each `obj.method` access
   creates a fresh object, so `obj.method == obj.method` is `False` and two
   accesses hash differently. CPython compares/hashes bound methods by
@@ -196,11 +192,10 @@ e.g. return a `dict` of the fields.
   Every decorator in a stack reports that same location; only the callee frame
   identifies which one raised.
 - Dunder protocols other than `__init__`, `__repr__`, `__str__`,
-  `__enter__`, `__exit__`, `__iter__`, `__next__`, `__contains__`, `__eq__`,
-  and `__hash__`: `__new__`, `__call__`, `__getitem__`, `__setitem__`,
-  `__add__`, `__ne__`, `__bool__`, etc. are not dispatched for user-defined
-  instances. `__ne__` is always the negation of `__eq__`, as CPython derives it
-  by default, so a custom `__ne__` is ignored.
+  `__enter__`, `__exit__`, `__iter__`, `__next__`, `__contains__`, the six rich
+  comparisons, and `__hash__`: `__new__`, `__call__`, `__getitem__`,
+  `__setitem__`, `__add__`, `__bool__`, etc. are not dispatched for user-defined
+  instances.
 - `__iter__` / `__next__` / `__contains__` **are** dispatched, but like
   `__repr__`/`__str__` they run synchronously, so one that calls an external or
   OS function cannot suspend and raises `NotImplementedError`. Two related

--- a/limitations/language.md
+++ b/limitations/language.md
@@ -148,38 +148,18 @@ attribute tagging for later discovery all have no equivalent.
 
 ## Ordering comparisons
 
-`<`, `<=`, `>`, `>=` on operands with no defined ordering raise
-`TypeError: '<' not supported between instances of '{a}' and '{b}'`, matching
-CPython (int vs str, `None` vs `None`, user-class instances without comparison
-dunders, etc.). Lists and tuples order lexicographically as in CPython. A `NaN`
-operand is *unordered* rather than incomparable, so `float('nan') < 1` (and
-every operator/direction, including two NaNs) returns `False` without raising,
-also matching CPython, and likewise inside `sorted`/`min`/`max`.
+Monty's immediate floats have bitwise structural identity rather than CPython's
+allocation identity. Distinct `float('nan')` values with the same bit pattern
+therefore appear identical to identity-based operations: `nan1 is nan2`,
+`[nan1] == [nan2]`, and `nan1 in [nan2]` are all `True` in Monty but `False` in
+CPython.
 
-One message divergence: when a **list or tuple** compares unequal only because
-an *inner element* pair is unorderable (e.g. `(1, 2) < (1, 'a')`), Monty names
-the outer container types (`'tuple' and 'tuple'`) where CPython names the inner
-element pair (`'int' and 'str'`). Both raise `TypeError`; only the message text
-differs.
-
-One value divergence: whenever CPython compares elements *inside* a container it
-shortcuts equality by **object identity** (`x is x` ⇒ equal) before falling back
-to `==`. Monty has no object identity for immediate floats, so it asks `==`, and
-a `NaN` is never equal to itself. Every container operation built on element
-comparison therefore differs when the *same* `NaN` object appears on both sides:
-
-| with `x = float('nan')` | CPython | Monty |
-|---|---|---|
-| `(x,) == (x,)`, `[x] == [x]` | `True` | `False` |
-| `x in [x]` | `True` | `False` |
-| `[x].count(x)` | `1` | `0` |
-| `[x].index(x)` | `0` | `ValueError` |
-| `[1, x] < [1, x, 3]` | `True` | `False` |
-
-`NaN` is the only practical way to reach this, being the one built-in value
-unequal to itself. *Distinct* `NaN` objects agree on both
-(`[1, float('nan')] < [1, float('nan'), 3]` is `False` either way), as does a
-direct `x == x` (`False` on both). Named tuples inherit all of this from `tuple`.
+Lexicographic ordering cannot use that structural identity without also treating
+distinct NaNs as one object, so it applies direct equality to immediate values.
+Consequently `[1, x] < [1, x, 3]` is `False` in Monty for
+`x = float('nan')`; CPython recognises the repeated object by identity, skips it
+as a shared prefix, and returns `True`. Lists, tuples, named tuples and deques
+share this divergence.
 
 ## What *does* work
 

--- a/limitations/language.md
+++ b/limitations/language.md
@@ -147,38 +147,18 @@ attribute tagging for later discovery all have no equivalent.
 
 ## Ordering comparisons
 
-`<`, `<=`, `>`, `>=` on operands with no defined ordering raise
-`TypeError: '<' not supported between instances of '{a}' and '{b}'`, matching
-CPython (int vs str, `None` vs `None`, user-class instances without comparison
-dunders, etc.). Lists and tuples order lexicographically as in CPython. A `NaN`
-operand is *unordered* rather than incomparable, so `float('nan') < 1` (and
-every operator/direction, including two NaNs) returns `False` without raising —
-also matching CPython, and likewise inside `sorted`/`min`/`max`.
+Monty's immediate floats have bitwise structural identity rather than CPython's
+allocation identity. Distinct `float('nan')` values with the same bit pattern
+therefore appear identical to identity-based operations: `nan1 is nan2`,
+`[nan1] == [nan2]`, and `nan1 in [nan2]` are all `True` in Monty but `False` in
+CPython.
 
-One message divergence: when a **list or tuple** compares unequal only because
-an *inner element* pair is unorderable (e.g. `(1, 2) < (1, 'a')`), Monty names
-the outer container types (`'tuple' and 'tuple'`) where CPython names the inner
-element pair (`'int' and 'str'`). Both raise `TypeError`; only the message text
-differs.
-
-One value divergence: whenever CPython compares elements *inside* a container it
-shortcuts equality by **object identity** (`x is x` ⇒ equal) before falling back
-to `==`. Monty has no object identity for immediate floats, so it asks `==`, and
-a `NaN` is never equal to itself. Every container operation built on element
-comparison therefore differs when the *same* `NaN` object appears on both sides:
-
-| with `x = float('nan')` | CPython | Monty |
-|---|---|---|
-| `(x,) == (x,)`, `[x] == [x]` | `True` | `False` |
-| `x in [x]` | `True` | `False` |
-| `[x].count(x)` | `1` | `0` |
-| `[x].index(x)` | `0` | `ValueError` |
-| `[1, x] < [1, x, 3]` | `True` | `False` |
-
-`NaN` is the only practical way to reach this, being the one built-in value
-unequal to itself. *Distinct* `NaN` objects agree on both
-(`[1, float('nan')] < [1, float('nan'), 3]` is `False` either way), as does a
-direct `x == x` (`False` on both). Named tuples inherit all of this from `tuple`.
+Lexicographic ordering cannot use that structural identity without also treating
+distinct NaNs as one object, so it applies direct equality to immediate values.
+Consequently `[1, x] < [1, x, 3]` is `False` in Monty for
+`x = float('nan')`; CPython recognises the repeated object by identity, skips it
+as a shared prefix, and returns `True`. Lists, tuples, named tuples and deques
+share this divergence.
 
 ## What *does* work
 


### PR DESCRIPTION
a bit of an experiment to see what happens if we create vtable-like structure on pytrait. might be useful to support inheritance (by enabling method resolution)?

heavily vibe coded, needs review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves rich comparisons to a `PyTrait` vtable, centralizing ==, !=, <, <=, >, >= dispatch and matching CPython behavior and error messages. Updates VM compare, sorting, and min/max to the new path, restores sort performance with a small-slice fast path, and adds an int/float fast path for rich-comparison boolean tests.

- User classes support full rich comparisons (`__lt__`, `__le__`, `__gt__`, `__ge__`, `__eq__`, `__ne__`) with reflected dispatch and `NotImplemented`; `__ne__` derives from `__eq__`.
- Correct cross-representation comparisons for `str` and `bytes` (interned vs heap).
- Value-based equality/ordering for core types: dates/datetimes/timedeltas (aware/naive rules preserved), `range` (sequence semantics), `path`, `slice`, regex patterns, sets/frozensets, dict views, lists/tuples/namedtuples, and deques (ignores `maxlen`); large integers compare across numeric types.
- `Counter` sorts and computes extrema using operator-specific partial ordering; NaN semantics preserved.
- Mixed-type comparison errors now match CPython messages, including nested element mismatches.

- Replaced `CmpOrder` with `RichCmpOp`, `RichCmpVtable`, and `invoke_rich_cmp_slot`; moved `py_cmp` into `PyTrait` and implemented per-type rich-compare slots.
- Reworked `Value`/VM comparison, `sorting::sort_indices`, and `builtins::min/max` to route through rich-compare; added insertion-sort for small slices and a `SmallVec` index buffer; added an int/float fast path for boolean comparison checks.
- Removed many `py_eq_impl` stubs; equality/ordering now live in type slots.
- Migration: custom types implementing `PyTrait` must define a `RICH_COMPARE` vtable (or rich-compare slots). Remove uses of `py_eq_impl` and `py_cmp`.

<sup>Written for commit cda791054698b9e3e5bd5595cb52595d795a7334. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

