### PR TITLE
Bind mount file access to file identity, not to a path name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,6 +2082,7 @@ dependencies = [
  "ahash",
  "monty-types",
  "tempfile",
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,10 @@ tokio-tungstenite = { version = "0.27", features = ["rustls-tls-webpki-roots"] }
 futures-util = { version = "0.3", default-features = false, features = ["std", "sink"] }
 # Unique, exclusively-created temp dirs (pool tests).
 tempfile = "3"
+# Windows-only: `GetFileInformationByHandle` without hand-written `unsafe`, for
+# the file-identity check in monty-fs. Unix gets `st_dev`/`st_ino` from std, but
+# std's Windows equivalent is still unstable (`windows_by_handle`, rust#63010).
+winapi-util = "0.1.11"
 # Pulled in only to install a process-level rustls `CryptoProvider` before the
 # first `wss://` dial: rustls 0.23 panics on first TLS use when it can't pick a
 # provider automatically (both `aws-lc-rs` and `ring`, or neither, in the dep

--- a/crates/monty-fs/Cargo.toml
+++ b/crates/monty-fs/Cargo.toml
@@ -19,6 +19,9 @@ name = "monty_fs"
 monty-types = { workspace = true }
 ahash = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+winapi-util = { workspace = true }
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/crates/monty-fs/src/common.rs
+++ b/crates/monty-fs/src/common.rs
@@ -13,7 +13,7 @@ use std::{
 
 use monty_types::{MontyObject, UnicodeErrorData, dir_stat, file_stat, utf8_error_reason};
 
-use super::error::MountError;
+use super::{error::MountError, file_identity::FileIdentity};
 
 /// Conservative per-item charge for transient listing bookkeeping: string
 /// headers, container slots, and dedup-set entries. Variable-size name and
@@ -97,8 +97,13 @@ pub(super) struct MountContext<'a> {
 ///
 /// Directory-read errors differ across platforms, so the target is checked
 /// explicitly before reading.
-pub(super) fn read_text_fs(path: &Path, vpath: &str, budget: MemoryBudget) -> Result<MontyObject, MountError> {
-    let bytes = read_file_limited(path, vpath, budget)?;
+pub(super) fn read_text_fs(
+    path: &Path,
+    identity: Option<FileIdentity>,
+    vpath: &str,
+    budget: MemoryBudget,
+) -> Result<MontyObject, MountError> {
+    let bytes = read_file_limited(path, identity, vpath, budget)?;
     let content = bytes_to_utf8(bytes)?;
     Ok(MontyObject::String(content))
 }
@@ -107,8 +112,13 @@ pub(super) fn read_text_fs(path: &Path, vpath: &str, budget: MemoryBudget) -> Re
 ///
 /// Directory-read errors differ across platforms, so the target is checked
 /// explicitly before reading.
-pub(super) fn read_bytes_fs(path: &Path, vpath: &str, budget: MemoryBudget) -> Result<MontyObject, MountError> {
-    Ok(MontyObject::Bytes(read_file_limited(path, vpath, budget)?))
+pub(super) fn read_bytes_fs(
+    path: &Path,
+    identity: Option<FileIdentity>,
+    vpath: &str,
+    budget: MemoryBudget,
+) -> Result<MontyObject, MountError> {
+    Ok(MontyObject::Bytes(read_file_limited(path, identity, vpath, budget)?))
 }
 
 /// Reads at most `budget + 1` bytes so an oversized file is rejected before it
@@ -119,9 +129,18 @@ pub(super) fn read_bytes_fs(path: &Path, vpath: &str, budget: MemoryBudget) -> R
 /// with one `stat`, and pre-sizing the buffer (capped by the budget) to avoid
 /// `read_to_end`'s doubling reallocations. Enforcement is always the byte
 /// count actually read, so lying or racing metadata cannot evade the limit.
-fn read_file_limited(path: &Path, vpath: &str, budget: MemoryBudget) -> Result<Vec<u8>, MountError> {
+///
+/// `identity` binds the read to the file the boundary check cleared, since
+/// `open` resolves `path` afresh.
+fn read_file_limited(
+    path: &Path,
+    identity: Option<FileIdentity>,
+    vpath: &str,
+    budget: MemoryBudget,
+) -> Result<Vec<u8>, MountError> {
     reject_non_regular(path, vpath)?;
     let file = File::open(path).map_err(|err| MountError::Io(err, vpath.to_owned()))?;
+    FileIdentity::verify(identity, &file, vpath)?;
     let meta_len = file
         .metadata()
         .map_err(|err| MountError::Io(err, vpath.to_owned()))?
@@ -141,9 +160,13 @@ fn read_file_limited(path: &Path, vpath: &str, budget: MemoryBudget) -> Result<V
 ///
 /// On Windows, `fs::write()` on a directory returns `PermissionDenied` instead of
 /// `IsADirectory`, so we check explicitly before writing.
-pub(super) fn write_text_fs(path: &Path, content: &str, vpath: &str) -> Result<MontyObject, MountError> {
-    reject_non_regular(path, vpath)?;
-    fs::write(path, content).map_err(|err| MountError::Io(err, vpath.to_owned()))?;
+pub(super) fn write_text_fs(
+    path: &Path,
+    identity: Option<FileIdentity>,
+    content: &str,
+    vpath: &str,
+) -> Result<MontyObject, MountError> {
+    write_bytes_to_file(path, identity, content.as_bytes(), vpath)?;
     Ok(MontyObject::Int(
         i64::try_from(content.chars().count()).unwrap_or(i64::MAX),
     ))
@@ -153,18 +176,50 @@ pub(super) fn write_text_fs(path: &Path, content: &str, vpath: &str) -> Result<M
 ///
 /// On Windows, `fs::write()` on a directory returns `PermissionDenied` instead of
 /// `IsADirectory`, so we check explicitly before writing.
-pub(super) fn write_bytes_fs(path: &Path, content: &[u8], vpath: &str) -> Result<MontyObject, MountError> {
-    reject_non_regular(path, vpath)?;
-    fs::write(path, content).map_err(|err| MountError::Io(err, vpath.to_owned()))?;
+pub(super) fn write_bytes_fs(
+    path: &Path,
+    identity: Option<FileIdentity>,
+    content: &[u8],
+    vpath: &str,
+) -> Result<MontyObject, MountError> {
+    write_bytes_to_file(path, identity, content, vpath)?;
     Ok(MontyObject::Int(i64::try_from(content.len()).unwrap_or(i64::MAX)))
+}
+
+/// Truncates `path` and writes `content`, verifying identity first.
+///
+/// Deliberately not `fs::write`: that truncates as part of opening, emptying a
+/// substituted file before the check could reject it.
+fn write_bytes_to_file(
+    path: &Path,
+    identity: Option<FileIdentity>,
+    content: &[u8],
+    vpath: &str,
+) -> Result<(), MountError> {
+    reject_non_regular(path, vpath)?;
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)
+        .map_err(|err| MountError::Io(err, vpath.to_owned()))?;
+    FileIdentity::verify(identity, &file, vpath)?;
+    file.set_len(0).map_err(|err| MountError::Io(err, vpath.to_owned()))?;
+    file.write_all(content)
+        .map_err(|err| MountError::Io(err, vpath.to_owned()))
 }
 
 /// Appends text to a file and returns the number of characters written.
 ///
 /// The host file is opened only for the duration of this call, preserving the
 /// sandbox invariant that Monty never keeps native file handles alive.
-pub(super) fn append_text_fs(path: &Path, content: &str, vpath: &str) -> Result<MontyObject, MountError> {
-    append_bytes_to_file(path, content.as_bytes(), vpath)?;
+pub(super) fn append_text_fs(
+    path: &Path,
+    identity: Option<FileIdentity>,
+    content: &str,
+    vpath: &str,
+) -> Result<MontyObject, MountError> {
+    append_bytes_to_file(path, identity, content.as_bytes(), vpath)?;
     Ok(MontyObject::Int(
         i64::try_from(content.chars().count()).unwrap_or(i64::MAX),
     ))
@@ -173,19 +228,30 @@ pub(super) fn append_text_fs(path: &Path, content: &str, vpath: &str) -> Result<
 /// Appends bytes to a file and returns the number of bytes written.
 ///
 /// This is the binary counterpart of [`append_text_fs`].
-pub(super) fn append_bytes_fs(path: &Path, content: &[u8], vpath: &str) -> Result<MontyObject, MountError> {
-    append_bytes_to_file(path, content, vpath)?;
+pub(super) fn append_bytes_fs(
+    path: &Path,
+    identity: Option<FileIdentity>,
+    content: &[u8],
+    vpath: &str,
+) -> Result<MontyObject, MountError> {
+    append_bytes_to_file(path, identity, content, vpath)?;
     Ok(MontyObject::Int(i64::try_from(content.len()).unwrap_or(i64::MAX)))
 }
 
-/// Opens `path` in append mode, writes all bytes, and closes it before returning.
-fn append_bytes_to_file(path: &Path, content: &[u8], vpath: &str) -> Result<(), MountError> {
+/// Opens `path` in append mode, verifies identity, and writes all bytes.
+fn append_bytes_to_file(
+    path: &Path,
+    identity: Option<FileIdentity>,
+    content: &[u8],
+    vpath: &str,
+) -> Result<(), MountError> {
     reject_non_regular(path, vpath)?;
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
         .open(path)
         .map_err(|err| MountError::Io(err, vpath.to_owned()))?;
+    FileIdentity::verify(identity, &file, vpath)?;
     file.write_all(content)
         .map_err(|err| MountError::Io(err, vpath.to_owned()))
 }

--- a/crates/monty-fs/src/direct.rs
+++ b/crates/monty-fs/src/direct.rs
@@ -38,11 +38,21 @@ pub(super) fn execute(request: FsRequest, ctx: &mut MountContext<'_>) -> Result<
         FsRequest::IsSymlink { path } => is_symlink(&path, ctx),
         FsRequest::ReadText { path } => {
             let resolved = resolve_path(&path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)?;
-            read_text_fs(&resolved.host_path, &path, MemoryBudget::full(ctx.memory_usage_limit))
+            read_text_fs(
+                &resolved.host_path,
+                resolved.identity,
+                &path,
+                MemoryBudget::full(ctx.memory_usage_limit),
+            )
         }
         FsRequest::ReadBytes { path } => {
             let resolved = resolve_path(&path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)?;
-            read_bytes_fs(&resolved.host_path, &path, MemoryBudget::full(ctx.memory_usage_limit))
+            read_bytes_fs(
+                &resolved.host_path,
+                resolved.identity,
+                &path,
+                MemoryBudget::full(ctx.memory_usage_limit),
+            )
         }
         FsRequest::WriteText { path, data } => write_text(&path, &data, ctx),
         FsRequest::WriteBytes { path, data } => write_bytes(&path, &data, ctx),
@@ -95,12 +105,12 @@ fn open(path: &str, mode: FileMode, ctx: &mut MountContext<'_>) -> Result<MontyO
         FileMode::Write(_) | FileMode::WriteUpdate(_) => {
             check_write_limit(0, ctx)?;
             let resolved = resolve_path(path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Creation)?;
-            write_text_fs(&resolved.host_path, "", path)?;
+            write_text_fs(&resolved.host_path, resolved.identity, "", path)?;
             commit_write_bytes(0, ctx);
         }
         FileMode::Append(_) | FileMode::AppendUpdate(_) => {
             let resolved = resolve_path(path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Creation)?;
-            append_bytes_fs(&resolved.host_path, &[], path)?;
+            append_bytes_fs(&resolved.host_path, resolved.identity, &[], path)?;
         }
     }
     Ok(file_handle_result(path, mode))
@@ -143,7 +153,7 @@ fn is_symlink(path: &str, ctx: &MountContext<'_>) -> Result<MontyObject, MountEr
 fn write_text(path: &str, data: &str, ctx: &mut MountContext<'_>) -> Result<MontyObject, MountError> {
     check_write_limit(data.len(), ctx)?;
     let resolved = resolve_path(path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Creation)?;
-    let result = write_text_fs(&resolved.host_path, data, path)?;
+    let result = write_text_fs(&resolved.host_path, resolved.identity, data, path)?;
     commit_write_bytes(data.len(), ctx);
     Ok(result)
 }
@@ -152,7 +162,7 @@ fn write_text(path: &str, data: &str, ctx: &mut MountContext<'_>) -> Result<Mont
 fn write_bytes(path: &str, data: &[u8], ctx: &mut MountContext<'_>) -> Result<MontyObject, MountError> {
     check_write_limit(data.len(), ctx)?;
     let resolved = resolve_path(path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Creation)?;
-    let result = write_bytes_fs(&resolved.host_path, data, path)?;
+    let result = write_bytes_fs(&resolved.host_path, resolved.identity, data, path)?;
     commit_write_bytes(data.len(), ctx);
     Ok(result)
 }
@@ -161,7 +171,7 @@ fn write_bytes(path: &str, data: &[u8], ctx: &mut MountContext<'_>) -> Result<Mo
 fn append_text(path: &str, data: &str, ctx: &mut MountContext<'_>) -> Result<MontyObject, MountError> {
     check_write_limit(data.len(), ctx)?;
     let resolved = resolve_path(path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Creation)?;
-    let result = append_text_fs(&resolved.host_path, data, path)?;
+    let result = append_text_fs(&resolved.host_path, resolved.identity, data, path)?;
     commit_write_bytes(data.len(), ctx);
     Ok(result)
 }
@@ -170,7 +180,7 @@ fn append_text(path: &str, data: &str, ctx: &mut MountContext<'_>) -> Result<Mon
 fn append_bytes(path: &str, data: &[u8], ctx: &mut MountContext<'_>) -> Result<MontyObject, MountError> {
     check_write_limit(data.len(), ctx)?;
     let resolved = resolve_path(path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Creation)?;
-    let result = append_bytes_fs(&resolved.host_path, data, path)?;
+    let result = append_bytes_fs(&resolved.host_path, resolved.identity, data, path)?;
     commit_write_bytes(data.len(), ctx);
     Ok(result)
 }

--- a/crates/monty-fs/src/file_identity.rs
+++ b/crates/monty-fs/src/file_identity.rs
@@ -1,0 +1,188 @@
+//! Host file identity, used to bind a security check to the file it checked.
+//!
+//! Path resolution validates a *name*, and the operation that follows resolves
+//! it again — a concurrent `os.rename` in between decides which file that is.
+//! Capturing identity where the boundary check passes and re-checking it
+//! against the opened handle turns that substitution into a `PathEscape`.
+//!
+//! `(device, inode)` on Unix, `(volume serial, file index)` on Windows. Both
+//! are reused after a delete, so this detects substitution rather than proving
+//! a file is the same one across a deletion.
+
+#[cfg(unix)]
+use std::{fs, os::unix::fs::MetadataExt};
+use std::{fs::File, path::Path};
+
+use super::error::MountError;
+
+/// Identifies a specific file on the host, independent of the name used to
+/// reach it.
+///
+/// Capture with [`from_path`](Self::from_path) where a boundary check passes,
+/// then [`verify`](Self::verify) against the handle actually opened.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct FileIdentity {
+    /// `st_dev` on Unix, volume serial number on Windows.
+    volume: u64,
+    /// `st_ino` on Unix, file index on Windows.
+    index: u64,
+}
+
+impl FileIdentity {
+    /// Captures the identity of whatever `path` currently names, following
+    /// symlinks.
+    ///
+    /// `None` (unreadable file) means callers skip verification, so this is a
+    /// second lock on the door — never the door itself.
+    pub fn from_path(path: &Path) -> Option<Self> {
+        #[cfg(unix)]
+        {
+            let metadata = fs::metadata(path).ok()?;
+            Some(Self {
+                volume: metadata.dev(),
+                index: metadata.ino(),
+            })
+        }
+        #[cfg(windows)]
+        {
+            // Windows fills these in only for handle-derived info. The handle
+            // is dropped at once: holding it would block a later `remove_file`.
+
+            let handle = winapi_util::Handle::from_path_any(path).ok()?;
+            Self::from_handle(&handle)
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = path;
+            None
+        }
+    }
+
+    /// Captures the identity of an already-open file — the file the operation
+    /// will actually touch, rather than the one a name points at.
+    pub fn from_file(file: &File) -> Option<Self> {
+        #[cfg(unix)]
+        {
+            let metadata = file.metadata().ok()?;
+            Some(Self {
+                volume: metadata.dev(),
+                index: metadata.ino(),
+            })
+        }
+        #[cfg(windows)]
+        {
+            Self::from_handle(file)
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = file;
+            None
+        }
+    }
+
+    /// Reads `BY_HANDLE_FILE_INFORMATION` for an open Windows handle.
+    #[cfg(windows)]
+    fn from_handle(handle: impl winapi_util::AsHandleRef) -> Option<Self> {
+        let info = winapi_util::file::information(handle).ok()?;
+        Some(Self {
+            volume: info.volume_serial_number(),
+            index: info.file_index(),
+        })
+    }
+
+    /// Rejects `file` unless it is the file `expected` described — a mismatch
+    /// means the handle refers to a file that was never validated.
+    ///
+    /// `expected` of `None` skips the check, leaving the boundary check to
+    /// stand alone; with a baseline it fails closed, rejecting a handle whose
+    /// identity cannot be read.
+    pub fn verify(expected: Option<Self>, file: &File, vpath: &str) -> Result<(), MountError> {
+        match expected {
+            Some(expected) if Self::from_file(file) != Some(expected) => Err(MountError::PathEscape {
+                virtual_path: vpath.to_owned(),
+            }),
+            _ => Ok(()),
+        }
+    }
+}
+
+// Tests live here because the check is unreachable from outside the crate:
+// triggering it needs a substitution inside the resolve→open window, and
+// anything staged via the public API lands before resolution, where the
+// boundary check rejects it first.
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    /// Must match, or every legitimate read is rejected.
+    #[test]
+    fn path_and_handle_agree_for_the_same_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("file.txt");
+        fs::write(&path, "content").unwrap();
+
+        let from_path = FileIdentity::from_path(&path).expect("path capture failed");
+        let file = File::open(&path).unwrap();
+        assert_eq!(Some(from_path), FileIdentity::from_file(&file));
+        assert!(FileIdentity::verify(Some(from_path), &file, "/mnt/file.txt").is_ok());
+    }
+
+    /// Must differ, or substitution goes undetected.
+    #[test]
+    fn distinct_files_have_distinct_identities() {
+        let dir = TempDir::new().unwrap();
+        let (a, b) = (dir.path().join("a.txt"), dir.path().join("b.txt"));
+        fs::write(&a, "a").unwrap();
+        fs::write(&b, "b").unwrap();
+
+        assert_ne!(FileIdentity::from_path(&a), FileIdentity::from_path(&b));
+    }
+
+    /// Identity follows the file, not the name — the property the whole check
+    /// rests on.
+    #[test]
+    fn identity_survives_rename() {
+        let dir = TempDir::new().unwrap();
+        let (before, after) = (dir.path().join("before.txt"), dir.path().join("after.txt"));
+        fs::write(&before, "content").unwrap();
+
+        let captured = FileIdentity::from_path(&before);
+        fs::rename(&before, &after).unwrap();
+        assert_eq!(captured, FileIdentity::from_path(&after));
+    }
+
+    /// The case the module exists for: the name now refers to a different file.
+    #[test]
+    fn verify_rejects_a_substituted_file() {
+        let dir = TempDir::new().unwrap();
+        let (target, decoy) = (dir.path().join("target.txt"), dir.path().join("decoy.txt"));
+        fs::write(&target, "target").unwrap();
+        fs::write(&decoy, "decoy").unwrap();
+
+        let captured = FileIdentity::from_path(&target);
+        // Stand in for a rename landing between capture and open.
+        fs::rename(&decoy, &target).unwrap();
+
+        let opened = File::open(&target).unwrap();
+        let outcome = FileIdentity::verify(captured, &opened, "/mnt/target.txt");
+        assert!(
+            matches!(outcome, Err(MountError::PathEscape { .. })),
+            "expected PathEscape, got {outcome:?}"
+        );
+    }
+
+    /// Creation targets resolve with `None` and must not be rejected.
+    #[test]
+    fn verify_without_a_baseline_permits_the_open() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("file.txt");
+        fs::write(&path, "content").unwrap();
+
+        let file = File::open(&path).unwrap();
+        assert!(FileIdentity::verify(None, &file, "/mnt/file.txt").is_ok());
+    }
+}

--- a/crates/monty-fs/src/lib.rs
+++ b/crates/monty-fs/src/lib.rs
@@ -37,6 +37,7 @@ mod common;
 mod direct;
 mod dispatch;
 mod error;
+mod file_identity;
 mod mount_mode;
 mod mount_table;
 mod overlay;

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -21,6 +21,7 @@ use super::{
     },
     dispatch::{FsRequest, file_handle_result},
     error::MountError,
+    file_identity::FileIdentity,
     overlay_state::{ENTRY_MEMORY_USAGE, OverlayEntry, OverlayFile, OverlayFileRef, OverlayState},
     path_security::{
         ResolveMode, normalize_virtual_path, reject_escaping_symlink, reject_overlong_path, resolve_path,
@@ -113,10 +114,10 @@ fn open(
                 }
                 Some(OverlayEntry::Deleted) => return Err(MountError::not_found(path)),
                 None => match resolve_real_path_state(path, ctx, ResolveMode::Existing)? {
-                    RealPathState::Present(host_path) if host_path.is_dir() => {
+                    RealPathState::Present(host_path, _) if host_path.is_dir() => {
                         return Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", path));
                     }
-                    RealPathState::Present(_) => {}
+                    RealPathState::Present(..) => {}
                     RealPathState::Missing => return Err(MountError::not_found(path)),
                 },
             }
@@ -170,10 +171,10 @@ fn ensure_append_target_exists(
             Ok(())
         }
         None => match resolve_real_path_state(vpath, ctx, ResolveMode::Existing)? {
-            RealPathState::Present(host_path) if host_path.is_dir() => {
+            RealPathState::Present(host_path, _) if host_path.is_dir() => {
                 Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
             }
-            RealPathState::Present(_) => Ok(()),
+            RealPathState::Present(..) => Ok(()),
             RealPathState::Missing => {
                 ensure_parent_exists(state, &relative, ctx, vpath)?;
                 state.insert(
@@ -201,7 +202,7 @@ fn exists(
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_) | OverlayEntry::Directory { .. }) => true,
         Some(OverlayEntry::Deleted) => false,
         None => match resolve_real_path_state(vpath, ctx, ResolveMode::Existing)? {
-            RealPathState::Present(_) => true,
+            RealPathState::Present(..) => true,
             RealPathState::Missing => false,
         },
     };
@@ -219,7 +220,7 @@ fn is_file(
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_)) => true,
         Some(OverlayEntry::Directory { .. } | OverlayEntry::Deleted) => false,
         None => match resolve_real_path_state(vpath, ctx, ResolveMode::Existing)? {
-            RealPathState::Present(host_path) => host_path.is_file(),
+            RealPathState::Present(host_path, _) => host_path.is_file(),
             RealPathState::Missing => false,
         },
     };
@@ -237,7 +238,7 @@ fn is_dir(
         Some(OverlayEntry::Directory { .. }) => true,
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_) | OverlayEntry::Deleted) => false,
         None => match resolve_real_path_state(vpath, ctx, ResolveMode::Existing)? {
-            RealPathState::Present(host_path) => host_path.is_dir(),
+            RealPathState::Present(host_path, _) => host_path.is_dir(),
             RealPathState::Missing => false,
         },
     };
@@ -254,7 +255,7 @@ fn is_symlink(
     let is_symlink = match state.get(relative) {
         Some(_) => false,
         None => match resolve_real_path_state(vpath, ctx, ResolveMode::Lstat)? {
-            RealPathState::Present(host_path) => host_path.is_symlink(),
+            RealPathState::Present(host_path, _) => host_path.is_symlink(),
             RealPathState::Missing => false,
         },
     };
@@ -274,7 +275,7 @@ fn read_text(
             Ok(MontyObject::String(bytes_to_utf8(file.content.clone())?))
         }
         Some(OverlayEntry::RealFileRef(file_ref)) => {
-            read_text_fs(&file_ref.host_path, vpath, available_memory(state, ctx)?)
+            read_text_fs(&file_ref.host_path, None, vpath, available_memory(state, ctx)?)
         }
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
@@ -282,7 +283,12 @@ fn read_text(
         Some(OverlayEntry::Deleted) => Err(MountError::not_found(vpath)),
         None => {
             let resolved = resolve_path(vpath, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)?;
-            read_text_fs(&resolved.host_path, vpath, available_memory(state, ctx)?)
+            read_text_fs(
+                &resolved.host_path,
+                resolved.identity,
+                vpath,
+                available_memory(state, ctx)?,
+            )
         }
     }
 }
@@ -300,7 +306,7 @@ fn read_bytes(
             Ok(MontyObject::Bytes(file.content.clone()))
         }
         Some(OverlayEntry::RealFileRef(file_ref)) => {
-            read_bytes_fs(&file_ref.host_path, vpath, available_memory(state, ctx)?)
+            read_bytes_fs(&file_ref.host_path, None, vpath, available_memory(state, ctx)?)
         }
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
@@ -308,7 +314,12 @@ fn read_bytes(
         Some(OverlayEntry::Deleted) => Err(MountError::not_found(vpath)),
         None => {
             let resolved = resolve_path(vpath, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)?;
-            read_bytes_fs(&resolved.host_path, vpath, available_memory(state, ctx)?)
+            read_bytes_fs(
+                &resolved.host_path,
+                resolved.identity,
+                vpath,
+                available_memory(state, ctx)?,
+            )
         }
     }
 }
@@ -450,7 +461,7 @@ fn existing_file_len(
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
         }
         None => match resolve_real_path_state(vpath, ctx, ResolveMode::Existing)? {
-            RealPathState::Present(host_path) => file_len(&host_path, vpath),
+            RealPathState::Present(host_path, _) => file_len(&host_path, vpath),
             RealPathState::Missing => Ok(0),
         },
     }
@@ -481,7 +492,7 @@ fn existing_file_bytes(
             Ok(file.content.clone())
         }
         Some(OverlayEntry::Deleted) => Ok(Vec::new()),
-        Some(OverlayEntry::RealFileRef(file_ref)) => match read_bytes_fs(&file_ref.host_path, vpath, budget)? {
+        Some(OverlayEntry::RealFileRef(file_ref)) => match read_bytes_fs(&file_ref.host_path, None, vpath, budget)? {
             MontyObject::Bytes(bytes) => Ok(bytes),
             _ => unreachable!("read_bytes_fs should return bytes"),
         },
@@ -489,7 +500,7 @@ fn existing_file_bytes(
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
         }
         None => match resolve_real_path_state(vpath, ctx, ResolveMode::Existing)? {
-            RealPathState::Present(host_path) => match read_bytes_fs(&host_path, vpath, budget)? {
+            RealPathState::Present(host_path, identity) => match read_bytes_fs(&host_path, identity, vpath, budget)? {
                 MontyObject::Bytes(bytes) => Ok(bytes),
                 _ => unreachable!("read_bytes_fs should return bytes"),
             },
@@ -1197,7 +1208,7 @@ fn resolve_real_path_state(
     mode: ResolveMode,
 ) -> Result<RealPathState, MountError> {
     match resolve_path(vpath, ctx.mount_virtual, ctx.mount_host, mode) {
-        Ok(resolved) => Ok(RealPathState::Present(resolved.host_path)),
+        Ok(resolved) => Ok(RealPathState::Present(resolved.host_path, resolved.identity)),
         Err(MountError::Io(_, _)) => Ok(RealPathState::Missing),
         Err(err) => Err(err),
     }
@@ -1205,8 +1216,9 @@ fn resolve_real_path_state(
 
 /// Result of resolving a real fallthrough path for overlay queries.
 enum RealPathState {
-    /// The path exists and can be queried on the host.
-    Present(PathBuf),
+    /// The path exists and can be queried on the host, with the identity the
+    /// boundary check cleared.
+    Present(PathBuf, Option<FileIdentity>),
     /// The path should behave as nonexistent.
     Missing,
 }

--- a/crates/monty-fs/src/path_security.rs
+++ b/crates/monty-fs/src/path_security.rs
@@ -15,7 +15,7 @@ use std::{
     path::{Component, Path, PathBuf},
 };
 
-use super::error::MountError;
+use super::{error::MountError, file_identity::FileIdentity};
 
 /// Maximum total path length in bytes (Linux `PATH_MAX`).
 const PATH_MAX: usize = 4096;
@@ -28,6 +28,10 @@ const NAME_MAX: usize = 255;
 pub(super) struct ResolvedPath {
     /// Validated host filesystem path suitable for the requested operation.
     pub host_path: PathBuf,
+    /// Identity of the file the boundary check inspected, the only link back to
+    /// what was validated once `host_path` is resolved again. `None` for
+    /// creation targets that do not exist yet.
+    pub identity: Option<FileIdentity>,
 }
 
 /// Resolution strategy for a filesystem operation.
@@ -57,13 +61,13 @@ pub(super) fn resolve_path(
     mode: ResolveMode,
 ) -> Result<ResolvedPath, MountError> {
     let request = ResolutionRequest::new(virtual_path, mount_virtual_path, mount_host_path)?;
-    let host_path = match mode {
+    let (host_path, identity) = match mode {
         ResolveMode::Existing => resolve_existing(&request, mount_host_path)?,
-        ResolveMode::Lstat => resolve_lstat(&request, mount_host_path)?,
+        ResolveMode::Lstat => (resolve_lstat(&request, mount_host_path)?, None),
         ResolveMode::Creation => resolve_creation(&request, mount_host_path)?,
-        ResolveMode::MkdirParents => resolve_mkdir_parents(&request, mount_host_path)?,
+        ResolveMode::MkdirParents => (resolve_mkdir_parents(&request, mount_host_path)?, None),
     };
-    Ok(ResolvedPath { host_path })
+    Ok(ResolvedPath { host_path, identity })
 }
 
 /// Normalizes a virtual sandbox path by removing `.` and resolving `..`.
@@ -168,12 +172,20 @@ impl ResolutionRequest {
     }
 }
 
-/// Resolves an existing path by canonicalizing the full target.
-fn resolve_existing(request: &ResolutionRequest, mount_host_path: &Path) -> Result<PathBuf, MountError> {
+/// Resolves an existing path by canonicalizing the full target, capturing the
+/// identity of the file the boundary check cleared.
+///
+/// The capture sits immediately after `check_boundary` to keep the gap between
+/// the two down to adjacent syscalls; it does not close it.
+fn resolve_existing(
+    request: &ResolutionRequest,
+    mount_host_path: &Path,
+) -> Result<(PathBuf, Option<FileIdentity>), MountError> {
     let canonical = fs::canonicalize(&request.candidate_host)
         .map_err(|err| MountError::Io(err, request.normalized_virtual.clone()))?;
     check_boundary(&canonical, mount_host_path, &request.normalized_virtual)?;
-    Ok(canonical)
+    let identity = FileIdentity::from_path(&canonical);
+    Ok((canonical, identity))
 }
 
 /// Resolves a path for `lstat`-style calls without following the final component.
@@ -202,7 +214,13 @@ fn resolve_lstat(request: &ResolutionRequest, mount_host_path: &Path) -> Result<
 }
 
 /// Resolves a path for creation by validating the parent directory first.
-fn resolve_creation(request: &ResolutionRequest, mount_host_path: &Path) -> Result<PathBuf, MountError> {
+///
+/// A target that does not exist yet has no identity to capture: what was
+/// validated is the parent directory, which a file handle cannot express.
+fn resolve_creation(
+    request: &ResolutionRequest,
+    mount_host_path: &Path,
+) -> Result<(PathBuf, Option<FileIdentity>), MountError> {
     if request.candidate_host.exists() {
         return resolve_existing(request, mount_host_path);
     }
@@ -223,7 +241,7 @@ fn resolve_creation(request: &ResolutionRequest, mount_host_path: &Path) -> Resu
         mount_host_path,
         &request.normalized_virtual,
     )?;
-    Ok(resolved_path)
+    Ok((resolved_path, None))
 }
 
 /// Resolves a path for `mkdir(parents=True)` while checking every existing ancestor.

--- a/crates/monty-fs/tests/file_identity.rs
+++ b/crates/monty-fs/tests/file_identity.rs
@@ -1,0 +1,228 @@
+//! Directory-swap and concurrent-rename coverage for the mount boundary.
+//!
+//! These do **not** cover the identity check — all three pass with it removed,
+//! because a swap staged from outside the crate lands before resolution, where
+//! the boundary check already rejects it. Its semantics live in the unit tests
+//! in `src/file_identity.rs`.
+
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
+#[cfg(windows)]
+use std::os::windows::fs::symlink_dir as win_symlink_dir;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable};
+use monty_types::{MontyObject, OsFunctionCall, PathStringDataArgs};
+use tempfile::TempDir;
+
+/// Cross-platform symlink to a directory. Windows needs Developer Mode or
+/// elevation.
+///
+/// Duplicated from `fs_security.rs` to stay off the paths #656 moves into
+/// `tests/common/`; fold it in once that lands.
+fn symlink_dir(original: impl AsRef<Path>, link: impl AsRef<Path>) {
+    #[cfg(unix)]
+    symlink(original.as_ref(), link.as_ref()).expect("failed to create directory symlink");
+    #[cfg(windows)]
+    win_symlink_dir(original.as_ref(), link.as_ref())
+        .expect("failed to create directory symlink (enable Windows Developer Mode or run elevated)");
+}
+
+/// Marker written to the out-of-mount file; its appearance in any result is the
+/// disclosure these tests guard against.
+const SECRET: &str = "SECRET-HOST-CONTENT";
+
+/// Dispatches a call, panicking if the mount table declines to handle it.
+fn dispatch(mounts: &mut MountTable, call: OsFunctionCall) -> Result<MontyObject, MountError> {
+    match mounts.handle_os_call(call) {
+        MountCallOutcome::Handled(result) => result,
+        MountCallOutcome::NotHandled(call) => panic!("mount table returned NotHandled: {call:?}"),
+    }
+}
+
+/// A `ReadWrite` mount whose `/mnt/data` directory can be swapped for one that
+/// escapes the mount, standing in for a concurrent session's `os.rename`.
+///
+/// The swap is between two *ordinary directories*, only a child of the second
+/// being a symlink out — the shape that defeats any rename-time symlink
+/// filter.
+struct SwappableMount {
+    mounts: MountTable,
+    /// `/mnt/data` in host terms — the directory a read resolves through.
+    data_dir: PathBuf,
+    /// A sibling directory holding an outbound symlink named `file.txt`.
+    escaping_dir: PathBuf,
+    _mount_dir: TempDir,
+    _outside_dir: TempDir,
+}
+
+impl SwappableMount {
+    fn new() -> Self {
+        let mount_dir = TempDir::new().unwrap();
+        let outside_dir = TempDir::new().unwrap();
+
+        let secret = outside_dir.path().join("secret.txt");
+        fs::write(&secret, SECRET).unwrap();
+
+        // The path a read targets: /mnt/data/file.txt, entirely in bounds.
+        let data_dir = mount_dir.path().join("data");
+        fs::create_dir(&data_dir).unwrap();
+        fs::write(data_dir.join("file.txt"), "public").unwrap();
+
+        // The pre-existing outbound symlink the sandbox can relocate but never
+        // create. Pointing it at the *directory* means the whole subtree leaks.
+        let escaping_dir = mount_dir.path().join("escape");
+        fs::create_dir(&escaping_dir).unwrap();
+        symlink_dir(outside_dir.path(), escaping_dir.join("file.txt"));
+
+        let mut mounts = MountTable::new();
+        mounts
+            .mount("/mnt", mount_dir.path(), MountMode::ReadWrite, None)
+            .expect("failed to configure mount");
+
+        Self {
+            mounts,
+            data_dir,
+            escaping_dir,
+            _mount_dir: mount_dir,
+            _outside_dir: outside_dir,
+        }
+    }
+
+    /// Swaps `data` and `escape`, so `/mnt/data/file.txt` now traverses the
+    /// outbound symlink. This is what a concurrent `os.rename` achieves.
+    fn swap_directories(&self) {
+        let staging = self.data_dir.with_file_name("staging");
+        fs::rename(&self.data_dir, &staging).unwrap();
+        fs::rename(&self.escaping_dir, &self.data_dir).unwrap();
+        fs::rename(&staging, &self.escaping_dir).unwrap();
+    }
+}
+
+/// Swapping two ordinary directories, where only a child of one is an outbound
+/// symlink, must not open a read path out of the mount.
+#[test]
+fn read_rejects_path_through_swapped_directory() {
+    let mut scenario = SwappableMount::new();
+
+    // Before the swap the read is ordinary and in bounds.
+    let before = dispatch(
+        &mut scenario.mounts,
+        OsFunctionCall::ReadText("/mnt/data/file.txt".into()),
+    );
+    assert!(
+        matches!(&before, Ok(MontyObject::String(s)) if s == "public"),
+        "expected the pre-swap read to succeed, got {before:?}"
+    );
+
+    scenario.swap_directories();
+
+    // `/mnt/data/file.txt` now traverses a symlink out of the mount, so it must
+    // be refused — by the boundary check here, since resolution runs afresh.
+    let after = dispatch(
+        &mut scenario.mounts,
+        OsFunctionCall::ReadText("/mnt/data/secret.txt".into()),
+    );
+    let leaked = matches!(&after, Ok(MontyObject::String(s)) if s.contains(SECRET));
+    assert!(!leaked, "HOST FILE DISCLOSURE: read returned out-of-mount content");
+}
+
+/// A rejected write must leave the out-of-mount file untouched — `fs::write`
+/// would have truncated it while opening, before the rejection.
+#[test]
+fn rejected_write_does_not_truncate_out_of_mount_file() {
+    let mount_dir = TempDir::new().unwrap();
+    let outside_dir = TempDir::new().unwrap();
+
+    let secret = outside_dir.path().join("secret.txt");
+    fs::write(&secret, SECRET).unwrap();
+
+    let data_dir = mount_dir.path().join("data");
+    fs::create_dir(&data_dir).unwrap();
+    fs::write(data_dir.join("file.txt"), "public").unwrap();
+
+    let mut mounts = MountTable::new();
+    mounts
+        .mount("/mnt", mount_dir.path(), MountMode::ReadWrite, None)
+        .unwrap();
+
+    // Point the whole `data` directory out of the mount.
+    fs::remove_dir_all(&data_dir).unwrap();
+    symlink_dir(outside_dir.path(), &data_dir);
+
+    let outcome = dispatch(
+        &mut mounts,
+        OsFunctionCall::WriteText(PathStringDataArgs {
+            path: "/mnt/data/secret.txt".into(),
+            data: "clobbered".to_owned(),
+        }),
+    );
+    assert!(
+        matches!(outcome, Err(MountError::PathEscape { .. })),
+        "expected PathEscape, got {outcome:?}"
+    );
+    assert_eq!(
+        fs::read_to_string(&secret).unwrap(),
+        SECRET,
+        "the out-of-mount file was modified"
+    );
+}
+
+/// The reported vector end to end: two sessions on one shared `ReadWrite`
+/// mount, one reading while the other renames.
+///
+/// Asserts only that no read discloses out-of-mount content, never that the
+/// race is won — win rates swing wildly across filesystems, so requiring a win
+/// would be flaky exactly where substitution is hardest to land.
+#[test]
+fn concurrent_rename_never_discloses_out_of_mount_content() {
+    let scenario = SwappableMount::new();
+    let SwappableMount {
+        mut mounts,
+        data_dir,
+        escaping_dir,
+        _mount_dir,
+        _outside_dir,
+    } = scenario;
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let swapper = {
+        let stop = Arc::clone(&stop);
+        let staging = data_dir.with_file_name("staging");
+        thread::spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                // Ignore failures: the reader may hold the directory busy, and
+                // a partially-applied swap is exactly the state under test.
+                let _ = fs::rename(&data_dir, &staging);
+                let _ = fs::rename(&escaping_dir, &data_dir);
+                let _ = fs::rename(&staging, &escaping_dir);
+            }
+        })
+    };
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let mut leaks = 0_u32;
+    while Instant::now() < deadline {
+        for path in ["/mnt/data/file.txt", "/mnt/data/secret.txt"] {
+            if let MountCallOutcome::Handled(Ok(MontyObject::String(s))) =
+                mounts.handle_os_call(OsFunctionCall::ReadText(path.into()))
+                && s.contains(SECRET)
+            {
+                leaks += 1;
+            }
+        }
+    }
+    stop.store(true, Ordering::Relaxed);
+    swapper.join().unwrap();
+
+    assert_eq!(leaks, 0, "HOST FILE DISCLOSURE: a racing read returned host content");
+}

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -73,12 +73,22 @@ The host enforces these invariants on every path operation:
 - The canonical path must remain inside the mount; `..` traversal cannot
   escape (raises `PermissionError`).
 - Symlinks pointing outside the mount are rejected on resolution.
+- Reads, writes and appends verify the file they opened is the one the boundary
+  check cleared, raising `PermissionError` on a mismatch where CPython would act
+  on whatever the name now refers to.
 - Null bytes in any path component are rejected (`ValueError`).
 - Resolved paths returned to the sandbox (e.g. via `Path.resolve()`) are
   virtual paths, never host paths.
 
 `/tmp`, `/etc`, `/proc`, `/dev`, `~`, and the host current working
 directory are **not** available unless the host explicitly mounts them.
+
+That verification does not extend to operations acting on a directory entry by
+name, where there is no handle to bind to: `os.rename`, `Path.unlink`,
+`Path.rmdir`, `Path.mkdir`, creating a file that does not exist yet, and the
+`stat()`/`exists()`/`is_*()` family. A concurrent rename can still substitute a
+different entry, though only where an outbound symlink already exists inside
+the mount — sandboxed code cannot create one.
 
 ## No live host descriptors
 


### PR DESCRIPTION
Path resolution validates a name and the operation that follows resolves it again, so a concurrent `os.rename` from a second session sharing the mount can substitute a different file in between. `FileIdentity` now captures the file the boundary check cleared and verifies it against the handle that reads, writes and appends actually open.

Does not cover `rename`/`unlink`/`rmdir`/`mkdir` or the `stat`/`exists`/`is_*` family, which act on a name with no handle to bind to — see `limitations/filesystem.md`. Complements #656.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind mount file I/O to file identity instead of path names to close a TOCTOU window where a concurrent rename could substitute an out-of-mount file. Reads, writes, and appends now verify the opened handle matches the file the boundary check cleared, preventing host file disclosure and avoiding truncation on rejected writes.

- **Bug Fixes**
  - Added `FileIdentity` capturing `(dev, ino)` on Unix and `(volume serial, file index)` on Windows; propagated via `ResolvedPath` and verified after `open`.
  - Updated read/write/append paths to accept identity and reject mismatches with `PathEscape`.
  - Reworked writes to open without truncation, verify identity, then `set_len(0)` to avoid clobbering substituted files.
  - Extended tests for directory swaps and concurrent renames; documented unsupported name-only ops (`rename`/`unlink`/`mkdir` and `stat`/`exists`/`is_*`) in limitations.

- **Dependencies**
  - Added Windows-only `winapi-util` for safe file identity retrieval.

<sup>Written for commit 46db904a344ec4ceee0880c90f88ab7df1760c67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

