### PR TITLE
Fix test_type_check_format_not_a_string against pyo3 0.29.2

### DIFF
--- a/crates/monty-python/tests/test_type_check.py
+++ b/crates/monty-python/tests/test_type_check.py
@@ -288,7 +288,7 @@ def test_type_check_format_invalid(pool: Monty):
 def test_type_check_format_not_a_string(pool: Monty):
     with pytest.raises(TypeError) as exc_info:
         pool.checkout(type_check=True, type_check_format=123)  # pyright: ignore[reportArgumentType]
-    assert exc_info.value.args[0] == snapshot("argument 'type_check_format': type_check_format must be a str")
+    assert exc_info.value.args[0] == snapshot('type_check_format must be a str')
 
 
 # === type_check_stubs ===


### PR DESCRIPTION
The pyo3 0.29.2 uprev dropped the `argument '<name>': ` prefix from argument-extraction errors, breaking a snapshot test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `test_type_check_format_not_a_string` to expect `type_check_format must be a str`, matching `pyo3 0.29.2` which no longer adds the `argument '<name>':` prefix to argument-extraction errors. Fixes the failing test on main; only this assertion changed.

<sup>Written for commit 4d1e6c44e63615f684bc3ebd1f0518162f0a00bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

