### PR TITLE
Fix three mount-confinement defects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,18 +95,23 @@ bindings) services via `MountTable::handle_os_call`.
 obtain any information about any file or directory outside the specific directory
 that is mounted. This is enforced by:
 
-- Path canonicalization after mapping virtual → host paths
-- Boundary checks verifying canonical paths remain within the mount
-- Symlink resolution that rejects links pointing outside the mount
-- Virtual-space normalization that prevents `..` escape
+- A `cap_std::fs::Dir` descriptor opened once at mount time, which every
+  operation runs relative to — so `..`, symlinks and intermediate directories
+  swapped mid-operation cannot reach out
+- Virtual-space normalization that prevents `..` escape in the sandbox namespace
 - `Resolve` and `Absolute` returning virtual paths, never host paths
 - Null byte rejection in all paths
 
-All path resolution goes through `path_security::resolve_path()` (in
-`crates/monty-fs/src/path_security.rs`) which is the sole security boundary.
-**Changes to `path_security.rs` require careful security review.**
+Path confinement is **structural**, not a check: `Mount::dir` (in
+`crates/monty-fs/src/mount_table.rs`) is the boundary; `path_security.rs` is
+now only path policy. The cost is that an absolute symlink target is never
+followed, even inside the mount (see `limitations/filesystem.md`) — do not
+"fix" that by comparing against the mount's host path, which restores the
+check-then-use this removes.
 
-`heap.rs` and `path_security.rs` are the two most security-critical files in the codebase.
+**Changes to `mount_table.rs` or `path_security.rs` require careful security
+review.** `heap.rs` and the mount boundary are the most security-critical
+code in the codebase.
 
 ## Subprocess isolation (`monty-proto`, `monty subprocess`, `monty-pool`)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,6 +2464,8 @@ dependencies = [
  "ahash",
  "cap-std",
  "monty-types",
+ "nix 0.31.2",
+ "rustix",
  "tempfile",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +433,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix",
 ]
 
 [[package]]
@@ -1230,6 +1266,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1834,10 +1881,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipnet"
-version = "2.12.0"
+name = "io-extras"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is-macro"
@@ -2238,6 +2307,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3eede3bdf92f3b4f9dc04072a9ce5ab557d5ec9038773bf9ffcd5588b3cc05b"
 
 [[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2387,6 +2462,7 @@ name = "monty-fs"
 version = "0.0.19"
 dependencies = [
  "ahash",
+ "cap-std",
  "monty-types",
  "tempfile",
 ]
@@ -3877,6 +3953,16 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -5486,6 +5572,16 @@ name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.13.1",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,10 @@ tokio-tungstenite = { version = "0.27", features = ["rustls-tls-webpki-roots"] }
 futures-util = { version = "0.3", default-features = false, features = ["std", "sink"] }
 # Unique, exclusively-created temp dirs (pool tests).
 tempfile = "3"
+# Capability-based filesystem access for monty-fs: every mount operation runs
+# relative to a directory descriptor opened at mount time, so path resolution
+# cannot escape the mount and there is no check-to-use window to race.
+cap-std = "4.0"
 # Pulled in only to install a process-level rustls `CryptoProvider` before the
 # first `wss://` dial: rustls 0.23 panics on first TLS use when it can't pick a
 # provider automatically (both `aws-lc-rs` and `ring`, or neither, in the dep

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,11 @@ tempfile = "3"
 # relative to a directory descriptor opened at mount time, so path resolution
 # cannot escape the mount and there is no check-to-use window to race.
 cap-std = "4.0"
+# Unix `O_NONBLOCK` for monty-fs's special-file guard; already in the tree as
+# cap-std's own backend, so this adds no new crate.
+rustix = { version = "1.1", features = ["fs"] }
+# `mkfifo` for the tests behind that guard — rustix gates its own out on Apple.
+nix = { version = "0.31", features = ["fs"] }
 # Pulled in only to install a process-level rustls `CryptoProvider` before the
 # first `wss://` dial: rustls 0.23 panics on first TLS use when it can't pick a
 # provider automatically (both `aws-lc-rs` and `ring`, or neither, in the dep

--- a/crates/monty-fs/Cargo.toml
+++ b/crates/monty-fs/Cargo.toml
@@ -18,6 +18,7 @@ name = "monty_fs"
 [dependencies]
 monty-types = { workspace = true }
 ahash = { workspace = true }
+cap-std = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/monty-fs/Cargo.toml
+++ b/crates/monty-fs/Cargo.toml
@@ -20,6 +20,14 @@ monty-types = { workspace = true }
 ahash = { workspace = true }
 cap-std = { workspace = true }
 
+# `O_NONBLOCK` for the special-file guard; Windows needs no equivalent.
+[target.'cfg(unix)'.dependencies]
+rustix = { workspace = true }
+
+# `mkfifo`, to build the special file the guard is tested against.
+[target.'cfg(unix)'.dev-dependencies]
+nix = { workspace = true }
+
 [dev-dependencies]
 tempfile = { workspace = true }
 

--- a/crates/monty-fs/src/common.rs
+++ b/crates/monty-fs/src/common.rs
@@ -5,7 +5,9 @@
 //! byte decoding, stat conversion, and quota bookkeeping logic.
 
 use std::{
+    ffi::OsStr,
     io::{Error as IoError, ErrorKind, Read, Write},
+    path::{Path, PathBuf},
     time::SystemTime,
 };
 
@@ -327,7 +329,11 @@ pub(super) fn list_visible_real_dir_entry_names(
         let file_type = entry.file_type().map_err(|err| map_io(err, vpath))?;
 
         if file_type.is_symlink() {
-            let child = join_relative(rel, &entry.file_name().to_string_lossy());
+            // Join the raw name: a lossy `String` round-trip would look up a
+            // different entry and silently drop this one. The lookup must stay
+            // path-based so it runs through the descriptor's confinement check —
+            // `entry.metadata()` resolves the link without one.
+            let child = join_relative_os(rel, &entry.file_name());
             if dir.metadata(&child).is_err() {
                 continue;
             }
@@ -386,6 +392,17 @@ pub(super) fn dir_mtime(dir: &Dir, rel: &str) -> f64 {
         .map_or_else(|_| SystemTime::now(), CapSystemTime::into_std)
         .duration_since(SystemTime::UNIX_EPOCH)
         .map_or(0.0, |duration| duration.as_secs_f64())
+}
+
+/// Joins a mount-relative directory path with a raw directory entry name.
+///
+/// Takes the name as an `OsStr` so a non-UTF-8 filename survives the join.
+pub(super) fn join_relative_os(rel: &str, child: &OsStr) -> PathBuf {
+    if rel.is_empty() || rel == "." {
+        PathBuf::from(child)
+    } else {
+        Path::new(rel).join(child)
+    }
 }
 
 /// Joins a mount-relative directory path with a child name.

--- a/crates/monty-fs/src/common.rs
+++ b/crates/monty-fs/src/common.rs
@@ -103,7 +103,12 @@ pub(super) struct MountContext<'a> {
 ///
 /// Directory-read errors differ across platforms, so the target is checked
 /// explicitly before reading.
-pub(super) fn read_text_fs(dir: &Dir, rel: &str, vpath: &str, budget: MemoryBudget) -> Result<MontyObject, MountError> {
+pub(super) fn host_read_text(
+    dir: &Dir,
+    rel: &str,
+    vpath: &str,
+    budget: MemoryBudget,
+) -> Result<MontyObject, MountError> {
     let bytes = read_file_limited(dir, rel, vpath, budget)?;
     let content = bytes_to_utf8(bytes)?;
     Ok(MontyObject::String(content))
@@ -113,7 +118,7 @@ pub(super) fn read_text_fs(dir: &Dir, rel: &str, vpath: &str, budget: MemoryBudg
 ///
 /// Directory-read errors differ across platforms, so the target is checked
 /// explicitly before reading.
-pub(super) fn read_bytes_fs(
+pub(super) fn host_read_bytes(
     dir: &Dir,
     rel: &str,
     vpath: &str,
@@ -149,7 +154,7 @@ fn read_file_limited(dir: &Dir, rel: &str, vpath: &str, budget: MemoryBudget) ->
 ///
 /// On Windows, `fs::write()` on a directory returns `PermissionDenied` instead of
 /// `IsADirectory`, so we check explicitly before writing.
-pub(super) fn write_text_fs(dir: &Dir, rel: &str, content: &str, vpath: &str) -> Result<MontyObject, MountError> {
+pub(super) fn host_write_text(dir: &Dir, rel: &str, content: &str, vpath: &str) -> Result<MontyObject, MountError> {
     write_bytes_to_file(dir, rel, content.as_bytes(), vpath)?;
     Ok(MontyObject::Int(
         i64::try_from(content.chars().count()).unwrap_or(i64::MAX),
@@ -160,7 +165,7 @@ pub(super) fn write_text_fs(dir: &Dir, rel: &str, content: &str, vpath: &str) ->
 ///
 /// On Windows, `fs::write()` on a directory returns `PermissionDenied` instead of
 /// `IsADirectory`, so we check explicitly before writing.
-pub(super) fn write_bytes_fs(dir: &Dir, rel: &str, content: &[u8], vpath: &str) -> Result<MontyObject, MountError> {
+pub(super) fn host_write_bytes(dir: &Dir, rel: &str, content: &[u8], vpath: &str) -> Result<MontyObject, MountError> {
     write_bytes_to_file(dir, rel, content, vpath)?;
     Ok(MontyObject::Int(i64::try_from(content.len()).unwrap_or(i64::MAX)))
 }
@@ -178,7 +183,7 @@ fn write_bytes_to_file(dir: &Dir, rel: &str, content: &[u8], vpath: &str) -> Res
 ///
 /// The host file is opened only for the duration of this call, preserving the
 /// sandbox invariant that Monty never keeps native file handles alive.
-pub(super) fn append_text_fs(dir: &Dir, rel: &str, content: &str, vpath: &str) -> Result<MontyObject, MountError> {
+pub(super) fn host_append_text(dir: &Dir, rel: &str, content: &str, vpath: &str) -> Result<MontyObject, MountError> {
     append_bytes_to_file(dir, rel, content.as_bytes(), vpath)?;
     Ok(MontyObject::Int(
         i64::try_from(content.chars().count()).unwrap_or(i64::MAX),
@@ -187,8 +192,8 @@ pub(super) fn append_text_fs(dir: &Dir, rel: &str, content: &str, vpath: &str) -
 
 /// Appends bytes to a file and returns the number of bytes written.
 ///
-/// This is the binary counterpart of [`append_text_fs`].
-pub(super) fn append_bytes_fs(dir: &Dir, rel: &str, content: &[u8], vpath: &str) -> Result<MontyObject, MountError> {
+/// This is the binary counterpart of [`host_append_text`].
+pub(super) fn host_append_bytes(dir: &Dir, rel: &str, content: &[u8], vpath: &str) -> Result<MontyObject, MountError> {
     append_bytes_to_file(dir, rel, content, vpath)?;
     Ok(MontyObject::Int(i64::try_from(content.len()).unwrap_or(i64::MAX)))
 }
@@ -208,7 +213,7 @@ fn append_bytes_to_file(dir: &Dir, rel: &str, content: &[u8], vpath: &str) -> Re
 ///   (whether file or directory), even with `parents=True`.
 /// - `exist_ok=True`: silently succeeds only if the path is an existing **directory**.
 ///   If the path is an existing **file**, raises `FileExistsError` regardless.
-pub(super) fn mkdir_fs(
+pub(super) fn host_mkdir(
     dir: &Dir,
     rel: &str,
     parents: bool,
@@ -239,25 +244,27 @@ pub(super) fn mkdir_fs(
 
     match result {
         Ok(()) => Ok(MontyObject::None),
-        Err(err) if err.kind() == ErrorKind::AlreadyExists && exist_ok && is_dir(dir, rel) => Ok(MontyObject::None),
+        Err(err) if err.kind() == ErrorKind::AlreadyExists && exist_ok && host_is_dir(dir, rel) => {
+            Ok(MontyObject::None)
+        }
         Err(err) => Err(map_io(err, vpath)),
     }
 }
 
 /// Removes a file, or the symlink itself when `rel` names one.
-pub(super) fn unlink_fs(dir: &Dir, rel: &str, vpath: &str) -> Result<MontyObject, MountError> {
+pub(super) fn host_unlink(dir: &Dir, rel: &str, vpath: &str) -> Result<MontyObject, MountError> {
     dir.remove_file(rel).map_err(|err| map_io(err, vpath))?;
     Ok(MontyObject::None)
 }
 
 /// Removes an empty directory.
-pub(super) fn rmdir_fs(dir: &Dir, rel: &str, vpath: &str) -> Result<MontyObject, MountError> {
+pub(super) fn host_rmdir(dir: &Dir, rel: &str, vpath: &str) -> Result<MontyObject, MountError> {
     dir.remove_dir(rel).map_err(|err| map_io(err, vpath))?;
     Ok(MontyObject::None)
 }
 
 /// Returns a `stat_result`-shaped object for a file or directory.
-pub(super) fn stat_fs(dir: &Dir, rel: &str, vpath: &str) -> Result<MontyObject, MountError> {
+pub(super) fn host_stat(dir: &Dir, rel: &str, vpath: &str) -> Result<MontyObject, MountError> {
     let metadata = dir.metadata(rel).map_err(|err| map_io(err, vpath))?;
     let mtime = mtime_secs(&metadata);
     let size = i64::try_from(metadata.len()).unwrap_or(i64::MAX);
@@ -270,8 +277,8 @@ pub(super) fn stat_fs(dir: &Dir, rel: &str, vpath: &str) -> Result<MontyObject, 
 }
 
 /// Lists visible directory entries within the mount memory budget.
-pub(super) fn iterdir_fs(dir: &Dir, rel: &str, vpath: &str, budget: MemoryBudget) -> Result<MontyObject, MountError> {
-    let names = list_visible_real_dir_entry_names(dir, rel, vpath, budget.halved())?;
+pub(super) fn host_iterdir(dir: &Dir, rel: &str, vpath: &str, budget: MemoryBudget) -> Result<MontyObject, MountError> {
+    let names = host_list_visible_dir_entry_names(dir, rel, vpath, budget.halved())?;
     let mut memory_usage = names.iter().fold(0_u64, |usage, name| {
         usage
             .saturating_add(as_u64(name.len()))
@@ -311,7 +318,7 @@ pub(super) fn commit_write_bytes(bytes: usize, ctx: &mut MountContext<'_>) {
 ///
 /// Symlinks are only exposed when they still resolve inside the mount, so
 /// iteration does not leak the existence of outbound or broken links.
-pub(super) fn list_visible_real_dir_entry_names(
+pub(super) fn host_list_visible_dir_entry_names(
     dir: &Dir,
     rel: &str,
     vpath: &str,
@@ -333,7 +340,7 @@ pub(super) fn list_visible_real_dir_entry_names(
             // different entry and silently drop this one. The lookup must stay
             // path-based so it runs through the descriptor's confinement check —
             // `entry.metadata()` resolves the link without one.
-            let child = join_relative_os(rel, &entry.file_name());
+            let child = join_mount_relative_os(rel, &entry.file_name());
             if dir.metadata(&child).is_err() {
                 continue;
             }
@@ -386,7 +393,7 @@ pub(super) fn mtime_secs(metadata: &Metadata) -> f64 {
 }
 
 /// Reads a directory modification time, falling back to `now` if needed.
-pub(super) fn dir_mtime(dir: &Dir, rel: &str) -> f64 {
+pub(super) fn host_dir_mtime(dir: &Dir, rel: &str) -> f64 {
     dir.metadata(rel)
         .and_then(|metadata| metadata.modified())
         .map_or_else(|_| SystemTime::now(), CapSystemTime::into_std)
@@ -394,10 +401,11 @@ pub(super) fn dir_mtime(dir: &Dir, rel: &str) -> f64 {
         .map_or(0.0, |duration| duration.as_secs_f64())
 }
 
-/// Joins a mount-relative directory path with a raw directory entry name.
-///
-/// Takes the name as an `OsStr` so a non-UTF-8 filename survives the join.
-pub(super) fn join_relative_os(rel: &str, child: &OsStr) -> PathBuf {
+/// [`join_mount_relative`] for a raw directory-entry name: the child stays an
+/// `OsStr` so a non-UTF-8 name survives the join and the resulting lookup
+/// names the entry itself — a lossy `String` round-trip would name a
+/// different path.
+pub(super) fn join_mount_relative_os(rel: &str, child: &OsStr) -> PathBuf {
     if rel.is_empty() || rel == "." {
         PathBuf::from(child)
     } else {
@@ -405,8 +413,10 @@ pub(super) fn join_relative_os(rel: &str, child: &OsStr) -> PathBuf {
     }
 }
 
-/// Joins a mount-relative directory path with a child name.
-pub(super) fn join_relative(rel: &str, child: &str) -> String {
+/// Joins a mount-relative directory path with a child name, yielding the
+/// child's own mount-relative path — the coordinate system `Dir` operations
+/// and overlay keys share. `""` and `"."` both mean the mount root.
+pub(super) fn join_mount_relative(rel: &str, child: &str) -> String {
     if rel.is_empty() || rel == "." {
         child.to_owned()
     } else {
@@ -415,12 +425,12 @@ pub(super) fn join_relative(rel: &str, child: &str) -> String {
 }
 
 /// Whether `rel` resolves to a directory inside the mount.
-pub(super) fn is_dir(dir: &Dir, rel: &str) -> bool {
+pub(super) fn host_is_dir(dir: &Dir, rel: &str) -> bool {
     dir.metadata(rel).is_ok_and(|meta| meta.is_dir())
 }
 
 /// Whether `rel` resolves to a regular file inside the mount.
-pub(super) fn is_file(dir: &Dir, rel: &str) -> bool {
+pub(super) fn host_is_file(dir: &Dir, rel: &str) -> bool {
     dir.metadata(rel).is_ok_and(|meta| meta.is_file())
 }
 

--- a/crates/monty-fs/src/common.rs
+++ b/crates/monty-fs/src/common.rs
@@ -11,11 +11,15 @@ use std::{
     time::SystemTime,
 };
 
+#[cfg(unix)]
+use cap_std::fs::OpenOptionsExt;
 use cap_std::{
-    fs::{Dir, Metadata, OpenOptions},
+    fs::{Dir, File, Metadata, OpenOptions},
     time::SystemTime as CapSystemTime,
 };
 use monty_types::{MontyObject, UnicodeErrorData, dir_stat, file_stat, utf8_error_reason};
+#[cfg(unix)]
+use rustix::fs::OFlags;
 
 use super::error::MountError;
 
@@ -137,7 +141,7 @@ pub(super) fn host_read_bytes(
 /// count actually read, so lying or racing metadata cannot evade the limit.
 fn read_file_limited(dir: &Dir, rel: &str, vpath: &str, budget: MemoryBudget) -> Result<Vec<u8>, MountError> {
     reject_non_regular(dir, rel, vpath)?;
-    let file = dir.open(rel).map_err(|err| map_io(err, vpath))?;
+    let file = open_regular(dir, rel, vpath, OpenOptions::new().read(true))?;
     let meta_len = file.metadata().map_err(|err| map_io(err, vpath))?.len();
     budget.check(meta_len)?;
     // The check above bounds `meta_len` by the budget, so this pre-allocation
@@ -173,9 +177,12 @@ pub(super) fn host_write_bytes(dir: &Dir, rel: &str, content: &[u8], vpath: &str
 /// Truncates `rel` and writes `content` through the mount descriptor.
 fn write_bytes_to_file(dir: &Dir, rel: &str, content: &[u8], vpath: &str) -> Result<(), MountError> {
     reject_non_regular(dir, rel, vpath)?;
-    let mut file = dir
-        .open_with(rel, OpenOptions::new().write(true).create(true).truncate(true))
-        .map_err(|err| map_io(err, vpath))?;
+    let mut file = open_regular(
+        dir,
+        rel,
+        vpath,
+        OpenOptions::new().write(true).create(true).truncate(true),
+    )?;
     file.write_all(content).map_err(|err| map_io(err, vpath))
 }
 
@@ -201,10 +208,43 @@ pub(super) fn host_append_bytes(dir: &Dir, rel: &str, content: &[u8], vpath: &st
 /// Opens `rel` in append mode, writes all bytes, and closes it before returning.
 fn append_bytes_to_file(dir: &Dir, rel: &str, content: &[u8], vpath: &str) -> Result<(), MountError> {
     reject_non_regular(dir, rel, vpath)?;
-    let mut file = dir
-        .open_with(rel, OpenOptions::new().create(true).append(true))
-        .map_err(|err| map_io(err, vpath))?;
+    let mut file = open_regular(dir, rel, vpath, OpenOptions::new().create(true).append(true))?;
     file.write_all(content).map_err(|err| map_io(err, vpath))
+}
+
+/// Opens `rel` and rejects it unless the *handle* is a regular file — the
+/// authoritative special-file guard, since a handle is bound to one inode and
+/// cannot be raced the way [`reject_non_regular`]'s path check can.
+fn open_regular(dir: &Dir, rel: &str, vpath: &str, options: &mut OpenOptions) -> Result<File, MountError> {
+    let file = dir
+        .open_with(rel, non_blocking(options))
+        .map_err(|err| map_io(err, vpath))?;
+    let metadata = file.metadata().map_err(|err| map_io(err, vpath))?;
+    if metadata.is_file() {
+        Ok(file)
+    } else if metadata.is_dir() {
+        Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
+    } else {
+        Err(MountError::io_err(
+            ErrorKind::PermissionDenied,
+            "Permission denied",
+            vpath,
+        ))
+    }
+}
+
+/// Adds `O_NONBLOCK` so opening a FIFO returns instead of waiting for a peer,
+/// which is what lets the guard above run after the open. No-op on regular files.
+#[cfg(unix)]
+fn non_blocking(options: &mut OpenOptions) -> &mut OpenOptions {
+    options.custom_flags(OFlags::NONBLOCK.bits().cast_signed())
+}
+
+/// No-op: Windows named pipes aren't reachable through a `Dir`, so no open here
+/// can block on a peer.
+#[cfg(not(unix))]
+fn non_blocking(options: &mut OpenOptions) -> &mut OpenOptions {
+    options
 }
 
 /// Creates a directory, matching CPython `pathlib.Path.mkdir()` semantics:
@@ -454,17 +494,9 @@ pub(super) fn map_io(err: IoError, vpath: &str) -> MountError {
 /// `IsADirectory` error, and special files (FIFOs, sockets, devices) get
 /// `PermissionDenied`. A missing path passes — write/append create it.
 ///
-/// The directory check normalises Windows (where many `std::fs` operations on
-/// directories return `PermissionDenied` instead of `IsADirectory`). The
-/// special-file check is a hang guard: reading or writing a FIFO blocks until
-/// a peer appears, and mount I/O runs on the *host* thread servicing the
-/// sandbox, so it must never block on sandbox-reachable input.
-///
-/// TOCTOU caveat: this is a check-then-open, so another *host* process with
-/// write access to the mounted directory can swap a regular file for a FIFO
-/// between check and open and block the servicing thread. Sandbox code alone
-/// cannot exploit this — no mount mode can create special files or symlinks —
-/// so do not mount directories writable by untrusted local processes.
+/// A path check, so raceable — [`open_regular`] is the guard that decides. This
+/// only buys error quality: `IsADirectory` on every platform, where the
+/// post-open error depends on what the host's `open` made of the directory.
 pub(super) fn reject_non_regular(dir: &Dir, rel: &str, vpath: &str) -> Result<(), MountError> {
     match dir.metadata(rel) {
         Ok(meta) if meta.is_dir() => Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath)),

--- a/crates/monty-fs/src/common.rs
+++ b/crates/monty-fs/src/common.rs
@@ -5,12 +5,14 @@
 //! byte decoding, stat conversion, and quota bookkeeping logic.
 
 use std::{
-    fs::{self, File, OpenOptions},
-    io::{ErrorKind, Read, Write},
-    path::Path,
+    io::{Error as IoError, ErrorKind, Read, Write},
     time::SystemTime,
 };
 
+use cap_std::{
+    fs::{Dir, Metadata, OpenOptions},
+    time::SystemTime as CapSystemTime,
+};
 use monty_types::{MontyObject, UnicodeErrorData, dir_stat, file_stat, utf8_error_reason};
 
 use super::error::MountError;
@@ -83,8 +85,10 @@ impl MemoryBudget {
 pub(super) struct MountContext<'a> {
     /// Virtual mount prefix such as `"/mnt/data"`.
     pub mount_virtual: &'a str,
-    /// Canonical host directory that backs the mount.
-    pub mount_host: &'a Path,
+    /// Descriptor for the mounted directory — the sandbox boundary. Every
+    /// operation resolves relative to this, so no path can leave the mount and
+    /// no concurrent rename can redirect one.
+    pub mount_dir: &'a Dir,
     /// Cumulative bytes written through this mount.
     pub write_bytes_used: &'a mut u64,
     /// Optional cumulative write cap for the mount.
@@ -97,8 +101,8 @@ pub(super) struct MountContext<'a> {
 ///
 /// Directory-read errors differ across platforms, so the target is checked
 /// explicitly before reading.
-pub(super) fn read_text_fs(path: &Path, vpath: &str, budget: MemoryBudget) -> Result<MontyObject, MountError> {
-    let bytes = read_file_limited(path, vpath, budget)?;
+pub(super) fn read_text_fs(dir: &Dir, rel: &str, vpath: &str, budget: MemoryBudget) -> Result<MontyObject, MountError> {
+    let bytes = read_file_limited(dir, rel, vpath, budget)?;
     let content = bytes_to_utf8(bytes)?;
     Ok(MontyObject::String(content))
 }
@@ -107,8 +111,13 @@ pub(super) fn read_text_fs(path: &Path, vpath: &str, budget: MemoryBudget) -> Re
 ///
 /// Directory-read errors differ across platforms, so the target is checked
 /// explicitly before reading.
-pub(super) fn read_bytes_fs(path: &Path, vpath: &str, budget: MemoryBudget) -> Result<MontyObject, MountError> {
-    Ok(MontyObject::Bytes(read_file_limited(path, vpath, budget)?))
+pub(super) fn read_bytes_fs(
+    dir: &Dir,
+    rel: &str,
+    vpath: &str,
+    budget: MemoryBudget,
+) -> Result<MontyObject, MountError> {
+    Ok(MontyObject::Bytes(read_file_limited(dir, rel, vpath, budget)?))
 }
 
 /// Reads at most `budget + 1` bytes so an oversized file is rejected before it
@@ -119,20 +128,17 @@ pub(super) fn read_bytes_fs(path: &Path, vpath: &str, budget: MemoryBudget) -> R
 /// with one `stat`, and pre-sizing the buffer (capped by the budget) to avoid
 /// `read_to_end`'s doubling reallocations. Enforcement is always the byte
 /// count actually read, so lying or racing metadata cannot evade the limit.
-fn read_file_limited(path: &Path, vpath: &str, budget: MemoryBudget) -> Result<Vec<u8>, MountError> {
-    reject_non_regular(path, vpath)?;
-    let file = File::open(path).map_err(|err| MountError::Io(err, vpath.to_owned()))?;
-    let meta_len = file
-        .metadata()
-        .map_err(|err| MountError::Io(err, vpath.to_owned()))?
-        .len();
+fn read_file_limited(dir: &Dir, rel: &str, vpath: &str, budget: MemoryBudget) -> Result<Vec<u8>, MountError> {
+    reject_non_regular(dir, rel, vpath)?;
+    let file = dir.open(rel).map_err(|err| map_io(err, vpath))?;
+    let meta_len = file.metadata().map_err(|err| map_io(err, vpath))?.len();
     budget.check(meta_len)?;
     // The check above bounds `meta_len` by the budget, so this pre-allocation
     // can never exceed the limit being enforced.
     let mut content = Vec::with_capacity(usize::try_from(meta_len).unwrap_or(0));
     file.take(budget.available.saturating_add(1))
         .read_to_end(&mut content)
-        .map_err(|err| MountError::Io(err, vpath.to_owned()))?;
+        .map_err(|err| map_io(err, vpath))?;
     budget.check(as_u64(content.len()))?;
     Ok(content)
 }
@@ -141,9 +147,8 @@ fn read_file_limited(path: &Path, vpath: &str, budget: MemoryBudget) -> Result<V
 ///
 /// On Windows, `fs::write()` on a directory returns `PermissionDenied` instead of
 /// `IsADirectory`, so we check explicitly before writing.
-pub(super) fn write_text_fs(path: &Path, content: &str, vpath: &str) -> Result<MontyObject, MountError> {
-    reject_non_regular(path, vpath)?;
-    fs::write(path, content).map_err(|err| MountError::Io(err, vpath.to_owned()))?;
+pub(super) fn write_text_fs(dir: &Dir, rel: &str, content: &str, vpath: &str) -> Result<MontyObject, MountError> {
+    write_bytes_to_file(dir, rel, content.as_bytes(), vpath)?;
     Ok(MontyObject::Int(
         i64::try_from(content.chars().count()).unwrap_or(i64::MAX),
     ))
@@ -153,18 +158,26 @@ pub(super) fn write_text_fs(path: &Path, content: &str, vpath: &str) -> Result<M
 ///
 /// On Windows, `fs::write()` on a directory returns `PermissionDenied` instead of
 /// `IsADirectory`, so we check explicitly before writing.
-pub(super) fn write_bytes_fs(path: &Path, content: &[u8], vpath: &str) -> Result<MontyObject, MountError> {
-    reject_non_regular(path, vpath)?;
-    fs::write(path, content).map_err(|err| MountError::Io(err, vpath.to_owned()))?;
+pub(super) fn write_bytes_fs(dir: &Dir, rel: &str, content: &[u8], vpath: &str) -> Result<MontyObject, MountError> {
+    write_bytes_to_file(dir, rel, content, vpath)?;
     Ok(MontyObject::Int(i64::try_from(content.len()).unwrap_or(i64::MAX)))
+}
+
+/// Truncates `rel` and writes `content` through the mount descriptor.
+fn write_bytes_to_file(dir: &Dir, rel: &str, content: &[u8], vpath: &str) -> Result<(), MountError> {
+    reject_non_regular(dir, rel, vpath)?;
+    let mut file = dir
+        .open_with(rel, OpenOptions::new().write(true).create(true).truncate(true))
+        .map_err(|err| map_io(err, vpath))?;
+    file.write_all(content).map_err(|err| map_io(err, vpath))
 }
 
 /// Appends text to a file and returns the number of characters written.
 ///
 /// The host file is opened only for the duration of this call, preserving the
 /// sandbox invariant that Monty never keeps native file handles alive.
-pub(super) fn append_text_fs(path: &Path, content: &str, vpath: &str) -> Result<MontyObject, MountError> {
-    append_bytes_to_file(path, content.as_bytes(), vpath)?;
+pub(super) fn append_text_fs(dir: &Dir, rel: &str, content: &str, vpath: &str) -> Result<MontyObject, MountError> {
+    append_bytes_to_file(dir, rel, content.as_bytes(), vpath)?;
     Ok(MontyObject::Int(
         i64::try_from(content.chars().count()).unwrap_or(i64::MAX),
     ))
@@ -173,21 +186,18 @@ pub(super) fn append_text_fs(path: &Path, content: &str, vpath: &str) -> Result<
 /// Appends bytes to a file and returns the number of bytes written.
 ///
 /// This is the binary counterpart of [`append_text_fs`].
-pub(super) fn append_bytes_fs(path: &Path, content: &[u8], vpath: &str) -> Result<MontyObject, MountError> {
-    append_bytes_to_file(path, content, vpath)?;
+pub(super) fn append_bytes_fs(dir: &Dir, rel: &str, content: &[u8], vpath: &str) -> Result<MontyObject, MountError> {
+    append_bytes_to_file(dir, rel, content, vpath)?;
     Ok(MontyObject::Int(i64::try_from(content.len()).unwrap_or(i64::MAX)))
 }
 
-/// Opens `path` in append mode, writes all bytes, and closes it before returning.
-fn append_bytes_to_file(path: &Path, content: &[u8], vpath: &str) -> Result<(), MountError> {
-    reject_non_regular(path, vpath)?;
-    let mut file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-        .map_err(|err| MountError::Io(err, vpath.to_owned()))?;
-    file.write_all(content)
-        .map_err(|err| MountError::Io(err, vpath.to_owned()))
+/// Opens `rel` in append mode, writes all bytes, and closes it before returning.
+fn append_bytes_to_file(dir: &Dir, rel: &str, content: &[u8], vpath: &str) -> Result<(), MountError> {
+    reject_non_regular(dir, rel, vpath)?;
+    let mut file = dir
+        .open_with(rel, OpenOptions::new().create(true).append(true))
+        .map_err(|err| map_io(err, vpath))?;
+    file.write_all(content).map_err(|err| map_io(err, vpath))
 }
 
 /// Creates a directory, matching CPython `pathlib.Path.mkdir()` semantics:
@@ -196,11 +206,17 @@ fn append_bytes_to_file(path: &Path, content: &[u8], vpath: &str) -> Result<(), 
 ///   (whether file or directory), even with `parents=True`.
 /// - `exist_ok=True`: silently succeeds only if the path is an existing **directory**.
 ///   If the path is an existing **file**, raises `FileExistsError` regardless.
-pub(super) fn mkdir_fs(path: &Path, parents: bool, exist_ok: bool, vpath: &str) -> Result<MontyObject, MountError> {
+pub(super) fn mkdir_fs(
+    dir: &Dir,
+    rel: &str,
+    parents: bool,
+    exist_ok: bool,
+    vpath: &str,
+) -> Result<MontyObject, MountError> {
     let result = if parents {
         // `create_dir_all` silently returns `Ok(())` when the directory already exists,
         // so we must check for pre-existing paths ourselves.
-        match path.symlink_metadata() {
+        match dir.symlink_metadata(rel) {
             Ok(meta) if meta.is_dir() => {
                 return if exist_ok {
                     Ok(MontyObject::None)
@@ -214,38 +230,34 @@ pub(super) fn mkdir_fs(path: &Path, parents: bool, exist_ok: bool, vpath: &str) 
             }
             Err(_) => {} // Path doesn't exist, proceed with creation.
         }
-        fs::create_dir_all(path)
+        dir.create_dir_all(rel)
     } else {
-        fs::create_dir(path)
+        dir.create_dir(rel)
     };
 
     match result {
         Ok(()) => Ok(MontyObject::None),
-        Err(err) if err.kind() == ErrorKind::AlreadyExists && exist_ok && path.is_dir() => Ok(MontyObject::None),
-        Err(err) => Err(MountError::Io(err, vpath.to_owned())),
+        Err(err) if err.kind() == ErrorKind::AlreadyExists && exist_ok && is_dir(dir, rel) => Ok(MontyObject::None),
+        Err(err) => Err(map_io(err, vpath)),
     }
 }
 
-/// Removes a file.
-pub(super) fn unlink_fs(path: &Path, vpath: &str) -> Result<MontyObject, MountError> {
-    fs::remove_file(path).map_err(|err| MountError::Io(err, vpath.to_owned()))?;
+/// Removes a file, or the symlink itself when `rel` names one.
+pub(super) fn unlink_fs(dir: &Dir, rel: &str, vpath: &str) -> Result<MontyObject, MountError> {
+    dir.remove_file(rel).map_err(|err| map_io(err, vpath))?;
     Ok(MontyObject::None)
 }
 
 /// Removes an empty directory.
-pub(super) fn rmdir_fs(path: &Path, vpath: &str) -> Result<MontyObject, MountError> {
-    fs::remove_dir(path).map_err(|err| MountError::Io(err, vpath.to_owned()))?;
+pub(super) fn rmdir_fs(dir: &Dir, rel: &str, vpath: &str) -> Result<MontyObject, MountError> {
+    dir.remove_dir(rel).map_err(|err| map_io(err, vpath))?;
     Ok(MontyObject::None)
 }
 
 /// Returns a `stat_result`-shaped object for a file or directory.
-pub(super) fn stat_fs(path: &Path, vpath: &str) -> Result<MontyObject, MountError> {
-    let metadata = fs::metadata(path).map_err(|err| MountError::Io(err, vpath.to_owned()))?;
-    let mtime = metadata
-        .modified()
-        .unwrap_or(SystemTime::UNIX_EPOCH)
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map_or(0.0, |duration| duration.as_secs_f64());
+pub(super) fn stat_fs(dir: &Dir, rel: &str, vpath: &str) -> Result<MontyObject, MountError> {
+    let metadata = dir.metadata(rel).map_err(|err| map_io(err, vpath))?;
+    let mtime = mtime_secs(&metadata);
     let size = i64::try_from(metadata.len()).unwrap_or(i64::MAX);
 
     if metadata.is_dir() {
@@ -256,13 +268,8 @@ pub(super) fn stat_fs(path: &Path, vpath: &str) -> Result<MontyObject, MountErro
 }
 
 /// Lists visible directory entries within the mount memory budget.
-pub(super) fn iterdir_fs(
-    host_path: &Path,
-    vpath: &str,
-    mount_host_path: &Path,
-    budget: MemoryBudget,
-) -> Result<MontyObject, MountError> {
-    let names = list_visible_real_dir_entry_names(host_path, mount_host_path, vpath, budget.halved())?;
+pub(super) fn iterdir_fs(dir: &Dir, rel: &str, vpath: &str, budget: MemoryBudget) -> Result<MontyObject, MountError> {
+    let names = list_visible_real_dir_entry_names(dir, rel, vpath, budget.halved())?;
     let mut memory_usage = names.iter().fold(0_u64, |usage, name| {
         usage
             .saturating_add(as_u64(name.len()))
@@ -300,28 +307,29 @@ pub(super) fn commit_write_bytes(bytes: usize, ctx: &mut MountContext<'_>) {
 
 /// Returns visible real directory entry names for `iterdir()`.
 ///
-/// Symlinks are only exposed when their canonical target remains within the
-/// mount boundary so directory iteration does not leak the existence of
-/// outbound or broken links.
+/// Symlinks are only exposed when they still resolve inside the mount, so
+/// iteration does not leak the existence of outbound or broken links.
 pub(super) fn list_visible_real_dir_entry_names(
-    host_path: &Path,
-    mount_host_path: &Path,
+    dir: &Dir,
+    rel: &str,
     vpath: &str,
     budget: MemoryBudget,
 ) -> Result<Vec<String>, MountError> {
-    let read_dir = fs::read_dir(host_path).map_err(|err| MountError::Io(err, vpath.to_owned()))?;
+    // `read_dir` on a missing path reports ENOTDIR, but CPython raises
+    // `FileNotFoundError`, so surface the lookup failure first.
+    dir.metadata(rel).map_err(|err| map_io(err, vpath))?;
+    let read_dir = dir.read_dir(rel).map_err(|err| map_io(err, vpath))?;
     let mut names = Vec::new();
     let mut memory_usage = 0_u64;
 
     for entry in read_dir {
-        let entry = entry.map_err(|err| MountError::Io(err, vpath.to_owned()))?;
-        let file_type = entry.file_type().map_err(|err| MountError::Io(err, vpath.to_owned()))?;
+        let entry = entry.map_err(|err| map_io(err, vpath))?;
+        let file_type = entry.file_type().map_err(|err| map_io(err, vpath))?;
 
         if file_type.is_symlink() {
-            match fs::canonicalize(entry.path()) {
-                Ok(canonical) if !canonical.starts_with(mount_host_path) => continue,
-                Err(_) => continue,
-                _ => {}
+            let child = join_relative(rel, &entry.file_name().to_string_lossy());
+            if dir.metadata(&child).is_err() {
+                continue;
             }
         }
 
@@ -362,13 +370,57 @@ pub(super) fn current_timestamp() -> f64 {
         .map_or(0.0, |duration| duration.as_secs_f64())
 }
 
-/// Reads a directory modification time, falling back to `now` if needed.
-pub(super) fn dir_mtime(path: &Path) -> f64 {
-    fs::metadata(path)
-        .and_then(|metadata| metadata.modified())
-        .unwrap_or_else(|_| SystemTime::now())
+/// Seconds since the Unix epoch for a file's mtime, or `0.0` if unavailable.
+pub(super) fn mtime_secs(metadata: &Metadata) -> f64 {
+    metadata
+        .modified()
+        .map_or(SystemTime::UNIX_EPOCH, CapSystemTime::into_std)
         .duration_since(SystemTime::UNIX_EPOCH)
         .map_or(0.0, |duration| duration.as_secs_f64())
+}
+
+/// Reads a directory modification time, falling back to `now` if needed.
+pub(super) fn dir_mtime(dir: &Dir, rel: &str) -> f64 {
+    dir.metadata(rel)
+        .and_then(|metadata| metadata.modified())
+        .map_or_else(|_| SystemTime::now(), CapSystemTime::into_std)
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map_or(0.0, |duration| duration.as_secs_f64())
+}
+
+/// Joins a mount-relative directory path with a child name.
+pub(super) fn join_relative(rel: &str, child: &str) -> String {
+    if rel.is_empty() || rel == "." {
+        child.to_owned()
+    } else {
+        format!("{rel}/{child}")
+    }
+}
+
+/// Whether `rel` resolves to a directory inside the mount.
+pub(super) fn is_dir(dir: &Dir, rel: &str) -> bool {
+    dir.metadata(rel).is_ok_and(|meta| meta.is_dir())
+}
+
+/// Whether `rel` resolves to a regular file inside the mount.
+pub(super) fn is_file(dir: &Dir, rel: &str) -> bool {
+    dir.metadata(rel).is_ok_and(|meta| meta.is_file())
+}
+
+/// Converts a `cap-std` error into a [`MountError`].
+///
+/// `cap-std` reports both an escape attempt and a genuine in-mount `EACCES` as
+/// `PermissionDenied`; the errno tells them apart, since its escape error is
+/// synthetic on every platform (Linux maps `EXDEV` through the same
+/// constructor). Keeps [`MountError::PathEscape`] meaningful for diagnostics.
+pub(super) fn map_io(err: IoError, vpath: &str) -> MountError {
+    if err.kind() == ErrorKind::PermissionDenied && err.raw_os_error().is_none() {
+        MountError::PathEscape {
+            virtual_path: vpath.to_owned(),
+        }
+    } else {
+        MountError::Io(err, vpath.to_owned())
+    }
 }
 
 /// Rejects an existing `path` that is not a regular file: directories get an
@@ -386,8 +438,8 @@ pub(super) fn dir_mtime(path: &Path) -> f64 {
 /// between check and open and block the servicing thread. Sandbox code alone
 /// cannot exploit this — no mount mode can create special files or symlinks —
 /// so do not mount directories writable by untrusted local processes.
-pub(super) fn reject_non_regular(path: &Path, vpath: &str) -> Result<(), MountError> {
-    match fs::metadata(path) {
+pub(super) fn reject_non_regular(dir: &Dir, rel: &str, vpath: &str) -> Result<(), MountError> {
+    match dir.metadata(rel) {
         Ok(meta) if meta.is_dir() => Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath)),
         Ok(meta) if !meta.is_file() => Err(MountError::io_err(
             ErrorKind::PermissionDenied,

--- a/crates/monty-fs/src/direct.rs
+++ b/crates/monty-fs/src/direct.rs
@@ -1,30 +1,23 @@
 //! Direct host-backed filesystem behavior for read-write and read-only mounts.
 //!
-//! This backend resolves a sandbox path to a validated host path and then calls
-//! the corresponding `std::fs` operation without any overlay indirection.
+//! This backend maps a sandbox path to a mount-relative path and calls the
+//! corresponding operation on the mount's descriptor. Confinement is structural:
+//! there is no host path to validate, because nothing is ever resolved from the
+//! filesystem root.
 
-use std::{fs, path::PathBuf};
-
+use cap_std::fs::Dir;
 use monty_types::{FileMode, MontyObject};
 
 use super::{
     common::{
-        MemoryBudget, MountContext, append_bytes_fs, append_text_fs, check_write_limit, commit_write_bytes, iterdir_fs,
-        mkdir_fs, read_bytes_fs, read_text_fs, reject_non_regular, rmdir_fs, stat_fs, unlink_fs, write_bytes_fs,
-        write_text_fs,
+        MemoryBudget, MountContext, append_bytes_fs, append_text_fs, check_write_limit, commit_write_bytes, is_dir,
+        is_file, iterdir_fs, map_io, mkdir_fs, read_bytes_fs, read_text_fs, reject_non_regular, rmdir_fs, stat_fs,
+        unlink_fs, write_bytes_fs, write_text_fs,
     },
     dispatch::{FsRequest, file_handle_result},
     error::MountError,
-    path_security::{ResolveMode, resolve_path},
+    path_security::{MountRelativePath, normalize_virtual_path, resolve_virtual_path},
 };
-
-/// Internal result used for existence-style queries where "missing" is not an error.
-enum ResolvedPathState {
-    /// The path resolved successfully and can be queried on the host.
-    Present(PathBuf),
-    /// Resolution determined that the path should behave as nonexistent.
-    Missing,
-}
 
 /// Executes a parsed filesystem request directly against the host filesystem.
 ///
@@ -32,17 +25,29 @@ enum ResolvedPathState {
 /// request is simply borrowed from and dropped when the operation finishes.
 pub(super) fn execute(request: FsRequest, ctx: &mut MountContext<'_>) -> Result<MontyObject, MountError> {
     match request {
-        FsRequest::Exists { path } => exists(&path, ctx),
-        FsRequest::IsFile { path } => is_file(&path, ctx),
-        FsRequest::IsDir { path } => is_dir(&path, ctx),
-        FsRequest::IsSymlink { path } => is_symlink(&path, ctx),
+        FsRequest::Exists { path } => bool_query(&path, ctx, |dir, rel| dir.exists(rel)),
+        FsRequest::IsFile { path } => bool_query(&path, ctx, is_file),
+        FsRequest::IsDir { path } => bool_query(&path, ctx, is_dir),
+        FsRequest::IsSymlink { path } => bool_query(&path, ctx, |dir, rel| {
+            dir.symlink_metadata(rel).is_ok_and(|meta| meta.is_symlink())
+        }),
         FsRequest::ReadText { path } => {
-            let resolved = resolve_path(&path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)?;
-            read_text_fs(&resolved.host_path, &path, MemoryBudget::full(ctx.memory_usage_limit))
+            let target = resolve_virtual_path(&path, ctx.mount_virtual)?;
+            read_text_fs(
+                ctx.mount_dir,
+                target.for_dir_op(),
+                &path,
+                MemoryBudget::full(ctx.memory_usage_limit),
+            )
         }
         FsRequest::ReadBytes { path } => {
-            let resolved = resolve_path(&path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)?;
-            read_bytes_fs(&resolved.host_path, &path, MemoryBudget::full(ctx.memory_usage_limit))
+            let target = resolve_virtual_path(&path, ctx.mount_virtual)?;
+            read_bytes_fs(
+                ctx.mount_dir,
+                target.for_dir_op(),
+                &path,
+                MemoryBudget::full(ctx.memory_usage_limit),
+            )
         }
         FsRequest::WriteText { path, data } => write_text(&path, &data, ctx),
         FsRequest::WriteBytes { path, data } => write_bytes(&path, &data, ctx),
@@ -53,27 +58,30 @@ pub(super) fn execute(request: FsRequest, ctx: &mut MountContext<'_>) -> Result<
             parents,
             exist_ok,
         } => mkdir(&path, parents, exist_ok, ctx),
-        FsRequest::Unlink { path } => unlink(&path, ctx),
+        FsRequest::Unlink { path } => {
+            let target = resolve_virtual_path(&path, ctx.mount_virtual)?;
+            unlink_fs(ctx.mount_dir, target.for_dir_op(), &path)
+        }
         FsRequest::Rmdir { path } => {
-            let resolved = resolve_path(&path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)?;
-            rmdir_fs(&resolved.host_path, &path)
+            let target = resolve_virtual_path(&path, ctx.mount_virtual)?;
+            rmdir_fs(ctx.mount_dir, target.for_dir_op(), &path)
         }
         FsRequest::Iterdir { path } => {
-            let resolved = resolve_path(&path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)?;
+            let target = resolve_virtual_path(&path, ctx.mount_virtual)?;
             iterdir_fs(
-                &resolved.host_path,
+                ctx.mount_dir,
+                target.for_dir_op(),
                 &path,
-                ctx.mount_host,
                 MemoryBudget::full(ctx.memory_usage_limit),
             )
         }
         FsRequest::Stat { path } => {
-            let resolved = resolve_path(&path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)?;
-            stat_fs(&resolved.host_path, &path)
+            let target = resolve_virtual_path(&path, ctx.mount_virtual)?;
+            stat_fs(ctx.mount_dir, target.for_dir_op(), &path)
         }
         FsRequest::Rename { src, dst } => rename(&src, &dst, ctx),
         FsRequest::Resolve { path } | FsRequest::Absolute { path } => {
-            Ok(MontyObject::Path(super::path_security::normalize_virtual_path(&path)))
+            Ok(MontyObject::Path(normalize_virtual_path(&path)))
         }
         FsRequest::Open { path, mode } => open(&path, mode, ctx),
     }
@@ -82,136 +90,113 @@ pub(super) fn execute(request: FsRequest, ctx: &mut MountContext<'_>) -> Result<
 /// Performs the open-time effect for `open()` and returns the file handle.
 ///
 /// The effect depends on the [`FileMode`]: read modes only check the file
-/// exists (the `resolve_path` failure for a missing file surfaces as
-/// `FileNotFoundError`); write modes truncate or create an empty file; append
-/// modes create the file if missing without disturbing existing content. The
-/// host keeps no handle open — this single call opens, acts, and closes.
+/// exists; write modes truncate or create an empty file; append modes create the
+/// file if missing without disturbing existing content. The host keeps no handle
+/// open — this single call opens, acts, and closes.
 fn open(path: &str, mode: FileMode, ctx: &mut MountContext<'_>) -> Result<MontyObject, MountError> {
+    let target = resolve_virtual_path(path, ctx.mount_virtual)?;
+    let rel = target.for_dir_op();
     match mode {
         FileMode::Read(_) | FileMode::ReadUpdate(_) => {
-            let resolved = resolve_path(path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)?;
-            reject_non_regular(&resolved.host_path, path)?;
+            // Surface a missing file as `FileNotFoundError` before the mode's
+            // effect applies.
+            ctx.mount_dir.metadata(rel).map_err(|err| map_io(err, path))?;
+            reject_non_regular(ctx.mount_dir, rel, path)?;
         }
         FileMode::Write(_) | FileMode::WriteUpdate(_) => {
             check_write_limit(0, ctx)?;
-            let resolved = resolve_path(path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Creation)?;
-            write_text_fs(&resolved.host_path, "", path)?;
+            write_text_fs(ctx.mount_dir, rel, "", path)?;
             commit_write_bytes(0, ctx);
         }
         FileMode::Append(_) | FileMode::AppendUpdate(_) => {
-            let resolved = resolve_path(path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Creation)?;
-            append_bytes_fs(&resolved.host_path, &[], path)?;
+            append_bytes_fs(ctx.mount_dir, rel, &[], path)?;
         }
     }
     Ok(file_handle_result(path, mode))
 }
 
-/// Implements `Path.exists()` without leaking path-resolution details.
-fn exists(path: &str, ctx: &MountContext<'_>) -> Result<MontyObject, MountError> {
-    let resolved = resolve_existence_state(path, ctx, ResolveMode::Existing)?;
-    Ok(MontyObject::Bool(matches!(resolved, ResolvedPathState::Present(_))))
+/// Answers a `pathlib` boolean query, treating resolution failure as `false`.
+///
+/// `pathlib` predicates never raise, and answering `false` for anything leaving
+/// the mount is what keeps out-of-mount files unobservable.
+fn bool_query(
+    path: &str,
+    ctx: &MountContext<'_>,
+    query: impl Fn(&Dir, &str) -> bool,
+) -> Result<MontyObject, MountError> {
+    let answer = match resolve_virtual_path(path, ctx.mount_virtual) {
+        Ok(target) => query(ctx.mount_dir, target.for_dir_op()),
+        Err(MountError::NoMountPoint(_)) => false,
+        Err(err) => return Err(err),
+    };
+    Ok(MontyObject::Bool(answer))
 }
 
-/// Implements `Path.is_file()` while treating resolution misses as `false`.
-fn is_file(path: &str, ctx: &MountContext<'_>) -> Result<MontyObject, MountError> {
-    let resolved = resolve_existence_state(path, ctx, ResolveMode::Existing)?;
-    Ok(MontyObject::Bool(match resolved {
-        ResolvedPathState::Present(host_path) => host_path.is_file(),
-        ResolvedPathState::Missing => false,
-    }))
-}
-
-/// Implements `Path.is_dir()` while treating resolution misses as `false`.
-fn is_dir(path: &str, ctx: &MountContext<'_>) -> Result<MontyObject, MountError> {
-    let resolved = resolve_existence_state(path, ctx, ResolveMode::Existing)?;
-    Ok(MontyObject::Bool(match resolved {
-        ResolvedPathState::Present(host_path) => host_path.is_dir(),
-        ResolvedPathState::Missing => false,
-    }))
-}
-
-/// Implements `Path.is_symlink()` without following the final symlink component.
-fn is_symlink(path: &str, ctx: &MountContext<'_>) -> Result<MontyObject, MountError> {
-    let resolved = resolve_existence_state(path, ctx, ResolveMode::Lstat)?;
-    Ok(MontyObject::Bool(match resolved {
-        ResolvedPathState::Present(host_path) => host_path.is_symlink(),
-        ResolvedPathState::Missing => false,
-    }))
-}
-
-/// Writes text after validating quota and creation-path security.
+/// Writes text after validating quota.
 fn write_text(path: &str, data: &str, ctx: &mut MountContext<'_>) -> Result<MontyObject, MountError> {
     check_write_limit(data.len(), ctx)?;
-    let resolved = resolve_path(path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Creation)?;
-    let result = write_text_fs(&resolved.host_path, data, path)?;
+    let target = resolve_virtual_path(path, ctx.mount_virtual)?;
+    let result = write_text_fs(ctx.mount_dir, target.for_dir_op(), data, path)?;
     commit_write_bytes(data.len(), ctx);
     Ok(result)
 }
 
-/// Writes bytes after validating quota and creation-path security.
+/// Writes bytes after validating quota.
 fn write_bytes(path: &str, data: &[u8], ctx: &mut MountContext<'_>) -> Result<MontyObject, MountError> {
     check_write_limit(data.len(), ctx)?;
-    let resolved = resolve_path(path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Creation)?;
-    let result = write_bytes_fs(&resolved.host_path, data, path)?;
+    let target = resolve_virtual_path(path, ctx.mount_virtual)?;
+    let result = write_bytes_fs(ctx.mount_dir, target.for_dir_op(), data, path)?;
     commit_write_bytes(data.len(), ctx);
     Ok(result)
 }
 
-/// Appends text after validating quota and creation-path security.
+/// Appends text after validating quota.
 fn append_text(path: &str, data: &str, ctx: &mut MountContext<'_>) -> Result<MontyObject, MountError> {
     check_write_limit(data.len(), ctx)?;
-    let resolved = resolve_path(path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Creation)?;
-    let result = append_text_fs(&resolved.host_path, data, path)?;
+    let target = resolve_virtual_path(path, ctx.mount_virtual)?;
+    let result = append_text_fs(ctx.mount_dir, target.for_dir_op(), data, path)?;
     commit_write_bytes(data.len(), ctx);
     Ok(result)
 }
 
-/// Appends bytes after validating quota and creation-path security.
+/// Appends bytes after validating quota.
 fn append_bytes(path: &str, data: &[u8], ctx: &mut MountContext<'_>) -> Result<MontyObject, MountError> {
     check_write_limit(data.len(), ctx)?;
-    let resolved = resolve_path(path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Creation)?;
-    let result = append_bytes_fs(&resolved.host_path, data, path)?;
+    let target = resolve_virtual_path(path, ctx.mount_virtual)?;
+    let result = append_bytes_fs(ctx.mount_dir, target.for_dir_op(), data, path)?;
     commit_write_bytes(data.len(), ctx);
     Ok(result)
 }
 
-/// Creates a directory with the resolution mode required by `parents=...`.
+/// Creates a directory, using `create_dir_all` only when `parents` is set.
 fn mkdir(path: &str, parents: bool, exist_ok: bool, ctx: &MountContext<'_>) -> Result<MontyObject, MountError> {
-    let mode = if parents {
-        ResolveMode::MkdirParents
-    } else {
-        ResolveMode::Creation
-    };
-    let resolved = resolve_path(path, ctx.mount_virtual, ctx.mount_host, mode)?;
-    mkdir_fs(&resolved.host_path, parents, exist_ok, path)
+    let target = resolve_virtual_path(path, ctx.mount_virtual)?;
+    mkdir_fs(ctx.mount_dir, target.for_dir_op(), parents, exist_ok, path)
 }
 
-/// Removes a file or symlink entry itself rather than following symlink targets.
-fn unlink(path: &str, ctx: &MountContext<'_>) -> Result<MontyObject, MountError> {
-    let resolved = resolve_path(path, ctx.mount_virtual, ctx.mount_host, ResolveMode::Lstat)?;
-    unlink_fs(&resolved.host_path, path)
-}
-
-/// Renames a filesystem entry within the same mount.
+/// Renames an entry within the same mount.
+///
+/// Both ends resolve against the same descriptor, so neither can name anything
+/// outside it and the operation itself is a single `renameat`.
 fn rename(src: &str, dst: &str, ctx: &MountContext<'_>) -> Result<MontyObject, MountError> {
-    let src_resolved = resolve_path(src, ctx.mount_virtual, ctx.mount_host, ResolveMode::Lstat)?;
-    let dst_resolved = resolve_path(dst, ctx.mount_virtual, ctx.mount_host, ResolveMode::Creation)?;
-    fs::rename(&src_resolved.host_path, &dst_resolved.host_path).map_err(|err| MountError::Io(err, src.to_owned()))?;
+    let src_target = resolve_virtual_path(src, ctx.mount_virtual)?;
+    let dst_target = resolve_virtual_path(dst, ctx.mount_virtual)?;
+    reject_mount_root_rename(&src_target, src)?;
+    reject_mount_root_rename(&dst_target, dst)?;
+
+    ctx.mount_dir
+        .rename(src_target.for_dir_op(), ctx.mount_dir, dst_target.for_dir_op())
+        .map_err(|err| map_io(err, src))?;
     Ok(MontyObject::None)
 }
 
-/// Resolves a path for boolean existence-style operations.
-///
-/// These calls intentionally collapse host-side I/O misses into `Missing`
-/// because `pathlib` returns `False` instead of raising for missing paths.
-fn resolve_existence_state(
-    path: &str,
-    ctx: &MountContext<'_>,
-    mode: ResolveMode,
-) -> Result<ResolvedPathState, MountError> {
-    match resolve_path(path, ctx.mount_virtual, ctx.mount_host, mode) {
-        Ok(resolved) => Ok(ResolvedPathState::Present(resolved.host_path)),
-        Err(MountError::Io(_, _)) => Ok(ResolvedPathState::Missing),
-        Err(err) => Err(err),
+/// Refuses to rename the mount root itself, which has no name inside the mount.
+fn reject_mount_root_rename(target: &MountRelativePath, vpath: &str) -> Result<(), MountError> {
+    if target.is_mount_root() {
+        Err(MountError::PathEscape {
+            virtual_path: vpath.to_owned(),
+        })
+    } else {
+        Ok(())
     }
 }

--- a/crates/monty-fs/src/direct.rs
+++ b/crates/monty-fs/src/direct.rs
@@ -10,9 +10,9 @@ use monty_types::{FileMode, MontyObject};
 
 use super::{
     common::{
-        MemoryBudget, MountContext, append_bytes_fs, append_text_fs, check_write_limit, commit_write_bytes, is_dir,
-        is_file, iterdir_fs, map_io, mkdir_fs, read_bytes_fs, read_text_fs, reject_non_regular, rmdir_fs, stat_fs,
-        unlink_fs, write_bytes_fs, write_text_fs,
+        MemoryBudget, MountContext, check_write_limit, commit_write_bytes, host_append_bytes, host_append_text,
+        host_is_dir, host_is_file, host_iterdir, host_mkdir, host_read_bytes, host_read_text, host_rmdir, host_stat,
+        host_unlink, host_write_bytes, host_write_text, map_io, reject_non_regular,
     },
     dispatch::{FsRequest, file_handle_result},
     error::MountError,
@@ -26,14 +26,14 @@ use super::{
 pub(super) fn execute(request: FsRequest, ctx: &mut MountContext<'_>) -> Result<MontyObject, MountError> {
     match request {
         FsRequest::Exists { path } => bool_query(&path, ctx, |dir, rel| dir.exists(rel)),
-        FsRequest::IsFile { path } => bool_query(&path, ctx, is_file),
-        FsRequest::IsDir { path } => bool_query(&path, ctx, is_dir),
+        FsRequest::IsFile { path } => bool_query(&path, ctx, host_is_file),
+        FsRequest::IsDir { path } => bool_query(&path, ctx, host_is_dir),
         FsRequest::IsSymlink { path } => bool_query(&path, ctx, |dir, rel| {
             dir.symlink_metadata(rel).is_ok_and(|meta| meta.is_symlink())
         }),
         FsRequest::ReadText { path } => {
             let target = resolve_virtual_path(&path, ctx.mount_virtual)?;
-            read_text_fs(
+            host_read_text(
                 ctx.mount_dir,
                 target.for_dir_op(),
                 &path,
@@ -42,7 +42,7 @@ pub(super) fn execute(request: FsRequest, ctx: &mut MountContext<'_>) -> Result<
         }
         FsRequest::ReadBytes { path } => {
             let target = resolve_virtual_path(&path, ctx.mount_virtual)?;
-            read_bytes_fs(
+            host_read_bytes(
                 ctx.mount_dir,
                 target.for_dir_op(),
                 &path,
@@ -60,15 +60,15 @@ pub(super) fn execute(request: FsRequest, ctx: &mut MountContext<'_>) -> Result<
         } => mkdir(&path, parents, exist_ok, ctx),
         FsRequest::Unlink { path } => {
             let target = resolve_virtual_path(&path, ctx.mount_virtual)?;
-            unlink_fs(ctx.mount_dir, target.for_dir_op(), &path)
+            host_unlink(ctx.mount_dir, target.for_dir_op(), &path)
         }
         FsRequest::Rmdir { path } => {
             let target = resolve_virtual_path(&path, ctx.mount_virtual)?;
-            rmdir_fs(ctx.mount_dir, target.for_dir_op(), &path)
+            host_rmdir(ctx.mount_dir, target.for_dir_op(), &path)
         }
         FsRequest::Iterdir { path } => {
             let target = resolve_virtual_path(&path, ctx.mount_virtual)?;
-            iterdir_fs(
+            host_iterdir(
                 ctx.mount_dir,
                 target.for_dir_op(),
                 &path,
@@ -77,7 +77,7 @@ pub(super) fn execute(request: FsRequest, ctx: &mut MountContext<'_>) -> Result<
         }
         FsRequest::Stat { path } => {
             let target = resolve_virtual_path(&path, ctx.mount_virtual)?;
-            stat_fs(ctx.mount_dir, target.for_dir_op(), &path)
+            host_stat(ctx.mount_dir, target.for_dir_op(), &path)
         }
         FsRequest::Rename { src, dst } => rename(&src, &dst, ctx),
         FsRequest::Resolve { path } | FsRequest::Absolute { path } => {
@@ -105,11 +105,11 @@ fn open(path: &str, mode: FileMode, ctx: &mut MountContext<'_>) -> Result<MontyO
         }
         FileMode::Write(_) | FileMode::WriteUpdate(_) => {
             check_write_limit(0, ctx)?;
-            write_text_fs(ctx.mount_dir, rel, "", path)?;
+            host_write_text(ctx.mount_dir, rel, "", path)?;
             commit_write_bytes(0, ctx);
         }
         FileMode::Append(_) | FileMode::AppendUpdate(_) => {
-            append_bytes_fs(ctx.mount_dir, rel, &[], path)?;
+            host_append_bytes(ctx.mount_dir, rel, &[], path)?;
         }
     }
     Ok(file_handle_result(path, mode))
@@ -134,7 +134,7 @@ fn bool_query(
 fn write_text(path: &str, data: &str, ctx: &mut MountContext<'_>) -> Result<MontyObject, MountError> {
     check_write_limit(data.len(), ctx)?;
     let target = resolve_virtual_path(path, ctx.mount_virtual)?;
-    let result = write_text_fs(ctx.mount_dir, target.for_dir_op(), data, path)?;
+    let result = host_write_text(ctx.mount_dir, target.for_dir_op(), data, path)?;
     commit_write_bytes(data.len(), ctx);
     Ok(result)
 }
@@ -143,7 +143,7 @@ fn write_text(path: &str, data: &str, ctx: &mut MountContext<'_>) -> Result<Mont
 fn write_bytes(path: &str, data: &[u8], ctx: &mut MountContext<'_>) -> Result<MontyObject, MountError> {
     check_write_limit(data.len(), ctx)?;
     let target = resolve_virtual_path(path, ctx.mount_virtual)?;
-    let result = write_bytes_fs(ctx.mount_dir, target.for_dir_op(), data, path)?;
+    let result = host_write_bytes(ctx.mount_dir, target.for_dir_op(), data, path)?;
     commit_write_bytes(data.len(), ctx);
     Ok(result)
 }
@@ -152,7 +152,7 @@ fn write_bytes(path: &str, data: &[u8], ctx: &mut MountContext<'_>) -> Result<Mo
 fn append_text(path: &str, data: &str, ctx: &mut MountContext<'_>) -> Result<MontyObject, MountError> {
     check_write_limit(data.len(), ctx)?;
     let target = resolve_virtual_path(path, ctx.mount_virtual)?;
-    let result = append_text_fs(ctx.mount_dir, target.for_dir_op(), data, path)?;
+    let result = host_append_text(ctx.mount_dir, target.for_dir_op(), data, path)?;
     commit_write_bytes(data.len(), ctx);
     Ok(result)
 }
@@ -161,7 +161,7 @@ fn append_text(path: &str, data: &str, ctx: &mut MountContext<'_>) -> Result<Mon
 fn append_bytes(path: &str, data: &[u8], ctx: &mut MountContext<'_>) -> Result<MontyObject, MountError> {
     check_write_limit(data.len(), ctx)?;
     let target = resolve_virtual_path(path, ctx.mount_virtual)?;
-    let result = append_bytes_fs(ctx.mount_dir, target.for_dir_op(), data, path)?;
+    let result = host_append_bytes(ctx.mount_dir, target.for_dir_op(), data, path)?;
     commit_write_bytes(data.len(), ctx);
     Ok(result)
 }
@@ -169,7 +169,7 @@ fn append_bytes(path: &str, data: &[u8], ctx: &mut MountContext<'_>) -> Result<M
 /// Creates a directory, using `create_dir_all` only when `parents` is set.
 fn mkdir(path: &str, parents: bool, exist_ok: bool, ctx: &MountContext<'_>) -> Result<MontyObject, MountError> {
     let target = resolve_virtual_path(path, ctx.mount_virtual)?;
-    mkdir_fs(ctx.mount_dir, target.for_dir_op(), parents, exist_ok, path)
+    host_mkdir(ctx.mount_dir, target.for_dir_op(), parents, exist_ok, path)
 }
 
 /// Renames an entry within the same mount.

--- a/crates/monty-fs/src/direct.rs
+++ b/crates/monty-fs/src/direct.rs
@@ -64,6 +64,7 @@ pub(super) fn execute(request: FsRequest, ctx: &mut MountContext<'_>) -> Result<
         }
         FsRequest::Rmdir { path } => {
             let target = resolve_virtual_path(&path, ctx.mount_virtual)?;
+            reject_mount_root(&target, &path)?;
             host_rmdir(ctx.mount_dir, target.for_dir_op(), &path)
         }
         FsRequest::Iterdir { path } => {
@@ -179,8 +180,8 @@ fn mkdir(path: &str, parents: bool, exist_ok: bool, ctx: &MountContext<'_>) -> R
 fn rename(src: &str, dst: &str, ctx: &MountContext<'_>) -> Result<MontyObject, MountError> {
     let src_target = resolve_virtual_path(src, ctx.mount_virtual)?;
     let dst_target = resolve_virtual_path(dst, ctx.mount_virtual)?;
-    reject_mount_root_rename(&src_target, src)?;
-    reject_mount_root_rename(&dst_target, dst)?;
+    reject_mount_root(&src_target, src)?;
+    reject_mount_root(&dst_target, dst)?;
 
     ctx.mount_dir
         .rename(src_target.for_dir_op(), ctx.mount_dir, dst_target.for_dir_op())
@@ -188,8 +189,10 @@ fn rename(src: &str, dst: &str, ctx: &MountContext<'_>) -> Result<MontyObject, M
     Ok(MontyObject::None)
 }
 
-/// Refuses to rename the mount root itself, which has no name inside the mount.
-fn reject_mount_root_rename(target: &MountRelativePath, vpath: &str) -> Result<(), MountError> {
+/// Refuses to rename or remove the mount root itself, which has no name inside
+/// the mount. An explicit guard gives every platform and mount mode the same
+/// `PermissionError`, instead of whatever errno the OS picks for `"."`.
+fn reject_mount_root(target: &MountRelativePath, vpath: &str) -> Result<(), MountError> {
     if target.is_mount_root() {
         Err(MountError::PathEscape {
             virtual_path: vpath.to_owned(),

--- a/crates/monty-fs/src/direct.rs
+++ b/crates/monty-fs/src/direct.rs
@@ -115,21 +115,19 @@ fn open(path: &str, mode: FileMode, ctx: &mut MountContext<'_>) -> Result<MontyO
     Ok(file_handle_result(path, mode))
 }
 
-/// Answers a `pathlib` boolean query, treating resolution failure as `false`.
+/// Answers a `pathlib` boolean query.
 ///
-/// `pathlib` predicates never raise, and answering `false` for anything leaving
-/// the mount is what keeps out-of-mount files unobservable.
+/// A path leaving the mount simply fails to resolve against the descriptor and
+/// answers `false`, which is what keeps out-of-mount files unobservable. A path
+/// belonging to no mount never reaches here — `MountTable` returns those as
+/// `NotHandled` before dispatch.
 fn bool_query(
     path: &str,
     ctx: &MountContext<'_>,
     query: impl Fn(&Dir, &str) -> bool,
 ) -> Result<MontyObject, MountError> {
-    let answer = match resolve_virtual_path(path, ctx.mount_virtual) {
-        Ok(target) => query(ctx.mount_dir, target.for_dir_op()),
-        Err(MountError::NoMountPoint(_)) => false,
-        Err(err) => return Err(err),
-    };
-    Ok(MontyObject::Bool(answer))
+    let target = resolve_virtual_path(path, ctx.mount_virtual)?;
+    Ok(MontyObject::Bool(query(ctx.mount_dir, target.for_dir_op())))
 }
 
 /// Writes text after validating quota.

--- a/crates/monty-fs/src/dispatch.rs
+++ b/crates/monty-fs/src/dispatch.rs
@@ -194,7 +194,7 @@ pub(super) fn execute(
 /// Builds the [`MontyObject::FileHandle`] an `Open` request resolves to.
 ///
 /// The handle carries the **virtual** (sandbox) path — never a host path — so
-/// subsequent `read`/`write` calls re-resolve it through `resolve_path`.
+/// subsequent `read`/`write` calls re-resolve it against the mount descriptor.
 pub(super) fn file_handle_result(path: &str, mode: FileMode) -> MontyObject {
     MontyObject::FileHandle(MontyFileHandle {
         path: normalize_virtual_path(path),

--- a/crates/monty-fs/src/dispatch.rs
+++ b/crates/monty-fs/src/dispatch.rs
@@ -125,8 +125,8 @@ impl FsRequest {
 ///
 /// This is a trivial 1:1 mapping — every field is already typed on the
 /// caller side (no `MontyObject` introspection, no kwarg walks, no mode
-/// reparse), so the function is infallible. Non-FS variants are filtered
-/// out by [`OsFunctionCall::is_filesystem`] before reaching here and panic
+/// reparse), so the function is infallible. Non-FS variants never reach here
+/// — they have no [`OsFunctionCall::fs_primary_path`] to route on — and panic
 /// the catch-all arm if they slip through.
 pub(super) fn fs_request_from_call(call: OsFunctionCall) -> FsRequest {
     match call {

--- a/crates/monty-fs/src/lib.rs
+++ b/crates/monty-fs/src/lib.rs
@@ -17,8 +17,11 @@
 //! **The monty runtime MUST NEVER read, write, or obtain any information about
 //! any file or directory outside the specific directory that is mounted.**
 //!
-//! Enforced by `path_security::resolve_path` via path canonicalization,
-//! boundary checks, and symlink escape detection.
+//! Enforced by the operating system, not by path arithmetic: each mount holds
+//! a `cap_std::fs::Dir` opened once at mount time, and every operation is
+//! performed relative to that descriptor, which refuses to resolve past its
+//! own root. `path_security` only normalizes the virtual path and strips the
+//! mount prefix — it is path policy, not the boundary.
 //! Each mount has an aggregate memory budget, defaulting to
 //! [`DEFAULT_MEMORY_USAGE_LIMIT`], for retained overlay data and results.
 //!

--- a/crates/monty-fs/src/lib.rs
+++ b/crates/monty-fs/src/lib.rs
@@ -33,7 +33,7 @@
 
 pub use error::MountError;
 pub use mount_mode::MountMode;
-pub use mount_table::{DEFAULT_MEMORY_USAGE_LIMIT, Mount, MountCallOutcome, MountTable};
+pub use mount_table::{DEFAULT_MEMORY_USAGE_LIMIT, Mount, MountCallOutcome, MountRoot, MountTable};
 pub use overlay_state::OverlayState;
 
 mod common;

--- a/crates/monty-fs/src/mount_table.rs
+++ b/crates/monty-fs/src/mount_table.rs
@@ -8,6 +8,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use cap_std::{ambient_authority, fs::Dir};
 use monty_types::{MontyObject, OsFunctionCall};
 
 use super::{
@@ -152,8 +153,12 @@ impl MountTable {
 pub struct Mount {
     /// Virtual path prefix (absolute, normalized).
     virtual_path: String,
-    /// Canonical host directory path (resolved at construction time).
+    /// Canonical host directory path. Diagnostics only — see `dir`.
     host_path: PathBuf,
+    /// Descriptor for the mounted directory, opened once here — the sandbox
+    /// boundary. Resolution cannot leave it, and no rename can re-point a name
+    /// between a check and its use.
+    dir: Dir,
     /// Access mode (also owns overlay state for [`MountMode::OverlayMemory`]).
     mode: MountMode,
     /// Cumulative bytes written through this mount (monotonically increasing).
@@ -199,9 +204,15 @@ impl Mount {
             )));
         }
 
+        // The only use of ambient authority: the host is trusted to name the
+        // directory it shares. Everything afterwards is relative to `dir`.
+        let dir = Dir::open_ambient_dir(&canonical_host, ambient_authority())
+            .map_err(|e| MountError::InvalidMount(format!("cannot open host path '{}': {e}", host_path.display())))?;
+
         Ok(Self {
             virtual_path: normalized_virtual,
             host_path: canonical_host,
+            dir,
             mode,
             write_bytes_used: 0,
             write_bytes_limit,
@@ -215,7 +226,7 @@ impl Mount {
         &self.virtual_path
     }
 
-    /// Returns the canonical host directory path.
+    /// Returns the canonical host directory path. Diagnostics only.
     #[must_use]
     pub fn host_path(&self) -> &Path {
         &self.host_path
@@ -266,7 +277,7 @@ impl Mount {
     fn execute(&mut self, call: OsFunctionCall) -> Result<MontyObject, MountError> {
         let mut ctx = MountContext {
             mount_virtual: &self.virtual_path,
-            mount_host: &self.host_path,
+            mount_dir: &self.dir,
             write_bytes_used: &mut self.write_bytes_used,
             write_bytes_limit: self.write_bytes_limit,
             memory_usage_limit: self.memory_usage_limit,

--- a/crates/monty-fs/src/mount_table.rs
+++ b/crates/monty-fs/src/mount_table.rs
@@ -122,20 +122,26 @@ impl MountTable {
     ///
     /// Rename requests require both source and destination to resolve to the
     /// same longest-prefix mount. Other requests only route on the primary path.
+    ///
+    /// A rename with one side covered and the other not is refused, never handed
+    /// on: passing it to the fallback would hand the *mounted* side to a handler
+    /// that answers on raw virtual paths, skipping the mount's access mode.
     fn route_call(&self, primary_path: &str, call: &OsFunctionCall) -> Option<Result<usize, MountError>> {
-        let src_mount_index = self.find_mount_index(primary_path)?;
+        let src_mount_index = self.find_mount_index(primary_path);
 
         if let Some(dst_path) = call.rename_destination() {
-            let dst_mount_index = self.find_mount_index(dst_path)?;
-            if src_mount_index != dst_mount_index {
-                return Some(Err(MountError::CrossMountRename {
+            match (src_mount_index, self.find_mount_index(dst_path)) {
+                // Neither side is ours; the whole call belongs to the fallback.
+                (None, None) => None,
+                (Some(src), Some(dst)) if src == dst => Some(Ok(src)),
+                _ => Some(Err(MountError::CrossMountRename {
                     src: primary_path.to_owned(),
                     dst: dst_path.to_owned(),
-                }));
+                })),
             }
+        } else {
+            src_mount_index.map(Ok)
         }
-
-        Some(Ok(src_mount_index))
     }
 
     /// Finds the longest-prefix mount index for `virtual_path`.

--- a/crates/monty-fs/src/mount_table.rs
+++ b/crates/monty-fs/src/mount_table.rs
@@ -59,9 +59,9 @@ impl MountTable {
     /// # Errors
     ///
     /// Returns [`MountError::InvalidMount`] if the virtual path is not absolute,
-    /// the host path doesn't exist or isn't a directory, or it cannot be opened.
-    /// The descriptor needs read permission, so a search-only (`0o111`)
-    /// directory is not mountable even though its contents are reachable.
+    /// the host path doesn't exist or isn't a directory, or it cannot be opened
+    /// — on macOS/BSD that includes a search-only (`0o111`) directory, which
+    /// Linux accepts because it opens directories with `O_PATH`.
     pub fn mount(
         &mut self,
         virtual_path: &str,

--- a/crates/monty-fs/src/mount_table.rs
+++ b/crates/monty-fs/src/mount_table.rs
@@ -6,6 +6,7 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use cap_std::{ambient_authority, fs::Dir};
@@ -82,7 +83,7 @@ impl MountTable {
         // first match without re-sorting the whole table on every insertion.
         let insert_at = self
             .mounts
-            .partition_point(|existing| existing.virtual_path.len() > mount.virtual_path.len());
+            .partition_point(|existing| existing.virtual_path().len() > mount.virtual_path().len());
         self.mounts.insert(insert_at, mount);
     }
 
@@ -123,9 +124,8 @@ impl MountTable {
     /// Rename requests require both source and destination to resolve to the
     /// same longest-prefix mount. Other requests only route on the primary path.
     ///
-    /// A rename with one side covered and the other not is refused, never handed
-    /// on: passing it to the fallback would hand the *mounted* side to a handler
-    /// that answers on raw virtual paths, skipping the mount's access mode.
+    /// One side covered and the other not is refused rather than handed on: the
+    /// fallback answers on raw virtual paths, skipping the mount's access mode.
     fn route_call(&self, primary_path: &str, call: &OsFunctionCall) -> Option<Result<usize, MountError>> {
         let src_mount_index = self.find_mount_index(primary_path);
 
@@ -149,7 +149,7 @@ impl MountTable {
         let normalized = normalize_virtual_path(virtual_path);
         self.mounts
             .iter()
-            .position(|mount| path_matches_mount(&normalized, &mount.virtual_path))
+            .position(|mount| path_matches_mount(&normalized, mount.virtual_path()))
     }
 }
 
@@ -160,14 +160,8 @@ impl MountTable {
 /// and transferred into it with [`MountTable::push_mount`].
 #[derive(Debug)]
 pub struct Mount {
-    /// Virtual path prefix (absolute, normalized).
-    virtual_path: String,
-    /// Canonical host directory path. Diagnostics only — see `dir`.
-    host_path: PathBuf,
-    /// Descriptor for the mounted directory, opened once here — the sandbox
-    /// boundary. Resolution cannot leave it, and no rename can re-point a name
-    /// between a check and its use.
-    dir: Dir,
+    /// The opened directory this mount serves, and the virtual path it answers on.
+    root: MountRoot,
     /// Access mode (also owns overlay state for [`MountMode::OverlayMemory`]).
     mode: MountMode,
     /// Cumulative bytes written through this mount (monotonically increasing).
@@ -182,6 +176,9 @@ impl Mount {
     /// Creates a new mount point, opening a descriptor on the host directory.
     /// Mount memory defaults to [`DEFAULT_MEMORY_USAGE_LIMIT`].
     ///
+    /// A host mounting the same directory repeatedly should open a [`MountRoot`]
+    /// once and use [`Mount::with_root`], resolving the name only once.
+    ///
     /// # Errors
     ///
     /// Returns [`MountError::InvalidMount`] if the virtual path is not absolute,
@@ -192,54 +189,42 @@ impl Mount {
         mode: MountMode,
         write_bytes_limit: Option<u64>,
     ) -> Result<Self, MountError> {
-        let host_path = host_path.as_ref();
+        Ok(Self::with_root(
+            MountRoot::open(virtual_path, host_path)?,
+            mode,
+            write_bytes_limit,
+        ))
+    }
 
-        if !virtual_path.starts_with('/') {
-            return Err(MountError::InvalidMount(format!(
-                "virtual path must be absolute, got: '{virtual_path}'"
-            )));
-        }
-
-        let normalized_virtual = normalize_virtual_path(virtual_path);
-
-        // The only use of ambient authority, and the mount's whole trust root.
-        // Deliberately first: resolving the name to a validated path and *then*
-        // opening that path would let whoever can rename in the parent swap a
-        // symlink into the gap. The directory check rides on the open itself
-        // (`O_DIRECTORY`, a handle `metadata()` on Windows), so it cannot.
-        let dir = Dir::open_ambient_dir(host_path, ambient_authority())
-            .map_err(|e| MountError::InvalidMount(format!("cannot open host path '{}': {e}", host_path.display())))?;
-
-        // Diagnostics only — nothing resolves through this path. Resolved after
-        // the open, so a host racing it leaves a stale label on the right
-        // descriptor, never the reverse. Still fatal on failure: callers copy
-        // this out as a mount's durable identity, and a relative path would
-        // later re-resolve against the process CWD.
-        let canonical_host = fs::canonicalize(host_path).map_err(|e| {
-            MountError::InvalidMount(format!("cannot resolve host path '{}': {e}", host_path.display()))
-        })?;
-
-        Ok(Self {
-            virtual_path: normalized_virtual,
-            host_path: canonical_host,
-            dir,
+    /// Mounts an already-opened [`MountRoot`], touching no filesystem at all.
+    /// Mount memory defaults to [`DEFAULT_MEMORY_USAGE_LIMIT`].
+    #[must_use]
+    pub fn with_root(root: MountRoot, mode: MountMode, write_bytes_limit: Option<u64>) -> Self {
+        Self {
+            root,
             mode,
             write_bytes_used: 0,
             write_bytes_limit,
             memory_usage_limit: DEFAULT_MEMORY_USAGE_LIMIT,
-        })
+        }
+    }
+
+    /// Returns the opened root, to clone into a later mount of the same directory.
+    #[must_use]
+    pub fn root(&self) -> &MountRoot {
+        &self.root
     }
 
     /// Returns the normalized virtual path prefix for this mount.
     #[must_use]
     pub fn virtual_path(&self) -> &str {
-        &self.virtual_path
+        self.root.virtual_path()
     }
 
     /// Returns the canonical host directory path. Diagnostics only.
     #[must_use]
     pub fn host_path(&self) -> &Path {
-        &self.host_path
+        self.root.host_path()
     }
 
     /// Returns the access mode for this mount.
@@ -286,13 +271,86 @@ impl Mount {
     /// payloads move into the backend.
     fn execute(&mut self, call: OsFunctionCall) -> Result<MontyObject, MountError> {
         let mut ctx = MountContext {
-            mount_virtual: &self.virtual_path,
-            mount_dir: &self.dir,
+            mount_virtual: &self.root.virtual_path,
+            mount_dir: &self.root.dir,
             write_bytes_used: &mut self.write_bytes_used,
             write_bytes_limit: self.write_bytes_limit,
             memory_usage_limit: self.memory_usage_limit,
         };
         dispatch::execute(dispatch::fs_request_from_call(call), &mut ctx, &mut self.mode)
+    }
+}
+
+/// A host directory opened once, mountable as often as the host likes; cloning
+/// shares the descriptor.
+///
+/// Reuse one instead of re-deriving a mount from its path: sandbox code that
+/// can rename inside a parent mount redirects that name between rebuilds, and
+/// an open descriptor cannot be redirected.
+#[derive(Debug, Clone)]
+pub struct MountRoot {
+    /// Virtual path prefix (absolute, normalized).
+    virtual_path: String,
+    /// Canonical host directory path. Diagnostics only — see `dir`.
+    host_path: PathBuf,
+    /// Descriptor for the mounted directory — the sandbox boundary, which
+    /// resolution cannot leave. Shared, so every mount built from this root is
+    /// the same directory rather than the same name resolved again.
+    dir: Arc<Dir>,
+}
+
+impl MountRoot {
+    /// Opens `host_path`, pinning the root to the directory that is there now.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MountError::InvalidMount`] if the virtual path is not absolute,
+    /// or the host path cannot be opened as a directory or canonicalized.
+    pub fn open(virtual_path: &str, host_path: impl AsRef<Path>) -> Result<Self, MountError> {
+        let host_path = host_path.as_ref();
+
+        if !virtual_path.starts_with('/') {
+            return Err(MountError::InvalidMount(format!(
+                "virtual path must be absolute, got: '{virtual_path}'"
+            )));
+        }
+
+        let normalized_virtual = normalize_virtual_path(virtual_path);
+
+        // The only use of ambient authority, and the mount's whole trust root.
+        // Deliberately first: resolving the name to a validated path and *then*
+        // opening that path would let whoever can rename in the parent swap a
+        // symlink into the gap. The directory check rides on the open itself
+        // (`O_DIRECTORY`, a handle `metadata()` on Windows), so it cannot.
+        let dir = Dir::open_ambient_dir(host_path, ambient_authority())
+            .map_err(|e| MountError::InvalidMount(format!("cannot open host path '{}': {e}", host_path.display())))?;
+
+        // Diagnostics only — nothing resolves through this path. Resolved after
+        // the open, so a host racing it leaves a stale label on the right
+        // descriptor, never the reverse. Still fatal on failure: callers copy
+        // this out as a mount's durable identity, and a relative path would
+        // later re-resolve against the process CWD.
+        let canonical_host = fs::canonicalize(host_path).map_err(|e| {
+            MountError::InvalidMount(format!("cannot resolve host path '{}': {e}", host_path.display()))
+        })?;
+
+        Ok(Self {
+            virtual_path: normalized_virtual,
+            host_path: canonical_host,
+            dir: Arc::new(dir),
+        })
+    }
+
+    /// Returns the normalized virtual path prefix this root answers on.
+    #[must_use]
+    pub fn virtual_path(&self) -> &str {
+        &self.virtual_path
+    }
+
+    /// Returns the canonical host directory path. Diagnostics only.
+    #[must_use]
+    pub fn host_path(&self) -> &Path {
+        &self.host_path
     }
 }
 

--- a/crates/monty-fs/src/mount_table.rs
+++ b/crates/monty-fs/src/mount_table.rs
@@ -156,7 +156,7 @@ impl MountTable {
 pub struct Mount {
     /// Virtual path prefix (absolute, normalized).
     virtual_path: String,
-    /// Canonical host directory path. Diagnostics only — see `dir`.
+    /// Best-effort canonical host directory path. Diagnostics only — see `dir`.
     host_path: PathBuf,
     /// Descriptor for the mounted directory, opened once here — the sandbox
     /// boundary. Resolution cannot leave it, and no rename can re-point a name
@@ -173,13 +173,13 @@ pub struct Mount {
 }
 
 impl Mount {
-    /// Creates a new mount point, canonicalizing the host path.
+    /// Creates a new mount point, opening a descriptor on the host directory.
     /// Mount memory defaults to [`DEFAULT_MEMORY_USAGE_LIMIT`].
     ///
     /// # Errors
     ///
     /// Returns [`MountError::InvalidMount`] if the virtual path is not absolute,
-    /// or the host path doesn't exist or isn't a directory.
+    /// or the host path cannot be opened as a directory.
     pub fn new(
         virtual_path: &str,
         host_path: impl AsRef<Path>,
@@ -196,21 +196,18 @@ impl Mount {
 
         let normalized_virtual = normalize_virtual_path(virtual_path);
 
-        let canonical_host = fs::canonicalize(host_path).map_err(|e| {
-            MountError::InvalidMount(format!("cannot canonicalize host path '{}': {e}", host_path.display()))
-        })?;
-
-        if !canonical_host.is_dir() {
-            return Err(MountError::InvalidMount(format!(
-                "host path is not a directory: '{}'",
-                host_path.display()
-            )));
-        }
-
-        // The only use of ambient authority: the host is trusted to name the
-        // directory it shares. Everything afterwards is relative to `dir`.
-        let dir = Dir::open_ambient_dir(&canonical_host, ambient_authority())
+        // The only use of ambient authority, and the mount's whole trust root.
+        // Deliberately first: resolving the name to a validated path and *then*
+        // opening that path would let whoever can rename in the parent swap a
+        // symlink into the gap. The directory check rides on the open itself
+        // (`O_DIRECTORY`, a handle `metadata()` on Windows), so it cannot.
+        let dir = Dir::open_ambient_dir(host_path, ambient_authority())
             .map_err(|e| MountError::InvalidMount(format!("cannot open host path '{}': {e}", host_path.display())))?;
+
+        // Diagnostics only, and best-effort: resolved after the open, so a host
+        // that raced it leaves a stale label on the right descriptor, never the
+        // reverse. Nothing resolves through this path.
+        let canonical_host = fs::canonicalize(host_path).unwrap_or_else(|_| host_path.to_path_buf());
 
         Ok(Self {
             virtual_path: normalized_virtual,
@@ -229,7 +226,7 @@ impl Mount {
         &self.virtual_path
     }
 
-    /// Returns the canonical host directory path. Diagnostics only.
+    /// Returns the best-effort canonical host directory path. Diagnostics only.
     #[must_use]
     pub fn host_path(&self) -> &Path {
         &self.host_path

--- a/crates/monty-fs/src/mount_table.rs
+++ b/crates/monty-fs/src/mount_table.rs
@@ -156,7 +156,7 @@ impl MountTable {
 pub struct Mount {
     /// Virtual path prefix (absolute, normalized).
     virtual_path: String,
-    /// Best-effort canonical host directory path. Diagnostics only — see `dir`.
+    /// Canonical host directory path. Diagnostics only — see `dir`.
     host_path: PathBuf,
     /// Descriptor for the mounted directory, opened once here — the sandbox
     /// boundary. Resolution cannot leave it, and no rename can re-point a name
@@ -179,7 +179,7 @@ impl Mount {
     /// # Errors
     ///
     /// Returns [`MountError::InvalidMount`] if the virtual path is not absolute,
-    /// or the host path cannot be opened as a directory.
+    /// or the host path cannot be opened as a directory or canonicalized.
     pub fn new(
         virtual_path: &str,
         host_path: impl AsRef<Path>,
@@ -204,10 +204,14 @@ impl Mount {
         let dir = Dir::open_ambient_dir(host_path, ambient_authority())
             .map_err(|e| MountError::InvalidMount(format!("cannot open host path '{}': {e}", host_path.display())))?;
 
-        // Diagnostics only, and best-effort: resolved after the open, so a host
-        // that raced it leaves a stale label on the right descriptor, never the
-        // reverse. Nothing resolves through this path.
-        let canonical_host = fs::canonicalize(host_path).unwrap_or_else(|_| host_path.to_path_buf());
+        // Diagnostics only — nothing resolves through this path. Resolved after
+        // the open, so a host racing it leaves a stale label on the right
+        // descriptor, never the reverse. Still fatal on failure: callers copy
+        // this out as a mount's durable identity, and a relative path would
+        // later re-resolve against the process CWD.
+        let canonical_host = fs::canonicalize(host_path).map_err(|e| {
+            MountError::InvalidMount(format!("cannot resolve host path '{}': {e}", host_path.display()))
+        })?;
 
         Ok(Self {
             virtual_path: normalized_virtual,
@@ -226,7 +230,7 @@ impl Mount {
         &self.virtual_path
     }
 
-    /// Returns the best-effort canonical host directory path. Diagnostics only.
+    /// Returns the canonical host directory path. Diagnostics only.
     #[must_use]
     pub fn host_path(&self) -> &Path {
         &self.host_path

--- a/crates/monty-fs/src/mount_table.rs
+++ b/crates/monty-fs/src/mount_table.rs
@@ -90,8 +90,8 @@ impl MountTable {
     /// back untouched for the caller's fallback handler (a host callback or
     /// [`OsFunctionCall::on_no_handler`]).
     pub fn handle_os_call(&mut self, call: OsFunctionCall) -> MountCallOutcome {
-        if call.is_filesystem() {
-            match self.route_call(&call) {
+        if let Some(primary_path) = call.fs_primary_path() {
+            match self.route_call(primary_path, &call) {
                 Some(Ok(index)) => MountCallOutcome::Handled(self.mounts[index].execute(call)),
                 Some(Err(err)) => MountCallOutcome::Handled(Err(err)),
                 None => MountCallOutcome::NotHandled(call),
@@ -118,8 +118,7 @@ impl MountTable {
     ///
     /// Rename requests require both source and destination to resolve to the
     /// same longest-prefix mount. Other requests only route on the primary path.
-    fn route_call(&self, call: &OsFunctionCall) -> Option<Result<usize, MountError>> {
-        let primary_path = call.primary_path().expect("filesystem call always has a primary path");
+    fn route_call(&self, primary_path: &str, call: &OsFunctionCall) -> Option<Result<usize, MountError>> {
         let src_mount_index = self.find_mount_index(primary_path)?;
 
         if let Some(dst_path) = call.rename_destination() {

--- a/crates/monty-fs/src/mount_table.rs
+++ b/crates/monty-fs/src/mount_table.rs
@@ -50,14 +50,18 @@ impl MountTable {
 
     /// Adds a mount point mapping a virtual path to a host directory.
     ///
-    /// The host path is canonicalized at mount time so that all subsequent
-    /// boundary checks compare canonical-to-canonical. Mount memory uses
-    /// [`DEFAULT_MEMORY_USAGE_LIMIT`] unless a pre-built [`Mount`] overrides it.
+    /// The host directory is opened once here, and every later operation runs
+    /// relative to that descriptor — so the mount stays attached to the
+    /// directory that was named, whatever the host does to the path afterwards.
+    /// Mount memory uses [`DEFAULT_MEMORY_USAGE_LIMIT`] unless a pre-built
+    /// [`Mount`] overrides it.
     ///
     /// # Errors
     ///
     /// Returns [`MountError::InvalidMount`] if the virtual path is not absolute,
-    /// or the host path doesn't exist or isn't a directory.
+    /// the host path doesn't exist or isn't a directory, or it cannot be opened.
+    /// The descriptor needs read permission, so a search-only (`0o111`)
+    /// directory is not mountable even though its contents are reachable.
     pub fn mount(
         &mut self,
         virtual_path: &str,

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -171,24 +171,28 @@ fn ensure_append_target_exists(
             )?;
             Ok(())
         }
-        None => match resolve_real_path_state(vpath, ctx, Follow::Yes, OnLookupFailure::Propagate)? {
-            RealPathState::Present(rel) if host_is_dir(ctx.mount_dir, &rel) => {
-                Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
+        None => {
+            let target = resolve_virtual_path(vpath, ctx.mount_virtual)?;
+            match classify_write_target(ctx.mount_dir, target.for_dir_op(), vpath)? {
+                RealTarget::Dir => Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath)),
+                RealTarget::Symlink => Err(MountError::PathEscape {
+                    virtual_path: vpath.to_owned(),
+                }),
+                RealTarget::File => Ok(()),
+                RealTarget::Absent => {
+                    ensure_parent_exists(state, &relative, ctx, vpath)?;
+                    state.insert(
+                        relative,
+                        OverlayEntry::File(OverlayFile {
+                            content: Vec::new(),
+                            mtime: current_timestamp(),
+                        }),
+                        ctx.memory_usage_limit,
+                    )?;
+                    Ok(())
+                }
             }
-            RealPathState::Present(_) => Ok(()),
-            RealPathState::Missing => {
-                ensure_parent_exists(state, &relative, ctx, vpath)?;
-                state.insert(
-                    relative,
-                    OverlayEntry::File(OverlayFile {
-                        content: Vec::new(),
-                        mtime: current_timestamp(),
-                    }),
-                    ctx.memory_usage_limit,
-                )?;
-                Ok(())
-            }
-        },
+        }
     }
 }
 
@@ -500,49 +504,81 @@ fn existing_file_bytes(
     }
 }
 
-/// Rejects writes when the target path is an existing directory.
+/// Rejects writes when the target path is an existing directory or a symlink.
 ///
-/// On real filesystems, writing to a directory path returns `EISDIR`.
-/// The overlay must enforce the same invariant to prevent silently
-/// overwriting a directory entry with a file.
+/// On real filesystems, writing to a directory returns `EISDIR`; the overlay
+/// enforces the same. A direct mount writes *through* a symlink to its target,
+/// which the overlay cannot replicate without aliasing the name, so writing
+/// over any symlink raises `PermissionError` instead of silently shadowing it.
 fn reject_directory_target(
     state: &OverlayState,
     relative: &str,
     ctx: &MountContext<'_>,
     vpath: &str,
 ) -> Result<(), MountError> {
-    if relative_dir_exists(state, relative, ctx) {
-        return Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath));
+    match state.get(relative) {
+        Some(OverlayEntry::Directory { .. }) => {
+            Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
+        }
+        // An overlay file, ref, or tombstone already shadows whatever is real.
+        Some(_) => Ok(()),
+        None => match resolve_virtual_path(vpath, ctx.mount_virtual) {
+            Ok(target) => match classify_write_target(ctx.mount_dir, target.for_dir_op(), vpath)? {
+                RealTarget::Dir => Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath)),
+                RealTarget::Symlink => Err(MountError::PathEscape {
+                    virtual_path: vpath.to_owned(),
+                }),
+                RealTarget::File | RealTarget::Absent => Ok(()),
+            },
+            Err(_) => Ok(()),
+        },
     }
-    Ok(())
 }
 
-/// Ensures the parent directory of `relative` exists in overlay or real storage.
+/// Ensures every component of `relative`'s parent chain is a directory the
+/// overlay may write beneath.
+///
+/// The chain is walked component by component because a single lookup of the
+/// immediate parent resolves *through* intermediate symlinks without seeing
+/// them — and overlay writes must refuse symlinks anywhere in the path, not
+/// just at its end (see `limitations/filesystem.md`).
 fn ensure_parent_exists(
     state: &OverlayState,
     relative: &str,
     ctx: &MountContext<'_>,
     vpath: &str,
 ) -> Result<(), MountError> {
-    if let Some((parent_rel, _)) = relative.rsplit_once('/')
-        && !relative_dir_exists(state, parent_rel, ctx)
-    {
-        return Err(MountError::not_found(vpath));
-    }
-    Ok(())
-}
-
-/// Returns whether `relative` exists as a directory in the overlay or real filesystem.
-fn relative_dir_exists(state: &OverlayState, relative: &str, ctx: &MountContext<'_>) -> bool {
-    match state.get(relative) {
-        Some(OverlayEntry::Directory { .. }) => true,
-        Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_) | OverlayEntry::Deleted) => false,
-        None => {
-            let parent_vpath = format!("{}/{relative}", ctx.mount_virtual);
-            resolve_virtual_path(&parent_vpath, ctx.mount_virtual)
-                .is_ok_and(|target| host_is_dir(ctx.mount_dir, target.for_dir_op()))
+    let Some((parents, _)) = relative.rsplit_once('/') else {
+        return Ok(());
+    };
+    let mut current = String::new();
+    for component in parents.split('/') {
+        if !current.is_empty() {
+            current.push('/');
+        }
+        current.push_str(component);
+        match state.get(&current) {
+            // Overlay directories are symlink-free by construction.
+            Some(OverlayEntry::Directory { .. }) => {}
+            Some(_) => return Err(MountError::not_found(vpath)),
+            None => {
+                let dir_vpath = format!("{}/{current}", ctx.mount_virtual);
+                let Ok(target) = resolve_virtual_path(&dir_vpath, ctx.mount_virtual) else {
+                    return Err(MountError::not_found(vpath));
+                };
+                match classify_write_target(ctx.mount_dir, target.for_dir_op(), vpath)? {
+                    RealTarget::Dir => {}
+                    RealTarget::Symlink => {
+                        return Err(MountError::PathEscape {
+                            virtual_path: vpath.to_owned(),
+                        });
+                    }
+                    RealTarget::File | RealTarget::Absent => return Err(MountError::not_found(vpath)),
+                }
+            }
         }
     }
+    Ok(())
 }
 
 /// Creates a directory inside the overlay.
@@ -582,10 +618,8 @@ fn mkdir(
 
     if parents {
         create_overlay_parents(state, relative, ctx)?;
-    } else if let Some((parent_rel, _)) = relative.rsplit_once('/')
-        && !relative_dir_exists(state, parent_rel, ctx)
-    {
-        return Err(MountError::not_found(vpath));
+    } else {
+        ensure_parent_exists(state, relative, ctx, vpath)?;
     }
 
     state.insert(
@@ -599,6 +633,10 @@ fn mkdir(
 }
 
 /// Creates parent directories for `mkdir(parents=True)` with overlay semantics.
+///
+/// Each component is classified through the descriptor: any symlink raises
+/// `PermissionError` instead of being shadowed by (or aliased under) an
+/// in-memory tree.
 fn create_overlay_parents(state: &mut OverlayState, relative: &str, ctx: &MountContext<'_>) -> Result<(), MountError> {
     let mut current = String::new();
 
@@ -630,15 +668,21 @@ fn create_overlay_parents(state: &mut OverlayState, relative: &str, ctx: &MountC
             None => {
                 let current_vpath = format!("{}/{current}", ctx.mount_virtual);
                 if let Ok(resolved) = resolve_virtual_path(&current_vpath, ctx.mount_virtual) {
-                    if host_is_file(ctx.mount_dir, resolved.for_dir_op()) {
-                        return Err(MountError::io_err(
-                            ErrorKind::NotADirectory,
-                            "Not a directory",
-                            &current_vpath,
-                        ));
-                    }
-                    if host_is_dir(ctx.mount_dir, resolved.for_dir_op()) {
-                        continue;
+                    match classify_write_target(ctx.mount_dir, resolved.for_dir_op(), &current_vpath)? {
+                        RealTarget::Dir => continue,
+                        RealTarget::Symlink => {
+                            return Err(MountError::PathEscape {
+                                virtual_path: current_vpath,
+                            });
+                        }
+                        RealTarget::File => {
+                            return Err(MountError::io_err(
+                                ErrorKind::NotADirectory,
+                                "Not a directory",
+                                &current_vpath,
+                            ));
+                        }
+                        RealTarget::Absent => {}
                     }
                 }
 
@@ -1282,6 +1326,38 @@ enum RealPathState {
     Present(String),
     /// The path should behave as nonexistent.
     Missing,
+}
+
+/// What a *write*-path lookup found on the real filesystem at a mount-relative
+/// path. Symlinks are surfaced, never resolved: overlay writes refuse them.
+enum RealTarget {
+    /// A directory.
+    Dir,
+    /// A non-directory, non-symlink entry.
+    File,
+    /// A symlink of any kind — its target is deliberately not examined.
+    Symlink,
+    /// Nothing there.
+    Absent,
+}
+
+/// Classifies what sits at `rel` for overlay write paths.
+///
+/// Overlay writes never touch symlinks: a direct mount writes *through* a link
+/// to its target, which the overlay cannot replicate without silently aliasing
+/// the two names, so callers refuse `Symlink` with `PermissionError` wherever
+/// it appears in a write path. The single `lstat` never resolves the target,
+/// so the refusal reveals nothing about where the link points.
+fn classify_write_target(dir: &Dir, rel: &str, vpath: &str) -> Result<RealTarget, MountError> {
+    match dir.symlink_metadata(rel) {
+        Ok(meta) if meta.is_symlink() => Ok(RealTarget::Symlink),
+        Ok(meta) if meta.is_dir() => Ok(RealTarget::Dir),
+        Ok(_) => Ok(RealTarget::File),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(RealTarget::Absent),
+        // An escaping symlink earlier in the walk fails here; `map_io` turns
+        // cap-std's synthetic denial into `PathEscape`.
+        Err(err) => Err(map_io(err, vpath)),
+    }
 }
 
 /// Returns the prefix used to scan direct children of `relative`.

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -115,7 +115,7 @@ fn open(
                     return Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", path));
                 }
                 Some(OverlayEntry::Deleted) => return Err(MountError::not_found(path)),
-                None => match resolve_real_path_state(path, ctx, Follow::Yes)? {
+                None => match resolve_real_path_state(path, ctx, Follow::Yes, OnLookupFailure::Propagate)? {
                     RealPathState::Present(rel) if real_is_dir(ctx.mount_dir, &rel) => {
                         return Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", path));
                     }
@@ -172,7 +172,7 @@ fn ensure_append_target_exists(
             )?;
             Ok(())
         }
-        None => match resolve_real_path_state(vpath, ctx, Follow::Yes)? {
+        None => match resolve_real_path_state(vpath, ctx, Follow::Yes, OnLookupFailure::Propagate)? {
             RealPathState::Present(rel) if real_is_dir(ctx.mount_dir, &rel) => {
                 Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
             }
@@ -203,7 +203,7 @@ fn exists(
     let exists = match state.get(relative) {
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_) | OverlayEntry::Directory { .. }) => true,
         Some(OverlayEntry::Deleted) => false,
-        None => match resolve_real_path_state(vpath, ctx, Follow::Yes)? {
+        None => match resolve_real_path_state(vpath, ctx, Follow::Yes, OnLookupFailure::Missing)? {
             RealPathState::Present(_) => true,
             RealPathState::Missing => false,
         },
@@ -221,7 +221,7 @@ fn is_file(
     let is_file = match state.get(relative) {
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_)) => true,
         Some(OverlayEntry::Directory { .. } | OverlayEntry::Deleted) => false,
-        None => match resolve_real_path_state(vpath, ctx, Follow::Yes)? {
+        None => match resolve_real_path_state(vpath, ctx, Follow::Yes, OnLookupFailure::Missing)? {
             RealPathState::Present(rel) => real_is_file(ctx.mount_dir, &rel),
             RealPathState::Missing => false,
         },
@@ -239,7 +239,7 @@ fn is_dir(
     let is_dir = match state.get(relative) {
         Some(OverlayEntry::Directory { .. }) => true,
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_) | OverlayEntry::Deleted) => false,
-        None => match resolve_real_path_state(vpath, ctx, Follow::Yes)? {
+        None => match resolve_real_path_state(vpath, ctx, Follow::Yes, OnLookupFailure::Missing)? {
             RealPathState::Present(rel) => real_is_dir(ctx.mount_dir, &rel),
             RealPathState::Missing => false,
         },
@@ -256,7 +256,7 @@ fn is_symlink(
 ) -> Result<MontyObject, MountError> {
     let is_symlink = match state.get(relative) {
         Some(_) => false,
-        None => match resolve_real_path_state(vpath, ctx, Follow::No)? {
+        None => match resolve_real_path_state(vpath, ctx, Follow::No, OnLookupFailure::Missing)? {
             RealPathState::Present(rel) => ctx.mount_dir.symlink_metadata(&rel).is_ok_and(|m| m.is_symlink()),
             RealPathState::Missing => false,
         },
@@ -452,7 +452,7 @@ fn existing_file_len(
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
         }
-        None => match resolve_real_path_state(vpath, ctx, Follow::Yes)? {
+        None => match resolve_real_path_state(vpath, ctx, Follow::Yes, OnLookupFailure::Propagate)? {
             RealPathState::Present(rel) => file_len(ctx.mount_dir, &rel, vpath),
             RealPathState::Missing => Ok(0),
         },
@@ -491,7 +491,7 @@ fn existing_file_bytes(
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
         }
-        None => match resolve_real_path_state(vpath, ctx, Follow::Yes)? {
+        None => match resolve_real_path_state(vpath, ctx, Follow::Yes, OnLookupFailure::Propagate)? {
             RealPathState::Present(rel) => match read_bytes_fs(ctx.mount_dir, &rel, vpath, budget)? {
                 MontyObject::Bytes(bytes) => Ok(bytes),
                 _ => unreachable!("read_bytes_fs should return bytes"),
@@ -1205,24 +1205,44 @@ fn collect_real_descendants(
 
 /// Resolves a real host path for an overlay fallthrough lookup.
 ///
-/// Overlay existence-style queries intentionally collapse host-side I/O misses
-/// into `Missing` so they return `false` instead of raising.
-fn resolve_real_path_state(vpath: &str, ctx: &MountContext<'_>, follow: Follow) -> Result<RealPathState, MountError> {
+/// Path *policy* rejections (null bytes, drive segments) always raise, as they
+/// do in direct mode and CPython. A failed host *lookup* is governed by
+/// `on_failure`: only a genuinely absent path is `Missing` for everyone.
+fn resolve_real_path_state(
+    vpath: &str,
+    ctx: &MountContext<'_>,
+    follow: Follow,
+    on_failure: OnLookupFailure,
+) -> Result<RealPathState, MountError> {
     let target = match resolve_virtual_path(vpath, ctx.mount_virtual) {
         Ok(target) => target,
         Err(MountError::Io(_, _)) => return Ok(RealPathState::Missing),
         Err(err) => return Err(err),
     };
     let rel = target.for_dir_op();
-    let exists = match follow {
-        Follow::Yes => ctx.mount_dir.metadata(rel).is_ok(),
-        Follow::No => ctx.mount_dir.symlink_metadata(rel).is_ok(),
+    let metadata = match follow {
+        Follow::Yes => ctx.mount_dir.metadata(rel),
+        Follow::No => ctx.mount_dir.symlink_metadata(rel),
     };
-    if exists {
-        Ok(RealPathState::Present(rel.to_owned()))
-    } else {
-        Ok(RealPathState::Missing)
+    match metadata {
+        Ok(_) => Ok(RealPathState::Present(rel.to_owned())),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(RealPathState::Missing),
+        Err(_) if matches!(on_failure, OnLookupFailure::Missing) => Ok(RealPathState::Missing),
+        Err(err) => Err(map_io(err, vpath)),
     }
+}
+
+/// What a caller wants done with a host lookup that failed for a reason other
+/// than the path being absent — a permission error, say.
+#[derive(Clone, Copy)]
+enum OnLookupFailure {
+    /// Treat as absent. `pathlib` predicates answer `False` rather than raise,
+    /// which also keeps out-of-mount paths unobservable.
+    Missing,
+    /// Report it, as a direct mount would. Collapsing it made `open` say
+    /// `FileNotFoundError` for a denied file, and let `append` create an
+    /// overlay entry shadowing a real file it could not see.
+    Propagate,
 }
 
 /// Whether a lookup follows a final symlink, replacing the old resolve modes.

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -720,14 +720,21 @@ fn unlink(
         }
         Some(OverlayEntry::Deleted) => Err(MountError::not_found(vpath)),
         None => {
+            // A delete is a write: the same symlink refusal applies. Tombstoning
+            // a link's spelling would leave its target readable under the real
+            // name — the aliasing the write policy exists to prevent.
+            ensure_parent_exists(state, relative, ctx, vpath)?;
             let resolved = resolve_virtual_path(vpath, ctx.mount_virtual)?;
-            if host_is_file(ctx.mount_dir, resolved.for_dir_op()) {
-                state.insert(relative.to_owned(), OverlayEntry::Deleted, ctx.memory_usage_limit)?;
-                Ok(MontyObject::None)
-            } else if host_is_dir(ctx.mount_dir, resolved.for_dir_op()) {
-                Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
-            } else {
-                Err(MountError::not_found(vpath))
+            match classify_write_target(ctx.mount_dir, resolved.for_dir_op(), vpath)? {
+                RealTarget::File => {
+                    state.insert(relative.to_owned(), OverlayEntry::Deleted, ctx.memory_usage_limit)?;
+                    Ok(MontyObject::None)
+                }
+                RealTarget::Dir => Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath)),
+                RealTarget::Symlink => Err(MountError::PathEscape {
+                    virtual_path: vpath.to_owned(),
+                }),
+                RealTarget::Absent => Err(MountError::not_found(vpath)),
             }
         }
     }
@@ -761,8 +768,16 @@ fn rmdir(
         }
         Some(OverlayEntry::Deleted) => Err(MountError::not_found(vpath)),
         None => {
+            ensure_parent_exists(state, relative, ctx, vpath)?;
             let resolved = resolve_virtual_path(vpath, ctx.mount_virtual)?;
             let rel = resolved.for_dir_op();
+            // A symlink is not a directory to remove — POSIX answers ENOTDIR —
+            // and tombstoning its name would alias it against its target.
+            if matches!(classify_write_target(ctx.mount_dir, rel, vpath)?, RealTarget::Symlink) {
+                return Err(MountError::PathEscape {
+                    virtual_path: vpath.to_owned(),
+                });
+            }
             if !host_is_dir(ctx.mount_dir, rel) {
                 // `resolve_virtual_path` never touches the filesystem, so a
                 // missing path arrives as `Ok` and must be told apart from one
@@ -953,6 +968,21 @@ fn rename(
 
     ensure_parent_exists(state, &dst_rel, ctx, dst_vpath)?;
 
+    // The destination's own name must not be a symlink either. An overlay entry
+    // under it would shadow the link and alias it against its target — exactly
+    // what `write_text` on the same path refuses.
+    if state.get(&dst_rel).is_none()
+        && let Ok(target) = resolve_virtual_path(dst_vpath, ctx.mount_virtual)
+        && matches!(
+            classify_write_target(ctx.mount_dir, target.for_dir_op(), dst_vpath)?,
+            RealTarget::Symlink
+        )
+    {
+        return Err(MountError::PathEscape {
+            virtual_path: dst_vpath.to_owned(),
+        });
+    }
+
     if matches!(state.get(&src_rel), Some(OverlayEntry::Deleted)) {
         return Err(MountError::not_found(src_vpath));
     }
@@ -1063,11 +1093,11 @@ fn rename(
             ) {
                 Ok(children) => children,
                 // Lookup failures degrade to "no real children" (the host may
-                // have removed them mid-plan), but resource errors and
-                // unrepresentable names must fail the rename rather than
+                // have removed them mid-plan), but resource errors, refusals
+                // and unrepresentable names must fail the rename rather than
                 // silently shrink it.
                 Err(error) => match &error {
-                    MountError::MemoryUsageLimitExceeded(_) => return Err(error),
+                    MountError::MemoryUsageLimitExceeded(_) | MountError::PathEscape { .. } => return Err(error),
                     MountError::Io(io_error, _) if io_error.kind() == ErrorKind::InvalidData => {
                         return Err(error);
                     }
@@ -1254,13 +1284,15 @@ fn collect_real_descendants(
             let file_type = entry
                 .file_type()
                 .map_err(|error| MountError::Io(error, vpath.to_owned()))?;
-            // Defense-in-depth: explicitly skip symlinks so that a symlink
-            // pointing outside the mount boundary cannot be captured as an
-            // OverlayFileRef during a directory rename. On Unix,
-            // DirEntry::file_type() already distinguishes symlinks from files
-            // and dirs, but Windows behavior may differ.
+            // A symlink can move neither way: capturing it as a file ref would
+            // resolve the target the overlay refuses to write through, and
+            // skipping it strands the link — unreachable at the new name, yet
+            // still live at the old one inside a directory the overlay now
+            // reports as deleted. Refuse the move, as for a non-UTF-8 name.
             if file_type.is_symlink() {
-                continue;
+                return Err(MountError::PathEscape {
+                    virtual_path: vpath.to_owned(),
+                });
             }
             let child_rel = join_mount_relative(&current_rel, name);
             if file_type.is_file() {

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -948,10 +948,10 @@ fn rename(
         let entry = if is_symlink {
             // A stored reference could not escape anyway, but failing here puts
             // the error where the user caused it rather than on a later read.
-            if ctx.mount_dir.metadata(rel).is_err() {
-                return Err(MountError::PathEscape {
-                    virtual_path: src_vpath.to_owned(),
-                });
+            // Route through `map_io` so only a confinement failure reads as
+            // `PathEscape` — a denied in-mount target is a permission error.
+            if let Err(err) = ctx.mount_dir.metadata(rel) {
+                return Err(map_io(err, src_vpath));
             }
             // Preserve the symlink entry itself rather than its target.
             OverlayFileRef::from_lstat(ctx.mount_dir, rel)

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -4,27 +4,25 @@
 //! filesystem when no overlay entry is present. Writes and deletions stay in
 //! memory so the real mounted directory is never modified.
 
-use std::{
-    fs,
-    io::ErrorKind,
-    path::{Path, PathBuf},
-};
+use std::io::ErrorKind;
 
 use ahash::AHashSet;
+use cap_std::fs::Dir;
 use monty_types::{FileMode, MontyObject, dir_stat, file_stat};
 
 use super::{
     common::{
         LISTING_ENTRY_MEMORY_USAGE, MemoryBudget, MountContext, as_u64, bytes_to_utf8, check_write_limit,
-        commit_write_bytes, current_timestamp, dir_mtime, format_child_path, list_visible_real_dir_entry_names,
-        read_bytes_fs, read_text_fs, stat_fs,
+        commit_write_bytes, current_timestamp, dir_mtime, format_child_path, is_dir as real_is_dir,
+        is_file as real_is_file, join_relative, list_visible_real_dir_entry_names, map_io, read_bytes_fs, read_text_fs,
+        stat_fs,
     },
     dispatch::{FsRequest, file_handle_result},
     error::MountError,
     overlay_state::{ENTRY_MEMORY_USAGE, OverlayEntry, OverlayFile, OverlayFileRef, OverlayState},
     path_security::{
-        ResolveMode, normalize_virtual_path, reject_drive_or_unc_segments, reject_escaping_symlink,
-        reject_overlong_path, resolve_path, revalidate_cached_host_path, strip_mount_prefix,
+        normalize_virtual_path, reject_drive_or_unc_segments, reject_overlong_path, resolve_virtual_path,
+        strip_mount_prefix,
     },
 };
 
@@ -117,8 +115,8 @@ fn open(
                     return Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", path));
                 }
                 Some(OverlayEntry::Deleted) => return Err(MountError::not_found(path)),
-                None => match resolve_real_path_state(path, ctx, ResolveMode::Existing)? {
-                    RealPathState::Present(host_path) if host_path.is_dir() => {
+                None => match resolve_real_path_state(path, ctx, Follow::Yes)? {
+                    RealPathState::Present(rel) if real_is_dir(ctx.mount_dir, &rel) => {
                         return Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", path));
                     }
                     RealPathState::Present(_) => {}
@@ -174,8 +172,8 @@ fn ensure_append_target_exists(
             )?;
             Ok(())
         }
-        None => match resolve_real_path_state(vpath, ctx, ResolveMode::Existing)? {
-            RealPathState::Present(host_path) if host_path.is_dir() => {
+        None => match resolve_real_path_state(vpath, ctx, Follow::Yes)? {
+            RealPathState::Present(rel) if real_is_dir(ctx.mount_dir, &rel) => {
                 Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
             }
             RealPathState::Present(_) => Ok(()),
@@ -205,7 +203,7 @@ fn exists(
     let exists = match state.get(relative) {
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_) | OverlayEntry::Directory { .. }) => true,
         Some(OverlayEntry::Deleted) => false,
-        None => match resolve_real_path_state(vpath, ctx, ResolveMode::Existing)? {
+        None => match resolve_real_path_state(vpath, ctx, Follow::Yes)? {
             RealPathState::Present(_) => true,
             RealPathState::Missing => false,
         },
@@ -223,8 +221,8 @@ fn is_file(
     let is_file = match state.get(relative) {
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_)) => true,
         Some(OverlayEntry::Directory { .. } | OverlayEntry::Deleted) => false,
-        None => match resolve_real_path_state(vpath, ctx, ResolveMode::Existing)? {
-            RealPathState::Present(host_path) => host_path.is_file(),
+        None => match resolve_real_path_state(vpath, ctx, Follow::Yes)? {
+            RealPathState::Present(rel) => real_is_file(ctx.mount_dir, &rel),
             RealPathState::Missing => false,
         },
     };
@@ -241,8 +239,8 @@ fn is_dir(
     let is_dir = match state.get(relative) {
         Some(OverlayEntry::Directory { .. }) => true,
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_) | OverlayEntry::Deleted) => false,
-        None => match resolve_real_path_state(vpath, ctx, ResolveMode::Existing)? {
-            RealPathState::Present(host_path) => host_path.is_dir(),
+        None => match resolve_real_path_state(vpath, ctx, Follow::Yes)? {
+            RealPathState::Present(rel) => real_is_dir(ctx.mount_dir, &rel),
             RealPathState::Missing => false,
         },
     };
@@ -258,8 +256,8 @@ fn is_symlink(
 ) -> Result<MontyObject, MountError> {
     let is_symlink = match state.get(relative) {
         Some(_) => false,
-        None => match resolve_real_path_state(vpath, ctx, ResolveMode::Lstat)? {
-            RealPathState::Present(host_path) => host_path.is_symlink(),
+        None => match resolve_real_path_state(vpath, ctx, Follow::No)? {
+            RealPathState::Present(rel) => ctx.mount_dir.symlink_metadata(&rel).is_ok_and(|m| m.is_symlink()),
             RealPathState::Missing => false,
         },
     };
@@ -279,16 +277,15 @@ fn read_text(
             Ok(MontyObject::String(bytes_to_utf8(file.content.clone())?))
         }
         Some(OverlayEntry::RealFileRef(file_ref)) => {
-            let host_path = revalidate_cached_host_path(&file_ref.host_path, ctx.mount_host, vpath)?;
-            read_text_fs(&host_path, vpath, available_memory(state, ctx)?)
+            read_text_fs(ctx.mount_dir, &file_ref.relative, vpath, available_memory(state, ctx)?)
         }
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
         }
         Some(OverlayEntry::Deleted) => Err(MountError::not_found(vpath)),
         None => {
-            let resolved = resolve_path(vpath, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)?;
-            read_text_fs(&resolved.host_path, vpath, available_memory(state, ctx)?)
+            let target = resolve_virtual_path(vpath, ctx.mount_virtual)?;
+            read_text_fs(ctx.mount_dir, target.for_dir_op(), vpath, available_memory(state, ctx)?)
         }
     }
 }
@@ -306,16 +303,15 @@ fn read_bytes(
             Ok(MontyObject::Bytes(file.content.clone()))
         }
         Some(OverlayEntry::RealFileRef(file_ref)) => {
-            let host_path = revalidate_cached_host_path(&file_ref.host_path, ctx.mount_host, vpath)?;
-            read_bytes_fs(&host_path, vpath, available_memory(state, ctx)?)
+            read_bytes_fs(ctx.mount_dir, &file_ref.relative, vpath, available_memory(state, ctx)?)
         }
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
         }
         Some(OverlayEntry::Deleted) => Err(MountError::not_found(vpath)),
         None => {
-            let resolved = resolve_path(vpath, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)?;
-            read_bytes_fs(&resolved.host_path, vpath, available_memory(state, ctx)?)
+            let target = resolve_virtual_path(vpath, ctx.mount_virtual)?;
+            read_bytes_fs(ctx.mount_dir, target.for_dir_op(), vpath, available_memory(state, ctx)?)
         }
     }
 }
@@ -452,15 +448,12 @@ fn existing_file_len(
     match state.get(relative) {
         Some(OverlayEntry::File(file)) => Ok(file.content.len()),
         Some(OverlayEntry::Deleted) => Ok(0),
-        Some(OverlayEntry::RealFileRef(file_ref)) => {
-            let host_path = revalidate_cached_host_path(&file_ref.host_path, ctx.mount_host, vpath)?;
-            file_len(&host_path, vpath)
-        }
+        Some(OverlayEntry::RealFileRef(file_ref)) => file_len(ctx.mount_dir, &file_ref.relative, vpath),
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
         }
-        None => match resolve_real_path_state(vpath, ctx, ResolveMode::Existing)? {
-            RealPathState::Present(host_path) => file_len(&host_path, vpath),
+        None => match resolve_real_path_state(vpath, ctx, Follow::Yes)? {
+            RealPathState::Present(rel) => file_len(ctx.mount_dir, &rel, vpath),
             RealPathState::Missing => Ok(0),
         },
     }
@@ -470,10 +463,8 @@ fn existing_file_len(
 ///
 /// File sizes larger than addressable memory saturate so quota comparison fails
 /// closed instead of wrapping before the overlay tries to allocate.
-fn file_len(path: &Path, vpath: &str) -> Result<usize, MountError> {
-    let len = fs::metadata(path)
-        .map_err(|error| MountError::Io(error, vpath.to_owned()))?
-        .len();
+fn file_len(dir: &Dir, rel: &str, vpath: &str) -> Result<usize, MountError> {
+    let len = dir.metadata(rel).map_err(|error| map_io(error, vpath))?.len();
     Ok(usize::try_from(len).unwrap_or(usize::MAX))
 }
 
@@ -492,8 +483,7 @@ fn existing_file_bytes(
         }
         Some(OverlayEntry::Deleted) => Ok(Vec::new()),
         Some(OverlayEntry::RealFileRef(file_ref)) => {
-            let host_path = revalidate_cached_host_path(&file_ref.host_path, ctx.mount_host, vpath)?;
-            match read_bytes_fs(&host_path, vpath, budget)? {
+            match read_bytes_fs(ctx.mount_dir, &file_ref.relative, vpath, budget)? {
                 MontyObject::Bytes(bytes) => Ok(bytes),
                 _ => unreachable!("read_bytes_fs should return bytes"),
             }
@@ -501,8 +491,8 @@ fn existing_file_bytes(
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
         }
-        None => match resolve_real_path_state(vpath, ctx, ResolveMode::Existing)? {
-            RealPathState::Present(host_path) => match read_bytes_fs(&host_path, vpath, budget)? {
+        None => match resolve_real_path_state(vpath, ctx, Follow::Yes)? {
+            RealPathState::Present(rel) => match read_bytes_fs(ctx.mount_dir, &rel, vpath, budget)? {
                 MontyObject::Bytes(bytes) => Ok(bytes),
                 _ => unreachable!("read_bytes_fs should return bytes"),
             },
@@ -550,8 +540,8 @@ fn relative_dir_exists(state: &OverlayState, relative: &str, ctx: &MountContext<
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_) | OverlayEntry::Deleted) => false,
         None => {
             let parent_vpath = format!("{}/{relative}", ctx.mount_virtual);
-            resolve_path(&parent_vpath, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)
-                .is_ok_and(|resolved| resolved.host_path.is_dir())
+            resolve_virtual_path(&parent_vpath, ctx.mount_virtual)
+                .is_ok_and(|target| real_is_dir(ctx.mount_dir, target.for_dir_op()))
         }
     }
 }
@@ -578,8 +568,8 @@ fn mkdir(
         }
         Some(OverlayEntry::Deleted) => {}
         None => {
-            if let Ok(resolved) = resolve_path(vpath, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)
-                && let Ok(meta) = resolved.host_path.symlink_metadata()
+            if let Ok(target) = resolve_virtual_path(vpath, ctx.mount_virtual)
+                && let Ok(meta) = ctx.mount_dir.symlink_metadata(target.for_dir_op())
             {
                 return if meta.is_dir() && exist_ok {
                     Ok(MontyObject::None)
@@ -640,17 +630,15 @@ fn create_overlay_parents(state: &mut OverlayState, relative: &str, ctx: &MountC
             }
             None => {
                 let current_vpath = format!("{}/{current}", ctx.mount_virtual);
-                if let Ok(resolved) =
-                    resolve_path(&current_vpath, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)
-                {
-                    if resolved.host_path.is_file() {
+                if let Ok(resolved) = resolve_virtual_path(&current_vpath, ctx.mount_virtual) {
+                    if real_is_file(ctx.mount_dir, resolved.for_dir_op()) {
                         return Err(MountError::io_err(
                             ErrorKind::NotADirectory,
                             "Not a directory",
                             &current_vpath,
                         ));
                     }
-                    if resolved.host_path.is_dir() {
+                    if real_is_dir(ctx.mount_dir, resolved.for_dir_op()) {
                         continue;
                     }
                 }
@@ -686,11 +674,11 @@ fn unlink(
         }
         Some(OverlayEntry::Deleted) => Err(MountError::not_found(vpath)),
         None => {
-            let resolved = resolve_path(vpath, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)?;
-            if resolved.host_path.is_file() {
+            let resolved = resolve_virtual_path(vpath, ctx.mount_virtual)?;
+            if real_is_file(ctx.mount_dir, resolved.for_dir_op()) {
                 state.insert(relative.to_owned(), OverlayEntry::Deleted, ctx.memory_usage_limit)?;
                 Ok(MontyObject::None)
-            } else if resolved.host_path.is_dir() {
+            } else if real_is_dir(ctx.mount_dir, resolved.for_dir_op()) {
                 Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
             } else {
                 Err(MountError::not_found(vpath))
@@ -723,11 +711,19 @@ fn rmdir(
         }
         Some(OverlayEntry::Deleted) => Err(MountError::not_found(vpath)),
         None => {
-            let resolved = resolve_path(vpath, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)?;
-            if !resolved.host_path.is_dir() {
-                return Err(MountError::io_err(ErrorKind::NotADirectory, "Not a directory", vpath));
+            let resolved = resolve_virtual_path(vpath, ctx.mount_virtual)?;
+            let rel = resolved.for_dir_op();
+            if !real_is_dir(ctx.mount_dir, rel) {
+                // `resolve_virtual_path` never touches the filesystem, so a
+                // missing path arrives as `Ok` and must be told apart from one
+                // that exists but is not a directory.
+                return Err(if ctx.mount_dir.exists(rel) {
+                    MountError::io_err(ErrorKind::NotADirectory, "Not a directory", vpath)
+                } else {
+                    MountError::not_found(vpath)
+                });
             }
-            if real_directory_has_visible_children(state, relative, &resolved.host_path, vpath)? {
+            if real_directory_has_visible_children(state, relative, ctx.mount_dir, resolved.for_dir_op(), vpath)? {
                 return Err(MountError::io_err(
                     ErrorKind::DirectoryNotEmpty,
                     "Directory not empty",
@@ -762,11 +758,12 @@ fn overlay_directory_has_children(state: &OverlayState, relative: &str) -> bool 
 fn real_directory_has_visible_children(
     state: &OverlayState,
     relative: &str,
-    host_path: &Path,
+    dir: &Dir,
+    rel: &str,
     vpath: &str,
 ) -> Result<bool, MountError> {
     let prefix = directory_prefix(relative);
-    let entries = fs::read_dir(host_path).map_err(|err| MountError::Io(err, vpath.to_owned()))?;
+    let entries = dir.read_dir(rel).map_err(|err| map_io(err, vpath))?;
 
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
@@ -795,8 +792,8 @@ fn stat(state: &OverlayState, relative: &str, ctx: &MountContext<'_>, vpath: &st
         Some(OverlayEntry::Directory { mtime }) => Ok(dir_stat(0o755, *mtime)),
         Some(OverlayEntry::Deleted) => Err(MountError::not_found(vpath)),
         None => {
-            let resolved = resolve_path(vpath, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)?;
-            stat_fs(&resolved.host_path, vpath)
+            let target = resolve_virtual_path(vpath, ctx.mount_virtual)?;
+            stat_fs(ctx.mount_dir, target.for_dir_op(), vpath)
         }
     }
 }
@@ -814,12 +811,12 @@ fn iterdir(
             return Err(MountError::io_err(ErrorKind::NotADirectory, "Not a directory", vpath));
         }
         Some(OverlayEntry::Deleted) => return Err(MountError::not_found(vpath)),
-        None => match resolve_path(vpath, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing) {
-            Ok(resolved) if resolved.host_path.is_dir() => Some(resolved.host_path),
+        None => match resolve_virtual_path(vpath, ctx.mount_virtual) {
+            Ok(target) if real_is_dir(ctx.mount_dir, target.for_dir_op()) => Some(target.for_dir_op().to_owned()),
+            // `resolve_virtual_path` never touches the filesystem, so a missing
+            // path arrives as `Ok` and must be told apart from a non-directory.
+            Ok(target) if !ctx.mount_dir.exists(target.for_dir_op()) => return Err(MountError::not_found(vpath)),
             Ok(_) => return Err(MountError::io_err(ErrorKind::NotADirectory, "Not a directory", vpath)),
-            Err(MountError::Io(err, _)) if err.kind() == ErrorKind::NotFound => {
-                return Err(MountError::not_found(vpath));
-            }
             Err(err) => return Err(err),
         },
     };
@@ -856,7 +853,7 @@ fn iterdir(
 
     if let Some(host_dir) = host_dir_to_merge {
         let remaining = budget.shrink(transient_usage)?;
-        let names = match list_visible_real_dir_entry_names(&host_dir, ctx.mount_host, vpath, remaining.halved()) {
+        let names = match list_visible_real_dir_entry_names(ctx.mount_dir, &host_dir, vpath, remaining.halved()) {
             Ok(names) => names,
             Err(error @ MountError::MemoryUsageLimitExceeded(_)) => return Err(error),
             Err(_) => Vec::new(),
@@ -910,8 +907,8 @@ fn rename(
         Some(OverlayEntry::Directory { .. }) => true,
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_)) => false,
         Some(OverlayEntry::Deleted) => return Err(MountError::not_found(src_vpath)),
-        None => resolve_path(src_vpath, ctx.mount_virtual, ctx.mount_host, ResolveMode::Lstat)
-            .is_ok_and(|r| r.host_path.is_dir()),
+        None => resolve_virtual_path(src_vpath, ctx.mount_virtual)
+            .is_ok_and(|target| real_is_dir(ctx.mount_dir, target.for_dir_op())),
     };
 
     reject_rename_type_mismatch(state, &dst_rel, src_is_dir, ctx, dst_vpath)?;
@@ -939,25 +936,28 @@ fn rename(
     let real_source_entry = if source_is_overlay {
         None
     } else {
-        // Use Lstat so symlinks are detected without following them,
-        // matching the direct-mode rename behavior.
-        let resolved = resolve_path(src_vpath, ctx.mount_virtual, ctx.mount_host, ResolveMode::Lstat)?;
-        let entry = if resolved.host_path.is_symlink() {
-            // Block symlinks whose target escapes the mount boundary — allowing
-            // them into the overlay as a `RealFileRef` would let subsequent
-            // reads bypass boundary checks and leak host files.
-            reject_escaping_symlink(&resolved.host_path, ctx.mount_host, src_vpath)?;
+        let target = resolve_virtual_path(src_vpath, ctx.mount_virtual)?;
+        let rel = target.for_dir_op();
+        let is_symlink = ctx.mount_dir.symlink_metadata(rel).is_ok_and(|meta| meta.is_symlink());
+        let entry = if is_symlink {
+            // A stored reference could not escape anyway, but failing here puts
+            // the error where the user caused it rather than on a later read.
+            if ctx.mount_dir.metadata(rel).is_err() {
+                return Err(MountError::PathEscape {
+                    virtual_path: src_vpath.to_owned(),
+                });
+            }
             // Preserve the symlink entry itself rather than its target.
-            OverlayFileRef::from_lstat(&resolved.host_path)
+            OverlayFileRef::from_lstat(ctx.mount_dir, rel)
                 .map(OverlayEntry::RealFileRef)
                 .ok_or_else(|| MountError::not_found(src_vpath))?
-        } else if resolved.host_path.is_file() {
-            OverlayFileRef::from_host_path(&resolved.host_path)
+        } else if real_is_file(ctx.mount_dir, rel) {
+            OverlayFileRef::from_relative(ctx.mount_dir, rel)
                 .map(OverlayEntry::RealFileRef)
                 .ok_or_else(|| MountError::not_found(src_vpath))?
-        } else if resolved.host_path.is_dir() {
+        } else if real_is_dir(ctx.mount_dir, rel) {
             OverlayEntry::Directory {
-                mtime: dir_mtime(&resolved.host_path),
+                mtime: dir_mtime(ctx.mount_dir, rel),
             }
         } else {
             return Err(MountError::not_found(src_vpath));
@@ -993,9 +993,12 @@ fn rename(
             overlay_moves.push((key, new_key));
         }
 
-        if let Ok(resolved) = resolve_path(src_vpath, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing) {
+        if let Ok(target) = resolve_virtual_path(src_vpath, ctx.mount_virtual)
+            && real_is_dir(ctx.mount_dir, target.for_dir_op())
+        {
             let real_children = match collect_real_descendants(
-                &resolved.host_path,
+                ctx.mount_dir,
+                target.for_dir_op(),
                 &src_prefix,
                 state,
                 &handled_keys,
@@ -1065,13 +1068,11 @@ fn reject_rename_type_mismatch(
     let dst_is_dir = match state.get(dst_rel) {
         Some(OverlayEntry::Directory { .. }) => Some(true),
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_)) => Some(false),
-        Some(OverlayEntry::Deleted) | None => {
-            match resolve_path(dst_vpath, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing) {
-                Ok(resolved) if resolved.host_path.is_dir() => Some(true),
-                Ok(resolved) if resolved.host_path.exists() => Some(false),
-                _ => None,
-            }
-        }
+        Some(OverlayEntry::Deleted) | None => match resolve_virtual_path(dst_vpath, ctx.mount_virtual) {
+            Ok(target) if real_is_dir(ctx.mount_dir, target.for_dir_op()) => Some(true),
+            Ok(target) if ctx.mount_dir.exists(target.for_dir_op()) => Some(false),
+            _ => None,
+        },
     };
 
     match dst_is_dir {
@@ -1099,8 +1100,8 @@ fn reject_rename_onto_nonempty_dir(
     let dst_is_dir = match state.get(dst_rel) {
         Some(OverlayEntry::Directory { .. }) => true,
         Some(OverlayEntry::Deleted | OverlayEntry::File(_) | OverlayEntry::RealFileRef(_)) => return Ok(()),
-        None => match resolve_path(dst_vpath, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing) {
-            Ok(resolved) if resolved.host_path.is_dir() => true,
+        None => match resolve_virtual_path(dst_vpath, ctx.mount_virtual) {
+            Ok(target) if real_is_dir(ctx.mount_dir, target.for_dir_op()) => true,
             _ => return Ok(()),
         },
     };
@@ -1116,8 +1117,9 @@ fn reject_rename_onto_nonempty_dir(
             dst_vpath,
         ));
     }
-    if let Ok(resolved) = resolve_path(dst_vpath, ctx.mount_virtual, ctx.mount_host, ResolveMode::Existing)
-        && real_directory_has_visible_children(state, dst_rel, &resolved.host_path, dst_vpath)?
+    if let Ok(target) = resolve_virtual_path(dst_vpath, ctx.mount_virtual)
+        && real_is_dir(ctx.mount_dir, target.for_dir_op())
+        && real_directory_has_visible_children(state, dst_rel, ctx.mount_dir, target.for_dir_op(), dst_vpath)?
     {
         return Err(MountError::io_err(
             ErrorKind::DirectoryNotEmpty,
@@ -1131,10 +1133,11 @@ fn reject_rename_onto_nonempty_dir(
 
 /// Recursively collects real descendants that should follow an overlay rename.
 ///
-/// Each captured entry is charged for its key, its host path, and
+/// Each captured entry is charged for its key, its relative path, and
 /// [`REAL_DESCENDANT_MEMORY_USAGE`] of container overhead against `budget`.
 fn collect_real_descendants(
-    host_dir: &Path,
+    dir: &Dir,
+    root_rel: &str,
     prefix: &str,
     state: &OverlayState,
     already_handled: &AHashSet<String>,
@@ -1142,13 +1145,13 @@ fn collect_real_descendants(
     budget: MemoryBudget,
 ) -> Result<Vec<(String, OverlayEntry)>, MountError> {
     let mut result = Vec::new();
-    let mut dirs = vec![(host_dir.to_path_buf(), prefix.to_owned())];
-    let mut memory_usage = as_u64(host_dir.as_os_str().len().saturating_add(prefix.len()));
+    let mut dirs = vec![(root_rel.to_owned(), prefix.to_owned())];
+    let mut memory_usage = as_u64(root_rel.len().saturating_add(prefix.len()));
 
-    while let Some((dir, rel_prefix)) = dirs.pop() {
-        let entries = fs::read_dir(&dir).map_err(|error| MountError::Io(error, vpath.to_owned()))?;
+    while let Some((current_rel, rel_prefix)) = dirs.pop() {
+        let entries = dir.read_dir(&current_rel).map_err(|error| map_io(error, vpath))?;
         for entry in entries {
-            let entry = entry.map_err(|error| MountError::Io(error, vpath.to_owned()))?;
+            let entry = entry.map_err(|error| map_io(error, vpath))?;
             let name = entry.file_name();
             let name = name.to_string_lossy();
             let rel_key = format!("{rel_prefix}{name}");
@@ -1168,11 +1171,12 @@ fn collect_real_descendants(
             if file_type.is_symlink() {
                 continue;
             }
+            let child_rel = join_relative(&current_rel, &name);
             if file_type.is_file() {
-                if let Some(file_ref) = OverlayFileRef::from_host_path(&entry.path()) {
+                if let Some(file_ref) = OverlayFileRef::from_relative(dir, &child_rel) {
                     memory_usage = memory_usage
                         .saturating_add(as_u64(rel_key.len()))
-                        .saturating_add(as_u64(file_ref.host_path.as_os_str().len()))
+                        .saturating_add(as_u64(file_ref.relative.len()))
                         .saturating_add(REAL_DESCENDANT_MEMORY_USAGE);
                     budget.check(memory_usage)?;
                     result.push((rel_key, OverlayEntry::RealFileRef(file_ref)));
@@ -1180,19 +1184,18 @@ fn collect_real_descendants(
             } else if file_type.is_dir() {
                 // Directory keys are charged twice: the result entry and the
                 // recursion-queue prefix.
-                let entry_path = entry.path();
                 memory_usage = memory_usage
                     .saturating_add(as_u64(rel_key.len().saturating_mul(2)))
-                    .saturating_add(as_u64(entry_path.as_os_str().len()))
+                    .saturating_add(as_u64(child_rel.len()))
                     .saturating_add(REAL_DESCENDANT_MEMORY_USAGE);
                 budget.check(memory_usage)?;
                 result.push((
                     rel_key.clone(),
                     OverlayEntry::Directory {
-                        mtime: dir_mtime(&entry_path),
+                        mtime: dir_mtime(dir, &child_rel),
                     },
                 ));
-                dirs.push((entry_path, format!("{rel_key}/")));
+                dirs.push((child_rel, format!("{rel_key}/")));
             }
         }
     }
@@ -1204,22 +1207,37 @@ fn collect_real_descendants(
 ///
 /// Overlay existence-style queries intentionally collapse host-side I/O misses
 /// into `Missing` so they return `false` instead of raising.
-fn resolve_real_path_state(
-    vpath: &str,
-    ctx: &MountContext<'_>,
-    mode: ResolveMode,
-) -> Result<RealPathState, MountError> {
-    match resolve_path(vpath, ctx.mount_virtual, ctx.mount_host, mode) {
-        Ok(resolved) => Ok(RealPathState::Present(resolved.host_path)),
-        Err(MountError::Io(_, _)) => Ok(RealPathState::Missing),
-        Err(err) => Err(err),
+fn resolve_real_path_state(vpath: &str, ctx: &MountContext<'_>, follow: Follow) -> Result<RealPathState, MountError> {
+    let target = match resolve_virtual_path(vpath, ctx.mount_virtual) {
+        Ok(target) => target,
+        Err(MountError::Io(_, _)) => return Ok(RealPathState::Missing),
+        Err(err) => return Err(err),
+    };
+    let rel = target.for_dir_op();
+    let exists = match follow {
+        Follow::Yes => ctx.mount_dir.metadata(rel).is_ok(),
+        Follow::No => ctx.mount_dir.symlink_metadata(rel).is_ok(),
+    };
+    if exists {
+        Ok(RealPathState::Present(rel.to_owned()))
+    } else {
+        Ok(RealPathState::Missing)
     }
+}
+
+/// Whether a lookup follows a final symlink, replacing the old resolve modes.
+#[derive(Clone, Copy)]
+enum Follow {
+    /// Resolve the target, as `stat` does.
+    Yes,
+    /// Report the entry itself, as `lstat` does.
+    No,
 }
 
 /// Result of resolving a real fallthrough path for overlay queries.
 enum RealPathState {
-    /// The path exists and can be queried on the host.
-    Present(PathBuf),
+    /// The path exists; the payload is its mount-relative form.
+    Present(String),
     /// The path should behave as nonexistent.
     Missing,
 }

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -13,9 +13,8 @@ use monty_types::{FileMode, MontyObject, dir_stat, file_stat};
 use super::{
     common::{
         LISTING_ENTRY_MEMORY_USAGE, MemoryBudget, MountContext, as_u64, bytes_to_utf8, check_write_limit,
-        commit_write_bytes, current_timestamp, dir_mtime, format_child_path, is_dir as real_is_dir,
-        is_file as real_is_file, join_relative, list_visible_real_dir_entry_names, map_io, read_bytes_fs, read_text_fs,
-        stat_fs,
+        commit_write_bytes, current_timestamp, format_child_path, host_dir_mtime, host_is_dir, host_is_file,
+        host_list_visible_dir_entry_names, host_read_bytes, host_read_text, host_stat, join_mount_relative, map_io,
     },
     dispatch::{FsRequest, file_handle_result},
     error::MountError,
@@ -116,7 +115,7 @@ fn open(
                 }
                 Some(OverlayEntry::Deleted) => return Err(MountError::not_found(path)),
                 None => match resolve_real_path_state(path, ctx, Follow::Yes, OnLookupFailure::Propagate)? {
-                    RealPathState::Present(rel) if real_is_dir(ctx.mount_dir, &rel) => {
+                    RealPathState::Present(rel) if host_is_dir(ctx.mount_dir, &rel) => {
                         return Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", path));
                     }
                     RealPathState::Present(_) => {}
@@ -173,7 +172,7 @@ fn ensure_append_target_exists(
             Ok(())
         }
         None => match resolve_real_path_state(vpath, ctx, Follow::Yes, OnLookupFailure::Propagate)? {
-            RealPathState::Present(rel) if real_is_dir(ctx.mount_dir, &rel) => {
+            RealPathState::Present(rel) if host_is_dir(ctx.mount_dir, &rel) => {
                 Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
             }
             RealPathState::Present(_) => Ok(()),
@@ -222,7 +221,7 @@ fn is_file(
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_)) => true,
         Some(OverlayEntry::Directory { .. } | OverlayEntry::Deleted) => false,
         None => match resolve_real_path_state(vpath, ctx, Follow::Yes, OnLookupFailure::Missing)? {
-            RealPathState::Present(rel) => real_is_file(ctx.mount_dir, &rel),
+            RealPathState::Present(rel) => host_is_file(ctx.mount_dir, &rel),
             RealPathState::Missing => false,
         },
     };
@@ -240,7 +239,7 @@ fn is_dir(
         Some(OverlayEntry::Directory { .. }) => true,
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_) | OverlayEntry::Deleted) => false,
         None => match resolve_real_path_state(vpath, ctx, Follow::Yes, OnLookupFailure::Missing)? {
-            RealPathState::Present(rel) => real_is_dir(ctx.mount_dir, &rel),
+            RealPathState::Present(rel) => host_is_dir(ctx.mount_dir, &rel),
             RealPathState::Missing => false,
         },
     };
@@ -277,7 +276,7 @@ fn read_text(
             Ok(MontyObject::String(bytes_to_utf8(file.content.clone())?))
         }
         Some(OverlayEntry::RealFileRef(file_ref)) => {
-            read_text_fs(ctx.mount_dir, &file_ref.relative, vpath, available_memory(state, ctx)?)
+            host_read_text(ctx.mount_dir, &file_ref.relative, vpath, available_memory(state, ctx)?)
         }
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
@@ -285,7 +284,7 @@ fn read_text(
         Some(OverlayEntry::Deleted) => Err(MountError::not_found(vpath)),
         None => {
             let target = resolve_virtual_path(vpath, ctx.mount_virtual)?;
-            read_text_fs(ctx.mount_dir, target.for_dir_op(), vpath, available_memory(state, ctx)?)
+            host_read_text(ctx.mount_dir, target.for_dir_op(), vpath, available_memory(state, ctx)?)
         }
     }
 }
@@ -303,7 +302,7 @@ fn read_bytes(
             Ok(MontyObject::Bytes(file.content.clone()))
         }
         Some(OverlayEntry::RealFileRef(file_ref)) => {
-            read_bytes_fs(ctx.mount_dir, &file_ref.relative, vpath, available_memory(state, ctx)?)
+            host_read_bytes(ctx.mount_dir, &file_ref.relative, vpath, available_memory(state, ctx)?)
         }
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
@@ -311,7 +310,7 @@ fn read_bytes(
         Some(OverlayEntry::Deleted) => Err(MountError::not_found(vpath)),
         None => {
             let target = resolve_virtual_path(vpath, ctx.mount_virtual)?;
-            read_bytes_fs(ctx.mount_dir, target.for_dir_op(), vpath, available_memory(state, ctx)?)
+            host_read_bytes(ctx.mount_dir, target.for_dir_op(), vpath, available_memory(state, ctx)?)
         }
     }
 }
@@ -483,18 +482,18 @@ fn existing_file_bytes(
         }
         Some(OverlayEntry::Deleted) => Ok(Vec::new()),
         Some(OverlayEntry::RealFileRef(file_ref)) => {
-            match read_bytes_fs(ctx.mount_dir, &file_ref.relative, vpath, budget)? {
+            match host_read_bytes(ctx.mount_dir, &file_ref.relative, vpath, budget)? {
                 MontyObject::Bytes(bytes) => Ok(bytes),
-                _ => unreachable!("read_bytes_fs should return bytes"),
+                _ => unreachable!("host_read_bytes should return bytes"),
             }
         }
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
         }
         None => match resolve_real_path_state(vpath, ctx, Follow::Yes, OnLookupFailure::Propagate)? {
-            RealPathState::Present(rel) => match read_bytes_fs(ctx.mount_dir, &rel, vpath, budget)? {
+            RealPathState::Present(rel) => match host_read_bytes(ctx.mount_dir, &rel, vpath, budget)? {
                 MontyObject::Bytes(bytes) => Ok(bytes),
-                _ => unreachable!("read_bytes_fs should return bytes"),
+                _ => unreachable!("host_read_bytes should return bytes"),
             },
             RealPathState::Missing => Ok(Vec::new()),
         },
@@ -541,7 +540,7 @@ fn relative_dir_exists(state: &OverlayState, relative: &str, ctx: &MountContext<
         None => {
             let parent_vpath = format!("{}/{relative}", ctx.mount_virtual);
             resolve_virtual_path(&parent_vpath, ctx.mount_virtual)
-                .is_ok_and(|target| real_is_dir(ctx.mount_dir, target.for_dir_op()))
+                .is_ok_and(|target| host_is_dir(ctx.mount_dir, target.for_dir_op()))
         }
     }
 }
@@ -631,14 +630,14 @@ fn create_overlay_parents(state: &mut OverlayState, relative: &str, ctx: &MountC
             None => {
                 let current_vpath = format!("{}/{current}", ctx.mount_virtual);
                 if let Ok(resolved) = resolve_virtual_path(&current_vpath, ctx.mount_virtual) {
-                    if real_is_file(ctx.mount_dir, resolved.for_dir_op()) {
+                    if host_is_file(ctx.mount_dir, resolved.for_dir_op()) {
                         return Err(MountError::io_err(
                             ErrorKind::NotADirectory,
                             "Not a directory",
                             &current_vpath,
                         ));
                     }
-                    if real_is_dir(ctx.mount_dir, resolved.for_dir_op()) {
+                    if host_is_dir(ctx.mount_dir, resolved.for_dir_op()) {
                         continue;
                     }
                 }
@@ -675,10 +674,10 @@ fn unlink(
         Some(OverlayEntry::Deleted) => Err(MountError::not_found(vpath)),
         None => {
             let resolved = resolve_virtual_path(vpath, ctx.mount_virtual)?;
-            if real_is_file(ctx.mount_dir, resolved.for_dir_op()) {
+            if host_is_file(ctx.mount_dir, resolved.for_dir_op()) {
                 state.insert(relative.to_owned(), OverlayEntry::Deleted, ctx.memory_usage_limit)?;
                 Ok(MontyObject::None)
-            } else if real_is_dir(ctx.mount_dir, resolved.for_dir_op()) {
+            } else if host_is_dir(ctx.mount_dir, resolved.for_dir_op()) {
                 Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
             } else {
                 Err(MountError::not_found(vpath))
@@ -713,7 +712,7 @@ fn rmdir(
         None => {
             let resolved = resolve_virtual_path(vpath, ctx.mount_virtual)?;
             let rel = resolved.for_dir_op();
-            if !real_is_dir(ctx.mount_dir, rel) {
+            if !host_is_dir(ctx.mount_dir, rel) {
                 // `resolve_virtual_path` never touches the filesystem, so a
                 // missing path arrives as `Ok` and must be told apart from one
                 // that exists but is not a directory.
@@ -793,7 +792,7 @@ fn stat(state: &OverlayState, relative: &str, ctx: &MountContext<'_>, vpath: &st
         Some(OverlayEntry::Deleted) => Err(MountError::not_found(vpath)),
         None => {
             let target = resolve_virtual_path(vpath, ctx.mount_virtual)?;
-            stat_fs(ctx.mount_dir, target.for_dir_op(), vpath)
+            host_stat(ctx.mount_dir, target.for_dir_op(), vpath)
         }
     }
 }
@@ -812,7 +811,7 @@ fn iterdir(
         }
         Some(OverlayEntry::Deleted) => return Err(MountError::not_found(vpath)),
         None => match resolve_virtual_path(vpath, ctx.mount_virtual) {
-            Ok(target) if real_is_dir(ctx.mount_dir, target.for_dir_op()) => Some(target.for_dir_op().to_owned()),
+            Ok(target) if host_is_dir(ctx.mount_dir, target.for_dir_op()) => Some(target.for_dir_op().to_owned()),
             // `resolve_virtual_path` never touches the filesystem, so a missing
             // path arrives as `Ok` and must be told apart from a non-directory.
             Ok(target) if !ctx.mount_dir.exists(target.for_dir_op()) => return Err(MountError::not_found(vpath)),
@@ -853,7 +852,7 @@ fn iterdir(
 
     if let Some(host_dir) = host_dir_to_merge {
         let remaining = budget.shrink(transient_usage)?;
-        let names = match list_visible_real_dir_entry_names(ctx.mount_dir, &host_dir, vpath, remaining.halved()) {
+        let names = match host_list_visible_dir_entry_names(ctx.mount_dir, &host_dir, vpath, remaining.halved()) {
             Ok(names) => names,
             Err(error @ MountError::MemoryUsageLimitExceeded(_)) => return Err(error),
             Err(_) => Vec::new(),
@@ -914,7 +913,7 @@ fn rename(
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_)) => false,
         Some(OverlayEntry::Deleted) => return Err(MountError::not_found(src_vpath)),
         None => resolve_virtual_path(src_vpath, ctx.mount_virtual)
-            .is_ok_and(|target| real_is_dir(ctx.mount_dir, target.for_dir_op())),
+            .is_ok_and(|target| host_is_dir(ctx.mount_dir, target.for_dir_op())),
     };
 
     reject_rename_type_mismatch(state, &dst_rel, src_is_dir, ctx, dst_vpath)?;
@@ -957,13 +956,13 @@ fn rename(
             OverlayFileRef::from_lstat(ctx.mount_dir, rel)
                 .map(OverlayEntry::RealFileRef)
                 .ok_or_else(|| MountError::not_found(src_vpath))?
-        } else if real_is_file(ctx.mount_dir, rel) {
+        } else if host_is_file(ctx.mount_dir, rel) {
             OverlayFileRef::from_relative(ctx.mount_dir, rel)
                 .map(OverlayEntry::RealFileRef)
                 .ok_or_else(|| MountError::not_found(src_vpath))?
-        } else if real_is_dir(ctx.mount_dir, rel) {
+        } else if host_is_dir(ctx.mount_dir, rel) {
             OverlayEntry::Directory {
-                mtime: dir_mtime(ctx.mount_dir, rel),
+                mtime: host_dir_mtime(ctx.mount_dir, rel),
             }
         } else {
             return Err(MountError::not_found(src_vpath));
@@ -1000,7 +999,7 @@ fn rename(
         }
 
         if let Ok(target) = resolve_virtual_path(src_vpath, ctx.mount_virtual)
-            && real_is_dir(ctx.mount_dir, target.for_dir_op())
+            && host_is_dir(ctx.mount_dir, target.for_dir_op())
         {
             let real_children = match collect_real_descendants(
                 ctx.mount_dir,
@@ -1086,7 +1085,7 @@ fn reject_rename_type_mismatch(
         Some(OverlayEntry::Directory { .. }) => Some(true),
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_)) => Some(false),
         Some(OverlayEntry::Deleted) | None => match resolve_virtual_path(dst_vpath, ctx.mount_virtual) {
-            Ok(target) if real_is_dir(ctx.mount_dir, target.for_dir_op()) => Some(true),
+            Ok(target) if host_is_dir(ctx.mount_dir, target.for_dir_op()) => Some(true),
             Ok(target) if ctx.mount_dir.exists(target.for_dir_op()) => Some(false),
             _ => None,
         },
@@ -1118,7 +1117,7 @@ fn reject_rename_onto_nonempty_dir(
         Some(OverlayEntry::Directory { .. }) => true,
         Some(OverlayEntry::Deleted | OverlayEntry::File(_) | OverlayEntry::RealFileRef(_)) => return Ok(()),
         None => match resolve_virtual_path(dst_vpath, ctx.mount_virtual) {
-            Ok(target) if real_is_dir(ctx.mount_dir, target.for_dir_op()) => true,
+            Ok(target) if host_is_dir(ctx.mount_dir, target.for_dir_op()) => true,
             _ => return Ok(()),
         },
     };
@@ -1135,7 +1134,7 @@ fn reject_rename_onto_nonempty_dir(
         ));
     }
     if let Ok(target) = resolve_virtual_path(dst_vpath, ctx.mount_virtual)
-        && real_is_dir(ctx.mount_dir, target.for_dir_op())
+        && host_is_dir(ctx.mount_dir, target.for_dir_op())
         && real_directory_has_visible_children(state, dst_rel, ctx.mount_dir, target.for_dir_op(), dst_vpath)?
     {
         return Err(MountError::io_err(
@@ -1188,7 +1187,7 @@ fn collect_real_descendants(
             if file_type.is_symlink() {
                 continue;
             }
-            let child_rel = join_relative(&current_rel, &name);
+            let child_rel = join_mount_relative(&current_rel, &name);
             if file_type.is_file() {
                 if let Some(file_ref) = OverlayFileRef::from_relative(dir, &child_rel) {
                     memory_usage = memory_usage
@@ -1209,7 +1208,7 @@ fn collect_real_descendants(
                 result.push((
                     rel_key.clone(),
                     OverlayEntry::Directory {
-                        mtime: dir_mtime(dir, &child_rel),
+                        mtime: host_dir_mtime(dir, &child_rel),
                     },
                 ));
                 dirs.push((child_rel, format!("{rel_key}/")));

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -178,7 +178,10 @@ fn ensure_append_target_exists(
                 RealTarget::Symlink => Err(MountError::PathEscape {
                     virtual_path: vpath.to_owned(),
                 }),
-                RealTarget::File => Ok(()),
+                // The file is already there, but the write policy still refuses
+                // a symlink anywhere in the path; checking it here rather than
+                // at the first append makes `open` fail where the user asked.
+                RealTarget::File => ensure_parent_exists(state, &relative, ctx, vpath),
                 RealTarget::Absent => {
                     ensure_parent_exists(state, &relative, ctx, vpath)?;
                     state.insert(

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -1059,8 +1059,17 @@ fn rename(
                 remaining,
             ) {
                 Ok(children) => children,
-                Err(error @ MountError::MemoryUsageLimitExceeded(_)) => return Err(error),
-                Err(_) => Vec::new(),
+                // Lookup failures degrade to "no real children" (the host may
+                // have removed them mid-plan), but resource errors and
+                // unrepresentable names must fail the rename rather than
+                // silently shrink it.
+                Err(error) => match &error {
+                    MountError::MemoryUsageLimitExceeded(_) => return Err(error),
+                    MountError::Io(io_error, _) if io_error.kind() == ErrorKind::InvalidData => {
+                        return Err(error);
+                    }
+                    _ => Vec::new(),
+                },
             };
             for (old_rel, child_entry) in real_children {
                 let new_rel = format!("{dst_prefix}{}", old_rel.strip_prefix(&src_prefix).unwrap_or(&old_rel));
@@ -1201,6 +1210,9 @@ fn reject_rename_onto_nonempty_dir(
 ///
 /// Each captured entry is charged for its key, its relative path, and
 /// [`REAL_DESCENDANT_MEMORY_USAGE`] of container overhead against `budget`.
+/// A descendant whose name is not valid UTF-8 fails the collection (and so the
+/// rename) with `OSError`: overlay keys are `String`s, so such an entry cannot
+/// follow the move and must not be silently dropped.
 fn collect_real_descendants(
     dir: &Dir,
     root_rel: &str,
@@ -1219,7 +1231,17 @@ fn collect_real_descendants(
         for entry in entries {
             let entry = entry.map_err(|error| map_io(error, vpath))?;
             let name = entry.file_name();
-            let name = name.to_string_lossy();
+            // A non-UTF-8 name has no overlay-key representation, so the entry
+            // cannot follow the rename. Refuse the whole operation: a lossy key
+            // would look up a path that does not exist, silently leaving the
+            // file behind in a directory the overlay then claims is deleted.
+            let Some(name) = name.to_str() else {
+                return Err(MountError::io_err(
+                    ErrorKind::InvalidData,
+                    "directory contains an entry with a non-UTF-8 name",
+                    vpath,
+                ));
+            };
             let rel_key = format!("{rel_prefix}{name}");
 
             if state.get(&rel_key).is_some() || already_handled.contains(&rel_key) {
@@ -1237,7 +1259,7 @@ fn collect_real_descendants(
             if file_type.is_symlink() {
                 continue;
             }
-            let child_rel = join_mount_relative(&current_rel, &name);
+            let child_rel = join_mount_relative(&current_rel, name);
             if file_type.is_file() {
                 if let Some(file_ref) = OverlayFileRef::from_relative(dir, &child_rel) {
                     memory_usage = memory_usage

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -35,8 +35,8 @@ const REAL_DESCENDANT_MEMORY_USAGE: u64 = 512;
 /// Keys never reach a host path, but are rejected on the same grounds one
 /// would be — a name only this mode accepts is a divergence in itself.
 fn relative_path(path: &str, ctx: &MountContext<'_>) -> Result<String, MountError> {
+    reject_overlong_path(path)?;
     let normalized = normalize_virtual_path(path);
-    reject_overlong_path(&normalized, path)?;
     let relative = strip_mount_prefix(&normalized, ctx.mount_virtual)
         .map(str::to_owned)
         .ok_or_else(|| MountError::NoMountPoint(path.to_owned()))?;

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -895,6 +895,12 @@ fn rename(
     let src_rel = relative_path(src_vpath, ctx)?;
     let dst_rel = relative_path(dst_vpath, ctx)?;
 
+    // The mount root has no name inside the mount. The descriptor would refuse,
+    // but the overlay commits its in-memory plan first, so it has to refuse too
+    // or the two backends disagree.
+    reject_mount_root_rename(&src_rel, src_vpath)?;
+    reject_mount_root_rename(&dst_rel, dst_vpath)?;
+
     ensure_parent_exists(state, &dst_rel, ctx, dst_vpath)?;
 
     if matches!(state.get(&src_rel), Some(OverlayEntry::Deleted)) {
@@ -1051,6 +1057,17 @@ fn rename(
     }
 
     Ok(MontyObject::None)
+}
+
+/// Refuses to rename the mount root, which has no name inside the mount.
+fn reject_mount_root_rename(relative: &str, vpath: &str) -> Result<(), MountError> {
+    if relative.is_empty() {
+        Err(MountError::PathEscape {
+            virtual_path: vpath.to_owned(),
+        })
+    } else {
+        Ok(())
+    }
 }
 
 /// Rejects rename when the source and destination types are incompatible.

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -693,6 +693,10 @@ fn rmdir(
     ctx: &MountContext<'_>,
     vpath: &str,
 ) -> Result<MontyObject, MountError> {
+    // Without this guard the root would tombstone in memory while writes to
+    // its children kept succeeding — self-contradictory state the direct
+    // backend refuses to enter.
+    reject_mount_root(relative, vpath)?;
     match state.get(relative) {
         Some(OverlayEntry::Directory { .. }) => {
             if overlay_directory_has_children(state, relative) {
@@ -897,8 +901,8 @@ fn rename(
     // The mount root has no name inside the mount. The descriptor would refuse,
     // but the overlay commits its in-memory plan first, so it has to refuse too
     // or the two backends disagree.
-    reject_mount_root_rename(&src_rel, src_vpath)?;
-    reject_mount_root_rename(&dst_rel, dst_vpath)?;
+    reject_mount_root(&src_rel, src_vpath)?;
+    reject_mount_root(&dst_rel, dst_vpath)?;
 
     ensure_parent_exists(state, &dst_rel, ctx, dst_vpath)?;
 
@@ -1058,8 +1062,10 @@ fn rename(
     Ok(MontyObject::None)
 }
 
-/// Refuses to rename the mount root, which has no name inside the mount.
-fn reject_mount_root_rename(relative: &str, vpath: &str) -> Result<(), MountError> {
+/// Refuses to rename or remove the mount root, which has no name inside the
+/// mount — matching the direct backend's guard, since the overlay commits its
+/// in-memory plan before any descriptor could refuse.
+fn reject_mount_root(relative: &str, vpath: &str) -> Result<(), MountError> {
     if relative.is_empty() {
         Err(MountError::PathEscape {
             virtual_path: vpath.to_owned(),

--- a/crates/monty-fs/src/overlay_state.rs
+++ b/crates/monty-fs/src/overlay_state.rs
@@ -4,15 +4,14 @@
 //! [`MountMode`](super::MountMode) definition so the public API stays easy to
 //! scan while the storage internals can evolve independently.
 
-use std::{
-    collections::BTreeMap,
-    fs, mem,
-    ops::Bound,
-    path::{Path, PathBuf},
-    time::SystemTime,
-};
+use std::{collections::BTreeMap, mem, ops::Bound};
 
-use super::{MountError, common::as_u64};
+use cap_std::fs::{Dir, Metadata};
+
+use super::{
+    MountError,
+    common::{as_u64, mtime_secs},
+};
 
 /// Conservative bookkeeping charge for each overlay map entry.
 ///
@@ -189,7 +188,7 @@ impl OverlayState {
 fn entry_memory_usage(relative_path: &str, entry: &OverlayEntry) -> u64 {
     let variable = match entry {
         OverlayEntry::File(file) => file.content.len(),
-        OverlayEntry::RealFileRef(file_ref) => file_ref.host_path.as_os_str().len(),
+        OverlayEntry::RealFileRef(file_ref) => file_ref.relative.len(),
         OverlayEntry::Directory { .. } | OverlayEntry::Deleted => 0,
     };
     base_entry_memory_usage(relative_path).saturating_add(as_u64(variable))
@@ -231,11 +230,15 @@ pub(super) struct OverlayFile {
     pub mtime: f64,
 }
 
-/// A lazy reference to a real host file preserved during overlay rename.
+/// A lazy reference to a real file preserved during overlay rename.
+///
+/// The path is *mount-relative*, so reads go back through the mount descriptor
+/// and the reference cannot come to name anything outside the mount however the
+/// host directory changes. That is what makes it safe to keep unvalidated.
 #[derive(Debug)]
 pub(super) struct OverlayFileRef {
-    /// Canonical host path for the original file contents.
-    pub host_path: PathBuf,
+    /// Path relative to the mount root.
+    pub relative: String,
     /// Modification time copied from the original file.
     pub mtime: f64,
     /// File size in bytes.
@@ -243,45 +246,26 @@ pub(super) struct OverlayFileRef {
 }
 
 impl OverlayFileRef {
-    /// Builds a lazy file reference from a host path if metadata can be read.
-    ///
-    /// Uses `fs::metadata` which follows symlinks, so the size and mtime
-    /// reflect the target file. Use [`from_lstat`](Self::from_lstat) when
-    /// the path itself is a symlink that should be preserved as-is.
+    /// Builds a lazy reference, following symlinks so size and mtime describe
+    /// the target. Use [`from_lstat`](Self::from_lstat) to preserve a symlink.
     #[must_use]
-    pub fn from_host_path(path: &Path) -> Option<Self> {
-        let metadata = fs::metadata(path).ok()?;
-        let mtime = metadata
-            .modified()
-            .unwrap_or(SystemTime::UNIX_EPOCH)
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .map_or(0.0, |duration| duration.as_secs_f64());
-        let size = i64::try_from(metadata.len()).unwrap_or(i64::MAX);
-        Some(Self {
-            host_path: path.to_path_buf(),
-            mtime,
-            size,
-        })
+    pub fn from_relative(dir: &Dir, relative: &str) -> Option<Self> {
+        Some(Self::build(&dir.metadata(relative).ok()?, relative))
     }
 
-    /// Builds a lazy file reference using `symlink_metadata` (lstat).
-    ///
-    /// Unlike [`from_host_path`](Self::from_host_path), this does not follow
-    /// symlinks. The stored `host_path` is the symlink itself, preserving
-    /// symlink identity across overlay renames.
+    /// Builds a lazy reference without following the final component, so a
+    /// symlink keeps its own identity across the rename.
     #[must_use]
-    pub fn from_lstat(path: &Path) -> Option<Self> {
-        let metadata = fs::symlink_metadata(path).ok()?;
-        let mtime = metadata
-            .modified()
-            .unwrap_or(SystemTime::UNIX_EPOCH)
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .map_or(0.0, |duration| duration.as_secs_f64());
-        let size = i64::try_from(metadata.len()).unwrap_or(i64::MAX);
-        Some(Self {
-            host_path: path.to_path_buf(),
-            mtime,
-            size,
-        })
+    pub fn from_lstat(dir: &Dir, relative: &str) -> Option<Self> {
+        Some(Self::build(&dir.symlink_metadata(relative).ok()?, relative))
+    }
+
+    /// Shared construction from whichever metadata the caller obtained.
+    fn build(metadata: &Metadata, relative: &str) -> Self {
+        Self {
+            relative: relative.to_owned(),
+            mtime: mtime_secs(metadata),
+            size: i64::try_from(metadata.len()).unwrap_or(i64::MAX),
+        }
     }
 }

--- a/crates/monty-fs/src/path_security.rs
+++ b/crates/monty-fs/src/path_security.rs
@@ -1,19 +1,14 @@
-//! Path resolution and security checks for filesystem mounts.
+//! Virtual path handling for filesystem mounts.
 //!
-//! This module is the sole security boundary between sandbox virtual paths and
-//! host filesystem paths. Every virtual-path lookup flows through
-//! [`resolve_path`], which performs normalization, mount membership checks,
-//! host-path construction, symlink-aware canonicalization, and final boundary
-//! validation before any host path is returned to the caller.
+//! Maps sandbox virtual paths onto mount-relative paths. This is **not** the
+//! sandbox boundary — that is the mount's `Dir` descriptor (see
+//! [`MountContext::mount_dir`]). What remains here is Monty path policy:
+//! normalization, null-byte rejection, and length limits applied uniformly
+//! across hosts.
 //!
-//! The key invariant is that sandbox code must never learn about or access
-//! filesystem state outside the mounted host directory.
+//! [`MountContext::mount_dir`]: super::common::MountContext::mount_dir
 
-use std::{
-    fs,
-    io::ErrorKind,
-    path::{Component, Path, PathBuf},
-};
+use std::io::ErrorKind;
 
 use super::error::MountError;
 
@@ -23,47 +18,49 @@ const PATH_MAX: usize = 4096;
 /// Maximum single path component length in bytes (universal `NAME_MAX`).
 const NAME_MAX: usize = 255;
 
-/// Host path returned after successful security validation.
-#[derive(Debug)]
-pub(super) struct ResolvedPath {
-    /// Validated host filesystem path suitable for the requested operation.
-    pub host_path: PathBuf,
-}
-
-/// Resolution strategy for a filesystem operation.
+/// A virtual path checked against Monty's path policy and made relative to its
+/// mount, ready to hand to a [`Dir`](cap_std::fs::Dir) method.
 ///
-/// Each mode shares the same preprocessing pipeline and only differs in how the
-/// final host path is validated and canonicalized.
-#[derive(Clone, Copy, Debug)]
-pub(super) enum ResolveMode {
-    /// Resolve an existing path by canonicalizing the full target.
-    Existing,
-    /// Resolve a path for `lstat`-style operations that must preserve the final
-    /// symlink entry rather than following it.
-    Lstat,
-    /// Resolve a creation target by canonicalizing the parent and validating
-    /// the final component.
-    Creation,
-    /// Resolve a `mkdir(parents=True)` target by walking existing ancestors and
-    /// then appending missing components lexically.
-    MkdirParents,
+/// `relative` is empty for the mount root itself; `cap-std` treats `""` as an
+/// error, so callers wanting the root use `"."` via [`Self::for_dir_op`].
+#[derive(Debug)]
+pub(super) struct MountRelativePath {
+    /// Path relative to the mount root, with no `.` or `..` components.
+    relative: String,
 }
 
-/// Resolves a virtual path into a validated host path for `mode`.
-pub(super) fn resolve_path(
+impl MountRelativePath {
+    /// The path to pass to a `Dir` method, mapping the mount root to `.`.
+    pub fn for_dir_op(&self) -> &str {
+        if self.relative.is_empty() { "." } else { &self.relative }
+    }
+
+    /// Whether this refers to the mount root rather than something inside it.
+    pub fn is_mount_root(&self) -> bool {
+        self.relative.is_empty()
+    }
+}
+
+/// Maps a virtual path into its mount-relative form, applying path policy.
+///
+/// Rejects null bytes and over-long paths/components, and resolves `.` and `..`
+/// within the *virtual* namespace so `..` cannot climb out of the sandbox's own
+/// view. Escaping the mount on the host side is not this function's job: the
+/// `Dir` descriptor makes it impossible.
+pub(super) fn resolve_virtual_path(
     virtual_path: &str,
     mount_virtual_path: &str,
-    mount_host_path: &Path,
-    mode: ResolveMode,
-) -> Result<ResolvedPath, MountError> {
-    let request = ResolutionRequest::new(virtual_path, mount_virtual_path, mount_host_path)?;
-    let host_path = match mode {
-        ResolveMode::Existing => resolve_existing(&request, mount_host_path)?,
-        ResolveMode::Lstat => resolve_lstat(&request, mount_host_path)?,
-        ResolveMode::Creation => resolve_creation(&request, mount_host_path)?,
-        ResolveMode::MkdirParents => resolve_mkdir_parents(&request, mount_host_path)?,
-    };
-    Ok(ResolvedPath { host_path })
+) -> Result<MountRelativePath, MountError> {
+    reject_null_bytes(virtual_path)?;
+
+    let normalized = normalize_virtual_path(virtual_path);
+    reject_overlong_path(&normalized, virtual_path)?;
+    let relative = strip_mount_prefix(&normalized, mount_virtual_path)
+        .ok_or_else(|| MountError::NoMountPoint(virtual_path.to_owned()))?
+        .to_owned();
+    reject_drive_or_unc_segments(&relative, &normalized)?;
+
+    Ok(MountRelativePath { relative })
 }
 
 /// Normalizes a virtual sandbox path by removing `.` and resolving `..`.
@@ -110,213 +107,13 @@ pub(super) fn strip_mount_prefix<'a>(normalized_path: &'a str, mount_virtual_pat
         .and_then(|rest| rest.strip_prefix('/'))
 }
 
-/// Shared preprocessed resolution input.
-struct ResolutionRequest {
-    /// Normalized absolute sandbox path used for boundary-safe error reporting.
-    normalized_virtual: String,
-    /// Mount-relative path inside the sandbox namespace.
-    relative: String,
-    /// Lexically joined host candidate path before mode-specific validation.
-    candidate_host: PathBuf,
-}
-
-impl ResolutionRequest {
-    /// Builds the normalized resolution request shared by all modes.
-    fn new(virtual_path: &str, mount_virtual_path: &str, mount_host_path: &Path) -> Result<Self, MountError> {
-        reject_null_bytes(virtual_path)?;
-
-        let normalized_virtual = normalize_virtual_path(virtual_path);
-        reject_overlong_path(&normalized_virtual, virtual_path)?;
-        let relative = strip_mount_prefix(&normalized_virtual, mount_virtual_path)
-            .ok_or_else(|| MountError::NoMountPoint(virtual_path.to_owned()))?
-            .to_owned();
-        reject_drive_or_unc_segments(&relative, &normalized_virtual)?;
-
-        let candidate_host = if relative.is_empty() {
-            mount_host_path.to_path_buf()
-        } else {
-            mount_host_path.join(&relative)
-        };
-        reject_parent_components(&candidate_host, &normalized_virtual)?;
-        // A join that stayed inside the mount makes this a no-op; one whose
-        // segment clobbered the base is caught before any host I/O runs. It
-        // cannot catch a symlink escape — only canonicalization sees those.
-        check_boundary(&candidate_host, mount_host_path, &normalized_virtual)?;
-
-        Ok(Self {
-            normalized_virtual,
-            relative,
-            candidate_host,
-        })
-    }
-
-    /// Returns the final path component as a UTF-8 file name.
-    fn final_component(&self) -> Result<&str, MountError> {
-        let file_name = self
-            .candidate_host
-            .file_name()
-            .ok_or_else(|| MountError::PathEscape {
-                virtual_path: self.normalized_virtual.clone(),
-            })?
-            .to_str()
-            .ok_or_else(|| MountError::PathEscape {
-                virtual_path: self.normalized_virtual.clone(),
-            })?;
-
-        if file_name.contains('/') || file_name.contains('\\') || matches!(file_name, "." | "..") {
-            return Err(MountError::PathEscape {
-                virtual_path: self.normalized_virtual.clone(),
-            });
-        }
-
-        Ok(file_name)
-    }
-}
-
-/// Resolves an existing path by canonicalizing the full target.
-fn resolve_existing(request: &ResolutionRequest, mount_host_path: &Path) -> Result<PathBuf, MountError> {
-    let canonical = fs::canonicalize(&request.candidate_host)
-        .map_err(|err| MountError::Io(err, request.normalized_virtual.clone()))?;
-    check_boundary(&canonical, mount_host_path, &request.normalized_virtual)?;
-    Ok(canonical)
-}
-
-/// Resolves a path for `lstat`-style calls without following the final component.
-fn resolve_lstat(request: &ResolutionRequest, mount_host_path: &Path) -> Result<PathBuf, MountError> {
-    if request.relative.is_empty() {
-        let canonical =
-            fs::canonicalize(mount_host_path).map_err(|err| MountError::Io(err, request.normalized_virtual.clone()))?;
-        check_boundary(&canonical, mount_host_path, &request.normalized_virtual)?;
-        return Ok(canonical);
-    }
-
-    let parent = request.candidate_host.parent().ok_or_else(|| MountError::PathEscape {
-        virtual_path: request.normalized_virtual.clone(),
-    })?;
-    let file_name = request
-        .candidate_host
-        .file_name()
-        .ok_or_else(|| MountError::PathEscape {
-            virtual_path: request.normalized_virtual.clone(),
-        })?;
-
-    let canonical_parent =
-        fs::canonicalize(parent).map_err(|err| MountError::Io(err, request.normalized_virtual.clone()))?;
-    check_boundary(&canonical_parent, mount_host_path, &request.normalized_virtual)?;
-    Ok(canonical_parent.join(file_name))
-}
-
-/// Resolves a path for creation by validating the parent directory first.
-fn resolve_creation(request: &ResolutionRequest, mount_host_path: &Path) -> Result<PathBuf, MountError> {
-    if request.candidate_host.exists() {
-        return resolve_existing(request, mount_host_path);
-    }
-
-    let parent = request.candidate_host.parent().ok_or_else(|| MountError::PathEscape {
-        virtual_path: request.normalized_virtual.clone(),
-    })?;
-    let file_name = request.final_component()?;
-
-    let canonical_parent =
-        fs::canonicalize(parent).map_err(|err| MountError::Io(err, request.normalized_virtual.clone()))?;
-    check_boundary(&canonical_parent, mount_host_path, &request.normalized_virtual)?;
-
-    let resolved_path = canonical_parent.join(file_name);
-    validate_creation_symlink_target(
-        &resolved_path,
-        &canonical_parent,
-        mount_host_path,
-        &request.normalized_virtual,
-    )?;
-    Ok(resolved_path)
-}
-
-/// Resolves a path for `mkdir(parents=True)` while checking every existing ancestor.
-fn resolve_mkdir_parents(request: &ResolutionRequest, mount_host_path: &Path) -> Result<PathBuf, MountError> {
-    if request.relative.is_empty() {
-        let canonical =
-            fs::canonicalize(mount_host_path).map_err(|err| MountError::Io(err, request.normalized_virtual.clone()))?;
-        check_boundary(&canonical, mount_host_path, &request.normalized_virtual)?;
-        return Ok(canonical);
-    }
-
-    let components: Vec<&str> = request
-        .relative
-        .split('/')
-        .filter(|component| !component.is_empty())
-        .collect();
-    let mut current = mount_host_path.to_path_buf();
-
-    for (index, component) in components.iter().enumerate() {
-        if matches!(*component, "." | "..") {
-            return Err(MountError::PathEscape {
-                virtual_path: request.normalized_virtual.clone(),
-            });
-        }
-
-        let next = current.join(component);
-        if next.exists() {
-            let canonical =
-                fs::canonicalize(&next).map_err(|err| MountError::Io(err, request.normalized_virtual.clone()))?;
-            check_boundary(&canonical, mount_host_path, &request.normalized_virtual)?;
-            current = canonical;
-        } else {
-            for remaining in &components[index..] {
-                current = current.join(remaining);
-            }
-            // The missing tail is appended lexically, so nothing else has
-            // checked it — no mode may return an unvalidated path.
-            check_boundary(&current, mount_host_path, &request.normalized_virtual)?;
-            return Ok(current);
-        }
-    }
-
-    Ok(current)
-}
-
-/// Rejects embedded null bytes before any path manipulation occurs.
-fn reject_null_bytes(virtual_path: &str) -> Result<(), MountError> {
-    if virtual_path.contains('\0') {
-        return Err(MountError::PathEscape {
-            virtual_path: virtual_path.to_owned(),
-        });
-    }
-    Ok(())
-}
-
-/// Rejects paths that exceed Linux filesystem length limits.
+/// Rejects segments a host parser treats as drive/UNC/root-absolute (`C:\x`,
+/// `C:`, `\\host\share`).
 ///
-/// Enforces `PATH_MAX` (4096) for the total normalized path and `NAME_MAX`
-/// (255) for each individual component. These match Linux defaults and are
-/// applied regardless of the host OS so the sandbox behaves consistently.
-pub(super) fn reject_overlong_path(normalized: &str, original: &str) -> Result<(), MountError> {
-    if normalized.len() > PATH_MAX {
-        return Err(MountError::io_err(
-            ErrorKind::InvalidFilename,
-            "File name too long",
-            original,
-        ));
-    }
-    for component in normalized.split('/') {
-        if component.len() > NAME_MAX {
-            return Err(MountError::io_err(
-                ErrorKind::InvalidFilename,
-                "File name too long",
-                original,
-            ));
-        }
-    }
-    Ok(())
-}
-
-/// Rejects segments a host parser treats as drive/UNC/root-absolute: on
-/// Windows `PathBuf::join` discards the mount base for `C:\x`, `C:`, or
-/// `\\host\share`, escaping before any boundary check. Runs on all hosts for
-/// consistent behavior, and must precede the `candidate_host` join.
-///
-/// `OverlayMemory` needs it too: it serves requests from memory via
-/// `overlay::relative_path`, where these segments would otherwise become valid
-/// keys that every other mode refuses.
+/// Windows parses these as a path prefix and the descriptor refuses them; Unix
+/// reads them as ordinary filenames. Rejecting everywhere keeps hosts identical.
+/// `OverlayMemory` needs it independently — its keys never reach the filesystem,
+/// so the descriptor never sees them (#655).
 pub(super) fn reject_drive_or_unc_segments(relative: &str, normalized_virtual_path: &str) -> Result<(), MountError> {
     // A backslash can only smuggle a Windows separator/UNC/root prefix; `X:` a drive.
     let has_escape_prefix = relative.contains('\\') || relative.split('/').any(is_windows_drive_prefix);
@@ -329,179 +126,54 @@ pub(super) fn reject_drive_or_unc_segments(relative: &str, normalized_virtual_pa
     }
 }
 
-/// Whether `segment` starts with a Windows drive prefix (`X:`), which
-/// `PathBuf::join` treats as base-clobbering.
+/// Whether `segment` starts with a Windows drive prefix (`X:`).
 fn is_windows_drive_prefix(segment: &str) -> bool {
     let bytes = segment.as_bytes();
     bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
 }
 
-/// Rejects `..` components in the joined host candidate as defense in depth.
-fn reject_parent_components(candidate_host_path: &Path, normalized_virtual_path: &str) -> Result<(), MountError> {
-    for component in candidate_host_path.components() {
-        if matches!(component, Component::ParentDir) {
-            return Err(MountError::PathEscape {
-                virtual_path: normalized_virtual_path.to_owned(),
-            });
-        }
-    }
-    Ok(())
-}
-
-/// Validates that creation does not follow a dangling or outbound final symlink.
-fn validate_creation_symlink_target(
-    resolved_path: &Path,
-    canonical_parent: &Path,
-    mount_host_path: &Path,
-    normalized_virtual_path: &str,
-) -> Result<(), MountError> {
-    if !resolved_path
-        .symlink_metadata()
-        .is_ok_and(|metadata| metadata.file_type().is_symlink())
-    {
-        return Ok(());
-    }
-
-    let link_target =
-        fs::read_link(resolved_path).map_err(|err| MountError::Io(err, normalized_virtual_path.to_owned()))?;
-    let resolved_target = if link_target.is_absolute() {
-        link_target
-    } else {
-        canonical_parent.join(&link_target)
-    };
-
-    let canonical_target = if let Ok(canonical) = fs::canonicalize(&resolved_target) {
-        canonical
-    } else if let Some(parent) = resolved_target.parent() {
-        match fs::canonicalize(parent) {
-            Ok(canonical_parent) => canonical_parent.join(resolved_target.file_name().unwrap_or_default()),
-            Err(_) => {
-                return Err(MountError::PathEscape {
-                    virtual_path: normalized_virtual_path.to_owned(),
-                });
-            }
-        }
-    } else {
-        return Err(MountError::PathEscape {
-            virtual_path: normalized_virtual_path.to_owned(),
-        });
-    };
-
-    check_boundary(&canonical_target, mount_host_path, normalized_virtual_path)
-}
-
-/// Returns whether `path` is already an absolute normalized sandbox path.
-fn is_already_normalized_absolute_path(path: &str) -> bool {
-    if path == "/" {
-        return true;
-    }
-    if !path.starts_with('/') || path.ends_with('/') {
-        return false;
-    }
-
-    for part in path[1..].split('/') {
-        if part.is_empty() || matches!(part, "." | "..") {
-            return false;
-        }
-    }
-
-    true
-}
-
-/// Checks whether a symlink's target escapes the mount boundary.
-///
-/// If `host_path` is a symlink, this resolves its target (relative to the
-/// symlink's parent directory) and verifies the result stays within
-/// `mount_host_path`. Returns `Err(PathEscape)` if the target escapes.
-///
-/// This prevents attacks where a symlink pointing outside the mount is
-/// renamed within the overlay, creating a `RealFileRef` that later bypasses
-/// boundary checks when the path is read.
-pub(super) fn reject_escaping_symlink(
-    host_path: &Path,
-    mount_host_path: &Path,
-    virtual_path: &str,
-) -> Result<(), MountError> {
-    let target = fs::read_link(host_path).map_err(|e| MountError::Io(e, virtual_path.to_owned()))?;
-
-    // Resolve relative targets against the symlink's parent directory.
-    let resolved = if target.is_relative() {
-        let parent = host_path.parent().ok_or_else(|| MountError::PathEscape {
-            virtual_path: virtual_path.to_owned(),
-        })?;
-        parent.join(&target)
-    } else {
-        target
-    };
-
-    // Check against the root canonicalized at mount time: re-canonicalizing
-    // would follow a mount root since replaced with an escaping symlink.
-    let canonical = fs::canonicalize(&resolved).map_err(|_| MountError::PathEscape {
-        virtual_path: virtual_path.to_owned(),
-    })?;
-
-    check_boundary(&canonical, mount_host_path, virtual_path)
-}
-
-/// Re-validates a cached overlay host path against the mount boundary,
-/// returning the canonical path to read from.
-///
-/// `RealFileRef` caches a path validated once at rename time, so a host-side
-/// process sharing the mount can re-point it before the read. Read the
-/// returned path, not the cached one, so the check and the open cannot
-/// disagree about which file they mean.
-///
-/// `mount_host_path` must be the root canonicalized at mount time
-/// (`MountContext::mount_host`) — see `reject_escaping_symlink`.
-pub(super) fn revalidate_cached_host_path(
-    host_path: &Path,
-    mount_host_path: &Path,
-    virtual_path: &str,
-) -> Result<PathBuf, MountError> {
-    let canonical = fs::canonicalize(host_path).map_err(|e| MountError::Io(e, virtual_path.to_owned()))?;
-
-    check_boundary(&canonical, mount_host_path, virtual_path)?;
-    Ok(canonical)
-}
-
-/// Ensures a host path stays within the mount boundary, component-wise.
-///
-/// Applied to canonicalized paths as the authoritative check, and to lexically
-/// joined candidates as a backstop that traps a base-clobbering segment before
-/// any host I/O. `mount_host_path` is canonical: `Mount::new` resolves it.
-fn check_boundary(candidate_path: &Path, mount_host_path: &Path, virtual_path: &str) -> Result<(), MountError> {
-    if candidate_path.starts_with(mount_host_path) {
-        Ok(())
-    } else {
+/// Rejects embedded null bytes before any path manipulation occurs.
+fn reject_null_bytes(virtual_path: &str) -> Result<(), MountError> {
+    if virtual_path.contains('\0') {
         Err(MountError::PathEscape {
             virtual_path: virtual_path.to_owned(),
         })
+    } else {
+        Ok(())
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+/// Rejects paths that exceed Linux filesystem length limits.
+///
+/// Applied regardless of host OS so the sandbox behaves identically everywhere,
+/// rather than inheriting whatever the host filesystem happens to allow.
+pub(super) fn reject_overlong_path(normalized: &str, original: &str) -> Result<(), MountError> {
+    let too_long = normalized.len() > PATH_MAX || normalized.split('/').any(|component| component.len() > NAME_MAX);
+    if too_long {
+        Err(MountError::io_err(
+            ErrorKind::InvalidFilename,
+            "File name too long",
+            original,
+        ))
+    } else {
+        Ok(())
+    }
+}
 
-    #[test]
-    fn test_normalize_virtual_path() {
-        assert_eq!(normalize_virtual_path("/data/file.txt"), "/data/file.txt");
-        assert_eq!(normalize_virtual_path("/data/./file.txt"), "/data/file.txt");
-        assert_eq!(normalize_virtual_path("/data/../etc/passwd"), "/etc/passwd");
-        assert_eq!(normalize_virtual_path("/../../../etc/passwd"), "/etc/passwd");
-        assert_eq!(normalize_virtual_path("/"), "/");
-        assert_eq!(normalize_virtual_path("/data/"), "/data");
-        assert_eq!(normalize_virtual_path("/a/b/../c/./d"), "/a/c/d");
+/// Fast path for paths already in normalized absolute form.
+fn is_already_normalized_absolute_path(path: &str) -> bool {
+    if !path.starts_with('/') {
+        return false;
+    }
+    if path == "/" {
+        return true;
+    }
+    if path.ends_with('/') {
+        return false;
     }
 
-    #[test]
-    fn test_strip_mount_prefix() {
-        assert_eq!(strip_mount_prefix("/data/file.txt", "/data"), Some("file.txt"));
-        assert_eq!(strip_mount_prefix("/data", "/data"), Some(""));
-        assert_eq!(strip_mount_prefix("/data/sub/file", "/data"), Some("sub/file"));
-        assert_eq!(strip_mount_prefix("/other/file", "/data"), None);
-        assert_eq!(strip_mount_prefix("/anything", "/"), Some("anything"));
-        assert_eq!(strip_mount_prefix("/", "/"), Some(""));
-        assert_eq!(strip_mount_prefix("/data2/file", "/data"), None);
-    }
+    !path
+        .split('/')
+        .skip(1)
+        .any(|component| component.is_empty() || component == "." || component == "..")
 }

--- a/crates/monty-fs/src/path_security.rs
+++ b/crates/monty-fs/src/path_security.rs
@@ -52,9 +52,9 @@ pub(super) fn resolve_virtual_path(
     mount_virtual_path: &str,
 ) -> Result<MountRelativePath, MountError> {
     reject_null_bytes(virtual_path)?;
+    reject_overlong_path(virtual_path)?;
 
     let normalized = normalize_virtual_path(virtual_path);
-    reject_overlong_path(&normalized, virtual_path)?;
     let relative = strip_mount_prefix(&normalized, mount_virtual_path)
         .ok_or_else(|| MountError::NoMountPoint(virtual_path.to_owned()))?
         .to_owned();
@@ -146,14 +146,18 @@ fn reject_null_bytes(virtual_path: &str) -> Result<(), MountError> {
 /// Rejects paths that exceed Linux filesystem length limits.
 ///
 /// Applied regardless of host OS so the sandbox behaves identically everywhere,
-/// rather than inheriting whatever the host filesystem happens to allow.
-pub(super) fn reject_overlong_path(normalized: &str, original: &str) -> Result<(), MountError> {
-    let too_long = normalized.len() > PATH_MAX || normalized.split('/').any(|component| component.len() > NAME_MAX);
+/// rather than inheriting whatever the host filesystem happens to allow. Measures
+/// the path as sent, before normalization: a request padded with `..` collapses
+/// short, and the kernel would reject the bytes handed to it, not the collapsed
+/// form. Checking first also keeps the per-segment normalization off oversized
+/// input.
+pub(super) fn reject_overlong_path(path: &str) -> Result<(), MountError> {
+    let too_long = path.len() > PATH_MAX || path.split('/').any(|component| component.len() > NAME_MAX);
     if too_long {
         Err(MountError::io_err(
             ErrorKind::InvalidFilename,
             "File name too long",
-            original,
+            path,
         ))
     } else {
         Ok(())

--- a/crates/monty-fs/tests/common/mod.rs
+++ b/crates/monty-fs/tests/common/mod.rs
@@ -7,24 +7,55 @@
 use std::os::unix::fs::symlink;
 #[cfg(windows)]
 use std::os::windows::fs::{symlink_dir as win_symlink_dir, symlink_file as win_symlink_file};
-use std::{fs, path::Path};
+use std::{fs, io, path::Path, sync::OnceLock};
 
-/// Cross-platform symlink to a file. Windows needs Developer Mode or elevation.
+use tempfile::TempDir;
+
+/// Cross-platform symlink to a file. Guard the test with [`symlinks_supported`].
 pub fn symlink_file(original: impl AsRef<Path>, link: impl AsRef<Path>) {
-    #[cfg(unix)]
-    symlink(original.as_ref(), link.as_ref()).expect("failed to create file symlink");
-    #[cfg(windows)]
-    win_symlink_file(original.as_ref(), link.as_ref())
-        .expect("failed to create file symlink (enable Windows Developer Mode or run elevated)");
+    try_symlink_file(original, link).expect("failed to create file symlink");
 }
 
-/// Cross-platform symlink to a directory. Windows needs Developer Mode or elevation.
+/// Cross-platform symlink to a directory. Guard the test with [`symlinks_supported`].
 pub fn symlink_dir(original: impl AsRef<Path>, link: impl AsRef<Path>) {
+    try_symlink_dir(original, link).expect("failed to create directory symlink");
+}
+
+/// Whether this host can create symlinks at all, probed once per test binary.
+///
+/// Windows needs Developer Mode or elevation; without it there is nothing under
+/// test, so symlink tests should skip rather than fail the whole suite. Keep the
+/// panicking helpers for use *after* this returns true, where a failure is a
+/// real bug rather than a missing privilege.
+pub fn symlinks_supported() -> bool {
+    static SUPPORTED: OnceLock<bool> = OnceLock::new();
+    *SUPPORTED.get_or_init(|| {
+        let Ok(dir) = TempDir::new() else {
+            return false;
+        };
+        let supported = try_symlink_file("probe-target", dir.path().join("probe-link")).is_ok();
+        if !supported {
+            eprintln!(
+                "symlink tests will skip: this host cannot create symlinks \
+                 (Windows needs Developer Mode or elevation)"
+            );
+        }
+        supported
+    })
+}
+
+fn try_symlink_file(original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
     #[cfg(unix)]
-    symlink(original.as_ref(), link.as_ref()).expect("failed to create directory symlink");
+    return symlink(original.as_ref(), link.as_ref());
     #[cfg(windows)]
-    win_symlink_dir(original.as_ref(), link.as_ref())
-        .expect("failed to create directory symlink (enable Windows Developer Mode or run elevated)");
+    return win_symlink_file(original.as_ref(), link.as_ref());
+}
+
+fn try_symlink_dir(original: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
+    #[cfg(unix)]
+    return symlink(original.as_ref(), link.as_ref());
+    #[cfg(windows)]
+    return win_symlink_dir(original.as_ref(), link.as_ref());
 }
 
 /// Renames a mount's host directory, reporting whether the OS allowed it.

--- a/crates/monty-fs/tests/common/mod.rs
+++ b/crates/monty-fs/tests/common/mod.rs
@@ -7,7 +7,7 @@
 use std::os::unix::fs::symlink;
 #[cfg(windows)]
 use std::os::windows::fs::{symlink_dir as win_symlink_dir, symlink_file as win_symlink_file};
-use std::path::Path;
+use std::{fs, path::Path};
 
 /// Cross-platform symlink to a file. Windows needs Developer Mode or elevation.
 pub fn symlink_file(original: impl AsRef<Path>, link: impl AsRef<Path>) {
@@ -25,4 +25,17 @@ pub fn symlink_dir(original: impl AsRef<Path>, link: impl AsRef<Path>) {
     #[cfg(windows)]
     win_symlink_dir(original.as_ref(), link.as_ref())
         .expect("failed to create directory symlink (enable Windows Developer Mode or run elevated)");
+}
+
+/// Renames a mount's host directory, reporting whether the OS allowed it.
+///
+/// Windows refuses with `ERROR_SHARING_VIOLATION` while a mount holds the
+/// directory open: cap-std deliberately omits `FILE_SHARE_DELETE` for
+/// directories, so a mounted directory cannot be renamed or deleted at all.
+pub fn try_rename_mount_root(from: impl AsRef<Path>, to: impl AsRef<Path>) -> bool {
+    match fs::rename(from.as_ref(), to.as_ref()) {
+        Ok(()) => true,
+        Err(err) if cfg!(windows) && err.raw_os_error() == Some(32) => false,
+        Err(err) => panic!("unexpected rename failure: {err:?}"),
+    }
 }

--- a/crates/monty-fs/tests/fs.rs
+++ b/crates/monty-fs/tests/fs.rs
@@ -1001,6 +1001,32 @@ fn ovl_mem_rmdir_overlay() {
     );
 }
 
+/// The mount root has no name inside the mount, so renaming it must be refused
+/// in every mode.
+///
+/// Overlay mode plans its move in memory before the descriptor is consulted, so
+/// without this check it silently "succeeds" at an operation the descriptor
+/// would refuse, leaving overlay state disagreeing with the real backend.
+#[test]
+fn rename_of_mount_root_is_refused_in_both_modes() {
+    for mode in [MountMode::ReadWrite, MountMode::OverlayMemory(OverlayState::new())] {
+        let dir = create_test_dir();
+        let mut mt = mount_at_mnt(&dir, mode);
+
+        // Whichever end names the root is the one reported.
+        for (src, dst) in [("/mnt", "/mnt/moved"), ("/mnt/moved", "/mnt")] {
+            let err = call(&mut mt, &rename(src, dst)).unwrap().unwrap_err().into_exception();
+            assert_exc(&err, ExcType::PermissionError, "[Errno 13] Permission denied: '/mnt'");
+        }
+
+        // The mount must be untouched by the refusal.
+        assert_eq!(
+            call_ok(&mut mt, &OsFunctionCall::Exists("/mnt/hello.txt".into())),
+            MontyObject::Bool(true)
+        );
+    }
+}
+
 /// A missing path must be `FileNotFoundError`, not `NotADirectoryError`.
 ///
 /// `resolve_virtual_path` never touches the filesystem, so "does not exist" and

--- a/crates/monty-fs/tests/fs.rs
+++ b/crates/monty-fs/tests/fs.rs
@@ -1001,6 +1001,40 @@ fn ovl_mem_rmdir_overlay() {
     );
 }
 
+/// A missing path must be `FileNotFoundError`, not `NotADirectoryError`.
+///
+/// `resolve_virtual_path` never touches the filesystem, so "does not exist" and
+/// "exists but is not a directory" both arrive as `Ok` and must be separated
+/// here; both modes must agree.
+#[test]
+fn rmdir_nonexistent_is_not_found_in_both_modes() {
+    for mode in [MountMode::ReadWrite, MountMode::OverlayMemory(OverlayState::new())] {
+        let dir = create_test_dir();
+        let mut mt = mount_at_mnt(&dir, mode);
+
+        let err = call(&mut mt, &OsFunctionCall::Rmdir("/mnt/nonexistent_dir".into()))
+            .unwrap()
+            .unwrap_err()
+            .into_exception();
+        assert_exc(
+            &err,
+            ExcType::FileNotFoundError,
+            "[Errno 2] No such file or directory: '/mnt/nonexistent_dir'",
+        );
+
+        // The neighbouring case must keep its own error.
+        let err = call(&mut mt, &OsFunctionCall::Rmdir("/mnt/hello.txt".into()))
+            .unwrap()
+            .unwrap_err()
+            .into_exception();
+        assert_exc(
+            &err,
+            ExcType::NotADirectoryError,
+            "[Errno 20] Not a directory: '/mnt/hello.txt'",
+        );
+    }
+}
+
 #[test]
 fn ovl_mem_rename() {
     let dir = create_test_dir();
@@ -2300,7 +2334,7 @@ fn ovl_mem_rename_overlay_file_onto_overlay_dir() {
 #[cfg(unix)]
 fn ovl_mem_rename_symlink_preserves_symlink() {
     let dir = create_test_dir();
-    symlink_file(dir.path().join("hello.txt"), dir.path().join("link.txt"));
+    symlink_file("hello.txt", dir.path().join("link.txt"));
 
     let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
 

--- a/crates/monty-fs/tests/fs.rs
+++ b/crates/monty-fs/tests/fs.rs
@@ -16,7 +16,7 @@ use tempfile::TempDir;
 // Only `symlink_file` is needed here; `symlink_dir` is dead in this crate.
 #[expect(dead_code, reason = "shared helper module; not every test crate uses all of it")]
 mod common;
-use common::symlink_file;
+use common::{symlink_file, symlinks_supported};
 
 // =============================================================================
 // Helpers
@@ -220,6 +220,9 @@ fn rw_is_symlink() {
 
 #[test]
 fn rw_is_symlink_true_for_symlink() {
+    if !symlinks_supported() {
+        return;
+    }
     let dir = create_test_dir();
     symlink_file(dir.path().join("hello.txt"), dir.path().join("link.txt"));
     let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
@@ -243,6 +246,9 @@ fn rw_is_symlink_true_for_symlink() {
 
 #[test]
 fn overlay_is_symlink_true_for_symlink() {
+    if !symlinks_supported() {
+        return;
+    }
     let dir = create_test_dir();
     symlink_file(dir.path().join("hello.txt"), dir.path().join("link.txt"));
     let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
@@ -2176,6 +2182,9 @@ fn no_limit_allows_large_writes() {
 #[test]
 #[cfg(unix)]
 fn rw_unlink_symlink_removes_link_not_target() {
+    if !symlinks_supported() {
+        return;
+    }
     let dir = create_test_dir();
     symlink_file(dir.path().join("hello.txt"), dir.path().join("link.txt"));
 
@@ -2197,6 +2206,9 @@ fn rw_unlink_symlink_removes_link_not_target() {
 #[test]
 #[cfg(unix)]
 fn rw_rename_symlink_renames_link_not_target() {
+    if !symlinks_supported() {
+        return;
+    }
     let dir = create_test_dir();
     symlink_file(dir.path().join("hello.txt"), dir.path().join("link.txt"));
 
@@ -2359,6 +2371,9 @@ fn ovl_mem_rename_overlay_file_onto_overlay_dir() {
 #[test]
 #[cfg(unix)]
 fn ovl_mem_rename_symlink_preserves_symlink() {
+    if !symlinks_supported() {
+        return;
+    }
     let dir = create_test_dir();
     symlink_file("hello.txt", dir.path().join("link.txt"));
 

--- a/crates/monty-fs/tests/fs.rs
+++ b/crates/monty-fs/tests/fs.rs
@@ -1033,6 +1033,36 @@ fn rename_of_mount_root_is_refused_in_both_modes() {
     }
 }
 
+/// `rmdir` of the mount root must be refused in every mode, like rename.
+///
+/// Without the guard, overlay mode tombstoned the root in memory while writes
+/// to its children kept succeeding, and direct mode surfaced whatever errno the
+/// OS picks for `rmdir(".")`. The explicit guard gives both modes the same
+/// `PermissionError` on every platform.
+#[test]
+fn rmdir_of_mount_root_is_refused_in_both_modes() {
+    for mode in [MountMode::ReadWrite, MountMode::OverlayMemory(OverlayState::new())] {
+        let dir = create_test_dir();
+        let mut mt = mount_at_mnt(&dir, mode);
+
+        let err = call(&mut mt, &OsFunctionCall::Rmdir("/mnt".into()))
+            .unwrap()
+            .unwrap_err()
+            .into_exception();
+        assert_exc(&err, ExcType::PermissionError, "[Errno 13] Permission denied: '/mnt'");
+
+        // The refusal must leave the mount fully live, root included.
+        assert_eq!(
+            call_ok(&mut mt, &OsFunctionCall::Exists("/mnt".into())),
+            MontyObject::Bool(true)
+        );
+        assert_eq!(
+            call_ok(&mut mt, &OsFunctionCall::Exists("/mnt/hello.txt".into())),
+            MontyObject::Bool(true)
+        );
+    }
+}
+
 /// A missing path must be `FileNotFoundError`, not `NotADirectoryError`.
 ///
 /// `resolve_virtual_path` never touches the filesystem, so "does not exist" and

--- a/crates/monty-fs/tests/fs_security.rs
+++ b/crates/monty-fs/tests/fs_security.rs
@@ -449,6 +449,26 @@ mod symlink_tests {
         );
     }
 
+    /// `open(..., 'a')` on a file that already exists below an in-mount symlink
+    /// is refused at open time, not on the first append. Only the append path
+    /// takes the "target already exists" shortcut, which used to skip the
+    /// parent walk that every other overlay write runs.
+    #[test]
+    fn overlay_append_open_below_inbound_symlink_dir_is_refused() {
+        if !symlinks_supported() {
+            return;
+        }
+        let dir = create_test_dir();
+        symlink_dir("subdir", dir.path().join("link_dir"));
+
+        let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
+        assert_open_blocked(&mut mt, "/mnt/link_dir/nested.txt", "a");
+        assert_eq!(
+            fs::read_to_string(dir.path().join("subdir/nested.txt")).unwrap(),
+            "nested content"
+        );
+    }
+
     /// Even a symlink resolving to an in-mount directory blocks overlay writes
     /// through it: entries would be keyed under the link's spelling, invisible
     /// via the resolved name. Direct mode follows such links; the overlay

--- a/crates/monty-fs/tests/fs_security.rs
+++ b/crates/monty-fs/tests/fs_security.rs
@@ -1454,11 +1454,10 @@ fn rename_traversal_src() {
             dst: MontyPath::new("/mnt/stolen.txt".to_owned()),
         }),
     );
+    // The src normalizes to `/etc/passwd`, under no mount, so the rename is
+    // refused outright rather than handed to the fallback with the mounted dst.
     match result {
-        Some(Err(MountError::PathEscape { .. } | MountError::NoMountPoint(_) | MountError::Io(_, _))) => {}
-        // If src doesn't match any mount, handle_rename returns None and normal dispatch
-        // handles it — that will also fail.
-        None => {}
+        Some(Err(MountError::CrossMountRename { .. })) => {}
         other => panic!("expected rename src traversal blocked, got {other:?}"),
     }
 }
@@ -1475,14 +1474,9 @@ fn rename_traversal_dst() {
             dst: MontyPath::new("/mnt/../escape.txt".to_owned()),
         }),
     );
+    // Likewise for a dst that normalizes out of the mount.
     match result {
-        Some(Err(
-            MountError::PathEscape { .. }
-            | MountError::NoMountPoint(_)
-            | MountError::Io(_, _)
-            | MountError::CrossMountRename { .. },
-        )) => {}
-        None => {} // Also acceptable — dst doesn't match any mount.
+        Some(Err(MountError::CrossMountRename { .. })) => {}
         other => panic!("expected rename dst traversal blocked, got {other:?}"),
     }
 }

--- a/crates/monty-fs/tests/fs_security.rs
+++ b/crates/monty-fs/tests/fs_security.rs
@@ -5,7 +5,7 @@
 //! Tests cover all mount modes to ensure the security invariant holds everywhere.
 
 #[cfg(unix)]
-use std::os::unix::fs::symlink;
+use std::{ffi::OsStr, os::unix::ffi::OsStrExt, os::unix::fs::symlink};
 use std::{fmt, fs};
 
 use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable, OverlayState};
@@ -813,6 +813,35 @@ mod hard_link_tests {
         } else {
             panic!("expected List from iterdir, got {result:?}");
         }
+    }
+
+    /// An in-mount symlink whose *name* is not valid UTF-8 must still be listed.
+    ///
+    /// The in-mount check has to run against the raw directory entry: rebuilding
+    /// the path from a lossy name looks up something that does not exist, so the
+    /// link is silently dropped. Its listed name is still lossy — that predates
+    /// this and is unchanged here.
+    #[test]
+    #[cfg(unix)]
+    fn iterdir_keeps_inbound_symlink_with_non_utf8_name() {
+        let dir = create_test_dir();
+        let raw_name = OsStr::from_bytes(b"caf\xff_link");
+        if symlink("hello.txt", dir.path().join(raw_name)).is_err() {
+            // APFS and friends reject non-UTF-8 filenames outright, so the bug
+            // this guards is unobservable there. ext4 exercises it.
+            eprintln!("skipped: filesystem rejects non-UTF-8 filenames");
+            return;
+        }
+
+        let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
+        let result = call(&mut mt, PathOp::Iterdir, "/mnt").unwrap().unwrap();
+        let names = sorted_names_from_list(&result);
+
+        let lossy = raw_name.to_string_lossy().to_string();
+        assert!(
+            names.contains(&lossy),
+            "in-mount symlink with a non-UTF-8 name was dropped: {names:?}"
+        );
     }
 
     /// Overlay mode should expose the same visible real entries as direct mode:

--- a/crates/monty-fs/tests/fs_security.rs
+++ b/crates/monty-fs/tests/fs_security.rs
@@ -17,7 +17,7 @@ use tempfile::TempDir;
 
 #[expect(dead_code, reason = "shared helper module; not every test crate uses all of it")]
 mod common;
-use common::{symlink_dir, symlink_file};
+use common::{symlink_dir, symlink_file, symlinks_supported};
 
 // =============================================================================
 // Helpers
@@ -390,6 +390,9 @@ mod symlink_tests {
 
     #[test]
     fn symlink_to_outside_directory() {
+        if !symlinks_supported() {
+            return;
+        }
         let dir = create_test_dir();
         let outside = TempDir::new().unwrap();
         fs::write(outside.path().join("secret.txt"), "secret data").unwrap();
@@ -405,6 +408,9 @@ mod symlink_tests {
 
     #[test]
     fn symlink_to_outside_file() {
+        if !symlinks_supported() {
+            return;
+        }
         let dir = create_test_dir();
         let outside = TempDir::new().unwrap();
         fs::write(outside.path().join("secret.txt"), "secret").unwrap();
@@ -417,6 +423,9 @@ mod symlink_tests {
 
     #[test]
     fn symlink_open_escape() {
+        if !symlinks_supported() {
+            return;
+        }
         // `open()` on a path that escapes the mount via a symlink must be
         // rejected — for read (would read an outside file) and for write
         // (the open-time truncate would write outside the mount).
@@ -433,6 +442,9 @@ mod symlink_tests {
 
     #[test]
     fn symlink_to_parent() {
+        if !symlinks_supported() {
+            return;
+        }
         let dir = create_test_dir();
         let parent = dir.path().parent().unwrap();
 
@@ -445,6 +457,9 @@ mod symlink_tests {
     #[test]
     #[cfg(unix)] // Relative symlink targets are not supported on Windows
     fn relative_symlink_escape() {
+        if !symlinks_supported() {
+            return;
+        }
         let dir = create_test_dir();
 
         // Create symlink that uses relative path to escape.
@@ -459,6 +474,9 @@ mod symlink_tests {
     /// revealing nothing about where it points. The following predicates differ.
     #[test]
     fn is_symlink_reports_an_outbound_link_that_lives_in_the_mount() {
+        if !symlinks_supported() {
+            return;
+        }
         let dir = create_test_dir();
         let outside = TempDir::new().unwrap();
         fs::write(outside.path().join("secret.txt"), "secret").unwrap();
@@ -477,6 +495,9 @@ mod symlink_tests {
 
     #[test]
     fn symlink_escape_no_info_leak() {
+        if !symlinks_supported() {
+            return;
+        }
         // Error messages should only contain virtual path, not host path.
         let dir = create_test_dir();
         let outside = TempDir::new().unwrap();
@@ -499,6 +520,9 @@ mod symlink_tests {
 
     #[test]
     fn symlink_escape_overlay_memory() {
+        if !symlinks_supported() {
+            return;
+        }
         let dir = create_test_dir();
         let outside = TempDir::new().unwrap();
         fs::write(outside.path().join("secret.txt"), "secret").unwrap();
@@ -511,6 +535,9 @@ mod symlink_tests {
 
     #[test]
     fn symlink_within_mount_allowed() {
+        if !symlinks_supported() {
+            return;
+        }
         // Symlinks that stay within the mount boundary should work.
         let dir = create_test_dir();
         symlink_file("hello.txt", dir.path().join("internal_link"));
@@ -522,6 +549,9 @@ mod symlink_tests {
 
     #[test]
     fn symlink_to_directory_within_mount_allowed() {
+        if !symlinks_supported() {
+            return;
+        }
         // Symlink to a subdirectory within the mount should work for all operations.
         let dir = create_test_dir();
         symlink_dir("subdir", dir.path().join("dir_link"));
@@ -547,6 +577,9 @@ mod symlink_tests {
 
     #[test]
     fn chained_symlinks_within_mount_allowed() {
+        if !symlinks_supported() {
+            return;
+        }
         // A symlink pointing to another symlink, both within the mount, should work.
         let dir = create_test_dir();
         symlink_file("hello.txt", dir.path().join("link1"));
@@ -559,6 +592,9 @@ mod symlink_tests {
 
     #[test]
     fn chained_symlinks_escape_blocked() {
+        if !symlinks_supported() {
+            return;
+        }
         // A symlink within mount pointing to another symlink that escapes should be blocked.
         let dir = create_test_dir();
         let outside = TempDir::new().unwrap();
@@ -574,6 +610,9 @@ mod symlink_tests {
 
     #[test]
     fn mkdir_parents_through_symlink_escape_blocked_readwrite() {
+        if !symlinks_supported() {
+            return;
+        }
         // Regression test: mkdir(parents=True) through a symlinked ancestor must
         // not create directories outside the mount boundary in ReadWrite mode.
         let dir = create_test_dir();
@@ -600,6 +639,9 @@ mod symlink_tests {
 
     #[test]
     fn mkdir_parents_through_symlink_escape_blocked_readonly() {
+        if !symlinks_supported() {
+            return;
+        }
         // ReadOnly mode should also block mkdir through symlink escape.
         let dir = create_test_dir();
         let outside = TempDir::new().unwrap();
@@ -622,6 +664,9 @@ mod symlink_tests {
 
     #[test]
     fn mkdir_parents_through_nested_symlink_escape_blocked() {
+        if !symlinks_supported() {
+            return;
+        }
         // mkdir(parents=True) through a symlinked directory deeper in the tree.
         let dir = create_test_dir();
         let outside = TempDir::new().unwrap();
@@ -657,6 +702,9 @@ mod symlink_tests {
 
     #[test]
     fn mkdir_parents_through_internal_symlink_allowed() {
+        if !symlinks_supported() {
+            return;
+        }
         // mkdir(parents=True) through a symlink that stays within the mount is fine.
         let dir = create_test_dir();
 
@@ -739,6 +787,9 @@ mod hard_link_tests {
     #[test]
     #[cfg(unix)]
     fn broken_symlink_write_escape_blocked() {
+        if !symlinks_supported() {
+            return;
+        }
         let dir = create_test_dir();
         let outside = TempDir::new().unwrap();
         let escape_target = outside.path().join("pwned.txt");
@@ -767,6 +818,9 @@ mod hard_link_tests {
     #[test]
     #[cfg(unix)]
     fn broken_symlink_overlay_writes_to_memory_not_real_fs() {
+        if !symlinks_supported() {
+            return;
+        }
         let dir = create_test_dir();
         let outside = TempDir::new().unwrap();
         let escape_target = outside.path().join("pwned.txt");
@@ -796,6 +850,9 @@ mod hard_link_tests {
     #[test]
     #[cfg(unix)]
     fn iterdir_filters_outbound_symlinks_but_keeps_regular_and_inbound() {
+        if !symlinks_supported() {
+            return;
+        }
         let dir = create_test_dir();
         let outside = TempDir::new().unwrap();
         fs::write(outside.path().join("external.txt"), "external").unwrap();
@@ -845,6 +902,9 @@ mod hard_link_tests {
     #[test]
     #[cfg(unix)]
     fn iterdir_keeps_inbound_symlink_with_non_utf8_name() {
+        if !symlinks_supported() {
+            return;
+        }
         let dir = create_test_dir();
         let raw_name = OsStr::from_bytes(b"nonutf8\xff_link");
         if symlink("hello.txt", dir.path().join(raw_name)).is_err() {
@@ -870,6 +930,9 @@ mod hard_link_tests {
     #[test]
     #[cfg(unix)]
     fn overlay_iterdir_filters_symlinks_like_direct_mode() {
+        if !symlinks_supported() {
+            return;
+        }
         let dir = create_test_dir();
         let outside = TempDir::new().unwrap();
         fs::write(outside.path().join("external.txt"), "external").unwrap();
@@ -1139,6 +1202,9 @@ fn rename_traversal_dst() {
 ///    the outside file's contents, completely bypassing boundary checks.
 #[test]
 fn rename_symlink_escape_overlay_read_text() {
+    if !symlinks_supported() {
+        return;
+    }
     // Create the mount directory and a file *outside* it.
     let mount_dir = TempDir::new().unwrap();
     let outside_dir = TempDir::new().unwrap();
@@ -1190,6 +1256,9 @@ fn rename_symlink_escape_overlay_read_text() {
 /// Same as above but for `read_bytes`.
 #[test]
 fn rename_symlink_escape_overlay_read_bytes() {
+    if !symlinks_supported() {
+        return;
+    }
     let mount_dir = TempDir::new().unwrap();
     let outside_dir = TempDir::new().unwrap();
     let secret = b"TOP SECRET BYTES";

--- a/crates/monty-fs/tests/fs_security.rs
+++ b/crates/monty-fs/tests/fs_security.rs
@@ -388,6 +388,113 @@ fn null_byte_overlay_memory() {
 mod symlink_tests {
     use super::*;
 
+    /// Overlay writes refuse to land on a symlink, even one resolving inside
+    /// the mount: a direct mount writes *through* the link to its target, and
+    /// shadowing the link name in memory instead would silently alias the two.
+    #[test]
+    fn overlay_write_over_inbound_symlink_is_refused() {
+        if !symlinks_supported() {
+            return;
+        }
+        let dir = create_test_dir();
+        symlink_file(dir.path().join("hello.txt"), dir.path().join("link.txt"));
+
+        let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
+        let outcome = dispatch(
+            &mut mt,
+            OsFunctionCall::WriteText(PathStringDataArgs {
+                path: MontyPath::new("/mnt/link.txt".to_owned()),
+                data: "aliased".to_owned(),
+            }),
+        )
+        .unwrap();
+        assert!(
+            matches!(&outcome, Err(MountError::PathEscape { .. })),
+            "overlay write over an in-mount symlink must be refused, got {outcome:?}"
+        );
+
+        // The link's target must be untouched.
+        assert_eq!(
+            fs::read_to_string(dir.path().join("hello.txt")).unwrap(),
+            "hello world\n"
+        );
+    }
+
+    /// A dangling in-mount symlink gets the same refusal — writing "through" it
+    /// would create the target on a direct mount, which the overlay cannot do.
+    #[test]
+    fn overlay_write_over_dangling_symlink_is_refused() {
+        if !symlinks_supported() {
+            return;
+        }
+        let dir = create_test_dir();
+        symlink_file(dir.path().join("missing.txt"), dir.path().join("dangle.txt"));
+
+        let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
+        let outcome = dispatch(
+            &mut mt,
+            OsFunctionCall::WriteText(PathStringDataArgs {
+                path: MontyPath::new("/mnt/dangle.txt".to_owned()),
+                data: "ghost".to_owned(),
+            }),
+        )
+        .unwrap();
+        assert!(
+            matches!(&outcome, Err(MountError::PathEscape { .. })),
+            "overlay write over a dangling symlink must be refused, got {outcome:?}"
+        );
+        assert!(
+            !dir.path().join("missing.txt").exists(),
+            "link target must not be created"
+        );
+    }
+
+    /// Even a symlink resolving to an in-mount directory blocks overlay writes
+    /// through it: entries would be keyed under the link's spelling, invisible
+    /// via the resolved name. Direct mode follows such links; the overlay
+    /// refuses, whether the link is the immediate parent or deeper in the path.
+    #[test]
+    fn overlay_write_through_inbound_symlink_dir_is_refused() {
+        if !symlinks_supported() {
+            return;
+        }
+        let dir = create_test_dir();
+        // A relative target — an absolute one is never followed, even in-mount
+        // (see `limitations/filesystem.md`).
+        symlink_dir("subdir", dir.path().join("link_dir"));
+
+        let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
+        let outcome = dispatch(
+            &mut mt,
+            OsFunctionCall::Mkdir(MkdirCallArgs {
+                path: MontyPath::new("/mnt/link_dir/new".to_owned()),
+                parents: true,
+                exist_ok: false,
+            }),
+        )
+        .unwrap();
+        assert!(
+            matches!(&outcome, Err(MountError::PathEscape { .. })),
+            "overlay mkdir through an in-mount symlink dir must be refused, got {outcome:?}"
+        );
+
+        // The link as a non-immediate parent is caught by the component walk,
+        // not just the final-parent lookup ("subdir/deep" exists for real).
+        let outcome = dispatch(
+            &mut mt,
+            OsFunctionCall::WriteText(PathStringDataArgs {
+                path: MontyPath::new("/mnt/link_dir/deep/x.txt".to_owned()),
+                data: "aliased".to_owned(),
+            }),
+        )
+        .unwrap();
+        assert!(
+            matches!(&outcome, Err(MountError::PathEscape { .. })),
+            "overlay write below an in-mount symlink dir must be refused, got {outcome:?}"
+        );
+        assert!(!dir.path().join("subdir/deep/x.txt").exists(), "host must be untouched");
+    }
+
     #[test]
     fn symlink_to_outside_directory() {
         if !symlinks_supported() {
@@ -812,12 +919,12 @@ mod hard_link_tests {
         );
     }
 
-    /// Overlay mode writes to in-memory storage, never the real filesystem,
-    /// so a broken outbound symlink on the real FS is harmless — the overlay
-    /// simply stores the content in memory under the virtual path.
+    /// Overlay mode refuses to write over a symlink the descriptor cannot
+    /// follow — shadowing it in memory would alias the name, so the write
+    /// raises `PermissionError` instead, and the real target is never created.
     #[test]
     #[cfg(unix)]
-    fn broken_symlink_overlay_writes_to_memory_not_real_fs() {
+    fn broken_symlink_overlay_write_is_refused() {
         if !symlinks_supported() {
             return;
         }
@@ -829,17 +936,18 @@ mod hard_link_tests {
 
         let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
 
-        // Write succeeds (goes to overlay memory).
-        let result = dispatch(
+        let outcome = dispatch(
             &mut mt,
             OsFunctionCall::WriteText(PathStringDataArgs {
                 path: MontyPath::new("/mnt/broken_link.txt".to_owned()),
                 data: "safe".to_owned(),
             }),
         )
-        .unwrap()
         .unwrap();
-        assert_eq!(result, MontyObject::Int(4));
+        assert!(
+            matches!(&outcome, Err(MountError::PathEscape { .. })),
+            "overlay write over an outbound symlink must be refused, got {outcome:?}"
+        );
 
         // Real FS target was NOT created.
         assert!(!escape_target.exists());

--- a/crates/monty-fs/tests/fs_security.rs
+++ b/crates/monty-fs/tests/fs_security.rs
@@ -6,7 +6,7 @@
 
 #[cfg(unix)]
 use std::{ffi::OsStr, os::unix::ffi::OsStrExt, os::unix::fs::symlink};
-use std::{fmt, fs};
+use std::{fmt, fs, io::ErrorKind};
 
 use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable, OverlayState};
 use monty_types::{
@@ -1031,6 +1031,48 @@ mod hard_link_tests {
             names.contains(&lossy),
             "in-mount symlink with a non-UTF-8 name was dropped: {names:?}"
         );
+    }
+
+    /// Renaming a directory whose real contents include a non-UTF-8 name must
+    /// fail loudly and leave everything in place.
+    ///
+    /// Such a name cannot be an overlay key, so the rename plan cannot
+    /// represent the move. It used to be built from the lossy name instead,
+    /// which stats a path that does not exist — the file silently vanished
+    /// from the destination while the source read as deleted.
+    #[test]
+    #[cfg(unix)]
+    fn overlay_rename_of_dir_with_non_utf8_named_entry_is_refused() {
+        let dir = create_test_dir();
+        let raw_name = OsStr::from_bytes(b"nonutf8\xff.txt");
+        if fs::write(dir.path().join("subdir").join(raw_name), b"data").is_err() {
+            // APFS and friends reject non-UTF-8 filenames outright, so the bug
+            // this guards is unobservable there. ext4 exercises it.
+            eprintln!("skipped: filesystem rejects non-UTF-8 filenames");
+            return;
+        }
+
+        let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
+        let outcome = dispatch(
+            &mut mt,
+            OsFunctionCall::Rename(monty_types::RenameCallArgs {
+                src: MontyPath::new("/mnt/subdir".to_owned()),
+                dst: MontyPath::new("/mnt/moved".to_owned()),
+            }),
+        )
+        .unwrap();
+        assert!(
+            matches!(&outcome, Err(MountError::Io(err, _)) if err.kind() == ErrorKind::InvalidData),
+            "rename over a non-UTF-8 name must fail with InvalidData, got {outcome:?}"
+        );
+
+        // The refusal must leave the source tree fully visible and create nothing.
+        let exists = call(&mut mt, PathOp::Exists, "/mnt/subdir/nested.txt")
+            .unwrap()
+            .unwrap();
+        assert_eq!(exists, MontyObject::Bool(true));
+        let moved = call(&mut mt, PathOp::Exists, "/mnt/moved").unwrap().unwrap();
+        assert_eq!(moved, MontyObject::Bool(false));
     }
 
     /// Overlay mode should expose the same visible real entries as direct mode:

--- a/crates/monty-fs/tests/fs_security.rs
+++ b/crates/monty-fs/tests/fs_security.rs
@@ -454,6 +454,27 @@ mod symlink_tests {
         assert_blocked(&mut mt, PathOp::Iterdir, "/mnt/rel_escape");
     }
 
+    /// `is_symlink()` does not follow the final component, so an outbound link
+    /// that is itself inside the mount still answers `True` — as in CPython, and
+    /// revealing nothing about where it points. The following predicates differ.
+    #[test]
+    fn is_symlink_reports_an_outbound_link_that_lives_in_the_mount() {
+        let dir = create_test_dir();
+        let outside = TempDir::new().unwrap();
+        fs::write(outside.path().join("secret.txt"), "secret").unwrap();
+        symlink_file(outside.path().join("secret.txt"), dir.path().join("escape_link"));
+
+        for mode in [MountMode::ReadWrite, MountMode::OverlayMemory(OverlayState::new())] {
+            let mut mt = mount_at_mnt(&dir, mode);
+            assert_eq!(
+                call(&mut mt, PathOp::IsSymlink, "/mnt/escape_link").unwrap().unwrap(),
+                MontyObject::Bool(true)
+            );
+            assert_invisible(&mut mt, PathOp::Exists, "/mnt/escape_link");
+            assert_invisible(&mut mt, PathOp::IsFile, "/mnt/escape_link");
+        }
+    }
+
     #[test]
     fn symlink_escape_no_info_leak() {
         // Error messages should only contain virtual path, not host path.

--- a/crates/monty-fs/tests/fs_security.rs
+++ b/crates/monty-fs/tests/fs_security.rs
@@ -15,6 +15,7 @@ use monty_types::{
 };
 use tempfile::TempDir;
 
+#[expect(dead_code, reason = "shared helper module; not every test crate uses all of it")]
 mod common;
 use common::{symlink_dir, symlink_file};
 
@@ -148,6 +149,18 @@ fn assert_blocked(mt: &mut MountTable, op: PathOp, path: &str) {
         Some(Err(MountError::PathEscape { .. } | MountError::NoMountPoint(_) | MountError::Io(_, _))) | None => {}
         Some(Ok(val)) => panic!("expected blocked, got Ok({val:?}) for path: {path}"),
         Some(Err(other)) => panic!("unexpected error variant for {path}: {other}"),
+    }
+}
+
+/// Asserts a boolean query answers `False` rather than raising.
+///
+/// `pathlib` predicates never raise, so a path leaving the mount comes back as
+/// `False` — indistinguishable from "does not exist". Raising would leak that
+/// something is there to be blocked.
+fn assert_invisible(mt: &mut MountTable, op: PathOp, path: &str) {
+    match call(mt, op, path) {
+        Some(Ok(MontyObject::Bool(false))) => {}
+        other => panic!("expected Ok(Bool(false)) for path: {path}, got {other:?}"),
     }
 }
 
@@ -386,7 +399,7 @@ mod symlink_tests {
 
         let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
         assert_blocked(&mut mt, PathOp::ReadText, "/mnt/escape_link/secret.txt");
-        assert_blocked(&mut mt, PathOp::Exists, "/mnt/escape_link/secret.txt");
+        assert_invisible(&mut mt, PathOp::Exists, "/mnt/escape_link/secret.txt");
         assert_blocked(&mut mt, PathOp::Iterdir, "/mnt/escape_link");
     }
 
@@ -472,14 +485,14 @@ mod symlink_tests {
 
         let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
         assert_blocked(&mut mt, PathOp::ReadText, "/mnt/escape/secret.txt");
-        assert_blocked(&mut mt, PathOp::Exists, "/mnt/escape/secret.txt");
+        assert_invisible(&mut mt, PathOp::Exists, "/mnt/escape/secret.txt");
     }
 
     #[test]
     fn symlink_within_mount_allowed() {
         // Symlinks that stay within the mount boundary should work.
         let dir = create_test_dir();
-        symlink_file(dir.path().join("hello.txt"), dir.path().join("internal_link"));
+        symlink_file("hello.txt", dir.path().join("internal_link"));
 
         let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
         let result = call(&mut mt, PathOp::ReadText, "/mnt/internal_link").unwrap().unwrap();
@@ -490,7 +503,7 @@ mod symlink_tests {
     fn symlink_to_directory_within_mount_allowed() {
         // Symlink to a subdirectory within the mount should work for all operations.
         let dir = create_test_dir();
-        symlink_dir(dir.path().join("subdir"), dir.path().join("dir_link"));
+        symlink_dir("subdir", dir.path().join("dir_link"));
 
         let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
 
@@ -515,8 +528,8 @@ mod symlink_tests {
     fn chained_symlinks_within_mount_allowed() {
         // A symlink pointing to another symlink, both within the mount, should work.
         let dir = create_test_dir();
-        symlink_file(dir.path().join("hello.txt"), dir.path().join("link1"));
-        symlink_file(dir.path().join("link1"), dir.path().join("link2"));
+        symlink_file("hello.txt", dir.path().join("link1"));
+        symlink_file("link1", dir.path().join("link2"));
 
         let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
         let result = call(&mut mt, PathOp::ReadText, "/mnt/link2").unwrap().unwrap();
@@ -627,7 +640,7 @@ mod symlink_tests {
         let dir = create_test_dir();
 
         // Create a symlink within mount pointing to another dir within mount.
-        symlink_dir(dir.path().join("subdir"), dir.path().join("internal_link"));
+        symlink_dir("subdir", dir.path().join("internal_link"));
 
         let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
 
@@ -769,7 +782,7 @@ mod hard_link_tests {
         // Outbound symlink (points outside mount) — should be filtered.
         symlink(outside.path().join("external.txt"), dir.path().join("escape_link")).unwrap();
         // Inbound symlink (points inside mount) — should be kept.
-        symlink(dir.path().join("hello.txt"), dir.path().join("internal_link")).unwrap();
+        symlink("hello.txt", dir.path().join("internal_link")).unwrap();
 
         let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
         let result = call(&mut mt, PathOp::Iterdir, "/mnt").unwrap().unwrap();
@@ -813,7 +826,7 @@ mod hard_link_tests {
 
         symlink(outside.path().join("external.txt"), dir.path().join("escape_link")).unwrap();
         symlink(outside.path().join("missing.txt"), dir.path().join("broken_link")).unwrap();
-        symlink(dir.path().join("hello.txt"), dir.path().join("internal_link")).unwrap();
+        symlink("hello.txt", dir.path().join("internal_link")).unwrap();
 
         let mut direct = mount_at_mnt(&dir, MountMode::ReadWrite);
         let direct_result = call(&mut direct, PathOp::Iterdir, "/mnt").unwrap().unwrap();
@@ -832,6 +845,7 @@ mod hard_link_tests {
 }
 
 /// Extracts sorted entry basenames from an `iterdir()` result list.
+#[cfg(unix)]
 fn sorted_names_from_list(obj: &MontyObject) -> Vec<String> {
     match obj {
         MontyObject::List(entries) => {

--- a/crates/monty-fs/tests/fs_security.rs
+++ b/crates/monty-fs/tests/fs_security.rs
@@ -825,7 +825,7 @@ mod hard_link_tests {
     #[cfg(unix)]
     fn iterdir_keeps_inbound_symlink_with_non_utf8_name() {
         let dir = create_test_dir();
-        let raw_name = OsStr::from_bytes(b"caf\xff_link");
+        let raw_name = OsStr::from_bytes(b"nonutf8\xff_link");
         if symlink("hello.txt", dir.path().join(raw_name)).is_err() {
             // APFS and friends reject non-UTF-8 filenames outright, so the bug
             // this guards is unobservable there. ext4 exercises it.

--- a/crates/monty-fs/tests/fs_security.rs
+++ b/crates/monty-fs/tests/fs_security.rs
@@ -11,7 +11,7 @@ use std::{fmt, fs, io::ErrorKind};
 use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable, OverlayState};
 use monty_types::{
     FileMode, MkdirCallArgs, MontyObject, MontyPath, OpenCallArgs, OsFunctionCall, PathBytesDataArgs,
-    PathStringDataArgs,
+    PathStringDataArgs, RenameCallArgs,
 };
 use tempfile::TempDir;
 
@@ -446,6 +446,137 @@ mod symlink_tests {
         assert!(
             !dir.path().join("missing.txt").exists(),
             "link target must not be created"
+        );
+    }
+
+    /// Renaming a directory that contains a symlink is refused outright.
+    ///
+    /// The link has no overlay representation, so the move could only skip it,
+    /// stranding a live file: unreachable at the new name, still readable at
+    /// the old one inside a directory the overlay now reports as deleted.
+    #[test]
+    fn overlay_rename_of_dir_containing_a_symlink_is_refused() {
+        if !symlinks_supported() {
+            return;
+        }
+        let dir = create_test_dir();
+        symlink_file("nested.txt", dir.path().join("subdir/link.txt"));
+
+        let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
+        let outcome = dispatch(
+            &mut mt,
+            OsFunctionCall::Rename(RenameCallArgs {
+                src: MontyPath::new("/mnt/subdir".to_owned()),
+                dst: MontyPath::new("/mnt/moved".to_owned()),
+            }),
+        )
+        .unwrap();
+        assert!(
+            matches!(&outcome, Err(MountError::PathEscape { .. })),
+            "renaming a directory containing a symlink must be refused, got {outcome:?}"
+        );
+
+        // The refusal must be total: the directory keeps its name and contents,
+        // rather than half-moving and leaving the link behind.
+        assert_eq!(
+            call(&mut mt, PathOp::Exists, "/mnt/subdir").unwrap().unwrap(),
+            MontyObject::Bool(true)
+        );
+        assert_eq!(
+            call(&mut mt, PathOp::ReadText, "/mnt/subdir/nested.txt")
+                .unwrap()
+                .unwrap(),
+            MontyObject::String("nested content".to_owned())
+        );
+        assert_eq!(
+            call(&mut mt, PathOp::Exists, "/mnt/moved").unwrap().unwrap(),
+            MontyObject::Bool(false)
+        );
+    }
+
+    /// `unlink` and `rmdir` are writes, so the symlink refusal covers them too.
+    ///
+    /// Tombstoning a link's spelling would report it gone while its target
+    /// stayed readable under the real name — the aliasing the write policy
+    /// exists to prevent, arrived at by deleting instead of writing.
+    #[test]
+    fn overlay_delete_through_a_symlink_is_refused() {
+        if !symlinks_supported() {
+            return;
+        }
+        let dir = create_test_dir();
+        symlink_dir("subdir", dir.path().join("link_dir"));
+        symlink_file("hello.txt", dir.path().join("link.txt"));
+
+        let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
+        // Below an intermediate link, on the link itself, and rmdir of a link
+        // to a directory (POSIX answers ENOTDIR; either way it is not removed).
+        for path in ["/mnt/link_dir/nested.txt", "/mnt/link.txt"] {
+            let outcome = call(&mut mt, PathOp::Unlink, path).unwrap();
+            assert!(
+                matches!(&outcome, Err(MountError::PathEscape { .. })),
+                "unlink of {path} must be refused, got {outcome:?}"
+            );
+        }
+        let outcome = dispatch(
+            &mut mt,
+            OsFunctionCall::Rmdir(MontyPath::new("/mnt/link_dir".to_owned())),
+        )
+        .unwrap();
+        assert!(
+            matches!(&outcome, Err(MountError::PathEscape { .. })),
+            "rmdir of a symlink must be refused, got {outcome:?}"
+        );
+
+        // Nothing was shadowed, so both spellings still agree with the host.
+        assert_eq!(
+            call(&mut mt, PathOp::ReadText, "/mnt/subdir/nested.txt")
+                .unwrap()
+                .unwrap(),
+            MontyObject::String("nested content".to_owned())
+        );
+        assert_eq!(
+            call(&mut mt, PathOp::Exists, "/mnt/link_dir/nested.txt")
+                .unwrap()
+                .unwrap(),
+            MontyObject::Bool(true)
+        );
+    }
+
+    /// A rename destination is classified like any other write target, so it
+    /// cannot land on an existing symlink — which `write_text` already refuses
+    /// for the same path.
+    #[test]
+    fn overlay_rename_onto_a_symlink_is_refused() {
+        if !symlinks_supported() {
+            return;
+        }
+        let dir = create_test_dir();
+        symlink_file("hello.txt", dir.path().join("link.txt"));
+        fs::write(dir.path().join("src.txt"), "moved").unwrap();
+
+        let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
+        let outcome = dispatch(
+            &mut mt,
+            OsFunctionCall::Rename(RenameCallArgs {
+                src: MontyPath::new("/mnt/src.txt".to_owned()),
+                dst: MontyPath::new("/mnt/link.txt".to_owned()),
+            }),
+        )
+        .unwrap();
+        assert!(
+            matches!(&outcome, Err(MountError::PathEscape { .. })),
+            "renaming onto a symlink must be refused, got {outcome:?}"
+        );
+
+        // The link still resolves to its own target, not the moved file.
+        assert_eq!(
+            call(&mut mt, PathOp::ReadText, "/mnt/link.txt").unwrap().unwrap(),
+            MontyObject::String("hello world\n".to_owned())
+        );
+        assert_eq!(
+            call(&mut mt, PathOp::Exists, "/mnt/src.txt").unwrap().unwrap(),
+            MontyObject::Bool(true)
         );
     }
 

--- a/crates/monty-fs/tests/mount_confinement.rs
+++ b/crates/monty-fs/tests/mount_confinement.rs
@@ -486,6 +486,40 @@ fn denied_write_is_not_reported_as_an_escape() {
     );
 }
 
+/// Mount construction resolves the host name exactly once, at the open.
+///
+/// Validating a path and then opening it would be a check-to-open race: a host
+/// able to rename in the parent could swap a symlink into the gap and hand the
+/// mount a descriptor on a directory it never shared. Nothing observes the name
+/// beforehand, so every rejection has to surface as a failure of the open — the
+/// symptom a reintroduced pre-check would change, since it would answer first.
+#[test]
+fn mount_construction_rejects_only_at_the_open() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("not-a-directory.txt");
+    fs::write(&file, "content").unwrap();
+
+    // A non-directory: rejected by `O_DIRECTORY` (a handle `metadata()` on
+    // Windows), not by a `is_dir()` stat on a path resolved separately.
+    let mut mounts = MountTable::new();
+    match mounts.mount("/mnt", &file, MountMode::ReadWrite, None) {
+        Err(MountError::InvalidMount(msg)) => assert!(
+            msg.starts_with("cannot open host path"),
+            "a pre-check answered before the open: {msg}"
+        ),
+        outcome => panic!("expected InvalidMount for a file, got {outcome:?}"),
+    }
+
+    let mut mounts = MountTable::new();
+    match mounts.mount("/mnt", dir.path().join("absent"), MountMode::ReadWrite, None) {
+        Err(MountError::InvalidMount(msg)) => assert!(
+            msg.starts_with("cannot open host path"),
+            "a pre-check answered before the open: {msg}"
+        ),
+        outcome => panic!("expected InvalidMount for a missing path, got {outcome:?}"),
+    }
+}
+
 /// Whether a search-only directory can be mounted is platform-specific: Linux
 /// opens directories with `O_PATH` and accepts one, macOS and the BSDs need
 /// read permission and reject it where the old canonicalize-and-stat did not.

--- a/crates/monty-fs/tests/mount_confinement.rs
+++ b/crates/monty-fs/tests/mount_confinement.rs
@@ -9,8 +9,11 @@
 //! `concurrent_rename_cannot_redirect_a_read` is a soak: the race was never won
 //! on macOS/APFS, so a green run proves little on any one platform.
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::{
     fs,
+    io::ErrorKind,
     path::{Path, PathBuf},
     sync::{
         Arc,
@@ -19,16 +22,14 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
-#[cfg(unix)]
-use std::{io::ErrorKind, os::unix::fs::PermissionsExt};
 
 use common::{symlink_dir, symlink_file, symlinks_supported, try_rename_mount_root};
 #[cfg(unix)]
 use monty_fs::OverlayState;
 use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable};
 #[cfg(unix)]
-use monty_types::{FileMode, OpenCallArgs, PathStringDataArgs};
-use monty_types::{MontyObject, OsFunctionCall};
+use monty_types::{FileMode, OpenCallArgs};
+use monty_types::{MontyObject, OsFunctionCall, PathStringDataArgs};
 use tempfile::TempDir;
 
 mod common;
@@ -443,4 +444,50 @@ fn overlay_permission_errors_match_direct_mode() {
 
         fs::set_permissions(&sub, fs::Permissions::from_mode(0o755)).unwrap();
     }
+}
+
+/// The same guarantee as the test above, on every platform.
+///
+/// That one needs Unix mode bits; this uses the read-only attribute, which
+/// Windows honours even for an elevated process. It is what actually exercises
+/// `map_io`'s errno check on Windows, where std's error plumbing differs and a
+/// misclassification would report a plain denial as a sandbox-boundary error.
+#[test]
+fn denied_write_is_not_reported_as_an_escape() {
+    let mount_dir = TempDir::new().unwrap();
+    let locked = mount_dir.path().join("locked.txt");
+    fs::write(&locked, "content").unwrap();
+    set_readonly(&locked, true);
+
+    // Root ignores Unix mode bits, leaving nothing to assert.
+    if fs::OpenOptions::new().write(true).open(&locked).is_ok() {
+        set_readonly(&locked, false);
+        eprintln!("skipped: host permits writing a read-only file");
+        return;
+    }
+
+    let mut mounts = mount_rw(mount_dir.path());
+    let outcome = dispatch(
+        &mut mounts,
+        OsFunctionCall::WriteText(PathStringDataArgs {
+            path: "/mnt/locked.txt".into(),
+            data: "x".to_owned(),
+        }),
+    );
+
+    // Restore before asserting: Windows cannot delete a read-only file, so a
+    // failure here would otherwise break the temp-dir cleanup too.
+    set_readonly(&locked, false);
+
+    assert!(
+        matches!(&outcome, Err(MountError::Io(err, _)) if err.kind() == ErrorKind::PermissionDenied),
+        "expected a plain IO permission error, got {outcome:?}"
+    );
+}
+
+/// Toggles the read-only attribute (Windows) / write mode bits (Unix).
+fn set_readonly(path: &Path, readonly: bool) {
+    let mut perms = fs::metadata(path).expect("failed to stat").permissions();
+    perms.set_readonly(readonly);
+    fs::set_permissions(path, perms).expect("failed to set permissions");
 }

--- a/crates/monty-fs/tests/mount_confinement.rs
+++ b/crates/monty-fs/tests/mount_confinement.rs
@@ -483,6 +483,36 @@ fn denied_write_is_not_reported_as_an_escape() {
     );
 }
 
+/// A search-only directory cannot be mounted, because opening the descriptor
+/// needs read permission where the old canonicalize-and-stat did not.
+///
+/// Documented in `limitations/filesystem.md`; asserted here so the failure
+/// stays a clean `InvalidMount` at construction rather than a surprise later.
+#[test]
+#[cfg(unix)]
+fn search_only_directory_is_not_mountable() {
+    let base = TempDir::new().unwrap();
+    let target = base.path().join("searchonly");
+    fs::create_dir(&target).unwrap();
+    fs::set_permissions(&target, fs::Permissions::from_mode(0o111)).unwrap();
+
+    let mut mounts = MountTable::new();
+    let outcome = mounts.mount("/mnt", &target, MountMode::ReadWrite, None);
+
+    // Restore before asserting so the temp dir can still be cleaned up.
+    fs::set_permissions(&target, fs::Permissions::from_mode(0o755)).unwrap();
+
+    // Root ignores mode bits, leaving nothing to assert.
+    if outcome.is_ok() {
+        eprintln!("skipped: host permits opening a search-only directory");
+        return;
+    }
+    assert!(
+        matches!(&outcome, Err(MountError::InvalidMount(msg)) if msg.contains("cannot open host path")),
+        "expected InvalidMount for a search-only directory, got {outcome:?}"
+    );
+}
+
 /// The mount root itself cannot be deleted through the mount.
 ///
 /// It has no name inside the mount, so there is nothing to unlink it from:

--- a/crates/monty-fs/tests/mount_confinement.rs
+++ b/crates/monty-fs/tests/mount_confinement.rs
@@ -530,10 +530,11 @@ fn overlay_rmdir_of_the_mount_root_leaves_the_host_directory() {
 
 /// `mkdir(parents=True)` through an escaping symlink cannot reach the host.
 ///
-/// Both modes refuse it with `PermissionError`: direct at the descriptor,
-/// overlay via `classify_write_target` — which used to treat the unobservable
-/// link as absent and build an in-memory shadow tree. Nothing may appear on
-/// the host and the link's real target must stay unreadable.
+/// Both modes refuse it with `PathEscape` (`PermissionError` in the sandbox):
+/// direct at the descriptor, overlay via `classify_write_target` — which used
+/// to treat the unobservable link as absent and build an in-memory shadow
+/// tree. Nothing may appear on the host and the link's real target must stay
+/// unreadable.
 #[test]
 fn mkdir_parents_under_an_escaping_symlink_cannot_reach_the_host() {
     if !symlinks_supported() {

--- a/crates/monty-fs/tests/mount_confinement.rs
+++ b/crates/monty-fs/tests/mount_confinement.rs
@@ -486,15 +486,19 @@ fn denied_write_is_not_reported_as_an_escape() {
     );
 }
 
-/// Mount construction resolves the host name exactly once, at the open.
+/// The open is the first thing mount construction does with the host name.
 ///
 /// Validating a path and then opening it would be a check-to-open race: a host
 /// able to rename in the parent could swap a symlink into the gap and hand the
-/// mount a descriptor on a directory it never shared. Nothing observes the name
-/// beforehand, so every rejection has to surface as a failure of the open — the
-/// symptom a reintroduced pre-check would change, since it would answer first.
+/// mount a descriptor on a directory it never shared. Nothing may observe the
+/// name beforehand, so a rejection the open itself accounts for — a file, a
+/// missing path — has to arrive as a failure of the open. That is the symptom a
+/// reintroduced pre-check would change, since it would answer first.
+///
+/// Construction can still fail *after* the open, canonicalizing the diagnostic
+/// label; that ordering is the point, so those failures read differently.
 #[test]
-fn mount_construction_rejects_only_at_the_open() {
+fn mount_construction_rejects_at_the_open_first() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("not-a-directory.txt");
     fs::write(&file, "content").unwrap();

--- a/crates/monty-fs/tests/mount_confinement.rs
+++ b/crates/monty-fs/tests/mount_confinement.rs
@@ -192,6 +192,17 @@ fn concurrent_rename_cannot_redirect_a_read() {
         let staging = mount_dir.path().join("staging");
         thread::spawn(move || {
             while !stop.load(Ordering::Relaxed) {
+                // Restore the known-good arrangement first. The swap below is
+                // four non-atomic renames, and a partial one leaves `target`
+                // absent — every later iteration would then fail at its first
+                // rename, freezing `swaps` and silently ending the race.
+                if fs::symlink_metadata(&target).is_err() {
+                    let _ = fs::rename(&staging, &target);
+                } else if fs::symlink_metadata(&decoy).is_err() {
+                    let _ = fs::rename(&target, &decoy);
+                    let _ = fs::rename(&staging, &target);
+                }
+
                 // Swap the symlink in for the real file, then back.
                 if fs::rename(&target, &staging).is_ok()
                     && fs::rename(&decoy, &target).is_ok()

--- a/crates/monty-fs/tests/mount_confinement.rs
+++ b/crates/monty-fs/tests/mount_confinement.rs
@@ -1,0 +1,345 @@
+//! Confinement guarantees that hold regardless of what happens to the host
+//! directory *after* the mount is created.
+//!
+//! Only `mount_root_swapped_for_symlink_still_reads_original` and
+//! `mount_survives_host_directory_rename` distinguish this design from
+//! path-based resolution — verified red against it, on Unix; Windows refuses to
+//! rename a mounted directory at all, so it gets its own pair. The other escape
+//! tests pass under both, so they are regression guards, not evidence, and
+//! `concurrent_rename_cannot_redirect_a_read` is a soak: the race was never won
+//! on macOS/APFS, so a green run proves little on any one platform.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU32, Ordering},
+    },
+    thread,
+    time::{Duration, Instant},
+};
+#[cfg(unix)]
+use std::{io::ErrorKind, os::unix::fs::PermissionsExt};
+
+use common::{symlink_dir, symlink_file, try_rename_mount_root};
+use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable};
+use monty_types::{MontyObject, OsFunctionCall};
+use tempfile::TempDir;
+
+mod common;
+
+/// Marker written to the out-of-mount file; its appearance in any result is the
+/// disclosure these tests guard against.
+const SECRET: &str = "SECRET-HOST-CONTENT";
+
+/// Dispatches a call, panicking if the mount table declines to handle it.
+fn dispatch(mounts: &mut MountTable, call: OsFunctionCall) -> Result<MontyObject, MountError> {
+    match mounts.handle_os_call(call) {
+        MountCallOutcome::Handled(result) => result,
+        MountCallOutcome::NotHandled(call) => panic!("mount table returned NotHandled: {call:?}"),
+    }
+}
+
+fn read_text(mounts: &mut MountTable, path: &str) -> Result<MontyObject, MountError> {
+    dispatch(mounts, OsFunctionCall::ReadText(path.into()))
+}
+
+fn mount_rw(host: &Path) -> MountTable {
+    let mut mounts = MountTable::new();
+    mounts
+        .mount("/mnt", host, MountMode::ReadWrite, None)
+        .expect("failed to configure mount");
+    mounts
+}
+
+/// The mount is pinned at mount time, so replacing the host directory with a
+/// symlink elsewhere must not redirect reads to it.
+///
+/// Deterministic, and the two designs differ observably: resolving by path
+/// re-reads the swapped root on every call, whereas a descriptor opened at
+/// mount time still refers to the original directory.
+#[test]
+fn mount_root_swapped_for_symlink_still_reads_original() {
+    let base = TempDir::new().unwrap();
+    let mount_path = base.path().join("mount");
+    let elsewhere = base.path().join("elsewhere");
+    fs::create_dir(&mount_path).unwrap();
+    fs::create_dir(&elsewhere).unwrap();
+    fs::write(mount_path.join("file.txt"), "public").unwrap();
+    fs::write(elsewhere.join("file.txt"), SECRET).unwrap();
+
+    let mut mounts = mount_rw(&mount_path);
+
+    // Replace the mount root with a symlink pointing somewhere else entirely.
+    if !try_rename_mount_root(&mount_path, base.path().join("moved")) {
+        // Windows blocks the rename outright, so the swap cannot even be staged
+        // — a stronger guarantee than the one asserted below.
+        assert!(matches!(read_text(&mut mounts, "/mnt/file.txt"), Ok(MontyObject::String(s)) if s == "public"));
+        return;
+    }
+    symlink_dir(&elsewhere, &mount_path);
+
+    let outcome = read_text(&mut mounts, "/mnt/file.txt");
+    let leaked = matches!(&outcome, Ok(MontyObject::String(s)) if s.contains(SECRET));
+    assert!(!leaked, "HOST FILE DISCLOSURE: read followed the swapped mount root");
+    assert!(
+        matches!(&outcome, Ok(MontyObject::String(s)) if s == "public"),
+        "expected the original directory to still back the mount, got {outcome:?}"
+    );
+}
+
+/// Renaming the mount's host directory must not detach the mount.
+///
+/// A descriptor follows the directory through a rename; a stored path does not.
+/// Unix-only: Windows refuses the rename outright, covered below.
+#[test]
+#[cfg(unix)]
+fn mount_survives_host_directory_rename() {
+    let base = TempDir::new().unwrap();
+    let mount_path = base.path().join("mount");
+    fs::create_dir(&mount_path).unwrap();
+    fs::write(mount_path.join("file.txt"), "public").unwrap();
+
+    let mut mounts = mount_rw(&mount_path);
+    fs::rename(&mount_path, base.path().join("renamed")).unwrap();
+
+    let outcome = read_text(&mut mounts, "/mnt/file.txt");
+    assert!(
+        matches!(&outcome, Ok(MontyObject::String(s)) if s == "public"),
+        "expected the mount to follow its directory through a rename, got {outcome:?}"
+    );
+}
+
+/// On Windows the mount's open handle blocks the rename entirely, so the host
+/// cannot move or delete a mounted directory until the mount is dropped.
+#[test]
+#[cfg(windows)]
+fn mounted_directory_cannot_be_renamed_on_windows() {
+    let base = TempDir::new().unwrap();
+    let mount_path = base.path().join("mount");
+    fs::create_dir(&mount_path).unwrap();
+    fs::write(mount_path.join("file.txt"), "public").unwrap();
+
+    let mut mounts = mount_rw(&mount_path);
+    let err = fs::rename(&mount_path, base.path().join("renamed")).unwrap_err();
+    assert_eq!(err.raw_os_error(), Some(32), "expected ERROR_SHARING_VIOLATION");
+
+    let outcome = read_text(&mut mounts, "/mnt/file.txt");
+    assert!(matches!(&outcome, Ok(MontyObject::String(s)) if s == "public"));
+}
+
+/// An intermediate directory replaced by a symlink out of the mount must not
+/// become a route out, whether or not any read is in flight.
+///
+/// Not a design differentiator on its own — resolving by path also rejects this,
+/// via a boundary check rather than structurally.
+#[test]
+fn read_through_swapped_intermediate_directory_is_rejected() {
+    let mount_dir = TempDir::new().unwrap();
+    let outside_dir = TempDir::new().unwrap();
+    fs::write(outside_dir.path().join("secret.txt"), SECRET).unwrap();
+
+    let data = mount_dir.path().join("data");
+    fs::create_dir(&data).unwrap();
+    fs::write(data.join("file.txt"), "public").unwrap();
+
+    let mut mounts = mount_rw(mount_dir.path());
+
+    fs::remove_dir_all(&data).unwrap();
+    symlink_dir(outside_dir.path(), &data);
+
+    let outcome = read_text(&mut mounts, "/mnt/data/secret.txt");
+    let leaked = matches!(&outcome, Ok(MontyObject::String(s)) if s.contains(SECRET));
+    assert!(!leaked, "HOST FILE DISCLOSURE: read traversed an outbound symlink");
+}
+
+/// The reported vector: one session renaming while another reads the same path.
+///
+/// The swap alternates `/mnt/data/file.txt` between a real in-mount file and a
+/// symlink to an out-of-mount file, so a read whose check and open disagree
+/// returns the secret. A descriptor-relative open has no window to lose — but
+/// this only ever *detects* the old failure when the race is won, which did not
+/// happen on macOS/APFS, so treat a green run as a soak rather than a proof.
+#[test]
+fn concurrent_rename_cannot_redirect_a_read() {
+    let mount_dir = TempDir::new().unwrap();
+    let outside_dir = TempDir::new().unwrap();
+
+    let secret = outside_dir.path().join("secret.txt");
+    fs::write(&secret, SECRET).unwrap();
+
+    let data = mount_dir.path().join("data");
+    fs::create_dir(&data).unwrap();
+    let target = data.join("file.txt");
+    fs::write(&target, "public").unwrap();
+
+    // The pre-existing outbound symlink: sandboxed code can relocate it but
+    // never create one.
+    let decoy = mount_dir.path().join("decoy");
+    symlink_file(&secret, &decoy);
+
+    let mut mounts = mount_rw(mount_dir.path());
+    let stop = Arc::new(AtomicBool::new(false));
+    let swaps = Arc::new(AtomicU32::new(0));
+
+    let swapper = {
+        let (stop, swaps) = (Arc::clone(&stop), Arc::clone(&swaps));
+        let staging = mount_dir.path().join("staging");
+        thread::spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                // Swap the symlink in for the real file, then back.
+                if fs::rename(&target, &staging).is_ok()
+                    && fs::rename(&decoy, &target).is_ok()
+                    && fs::rename(&target, &decoy).is_ok()
+                    && fs::rename(&staging, &target).is_ok()
+                {
+                    swaps.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        })
+    };
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    let mut leaks = 0_u32;
+    let mut reads = 0_u32;
+    while Instant::now() < deadline {
+        if let Ok(MontyObject::String(s)) = read_text(&mut mounts, "/mnt/data/file.txt") {
+            reads += 1;
+            if s.contains(SECRET) {
+                leaks += 1;
+            }
+        }
+    }
+    stop.store(true, Ordering::Relaxed);
+    swapper.join().unwrap();
+
+    // Guard against the test silently doing nothing: both sides must have run.
+    assert!(reads > 0, "no read ever succeeded — the scenario did not run");
+    assert!(
+        swaps.load(Ordering::Relaxed) > 0,
+        "no swap ever completed — the scenario did not run"
+    );
+    assert_eq!(leaks, 0, "HOST FILE DISCLOSURE: a racing read returned host content");
+}
+
+/// Writes must be confined too: a rejected write must not create or modify
+/// anything outside the mount.
+#[test]
+fn write_through_swapped_directory_cannot_escape() {
+    let mount_dir = TempDir::new().unwrap();
+    let outside_dir = TempDir::new().unwrap();
+    let outside_file = outside_dir.path().join("target.txt");
+    fs::write(&outside_file, SECRET).unwrap();
+
+    let data = mount_dir.path().join("data");
+    fs::create_dir(&data).unwrap();
+
+    let mut mounts = mount_rw(mount_dir.path());
+
+    fs::remove_dir_all(&data).unwrap();
+    symlink_dir(outside_dir.path(), &data);
+
+    let _ = dispatch(
+        &mut mounts,
+        OsFunctionCall::WriteText(monty_types::PathStringDataArgs {
+            path: "/mnt/data/target.txt".into(),
+            data: "clobbered".to_owned(),
+        }),
+    );
+    assert_eq!(
+        fs::read_to_string(&outside_file).unwrap(),
+        SECRET,
+        "the out-of-mount file was modified"
+    );
+
+    // ...and no new file was created out there either.
+    let created: Vec<PathBuf> = fs::read_dir(outside_dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p != &outside_file)
+        .collect();
+    assert!(created.is_empty(), "files were created outside the mount: {created:?}");
+}
+
+/// Relative symlink targets are followed normally; paired with the test below,
+/// this pins the rule that decides which links work.
+#[test]
+fn relative_symlink_target_is_followed_inside_the_mount() {
+    let mount_dir = TempDir::new().unwrap();
+    fs::write(mount_dir.path().join("hello.txt"), "in-mount").unwrap();
+    symlink_file("hello.txt", mount_dir.path().join("link.txt"));
+
+    let mut mounts = mount_rw(mount_dir.path());
+
+    assert_eq!(
+        read_text(&mut mounts, "/mnt/link.txt").unwrap(),
+        MontyObject::String("in-mount".to_owned())
+    );
+}
+
+/// An absolute symlink target is refused even pointing back into the same mount.
+///
+/// A descriptor has no path, so a leading `/` cannot be interpreted and
+/// "absolute but inside" is indistinguishable from "absolute and outside".
+/// Re-rooting it ourselves would restore the check-then-use this design removes.
+#[test]
+fn absolute_symlink_target_is_refused_even_inside_the_mount() {
+    let mount_dir = TempDir::new().unwrap();
+    fs::write(mount_dir.path().join("hello.txt"), "in-mount").unwrap();
+    symlink_file(mount_dir.path().join("hello.txt"), mount_dir.path().join("abs.txt"));
+
+    let mut mounts = mount_rw(mount_dir.path());
+
+    // The target is the same file the relative link reaches successfully.
+    assert!(
+        matches!(
+            read_text(&mut mounts, "/mnt/abs.txt"),
+            Err(MountError::PathEscape { .. })
+        ),
+        "absolute in-mount symlink should be refused"
+    );
+
+    // `pathlib` predicates cannot raise, so they answer `False` instead.
+    for call in [
+        OsFunctionCall::Exists("/mnt/abs.txt".into()),
+        OsFunctionCall::IsFile("/mnt/abs.txt".into()),
+        OsFunctionCall::IsDir("/mnt/abs.txt".into()),
+    ] {
+        assert_eq!(dispatch(&mut mounts, call).unwrap(), MontyObject::Bool(false));
+    }
+
+    // `is_symlink` does not follow the final component, so it still sees a link.
+    assert_eq!(
+        dispatch(&mut mounts, OsFunctionCall::IsSymlink("/mnt/abs.txt".into())).unwrap(),
+        MontyObject::Bool(true)
+    );
+}
+
+/// A genuine host permission error must not be reported as a path escape.
+///
+/// `cap-std` answers both with `PermissionDenied`; only the errno separates them,
+/// its escape error being synthetic. Conflating them would make `PathEscape`
+/// mean "something was denied" rather than "the boundary caught something".
+#[test]
+#[cfg(unix)]
+fn genuine_permission_error_is_not_reported_as_an_escape() {
+    let mount_dir = TempDir::new().unwrap();
+    let unreadable = mount_dir.path().join("locked.txt");
+    fs::write(&unreadable, "in-mount").unwrap();
+    fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
+
+    // Running as root defeats the mode bits, leaving nothing to assert.
+    if fs::read(&unreadable).is_ok() {
+        eprintln!("skipped: running as root, mode 0o000 is not enforced");
+        return;
+    }
+
+    let mut mounts = mount_rw(mount_dir.path());
+    let outcome = read_text(&mut mounts, "/mnt/locked.txt");
+
+    assert!(
+        matches!(&outcome, Err(MountError::Io(err, _)) if err.kind() == ErrorKind::PermissionDenied),
+        "expected a plain IO permission error, got {outcome:?}"
+    );
+}

--- a/crates/monty-fs/tests/mount_confinement.rs
+++ b/crates/monty-fs/tests/mount_confinement.rs
@@ -486,14 +486,16 @@ fn denied_write_is_not_reported_as_an_escape() {
     );
 }
 
-/// A search-only directory cannot be mounted, because opening the descriptor
-/// needs read permission where the old canonicalize-and-stat did not.
+/// Whether a search-only directory can be mounted is platform-specific: Linux
+/// opens directories with `O_PATH` and accepts one, macOS and the BSDs need
+/// read permission and reject it where the old canonicalize-and-stat did not.
 ///
-/// Documented in `limitations/filesystem.md`; asserted here so the failure
-/// stays a clean `InvalidMount` at construction rather than a surprise later.
+/// Documented in `limitations/filesystem.md`; asserted here so that where it
+/// is refused, the failure stays a clean `InvalidMount` at construction rather
+/// than a surprise on the first read.
 #[test]
 #[cfg(unix)]
-fn search_only_directory_is_not_mountable() {
+fn search_only_directory_mountability() {
     let base = TempDir::new().unwrap();
     let target = base.path().join("searchonly");
     fs::create_dir(&target).unwrap();
@@ -505,9 +507,8 @@ fn search_only_directory_is_not_mountable() {
     // Restore before asserting so the temp dir can still be cleaned up.
     fs::set_permissions(&target, fs::Permissions::from_mode(0o755)).unwrap();
 
-    // Root ignores mode bits, leaving nothing to assert.
+    // Linux's `O_PATH`, or running as root, which ignores mode bits.
     if outcome.is_ok() {
-        eprintln!("skipped: host permits opening a search-only directory");
         return;
     }
     assert!(

--- a/crates/monty-fs/tests/mount_confinement.rs
+++ b/crates/monty-fs/tests/mount_confinement.rs
@@ -22,7 +22,7 @@ use std::{
 #[cfg(unix)]
 use std::{io::ErrorKind, os::unix::fs::PermissionsExt};
 
-use common::{symlink_dir, symlink_file, try_rename_mount_root};
+use common::{symlink_dir, symlink_file, symlinks_supported, try_rename_mount_root};
 #[cfg(unix)]
 use monty_fs::OverlayState;
 use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable};
@@ -65,6 +65,9 @@ fn mount_rw(host: &Path) -> MountTable {
 /// mount time still refers to the original directory.
 #[test]
 fn mount_root_swapped_for_symlink_still_reads_original() {
+    if !symlinks_supported() {
+        return;
+    }
     let base = TempDir::new().unwrap();
     let mount_path = base.path().join("mount");
     let elsewhere = base.path().join("elsewhere");
@@ -140,6 +143,9 @@ fn mounted_directory_cannot_be_renamed_on_windows() {
 /// via a boundary check rather than structurally.
 #[test]
 fn read_through_swapped_intermediate_directory_is_rejected() {
+    if !symlinks_supported() {
+        return;
+    }
     let mount_dir = TempDir::new().unwrap();
     let outside_dir = TempDir::new().unwrap();
     fs::write(outside_dir.path().join("secret.txt"), SECRET).unwrap();
@@ -167,6 +173,9 @@ fn read_through_swapped_intermediate_directory_is_rejected() {
 /// happen on macOS/APFS, so treat a green run as a soak rather than a proof.
 #[test]
 fn concurrent_rename_cannot_redirect_a_read() {
+    if !symlinks_supported() {
+        return;
+    }
     let mount_dir = TempDir::new().unwrap();
     let outside_dir = TempDir::new().unwrap();
 
@@ -242,6 +251,9 @@ fn concurrent_rename_cannot_redirect_a_read() {
 /// anything outside the mount.
 #[test]
 fn write_through_swapped_directory_cannot_escape() {
+    if !symlinks_supported() {
+        return;
+    }
     let mount_dir = TempDir::new().unwrap();
     let outside_dir = TempDir::new().unwrap();
     let outside_file = outside_dir.path().join("target.txt");
@@ -281,6 +293,9 @@ fn write_through_swapped_directory_cannot_escape() {
 /// this pins the rule that decides which links work.
 #[test]
 fn relative_symlink_target_is_followed_inside_the_mount() {
+    if !symlinks_supported() {
+        return;
+    }
     let mount_dir = TempDir::new().unwrap();
     fs::write(mount_dir.path().join("hello.txt"), "in-mount").unwrap();
     symlink_file("hello.txt", mount_dir.path().join("link.txt"));
@@ -300,6 +315,9 @@ fn relative_symlink_target_is_followed_inside_the_mount() {
 /// Re-rooting it ourselves would restore the check-then-use this design removes.
 #[test]
 fn absolute_symlink_target_is_refused_even_inside_the_mount() {
+    if !symlinks_supported() {
+        return;
+    }
     let mount_dir = TempDir::new().unwrap();
     fs::write(mount_dir.path().join("hello.txt"), "in-mount").unwrap();
     symlink_file(mount_dir.path().join("hello.txt"), mount_dir.path().join("abs.txt"));

--- a/crates/monty-fs/tests/mount_confinement.rs
+++ b/crates/monty-fs/tests/mount_confinement.rs
@@ -530,10 +530,10 @@ fn overlay_rmdir_of_the_mount_root_leaves_the_host_directory() {
 
 /// `mkdir(parents=True)` through an escaping symlink cannot reach the host.
 ///
-/// Direct mode refuses it at the boundary. Overlay mode instead treats the
-/// (unobservable) link as absent and builds the tree in memory — consistent
-/// with its predicates answering `False` — but nothing may appear on the host
-/// and the link's real target must stay unreadable.
+/// Both modes refuse it with `PermissionError`: direct at the descriptor,
+/// overlay via `classify_write_target` — which used to treat the unobservable
+/// link as absent and build an in-memory shadow tree. Nothing may appear on
+/// the host and the link's real target must stay unreadable.
 #[test]
 fn mkdir_parents_under_an_escaping_symlink_cannot_reach_the_host() {
     if !symlinks_supported() {
@@ -572,13 +572,21 @@ fn mkdir_parents_under_an_escaping_symlink_cannot_reach_the_host() {
             None,
         )
         .expect("failed to mount");
-    let _ = dispatch(&mut overlay, mkdir_call());
-    let _ = dispatch(
+    let outcome = dispatch(&mut overlay, mkdir_call());
+    assert!(
+        matches!(&outcome, Err(MountError::PathEscape { .. })),
+        "overlay mkdir through an escaping symlink must be refused, got {outcome:?}"
+    );
+    let outcome = dispatch(
         &mut overlay,
         OsFunctionCall::WriteText(PathStringDataArgs {
             path: "/mnt/evil/foo/x.txt".into(),
             data: "data".to_owned(),
         }),
+    );
+    assert!(
+        matches!(&outcome, Err(MountError::PathEscape { .. })),
+        "overlay write under an escaping symlink must be refused, got {outcome:?}"
     );
     assert!(
         !outside.path().join("foo").exists(),

--- a/crates/monty-fs/tests/mount_confinement.rs
+++ b/crates/monty-fs/tests/mount_confinement.rs
@@ -18,6 +18,7 @@ use std::{
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicU32, Ordering},
+        mpsc,
     },
     thread,
     time::{Duration, Instant},
@@ -28,6 +29,8 @@ use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable, OverlayState
 #[cfg(unix)]
 use monty_types::{FileMode, OpenCallArgs};
 use monty_types::{MkdirCallArgs, MontyObject, OsFunctionCall, PathStringDataArgs};
+#[cfg(unix)]
+use nix::{sys::stat::Mode, unistd::mkfifo};
 use tempfile::TempDir;
 
 mod common;
@@ -636,4 +639,94 @@ fn set_readonly(path: &Path, readonly: bool) {
     let mut perms = fs::metadata(path).expect("failed to stat").permissions();
     perms.set_readonly(readonly);
     fs::set_permissions(path, perms).expect("failed to set permissions");
+}
+
+/// A FIFO in the mount is refused, and refused *promptly*.
+///
+/// Reading one with no writer blocks forever, and mount I/O runs on the host
+/// thread servicing the sandbox, so a regression here hangs the host rather
+/// than failing. The dispatch runs on its own thread so that shows up as a
+/// failed assertion instead of a wedged test binary.
+#[test]
+#[cfg(unix)]
+fn fifo_in_the_mount_is_refused_promptly() {
+    let mount_dir = TempDir::new().unwrap();
+    make_fifo(&mount_dir.path().join("pipe"));
+
+    let (tx, rx) = mpsc::channel();
+    let host = mount_dir.path().to_path_buf();
+    thread::spawn(move || {
+        let mut mounts = mount_rw(&host);
+        tx.send(format!("{:?}", read_text(&mut mounts, "/mnt/pipe"))).ok();
+    });
+
+    let outcome = rx
+        .recv_timeout(Duration::from_secs(10))
+        .expect("reading a FIFO blocked the servicing thread");
+    assert!(
+        outcome.contains("PermissionDenied"),
+        "expected a refusal, got {outcome}"
+    );
+}
+
+/// The guard holds when the FIFO arrives *after* the path check.
+///
+/// This is the race the pre-open check cannot win: a second session renames a
+/// host-planted FIFO over a regular file between the check and the open. The
+/// open is non-blocking and the handle is re-checked, so neither the hang nor a
+/// successful FIFO read is reachable. Verified red with either half removed.
+#[test]
+#[cfg(unix)]
+fn fifo_raced_into_place_between_check_and_open_is_refused() {
+    let mount_dir = TempDir::new().unwrap();
+    let target = mount_dir.path().join("file.txt");
+    let regular = mount_dir.path().join("regular");
+    let fifo = mount_dir.path().join("fifo");
+    fs::write(&target, "public").unwrap();
+    fs::write(&regular, "public").unwrap();
+    make_fifo(&fifo);
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let swapper = {
+        let stop = Arc::clone(&stop);
+        thread::spawn(move || {
+            while !stop.load(Ordering::Relaxed) {
+                // Restore a known-good state first so one failed rename cannot
+                // wedge the loop and silently stop the race.
+                if !target.exists() {
+                    let _ = fs::rename(&regular, &target).or_else(|_| fs::rename(&fifo, &target));
+                }
+                let _ = fs::rename(&target, &regular).and_then(|()| fs::rename(&fifo, &target));
+                let _ = fs::rename(&target, &fifo).and_then(|()| fs::rename(&regular, &target));
+            }
+        })
+    };
+
+    let (tx, rx) = mpsc::channel();
+    let host = mount_dir.path().to_path_buf();
+    let reader = thread::spawn(move || {
+        let mut mounts = mount_rw(&host);
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            match read_text(&mut mounts, "/mnt/file.txt") {
+                // The FIFO has no writer, so any success is a regular file.
+                Ok(MontyObject::String(s)) => assert_eq!(s, "public"),
+                Ok(other) => panic!("unexpected value: {other:?}"),
+                Err(_) => {} // Missing mid-swap, or refused as a FIFO: both fine.
+            }
+        }
+        tx.send(()).ok();
+    });
+
+    let finished = rx.recv_timeout(Duration::from_secs(30)).is_ok();
+    stop.store(true, Ordering::Relaxed);
+    swapper.join().unwrap();
+    reader.join().unwrap();
+    assert!(finished, "a read blocked on the raced-in FIFO");
+}
+
+/// Creates a FIFO, the one special file a test can make portably across Unix.
+#[cfg(unix)]
+fn make_fifo(path: &Path) {
+    mkfifo(path, Mode::from_bits_truncate(0o644)).expect("failed to create FIFO");
 }

--- a/crates/monty-fs/tests/mount_confinement.rs
+++ b/crates/monty-fs/tests/mount_confinement.rs
@@ -23,7 +23,11 @@ use std::{
 use std::{io::ErrorKind, os::unix::fs::PermissionsExt};
 
 use common::{symlink_dir, symlink_file, try_rename_mount_root};
+#[cfg(unix)]
+use monty_fs::OverlayState;
 use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable};
+#[cfg(unix)]
+use monty_types::{FileMode, OpenCallArgs, PathStringDataArgs};
 use monty_types::{MontyObject, OsFunctionCall};
 use tempfile::TempDir;
 
@@ -342,4 +346,72 @@ fn genuine_permission_error_is_not_reported_as_an_escape() {
         matches!(&outcome, Err(MountError::Io(err, _)) if err.kind() == ErrorKind::PermissionDenied),
         "expected a plain IO permission error, got {outcome:?}"
     );
+}
+
+/// Overlay mode must classify an in-mount permission failure the way a direct
+/// mount does, instead of collapsing every lookup failure into "missing".
+///
+/// Collapsing turned a denied `open` into `FileNotFoundError`, let `append`
+/// silently succeed into the overlay — shadowing a real file it could not see —
+/// and made `stat` return a result for an unreadable path.
+#[test]
+#[cfg(unix)]
+fn overlay_permission_errors_match_direct_mode() {
+    let probe = TempDir::new().unwrap();
+    let sub = probe.path().join("sub");
+    fs::create_dir(&sub).unwrap();
+    fs::write(sub.join("f.txt"), "content").unwrap();
+    fs::set_permissions(&sub, fs::Permissions::from_mode(0o000)).unwrap();
+    if fs::read(sub.join("f.txt")).is_ok() {
+        eprintln!("skipped: running as root, mode 0o000 is not enforced");
+        return;
+    }
+    drop(probe);
+
+    for mode in [MountMode::ReadWrite, MountMode::OverlayMemory(OverlayState::new())] {
+        let dir = TempDir::new().unwrap();
+        let sub = dir.path().join("sub");
+        fs::create_dir(&sub).unwrap();
+        fs::write(sub.join("f.txt"), "content").unwrap();
+        fs::set_permissions(&sub, fs::Permissions::from_mode(0o000)).unwrap();
+
+        let mut mounts = MountTable::new();
+        mounts.mount("/mnt", dir.path(), mode, None).expect("failed to mount");
+
+        for call in [
+            OsFunctionCall::ReadText("/mnt/sub/f.txt".into()),
+            OsFunctionCall::Open(OpenCallArgs {
+                path: "/mnt/sub/f.txt".into(),
+                mode: FileMode::Read(false),
+            }),
+            OsFunctionCall::AppendText(PathStringDataArgs {
+                path: "/mnt/sub/f.txt".into(),
+                data: "x".to_owned(),
+            }),
+            OsFunctionCall::Stat("/mnt/sub/f.txt".into()),
+        ] {
+            let label = format!("{call:?}");
+            let outcome = dispatch(&mut mounts, call);
+            assert!(
+                matches!(&outcome, Err(MountError::Io(err, _)) if err.kind() == ErrorKind::PermissionDenied),
+                "{label}: expected a permission error, got {outcome:?}"
+            );
+        }
+
+        // Predicates still must not raise.
+        for call in [
+            OsFunctionCall::Exists("/mnt/sub/f.txt".into()),
+            OsFunctionCall::IsFile("/mnt/sub/f.txt".into()),
+            OsFunctionCall::IsDir("/mnt/sub/f.txt".into()),
+        ] {
+            let label = format!("{call:?}");
+            assert_eq!(
+                dispatch(&mut mounts, call).unwrap(),
+                MontyObject::Bool(false),
+                "{label}: predicates must answer False, not raise"
+            );
+        }
+
+        fs::set_permissions(&sub, fs::Permissions::from_mode(0o755)).unwrap();
+    }
 }

--- a/crates/monty-fs/tests/mount_confinement.rs
+++ b/crates/monty-fs/tests/mount_confinement.rs
@@ -722,8 +722,11 @@ fn fifo_raced_into_place_between_check_and_open_is_refused() {
     let finished = rx.recv_timeout(Duration::from_secs(30)).is_ok();
     stop.store(true, Ordering::Relaxed);
     swapper.join().unwrap();
-    reader.join().unwrap();
+    // Assert before joining the reader: a read that blocked on the FIFO never
+    // returns, so joining first would hang the test binary rather than fail it
+    // — exactly the regression this test exists to catch.
     assert!(finished, "a read blocked on the raced-in FIFO");
+    reader.join().unwrap();
 }
 
 /// Creates a FIFO, the one special file a test can make portably across Unix.

--- a/crates/monty-fs/tests/mount_confinement.rs
+++ b/crates/monty-fs/tests/mount_confinement.rs
@@ -485,9 +485,9 @@ fn denied_write_is_not_reported_as_an_escape() {
 
 /// The mount root itself cannot be deleted through the mount.
 ///
-/// It has no name inside the mount, so the descriptor has nothing to unlink it
-/// from: `rmdir` and `unlink` on the root fail and the host directory survives.
-/// (Renaming the root is refused by both backends before any host I/O.)
+/// It has no name inside the mount, so there is nothing to unlink it from:
+/// `rmdir` is refused by the explicit guard (like rename), `unlink` fails at
+/// the OS, and the host directory survives both.
 #[test]
 fn deleting_the_mount_root_is_refused() {
     let mount_dir = TempDir::new().unwrap();
@@ -504,9 +504,9 @@ fn deleting_the_mount_root_is_refused() {
 
 /// Overlay `rmdir` of the mount root must never touch the host directory.
 ///
-/// The overlay currently accepts the call and tombstones the root in memory —
-/// a divergence from direct mode, which refuses it — so this pins only the
-/// host-side guarantee, not the in-memory answer.
+/// The overlay now refuses the call outright (see
+/// `rmdir_of_mount_root_is_refused_in_both_modes` in `fs.rs`); this pins the
+/// host-side guarantee that survives whatever the in-memory answer is.
 #[test]
 fn overlay_rmdir_of_the_mount_root_leaves_the_host_directory() {
     let mount_dir = TempDir::new().unwrap();
@@ -520,7 +520,11 @@ fn overlay_rmdir_of_the_mount_root_leaves_the_host_directory() {
         )
         .expect("failed to mount");
 
-    let _ = dispatch(&mut mounts, OsFunctionCall::Rmdir("/mnt".into()));
+    let rmdir = dispatch(&mut mounts, OsFunctionCall::Rmdir("/mnt".into()));
+    assert!(
+        rmdir.is_err(),
+        "overlay rmdir of the mount root must fail, got {rmdir:?}"
+    );
     assert!(mount_dir.path().exists(), "host directory must survive overlay rmdir");
 }
 

--- a/crates/monty-fs/tests/mount_confinement.rs
+++ b/crates/monty-fs/tests/mount_confinement.rs
@@ -24,12 +24,10 @@ use std::{
 };
 
 use common::{symlink_dir, symlink_file, symlinks_supported, try_rename_mount_root};
-#[cfg(unix)]
-use monty_fs::OverlayState;
-use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable};
+use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable, OverlayState};
 #[cfg(unix)]
 use monty_types::{FileMode, OpenCallArgs};
-use monty_types::{MontyObject, OsFunctionCall, PathStringDataArgs};
+use monty_types::{MkdirCallArgs, MontyObject, OsFunctionCall, PathStringDataArgs};
 use tempfile::TempDir;
 
 mod common;
@@ -483,6 +481,111 @@ fn denied_write_is_not_reported_as_an_escape() {
         matches!(&outcome, Err(MountError::Io(err, _)) if err.kind() == ErrorKind::PermissionDenied),
         "expected a plain IO permission error, got {outcome:?}"
     );
+}
+
+/// The mount root itself cannot be deleted through the mount.
+///
+/// It has no name inside the mount, so the descriptor has nothing to unlink it
+/// from: `rmdir` and `unlink` on the root fail and the host directory survives.
+/// (Renaming the root is refused by both backends before any host I/O.)
+#[test]
+fn deleting_the_mount_root_is_refused() {
+    let mount_dir = TempDir::new().unwrap();
+    let mut mounts = mount_rw(mount_dir.path());
+
+    let rmdir = dispatch(&mut mounts, OsFunctionCall::Rmdir("/mnt".into()));
+    assert!(rmdir.is_err(), "rmdir of the mount root must fail, got {rmdir:?}");
+    assert!(mount_dir.path().exists(), "host directory must survive rmdir");
+
+    let unlink = dispatch(&mut mounts, OsFunctionCall::Unlink("/mnt".into()));
+    assert!(unlink.is_err(), "unlink of the mount root must fail, got {unlink:?}");
+    assert!(mount_dir.path().exists(), "host directory must survive unlink");
+}
+
+/// Overlay `rmdir` of the mount root must never touch the host directory.
+///
+/// The overlay currently accepts the call and tombstones the root in memory —
+/// a divergence from direct mode, which refuses it — so this pins only the
+/// host-side guarantee, not the in-memory answer.
+#[test]
+fn overlay_rmdir_of_the_mount_root_leaves_the_host_directory() {
+    let mount_dir = TempDir::new().unwrap();
+    let mut mounts = MountTable::new();
+    mounts
+        .mount(
+            "/mnt",
+            mount_dir.path(),
+            MountMode::OverlayMemory(OverlayState::new()),
+            None,
+        )
+        .expect("failed to mount");
+
+    let _ = dispatch(&mut mounts, OsFunctionCall::Rmdir("/mnt".into()));
+    assert!(mount_dir.path().exists(), "host directory must survive overlay rmdir");
+}
+
+/// `mkdir(parents=True)` through an escaping symlink cannot reach the host.
+///
+/// Direct mode refuses it at the boundary. Overlay mode instead treats the
+/// (unobservable) link as absent and builds the tree in memory — consistent
+/// with its predicates answering `False` — but nothing may appear on the host
+/// and the link's real target must stay unreadable.
+#[test]
+fn mkdir_parents_under_an_escaping_symlink_cannot_reach_the_host() {
+    if !symlinks_supported() {
+        return;
+    }
+    let mount_dir = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    fs::write(outside.path().join("secret.txt"), SECRET).unwrap();
+    symlink_dir(outside.path(), mount_dir.path().join("evil"));
+
+    let mkdir_call = || {
+        OsFunctionCall::Mkdir(MkdirCallArgs {
+            path: "/mnt/evil/foo".into(),
+            parents: true,
+            exist_ok: false,
+        })
+    };
+
+    let mut direct = mount_rw(mount_dir.path());
+    let outcome = dispatch(&mut direct, mkdir_call());
+    assert!(
+        matches!(&outcome, Err(MountError::PathEscape { .. })),
+        "direct mkdir through an escaping symlink must be refused, got {outcome:?}"
+    );
+    assert!(
+        !outside.path().join("foo").exists(),
+        "directory created outside the mount"
+    );
+
+    let mut overlay = MountTable::new();
+    overlay
+        .mount(
+            "/mnt",
+            mount_dir.path(),
+            MountMode::OverlayMemory(OverlayState::new()),
+            None,
+        )
+        .expect("failed to mount");
+    let _ = dispatch(&mut overlay, mkdir_call());
+    let _ = dispatch(
+        &mut overlay,
+        OsFunctionCall::WriteText(PathStringDataArgs {
+            path: "/mnt/evil/foo/x.txt".into(),
+            data: "data".to_owned(),
+        }),
+    );
+    assert!(
+        !outside.path().join("foo").exists(),
+        "directory created outside the mount"
+    );
+    assert!(!outside.path().join("x.txt").exists(), "file created outside the mount");
+
+    let outcome = read_text(&mut overlay, "/mnt/evil/secret.txt");
+    let leaked = matches!(&outcome, Ok(MontyObject::String(s)) if s.contains(SECRET));
+    assert!(!leaked, "HOST FILE DISCLOSURE: read followed the escaping symlink");
+    assert!(outcome.is_err(), "outside read must be refused, got {outcome:?}");
 }
 
 /// Toggles the read-only attribute (Windows) / write mode bits (Unix).

--- a/crates/monty-fs/tests/mount_escape_repro.rs
+++ b/crates/monty-fs/tests/mount_escape_repro.rs
@@ -1,0 +1,131 @@
+//! Reproductions of known, unfixed mount-confinement defects.
+//!
+//! Each test asserts the *current, vulnerable* behaviour so the suite stays
+//! green; invert the assertion marked `FIX:` once the defect is fixed.
+
+use std::{fs, io::ErrorKind};
+
+use monty_fs::{Mount, MountCallOutcome, MountError, MountMode, MountTable};
+use monty_types::{MontyObject, MontyPath, OsFunctionCall, RenameCallArgs};
+use tempfile::TempDir;
+
+// Only the directory helper is used here; the rest is shared with other tests.
+#[expect(dead_code)]
+mod common;
+use common::symlink_dir;
+
+/// Dispatches `call`, panicking on the `NotHandled` these tests never expect.
+fn handled(mt: &mut MountTable, call: OsFunctionCall) -> Result<MontyObject, MountError> {
+    match mt.handle_os_call(call) {
+        MountCallOutcome::Handled(result) => result,
+        MountCallOutcome::NotHandled(call) => panic!("expected the mount table to handle {call:?}"),
+    }
+}
+
+/// Builds a `Path.rename(src, dst)` call.
+fn rename(src: &str, dst: &str) -> OsFunctionCall {
+    OsFunctionCall::Rename(RenameCallArgs {
+        src: MontyPath::new(src.to_owned()),
+        dst: MontyPath::new(dst.to_owned()),
+    })
+}
+
+/// Reads `path` through the table.
+fn read_text(mt: &mut MountTable, path: &str) -> Result<MontyObject, MountError> {
+    handled(mt, OsFunctionCall::ReadText(MontyPath::new(path.to_owned())))
+}
+
+/// A mount root is only a path string, so a rebuilt table (one per feed)
+/// re-resolves it — and renaming a symlink over that name, which sandbox code
+/// can do because a rename never dereferences, redirects the next rebuild.
+#[test]
+fn mount_root_redirected_by_rename_between_rebuilds() {
+    let base = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+
+    let shared = base.path().join("shared");
+    fs::create_dir(&shared).unwrap();
+    fs::write(outside.path().join("secret.txt"), "HOST SECRET").unwrap();
+    // Host-planted link out of the tree; the sandbox only moves it.
+    symlink_dir(outside.path(), base.path().join("prepared-link"));
+
+    // The reusable configuration, as `MountSpec` (monty-pool) records it.
+    let child_host_path = Mount::new("/child", &shared, MountMode::ReadOnly, None)
+        .unwrap()
+        .host_path()
+        .to_path_buf();
+
+    // Feed 1: swap the real directory out and the link in, under one name.
+    let mut writable = MountTable::new();
+    writable
+        .mount("/parent", base.path(), MountMode::ReadWrite, None)
+        .unwrap();
+    handled(&mut writable, rename("/parent/shared", "/parent/old-shared")).unwrap();
+    handled(&mut writable, rename("/parent/prepared-link", "/parent/shared")).unwrap();
+
+    // Feed 2: the same configuration, rebuilt into a fresh table.
+    let mut rebuilt = MountTable::new();
+    rebuilt
+        .mount("/child", &child_host_path, MountMode::ReadOnly, None)
+        .unwrap();
+
+    // FIX: the rebuild must stay pinned to the directory validated above.
+    let leaked = read_text(&mut rebuilt, "/child/secret.txt").expect("reproduction: reads outside the mount");
+    assert_eq!(leaked, MontyObject::String("HOST SECRET".to_owned()));
+}
+
+/// `route_call` looks the rename destination up with `?`, so an unmounted
+/// destination abandons routing and hands the mounted source to the host
+/// fallback — never reaching the mode check in `Mount::execute`.
+#[test]
+fn rename_out_of_mount_bypasses_the_mount_table() {
+    let host = TempDir::new().unwrap();
+    fs::write(host.path().join("source.txt"), "public").unwrap();
+    let other = TempDir::new().unwrap();
+
+    let mut mt = MountTable::new();
+    mt.mount("/data", host.path(), MountMode::ReadOnly, None).unwrap();
+    mt.mount("/other", other.path(), MountMode::ReadOnly, None).unwrap();
+
+    // Control: a destination in a *different* mount is refused.
+    match mt.handle_os_call(rename("/data/source.txt", "/other/result.txt")) {
+        MountCallOutcome::Handled(Err(MountError::CrossMountRename { .. })) => {}
+        outcome => panic!("expected CrossMountRename, got {outcome:?}"),
+    }
+
+    // FIX: an unmounted destination must be refused too, not handed on.
+    match mt.handle_os_call(rename("/data/source.txt", "/outside/result.txt")) {
+        MountCallOutcome::NotHandled(call) => assert_eq!(call.fs_primary_path(), Some("/data/source.txt")),
+        outcome @ MountCallOutcome::Handled(_) => panic!("reproduction expects NotHandled, got {outcome:?}"),
+    }
+    assert!(host.path().join("source.txt").exists());
+}
+
+/// `PATH_MAX` is checked after normalization, so it bounds the collapsed path
+/// rather than the bytes the sandbox sent.
+#[test]
+fn overlong_path_accepted_when_it_normalizes_short() {
+    let host = TempDir::new().unwrap();
+    fs::write(host.path().join("hello.txt"), "hello").unwrap();
+
+    let mut mt = MountTable::new();
+    mt.mount("/mnt", host.path(), MountMode::ReadOnly, None).unwrap();
+
+    // Control: the same length without `..` is rejected before any host I/O.
+    let long_and_deep = format!("/mnt/{}hello.txt", "a/".repeat(5_000));
+    assert!(long_and_deep.len() > 4096);
+    match read_text(&mut mt, &long_and_deep) {
+        Err(MountError::Io(err, _)) => {
+            assert_eq!(err.kind(), ErrorKind::InvalidFilename);
+            assert_eq!(err.to_string(), "File name too long");
+        }
+        other => panic!("expected the overlong path to be rejected, got {other:?}"),
+    }
+
+    let long_but_collapsing = format!("/mnt/{}{}hello.txt", "a/".repeat(5_000), "../".repeat(5_000));
+    assert!(long_but_collapsing.len() > 4096);
+
+    // FIX: reject on raw length, before normalization allocates per segment.
+    let read = read_text(&mut mt, &long_but_collapsing).expect("reproduction: the overlong request is accepted");
+    assert_eq!(read, MontyObject::String("hello".to_owned()));
+}

--- a/crates/monty-fs/tests/mount_escape_repro.rs
+++ b/crates/monty-fs/tests/mount_escape_repro.rs
@@ -1,7 +1,4 @@
-//! Reproductions of known, unfixed mount-confinement defects.
-//!
-//! Each test asserts the *current, vulnerable* behaviour so the suite stays
-//! green; invert the assertion marked `FIX:` once the defect is fixed.
+//! Regression tests for three mount-confinement defects.
 
 use std::{fs, io::ErrorKind};
 
@@ -35,25 +32,26 @@ fn read_text(mt: &mut MountTable, path: &str) -> Result<MontyObject, MountError>
     handled(mt, OsFunctionCall::ReadText(MontyPath::new(path.to_owned())))
 }
 
-/// A mount root is only a path string, so a rebuilt table (one per feed)
-/// re-resolves it — and renaming a symlink over that name, which sandbox code
-/// can do because a rename never dereferences, redirects the next rebuild.
+/// A reusable configuration carries the opened root, so each rebuild mounts the
+/// directory that was validated, not whatever its name resolves to now — even
+/// after sandbox code renames a symlink over that name, which it can do because
+/// a rename never dereferences.
 #[test]
-fn mount_root_redirected_by_rename_between_rebuilds() {
+fn mount_root_stays_pinned_across_rebuilds() {
     let base = TempDir::new().unwrap();
     let outside = TempDir::new().unwrap();
 
     let shared = base.path().join("shared");
     fs::create_dir(&shared).unwrap();
+    fs::write(shared.join("inside.txt"), "in-mount").unwrap();
     fs::write(outside.path().join("secret.txt"), "HOST SECRET").unwrap();
     // Host-planted link out of the tree; the sandbox only moves it.
     symlink_dir(outside.path(), base.path().join("prepared-link"));
 
     // The reusable configuration, as `MountSpec` (monty-pool) records it.
-    let child_host_path = Mount::new("/child", &shared, MountMode::ReadOnly, None)
-        .unwrap()
-        .host_path()
-        .to_path_buf();
+    let configured = Mount::new("/child", &shared, MountMode::ReadOnly, None).unwrap();
+    let child_root = configured.root().clone();
+    let child_host_path = configured.host_path().to_path_buf();
 
     // Feed 1: swap the real directory out and the link in, under one name.
     let mut writable = MountTable::new();
@@ -65,18 +63,30 @@ fn mount_root_redirected_by_rename_between_rebuilds() {
 
     // Feed 2: the same configuration, rebuilt into a fresh table.
     let mut rebuilt = MountTable::new();
-    rebuilt
+    rebuilt.push_mount(Mount::with_root(child_root, MountMode::ReadOnly, None));
+
+    // The rebuild still serves the directory that was validated, and the file
+    // the redirect aimed at is simply not in it.
+    let inside = read_text(&mut rebuilt, "/child/inside.txt").unwrap();
+    assert_eq!(inside, MontyObject::String("in-mount".to_owned()));
+    match read_text(&mut rebuilt, "/child/secret.txt") {
+        Err(MountError::Io(err, _)) => assert_eq!(err.kind(), ErrorKind::NotFound),
+        other => panic!("expected the redirected read to miss, got {other:?}"),
+    }
+
+    // Re-deriving the mount from the host *path* is what the rename defeats —
+    // which is why a host must keep the root, not the path it came from.
+    let mut from_path = MountTable::new();
+    from_path
         .mount("/child", &child_host_path, MountMode::ReadOnly, None)
         .unwrap();
-
-    // FIX: the rebuild must stay pinned to the directory validated above.
-    let leaked = read_text(&mut rebuilt, "/child/secret.txt").expect("reproduction: reads outside the mount");
+    let leaked = read_text(&mut from_path, "/child/secret.txt").unwrap();
     assert_eq!(leaked, MontyObject::String("HOST SECRET".to_owned()));
 }
 
-/// Once either side of a rename is covered, the table owns the call: handing it
-/// to the fallback would give a handler answering on raw virtual paths the
-/// mounted side, never reaching the mode check in `Mount::execute`.
+/// Once either side of a rename is covered, the table owns the call: the
+/// fallback answers on raw virtual paths, so handing it on would skip the mode
+/// check in `Mount::execute`.
 #[test]
 fn rename_with_one_side_out_of_mount_is_refused() {
     let host = TempDir::new().unwrap();
@@ -121,7 +131,7 @@ fn overlong_path_rejected_even_when_it_normalizes_short() {
     let long_but_collapsing = format!("/mnt/{}{}hello.txt", "a/".repeat(5_000), "../".repeat(5_000));
     assert!(long_and_deep.len() > 4096 && long_but_collapsing.len() > 4096);
 
-    // Both backends resolve paths through their own entry point, so both are checked.
+    // Each backend has its own path entry point, so both are checked.
     for mode in [MountMode::ReadOnly, MountMode::OverlayMemory(OverlayState::new())] {
         let mut mt = MountTable::new();
         mt.mount("/mnt", host.path(), mode, None).unwrap();

--- a/crates/monty-fs/tests/mount_escape_repro.rs
+++ b/crates/monty-fs/tests/mount_escape_repro.rs
@@ -74,11 +74,11 @@ fn mount_root_redirected_by_rename_between_rebuilds() {
     assert_eq!(leaked, MontyObject::String("HOST SECRET".to_owned()));
 }
 
-/// `route_call` looks the rename destination up with `?`, so an unmounted
-/// destination abandons routing and hands the mounted source to the host
-/// fallback — never reaching the mode check in `Mount::execute`.
+/// Once either side of a rename is covered, the table owns the call: handing it
+/// to the fallback would give a handler answering on raw virtual paths the
+/// mounted side, never reaching the mode check in `Mount::execute`.
 #[test]
-fn rename_out_of_mount_bypasses_the_mount_table() {
+fn rename_with_one_side_out_of_mount_is_refused() {
     let host = TempDir::new().unwrap();
     fs::write(host.path().join("source.txt"), "public").unwrap();
     let other = TempDir::new().unwrap();
@@ -87,18 +87,27 @@ fn rename_out_of_mount_bypasses_the_mount_table() {
     mt.mount("/data", host.path(), MountMode::ReadOnly, None).unwrap();
     mt.mount("/other", other.path(), MountMode::ReadOnly, None).unwrap();
 
-    // Control: a destination in a *different* mount is refused.
-    match mt.handle_os_call(rename("/data/source.txt", "/other/result.txt")) {
+    // A destination in a *different* mount is refused.
+    assert_cross_mount(&mut mt, rename("/data/source.txt", "/other/result.txt"));
+
+    // So is one under no mount at all, in either direction.
+    assert_cross_mount(&mut mt, rename("/data/source.txt", "/outside/result.txt"));
+    assert_cross_mount(&mut mt, rename("/outside/source.txt", "/data/result.txt"));
+    assert!(host.path().join("source.txt").exists());
+
+    // A rename with neither side mounted is still the fallback's to answer.
+    match mt.handle_os_call(rename("/outside/source.txt", "/elsewhere/result.txt")) {
+        MountCallOutcome::NotHandled(call) => assert_eq!(call.fs_primary_path(), Some("/outside/source.txt")),
+        outcome @ MountCallOutcome::Handled(_) => panic!("expected NotHandled, got {outcome:?}"),
+    }
+}
+
+/// Asserts `call` was refused as a cross-mount rename (`EXDEV`).
+fn assert_cross_mount(mt: &mut MountTable, call: OsFunctionCall) {
+    match mt.handle_os_call(call) {
         MountCallOutcome::Handled(Err(MountError::CrossMountRename { .. })) => {}
         outcome => panic!("expected CrossMountRename, got {outcome:?}"),
     }
-
-    // FIX: an unmounted destination must be refused too, not handed on.
-    match mt.handle_os_call(rename("/data/source.txt", "/outside/result.txt")) {
-        MountCallOutcome::NotHandled(call) => assert_eq!(call.fs_primary_path(), Some("/data/source.txt")),
-        outcome @ MountCallOutcome::Handled(_) => panic!("reproduction expects NotHandled, got {outcome:?}"),
-    }
-    assert!(host.path().join("source.txt").exists());
 }
 
 /// `PATH_MAX` bounds the bytes the sandbox sent, not the path they collapse to,

--- a/crates/monty-fs/tests/mount_escape_repro.rs
+++ b/crates/monty-fs/tests/mount_escape_repro.rs
@@ -5,7 +5,7 @@
 
 use std::{fs, io::ErrorKind};
 
-use monty_fs::{Mount, MountCallOutcome, MountError, MountMode, MountTable};
+use monty_fs::{Mount, MountCallOutcome, MountError, MountMode, MountTable, OverlayState};
 use monty_types::{MontyObject, MontyPath, OsFunctionCall, RenameCallArgs};
 use tempfile::TempDir;
 
@@ -101,31 +101,42 @@ fn rename_out_of_mount_bypasses_the_mount_table() {
     assert!(host.path().join("source.txt").exists());
 }
 
-/// `PATH_MAX` is checked after normalization, so it bounds the collapsed path
-/// rather than the bytes the sandbox sent.
+/// `PATH_MAX` bounds the bytes the sandbox sent, not the path they collapse to,
+/// so padding a request with `..` no longer buys unlimited length.
 #[test]
-fn overlong_path_accepted_when_it_normalizes_short() {
+fn overlong_path_rejected_even_when_it_normalizes_short() {
     let host = TempDir::new().unwrap();
     fs::write(host.path().join("hello.txt"), "hello").unwrap();
 
-    let mut mt = MountTable::new();
-    mt.mount("/mnt", host.path(), MountMode::ReadOnly, None).unwrap();
-
-    // Control: the same length without `..` is rejected before any host I/O.
     let long_and_deep = format!("/mnt/{}hello.txt", "a/".repeat(5_000));
-    assert!(long_and_deep.len() > 4096);
-    match read_text(&mut mt, &long_and_deep) {
+    let long_but_collapsing = format!("/mnt/{}{}hello.txt", "a/".repeat(5_000), "../".repeat(5_000));
+    assert!(long_and_deep.len() > 4096 && long_but_collapsing.len() > 4096);
+
+    // Both backends resolve paths through their own entry point, so both are checked.
+    for mode in [MountMode::ReadOnly, MountMode::OverlayMemory(OverlayState::new())] {
+        let mut mt = MountTable::new();
+        mt.mount("/mnt", host.path(), mode, None).unwrap();
+
+        // A path without `..` is rejected before any host I/O.
+        assert_too_long(read_text(&mut mt, &long_and_deep));
+
+        // The same length collapsing to `/mnt/hello.txt` is rejected on the same
+        // grounds, rather than being measured after the `..` components cancel out.
+        assert_too_long(read_text(&mut mt, &long_but_collapsing));
+
+        // The path it collapses to is served normally, so only length is at issue.
+        let read = read_text(&mut mt, "/mnt/a/../hello.txt").unwrap();
+        assert_eq!(read, MontyObject::String("hello".to_owned()));
+    }
+}
+
+/// Asserts an operation failed with the `ENAMETOOLONG` form of [`MountError`].
+fn assert_too_long(result: Result<MontyObject, MountError>) {
+    match result {
         Err(MountError::Io(err, _)) => {
             assert_eq!(err.kind(), ErrorKind::InvalidFilename);
             assert_eq!(err.to_string(), "File name too long");
         }
         other => panic!("expected the overlong path to be rejected, got {other:?}"),
     }
-
-    let long_but_collapsing = format!("/mnt/{}{}hello.txt", "a/".repeat(5_000), "../".repeat(5_000));
-    assert!(long_but_collapsing.len() > 4096);
-
-    // FIX: reject on raw length, before normalization allocates per segment.
-    let read = read_text(&mut mt, &long_but_collapsing).expect("reproduction: the overlong request is accepted");
-    assert_eq!(read, MontyObject::String("hello".to_owned()));
 }

--- a/crates/monty-fs/tests/mount_escape_repro.rs
+++ b/crates/monty-fs/tests/mount_escape_repro.rs
@@ -58,7 +58,19 @@ fn mount_root_stays_pinned_across_rebuilds() {
     writable
         .mount("/parent", base.path(), MountMode::ReadWrite, None)
         .unwrap();
-    handled(&mut writable, rename("/parent/shared", "/parent/old-shared")).unwrap();
+    // Windows refuses to rename a directory while a handle to it is open, and
+    // `configured` holds one — so there the swap cannot even be staged while a
+    // mount is alive, and the redirect this guards against is unreachable.
+    match handled(&mut writable, rename("/parent/shared", "/parent/old-shared")) {
+        Ok(_) => {}
+        // Windows refuses to rename a directory while a handle to it is open,
+        // and the mount above holds one, so the swap cannot even be staged
+        // there — the redirect this guards against is unreachable.
+        #[cfg(windows)]
+        Err(_) => return,
+        #[cfg(not(windows))]
+        Err(err) => panic!("staging the swap failed: {err:?}"),
+    }
     handled(&mut writable, rename("/parent/prepared-link", "/parent/shared")).unwrap();
 
     // Feed 2: the same configuration, rebuilt into a fresh table.

--- a/crates/monty-fs/tests/overlay_stale_ref.rs
+++ b/crates/monty-fs/tests/overlay_stale_ref.rs
@@ -9,6 +9,8 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
+#[cfg(unix)]
+use std::{io::ErrorKind, os::unix::fs::PermissionsExt};
 
 use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable, OverlayState};
 use monty_types::{MontyObject, OsFunctionCall, PathStringDataArgs, RenameCallArgs};
@@ -171,6 +173,35 @@ fn mount_root_swap_does_not_redirect_a_cached_ref() {
         "HOST FILE DISCLOSURE: swapping the mount root redirected the read"
     );
     assert_eq!(outcome.unwrap(), MontyObject::String("public".to_owned()));
+}
+
+/// Renaming an in-mount symlink whose target is unreadable must report the I/O
+/// error, not a path escape.
+///
+/// `PathEscape` means the boundary caught something; a permission failure on a
+/// target that is plainly inside the mount is not that.
+#[test]
+#[cfg(unix)]
+fn renaming_symlink_to_denied_target_reports_the_io_error() {
+    let mount_dir = TempDir::new().unwrap();
+    let sub = mount_dir.path().join("sub");
+    fs::create_dir(&sub).unwrap();
+    fs::write(sub.join("target.txt"), "content").unwrap();
+    symlink_file("sub/target.txt", mount_dir.path().join("link.txt"));
+    fs::set_permissions(&sub, fs::Permissions::from_mode(0o000)).unwrap();
+    if fs::read(sub.join("target.txt")).is_ok() {
+        eprintln!("skipped: running as root, mode 0o000 is not enforced");
+        return;
+    }
+
+    let mut mt = mount_overlay(mount_dir.path());
+    let outcome = dispatch(&mut mt, rename_call("/mnt/link.txt", "/mnt/moved.txt"));
+
+    fs::set_permissions(&sub, fs::Permissions::from_mode(0o755)).unwrap();
+    assert!(
+        matches!(&outcome, Err(MountError::Io(err, _)) if err.kind() == ErrorKind::PermissionDenied),
+        "expected a permission error, got {outcome:?}"
+    );
 }
 
 /// Control — the same escaping symlink read through the normal resolution path

--- a/crates/monty-fs/tests/overlay_stale_ref.rs
+++ b/crates/monty-fs/tests/overlay_stale_ref.rs
@@ -15,7 +15,7 @@ use monty_types::{MontyObject, OsFunctionCall, PathStringDataArgs, RenameCallArg
 use tempfile::TempDir;
 
 mod common;
-use common::{symlink_dir, symlink_file};
+use common::{symlink_dir, symlink_file, try_rename_mount_root};
 
 /// Marker written to the out-of-mount file; its appearance in any result is
 /// the disclosure these tests guard against.
@@ -137,11 +137,14 @@ fn stale_ref_is_revalidated_on_append() {
     scenario.assert_rejected(OsFunctionCall::ReadText("/mnt/moved.txt".into()));
 }
 
-/// Swapping the mount root for an escaping symlink after the ref was cached:
-/// the check must compare against the root canonicalized at mount time, since
-/// re-canonicalizing here would follow the swap.
+/// Swapping the mount root for an escaping symlink after the ref was cached
+/// must not redirect the read.
+///
+/// The ref is mount-relative and the mount holds a descriptor, so the swap is
+/// invisible and the read still serves the original file. With a host path it
+/// had to be *rejected* instead.
 #[test]
-fn stale_ref_is_rejected_when_mount_root_is_swapped() {
+fn mount_root_swap_does_not_redirect_a_cached_ref() {
     let base = TempDir::new().unwrap();
     let mount_path = base.path().join("mount");
     let elsewhere = base.path().join("elsewhere");
@@ -153,21 +156,21 @@ fn stale_ref_is_rejected_when_mount_root_is_swapped() {
     let mut mt = mount_overlay(&mount_path);
     dispatch(&mut mt, rename_call("/mnt/inner/file.txt", "/mnt/moved.txt")).expect("rename should succeed");
 
-    // Swap the whole mount root for a link to `elsewhere`, so the cached ref's
-    // path resolves under a directory that was never mounted.
-    fs::rename(&mount_path, base.path().join("mount_old")).unwrap();
-    symlink_dir(&elsewhere, &mount_path);
+    // Swap the whole mount root for a link to `elsewhere`, so the ref's path
+    // *as a string* now names a directory that was never mounted. Windows
+    // refuses the rename while the mount holds the directory open, which denies
+    // the swap outright rather than merely making it ineffective.
+    if try_rename_mount_root(&mount_path, base.path().join("mount_old")) {
+        symlink_dir(&elsewhere, &mount_path);
+    }
 
     let outcome = dispatch(&mut mt, OsFunctionCall::ReadText("/mnt/moved.txt".into()));
     let leaked = matches!(&outcome, Ok(MontyObject::String(s)) if s.contains(SECRET));
     assert!(
         !leaked,
-        "HOST FILE DISCLOSURE: swapping the mount root defeated the check"
+        "HOST FILE DISCLOSURE: swapping the mount root redirected the read"
     );
-    assert!(
-        matches!(outcome, Err(MountError::PathEscape { .. })),
-        "expected PathEscape, got {outcome:?}"
-    );
+    assert_eq!(outcome.unwrap(), MontyObject::String("public".to_owned()));
 }
 
 /// Control — the same escaping symlink read through the normal resolution path

--- a/crates/monty-fs/tests/overlay_stale_ref.rs
+++ b/crates/monty-fs/tests/overlay_stale_ref.rs
@@ -17,7 +17,7 @@ use monty_types::{MontyObject, OsFunctionCall, PathStringDataArgs, RenameCallArg
 use tempfile::TempDir;
 
 mod common;
-use common::{symlink_dir, symlink_file, try_rename_mount_root};
+use common::{symlink_dir, symlink_file, symlinks_supported, try_rename_mount_root};
 
 /// Marker written to the out-of-mount file; its appearance in any result is
 /// the disclosure these tests guard against.
@@ -114,12 +114,18 @@ impl StaleRef {
 /// `read_text` must re-validate the cached ref rather than trust it.
 #[test]
 fn stale_ref_is_revalidated_on_read_text() {
+    if !symlinks_supported() {
+        return;
+    }
     StaleRef::new().assert_rejected(OsFunctionCall::ReadText("/mnt/moved.txt".into()));
 }
 
 /// `read_bytes` shares the `RealFileRef` shortcut and must re-validate too.
 #[test]
 fn stale_ref_is_revalidated_on_read_bytes() {
+    if !symlinks_supported() {
+        return;
+    }
     StaleRef::new().assert_rejected(OsFunctionCall::ReadBytes("/mnt/moved.txt".into()));
 }
 
@@ -128,6 +134,9 @@ fn stale_ref_is_revalidated_on_read_bytes() {
 /// otherwise the secret lands in overlay state and reads back from memory.
 #[test]
 fn stale_ref_is_revalidated_on_append() {
+    if !symlinks_supported() {
+        return;
+    }
     let mut scenario = StaleRef::new();
     scenario.assert_rejected(OsFunctionCall::AppendText(PathStringDataArgs {
         path: "/mnt/moved.txt".into(),
@@ -147,6 +156,9 @@ fn stale_ref_is_revalidated_on_append() {
 /// had to be *rejected* instead.
 #[test]
 fn mount_root_swap_does_not_redirect_a_cached_ref() {
+    if !symlinks_supported() {
+        return;
+    }
     let base = TempDir::new().unwrap();
     let mount_path = base.path().join("mount");
     let elsewhere = base.path().join("elsewhere");
@@ -183,6 +195,9 @@ fn mount_root_swap_does_not_redirect_a_cached_ref() {
 #[test]
 #[cfg(unix)]
 fn renaming_symlink_to_denied_target_reports_the_io_error() {
+    if !symlinks_supported() {
+        return;
+    }
     let mount_dir = TempDir::new().unwrap();
     let sub = mount_dir.path().join("sub");
     fs::create_dir(&sub).unwrap();
@@ -208,6 +223,9 @@ fn renaming_symlink_to_denied_target_reports_the_io_error() {
 /// is rejected, so the leak above is specific to the `RealFileRef` shortcut.
 #[test]
 fn direct_read_through_escaping_symlink_is_rejected() {
+    if !symlinks_supported() {
+        return;
+    }
     let mount_dir = TempDir::new().unwrap();
     let outside_dir = TempDir::new().unwrap();
 
@@ -244,6 +262,9 @@ fn junction_is_classified_as_symlink() {
 /// `reject_escaping_symlink` is exercised rather than the read-time check behind it.
 #[test]
 fn renaming_escaping_symlink_into_overlay_is_rejected() {
+    if !symlinks_supported() {
+        return;
+    }
     let mount_dir = TempDir::new().unwrap();
     let outside_dir = TempDir::new().unwrap();
 

--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -194,6 +194,10 @@ Modes: `'read-only'`, `'read-write'`, and `'overlay'` (default — writes are
 kept in memory and discarded at the end of the feed). Mount I/O is serviced
 on the host side of the pool, so mounts work even for remote workers.
 
+The constructor opens the host directory, so an unusable path throws there
+rather than at the first feed, and the mount then follows _that directory_ for
+its lifetime — renaming or replacing it afterwards changes nothing.
+
 `feedRun` answers every OS call automatically: mounts get first refusal, then
 the `os` callback. `feedStart` answers none — a mounted read surfaces as a
 `FunctionSnapshot` with `isOsFunction` set, and `resumeAuto()` is what consults

--- a/crates/monty-js/__test__/mount.spec.ts
+++ b/crates/monty-js/__test__/mount.spec.ts
@@ -85,7 +85,7 @@ test('MountDir nonexistent host path', async (ctx) => {
   // constructor). The OS-error suffix is platform specific.
   const md = new MountDir({ hostPath: '/nonexistent/path/that/does/not/exist', virtualPath: '/data' })
   const error = await t.throwsAsync(() => run('1 + 1', { mount: md }), { instanceOf: MontyRuntimeError })
-  t.true(error.message.startsWith("TypeError: cannot canonicalize host path '/nonexistent/path/that/does/not/exist':"))
+  t.true(error.message.startsWith("TypeError: cannot open host path '/nonexistent/path/that/does/not/exist':"))
 })
 
 test('MountDir non-absolute virtual path', async (ctx) => {

--- a/crates/monty-js/__test__/mount.spec.ts
+++ b/crates/monty-js/__test__/mount.spec.ts
@@ -42,11 +42,6 @@ test('browser wasm reports mounts as unsupported', async (ctx) => {
 
 test('a mount follows its directory across feeds, not its path', async (ctx) => {
   skipIfBrowser(ctx)
-  if (process.platform === 'win32') {
-    // Planting the link needs symlink creation, which Windows gates behind a
-    // privilege; the confinement itself is not platform-specific.
-    ctx.skip()
-  }
   const base = fs.mkdtempSync(path.join(os.tmpdir(), 'monty-mount-pin-'))
   const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'monty-mount-out-'))
   try {
@@ -54,8 +49,13 @@ test('a mount follows its directory across feeds, not its path', async (ctx) => 
     fs.mkdirSync(shared)
     fs.writeFileSync(path.join(shared, 'inside.txt'), 'in-mount')
     fs.writeFileSync(path.join(outside, 'secret.txt'), 'HOST SECRET')
-    // Host-planted link out of the tree; the sandbox only moves it.
-    fs.symlinkSync(outside, path.join(base, 'prepared-link'), 'dir')
+    // Host-planted link out of the tree; the sandbox only moves it. Windows
+    // gates symlink creation behind a privilege, so skip rather than fail.
+    try {
+      fs.symlinkSync(outside, path.join(base, 'prepared-link'), 'dir')
+    } catch {
+      ctx.skip()
+    }
 
     const child = new MountDir({ hostPath: shared, virtualPath: '/child', mode: 'read-only' })
     const parent = new MountDir({ hostPath: base, virtualPath: '/parent', mode: 'read-write' })

--- a/crates/monty-js/__test__/mount.spec.ts
+++ b/crates/monty-js/__test__/mount.spec.ts
@@ -5,7 +5,7 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 
-import { MontyFileHandle, MontyRuntimeError, MountDir } from '@pydantic/monty/node'
+import { MontyFileHandle, MontyRuntimeError, MountDir, type MountDirOptions } from '@pydantic/monty/node'
 import { setupPool } from './helpers.js'
 
 const { run, pool } = setupPool()
@@ -14,15 +14,32 @@ const { run, pool } = setupPool()
 // Helper: create a temporary directory with test files
 // =============================================================================
 
-function createTestDir(): { dir: string; cleanup: () => void } {
+function createTestDir(): {
+  dir: string
+  mount: (options: Omit<MountDirOptions, 'hostPath'>) => MountDir
+  cleanup: () => void
+} {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'monty-mount-test-'))
   fs.writeFileSync(path.join(dir, 'hello.txt'), 'hello world')
   fs.writeFileSync(path.join(dir, 'data.bin'), Buffer.from([0x00, 0x01, 0x02]))
   fs.mkdirSync(path.join(dir, 'subdir'))
   fs.writeFileSync(path.join(dir, 'subdir', 'nested.txt'), 'nested content')
+  const mounts: MountDir[] = []
   return {
     dir,
-    cleanup: () => fs.rmSync(dir, { recursive: true, force: true }),
+    // Mounts made here are closed by `cleanup`: Windows will not remove a
+    // directory while a mount still holds it open.
+    mount: (options) => {
+      const md = new MountDir({ hostPath: dir, ...options })
+      mounts.push(md)
+      return md
+    },
+    cleanup: () => {
+      for (const md of mounts) {
+        md.close()
+      }
+      fs.rmSync(dir, { recursive: true, force: true })
+    },
   }
 }
 
@@ -57,17 +74,26 @@ test('a mount follows its directory across feeds, not its path', async (ctx) => 
       ctx.skip()
     }
 
-    const child = new MountDir({ hostPath: shared, virtualPath: '/child', mode: 'read-only' })
-    const parent = new MountDir({ hostPath: base, virtualPath: '/parent', mode: 'read-write' })
+    using child = new MountDir({ hostPath: shared, virtualPath: '/child', mode: 'read-only' })
+    using parent = new MountDir({ hostPath: base, virtualPath: '/parent', mode: 'read-write' })
     await using session = await pool().checkout()
 
     // Feed 1: swap the real directory out and the link in, under one name.
-    await session.feedRun(
-      `from pathlib import Path
+    // Windows refuses to rename a directory while a handle to it is open, and
+    // the child mount holds one, so the swap cannot be staged there at all.
+    try {
+      await session.feedRun(
+        `from pathlib import Path
 Path('/parent/shared').rename('/parent/old-shared')
 Path('/parent/prepared-link').rename('/parent/shared')`,
-      { mount: parent },
-    )
+        { mount: parent },
+      )
+    } catch (err) {
+      if (process.platform === 'win32') {
+        ctx.skip()
+      }
+      throw err
+    }
 
     // Feed 2: the same mount object, and the redirect has not reached it.
     const result = await session.feedRun(
@@ -84,9 +110,9 @@ f"{Path('/child/inside.txt').read_text()}:{Path('/child/secret.txt').exists()}"`
 
 test('MountDir repr', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     t.is(md.repr(), `MountDir(host_path='${dir}', virtual_path='/data', mode='read-only')`)
   } finally {
     cleanup()
@@ -95,9 +121,9 @@ test('MountDir repr', (ctx) => {
 
 test('MountDir invalid mode', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const error = t.throws(() => new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'invalid' as never }))
+    const error = t.throws(() => mount({ virtualPath: '/data', mode: 'invalid' as never }))
     t.is(error?.message, "invalid mount mode: 'invalid'. Expected 'read-only', 'read-write' or 'overlay'")
   } finally {
     cleanup()
@@ -106,15 +132,15 @@ test('MountDir invalid mode', (ctx) => {
 
 test('MountDir attributes', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     t.is(md.virtualPath, '/data')
     t.is(md.hostPath, dir)
     t.is(md.mode, 'read-only')
     t.is(md.memoryUsageLimit, 100_000_000)
 
-    const limited = new MountDir({ hostPath: dir, virtualPath: '/limited', memoryUsageLimit: 1234 })
+    const limited = mount({ virtualPath: '/limited', memoryUsageLimit: 1234 })
     t.is(limited.memoryUsageLimit, 1234)
   } finally {
     cleanup()
@@ -133,10 +159,27 @@ test('MountDir nonexistent host path', (ctx) => {
 
 test('MountDir non-absolute virtual path', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const error = t.throws(() => new MountDir({ hostPath: dir, virtualPath: 'relative' }))
+    const error = t.throws(() => mount({ virtualPath: 'relative' }))
     t.is(error.message, "TypeError: virtual path must be absolute, got: 'relative'")
+  } finally {
+    cleanup()
+  }
+})
+
+test('closing a mount releases it and later feeds are refused', async (ctx) => {
+  skipIfBrowser(ctx)
+  const { mount, cleanup } = createTestDir()
+  try {
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
+    t.is(await run("open('/data/hello.txt').read()", { mount: md }), 'hello world')
+
+    md.close()
+    md.close() // idempotent
+    await t.throwsAsync(() => run("open('/data/hello.txt').read()", { mount: md }))
+    // The configuration it reports outlives the descriptor.
+    t.is(md.virtualPath, '/data')
   } finally {
     cleanup()
   }
@@ -144,9 +187,9 @@ test('MountDir non-absolute virtual path', (ctx) => {
 
 test('MountDir default mode is overlay', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data' })
+    const md = mount({ virtualPath: '/data' })
     t.is(md.mode, 'overlay')
   } finally {
     cleanup()
@@ -155,12 +198,12 @@ test('MountDir default mode is overlay', (ctx) => {
 
 test('MountDir write_bytes_limit', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', writeBytesLimit: 1024 })
+    const md = mount({ virtualPath: '/data', writeBytesLimit: 1024 })
     t.is(md.writeBytesLimit, 1024)
 
-    const md2 = new MountDir({ hostPath: dir, virtualPath: '/data' })
+    const md2 = mount({ virtualPath: '/data' })
     t.is(md2.writeBytesLimit, null)
   } finally {
     cleanup()
@@ -257,9 +300,9 @@ test('MontyFileHandle rejects invalid arguments', () => {
 
 test('read_text via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; Path('/data/hello.txt').read_text()", { mount: md })
     t.is(result, 'hello world')
   } finally {
@@ -269,9 +312,9 @@ test('read_text via mount', async (ctx) => {
 
 test('read_bytes via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; Path('/data/data.bin').read_bytes()", { mount: md })
     t.deepEqual(result, Buffer.from([0x00, 0x01, 0x02]))
   } finally {
@@ -281,9 +324,9 @@ test('read_bytes via mount', async (ctx) => {
 
 test('path exists via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
 from pathlib import Path
 exists_file = Path('/data/hello.txt').exists()
@@ -299,9 +342,9 @@ exists_missing = Path('/data/nope.txt').exists()
 
 test('is_file and is_dir via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
 from pathlib import Path
 [Path('/data/hello.txt').is_file(), Path('/data/hello.txt').is_dir(),
@@ -315,9 +358,9 @@ from pathlib import Path
 
 test('iterdir via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
 from pathlib import Path
 sorted([p.name for p in Path('/data').iterdir()])
@@ -330,9 +373,9 @@ sorted([p.name for p in Path('/data').iterdir()])
 
 test('stat via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
 from pathlib import Path
 s = Path('/data/hello.txt').stat()
@@ -346,9 +389,9 @@ s.st_size
 
 test('read nested file via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; Path('/data/subdir/nested.txt').read_text()", { mount: md })
     t.is(result, 'nested content')
   } finally {
@@ -362,9 +405,9 @@ test('read nested file via mount', async (ctx) => {
 
 test('write blocked on read-only mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(
       () => run("from pathlib import Path; Path('/data/new.txt').write_text('x')", { mount: md }),
       { instanceOf: MontyRuntimeError },
@@ -377,9 +420,9 @@ test('write blocked on read-only mount', async (ctx) => {
 
 test('write succeeds on read-write mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-write' })
+    const md = mount({ virtualPath: '/data', mode: 'read-write' })
     const code = `
 from pathlib import Path
 Path('/data/new.txt').write_text('written by monty')
@@ -395,9 +438,9 @@ Path('/data/new.txt').read_text()
 
 test('overlay write does not modify host', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const code = `
 from pathlib import Path
 Path('/data/overlay_file.txt').write_text('overlay content')
@@ -413,9 +456,9 @@ Path('/data/overlay_file.txt').read_text()
 
 test('overlay read falls through to host', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const result = await run("from pathlib import Path; Path('/data/hello.txt').read_text()", { mount: md })
     t.is(result, 'hello world')
   } finally {
@@ -427,9 +470,9 @@ test('overlay writes do not persist across runs', async (ctx) => {
   skipIfBrowser(ctx)
   // Overlay state lives in the pool's per-feed mount table, so unlike the old
   // in-process API it does NOT persist across runs sharing the same MountDir.
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     await run("from pathlib import Path; Path('/data/persistent.txt').write_text('run1')", { mount: md })
     const error = await t.throwsAsync(
       () => run("from pathlib import Path; Path('/data/persistent.txt').read_text()", { mount: md }),
@@ -443,9 +486,9 @@ test('overlay writes do not persist across runs', async (ctx) => {
 
 test('overlay memory usage limit is aggregate', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay', memoryUsageLimit: 1000 })
+    const md = mount({ virtualPath: '/data', mode: 'overlay', memoryUsageLimit: 1000 })
     const code = `
 from pathlib import Path
 p = Path('/data/retained.bin')
@@ -465,9 +508,9 @@ p.read_bytes()
 
 test('mkdir and rmdir via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const code = `
 from pathlib import Path
 Path('/data/newdir').mkdir()
@@ -484,9 +527,9 @@ after = Path('/data/newdir').exists()
 
 test('unlink via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const code = `
 from pathlib import Path
 Path('/data/hello.txt').unlink()
@@ -502,9 +545,9 @@ Path('/data/hello.txt').exists()
 
 test('rename via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const code = `
 from pathlib import Path
 Path('/data/hello.txt').rename('/data/renamed.txt')
@@ -518,9 +561,9 @@ Path('/data/hello.txt').rename('/data/renamed.txt')
 
 test('resolve via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; str(Path('/data/subdir/../hello.txt').resolve())", {
       mount: md,
     })
@@ -536,9 +579,9 @@ test('resolve via mount', async (ctx) => {
 
 test('path traversal blocked', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(
       () => run("from pathlib import Path; Path('/data/../../etc/passwd').read_text()", { mount: md }),
       { instanceOf: MontyRuntimeError },
@@ -551,9 +594,9 @@ test('path traversal blocked', async (ctx) => {
 
 test('unmounted path denied', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(
       () => run("from pathlib import Path; Path('/other/file.txt').exists()", { mount: md }),
       { instanceOf: MontyRuntimeError },
@@ -570,9 +613,9 @@ test('unmounted path denied', async (ctx) => {
 
 test('non-filesystem os call without fallback', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(() => run("import os; os.getenv('PATH')", { mount: md }), {
       instanceOf: MontyRuntimeError,
     })
@@ -615,9 +658,9 @@ b = Path('/rw/file2.txt').read_text()
 
 test('mount works with external functions', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
 from pathlib import Path
 content = Path('/data/hello.txt').read_text()
@@ -637,10 +680,10 @@ result + content
 
 test('session feed with mount read', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     await session.feedRun('from pathlib import Path', { mount: md })
     t.is(await session.feedRun("Path('/data/hello.txt').read_text()", { mount: md }), 'hello world')
   } finally {
@@ -656,10 +699,10 @@ test('session feed with mount read', async (ctx) => {
 
 test('session overlay write is discarded between feeds', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     await session.feedRun('from pathlib import Path', { mount: md })
     await session.feedRun("Path('/data/new.txt').write_text('from repl')", { mount: md })
     const error = await t.throwsAsync(() => session.feedRun("Path('/data/new.txt').read_text()", { mount: md }), {
@@ -676,10 +719,10 @@ test('session overlay write is discarded between feeds', async (ctx) => {
 
 test('session overlay overwrite reverts between feeds', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     await session.feedRun('from pathlib import Path', { mount: md })
     await session.feedRun("Path('/data/hello.txt').write_text('version1')", { mount: md })
     // The next feed sees the pristine host content again ...
@@ -694,10 +737,10 @@ test('session overlay overwrite reverts between feeds', async (ctx) => {
 
 test('session overlay delete reverts between feeds', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     await session.feedRun('from pathlib import Path', { mount: md })
     await session.feedRun("Path('/data/hello.txt').unlink()", { mount: md })
     // The deletion only lived inside the previous feed's overlay.
@@ -711,9 +754,9 @@ test('session overlay delete reverts between feeds', async (ctx) => {
 
 test('overlay mkdir and nested write within one feed', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const code = `
 from pathlib import Path
 Path('/data/mydir').mkdir()
@@ -729,9 +772,9 @@ Path('/data/mydir/file.txt').read_text()
 
 test('overlay iterdir sees overlay files', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const code = `
 from pathlib import Path
 Path('/data/extra.txt').write_text('extra')
@@ -745,10 +788,10 @@ sorted([p.name for p in Path('/data').iterdir()])
 
 test('session read-write mount writes to host', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-write' })
+    const md = mount({ virtualPath: '/data', mode: 'read-write' })
     await session.feedRun('from pathlib import Path', { mount: md })
     await session.feedRun("Path('/data/rw_file.txt').write_text('written')", { mount: md })
     t.is(await session.feedRun("Path('/data/rw_file.txt').read_text()", { mount: md }), 'written')
@@ -762,10 +805,10 @@ test('session read-write mount writes to host', async (ctx) => {
 
 test('session read-only mount blocks write', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     await session.feedRun('from pathlib import Path', { mount: md })
     const error = await t.throwsAsync(() => session.feedRun("Path('/data/nope.txt').write_text('x')", { mount: md }), {
       instanceOf: MontyRuntimeError,
@@ -794,10 +837,10 @@ function makeSymlink(target: string, link: string): boolean {
 
 test('relative symlink inside a mount is followed', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
     if (!makeSymlink('hello.txt', path.join(dir, 'rel_link.txt'))) return
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; Path('/data/rel_link.txt').read_text()", { mount: md })
     t.is(result, 'hello world')
   } finally {
@@ -807,12 +850,12 @@ test('relative symlink inside a mount is followed', async (ctx) => {
 
 test('absolute symlink target is refused inside a mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
     // Absolute even though it points back into the same mount: a descriptor has
     // no path of its own, so a leading '/' cannot be interpreted.
     if (!makeSymlink(path.join(dir, 'hello.txt'), path.join(dir, 'abs_link.txt'))) return
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
 
     const error = await t.throwsAsync(
       () => run("from pathlib import Path; Path('/data/abs_link.txt').read_text()", { mount: md }),

--- a/crates/monty-js/__test__/mount.spec.ts
+++ b/crates/monty-js/__test__/mount.spec.ts
@@ -734,3 +734,58 @@ test('session read-only mount blocks write', async (ctx) => {
     cleanup()
   }
 })
+
+// =============================================================================
+// Symlinks inside a mount
+// =============================================================================
+
+/** Create a symlink, returning false where the host forbids it (Windows
+ *  without Developer Mode or elevation), so those tests skip rather than fail. */
+function makeSymlink(target: string, link: string): boolean {
+  try {
+    fs.symlinkSync(target, link)
+    return true
+  } catch {
+    return false
+  }
+}
+
+test('relative symlink inside a mount is followed', async (ctx) => {
+  skipIfBrowser(ctx)
+  const { dir, cleanup } = createTestDir()
+  try {
+    if (!makeSymlink('hello.txt', path.join(dir, 'rel_link.txt'))) return
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const result = await run("from pathlib import Path; Path('/data/rel_link.txt').read_text()", { mount: md })
+    t.is(result, 'hello world')
+  } finally {
+    cleanup()
+  }
+})
+
+test('absolute symlink target is refused inside a mount', async (ctx) => {
+  skipIfBrowser(ctx)
+  const { dir, cleanup } = createTestDir()
+  try {
+    // Absolute even though it points back into the same mount: a descriptor has
+    // no path of its own, so a leading '/' cannot be interpreted.
+    if (!makeSymlink(path.join(dir, 'hello.txt'), path.join(dir, 'abs_link.txt'))) return
+    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+
+    const error = await t.throwsAsync(
+      () => run("from pathlib import Path; Path('/data/abs_link.txt').read_text()", { mount: md }),
+      {
+        instanceOf: MontyRuntimeError,
+      },
+    )
+    t.is(error.message, "PermissionError: [Errno 13] Permission denied: '/data/abs_link.txt'")
+
+    // Predicates answer False rather than raising.
+    const seen = await run("from pathlib import Path; p = Path('/data/abs_link.txt'); (p.exists(), p.is_file())", {
+      mount: md,
+    })
+    t.deepEqual(seen, [false, false])
+  } finally {
+    cleanup()
+  }
+})

--- a/crates/monty-js/__test__/mount.spec.ts
+++ b/crates/monty-js/__test__/mount.spec.ts
@@ -40,6 +40,48 @@ test('browser wasm reports mounts as unsupported', async (ctx) => {
   t.is(error.message, 'the wasm worker does not support filesystem mounts (browser has no host filesystem)')
 })
 
+test('a mount follows its directory across feeds, not its path', async (ctx) => {
+  skipIfBrowser(ctx)
+  if (process.platform === 'win32') {
+    // Planting the link needs symlink creation, which Windows gates behind a
+    // privilege; the confinement itself is not platform-specific.
+    ctx.skip()
+  }
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'monty-mount-pin-'))
+  const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'monty-mount-out-'))
+  try {
+    const shared = path.join(base, 'shared')
+    fs.mkdirSync(shared)
+    fs.writeFileSync(path.join(shared, 'inside.txt'), 'in-mount')
+    fs.writeFileSync(path.join(outside, 'secret.txt'), 'HOST SECRET')
+    // Host-planted link out of the tree; the sandbox only moves it.
+    fs.symlinkSync(outside, path.join(base, 'prepared-link'), 'dir')
+
+    const child = new MountDir({ hostPath: shared, virtualPath: '/child', mode: 'read-only' })
+    const parent = new MountDir({ hostPath: base, virtualPath: '/parent', mode: 'read-write' })
+    await using session = await pool().checkout()
+
+    // Feed 1: swap the real directory out and the link in, under one name.
+    await session.feedRun(
+      `from pathlib import Path
+Path('/parent/shared').rename('/parent/old-shared')
+Path('/parent/prepared-link').rename('/parent/shared')`,
+      { mount: parent },
+    )
+
+    // Feed 2: the same mount object, and the redirect has not reached it.
+    const result = await session.feedRun(
+      `from pathlib import Path
+f"{Path('/child/inside.txt').read_text()}:{Path('/child/secret.txt').exists()}"`,
+      { mount: child },
+    )
+    t.is(result, 'in-mount:False')
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true })
+    fs.rmSync(outside, { recursive: true, force: true })
+  }
+})
+
 test('MountDir repr', (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
@@ -79,21 +121,21 @@ test('MountDir attributes', (ctx) => {
   }
 })
 
-test('MountDir nonexistent host path', async (ctx) => {
+test('MountDir nonexistent host path', (ctx) => {
   skipIfBrowser(ctx)
-  // Host paths are validated by the pool when the feed starts (not the
-  // constructor). The OS-error suffix is platform specific.
-  const md = new MountDir({ hostPath: '/nonexistent/path/that/does/not/exist', virtualPath: '/data' })
-  const error = await t.throwsAsync(() => run('1 + 1', { mount: md }), { instanceOf: MontyRuntimeError })
+  // The constructor opens the host directory, so a bad path fails there rather
+  // than at the first feed. The OS-error suffix is platform specific.
+  const error = t.throws(
+    () => new MountDir({ hostPath: '/nonexistent/path/that/does/not/exist', virtualPath: '/data' }),
+  )
   t.true(error.message.startsWith("TypeError: cannot open host path '/nonexistent/path/that/does/not/exist':"))
 })
 
-test('MountDir non-absolute virtual path', async (ctx) => {
+test('MountDir non-absolute virtual path', (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: 'relative' })
-    const error = await t.throwsAsync(() => run('1 + 1', { mount: md }), { instanceOf: MontyRuntimeError })
+    const error = t.throws(() => new MountDir({ hostPath: dir, virtualPath: 'relative' }))
     t.is(error.message, "TypeError: virtual path must be absolute, got: 'relative'")
   } finally {
     cleanup()

--- a/crates/monty-js/__test__/mount.spec.ts
+++ b/crates/monty-js/__test__/mount.spec.ts
@@ -61,6 +61,9 @@ test('a mount follows its directory across feeds, not its path', async (ctx) => 
   skipIfBrowser(ctx)
   const base = fs.mkdtempSync(path.join(os.tmpdir(), 'monty-mount-pin-'))
   const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'monty-mount-out-'))
+  // Closed before the directories are removed; Windows would refuse otherwise.
+  let child: MountDir | undefined
+  let parent: MountDir | undefined
   try {
     const shared = path.join(base, 'shared')
     fs.mkdirSync(shared)
@@ -74,8 +77,8 @@ test('a mount follows its directory across feeds, not its path', async (ctx) => 
       ctx.skip()
     }
 
-    using child = new MountDir({ hostPath: shared, virtualPath: '/child', mode: 'read-only' })
-    using parent = new MountDir({ hostPath: base, virtualPath: '/parent', mode: 'read-write' })
+    child = new MountDir({ hostPath: shared, virtualPath: '/child', mode: 'read-only' })
+    parent = new MountDir({ hostPath: base, virtualPath: '/parent', mode: 'read-write' })
     await using session = await pool().checkout()
 
     // Feed 1: swap the real directory out and the link in, under one name.
@@ -103,6 +106,8 @@ f"{Path('/child/inside.txt').read_text()}:{Path('/child/secret.txt').exists()}"`
     )
     t.is(result, 'in-mount:False')
   } finally {
+    child?.close()
+    parent?.close()
     fs.rmSync(base, { recursive: true, force: true })
     fs.rmSync(outside, { recursive: true, force: true })
   }
@@ -121,7 +126,7 @@ test('MountDir repr', (ctx) => {
 
 test('MountDir invalid mode', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const error = t.throws(() => mount({ virtualPath: '/data', mode: 'invalid' as never }))
     t.is(error?.message, "invalid mount mode: 'invalid'. Expected 'read-only', 'read-write' or 'overlay'")
@@ -159,7 +164,7 @@ test('MountDir nonexistent host path', (ctx) => {
 
 test('MountDir non-absolute virtual path', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const error = t.throws(() => mount({ virtualPath: 'relative' }))
     t.is(error.message, "TypeError: virtual path must be absolute, got: 'relative'")
@@ -180,6 +185,15 @@ test('closing a mount releases it and later feeds are refused', async (ctx) => {
     await t.throwsAsync(() => run("open('/data/hello.txt').read()", { mount: md }))
     // The configuration it reports outlives the descriptor.
     t.is(md.virtualPath, '/data')
+
+    // `using` closes it the same way at the end of the block.
+    let disposed: MountDir
+    {
+      using scoped = mount({ virtualPath: '/scoped', mode: 'read-only' })
+      t.is(await run("open('/scoped/hello.txt').read()", { mount: scoped }), 'hello world')
+      disposed = scoped
+    }
+    await t.throwsAsync(() => run("open('/scoped/hello.txt').read()", { mount: disposed }))
   } finally {
     cleanup()
   }
@@ -187,7 +201,7 @@ test('closing a mount releases it and later feeds are refused', async (ctx) => {
 
 test('MountDir default mode is overlay', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data' })
     t.is(md.mode, 'overlay')
@@ -198,7 +212,7 @@ test('MountDir default mode is overlay', (ctx) => {
 
 test('MountDir write_bytes_limit', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', writeBytesLimit: 1024 })
     t.is(md.writeBytesLimit, 1024)
@@ -300,7 +314,7 @@ test('MontyFileHandle rejects invalid arguments', () => {
 
 test('read_text via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; Path('/data/hello.txt').read_text()", { mount: md })
@@ -312,7 +326,7 @@ test('read_text via mount', async (ctx) => {
 
 test('read_bytes via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; Path('/data/data.bin').read_bytes()", { mount: md })
@@ -324,7 +338,7 @@ test('read_bytes via mount', async (ctx) => {
 
 test('path exists via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
@@ -342,7 +356,7 @@ exists_missing = Path('/data/nope.txt').exists()
 
 test('is_file and is_dir via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
@@ -358,7 +372,7 @@ from pathlib import Path
 
 test('iterdir via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
@@ -373,7 +387,7 @@ sorted([p.name for p in Path('/data').iterdir()])
 
 test('stat via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
@@ -389,7 +403,7 @@ s.st_size
 
 test('read nested file via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; Path('/data/subdir/nested.txt').read_text()", { mount: md })
@@ -405,7 +419,7 @@ test('read nested file via mount', async (ctx) => {
 
 test('write blocked on read-only mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(
@@ -456,7 +470,7 @@ Path('/data/overlay_file.txt').read_text()
 
 test('overlay read falls through to host', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const result = await run("from pathlib import Path; Path('/data/hello.txt').read_text()", { mount: md })
@@ -470,7 +484,7 @@ test('overlay writes do not persist across runs', async (ctx) => {
   skipIfBrowser(ctx)
   // Overlay state lives in the pool's per-feed mount table, so unlike the old
   // in-process API it does NOT persist across runs sharing the same MountDir.
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'overlay' })
     await run("from pathlib import Path; Path('/data/persistent.txt').write_text('run1')", { mount: md })
@@ -486,7 +500,7 @@ test('overlay writes do not persist across runs', async (ctx) => {
 
 test('overlay memory usage limit is aggregate', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'overlay', memoryUsageLimit: 1000 })
     const code = `
@@ -508,7 +522,7 @@ p.read_bytes()
 
 test('mkdir and rmdir via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const code = `
@@ -545,7 +559,7 @@ Path('/data/hello.txt').exists()
 
 test('rename via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const code = `
@@ -561,7 +575,7 @@ Path('/data/hello.txt').rename('/data/renamed.txt')
 
 test('resolve via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; str(Path('/data/subdir/../hello.txt').resolve())", {
@@ -579,7 +593,7 @@ test('resolve via mount', async (ctx) => {
 
 test('path traversal blocked', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(
@@ -594,7 +608,7 @@ test('path traversal blocked', async (ctx) => {
 
 test('unmounted path denied', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(
@@ -613,7 +627,7 @@ test('unmounted path denied', async (ctx) => {
 
 test('non-filesystem os call without fallback', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(() => run("import os; os.getenv('PATH')", { mount: md }), {
@@ -631,14 +645,14 @@ test('non-filesystem os call without fallback', async (ctx) => {
 
 test('multiple mounts with different modes', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir: dir1, cleanup: cleanup1 } = createTestDir()
+  const { mount, cleanup: cleanup1 } = createTestDir()
   const dir2 = fs.mkdtempSync(path.join(os.tmpdir(), 'monty-mount-test2-'))
   fs.writeFileSync(path.join(dir2, 'file2.txt'), 'from mount2')
+  // Closed in `finally`: Windows will not remove dir2 while this mount holds
+  // it open. The `/ro` one is closed by `cleanup1`.
+  const writable = new MountDir({ hostPath: dir2, virtualPath: '/rw', mode: 'read-write' })
   try {
-    const mounts = [
-      new MountDir({ hostPath: dir1, virtualPath: '/ro', mode: 'read-only' }),
-      new MountDir({ hostPath: dir2, virtualPath: '/rw', mode: 'read-write' }),
-    ]
+    const mounts = [mount({ virtualPath: '/ro', mode: 'read-only' }), writable]
     const code = `
 from pathlib import Path
 a = Path('/ro/hello.txt').read_text()
@@ -647,6 +661,7 @@ b = Path('/rw/file2.txt').read_text()
 `
     t.deepEqual(await run(code, { mount: mounts }), ['hello world', 'from mount2'])
   } finally {
+    writable.close()
     cleanup1()
     fs.rmSync(dir2, { recursive: true, force: true })
   }
@@ -658,7 +673,7 @@ b = Path('/rw/file2.txt').read_text()
 
 test('mount works with external functions', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
@@ -680,7 +695,7 @@ result + content
 
 test('session feed with mount read', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
@@ -772,7 +787,7 @@ Path('/data/mydir/file.txt').read_text()
 
 test('overlay iterdir sees overlay files', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const code = `
@@ -805,7 +820,7 @@ test('session read-write mount writes to host', async (ctx) => {
 
 test('session read-only mount blocks write', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })

--- a/crates/monty-js/native-addon.d.ts
+++ b/crates/monty-js/native-addon.d.ts
@@ -10,6 +10,10 @@ export interface NativeMount {
   memoryUsageLimit: number
 }
 
+export declare class NativeMountDir {
+  constructor(mount: NativeMount)
+}
+
 export declare class NativePool {
   constructor(options?: unknown)
   start(): Promise<void>

--- a/crates/monty-js/native-addon.d.ts
+++ b/crates/monty-js/native-addon.d.ts
@@ -12,6 +12,7 @@ export interface NativeMount {
 
 export declare class NativeMountDir {
   constructor(mount: NativeMount)
+  close(): void
 }
 
 export declare class NativePool {

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -1176,9 +1176,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1196,9 +1193,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1216,9 +1210,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1236,9 +1227,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1256,9 +1244,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1276,9 +1261,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1296,9 +1278,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1514,9 +1493,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1534,9 +1510,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1554,9 +1527,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1574,9 +1544,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1594,9 +1561,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1614,9 +1578,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1830,9 +1791,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1850,9 +1808,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1870,9 +1825,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1890,9 +1842,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2264,9 +2213,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2284,9 +2230,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2304,9 +2247,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2324,9 +2264,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2344,9 +2281,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2364,9 +2298,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2384,9 +2315,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2404,9 +2332,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2546,9 +2471,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2564,9 +2486,6 @@
       "integrity": "sha512-h1hx2YAOBFUqXXI7sMBTHwi4JdWHUT4r+MuiXW7xbarPwkaRlsnq7iHbT+goHoG9qj8hIQxJnb7GD/eyDVauiQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2685,9 +2604,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2702,9 +2618,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2719,9 +2632,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2736,9 +2646,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2753,9 +2660,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2770,9 +2674,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2787,9 +2688,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2804,9 +2702,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2821,9 +2716,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2838,9 +2730,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2855,9 +2744,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2872,9 +2758,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2889,9 +2772,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -154,7 +154,9 @@ pub struct NativeMount {
 /// TypeScript `MountDir` — not part of the public API.
 #[napi(js_name = "NativeMountDir")]
 pub struct NativeMountDir {
-    spec: MountSpec,
+    /// `None` once closed: the open directory is released and no later feed
+    /// can mount it. A feed already running holds its own reference.
+    spec: Option<MountSpec>,
 }
 
 #[napi]
@@ -164,8 +166,14 @@ impl NativeMountDir {
     #[napi(constructor)]
     pub fn new(mount: NativeMount) -> Result<Self> {
         Ok(Self {
-            spec: MountSpec::try_from(mount)?,
+            spec: Some(MountSpec::try_from(mount)?),
         })
+    }
+
+    /// Releases the open directory. Idempotent.
+    #[napi]
+    pub fn close(&mut self) {
+        self.spec = None;
     }
 }
 
@@ -343,7 +351,7 @@ impl NativeSession {
         on_print: PrintCallback<'env>,
     ) -> Result<PromiseRaw<'env, Object<'env>>> {
         let inputs = convert_inputs(env, inputs)?;
-        let mounts = mount_specs(&mounts);
+        let mounts = mount_specs(&mounts)?;
         self.run_turn(
             env,
             on_print,
@@ -534,7 +542,7 @@ impl NativeSession {
         mounts: Vec<ClassInstance<'env, NativeMountDir>>,
         on_print: PrintCallback<'env>,
     ) -> Result<PromiseRaw<'env, Object<'env>>> {
-        let mounts = mount_specs(&mounts);
+        let mounts = mount_specs(&mounts)?;
         let state = state.to_vec();
         self.run_outcome(
             env,
@@ -1013,8 +1021,20 @@ fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
 
 /// Clones each mount's opened configuration for one turn — the descriptor is
 /// shared, so nothing is reopened and no host path is resolved again.
-fn mount_specs(mounts: &[ClassInstance<'_, NativeMountDir>]) -> Vec<MountSpec> {
-    mounts.iter().map(|mount| mount.spec.clone()).collect()
+///
+/// # Errors
+///
+/// Rejects the turn if any mount has been closed.
+fn mount_specs(mounts: &[ClassInstance<'_, NativeMountDir>]) -> Result<Vec<MountSpec>> {
+    mounts
+        .iter()
+        .map(|mount| {
+            mount
+                .spec
+                .clone()
+                .ok_or_else(|| invalid("mount is closed: create a new MountDir"))
+        })
+        .collect()
 }
 
 fn pool_error(err: PoolError) -> napi::Error {

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -961,13 +961,12 @@ impl TryFrom<NativeMount> for MountSpec {
             .map(|limit| bytes_limit(limit, "writeBytesLimit"))
             .transpose()?;
         let memory_usage_limit = bytes_limit(mount.memory_usage_limit, "memoryUsageLimit")?;
-        Ok(Self {
-            virtual_path: mount.virtual_path,
-            host_path: mount.host_path.into(),
-            mode,
-            write_bytes_limit,
-            memory_usage_limit,
-        })
+        // Opens the directory: the spec carries a descriptor from here on, so
+        // the host path is resolved once per mount object rather than per feed.
+        let mut spec = Self::new(&mount.virtual_path, &mount.host_path, mode).map_err(pool_error)?;
+        spec.write_bytes_limit = write_bytes_limit;
+        spec.memory_usage_limit = memory_usage_limit;
+        Ok(spec)
     }
 }
 

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -40,7 +40,9 @@ use monty_types::{
     TypeCheckingFormat,
 };
 use napi::{
-    bindgen_prelude::{Array, Buffer, FnArgs, FromNapiValue, Function, JsObjectValue, Object, PromiseRaw, Unknown},
+    bindgen_prelude::{
+        Array, Buffer, ClassInstance, FnArgs, FromNapiValue, Function, JsObjectValue, Object, PromiseRaw, Unknown,
+    },
     threadsafe_function::UnknownReturnValue,
     Env, Error, Result,
 };
@@ -145,6 +147,26 @@ pub struct NativeMount {
     pub write_bytes_limit: Option<f64>,
     /// Aggregate budget for retained overlay data and transient results.
     pub memory_usage_limit: f64,
+}
+
+/// A mount whose host directory is opened here and held until this object is
+/// dropped, so every feed using it mounts that same directory. Wrapped by the
+/// TypeScript `MountDir` — not part of the public API.
+#[napi(js_name = "NativeMountDir")]
+pub struct NativeMountDir {
+    spec: MountSpec,
+}
+
+#[napi]
+impl NativeMountDir {
+    /// Opens the host directory, throwing if it is missing, is not a directory,
+    /// or the virtual path is not absolute.
+    #[napi(constructor)]
+    pub fn new(mount: NativeMount) -> Result<Self> {
+        Ok(Self {
+            spec: MountSpec::try_from(mount)?,
+        })
+    }
 }
 
 /// A pool of `monty` worker subprocesses. Wrapped by the TypeScript `Monty`
@@ -316,15 +338,12 @@ impl NativeSession {
         env: &'env Env,
         code: String,
         inputs: Option<Object<'env>>,
-        mounts: Vec<NativeMount>,
+        mounts: Vec<ClassInstance<'env, NativeMountDir>>,
         skip_type_check: bool,
         on_print: PrintCallback<'env>,
     ) -> Result<PromiseRaw<'env, Object<'env>>> {
         let inputs = convert_inputs(env, inputs)?;
-        let mounts = mounts
-            .into_iter()
-            .map(MountSpec::try_from)
-            .collect::<Result<Vec<_>>>()?;
+        let mounts = mount_specs(&mounts);
         self.run_turn(
             env,
             on_print,
@@ -512,13 +531,10 @@ impl NativeSession {
         &self,
         env: &'env Env,
         state: Buffer,
-        mounts: Vec<NativeMount>,
+        mounts: Vec<ClassInstance<'env, NativeMountDir>>,
         on_print: PrintCallback<'env>,
     ) -> Result<PromiseRaw<'env, Object<'env>>> {
-        let mounts = mounts
-            .into_iter()
-            .map(MountSpec::try_from)
-            .collect::<Result<Vec<_>>>()?;
+        let mounts = mount_specs(&mounts);
         let state = state.to_vec();
         self.run_outcome(
             env,
@@ -993,6 +1009,12 @@ fn duration_from_ms(ms: f64) -> Result<Duration> {
 /// `.lock().await` (or `try_lock` on the event-loop thread).
 fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
     mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// Clones each mount's opened configuration for one turn — the descriptor is
+/// shared, so nothing is reopened and no host path is resolved again.
+fn mount_specs(mounts: &[ClassInstance<'_, NativeMountDir>]) -> Vec<MountSpec> {
+    mounts.iter().map(|mount| mount.spec.clone()).collect()
 }
 
 fn pool_error(err: PoolError) -> napi::Error {

--- a/crates/monty-js/ts/mount.ts
+++ b/crates/monty-js/ts/mount.ts
@@ -18,7 +18,10 @@ export type MountDirMode = 'read-only' | 'read-write' | 'overlay'
  *  ambiguity. */
 export interface MountDirOptions {
   /** Real host directory to expose. Sandbox code can never see this path or
-   *  reach outside it. */
+   *  reach outside it. Opened once per mount, so it must be readable (a
+   *  search-only directory cannot be mounted) and, on Windows, cannot be
+   *  renamed or deleted by anyone while the mount lives. Symlinks inside it
+   *  are followed only if their targets are relative. */
   hostPath: string
   /** Absolute virtual POSIX path prefix inside the sandbox (e.g. `'/data'`),
    *  regardless of host OS. */

--- a/crates/monty-js/ts/mount.ts
+++ b/crates/monty-js/ts/mount.ts
@@ -3,11 +3,16 @@
 // side of the pool (the worker never sees host paths), so they work even for
 // remote workers. OS calls the mounts do not cover bubble up to the `os`
 // callback.
+//
+// The `MountDir` class lives in `mountDir.js` because constructing one loads
+// the native addon; everything here stays importable from the wasm bundle,
+// which shares `session.ts`.
 
-import type { NativeMount } from '../native-addon.js'
+import type { NativeMountDir } from '../native-addon.js'
+import type { MountDir } from './mountDir.js'
 
 // Mirrors monty-fs's DEFAULT_MEMORY_USAGE_LIMIT (100 MB in decimal bytes).
-const DEFAULT_MEMORY_USAGE_LIMIT = 100_000_000
+export const DEFAULT_MEMORY_USAGE_LIMIT = 100_000_000
 
 /** Sandbox access mode for a mounted directory. */
 export type MountDirMode = 'read-only' | 'read-write' | 'overlay'
@@ -18,9 +23,11 @@ export type MountDirMode = 'read-only' | 'read-write' | 'overlay'
  *  ambiguity. */
 export interface MountDirOptions {
   /** Real host directory to expose. Sandbox code can never see this path or
-   *  reach outside it. Opened once per mount, so on macOS/BSD it must be
-   *  readable (a search-only directory cannot be mounted there) and, on
-   *  Windows, cannot be renamed or deleted by anyone while the mount lives.
+   *  reach outside it. Opened by the constructor and held for the mount's
+   *  lifetime, so on macOS/BSD it must be readable (a search-only directory
+   *  cannot be mounted there) and, on Windows, cannot be renamed or deleted by
+   *  anyone until the mount is dropped. The mount then follows that directory,
+   *  not the path: renaming or replacing it afterwards changes nothing.
    *  Symlinks inside it are followed only if their targets are relative. */
   hostPath: string
   /** Absolute virtual POSIX path prefix inside the sandbox (e.g. `'/data'`),
@@ -38,62 +45,17 @@ export interface MountDirOptions {
   memoryUsageLimit?: number
 }
 
-const VALID_MODES: Record<MountDirMode, true> = {
+export const VALID_MODES: Record<MountDirMode, true> = {
   'read-only': true,
   'read-write': true,
   overlay: true,
 }
 
-/**
- * Mounts a real host directory into the sandbox at a virtual path.
- * Retained overlay data and filesystem results share a per-mount memory
- * budget, `memoryUsageLimit` (100 MB by default).
- *
- * ```ts
- * const mount = new MountDir({ hostPath: '/path/on/host', virtualPath: '/mnt/data', mode: 'read-only' })
- * await session.feedRun("open('/mnt/data/file.txt').read()", { mount })
- * ```
- */
-export class MountDir {
-  readonly hostPath: string
-  readonly virtualPath: string
-  readonly mode: MountDirMode
-  readonly writeBytesLimit: number | null
-  readonly memoryUsageLimit: number
-
-  constructor(options: MountDirOptions) {
-    const mode = options.mode ?? 'overlay'
-    // hasOwn, not `in`: prototype keys like 'toString' must not pass as modes
-    if (!Object.hasOwn(VALID_MODES, mode)) {
-      throw new Error(`invalid mount mode: '${mode}'. Expected 'read-only', 'read-write' or 'overlay'`)
-    }
-    this.hostPath = options.hostPath
-    this.virtualPath = options.virtualPath
-    this.mode = mode
-    this.writeBytesLimit = options.writeBytesLimit ?? null
-    this.memoryUsageLimit = options.memoryUsageLimit ?? DEFAULT_MEMORY_USAGE_LIMIT
-    if (!Number.isSafeInteger(this.memoryUsageLimit) || this.memoryUsageLimit < 0) {
-      throw new Error('memoryUsageLimit must be a non-negative safe integer')
-    }
-  }
-
-  /** Returns a string representation of the mount. */
-  repr(): string {
-    return `MountDir(host_path='${this.hostPath}', virtual_path='${this.virtualPath}', mode='${this.mode}')`
-  }
-}
-
-/** Encodes the `mount` option (one or many) for the native binding. */
-export function mountsToNative(mount: MountDir | MountDir[] | undefined): NativeMount[] {
+/** Collects the `mount` option (one or many) for the native binding. */
+export function mountsToNative(mount: MountDir | MountDir[] | undefined): NativeMountDir[] {
   if (mount === undefined) {
     return []
   }
   const mounts = Array.isArray(mount) ? mount : [mount]
-  return mounts.map((m) => ({
-    virtualPath: m.virtualPath,
-    hostPath: m.hostPath,
-    mode: m.mode,
-    memoryUsageLimit: m.memoryUsageLimit,
-    ...(m.writeBytesLimit !== null ? { writeBytesLimit: m.writeBytesLimit } : {}),
-  }))
+  return mounts.map((m) => m.native)
 }

--- a/crates/monty-js/ts/mount.ts
+++ b/crates/monty-js/ts/mount.ts
@@ -18,10 +18,10 @@ export type MountDirMode = 'read-only' | 'read-write' | 'overlay'
  *  ambiguity. */
 export interface MountDirOptions {
   /** Real host directory to expose. Sandbox code can never see this path or
-   *  reach outside it. Opened once per mount, so it must be readable (a
-   *  search-only directory cannot be mounted) and, on Windows, cannot be
-   *  renamed or deleted by anyone while the mount lives. Symlinks inside it
-   *  are followed only if their targets are relative. */
+   *  reach outside it. Opened once per mount, so on macOS/BSD it must be
+   *  readable (a search-only directory cannot be mounted there) and, on
+   *  Windows, cannot be renamed or deleted by anyone while the mount lives.
+   *  Symlinks inside it are followed only if their targets are relative. */
   hostPath: string
   /** Absolute virtual POSIX path prefix inside the sandbox (e.g. `'/data'`),
    *  regardless of host OS. */

--- a/crates/monty-js/ts/mountDir.ts
+++ b/crates/monty-js/ts/mountDir.ts
@@ -1,0 +1,58 @@
+// The `MountDir` class: a mount that owns its opened host directory. Separate
+// from `mount.ts` because constructing one loads the native addon, and the
+// wasm bundle imports `mount.ts` (via `session.ts`) but has no addon.
+
+import { NativeMountDir } from '../native-addon.js'
+import { DEFAULT_MEMORY_USAGE_LIMIT, VALID_MODES, type MountDirMode, type MountDirOptions } from './mount.js'
+
+/**
+ * Mounts a real host directory into the sandbox at a virtual path.
+ * Retained overlay data and filesystem results share a per-mount memory
+ * budget, `memoryUsageLimit` (100 MB by default).
+ *
+ * ```ts
+ * const mount = new MountDir({ hostPath: '/path/on/host', virtualPath: '/mnt/data', mode: 'read-only' })
+ * await session.feedRun("open('/mnt/data/file.txt').read()", { mount })
+ * ```
+ */
+export class MountDir {
+  readonly hostPath: string
+  readonly virtualPath: string
+  readonly mode: MountDirMode
+  readonly writeBytesLimit: number | null
+  readonly memoryUsageLimit: number
+  /** The opened host directory, shared by every feed this mount is passed to.
+   *  @internal */
+  readonly native: NativeMountDir
+
+  constructor(options: MountDirOptions) {
+    const mode = options.mode ?? 'overlay'
+    // hasOwn, not `in`: prototype keys like 'toString' must not pass as modes
+    if (!Object.hasOwn(VALID_MODES, mode)) {
+      throw new Error(`invalid mount mode: '${mode}'. Expected 'read-only', 'read-write' or 'overlay'`)
+    }
+    this.hostPath = options.hostPath
+    this.virtualPath = options.virtualPath
+    this.mode = mode
+    this.writeBytesLimit = options.writeBytesLimit ?? null
+    this.memoryUsageLimit = options.memoryUsageLimit ?? DEFAULT_MEMORY_USAGE_LIMIT
+    if (!Number.isSafeInteger(this.memoryUsageLimit) || this.memoryUsageLimit < 0) {
+      throw new Error('memoryUsageLimit must be a non-negative safe integer')
+    }
+    // Opens the directory, so a bad host path throws here rather than at the
+    // first feed — and every feed then mounts this descriptor, which no rename
+    // of the host path can redirect.
+    this.native = new NativeMountDir({
+      virtualPath: this.virtualPath,
+      hostPath: this.hostPath,
+      mode: this.mode,
+      memoryUsageLimit: this.memoryUsageLimit,
+      ...(this.writeBytesLimit !== null ? { writeBytesLimit: this.writeBytesLimit } : {}),
+    })
+  }
+
+  /** Returns a string representation of the mount. */
+  repr(): string {
+    return `MountDir(host_path='${this.hostPath}', virtual_path='${this.virtualPath}', mode='${this.mode}')`
+  }
+}

--- a/crates/monty-js/ts/mountDir.ts
+++ b/crates/monty-js/ts/mountDir.ts
@@ -51,6 +51,22 @@ export class MountDir {
     })
   }
 
+  /** Releases the open host directory. Later feeds using this mount throw;
+   *  the properties above keep answering. Idempotent.
+   *
+   *  Only Windows needs this: it refuses to rename or delete a directory while
+   *  a handle to it is open, so a mount left open blocks the host from touching
+   *  it, and JS has no deterministic drop. A feed already running is unaffected.
+   */
+  close(): void {
+    this.native.close()
+  }
+
+  /** Closes the mount at the end of a `using` block. */
+  [Symbol.dispose](): void {
+    this.close()
+  }
+
   /** Returns a string representation of the mount. */
   repr(): string {
     return `MountDir(host_path='${this.hostPath}', virtual_path='${this.virtualPath}', mode='${this.mode}')`

--- a/crates/monty-js/ts/node.ts
+++ b/crates/monty-js/ts/node.ts
@@ -20,7 +20,8 @@ export {
   type Snapshot,
 } from './session.js'
 export { CollectString, CollectStreams, DEFAULT_MAX_PRINT_COLLECT_BYTES, type CollectedStreamEntry } from './print.js'
-export { MountDir, type MountDirMode, type MountDirOptions } from './mount.js'
+export { type MountDirMode, type MountDirOptions } from './mount.js'
+export { MountDir } from './mountDir.js'
 export {
   MontyCrashedError,
   MontyError,

--- a/crates/monty-js/ts/session.ts
+++ b/crates/monty-js/ts/session.ts
@@ -19,7 +19,8 @@ import {
   ProtocolError,
 } from './errors.js'
 import { PYTHON_EXC_NAMES } from './errors.js'
-import { mountsToNative, type MountDir } from './mount.js'
+import { mountsToNative } from './mount.js'
+import type { MountDir } from './mountDir.js'
 import type {
   FunctionCallTurn,
   LoadedTurn,

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -3,13 +3,13 @@
 use std::{
     borrow::Cow,
     future::{Future, ready},
-    path::PathBuf,
+    path::Path,
     pin::Pin,
     sync::Arc,
     time::Duration,
 };
 
-use monty_fs::{MountCallOutcome, MountMode, MountTable, OverlayState};
+use monty_fs::{MountCallOutcome, MountMode, MountRoot, MountTable, OverlayState};
 use monty_proto::{FrameError, MONTY_VERSION, exceeds_max_value_depth, pb, validate_requirement};
 use monty_types::{
     AssertMessageAnnotations, ExcType, MontyException, MontyObject, OsFunctionCall, PrintStream, ResourceLimits,
@@ -67,10 +67,10 @@ impl Default for ReplConfig {
 /// [`Checkout::resume_from_mounts`].
 #[derive(Debug, Clone)]
 pub struct MountSpec {
-    /// Absolute virtual POSIX path inside the sandbox, e.g. `/mnt/data`.
-    pub virtual_path: String,
-    /// Host directory to expose.
-    pub host_path: PathBuf,
+    /// The host directory, opened when this spec was built and shared by every
+    /// feed that reuses it. The path is never resolved again, so sandbox code
+    /// cannot make it name a different directory between feeds.
+    root: MountRoot,
     /// Access mode.
     pub mode: MountSpecMode,
     /// Cap on total bytes written through this mount.
@@ -80,17 +80,43 @@ pub struct MountSpec {
 }
 
 impl MountSpec {
-    /// Creates mount configuration with the default 100 MB memory budget and
-    /// no cumulative write limit.
+    /// Opens `host_path` and creates mount configuration with the default
+    /// 100 MB memory budget and no cumulative write limit.
+    ///
+    /// Build this once and reuse it; each call resolves the path afresh.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PoolError::Runtime`] if the virtual path is not absolute, or
+    /// the host path cannot be opened as a directory.
+    pub fn new(virtual_path: &str, host_path: impl AsRef<Path>, mode: MountSpecMode) -> Result<Self, PoolError> {
+        let root = MountRoot::open(virtual_path, host_path).map_err(|err| PoolError::Runtime(err.into_exception()))?;
+        Ok(Self::from_root(root, mode))
+    }
+
+    /// Creates mount configuration from an already-opened [`MountRoot`], for
+    /// hosts that open it themselves to map failures their own way.
     #[must_use]
-    pub fn new(virtual_path: String, host_path: PathBuf, mode: MountSpecMode) -> Self {
+    pub fn from_root(root: MountRoot, mode: MountSpecMode) -> Self {
         Self {
-            virtual_path,
-            host_path,
+            root,
             mode,
             write_bytes_limit: None,
             memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
         }
+    }
+
+    /// Returns the normalized virtual path this mount answers on.
+    #[must_use]
+    pub fn virtual_path(&self) -> &str {
+        self.root.virtual_path()
+    }
+
+    /// Returns the host directory path. Diagnostics only — operations run
+    /// against the descriptor, not this path.
+    #[must_use]
+    pub fn host_path(&self) -> &Path {
+        self.root.host_path()
     }
 }
 
@@ -324,11 +350,10 @@ impl Checkout {
         on_print: OnPrint<'_>,
     ) -> Result<(Option<TurnEvent>, Option<String>), PoolError> {
         self.ensure_ready()?;
-        // Build mounts before touching any state: this await is the only
-        // cancellation point before the Load turn, and a cancelled build must
-        // leave the checkout unchanged (notably `duration_budget`, whose loss
-        // would silently drop the parent-side backstop from later feeds).
-        let feed_mounts = self.build_feed_mounts(mounts).await?;
+        // Build mounts before touching any state, so a failure here leaves the
+        // checkout unchanged (notably `duration_budget`, whose loss would
+        // silently drop the parent-side backstop from later feeds).
+        let feed_mounts = Self::build_feed_mounts(mounts);
         // the dump carries its own limits/consumed time/script name — forget
         // what the worker's Configure established and re-adopt from the reply
         self.pending = None;
@@ -375,7 +400,7 @@ impl Checkout {
             ));
         }
         ensure_sendable(inputs.iter().map(|(_, value)| value))?;
-        self.feed_mounts = self.build_feed_mounts(mounts).await?;
+        self.feed_mounts = Self::build_feed_mounts(mounts);
         let request = request(pb::parent_request::Kind::Feed(pb::Feed {
             code: code.to_owned(),
             inputs: inputs
@@ -939,16 +964,11 @@ impl Checkout {
         }
     }
 
-    /// Builds this feed's mount table on the blocking pool — mount validation
-    /// (existence checks, canonicalization) is host filesystem I/O. Skips the
-    /// dispatch entirely for the common mount-less feed. Cancel-safe: nothing
-    /// is mutated until the built table is returned.
-    async fn build_feed_mounts(&mut self, mounts: Vec<MountSpec>) -> Result<Option<MountTable>, PoolError> {
-        if mounts.is_empty() {
-            Ok(None)
-        } else {
-            self.run_blocking(move || build_mount_table(mounts)).await?.map(Some)
-        }
+    /// Builds this feed's mount table, or `None` for the common mount-less
+    /// feed. Runs inline: the specs' directories were opened when the caller
+    /// built them, so nothing here touches the host filesystem.
+    fn build_feed_mounts(mounts: Vec<MountSpec>) -> Option<MountTable> {
+        (!mounts.is_empty()).then(|| build_mount_table(mounts))
     }
 
     /// Runs blocking host mount work on tokio's blocking pool, so a stalled
@@ -1156,11 +1176,9 @@ fn min_deadline(a: Option<Duration>, b: Option<Duration>) -> Option<Duration> {
 }
 
 /// Builds the parent-side [`MountTable`] for one feed from its (non-empty)
-/// specs. An invalid mount (host path missing, not a directory, relative
-/// virtual path, …) fails as a session-preserving [`PoolError::Runtime`] —
-/// [`Checkout::build_feed_mounts`] runs this on the blocking pool before any
-/// frame is sent, so the worker never sees a half-configured feed.
-fn build_mount_table(mounts: Vec<MountSpec>) -> Result<MountTable, PoolError> {
+/// specs. Infallible and free of filesystem I/O: each spec already carries its
+/// opened directory, so this only pairs those descriptors with a per-feed mode.
+fn build_mount_table(mounts: Vec<MountSpec>) -> MountTable {
     let mut table = MountTable::new();
     for mount in mounts {
         let mode = match mount.mode {
@@ -1170,10 +1188,10 @@ fn build_mount_table(mounts: Vec<MountSpec>) -> Result<MountTable, PoolError> {
             // long as the feed and are discarded with it.
             MountSpecMode::Overlay => MountMode::OverlayMemory(OverlayState::new()),
         };
-        let mount = monty_fs::Mount::new(&mount.virtual_path, &mount.host_path, mode, mount.write_bytes_limit)
-            .map_err(|err| PoolError::Runtime(err.into_exception()))?
+        // No filesystem access: the root was opened when the spec was built.
+        let mount = monty_fs::Mount::with_root(mount.root, mode, mount.write_bytes_limit)
             .with_memory_usage_limit(mount.memory_usage_limit);
         table.push_mount(mount);
     }
-    Ok(table)
+    table
 }

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -350,9 +350,6 @@ impl Checkout {
         on_print: OnPrint<'_>,
     ) -> Result<(Option<TurnEvent>, Option<String>), PoolError> {
         self.ensure_ready()?;
-        // Build mounts before touching any state, so a failure here leaves the
-        // checkout unchanged (notably `duration_budget`, whose loss would
-        // silently drop the parent-side backstop from later feeds).
         let feed_mounts = Self::build_feed_mounts(mounts);
         // the dump carries its own limits/consumed time/script name — forget
         // what the worker's Configure established and re-adopt from the reply

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -4,6 +4,8 @@
 
 #[cfg(unix)]
 use std::os::unix::fs::{PermissionsExt, symlink};
+#[cfg(windows)]
+use std::os::windows::fs::symlink_dir;
 use std::{
     env, fs,
     future::ready,

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -377,8 +377,16 @@ Path('/parent/shared').rename('/parent/old-shared')
 Path('/parent/prepared-link').rename('/parent/shared')
 'swapped'";
     let result = session.feed(code, vec![], vec![parent], false, &mut no_print).await;
-    let event = feed_with_mounts(&mut session, result).await.unwrap();
-    assert_eq!(expect_complete(event), MontyObject::String("swapped".to_owned()));
+    match feed_with_mounts(&mut session, result).await {
+        Ok(event) => assert_eq!(expect_complete(event), MontyObject::String("swapped".to_owned())),
+        // Windows refuses to rename a directory while a handle to it is open,
+        // and the child mount holds one — so the swap cannot even be staged
+        // there while the mount is alive.
+        #[cfg(windows)]
+        Err(_) => return,
+        #[cfg(not(windows))]
+        Err(err) => panic!("staging the swap failed: {err:?}"),
+    }
 
     // Feed 2: the child mount, rebuilt from the same spec, still serves the
     // original directory and cannot see the one the name now points at.

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -7,6 +7,7 @@ use std::os::unix::fs::{PermissionsExt, symlink};
 use std::{
     env, fs,
     future::ready,
+    io,
     path::{Path, PathBuf},
     process::Command,
     sync::Once,
@@ -89,6 +90,15 @@ async fn feed_with_mounts(
             None => return Ok(event),
         }
     }
+}
+
+/// Creates a directory symlink, reporting the failure a host without the
+/// privilege gives so the caller can skip rather than fail.
+fn try_symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    return symlink(original, link);
+    #[cfg(windows)]
+    return symlink_dir(original, link);
 }
 
 /// Kills a process by pid with SIGKILL — simulates a hard crash.
@@ -337,9 +347,8 @@ body";
 /// the sandbox renaming a symlink over that directory's name, from inside a
 /// read-write mount of the parent, redirects the *path* and nothing else.
 ///
-/// Unix-only because planting the link needs symlink creation; the confinement
-/// itself is not platform-specific.
-#[cfg(unix)]
+/// Skipped where the host cannot create symlinks (Windows without Developer
+/// Mode or elevation), since planting the link needs one.
 #[tokio::test]
 async fn a_reused_mount_spec_survives_a_rename_of_its_host_directory() {
     let base = tempfile::tempdir().unwrap();
@@ -349,7 +358,10 @@ async fn a_reused_mount_spec_survives_a_rename_of_its_host_directory() {
     fs::write(shared.join("inside.txt"), "in-mount").unwrap();
     fs::write(outside.path().join("secret.txt"), "HOST SECRET").unwrap();
     // Host-planted link out of the tree; the sandbox only moves it.
-    symlink(outside.path(), base.path().join("prepared-link")).unwrap();
+    if try_symlink_dir(outside.path(), &base.path().join("prepared-link")).is_err() {
+        eprintln!("skipping: this host cannot create symlinks");
+        return;
+    }
 
     // Both built once, as a host holding long-lived mount objects would.
     let child = MountSpec::new("/child", shared, MountSpecMode::ReadOnly).unwrap();

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -295,8 +295,7 @@ async fn invalid_mount_host_path_is_rejected_cleanly() {
         panic!("expected Runtime, got {err:?}");
     };
     assert!(
-        exc.message()
-            .is_some_and(|m| m.contains("cannot canonicalize host path")),
+        exc.message().is_some_and(|m| m.contains("cannot open host path")),
         "unexpected message: {:?}",
         exc.message()
     );

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -3,7 +3,7 @@
 //! must surface as a clean error and never poison the pool.
 
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{PermissionsExt, symlink};
 use std::{
     env, fs,
     future::ready,
@@ -250,13 +250,7 @@ async fn non_utf8_mount_path_works() {
         .feed(
             "from pathlib import Path\nPath('/mnt/data/data.txt').read_text()",
             vec![],
-            vec![MountSpec {
-                virtual_path: "/mnt/data".to_owned(),
-                host_path: weird_dir,
-                mode: MountSpecMode::ReadOnly,
-                write_bytes_limit: None,
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-            }],
+            vec![MountSpec::new("/mnt/data", weird_dir, MountSpecMode::ReadOnly).unwrap()],
             false,
             &mut no_print,
         )
@@ -269,28 +263,16 @@ async fn non_utf8_mount_path_works() {
     session.finish().await.unwrap();
 }
 
-/// A mount whose host path does not exist fails at `feed()` — on the parent,
-/// before any frame is sent — as a session-preserving error.
+/// A mount whose host path does not exist is rejected where the directory is
+/// opened — building the [`MountSpec`] — so no feed inherits the failure.
 #[tokio::test]
 async fn invalid_mount_host_path_is_rejected_cleanly() {
-    let pool = Pool::new(config()).await.unwrap();
-    let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
-    let err = session
-        .feed(
-            "1 + 1",
-            vec![],
-            vec![MountSpec {
-                virtual_path: "/mnt/data".to_owned(),
-                host_path: PathBuf::from("/nonexistent/monty/mount/dir"),
-                mode: MountSpecMode::ReadOnly,
-                write_bytes_limit: None,
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-            }],
-            false,
-            &mut no_print,
-        )
-        .await
-        .unwrap_err();
+    let err = MountSpec::new(
+        "/mnt/data",
+        PathBuf::from("/nonexistent/monty/mount/dir"),
+        MountSpecMode::ReadOnly,
+    )
+    .unwrap_err();
     let PoolError::Runtime(exc) = err else {
         panic!("expected Runtime, got {err:?}");
     };
@@ -299,7 +281,9 @@ async fn invalid_mount_host_path_is_rejected_cleanly() {
         "unexpected message: {:?}",
         exc.message()
     );
-    // nothing was sent, so the worker is still synced and the session usable
+
+    let pool = Pool::new(config()).await.unwrap();
+    let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
     let event = session
         .feed("1 + 1", vec![], vec![], false, &mut no_print)
         .await
@@ -316,15 +300,7 @@ async fn mounted_filesystem_ops_are_serviced_by_the_parent() {
     let dir = tempfile::tempdir().unwrap();
     fs::write(dir.path().join("data.txt"), "mounted!").unwrap();
 
-    let mount = || {
-        vec![MountSpec {
-            virtual_path: "/mnt".to_owned(),
-            host_path: dir.path().to_path_buf(),
-            mode: MountSpecMode::ReadWrite,
-            write_bytes_limit: None,
-            memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-        }]
-    };
+    let mount = || vec![MountSpec::new("/mnt", dir.path(), MountSpecMode::ReadWrite).unwrap()];
     let pool = Pool::new(config()).await.unwrap();
     let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
 
@@ -357,6 +333,52 @@ body";
     session.finish().await.unwrap();
 }
 
+/// A [`MountSpec`] reused across feeds stays bound to the directory it opened:
+/// the sandbox renaming a symlink over that directory's name, from inside a
+/// read-write mount of the parent, redirects the *path* and nothing else.
+///
+/// Unix-only because planting the link needs symlink creation; the confinement
+/// itself is not platform-specific.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_reused_mount_spec_survives_a_rename_of_its_host_directory() {
+    let base = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let shared = base.path().join("shared");
+    fs::create_dir(&shared).unwrap();
+    fs::write(shared.join("inside.txt"), "in-mount").unwrap();
+    fs::write(outside.path().join("secret.txt"), "HOST SECRET").unwrap();
+    // Host-planted link out of the tree; the sandbox only moves it.
+    symlink(outside.path(), base.path().join("prepared-link")).unwrap();
+
+    // Both built once, as a host holding long-lived mount objects would.
+    let child = MountSpec::new("/child", shared, MountSpecMode::ReadOnly).unwrap();
+    let parent = MountSpec::new("/parent", base.path(), MountSpecMode::ReadWrite).unwrap();
+
+    let pool = Pool::new(config()).await.unwrap();
+    let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
+
+    // Feed 1: swap the real directory out and the link in, under one name.
+    let code = "\
+from pathlib import Path
+Path('/parent/shared').rename('/parent/old-shared')
+Path('/parent/prepared-link').rename('/parent/shared')
+'swapped'";
+    let result = session.feed(code, vec![], vec![parent], false, &mut no_print).await;
+    let event = feed_with_mounts(&mut session, result).await.unwrap();
+    assert_eq!(expect_complete(event), MontyObject::String("swapped".to_owned()));
+
+    // Feed 2: the child mount, rebuilt from the same spec, still serves the
+    // original directory and cannot see the one the name now points at.
+    let code = "\
+from pathlib import Path
+f\"{Path('/child/inside.txt').read_text()}:{Path('/child/secret.txt').exists()}\"";
+    let result = session.feed(code, vec![], vec![child], false, &mut no_print).await;
+    let event = feed_with_mounts(&mut session, result).await.unwrap();
+    assert_eq!(expect_complete(event), MontyObject::String("in-mount:False".to_owned()));
+    session.finish().await.unwrap();
+}
+
 /// A write through a read-only mount raises `PermissionError` inside the
 /// sandbox (catchable, session-preserving); overlay writes are visible within
 /// the feed, never reach the host, and are discarded when the feed ends.
@@ -365,15 +387,7 @@ async fn read_only_and_overlay_mount_semantics() {
     let dir = tempfile::tempdir().unwrap();
     fs::write(dir.path().join("data.txt"), "original").unwrap();
 
-    let mount = |mode| {
-        vec![MountSpec {
-            virtual_path: "/mnt".to_owned(),
-            host_path: dir.path().to_path_buf(),
-            mode,
-            write_bytes_limit: None,
-            memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-        }]
-    };
+    let mount = |mode| vec![MountSpec::new("/mnt", dir.path(), mode).unwrap()];
     let pool = Pool::new(config()).await.unwrap();
     let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
 
@@ -435,12 +449,10 @@ msg";
         .feed(
             code,
             vec![],
-            vec![MountSpec {
-                virtual_path: "/mnt".to_owned(),
-                host_path: dir.path().to_path_buf(),
-                mode: MountSpecMode::ReadWrite,
-                write_bytes_limit: Some(10),
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
+            vec![{
+                let mut spec = MountSpec::new("/mnt", dir.path(), MountSpecMode::ReadWrite).unwrap();
+                spec.write_bytes_limit = Some(10);
+                spec
             }],
             false,
             &mut no_print,
@@ -472,7 +484,7 @@ try:
 except MemoryError as exc:
     msg = str(exc)
 msg";
-    let mut spec = MountSpec::new("/mnt".to_owned(), dir.path().to_path_buf(), MountSpecMode::Overlay);
+    let mut spec = MountSpec::new("/mnt", dir.path(), MountSpecMode::Overlay).unwrap();
     spec.memory_usage_limit = 1_000;
     let result = session.feed(code, vec![], vec![spec], false, &mut no_print).await;
     let event = feed_with_mounts(&mut session, result).await.unwrap();
@@ -500,13 +512,7 @@ covered + ':' + Path('/elsewhere/file.txt').read_text()";
         .feed(
             code,
             vec![],
-            vec![MountSpec {
-                virtual_path: "/mnt".to_owned(),
-                host_path: dir.path().to_path_buf(),
-                mode: MountSpecMode::ReadOnly,
-                write_bytes_limit: None,
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-            }],
+            vec![MountSpec::new("/mnt", dir.path(), MountSpecMode::ReadOnly).unwrap()],
             false,
             &mut no_print,
         )
@@ -543,15 +549,7 @@ async fn suspended_feed_restores_with_mounts_re_supplied() {
     let dir = tempfile::tempdir().unwrap();
     fs::write(dir.path().join("data.txt"), "after resume").unwrap();
 
-    let mount = || {
-        vec![MountSpec {
-            virtual_path: "/mnt".to_owned(),
-            host_path: dir.path().to_path_buf(),
-            mode: MountSpecMode::ReadOnly,
-            write_bytes_limit: None,
-            memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-        }]
-    };
+    let mount = || vec![MountSpec::new("/mnt", dir.path(), MountSpecMode::ReadOnly).unwrap()];
     let pool = Pool::new(config()).await.unwrap();
     let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
     // suspend on an *uncovered* call, dump, and restore into a fresh worker
@@ -624,13 +622,7 @@ async fn restored_os_call_is_serviced_by_restore_mounts() {
     let (event, _) = restored
         .restore(
             state,
-            vec![MountSpec {
-                virtual_path: "/mnt".to_owned(),
-                host_path: dir.path().to_path_buf(),
-                mode: MountSpecMode::ReadOnly,
-                write_bytes_limit: None,
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-            }],
+            vec![MountSpec::new("/mnt", dir.path(), MountSpecMode::ReadOnly).unwrap()],
             &mut no_print,
         )
         .await
@@ -1213,13 +1205,7 @@ async fn special_files_in_mounts_are_rejected_without_blocking() {
         .feed(
             "from pathlib import Path\nPath('/mnt/pipe').read_text()",
             vec![],
-            vec![MountSpec {
-                virtual_path: "/mnt".to_owned(),
-                host_path: dir.path().to_path_buf(),
-                mode: MountSpecMode::ReadOnly,
-                write_bytes_limit: None,
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-            }],
+            vec![MountSpec::new("/mnt", dir.path(), MountSpecMode::ReadOnly).unwrap()],
             false,
             &mut no_print,
         )

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -181,13 +181,7 @@ async fn mounted_reads_are_serviced_from_the_parent_filesystem() {
         .feed(
             "unused",
             vec![],
-            vec![MountSpec {
-                virtual_path: "/mnt".to_owned(),
-                host_path: dir.path().to_path_buf(),
-                mode: MountSpecMode::ReadOnly,
-                write_bytes_limit: None,
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-            }],
+            vec![MountSpec::new("/mnt", dir.path(), MountSpecMode::ReadOnly).unwrap()],
             false,
             &mut no_print,
         )
@@ -247,13 +241,7 @@ async fn malformed_os_call_is_a_protocol_error() {
         .feed(
             "unused",
             vec![],
-            vec![MountSpec {
-                virtual_path: "/mnt".to_owned(),
-                host_path: dir.path().to_path_buf(),
-                mode: MountSpecMode::ReadOnly,
-                write_bytes_limit: None,
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-            }],
+            vec![MountSpec::new("/mnt", dir.path(), MountSpecMode::ReadOnly).unwrap()],
             false,
             &mut no_print,
         )
@@ -339,11 +327,7 @@ async fn a_mounted_feed_turn_is_still_bounded_by_the_request_timeout() {
         .feed(
             "unused",
             vec![],
-            vec![MountSpec::new(
-                "/mnt".to_owned(),
-                dir.path().to_path_buf(),
-                MountSpecMode::ReadOnly,
-            )],
+            vec![MountSpec::new("/mnt", dir.path(), MountSpecMode::ReadOnly).unwrap()],
             false,
             &mut no_print,
         )

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -107,9 +107,9 @@ class MountDir:
         Arguments:
             host_path: Real host directory to expose. Opened at construction;
                 raises if it doesn't exist, isn't a directory, or cannot be
-                opened — on macOS/BSD that includes a search-only (`0o111`)
-                directory, which Linux accepts. Sandbox code can never see this
-                path or reach outside it. The mount tracks the directory
+                opened — on macOS/BSD a search-only (`0o111`) directory is not
+                mountable, though Linux accepts one. Sandbox code can never see
+                this path or reach outside it. The mount tracks the directory
                 itself rather than its name, so renaming it on the host does
                 not detach the mount; on Windows the open handle prevents the
                 host renaming or deleting it at all while the mount lives.

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -107,8 +107,8 @@ class MountDir:
         Arguments:
             host_path: Real host directory to expose. Opened at construction;
                 raises if it doesn't exist, isn't a directory, or cannot be
-                opened — it must be readable, so a search-only (`0o111`)
-                directory is not mountable. Sandbox code can never see this
+                opened — on macOS/BSD that includes a search-only (`0o111`)
+                directory, which Linux accepts. Sandbox code can never see this
                 path or reach outside it. The mount tracks the directory
                 itself rather than its name, so renaming it on the host does
                 not detach the mount; on Windows the open handle prevents the

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -132,6 +132,18 @@ class MountDir:
                 would exceed it raises `MemoryError` in the sandbox.
         """
 
+    def close(self) -> None:
+        """Release the open host directory. Idempotent.
+
+        Feeds passed this mount afterwards raise `ValueError`; the attributes
+        above keep answering. Only Windows needs this — it refuses to rename or
+        delete a directory while a handle to it is open — but `MountDir` also
+        works as a context manager, which closes on exit.
+        """
+
+    def __enter__(self) -> MountDir: ...
+    def __exit__(self, *args: object) -> bool: ...
+
 class MontyError(Exception):
     """Base exception for all Monty interpreter errors.
 

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -105,9 +105,17 @@ class MountDir:
         names removes the ambiguity.
 
         Arguments:
-            host_path: Real host directory to expose. Canonicalized at
-                construction; raises if it doesn't exist or isn't a directory.
-                Sandbox code can never see this path or reach outside it.
+            host_path: Real host directory to expose. Opened at construction;
+                raises if it doesn't exist, isn't a directory, or cannot be
+                opened — it must be readable, so a search-only (`0o111`)
+                directory is not mountable. Sandbox code can never see this
+                path or reach outside it. The mount tracks the directory
+                itself rather than its name, so renaming it on the host does
+                not detach the mount; on Windows the open handle prevents the
+                host renaming or deleting it at all while the mount lives.
+                Symlinks inside it are followed only if their targets are
+                relative — an absolute target raises `PermissionError` in the
+                sandbox even when it points back into the same mount.
             virtual_path: Absolute POSIX-style path prefix inside the sandbox
                 (e.g. `'/data'`), regardless of host OS. Raises `ValueError`
                 if not absolute.

--- a/crates/monty-python/src/mount.rs
+++ b/crates/monty-python/src/mount.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use monty_fs::{MountMode, MountRoot};
 use monty_pool::{MountSpec, MountSpecMode};
 use monty_proto::python::exc_monty_to_py;
-use pyo3::{exceptions::PyValueError, prelude::*};
+use pyo3::{exceptions::PyValueError, prelude::*, types::PyTuple};
 
 // =============================================================================
 // MountDir — immutable mount configuration
@@ -28,8 +28,20 @@ use pyo3::{exceptions::PyValueError, prelude::*};
 /// - `'overlay'` — reads fall through to host; writes are captured in memory
 #[pyclass(name = "MountDir")]
 pub struct PyMountDir {
-    /// Validated configuration copied into each feed's mount table.
-    spec: MountSpec,
+    /// Validated configuration copied into each feed's mount table. `None`
+    /// once closed — the open directory is released, so nothing can mount it.
+    spec: Option<MountSpec>,
+    /// What the getters report, kept so they still answer after `close()`.
+    label: MountLabel,
+}
+
+/// The parts of a mount that outlive its descriptor.
+struct MountLabel {
+    virtual_path: String,
+    host_path: String,
+    mode: MountSpecMode,
+    write_bytes_limit: Option<u64>,
+    memory_usage_limit: u64,
 }
 
 #[pymethods]
@@ -80,53 +92,88 @@ impl PyMountDir {
         );
         spec.write_bytes_limit = write_bytes_limit;
         spec.memory_usage_limit = memory_usage_limit;
-        Ok(Self { spec })
+        Ok(Self {
+            label: MountLabel {
+                virtual_path: spec.virtual_path().to_owned(),
+                host_path: spec.host_path().display().to_string(),
+                mode: spec.mode,
+                write_bytes_limit,
+                memory_usage_limit,
+            },
+            spec: Some(spec),
+        })
+    }
+
+    /// Releases the open host directory. Later feeds using this mount raise
+    /// `ValueError`; the attributes below keep answering. Idempotent.
+    ///
+    /// Only Windows needs this: it refuses to rename or delete a directory
+    /// while a handle to it is open, so a mount left open blocks the host from
+    /// touching it. A feed already running keeps its own reference.
+    fn close(&mut self) {
+        self.spec = None;
+    }
+
+    fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    #[pyo3(signature = (*_args))]
+    fn __exit__(&mut self, _args: &Bound<'_, PyTuple>) -> bool {
+        self.close();
+        false
     }
 
     /// The canonical host directory path.
     #[getter]
     fn host_path(&self) -> String {
-        self.spec.host_path().display().to_string()
+        self.label.host_path.clone()
     }
 
     /// The normalized virtual path prefix inside the sandbox.
     #[getter]
     fn virtual_path(&self) -> String {
-        self.spec.virtual_path().to_owned()
+        self.label.virtual_path.clone()
     }
 
     /// The access mode: `"read-only"`, `"read-write"`, or `"overlay"`.
     #[getter]
     fn mode(&self) -> &'static str {
-        mount_mode_name(self.spec.mode)
+        mount_mode_name(self.label.mode)
     }
 
     /// The optional write bytes limit, or `None` if unlimited.
     #[getter]
     fn write_bytes_limit(&self) -> Option<u64> {
-        self.spec.write_bytes_limit
+        self.label.write_bytes_limit
     }
 
     /// The aggregate memory budget for this mount.
     #[getter]
     fn memory_usage_limit(&self) -> u64 {
-        self.spec.memory_usage_limit
+        self.label.memory_usage_limit
     }
 
     fn __repr__(&self) -> String {
         format!(
             "MountDir(host_path='{}', virtual_path='{}', mode='{}')",
-            self.spec.host_path().display(),
-            self.spec.virtual_path(),
-            mount_mode_name(self.spec.mode)
+            self.label.host_path,
+            self.label.virtual_path,
+            mount_mode_name(self.label.mode)
         )
     }
 }
 
 impl PyMountDir {
     /// Copies the validated configuration for a new parent-side mount table.
-    pub(crate) fn spec(&self) -> MountSpec {
-        self.spec.clone()
+    ///
+    /// # Errors
+    ///
+    /// Raises `ValueError` if the mount has been closed.
+    pub(crate) fn spec(&self) -> PyResult<MountSpec> {
+        self.spec
+            .clone()
+            .ok_or_else(|| PyValueError::new_err(format!("mount '{}' is closed", self.label.virtual_path)))
     }
 }
 

--- a/crates/monty-python/src/mount.rs
+++ b/crates/monty-python/src/mount.rs
@@ -6,7 +6,7 @@
 
 use std::path::PathBuf;
 
-use monty_fs::{Mount, MountMode};
+use monty_fs::{MountMode, MountRoot};
 use monty_pool::{MountSpec, MountSpecMode};
 use monty_proto::python::exc_monty_to_py;
 use pyo3::{exceptions::PyValueError, prelude::*};
@@ -67,33 +67,32 @@ impl PyMountDir {
         memory_usage_limit: u64,
     ) -> PyResult<Self> {
         let mount_mode = MountMode::from_mode_str(mode).map_err(PyValueError::new_err)?;
-        let mount = Mount::new(virtual_path, &host_path, mount_mode, write_bytes_limit)
-            .map_err(|e| exc_monty_to_py(py, e.into_exception()))?;
-        Ok(Self {
-            spec: MountSpec {
-                virtual_path: mount.virtual_path().to_owned(),
-                host_path: mount.host_path().to_path_buf(),
-                mode: match mount.mode() {
-                    MountMode::ReadOnly => MountSpecMode::ReadOnly,
-                    MountMode::ReadWrite => MountSpecMode::ReadWrite,
-                    MountMode::OverlayMemory(_) => MountSpecMode::Overlay,
-                },
-                write_bytes_limit: mount.write_bytes_limit(),
-                memory_usage_limit,
+        // Held for this object's lifetime: later feeds mount the descriptor
+        // rather than re-resolving `host_path`, which the sandbox can redirect.
+        let root = MountRoot::open(virtual_path, &host_path).map_err(|e| exc_monty_to_py(py, e.into_exception()))?;
+        let mut spec = MountSpec::from_root(
+            root,
+            match mount_mode {
+                MountMode::ReadOnly => MountSpecMode::ReadOnly,
+                MountMode::ReadWrite => MountSpecMode::ReadWrite,
+                MountMode::OverlayMemory(_) => MountSpecMode::Overlay,
             },
-        })
+        );
+        spec.write_bytes_limit = write_bytes_limit;
+        spec.memory_usage_limit = memory_usage_limit;
+        Ok(Self { spec })
     }
 
     /// The canonical host directory path.
     #[getter]
     fn host_path(&self) -> String {
-        self.spec.host_path.display().to_string()
+        self.spec.host_path().display().to_string()
     }
 
     /// The normalized virtual path prefix inside the sandbox.
     #[getter]
     fn virtual_path(&self) -> String {
-        self.spec.virtual_path.clone()
+        self.spec.virtual_path().to_owned()
     }
 
     /// The access mode: `"read-only"`, `"read-write"`, or `"overlay"`.
@@ -117,8 +116,8 @@ impl PyMountDir {
     fn __repr__(&self) -> String {
         format!(
             "MountDir(host_path='{}', virtual_path='{}', mode='{}')",
-            self.spec.host_path.display(),
-            self.spec.virtual_path,
+            self.spec.host_path().display(),
+            self.spec.virtual_path(),
             mount_mode_name(self.spec.mode)
         )
     }

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -1750,14 +1750,14 @@ fn extract_mount_specs(mount: Option<&Bound<'_, PyAny>>) -> PyResult<Vec<MountSp
         return Ok(vec![]);
     };
     if let Ok(single) = mount.extract::<PyRef<'_, PyMountDir>>() {
-        return Ok(vec![single.spec()]);
+        return Ok(vec![single.spec()?]);
     }
     if let Ok(list) = mount.cast::<PyList>() {
         return list
             .iter()
             .map(|item| {
                 let dir = item.extract::<PyRef<'_, PyMountDir>>()?;
-                Ok(dir.spec())
+                dir.spec()
             })
             .collect();
     }

--- a/crates/monty-python/tests/test_mount_table.py
+++ b/crates/monty-python/tests/test_mount_table.py
@@ -596,15 +596,18 @@ def test_absolute_symlink_target_is_refused(monty_run: RunMonty, test_dir: Path)
 
 
 @pytest.mark.skipif(sys.platform == 'win32', reason='POSIX mode bits')
-def test_search_only_directory_is_not_mountable(test_dir: Path):
-    """Mounting opens a descriptor, which needs read permission — a
-    search-only directory is rejected at construction."""
+def test_search_only_directory_mountability(test_dir: Path):
+    """Mounting opens a descriptor on the host directory, and whether that
+    needs read permission is platform-specific: Linux opens directories with
+    `O_PATH` and accepts a search-only one, macOS and the BSDs reject it at
+    construction. Root ignores mode bits everywhere."""
     target = test_dir / 'searchonly'
     target.mkdir()
     target.chmod(0o111)
     try:
-        if os.access(target, os.R_OK):
-            pytest.skip('host ignores mode bits (running as root)')
+        if sys.platform.startswith('linux') or os.access(target, os.R_OK):
+            assert MountDir(host_path=target, virtual_path='/data').virtual_path == '/data'
+            return
         with pytest.raises(TypeError) as exc_info:
             MountDir(host_path=target, virtual_path='/data')
         # The temp path varies per run; everything around it must not.

--- a/crates/monty-python/tests/test_mount_table.py
+++ b/crates/monty-python/tests/test_mount_table.py
@@ -54,6 +54,30 @@ def test_mount_directory_repr(test_dir: Path):
     assert '/data' in repr(md)
 
 
+def test_mount_close_releases_the_directory(monty_run: RunMonty, test_dir: Path):
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
+    assert monty_run("from pathlib import Path; Path('/data/hello.txt').read_text()", mount=md) == snapshot(
+        'hello world'
+    )
+
+    md.close()
+    md.close()  # idempotent
+    with pytest.raises(ValueError) as exc_info:
+        monty_run("from pathlib import Path; Path('/data/hello.txt').read_text()", mount=md)
+    assert str(exc_info.value) == snapshot("mount '/data' is closed")
+    # The configuration it reports outlives the descriptor.
+    assert md.virtual_path == snapshot('/data')
+
+
+def test_mount_context_manager_closes(monty_run: RunMonty, test_dir: Path):
+    with MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only') as md:
+        assert monty_run("from pathlib import Path; Path('/data/hello.txt').read_text()", mount=md) == snapshot(
+            'hello world'
+        )
+    with pytest.raises(ValueError):
+        monty_run("from pathlib import Path; Path('/data/hello.txt').read_text()", mount=md)
+
+
 def test_mount_directory_invalid_mode():
     with pytest.raises(ValueError) as exc_info:
         MountDir(host_path='/tmp', virtual_path='/data', mode='invalid')  # pyright: ignore[reportArgumentType]

--- a/crates/monty-python/tests/test_mount_table.py
+++ b/crates/monty-python/tests/test_mount_table.py
@@ -95,7 +95,7 @@ def test_nonexistent_host_path():
     with pytest.raises(TypeError) as exc_info:
         MountDir(host_path='/nonexistent/path/that/does/not/exist', virtual_path='/data')
     assert str(exc_info.value) == snapshot(
-        "cannot canonicalize host path '/nonexistent/path/that/does/not/exist': No such file or directory (os error 2)"
+        "cannot open host path '/nonexistent/path/that/does/not/exist': No such file or directory (os error 2)"
     )
 
 

--- a/crates/monty-python/tests/test_mount_table.py
+++ b/crates/monty-python/tests/test_mount_table.py
@@ -12,6 +12,8 @@ the feed ends; `'read-write'` mounts write through to the real host
 directory.
 """
 
+import os
+import sys
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
@@ -548,3 +550,65 @@ def test_open_binary_write_handle_attrs(monty_run: RunMonty, test_dir: Path):
     assert isinstance(f, MontyFileHandle)
     assert f.mode == snapshot('wb')
     assert (f.binary, f.readable, f.writable) == snapshot((True, False, True))
+
+
+# =============================================================================
+# Symlinks and host-directory requirements
+# =============================================================================
+
+
+def make_symlink(target: Path, link: Path) -> bool:
+    """Create a symlink, returning False where the host forbids it.
+
+    Windows needs Developer Mode or elevation, so the symlink tests skip
+    rather than fail there.
+    """
+    try:
+        link.symlink_to(target)
+    except OSError:
+        return False
+    return True
+
+
+def test_relative_symlink_is_followed(monty_run: RunMonty, test_dir: Path):
+    """A relative in-mount symlink resolves normally, as in CPython."""
+    if not make_symlink(Path('hello.txt'), test_dir / 'rel_link.txt'):
+        pytest.skip('host does not permit creating symlinks')
+    md = MountDir(host_path=test_dir, virtual_path='/data', mode='read-only')
+    code = "from pathlib import Path; Path('/data/rel_link.txt').read_text()"
+    assert monty_run(code, mount=md) == snapshot('hello world')
+
+
+def test_absolute_symlink_target_is_refused(monty_run: RunMonty, test_dir: Path):
+    """An absolute symlink target is never followed, even pointing back inside
+    the mount: the descriptor has no path of its own, so a leading `/` cannot
+    be interpreted. Predicates answer False instead of raising."""
+    if not make_symlink(test_dir / 'hello.txt', test_dir / 'abs_link.txt'):
+        pytest.skip('host does not permit creating symlinks')
+    md = MountDir(host_path=test_dir, virtual_path='/data', mode='read-only')
+
+    with pytest.raises(MontyRuntimeError) as exc_info:
+        monty_run("from pathlib import Path; Path('/data/abs_link.txt').read_text()", mount=md)
+    assert str(exc_info.value) == snapshot("PermissionError: [Errno 13] Permission denied: '/data/abs_link.txt'")
+
+    predicates = "from pathlib import Path; p = Path('/data/abs_link.txt'); (p.exists(), p.is_file())"
+    assert monty_run(predicates, mount=md) == snapshot((False, False))
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='POSIX mode bits')
+def test_search_only_directory_is_not_mountable(test_dir: Path):
+    """Mounting opens a descriptor, which needs read permission — a
+    search-only directory is rejected at construction."""
+    target = test_dir / 'searchonly'
+    target.mkdir()
+    target.chmod(0o111)
+    try:
+        if os.access(target, os.R_OK):
+            pytest.skip('host ignores mode bits (running as root)')
+        with pytest.raises(TypeError) as exc_info:
+            MountDir(host_path=target, virtual_path='/data')
+        # The temp path varies per run; everything around it must not.
+        message = str(exc_info.value).replace(str(target), '<dir>')
+        assert message == snapshot("cannot open host path '<dir>': Permission denied (os error 13)")
+    finally:
+        target.chmod(0o755)

--- a/crates/monty-types/src/os.rs
+++ b/crates/monty-types/src/os.rs
@@ -154,39 +154,6 @@ impl OsFunctionCall {
         }
     }
 
-    /// Whether this call can be handled by a `MountTable` (in the `monty-fs` crate).
-    /// Non-FS variants (`Getenv`, `GetEnviron`, `DateToday`, `DateTimeNow`)
-    /// must fall through to the host callback.
-    ///
-    /// Deliberately an allowlist: any future non-FS variant must return
-    /// `false`, because `monty-fs` panics if a call without a
-    /// [`Self::primary_path`] reaches its filesystem dispatch.
-    #[must_use]
-    pub fn is_filesystem(&self) -> bool {
-        matches!(
-            self,
-            Self::Exists(_)
-                | Self::IsFile(_)
-                | Self::IsDir(_)
-                | Self::IsSymlink(_)
-                | Self::ReadText(_)
-                | Self::ReadBytes(_)
-                | Self::WriteText(_)
-                | Self::WriteBytes(_)
-                | Self::AppendText(_)
-                | Self::AppendBytes(_)
-                | Self::Stat(_)
-                | Self::Iterdir(_)
-                | Self::Resolve(_)
-                | Self::Absolute(_)
-                | Self::Open(_)
-                | Self::Mkdir(_)
-                | Self::Unlink(_)
-                | Self::Rmdir(_)
-                | Self::Rename(_)
-        )
-    }
-
     /// Whether this call mutates filesystem state — the read-only-mount gate.
     /// `Open`'s write-ness is mode-dependent (`w`/`w+`/`a`/`a+` write; `r`/`r+`
     /// don't).
@@ -217,10 +184,11 @@ impl OsFunctionCall {
         )
     }
 
-    /// The call's primary path (for routing and error reporting), or `None`
-    /// for non-FS variants.
+    /// The call's primary path if it's a FS operation, `None` otherwise.
+    ///
+    /// Used for routing and error reporting.
     #[must_use]
-    pub fn primary_path(&self) -> Option<&str> {
+    pub fn fs_primary_path(&self) -> Option<&str> {
         match self {
             Self::Exists(p)
             | Self::IsFile(p)
@@ -258,8 +226,8 @@ impl OsFunctionCall {
     /// for FS ops (with the path), `RuntimeError` for non-FS ops.
     #[must_use]
     pub fn on_no_handler(&self) -> MontyException {
-        if self.is_filesystem() {
-            let path = self.primary_path().unwrap_or("<unknown>");
+        if self.fs_primary_path().is_some() {
+            let path = self.fs_primary_path().unwrap_or("<unknown>");
             MontyException::new(
                 ExcType::PermissionError,
                 Some(format!("Permission denied: {}", StringRepr(path))),

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -100,6 +100,23 @@ root.
 `/tmp`, `/etc`, `/proc`, `/dev`, `~`, and the host current working
 directory are **not** available unless the host explicitly mounts them.
 
+### `..` is resolved in the virtual namespace, not through symlinks
+
+`..` is collapsed textually before anything touches the filesystem, so it
+always names the lexical parent. POSIX instead resolves it *after* following
+the preceding component, which differs whenever a symlink is involved: with
+`ld -> sub/deep`, CPython reads `ld/../sibling.txt` as `sub/sibling.txt`,
+while Monty reads it as `sibling.txt` — each finds a file the other does not.
+The textual rule is what makes `..` unable to escape at all, so it is
+deliberate; only paths mixing `..` with symlinked directories are affected.
+
+### A mount needs read permission on its host directory
+
+Mounting opens a descriptor, which requires read access. A search-only
+directory (mode `0o111`) is therefore not mountable — `MountDir` raises at
+construction — even though a host process can traverse it and read known
+paths inside. Grant `r-x` on the directory being mounted.
+
 ### Symlink targets must be relative
 
 **A symlink inside a mount is followed only if its target is relative; an

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -122,10 +122,14 @@ would not find the renamed-away original.
 
 ### Boolean predicates never raise
 
-`exists()`, `is_file()`, `is_dir()` and `is_symlink()` answer `False` for any
-path leaving the mount, so a blocked path is indistinguishable from a missing
-one — raising would confirm something is there to be blocked. CPython follows
-the link and answers `True`.
+`exists()`, `is_file()` and `is_dir()` answer `False` for any path leaving the
+mount, so a blocked path is indistinguishable from a missing one — raising
+would confirm something is there to be blocked. CPython follows the link and
+answers `True`.
+
+`is_symlink()` is the exception: it does not follow the final component, so a
+symlink that is itself inside the mount answers `True` even when its target
+escapes. That matches CPython, and reveals nothing about the target.
 
 ## No live host descriptors
 

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -139,6 +139,12 @@ the host replaces the underlying file before the read, the read sees whatever
 now occupies that path inside the mount; CPython, holding no such reference,
 would not find the renamed-away original.
 
+Renaming a directory that really contains an entry with a non-UTF-8 name
+raises `OSError` (`directory contains an entry with a non-UTF-8 name`):
+Monty's sandbox namespace is strictly UTF-8, so the entry cannot follow the
+move. CPython renames the directory inode and never looks at the names
+inside.
+
 ### Boolean predicates never raise
 
 `exists()`, `is_file()` and `is_dir()` answer `False` for any path leaving the

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -90,6 +90,11 @@ root.
   the mount's own path raise `PermissionError` in every mode, where CPython on
   an ordinary empty directory would succeed (the root has no name inside the
   mount, so there is nothing to detach it from).
+- A rename is only serviced when source and destination land in the *same*
+  mount. Any other combination — different mounts, or one side under no mount
+  at all — raises `OSError` `[Errno 18] Invalid cross-device link`, including
+  where CPython would report `FileNotFoundError` for a missing destination
+  directory. Neither side moves.
 - Null bytes in any path component are rejected (`ValueError`).
 - Resolved paths returned to the sandbox (e.g. via `Path.resolve()`) are
   virtual paths, never host paths.

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -79,9 +79,7 @@ root.
 
 - The mount is pinned to the **directory**, not its path: renaming the host
   directory does not detach the mount, and replacing it with a symlink does
-  not redirect reads. On Windows the open handle goes further and blocks the
-  rename outright — a mounted directory cannot be moved or deleted by anyone,
-  including the host, until the mount is dropped.
+  not redirect reads.
 - `..` cannot escape, and neither can a symlink or an intermediate directory
   swapped for one mid-operation; such paths raise `PermissionError`.
 - Path segments a host parser reads as absolute are rejected
@@ -133,6 +131,15 @@ the error is loud, and nothing returns wrong data. `exists()`, `is_file()` and
 `is_dir()` answer `False` rather than raising. To keep such links working,
 rewrite them as relative before mounting.
 
+### Windows locks a mounted directory against the host
+
+Windows refuses to rename or delete a directory while a handle to it is open,
+so the host cannot move or delete a directory for as long as it is mounted —
+the attempt fails with `ERROR_SHARING_VIOLATION`. Unix is unaffected. The
+window is the mount's lifetime, which for `pydantic_monty` and
+`@pydantic/monty` is one feed (see
+[pool-architecture.md](pool-architecture.md)).
+
 ### `OverlayMemory` writes refuse symlinks
 
 CPython (and a direct mount) writes *through* a symlink to its target. An
@@ -150,7 +157,9 @@ the real name — the same aliasing, reached by deleting rather than writing.
 Renaming a **directory that contains a symlink** is refused for the same
 reason: the link cannot move with it (there is nothing to record) and cannot
 be left behind (it would stay readable inside a directory the overlay then
-reports as deleted). CPython moves the directory and the link together. Reads still follow relative in-mount links as before, and direct mounts
+reports as deleted). CPython moves the directory and the link together.
+
+Reads still follow relative in-mount links as before, and direct mounts
 still allow writes through them; only escaping/absolute links are refused
 there. `mkdir(parents=True)` through an escaping symlink raises
 `PermissionError` in every mode.

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -138,12 +138,19 @@ rewrite them as relative before mounting.
 CPython (and a direct mount) writes *through* a symlink to its target. An
 overlay write never touches the host, so it cannot do that — recording the
 entry under the link's spelling instead would silently alias the two paths.
-Any write (`write_text`, `open('w'/'a')`, `mkdir`, rename destinations, …)
-whose path contains a symlink **anywhere** — as the final component or an
-intermediate directory, whether it resolves in-mount, dangles, is absolute,
-or escapes — raises `PermissionError`. The refusal is uniform on purpose:
-the link's target is never even resolved, so the error reveals nothing about
-it. Reads still follow relative in-mount links as before, and direct mounts
+Any write (`write_text`, `open('w'/'a')`, `mkdir`, `unlink`, `rmdir`, rename
+sources and destinations, …) whose path contains a symlink **anywhere** — as
+the final component or an intermediate directory, whether it resolves
+in-mount, dangles, is absolute, or escapes — raises `PermissionError`. The
+refusal is uniform on purpose: the link's target is never even resolved, so
+the error reveals nothing about it. Deletes are included because tombstoning
+a link's spelling would report it gone while its target stayed readable under
+the real name — the same aliasing, reached by deleting rather than writing.
+
+Renaming a **directory that contains a symlink** is refused for the same
+reason: the link cannot move with it (there is nothing to record) and cannot
+be left behind (it would stay readable inside a directory the overlay then
+reports as deleted). CPython moves the directory and the link together. Reads still follow relative in-mount links as before, and direct mounts
 still allow writes through them; only escaping/absolute links are refused
 there. `mkdir(parents=True)` through an escaping symlink raises
 `PermissionError` in every mode.

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -107,6 +107,17 @@ while Monty reads it as `sibling.txt` — each finds a file the other does not.
 The textual rule is what makes `..` unable to escape at all, so it is
 deliberate; only paths mixing `..` with symlinked directories are affected.
 
+### Path length is Linux's, measured before `..` collapses
+
+A path over 4096 bytes, or with a component over 255, raises `OSError`
+`[Errno 36] File name too long`. Both limits are Linux's and apply on every
+host, so a path macOS (`PATH_MAX` 1024) or Windows would reject is accepted,
+and a long one they would accept is not. The length counts the path as sent,
+before `.`/`..` are collapsed: `'/mnt/' + 'a/' * 5000 + '../' * 5000 + 'f.txt'`
+is refused even though it names `/mnt/f.txt`. CPython hands the uncollapsed
+bytes to the kernel and gets `ENAMETOOLONG` too, so this matches — but Monty
+applies it uniformly rather than deferring to the host filesystem.
+
 ### A search-only host directory may not be mountable
 
 Mounting opens a descriptor on the host directory. On macOS and the BSDs that

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -153,7 +153,9 @@ Windows refuses to rename or delete a directory while a handle to it is open,
 so the host cannot move or delete a directory for as long as it is mounted —
 the attempt fails with `ERROR_SHARING_VIOLATION`. Unix is unaffected. The
 window is the mount's lifetime, which for `pydantic_monty` and
-`@pydantic/monty` is the lifetime of the mount object, not one feed (see
+`@pydantic/monty` is the lifetime of the mount object, not one feed — close it
+(`MountDir.close()`, or the `with` / `using` block) to release the directory
+before the host touches it (see
 [pool-architecture.md](pool-architecture.md)).
 
 ### A mount follows its directory, not its path

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -107,12 +107,13 @@ while Monty reads it as `sibling.txt` — each finds a file the other does not.
 The textual rule is what makes `..` unable to escape at all, so it is
 deliberate; only paths mixing `..` with symlinked directories are affected.
 
-### A mount needs read permission on its host directory
+### A search-only host directory may not be mountable
 
-Mounting opens a descriptor, which requires read access. A search-only
-directory (mode `0o111`) is therefore not mountable — `MountDir` raises at
-construction — even though a host process can traverse it and read known
-paths inside. Grant `r-x` on the directory being mounted.
+Mounting opens a descriptor on the host directory. On macOS and the BSDs that
+needs read permission, so a search-only directory (mode `0o111`) is refused —
+`MountDir` raises at construction — even though a host process can traverse it
+and read known paths inside. Linux opens directories with `O_PATH` and accepts
+it. Grant `r-x` on anything you intend to mount portably.
 
 ### Symlink targets must be relative
 

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -37,11 +37,10 @@ sandbox-reachable input. Directories raise `IsADirectoryError` as in CPython.
 Existence checks (`exists`, `is_file`, `is_dir`, `is_symlink`) and `stat()`
 still work on special files.
 
-The check runs before the open rather than on the handle, so a *host* process
-with write access to the mount could swap in a FIFO in between and block the
-servicing thread. Sandboxed code cannot — no mount mode creates special files
-or symlinks — so do not mount directories untrusted local processes can write
-to.
+The verdict is taken from the opened handle, not from a prior stat of the
+path, so swapping a FIFO in mid-operation cannot get one past the guard: the
+open itself is non-blocking and the descriptor it returns is bound to one
+inode. The path is still stat-ed first, but only to phrase the error.
 
 ## Mount memory limits
 

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -116,6 +116,21 @@ the error is loud, and nothing returns wrong data. `exists()`, `is_file()` and
 `is_dir()` answer `False` rather than raising. To keep such links working,
 rewrite them as relative before mounting.
 
+### `OverlayMemory` writes refuse symlinks
+
+CPython (and a direct mount) writes *through* a symlink to its target. An
+overlay write never touches the host, so it cannot do that — recording the
+entry under the link's spelling instead would silently alias the two paths.
+Any write (`write_text`, `open('w'/'a')`, `mkdir`, rename destinations, …)
+whose path contains a symlink **anywhere** — as the final component or an
+intermediate directory, whether it resolves in-mount, dangles, is absolute,
+or escapes — raises `PermissionError`. The refusal is uniform on purpose:
+the link's target is never even resolved, so the error reveals nothing about
+it. Reads still follow relative in-mount links as before, and direct mounts
+still allow writes through them; only escaping/absolute links are refused
+there. `mkdir(parents=True)` through an escaping symlink raises
+`PermissionError` in every mode.
+
 ### `OverlayMemory` renames of real files
 
 A rename records a mount-relative reference to the existing file rather than

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -37,6 +37,12 @@ sandbox-reachable input. Directories raise `IsADirectoryError` as in CPython.
 Existence checks (`exists`, `is_file`, `is_dir`, `is_symlink`) and `stat()`
 still work on special files.
 
+The check runs before the open rather than on the handle, so a *host* process
+with write access to the mount could swap in a FIFO in between and block the
+servicing thread. Sandboxed code cannot — no mount mode creates special files
+or symlinks — so do not mount directories untrusted local processes can write
+to.
+
 ## Mount memory limits
 
 Each mount has a configurable `memory_usage_limit`, defaulting to 100 MB
@@ -67,28 +73,59 @@ the limit along with the newly appended bytes.
 
 ## Sandbox guarantees
 
-The host enforces these invariants on every path operation:
+A mount opens a descriptor on its host directory once, at mount time, and
+every operation runs relative to it, so nothing resolves from the filesystem
+root.
 
-- Canonicalization happens *after* mapping virtual → host paths.
-- The canonical path must remain inside the mount; `..` traversal cannot
-  escape (raises `PermissionError`).
+- The mount is pinned to the **directory**, not its path: renaming the host
+  directory does not detach the mount, and replacing it with a symlink does
+  not redirect reads. On Windows the open handle goes further and blocks the
+  rename outright — a mounted directory cannot be moved or deleted by anyone,
+  including the host, until the mount is dropped.
+- `..` cannot escape, and neither can a symlink or an intermediate directory
+  swapped for one mid-operation; such paths raise `PermissionError`.
 - Path segments a host parser reads as absolute are rejected
   (`PermissionError`) on every OS and in every mount mode: any segment
   containing a backslash or starting with `X:`. So names CPython allows on
   Unix — `a\b.txt`, `a:b.txt` — are refused there too, since Windows would
   read them as drive-relative. Colons elsewhere are fine (`note:2026.txt`).
-- Symlinks pointing outside the mount are rejected on resolution.
-- `OverlayMemory` renames of real files keep a reference to the backing host
-  path rather than copying it. That path is re-checked against the mount on
-  every read, so if a host-side process replaces it with a symlink out of the
-  mount after the rename, the read raises `PermissionError` — where CPython
-  would follow the new symlink and return its contents.
 - Null bytes in any path component are rejected (`ValueError`).
 - Resolved paths returned to the sandbox (e.g. via `Path.resolve()`) are
   virtual paths, never host paths.
 
 `/tmp`, `/etc`, `/proc`, `/dev`, `~`, and the host current working
 directory are **not** available unless the host explicitly mounts them.
+
+### Symlink targets must be relative
+
+**A symlink inside a mount is followed only if its target is relative; an
+absolute target raises `PermissionError` even when it points back into the
+same mount.** CPython follows both. A descriptor has no path of its own, so a
+leading `/` cannot be interpreted and "absolute but inside" is
+indistinguishable from "absolute and outside".
+
+This is the one thing to check before mounting an existing directory.
+Sandboxed code cannot create symlinks, so only links **already present** are
+affected — `node_modules` installs, Homebrew/Nix store trees, build output
+with linked artifacts. Only the links fail; the files themselves are readable,
+the error is loud, and nothing returns wrong data. `exists()`, `is_file()` and
+`is_dir()` answer `False` rather than raising. To keep such links working,
+rewrite them as relative before mounting.
+
+### `OverlayMemory` renames of real files
+
+A rename records a mount-relative reference to the existing file rather than
+copying its bytes, so it cannot come to name anything outside the mount. If
+the host replaces the underlying file before the read, the read sees whatever
+now occupies that path inside the mount; CPython, holding no such reference,
+would not find the renamed-away original.
+
+### Boolean predicates never raise
+
+`exists()`, `is_file()`, `is_dir()` and `is_symlink()` answer `False` for any
+path leaving the mount, so a blocked path is indistinguishable from a missing
+one — raising would confirm something is there to be blocked. CPython follows
+the link and answers `True`.
 
 ## No live host descriptors
 

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -146,9 +146,11 @@ CPython (and a direct mount) writes *through* a symlink to its target. An
 overlay write never touches the host, so it cannot do that — recording the
 entry under the link's spelling instead would silently alias the two paths.
 Any write (`write_text`, `open('w'/'a')`, `mkdir`, `unlink`, `rmdir`, rename
-sources and destinations, …) whose path contains a symlink **anywhere** — as
-the final component or an intermediate directory, whether it resolves
-in-mount, dangles, is absolute, or escapes — raises `PermissionError`. The
+destinations, …) whose path contains a symlink **anywhere** — as the final
+component or an intermediate directory, whether it resolves in-mount, dangles,
+is absolute, or escapes — raises `PermissionError`. A rename *source* is the
+exception: a symlink named as one is moved intact, recorded as itself rather
+than as its target. The
 refusal is uniform on purpose: the link's target is never even resolved, so
 the error reveals nothing about it. Deletes are included because tombstoning
 a link's spelling would report it gone while its target stayed readable under

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -153,8 +153,17 @@ Windows refuses to rename or delete a directory while a handle to it is open,
 so the host cannot move or delete a directory for as long as it is mounted —
 the attempt fails with `ERROR_SHARING_VIOLATION`. Unix is unaffected. The
 window is the mount's lifetime, which for `pydantic_monty` and
-`@pydantic/monty` is one feed (see
+`@pydantic/monty` is the lifetime of the mount object, not one feed (see
 [pool-architecture.md](pool-architecture.md)).
+
+### A mount follows its directory, not its path
+
+The host directory is opened when the mount is created, and everything runs
+against that descriptor. Renaming or replacing the directory afterwards is
+therefore invisible to the mount: it keeps serving the same directory under
+whatever name it now has, and a *new* directory created at the original path
+is not picked up. CPython, resolving each path afresh, would see the
+replacement. Recreate the mount to follow a path.
 
 ### `OverlayMemory` writes refuse symlinks
 

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -89,6 +89,10 @@ root.
   containing a backslash or starting with `X:`. So names CPython allows on
   Unix — `a\b.txt`, `a:b.txt` — are refused there too, since Windows would
   read them as drive-relative. Colons elsewhere are fine (`note:2026.txt`).
+- The mount root itself cannot be renamed or removed: `rename` and `rmdir` on
+  the mount's own path raise `PermissionError` in every mode, where CPython on
+  an ordinary empty directory would succeed (the root has no name inside the
+  mount, so there is nothing to detach it from).
 - Null bytes in any path component are rejected (`ValueError`).
 - Resolved paths returned to the sandbox (e.g. via `Path.resolve()`) are
   virtual paths, never host paths.

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -229,6 +229,11 @@ properties that real CPython does not provide, per the caveat above.
   `read-write` mounts write through to the real host directory as before. An
   invalid mount (host path missing / not a directory) raises at `feed` time,
   before the snippet runs, as a session-preserving error.
+- **On Windows a mounted directory is locked for the feed.** The per-feed mount
+  table holds an open descriptor on each host directory, and Windows refuses to
+  rename or delete a directory while a handle to it is open, so the host gets
+  `ERROR_SHARING_VIOLATION` until the feed ends and the table is dropped. Unix
+  is unaffected. Rotate mounted directories between feeds, not during one.
 - **Mounts only answer calls on the automatic path.** Every OS call the sandbox
   makes surfaces as a suspension; the pool consults the mount table only when
   the caller asks it to. `feed_run` (and the JS `feedRun`) asks on every OS

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -227,13 +227,21 @@ properties that real CPython does not provide, per the caveat above.
   `mode='overlay'` writes live in that per-feed table and are discarded when
   the feed ends — the `MountDir` object's overlay state is never updated.
   `read-write` mounts write through to the real host directory as before. An
-  invalid mount (host path missing / not a directory) raises at `feed` time,
-  before the snippet runs, as a session-preserving error.
-- **On Windows a mounted directory is locked for the feed.** The per-feed mount
-  table holds an open descriptor on each host directory, and Windows refuses to
-  rename or delete a directory while a handle to it is open, so the host gets
-  `ERROR_SHARING_VIOLATION` until the feed ends and the table is dropped. Unix
-  is unaffected. Rotate mounted directories between feeds, not during one.
+  invalid mount (host path missing / not a directory) raises when the mount
+  object is *created*, not at `feed` time: constructing it opens the directory.
+- **A mount object is bound to a directory, not to a path.** `MountDir` opens
+  the host directory once and every feed mounts that descriptor, so renaming or
+  replacing the directory afterwards does not change what the mount serves —
+  the mount keeps following the original directory under its new name, and a
+  new directory at the old path is not picked up. Recreate the `MountDir` to
+  follow a path instead. (This is deliberate: the sandbox can rename inside a
+  `read-write` mount, so a path re-resolved each feed is a path the sandbox can
+  redirect.)
+- **On Windows a mounted directory is locked for as long as the mount object
+  lives.** It holds an open descriptor, and Windows refuses to rename or delete
+  a directory while a handle to it is open, so the host gets
+  `ERROR_SHARING_VIOLATION` until the mount object is dropped — not just until
+  the feed ends. Unix is unaffected.
 - **Mounts only answer calls on the automatic path.** Every OS call the sandbox
   makes surfaces as a suspension; the pool consults the mount table only when
   the caller asks it to. `feed_run` (and the JS `feedRun`) asks on every OS

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -240,8 +240,10 @@ properties that real CPython does not provide, per the caveat above.
 - **On Windows a mounted directory is locked for as long as the mount object
   lives.** It holds an open descriptor, and Windows refuses to rename or delete
   a directory while a handle to it is open, so the host gets
-  `ERROR_SHARING_VIOLATION` until the mount object is dropped — not just until
-  the feed ends. Unix is unaffected.
+  `ERROR_SHARING_VIOLATION` until the mount is closed — not just until the feed
+  ends. `MountDir.close()` releases it (also `with` in Python, `using` in
+  JavaScript); a feed already running keeps its own reference, and feeding a
+  closed mount raises. Unix is unaffected, and closing is optional there.
 - **Mounts only answer calls on the automatic path.** Every OS call the sandbox
   makes surfaces as a suspension; the pool consults the mount table only when
   the caller asks it to. `feed_run` (and the JS `feedRun`) asks on every OS


### PR DESCRIPTION
Stacked on #669, whose commits GitHub shows here too until it merges — the last six are this PR. Each defect is reproduced first, then fixed by inverting its assertion.

## Path length measured after `..` collapsed (limit bypass)

**on main:** a request padded with `../` was measured once the padding cancelled out, so any length passed.
**with fix:** measured as sent.

## A rename with one side unmounted fell through (access-mode bypass)

**on main:** an unmounted destination abandoned routing, handing the *mounted* source to the fallback — past the mount's access mode.
**with fix:** refused (EXDEV), both directions.

## Mount roots re-resolved every feed (mount escape)

**on main:** configuration recorded a path, so a renamed symlink redirected the next feed's mount.
**with fix:** configuration carries the opened descriptor, on all three surfaces.
