### PR TITLE
vendor abc.pyi so `@abstractmethod` members keep their types

### DIFF
--- a/crates/monty-type-checking/tests/bad_types.py
+++ b/crates/monty-type-checking/tests/bad_types.py
@@ -3,7 +3,7 @@
 # ===
 
 import sys
-from typing import assert_type
+from typing import TypedDict, assert_type
 
 
 def takes_int(x: int) -> None:
@@ -105,5 +105,32 @@ takes_two(a=1, c='wrong')
 
 not_callable: int = 42
 not_callable()
+
+
+# === Errors on loop variables ===
+# The loop variable's element type comes through `Iterator.__next__`, which is
+# `@abstractmethod`; without `abc` in the stub tree it is `Unknown` and none of
+# these errors are reported (https://github.com/pydantic/monty/issues/197).
+
+
+class SearchTag(TypedDict):
+    id: str
+
+
+def loop_over_typed_dicts(tags: list[SearchTag]) -> None:
+    for tag in tags:
+        takes_str(tag['uuid'])
+
+
+def loop_over_ints(values: list[int]) -> None:
+    for value in values:
+        takes_str(value)
+
+
+def loop_over_dict_items(mapping: dict[str, int]) -> None:
+    for key, value in mapping.items():
+        takes_int(key)
+        takes_str(value)
+
 
 print(sys.copyright)

--- a/crates/monty-type-checking/tests/good_types.py
+++ b/crates/monty-type-checking/tests/good_types.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import sys
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, assert_type
@@ -591,14 +592,24 @@ assert_type(json.loads('null'), Any)
 assert_type(json.dumps(None), str)
 
 # === iter() / next() ===
-# Asserts only that these resolve and check. Precise element inference through
-# `Iterable[_T]` is a pre-existing gap in the trimmed stub — `sorted([1, 2])`
-# is `list[Unknown]` too — so element types are deliberately not asserted here.
+# Element types must survive the `Iterator` protocol: `Iterator.__next__` is
+# decorated `@abstractmethod`, so a stub tree missing `abc` degrades every one
+# of these to `Unknown` and silently disables checking inside `for` loops.
 it = iter([1, 2, 3])
-next(it)
-next(it, 0)
-list(it)
-for _x in iter([1, 2, 3]):
-    pass
+assert_type(it, Iterator[int])
+assert_type(next(it), int)
+assert_type(next(it, 0), int)
+assert_type(list(it), list[int])
+assert_type(sorted([1, 2]), list[int])
+for x_it in iter([1, 2, 3]):
+    assert_type(x_it, int)
 # two-argument iter(callable, sentinel)
-list(iter(lambda: 0, 0))
+assert_type(list(iter(lambda: 0, 0)), list[int])
+
+# Loop variables keep their element type for every iterable, not just lists
+for x_list in get_list_int():
+    assert_type(x_list, int)
+for k_dict, v_dict in {'a': 1}.items():
+    assert_type(k_dict, str)
+    assert_type(v_dict, int)
+assert_type([y_comp for y_comp in [1, 2]], list[int])

--- a/crates/monty-type-checking/tests/snapshots/main__reveal_types.snap
+++ b/crates/monty-type-checking/tests/snapshots/main__reveal_types.snap
@@ -14,11 +14,11 @@ reveal_types.py:18:13: info[revealed-type] Revealed type: `list[int]`
 reveal_types.py:19:13: info[revealed-type] Revealed type: `tuple[Literal[1], Literal[2]]`
 reveal_types.py:20:13: info[revealed-type] Revealed type: `dict[int, int]`
 reveal_types.py:21:13: info[revealed-type] Revealed type: `set[int]`
-reveal_types.py:22:13: info[revealed-type] Revealed type: `frozenset[Unknown]`
+reveal_types.py:22:13: info[revealed-type] Revealed type: `frozenset[int]`
 reveal_types.py:23:13: info[revealed-type] Revealed type: `range`
-reveal_types.py:26:13: info[revealed-type] Revealed type: `enumerate[Unknown]`
-reveal_types.py:27:13: info[revealed-type] Revealed type: `Iterator[Unknown]`
-reveal_types.py:28:13: info[revealed-type] Revealed type: `zip[tuple[Unknown, Unknown]]`
+reveal_types.py:26:13: info[revealed-type] Revealed type: `enumerate[int]`
+reveal_types.py:27:13: info[revealed-type] Revealed type: `Iterator[int]`
+reveal_types.py:28:13: info[revealed-type] Revealed type: `zip[tuple[int, int]]`
 reveal_types.py:31:13: info[revealed-type] Revealed type: `slice[Literal[1], Literal[2], Any]`
 reveal_types.py:34:13: info[revealed-type] Revealed type: `BaseException`
 reveal_types.py:35:13: info[revealed-type] Revealed type: `Exception`

--- a/crates/monty-type-checking/tests/snapshots/main__type_bad_types.snap
+++ b/crates/monty-type-checking/tests/snapshots/main__type_bad_types.snap
@@ -22,4 +22,8 @@ bad_types.py:96:23: error[too-many-positional-arguments] Too many positional arg
 bad_types.py:101:1: error[missing-argument] No argument provided for required parameter `b` of function `takes_two`
 bad_types.py:101:16: error[unknown-argument] Argument `c` does not match any known parameter of function `takes_two`
 bad_types.py:107:1: error[call-non-callable] Object of type `Literal[42]` is not callable
-bad_types.py:109:7: error[unresolved-attribute] Module `sys` has no member `copyright`
+bad_types.py:122:23: error[invalid-key] Unknown key "uuid" for TypedDict `SearchTag`
+bad_types.py:127:19: error[invalid-argument-type] Argument to function `takes_str` is incorrect: Expected `str`, found `int`
+bad_types.py:132:19: error[invalid-argument-type] Argument to function `takes_int` is incorrect: Expected `int`, found `str`
+bad_types.py:133:19: error[invalid-argument-type] Argument to function `takes_str` is incorrect: Expected `str`, found `int`
+bad_types.py:136:7: error[unresolved-attribute] Module `sys` has no member `copyright`

--- a/crates/monty-typeshed/update.py
+++ b/crates/monty-typeshed/update.py
@@ -101,6 +101,10 @@ COPY_FILES = [
     'typing.pyi',
     'typing_extensions.pyi',
     '_collections_abc.pyi',
+    # `@abstractmethod` decorates protocol members throughout the stubs above
+    # (e.g. `Iterator.__next__`); without it every such member infers as
+    # `Unknown` and silences downstream errors
+    'abc.pyi',
     # Used in type annotations
     'types.pyi',
     # So type checking works with dataclasses
@@ -138,6 +142,7 @@ VERSIONS = """\
 
 _collections_abc: 3.3-
 _typeshed: 3.0-  # not present at runtime, only for type checking
+abc: 3.0-  # not importable at runtime, only for type checking
 asyncio: 3.4-
 builtins: 3.0-
 collections: 3.0-

--- a/crates/monty-typeshed/vendor/typeshed/stdlib/VERSIONS
+++ b/crates/monty-typeshed/vendor/typeshed/stdlib/VERSIONS
@@ -5,6 +5,7 @@
 
 _collections_abc: 3.3-
 _typeshed: 3.0-  # not present at runtime, only for type checking
+abc: 3.0-  # not importable at runtime, only for type checking
 asyncio: 3.4-
 builtins: 3.0-
 collections: 3.0-

--- a/crates/monty-typeshed/vendor/typeshed/stdlib/abc.pyi
+++ b/crates/monty-typeshed/vendor/typeshed/stdlib/abc.pyi
@@ -1,0 +1,53 @@
+import sys
+from collections.abc import Callable
+from typing import Any, Literal, TypeVar
+
+import _typeshed
+from _typeshed import SupportsWrite
+from typing_extensions import Concatenate, ParamSpec, deprecated
+
+_T = TypeVar('_T')
+_R_co = TypeVar('_R_co', covariant=True)
+_FuncT = TypeVar('_FuncT', bound=Callable[..., Any])
+_P = ParamSpec('_P')
+
+# These definitions have special processing in mypy
+class ABCMeta(type):
+    __abstractmethods__: frozenset[str]
+    if sys.version_info >= (3, 11):
+        def __new__(
+            mcls: type[_typeshed.Self], name: str, bases: tuple[type, ...], namespace: dict[str, Any], /, **kwargs: Any
+        ) -> _typeshed.Self: ...
+    else:
+        def __new__(
+            mcls: type[_typeshed.Self], name: str, bases: tuple[type, ...], namespace: dict[str, Any], **kwargs: Any
+        ) -> _typeshed.Self: ...
+
+    def __instancecheck__(cls: ABCMeta, instance: Any, /) -> bool: ...
+    def __subclasscheck__(cls: ABCMeta, subclass: type, /) -> bool: ...
+    def _dump_registry(cls: ABCMeta, file: SupportsWrite[str] | None = None) -> None: ...
+    def register(cls: ABCMeta, subclass: type[_T]) -> type[_T]: ...
+
+def abstractmethod(funcobj: _FuncT) -> _FuncT: ...
+
+@deprecated('Deprecated since Python 3.3. Use `@classmethod` stacked on top of `@abstractmethod` instead.')
+class abstractclassmethod(classmethod[_T, _P, _R_co]):
+    __isabstractmethod__: Literal[True]
+    def __init__(self, callable: Callable[Concatenate[type[_T], _P], _R_co]) -> None: ...
+
+@deprecated('Deprecated since Python 3.3. Use `@staticmethod` stacked on top of `@abstractmethod` instead.')
+class abstractstaticmethod(staticmethod[_P, _R_co]):
+    __isabstractmethod__: Literal[True]
+    def __init__(self, callable: Callable[_P, _R_co]) -> None: ...
+
+@deprecated('Deprecated since Python 3.3. Use `@property` stacked on top of `@abstractmethod` instead.')
+class abstractproperty(property):
+    __isabstractmethod__: Literal[True]
+
+class ABC(metaclass=ABCMeta):
+    __slots__ = ()
+
+def get_cache_token() -> object: ...
+
+if sys.version_info >= (3, 10):
+    def update_abstractmethods(cls: type[_T]) -> type[_T]: ...

--- a/limitations/modules.md
+++ b/limitations/modules.md
@@ -51,3 +51,10 @@ implements just `count` and `repeat` so far, and `collections` only the four
 types above. The absent names are missing from the module namespace rather than
 stubbed, so they fail type checking as well as raising `AttributeError` at
 runtime; see each module's page for the specifics.
+
+## Modules the type checker resolves but the runtime does not
+
+`abc`, `types`, `typing_extensions`, `_collections_abc` and `_typeshed` back
+the vendored stubs (e.g. `@abstractmethod` on protocol members), so they have
+to resolve during type checking. Importing them therefore type-checks clean but
+still raises `ModuleNotFoundError` at runtime.


### PR DESCRIPTION
`Iterator.__next__` and many other protocol members in the vendored stubs are decorated `@abstractmethod`, imported from `abc` — a module the vendored tree did not include. `abstractmethod` therefore resolved to `Unknown`, and so did every member it decorated, meaning every loop variable and iterator element inferred as `Unknown` and silenced all downstream diagnostics.

Copying `abc.pyi` is not enough on its own: a stub missing from `VERSIONS` is treated as not existing at all, so both are needed.

Fixes #197.

Note `import abc` now passes type checking while still raising ModuleNotFoundError at runtime, joining `types`, `typing_extensions`, `_collections_abc` and `_typeshed`; documented in limitations/modules.md.


Claude-Session: https://claude.ai/code/session_017H1dc3DBcFqjyHMF5Aj2C7

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vendored `abc.pyi` and added it to `VERSIONS` so `@abstractmethod` members (e.g., `Iterator.__next__`) keep their types instead of becoming `Unknown`. This restores correct element inference in loops and iterator APIs and re-enables downstream diagnostics.

- **Bug Fixes**
  - Vendor `stdlib/abc.pyi` and include it in `VERSIONS` and the updater so `abstractmethod` resolves during type checking.
  - Preserve element types through the `Iterator` protocol and common iterables/APIs: `next()`/`iter()`, `enumerate`, `zip`, `frozenset`, `sorted`, `dict.items()`, `for` loops, and comprehensions; update tests and snapshots to assert types and surface errors.
  - Document that importing `abc` (and `types`, `typing_extensions`, `_collections_abc`, `_typeshed`) type-checks clean but still raises `ModuleNotFoundError` at runtime.

<sup>Written for commit 57f5b48009221dd0ced575533bbf94ada4e9eb5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

