### PR TITLE
Memory limit followups

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -11,11 +11,8 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-# Pinned rather than `astral.sh/uv/install.sh`, which serves whatever is current:
-# CI pins its actions by digest for the same reason. Bump deliberately.
-UV_INSTALL_VERSION=0.11.16
 if ! command -v uv >/dev/null; then
-    curl -LsSf "https://astral.sh/uv/$UV_INSTALL_VERSION/install.sh" | sh
+    curl -LsSf https://astral.sh/uv/install.sh | sh
 fi
 export PATH="$HOME/.local/bin:$PATH"
 

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -11,8 +11,11 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+# Pinned rather than `astral.sh/uv/install.sh`, which serves whatever is current:
+# CI pins its actions by digest for the same reason. Bump deliberately.
+UV_INSTALL_VERSION=0.11.16
 if ! command -v uv >/dev/null; then
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    curl -LsSf "https://astral.sh/uv/$UV_INSTALL_VERSION/install.sh" | sh
 fi
 export PATH="$HOME/.local/bin:$PATH"
 

--- a/README.md
+++ b/README.md
@@ -240,15 +240,7 @@ assert_eq!(result, MontyObject::Int(42));
 
 A session's `max_memory` is enforced in the worker's own allocator as well as by
 the interpreter, so it bounds the bytes the worker holds at once rather than
-only what the interpreter can account for. There is nothing to configure: set
-the limit, and a session that exceeds it fails — the worker is killed with a
-`MemoryError` and replaced by the pool.
-
-The bound is a count the worker keeps, not something the kernel enforces: it
-covers what the process allocates through its allocator, so resident memory can
-still exceed it (thread stacks, direct `mmap`, and pages an allocator holds
-after a free). Where a hard guarantee is needed, wrap the worker in an
-OS-enforced limit — `ulimit -v`, or a cgroup memory limit.
+only what the interpreter can account for.
 
 See [`limitations/resource_limits.md`](limitations/resource_limits.md) for how
 exceeding a limit surfaces to a host, and `monty-alloc` for the allocator both

--- a/README.md
+++ b/README.md
@@ -239,10 +239,16 @@ assert_eq!(result, MontyObject::Int(42));
 ## Memory limits in workers
 
 A session's `max_memory` is enforced in the worker's own allocator as well as by
-the interpreter, so it covers every byte the process asks for. There is nothing
-to configure: set the limit, and a session that exceeds it fails. A worker that
-cannot honour the limit is killed with a `MemoryError` and replaced by the pool,
-rather than growing until the OS OOM killer picks a victim.
+the interpreter, so it bounds the bytes the worker holds at once rather than
+only what the interpreter can account for. There is nothing to configure: set
+the limit, and a session that exceeds it fails — the worker is killed with a
+`MemoryError` and replaced by the pool.
+
+The bound is a count the worker keeps, not something the kernel enforces: it
+covers what the process allocates through its allocator, so resident memory can
+still exceed it (thread stacks, direct `mmap`, and pages an allocator holds
+after a free). Where a hard guarantee is needed, wrap the worker in an
+OS-enforced limit — `ulimit -v`, or a cgroup memory limit.
 
 See [`limitations/resource_limits.md`](limitations/resource_limits.md) for how
 exceeding a limit surfaces to a host, and `monty-alloc` for the allocator both

--- a/crates/monty-alloc/src/lib.rs
+++ b/crates/monty-alloc/src/lib.rs
@@ -100,8 +100,8 @@ unsafe impl GlobalAlloc for LimitedAllocator {
     // Overridden for the same reason: the default reallocates and copies, while
     // `System` can often grow a block in place.
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
-        if new_size >= layout.size() {
-            charge(new_size - layout.size());
+        if let Some(size_change) = new_size.checked_sub(layout.size()) {
+            charge(size_change);
         } else {
             refund(layout.size() - new_size);
         }

--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -322,8 +322,9 @@ const pool = await Monty.create({
 ```
 
 A session's `maxMemory` is enforced in the worker's own allocator too (the
-[`monty-alloc`](https://crates.io/crates/monty-alloc) crate), so it covers every
-byte the worker asks for instead of letting it grow the host without bound. A
+[`monty-alloc`](https://crates.io/crates/monty-alloc) crate), which bounds the
+bytes the worker holds at once — allocated minus freed, plus headroom — instead
+of letting it grow the host without bound. A
 worker that cannot honour the limit raises `MontyRuntimeError` wrapping
 `MemoryError` — but unlike other runtime errors it takes the worker with it, so
 the session is finished (the pool recovers). The wasm worker applies the same

--- a/crates/monty-js/__test__/pool.spec.ts
+++ b/crates/monty-js/__test__/pool.spec.ts
@@ -81,6 +81,7 @@ test('a refused allocation raises MemoryError and the pool recovers', async (ctx
     instanceOf: MontyRuntimeError,
   })
   t.is(error.message, 'MemoryError: the worker exceeded its memory limit and was terminated')
+  t.is(error.exception.typeName, 'MemoryError')
   const next = await pool.checkout()
   t.is(await next.feedRun('1 + 1'), 2)
   await next.close()
@@ -97,6 +98,7 @@ test('exceeding maxMemory in the allocator raises MemoryError and the pool recov
     instanceOf: MontyRuntimeError,
   })
   t.is(error.message, 'MemoryError: the worker exceeded its memory limit and was terminated')
+  t.is(error.exception.typeName, 'MemoryError')
   const next = await pool.checkout()
   t.is(await next.feedRun('1 + 1'), 2)
   await next.close()

--- a/crates/monty-js/__test__/wasm_memory_limit.spec.ts
+++ b/crates/monty-js/__test__/wasm_memory_limit.spec.ts
@@ -34,6 +34,7 @@ test('an overrun the interpreter catches leaves the instance alive', async (ctx)
     instanceOf: MontyRuntimeError,
   })
   t.is(error.message, 'MemoryError: memory limit exceeded: 1048600 bytes > 1048576 bytes')
+  t.is(error.exception.typeName, 'MemoryError')
   await session.close()
   await pool.close()
 })

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -181,9 +181,10 @@ pub enum CrashCause {
         context: String,
     },
     /// It announced a `FatalError` and exited, so its own account replaces
-    /// the pool's — as does a death the pool can name from the exit code
-    /// alone. A serving relay also uses this to report that it could not
-    /// start a worker at all.
+    /// the pool's. A serving relay also uses this to report that it could not
+    /// start a worker at all. A worker that exceeded its memory limit is not
+    /// here at all: that exit code classifies into
+    /// [`PoolError::Runtime`] carrying a `MemoryError`.
     Announced {
         /// What the worker said before dying.
         reason: String,

--- a/crates/monty-runtime/README.md
+++ b/crates/monty-runtime/README.md
@@ -35,9 +35,10 @@ process, not by hand.
 
 The binary runs under the
 [`monty-alloc`](https://crates.io/crates/monty-alloc) global allocator, which
-enforces the sandbox session's `max_memory` and turns an allocation failure into
-a dedicated exit code the parent can classify, rather than the `SIGABRT` a stack
-overflow also produces.
+enforces the sandbox session's `max_memory`. It enables that crate's
+`exit-code` feature, so a refused allocation ends the process with a status the
+parent can classify — see the crate's docs for what the alternative is and why
+a wasm worker takes it.
 
 ## PyPI packaging (`pydantic-monty-runtime`)
 

--- a/crates/monty-runtime/src/subprocess.rs
+++ b/crates/monty-runtime/src/subprocess.rs
@@ -86,9 +86,9 @@ pub(crate) fn run() -> ExitCode {
 ///
 /// Reading the child's state rather than the request is what keeps the limit
 /// honest: a rejected `Configure` changes nothing, a `Load` brings the dump's
-/// own limits, and `Reset` ends the session. It lives in the shell because only
-/// a binary may own a global allocator — the same state machine also drives the
-/// wasm worker, which has none.
+/// own limits, and `Reset` ends the session. It lives in the shell rather than
+/// in the shared state machine because each entry point declares its own
+/// allocator: the wasm worker does the same thing in its own turn loop.
 fn apply_memory_limit(child: &Child) {
     let budget = child.session_budget();
     monty_alloc::set_limit(budget.max_memory, budget.type_check);

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -7,11 +7,16 @@ use std::{
     io::{Read, Write},
     process::{Child, ChildStdin, ChildStdout, Command, ExitStatus, Stdio},
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use monty_proto::{FrameError, FrameReader, WireObject, pb, write_frame};
 use monty_types::MontyObject;
+
+/// How long a death-expecting helper waits for the child to exit. Generous:
+/// the regression it guards is "the child never dies", so the only cost of a
+/// long wait is how late that failure is reported on a slow CI machine.
+const DEATH_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// A spawned `monty subprocess` child with framed pipes.
 struct ChildProc {
@@ -139,20 +144,35 @@ impl ChildProc {
             inputs: vec![],
             skip_type_check: false,
         }));
-        match self.reader.read::<pb::ChildEvent>() {
-            Ok(None) | Err(_) => {}
-            Ok(Some(event)) => panic!("expected the child to die, got {:?}", event.kind),
-        }
+        self.expect_death();
     }
 
     /// Writes a bare 200 MiB frame-length prefix — no body — and expects the
     /// child to die buying the buffer: under the wire cap, over any limit a
     /// test applies, and four bytes of writing, so the parent cannot block on a
     /// pipe whose reader has already gone.
+    #[track_caller]
     fn oversized_prefix_expecting_death(&mut self) {
         self.writer
             .write_all(&(200u32 * 1024 * 1024).to_le_bytes())
             .expect("failed to write length prefix");
+        self.expect_death();
+    }
+
+    /// Asserts the child dies without a turn-ending event: EOF (the usual
+    /// case) or a truncated frame. Waits for the exit *first* — a surviving
+    /// child writes nothing, so reading it would block forever and hang the
+    /// suite instead of failing it; once it is dead the read cannot block.
+    #[track_caller]
+    fn expect_death(&mut self) {
+        let deadline = Instant::now() + DEATH_TIMEOUT;
+        while self.child.try_wait().expect("failed to poll child").is_none() {
+            assert!(
+                Instant::now() < deadline,
+                "expected the child to die, still alive after {DEATH_TIMEOUT:?}"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
         match self.reader.read::<pb::ChildEvent>() {
             Ok(None) | Err(_) => {}
             Ok(Some(event)) => panic!("expected the child to die, got {:?}", event.kind),

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -110,8 +110,9 @@ properties that real CPython does not provide, per the caveat above.
   bytes the worker's allocator will hand out (plus headroom — see
   `limitations/resource_limits.md`, which covers how exceeding it surfaces); a
   session without a limit is uncapped. The worker derives it from the session it
-  holds, so nothing travels outside the protocol, and the wasm worker applies it
-  to its linear memory. Ignored by the WebSocket transport (whose exit codes do
+  holds, so nothing travels outside the protocol, and the wasm worker counts the
+  same way (not the linear memory it has grown to, which never shrinks).
+  Ignored by the WebSocket transport (whose exit codes do
   not travel, so a remote failure degrades to `Disconnected`). The exit code
   borrows [`sysexits.h`](https://man.freebsd.org/sysexits) so a bare status is
   legible in a log.

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -101,9 +101,10 @@ below collapse into the allocator's, and only its outcome remains. -->
 
 Independently of any limit, **any** allocation a worker's allocator refuses —
 plain host OOM, or a request beyond the usable address space such as
-`' ' * (1 << 60)` — takes this same path on every platform: the worker exits and
-the host sees that `MemoryError` with its session gone. CPython raises a
-catchable `MemoryError` in-process and carries on. Monty cannot: the failure
+`' ' * (1 << 60)` — takes this same path: on a worker with an exit status the
+host sees that `MemoryError` with its session gone, and on wasm the same
+refusal traps, reported as `MontyCrashedError` per the bullet above. CPython
+raises a catchable `MemoryError` in-process and carries on. Monty cannot: the failure
 happens below the interpreter, where no Python-level exception can be raised, so
 the worker classifies the failure into a dedicated exit code and dies. (Without
 that, the process would abort with `SIGABRT` — indistinguishable from a stack


### PR DESCRIPTION
I accidently pushed these to the #646 branch after it was merged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens memory-limit behavior and makes death-expecting tests fail fast instead of hanging. Clarifies that limits bound live bytes in both workers and wasm, and that memory-limit exits classify into `Runtime(MemoryError)` with guidance on resident memory, ulimit, and cgroups.

- **Bug Fixes**
  - Subprocess tests now wait for child exit with a 20s timeout to avoid hangs when the limit isn’t armed.
  - Fixed `realloc` accounting in `monty-alloc` using checked subtraction to prevent underflow and mischarging.
  - JS tests now assert the wrapped exception type is `MemoryError`.

<sup>Written for commit 3c7425729c8f35178dded265606582e0f77fb5fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

