### PR TITLE
Add Macroscope review config (correctness tuning, ignore, approvability)

### DIFF
--- a/.macroscope/approvability.md
+++ b/.macroscope/approvability.md
@@ -1,0 +1,85 @@
+---
+conclusion: neutral
+---
+
+# Macroscope approvability (auto-approval eligibility)
+
+These rules decide when Macroscope may auto-approve a PR versus when it must step
+back and let a human review it. See https://docs.macroscope.com/approvability.
+
+**The bar for withholding auto-approval is deliberately very high.** The default is
+to auto-approve. Only genuinely high-stakes, non-correctness risk should send a PR
+to a human.
+
+## Correctness is out of scope here
+
+Correctness (bugs, CPython divergence, sandbox and resource-limit escapes, panics,
+missing `limitations/` entries, missing tests, style, naming, comment verbosity, AI
+slop) is owned by the Macroscope **Correctness** check, tuned by the instructions in
+`.macroscope/correctness/`. Auto-approval already waits for that check and will not
+fire if Correctness fails.
+
+So these eligibility rules must **not** withhold auto-approval for a correctness
+reason. Do not hold a PR because "there might be a bug", "this looks complex", "the
+sandbox could escape", or "the tests could be stronger". If the Correctness check
+passes, treat the code as correct and do not re-litigate it here.
+This file evaluates one thing only: does this change carry non-correctness risk large
+enough that a human must sign off even when the code is correct?
+
+## Withhold auto-approval only for these categories
+
+Require human review only when the PR **clearly and materially** does one of the
+following. A drive-by, comment-only, or cosmetic touch to one of these areas is not
+enough: the change must materially alter behaviour in the category.
+
+1. **`unsafe` and the core safety boundary.** Any change to `unsafe` code or to the
+   invariants it rests on, especially `crates/monty/src/heap.rs` (pointer arithmetic,
+   `UnsafeCell` access, reader-count invariants). A soundness mistake here is
+   memory-unsafe, not merely wrong.
+
+2. **The sandbox boundary.** Changes to how untrusted code is confined:
+   `crates/monty-fs/` (path security, mounts, symlink resolution), the syscall/OS
+   surface, or anything that could let sandboxed Python reach the host filesystem,
+   environment, network, or subprocesses.
+
+3. **The wire protocol and host/child trust boundary.** Changes to `monty-proto`
+   frame decoding or proto->Rust conversion, or to `monty-pool`'s handling of frames
+   from a child. These run in host/parent context where a mistake takes down the
+   embedder, and they parse hostile input.
+
+4. **Snapshot / dump format.** Changes to the serialization or on-disk/on-wire format
+   of snapshots or session dumps. These are a compatibility and trust contract; a
+   format change can silently break or mis-validate signed state.
+
+5. **Public API / ABI of the crates and bindings.** Removing or renaming an exported
+   item, or changing the type or shape of something `pydantic_monty`
+   (`crates/monty-python`), `@pydantic/monty` (`crates/monty-js`), or a Rust embedder
+   of the `monty` crate depends on. (Adding new, not-yet-depended-on API does not
+   count.)
+
+6. **Release and supply chain.** Changes to how crates/npm/PyPI artifacts are built,
+   versioned, or published; workflow changes that handle publish credentials; or new
+   runtime dependencies from a source we do not already trust. (Routine dev-only CI
+   tweaks and lockfile bumps of existing dependencies do not count.)
+
+## Not reasons to withhold auto-approval
+
+None of the following, on their own, require a human. Auto-approve them when
+Correctness passes:
+
+- Large diffs, many files, or a broadly-scoped but mechanical change.
+- Refactors, renames, and moves that keep behaviour the same.
+- New language features, builtins, or method implementations (new behaviour, not a
+  contract change) -- even large ones.
+- New CPython-divergence `limitations/` entries and documentation.
+- Bug fixes that do not touch the categories above.
+- Test-only changes, playground probes, comments, and configuration.
+- Dependency version bumps for dependencies we already use.
+- A general feeling that the change is important or that review would be "safer".
+
+## Decision rule
+
+When in doubt, auto-approve. Withhold auto-approval only when the PR unambiguously
+and materially lands in one of the categories above. The question is never "could a
+human add value here?" (a human always could); it is "is the non-correctness risk of
+this change high enough that it must not merge without a human deciding?".

--- a/.macroscope/correctness/cpython-parity.md
+++ b/.macroscope/correctness/cpython-parity.md
@@ -1,0 +1,16 @@
+---
+include:
+  - "crates/**/*.rs"
+---
+
+Monty exists so LLMs can write ordinary Python; silent divergence from CPython
+in a common idiom is the worst failure, because the model has no signal to write
+something else. When a change alters a builtin, dunder, method, or exception's
+result, type, message, or attributes, verify it matches CPython. A change that
+diverges (or widens an existing divergence) needs a matching entry under
+`limitations/`; a new or widened divergence with no `limitations/` entry is a
+finding. Prefer flagging a plausibly-silent wrong result over a clean
+`AttributeError`, which is recoverable. This is diff-level review only -- the
+executable run-both-and-diff check against CPython is the `review-usability`
+skill and is out of scope here; do not claim a divergence you cannot see in the
+change.

--- a/.macroscope/correctness/drop-discipline.md
+++ b/.macroscope/correctness/drop-discipline.md
@@ -18,5 +18,5 @@ with no guard covering it, and a guard used only by borrowing its contents
 (`as_parts`/`as_parts_mut`) when it is never moved back out -- that case wants the
 scope-bound form, not an explicit guard. Do not flag a single straight-line path
 with no branch between acquiring and releasing, where a direct release is already
-the clearest code. Rate a genuinely missed release (a real leak on some path)
-high; rate a guard-style preference low.
+the clearest code. Rate a missed release (a real leak on some path) high; rate a
+guard-style preference low.

--- a/.macroscope/correctness/drop-discipline.md
+++ b/.macroscope/correctness/drop-discipline.md
@@ -1,0 +1,22 @@
+---
+include:
+  - "crates/**/*.rs"
+exclude:
+  - "crates/monty-bench/**"
+  - "crates/fuzz/**"
+---
+
+A `DropWithContext` value carries a cleanup obligation that Rust's own `Drop`
+cannot discharge, because releasing it needs a context borrow (the heap, the VM)
+that a bare `Drop` does not have. So the model is: once such a value is live, it
+must reach a release on **every** exit -- normal return, `?`, `continue`,
+`break`, panic -- and the way to guarantee that against all branches is to bind
+it into a guard, not to hand-place a release in each branch.
+
+Flag a `DropWithContext` value that stays live across a branch or early exit
+with no guard covering it, and a guard used only by borrowing its contents
+(`as_parts`/`as_parts_mut`) when it is never moved back out -- that case wants the
+scope-bound form, not an explicit guard. Do not flag a single straight-line path
+with no branch between acquiring and releasing, where a direct release is already
+the clearest code. Rate a genuinely missed release (a real leak on some path)
+high; rate a guard-style preference low.

--- a/.macroscope/correctness/resource-limits.md
+++ b/.macroscope/correctness/resource-limits.md
@@ -7,34 +7,39 @@ exclude:
 ---
 
 Sandboxed Python can drive allocation, so the model to apply is: any allocation
-whose size an attacker can influence must be bounded, and which mechanism bounds
-it depends on the shape of the allocation.
+whose size an attacker can influence must be preflighted, memory and time are
+guarded by different mechanisms, and a limit failure is terminal for the sandbox
+but not for Rust-side cleanup.
 
-- A single allocation sized from untrusted input -- one opcode computing a large
-  size and allocating it in one shot -- must be preflighted with an explicit
-  charge to the `ResourceTracker` before it allocates. `check_time()` cannot
-  cover this: it only probes memory *already* allocated, so a one-shot
-  allocation can overshoot `max_memory` or OOM before the next poll ever runs.
-- An incremental native loop that allocates a bounded amount per iteration must
-  call `check_time()` each iteration. The poll catches cumulative memory overage
-  (and elapsed time) within one iteration's worth of overshoot, which is the
-  correct and sufficient guard for that shape.
+- **Preflight attacker-influenceable sizes.** An allocation sized from untrusted
+  input must be charged to the `ResourceTracker` (`check_allocation`) before it
+  allocates, and the charged size must be the size actually allocated. A combined
+  allocation must preflight the *combined* size, not rely on its inputs having
+  been charged individually -- two separately-charged inputs can still sum past
+  `max_memory`, which is why `concat_bytes`, `concat_allocate_str`, and the
+  list/tuple/deque growth paths preflight the result. `check_time()` cannot stand
+  in here: it only probes memory already allocated, after the fact.
+- **`check_time()` guards time, not allocation size.** Call it in a native loop
+  that can run unboundedly long so a CPU limit can fire. Do not require a
+  per-iteration `check_time()` for memory's sake in a bounded loop -- AGENTS.md
+  explicitly discourages that, and an oversized case a preflight missed is the
+  allocator hard limit's job, not a per-iteration poll's.
 
-A preflight charge and the poll are therefore not interchangeable: the first
-bounds the size of a single allocation, the second bounds the accumulation of
-many small ones. And a resource limit is a terminal failure of the whole
-execution context, not a recoverable per-operation error.
+Flag an attacker-influenceable allocation (single or combined) that reaches the
+allocator with no `check_allocation` of its actual size -- an amplifying `String`
+built without `StringBuilder`, a buffer or collection reserved to an untrusted or
+combined count -- or a native loop that can run unboundedly with no
+`check_time()`. A resource-limit escape rates high.
 
-Flag allocations that escape this model: a one-shot allocation sized from
-untrusted input with no preflight charge (an amplifying `String` built without
-`StringBuilder`, a collection reserved to an untrusted count), or an unbounded
-native loop with no `check_time()`. A resource-limit escape rates high.
+Do not flag an allocation whose actual size is itself directly preflighted or is
+a small bounded result; a bounded native loop that leans on the hard-limit
+backstop instead of a per-iteration memory poll (that is the intended pattern);
+or a fine-grained charge a correct outer preflight already covers.
 
-Do not flag the mirror image, which is correct by design and whose reporting is
-noise: an allocation already bounded by inputs that are themselves charged; an
-incremental loop that already polls `check_time()` (do not also demand a
-per-element preflight there); a fine-grained charge a correct outer preflight
-already covers; or heap/refcount state observed after a terminal resource limit
--- the context is being torn down, so that state is out of scope, not a leak.
-When unsure whether a charge is redundant, prefer silence: a missed nit costs
-nothing, a false "unbounded allocation" trains the team to ignore the check.
+On a terminal limit the sandbox context is discarded, so the Python-visible heap
+state afterward carries no guarantee -- do not report that. But the error unwinds
+through Rust, where `Drop` still runs, so a Rust-side leak or refcount imbalance
+on the unwind path is a real defect (it matters for in-process embedders and is
+covered by memory-model tests) -- treat it under drop-discipline, not as out of
+scope. When unsure whether a charge is redundant, prefer silence: a missed nit
+costs nothing, a false "unbounded allocation" trains the team to ignore the check.

--- a/.macroscope/correctness/resource-limits.md
+++ b/.macroscope/correctness/resource-limits.md
@@ -1,0 +1,30 @@
+---
+include:
+  - "crates/**/*.rs"
+exclude:
+  - "crates/monty-bench/**"
+  - "crates/fuzz/**"
+---
+
+Sandboxed Python can drive allocation, so the model to apply is: every
+allocation whose size an attacker can influence must be both **bounded** and
+**accounted**. Accounting happens two ways -- an explicit preflight charge to the
+`ResourceTracker`, or the per-instruction `check_time()` poll that bounds any
+work done between VM instruction boundaries. And a resource limit is a
+**terminal** failure of the whole execution context, not a recoverable
+per-operation error.
+
+Flag allocations that escape that model: a size derived from untrusted input
+with no corresponding charge or bound -- an amplifying `String` built without
+`StringBuilder`, a collection grown by an untrusted count inside a native loop
+that never yields to a VM boundary, a small input that fans out into a large
+allocation. This is a resource-limit escape, so rate it high.
+
+Do not flag the mirror image of the model, because it is correct by design and
+reporting it is noise: an allocation already bounded by inputs that are
+themselves charged; a fine-grained charge that a coarser mechanism (an outer
+preflight, or the per-instruction poll) already bounds; or heap/refcount state
+observed after a terminal resource limit -- the context is being torn down, so
+that state is out of scope, not a leak. When unsure whether a charge is
+redundant, prefer silence: a missed nit costs nothing, a false "unbounded
+allocation" trains the team to ignore the check.

--- a/.macroscope/correctness/resource-limits.md
+++ b/.macroscope/correctness/resource-limits.md
@@ -6,25 +6,35 @@ exclude:
   - "crates/fuzz/**"
 ---
 
-Sandboxed Python can drive allocation, so the model to apply is: every
-allocation whose size an attacker can influence must be both **bounded** and
-**accounted**. Accounting happens two ways -- an explicit preflight charge to the
-`ResourceTracker`, or the per-instruction `check_time()` poll that bounds any
-work done between VM instruction boundaries. And a resource limit is a
-**terminal** failure of the whole execution context, not a recoverable
-per-operation error.
+Sandboxed Python can drive allocation, so the model to apply is: any allocation
+whose size an attacker can influence must be bounded, and which mechanism bounds
+it depends on the shape of the allocation.
 
-Flag allocations that escape that model: a size derived from untrusted input
-with no corresponding charge or bound -- an amplifying `String` built without
-`StringBuilder`, a collection grown by an untrusted count inside a native loop
-that never yields to a VM boundary, a small input that fans out into a large
-allocation. This is a resource-limit escape, so rate it high.
+- A single allocation sized from untrusted input -- one opcode computing a large
+  size and allocating it in one shot -- must be preflighted with an explicit
+  charge to the `ResourceTracker` before it allocates. `check_time()` cannot
+  cover this: it only probes memory *already* allocated, so a one-shot
+  allocation can overshoot `max_memory` or OOM before the next poll ever runs.
+- An incremental native loop that allocates a bounded amount per iteration must
+  call `check_time()` each iteration. The poll catches cumulative memory overage
+  (and elapsed time) within one iteration's worth of overshoot, which is the
+  correct and sufficient guard for that shape.
 
-Do not flag the mirror image of the model, because it is correct by design and
-reporting it is noise: an allocation already bounded by inputs that are
-themselves charged; a fine-grained charge that a coarser mechanism (an outer
-preflight, or the per-instruction poll) already bounds; or heap/refcount state
-observed after a terminal resource limit -- the context is being torn down, so
-that state is out of scope, not a leak. When unsure whether a charge is
-redundant, prefer silence: a missed nit costs nothing, a false "unbounded
-allocation" trains the team to ignore the check.
+A preflight charge and the poll are therefore not interchangeable: the first
+bounds the size of a single allocation, the second bounds the accumulation of
+many small ones. And a resource limit is a terminal failure of the whole
+execution context, not a recoverable per-operation error.
+
+Flag allocations that escape this model: a one-shot allocation sized from
+untrusted input with no preflight charge (an amplifying `String` built without
+`StringBuilder`, a collection reserved to an untrusted count), or an unbounded
+native loop with no `check_time()`. A resource-limit escape rates high.
+
+Do not flag the mirror image, which is correct by design and whose reporting is
+noise: an allocation already bounded by inputs that are themselves charged; an
+incremental loop that already polls `check_time()` (do not also demand a
+per-element preflight there); a fine-grained charge a correct outer preflight
+already covers; or heap/refcount state observed after a terminal resource limit
+-- the context is being torn down, so that state is out of scope, not a leak.
+When unsure whether a charge is redundant, prefer silence: a missed nit costs
+nothing, a false "unbounded allocation" trains the team to ignore the check.

--- a/.macroscope/correctness/sandbox-and-panics.md
+++ b/.macroscope/correctness/sandbox-and-panics.md
@@ -15,9 +15,11 @@ frame arriving from a child process (`monty-proto` proto->Rust conversion).
 Anything reachable from either must validate its input and cannot
 `unwrap`/`expect`/panic, index unchecked, or overflow an integer feeding a
 length or index; and it must not let sandboxed code reach the host filesystem
-outside a mount, the network, or a subprocess. Snapshots and dumps are the
-exception -- they are trusted by contract (host-signed and verified), so absent
-validation there is not a finding.
+outside a mount, the network, or a subprocess. A snapshot or dump the host loads
+through its own trusted, transport-verified path is trusted by contract, so
+absent validation there is not a finding -- but a dump or snapshot arriving from
+a subprocess child is hostile (a child can mint its own) and must be validated or
+rejected as a protocol violation like any other child frame.
 
 Calibrate severity by blast radius, not by the bug in isolation. The same panic
 is contained in a pool worker -- the child dies, the parent replaces it and

--- a/.macroscope/correctness/sandbox-and-panics.md
+++ b/.macroscope/correctness/sandbox-and-panics.md
@@ -1,0 +1,30 @@
+---
+include:
+  - "crates/**/*.rs"
+exclude:
+  - "crates/monty-bench/**"
+  - "crates/fuzz/**"
+---
+
+Monty runs untrusted, potentially malicious Python, so the model to apply is:
+input that crosses a trust boundary is hostile until validated, and the cost of
+a defect scales with which side of the boundary it lands on.
+
+Two boundaries carry hostile input: sandboxed Python reaching Rust, and a wire
+frame arriving from a child process (`monty-proto` proto->Rust conversion).
+Anything reachable from either must validate its input and cannot
+`unwrap`/`expect`/panic, index unchecked, or overflow an integer feeding a
+length or index; and it must not let sandboxed code reach the host filesystem
+outside a mount, the network, or a subprocess. Snapshots and dumps are the
+exception -- they are trusted by contract (host-signed and verified), so absent
+validation there is not a finding.
+
+Calibrate severity by blast radius, not by the bug in isolation. The same panic
+is contained in a pool worker -- the child dies, the parent replaces it and
+raises -- so rank it lower; but in host or parent code (`monty-pool`,
+`monty-proto` decoding, `monty-fs`, the `monty-python`/`monty-js` bindings) or in
+the `monty` crate embedded in-process, it takes down the caller, so rank it
+high, and treat a genuine sandbox escape or a memory-safety defect (use-after-
+free, aliasing violation, out-of-bounds) as critical. `heap.rs` and
+`path_security.rs` are the load-bearing safety files; hold changes to them to
+that critical bar.

--- a/.macroscope/correctness/sandbox-and-panics.md
+++ b/.macroscope/correctness/sandbox-and-panics.md
@@ -24,7 +24,7 @@ is contained in a pool worker -- the child dies, the parent replaces it and
 raises -- so rank it lower; but in host or parent code (`monty-pool`,
 `monty-proto` decoding, `monty-fs`, the `monty-python`/`monty-js` bindings) or in
 the `monty` crate embedded in-process, it takes down the caller, so rank it
-high, and treat a genuine sandbox escape or a memory-safety defect (use-after-
+high, and treat a confirmed sandbox escape or a memory-safety defect (use-after-
 free, aliasing violation, out-of-bounds) as critical. `heap.rs` and
 `path_security.rs` are the load-bearing safety files; hold changes to them to
 that critical bar.

--- a/.macroscope/ignore.md
+++ b/.macroscope/ignore.md
@@ -156,10 +156,11 @@ ENV/**
 
 # ---- This repo (monty): recorded / generated / scratch files ----
 
-# Vendored typeshed (copied upstream, incl. abc.pyi), not authored here. Only
-# this directory is ignored -- authored stubs like the public
-# crates/monty-python/python/pydantic_monty/_monty.pyi stay reviewed.
-crates/monty-typeshed/**
+# Vendored typeshed (copied upstream, incl. abc.pyi), not authored here. Scoped
+# to vendor/ only -- the authored custom stubs (crates/monty-typeshed/custom/)
+# and the crate's tooling stay reviewed, as do stubs like the public
+# crates/monty-python/python/pydantic_monty/_monty.pyi.
+crates/monty-typeshed/vendor/**
 
 # Scratch divergence probes written by the review-usability skill; throwaway,
 # not shipped code.

--- a/.macroscope/ignore.md
+++ b/.macroscope/ignore.md
@@ -1,0 +1,174 @@
+# Repository-wide Macroscope ignore (code review + any check-run agents).
+#
+# A custom ignore file REPLACES Macroscope's built-in defaults, so this copies
+# their default "base" patterns verbatim to preserve them, then adds this repo's
+# own recorded files on top. https://docs.macroscope.com/
+#
+# Macroscope's default *test-file* patterns are deliberately NOT copied here: we
+# want Macroscope to review test code. Recorded cassettes and binary fixtures
+# under tests/ stay ignored via the base binary/data patterns plus the explicit
+# cassettes rule below, so only real test *code* is reviewed.
+
+# ---- Macroscope default base patterns (copied to preserve them) ----
+**/.git/**
+**/__pycache__/**
+**/.pytest_cache/**
+**/.mypy_cache/**
+**/.ruff_cache/**
+**/venv/**
+**/.venv/**
+**/node_modules/**
+**/site-packages/**
+**/.pnpm-store/**
+**/__Snapshots__/**
+**/__snapshots__/**
+**/.agents/skills/**
+**/.claude/skills/**
+**/.github/skills/**
+**/bower_components/**
+**/jspm_packages/**
+**/.next/**
+**/.svelte-kit/**
+**/vendor/**
+**/_vendor/**
+**/third_party/**
+**/Pods/**
+**/.bundle/**
+build/**
+env/**
+ENV/**
+**/target/**
+**/generated/**
+**/intermediates/**
+**/generated_sources/**
+**/generated-sources/**
+**/generated-src/**
+**/src/main/generated/**
+**/*.min.js
+**/*.min.css
+**/*_pb.d.ts
+**/*_pb.js
+**/*.pb.go
+**/*_pb2.py
+**/*_pb2_grpc.py
+**/*_pb2.pyi
+**/*.grpc.swift
+**/*.pb.swift
+**/*.sql.go
+**/*.designer.cs
+**/*.g.dart
+**/*.pb.dart
+**/*_pb.rb
+**/go.mod
+**/package.json
+**/*.pbxproj
+**/*.xcstrings
+**/*.strings
+**/*.properties
+**/pom.xml
+**/Package.swift
+**/bun.lock
+**/.eslintrc
+**/.eslintignore
+**/go.sum
+**/package-lock.json
+**/pnpm-lock.yaml
+**/yarn.lock
+**/Package.resolved
+**/*.jpg
+**/*.jpeg
+**/*.png
+**/*.gif
+**/*.svg
+**/*.ico
+**/*.webp
+**/*.bmp
+**/*.tiff
+**/*.woff
+**/*.woff2
+**/*.ttf
+**/*.eot
+**/*.otf
+**/*.mp3
+**/*.mp4
+**/*.wav
+**/*.avi
+**/*.mov
+**/*.mkv
+**/*.flac
+**/*.ogg
+**/*.srt
+**/*.zip
+**/*.tar
+**/*.gz
+**/*.rar
+**/*.7z
+**/*.bz2
+**/*.pdf
+**/*.doc
+**/*.docx
+**/*.xls
+**/*.xlsx
+**/*.ppt
+**/*.pptx
+**/*.db
+**/*.sqlite
+**/*.sqlite3
+**/*.parquet
+**/*.avro
+**/*.arrow
+**/*.npy
+**/*.pkl
+**/*.jsonl
+**/*.onnx
+**/*.tflite
+**/*.h5
+**/*.safetensors
+**/*.exe
+**/*.dll
+**/*.so
+**/*.dylib
+**/*.bin
+**/*.pyc
+**/*.class
+**/*.o
+**/*.a
+**/*.wasm
+**/*.cer
+**/*.pem
+**/*.p12
+**/*.stringsdict
+**/*.snap
+**/*.adoc
+**/*.arb
+**/*.lock
+**/*.po
+**/*.fbx
+**/*.log
+**/*.xib
+**/*.meta
+**/*.kml
+**/*.prefab
+**/*.eml
+**/*.csv
+**/*.grpc.reflection
+**/*.js.map
+
+# ---- This repo (monty): recorded / generated / scratch files ----
+
+# Vendored typeshed (copied upstream, incl. abc.pyi), not authored here. Only
+# this directory is ignored -- authored stubs like the public
+# crates/monty-python/python/pydantic_monty/_monty.pyi stay reviewed.
+crates/monty-typeshed/**
+
+# Scratch divergence probes written by the review-usability skill; throwaway,
+# not shipped code.
+playground/**
+
+# Fuzz corpora and datatest fixtures are data, not code.
+crates/fuzz/corpus/**
+crates/monty-datatest/**/*.txt
+crates/monty-datatest/**/*.json
+
+# `./limitations/` is intentionally NOT ignored: the correctness instructions
+# check behaviour changes for parity with a documented divergence entry.


### PR DESCRIPTION
Configures Macroscope for this repo, in three parts:

- **`.macroscope/correctness/`** tunes the code review with Monty's invariants and, as importantly, what *not* to flag. Four topic files teach the mental model and the severity, not specific bugs: resource-limit accounting (bounded + charged; a limit is terminal), drop discipline (`DropWithContext` released on every path via a guard), sandbox/panic safety (hostile input at the sandbox and wire boundaries; severity by blast radius), and CPython parity (a divergence needs a `limitations/` entry). The "do not flag" guidance is there to stop redundant-charge / post-terminal-limit false positives.
- **`.macroscope/ignore.md`** ports our custom ignore (a custom file replaces Macroscope's defaults, so it copies the base patterns, then adds vendored typeshed, `playground/` probes, and fuzz/datatest fixtures). Authored stubs and `limitations/` stay reviewed.
- **`.macroscope/approvability.md`** routes only genuinely high-stakes, non-correctness changes to a human (unsafe/`heap.rs`, sandbox boundary, wire protocol, snapshot format, public API/ABI, release), and auto-approves everything else once Correctness passes.

No standalone check-run agents for now; the correctness instructions do the tuning. Suggest setting the repo's Minimum Blocking Severity to Medium so blast-radius-rated findings gate as intended.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Macroscope config for correctness review, repo-wide ignores, and auto-approval. Tightens resource-limit guidance (preflight combined sizes; `check_time()` guards time in unbounded loops) and clarifies trust boundaries, including child snapshots/dumps.

- **New Features**
  - Correctness rules in `.macroscope/correctness/`: resource-limits (preflight untrusted and combined sizes; `check_time()` is for time, not memory sizing; limits are terminal but Rust-side drops still matter), `DropWithContext` guard discipline, sandbox/panic safety at trust boundaries (child snapshots/dumps are hostile; host-loaded dumps are trusted), and CPython parity with required `limitations/` entries; plus minor wording cleanup.
  - Repo-wide ignore in `.macroscope/ignore.md`: preserves base patterns; scopes typeshed ignore to `crates/monty-typeshed/vendor/**`; adds `playground/` and fuzz/datatest fixtures; keeps authored stubs/tooling and `limitations/` reviewed.
  - Auto-approval policy in `.macroscope/approvability.md`: withhold only for `unsafe`/`heap.rs`, sandbox boundary, wire protocol/host–child handling, snapshot/dump format, public API/ABI, and release/supply-chain; auto-approve everything else after Correctness passes.

- **Migration**
  - Set the repo’s Minimum Blocking Severity to Medium so blast-radius ratings gate as intended.

<sup>Written for commit 56eb92d30c99d73e0400eb9894db574fe37d9567. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

