### PR TITLE
Add `Checkout::turn_raw` and `TelemetryContext::for_logfire` to `monty-pool`

### DIFF
--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -174,6 +174,11 @@ pub type PrintFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 /// copies of whatever it needs (including the text, if consumed async).
 pub type OnPrint<'a> = &'a mut (dyn FnMut(PrintStream, &str) -> PrintFuture + Send);
 
+/// Callback for the events [`Checkout::turn_raw`] streams before the
+/// turn-ender — `Print`s today. Returns a future for the same reason
+/// [`OnPrint`] does.
+pub type OnRawEvent<'a> = &'a mut (dyn FnMut(&pb::ChildEvent) -> PrintFuture + Send);
+
 /// Adapts a synchronous print sink to the [`OnPrint`] callback shape.
 ///
 /// ```rust,no_run
@@ -730,6 +735,90 @@ impl Checkout {
         };
         self.turn_in_flight = false;
         outcome
+    }
+
+    /// Sends `request` and returns the child's turn-ending event as protobuf,
+    /// streaming the events before it to `on_event`.
+    ///
+    /// For callers that already speak the wire: rebuilding a `ChildEvent` from
+    /// a [`TurnEvent`] means hand-inverting the whole protocol, so a relay
+    /// bridging a remote client gets what the child actually sent instead.
+    ///
+    /// **Bypasses this checkout's suspension bookkeeping** (`pending`,
+    /// `feed_mounts`, `restored_script_name`), so a checkout driven this way
+    /// must never be interleaved with `feed`/`resume`/`restore`. Everything
+    /// else — lifecycle, poisoning, the `max_duration` backstop — is shared.
+    pub async fn turn_raw(
+        &mut self,
+        request: &pb::ParentRequest,
+        on_event: OnRawEvent<'_>,
+    ) -> Result<pb::ChildEvent, PoolError> {
+        self.ensure_ready()?;
+        self.turn_in_flight = true;
+        // as `expect_turn`: `request_timeout` alone would drop the `max_duration`
+        // backstop, which may be the only bound a session has
+        let deadline = min_deadline(self.pool.config.request_timeout, self.backstop_deadline());
+        self.armed_deadline = deadline;
+        let outcome = match deadline {
+            Some(limit) => match timeout(limit, self.turn_io_raw(request, on_event)).await {
+                Ok(outcome) => outcome,
+                Err(_elapsed) => Err(self.poison_timeout().await),
+            },
+            None => self.turn_io_raw(request, on_event).await,
+        };
+        self.turn_in_flight = false;
+        outcome
+    }
+
+    /// The body of [`Self::turn_raw`], mirroring `turn_io`'s failure handling —
+    /// the difference is only that events are returned rather than classified.
+    async fn turn_io_raw(
+        &mut self,
+        request: &pb::ParentRequest,
+        on_event: OnRawEvent<'_>,
+    ) -> Result<pb::ChildEvent, PoolError> {
+        let Some(worker) = self.worker.as_mut() else {
+            return Err(PoolError::Finished);
+        };
+        if let Err(err) = worker.send(request).await {
+            // an oversize frame leaves the worker synced — see `turn_io`
+            return Err(match err {
+                FrameError::FrameTooLarge { len, max } => PoolError::Runtime(MontyException::new(
+                    ExcType::RuntimeError,
+                    Some(format!(
+                        "request frame of {len} bytes exceeds the maximum of {max} bytes"
+                    )),
+                )),
+                _ => self.poison("sending a request").await,
+            });
+        }
+        loop {
+            let event = match self.worker.as_mut().expect("checked above").recv().await {
+                Ok(event) => event,
+                Err(FrameError::Decode(err)) => {
+                    return Err(self.protocol_violation(format!("invalid payload from worker: {err}")));
+                }
+                Err(_) => return Err(self.poison("waiting for a reply").await),
+            };
+            self.note_reported_time(&event);
+            // strict alternation: zero or more `Print`s, then the turn-ender
+            if matches!(event.kind, Some(pb::child_event::Kind::Print(_))) {
+                on_event(&event).await;
+            } else if matches!(event.kind, Some(pb::child_event::Kind::Shutdown(_)))
+                && !self.pool.config.transport.is_websocket()
+            {
+                // only a serving relay sends this, never a child — and a relay
+                // signs what it forwards, so accepting one would have it vouch
+                // for bytes its own child minted (`turn_io` refuses it too)
+                return Err(self.protocol_violation("subprocess worker sent a ShutdownDump"));
+            } else if event.kind.is_none() {
+                // every proto field is optional, so an unset oneof is reachable;
+                // it ends no turn, as `turn_io`'s "unexpected event" says too
+                return Err(self.protocol_violation("worker sent an event with no kind"));
+            } else {
+                return Ok(event);
+            }
+        }
     }
 
     /// Fails fast when the checkout cannot start protocol work: the worker is

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -17,7 +17,8 @@ use monty_types::MontyException;
 
 pub use crate::{
     checkout::{
-        Checkout, MountSpec, MountSpecMode, OnPrint, PrintFuture, ReplConfig, ResumeValue, TurnEvent, on_print_sync,
+        Checkout, MountSpec, MountSpecMode, OnPrint, OnRawEvent, PrintFuture, ReplConfig, ResumeValue, TurnEvent,
+        on_print_sync,
     },
     pool::Pool,
 };

--- a/crates/monty-pool/src/telemetry_adapter.rs
+++ b/crates/monty-pool/src/telemetry_adapter.rs
@@ -72,6 +72,20 @@ impl TelemetryAdapterHandle {
 }
 
 impl TelemetryContext {
+    /// Records the pool's spans straight into `logfire`, with no adapter.
+    ///
+    /// The rest of this module hands spans to a *foreign* SDK; a Rust host has
+    /// no such boundary to cross, and without this would need a
+    /// [`TelemetryAdapter`] plus a second OTLP exporter to receive its own
+    /// spans. Unparented like [`TelemetryAdapterHandle::unparented_context`],
+    /// since an in-process ambient span is reachable through `tracing`.
+    #[must_use]
+    pub fn for_logfire(logfire: Logfire) -> Self {
+        Self { parent: None, logfire }
+    }
+}
+
+impl TelemetryContext {
     /// Returns the isolated recorder installed while processing this checkout.
     pub(crate) fn logfire(&self) -> Logfire {
         self.logfire.clone()

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -23,6 +23,11 @@ use monty_pool::{
     MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, PrintFuture, ReplConfig, ResumeValue, TurnEvent,
     on_print_sync,
 };
+// only the unix-gated raw-path tests forge worker frames
+#[cfg(unix)]
+use monty_proto::encode_framed_into;
+// `turn_raw` speaks protobuf, so its test builds and inspects wire types directly.
+use monty_proto::{WireObject, pb};
 use monty_types::{MontyObject, PrintStream, ResourceLimits, TypeCheckingConfig, TypeCheckingFormat};
 use tokio::time::sleep;
 
@@ -882,6 +887,58 @@ async fn inputs_and_prints() {
     session.finish().await.unwrap();
 }
 
+/// The same turn as `inputs_and_prints`, driven at the wire level: a relay gets
+/// the child's own `Print` and turn-ending frames, not a decoded [`TurnEvent`].
+#[tokio::test]
+async fn turn_raw_streams_prints_and_returns_the_wire_turn_ender() {
+    let pool = Pool::new(config()).await.unwrap();
+    let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
+    let request = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::Feed(pb::Feed {
+            code: "print('hello', name)\nlen(name)".to_owned(),
+            inputs: vec![pb::NamedValue {
+                name: "name".to_owned(),
+                value: Some(MontyObject::String("monty".to_owned()).into()),
+            }],
+            skip_type_check: false,
+        })),
+        trace_parent: None,
+    };
+    let mut streamed = Vec::new();
+    let event = session
+        .turn_raw(&request, &mut |event: &pb::ChildEvent| {
+            streamed.push(event.clone());
+            Box::pin(ready(()))
+        })
+        .await
+        .unwrap();
+
+    // only the prints stream; the turn-ender is returned rather than streamed
+    let [
+        pb::ChildEvent {
+            kind: Some(pb::child_event::Kind::Print(print)),
+            ..
+        },
+    ] = streamed.as_slice()
+    else {
+        panic!("expected exactly one streamed Print, got {streamed:?}");
+    };
+    assert_eq!(print.stream, pb::PrintStream::Stdout as i32);
+    assert_eq!(print.text, "hello monty\n");
+    let Some(pb::child_event::Kind::Complete(complete)) = event.kind else {
+        panic!("expected Complete, got {event:?}");
+    };
+    assert_eq!(complete.value, Some(WireObject(Some(MontyObject::Int(5)))));
+
+    // the checkout is unharmed: a typed feed still works on the same worker
+    let event = session
+        .feed("1 + 1", vec![], vec![], false, &mut no_print)
+        .await
+        .unwrap();
+    assert_eq!(expect_complete(event), MontyObject::Int(2));
+    session.finish().await.unwrap();
+}
+
 #[tokio::test]
 async fn external_function_round_trip() {
     let pool = Pool::new(config()).await.unwrap();
@@ -1157,6 +1214,95 @@ async fn unrecognised_exit_code_stays_an_opaque_death() {
     // the message says only what the pool was doing and what it reaped — no
     // memory wording, which is what `OOM_EXIT_CODE` alone earns
     assert_snapshot!(err.to_string(), @"monty worker crashed while waiting for a reply (exit status: 64)");
+}
+
+/// A local child cannot pass a `ShutdownDump` off as a turn-ender on the raw
+/// path: only a serving relay sends one, and a relay signs whatever it
+/// forwards, so a dump the child minted itself would reach the relay's own
+/// client as trusted session state.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_subprocess_shutdown_dump_is_refused_on_the_raw_path() {
+    let dir = tempfile::tempdir().unwrap();
+    // the two frames the stand-in replays, in order: `Ok` answers the
+    // `Configure` that establishes the session, then the forged dump
+    let mut replies = framed(&child_event(pb::child_event::Kind::Ok(pb::Ok {})));
+    replies.extend(framed(&child_event(pb::child_event::Kind::Shutdown(
+        pb::ShutdownDump {
+            dump: Some(b"a dump the child minted itself".to_vec()),
+        },
+    ))));
+    let err = raw_turn_against_replies(dir.path(), &replies).await;
+    assert_snapshot!(
+        err.to_string(),
+        @"monty worker protocol error: subprocess worker sent a ShutdownDump"
+    );
+}
+
+/// An event with no `kind` ends no turn on the raw path: every field of
+/// `ChildEvent` is optional on the wire, so a frame that means nothing must not
+/// reach the raw driver's client as a successful turn.
+#[cfg(unix)]
+#[tokio::test]
+async fn an_event_with_no_kind_is_refused_on_the_raw_path() {
+    let dir = tempfile::tempdir().unwrap();
+    // `Ok` answers the establishing `Configure`, then the kindless frame
+    let mut replies = framed(&child_event(pb::child_event::Kind::Ok(pb::Ok {})));
+    replies.extend(framed(&pb::ChildEvent::default()));
+    let err = raw_turn_against_replies(dir.path(), &replies).await;
+    assert_snapshot!(
+        err.to_string(),
+        @"monty worker protocol error: worker sent an event with no kind"
+    );
+}
+
+/// Drives one `turn_raw` against a stand-in worker replaying `replies`, and
+/// returns the error it must fail with. The frames are written up front and the
+/// process stays alive, so the parent reads them as it sends `Configure` then
+/// the raw request.
+#[cfg(unix)]
+async fn raw_turn_against_replies(dir: &Path, replies: &[u8]) -> PoolError {
+    let replies_path = dir.join("replies.bin");
+    fs::write(&replies_path, replies).unwrap();
+    let fake = dir.join("monty");
+    fs::write(&fake, format!("#!/bin/sh\ncat '{}'\nsleep 5\n", replies_path.display())).unwrap();
+    fs::set_permissions(&fake, PermissionsExt::from_mode(0o755)).unwrap();
+
+    let pool = Pool::new(PoolConfig::subprocess(&fake)).await.unwrap();
+    let mut checkout = pool
+        .checkout(&ReplConfig::default())
+        .await
+        .expect("the stand-in answers Configure with Ok");
+    let request = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::Feed(pb::Feed {
+            code: "1 + 1".to_owned(),
+            inputs: vec![],
+            skip_type_check: false,
+        })),
+        ..pb::ParentRequest::default()
+    };
+    let mut on_event = |_: &pb::ChildEvent| Box::pin(ready(())) as PrintFuture;
+    checkout
+        .turn_raw(&request, &mut on_event)
+        .await
+        .expect_err("the forged turn-ender must not be accepted")
+}
+
+/// Length-prefixes one event exactly as a worker writes it.
+#[cfg(unix)]
+fn framed(event: &pb::ChildEvent) -> Vec<u8> {
+    let mut buf = Vec::new();
+    encode_framed_into(event, &mut buf).expect("encode");
+    buf
+}
+
+/// A `ChildEvent` carrying `kind` and nothing else.
+#[cfg(unix)]
+fn child_event(kind: pb::child_event::Kind) -> pb::ChildEvent {
+    pb::ChildEvent {
+        kind: Some(kind),
+        ..pb::ChildEvent::default()
+    }
 }
 
 /// A refused allocation is the one `Runtime` error whose worker is already

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -306,6 +306,51 @@ async fn duration_backstop_kills_an_unresponsive_worker() {
     join_server(server).await;
 }
 
+/// The same backstop arms on the raw path a relay drives instead of `feed`.
+/// With `request_timeout` alone, a session bounded only by `max_duration` —
+/// the shape a relay configures, applying limits rather than client timeouts —
+/// would have no parent-side deadline at all.
+#[tokio::test]
+async fn duration_backstop_arms_on_the_raw_path() {
+    let (listener, mut config) = ws_pool_config();
+    config.duration_limit_grace = Some(Duration::from_millis(300));
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        assert!(matches!(
+            read_request(&mut socket),
+            pb::parent_request::Kind::Configure(_)
+        ));
+        send_event(&mut socket, &event_kind(pb::child_event::Kind::Ok(pb::Ok {})));
+        assert!(matches!(read_request(&mut socket), pb::parent_request::Kind::Feed(_)));
+        // never reply; only the backstop can end this turn
+        let _ = socket.read();
+    });
+
+    let pool = Pool::new(config).await.expect("pool");
+    let mut checkout = pool
+        .checkout(&ReplConfig {
+            limits: Some(ResourceLimits::default().max_duration(Duration::from_millis(100))),
+            ..ReplConfig::default()
+        })
+        .await
+        .expect("checkout");
+    let request = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::Feed(pb::Feed {
+            code: "while True:\n    pass".to_owned(),
+            inputs: vec![],
+            skip_type_check: false,
+        })),
+        ..pb::ParentRequest::default()
+    };
+    let mut on_event = |_: &pb::ChildEvent| Box::pin(ready(())) as PrintFuture;
+    let err = checkout.turn_raw(&request, &mut on_event).await.unwrap_err();
+    let PoolError::Timeout { timeout } = err else {
+        panic!("expected Timeout, got {err:?}");
+    };
+    assert!(timeout <= Duration::from_millis(400), "deadline was {timeout:?}");
+    join_server(server).await;
+}
+
 /// A single turn is still bounded by `request_timeout` even when the worker is
 /// making mount-coverable calls: the OS call surfaces rather than being
 /// serviced inside the turn, so a worker that simply runs too long before


### PR DESCRIPTION
`Checkout::turn_raw` sends a `pb::ParentRequest` and hands back the child's turn-ending `pb::ChildEvent` verbatim, for relays that already speak the wire and would otherwise have to hand-invert the whole protocol to rebuild a frame from a `TurnEvent`. 

`TelemetryContext::for_logfire` lets a Rust host record the pool's spans straight into its own `Logfire`, rather than implementing a `TelemetryAdapter` and standing up a second OTLP exporter to receive its own spans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a wire-level checkout API and a direct telemetry path to simplify relays and Rust hosts. Enforces deadlines and validates frames on the raw path.

- **New Features**
  - `Checkout::turn_raw(request, on_event)`: sends a `pb::ParentRequest`, streams `Print` events to `OnRawEvent`, and returns the turn-ending `pb::ChildEvent` verbatim. Do not mix with `feed`/`resume`/`restore` on the same checkout.
  - `TelemetryContext::for_logfire(logfire)`: records pool spans directly into the host’s `Logfire` via `tracing`, removing the need for a `TelemetryAdapter` and a second OTLP exporter.

- **Bug Fixes**
  - `turn_raw` arms `min(request_timeout, max_duration_backstop)` so sessions bounded only by `max_duration` still have a parent-side deadline.
  - Rejects subprocess `ShutdownDump` and events with no `kind` on the raw path.

<sup>Written for commit f542bc68bd8852118ead851d18c69cb0ddacae17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

