### PR TITLE
Split `pydantic-monty` into a metapackage over client and runtime

### DIFF
--- a/.github/actions/build-pgo-wheel/action.yml
+++ b/.github/actions/build-pgo-wheel/action.yml
@@ -1,5 +1,5 @@
 name: Build PGO wheel
-description: Builds a PGO-optimized wheel for pydantic-monty
+description: Builds a PGO-optimized wheel for pydantic-monty-client
 
 inputs:
   interpreter:
@@ -37,7 +37,7 @@ runs:
 
     # `exercise.py` drives `pydantic_monty.Monty()` which spawns the `monty`
     # worker subprocess — build an instrumented worker so PGO data covers
-    # both the parent (FFI/pool/proto in pydantic-monty) and the worker
+    # both the parent (FFI/pool/proto in pydantic-monty-client) and the worker
     # (bytecode interpreter in monty-runtime).
     - name: build instrumented monty binary
       shell: bash
@@ -55,7 +55,7 @@ runs:
         fi
         export MONTY_BIN
         pip install typing_extensions
-        pip install pydantic-monty --no-index --no-deps --find-links pgo-wheel --force-reinstall
+        pip install pydantic-monty-client --no-index --no-deps --find-links pgo-wheel --force-reinstall
         python exercise.py
         rustup run ${INPUTS_RUST_TOOLCHAIN} bash -c 'echo LLVM_PROFDATA=$RUSTUP_HOME/toolchains/$RUSTUP_TOOLCHAIN/lib/rustlib/$RUST_HOST/bin/llvm-profdata >> "$GITHUB_ENV"'
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -835,11 +835,6 @@ jobs:
         with:
           version_file_path: 'Cargo.toml'
 
-      # the metapackage is published as committed — nothing in `build-sdist`
-      # runs Rust, so `crates/monty-python/build.rs`, which owns its version and
-      # its two `==` pins, cannot keep them current there. Checking the version
-      # against the tag covers the pins too: build.rs rewrites all three in one
-      # pass, so a version matching the tag means the file was regenerated here
       - name: check the pydantic-monty metapackage version
         uses: samuelcolvin/check-python-version@ee87cddb8049d2694cc03badc8569765a05cef00 # v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,9 +196,9 @@ jobs:
       - run: python3 -V
       - run: uv sync --all-packages --only-dev
 
-      # pydantic-monty depends on pydantic-monty-runtime; install it from the
-      # workspace so `maturin develop` can resolve it (plain build, outside
-      # the llvm-cov env, so the worker binary is not instrumented)
+      # the tests need the `monty` worker binary on PATH; build it from the
+      # workspace (plain build, outside the llvm-cov env, so the worker binary
+      # is not instrumented)
       - run: uv run maturin develop --uv -m crates/monty-runtime/Cargo.toml
 
       - name: Build and test Python bindings and run pytest with Rust coverage
@@ -207,7 +207,7 @@ jobs:
           eval "$(cargo llvm-cov show-env --export-prefix)"
           cargo llvm-cov clean --workspace
           uv run maturin develop --uv -m crates/monty-python/Cargo.toml
-          uv run --package pydantic-monty --only-dev pytest crates/monty-python/tests
+          uv run --package pydantic-monty-client --only-dev pytest crates/monty-python/tests
           cargo llvm-cov report --ignore-filename-regex "$LLVM_COV_IGNORE_FILENAME_REGEX"
           cargo llvm-cov report --codecov --output-path=python-rust-coverage.json --ignore-filename-regex "$LLVM_COV_IGNORE_FILENAME_REGEX"
 
@@ -483,6 +483,17 @@ jobs:
           rust-toolchain: stable
           working-directory: crates/monty-runtime
 
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+        with:
+          enable-cache: true # zizmor: ignore[cache-poisoning] -- Job does not produce release artifacts and does not have sensitive permissions
+
+      # the `pydantic-monty` metapackage is pure metadata pinning the client and
+      # runtime distributions, so one sdist plus one universal wheel cover every
+      # platform and Python version
+      - name: build metapackage
+        run: uv build --out-dir dist
+        working-directory: packages/pydantic-monty
+
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: pypi_files-cli-sdist
@@ -492,6 +503,11 @@ jobs:
         with:
           name: pypi_files-sdist
           path: crates/monty-python/dist
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: pypi_files-meta
+          path: packages/pydantic-monty/dist
 
   # Build wheels for exotic architectures (non-PGO)
   build:
@@ -685,7 +701,7 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             python3 -m pip install typing_extensions
-            python3 -m pip install pydantic-monty pydantic-monty-runtime --no-index --no-deps --find-links /dist --force-reinstall
+            python3 -m pip install pydantic-monty-client pydantic-monty-runtime --no-index --no-deps --find-links /dist --force-reinstall
             python3 - <<'EOF'
             from pydantic_monty import Monty
 
@@ -728,7 +744,7 @@ jobs:
           path: dist
 
       - run: pip install typing_extensions
-      - run: pip install pydantic-monty --no-index --no-deps --find-links dist --force-reinstall
+      - run: pip install pydantic-monty-client --no-index --no-deps --find-links dist --force-reinstall
       - run: python -c "import pydantic_monty; print(pydantic_monty.__version__)"
 
       # the cli wheel built for this platform must serve the worker pools
@@ -768,7 +784,7 @@ jobs:
         run: |
           ls -lhR dist/
           ls -1 dist/ | wc -l
-          echo "Expected ~62 files (5 Python versions × 10 platform variants + 12 cli wheels + sdists)"
+          echo "Expected ~64 files (5 Python versions × 10 platform variants + 12 cli wheels + sdists + metapackage)"
 
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
@@ -850,7 +866,7 @@ jobs:
           version_file_path: 'Cargo.toml'
 
       # Publishes every workspace member that is not `publish = false` (i.e. all
-      # the library/bin crates, but not the `pydantic-monty`/`monty-js` bindings,
+      # the library/bin crates, but not the `pydantic-monty-client`/`monty-js` bindings,
       # which ship to PyPI/npm). `--workspace` publishes in dependency order and
       # waits for each crate to land in the index before publishing dependents.
       - run: cargo publish --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,6 +483,31 @@ jobs:
           rust-toolchain: stable
           working-directory: crates/monty-runtime
 
+      - name: unpack the client sdist
+        run: |
+          mkdir sdist-check
+          tar -xzf crates/monty-python/dist/pydantic_monty_client-*.tar.gz -C sdist-check --strip-components=1
+
+      # the sdist carries only the client crate and its Rust path dependencies,
+      # so its build.rs must not reach for anything else in the workspace —
+      # check that here rather than discovering it from a PyPI install
+      - name: check the client sdist builds standalone
+        run: cargo check --manifest-path sdist-check/crates/monty-python/Cargo.toml
+
+      # the metapackage ships exactly as committed: `uv build` below runs no
+      # Rust, so `crates/monty-python/build.rs` — which owns its version and
+      # pins — never runs here. Check them against the version maturin just
+      # stamped into the client sdist, the same CARGO_PKG_VERSION build.rs uses
+      - name: check the metapackage version and pins are in sync
+        run: |
+          version=$(sed -n 's/^Version: //p' sdist-check/PKG-INFO | head -1)
+          for expected in "version = \"$version\"" "\"pydantic-monty-client==$version\"" "\"pydantic-monty-runtime==$version\""; do
+            if ! grep -qF -- "$expected" packages/pydantic-monty/pyproject.toml; then
+              echo "::error::packages/pydantic-monty/pyproject.toml is stale, expected a line containing: $expected"
+              exit 1
+            fi
+          done
+
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
           enable-cache: true # zizmor: ignore[cache-poisoning] -- Job does not produce release artifacts and does not have sensitive permissions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,30 +483,14 @@ jobs:
           rust-toolchain: stable
           working-directory: crates/monty-runtime
 
-      - name: unpack the client sdist
-        run: |
-          mkdir sdist-check
-          tar -xzf crates/monty-python/dist/pydantic_monty_client-*.tar.gz -C sdist-check --strip-components=1
-
       # the sdist carries only the client crate and its Rust path dependencies,
       # so its build.rs must not reach for anything else in the workspace —
       # check that here rather than discovering it from a PyPI install
       - name: check the client sdist builds standalone
-        run: cargo check --manifest-path sdist-check/crates/monty-python/Cargo.toml
-
-      # the metapackage ships exactly as committed: `uv build` below runs no
-      # Rust, so `crates/monty-python/build.rs` — which owns its version and
-      # pins — never runs here. Check them against the version maturin just
-      # stamped into the client sdist, the same CARGO_PKG_VERSION build.rs uses
-      - name: check the metapackage version and pins are in sync
         run: |
-          version=$(sed -n 's/^Version: //p' sdist-check/PKG-INFO | head -1)
-          for expected in "version = \"$version\"" "\"pydantic-monty-client==$version\"" "\"pydantic-monty-runtime==$version\""; do
-            if ! grep -qF -- "$expected" packages/pydantic-monty/pyproject.toml; then
-              echo "::error::packages/pydantic-monty/pyproject.toml is stale, expected a line containing: $expected"
-              exit 1
-            fi
-          done
+          mkdir sdist-check
+          tar -xzf crates/monty-python/dist/pydantic_monty_client-*.tar.gz -C sdist-check --strip-components=1
+          cargo check --manifest-path sdist-check/crates/monty-python/Cargo.toml
 
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
         with:
@@ -850,6 +834,16 @@ jobs:
         uses: samuelcolvin/check-python-version@ee87cddb8049d2694cc03badc8569765a05cef00 # v5
         with:
           version_file_path: 'Cargo.toml'
+
+      # the metapackage is published as committed — nothing in `build-sdist`
+      # runs Rust, so `crates/monty-python/build.rs`, which owns its version and
+      # its two `==` pins, cannot keep them current there. Checking the version
+      # against the tag covers the pins too: build.rs rewrites all three in one
+      # pass, so a version matching the tag means the file was regenerated here
+      - name: check the pydantic-monty metapackage version
+        uses: samuelcolvin/check-python-version@ee87cddb8049d2694cc03badc8569765a05cef00 # v5
+        with:
+          version_file_path: 'packages/pydantic-monty/pyproject.toml'
 
       - run: ls -lhR dist/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -707,7 +707,18 @@ Workflow: write `assert_snapshot!(value, @"");`, then `cargo insta test --accept
 
 ## Python Package (`pydantic-monty`)
 
-The Python package provides Python bindings for the Monty interpreter, located in `crates/monty-python/`.
+Three PyPI distributions are built from this repo:
+
+- `pydantic-monty-client` (`crates/monty-python/`, Cargo package
+  `pydantic-monty-client`) — the PyO3 bindings, i.e. the `pydantic_monty`
+  module. It deliberately does **not** depend on the runtime, so it can be
+  installed where the `monty` binary comes from a base image or system package.
+- `pydantic-monty-runtime` (`crates/monty-runtime/`) — the `monty` worker binary.
+- `pydantic-monty` (`packages/pydantic-monty/`) — a hatchling metapackage with
+  no code, exactly pinning the other two. This is what users install. Its
+  version and both pins are rewritten from the Cargo workspace version by
+  `crates/monty-python/build.rs`; never edit them by hand.
+
 Execution always happens in `monty` worker subprocesses — there is no in-process execution API.
 The surface is `Monty` (sync pool) and `AsyncMonty` (async pool), each with
 `pool.checkout(...)` sessions driven by `feed_run` (a coroutine on async sessions).
@@ -717,6 +728,8 @@ The surface is `Monty` (sync pool) and `AsyncMonty` (async pool), each with
 - `crates/monty-python/src/` - Rust source for PyO3 bindings
 - `crates/monty-python/python/pydantic_monty/_monty.pyi` - Type stubs for the Python module
 - `crates/monty-python/tests/` - Python tests using pytest
+- `crates/monty-python/README.md` - the `pydantic-monty-client` readme (binary
+  resolution); the full user-facing docs live in `packages/pydantic-monty/README.md`
 
 ### Building and Testing
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3257,7 +3257,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "pydantic-monty"
+name = "pydantic-monty-client"
 version = "0.0.19"
 dependencies = [
  "ahash",

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,11 @@ test-browser: install-js ## Browser (Vitest) test of the wasm path in a real hea
 	cd crates/monty-js && npm run build:wasm && npm run build:ts && npx playwright install chromium && npm run test:browser
 
 .PHONY: dev-py-pgo
-dev-py-pgo: ## Install the python package for development with profile-guided optimization
+dev-py-pgo: install-py ## Install the python package for development with profile-guided optimization
 	$(eval PROFDATA := $(shell mktemp -d))
+	# the profiling run below spawns `monty` workers; build the runtime outside
+	# the instrumented build so only the client extension is profiled
+	uv run maturin develop --uv -m crates/monty-runtime/Cargo.toml --release
 	RUSTFLAGS='-Cprofile-generate=$(PROFDATA)' uv run maturin develop --uv -m crates/monty-python/Cargo.toml --release
 	uv run --package pydantic-monty-client --only-dev pytest crates/monty-python/tests -k "not test_parallel_exec"
 	$(eval LLVM_PROFDATA := $(shell rustup run stable bash -c 'echo $$RUSTUP_HOME/toolchains/$$RUSTUP_TOOLCHAIN/lib/rustlib/$$(rustc -Vv | grep host | cut -d " " -f 2)/bin/llvm-profdata'))

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ test-browser: install-js ## Browser (Vitest) test of the wasm path in a real hea
 dev-py-pgo: ## Install the python package for development with profile-guided optimization
 	$(eval PROFDATA := $(shell mktemp -d))
 	RUSTFLAGS='-Cprofile-generate=$(PROFDATA)' uv run maturin develop --uv -m crates/monty-python/Cargo.toml --release
-	uv run --package pydantic-monty --only-dev pytest crates/monty-python/tests -k "not test_parallel_exec"
+	uv run --package pydantic-monty-client --only-dev pytest crates/monty-python/tests -k "not test_parallel_exec"
 	$(eval LLVM_PROFDATA := $(shell rustup run stable bash -c 'echo $$RUSTUP_HOME/toolchains/$$RUSTUP_TOOLCHAIN/lib/rustlib/$$(rustc -Vv | grep host | cut -d " " -f 2)/bin/llvm-profdata'))
 	$(LLVM_PROFDATA) merge -o $(PROFDATA)/merged.profdata $(PROFDATA)
 	RUSTFLAGS='-Cprofile-use=$(PROFDATA)/merged.profdata' $(uv-run-no-sync) maturin develop --uv -m crates/monty-python/Cargo.toml --release
@@ -165,14 +165,14 @@ test-subprocess: ## Run subprocess protocol, child-mode, and worker-pool tests
 
 .PHONY: pytest
 pytest: ## Run Python tests with pytest
-	uv run --package pydantic-monty --only-dev pytest crates/monty-python/tests
+	uv run --package pydantic-monty-client --only-dev pytest crates/monty-python/tests
 
 .PHONY: test-py
 test-py: dev-py pytest ## Build the python package (debug profile) and run tests
 
 .PHONY: test-docs
 test-docs: dev-py ## Test docs examples only
-	uv run --package pydantic-monty --only-dev pytest crates/monty-python/tests/test_readme_examples.py
+	uv run --package pydantic-monty-client --only-dev pytest crates/monty-python/tests/test_readme_examples.py
 	cargo test --doc -p monty
 
 .PHONY: test

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ uv add pydantic-monty
 
 (Or `pip install pydantic-monty` for the boomers)
 
+`pydantic-monty` is a metapackage pairing `pydantic-monty-client` (the
+`pydantic_monty` module) with `pydantic-monty-runtime` (the `monty` worker
+binary). Install `pydantic-monty-client` alone if the binary already comes from
+somewhere else.
+
 Usage:
 
 ```python

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,8 @@ make lint-rs
 ```
 
 This will update `Cargo.lock`, sync `package.json`/`package-lock.json` (via `crates/monty-js/build.rs`),
-and sync `pydantic-monty`'s exact pin on `pydantic-monty-runtime` (via `crates/monty-python/build.rs`).
+and sync the `pydantic-monty` metapackage's version and its exact pins on
+`pydantic-monty-client`/`pydantic-monty-runtime` (via `crates/monty-python/build.rs`).
 
 ## 2. Commit and Push
 
@@ -30,7 +31,8 @@ Once the PR is merged, create a release in the GitHub UI with a tag matching the
 
 Once the tag is pushed, CI will:
 - Build wheels for all platforms
-- Publish to PyPI (`pydantic-monty`)
+- Publish to PyPI (`pydantic-monty-client` wheels, `pydantic-monty-runtime` wheels,
+  and the `pydantic-monty` metapackage that pins both)
 - Publish to NPM (`@pydantic/monty` + the platform packages carrying the napi library, the `monty` binary, and the wasm build)
 - Publish the Rust crates to crates.io (`monty`, `monty-types`, `monty-alloc`, `monty-fs`, `monty-runtime`, `monty-macros`, `monty-proto`, `monty-pool`, `monty-type-checking`, `monty-typeshed`) via `cargo publish --workspace`
 

--- a/crates/monty-proto/README.md
+++ b/crates/monty-proto/README.md
@@ -32,7 +32,7 @@ for the schema and the protocol rules documented alongside it.
   be deployed in lockstep.
 - `python` (cargo feature, off by default) — the `python` module: PyO3-based
   conversions between live Python objects and `MontyObject`/`MontyException`,
-  used by the `pydantic-monty` extension module. The feature pulls in `pyo3` (but never its
+  used by the `pydantic-monty-client` extension module. The feature pulls in `pyo3` (but never its
   `extension-module` feature — how libpython is linked stays the top crate's
   decision), so pure-Rust consumers pay nothing for it.
 

--- a/crates/monty-python/Cargo.toml
+++ b/crates/monty-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "pydantic-monty"
-description = "Python bindings for the Monty sandboxed Python interpreter"
+name = "pydantic-monty-client"
+description = "Python client for the Monty sandboxed Python interpreter"
 readme = "README.md"
 # Distributed as a PyO3 extension wheel on PyPI, not as a crate on crates.io.
 publish = false

--- a/crates/monty-python/README.md
+++ b/crates/monty-python/README.md
@@ -1,26 +1,37 @@
-# pydantic-monty
+# pydantic-monty-client
 
-Python bindings for the Monty sandboxed Python interpreter.
+Python client for the Monty sandboxed Python interpreter.
+
+Most users want [`pydantic-monty`](https://pypi.org/project/pydantic-monty/)
+instead, which pulls in this package plus
+[`pydantic-monty-runtime`](https://pypi.org/project/pydantic-monty-runtime/) and
+is documented in full on its PyPI page. Install this one directly only when the
+`monty` binary is supplied some other way — a base image, a system package, or a
+build of this repository:
+
+```bash
+pip install pydantic-monty-client
+```
+
+## Locating the worker binary
 
 Execution always happens in a pool of `monty` worker subprocesses: a monty
 process can never be made fully crash-proof against memory errors (stack
-overflows, allocator aborts) triggered by adversarial input, so crash
-isolation is built in. A crashed worker raises `MontyCrashedError` and is
-replaced transparently — your process is never at risk.
+overflows, allocator aborts) triggered by adversarial input, so crash isolation
+is built in. Without `pydantic-monty-runtime` installed, `pydantic_monty` has to
+find that binary itself, in this order:
 
-## Installation
+1. the `binary_path=` argument to `Monty(...)` / `AsyncMonty(...)`
+2. the `MONTY_BIN` environment variable
+3. the environment's scripts directory (where `pydantic-monty-runtime` installs it)
+4. a `monty` executable on `PATH`
+5. a cargo-built binary in the monty workspace, for editable installs of this repo
 
-```bash
-pip install pydantic-monty
-```
-
-This installs the `monty` worker binary via the
-[`pydantic-monty-runtime`](https://pypi.org/project/pydantic-monty-runtime/)
-dependency (the same way `uv` and `ruff` ship their binaries).
+If none match, constructing a pool raises `FileNotFoundError`. The binary must be
+the same version as this package — the worker rejects a version mismatch when a
+session is checked out.
 
 ## Usage
-
-### Basic execution
 
 ```python
 from pydantic_monty import Monty
@@ -31,243 +42,7 @@ with Monty() as pool:
         #> 3
 ```
 
-`Monty()` is a pool of workers; `pool.checkout()` dedicates one worker to a
-REPL session. Session state persists across `feed_run` calls:
-
-```python
-from pydantic_monty import Monty
-
-with Monty() as pool:
-    with pool.checkout() as session:
-        session.feed_run('x = 40')
-        print(session.feed_run('x + 2'))
-        #> 42
-```
-
-### Async
-
-`AsyncMonty` is the asyncio counterpart: worker I/O runs off the event loop,
-and external functions may be coroutines.
-
-```python
-import asyncio
-
-from pydantic_monty import AsyncMonty
-
-
-async def fetch(url: str) -> str:
-    await asyncio.sleep(0.01)
-    return f'contents of {url}'
-
-
-async def main():
-    async with AsyncMonty() as pool:
-        async with pool.checkout() as session:
-            result = await session.feed_run(
-                "await fetch('https://example.com')",
-                external_lookup={'fetch': fetch},
-            )
-    print(result)
-    #> contents of https://example.com
-
-
-asyncio.run(main())
-```
-
-### Input variables and external lookup
-
-```python
-from pydantic_monty import Monty
-
-with Monty() as pool:
-    with pool.checkout() as session:
-        result = session.feed_run(
-            'double(x) + y',
-            inputs={'x': 5, 'y': 1},
-            external_lookup={'double': lambda x: x * 2},
-        )
-    print(result)
-    #> 11
-```
-
-### Snapshots: pausing and resuming execution
-
-`feed_start` is the suspendable counterpart of `feed_run`: instead of driving a
-snippet to completion, it hands control back at each external call, OS call,
-name lookup, or future resolution as a *snapshot*. You answer with
-`snapshot.resume(...)`, which returns the next snapshot or a `MontyComplete`.
-
-```python
-from pydantic_monty import FunctionSnapshot, Monty, MontyComplete
-
-with Monty() as pool:
-    with pool.checkout() as session:
-        snapshot = session.feed_start('greet(name) + "!"', inputs={'name': 'Ada'})
-        assert isinstance(snapshot, FunctionSnapshot)
-        print(snapshot.function_name, snapshot.args)
-        #> greet ('Ada',)
-        result = snapshot.resume({'return_value': 'hello Ada'})
-        assert isinstance(result, MontyComplete)
-        print(result.output)
-        #> hello Ada!
-```
-
-To iterate a snippet to completion without answering each suspension by hand,
-pass an `external_lookup` (and/or `os`) to `feed_start` and drive with
-`snapshot.resume_auto()`, which resolves each external call and name lookup from
-them automatically — the same resolution `feed_run` performs, but one step at a
-time so you can inspect or `dump()` each snapshot along the way:
-
-```python
-from pydantic_monty import Monty, MontyComplete
-
-with Monty() as pool:
-    with pool.checkout() as session:
-        snapshot = session.feed_start(
-            'greet(name) + "!"',
-            inputs={'name': 'Ada'},
-            external_lookup={'greet': lambda n: f'hello {n}'},
-        )
-        while not isinstance(snapshot, MontyComplete):
-            snapshot = snapshot.resume_auto()
-        print(snapshot.output)
-        #> hello Ada!
-```
-
-On `AsyncMonty`, `external_lookup` callables may be coroutine functions and
-`resume_auto` is awaitable (`snapshot = await snapshot.resume_auto()`); a
-coroutine external is awaited concurrently and settled via an
-`AsyncFutureSnapshot`.
-
-`snapshot.dump()` serializes the paused worker to bytes; a fresh session's
-`load_snapshot` restores it and returns the snapshot to resume. This lets you
-checkpoint execution and continue it later, even in a different process:
-
-```python
-from pydantic_monty import FunctionSnapshot, Monty, MontyComplete
-
-with Monty() as pool:
-    with pool.checkout() as session:
-        snapshot = session.feed_start(
-            'fetch(url)', inputs={'url': 'https://example.com'}
-        )
-        blob = snapshot.dump()
-
-    # later — restore into a fresh session and resume
-    with pool.checkout() as session:
-        snapshot = session.load_snapshot(blob)
-        assert isinstance(snapshot, FunctionSnapshot)
-        result = snapshot.resume({'return_value': 'page contents'})
-        assert isinstance(result, MontyComplete)
-        print(result.output)
-        #> page contents
-```
-
-If the paused feed used filesystem `mount`s, re-supply the same ones to
-`load_snapshot(blob, mount=...)` — their host paths are not stored in the dump.
-
-`session.dump()` between feeds serializes an idle session instead; restore it
-with `session.load_session(blob)` (which returns `None`) and keep feeding. Both
-`load_session` and `load_snapshot` are valid only on a fresh session, before
-any feed; using the wrong one for a dump's kind raises. `AsyncMonty` sessions
-expose the same `feed_start` / `load_session` / `load_snapshot`, with awaitable
-`resume(...)`.
-
-### Resource limits
-
-Limits are enforced inside the worker; the pool's `request_timeout` is a
-host-side backstop that kills a hung worker outright. An installed telemetry
-adapter invokes trusted Python SDK callbacks synchronously; enforcement is
-delayed while such a callback runs. `max_duration_secs`
-limits cumulative *execution* time — the clock runs only while the
-interpreter executes, never while suspended waiting on the host, and
-accumulates across feeds. The worker reports its execution time on every
-protocol turn, and sessions with the limit are additionally killed
-`duration_limit_grace` (1s, not currently configurable from Python) after
-the remaining budget expires, covering hangs the in-sandbox limit cannot
-catch (its check only runs at interpreter checkpoints).
-
-```python
-from pydantic_monty import Monty, MontyRuntimeError
-
-with Monty(request_timeout=10) as pool:
-    with pool.checkout(limits={'max_duration_secs': 0.1}) as session:
-        try:
-            session.feed_run('while True:\n    pass')
-        except MontyRuntimeError as exc:
-            print(exc.display(format='type-msg').split(':')[0])
-            #> TimeoutError
-```
-
-### Type checking
-
-Monty bundles [ty](https://docs.astral.sh/ty/): each fed snippet can be
-type-checked inside the worker before it runs, with successfully executed
-snippets accumulating into the checking context.
-
-```python
-from pydantic_monty import Monty, MontyTypingError
-
-with Monty() as pool:
-    with pool.checkout(type_check=True) as session:
-        try:
-            session.feed_run("x: int = 'not an int'")
-        except MontyTypingError as exc:
-            print('invalid-assignment' in exc.display())
-            #> True
-```
-
-`type_check_format` picks the rendering — ty's `'full'` (the default: source
-snippet and carets), `'concise'`, `'azure'`, `'json'`, `'jsonlines'`,
-`'rdjson'`, `'pylint'`, `'gitlab'` or `'github'` — and `type_check_color` adds
-ANSI colour to `'full'` and `'concise'`. Both are `checkout()` arguments rather
-than `display()` arguments because the diagnostics are rendered inside the
-worker: ty's structured diagnostics resolve their spans against the type
-checker's database, so only the rendered text crosses the wire.
-
-```python
-from pydantic_monty import Monty, MontyTypingError
-
-with Monty() as pool:
-    with pool.checkout(type_check=True, type_check_format='concise') as session:
-        try:
-            session.feed_run("x: int = 'not an int'")
-        except MontyTypingError as exc:
-            print(exc.display())
-            """
-            main.py:1:10: error[invalid-assignment] Object of type `Literal["not an int"]` is not assignable to `int`
-            """
-```
-
-### Crash isolation
-
-```python test="skip"
-from pydantic_monty import Monty, MontyCrashedError
-
-hostile_code = '...'
-
-with Monty() as pool:
-    with pool.checkout() as session:
-        try:
-            session.feed_run(hostile_code)  # even a segfault is contained
-        except MontyCrashedError:
-            ...  # the worker died; the pool already replaced it
-```
-
-### Observability
-
-The Python Logfire integration instruments the pool through a private adapter
-hook. It propagates the active Python OTel context into each checkout, which
-becomes one session span with nested feed and suspension
-spans recording code, inputs, external calls, exceptions, and `print` output.
-Session dumps and restores are recorded by size only.
-
-Logfire's Python SDK owns sampling, export credentials, resources, flushing,
-and shutdown. The Rust binding runs only an exporter-free processor pipeline;
-workers receive no credentials. Instrumentation is disabled unless an adapter
-is explicitly installed. Enabled instrumentation captures content, truncating
-large values at the telemetry attribute size limit.
-
-See `limitations/pool-architecture.md` in the repository for the behavioural
-details of subprocess execution (host-side mounts, buffered print
-callbacks, session dumps).
+See the [`pydantic-monty`](https://pypi.org/project/pydantic-monty/) README for
+async usage, external functions, snapshots, resource limits, type checking and
+observability, and `limitations/pool-architecture.md` in the repository for the
+behavioural details of subprocess execution.

--- a/crates/monty-python/build.rs
+++ b/crates/monty-python/build.rs
@@ -1,4 +1,8 @@
-use std::{borrow::Cow, env, fs, path::PathBuf};
+use std::{
+    borrow::Cow,
+    env, fs,
+    path::{Path, PathBuf},
+};
 
 // `cargo_version_to_pep440`, shared verbatim with the library so that the
 // version and pins written below always match the version maturin builds the
@@ -6,18 +10,20 @@ use std::{borrow::Cow, env, fs, path::PathBuf};
 // own crate.
 include!("src/version.rs");
 
-/// Build script that configures pyo3 and keeps the `pydantic-monty`
-/// metapackage's version and dependency pins matching the Cargo workspace
-/// version.
+/// Build script that configures pyo3 and, when building from the monty
+/// workspace, keeps the `pydantic-monty` metapackage's version and dependency
+/// pins matching the Cargo workspace version.
 ///
 /// Cargo sets `CARGO_PKG_VERSION` in the environment when executing build
 /// scripts, so we use that as the single source of truth — the same approach
 /// `crates/monty-js/build.rs` takes for package.json.
 fn main() {
-    // Re-run when either input to the metapackage rewrite changes.
-    println!("cargo:rerun-if-changed={}", meta_pyproject_path().display());
-    println!("cargo:rerun-if-changed=src/version.rs");
-    sync_meta_pyproject();
+    if let Some(path) = meta_pyproject_path() {
+        // Re-run when either input to the metapackage rewrite changes.
+        println!("cargo:rerun-if-changed={}", path.display());
+        println!("cargo:rerun-if-changed=src/version.rs");
+        sync_meta_pyproject(&path);
+    }
     // see https://pyo3.rs/main/building-and-distribution/multiple-python-versions.html
     pyo3_build_config::use_pyo3_cfgs();
 }
@@ -33,12 +39,11 @@ fn main() {
 ///
 /// Uses the runtime `CARGO_PKG_VERSION` env var (not `env!()`) so that the build
 /// script picks up version changes without needing to be recompiled.
-fn sync_meta_pyproject() {
+fn sync_meta_pyproject(path: &Path) {
     let cargo_version = env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION not set");
     let pin_version = cargo_version_to_pep440(&cargo_version);
-    let path = meta_pyproject_path();
 
-    let contents = fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+    let contents = fs::read_to_string(path).unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
 
     let mut result = String::with_capacity(contents.len());
     let mut changed = false;
@@ -87,20 +92,26 @@ fn sync_meta_pyproject() {
 
     if changed {
         eprintln!("Updating {} to {pin_version}", path.display());
-        fs::write(&path, &result).unwrap_or_else(|e| panic!("failed to write {}: {e}", path.display()));
+        fs::write(path, &result).unwrap_or_else(|e| panic!("failed to write {}: {e}", path.display()));
     }
 }
 
 /// The PyPI distributions the metapackage pins exactly; see [`sync_meta_pyproject`].
 const PINNED_DISTS: [&str; 2] = ["pydantic-monty-client", "pydantic-monty-runtime"];
 
-/// The metapackage's pyproject.toml, which owns the `pydantic-monty` name on PyPI.
+/// The metapackage's pyproject.toml, which owns the `pydantic-monty` name on
+/// PyPI, or `None` when this build is not running from the monty workspace.
 ///
-/// It has no Cargo package of its own to carry the version, so this build
-/// script — the one belonging to the distribution it pins — maintains it.
-fn meta_pyproject_path() -> PathBuf {
-    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
-    PathBuf::from(manifest_dir).join("../../packages/pydantic-monty/pyproject.toml")
+/// The metapackage has no Cargo package of its own to carry the version, so
+/// this build script — the one belonging to the distribution it pins —
+/// maintains it. maturin's sdist keeps this crate at `crates/monty-python/`
+/// but ships only its Rust path dependencies, so `packages/` is absent and
+/// there is nothing to sync; installing the sdist must not panic over that.
+/// The sdist root's `PKG-INFO`, which a checkout never has, marks that case —
+/// anywhere else a missing metapackage is a real error and must fail the build.
+fn meta_pyproject_path() -> Option<PathBuf> {
+    let root = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set")).join("../..");
+    (!root.join("PKG-INFO").is_file()).then(|| root.join("packages/pydantic-monty/pyproject.toml"))
 }
 
 /// The index in [`PINNED_DISTS`] of the distribution `line` pins, if any.

--- a/crates/monty-python/build.rs
+++ b/crates/monty-python/build.rs
@@ -100,18 +100,22 @@ fn sync_meta_pyproject(path: &Path) {
 const PINNED_DISTS: [&str; 2] = ["pydantic-monty-client", "pydantic-monty-runtime"];
 
 /// The metapackage's pyproject.toml, which owns the `pydantic-monty` name on
-/// PyPI, or `None` when this build is not running from the monty workspace.
+/// PyPI, or `None` when there is nothing to sync.
 ///
 /// The metapackage has no Cargo package of its own to carry the version, so
 /// this build script — the one belonging to the distribution it pins —
-/// maintains it. maturin's sdist keeps this crate at `crates/monty-python/`
-/// but ships only its Rust path dependencies, so `packages/` is absent and
-/// there is nothing to sync; installing the sdist must not panic over that.
-/// The sdist root's `PKG-INFO`, which a checkout never has, marks that case —
-/// anywhere else a missing metapackage is a real error and must fail the build.
+/// maintains it. It lives outside this crate, and maturin's sdist ships only
+/// the crate and its Rust path dependencies, so a source install legitimately
+/// has no metapackage and must not panic over that.
 fn meta_pyproject_path() -> Option<PathBuf> {
-    let root = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set")).join("../..");
-    (!root.join("PKG-INFO").is_file()).then(|| root.join("packages/pydantic-monty/pyproject.toml"))
+    let path = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set"))
+        .join("../../packages/pydantic-monty/pyproject.toml");
+    if path.is_file() {
+        Some(path)
+    } else {
+        println!("cargo:warning=no file at {}, skipping version sync", path.display());
+        None
+    }
 }
 
 /// The index in [`PINNED_DISTS`] of the distribution `line` pins, if any.

--- a/crates/monty-python/build.rs
+++ b/crates/monty-python/build.rs
@@ -1,54 +1,61 @@
-use std::{borrow::Cow, env, fs, path::Path};
+use std::{borrow::Cow, env, fs, path::PathBuf};
 
-// `cargo_version_to_pep440`, shared verbatim with the library so that the pin
-// written below always matches the version maturin builds the wheels under.
-// Included textually because a build script cannot depend on its own crate.
+// `cargo_version_to_pep440`, shared verbatim with the library so that the
+// version and pins written below always match the version maturin builds the
+// wheels under. Included textually because a build script cannot depend on its
+// own crate.
 include!("src/version.rs");
 
-/// Build script that configures pyo3 and keeps pyproject.toml's
-/// `pydantic-monty-runtime` pin exactly matching the Cargo workspace version.
+/// Build script that configures pyo3 and keeps the `pydantic-monty`
+/// metapackage's version and dependency pins matching the Cargo workspace
+/// version.
 ///
 /// Cargo sets `CARGO_PKG_VERSION` in the environment when executing build
 /// scripts, so we use that as the single source of truth — the same approach
 /// `crates/monty-js/build.rs` takes for package.json.
 fn main() {
-    // Re-run when either input to the pin changes.
-    println!("cargo:rerun-if-changed=pyproject.toml");
+    // Re-run when either input to the metapackage rewrite changes.
+    println!("cargo:rerun-if-changed={}", meta_pyproject_path().display());
     println!("cargo:rerun-if-changed=src/version.rs");
-    sync_runtime_pin();
+    sync_meta_pyproject();
     // see https://pyo3.rs/main/building-and-distribution/multiple-python-versions.html
     pyo3_build_config::use_pyo3_cfgs();
 }
 
-/// Rewrite the `pydantic-monty-runtime` dependency pin in pyproject.toml if it
-/// has drifted from the Cargo package version.
+/// Rewrite the metapackage's `version` and its pins on this distribution and
+/// `pydantic-monty-runtime` if any has drifted from the Cargo package version.
 ///
-/// The two distributions are built from the same workspace and released
-/// together, and `pydantic_monty` spawns the `monty` binary that
-/// `pydantic-monty-runtime` ships, so the pin must be exact. Unlike monty-js
-/// there is no lockfile to refresh afterwards: uv.lock records no specifier for
-/// the workspace-editable `pydantic-monty-runtime` source.
+/// All three distributions are built from the same workspace and released
+/// together — `pydantic-monty` exists only to install the other two, and the
+/// worker rejects a client whose version differs — so the pins must be exact.
+/// Unlike monty-js there is no lockfile to refresh afterwards: uv.lock records
+/// no specifier for workspace-editable sources.
 ///
 /// Uses the runtime `CARGO_PKG_VERSION` env var (not `env!()`) so that the build
 /// script picks up version changes without needing to be recompiled.
-fn sync_runtime_pin() {
+fn sync_meta_pyproject() {
     let cargo_version = env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION not set");
     let pin_version = cargo_version_to_pep440(&cargo_version);
-    let pyproject_path = Path::new("pyproject.toml");
+    let path = meta_pyproject_path();
 
-    let contents = fs::read_to_string(pyproject_path).expect("failed to read pyproject.toml");
+    let contents = fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
 
     let mut result = String::with_capacity(contents.len());
     let mut changed = false;
-    let mut pins = 0usize;
+    // one count per entry of `PINNED_DISTS`, plus the `version = ` line
+    let mut pins = [0usize; PINNED_DISTS.len()];
+    let mut versions = 0usize;
 
     for line in contents.lines() {
-        let synced = if is_runtime_pin(line) {
-            pins += 1;
+        let synced = if let Some(index) = pinned_dist(line) {
+            pins[index] += 1;
             // Preserve the presence/absence of the trailing comma (the last
             // entry in the dependencies array has none).
             let comma = if line.ends_with(',') { "," } else { "" };
-            Cow::Owned(format!("    \"{RUNTIME_DIST}=={pin_version}\"{comma}"))
+            Cow::Owned(format!("    \"{}=={pin_version}\"{comma}", PINNED_DISTS[index]))
+        } else if line.starts_with("version = \"") {
+            versions += 1;
+            Cow::Owned(format!("version = \"{pin_version}\""))
         } else {
             Cow::Borrowed(line)
         };
@@ -59,50 +66,72 @@ fn sync_runtime_pin() {
         result.push('\n');
     }
 
-    // Anything that stops the pin from being recognised — renaming it, adding
+    // Anything that stops a pin from being recognised — renaming it, adding
     // extras or an environment marker, dropping it — must fail the build rather
-    // than silently ship a stale or absent pin.
+    // than silently ship a stale or absent pin. The same goes for the version,
+    // which would otherwise leave the metapackage frozen at an old release.
+    for (dist, found) in PINNED_DISTS.iter().zip(pins) {
+        assert_eq!(
+            found,
+            1,
+            "expected exactly one `{dist}` pin in [project].dependencies of {}, found {found}",
+            path.display()
+        );
+    }
     assert_eq!(
-        pins, 1,
-        "expected exactly one `{RUNTIME_DIST}` pin in [project].dependencies of pyproject.toml, found {pins}"
+        versions,
+        1,
+        "expected exactly one `version = \"...\"` line in {}, found {versions}",
+        path.display()
     );
 
     if changed {
-        eprintln!("Updating {RUNTIME_DIST} pin in pyproject.toml to {pin_version}");
-        fs::write(pyproject_path, &result).expect("failed to write pyproject.toml");
+        eprintln!("Updating {} to {pin_version}", path.display());
+        fs::write(&path, &result).unwrap_or_else(|e| panic!("failed to write {}: {e}", path.display()));
     }
 }
 
-/// The PyPI distribution this package pins exactly; see [`sync_runtime_pin`].
-const RUNTIME_DIST: &str = "pydantic-monty-runtime";
+/// The PyPI distributions the metapackage pins exactly; see [`sync_meta_pyproject`].
+const PINNED_DISTS: [&str; 2] = ["pydantic-monty-client", "pydantic-monty-runtime"];
 
-/// Whether `line` is the [`RUNTIME_DIST`] entry in `[project].dependencies`.
+/// The metapackage's pyproject.toml, which owns the `pydantic-monty` name on PyPI.
+///
+/// It has no Cargo package of its own to carry the version, so this build
+/// script — the one belonging to the distribution it pins — maintains it.
+fn meta_pyproject_path() -> PathBuf {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    PathBuf::from(manifest_dir).join("../../packages/pydantic-monty/pyproject.toml")
+}
+
+/// The index in [`PINNED_DISTS`] of the distribution `line` pins, if any.
 ///
 /// The rewrite replaces the whole line, so this must recognise *only* what the
 /// rewrite can reproduce: the bare name plus an optional version specifier. A
 /// requirement carrying anything else — extras, an environment marker, a direct
 /// URL — is deliberately not matched, so the `pins == 1` assertion fires rather
 /// than the extra syntax being silently dropped.
-fn is_runtime_pin(line: &str) -> bool {
-    dependency_requirement(line)
-        .and_then(|requirement| requirement.strip_prefix(RUNTIME_DIST))
-        .is_some_and(is_version_specifier)
+fn pinned_dist(line: &str) -> Option<usize> {
+    let requirement = dependency_requirement(line)?;
+    PINNED_DISTS
+        .iter()
+        .position(|dist| requirement.strip_prefix(dist).is_some_and(is_version_specifier))
 }
 
 /// The PEP 508 requirement of a `[project].dependencies` array entry.
 ///
 /// Matching is indentation-sensitive (exactly 4 spaces, the array style used in
-/// this file) so that the bare `pydantic-monty-runtime = { workspace = true }`
-/// entry under `[tool.uv.sources]`, which must stay unpinned, is never touched.
-/// Only a trailing comma may follow the closing quote — the last entry has none.
+/// this file) so that the bare `pydantic-monty-client = { workspace = true }`
+/// entries under `[tool.uv.sources]`, which must stay unpinned, are never
+/// touched. Only a trailing comma may follow the closing quote — the last entry
+/// has none.
 fn dependency_requirement(line: &str) -> Option<&str> {
     let entry = line.strip_prefix("    \"")?;
     let (requirement, tail) = entry.split_once('"')?;
     matches!(tail, "" | ",").then_some(requirement)
 }
 
-/// Whether `specifier` is what may legally follow [`RUNTIME_DIST`] in a pin we
-/// are willing to rewrite: nothing at all, or a PEP 440 version specifier.
+/// Whether `specifier` is what may legally follow a [`PINNED_DISTS`] name in a
+/// pin we are willing to rewrite: nothing at all, or a PEP 440 version specifier.
 ///
 /// The leading-character check also enforces the name boundary. `-` is a legal
 /// PEP 508 name character, so accepting any suffix would claim (and clobber) a

--- a/crates/monty-python/pyproject.toml
+++ b/crates/monty-python/pyproject.toml
@@ -3,9 +3,10 @@ requires = ["maturin>=1.9.4,<2.0"]
 build-backend = "maturin"
 
 [project]
-# the module is named `pydantic_monty`
-name = "pydantic-monty"
-description = "Python bindings for the Monty sandboxed Python interpreter"
+# the module is named `pydantic_monty`; the `pydantic-monty` distribution is the
+# metapackage in `packages/pydantic-monty` that pairs this with the runtime
+name = "pydantic-monty-client"
+description = "Python client for the Monty sandboxed Python interpreter"
 readme = "README.md"
 requires-python = ">=3.10"
 classifiers = [
@@ -29,13 +30,9 @@ classifiers = [
     "Topic :: Internet",
     "Programming Language :: Python :: Implementation",
 ]
-dependencies = [
-    "typing_extensions>=4.5",
-    # ships the `monty` binary spawned as worker subprocesses; released in
-    # lockstep with this package, so the pin is exact and kept in sync with the
-    # workspace version by build.rs — don't edit it by hand
-    "pydantic-monty-runtime==0.0.19",
-]
+# deliberately does NOT depend on `pydantic-monty-runtime`,
+# to install it use the `pydantic-monty` package
+dependencies = ["typing_extensions>=4.5"]
 dynamic = ["license", "version"]
 
 [project.urls]
@@ -47,11 +44,6 @@ python-source = "python"
 module-name = "pydantic_monty._monty"
 features = ["pyo3/extension-module"]
 exclude = ["python/pydantic_monty/*.so", "python/pydantic_monty/__pycache__/**"]
-
-[tool.uv.sources]
-# during development the runtime package is built from this workspace rather
-# than fetched from PyPI
-pydantic-monty-runtime = { workspace = true }
 
 [dependency-groups]
 dev = [

--- a/crates/monty-python/python/pydantic_monty/_binary.py
+++ b/crates/monty-python/python/pydantic_monty/_binary.py
@@ -2,7 +2,9 @@
 
 The binary ships in the `pydantic-monty-runtime` wheel (a maturin `bin`-bindings
 package, the same pattern `uv` and `ruff` use), which installs it into the
-environment's scripts directory.
+environment's scripts directory. Installing `pydantic-monty` pulls that in; the
+`pydantic-monty-client` distribution alone does not, so the other resolution
+steps below matter when only the bindings are installed.
 """
 
 from __future__ import annotations
@@ -46,7 +48,7 @@ def find_monty_binary(explicit: str | Path | None = None) -> str:
         return str(dev)
     raise FileNotFoundError(
         'could not locate the `monty` binary required to run sandboxed code; '
-        'install it with `pip install pydantic-monty-runtime` (or `make dev-py` in the monty repo), '
+        'install it with `pip install pydantic-monty` (or `make dev-py` in the monty repo), '
         'pass binary_path=..., or set the MONTY_BIN environment variable'
     )
 

--- a/crates/monty-python/src/version.rs
+++ b/crates/monty-python/src/version.rs
@@ -10,9 +10,9 @@
 /// the rust spec and <https://peps.python.org/pep-0440/> for the python spec.
 ///
 /// Shared by `lib.rs` (for `pydantic_monty.__version__`) and `build.rs` (for the
-/// exact `pydantic-monty-runtime` pin), which `include!`s this file — the two
-/// must agree, since the pin has to match the version maturin builds the runtime
-/// wheel under.
+/// `pydantic-monty` metapackage's version and exact pins), which `include!`s
+/// this file — the two must agree, since the pins have to match the versions
+/// maturin builds the client and runtime wheels under.
 pub(crate) fn cargo_version_to_pep440(version: &str) -> String {
     version.replace("-alpha", "a").replace("-beta", "b")
 }

--- a/crates/monty-python/tests/test_readme_examples.py
+++ b/crates/monty-python/tests/test_readme_examples.py
@@ -2,6 +2,7 @@ import pytest
 from pytest_examples import CodeExample, EvalExample, find_examples
 
 paths = (
+    'packages/pydantic-monty/README.md',
     'crates/monty-python/README.md',
     'README.md',
 )

--- a/crates/monty-runtime/README.md
+++ b/crates/monty-runtime/README.md
@@ -56,9 +56,9 @@ The binary is also packaged for PyPI as
 [`pydantic-monty-runtime`](https://pypi.org/project/pydantic-monty-runtime/), the same
 way `uv` and `ruff` package theirs: installing the wheel places the compiled
 binary in the environment's scripts directory. It exists so that
-`pydantic-monty` can find a `monty` binary without any manual setup, and is
-installed automatically as a dependency of that package — you normally don't
-install it directly.
+`pydantic-monty-client` can find a `monty` binary without any manual setup, and
+is pulled in automatically by the `pydantic-monty` metapackage — you normally
+don't install it directly.
 
 ## Monty crates
 

--- a/crates/monty-types/README.md
+++ b/crates/monty-types/README.md
@@ -26,7 +26,7 @@ implementation**.
 Host-side crates that need these types without linking the interpreter —
 `monty-fs` (which services `OsFunctionCall`s locally via
 `MountTable::handle_os_call`), `monty-pool` (which talks to Monty workers
-over the wire), the `pydantic-monty` Python bindings and the
+over the wire), the `pydantic-monty-client` Python bindings and the
 `@pydantic/monty` JS bindings — depend on this crate **instead of `monty`**,
 so their binaries never link the interpreter itself. Only worker-side crates
 (`monty-runtime`, `monty-wasm-runtime`, and `monty-proto` with its `worker`

--- a/packages/pydantic-monty/README.md
+++ b/packages/pydantic-monty/README.md
@@ -1,0 +1,282 @@
+# pydantic-monty
+
+Python bindings for the Monty sandboxed Python interpreter.
+
+Execution always happens in a pool of `monty` worker subprocesses: a monty
+process can never be made fully crash-proof against memory errors (stack
+overflows, allocator aborts) triggered by adversarial input, so crash
+isolation is built in. A crashed worker raises `MontyCrashedError` and is
+replaced transparently — your process is never at risk.
+
+## Installation
+
+```bash
+pip install pydantic-monty
+```
+
+`pydantic-monty` is a metapackage with no code of its own; it installs the two
+distributions that make up a working sandbox:
+
+- [`pydantic-monty-client`](https://pypi.org/project/pydantic-monty-client/) —
+  the `pydantic_monty` module you import (pool, sessions, value conversion)
+- [`pydantic-monty-runtime`](https://pypi.org/project/pydantic-monty-runtime/) —
+  the `monty` worker binary the pool spawns, shipped the same way `uv` and
+  `ruff` ship their binaries
+
+Install `pydantic-monty-client` on its own when the worker binary comes from
+somewhere else — a base image, a system package, a build of this repo — and
+point `pydantic_monty` at it via `MONTY_BIN`, `binary_path=`, or `PATH`.
+
+## Usage
+
+### Basic execution
+
+```python
+from pydantic_monty import Monty
+
+with Monty() as pool:
+    with pool.checkout() as session:
+        print(session.feed_run('1 + 2'))
+        #> 3
+```
+
+`Monty()` is a pool of workers; `pool.checkout()` dedicates one worker to a
+REPL session. Session state persists across `feed_run` calls:
+
+```python
+from pydantic_monty import Monty
+
+with Monty() as pool:
+    with pool.checkout() as session:
+        session.feed_run('x = 40')
+        print(session.feed_run('x + 2'))
+        #> 42
+```
+
+### Async
+
+`AsyncMonty` is the asyncio counterpart: worker I/O runs off the event loop,
+and external functions may be coroutines.
+
+```python
+import asyncio
+
+from pydantic_monty import AsyncMonty
+
+
+async def fetch(url: str) -> str:
+    await asyncio.sleep(0.01)
+    return f'contents of {url}'
+
+
+async def main():
+    async with AsyncMonty() as pool:
+        async with pool.checkout() as session:
+            result = await session.feed_run(
+                "await fetch('https://example.com')",
+                external_lookup={'fetch': fetch},
+            )
+    print(result)
+    #> contents of https://example.com
+
+
+asyncio.run(main())
+```
+
+### Input variables and external lookup
+
+```python
+from pydantic_monty import Monty
+
+with Monty() as pool:
+    with pool.checkout() as session:
+        result = session.feed_run(
+            'double(x) + y',
+            inputs={'x': 5, 'y': 1},
+            external_lookup={'double': lambda x: x * 2},
+        )
+    print(result)
+    #> 11
+```
+
+### Snapshots: pausing and resuming execution
+
+`feed_start` is the suspendable counterpart of `feed_run`: instead of driving a
+snippet to completion, it hands control back at each external call, OS call,
+name lookup, or future resolution as a *snapshot*. You answer with
+`snapshot.resume(...)`, which returns the next snapshot or a `MontyComplete`.
+
+```python
+from pydantic_monty import FunctionSnapshot, Monty, MontyComplete
+
+with Monty() as pool:
+    with pool.checkout() as session:
+        snapshot = session.feed_start('greet(name) + "!"', inputs={'name': 'Ada'})
+        assert isinstance(snapshot, FunctionSnapshot)
+        print(snapshot.function_name, snapshot.args)
+        #> greet ('Ada',)
+        result = snapshot.resume({'return_value': 'hello Ada'})
+        assert isinstance(result, MontyComplete)
+        print(result.output)
+        #> hello Ada!
+```
+
+To iterate a snippet to completion without answering each suspension by hand,
+pass an `external_lookup` (and/or `os`) to `feed_start` and drive with
+`snapshot.resume_auto()`, which resolves each external call and name lookup from
+them automatically — the same resolution `feed_run` performs, but one step at a
+time so you can inspect or `dump()` each snapshot along the way:
+
+```python
+from pydantic_monty import Monty, MontyComplete
+
+with Monty() as pool:
+    with pool.checkout() as session:
+        snapshot = session.feed_start(
+            'greet(name) + "!"',
+            inputs={'name': 'Ada'},
+            external_lookup={'greet': lambda n: f'hello {n}'},
+        )
+        while not isinstance(snapshot, MontyComplete):
+            snapshot = snapshot.resume_auto()
+        print(snapshot.output)
+        #> hello Ada!
+```
+
+On `AsyncMonty`, `external_lookup` callables may be coroutine functions and
+`resume_auto` is awaitable (`snapshot = await snapshot.resume_auto()`); a
+coroutine external is awaited concurrently and settled via an
+`AsyncFutureSnapshot`.
+
+`snapshot.dump()` serializes the paused worker to bytes; a fresh session's
+`load_snapshot` restores it and returns the snapshot to resume. This lets you
+checkpoint execution and continue it later, even in a different process:
+
+```python
+from pydantic_monty import FunctionSnapshot, Monty, MontyComplete
+
+with Monty() as pool:
+    with pool.checkout() as session:
+        snapshot = session.feed_start(
+            'fetch(url)', inputs={'url': 'https://example.com'}
+        )
+        blob = snapshot.dump()
+
+    # later — restore into a fresh session and resume
+    with pool.checkout() as session:
+        snapshot = session.load_snapshot(blob)
+        assert isinstance(snapshot, FunctionSnapshot)
+        result = snapshot.resume({'return_value': 'page contents'})
+        assert isinstance(result, MontyComplete)
+        print(result.output)
+        #> page contents
+```
+
+If the paused feed used filesystem `mount`s, re-supply the same ones to
+`load_snapshot(blob, mount=...)` — their host paths are not stored in the dump.
+
+`session.dump()` between feeds serializes an idle session instead; restore it
+with `session.load_session(blob)` (which returns `None`) and keep feeding. Both
+`load_session` and `load_snapshot` are valid only on a fresh session, before
+any feed; using the wrong one for a dump's kind raises. `AsyncMonty` sessions
+expose the same `feed_start` / `load_session` / `load_snapshot`, with awaitable
+`resume(...)`.
+
+### Resource limits
+
+Limits are enforced inside the worker; the pool's `request_timeout` is a
+host-side backstop that kills a hung worker outright. An installed telemetry
+adapter invokes trusted Python SDK callbacks synchronously; enforcement is
+delayed while such a callback runs. `max_duration_secs`
+limits cumulative *execution* time — the clock runs only while the
+interpreter executes, never while suspended waiting on the host, and
+accumulates across feeds. The worker reports its execution time on every
+protocol turn, and sessions with the limit are additionally killed
+`duration_limit_grace` (1s, not currently configurable from Python) after
+the remaining budget expires, covering hangs the in-sandbox limit cannot
+catch (its check only runs at interpreter checkpoints).
+
+```python
+from pydantic_monty import Monty, MontyRuntimeError
+
+with Monty(request_timeout=10) as pool:
+    with pool.checkout(limits={'max_duration_secs': 0.1}) as session:
+        try:
+            session.feed_run('while True:\n    pass')
+        except MontyRuntimeError as exc:
+            print(exc.display(format='type-msg').split(':')[0])
+            #> TimeoutError
+```
+
+### Type checking
+
+Monty bundles [ty](https://docs.astral.sh/ty/): each fed snippet can be
+type-checked inside the worker before it runs, with successfully executed
+snippets accumulating into the checking context.
+
+```python
+from pydantic_monty import Monty, MontyTypingError
+
+with Monty() as pool:
+    with pool.checkout(type_check=True) as session:
+        try:
+            session.feed_run("x: int = 'not an int'")
+        except MontyTypingError as exc:
+            print('invalid-assignment' in exc.display())
+            #> True
+```
+
+`type_check_format` picks the rendering — ty's `'full'` (the default: source
+snippet and carets), `'concise'`, `'azure'`, `'json'`, `'jsonlines'`,
+`'rdjson'`, `'pylint'`, `'gitlab'` or `'github'` — and `type_check_color` adds
+ANSI colour to `'full'` and `'concise'`. Both are `checkout()` arguments rather
+than `display()` arguments because the diagnostics are rendered inside the
+worker: ty's structured diagnostics resolve their spans against the type
+checker's database, so only the rendered text crosses the wire.
+
+```python
+from pydantic_monty import Monty, MontyTypingError
+
+with Monty() as pool:
+    with pool.checkout(type_check=True, type_check_format='concise') as session:
+        try:
+            session.feed_run("x: int = 'not an int'")
+        except MontyTypingError as exc:
+            print(exc.display())
+            """
+            main.py:1:10: error[invalid-assignment] Object of type `Literal["not an int"]` is not assignable to `int`
+            """
+```
+
+### Crash isolation
+
+```python test="skip"
+from pydantic_monty import Monty, MontyCrashedError
+
+hostile_code = '...'
+
+with Monty() as pool:
+    with pool.checkout() as session:
+        try:
+            session.feed_run(hostile_code)  # even a segfault is contained
+        except MontyCrashedError:
+            ...  # the worker died; the pool already replaced it
+```
+
+### Observability
+
+The Python Logfire integration instruments the pool through a private adapter
+hook. It propagates the active Python OTel context into each checkout, which
+becomes one session span with nested feed and suspension
+spans recording code, inputs, external calls, exceptions, and `print` output.
+Session dumps and restores are recorded by size only.
+
+Logfire's Python SDK owns sampling, export credentials, resources, flushing,
+and shutdown. The Rust binding runs only an exporter-free processor pipeline;
+workers receive no credentials. Instrumentation is disabled unless an adapter
+is explicitly installed. Enabled instrumentation captures content, truncating
+large values at the telemetry attribute size limit.
+
+See `limitations/pool-architecture.md` in the repository for the behavioural
+details of subprocess execution (host-side mounts, buffered print
+callbacks, session dumps).

--- a/packages/pydantic-monty/pyproject.toml
+++ b/packages/pydantic-monty/pyproject.toml
@@ -1,0 +1,55 @@
+[build-system]
+requires = ["hatchling>=1.27"]
+build-backend = "hatchling.build"
+
+[project]
+name = "pydantic-monty"
+description = "The Monty sandboxed Python interpreter: bindings plus the worker binary"
+readme = "README.md"
+requires-python = ">=3.10"
+# SPDX expression only, no `license-files`: the maturin-built siblings carry the
+# licence the same way, from the Cargo workspace's `license` field
+license = "MIT"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
+    "Intended Audience :: System Administrators",
+    "Operating System :: Unix",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: Microsoft :: Windows",
+    "Environment :: MacOS X",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Internet",
+    "Programming Language :: Python :: Implementation",
+]
+# version and both pins are rewritten from the Cargo workspace version by
+# `crates/monty-python/build.rs` — don't edit them by hand
+version = "0.0.19"
+dependencies = [
+    "pydantic-monty-client==0.0.19",
+    "pydantic-monty-runtime==0.0.19",
+]
+
+[project.urls]
+Homepage = "https://github.com/pydantic/monty"
+Source = "https://github.com/pydantic/monty"
+
+# a metapackage ships no modules; without this hatchling errors out looking for
+# a package directory to include in the wheel
+[tool.hatch.build.targets.wheel]
+bypass-selection = true
+
+[tool.uv.sources]
+# during development both halves are built from this workspace rather than
+# fetched from PyPI
+pydantic-monty-client = { workspace = true }
+pydantic-monty-runtime = { workspace = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0"
 requires-python = ">=3.10"
 
 [tool.uv.workspace]
-members = ["crates/monty-python", "crates/monty-runtime"]
+members = ["crates/monty-python", "crates/monty-runtime", "packages/pydantic-monty"]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ exclude-newer-span = "P7D"
 members = [
     "monty-workspace",
     "pydantic-monty",
+    "pydantic-monty-client",
     "pydantic-monty-runtime",
 ]
 
@@ -1369,9 +1370,23 @@ wheels = [
 
 [[package]]
 name = "pydantic-monty"
+version = "0.0.19"
+source = { editable = "packages/pydantic-monty" }
+dependencies = [
+    { name = "pydantic-monty-client" },
+    { name = "pydantic-monty-runtime" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pydantic-monty-client", editable = "crates/monty-python" },
+    { name = "pydantic-monty-runtime", editable = "crates/monty-runtime" },
+]
+
+[[package]]
+name = "pydantic-monty-client"
 source = { editable = "crates/monty-python" }
 dependencies = [
-    { name = "pydantic-monty-runtime" },
     { name = "typing-extensions" },
 ]
 
@@ -1387,10 +1402,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "pydantic-monty-runtime", editable = "crates/monty-runtime" },
-    { name = "typing-extensions", specifier = ">=4.5" },
-]
+requires-dist = [{ name = "typing-extensions", specifier = ">=4.5" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
`pydantic-monty` bundled the bindings and hard-pinned the runtime wheel, so there was no way to install the bindings alone where the `monty` worker binary already comes from a base image, a system package, or a local build.

`crates/monty-python` now builds `pydantic-monty-client`, depending only on `typing_extensions`, and `packages/pydantic-monty` is a code-free hatchling metapackage pinning the client and the runtime exactly. The import name is unchanged, so `import pydantic_monty` works either way.

The metapackage has no Cargo package to carry its version, so `crates/monty-python/build.rs` now rewrites its `version` and both pins from `CARGO_PKG_VERSION` in place of the old single-pin sync, asserting it found exactly one of each so a rename or dropped pin fails the build rather than shipping a stale version.

The full user-facing docs move to `packages/pydantic-monty/README.md` (the PyPI page users land on); `crates/monty-python/README.md` becomes a short client-specific readme about worker-binary resolution.


Claude-Session: https://claude.ai/code/session_01V55eEMHZj6Muy1BqJMxPmU

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `pydantic-monty` into a metapackage that pins `pydantic-monty-client` (bindings) and `pydantic-monty-runtime` (worker binary), so users can install the client without the runtime while keeping `import pydantic_monty` unchanged. CI builds/publishes the metapackage and adds a release-time version check to keep it in sync with the Cargo workspace.

- **Refactors**
  - `crates/monty-python` now builds `pydantic-monty-client` (depends only on `typing_extensions`); new `packages/pydantic-monty` hatchling metapackage pins client+runtime exactly and is added to the `uv` workspace.
  - `build.rs` rewrites the metapackage `version` and both pins from `CARGO_PKG_VERSION`, asserting exactly one `version` line and one pin for each dist; it skips the rewrite when the metapackage path isn’t present (e.g., client sdist) and emits a warning.
  - CI/Makefile/tests switch to `pydantic-monty-client`; CI builds and uploads the metapackage (sdist + universal wheel), checks the client sdist builds standalone, updates expected artifact counts, and in the release job verifies the metapackage version with `samuelcolvin/check-python-version` before publish.
  - Docs: full user-facing docs move to `packages/pydantic-monty/README.md`; `crates/monty-python/README.md` focuses on worker-binary resolution; top-level README explains the split.

- **Migration**
  - Users: install `pydantic-monty` for the normal flow; install `pydantic-monty-client` only when the `monty` binary comes from your image/system/build (use `MONTY_BIN` or `binary_path=`).
  - Contributors: use `pydantic-monty-client` in local/CI pytest commands; releases publish client/runtime wheels plus the `pydantic-monty` metapackage.

<sup>Written for commit 680b833086a8a2fe4a93e0dbad52119a4f2e2f69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

