### PR TITLE
reduce gap between browser WASM and Node implementations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1053,6 +1053,10 @@ jobs:
           name: wasm-bindings
           path: crates/monty-js/dist/worker
 
+      - name: Test Node wasm bindings
+        run: npm run test:wasm
+        working-directory: crates/monty-js
+
       - name: Test browser bindings
         run: npx playwright install --with-deps chromium && npm run test:browser
         working-directory: crates/monty-js

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ dev-py-release: ## Install the python package for development with a release bui
 build-wasm: install-js ## Build the lean wasm worker module (requires the wasm32-wasip1 target)
 	cd crates/monty-js && npm run build:wasm && npm run build:ts
 
+.PHONY: test-wasm
+test-wasm: install-js ## Test the Node worker-thread wasm pool and transport
+	cd crates/monty-js && npm run build:wasm && npm run build:ts && npm run test:wasm
+
 .PHONY: test-browser
 test-browser: install-js ## Browser (Vitest) test of the wasm path in a real headless browser
 	cd crates/monty-js && npm run build:wasm && npm run build:ts && npx playwright install chromium && npm run test:browser

--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -5,11 +5,10 @@ crash-isolated `monty` interpreter subprocesses; browser bundlers resolve the
 same public API to a Web Worker pool backed by a lean wasm build.
 
 [Monty](https://github.com/pydantic/monty) is a sandboxed Python interpreter
-written in Rust. A sandbox process can never be made fully crash-proof against
-memory errors (stack overflow, allocator aborts), so this package _only_ runs
-the interpreter in worker subprocesses: a worker that crashes raises
-`MontyCrashedError`, is replaced by the pool, and your Node.js process is
-never at risk.
+written in Rust. The Node default runs it in worker subprocesses; browser and
+explicit `/wasm` imports use dedicated Web Workers or Node worker threads. A
+worker that crashes raises `MontyCrashedError`, is retired by the pool, and
+future checkouts use a fresh worker.
 
 The native binding and the `monty` binary ship together via platform-specific
 npm packages installed automatically (like esbuild). Browser builds use the
@@ -304,8 +303,10 @@ try {
 }
 ```
 
-`MontyError` is the base class; `MontyCrashedError` means the worker process
-died (the session is lost, the pool recovers).
+`MontyError` is the base class; `MontyCrashedError` means the worker died (the
+session is lost, the pool recovers). `session.workerId` identifies a worker
+across checkout/recycling backends; `session.workerPid` is set only for native
+subprocess workers.
 
 ## Pool Configuration
 

--- a/crates/monty-js/__test__/pool.spec.ts
+++ b/crates/monty-js/__test__/pool.spec.ts
@@ -5,9 +5,14 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { t } from './assertions.js'
-import { skipIfBrowser } from './env.js'
+import { kind, skipIfBrowser } from './env.js'
+import { runPoolConformanceTests } from './poolConformance.js'
 
 import { Monty, MontyCrashedError, MontyRuntimeError, MountDir } from '@pydantic/monty/node'
+
+if (kind === 'node') {
+  runPoolConformanceTests('native pool', (options) => Monty.create(options), { timeoutExitStatus: false })
+}
 
 // =============================================================================
 // Pool lifecycle

--- a/crates/monty-js/__test__/poolConformance.ts
+++ b/crates/monty-js/__test__/poolConformance.ts
@@ -1,0 +1,156 @@
+import { expect, test } from 'vitest'
+
+import { throwsAsync } from './assertions.js'
+
+interface PoolOptions {
+  minProcesses?: number
+  maxProcesses?: number
+  checkoutTimeout?: number
+  requestTimeout?: number
+  durationLimitGrace?: number | null
+  maxCheckoutsPerWorker?: number
+}
+
+interface CheckoutOptions {
+  limits?: { maxDurationSecs?: number }
+}
+
+interface Session {
+  readonly workerId?: number
+  feedRun(code: string, options?: FeedOptions): Promise<unknown>
+  close(): Promise<void>
+}
+
+interface FeedOptions {
+  externalLookup?: Record<string, (...args: never[]) => unknown>
+}
+
+interface Pool {
+  checkout(options?: CheckoutOptions): Promise<Session>
+  close(): Promise<void>
+}
+
+interface CrashError extends Error {
+  timedOut: boolean
+  exitStatus: string | null
+}
+
+interface PoolCapabilities {
+  /** Whether timeout-killed workers have an environment exit status. */
+  timeoutExitStatus: boolean
+}
+
+/** Registers lifecycle, timeout, recycling, and recovery tests for a pool backend. */
+export function runPoolConformanceTests(
+  name: string,
+  create: (options?: PoolOptions) => Promise<Pool>,
+  capabilities: PoolCapabilities,
+): void {
+  test(`${name}: checkout after close rejects`, async () => {
+    const pool = await create()
+    await pool.close()
+    const error = await throwsAsync(() => pool.checkout())
+    expect(error.message).toBe('the pool is closed — create a new Monty pool')
+  })
+
+  test(`${name}: close is idempotent`, async () => {
+    const pool = await create()
+    await Promise.all([pool.close(), pool.close()])
+    await pool.close()
+  })
+
+  test(`${name}: feed after session close rejects`, async () => {
+    await using pool = await create()
+    const session = await pool.checkout()
+    await session.close()
+    const error = await throwsAsync(() => session.feedRun('1'))
+    expect(error.message).toBe('the session is closed — check out a new one')
+  })
+
+  test(`${name}: workers are reused across checkouts`, async () => {
+    await using pool = await create({ maxProcesses: 1 })
+    const first = await pool.checkout()
+    const workerId = first.workerId
+    expect(workerId).toBeTypeOf('number')
+    await first.close()
+    const second = await pool.checkout()
+    expect(second.workerId).toBe(workerId)
+    await second.close()
+  })
+
+  test(`${name}: maxCheckoutsPerWorker recycles the worker`, async () => {
+    await using pool = await create({ maxProcesses: 1, maxCheckoutsPerWorker: 1 })
+    const first = await pool.checkout()
+    const workerId = first.workerId
+    await first.close()
+    const second = await pool.checkout()
+    expect(second.workerId).not.toBe(workerId)
+    await second.close()
+  })
+
+  test(`${name}: concurrent sessions use distinct workers`, async () => {
+    await using pool = await create({ maxProcesses: 2 })
+    const a = await pool.checkout()
+    const b = await pool.checkout()
+    try {
+      expect(a.workerId).not.toBe(b.workerId)
+      await expect(Promise.all([a.feedRun('1 + 1'), b.feedRun('2 + 2')])).resolves.toEqual([2, 4])
+    } finally {
+      await a.close()
+      await b.close()
+    }
+  })
+
+  test(`${name}: exhausted checkout observes checkoutTimeout`, async () => {
+    await using pool = await create({ maxProcesses: 1, checkoutTimeout: 0.05 })
+    const held = await pool.checkout()
+    try {
+      const error = await throwsAsync(() => pool.checkout())
+      expect(error.message).toBe('no monty worker became available within the checkout timeout')
+    } finally {
+      await held.close()
+    }
+  })
+
+  test(`${name}: released workers are handed to waiting checkouts`, async () => {
+    await using pool = await create({ maxProcesses: 1 })
+    const held = await pool.checkout()
+    const waiting = pool.checkout()
+    await held.close()
+    const session = await waiting
+    await expect(session.feedRun('40 + 2')).resolves.toBe(42)
+    await session.close()
+  })
+
+  test(`${name}: requestTimeout preserves crash metadata and the pool recovers`, async () => {
+    await using pool = await create({ maxProcesses: 1, checkoutTimeout: 1, requestTimeout: 0.2 })
+    const crashed = await pool.checkout()
+    const crash = await throwsAsync<CrashError>(() => crashed.feedRun('while True:\n    pass'))
+    expect(crash.name).toBe('MontyCrashedError')
+    expect(crash.timedOut).toBe(true)
+    expect(crash.message).toBe('RuntimeError: monty worker killed after exceeding request timeout of 200ms')
+    if (capabilities.timeoutExitStatus) expect(crash.exitStatus).toMatch(/^exit code: /)
+    else expect(crash.exitStatus).toBeNull()
+
+    // Capacity is released as soon as the worker dies, not when its poisoned
+    // session is eventually closed.
+    const fresh = await pool.checkout()
+    await expect(fresh.feedRun('1 + 1')).resolves.toBe(2)
+    await fresh.close()
+    await crashed.close()
+  })
+
+  test(`${name}: suspension time does not consume maxDurationSecs`, async () => {
+    await using pool = await create()
+    await using session = await pool.checkout({ limits: { maxDurationSecs: 0.2 } })
+    const result = await session.feedRun("await fetch_data('u') + '!'", {
+      externalLookup: {
+        fetch_data: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 400))
+          return 'body'
+        },
+      },
+    })
+    expect(result).toBe('body!')
+  })
+}

--- a/crates/monty-js/__test__/wasm_pool.spec.ts
+++ b/crates/monty-js/__test__/wasm_pool.spec.ts
@@ -1,0 +1,8 @@
+import { kind } from './env.js'
+import { runPoolConformanceTests } from './poolConformance.js'
+
+import { Monty } from '@pydantic/monty/wasm'
+
+runPoolConformanceTests(`${kind} wasm pool`, (options) => Monty.create(options), {
+  timeoutExitStatus: kind === 'node',
+})

--- a/crates/monty-js/__test__/worker_transport.spec.ts
+++ b/crates/monty-js/__test__/worker_transport.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from 'vitest'
+
+import { DispatchError, type Dispatcher } from '../ts/worker/host.js'
+import { Writer, frame } from '../ts/worker/proto.js'
+import { WorkerTransport } from '../ts/worker/transport.js'
+
+const EMPTY = new Uint8Array()
+
+/** Builds one framed ChildEvent with optional execution timing metadata. */
+function childEvent(kind: number, payload = EMPTY, totalMicros?: number, maxMicros?: number): Uint8Array {
+  const event = new Writer()
+  event.lengthDelimited(kind, payload)
+  if (totalMicros !== undefined) event.uint(20, totalMicros)
+  if (maxMicros !== undefined) event.uint(21, maxMicros)
+  return frame(event.finish())
+}
+
+/** Builds a timed turn-ending event that needs no value decoding. */
+function typingErrorEvent(totalMicros: number, maxMicros: number): Uint8Array {
+  const typingError = new Writer()
+  typingError.string(1, 'diagnostic')
+  return childEvent(8, typingError.finish(), totalMicros, maxMicros)
+}
+
+test('duration backstop ratchets from worker-reported execution time', async () => {
+  const deadlines: (number | undefined)[] = []
+  let call = 0
+  const dispatcher: Dispatcher = async (_request, options) => {
+    if (call++ === 0) return { reply: childEvent(10), status: 0 }
+    deadlines.push(options?.timeoutMs)
+    if (call === 2) return { reply: typingErrorEvent(50_000, 100_000), status: 0 }
+    throw new DispatchError('deadline fired', true, 'exit code: 1')
+  }
+  const transport = await WorkerTransport.create(
+    dispatcher,
+    { limits: { maxDurationSecs: 0.1 } },
+    { durationLimitGraceMs: 10, workerId: 1 },
+  )
+
+  expect((await transport.feed('pass', null, [], false, () => {})).kind).toBe('typingError')
+  const crash = await transport.feed('pass', null, [], false, () => {})
+
+  expect(deadlines).toEqual([110, 60])
+  expect(crash).toEqual({ kind: 'crashed', message: 'deadline fired', timedOut: true, exitStatus: 'exit code: 1' })
+})
+
+test('restored sessions adopt the worker-reported duration budget', async () => {
+  const deadlines: (number | undefined)[] = []
+  let call = 0
+  const dispatcher: Dispatcher = async (_request, options) => {
+    switch (call++) {
+      case 0:
+        return { reply: childEvent(10), status: 0 }
+      case 1:
+        return { reply: childEvent(10, EMPTY, 25_000, 100_000), status: 0 }
+      default:
+        deadlines.push(options?.timeoutMs)
+        throw new DispatchError('deadline fired', true)
+    }
+  }
+  const transport = await WorkerTransport.create(dispatcher, {}, { durationLimitGraceMs: 10, workerId: 1 })
+
+  await expect(transport.restore(new Uint8Array([1]), [], () => {})).resolves.toEqual({ kind: 'loaded' })
+  await transport.feed('pass', null, [], false, () => {})
+
+  expect(deadlines).toEqual([85])
+})

--- a/crates/monty-js/package.json
+++ b/crates/monty-js/package.json
@@ -62,6 +62,7 @@
     "format": "prettier . -w",
     "lint": "oxlint .",
     "test": "vitest run",
+    "test:wasm": "vitest --config vitest.wasm.config.ts run",
     "test:browser": "vitest --config vitest.browser.config.ts run",
     "assemble-packages": "node scripts/assemble-packages.mjs",
     "create-platform-packages": "node scripts/create-platform-packages.mjs"

--- a/crates/monty-js/ts/errors.ts
+++ b/crates/monty-js/ts/errors.ts
@@ -179,7 +179,7 @@ export class MontyTypingError extends MontyError {
 }
 
 /**
- * Raised when a worker process died: a hard crash (segfault, allocator abort
+ * Raised when a worker died: a hard crash (segfault, allocator abort
  * — the failure mode subprocess isolation exists to contain) or a watchdog
  * kill for exceeding `requestTimeout` / the `maxDurationSecs` backstop. The
  * session is lost; the pool replaces the worker, so other sessions and future

--- a/crates/monty-js/ts/session.ts
+++ b/crates/monty-js/ts/session.ts
@@ -133,6 +133,9 @@ export type Snapshot = FunctionSnapshot | NameLookupSnapshot | FutureSnapshot | 
 /** A settled future outcome passed to [`FutureSnapshot.resume`]. */
 export type FutureResolution = { callId: number; value: unknown } | { callId: number; error: unknown }
 
+/** Native-session contract extended with a backend-neutral worker identity. */
+type SessionNative = NativeSession & { readonly workerId?: number | null }
+
 /** A promise-returning external call registered as a sandbox future. */
 interface PendingFuture {
   readonly callId: number
@@ -143,13 +146,13 @@ interface PendingFuture {
 }
 
 /**
- * One worker process dedicated to one REPL session; created by
+ * One worker dedicated to one REPL session; created by
  * [`Monty.checkout`]. Session state (globals, functions) persists across
  * `feedRun` calls. Close it (or `await using`) to return the worker to the
  * pool.
  */
 export class MontySession {
-  private readonly native: NativeSession
+  private readonly native: SessionNative
   /** Set once the session is unusable: crashed worker or protocol error. */
   private broken: Error | null = null
   private closed = false
@@ -158,7 +161,7 @@ export class MontySession {
   private driven = false
 
   /** @internal — sessions are created by `Monty.checkout`. */
-  constructor(native: NativeSession) {
+  constructor(native: SessionNative) {
     this.native = native
   }
 
@@ -389,9 +392,15 @@ export class MontySession {
     }
   }
 
+  /** Stable identity of the worker serving this session. Native sessions use
+   * their PID; WASM pools assign an identity without pretending it is a PID. */
+  get workerId(): number | undefined {
+    return this.native.workerId ?? this.native.workerPid ?? undefined
+  }
+
   /**
-   * OS process id of this session's worker, or `undefined` when no worker is
-   * attached or a turn is in flight on this session (diagnostics/tests).
+   * OS process id of this session's worker, or `undefined` for non-process
+   * backends and while a native turn is in flight (diagnostics/tests).
    */
   get workerPid(): number | undefined {
     return this.native.workerPid ?? undefined

--- a/crates/monty-js/ts/worker/channel.ts
+++ b/crates/monty-js/ts/worker/channel.ts
@@ -1,14 +1,12 @@
 // Drives a Monty worker over a message channel (a Web Worker, or Node's
 // `worker_threads`) as a [`PooledWorker`].
 //
-// This is where the browser model earns its keep over the in-process one: each
-// turn is a `postMessage` round-trip, and a turn that runs too long is stopped
-// by `terminate()` — the hard, unconditional kill the in-process path lacks.
-// The channel correlates replies to requests by id, arms a per-turn watchdog,
-// and rejects every in-flight request when the worker dies or is killed (so the
-// transport sees a crash and the pool replaces it).
+// Each turn is a `postMessage` round-trip. The channel correlates replies,
+// applies the request and duration-backstop deadlines, and preserves the
+// runtime's timeout/exit metadata when a worker dies.
 
-import type { DecodedChildEvent, Dispatcher } from './host.js'
+import { deadlineTimer, type DeadlineTimer } from './deadline.js'
+import { DispatchError, type DecodedChildEvent, type DispatchResult, type Dispatcher } from './host.js'
 import type { PooledWorker } from './pool.js'
 
 /** A request sent to the worker: a turn's framed `ParentRequest`. */
@@ -26,26 +24,28 @@ export interface DispatchReply {
 }
 
 /**
- * The slice of a worker handle the channel needs, satisfied structurally by a
- * browser `Worker` (via a tiny adapter for its event API) and a Node
- * `worker_threads.Worker`.
+ * The worker operations shared by browser `Worker` and Node
+ * `worker_threads.Worker` adapters.
  */
 export interface WorkerLike {
   post(message: DispatchRequest): void
   onMessage(handler: (reply: DispatchReply) => void): void
   onError(handler: (err: unknown) => void): void
-  terminate(): void
+  /** Registers process/thread exit notification when the runtime provides it. */
+  onExit?(handler: (exitStatus: string | null) => void): void
+  /** Stops the worker, resolving to an exit description when available. */
+  terminate(): void | string | null | Promise<string | null>
 }
 
 export interface WorkerChannelOptions {
-  /** Hard per-turn deadline; on expiry the worker is terminated. */
+  /** Hard per-turn deadline applied independently of duration backstops. */
   requestTimeoutMs?: number
 }
 
 interface Pending {
-  resolve(value: { reply: Uint8Array; status: number; events?: DecodedChildEvent[] }): void
+  resolve(value: DispatchResult): void
   reject(err: Error): void
-  timer: ReturnType<typeof setTimeout> | null
+  timer: DeadlineTimer | null
 }
 
 /** A pooled worker backed by a message channel. */
@@ -53,13 +53,17 @@ export class WorkerChannel implements PooledWorker {
   private nextId = 1
   private readonly pending = new Map<number, Pending>()
   private live = true
+  private stopping: Promise<string | null> | null = null
+  private knownExitStatus: string | null = null
 
   constructor(
     private readonly worker: WorkerLike,
     private readonly options: WorkerChannelOptions = {},
+    readonly workerId?: number,
   ) {
     worker.onMessage((reply) => this.onReply(reply))
-    worker.onError((err) => this.kill(new Error(`worker error: ${String(err)}`)))
+    worker.onError((err) => void this.kill(`worker error: ${errorMessage(err)}`))
+    worker.onExit?.((exitStatus) => this.onExit(exitStatus))
   }
 
   get alive(): boolean {
@@ -67,43 +71,106 @@ export class WorkerChannel implements PooledWorker {
   }
 
   /** Posts one turn and resolves with its reply, or rejects on death/timeout. */
-  dispatch: Dispatcher = (frame) => {
-    if (!this.live) return Promise.reject(new Error('worker is dead'))
+  dispatch: Dispatcher = (frame, options = {}) => {
+    if (!this.live) return Promise.reject(new DispatchError('worker is dead', false, this.knownExitStatus))
     const id = this.nextId++
     return new Promise((resolve, reject) => {
-      const timeoutMs = this.options.requestTimeoutMs
-      const timer = timeoutMs === undefined ? null : setTimeout(() => this.onTimeout(), timeoutMs)
+      const timeoutMs = minimumTimeout(this.options.requestTimeoutMs, options.timeoutMs)
+      const timer = timeoutMs === undefined ? null : deadlineTimer(timeoutMs, () => void this.onTimeout(timeoutMs))
       this.pending.set(id, { resolve, reject, timer })
-      this.worker.post({ id, frame })
+      try {
+        this.worker.post({ id, frame })
+      } catch (err) {
+        void this.kill(`worker channel failed: ${errorMessage(err)}`)
+      }
     })
   }
 
-  /** Hard-kills the worker; any in-flight turn rejects. */
-  terminate(): void {
-    this.kill(new Error('worker terminated'))
+  /** Hard-kills and reaps the worker; any in-flight turn rejects. */
+  terminate(): Promise<void> {
+    return this.kill('worker terminated')
   }
 
   private onReply(reply: DispatchReply): void {
     const pending = this.pending.get(reply.id)
     if (!pending) return
     this.pending.delete(reply.id)
-    if (pending.timer) clearTimeout(pending.timer)
-    pending.resolve({ reply: reply.reply, status: reply.status })
+    pending.timer?.cancel()
+    const result = { reply: reply.reply, status: reply.status, events: reply.events }
+    if (reply.status === 0) {
+      pending.resolve(result)
+    } else {
+      // A FatalError/IO failure is the worker's final reply. Reap the Node
+      // thread before resolving so the transport can attach its exit code.
+      this.live = false
+      void this.stopWorker().then((exitStatus) => {
+        pending.resolve({ ...result, exitStatus })
+        this.rejectPending(new DispatchError('worker terminated', false, exitStatus))
+      })
+    }
   }
 
-  private onTimeout(): void {
-    // a synchronous sandbox turn can only be stopped by killing the worker
-    this.kill(new Error('turn exceeded the request timeout'))
+  private onTimeout(timeoutMs: number): void {
+    void this.kill(`monty worker killed after exceeding request timeout of ${formatDuration(timeoutMs)}`, true)
   }
 
-  private kill(err: Error): void {
-    if (!this.live) return
+  private onExit(exitStatus: string | null): void {
+    this.knownExitStatus = exitStatus
+    if (this.live) {
+      this.live = false
+      this.rejectPending(new DispatchError('worker exited', false, exitStatus))
+    }
+  }
+
+  private async kill(message: string, timedOut = false): Promise<void> {
+    if (!this.live) {
+      await this.stopping
+      return
+    }
     this.live = false
-    this.worker.terminate()
+    const pending = [...this.pending.values()]
+    this.pending.clear()
+    for (const item of pending) item.timer?.cancel()
+    const exitStatus = await this.stopWorker()
+    const error = new DispatchError(message, timedOut, exitStatus)
+    for (const item of pending) item.reject(error)
+  }
+
+  private stopWorker(): Promise<string | null> {
+    this.stopping ??= Promise.resolve(this.worker.terminate())
+      .then((exitStatus) => exitStatus ?? this.knownExitStatus)
+      .catch(() => this.knownExitStatus)
+    return this.stopping
+  }
+
+  private rejectPending(error: DispatchError): void {
     for (const pending of this.pending.values()) {
-      if (pending.timer) clearTimeout(pending.timer)
-      pending.reject(err)
+      pending.timer?.cancel()
+      pending.reject(error)
     }
     this.pending.clear()
   }
+}
+
+/** Chooses the earlier configured deadline, as the native pool does. */
+function minimumTimeout(
+  requestTimeoutMs: number | undefined,
+  backstopTimeoutMs: number | undefined,
+): number | undefined {
+  if (requestTimeoutMs === undefined) return backstopTimeoutMs
+  if (backstopTimeoutMs === undefined) return requestTimeoutMs
+  return Math.min(requestTimeoutMs, backstopTimeoutMs)
+}
+
+/** Formats milliseconds like Rust's `Duration` debug output used natively. */
+function formatDuration(ms: number): string {
+  if (ms >= 1000) return `${ms / 1000}s`
+  if (ms >= 1) return `${ms}ms`
+  if (ms >= 0.001) return `${ms * 1000}µs`
+  return `${ms * 1_000_000}ns`
+}
+
+/** Extracts a useful message from an arbitrary worker error event. */
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
 }

--- a/crates/monty-js/ts/worker/deadline.ts
+++ b/crates/monty-js/ts/worker/deadline.ts
@@ -1,0 +1,27 @@
+/** A cancellable wall-clock deadline, safe beyond `setTimeout`'s 32-bit cap. */
+export interface DeadlineTimer {
+  cancel(): void
+}
+
+/** Arms a deadline in milliseconds, chaining timers when it exceeds 2^31-1. */
+export function deadlineTimer(timeoutMs: number, callback: () => void): DeadlineTimer {
+  const deadline = Date.now() + timeoutMs
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let cancelled = false
+  const arm = () => {
+    if (cancelled) return
+    const remaining = deadline - Date.now()
+    if (remaining <= 0) {
+      timer = setTimeout(callback, 0)
+    } else {
+      timer = setTimeout(arm, Math.min(remaining, 2_147_483_647))
+    }
+  }
+  arm()
+  return {
+    cancel() {
+      cancelled = true
+      if (timer !== null) clearTimeout(timer)
+    },
+  }
+}

--- a/crates/monty-js/ts/worker/host.ts
+++ b/crates/monty-js/ts/worker/host.ts
@@ -23,15 +23,41 @@ interface WasmExports {
   monty_decode_child_events(): number
 }
 
+/** Per-turn deadline supplied by the transport in addition to a channel's
+ * configured `requestTimeout`. */
+export interface DispatchOptions {
+  timeoutMs?: number
+}
+
+/** The reply to one protocol turn, including terminal worker metadata. */
+export interface DispatchResult {
+  /** Concatenated framed `ChildEvent`s emitted during the turn. */
+  reply: Uint8Array
+  /** `monty_dispatch_turn` status, nonzero when the instance must be retired. */
+  status: number
+  /** Optional Rust-decoded event payloads produced by `WasmHost`. */
+  events?: DecodedChildEvent[]
+  /** Runtime exit description after a terminal turn, when available. */
+  exitStatus?: string | null
+}
+
+/** A worker-channel failure with the crash metadata exposed by the runtime. */
+export class DispatchError extends Error {
+  constructor(
+    message: string,
+    readonly timedOut = false,
+    readonly exitStatus: string | null = null,
+  ) {
+    super(message)
+    this.name = 'DispatchError'
+  }
+}
+
 /**
- * Sends one framed request and resolves to the turn's framed reply. The
- * abstraction `WorkerTransport` drives, so the same transport works over an
- * in-process [`WasmHost`] (see [`inProcessDispatcher`]) and over a Web Worker
- * `postMessage` channel.
+ * Sends one framed request and resolves to its reply. Implemented by both an
+ * in-process [`WasmHost`] and message-channel workers.
  */
-export type Dispatcher = (
-  requestFrame: Uint8Array,
-) => Promise<{ reply: Uint8Array; status: number; events?: DecodedChildEvent[] }>
+export type Dispatcher = (requestFrame: Uint8Array, options?: DispatchOptions) => Promise<DispatchResult>
 
 /** Adapts a synchronous in-process [`WasmHost`] to the async [`Dispatcher`]. */
 export function inProcessDispatcher(host: WasmHost): Dispatcher {

--- a/crates/monty-js/ts/worker/index.node.ts
+++ b/crates/monty-js/ts/worker/index.node.ts
@@ -1,13 +1,23 @@
 // Node entry for `@pydantic/monty/wasm` (the `node` export condition): loads
-// the bundled wasm asset from disk for `Monty.create()`.
+// the bundled wasm asset from disk and runs every instance in a worker thread.
+
+import { availableParallelism } from 'node:os'
+
+import { type WasmPoolOptions, type WorkerPool } from './index.js'
+import { loadModule } from './loadModule.node.js'
+import { nodeWorkerFactory } from './nodeFactory.js'
+import { createWorkerPoolFromFactory, workerChannelOptions } from './poolOptions.js'
 
 export * from './index.js'
 
-import { createWorkerPool, type WasmPoolOptions, type WorkerPool } from './index.js'
-import { loadModule } from './loadModule.node.js'
+/** Creates a hard-preemptible Node worker-thread pool for a compiled module. */
+export function createWorkerPool(module: WebAssembly.Module, options: WasmPoolOptions = {}): Promise<WorkerPool> {
+  const factory = nodeWorkerFactory(module, workerChannelOptions(options))
+  return createWorkerPoolFromFactory(factory, options, availableParallelism())
+}
 
 export class Monty {
-  /** Loads the bundled wasm from disk and creates a worker-backed pool. */
+  /** Loads the bundled wasm and creates a hard-preemptible worker-thread pool. */
   static async create(options: WasmPoolOptions = {}): Promise<WorkerPool> {
     return createWorkerPool(await loadModule(), options)
   }

--- a/crates/monty-js/ts/worker/index.ts
+++ b/crates/monty-js/ts/worker/index.ts
@@ -4,27 +4,27 @@
 // `createWorkerPool(module, options)` when they need to supply a compiled
 // `WebAssembly.Module` themselves.
 //
-// `createWorkerPool` picks the backend: a browser Web Worker where
-// `Worker` exists (off-thread + a hard-kill watchdog), else in-process wasm as
-// a degrade (same API, no crash isolation or preemption). Node users wanting
-// real threads import `nodeWorkerFactory` from `./nodeFactory.js` directly
-// (separate so browser bundles never pull in `node:worker_threads`).
+// `createWorkerPool` picks a browser Web Worker where `Worker` exists, else an
+// in-process degrade. The Node export condition has its own `Monty.create`
+// wired to `nodeWorkerFactory`; keeping that import in `index.node.ts` prevents
+// browser bundles from pulling in `node:worker_threads`.
 
 import { browserWorkerFactory } from './browserFactory.js'
 import { type WorkerFactory, WorkerPool, inProcessFactory } from './pool.js'
+import { createWorkerPoolFromFactory, workerChannelOptions } from './poolOptions.js'
 
 export interface WasmPoolOptions {
   /** Accepted for parity with the native API; wasm always loads the bundled asset. */
   binaryPath?: string
   /** Workers spawned up front by `create()` (default 1). */
   minProcesses?: number
-  /** Worker cap; checkouts beyond it wait (default 4). */
+  /** Worker cap; checkouts beyond it wait (default: host concurrency, or 4). */
   maxProcesses?: number
-  /** Accepted for parity with the native API; wasm currently waits forever. */
+  /** Seconds to wait for a free worker; omitted waits forever. */
   checkoutTimeout?: number
   /** Hard per-turn deadline in seconds; on expiry the worker is terminated. */
   requestTimeout?: number
-  /** Accepted for parity with the native API; wasm uses in-sandbox limits only. */
+  /** Grace in seconds for the `maxDurationSecs` hard backstop; `null` disables it. */
   durationLimitGrace?: number | null
   /** Recycle a worker after serving this many sessions. */
   maxCheckoutsPerWorker?: number
@@ -34,16 +34,12 @@ export interface WasmPoolOptions {
 
 /** Creates a pool over the best backend for this environment. */
 export async function createWorkerPool(module: WebAssembly.Module, options: WasmPoolOptions = {}): Promise<WorkerPool> {
-  const requestTimeoutMs = options.requestTimeout === undefined ? undefined : options.requestTimeout * 1000
   const factory: WorkerFactory =
     'Worker' in globalThis
-      ? browserWorkerFactory(module, { requestTimeoutMs }, options.workerUrl)
+      ? browserWorkerFactory(module, workerChannelOptions(options), options.workerUrl)
       : inProcessFactory(module)
-  return WorkerPool.create(factory, {
-    minWorkers: options.minProcesses,
-    maxWorkers: options.maxProcesses,
-    maxCheckoutsPerWorker: options.maxCheckoutsPerWorker,
-  })
+  const browserConcurrency = typeof navigator === 'undefined' ? undefined : navigator.hardwareConcurrency
+  return createWorkerPoolFromFactory(factory, options, browserConcurrency)
 }
 
 /** Loads the bundled wasm module and creates a browser/worker-backed pool. */

--- a/crates/monty-js/ts/worker/nodeFactory.ts
+++ b/crates/monty-js/ts/worker/nodeFactory.ts
@@ -5,29 +5,24 @@
 // Node-only (imports `node:worker_threads`); browsers use a `Worker`-based
 // factory instead. Both produce a `WorkerChannel`, so the pool is identical.
 
-import { dirname, join } from 'node:path'
-import { fileURLToPath } from 'node:url'
 import { Worker } from 'node:worker_threads'
 
 import { WorkerChannel, type WorkerChannelOptions, type WorkerLike } from './channel.js'
 import type { WorkerFactory } from './pool.js'
 
-const entryPath = join(dirname(fileURLToPath(import.meta.url)), 'nodeWorkerEntry.ts')
+const entryUrl = new URL('./nodeWorkerEntry.js', import.meta.url)
 
 /** Spawns workers that serve `module` in a worker thread. */
 export function nodeWorkerFactory(module: WebAssembly.Module, options: WorkerChannelOptions = {}): WorkerFactory {
   return () => {
-    const worker = new Worker(entryPath, {
-      // run the .ts entry through the same loader the tests use
-      execArgv: ['--import', '@oxc-node/core/register'],
-      workerData: { module },
-    })
+    const worker = new Worker(entryUrl, { workerData: { module } })
     const like: WorkerLike = {
       post: (message) => worker.postMessage(message),
       onMessage: (handler) => worker.on('message', handler),
       onError: (handler) => worker.on('error', handler),
-      terminate: () => void worker.terminate(),
+      onExit: (handler) => worker.on('exit', (code) => handler(`exit code: ${code}`)),
+      terminate: async () => `exit code: ${await worker.terminate()}`,
     }
-    return Promise.resolve(new WorkerChannel(like, options))
+    return Promise.resolve(new WorkerChannel(like, options, worker.threadId))
   }
 }

--- a/crates/monty-js/ts/worker/pool.ts
+++ b/crates/monty-js/ts/worker/pool.ts
@@ -1,23 +1,12 @@
 // A TypeScript reimplementation of `monty-pool` for the wasm worker path.
 //
-// `monty-pool` (the Rust pool the napi binding uses) is `std::process`/
-// `std::thread`-bound, so the browser gets this: the same elasticity, checkout,
-// recycle and crash-replacement *logic* over a pluggable worker backend —
-// in-process wasm instances for environments without `Worker`, or Web Workers
-// (whose `terminate()` is the hard-kill watchdog primitive) in the browser.
-//
-// One worker runs one session at a time. Checkout builds a `WorkerTransport`
-// (sending `ReplCreate`) over the worker's dispatch channel and wraps it in a
-// `MontySession`; closing the session `Reset`s the worker and returns it to the
-// idle set, unless it should be recycled (served its checkout quota) or died
-// (returned to the factory for disposal). State never leaks between sessions:
-// `Reset` clears the REPL before reuse.
-//
-// Not yet ported: the per-turn watchdog timeout. Hard preemption needs a real
-// `Worker.terminate()`; with the in-process backend a runaway turn cannot be
-// interrupted, exactly as the plan notes.
+// One worker runs one session at a time. A clean close resets and returns it;
+// a crash, protocol failure, or checkout quota retires it. Browser and Node
+// worker backends provide hard turn preemption, while `inProcessFactory`
+// remains an explicit degrade for runtimes without workers.
 
 import { MontySession } from '../session.js'
+import { deadlineTimer, type DeadlineTimer } from './deadline.js'
 import { WasmHost, type Dispatcher, inProcessDispatcher } from './host.js'
 import { WorkerTransport, type WorkerSessionConfig } from './transport.js'
 
@@ -29,19 +18,21 @@ export interface PooledWorker {
   /** Sends one framed request and resolves to the framed reply. */
   readonly dispatch: Dispatcher
   /** Force-terminates the worker (`Worker.terminate()`; a no-op in-process). */
-  terminate(): void
+  terminate(): void | Promise<void>
   /** Becomes false once the worker has died or been terminated. */
   readonly alive: boolean
+  /** Runtime-specific worker identity, when one exists. */
+  readonly workerId?: number
+  /** OS process identity, available only to process-backed factories. */
+  readonly workerPid?: number
 }
 
 /** Spawns a fresh worker for the pool. */
 export type WorkerFactory = () => Promise<PooledWorker>
 
 /**
- * A factory of in-process wasm workers (one `WasmHost` per worker), for
- * environments without `Worker` and for tests. `terminate` only flips `alive`
- * (an in-process instance cannot be force-killed); session isolation still
- * holds via `Reset`, but a runaway turn cannot be preempted.
+ * Creates in-process wasm workers for runtimes without a Worker primitive and
+ * low-level tests. A runaway turn cannot be preempted in this backend.
  */
 export function inProcessFactory(module: WebAssembly.Module): WorkerFactory {
   return async () => {
@@ -65,6 +56,10 @@ export interface WorkerPoolOptions {
   minWorkers?: number
   /** Hard ceiling on live workers; further checkouts wait. Default 4. */
   maxWorkers?: number
+  /** Milliseconds to wait for pool capacity. Omitted means forever. */
+  checkoutTimeoutMs?: number
+  /** Grace for the `maxDurationSecs` hard backstop. `null` disables it. */
+  durationLimitGraceMs?: number | null
   /** Recycle (terminate + replace) a worker after this many checkouts. */
   maxCheckoutsPerWorker?: number
 }
@@ -72,49 +67,83 @@ export interface WorkerPoolOptions {
 /** One pooled worker with its checkout bookkeeping. */
 interface WorkerSlot {
   readonly worker: PooledWorker
+  readonly id: number
   checkouts: number
 }
 
 interface Waiter {
   resolve(slot: WorkerSlot): void
   reject(err: Error): void
+  timer: DeadlineTimer | null
 }
 
 /**
- * An elastic pool of wasm workers. Mirrors `pydantic_monty`'s `Monty` /
- * `monty-pool`: `checkout` borrows a worker for one session, the session
- * returns it on close.
+ * An elastic pool of wasm workers. `checkout` dedicates one worker to a REPL
+ * session and the session returns or retires it on close/death.
  */
 export class WorkerPool {
   private readonly idle: WorkerSlot[] = []
   private readonly waiters: Waiter[] = []
   /** Live workers: idle + checked out + mid-spawn. */
   private total = 0
+  private nextWorkerId = 1
   private closed = false
+  private closePromise: Promise<void> | null = null
 
   private constructor(
     private readonly factory: WorkerFactory,
     private readonly maxWorkers: number,
+    private readonly checkoutTimeoutMs: number | undefined,
+    private readonly durationLimitGraceMs: number | undefined,
     private readonly maxCheckouts: number | undefined,
   ) {}
 
   /** Creates the pool and prewarms `minWorkers` idle workers. */
   static async create(factory: WorkerFactory, options: WorkerPoolOptions = {}): Promise<WorkerPool> {
-    const max = Math.max(1, options.maxWorkers ?? 4)
-    const min = Math.min(Math.max(0, options.minWorkers ?? 1), max)
-    const pool = new WorkerPool(factory, max, options.maxCheckoutsPerWorker)
-    const warm = await Promise.all(Array.from({ length: min }, () => pool.spawn()))
+    const max = integerOption(options.maxWorkers ?? 4, 'maxWorkers')
+    const min = integerOption(options.minWorkers ?? 1, 'minWorkers')
+    if (max < 1) throw new Error('maxProcesses must be at least 1')
+    if (min > max) throw new Error('minProcesses cannot exceed maxProcesses')
+    const checkoutTimeoutMs = timeoutOption(options.checkoutTimeoutMs, 'checkoutTimeout')
+    const durationLimitGraceMs =
+      options.durationLimitGraceMs === null
+        ? undefined
+        : timeoutOption(options.durationLimitGraceMs ?? 1000, 'durationLimitGrace')
+    const maxCheckouts =
+      options.maxCheckoutsPerWorker === undefined
+        ? undefined
+        : integerOption(options.maxCheckoutsPerWorker, 'maxCheckoutsPerWorker')
+    const pool = new WorkerPool(factory, max, checkoutTimeoutMs, durationLimitGraceMs, maxCheckouts)
+    const results = await Promise.allSettled(Array.from({ length: min }, () => pool.spawn()))
+    const warm: WorkerSlot[] = []
+    let failed = false
+    let failure: unknown
+    for (const result of results) {
+      if (result.status === 'fulfilled') warm.push(result.value)
+      else if (!failed) {
+        failed = true
+        failure = result.reason
+      }
+    }
+    if (failed) {
+      await Promise.allSettled(warm.map((slot) => slot.worker.terminate()))
+      throw failure
+    }
     pool.idle.push(...warm)
     return pool
   }
 
   /** Borrows a worker and returns a session bound to it. */
   async checkout(config: WorkerSessionConfig = {}): Promise<MontySession> {
-    if (this.closed) throw new Error('pool is closed')
+    if (this.closed) throw new Error('the pool is closed — create a new Monty pool')
     const slot = await this.acquire()
     let transport: WorkerTransport
     try {
-      transport = await WorkerTransport.create(slot.worker.dispatch, config)
+      transport = await WorkerTransport.create(slot.worker.dispatch, config, {
+        durationLimitGraceMs: this.durationLimitGraceMs,
+        workerId: slot.id,
+        workerPid: slot.worker.workerPid,
+      })
     } catch (err) {
       this.discard(slot)
       throw err
@@ -123,35 +152,55 @@ export class WorkerPool {
     return new MontySession(transport as unknown as SessionNative)
   }
 
-  /** Terminates every worker and rejects anyone still waiting. */
-  async close(): Promise<void> {
-    this.closed = true
-    for (const waiter of this.waiters.splice(0)) waiter.reject(new Error('pool is closed'))
-    for (const slot of this.idle.splice(0)) {
-      slot.worker.terminate()
-      this.total--
-    }
+  /** Terminates idle workers and rejects checkouts still waiting for capacity. */
+  close(): Promise<void> {
+    this.closePromise ??= this.closeWorkers()
+    return this.closePromise
   }
 
   async [Symbol.asyncDispose](): Promise<void> {
     await this.close()
   }
 
-  /** Live worker count, for tests/diagnostics. */
+  /** Live worker count, for diagnostics and low-level pool tests. */
   get size(): number {
     return this.total
   }
 
-  // === internals ===
+  /** Performs pool shutdown once; every `close` caller awaits this operation. */
+  private async closeWorkers(): Promise<void> {
+    this.closed = true
+    for (const waiter of this.waiters.splice(0)) {
+      waiter.timer?.cancel()
+      waiter.reject(new Error('the pool is closed — create a new Monty pool'))
+    }
+    const idle = this.idle.splice(0)
+    this.total -= idle.length
+    await Promise.all(idle.map((slot) => slot.worker.terminate()))
+  }
 
+  /** Reuses, spawns, or waits for one live worker slot. */
   private async acquire(): Promise<WorkerSlot> {
     while (this.idle.length > 0) {
       const slot = this.idle.pop()!
       if (slot.worker.alive) return slot
-      this.total-- // a worker that died while idle; reap and try the next
+      void slot.worker.terminate()
+      this.total--
     }
     if (this.total < this.maxWorkers) return this.spawn()
-    return new Promise<WorkerSlot>((resolve, reject) => this.waiters.push({ resolve, reject }))
+    return new Promise<WorkerSlot>((resolve, reject) => {
+      const waiter: Waiter = { resolve, reject, timer: null }
+      if (this.checkoutTimeoutMs !== undefined) {
+        waiter.timer = deadlineTimer(this.checkoutTimeoutMs, () => {
+          const index = this.waiters.indexOf(waiter)
+          if (index !== -1) {
+            this.waiters.splice(index, 1)
+            reject(new Error('no monty worker became available within the checkout timeout'))
+          }
+        })
+      }
+      this.waiters.push(waiter)
+    })
   }
 
   /** Returns a worker after a session ends; reuse, recycle, or discard. */
@@ -160,39 +209,68 @@ export class WorkerPool {
     const recycle = this.maxCheckouts !== undefined && slot.checkouts >= this.maxCheckouts
     if (this.closed || !reusable || !slot.worker.alive || recycle) {
       this.discard(slot)
-      return
+    } else {
+      const waiter = this.takeWaiter()
+      if (waiter) waiter.resolve(slot)
+      else this.idle.push(slot)
     }
-    const waiter = this.waiters.shift()
-    if (waiter) waiter.resolve(slot)
-    else this.idle.push(slot)
   }
 
-  /** Terminates a worker, frees its capacity, and serves any waiters. */
+  /** Terminates a worker, frees its capacity, and serves pending checkouts. */
   private discard(slot: WorkerSlot): void {
-    slot.worker.terminate()
+    void slot.worker.terminate()
     this.total--
     this.pump()
   }
 
-  /** Spawns replacements for any checkouts waiting on freed capacity. */
+  /** Spawns replacements for checkouts waiting on newly freed capacity. */
   private pump(): void {
-    while (this.waiters.length > 0 && this.total < this.maxWorkers) {
-      const waiter = this.waiters.shift()!
+    while (!this.closed && this.waiters.length > 0 && this.total < this.maxWorkers) {
+      const waiter = this.takeWaiter()!
       this.spawn().then(
         (slot) => waiter.resolve(slot),
-        (err) => waiter.reject(err instanceof Error ? err : new Error(String(err))),
+        (err) => {
+          waiter.reject(asError(err))
+          this.pump()
+        },
       )
     }
   }
 
-  /** Creates one worker, counting it against `total` (decremented on failure). */
+  /** Takes the oldest capacity waiter and disarms its checkout deadline. */
+  private takeWaiter(): Waiter | undefined {
+    const waiter = this.waiters.shift()
+    waiter?.timer?.cancel()
+    return waiter
+  }
+
+  /** Creates one worker, counting it against `total` until failure/disposal. */
   private async spawn(): Promise<WorkerSlot> {
     this.total++
     try {
-      return { worker: await this.factory(), checkouts: 0 }
+      const worker = await this.factory()
+      return { worker, id: worker.workerId ?? this.nextWorkerId++, checkouts: 0 }
     } catch (err) {
       this.total--
       throw err
     }
   }
+}
+
+/** Validates a non-negative process/count option. */
+function integerOption(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) throw new Error(`${name} must be a non-negative safe integer`)
+  return value
+}
+
+/** Validates an optional non-negative millisecond timeout. */
+function timeoutOption(value: number | undefined, name: string): number | undefined {
+  if (value === undefined) return undefined
+  if (!Number.isFinite(value) || value < 0) throw new Error(`${name} must be a finite non-negative number`)
+  return value
+}
+
+/** Normalizes a thrown JavaScript value for promise rejection. */
+function asError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err))
 }

--- a/crates/monty-js/ts/worker/poolOptions.ts
+++ b/crates/monty-js/ts/worker/poolOptions.ts
@@ -1,0 +1,39 @@
+import type { WasmPoolOptions } from './index.js'
+import type { WorkerChannelOptions } from './channel.js'
+import { type WorkerFactory, WorkerPool, type WorkerPoolOptions } from './pool.js'
+
+/** Creates a pool from an environment-specific worker factory. */
+export function createWorkerPoolFromFactory(
+  factory: WorkerFactory,
+  options: WasmPoolOptions = {},
+  defaultMaxProcesses = 4,
+): Promise<WorkerPool> {
+  return WorkerPool.create(factory, workerPoolOptions(options, defaultMaxProcesses))
+}
+
+/** Normalizes public request-timeout options for a worker channel. */
+export function workerChannelOptions(options: WasmPoolOptions): WorkerChannelOptions {
+  return { requestTimeoutMs: milliseconds(options.requestTimeout, 'requestTimeout') }
+}
+
+/** Normalizes the public seconds/process options for the low-level pool. */
+function workerPoolOptions(options: WasmPoolOptions, defaultMaxProcesses: number): WorkerPoolOptions {
+  return {
+    minWorkers: options.minProcesses,
+    maxWorkers: options.maxProcesses ?? defaultMaxProcesses,
+    checkoutTimeoutMs: milliseconds(options.checkoutTimeout, 'checkoutTimeout'),
+    durationLimitGraceMs:
+      options.durationLimitGrace === null ? null : milliseconds(options.durationLimitGrace ?? 1, 'durationLimitGrace'),
+    maxCheckoutsPerWorker: options.maxCheckoutsPerWorker,
+  }
+}
+
+/** Converts a validated public seconds option to channel milliseconds. */
+function milliseconds(value: number | undefined, name: string): number | undefined {
+  if (value === undefined) return undefined
+  const milliseconds = value * 1000
+  if (!Number.isFinite(value) || value < 0 || !Number.isFinite(milliseconds)) {
+    throw new Error(`${name} must be a finite non-negative number`)
+  }
+  return milliseconds
+}

--- a/crates/monty-js/ts/worker/transport.ts
+++ b/crates/monty-js/ts/worker/transport.ts
@@ -13,9 +13,16 @@
 // `traceback` strings are not yet rendered (frames are decoded; the rendered
 // string is a follow-up); mounts are rejected (no host filesystem in a worker).
 
-import type { NativeException, NativeFrame, NativeFutureResult, NativeTurn, NotMountedTurn } from '../native.js'
+import type {
+  CrashedTurn,
+  NativeException,
+  NativeFrame,
+  NativeFutureResult,
+  NativeTurn,
+  NotMountedTurn,
+} from '../native.js'
 import { type AssertMessageAnnotations, encodeAssertMessageAnnotations } from '../options.js'
-import type { Dispatcher } from './host.js'
+import { DispatchError, type Dispatcher } from './host.js'
 import { Reader, Wire, Writer, deframe, frame } from './proto.js'
 import { decodeMontyObject, decodeTimeZone, encodeMontyObject } from './value.js'
 
@@ -41,6 +48,16 @@ export interface WorkerSessionConfig {
    * off, an integer >= 1 customizes the truncation length.
    */
   assertMessageAnnotations?: AssertMessageAnnotations
+}
+
+/** Pool-owned worker metadata and duration-backstop configuration. */
+export interface WorkerTransportOptions {
+  /** Parent-side grace added to the worker's remaining duration budget. */
+  durationLimitGraceMs?: number
+  /** Pool-local identity retained across the session. */
+  workerId: number
+  /** OS process id for process-backed custom factories. */
+  workerPid?: number
 }
 
 // ParentRequest oneof field numbers (see proto/monty/v1/monty.proto). Note
@@ -77,28 +94,35 @@ export class WorkerTransport {
   /** The id/name of the suspension awaiting an answer, for the `resume*` family. */
   private pendingCallId = 0
   private pendingFunctionName = ''
-
-  /** No OS process backs a wasm worker. */
-  readonly workerPid: number | null = null
-
-  /**
-   * Set once a turn reveals the worker is dead (crash/channel error): `finish`
-   * then skips `Reset` and the owner reclaims via `onFinish(false)`.
-   */
   private dead = false
+  private released = false
+  private durationBudgetMicros: bigint | null
+  private reportedExecutionMicros = 0n
 
-  /**
-   * Invoked when the session ends, telling the owner (a pool) whether the
-   * worker may be reused. `true` after a clean `Reset`; `false` if the worker
-   * died and must be discarded.
-   */
+  readonly workerPid: number | null
+  readonly workerId: number
+
+  /** Reports clean reuse or terminal disposal to the owning pool exactly once. */
   onFinish?: (reusable: boolean) => void
 
-  private constructor(private readonly dispatcher: Dispatcher) {}
+  private constructor(
+    private readonly dispatcher: Dispatcher,
+    private readonly durationLimitGraceMs: number | undefined,
+    config: WorkerSessionConfig,
+    options: WorkerTransportOptions,
+  ) {
+    this.workerPid = options.workerPid ?? null
+    this.workerId = options.workerId
+    this.durationBudgetMicros = maxDurationMicros(config.limits)
+  }
 
   /** Creates the REPL session (`ReplCreate`) and returns the ready transport. */
-  static async create(dispatcher: Dispatcher, config: WorkerSessionConfig = {}): Promise<WorkerTransport> {
-    const transport = new WorkerTransport(dispatcher)
+  static async create(
+    dispatcher: Dispatcher,
+    config: WorkerSessionConfig = {},
+    options: WorkerTransportOptions = { workerId: 0 },
+  ): Promise<WorkerTransport> {
+    const transport = new WorkerTransport(dispatcher, options.durationLimitGraceMs, config, options)
     const create = new Writer()
     create.string(1, config.scriptName ?? 'main.py') // ReplCreate.script_name
     if (config.limits) create.lengthDelimited(2, encodeLimits(config.limits)) // ReplCreate.limits
@@ -231,12 +255,17 @@ export class WorkerTransport {
     if (mounts.length > 0) {
       throw new Error('the wasm worker does not support filesystem mounts (browser has no host filesystem)')
     }
+    // The dump carries its own budget and consumed time; adopt both from the
+    // Load reply rather than retaining the fresh checkout's configuration.
+    this.durationBudgetMicros = null
+    this.reportedExecutionMicros = 0n
     const load = new Writer()
     load.bytes(1, state) // Load.state
-    const event = await this.run(Req.Load, load.finish(), onPrint)
-    if (!event) return crashed('worker exited without a turn-ending event')
-    if (event.kind === Ev.Ok) return { kind: 'loaded' }
-    return this.toTurn(event)
+    const outcome = await this.run(Req.Load, load.finish(), onPrint)
+    if (outcome.crash) return outcome.crash
+    if (!outcome.event) return crashed('worker exited without a turn-ending event', false, outcome.exitStatus)
+    if (outcome.event.kind === Ev.Ok) return { kind: 'loaded' }
+    return this.toTurn(outcome.event, outcome.exitStatus)
   }
 
   /**
@@ -246,15 +275,14 @@ export class WorkerTransport {
    */
   async finish(): Promise<void> {
     if (this.dead) {
-      this.onFinish?.(false)
+      this.release(false)
       return
     }
     try {
       await this.control(Req.Reset, EMPTY, Ev.Ok, 'Reset')
-      this.onFinish?.(true)
+      this.release(true)
     } catch {
-      this.dead = true
-      this.onFinish?.(false)
+      this.markDead()
     }
   }
 
@@ -267,39 +295,56 @@ export class WorkerTransport {
     return this.turn(Req.ResumeCall, call.finish(), onPrint)
   }
 
-  /** Sends a request and decodes the terminating event into a `NativeTurn`. */
+  /** Sends an execution request and decodes its terminating event. */
   private async turn(field: number, payload: Uint8Array, onPrint: OnPrint): Promise<NativeTurn> {
-    const event = await this.run(field, payload, onPrint)
-    const turn = event ? this.toTurn(event) : crashed('worker exited without a turn-ending event')
-    if (turn.kind === 'crashed') this.dead = true
+    const outcome = await this.run(field, payload, onPrint, this.backstopTimeoutMs())
+    const turn = outcome.crash
+      ? outcome.crash
+      : outcome.event
+        ? this.toTurn(outcome.event, outcome.exitStatus)
+        : crashed('worker exited without a turn-ending event', false, outcome.exitStatus)
+    if (turn.kind === 'crashed' || turn.kind === 'protocol') this.markDead()
     return turn
   }
 
   /** Sends a control request (ReplCreate/Reset/Dump) and asserts its event kind. */
   private async control(field: number, payload: Uint8Array, kind: number, what: string): Promise<ChildEventFrame> {
-    const event = await this.run(field, payload, undefined)
+    const outcome = await this.run(field, payload, undefined)
+    if (outcome.crash) {
+      throw new DispatchError(outcome.crash.message, outcome.crash.timedOut, outcome.crash.exitStatus)
+    }
+    const event = outcome.event
     if (!event) throw new Error(`${what} produced no turn-ending event (worker crashed)`)
     if (event.kind !== kind) throw new Error(`${what} expected event ${kind}, got ${event.kind}`)
     return event
   }
 
-  /** Runs one turn, streaming `Print`s, and returns the single terminating event. */
-  private async run(field: number, payload: Uint8Array, onPrint: OnPrint | undefined): Promise<ChildEventFrame | null> {
+  /** Runs one turn, streams `Print`s, and retains worker crash metadata. */
+  private async run(
+    field: number,
+    payload: Uint8Array,
+    onPrint: OnPrint | undefined,
+    timeoutMs?: number,
+  ): Promise<RunOutcome> {
     const request = new Writer()
     request.lengthDelimited(field, payload) // ParentRequest oneof
     let reply: Uint8Array
-    let decodedEvents: ChildEventFrame[] | undefined
+    let exitStatus: string | null = null
     try {
-      const dispatched = await this.dispatcher(frame(request.finish()))
+      const dispatched = await this.dispatcher(frame(request.finish()), { timeoutMs })
       reply = dispatched.reply
-      decodedEvents = dispatched.events?.map((event) => ({ kind: event.kind, bytes: Uint8Array.from(event.bytes) }))
-    } catch {
-      // the dispatcher rejects when the worker died or the channel broke; the
-      // caller treats a missing terminating event as a crash
-      return null
+      exitStatus = dispatched.exitStatus ?? null
+      if (dispatched.status !== 0) this.markDead()
+    } catch (err) {
+      const failure =
+        err instanceof DispatchError
+          ? crashed(err.message, err.timedOut, err.exitStatus)
+          : crashed(errorMessage(err), false, null)
+      this.markDead()
+      return { event: null, crash: failure, exitStatus: failure.exitStatus ?? null }
     }
     let terminating: ChildEventFrame | null = null
-    for (const event of decodedEvents ?? decodeChildEvents(reply)) {
+    for (const event of decodeChildEvents(reply)) {
       if (event.kind === Ev.Print) {
         if (onPrint) {
           const [stream, text] = decodePrint(event.bytes)
@@ -309,10 +354,11 @@ export class WorkerTransport {
         terminating = event
       }
     }
-    return terminating
+    if (terminating) this.noteReportedTime(terminating)
+    return { event: terminating, crash: null, exitStatus }
   }
 
-  private toTurn(event: ChildEventFrame): NativeTurn {
+  private toTurn(event: ChildEventFrame, exitStatus: string | null = null): NativeTurn {
     switch (event.kind) {
       case Ev.Complete:
         return { kind: 'complete', value: decodeComplete(event.bytes) }
@@ -350,44 +396,83 @@ export class WorkerTransport {
       case Ev.ResolveFutures:
         return { kind: 'resolveFutures', pendingCallIds: decodeResolveFutures(event.bytes) }
       case Ev.FatalError:
-        return crashed(decodeSingleString(event.bytes))
+        return crashed(decodeSingleString(event.bytes), false, exitStatus)
       default:
         return { kind: 'protocol', message: `unexpected event kind ${event.kind}` }
     }
+  }
+
+  /** Remaining duration budget plus grace, derived solely from worker reports. */
+  private backstopTimeoutMs(): number | undefined {
+    if (this.durationLimitGraceMs === undefined || this.durationBudgetMicros === null) return undefined
+    const remaining = this.durationBudgetMicros - this.reportedExecutionMicros
+    return Number(remaining > 0n ? remaining : 0n) / 1000 + this.durationLimitGraceMs
+  }
+
+  /** Ratchets execution time and adopts a restored session's duration budget. */
+  private noteReportedTime(event: ChildEventFrame): void {
+    if (event.totalExecutionMicros > this.reportedExecutionMicros) {
+      this.reportedExecutionMicros = event.totalExecutionMicros
+    }
+    if (this.durationBudgetMicros === null && event.maxDurationMicros !== null) {
+      this.durationBudgetMicros = event.maxDurationMicros
+    }
+  }
+
+  /** Retires a failed worker and immediately frees its pool capacity. */
+  private markDead(): void {
+    this.dead = true
+    this.release(false)
+  }
+
+  /** Reports this transport's disposition to its pool at most once. */
+  private release(reusable: boolean): void {
+    if (this.released) return
+    this.released = true
+    this.onFinish?.(reusable)
   }
 }
 
 // === ChildEvent / value decoding ===
 
+interface RunOutcome {
+  readonly event: ChildEventFrame | null
+  readonly crash: CrashedTurn | null
+  readonly exitStatus: string | null
+}
+
 interface ChildEventFrame {
   readonly kind: number
   readonly bytes: Uint8Array
+  readonly totalExecutionMicros: bigint
+  readonly maxDurationMicros: bigint | null
 }
 
 function decodeChildEvents(reply: Uint8Array): ChildEventFrame[] {
   return [...deframe(reply)].map(readChildEvent)
 }
 
-/**
- * Extracts the oneof kind from a `ChildEvent`, ignoring the message-level
- * timing/name fields. Tags 1-19 are reserved for oneof arms and the message's
- * own fields start at 20 (see `monty.proto`), so this range needs no change
- * when an arm is added. Mirrors prost's decode: the last arm wins, and an arm
- * that is not a length-delimited message is rejected rather than surfaced
- * with an empty payload.
- */
+/** Decodes a `ChildEvent` envelope, including duration-backstop fields. */
 function readChildEvent(frameBytes: Uint8Array): ChildEventFrame {
   const reader = new Reader(frameBytes)
-  let event: ChildEventFrame | null = null
+  let kind = 0
+  let bytes: Uint8Array = EMPTY
+  let totalExecutionMicros = 0n
+  let maxDurationMicros: bigint | null = null
   while (!reader.done) {
     const f = reader.next()
     if (f.field >= 1 && f.field <= 19) {
       if (f.wire !== Wire.LengthDelimited) throw new Error(`ChildEvent kind ${f.field} is not a message`)
-      event = { kind: f.field, bytes: f.bytes }
+      kind = f.field
+      bytes = f.bytes
+    } else if (f.field === 20 && f.wire === Wire.Varint) {
+      totalExecutionMicros = f.value
+    } else if (f.field === 21 && f.wire === Wire.Varint) {
+      maxDurationMicros = f.value
     }
   }
-  if (!event) throw new Error('ChildEvent carried no kind')
-  return event
+  if (kind === 0) throw new Error('ChildEvent carried no kind')
+  return { kind, bytes, totalExecutionMicros, maxDurationMicros }
 }
 
 function decodeComplete(bytes: Uint8Array): unknown {
@@ -759,11 +844,24 @@ function decodeSingleString(bytes: Uint8Array): string {
 /** Encodes a `ResourceLimits` message (durations are seconds -> microseconds). */
 function encodeLimits(limits: ResourceLimits): Uint8Array {
   const w = new Writer()
-  if (limits.maxDurationSecs !== undefined) w.uint(1, Math.round(limits.maxDurationSecs * 1_000_000)) // max_duration_micros
+  const durationMicros = maxDurationMicros(limits)
+  if (durationMicros !== null) w.uint(1, durationMicros) // max_duration_micros
   if (limits.maxMemory !== undefined) w.uint(2, limits.maxMemory) // max_memory_bytes
   if (limits.gcInterval !== undefined) w.uint(3, limits.gcInterval) // gc_interval
   if (limits.maxRecursionDepth !== undefined) w.uint(4, limits.maxRecursionDepth) // max_recursion_depth
   return w.finish()
+}
+
+/** Normalizes a duration limit to the protocol's saturating u64 micros. */
+function maxDurationMicros(limits: ResourceLimits | undefined): bigint | null {
+  if (limits?.maxDurationSecs === undefined) return null
+  const seconds = limits.maxDurationSecs
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    throw new Error('maxDurationSecs must be a finite non-negative number')
+  }
+  const micros = seconds * 1_000_000
+  const maxU64 = (1n << 64n) - 1n
+  return !Number.isFinite(micros) || micros >= Number(maxU64) ? maxU64 : BigInt(Math.round(micros))
 }
 
 /** Wraps a payload as one `ExtFunctionResult` oneof field. */
@@ -798,8 +896,13 @@ function functionValue(name: string): Uint8Array {
   return obj.finish()
 }
 
-function crashed(message: string): NativeTurn {
-  return { kind: 'crashed', message, timedOut: false }
+function crashed(message: string, timedOut = false, exitStatus: string | null = null): CrashedTurn {
+  return { kind: 'crashed', message, timedOut, ...(exitStatus === null ? {} : { exitStatus }) }
+}
+
+/** Extracts a useful message from an arbitrary dispatcher rejection. */
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
 }
 
 function decodeString(bytes: Uint8Array): string {

--- a/crates/monty-js/vitest.wasm.config.ts
+++ b/crates/monty-js/vitest.wasm.config.ts
@@ -2,8 +2,7 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    include: ['__test__/*.spec.ts'],
-    exclude: ['__test__/wasm_pool.spec.ts'],
+    include: ['__test__/wasm_pool.spec.ts'],
     testTimeout: 120_000,
     hookTimeout: 120_000,
     fileParallelism: false,

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -368,3 +368,15 @@ same protocol in TypeScript over a WASM worker. Everything above applies, plus:
   `FutureSnapshot.resume([{callId, value}|{callId, error}])`).
 - Sessions and pools support `await using` (async disposal) in addition to
   explicit `close()`.
+- **WASM workers have no process identity.** `session.workerId` is stable for
+  reuse/recycling diagnostics, but `session.workerPid` is unset. Node `/wasm`
+  uses a `worker_threads` worker and can report its thread exit code on a
+  crash; browsers expose neither a PID nor an exit status.
+- **Node `/wasm` isolation is a worker thread, not a subprocess.** A trapped or
+  timed-out WASM instance is terminated without taking down other sessions,
+  but a whole-process failure such as a JavaScript heap OOM can still terminate
+  the host. The low-level in-process factory has no hard-preemption guarantee.
+- **WASM transports do not implement `MountDir`.** Browser workers have no host
+  path namespace, and Node `/wasm` does not duplicate the security-sensitive
+  `monty-fs` service in TypeScript. Filesystem OS calls can still be handled
+  explicitly through the `os` callback.


### PR DESCRIPTION
I asked AI to close the following gaps:

>The WASM backend has a TypeScript worker pool, but it lacks full native-pool parity. `checkoutTimeout` and `durationLimitGrace` are accepted but ignored, timeout failures lose native crash metadata, and there is no worker PID or process exit status. The Node `/wasm` entry currently uses the in-process fallback rather than the existing `nodeWorkerFactory`, so it lacks hard preemption and crash isolation by default. Pool lifecycle, recycling, timeout, and crash-recovery tests are also not shared across the native and WASM implementations.
>
> Filesystem mounts are explicitly rejected by the WASM transport. Browser host-directory mounts have no direct equivalent, while Node WASM mounts would require a security-reviewed host-side service equivalent to Rust’s `monty-fs::MountTable`. External `os` callbacks work, but native `MountDir` behavior—including read-only, read-write, overlay, path-security, and resource-limit guarantees—is absent.

... this is the result, I'll review and tidy up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings the WASM pool much closer to native parity: Node `@pydantic/monty/wasm` now runs in `worker_threads` with hard preemption and crash metadata, and the pool enforces timeouts and recycling consistently across browser and Node.

- **New Features**
  - Node `/wasm` uses a `worker_threads` pool (via `nodeWorkerFactory`) instead of the in-process fallback; timed-out turns are killed and report an exit status.
  - Enforces `checkoutTimeout`, `requestTimeout`, and `durationLimitGrace` in WASM pools; `maxCheckoutsPerWorker` now recycles workers.
  - Preserves timeout/crash details across the channel and transport; `MontyCrashedError` includes `timedOut` and, on Node `/wasm`, `exitStatus`.
  - Adds `session.workerId` for stable worker identity across backends; `session.workerPid` remains only for native subprocess workers.
  - Duration backstop tracks worker-reported execution time and adopts restored session budgets.
  - Adds shared pool conformance tests for native and WASM; runs Node WASM tests in CI and via `make test-wasm`.

- **Refactors**
  - `WorkerChannel` merges per-turn request deadlines with duration backstops, propagates runtime exit metadata, and uses a 64-bit–safe deadline timer.
  - `WorkerPool` validates options, supports `checkoutTimeout`, frees capacity immediately on worker death, and assigns stable worker ids.
  - Transport path now surfaces protocol crashes with exit info, and releases/retire workers exactly once.
  - Docs clarify worker identity and isolation differences; browser/Node `/wasm` mounts remain unsupported.

<sup>Written for commit 71ee4a7d11f59b5f6a3548bd093e223e5f578737. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

