### PR TITLE
Mount confinement defects

### DIFF
--- a/crates/monty-fs/src/lib.rs
+++ b/crates/monty-fs/src/lib.rs
@@ -33,7 +33,7 @@
 
 pub use error::MountError;
 pub use mount_mode::MountMode;
-pub use mount_table::{DEFAULT_MEMORY_USAGE_LIMIT, Mount, MountCallOutcome, MountTable};
+pub use mount_table::{DEFAULT_MEMORY_USAGE_LIMIT, Mount, MountCallOutcome, MountRoot, MountTable};
 pub use overlay_state::OverlayState;
 
 mod common;

--- a/crates/monty-fs/src/mount_table.rs
+++ b/crates/monty-fs/src/mount_table.rs
@@ -13,7 +13,11 @@ use cap_std::{ambient_authority, fs::Dir};
 use monty_types::{MontyObject, OsFunctionCall};
 
 use super::{
-    common::MountContext, dispatch, error::MountError, mount_mode::MountMode, path_security::normalize_virtual_path,
+    common::MountContext,
+    dispatch,
+    error::MountError,
+    mount_mode::MountMode,
+    path_security::{normalize_virtual_path, reject_overlong_path},
 };
 
 /// Default aggregate memory budget for one mount: 100 MB in decimal bytes.
@@ -94,12 +98,23 @@ impl MountTable {
     /// on a borrow first, so [`MountCallOutcome::NotHandled`] hands the call
     /// back untouched for the caller's fallback handler (a host callback or
     /// [`OsFunctionCall::on_no_handler`]).
+    ///
+    /// Path length is checked before anything else touches the path.
     pub fn handle_os_call(&mut self, call: OsFunctionCall) -> MountCallOutcome {
         if let Some(primary_path) = call.fs_primary_path() {
-            match self.route_call(primary_path, &call) {
-                Some(Ok(index)) => MountCallOutcome::Handled(self.mounts[index].execute(call)),
-                Some(Err(err)) => MountCallOutcome::Handled(Err(err)),
-                None => MountCallOutcome::NotHandled(call),
+            if let Err(e) = reject_overlong_path(primary_path) {
+                // existence checks return `false` on overlong paths in cpython
+                MountCallOutcome::Handled(if call.is_existence_check() {
+                    Ok(MontyObject::Bool(false))
+                } else {
+                    Err(e)
+                })
+            } else {
+                match self.route_call(primary_path, &call) {
+                    Some(Ok(index)) => MountCallOutcome::Handled(self.mounts[index].execute(call)),
+                    Some(Err(err)) => MountCallOutcome::Handled(Err(err)),
+                    None => MountCallOutcome::NotHandled(call),
+                }
             }
         } else {
             MountCallOutcome::NotHandled(call)
@@ -130,6 +145,10 @@ impl MountTable {
         let src_mount_index = self.find_mount_index(primary_path);
 
         if let Some(dst_path) = call.rename_destination() {
+            // we check the destination path length before routing, primary_path was checked above
+            if let Err(e) = reject_overlong_path(dst_path) {
+                return Some(Err(e));
+            }
             match (src_mount_index, self.find_mount_index(dst_path)) {
                 // Neither side is ours; the whole call belongs to the fallback.
                 (None, None) => None,

--- a/crates/monty-fs/src/mount_table.rs
+++ b/crates/monty-fs/src/mount_table.rs
@@ -122,20 +122,26 @@ impl MountTable {
     ///
     /// Rename requests require both source and destination to resolve to the
     /// same longest-prefix mount. Other requests only route on the primary path.
+    ///
+    /// A rename with one side covered and the other not is refused, never handed
+    /// on: passing it to the fallback would hand the *mounted* side to a handler
+    /// that answers on raw virtual paths, skipping the mount's access mode.
     fn route_call(&self, primary_path: &str, call: &OsFunctionCall) -> Option<Result<usize, MountError>> {
-        let src_mount_index = self.find_mount_index(primary_path)?;
+        let src_mount_index = self.find_mount_index(primary_path);
 
         if let Some(dst_path) = call.rename_destination() {
-            let dst_mount_index = self.find_mount_index(dst_path)?;
-            if src_mount_index != dst_mount_index {
-                return Some(Err(MountError::CrossMountRename {
+            match (src_mount_index, self.find_mount_index(dst_path)) {
+                // Neither side is ours; the whole call belongs to the fallback.
+                (None, None) => None,
+                (Some(src), Some(dst)) if src == dst => Some(Ok(src)),
+                _ => Some(Err(MountError::CrossMountRename {
                     src: primary_path.to_owned(),
                     dst: dst_path.to_owned(),
-                }));
+                })),
             }
+        } else {
+            src_mount_index.map(Ok)
         }
-
-        Some(Ok(src_mount_index))
     }
 
     /// Finds the longest-prefix mount index for `virtual_path`.

--- a/crates/monty-fs/src/mount_table.rs
+++ b/crates/monty-fs/src/mount_table.rs
@@ -6,6 +6,7 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use cap_std::{ambient_authority, fs::Dir};
@@ -82,7 +83,7 @@ impl MountTable {
         // first match without re-sorting the whole table on every insertion.
         let insert_at = self
             .mounts
-            .partition_point(|existing| existing.virtual_path.len() > mount.virtual_path.len());
+            .partition_point(|existing| existing.virtual_path().len() > mount.virtual_path().len());
         self.mounts.insert(insert_at, mount);
     }
 
@@ -123,9 +124,8 @@ impl MountTable {
     /// Rename requests require both source and destination to resolve to the
     /// same longest-prefix mount. Other requests only route on the primary path.
     ///
-    /// A rename with one side covered and the other not is refused, never handed
-    /// on: passing it to the fallback would hand the *mounted* side to a handler
-    /// that answers on raw virtual paths, skipping the mount's access mode.
+    /// One side covered and the other not is refused rather than handed on: the
+    /// fallback answers on raw virtual paths, skipping the mount's access mode.
     fn route_call(&self, primary_path: &str, call: &OsFunctionCall) -> Option<Result<usize, MountError>> {
         let src_mount_index = self.find_mount_index(primary_path);
 
@@ -149,7 +149,7 @@ impl MountTable {
         let normalized = normalize_virtual_path(virtual_path);
         self.mounts
             .iter()
-            .position(|mount| path_matches_mount(&normalized, &mount.virtual_path))
+            .position(|mount| path_matches_mount(&normalized, mount.virtual_path()))
     }
 }
 
@@ -160,14 +160,8 @@ impl MountTable {
 /// and transferred into it with [`MountTable::push_mount`].
 #[derive(Debug)]
 pub struct Mount {
-    /// Virtual path prefix (absolute, normalized).
-    virtual_path: String,
-    /// Canonical host directory path. Diagnostics only — see `dir`.
-    host_path: PathBuf,
-    /// Descriptor for the mounted directory, opened once here — the sandbox
-    /// boundary. Resolution cannot leave it, and no rename can re-point a name
-    /// between a check and its use.
-    dir: Dir,
+    /// The opened directory this mount serves, and the virtual path it answers on.
+    root: MountRoot,
     /// Access mode (also owns overlay state for [`MountMode::OverlayMemory`]).
     mode: MountMode,
     /// Cumulative bytes written through this mount (monotonically increasing).
@@ -182,6 +176,9 @@ impl Mount {
     /// Creates a new mount point, opening a descriptor on the host directory.
     /// Mount memory defaults to [`DEFAULT_MEMORY_USAGE_LIMIT`].
     ///
+    /// A host mounting the same directory repeatedly should open a [`MountRoot`]
+    /// once and use [`Mount::with_root`], resolving the name only once.
+    ///
     /// # Errors
     ///
     /// Returns [`MountError::InvalidMount`] if the virtual path is not absolute,
@@ -192,54 +189,42 @@ impl Mount {
         mode: MountMode,
         write_bytes_limit: Option<u64>,
     ) -> Result<Self, MountError> {
-        let host_path = host_path.as_ref();
+        Ok(Self::with_root(
+            MountRoot::open(virtual_path, host_path)?,
+            mode,
+            write_bytes_limit,
+        ))
+    }
 
-        if !virtual_path.starts_with('/') {
-            return Err(MountError::InvalidMount(format!(
-                "virtual path must be absolute, got: '{virtual_path}'"
-            )));
-        }
-
-        let normalized_virtual = normalize_virtual_path(virtual_path);
-
-        // The only use of ambient authority, and the mount's whole trust root.
-        // Deliberately first: resolving the name to a validated path and *then*
-        // opening that path would let whoever can rename in the parent swap a
-        // symlink into the gap. The directory check rides on the open itself
-        // (`O_DIRECTORY`, a handle `metadata()` on Windows), so it cannot.
-        let dir = Dir::open_ambient_dir(host_path, ambient_authority())
-            .map_err(|e| MountError::InvalidMount(format!("cannot open host path '{}': {e}", host_path.display())))?;
-
-        // Diagnostics only — nothing resolves through this path. Resolved after
-        // the open, so a host racing it leaves a stale label on the right
-        // descriptor, never the reverse. Still fatal on failure: callers copy
-        // this out as a mount's durable identity, and a relative path would
-        // later re-resolve against the process CWD.
-        let canonical_host = fs::canonicalize(host_path).map_err(|e| {
-            MountError::InvalidMount(format!("cannot resolve host path '{}': {e}", host_path.display()))
-        })?;
-
-        Ok(Self {
-            virtual_path: normalized_virtual,
-            host_path: canonical_host,
-            dir,
+    /// Mounts an already-opened [`MountRoot`], touching no filesystem at all.
+    /// Mount memory defaults to [`DEFAULT_MEMORY_USAGE_LIMIT`].
+    #[must_use]
+    pub fn with_root(root: MountRoot, mode: MountMode, write_bytes_limit: Option<u64>) -> Self {
+        Self {
+            root,
             mode,
             write_bytes_used: 0,
             write_bytes_limit,
             memory_usage_limit: DEFAULT_MEMORY_USAGE_LIMIT,
-        })
+        }
+    }
+
+    /// Returns the opened root, to clone into a later mount of the same directory.
+    #[must_use]
+    pub fn root(&self) -> &MountRoot {
+        &self.root
     }
 
     /// Returns the normalized virtual path prefix for this mount.
     #[must_use]
     pub fn virtual_path(&self) -> &str {
-        &self.virtual_path
+        self.root.virtual_path()
     }
 
     /// Returns the canonical host directory path. Diagnostics only.
     #[must_use]
     pub fn host_path(&self) -> &Path {
-        &self.host_path
+        self.root.host_path()
     }
 
     /// Returns the access mode for this mount.
@@ -286,13 +271,86 @@ impl Mount {
     /// payloads move into the backend.
     fn execute(&mut self, call: OsFunctionCall) -> Result<MontyObject, MountError> {
         let mut ctx = MountContext {
-            mount_virtual: &self.virtual_path,
-            mount_dir: &self.dir,
+            mount_virtual: &self.root.virtual_path,
+            mount_dir: &self.root.dir,
             write_bytes_used: &mut self.write_bytes_used,
             write_bytes_limit: self.write_bytes_limit,
             memory_usage_limit: self.memory_usage_limit,
         };
         dispatch::execute(dispatch::fs_request_from_call(call), &mut ctx, &mut self.mode)
+    }
+}
+
+/// A host directory opened once, mountable as often as the host likes; cloning
+/// shares the descriptor.
+///
+/// Reuse one instead of re-deriving a mount from its path: sandbox code that
+/// can rename inside a parent mount redirects that name between rebuilds, and
+/// an open descriptor cannot be redirected.
+#[derive(Debug, Clone)]
+pub struct MountRoot {
+    /// Virtual path prefix (absolute, normalized).
+    virtual_path: String,
+    /// Canonical host directory path. Diagnostics only — see `dir`.
+    host_path: PathBuf,
+    /// Descriptor for the mounted directory — the sandbox boundary, which
+    /// resolution cannot leave. Shared, so every mount built from this root is
+    /// the same directory rather than the same name resolved again.
+    dir: Arc<Dir>,
+}
+
+impl MountRoot {
+    /// Opens `host_path`, pinning the root to the directory that is there now.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MountError::InvalidMount`] if the virtual path is not absolute,
+    /// or the host path cannot be opened as a directory or canonicalized.
+    pub fn open(virtual_path: &str, host_path: impl AsRef<Path>) -> Result<Self, MountError> {
+        let host_path = host_path.as_ref();
+
+        if !virtual_path.starts_with('/') {
+            return Err(MountError::InvalidMount(format!(
+                "virtual path must be absolute, got: '{virtual_path}'"
+            )));
+        }
+
+        let normalized_virtual = normalize_virtual_path(virtual_path);
+
+        // The only use of ambient authority, and the mount's whole trust root.
+        // Deliberately first: resolving the name to a validated path and *then*
+        // opening that path would let whoever can rename in the parent swap a
+        // symlink into the gap. The directory check rides on the open itself
+        // (`O_DIRECTORY`, a handle `metadata()` on Windows), so it cannot.
+        let dir = Dir::open_ambient_dir(host_path, ambient_authority())
+            .map_err(|e| MountError::InvalidMount(format!("cannot open host path '{}': {e}", host_path.display())))?;
+
+        // Diagnostics only — nothing resolves through this path. Resolved after
+        // the open, so a host racing it leaves a stale label on the right
+        // descriptor, never the reverse. Still fatal on failure: callers copy
+        // this out as a mount's durable identity, and a relative path would
+        // later re-resolve against the process CWD.
+        let canonical_host = fs::canonicalize(host_path).map_err(|e| {
+            MountError::InvalidMount(format!("cannot resolve host path '{}': {e}", host_path.display()))
+        })?;
+
+        Ok(Self {
+            virtual_path: normalized_virtual,
+            host_path: canonical_host,
+            dir: Arc::new(dir),
+        })
+    }
+
+    /// Returns the normalized virtual path prefix this root answers on.
+    #[must_use]
+    pub fn virtual_path(&self) -> &str {
+        &self.virtual_path
+    }
+
+    /// Returns the canonical host directory path. Diagnostics only.
+    #[must_use]
+    pub fn host_path(&self) -> &Path {
+        &self.host_path
     }
 }
 

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -19,10 +19,7 @@ use super::{
     dispatch::{FsRequest, file_handle_result},
     error::MountError,
     overlay_state::{ENTRY_MEMORY_USAGE, OverlayEntry, OverlayFile, OverlayFileRef, OverlayState},
-    path_security::{
-        normalize_virtual_path, reject_drive_or_unc_segments, reject_overlong_path, resolve_virtual_path,
-        strip_mount_prefix,
-    },
+    path_security::{normalize_virtual_path, reject_drive_or_unc_segments, resolve_virtual_path, strip_mount_prefix},
 };
 
 /// Conservative per-entry charge while capturing a real directory tree for a
@@ -35,7 +32,6 @@ const REAL_DESCENDANT_MEMORY_USAGE: u64 = 512;
 /// Keys never reach a host path, but are rejected on the same grounds one
 /// would be — a name only this mode accepts is a divergence in itself.
 fn relative_path(path: &str, ctx: &MountContext<'_>) -> Result<String, MountError> {
-    reject_overlong_path(path)?;
     let normalized = normalize_virtual_path(path);
     let relative = strip_mount_prefix(&normalized, ctx.mount_virtual)
         .map(str::to_owned)

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -35,8 +35,8 @@ const REAL_DESCENDANT_MEMORY_USAGE: u64 = 512;
 /// Keys never reach a host path, but are rejected on the same grounds one
 /// would be — a name only this mode accepts is a divergence in itself.
 fn relative_path(path: &str, ctx: &MountContext<'_>) -> Result<String, MountError> {
+    reject_overlong_path(path)?;
     let normalized = normalize_virtual_path(path);
-    reject_overlong_path(&normalized, path)?;
     let relative = strip_mount_prefix(&normalized, ctx.mount_virtual)
         .map(str::to_owned)
         .ok_or_else(|| MountError::NoMountPoint(path.to_owned()))?;

--- a/crates/monty-fs/src/path_security.rs
+++ b/crates/monty-fs/src/path_security.rs
@@ -52,9 +52,9 @@ pub(super) fn resolve_virtual_path(
     mount_virtual_path: &str,
 ) -> Result<MountRelativePath, MountError> {
     reject_null_bytes(virtual_path)?;
+    reject_overlong_path(virtual_path)?;
 
     let normalized = normalize_virtual_path(virtual_path);
-    reject_overlong_path(&normalized, virtual_path)?;
     let relative = strip_mount_prefix(&normalized, mount_virtual_path)
         .ok_or_else(|| MountError::NoMountPoint(virtual_path.to_owned()))?
         .to_owned();
@@ -146,14 +146,18 @@ fn reject_null_bytes(virtual_path: &str) -> Result<(), MountError> {
 /// Rejects paths that exceed Linux filesystem length limits.
 ///
 /// Applied regardless of host OS so the sandbox behaves identically everywhere,
-/// rather than inheriting whatever the host filesystem happens to allow.
-pub(super) fn reject_overlong_path(normalized: &str, original: &str) -> Result<(), MountError> {
-    let too_long = normalized.len() > PATH_MAX || normalized.split('/').any(|component| component.len() > NAME_MAX);
+/// rather than inheriting whatever the host filesystem happens to allow. Measures
+/// the path as sent, before normalization: a request padded with `..` collapses
+/// short, and the kernel would reject the bytes handed to it, not the collapsed
+/// form. Checking first also keeps the per-segment normalization off oversized
+/// input.
+pub(super) fn reject_overlong_path(path: &str) -> Result<(), MountError> {
+    let too_long = path.len() > PATH_MAX || path.split('/').any(|component| component.len() > NAME_MAX);
     if too_long {
         Err(MountError::io_err(
             ErrorKind::InvalidFilename,
             "File name too long",
-            original,
+            path,
         ))
     } else {
         Ok(())

--- a/crates/monty-fs/src/path_security.rs
+++ b/crates/monty-fs/src/path_security.rs
@@ -52,7 +52,6 @@ pub(super) fn resolve_virtual_path(
     mount_virtual_path: &str,
 ) -> Result<MountRelativePath, MountError> {
     reject_null_bytes(virtual_path)?;
-    reject_overlong_path(virtual_path)?;
 
     let normalized = normalize_virtual_path(virtual_path);
     let relative = strip_mount_prefix(&normalized, mount_virtual_path)
@@ -154,14 +153,29 @@ fn reject_null_bytes(virtual_path: &str) -> Result<(), MountError> {
 pub(super) fn reject_overlong_path(path: &str) -> Result<(), MountError> {
     let too_long = path.len() > PATH_MAX || path.split('/').any(|component| component.len() > NAME_MAX);
     if too_long {
+        // Elided, because the error echoes the path back: quoting it whole would
+        // make the largest input produce the largest allocation, on the cheapest
+        // branch to reach.
         Err(MountError::io_err(
             ErrorKind::InvalidFilename,
             "File name too long",
-            path,
+            elide_middle(path).as_deref().unwrap_or(path),
         ))
     } else {
         Ok(())
     }
+}
+
+/// Characters kept at each end of an over-long path echoed into an error.
+const ERROR_PATH_EDGE: usize = 20;
+
+/// Replaces the middle of `path` with `…`, keeping [`ERROR_PATH_EDGE`]
+/// characters at each end.
+fn elide_middle(path: &str) -> Option<String> {
+    let mut boundaries = path.char_indices().map(|(index, _)| index);
+    let head_end = boundaries.nth(ERROR_PATH_EDGE)?;
+    let tail_start = boundaries.nth_back(ERROR_PATH_EDGE - 1)?;
+    Some(format!("{}…{}", &path[..head_end], &path[tail_start..]))
 }
 
 /// Fast path for paths already in normalized absolute form.

--- a/crates/monty-fs/tests/fs.rs
+++ b/crates/monty-fs/tests/fs.rs
@@ -69,7 +69,7 @@ fn call(mt: &mut MountTable, c: &OsFunctionCall) -> Option<Result<MontyObject, M
 
 /// Shorthand: call and unwrap both the Option and Result.
 fn call_ok(mt: &mut MountTable, c: &OsFunctionCall) -> MontyObject {
-    call(mt, c).expect("expected Some").expect("expected Ok")
+    call(mt, c).expect("expected Some").unwrap()
 }
 
 /// Shorthand: call and unwrap Option, expect Err, convert to exception.
@@ -878,11 +878,17 @@ fn ovl_mem_path_component_too_long() {
     let long_name = "a".repeat(256);
     let path = format!("/mnt/{long_name}");
 
-    let err = call_err(&mut mt, &OsFunctionCall::Exists(path.as_str().into()));
+    // `exists()` answers False rather than raising, as CPython's does.
+    assert_eq!(
+        call_ok(&mut mt, &OsFunctionCall::Exists(path.as_str().into())),
+        MontyObject::Bool(false)
+    );
+    // An operation that does raise quotes the path with its middle elided.
+    let err = call_err(&mut mt, &OsFunctionCall::Stat(path.as_str().into()));
     assert_exc(
         &err,
         ExcType::OSError,
-        &format!("[Errno 36] File name too long: '{path}'"),
+        "[Errno 36] File name too long: '/mnt/aaaaaaaaaaaaaaa…aaaaaaaaaaaaaaaaaaaa'",
     );
 
     // 255-byte component is fine
@@ -904,11 +910,15 @@ fn ovl_mem_path_total_too_long() {
     let path = format!("/mnt/{}", segments.join("/"));
     assert!(path.len() > 4096);
 
-    let err = call_err(&mut mt, &OsFunctionCall::Exists(path.as_str().into()));
+    assert_eq!(
+        call_ok(&mut mt, &OsFunctionCall::Exists(path.as_str().into())),
+        MontyObject::Bool(false)
+    );
+    let err = call_err(&mut mt, &OsFunctionCall::Stat(path.as_str().into()));
     assert_exc(
         &err,
         ExcType::OSError,
-        &format!("[Errno 36] File name too long: '{path}'"),
+        "[Errno 36] File name too long: '/mnt/xxxxxxxxxxxxxxx…xxxxxxxxxxxxxxxxxxxx'",
     );
 }
 
@@ -924,7 +934,7 @@ fn rw_path_component_too_long() {
     assert_exc(
         &err,
         ExcType::OSError,
-        &format!("[Errno 36] File name too long: '{path}'"),
+        "[Errno 36] File name too long: '/mnt/aaaaaaaaaaaaaaa…aaaaaaaaaaaaaaaaaaaa'",
     );
 }
 

--- a/crates/monty-fs/tests/fs_security.rs
+++ b/crates/monty-fs/tests/fs_security.rs
@@ -1454,11 +1454,10 @@ fn rename_traversal_src() {
             dst: MontyPath::new("/mnt/stolen.txt".to_owned()),
         }),
     );
+    // The src normalizes to `/etc/passwd`, under no mount, so the rename is
+    // refused outright rather than handed to the fallback with the mounted dst.
     match result {
-        Some(Err(MountError::PathEscape { .. } | MountError::NoMountPoint(_) | MountError::Io(_, _))) => {}
-        // If src doesn't match any mount, handle_rename returns None and normal dispatch
-        // handles it — that will also fail.
-        None => {}
+        Some(Err(MountError::CrossMountRename { .. })) => {}
         other => panic!("expected rename src traversal blocked, got {other:?}"),
     }
 }
@@ -1475,14 +1474,9 @@ fn rename_traversal_dst() {
             dst: MontyPath::new("/mnt/../escape.txt".to_owned()),
         }),
     );
+    // Likewise for a dst that normalizes out of the mount.
     match result {
-        Some(Err(
-            MountError::PathEscape { .. }
-            | MountError::NoMountPoint(_)
-            | MountError::Io(_, _)
-            | MountError::CrossMountRename { .. },
-        )) => {}
-        None => {} // Also acceptable — dst doesn't match any mount.
+        Some(Err(MountError::CrossMountRename { .. })) => {}
         other => panic!("expected rename dst traversal blocked, got {other:?}"),
     }
 }

--- a/crates/monty-fs/tests/mount_escape_repro.rs
+++ b/crates/monty-fs/tests/mount_escape_repro.rs
@@ -1,0 +1,131 @@
+//! Reproductions of known, unfixed mount-confinement defects.
+//!
+//! Each test asserts the *current, vulnerable* behaviour so the suite stays
+//! green; invert the assertion marked `FIX:` once the defect is fixed.
+
+use std::{fs, io::ErrorKind};
+
+use monty_fs::{Mount, MountCallOutcome, MountError, MountMode, MountTable};
+use monty_types::{MontyObject, MontyPath, OsFunctionCall, RenameCallArgs};
+use tempfile::TempDir;
+
+// Only the directory helper is used here; the rest is shared with other tests.
+#[expect(dead_code)]
+mod common;
+use common::symlink_dir;
+
+/// Dispatches `call`, panicking on the `NotHandled` these tests never expect.
+fn handled(mt: &mut MountTable, call: OsFunctionCall) -> Result<MontyObject, MountError> {
+    match mt.handle_os_call(call) {
+        MountCallOutcome::Handled(result) => result,
+        MountCallOutcome::NotHandled(call) => panic!("expected the mount table to handle {call:?}"),
+    }
+}
+
+/// Builds a `Path.rename(src, dst)` call.
+fn rename(src: &str, dst: &str) -> OsFunctionCall {
+    OsFunctionCall::Rename(RenameCallArgs {
+        src: MontyPath::new(src.to_owned()),
+        dst: MontyPath::new(dst.to_owned()),
+    })
+}
+
+/// Reads `path` through the table.
+fn read_text(mt: &mut MountTable, path: &str) -> Result<MontyObject, MountError> {
+    handled(mt, OsFunctionCall::ReadText(MontyPath::new(path.to_owned())))
+}
+
+/// A mount root is only a path string, so a rebuilt table (one per feed)
+/// re-resolves it — and renaming a symlink over that name, which sandbox code
+/// can do because a rename never dereferences, redirects the next rebuild.
+#[test]
+fn mount_root_redirected_by_rename_between_rebuilds() {
+    let base = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+
+    let shared = base.path().join("shared");
+    fs::create_dir(&shared).unwrap();
+    fs::write(outside.path().join("secret.txt"), "HOST SECRET").unwrap();
+    // Host-planted link out of the tree; the sandbox only moves it.
+    symlink_dir(outside.path(), base.path().join("prepared-link"));
+
+    // The reusable configuration, as `MountSpec` (monty-pool) records it.
+    let child_host_path = Mount::new("/child", &shared, MountMode::ReadOnly, None)
+        .unwrap()
+        .host_path()
+        .to_path_buf();
+
+    // Feed 1: swap the real directory out and the link in, under one name.
+    let mut writable = MountTable::new();
+    writable
+        .mount("/parent", base.path(), MountMode::ReadWrite, None)
+        .unwrap();
+    handled(&mut writable, rename("/parent/shared", "/parent/old-shared")).unwrap();
+    handled(&mut writable, rename("/parent/prepared-link", "/parent/shared")).unwrap();
+
+    // Feed 2: the same configuration, rebuilt into a fresh table.
+    let mut rebuilt = MountTable::new();
+    rebuilt
+        .mount("/child", &child_host_path, MountMode::ReadOnly, None)
+        .unwrap();
+
+    // FIX: the rebuild must stay pinned to the directory validated above.
+    let leaked = read_text(&mut rebuilt, "/child/secret.txt").expect("reproduction: reads outside the mount");
+    assert_eq!(leaked, MontyObject::String("HOST SECRET".to_owned()));
+}
+
+/// `route_call` looks the rename destination up with `?`, so an unmounted
+/// destination abandons routing and hands the mounted source to the host
+/// fallback — never reaching the mode check in `Mount::execute`.
+#[test]
+fn rename_out_of_mount_bypasses_the_mount_table() {
+    let host = TempDir::new().unwrap();
+    fs::write(host.path().join("source.txt"), "public").unwrap();
+    let other = TempDir::new().unwrap();
+
+    let mut mt = MountTable::new();
+    mt.mount("/data", host.path(), MountMode::ReadOnly, None).unwrap();
+    mt.mount("/other", other.path(), MountMode::ReadOnly, None).unwrap();
+
+    // Control: a destination in a *different* mount is refused.
+    match mt.handle_os_call(rename("/data/source.txt", "/other/result.txt")) {
+        MountCallOutcome::Handled(Err(MountError::CrossMountRename { .. })) => {}
+        outcome => panic!("expected CrossMountRename, got {outcome:?}"),
+    }
+
+    // FIX: an unmounted destination must be refused too, not handed on.
+    match mt.handle_os_call(rename("/data/source.txt", "/outside/result.txt")) {
+        MountCallOutcome::NotHandled(call) => assert_eq!(call.fs_primary_path(), Some("/data/source.txt")),
+        outcome @ MountCallOutcome::Handled(_) => panic!("reproduction expects NotHandled, got {outcome:?}"),
+    }
+    assert!(host.path().join("source.txt").exists());
+}
+
+/// `PATH_MAX` is checked after normalization, so it bounds the collapsed path
+/// rather than the bytes the sandbox sent.
+#[test]
+fn overlong_path_accepted_when_it_normalizes_short() {
+    let host = TempDir::new().unwrap();
+    fs::write(host.path().join("hello.txt"), "hello").unwrap();
+
+    let mut mt = MountTable::new();
+    mt.mount("/mnt", host.path(), MountMode::ReadOnly, None).unwrap();
+
+    // Control: the same length without `..` is rejected before any host I/O.
+    let long_and_deep = format!("/mnt/{}hello.txt", "a/".repeat(5_000));
+    assert!(long_and_deep.len() > 4096);
+    match read_text(&mut mt, &long_and_deep) {
+        Err(MountError::Io(err, _)) => {
+            assert_eq!(err.kind(), ErrorKind::InvalidFilename);
+            assert_eq!(err.to_string(), "File name too long");
+        }
+        other => panic!("expected the overlong path to be rejected, got {other:?}"),
+    }
+
+    let long_but_collapsing = format!("/mnt/{}{}hello.txt", "a/".repeat(5_000), "../".repeat(5_000));
+    assert!(long_but_collapsing.len() > 4096);
+
+    // FIX: reject on raw length, before normalization allocates per segment.
+    let read = read_text(&mut mt, &long_but_collapsing).expect("reproduction: the overlong request is accepted");
+    assert_eq!(read, MontyObject::String("hello".to_owned()));
+}

--- a/crates/monty-fs/tests/mount_escape_repro.rs
+++ b/crates/monty-fs/tests/mount_escape_repro.rs
@@ -1,7 +1,4 @@
-//! Reproductions of known, unfixed mount-confinement defects.
-//!
-//! Each test asserts the *current, vulnerable* behaviour so the suite stays
-//! green; invert the assertion marked `FIX:` once the defect is fixed.
+//! Regression tests for three mount-confinement defects.
 
 use std::{fs, io::ErrorKind};
 
@@ -35,25 +32,26 @@ fn read_text(mt: &mut MountTable, path: &str) -> Result<MontyObject, MountError>
     handled(mt, OsFunctionCall::ReadText(MontyPath::new(path.to_owned())))
 }
 
-/// A mount root is only a path string, so a rebuilt table (one per feed)
-/// re-resolves it — and renaming a symlink over that name, which sandbox code
-/// can do because a rename never dereferences, redirects the next rebuild.
+/// A reusable configuration carries the opened root, so each rebuild mounts the
+/// directory that was validated, not whatever its name resolves to now — even
+/// after sandbox code renames a symlink over that name, which it can do because
+/// a rename never dereferences.
 #[test]
-fn mount_root_redirected_by_rename_between_rebuilds() {
+fn mount_root_stays_pinned_across_rebuilds() {
     let base = TempDir::new().unwrap();
     let outside = TempDir::new().unwrap();
 
     let shared = base.path().join("shared");
     fs::create_dir(&shared).unwrap();
+    fs::write(shared.join("inside.txt"), "in-mount").unwrap();
     fs::write(outside.path().join("secret.txt"), "HOST SECRET").unwrap();
     // Host-planted link out of the tree; the sandbox only moves it.
     symlink_dir(outside.path(), base.path().join("prepared-link"));
 
     // The reusable configuration, as `MountSpec` (monty-pool) records it.
-    let child_host_path = Mount::new("/child", &shared, MountMode::ReadOnly, None)
-        .unwrap()
-        .host_path()
-        .to_path_buf();
+    let configured = Mount::new("/child", &shared, MountMode::ReadOnly, None).unwrap();
+    let child_root = configured.root().clone();
+    let child_host_path = configured.host_path().to_path_buf();
 
     // Feed 1: swap the real directory out and the link in, under one name.
     let mut writable = MountTable::new();
@@ -65,18 +63,30 @@ fn mount_root_redirected_by_rename_between_rebuilds() {
 
     // Feed 2: the same configuration, rebuilt into a fresh table.
     let mut rebuilt = MountTable::new();
-    rebuilt
+    rebuilt.push_mount(Mount::with_root(child_root, MountMode::ReadOnly, None));
+
+    // The rebuild still serves the directory that was validated, and the file
+    // the redirect aimed at is simply not in it.
+    let inside = read_text(&mut rebuilt, "/child/inside.txt").unwrap();
+    assert_eq!(inside, MontyObject::String("in-mount".to_owned()));
+    match read_text(&mut rebuilt, "/child/secret.txt") {
+        Err(MountError::Io(err, _)) => assert_eq!(err.kind(), ErrorKind::NotFound),
+        other => panic!("expected the redirected read to miss, got {other:?}"),
+    }
+
+    // Re-deriving the mount from the host *path* is what the rename defeats —
+    // which is why a host must keep the root, not the path it came from.
+    let mut from_path = MountTable::new();
+    from_path
         .mount("/child", &child_host_path, MountMode::ReadOnly, None)
         .unwrap();
-
-    // FIX: the rebuild must stay pinned to the directory validated above.
-    let leaked = read_text(&mut rebuilt, "/child/secret.txt").expect("reproduction: reads outside the mount");
+    let leaked = read_text(&mut from_path, "/child/secret.txt").unwrap();
     assert_eq!(leaked, MontyObject::String("HOST SECRET".to_owned()));
 }
 
-/// Once either side of a rename is covered, the table owns the call: handing it
-/// to the fallback would give a handler answering on raw virtual paths the
-/// mounted side, never reaching the mode check in `Mount::execute`.
+/// Once either side of a rename is covered, the table owns the call: the
+/// fallback answers on raw virtual paths, so handing it on would skip the mode
+/// check in `Mount::execute`.
 #[test]
 fn rename_with_one_side_out_of_mount_is_refused() {
     let host = TempDir::new().unwrap();
@@ -121,7 +131,7 @@ fn overlong_path_rejected_even_when_it_normalizes_short() {
     let long_but_collapsing = format!("/mnt/{}{}hello.txt", "a/".repeat(5_000), "../".repeat(5_000));
     assert!(long_and_deep.len() > 4096 && long_but_collapsing.len() > 4096);
 
-    // Both backends resolve paths through their own entry point, so both are checked.
+    // Each backend has its own path entry point, so both are checked.
     for mode in [MountMode::ReadOnly, MountMode::OverlayMemory(OverlayState::new())] {
         let mut mt = MountTable::new();
         mt.mount("/mnt", host.path(), mode, None).unwrap();

--- a/crates/monty-fs/tests/mount_escape_repro.rs
+++ b/crates/monty-fs/tests/mount_escape_repro.rs
@@ -161,6 +161,96 @@ fn overlong_path_rejected_even_when_it_normalizes_short() {
     }
 }
 
+/// The length check runs before routing, so no path the sandbox sends is ever
+/// normalized — the step that allocates several times the path's own size.
+///
+/// Measured against the check-after-routing order, a 64 MiB `..`-padded path
+/// cost ~400ms of *host* CPU per call and produced a 112 MB exception message;
+/// sandboxed code spending the parent's memory that way is the point of this
+/// test, so it asserts both the elision and that no mount has to match.
+#[test]
+fn overlong_path_is_refused_before_it_is_normalized() {
+    let host = TempDir::new().unwrap();
+    let mut mt = MountTable::new();
+    mt.mount("/mnt", host.path(), MountMode::ReadOnly, None).unwrap();
+
+    let long = format!("/mnt/{}x", "a/".repeat(2_000_000));
+    assert!(long.len() > 4_000_000);
+
+    // The message keeps 20 characters from each end and nothing in between, so
+    // its size is fixed however large the offending path is.
+    let message = message_of(read_text(&mut mt, &long));
+    assert_eq!(
+        message,
+        "[Errno 36] File name too long: '/mnt/a/a/a/a/a/a/a/a…/a/a/a/a/a/a/a/a/a/x'"
+    );
+
+    // Refused whether or not a mount covers it: handing a path this long to the
+    // fallback handler would only move the cost, not remove it.
+    let unmounted = format!("/nowhere/{}x", "a/".repeat(2_000_000));
+    assert_too_long(read_text(&mut mt, &unmounted));
+
+    // A rename is refused on either side's length.
+    let call = rename("/mnt/hello.txt", &long);
+    assert_too_long(handled(&mut mt, call));
+
+    // Paths within the limit still route exactly as before.
+    assert!(matches!(
+        mt.handle_os_call(OsFunctionCall::Exists(MontyPath::new("/nowhere/short.txt".to_owned()))),
+        MountCallOutcome::NotHandled(_)
+    ));
+}
+
+/// Eliding the middle must cut on character boundaries, not byte offsets.
+///
+/// The path is sandbox-controlled, so a multi-byte character straddling the cut
+/// would panic the *host* — `String` slicing is checked.
+#[test]
+fn overlong_path_with_multibyte_characters_is_elided_safely() {
+    let host = TempDir::new().unwrap();
+    let mut mt = MountTable::new();
+    mt.mount("/mnt", host.path(), MountMode::ReadOnly, None).unwrap();
+
+    // 4-byte characters, so every candidate cut lands mid-character.
+    let long = format!("/mnt/{}", "🦀".repeat(2_000));
+    let message = message_of(read_text(&mut mt, &long));
+    assert_eq!(
+        message,
+        "[Errno 36] File name too long: '/mnt/🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀…🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀🦀'"
+    );
+}
+
+/// `pathlib` predicates swallow `ENAMETOOLONG` and answer `False`; verified
+/// against CPython 3.13 for all four, on both a plain long path and one padded
+/// with `..`. Raising instead would be a divergence introduced by the length
+/// check, not by anything the sandbox did.
+#[test]
+fn overlong_path_predicates_answer_false() {
+    let host = TempDir::new().unwrap();
+    let mut mt = MountTable::new();
+    mt.mount("/mnt", host.path(), MountMode::ReadOnly, None).unwrap();
+
+    let plain = format!("/mnt/{}x", "a/".repeat(5_000));
+    let padded = format!("/mnt/{}{}x", "a/".repeat(5_000), "../".repeat(5_000));
+    let component = format!("/mnt/{}", "b".repeat(5_000));
+
+    for path in [&plain, &padded, &component] {
+        for call in [
+            OsFunctionCall::Exists(MontyPath::new(path.clone())),
+            OsFunctionCall::IsFile(MontyPath::new(path.clone())),
+            OsFunctionCall::IsDir(MontyPath::new(path.clone())),
+            OsFunctionCall::IsSymlink(MontyPath::new(path.clone())),
+        ] {
+            let name = call.name();
+            assert_eq!(
+                handled(&mut mt, call).unwrap(),
+                MontyObject::Bool(false),
+                "{name} on an overlong path must answer False, as CPython does"
+            );
+        }
+    }
+}
+
 /// Asserts an operation failed with the `ENAMETOOLONG` form of [`MountError`].
 fn assert_too_long(result: Result<MontyObject, MountError>) {
     match result {
@@ -170,4 +260,14 @@ fn assert_too_long(result: Result<MontyObject, MountError>) {
         }
         other => panic!("expected the overlong path to be rejected, got {other:?}"),
     }
+}
+
+/// The sandbox-visible exception message for a failed operation.
+fn message_of(result: Result<MontyObject, MountError>) -> String {
+    result
+        .expect_err("expected the operation to fail")
+        .into_exception()
+        .message()
+        .expect("expected a message")
+        .to_owned()
 }

--- a/crates/monty-fs/tests/mount_escape_repro.rs
+++ b/crates/monty-fs/tests/mount_escape_repro.rs
@@ -74,11 +74,11 @@ fn mount_root_redirected_by_rename_between_rebuilds() {
     assert_eq!(leaked, MontyObject::String("HOST SECRET".to_owned()));
 }
 
-/// `route_call` looks the rename destination up with `?`, so an unmounted
-/// destination abandons routing and hands the mounted source to the host
-/// fallback — never reaching the mode check in `Mount::execute`.
+/// Once either side of a rename is covered, the table owns the call: handing it
+/// to the fallback would give a handler answering on raw virtual paths the
+/// mounted side, never reaching the mode check in `Mount::execute`.
 #[test]
-fn rename_out_of_mount_bypasses_the_mount_table() {
+fn rename_with_one_side_out_of_mount_is_refused() {
     let host = TempDir::new().unwrap();
     fs::write(host.path().join("source.txt"), "public").unwrap();
     let other = TempDir::new().unwrap();
@@ -87,18 +87,27 @@ fn rename_out_of_mount_bypasses_the_mount_table() {
     mt.mount("/data", host.path(), MountMode::ReadOnly, None).unwrap();
     mt.mount("/other", other.path(), MountMode::ReadOnly, None).unwrap();
 
-    // Control: a destination in a *different* mount is refused.
-    match mt.handle_os_call(rename("/data/source.txt", "/other/result.txt")) {
+    // A destination in a *different* mount is refused.
+    assert_cross_mount(&mut mt, rename("/data/source.txt", "/other/result.txt"));
+
+    // So is one under no mount at all, in either direction.
+    assert_cross_mount(&mut mt, rename("/data/source.txt", "/outside/result.txt"));
+    assert_cross_mount(&mut mt, rename("/outside/source.txt", "/data/result.txt"));
+    assert!(host.path().join("source.txt").exists());
+
+    // A rename with neither side mounted is still the fallback's to answer.
+    match mt.handle_os_call(rename("/outside/source.txt", "/elsewhere/result.txt")) {
+        MountCallOutcome::NotHandled(call) => assert_eq!(call.fs_primary_path(), Some("/outside/source.txt")),
+        outcome @ MountCallOutcome::Handled(_) => panic!("expected NotHandled, got {outcome:?}"),
+    }
+}
+
+/// Asserts `call` was refused as a cross-mount rename (`EXDEV`).
+fn assert_cross_mount(mt: &mut MountTable, call: OsFunctionCall) {
+    match mt.handle_os_call(call) {
         MountCallOutcome::Handled(Err(MountError::CrossMountRename { .. })) => {}
         outcome => panic!("expected CrossMountRename, got {outcome:?}"),
     }
-
-    // FIX: an unmounted destination must be refused too, not handed on.
-    match mt.handle_os_call(rename("/data/source.txt", "/outside/result.txt")) {
-        MountCallOutcome::NotHandled(call) => assert_eq!(call.fs_primary_path(), Some("/data/source.txt")),
-        outcome @ MountCallOutcome::Handled(_) => panic!("reproduction expects NotHandled, got {outcome:?}"),
-    }
-    assert!(host.path().join("source.txt").exists());
 }
 
 /// `PATH_MAX` bounds the bytes the sandbox sent, not the path they collapse to,

--- a/crates/monty-fs/tests/mount_escape_repro.rs
+++ b/crates/monty-fs/tests/mount_escape_repro.rs
@@ -6,10 +6,10 @@ use monty_fs::{Mount, MountCallOutcome, MountError, MountMode, MountTable, Overl
 use monty_types::{MontyObject, MontyPath, OsFunctionCall, RenameCallArgs};
 use tempfile::TempDir;
 
-// Only the directory helper is used here; the rest is shared with other tests.
+// Only the directory helpers are used here; the rest is shared with other tests.
 #[expect(dead_code)]
 mod common;
-use common::symlink_dir;
+use common::{symlink_dir, symlinks_supported};
 
 /// Dispatches `call`, panicking on the `NotHandled` these tests never expect.
 fn handled(mt: &mut MountTable, call: OsFunctionCall) -> Result<MontyObject, MountError> {
@@ -38,6 +38,12 @@ fn read_text(mt: &mut MountTable, path: &str) -> Result<MontyObject, MountError>
 /// a rename never dereferences.
 #[test]
 fn mount_root_stays_pinned_across_rebuilds() {
+    // Planting the escaping link is the whole scenario, so a host that refuses
+    // symlinks has nothing to test — skip rather than fail on `symlink_dir`'s
+    // `expect`, as every other symlink test in this crate does.
+    if !symlinks_supported() {
+        return;
+    }
     let base = TempDir::new().unwrap();
     let outside = TempDir::new().unwrap();
 

--- a/crates/monty-fs/tests/mount_escape_repro.rs
+++ b/crates/monty-fs/tests/mount_escape_repro.rs
@@ -5,7 +5,7 @@
 
 use std::{fs, io::ErrorKind};
 
-use monty_fs::{Mount, MountCallOutcome, MountError, MountMode, MountTable};
+use monty_fs::{Mount, MountCallOutcome, MountError, MountMode, MountTable, OverlayState};
 use monty_types::{MontyObject, MontyPath, OsFunctionCall, RenameCallArgs};
 use tempfile::TempDir;
 
@@ -101,31 +101,42 @@ fn rename_out_of_mount_bypasses_the_mount_table() {
     assert!(host.path().join("source.txt").exists());
 }
 
-/// `PATH_MAX` is checked after normalization, so it bounds the collapsed path
-/// rather than the bytes the sandbox sent.
+/// `PATH_MAX` bounds the bytes the sandbox sent, not the path they collapse to,
+/// so padding a request with `..` no longer buys unlimited length.
 #[test]
-fn overlong_path_accepted_when_it_normalizes_short() {
+fn overlong_path_rejected_even_when_it_normalizes_short() {
     let host = TempDir::new().unwrap();
     fs::write(host.path().join("hello.txt"), "hello").unwrap();
 
-    let mut mt = MountTable::new();
-    mt.mount("/mnt", host.path(), MountMode::ReadOnly, None).unwrap();
-
-    // Control: the same length without `..` is rejected before any host I/O.
     let long_and_deep = format!("/mnt/{}hello.txt", "a/".repeat(5_000));
-    assert!(long_and_deep.len() > 4096);
-    match read_text(&mut mt, &long_and_deep) {
+    let long_but_collapsing = format!("/mnt/{}{}hello.txt", "a/".repeat(5_000), "../".repeat(5_000));
+    assert!(long_and_deep.len() > 4096 && long_but_collapsing.len() > 4096);
+
+    // Both backends resolve paths through their own entry point, so both are checked.
+    for mode in [MountMode::ReadOnly, MountMode::OverlayMemory(OverlayState::new())] {
+        let mut mt = MountTable::new();
+        mt.mount("/mnt", host.path(), mode, None).unwrap();
+
+        // A path without `..` is rejected before any host I/O.
+        assert_too_long(read_text(&mut mt, &long_and_deep));
+
+        // The same length collapsing to `/mnt/hello.txt` is rejected on the same
+        // grounds, rather than being measured after the `..` components cancel out.
+        assert_too_long(read_text(&mut mt, &long_but_collapsing));
+
+        // The path it collapses to is served normally, so only length is at issue.
+        let read = read_text(&mut mt, "/mnt/a/../hello.txt").unwrap();
+        assert_eq!(read, MontyObject::String("hello".to_owned()));
+    }
+}
+
+/// Asserts an operation failed with the `ENAMETOOLONG` form of [`MountError`].
+fn assert_too_long(result: Result<MontyObject, MountError>) {
+    match result {
         Err(MountError::Io(err, _)) => {
             assert_eq!(err.kind(), ErrorKind::InvalidFilename);
             assert_eq!(err.to_string(), "File name too long");
         }
         other => panic!("expected the overlong path to be rejected, got {other:?}"),
     }
-
-    let long_but_collapsing = format!("/mnt/{}{}hello.txt", "a/".repeat(5_000), "../".repeat(5_000));
-    assert!(long_but_collapsing.len() > 4096);
-
-    // FIX: reject on raw length, before normalization allocates per segment.
-    let read = read_text(&mut mt, &long_but_collapsing).expect("reproduction: the overlong request is accepted");
-    assert_eq!(read, MontyObject::String("hello".to_owned()));
 }

--- a/crates/monty-fs/tests/mount_escape_repro.rs
+++ b/crates/monty-fs/tests/mount_escape_repro.rs
@@ -58,7 +58,19 @@ fn mount_root_stays_pinned_across_rebuilds() {
     writable
         .mount("/parent", base.path(), MountMode::ReadWrite, None)
         .unwrap();
-    handled(&mut writable, rename("/parent/shared", "/parent/old-shared")).unwrap();
+    // Windows refuses to rename a directory while a handle to it is open, and
+    // `configured` holds one — so there the swap cannot even be staged while a
+    // mount is alive, and the redirect this guards against is unreachable.
+    match handled(&mut writable, rename("/parent/shared", "/parent/old-shared")) {
+        Ok(_) => {}
+        // Windows refuses to rename a directory while a handle to it is open,
+        // and the mount above holds one, so the swap cannot even be staged
+        // there — the redirect this guards against is unreachable.
+        #[cfg(windows)]
+        Err(_) => return,
+        #[cfg(not(windows))]
+        Err(err) => panic!("staging the swap failed: {err:?}"),
+    }
     handled(&mut writable, rename("/parent/prepared-link", "/parent/shared")).unwrap();
 
     // Feed 2: the same configuration, rebuilt into a fresh table.

--- a/crates/monty-js/README.md
+++ b/crates/monty-js/README.md
@@ -194,6 +194,10 @@ Modes: `'read-only'`, `'read-write'`, and `'overlay'` (default — writes are
 kept in memory and discarded at the end of the feed). Mount I/O is serviced
 on the host side of the pool, so mounts work even for remote workers.
 
+The constructor opens the host directory, so an unusable path throws there
+rather than at the first feed, and the mount then follows _that directory_ for
+its lifetime — renaming or replacing it afterwards changes nothing.
+
 `feedRun` answers every OS call automatically: mounts get first refusal, then
 the `os` callback. `feedStart` answers none — a mounted read surfaces as a
 `FunctionSnapshot` with `isOsFunction` set, and `resumeAuto()` is what consults

--- a/crates/monty-js/__test__/mount.spec.ts
+++ b/crates/monty-js/__test__/mount.spec.ts
@@ -147,6 +147,12 @@ test('MountDir attributes', (ctx) => {
 
     const limited = mount({ virtualPath: '/limited', memoryUsageLimit: 1234 })
     t.is(limited.memoryUsageLimit, 1234)
+
+    // The opened native handle is symbol-keyed, so it is not part of the
+    // public surface: no string key exposes it, and nothing reachable by name
+    // can close the directory out from under a feed.
+    t.deepEqual(Object.keys(md).sort(), ['hostPath', 'memoryUsageLimit', 'mode', 'virtualPath', 'writeBytesLimit'])
+    t.is((md as unknown as Record<string, unknown>).native, undefined)
   } finally {
     cleanup()
   }

--- a/crates/monty-js/__test__/mount.spec.ts
+++ b/crates/monty-js/__test__/mount.spec.ts
@@ -42,11 +42,6 @@ test('browser wasm reports mounts as unsupported', async (ctx) => {
 
 test('a mount follows its directory across feeds, not its path', async (ctx) => {
   skipIfBrowser(ctx)
-  if (process.platform === 'win32') {
-    // Planting the link needs symlink creation, which Windows gates behind a
-    // privilege; the confinement itself is not platform-specific.
-    ctx.skip()
-  }
   const base = fs.mkdtempSync(path.join(os.tmpdir(), 'monty-mount-pin-'))
   const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'monty-mount-out-'))
   try {
@@ -54,8 +49,13 @@ test('a mount follows its directory across feeds, not its path', async (ctx) => 
     fs.mkdirSync(shared)
     fs.writeFileSync(path.join(shared, 'inside.txt'), 'in-mount')
     fs.writeFileSync(path.join(outside, 'secret.txt'), 'HOST SECRET')
-    // Host-planted link out of the tree; the sandbox only moves it.
-    fs.symlinkSync(outside, path.join(base, 'prepared-link'), 'dir')
+    // Host-planted link out of the tree; the sandbox only moves it. Windows
+    // gates symlink creation behind a privilege, so skip rather than fail.
+    try {
+      fs.symlinkSync(outside, path.join(base, 'prepared-link'), 'dir')
+    } catch {
+      ctx.skip()
+    }
 
     const child = new MountDir({ hostPath: shared, virtualPath: '/child', mode: 'read-only' })
     const parent = new MountDir({ hostPath: base, virtualPath: '/parent', mode: 'read-write' })

--- a/crates/monty-js/__test__/mount.spec.ts
+++ b/crates/monty-js/__test__/mount.spec.ts
@@ -5,7 +5,7 @@ import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
 
-import { MontyFileHandle, MontyRuntimeError, MountDir } from '@pydantic/monty/node'
+import { MontyFileHandle, MontyRuntimeError, MountDir, type MountDirOptions } from '@pydantic/monty/node'
 import { setupPool } from './helpers.js'
 
 const { run, pool } = setupPool()
@@ -14,15 +14,32 @@ const { run, pool } = setupPool()
 // Helper: create a temporary directory with test files
 // =============================================================================
 
-function createTestDir(): { dir: string; cleanup: () => void } {
+function createTestDir(): {
+  dir: string
+  mount: (options: Omit<MountDirOptions, 'hostPath'>) => MountDir
+  cleanup: () => void
+} {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'monty-mount-test-'))
   fs.writeFileSync(path.join(dir, 'hello.txt'), 'hello world')
   fs.writeFileSync(path.join(dir, 'data.bin'), Buffer.from([0x00, 0x01, 0x02]))
   fs.mkdirSync(path.join(dir, 'subdir'))
   fs.writeFileSync(path.join(dir, 'subdir', 'nested.txt'), 'nested content')
+  const mounts: MountDir[] = []
   return {
     dir,
-    cleanup: () => fs.rmSync(dir, { recursive: true, force: true }),
+    // Mounts made here are closed by `cleanup`: Windows will not remove a
+    // directory while a mount still holds it open.
+    mount: (options) => {
+      const md = new MountDir({ hostPath: dir, ...options })
+      mounts.push(md)
+      return md
+    },
+    cleanup: () => {
+      for (const md of mounts) {
+        md.close()
+      }
+      fs.rmSync(dir, { recursive: true, force: true })
+    },
   }
 }
 
@@ -57,17 +74,26 @@ test('a mount follows its directory across feeds, not its path', async (ctx) => 
       ctx.skip()
     }
 
-    const child = new MountDir({ hostPath: shared, virtualPath: '/child', mode: 'read-only' })
-    const parent = new MountDir({ hostPath: base, virtualPath: '/parent', mode: 'read-write' })
+    using child = new MountDir({ hostPath: shared, virtualPath: '/child', mode: 'read-only' })
+    using parent = new MountDir({ hostPath: base, virtualPath: '/parent', mode: 'read-write' })
     await using session = await pool().checkout()
 
     // Feed 1: swap the real directory out and the link in, under one name.
-    await session.feedRun(
-      `from pathlib import Path
+    // Windows refuses to rename a directory while a handle to it is open, and
+    // the child mount holds one, so the swap cannot be staged there at all.
+    try {
+      await session.feedRun(
+        `from pathlib import Path
 Path('/parent/shared').rename('/parent/old-shared')
 Path('/parent/prepared-link').rename('/parent/shared')`,
-      { mount: parent },
-    )
+        { mount: parent },
+      )
+    } catch (err) {
+      if (process.platform === 'win32') {
+        ctx.skip()
+      }
+      throw err
+    }
 
     // Feed 2: the same mount object, and the redirect has not reached it.
     const result = await session.feedRun(
@@ -84,9 +110,9 @@ f"{Path('/child/inside.txt').read_text()}:{Path('/child/secret.txt').exists()}"`
 
 test('MountDir repr', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     t.is(md.repr(), `MountDir(host_path='${dir}', virtual_path='/data', mode='read-only')`)
   } finally {
     cleanup()
@@ -95,9 +121,9 @@ test('MountDir repr', (ctx) => {
 
 test('MountDir invalid mode', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const error = t.throws(() => new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'invalid' as never }))
+    const error = t.throws(() => mount({ virtualPath: '/data', mode: 'invalid' as never }))
     t.is(error?.message, "invalid mount mode: 'invalid'. Expected 'read-only', 'read-write' or 'overlay'")
   } finally {
     cleanup()
@@ -106,15 +132,15 @@ test('MountDir invalid mode', (ctx) => {
 
 test('MountDir attributes', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     t.is(md.virtualPath, '/data')
     t.is(md.hostPath, dir)
     t.is(md.mode, 'read-only')
     t.is(md.memoryUsageLimit, 100_000_000)
 
-    const limited = new MountDir({ hostPath: dir, virtualPath: '/limited', memoryUsageLimit: 1234 })
+    const limited = mount({ virtualPath: '/limited', memoryUsageLimit: 1234 })
     t.is(limited.memoryUsageLimit, 1234)
   } finally {
     cleanup()
@@ -133,10 +159,27 @@ test('MountDir nonexistent host path', (ctx) => {
 
 test('MountDir non-absolute virtual path', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const error = t.throws(() => new MountDir({ hostPath: dir, virtualPath: 'relative' }))
+    const error = t.throws(() => mount({ virtualPath: 'relative' }))
     t.is(error.message, "TypeError: virtual path must be absolute, got: 'relative'")
+  } finally {
+    cleanup()
+  }
+})
+
+test('closing a mount releases it and later feeds are refused', async (ctx) => {
+  skipIfBrowser(ctx)
+  const { mount, cleanup } = createTestDir()
+  try {
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
+    t.is(await run("open('/data/hello.txt').read()", { mount: md }), 'hello world')
+
+    md.close()
+    md.close() // idempotent
+    await t.throwsAsync(() => run("open('/data/hello.txt').read()", { mount: md }))
+    // The configuration it reports outlives the descriptor.
+    t.is(md.virtualPath, '/data')
   } finally {
     cleanup()
   }
@@ -144,9 +187,9 @@ test('MountDir non-absolute virtual path', (ctx) => {
 
 test('MountDir default mode is overlay', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data' })
+    const md = mount({ virtualPath: '/data' })
     t.is(md.mode, 'overlay')
   } finally {
     cleanup()
@@ -155,12 +198,12 @@ test('MountDir default mode is overlay', (ctx) => {
 
 test('MountDir write_bytes_limit', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', writeBytesLimit: 1024 })
+    const md = mount({ virtualPath: '/data', writeBytesLimit: 1024 })
     t.is(md.writeBytesLimit, 1024)
 
-    const md2 = new MountDir({ hostPath: dir, virtualPath: '/data' })
+    const md2 = mount({ virtualPath: '/data' })
     t.is(md2.writeBytesLimit, null)
   } finally {
     cleanup()
@@ -257,9 +300,9 @@ test('MontyFileHandle rejects invalid arguments', () => {
 
 test('read_text via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; Path('/data/hello.txt').read_text()", { mount: md })
     t.is(result, 'hello world')
   } finally {
@@ -269,9 +312,9 @@ test('read_text via mount', async (ctx) => {
 
 test('read_bytes via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; Path('/data/data.bin').read_bytes()", { mount: md })
     t.deepEqual(result, Buffer.from([0x00, 0x01, 0x02]))
   } finally {
@@ -281,9 +324,9 @@ test('read_bytes via mount', async (ctx) => {
 
 test('path exists via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
 from pathlib import Path
 exists_file = Path('/data/hello.txt').exists()
@@ -299,9 +342,9 @@ exists_missing = Path('/data/nope.txt').exists()
 
 test('is_file and is_dir via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
 from pathlib import Path
 [Path('/data/hello.txt').is_file(), Path('/data/hello.txt').is_dir(),
@@ -315,9 +358,9 @@ from pathlib import Path
 
 test('iterdir via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
 from pathlib import Path
 sorted([p.name for p in Path('/data').iterdir()])
@@ -330,9 +373,9 @@ sorted([p.name for p in Path('/data').iterdir()])
 
 test('stat via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
 from pathlib import Path
 s = Path('/data/hello.txt').stat()
@@ -346,9 +389,9 @@ s.st_size
 
 test('read nested file via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; Path('/data/subdir/nested.txt').read_text()", { mount: md })
     t.is(result, 'nested content')
   } finally {
@@ -362,9 +405,9 @@ test('read nested file via mount', async (ctx) => {
 
 test('write blocked on read-only mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(
       () => run("from pathlib import Path; Path('/data/new.txt').write_text('x')", { mount: md }),
       { instanceOf: MontyRuntimeError },
@@ -377,9 +420,9 @@ test('write blocked on read-only mount', async (ctx) => {
 
 test('write succeeds on read-write mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-write' })
+    const md = mount({ virtualPath: '/data', mode: 'read-write' })
     const code = `
 from pathlib import Path
 Path('/data/new.txt').write_text('written by monty')
@@ -395,9 +438,9 @@ Path('/data/new.txt').read_text()
 
 test('overlay write does not modify host', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const code = `
 from pathlib import Path
 Path('/data/overlay_file.txt').write_text('overlay content')
@@ -413,9 +456,9 @@ Path('/data/overlay_file.txt').read_text()
 
 test('overlay read falls through to host', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const result = await run("from pathlib import Path; Path('/data/hello.txt').read_text()", { mount: md })
     t.is(result, 'hello world')
   } finally {
@@ -427,9 +470,9 @@ test('overlay writes do not persist across runs', async (ctx) => {
   skipIfBrowser(ctx)
   // Overlay state lives in the pool's per-feed mount table, so unlike the old
   // in-process API it does NOT persist across runs sharing the same MountDir.
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     await run("from pathlib import Path; Path('/data/persistent.txt').write_text('run1')", { mount: md })
     const error = await t.throwsAsync(
       () => run("from pathlib import Path; Path('/data/persistent.txt').read_text()", { mount: md }),
@@ -443,9 +486,9 @@ test('overlay writes do not persist across runs', async (ctx) => {
 
 test('overlay memory usage limit is aggregate', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay', memoryUsageLimit: 1000 })
+    const md = mount({ virtualPath: '/data', mode: 'overlay', memoryUsageLimit: 1000 })
     const code = `
 from pathlib import Path
 p = Path('/data/retained.bin')
@@ -465,9 +508,9 @@ p.read_bytes()
 
 test('mkdir and rmdir via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const code = `
 from pathlib import Path
 Path('/data/newdir').mkdir()
@@ -484,9 +527,9 @@ after = Path('/data/newdir').exists()
 
 test('unlink via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const code = `
 from pathlib import Path
 Path('/data/hello.txt').unlink()
@@ -502,9 +545,9 @@ Path('/data/hello.txt').exists()
 
 test('rename via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const code = `
 from pathlib import Path
 Path('/data/hello.txt').rename('/data/renamed.txt')
@@ -518,9 +561,9 @@ Path('/data/hello.txt').rename('/data/renamed.txt')
 
 test('resolve via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; str(Path('/data/subdir/../hello.txt').resolve())", {
       mount: md,
     })
@@ -536,9 +579,9 @@ test('resolve via mount', async (ctx) => {
 
 test('path traversal blocked', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(
       () => run("from pathlib import Path; Path('/data/../../etc/passwd').read_text()", { mount: md }),
       { instanceOf: MontyRuntimeError },
@@ -551,9 +594,9 @@ test('path traversal blocked', async (ctx) => {
 
 test('unmounted path denied', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(
       () => run("from pathlib import Path; Path('/other/file.txt').exists()", { mount: md }),
       { instanceOf: MontyRuntimeError },
@@ -570,9 +613,9 @@ test('unmounted path denied', async (ctx) => {
 
 test('non-filesystem os call without fallback', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(() => run("import os; os.getenv('PATH')", { mount: md }), {
       instanceOf: MontyRuntimeError,
     })
@@ -615,9 +658,9 @@ b = Path('/rw/file2.txt').read_text()
 
 test('mount works with external functions', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
 from pathlib import Path
 content = Path('/data/hello.txt').read_text()
@@ -637,10 +680,10 @@ result + content
 
 test('session feed with mount read', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     await session.feedRun('from pathlib import Path', { mount: md })
     t.is(await session.feedRun("Path('/data/hello.txt').read_text()", { mount: md }), 'hello world')
   } finally {
@@ -656,10 +699,10 @@ test('session feed with mount read', async (ctx) => {
 
 test('session overlay write is discarded between feeds', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     await session.feedRun('from pathlib import Path', { mount: md })
     await session.feedRun("Path('/data/new.txt').write_text('from repl')", { mount: md })
     const error = await t.throwsAsync(() => session.feedRun("Path('/data/new.txt').read_text()", { mount: md }), {
@@ -676,10 +719,10 @@ test('session overlay write is discarded between feeds', async (ctx) => {
 
 test('session overlay overwrite reverts between feeds', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     await session.feedRun('from pathlib import Path', { mount: md })
     await session.feedRun("Path('/data/hello.txt').write_text('version1')", { mount: md })
     // The next feed sees the pristine host content again ...
@@ -694,10 +737,10 @@ test('session overlay overwrite reverts between feeds', async (ctx) => {
 
 test('session overlay delete reverts between feeds', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     await session.feedRun('from pathlib import Path', { mount: md })
     await session.feedRun("Path('/data/hello.txt').unlink()", { mount: md })
     // The deletion only lived inside the previous feed's overlay.
@@ -711,9 +754,9 @@ test('session overlay delete reverts between feeds', async (ctx) => {
 
 test('overlay mkdir and nested write within one feed', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const code = `
 from pathlib import Path
 Path('/data/mydir').mkdir()
@@ -729,9 +772,9 @@ Path('/data/mydir/file.txt').read_text()
 
 test('overlay iterdir sees overlay files', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'overlay' })
+    const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const code = `
 from pathlib import Path
 Path('/data/extra.txt').write_text('extra')
@@ -745,10 +788,10 @@ sorted([p.name for p in Path('/data').iterdir()])
 
 test('session read-write mount writes to host', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-write' })
+    const md = mount({ virtualPath: '/data', mode: 'read-write' })
     await session.feedRun('from pathlib import Path', { mount: md })
     await session.feedRun("Path('/data/rw_file.txt').write_text('written')", { mount: md })
     t.is(await session.feedRun("Path('/data/rw_file.txt').read_text()", { mount: md }), 'written')
@@ -762,10 +805,10 @@ test('session read-write mount writes to host', async (ctx) => {
 
 test('session read-only mount blocks write', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     await session.feedRun('from pathlib import Path', { mount: md })
     const error = await t.throwsAsync(() => session.feedRun("Path('/data/nope.txt').write_text('x')", { mount: md }), {
       instanceOf: MontyRuntimeError,
@@ -794,10 +837,10 @@ function makeSymlink(target: string, link: string): boolean {
 
 test('relative symlink inside a mount is followed', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
     if (!makeSymlink('hello.txt', path.join(dir, 'rel_link.txt'))) return
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; Path('/data/rel_link.txt').read_text()", { mount: md })
     t.is(result, 'hello world')
   } finally {
@@ -807,12 +850,12 @@ test('relative symlink inside a mount is followed', async (ctx) => {
 
 test('absolute symlink target is refused inside a mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, cleanup } = createTestDir()
+  const { dir, mount, cleanup } = createTestDir()
   try {
     // Absolute even though it points back into the same mount: a descriptor has
     // no path of its own, so a leading '/' cannot be interpreted.
     if (!makeSymlink(path.join(dir, 'hello.txt'), path.join(dir, 'abs_link.txt'))) return
-    const md = new MountDir({ hostPath: dir, virtualPath: '/data', mode: 'read-only' })
+    const md = mount({ virtualPath: '/data', mode: 'read-only' })
 
     const error = await t.throwsAsync(
       () => run("from pathlib import Path; Path('/data/abs_link.txt').read_text()", { mount: md }),

--- a/crates/monty-js/__test__/mount.spec.ts
+++ b/crates/monty-js/__test__/mount.spec.ts
@@ -40,6 +40,48 @@ test('browser wasm reports mounts as unsupported', async (ctx) => {
   t.is(error.message, 'the wasm worker does not support filesystem mounts (browser has no host filesystem)')
 })
 
+test('a mount follows its directory across feeds, not its path', async (ctx) => {
+  skipIfBrowser(ctx)
+  if (process.platform === 'win32') {
+    // Planting the link needs symlink creation, which Windows gates behind a
+    // privilege; the confinement itself is not platform-specific.
+    ctx.skip()
+  }
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), 'monty-mount-pin-'))
+  const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'monty-mount-out-'))
+  try {
+    const shared = path.join(base, 'shared')
+    fs.mkdirSync(shared)
+    fs.writeFileSync(path.join(shared, 'inside.txt'), 'in-mount')
+    fs.writeFileSync(path.join(outside, 'secret.txt'), 'HOST SECRET')
+    // Host-planted link out of the tree; the sandbox only moves it.
+    fs.symlinkSync(outside, path.join(base, 'prepared-link'), 'dir')
+
+    const child = new MountDir({ hostPath: shared, virtualPath: '/child', mode: 'read-only' })
+    const parent = new MountDir({ hostPath: base, virtualPath: '/parent', mode: 'read-write' })
+    await using session = await pool().checkout()
+
+    // Feed 1: swap the real directory out and the link in, under one name.
+    await session.feedRun(
+      `from pathlib import Path
+Path('/parent/shared').rename('/parent/old-shared')
+Path('/parent/prepared-link').rename('/parent/shared')`,
+      { mount: parent },
+    )
+
+    // Feed 2: the same mount object, and the redirect has not reached it.
+    const result = await session.feedRun(
+      `from pathlib import Path
+f"{Path('/child/inside.txt').read_text()}:{Path('/child/secret.txt').exists()}"`,
+      { mount: child },
+    )
+    t.is(result, 'in-mount:False')
+  } finally {
+    fs.rmSync(base, { recursive: true, force: true })
+    fs.rmSync(outside, { recursive: true, force: true })
+  }
+})
+
 test('MountDir repr', (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
@@ -79,21 +121,21 @@ test('MountDir attributes', (ctx) => {
   }
 })
 
-test('MountDir nonexistent host path', async (ctx) => {
+test('MountDir nonexistent host path', (ctx) => {
   skipIfBrowser(ctx)
-  // Host paths are validated by the pool when the feed starts (not the
-  // constructor). The OS-error suffix is platform specific.
-  const md = new MountDir({ hostPath: '/nonexistent/path/that/does/not/exist', virtualPath: '/data' })
-  const error = await t.throwsAsync(() => run('1 + 1', { mount: md }), { instanceOf: MontyRuntimeError })
+  // The constructor opens the host directory, so a bad path fails there rather
+  // than at the first feed. The OS-error suffix is platform specific.
+  const error = t.throws(
+    () => new MountDir({ hostPath: '/nonexistent/path/that/does/not/exist', virtualPath: '/data' }),
+  )
   t.true(error.message.startsWith("TypeError: cannot open host path '/nonexistent/path/that/does/not/exist':"))
 })
 
-test('MountDir non-absolute virtual path', async (ctx) => {
+test('MountDir non-absolute virtual path', (ctx) => {
   skipIfBrowser(ctx)
   const { dir, cleanup } = createTestDir()
   try {
-    const md = new MountDir({ hostPath: dir, virtualPath: 'relative' })
-    const error = await t.throwsAsync(() => run('1 + 1', { mount: md }), { instanceOf: MontyRuntimeError })
+    const error = t.throws(() => new MountDir({ hostPath: dir, virtualPath: 'relative' }))
     t.is(error.message, "TypeError: virtual path must be absolute, got: 'relative'")
   } finally {
     cleanup()

--- a/crates/monty-js/__test__/mount.spec.ts
+++ b/crates/monty-js/__test__/mount.spec.ts
@@ -61,6 +61,9 @@ test('a mount follows its directory across feeds, not its path', async (ctx) => 
   skipIfBrowser(ctx)
   const base = fs.mkdtempSync(path.join(os.tmpdir(), 'monty-mount-pin-'))
   const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'monty-mount-out-'))
+  // Closed before the directories are removed; Windows would refuse otherwise.
+  let child: MountDir | undefined
+  let parent: MountDir | undefined
   try {
     const shared = path.join(base, 'shared')
     fs.mkdirSync(shared)
@@ -74,8 +77,8 @@ test('a mount follows its directory across feeds, not its path', async (ctx) => 
       ctx.skip()
     }
 
-    using child = new MountDir({ hostPath: shared, virtualPath: '/child', mode: 'read-only' })
-    using parent = new MountDir({ hostPath: base, virtualPath: '/parent', mode: 'read-write' })
+    child = new MountDir({ hostPath: shared, virtualPath: '/child', mode: 'read-only' })
+    parent = new MountDir({ hostPath: base, virtualPath: '/parent', mode: 'read-write' })
     await using session = await pool().checkout()
 
     // Feed 1: swap the real directory out and the link in, under one name.
@@ -103,6 +106,8 @@ f"{Path('/child/inside.txt').read_text()}:{Path('/child/secret.txt').exists()}"`
     )
     t.is(result, 'in-mount:False')
   } finally {
+    child?.close()
+    parent?.close()
     fs.rmSync(base, { recursive: true, force: true })
     fs.rmSync(outside, { recursive: true, force: true })
   }
@@ -121,7 +126,7 @@ test('MountDir repr', (ctx) => {
 
 test('MountDir invalid mode', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const error = t.throws(() => mount({ virtualPath: '/data', mode: 'invalid' as never }))
     t.is(error?.message, "invalid mount mode: 'invalid'. Expected 'read-only', 'read-write' or 'overlay'")
@@ -159,7 +164,7 @@ test('MountDir nonexistent host path', (ctx) => {
 
 test('MountDir non-absolute virtual path', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const error = t.throws(() => mount({ virtualPath: 'relative' }))
     t.is(error.message, "TypeError: virtual path must be absolute, got: 'relative'")
@@ -180,6 +185,15 @@ test('closing a mount releases it and later feeds are refused', async (ctx) => {
     await t.throwsAsync(() => run("open('/data/hello.txt').read()", { mount: md }))
     // The configuration it reports outlives the descriptor.
     t.is(md.virtualPath, '/data')
+
+    // `using` closes it the same way at the end of the block.
+    let disposed: MountDir
+    {
+      using scoped = mount({ virtualPath: '/scoped', mode: 'read-only' })
+      t.is(await run("open('/scoped/hello.txt').read()", { mount: scoped }), 'hello world')
+      disposed = scoped
+    }
+    await t.throwsAsync(() => run("open('/scoped/hello.txt').read()", { mount: disposed }))
   } finally {
     cleanup()
   }
@@ -187,7 +201,7 @@ test('closing a mount releases it and later feeds are refused', async (ctx) => {
 
 test('MountDir default mode is overlay', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data' })
     t.is(md.mode, 'overlay')
@@ -198,7 +212,7 @@ test('MountDir default mode is overlay', (ctx) => {
 
 test('MountDir write_bytes_limit', (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', writeBytesLimit: 1024 })
     t.is(md.writeBytesLimit, 1024)
@@ -300,7 +314,7 @@ test('MontyFileHandle rejects invalid arguments', () => {
 
 test('read_text via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; Path('/data/hello.txt').read_text()", { mount: md })
@@ -312,7 +326,7 @@ test('read_text via mount', async (ctx) => {
 
 test('read_bytes via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; Path('/data/data.bin').read_bytes()", { mount: md })
@@ -324,7 +338,7 @@ test('read_bytes via mount', async (ctx) => {
 
 test('path exists via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
@@ -342,7 +356,7 @@ exists_missing = Path('/data/nope.txt').exists()
 
 test('is_file and is_dir via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
@@ -358,7 +372,7 @@ from pathlib import Path
 
 test('iterdir via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
@@ -373,7 +387,7 @@ sorted([p.name for p in Path('/data').iterdir()])
 
 test('stat via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
@@ -389,7 +403,7 @@ s.st_size
 
 test('read nested file via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; Path('/data/subdir/nested.txt').read_text()", { mount: md })
@@ -405,7 +419,7 @@ test('read nested file via mount', async (ctx) => {
 
 test('write blocked on read-only mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(
@@ -456,7 +470,7 @@ Path('/data/overlay_file.txt').read_text()
 
 test('overlay read falls through to host', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const result = await run("from pathlib import Path; Path('/data/hello.txt').read_text()", { mount: md })
@@ -470,7 +484,7 @@ test('overlay writes do not persist across runs', async (ctx) => {
   skipIfBrowser(ctx)
   // Overlay state lives in the pool's per-feed mount table, so unlike the old
   // in-process API it does NOT persist across runs sharing the same MountDir.
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'overlay' })
     await run("from pathlib import Path; Path('/data/persistent.txt').write_text('run1')", { mount: md })
@@ -486,7 +500,7 @@ test('overlay writes do not persist across runs', async (ctx) => {
 
 test('overlay memory usage limit is aggregate', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'overlay', memoryUsageLimit: 1000 })
     const code = `
@@ -508,7 +522,7 @@ p.read_bytes()
 
 test('mkdir and rmdir via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const code = `
@@ -545,7 +559,7 @@ Path('/data/hello.txt').exists()
 
 test('rename via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const code = `
@@ -561,7 +575,7 @@ Path('/data/hello.txt').rename('/data/renamed.txt')
 
 test('resolve via mount', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const result = await run("from pathlib import Path; str(Path('/data/subdir/../hello.txt').resolve())", {
@@ -579,7 +593,7 @@ test('resolve via mount', async (ctx) => {
 
 test('path traversal blocked', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(
@@ -594,7 +608,7 @@ test('path traversal blocked', async (ctx) => {
 
 test('unmounted path denied', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(
@@ -613,7 +627,7 @@ test('unmounted path denied', async (ctx) => {
 
 test('non-filesystem os call without fallback', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const error = await t.throwsAsync(() => run("import os; os.getenv('PATH')", { mount: md }), {
@@ -631,14 +645,14 @@ test('non-filesystem os call without fallback', async (ctx) => {
 
 test('multiple mounts with different modes', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir: dir1, cleanup: cleanup1 } = createTestDir()
+  const { mount, cleanup: cleanup1 } = createTestDir()
   const dir2 = fs.mkdtempSync(path.join(os.tmpdir(), 'monty-mount-test2-'))
   fs.writeFileSync(path.join(dir2, 'file2.txt'), 'from mount2')
+  // Closed in `finally`: Windows will not remove dir2 while this mount holds
+  // it open. The `/ro` one is closed by `cleanup1`.
+  const writable = new MountDir({ hostPath: dir2, virtualPath: '/rw', mode: 'read-write' })
   try {
-    const mounts = [
-      new MountDir({ hostPath: dir1, virtualPath: '/ro', mode: 'read-only' }),
-      new MountDir({ hostPath: dir2, virtualPath: '/rw', mode: 'read-write' }),
-    ]
+    const mounts = [mount({ virtualPath: '/ro', mode: 'read-only' }), writable]
     const code = `
 from pathlib import Path
 a = Path('/ro/hello.txt').read_text()
@@ -647,6 +661,7 @@ b = Path('/rw/file2.txt').read_text()
 `
     t.deepEqual(await run(code, { mount: mounts }), ['hello world', 'from mount2'])
   } finally {
+    writable.close()
     cleanup1()
     fs.rmSync(dir2, { recursive: true, force: true })
   }
@@ -658,7 +673,7 @@ b = Path('/rw/file2.txt').read_text()
 
 test('mount works with external functions', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
     const code = `
@@ -680,7 +695,7 @@ result + content
 
 test('session feed with mount read', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })
@@ -772,7 +787,7 @@ Path('/data/mydir/file.txt').read_text()
 
 test('overlay iterdir sees overlay files', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   try {
     const md = mount({ virtualPath: '/data', mode: 'overlay' })
     const code = `
@@ -805,7 +820,7 @@ test('session read-write mount writes to host', async (ctx) => {
 
 test('session read-only mount blocks write', async (ctx) => {
   skipIfBrowser(ctx)
-  const { dir, mount, cleanup } = createTestDir()
+  const { mount, cleanup } = createTestDir()
   const session = await pool().checkout()
   try {
     const md = mount({ virtualPath: '/data', mode: 'read-only' })

--- a/crates/monty-js/native-addon.d.ts
+++ b/crates/monty-js/native-addon.d.ts
@@ -10,6 +10,10 @@ export interface NativeMount {
   memoryUsageLimit: number
 }
 
+export declare class NativeMountDir {
+  constructor(mount: NativeMount)
+}
+
 export declare class NativePool {
   constructor(options?: unknown)
   start(): Promise<void>

--- a/crates/monty-js/native-addon.d.ts
+++ b/crates/monty-js/native-addon.d.ts
@@ -12,6 +12,7 @@ export interface NativeMount {
 
 export declare class NativeMountDir {
   constructor(mount: NativeMount)
+  close(): void
 }
 
 export declare class NativePool {

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -154,7 +154,9 @@ pub struct NativeMount {
 /// TypeScript `MountDir` — not part of the public API.
 #[napi(js_name = "NativeMountDir")]
 pub struct NativeMountDir {
-    spec: MountSpec,
+    /// `None` once closed: the open directory is released and no later feed
+    /// can mount it. A feed already running holds its own reference.
+    spec: Option<MountSpec>,
 }
 
 #[napi]
@@ -164,8 +166,14 @@ impl NativeMountDir {
     #[napi(constructor)]
     pub fn new(mount: NativeMount) -> Result<Self> {
         Ok(Self {
-            spec: MountSpec::try_from(mount)?,
+            spec: Some(MountSpec::try_from(mount)?),
         })
+    }
+
+    /// Releases the open directory. Idempotent.
+    #[napi]
+    pub fn close(&mut self) {
+        self.spec = None;
     }
 }
 
@@ -343,7 +351,7 @@ impl NativeSession {
         on_print: PrintCallback<'env>,
     ) -> Result<PromiseRaw<'env, Object<'env>>> {
         let inputs = convert_inputs(env, inputs)?;
-        let mounts = mount_specs(&mounts);
+        let mounts = mount_specs(&mounts)?;
         self.run_turn(
             env,
             on_print,
@@ -534,7 +542,7 @@ impl NativeSession {
         mounts: Vec<ClassInstance<'env, NativeMountDir>>,
         on_print: PrintCallback<'env>,
     ) -> Result<PromiseRaw<'env, Object<'env>>> {
-        let mounts = mount_specs(&mounts);
+        let mounts = mount_specs(&mounts)?;
         let state = state.to_vec();
         self.run_outcome(
             env,
@@ -1013,8 +1021,20 @@ fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
 
 /// Clones each mount's opened configuration for one turn — the descriptor is
 /// shared, so nothing is reopened and no host path is resolved again.
-fn mount_specs(mounts: &[ClassInstance<'_, NativeMountDir>]) -> Vec<MountSpec> {
-    mounts.iter().map(|mount| mount.spec.clone()).collect()
+///
+/// # Errors
+///
+/// Rejects the turn if any mount has been closed.
+fn mount_specs(mounts: &[ClassInstance<'_, NativeMountDir>]) -> Result<Vec<MountSpec>> {
+    mounts
+        .iter()
+        .map(|mount| {
+            mount
+                .spec
+                .clone()
+                .ok_or_else(|| invalid("mount is closed: create a new MountDir"))
+        })
+        .collect()
 }
 
 fn pool_error(err: PoolError) -> napi::Error {

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -961,13 +961,12 @@ impl TryFrom<NativeMount> for MountSpec {
             .map(|limit| bytes_limit(limit, "writeBytesLimit"))
             .transpose()?;
         let memory_usage_limit = bytes_limit(mount.memory_usage_limit, "memoryUsageLimit")?;
-        Ok(Self {
-            virtual_path: mount.virtual_path,
-            host_path: mount.host_path.into(),
-            mode,
-            write_bytes_limit,
-            memory_usage_limit,
-        })
+        // Opens the directory: the spec carries a descriptor from here on, so
+        // the host path is resolved once per mount object rather than per feed.
+        let mut spec = Self::new(&mount.virtual_path, &mount.host_path, mode).map_err(pool_error)?;
+        spec.write_bytes_limit = write_bytes_limit;
+        spec.memory_usage_limit = memory_usage_limit;
+        Ok(spec)
     }
 }
 

--- a/crates/monty-js/src/pool.rs
+++ b/crates/monty-js/src/pool.rs
@@ -40,7 +40,9 @@ use monty_types::{
     TypeCheckingFormat,
 };
 use napi::{
-    bindgen_prelude::{Array, Buffer, FnArgs, FromNapiValue, Function, JsObjectValue, Object, PromiseRaw, Unknown},
+    bindgen_prelude::{
+        Array, Buffer, ClassInstance, FnArgs, FromNapiValue, Function, JsObjectValue, Object, PromiseRaw, Unknown,
+    },
     threadsafe_function::UnknownReturnValue,
     Env, Error, Result,
 };
@@ -145,6 +147,26 @@ pub struct NativeMount {
     pub write_bytes_limit: Option<f64>,
     /// Aggregate budget for retained overlay data and transient results.
     pub memory_usage_limit: f64,
+}
+
+/// A mount whose host directory is opened here and held until this object is
+/// dropped, so every feed using it mounts that same directory. Wrapped by the
+/// TypeScript `MountDir` — not part of the public API.
+#[napi(js_name = "NativeMountDir")]
+pub struct NativeMountDir {
+    spec: MountSpec,
+}
+
+#[napi]
+impl NativeMountDir {
+    /// Opens the host directory, throwing if it is missing, is not a directory,
+    /// or the virtual path is not absolute.
+    #[napi(constructor)]
+    pub fn new(mount: NativeMount) -> Result<Self> {
+        Ok(Self {
+            spec: MountSpec::try_from(mount)?,
+        })
+    }
 }
 
 /// A pool of `monty` worker subprocesses. Wrapped by the TypeScript `Monty`
@@ -316,15 +338,12 @@ impl NativeSession {
         env: &'env Env,
         code: String,
         inputs: Option<Object<'env>>,
-        mounts: Vec<NativeMount>,
+        mounts: Vec<ClassInstance<'env, NativeMountDir>>,
         skip_type_check: bool,
         on_print: PrintCallback<'env>,
     ) -> Result<PromiseRaw<'env, Object<'env>>> {
         let inputs = convert_inputs(env, inputs)?;
-        let mounts = mounts
-            .into_iter()
-            .map(MountSpec::try_from)
-            .collect::<Result<Vec<_>>>()?;
+        let mounts = mount_specs(&mounts);
         self.run_turn(
             env,
             on_print,
@@ -512,13 +531,10 @@ impl NativeSession {
         &self,
         env: &'env Env,
         state: Buffer,
-        mounts: Vec<NativeMount>,
+        mounts: Vec<ClassInstance<'env, NativeMountDir>>,
         on_print: PrintCallback<'env>,
     ) -> Result<PromiseRaw<'env, Object<'env>>> {
-        let mounts = mounts
-            .into_iter()
-            .map(MountSpec::try_from)
-            .collect::<Result<Vec<_>>>()?;
+        let mounts = mount_specs(&mounts);
         let state = state.to_vec();
         self.run_outcome(
             env,
@@ -993,6 +1009,12 @@ fn duration_from_ms(ms: f64) -> Result<Duration> {
 /// `.lock().await` (or `try_lock` on the event-loop thread).
 fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
     mutex.lock().unwrap_or_else(PoisonError::into_inner)
+}
+
+/// Clones each mount's opened configuration for one turn — the descriptor is
+/// shared, so nothing is reopened and no host path is resolved again.
+fn mount_specs(mounts: &[ClassInstance<'_, NativeMountDir>]) -> Vec<MountSpec> {
+    mounts.iter().map(|mount| mount.spec.clone()).collect()
 }
 
 fn pool_error(err: PoolError) -> napi::Error {

--- a/crates/monty-js/ts/mount.ts
+++ b/crates/monty-js/ts/mount.ts
@@ -3,11 +3,16 @@
 // side of the pool (the worker never sees host paths), so they work even for
 // remote workers. OS calls the mounts do not cover bubble up to the `os`
 // callback.
+//
+// The `MountDir` class lives in `mountDir.js` because constructing one loads
+// the native addon; everything here stays importable from the wasm bundle,
+// which shares `session.ts`.
 
-import type { NativeMount } from '../native-addon.js'
+import type { NativeMountDir } from '../native-addon.js'
+import type { MountDir } from './mountDir.js'
 
 // Mirrors monty-fs's DEFAULT_MEMORY_USAGE_LIMIT (100 MB in decimal bytes).
-const DEFAULT_MEMORY_USAGE_LIMIT = 100_000_000
+export const DEFAULT_MEMORY_USAGE_LIMIT = 100_000_000
 
 /** Sandbox access mode for a mounted directory. */
 export type MountDirMode = 'read-only' | 'read-write' | 'overlay'
@@ -18,9 +23,11 @@ export type MountDirMode = 'read-only' | 'read-write' | 'overlay'
  *  ambiguity. */
 export interface MountDirOptions {
   /** Real host directory to expose. Sandbox code can never see this path or
-   *  reach outside it. Opened once per mount, so on macOS/BSD it must be
-   *  readable (a search-only directory cannot be mounted there) and, on
-   *  Windows, cannot be renamed or deleted by anyone while the mount lives.
+   *  reach outside it. Opened by the constructor and held for the mount's
+   *  lifetime, so on macOS/BSD it must be readable (a search-only directory
+   *  cannot be mounted there) and, on Windows, cannot be renamed or deleted by
+   *  anyone until the mount is dropped. The mount then follows that directory,
+   *  not the path: renaming or replacing it afterwards changes nothing.
    *  Symlinks inside it are followed only if their targets are relative. */
   hostPath: string
   /** Absolute virtual POSIX path prefix inside the sandbox (e.g. `'/data'`),
@@ -38,62 +45,17 @@ export interface MountDirOptions {
   memoryUsageLimit?: number
 }
 
-const VALID_MODES: Record<MountDirMode, true> = {
+export const VALID_MODES: Record<MountDirMode, true> = {
   'read-only': true,
   'read-write': true,
   overlay: true,
 }
 
-/**
- * Mounts a real host directory into the sandbox at a virtual path.
- * Retained overlay data and filesystem results share a per-mount memory
- * budget, `memoryUsageLimit` (100 MB by default).
- *
- * ```ts
- * const mount = new MountDir({ hostPath: '/path/on/host', virtualPath: '/mnt/data', mode: 'read-only' })
- * await session.feedRun("open('/mnt/data/file.txt').read()", { mount })
- * ```
- */
-export class MountDir {
-  readonly hostPath: string
-  readonly virtualPath: string
-  readonly mode: MountDirMode
-  readonly writeBytesLimit: number | null
-  readonly memoryUsageLimit: number
-
-  constructor(options: MountDirOptions) {
-    const mode = options.mode ?? 'overlay'
-    // hasOwn, not `in`: prototype keys like 'toString' must not pass as modes
-    if (!Object.hasOwn(VALID_MODES, mode)) {
-      throw new Error(`invalid mount mode: '${mode}'. Expected 'read-only', 'read-write' or 'overlay'`)
-    }
-    this.hostPath = options.hostPath
-    this.virtualPath = options.virtualPath
-    this.mode = mode
-    this.writeBytesLimit = options.writeBytesLimit ?? null
-    this.memoryUsageLimit = options.memoryUsageLimit ?? DEFAULT_MEMORY_USAGE_LIMIT
-    if (!Number.isSafeInteger(this.memoryUsageLimit) || this.memoryUsageLimit < 0) {
-      throw new Error('memoryUsageLimit must be a non-negative safe integer')
-    }
-  }
-
-  /** Returns a string representation of the mount. */
-  repr(): string {
-    return `MountDir(host_path='${this.hostPath}', virtual_path='${this.virtualPath}', mode='${this.mode}')`
-  }
-}
-
-/** Encodes the `mount` option (one or many) for the native binding. */
-export function mountsToNative(mount: MountDir | MountDir[] | undefined): NativeMount[] {
+/** Collects the `mount` option (one or many) for the native binding. */
+export function mountsToNative(mount: MountDir | MountDir[] | undefined): NativeMountDir[] {
   if (mount === undefined) {
     return []
   }
   const mounts = Array.isArray(mount) ? mount : [mount]
-  return mounts.map((m) => ({
-    virtualPath: m.virtualPath,
-    hostPath: m.hostPath,
-    mode: m.mode,
-    memoryUsageLimit: m.memoryUsageLimit,
-    ...(m.writeBytesLimit !== null ? { writeBytesLimit: m.writeBytesLimit } : {}),
-  }))
+  return mounts.map((m) => m.native)
 }

--- a/crates/monty-js/ts/mount.ts
+++ b/crates/monty-js/ts/mount.ts
@@ -51,11 +51,21 @@ export const VALID_MODES: Record<MountDirMode, true> = {
   overlay: true,
 }
 
+/** Key under which a `MountDir` carries its opened native handle.
+ *
+ *  `private` is what `Monty` and `MontySession` use, but it would put the
+ *  handle out of reach of `mountsToNative` below, which lives in this module
+ *  so the wasm bundle can import it without loading the addon. A symbol keeps
+ *  the handle off the public surface — absent from `Object.keys`, JSON and
+ *  completions — while both modules can still reach it. Deliberately not
+ *  re-exported from `node.ts`. */
+export const NATIVE_MOUNT: unique symbol = Symbol('nativeMount')
+
 /** Collects the `mount` option (one or many) for the native binding. */
 export function mountsToNative(mount: MountDir | MountDir[] | undefined): NativeMountDir[] {
   if (mount === undefined) {
     return []
   }
   const mounts = Array.isArray(mount) ? mount : [mount]
-  return mounts.map((m) => m.native)
+  return mounts.map((m) => m[NATIVE_MOUNT])
 }

--- a/crates/monty-js/ts/mountDir.ts
+++ b/crates/monty-js/ts/mountDir.ts
@@ -1,0 +1,58 @@
+// The `MountDir` class: a mount that owns its opened host directory. Separate
+// from `mount.ts` because constructing one loads the native addon, and the
+// wasm bundle imports `mount.ts` (via `session.ts`) but has no addon.
+
+import { NativeMountDir } from '../native-addon.js'
+import { DEFAULT_MEMORY_USAGE_LIMIT, VALID_MODES, type MountDirMode, type MountDirOptions } from './mount.js'
+
+/**
+ * Mounts a real host directory into the sandbox at a virtual path.
+ * Retained overlay data and filesystem results share a per-mount memory
+ * budget, `memoryUsageLimit` (100 MB by default).
+ *
+ * ```ts
+ * const mount = new MountDir({ hostPath: '/path/on/host', virtualPath: '/mnt/data', mode: 'read-only' })
+ * await session.feedRun("open('/mnt/data/file.txt').read()", { mount })
+ * ```
+ */
+export class MountDir {
+  readonly hostPath: string
+  readonly virtualPath: string
+  readonly mode: MountDirMode
+  readonly writeBytesLimit: number | null
+  readonly memoryUsageLimit: number
+  /** The opened host directory, shared by every feed this mount is passed to.
+   *  @internal */
+  readonly native: NativeMountDir
+
+  constructor(options: MountDirOptions) {
+    const mode = options.mode ?? 'overlay'
+    // hasOwn, not `in`: prototype keys like 'toString' must not pass as modes
+    if (!Object.hasOwn(VALID_MODES, mode)) {
+      throw new Error(`invalid mount mode: '${mode}'. Expected 'read-only', 'read-write' or 'overlay'`)
+    }
+    this.hostPath = options.hostPath
+    this.virtualPath = options.virtualPath
+    this.mode = mode
+    this.writeBytesLimit = options.writeBytesLimit ?? null
+    this.memoryUsageLimit = options.memoryUsageLimit ?? DEFAULT_MEMORY_USAGE_LIMIT
+    if (!Number.isSafeInteger(this.memoryUsageLimit) || this.memoryUsageLimit < 0) {
+      throw new Error('memoryUsageLimit must be a non-negative safe integer')
+    }
+    // Opens the directory, so a bad host path throws here rather than at the
+    // first feed — and every feed then mounts this descriptor, which no rename
+    // of the host path can redirect.
+    this.native = new NativeMountDir({
+      virtualPath: this.virtualPath,
+      hostPath: this.hostPath,
+      mode: this.mode,
+      memoryUsageLimit: this.memoryUsageLimit,
+      ...(this.writeBytesLimit !== null ? { writeBytesLimit: this.writeBytesLimit } : {}),
+    })
+  }
+
+  /** Returns a string representation of the mount. */
+  repr(): string {
+    return `MountDir(host_path='${this.hostPath}', virtual_path='${this.virtualPath}', mode='${this.mode}')`
+  }
+}

--- a/crates/monty-js/ts/mountDir.ts
+++ b/crates/monty-js/ts/mountDir.ts
@@ -3,7 +3,13 @@
 // wasm bundle imports `mount.ts` (via `session.ts`) but has no addon.
 
 import { NativeMountDir } from '../native-addon.js'
-import { DEFAULT_MEMORY_USAGE_LIMIT, VALID_MODES, type MountDirMode, type MountDirOptions } from './mount.js'
+import {
+  DEFAULT_MEMORY_USAGE_LIMIT,
+  NATIVE_MOUNT,
+  VALID_MODES,
+  type MountDirMode,
+  type MountDirOptions,
+} from './mount.js'
 
 /**
  * Mounts a real host directory into the sandbox at a virtual path.
@@ -22,8 +28,8 @@ export class MountDir {
   readonly writeBytesLimit: number | null
   readonly memoryUsageLimit: number
   /** The opened host directory, shared by every feed this mount is passed to.
-   *  @internal */
-  readonly native: NativeMountDir
+   *  Symbol-keyed, so it stays off the public surface — see [`NATIVE_MOUNT`]. */
+  readonly [NATIVE_MOUNT]: NativeMountDir
 
   constructor(options: MountDirOptions) {
     const mode = options.mode ?? 'overlay'
@@ -42,7 +48,7 @@ export class MountDir {
     // Opens the directory, so a bad host path throws here rather than at the
     // first feed — and every feed then mounts this descriptor, which no rename
     // of the host path can redirect.
-    this.native = new NativeMountDir({
+    this[NATIVE_MOUNT] = new NativeMountDir({
       virtualPath: this.virtualPath,
       hostPath: this.hostPath,
       mode: this.mode,
@@ -59,7 +65,7 @@ export class MountDir {
    *  it, and JS has no deterministic drop. A feed already running is unaffected.
    */
   close(): void {
-    this.native.close()
+    this[NATIVE_MOUNT].close()
   }
 
   /** Closes the mount at the end of a `using` block. */

--- a/crates/monty-js/ts/mountDir.ts
+++ b/crates/monty-js/ts/mountDir.ts
@@ -51,6 +51,22 @@ export class MountDir {
     })
   }
 
+  /** Releases the open host directory. Later feeds using this mount throw;
+   *  the properties above keep answering. Idempotent.
+   *
+   *  Only Windows needs this: it refuses to rename or delete a directory while
+   *  a handle to it is open, so a mount left open blocks the host from touching
+   *  it, and JS has no deterministic drop. A feed already running is unaffected.
+   */
+  close(): void {
+    this.native.close()
+  }
+
+  /** Closes the mount at the end of a `using` block. */
+  [Symbol.dispose](): void {
+    this.close()
+  }
+
   /** Returns a string representation of the mount. */
   repr(): string {
     return `MountDir(host_path='${this.hostPath}', virtual_path='${this.virtualPath}', mode='${this.mode}')`

--- a/crates/monty-js/ts/node.ts
+++ b/crates/monty-js/ts/node.ts
@@ -20,7 +20,8 @@ export {
   type Snapshot,
 } from './session.js'
 export { CollectString, CollectStreams, DEFAULT_MAX_PRINT_COLLECT_BYTES, type CollectedStreamEntry } from './print.js'
-export { MountDir, type MountDirMode, type MountDirOptions } from './mount.js'
+export { type MountDirMode, type MountDirOptions } from './mount.js'
+export { MountDir } from './mountDir.js'
 export {
   MontyCrashedError,
   MontyError,

--- a/crates/monty-js/ts/session.ts
+++ b/crates/monty-js/ts/session.ts
@@ -19,7 +19,8 @@ import {
   ProtocolError,
 } from './errors.js'
 import { PYTHON_EXC_NAMES } from './errors.js'
-import { mountsToNative, type MountDir } from './mount.js'
+import { mountsToNative } from './mount.js'
+import type { MountDir } from './mountDir.js'
 import type {
   FunctionCallTurn,
   LoadedTurn,

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -3,13 +3,13 @@
 use std::{
     borrow::Cow,
     future::{Future, ready},
-    path::PathBuf,
+    path::Path,
     pin::Pin,
     sync::Arc,
     time::Duration,
 };
 
-use monty_fs::{MountCallOutcome, MountMode, MountTable, OverlayState};
+use monty_fs::{MountCallOutcome, MountMode, MountRoot, MountTable, OverlayState};
 use monty_proto::{FrameError, MONTY_VERSION, exceeds_max_value_depth, pb, validate_requirement};
 use monty_types::{
     AssertMessageAnnotations, ExcType, MontyException, MontyObject, OsFunctionCall, PrintStream, ResourceLimits,
@@ -67,10 +67,10 @@ impl Default for ReplConfig {
 /// [`Checkout::resume_from_mounts`].
 #[derive(Debug, Clone)]
 pub struct MountSpec {
-    /// Absolute virtual POSIX path inside the sandbox, e.g. `/mnt/data`.
-    pub virtual_path: String,
-    /// Host directory to expose.
-    pub host_path: PathBuf,
+    /// The host directory, opened when this spec was built and shared by every
+    /// feed that reuses it. The path is never resolved again, so sandbox code
+    /// cannot make it name a different directory between feeds.
+    root: MountRoot,
     /// Access mode.
     pub mode: MountSpecMode,
     /// Cap on total bytes written through this mount.
@@ -80,17 +80,43 @@ pub struct MountSpec {
 }
 
 impl MountSpec {
-    /// Creates mount configuration with the default 100 MB memory budget and
-    /// no cumulative write limit.
+    /// Opens `host_path` and creates mount configuration with the default
+    /// 100 MB memory budget and no cumulative write limit.
+    ///
+    /// Build this once and reuse it; each call resolves the path afresh.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PoolError::Runtime`] if the virtual path is not absolute, or
+    /// the host path cannot be opened as a directory.
+    pub fn new(virtual_path: &str, host_path: impl AsRef<Path>, mode: MountSpecMode) -> Result<Self, PoolError> {
+        let root = MountRoot::open(virtual_path, host_path).map_err(|err| PoolError::Runtime(err.into_exception()))?;
+        Ok(Self::from_root(root, mode))
+    }
+
+    /// Creates mount configuration from an already-opened [`MountRoot`], for
+    /// hosts that open it themselves to map failures their own way.
     #[must_use]
-    pub fn new(virtual_path: String, host_path: PathBuf, mode: MountSpecMode) -> Self {
+    pub fn from_root(root: MountRoot, mode: MountSpecMode) -> Self {
         Self {
-            virtual_path,
-            host_path,
+            root,
             mode,
             write_bytes_limit: None,
             memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
         }
+    }
+
+    /// Returns the normalized virtual path this mount answers on.
+    #[must_use]
+    pub fn virtual_path(&self) -> &str {
+        self.root.virtual_path()
+    }
+
+    /// Returns the host directory path. Diagnostics only — operations run
+    /// against the descriptor, not this path.
+    #[must_use]
+    pub fn host_path(&self) -> &Path {
+        self.root.host_path()
     }
 }
 
@@ -324,11 +350,10 @@ impl Checkout {
         on_print: OnPrint<'_>,
     ) -> Result<(Option<TurnEvent>, Option<String>), PoolError> {
         self.ensure_ready()?;
-        // Build mounts before touching any state: this await is the only
-        // cancellation point before the Load turn, and a cancelled build must
-        // leave the checkout unchanged (notably `duration_budget`, whose loss
-        // would silently drop the parent-side backstop from later feeds).
-        let feed_mounts = self.build_feed_mounts(mounts).await?;
+        // Build mounts before touching any state, so a failure here leaves the
+        // checkout unchanged (notably `duration_budget`, whose loss would
+        // silently drop the parent-side backstop from later feeds).
+        let feed_mounts = Self::build_feed_mounts(mounts);
         // the dump carries its own limits/consumed time/script name — forget
         // what the worker's Configure established and re-adopt from the reply
         self.pending = None;
@@ -375,7 +400,7 @@ impl Checkout {
             ));
         }
         ensure_sendable(inputs.iter().map(|(_, value)| value))?;
-        self.feed_mounts = self.build_feed_mounts(mounts).await?;
+        self.feed_mounts = Self::build_feed_mounts(mounts);
         let request = request(pb::parent_request::Kind::Feed(pb::Feed {
             code: code.to_owned(),
             inputs: inputs
@@ -939,16 +964,11 @@ impl Checkout {
         }
     }
 
-    /// Builds this feed's mount table on the blocking pool — mount validation
-    /// (existence checks, canonicalization) is host filesystem I/O. Skips the
-    /// dispatch entirely for the common mount-less feed. Cancel-safe: nothing
-    /// is mutated until the built table is returned.
-    async fn build_feed_mounts(&mut self, mounts: Vec<MountSpec>) -> Result<Option<MountTable>, PoolError> {
-        if mounts.is_empty() {
-            Ok(None)
-        } else {
-            self.run_blocking(move || build_mount_table(mounts)).await?.map(Some)
-        }
+    /// Builds this feed's mount table, or `None` for the common mount-less
+    /// feed. Runs inline: the specs' directories were opened when the caller
+    /// built them, so nothing here touches the host filesystem.
+    fn build_feed_mounts(mounts: Vec<MountSpec>) -> Option<MountTable> {
+        (!mounts.is_empty()).then(|| build_mount_table(mounts))
     }
 
     /// Runs blocking host mount work on tokio's blocking pool, so a stalled
@@ -1156,11 +1176,9 @@ fn min_deadline(a: Option<Duration>, b: Option<Duration>) -> Option<Duration> {
 }
 
 /// Builds the parent-side [`MountTable`] for one feed from its (non-empty)
-/// specs. An invalid mount (host path missing, not a directory, relative
-/// virtual path, …) fails as a session-preserving [`PoolError::Runtime`] —
-/// [`Checkout::build_feed_mounts`] runs this on the blocking pool before any
-/// frame is sent, so the worker never sees a half-configured feed.
-fn build_mount_table(mounts: Vec<MountSpec>) -> Result<MountTable, PoolError> {
+/// specs. Infallible and free of filesystem I/O: each spec already carries its
+/// opened directory, so this only pairs those descriptors with a per-feed mode.
+fn build_mount_table(mounts: Vec<MountSpec>) -> MountTable {
     let mut table = MountTable::new();
     for mount in mounts {
         let mode = match mount.mode {
@@ -1170,10 +1188,10 @@ fn build_mount_table(mounts: Vec<MountSpec>) -> Result<MountTable, PoolError> {
             // long as the feed and are discarded with it.
             MountSpecMode::Overlay => MountMode::OverlayMemory(OverlayState::new()),
         };
-        let mount = monty_fs::Mount::new(&mount.virtual_path, &mount.host_path, mode, mount.write_bytes_limit)
-            .map_err(|err| PoolError::Runtime(err.into_exception()))?
+        // No filesystem access: the root was opened when the spec was built.
+        let mount = monty_fs::Mount::with_root(mount.root, mode, mount.write_bytes_limit)
             .with_memory_usage_limit(mount.memory_usage_limit);
         table.push_mount(mount);
     }
-    Ok(table)
+    table
 }

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -83,7 +83,12 @@ impl MountSpec {
     /// Opens `host_path` and creates mount configuration with the default
     /// 100 MB memory budget and no cumulative write limit.
     ///
-    /// Build this once and reuse it; each call resolves the path afresh.
+    /// Build this once and reuse it; each call resolves the path afresh. The
+    /// open is blocking filesystem I/O, so an async caller opening a directory
+    /// that may stall (NFS, FUSE) should either build the spec before entering
+    /// the runtime or open the [`MountRoot`] under `spawn_blocking` and pass it
+    /// to [`Self::from_root`]. Feeds never reopen it, so this cost is paid once
+    /// per mount rather than once per feed.
     ///
     /// # Errors
     ///

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -350,9 +350,6 @@ impl Checkout {
         on_print: OnPrint<'_>,
     ) -> Result<(Option<TurnEvent>, Option<String>), PoolError> {
         self.ensure_ready()?;
-        // Build mounts before touching any state, so a failure here leaves the
-        // checkout unchanged (notably `duration_budget`, whose loss would
-        // silently drop the parent-side backstop from later feeds).
         let feed_mounts = Self::build_feed_mounts(mounts);
         // the dump carries its own limits/consumed time/script name — forget
         // what the worker's Configure established and re-adopt from the reply

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -4,6 +4,8 @@
 
 #[cfg(unix)]
 use std::os::unix::fs::{PermissionsExt, symlink};
+#[cfg(windows)]
+use std::os::windows::fs::symlink_dir;
 use std::{
     env, fs,
     future::ready,

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -377,8 +377,16 @@ Path('/parent/shared').rename('/parent/old-shared')
 Path('/parent/prepared-link').rename('/parent/shared')
 'swapped'";
     let result = session.feed(code, vec![], vec![parent], false, &mut no_print).await;
-    let event = feed_with_mounts(&mut session, result).await.unwrap();
-    assert_eq!(expect_complete(event), MontyObject::String("swapped".to_owned()));
+    match feed_with_mounts(&mut session, result).await {
+        Ok(event) => assert_eq!(expect_complete(event), MontyObject::String("swapped".to_owned())),
+        // Windows refuses to rename a directory while a handle to it is open,
+        // and the child mount holds one — so the swap cannot even be staged
+        // there while the mount is alive.
+        #[cfg(windows)]
+        Err(_) => return,
+        #[cfg(not(windows))]
+        Err(err) => panic!("staging the swap failed: {err:?}"),
+    }
 
     // Feed 2: the child mount, rebuilt from the same spec, still serves the
     // original directory and cannot see the one the name now points at.

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -7,6 +7,7 @@ use std::os::unix::fs::{PermissionsExt, symlink};
 use std::{
     env, fs,
     future::ready,
+    io,
     path::{Path, PathBuf},
     process::Command,
     sync::Once,
@@ -89,6 +90,15 @@ async fn feed_with_mounts(
             None => return Ok(event),
         }
     }
+}
+
+/// Creates a directory symlink, reporting the failure a host without the
+/// privilege gives so the caller can skip rather than fail.
+fn try_symlink_dir(original: &Path, link: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    return symlink(original, link);
+    #[cfg(windows)]
+    return symlink_dir(original, link);
 }
 
 /// Kills a process by pid with SIGKILL — simulates a hard crash.
@@ -337,9 +347,8 @@ body";
 /// the sandbox renaming a symlink over that directory's name, from inside a
 /// read-write mount of the parent, redirects the *path* and nothing else.
 ///
-/// Unix-only because planting the link needs symlink creation; the confinement
-/// itself is not platform-specific.
-#[cfg(unix)]
+/// Skipped where the host cannot create symlinks (Windows without Developer
+/// Mode or elevation), since planting the link needs one.
 #[tokio::test]
 async fn a_reused_mount_spec_survives_a_rename_of_its_host_directory() {
     let base = tempfile::tempdir().unwrap();
@@ -349,7 +358,10 @@ async fn a_reused_mount_spec_survives_a_rename_of_its_host_directory() {
     fs::write(shared.join("inside.txt"), "in-mount").unwrap();
     fs::write(outside.path().join("secret.txt"), "HOST SECRET").unwrap();
     // Host-planted link out of the tree; the sandbox only moves it.
-    symlink(outside.path(), base.path().join("prepared-link")).unwrap();
+    if try_symlink_dir(outside.path(), &base.path().join("prepared-link")).is_err() {
+        eprintln!("skipping: this host cannot create symlinks");
+        return;
+    }
 
     // Both built once, as a host holding long-lived mount objects would.
     let child = MountSpec::new("/child", shared, MountSpecMode::ReadOnly).unwrap();

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -3,7 +3,7 @@
 //! must surface as a clean error and never poison the pool.
 
 #[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{PermissionsExt, symlink};
 use std::{
     env, fs,
     future::ready,
@@ -250,13 +250,7 @@ async fn non_utf8_mount_path_works() {
         .feed(
             "from pathlib import Path\nPath('/mnt/data/data.txt').read_text()",
             vec![],
-            vec![MountSpec {
-                virtual_path: "/mnt/data".to_owned(),
-                host_path: weird_dir,
-                mode: MountSpecMode::ReadOnly,
-                write_bytes_limit: None,
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-            }],
+            vec![MountSpec::new("/mnt/data", weird_dir, MountSpecMode::ReadOnly).unwrap()],
             false,
             &mut no_print,
         )
@@ -269,28 +263,16 @@ async fn non_utf8_mount_path_works() {
     session.finish().await.unwrap();
 }
 
-/// A mount whose host path does not exist fails at `feed()` — on the parent,
-/// before any frame is sent — as a session-preserving error.
+/// A mount whose host path does not exist is rejected where the directory is
+/// opened — building the [`MountSpec`] — so no feed inherits the failure.
 #[tokio::test]
 async fn invalid_mount_host_path_is_rejected_cleanly() {
-    let pool = Pool::new(config()).await.unwrap();
-    let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
-    let err = session
-        .feed(
-            "1 + 1",
-            vec![],
-            vec![MountSpec {
-                virtual_path: "/mnt/data".to_owned(),
-                host_path: PathBuf::from("/nonexistent/monty/mount/dir"),
-                mode: MountSpecMode::ReadOnly,
-                write_bytes_limit: None,
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-            }],
-            false,
-            &mut no_print,
-        )
-        .await
-        .unwrap_err();
+    let err = MountSpec::new(
+        "/mnt/data",
+        PathBuf::from("/nonexistent/monty/mount/dir"),
+        MountSpecMode::ReadOnly,
+    )
+    .unwrap_err();
     let PoolError::Runtime(exc) = err else {
         panic!("expected Runtime, got {err:?}");
     };
@@ -299,7 +281,9 @@ async fn invalid_mount_host_path_is_rejected_cleanly() {
         "unexpected message: {:?}",
         exc.message()
     );
-    // nothing was sent, so the worker is still synced and the session usable
+
+    let pool = Pool::new(config()).await.unwrap();
+    let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
     let event = session
         .feed("1 + 1", vec![], vec![], false, &mut no_print)
         .await
@@ -316,15 +300,7 @@ async fn mounted_filesystem_ops_are_serviced_by_the_parent() {
     let dir = tempfile::tempdir().unwrap();
     fs::write(dir.path().join("data.txt"), "mounted!").unwrap();
 
-    let mount = || {
-        vec![MountSpec {
-            virtual_path: "/mnt".to_owned(),
-            host_path: dir.path().to_path_buf(),
-            mode: MountSpecMode::ReadWrite,
-            write_bytes_limit: None,
-            memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-        }]
-    };
+    let mount = || vec![MountSpec::new("/mnt", dir.path(), MountSpecMode::ReadWrite).unwrap()];
     let pool = Pool::new(config()).await.unwrap();
     let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
 
@@ -357,6 +333,52 @@ body";
     session.finish().await.unwrap();
 }
 
+/// A [`MountSpec`] reused across feeds stays bound to the directory it opened:
+/// the sandbox renaming a symlink over that directory's name, from inside a
+/// read-write mount of the parent, redirects the *path* and nothing else.
+///
+/// Unix-only because planting the link needs symlink creation; the confinement
+/// itself is not platform-specific.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_reused_mount_spec_survives_a_rename_of_its_host_directory() {
+    let base = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let shared = base.path().join("shared");
+    fs::create_dir(&shared).unwrap();
+    fs::write(shared.join("inside.txt"), "in-mount").unwrap();
+    fs::write(outside.path().join("secret.txt"), "HOST SECRET").unwrap();
+    // Host-planted link out of the tree; the sandbox only moves it.
+    symlink(outside.path(), base.path().join("prepared-link")).unwrap();
+
+    // Both built once, as a host holding long-lived mount objects would.
+    let child = MountSpec::new("/child", shared, MountSpecMode::ReadOnly).unwrap();
+    let parent = MountSpec::new("/parent", base.path(), MountSpecMode::ReadWrite).unwrap();
+
+    let pool = Pool::new(config()).await.unwrap();
+    let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
+
+    // Feed 1: swap the real directory out and the link in, under one name.
+    let code = "\
+from pathlib import Path
+Path('/parent/shared').rename('/parent/old-shared')
+Path('/parent/prepared-link').rename('/parent/shared')
+'swapped'";
+    let result = session.feed(code, vec![], vec![parent], false, &mut no_print).await;
+    let event = feed_with_mounts(&mut session, result).await.unwrap();
+    assert_eq!(expect_complete(event), MontyObject::String("swapped".to_owned()));
+
+    // Feed 2: the child mount, rebuilt from the same spec, still serves the
+    // original directory and cannot see the one the name now points at.
+    let code = "\
+from pathlib import Path
+f\"{Path('/child/inside.txt').read_text()}:{Path('/child/secret.txt').exists()}\"";
+    let result = session.feed(code, vec![], vec![child], false, &mut no_print).await;
+    let event = feed_with_mounts(&mut session, result).await.unwrap();
+    assert_eq!(expect_complete(event), MontyObject::String("in-mount:False".to_owned()));
+    session.finish().await.unwrap();
+}
+
 /// A write through a read-only mount raises `PermissionError` inside the
 /// sandbox (catchable, session-preserving); overlay writes are visible within
 /// the feed, never reach the host, and are discarded when the feed ends.
@@ -365,15 +387,7 @@ async fn read_only_and_overlay_mount_semantics() {
     let dir = tempfile::tempdir().unwrap();
     fs::write(dir.path().join("data.txt"), "original").unwrap();
 
-    let mount = |mode| {
-        vec![MountSpec {
-            virtual_path: "/mnt".to_owned(),
-            host_path: dir.path().to_path_buf(),
-            mode,
-            write_bytes_limit: None,
-            memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-        }]
-    };
+    let mount = |mode| vec![MountSpec::new("/mnt", dir.path(), mode).unwrap()];
     let pool = Pool::new(config()).await.unwrap();
     let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
 
@@ -435,12 +449,10 @@ msg";
         .feed(
             code,
             vec![],
-            vec![MountSpec {
-                virtual_path: "/mnt".to_owned(),
-                host_path: dir.path().to_path_buf(),
-                mode: MountSpecMode::ReadWrite,
-                write_bytes_limit: Some(10),
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
+            vec![{
+                let mut spec = MountSpec::new("/mnt", dir.path(), MountSpecMode::ReadWrite).unwrap();
+                spec.write_bytes_limit = Some(10);
+                spec
             }],
             false,
             &mut no_print,
@@ -472,7 +484,7 @@ try:
 except MemoryError as exc:
     msg = str(exc)
 msg";
-    let mut spec = MountSpec::new("/mnt".to_owned(), dir.path().to_path_buf(), MountSpecMode::Overlay);
+    let mut spec = MountSpec::new("/mnt", dir.path(), MountSpecMode::Overlay).unwrap();
     spec.memory_usage_limit = 1_000;
     let result = session.feed(code, vec![], vec![spec], false, &mut no_print).await;
     let event = feed_with_mounts(&mut session, result).await.unwrap();
@@ -500,13 +512,7 @@ covered + ':' + Path('/elsewhere/file.txt').read_text()";
         .feed(
             code,
             vec![],
-            vec![MountSpec {
-                virtual_path: "/mnt".to_owned(),
-                host_path: dir.path().to_path_buf(),
-                mode: MountSpecMode::ReadOnly,
-                write_bytes_limit: None,
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-            }],
+            vec![MountSpec::new("/mnt", dir.path(), MountSpecMode::ReadOnly).unwrap()],
             false,
             &mut no_print,
         )
@@ -543,15 +549,7 @@ async fn suspended_feed_restores_with_mounts_re_supplied() {
     let dir = tempfile::tempdir().unwrap();
     fs::write(dir.path().join("data.txt"), "after resume").unwrap();
 
-    let mount = || {
-        vec![MountSpec {
-            virtual_path: "/mnt".to_owned(),
-            host_path: dir.path().to_path_buf(),
-            mode: MountSpecMode::ReadOnly,
-            write_bytes_limit: None,
-            memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-        }]
-    };
+    let mount = || vec![MountSpec::new("/mnt", dir.path(), MountSpecMode::ReadOnly).unwrap()];
     let pool = Pool::new(config()).await.unwrap();
     let mut session = pool.checkout(&ReplConfig::default()).await.unwrap();
     // suspend on an *uncovered* call, dump, and restore into a fresh worker
@@ -624,13 +622,7 @@ async fn restored_os_call_is_serviced_by_restore_mounts() {
     let (event, _) = restored
         .restore(
             state,
-            vec![MountSpec {
-                virtual_path: "/mnt".to_owned(),
-                host_path: dir.path().to_path_buf(),
-                mode: MountSpecMode::ReadOnly,
-                write_bytes_limit: None,
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-            }],
+            vec![MountSpec::new("/mnt", dir.path(), MountSpecMode::ReadOnly).unwrap()],
             &mut no_print,
         )
         .await
@@ -1213,13 +1205,7 @@ async fn special_files_in_mounts_are_rejected_without_blocking() {
         .feed(
             "from pathlib import Path\nPath('/mnt/pipe').read_text()",
             vec![],
-            vec![MountSpec {
-                virtual_path: "/mnt".to_owned(),
-                host_path: dir.path().to_path_buf(),
-                mode: MountSpecMode::ReadOnly,
-                write_bytes_limit: None,
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-            }],
+            vec![MountSpec::new("/mnt", dir.path(), MountSpecMode::ReadOnly).unwrap()],
             false,
             &mut no_print,
         )

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -181,13 +181,7 @@ async fn mounted_reads_are_serviced_from_the_parent_filesystem() {
         .feed(
             "unused",
             vec![],
-            vec![MountSpec {
-                virtual_path: "/mnt".to_owned(),
-                host_path: dir.path().to_path_buf(),
-                mode: MountSpecMode::ReadOnly,
-                write_bytes_limit: None,
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-            }],
+            vec![MountSpec::new("/mnt", dir.path(), MountSpecMode::ReadOnly).unwrap()],
             false,
             &mut no_print,
         )
@@ -247,13 +241,7 @@ async fn malformed_os_call_is_a_protocol_error() {
         .feed(
             "unused",
             vec![],
-            vec![MountSpec {
-                virtual_path: "/mnt".to_owned(),
-                host_path: dir.path().to_path_buf(),
-                mode: MountSpecMode::ReadOnly,
-                write_bytes_limit: None,
-                memory_usage_limit: monty_fs::DEFAULT_MEMORY_USAGE_LIMIT,
-            }],
+            vec![MountSpec::new("/mnt", dir.path(), MountSpecMode::ReadOnly).unwrap()],
             false,
             &mut no_print,
         )
@@ -339,11 +327,7 @@ async fn a_mounted_feed_turn_is_still_bounded_by_the_request_timeout() {
         .feed(
             "unused",
             vec![],
-            vec![MountSpec::new(
-                "/mnt".to_owned(),
-                dir.path().to_path_buf(),
-                MountSpecMode::ReadOnly,
-            )],
+            vec![MountSpec::new("/mnt", dir.path(), MountSpecMode::ReadOnly).unwrap()],
             false,
             &mut no_print,
         )

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -81,7 +81,29 @@ class CollectString:
 
 @final
 class MountDir:
-    """A mount point mapping a virtual path to a host directory."""
+    """A mount point mapping a virtual path to a host directory.
+
+    The directory is opened here, and every feed this mount is passed to serves
+    that same directory — so build one and reuse it. `'overlay'` writes live in
+    each feed's own table and are discarded when the feed ends.
+
+    ```python
+    from pathlib import Path
+
+    from pydantic_monty import Monty, MountDir
+
+    with Monty() as pool, MountDir(host_path=Path('host-dir'), virtual_path='/data') as mount:
+        with pool.checkout() as session:
+            contents = session.feed_run("open('/data/notes.txt').read()", mount=mount)
+    ```
+
+    The directory is held open from construction until the mount is closed, not
+    for the duration of a feed — so reusing one across feeds is free, and works
+    the same inside a `with` block or outside it. `with` (or `close()`) is what
+    hands the directory back; feeds passed a closed mount raise `ValueError`.
+    Without it the directory stays open until the object is collected: a file
+    descriptor on Unix, but on Windows that blocks renaming or deleting it.
+    """
 
     host_path: str
     virtual_path: str

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -132,6 +132,18 @@ class MountDir:
                 would exceed it raises `MemoryError` in the sandbox.
         """
 
+    def close(self) -> None:
+        """Release the open host directory. Idempotent.
+
+        Feeds passed this mount afterwards raise `ValueError`; the attributes
+        above keep answering. Only Windows needs this — it refuses to rename or
+        delete a directory while a handle to it is open — but `MountDir` also
+        works as a context manager, which closes on exit.
+        """
+
+    def __enter__(self) -> MountDir: ...
+    def __exit__(self, *args: object) -> bool: ...
+
 class MontyError(Exception):
     """Base exception for all Monty interpreter errors.
 

--- a/crates/monty-python/src/mount.rs
+++ b/crates/monty-python/src/mount.rs
@@ -126,14 +126,14 @@ impl PyMountDir {
 
     /// The canonical host directory path.
     #[getter]
-    fn host_path(&self) -> String {
-        self.label.host_path.clone()
+    fn host_path(&self) -> &str {
+        &self.label.host_path
     }
 
     /// The normalized virtual path prefix inside the sandbox.
     #[getter]
-    fn virtual_path(&self) -> String {
-        self.label.virtual_path.clone()
+    fn virtual_path(&self) -> &str {
+        &self.label.virtual_path
     }
 
     /// The access mode: `"read-only"`, `"read-write"`, or `"overlay"`.

--- a/crates/monty-python/src/mount.rs
+++ b/crates/monty-python/src/mount.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use monty_fs::{MountMode, MountRoot};
 use monty_pool::{MountSpec, MountSpecMode};
 use monty_proto::python::exc_monty_to_py;
-use pyo3::{exceptions::PyValueError, prelude::*};
+use pyo3::{exceptions::PyValueError, prelude::*, types::PyTuple};
 
 // =============================================================================
 // MountDir — immutable mount configuration
@@ -28,8 +28,20 @@ use pyo3::{exceptions::PyValueError, prelude::*};
 /// - `'overlay'` — reads fall through to host; writes are captured in memory
 #[pyclass(name = "MountDir")]
 pub struct PyMountDir {
-    /// Validated configuration copied into each feed's mount table.
-    spec: MountSpec,
+    /// Validated configuration copied into each feed's mount table. `None`
+    /// once closed — the open directory is released, so nothing can mount it.
+    spec: Option<MountSpec>,
+    /// What the getters report, kept so they still answer after `close()`.
+    label: MountLabel,
+}
+
+/// The parts of a mount that outlive its descriptor.
+struct MountLabel {
+    virtual_path: String,
+    host_path: String,
+    mode: MountSpecMode,
+    write_bytes_limit: Option<u64>,
+    memory_usage_limit: u64,
 }
 
 #[pymethods]
@@ -80,53 +92,88 @@ impl PyMountDir {
         );
         spec.write_bytes_limit = write_bytes_limit;
         spec.memory_usage_limit = memory_usage_limit;
-        Ok(Self { spec })
+        Ok(Self {
+            label: MountLabel {
+                virtual_path: spec.virtual_path().to_owned(),
+                host_path: spec.host_path().display().to_string(),
+                mode: spec.mode,
+                write_bytes_limit,
+                memory_usage_limit,
+            },
+            spec: Some(spec),
+        })
+    }
+
+    /// Releases the open host directory. Later feeds using this mount raise
+    /// `ValueError`; the attributes below keep answering. Idempotent.
+    ///
+    /// Only Windows needs this: it refuses to rename or delete a directory
+    /// while a handle to it is open, so a mount left open blocks the host from
+    /// touching it. A feed already running keeps its own reference.
+    fn close(&mut self) {
+        self.spec = None;
+    }
+
+    fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    #[pyo3(signature = (*_args))]
+    fn __exit__(&mut self, _args: &Bound<'_, PyTuple>) -> bool {
+        self.close();
+        false
     }
 
     /// The canonical host directory path.
     #[getter]
     fn host_path(&self) -> String {
-        self.spec.host_path().display().to_string()
+        self.label.host_path.clone()
     }
 
     /// The normalized virtual path prefix inside the sandbox.
     #[getter]
     fn virtual_path(&self) -> String {
-        self.spec.virtual_path().to_owned()
+        self.label.virtual_path.clone()
     }
 
     /// The access mode: `"read-only"`, `"read-write"`, or `"overlay"`.
     #[getter]
     fn mode(&self) -> &'static str {
-        mount_mode_name(self.spec.mode)
+        mount_mode_name(self.label.mode)
     }
 
     /// The optional write bytes limit, or `None` if unlimited.
     #[getter]
     fn write_bytes_limit(&self) -> Option<u64> {
-        self.spec.write_bytes_limit
+        self.label.write_bytes_limit
     }
 
     /// The aggregate memory budget for this mount.
     #[getter]
     fn memory_usage_limit(&self) -> u64 {
-        self.spec.memory_usage_limit
+        self.label.memory_usage_limit
     }
 
     fn __repr__(&self) -> String {
         format!(
             "MountDir(host_path='{}', virtual_path='{}', mode='{}')",
-            self.spec.host_path().display(),
-            self.spec.virtual_path(),
-            mount_mode_name(self.spec.mode)
+            self.label.host_path,
+            self.label.virtual_path,
+            mount_mode_name(self.label.mode)
         )
     }
 }
 
 impl PyMountDir {
     /// Copies the validated configuration for a new parent-side mount table.
-    pub(crate) fn spec(&self) -> MountSpec {
-        self.spec.clone()
+    ///
+    /// # Errors
+    ///
+    /// Raises `ValueError` if the mount has been closed.
+    pub(crate) fn spec(&self) -> PyResult<MountSpec> {
+        self.spec
+            .clone()
+            .ok_or_else(|| PyValueError::new_err(format!("mount '{}' is closed", self.label.virtual_path)))
     }
 }
 

--- a/crates/monty-python/src/mount.rs
+++ b/crates/monty-python/src/mount.rs
@@ -6,7 +6,7 @@
 
 use std::path::PathBuf;
 
-use monty_fs::{Mount, MountMode};
+use monty_fs::{MountMode, MountRoot};
 use monty_pool::{MountSpec, MountSpecMode};
 use monty_proto::python::exc_monty_to_py;
 use pyo3::{exceptions::PyValueError, prelude::*};
@@ -67,33 +67,32 @@ impl PyMountDir {
         memory_usage_limit: u64,
     ) -> PyResult<Self> {
         let mount_mode = MountMode::from_mode_str(mode).map_err(PyValueError::new_err)?;
-        let mount = Mount::new(virtual_path, &host_path, mount_mode, write_bytes_limit)
-            .map_err(|e| exc_monty_to_py(py, e.into_exception()))?;
-        Ok(Self {
-            spec: MountSpec {
-                virtual_path: mount.virtual_path().to_owned(),
-                host_path: mount.host_path().to_path_buf(),
-                mode: match mount.mode() {
-                    MountMode::ReadOnly => MountSpecMode::ReadOnly,
-                    MountMode::ReadWrite => MountSpecMode::ReadWrite,
-                    MountMode::OverlayMemory(_) => MountSpecMode::Overlay,
-                },
-                write_bytes_limit: mount.write_bytes_limit(),
-                memory_usage_limit,
+        // Held for this object's lifetime: later feeds mount the descriptor
+        // rather than re-resolving `host_path`, which the sandbox can redirect.
+        let root = MountRoot::open(virtual_path, &host_path).map_err(|e| exc_monty_to_py(py, e.into_exception()))?;
+        let mut spec = MountSpec::from_root(
+            root,
+            match mount_mode {
+                MountMode::ReadOnly => MountSpecMode::ReadOnly,
+                MountMode::ReadWrite => MountSpecMode::ReadWrite,
+                MountMode::OverlayMemory(_) => MountSpecMode::Overlay,
             },
-        })
+        );
+        spec.write_bytes_limit = write_bytes_limit;
+        spec.memory_usage_limit = memory_usage_limit;
+        Ok(Self { spec })
     }
 
     /// The canonical host directory path.
     #[getter]
     fn host_path(&self) -> String {
-        self.spec.host_path.display().to_string()
+        self.spec.host_path().display().to_string()
     }
 
     /// The normalized virtual path prefix inside the sandbox.
     #[getter]
     fn virtual_path(&self) -> String {
-        self.spec.virtual_path.clone()
+        self.spec.virtual_path().to_owned()
     }
 
     /// The access mode: `"read-only"`, `"read-write"`, or `"overlay"`.
@@ -117,8 +116,8 @@ impl PyMountDir {
     fn __repr__(&self) -> String {
         format!(
             "MountDir(host_path='{}', virtual_path='{}', mode='{}')",
-            self.spec.host_path.display(),
-            self.spec.virtual_path,
+            self.spec.host_path().display(),
+            self.spec.virtual_path(),
             mount_mode_name(self.spec.mode)
         )
     }

--- a/crates/monty-python/src/pool.rs
+++ b/crates/monty-python/src/pool.rs
@@ -1750,14 +1750,14 @@ fn extract_mount_specs(mount: Option<&Bound<'_, PyAny>>) -> PyResult<Vec<MountSp
         return Ok(vec![]);
     };
     if let Ok(single) = mount.extract::<PyRef<'_, PyMountDir>>() {
-        return Ok(vec![single.spec()]);
+        return Ok(vec![single.spec()?]);
     }
     if let Ok(list) = mount.cast::<PyList>() {
         return list
             .iter()
             .map(|item| {
                 let dir = item.extract::<PyRef<'_, PyMountDir>>()?;
-                Ok(dir.spec())
+                dir.spec()
             })
             .collect();
     }

--- a/crates/monty-python/tests/test_mount_table.py
+++ b/crates/monty-python/tests/test_mount_table.py
@@ -54,6 +54,30 @@ def test_mount_directory_repr(test_dir: Path):
     assert '/data' in repr(md)
 
 
+def test_mount_close_releases_the_directory(monty_run: RunMonty, test_dir: Path):
+    md = MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only')
+    assert monty_run("from pathlib import Path; Path('/data/hello.txt').read_text()", mount=md) == snapshot(
+        'hello world'
+    )
+
+    md.close()
+    md.close()  # idempotent
+    with pytest.raises(ValueError) as exc_info:
+        monty_run("from pathlib import Path; Path('/data/hello.txt').read_text()", mount=md)
+    assert str(exc_info.value) == snapshot("mount '/data' is closed")
+    # The configuration it reports outlives the descriptor.
+    assert md.virtual_path == snapshot('/data')
+
+
+def test_mount_context_manager_closes(monty_run: RunMonty, test_dir: Path):
+    with MountDir(host_path=str(test_dir), virtual_path='/data', mode='read-only') as md:
+        assert monty_run("from pathlib import Path; Path('/data/hello.txt').read_text()", mount=md) == snapshot(
+            'hello world'
+        )
+    with pytest.raises(ValueError):
+        monty_run("from pathlib import Path; Path('/data/hello.txt').read_text()", mount=md)
+
+
 def test_mount_directory_invalid_mode():
     with pytest.raises(ValueError) as exc_info:
         MountDir(host_path='/tmp', virtual_path='/data', mode='invalid')  # pyright: ignore[reportArgumentType]

--- a/crates/monty/test_cases/mount_fs__errors.py
+++ b/crates/monty/test_cases/mount_fs__errors.py
@@ -351,9 +351,7 @@ try:
     long_component_path.write_text('test')
     assert False, 'expected OSError on long component'
 except OSError as exc:
-    if is_monty:
-        assert str(exc) == "[Errno 36] File name too long: '/mnt/" + long_name + "'", f'unexpected message: {exc}'
-    elif not is_windows:
+    if not is_windows:
         assert str(exc).startswith(("[Errno 36] File name too long: '", "[Errno 63] File name too long: '")), (
             f'exc message: {exc}'
         )
@@ -368,9 +366,7 @@ try:
     Path(long_path_str).write_text('test')
     assert False, 'expected OSError on long total path'
 except OSError as exc:
-    if is_monty:
-        assert str(exc).startswith("[Errno 36] File name too long: '"), f'unexpected message: {exc}'
-    elif not is_windows:
+    if not is_windows:
         assert str(exc).startswith(("[Errno 36] File name too long: '", "[Errno 63] File name too long: '")), (
             f'exc message: {exc}'
         )
@@ -380,9 +376,7 @@ try:
     long_component_path.read_text()
     assert False, 'expected OSError on read_text with long component'
 except OSError as exc:
-    if is_monty:
-        assert str(exc) == "[Errno 36] File name too long: '/mnt/" + long_name + "'", f'unexpected message: {exc}'
-    elif not is_windows:
+    if not is_windows:
         assert str(exc).startswith(("[Errno 36] File name too long: '", "[Errno 63] File name too long: '")), (
             f'exc message: {exc}'
         )
@@ -392,9 +386,7 @@ try:
     long_component_path.stat()
     assert False, 'expected OSError on stat with long component'
 except OSError as exc:
-    if is_monty:
-        assert str(exc) == "[Errno 36] File name too long: '/mnt/" + long_name + "'", f'unexpected message: {exc}'
-    elif not is_windows:
+    if not is_windows:
         assert str(exc).startswith(("[Errno 36] File name too long: '", "[Errno 63] File name too long: '")), (
             f'exc message: {exc}'
         )
@@ -404,9 +396,7 @@ try:
     long_component_path.mkdir()
     assert False, 'expected OSError on mkdir with long component'
 except OSError as exc:
-    if is_monty:
-        assert str(exc) == "[Errno 36] File name too long: '/mnt/" + long_name + "'", f'unexpected message: {exc}'
-    elif not is_windows:
+    if not is_windows:
         assert str(exc).startswith(("[Errno 36] File name too long: '", "[Errno 63] File name too long: '")), (
             f'exc message: {exc}'
         )

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -90,6 +90,11 @@ root.
   the mount's own path raise `PermissionError` in every mode, where CPython on
   an ordinary empty directory would succeed (the root has no name inside the
   mount, so there is nothing to detach it from).
+- A rename is only serviced when source and destination land in the *same*
+  mount. Any other combination — different mounts, or one side under no mount
+  at all — raises `OSError` `[Errno 18] Invalid cross-device link`, including
+  where CPython would report `FileNotFoundError` for a missing destination
+  directory. Neither side moves.
 - Null bytes in any path component are rejected (`ValueError`).
 - Resolved paths returned to the sandbox (e.g. via `Path.resolve()`) are
   virtual paths, never host paths.

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -123,6 +123,22 @@ is refused even though it names `/mnt/f.txt`. CPython hands the uncollapsed
 bytes to the kernel and gets `ENAMETOOLONG` too, so this matches — but Monty
 applies it uniformly rather than deferring to the host filesystem.
 
+The check runs before anything else looks at the path, which has three visible
+consequences:
+
+- `resolve()` and `absolute()` raise, where CPython returns the path — they are
+  the only operations that would otherwise succeed on an over-long path, since
+  they never reach the filesystem. Collapsing a path costs memory proportional
+  to its length, so an unbounded one is refused rather than normalized.
+- The rejection applies even where no mount covers the path, so an over-long
+  path never reaches the `os` callback.
+- `exists()`, `is_file()`, `is_dir()` and `is_symlink()` answer `False`, as
+  CPython's do — `pathlib` swallows `ENAMETOOLONG` in the predicates.
+
+The error quotes the path with its middle elided — the first and last 20
+characters around a `…` — where CPython quotes it whole. An over-long path
+is by definition too big to repeat back.
+
 ### A search-only host directory may not be mountable
 
 Mounting opens a descriptor on the host directory. On macOS and the BSDs that

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -107,6 +107,17 @@ while Monty reads it as `sibling.txt` — each finds a file the other does not.
 The textual rule is what makes `..` unable to escape at all, so it is
 deliberate; only paths mixing `..` with symlinked directories are affected.
 
+### Path length is Linux's, measured before `..` collapses
+
+A path over 4096 bytes, or with a component over 255, raises `OSError`
+`[Errno 36] File name too long`. Both limits are Linux's and apply on every
+host, so a path macOS (`PATH_MAX` 1024) or Windows would reject is accepted,
+and a long one they would accept is not. The length counts the path as sent,
+before `.`/`..` are collapsed: `'/mnt/' + 'a/' * 5000 + '../' * 5000 + 'f.txt'`
+is refused even though it names `/mnt/f.txt`. CPython hands the uncollapsed
+bytes to the kernel and gets `ENAMETOOLONG` too, so this matches — but Monty
+applies it uniformly rather than deferring to the host filesystem.
+
 ### A search-only host directory may not be mountable
 
 Mounting opens a descriptor on the host directory. On macOS and the BSDs that

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -153,7 +153,9 @@ Windows refuses to rename or delete a directory while a handle to it is open,
 so the host cannot move or delete a directory for as long as it is mounted —
 the attempt fails with `ERROR_SHARING_VIOLATION`. Unix is unaffected. The
 window is the mount's lifetime, which for `pydantic_monty` and
-`@pydantic/monty` is the lifetime of the mount object, not one feed (see
+`@pydantic/monty` is the lifetime of the mount object, not one feed — close it
+(`MountDir.close()`, or the `with` / `using` block) to release the directory
+before the host touches it (see
 [pool-architecture.md](pool-architecture.md)).
 
 ### A mount follows its directory, not its path

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -153,8 +153,17 @@ Windows refuses to rename or delete a directory while a handle to it is open,
 so the host cannot move or delete a directory for as long as it is mounted —
 the attempt fails with `ERROR_SHARING_VIOLATION`. Unix is unaffected. The
 window is the mount's lifetime, which for `pydantic_monty` and
-`@pydantic/monty` is one feed (see
+`@pydantic/monty` is the lifetime of the mount object, not one feed (see
 [pool-architecture.md](pool-architecture.md)).
+
+### A mount follows its directory, not its path
+
+The host directory is opened when the mount is created, and everything runs
+against that descriptor. Renaming or replacing the directory afterwards is
+therefore invisible to the mount: it keeps serving the same directory under
+whatever name it now has, and a *new* directory created at the original path
+is not picked up. CPython, resolving each path afresh, would see the
+replacement. Recreate the mount to follow a path.
 
 ### `OverlayMemory` writes refuse symlinks
 

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -227,13 +227,21 @@ properties that real CPython does not provide, per the caveat above.
   `mode='overlay'` writes live in that per-feed table and are discarded when
   the feed ends — the `MountDir` object's overlay state is never updated.
   `read-write` mounts write through to the real host directory as before. An
-  invalid mount (host path missing / not a directory) raises at `feed` time,
-  before the snippet runs, as a session-preserving error.
-- **On Windows a mounted directory is locked for the feed.** The per-feed mount
-  table holds an open descriptor on each host directory, and Windows refuses to
-  rename or delete a directory while a handle to it is open, so the host gets
-  `ERROR_SHARING_VIOLATION` until the feed ends and the table is dropped. Unix
-  is unaffected. Rotate mounted directories between feeds, not during one.
+  invalid mount (host path missing / not a directory) raises when the mount
+  object is *created*, not at `feed` time: constructing it opens the directory.
+- **A mount object is bound to a directory, not to a path.** `MountDir` opens
+  the host directory once and every feed mounts that descriptor, so renaming or
+  replacing the directory afterwards does not change what the mount serves —
+  the mount keeps following the original directory under its new name, and a
+  new directory at the old path is not picked up. Recreate the `MountDir` to
+  follow a path instead. (This is deliberate: the sandbox can rename inside a
+  `read-write` mount, so a path re-resolved each feed is a path the sandbox can
+  redirect.)
+- **On Windows a mounted directory is locked for as long as the mount object
+  lives.** It holds an open descriptor, and Windows refuses to rename or delete
+  a directory while a handle to it is open, so the host gets
+  `ERROR_SHARING_VIOLATION` until the mount object is dropped — not just until
+  the feed ends. Unix is unaffected.
 - **Mounts only answer calls on the automatic path.** Every OS call the sandbox
   makes surfaces as a suspension; the pool consults the mount table only when
   the caller asks it to. `feed_run` (and the JS `feedRun`) asks on every OS

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -240,8 +240,10 @@ properties that real CPython does not provide, per the caveat above.
 - **On Windows a mounted directory is locked for as long as the mount object
   lives.** It holds an open descriptor, and Windows refuses to rename or delete
   a directory while a handle to it is open, so the host gets
-  `ERROR_SHARING_VIOLATION` until the mount object is dropped — not just until
-  the feed ends. Unix is unaffected.
+  `ERROR_SHARING_VIOLATION` until the mount is closed — not just until the feed
+  ends. `MountDir.close()` releases it (also `with` in Python, `using` in
+  JavaScript); a feed already running keeps its own reference, and feeding a
+  closed mount raises. Unix is unaffected, and closing is optional there.
 - **Mounts only answer calls on the automatic path.** Every OS call the sandbox
   makes surfaces as a suspension; the pool consults the mount table only when
   the caller asks it to. `feed_run` (and the JS `feedRun`) asks on every OS


### PR DESCRIPTION
replace #676

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three mount-confinement defects and tightens path-length handling. Mounts are pinned to an opened directory, cross-mount renames are refused, and overlong paths are blocked early with safer errors.

- **Bug Fixes**
  - Mounts now follow an opened `MountRoot` (not a path). Rebuilds reuse the same directory, blocking symlink-redirect escapes between feeds.
  - Renames are only allowed when both paths resolve to the same mount. If only one side is mounted, return `CrossMountRename` (EXDEV) instead of falling back without mode checks.
  - Path length is validated at routing on the original input (before normalization), so oversized requests are rejected early with elided messages; `exists`-style checks return `False`, while `resolve()`/`absolute()` now raise.

- **Migration**
  - JS: `new MountDir({ hostPath, virtualPath, ... })` opens the host directory immediately; invalid paths now throw on construction. Use `mount.close()` or a `using` block to release the directory (required on Windows before renaming/deleting the directory).
  - Python: `MountDir` opens on construction and supports `close()` and `with MountDir(...) as md:`. Feeding a closed mount raises `ValueError`.

<sup>Written for commit a33fb73305eb1d8f6098d02f3bcc7f680b1e9a4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

