### PR TITLE
Close the mount defects the confinement PR deferred

### DIFF
--- a/.agents/skills/review-security/SKILL.md
+++ b/.agents/skills/review-security/SKILL.md
@@ -28,6 +28,14 @@ is in scope even if it isn't in the diff. Ask:
   dumps are trusted by contract — hosts sign and verify them.)
 - **Panics or aborts?** `unwrap`/`expect` reachable from sandboxed input, unbounded
   recursion hitting a stack-overflow abort.
+- **Mount escapes?** Any behaviour that allows sandbox code to escape a filesystem mount
+  and read or alter files outside the mount point. This is particularly severe since
+  mounts are run on the host/client connecting to a sandbox - accessing that environment
+  is a very serious breach of the sandbox and security issue.
+
+You should use a subagent to run `.agents/skills/fix-pr-comments/pr-threads.sh`
+from the `fix-pr-comments` skill to get any PR comments related to security, and make
+sure those points out are correctly addressed.
 
 Weight both classes by where they land. In a pool worker the process dies, the parent
 replaces the child and raises an exception — contained. Nothing else is: in host/parent

--- a/.agents/skills/review-security/SKILL.md
+++ b/.agents/skills/review-security/SKILL.md
@@ -11,6 +11,10 @@ Monty runs untrusted, potentially malicious Python. Review this branch on that b
 git diff origin/main...HEAD
 ```
 
+Use a subagent to run `.agents/skills/fix-pr-comments/pr-threads.sh` (from the
+`fix-pr-comments` skill) for security findings already raised on the PR, and confirm
+each is properly addressed.
+
 Cover the changes **and any code they touch** — a caller made unsafe by a changed callee
 is in scope even if it isn't in the diff. Ask:
 
@@ -32,10 +36,6 @@ is in scope even if it isn't in the diff. Ask:
   and read or alter files outside the mount point. This is particularly severe since
   mounts are run on the host/client connecting to a sandbox - accessing that environment
   is a very serious breach of the sandbox and security issue.
-
-You should use a subagent to run `.agents/skills/fix-pr-comments/pr-threads.sh`
-from the `fix-pr-comments` skill to get any PR comments related to security, and make
-sure those points out are correctly addressed.
 
 Weight both classes by where they land. In a pool worker the process dies, the parent
 replaces the child and raises an exception — contained. Nothing else is: in host/parent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,11 @@ jobs:
       - run: cargo llvm-cov clean --workspace
 
       # coverage for `make test-no-features`
+      # `test-rust-os` has no Linux entry, so this is the only Linux run of
+      # monty-fs: its race soaks are enabled here or they never run on Linux.
       - run: cargo llvm-cov --no-report -p monty -p monty-fs
+        env:
+          MONTY_FS_SOAK: '1'
       - run: cargo llvm-cov run --no-report -p monty-datatest
       # coverage for `make test-memory-model-checks`
       - run: cargo llvm-cov --no-report -p monty --features memory-model-checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -336,6 +336,13 @@ jobs:
       # pass on all three OSes (it has no memory-model-checks feature — the
       # mount table never touches the interpreter heap).
       - run: cargo test -p monty-fs
+      # The two race soaks are opt-in so a local `cargo test -p monty-fs` does
+      # not pay ~5s for them, but they are regression guards on the
+      # descriptor-relative open and the FIFO re-check, so CI must run them.
+      - name: Test monty-fs race soaks
+        run: cargo test -p monty-fs --test mount_confinement
+        env:
+          MONTY_FS_SOAK: '1'
       - run: cargo run -p monty-datatest --features memory-model-checks
       - run: cargo build -p monty-runtime
       - name: Test subprocess crates (Unix)

--- a/crates/monty-fs/src/common.rs
+++ b/crates/monty-fs/src/common.rs
@@ -262,8 +262,10 @@ pub(super) fn host_mkdir(
 ) -> Result<MontyObject, MountError> {
     let result = if parents {
         // `create_dir_all` silently returns `Ok(())` when the directory already exists,
-        // so we must check for pre-existing paths ourselves.
-        match dir.symlink_metadata(rel) {
+        // so we must check for pre-existing paths ourselves. The lookup follows,
+        // matching both CPython and the `parents=false` recovery arm below: a
+        // symlink to a directory satisfies `exist_ok` either way.
+        match dir.metadata(rel) {
             Ok(meta) if meta.is_dir() => {
                 return if exist_ok {
                     Ok(MontyObject::None)
@@ -467,6 +469,15 @@ pub(super) fn join_mount_relative(rel: &str, child: &str) -> String {
 /// Whether `rel` resolves to a directory inside the mount.
 pub(super) fn host_is_dir(dir: &Dir, rel: &str) -> bool {
     dir.metadata(rel).is_ok_and(|meta| meta.is_dir())
+}
+
+/// Whether `rel` *is* a directory, without following a final symlink.
+///
+/// The overlay needs this to tell a real directory from a symlink pointing at
+/// one: the two take different rename paths, and [`host_is_dir`] cannot tell
+/// them apart.
+pub(super) fn host_lstat_is_dir(dir: &Dir, rel: &str) -> bool {
+    dir.symlink_metadata(rel).is_ok_and(|meta| meta.is_dir())
 }
 
 /// Whether `rel` resolves to a regular file inside the mount.

--- a/crates/monty-fs/src/common.rs
+++ b/crates/monty-fs/src/common.rs
@@ -471,15 +471,6 @@ pub(super) fn host_is_dir(dir: &Dir, rel: &str) -> bool {
     dir.metadata(rel).is_ok_and(|meta| meta.is_dir())
 }
 
-/// Whether `rel` *is* a directory, without following a final symlink.
-///
-/// The overlay needs this to tell a real directory from a symlink pointing at
-/// one: the two take different rename paths, and [`host_is_dir`] cannot tell
-/// them apart.
-pub(super) fn host_lstat_is_dir(dir: &Dir, rel: &str) -> bool {
-    dir.symlink_metadata(rel).is_ok_and(|meta| meta.is_dir())
-}
-
 /// Whether `rel` resolves to a regular file inside the mount.
 pub(super) fn host_is_file(dir: &Dir, rel: &str) -> bool {
     dir.metadata(rel).is_ok_and(|meta| meta.is_file())

--- a/crates/monty-fs/src/error.rs
+++ b/crates/monty-fs/src/error.rs
@@ -21,6 +21,15 @@ pub enum MountError {
         virtual_path: String,
     },
 
+    /// A path contained an embedded null byte, which no filesystem name may.
+    ///
+    /// Carries CPython's wording for the operation that saw it rather than a
+    /// path: CPython raises this from argument parsing, before the path is
+    /// echoed anywhere. See [`OsFunctionCall::embedded_null_message`].
+    ///
+    /// [`OsFunctionCall::embedded_null_message`]: monty_types::OsFunctionCall::embedded_null_message
+    EmbeddedNullByte(&'static str),
+
     /// A write operation was attempted on a read-only mount.
     ReadOnly(String),
 
@@ -79,6 +88,10 @@ impl MountError {
                 ExcType::PermissionError,
                 Some(format!("[Errno 13] Permission denied: {}", StringRepr(&virtual_path))),
             ),
+            // A `ValueError`, as in CPython: a null byte is a malformed
+            // argument, not a denied path, and answering `PermissionError`
+            // implied the sandbox had refused something it could have allowed.
+            Self::EmbeddedNullByte(message) => MontyException::new(ExcType::ValueError, Some(message.to_owned())),
             Self::ReadOnly(path) => MontyException::new(
                 ExcType::PermissionError,
                 Some(format!("[Errno 30] Read-only file system: {}", StringRepr(&path))),
@@ -168,6 +181,7 @@ impl fmt::Display for MountError {
         match self {
             Self::NoMountPoint(path) => write!(f, "no mount point for path: {path}"),
             Self::PathEscape { virtual_path } => write!(f, "path escape detected: {virtual_path}"),
+            Self::EmbeddedNullByte(message) => write!(f, "{message}"),
             Self::ReadOnly(path) => write!(f, "read-only mount: {path}"),
             Self::CrossMountRename { src, dst } => write!(f, "cross-mount rename: {src} -> {dst}"),
             Self::Io(err, path) => write!(f, "I/O error on {path}: {err}"),

--- a/crates/monty-fs/src/mount_table.rs
+++ b/crates/monty-fs/src/mount_table.rs
@@ -17,7 +17,7 @@ use super::{
     dispatch,
     error::MountError,
     mount_mode::MountMode,
-    path_security::{normalize_virtual_path, reject_overlong_path},
+    path_security::{contains_null_byte, normalize_virtual_path, reject_overlong_path},
 };
 
 /// Default aggregate memory budget for one mount: 100 MB in decimal bytes.
@@ -99,11 +99,21 @@ impl MountTable {
     /// back untouched for the caller's fallback handler (a host callback or
     /// [`OsFunctionCall::on_no_handler`]).
     ///
-    /// Path length is checked before anything else touches the path.
+    /// Path length and null bytes are checked before anything else touches the
+    /// path, so both apply whether or not a mount covers it — as in CPython,
+    /// where neither reaches a syscall.
     pub fn handle_os_call(&mut self, call: OsFunctionCall) -> MountCallOutcome {
         if let Some(primary_path) = call.fs_primary_path() {
-            if let Err(e) = reject_overlong_path(primary_path) {
-                // existence checks return `false` on overlong paths in cpython
+            // Length first: it is the only check that stays O(1) on a hostile
+            // path, so a null scan must not run ahead of it. A path that is
+            // both reports its length, where CPython reports the null byte.
+            let rejection = reject_overlong_path(primary_path).err().or_else(|| {
+                contains_null_byte(primary_path)
+                    .then(|| MountError::EmbeddedNullByte(call.embedded_null_message(false)))
+            });
+            if let Some(e) = rejection {
+                // Both make CPython's predicates answer `False` rather than
+                // raise — `pathlib` swallows `OSError` and `ValueError` alike.
                 MountCallOutcome::Handled(if call.is_existence_check() {
                     Ok(MontyObject::Bool(false))
                 } else {
@@ -145,9 +155,14 @@ impl MountTable {
         let src_mount_index = self.find_mount_index(primary_path);
 
         if let Some(dst_path) = call.rename_destination() {
-            // we check the destination path length before routing, primary_path was checked above
+            // The destination gets the same pre-routing checks the source had
+            // above, so an unusable name is refused even when neither side is
+            // mounted. `in dst` is what tells the two apart to the caller.
             if let Err(e) = reject_overlong_path(dst_path) {
                 return Some(Err(e));
+            }
+            if contains_null_byte(dst_path) {
+                return Some(Err(MountError::EmbeddedNullByte(call.embedded_null_message(true))));
             }
             match (src_mount_index, self.find_mount_index(dst_path)) {
                 // Neither side is ours; the whole call belongs to the fallback.

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -14,15 +14,14 @@ use super::{
     common::{
         LISTING_ENTRY_MEMORY_USAGE, MemoryBudget, MountContext, as_u64, bytes_to_utf8, check_write_limit,
         commit_write_bytes, current_timestamp, format_child_path, host_dir_mtime, host_is_dir, host_is_file,
-        host_list_visible_dir_entry_names, host_lstat_is_dir, host_read_bytes, host_read_text, host_stat,
-        join_mount_relative, map_io,
+        host_list_visible_dir_entry_names, host_read_bytes, host_read_text, host_stat, join_mount_relative, map_io,
     },
     dispatch::{FsRequest, file_handle_result},
     error::MountError,
     overlay_state::{ENTRY_MEMORY_USAGE, OverlayEntry, OverlayFile, OverlayFileRef, OverlayState},
     path_security::{
-        normalize_virtual_path, reject_drive_or_unc_segments, reject_null_bytes, resolve_virtual_path,
-        strip_mount_prefix,
+        MountRelativePath, normalize_virtual_path, reject_drive_or_unc_segments, reject_null_bytes,
+        resolve_virtual_path, strip_mount_prefix,
     },
 };
 
@@ -44,6 +43,55 @@ fn relative_path(path: &str, ctx: &MountContext<'_>) -> Result<String, MountErro
         .ok_or_else(|| MountError::NoMountPoint(path.to_owned()))?;
     reject_drive_or_unc_segments(&relative, &normalized)?;
     Ok(relative)
+}
+
+/// Resolves a virtual path for host fallthrough, refusing symlinked paths.
+///
+/// Every overlay operation that names a host path goes through here, so the
+/// mode's rule — it never follows a symlink — is enforced in one place rather
+/// than re-derived per operation. The `Symlink` arms that remain downstream
+/// are not redundant: this and a later `classify_target` are separate lookups,
+/// so a link swapped in between them must still land somewhere that refuses
+/// it rather than in a `File` arm.
+fn resolve_real(vpath: &str, ctx: &MountContext<'_>) -> Result<MountRelativePath, MountError> {
+    let target = resolve_virtual_path(vpath, ctx.mount_virtual)?;
+    reject_symlink_chain(ctx.mount_dir, target.for_dir_op(), vpath)?;
+    Ok(target)
+}
+
+/// Refuses `rel` if any component of it is a symlink.
+///
+/// Overlay entries are keyed by name, but a symlink resolves on the *host* and
+/// so bypasses every entry keyed under its target's name: a read through one
+/// serves content the overlay has already replaced or deleted. No in-memory
+/// representation fixes that — the link is a second name for a file the
+/// overlay only knows by the first — so the mode refuses symlinks outright.
+///
+/// The whole chain is walked because a single lookup of the final component
+/// resolves *through* intermediate links without ever seeing them.
+fn reject_symlink_chain(dir: &Dir, rel: &str, vpath: &str) -> Result<(), MountError> {
+    if rel.is_empty() || rel == "." {
+        return Ok(());
+    }
+    let mut current = String::new();
+    for component in rel.split('/') {
+        if !current.is_empty() {
+            current.push('/');
+        }
+        current.push_str(component);
+        match classify_target(dir, &current, vpath)? {
+            RealTarget::Symlink => {
+                return Err(MountError::PathEscape {
+                    virtual_path: vpath.to_owned(),
+                });
+            }
+            // Nothing below a missing component can exist, so there is no
+            // further link to find — and absence is not a refusal.
+            RealTarget::Absent => return Ok(()),
+            RealTarget::Dir | RealTarget::File => {}
+        }
+    }
+    Ok(())
 }
 
 /// Returns budget available for a transient result alongside retained state.
@@ -71,7 +119,7 @@ pub(super) fn execute(
         FsRequest::Exists { path } => exists(state, &relative_path(&path, ctx)?, ctx, &path),
         FsRequest::IsFile { path } => is_file(state, &relative_path(&path, ctx)?, ctx, &path),
         FsRequest::IsDir { path } => is_dir(state, &relative_path(&path, ctx)?, ctx, &path),
-        FsRequest::IsSymlink { path } => is_symlink(state, &relative_path(&path, ctx)?, ctx, &path),
+        FsRequest::IsSymlink { path } => Ok(is_symlink(state, &relative_path(&path, ctx)?, ctx, &path)),
         FsRequest::ReadText { path } => read_text(state, &relative_path(&path, ctx)?, ctx, &path),
         FsRequest::ReadBytes { path } => read_bytes(state, &relative_path(&path, ctx)?, ctx, &path),
         FsRequest::WriteText { path, data } => write_text(state, &path, data, ctx),
@@ -116,7 +164,7 @@ fn open(
                     return Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", path));
                 }
                 Some(OverlayEntry::Deleted) => return Err(MountError::not_found(path)),
-                None => match resolve_real_path_state(path, ctx, Follow::Yes, OnLookupFailure::Propagate)? {
+                None => match resolve_real_path_state(path, ctx, OnLookupFailure::Propagate)? {
                     RealPathState::Present(rel) if host_is_dir(ctx.mount_dir, &rel) => {
                         return Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", path));
                     }
@@ -174,15 +222,14 @@ fn ensure_append_target_exists(
             Ok(())
         }
         None => {
-            let target = resolve_virtual_path(vpath, ctx.mount_virtual)?;
-            match classify_write_target(ctx.mount_dir, target.for_dir_op(), vpath)? {
+            // `resolve_real` refuses a symlink anywhere in the path here rather
+            // than at the first append, so `open` fails where the user asked.
+            let target = resolve_real(vpath, ctx)?;
+            match classify_target(ctx.mount_dir, target.for_dir_op(), vpath)? {
                 RealTarget::Dir => Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath)),
                 RealTarget::Symlink => Err(MountError::PathEscape {
                     virtual_path: vpath.to_owned(),
                 }),
-                // The file is already there, but the write policy still refuses
-                // a symlink anywhere in the path; checking it here rather than
-                // at the first append makes `open` fail where the user asked.
                 RealTarget::File => ensure_parent_exists(state, &relative, ctx, vpath),
                 RealTarget::Absent => {
                     ensure_parent_exists(state, &relative, ctx, vpath)?;
@@ -211,7 +258,7 @@ fn exists(
     let exists = match state.get(relative) {
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_) | OverlayEntry::Directory { .. }) => true,
         Some(OverlayEntry::Deleted) => false,
-        None => match resolve_real_path_state(vpath, ctx, Follow::Yes, OnLookupFailure::Missing)? {
+        None => match resolve_real_path_state(vpath, ctx, OnLookupFailure::Missing)? {
             RealPathState::Present(_) => true,
             RealPathState::Missing => false,
         },
@@ -229,7 +276,7 @@ fn is_file(
     let is_file = match state.get(relative) {
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_)) => true,
         Some(OverlayEntry::Directory { .. } | OverlayEntry::Deleted) => false,
-        None => match resolve_real_path_state(vpath, ctx, Follow::Yes, OnLookupFailure::Missing)? {
+        None => match resolve_real_path_state(vpath, ctx, OnLookupFailure::Missing)? {
             RealPathState::Present(rel) => host_is_file(ctx.mount_dir, &rel),
             RealPathState::Missing => false,
         },
@@ -247,7 +294,7 @@ fn is_dir(
     let is_dir = match state.get(relative) {
         Some(OverlayEntry::Directory { .. }) => true,
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_) | OverlayEntry::Deleted) => false,
-        None => match resolve_real_path_state(vpath, ctx, Follow::Yes, OnLookupFailure::Missing)? {
+        None => match resolve_real_path_state(vpath, ctx, OnLookupFailure::Missing)? {
             RealPathState::Present(rel) => host_is_dir(ctx.mount_dir, &rel),
             RealPathState::Missing => false,
         },
@@ -256,20 +303,24 @@ fn is_dir(
 }
 
 /// Implements `Path.is_symlink()`. Overlay entries are never symlinks.
-fn is_symlink(
-    state: &OverlayState,
-    relative: &str,
-    ctx: &MountContext<'_>,
-    vpath: &str,
-) -> Result<MontyObject, MountError> {
+///
+/// Infallible: a refused or unreadable path is simply not a symlink, since a
+/// predicate must not raise.
+fn is_symlink(state: &OverlayState, relative: &str, ctx: &MountContext<'_>, vpath: &str) -> MontyObject {
     let is_symlink = match state.get(relative) {
         Some(_) => false,
-        None => match resolve_real_path_state(vpath, ctx, Follow::No, OnLookupFailure::Missing)? {
-            RealPathState::Present(rel) => ctx.mount_dir.symlink_metadata(&rel).is_ok_and(|m| m.is_symlink()),
-            RealPathState::Missing => false,
-        },
+        // The one question a symlink may answer, since it reports only that
+        // the name is a link and nothing about the target — CPython answers
+        // the same. The parent chain must still be link-free, or the name is
+        // not the one the sandbox thinks it is.
+        None => resolve_virtual_path(vpath, ctx.mount_virtual).is_ok_and(|target| {
+            let rel = target.for_dir_op();
+            let parent = rel.rsplit_once('/').map_or("", |(parent, _)| parent);
+            reject_symlink_chain(ctx.mount_dir, parent, vpath).is_ok()
+                && ctx.mount_dir.symlink_metadata(rel).is_ok_and(|meta| meta.is_symlink())
+        }),
     };
-    Ok(MontyObject::Bool(is_symlink))
+    MontyObject::Bool(is_symlink)
 }
 
 /// Reads text from the overlay or from the real filesystem on fallback.
@@ -292,7 +343,7 @@ fn read_text(
         }
         Some(OverlayEntry::Deleted) => Err(MountError::not_found(vpath)),
         None => {
-            let target = resolve_virtual_path(vpath, ctx.mount_virtual)?;
+            let target = resolve_real(vpath, ctx)?;
             host_read_text(ctx.mount_dir, target.for_dir_op(), vpath, available_memory(state, ctx)?)
         }
     }
@@ -318,7 +369,7 @@ fn read_bytes(
         }
         Some(OverlayEntry::Deleted) => Err(MountError::not_found(vpath)),
         None => {
-            let target = resolve_virtual_path(vpath, ctx.mount_virtual)?;
+            let target = resolve_real(vpath, ctx)?;
             host_read_bytes(ctx.mount_dir, target.for_dir_op(), vpath, available_memory(state, ctx)?)
         }
     }
@@ -460,7 +511,7 @@ fn existing_file_len(
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
         }
-        None => match resolve_real_path_state(vpath, ctx, Follow::Yes, OnLookupFailure::Propagate)? {
+        None => match resolve_real_path_state(vpath, ctx, OnLookupFailure::Propagate)? {
             RealPathState::Present(rel) => file_len(ctx.mount_dir, &rel, vpath),
             RealPathState::Missing => Ok(0),
         },
@@ -499,7 +550,7 @@ fn existing_file_bytes(
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
         }
-        None => match resolve_real_path_state(vpath, ctx, Follow::Yes, OnLookupFailure::Propagate)? {
+        None => match resolve_real_path_state(vpath, ctx, OnLookupFailure::Propagate)? {
             RealPathState::Present(rel) => match host_read_bytes(ctx.mount_dir, &rel, vpath, budget)? {
                 MontyObject::Bytes(bytes) => Ok(bytes),
                 _ => unreachable!("host_read_bytes should return bytes"),
@@ -531,8 +582,8 @@ fn reject_directory_target(
             // Propagated, not swallowed: a path policy rejection here is the
             // same refusal a direct mount raises, and discarding it let names
             // only this mode accepts (embedded nulls) through to a write.
-            let target = resolve_virtual_path(vpath, ctx.mount_virtual)?;
-            match classify_write_target(ctx.mount_dir, target.for_dir_op(), vpath)? {
+            let target = resolve_real(vpath, ctx)?;
+            match classify_target(ctx.mount_dir, target.for_dir_op(), vpath)? {
                 RealTarget::Dir => Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath)),
                 RealTarget::Symlink => Err(MountError::PathEscape {
                     virtual_path: vpath.to_owned(),
@@ -574,7 +625,7 @@ fn ensure_parent_exists(
                 let Ok(target) = resolve_virtual_path(&dir_vpath, ctx.mount_virtual) else {
                     return Err(MountError::not_found(vpath));
                 };
-                match classify_write_target(ctx.mount_dir, target.for_dir_op(), vpath)? {
+                match classify_target(ctx.mount_dir, target.for_dir_op(), vpath)? {
                     RealTarget::Dir => {}
                     RealTarget::Symlink => {
                         return Err(MountError::PathEscape {
@@ -611,15 +662,17 @@ fn mkdir(
         }
         Some(OverlayEntry::Deleted) => {}
         None => {
-            if let Ok(target) = resolve_virtual_path(vpath, ctx.mount_virtual)
-                && let Ok(meta) = ctx.mount_dir.symlink_metadata(target.for_dir_op())
-            {
-                return if meta.is_dir() && exist_ok {
-                    Ok(MontyObject::None)
-                } else {
-                    // Either it's a file (always an error) or a dir with exist_ok=false.
-                    Err(MountError::io_err(ErrorKind::AlreadyExists, "File exists", vpath))
-                };
+            // Propagated, not swallowed: discarding this refusal created an
+            // overlay directory shadowing the symlink it had just refused.
+            let target = resolve_real(vpath, ctx)?;
+            match classify_target(ctx.mount_dir, target.for_dir_op(), vpath)? {
+                RealTarget::Dir if exist_ok => return Ok(MontyObject::None),
+                // Either a file (always an error) or a dir with exist_ok=false.
+                RealTarget::Dir | RealTarget::File => {
+                    return Err(MountError::io_err(ErrorKind::AlreadyExists, "File exists", vpath));
+                }
+                // `resolve_real` already refused any symlink in the path.
+                RealTarget::Symlink | RealTarget::Absent => {}
             }
         }
     }
@@ -676,7 +729,7 @@ fn create_overlay_parents(state: &mut OverlayState, relative: &str, ctx: &MountC
             None => {
                 let current_vpath = format!("{}/{current}", ctx.mount_virtual);
                 if let Ok(resolved) = resolve_virtual_path(&current_vpath, ctx.mount_virtual) {
-                    match classify_write_target(ctx.mount_dir, resolved.for_dir_op(), &current_vpath)? {
+                    match classify_target(ctx.mount_dir, resolved.for_dir_op(), &current_vpath)? {
                         RealTarget::Dir => continue,
                         RealTarget::Symlink => {
                             return Err(MountError::PathEscape {
@@ -729,8 +782,8 @@ fn unlink(
             // a link's spelling would leave its target readable under the real
             // name — the aliasing the write policy exists to prevent.
             ensure_parent_exists(state, relative, ctx, vpath)?;
-            let resolved = resolve_virtual_path(vpath, ctx.mount_virtual)?;
-            match classify_write_target(ctx.mount_dir, resolved.for_dir_op(), vpath)? {
+            let resolved = resolve_real(vpath, ctx)?;
+            match classify_target(ctx.mount_dir, resolved.for_dir_op(), vpath)? {
                 RealTarget::File => {
                     state.insert(relative.to_owned(), OverlayEntry::Deleted, ctx.memory_usage_limit)?;
                     Ok(MontyObject::None)
@@ -774,19 +827,12 @@ fn rmdir(
         Some(OverlayEntry::Deleted) => Err(MountError::not_found(vpath)),
         None => {
             ensure_parent_exists(state, relative, ctx, vpath)?;
-            let resolved = resolve_virtual_path(vpath, ctx.mount_virtual)?;
+            let resolved = resolve_real(vpath, ctx)?;
             let rel = resolved.for_dir_op();
-            // A symlink is not a directory to remove — POSIX answers ENOTDIR —
-            // and tombstoning its name would alias it against its target.
-            if matches!(classify_write_target(ctx.mount_dir, rel, vpath)?, RealTarget::Symlink) {
-                return Err(MountError::PathEscape {
-                    virtual_path: vpath.to_owned(),
-                });
-            }
             if !host_is_dir(ctx.mount_dir, rel) {
-                // `resolve_virtual_path` never touches the filesystem, so a
-                // missing path arrives as `Ok` and must be told apart from one
-                // that exists but is not a directory.
+                // Resolution only rules out symlinks, so a missing path still
+                // arrives as `Ok` and must be told apart from one that exists
+                // but is not a directory.
                 return Err(if ctx.mount_dir.exists(rel) {
                     MountError::io_err(ErrorKind::NotADirectory, "Not a directory", vpath)
                 } else {
@@ -862,7 +908,7 @@ fn stat(state: &OverlayState, relative: &str, ctx: &MountContext<'_>, vpath: &st
         Some(OverlayEntry::Directory { mtime }) => Ok(dir_stat(0o755, *mtime)),
         Some(OverlayEntry::Deleted) => Err(MountError::not_found(vpath)),
         None => {
-            let target = resolve_virtual_path(vpath, ctx.mount_virtual)?;
+            let target = resolve_real(vpath, ctx)?;
             host_stat(ctx.mount_dir, target.for_dir_op(), vpath)
         }
     }
@@ -881,7 +927,7 @@ fn iterdir(
             return Err(MountError::io_err(ErrorKind::NotADirectory, "Not a directory", vpath));
         }
         Some(OverlayEntry::Deleted) => return Err(MountError::not_found(vpath)),
-        None => match resolve_virtual_path(vpath, ctx.mount_virtual) {
+        None => match resolve_real(vpath, ctx) {
             Ok(target) if host_is_dir(ctx.mount_dir, target.for_dir_op()) => Some(target.for_dir_op().to_owned()),
             // `resolve_virtual_path` never touches the filesystem, so a missing
             // path arrives as `Ok` and must be told apart from a non-directory.
@@ -973,19 +1019,10 @@ fn rename(
 
     ensure_parent_exists(state, &dst_rel, ctx, dst_vpath)?;
 
-    // The destination's own name must not be a symlink either. An overlay entry
-    // under it would shadow the link and alias it against its target — exactly
-    // what `write_text` on the same path refuses.
-    if state.get(&dst_rel).is_none()
-        && let Ok(target) = resolve_virtual_path(dst_vpath, ctx.mount_virtual)
-        && matches!(
-            classify_write_target(ctx.mount_dir, target.for_dir_op(), dst_vpath)?,
-            RealTarget::Symlink
-        )
-    {
-        return Err(MountError::PathEscape {
-            virtual_path: dst_vpath.to_owned(),
-        });
+    // The destination's own name must not be a symlink either: an overlay entry
+    // under it would shadow the link and alias it against its target.
+    if state.get(&dst_rel).is_none() {
+        resolve_real(dst_vpath, ctx)?;
     }
 
     // The source is a write path too — it ends up tombstoned — so the same
@@ -1004,11 +1041,9 @@ fn rename(
         Some(OverlayEntry::Directory { .. }) => true,
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_)) => false,
         Some(OverlayEntry::Deleted) => return Err(MountError::not_found(src_vpath)),
-        // `lstat`, not `stat`: a symlink to a directory is recorded as the link
-        // itself below, so it must not take the directory-move path as well —
-        // that would walk the target's children into a "file" entry.
-        None => resolve_virtual_path(src_vpath, ctx.mount_virtual)
-            .is_ok_and(|target| host_lstat_is_dir(ctx.mount_dir, target.for_dir_op())),
+        // `resolve_real` refuses a symlinked source here, so every check below
+        // sees a path where `stat` and `lstat` agree.
+        None => host_is_dir(ctx.mount_dir, resolve_real(src_vpath, ctx)?.for_dir_op()),
     };
 
     reject_rename_type_mismatch(state, &dst_rel, src_is_dir, ctx, dst_vpath)?;
@@ -1036,22 +1071,9 @@ fn rename(
     let real_source_entry = if source_is_overlay {
         None
     } else {
-        let target = resolve_virtual_path(src_vpath, ctx.mount_virtual)?;
+        let target = resolve_real(src_vpath, ctx)?;
         let rel = target.for_dir_op();
-        let is_symlink = ctx.mount_dir.symlink_metadata(rel).is_ok_and(|meta| meta.is_symlink());
-        let entry = if is_symlink {
-            // A stored reference could not escape anyway, but failing here puts
-            // the error where the user caused it rather than on a later read.
-            // Route through `map_io` so only a confinement failure reads as
-            // `PathEscape` — a denied in-mount target is a permission error.
-            if let Err(err) = ctx.mount_dir.metadata(rel) {
-                return Err(map_io(err, src_vpath));
-            }
-            // Preserve the symlink entry itself rather than its target.
-            OverlayFileRef::from_lstat(ctx.mount_dir, rel)
-                .map(OverlayEntry::RealFileRef)
-                .ok_or_else(|| MountError::not_found(src_vpath))?
-        } else if host_is_file(ctx.mount_dir, rel) {
+        let entry = if host_is_file(ctx.mount_dir, rel) {
             OverlayFileRef::from_relative(ctx.mount_dir, rel)
                 .map(OverlayEntry::RealFileRef)
                 .ok_or_else(|| MountError::not_found(src_vpath))?
@@ -1093,10 +1115,8 @@ fn rename(
             overlay_moves.push((key, new_key));
         }
 
-        // Same `lstat` as `src_is_dir`: only a real directory has children to
-        // capture, and following a link here would walk the target's.
-        if let Ok(target) = resolve_virtual_path(src_vpath, ctx.mount_virtual)
-            && host_lstat_is_dir(ctx.mount_dir, target.for_dir_op())
+        if let Ok(target) = resolve_real(src_vpath, ctx)
+            && host_is_dir(ctx.mount_dir, target.for_dir_op())
         {
             let real_children = match collect_real_descendants(
                 ctx.mount_dir,
@@ -1348,26 +1368,28 @@ fn collect_real_descendants(
 
 /// Resolves a real host path for an overlay fallthrough lookup.
 ///
-/// Path *policy* rejections (null bytes, drive segments) always raise, as they
-/// do in direct mode and CPython. A failed host *lookup* is governed by
-/// `on_failure`: only a genuinely absent path is `Missing` for everyone.
+/// Path *policy* rejections (null bytes, drive segments, symlinks) always
+/// raise, as they do in direct mode and CPython. A failed host *lookup* is
+/// governed by `on_failure`: only a genuinely absent path is `Missing`.
 fn resolve_real_path_state(
     vpath: &str,
     ctx: &MountContext<'_>,
-    follow: Follow,
     on_failure: OnLookupFailure,
 ) -> Result<RealPathState, MountError> {
-    let target = match resolve_virtual_path(vpath, ctx.mount_virtual) {
+    let target = match resolve_real(vpath, ctx) {
         Ok(target) => target,
-        Err(MountError::Io(_, _)) => return Ok(RealPathState::Missing),
+        // To a predicate an unusable path is indistinguishable from a missing
+        // one, which is the point: raising would confirm there is something
+        // there to refuse. `Propagate` callers must still see the real error —
+        // resolution now touches the filesystem, so a denied directory reaches
+        // here, and reporting it as absent is what this once got wrong.
+        Err(_) if matches!(on_failure, OnLookupFailure::Missing) => return Ok(RealPathState::Missing),
         Err(err) => return Err(err),
     };
     let rel = target.for_dir_op();
-    let metadata = match follow {
-        Follow::Yes => ctx.mount_dir.metadata(rel),
-        Follow::No => ctx.mount_dir.symlink_metadata(rel),
-    };
-    match metadata {
+    // `resolve_real` refused every symlink in the path, so following costs
+    // nothing: there is none left to follow.
+    match ctx.mount_dir.metadata(rel) {
         Ok(_) => Ok(RealPathState::Present(rel.to_owned())),
         Err(err) if err.kind() == ErrorKind::NotFound => Ok(RealPathState::Missing),
         Err(_) if matches!(on_failure, OnLookupFailure::Missing) => Ok(RealPathState::Missing),
@@ -1386,15 +1408,6 @@ enum OnLookupFailure {
     /// `FileNotFoundError` for a denied file, and let `append` create an
     /// overlay entry shadowing a real file it could not see.
     Propagate,
-}
-
-/// Whether a lookup follows a final symlink, replacing the old resolve modes.
-#[derive(Clone, Copy)]
-enum Follow {
-    /// Resolve the target, as `stat` does.
-    Yes,
-    /// Report the entry itself, as `lstat` does.
-    No,
 }
 
 /// Result of resolving a real fallthrough path for overlay queries.
@@ -1418,14 +1431,12 @@ enum RealTarget {
     Absent,
 }
 
-/// Classifies what sits at `rel` for overlay write paths.
+/// Classifies what sits at `rel`, without ever resolving a symlink.
 ///
-/// Overlay writes never touch symlinks: a direct mount writes *through* a link
-/// to its target, which the overlay cannot replicate without silently aliasing
-/// the two names, so callers refuse `Symlink` with `PermissionError` wherever
-/// it appears in a write path. The single `lstat` never resolves the target,
-/// so the refusal reveals nothing about where the link points.
-fn classify_write_target(dir: &Dir, rel: &str, vpath: &str) -> Result<RealTarget, MountError> {
+/// The overlay refuses symlinks outright (see [`reject_symlink_chain`]), so
+/// every caller treats `Symlink` as `PermissionError`. The single `lstat`
+/// never resolves the target, so the refusal reveals nothing about it.
+fn classify_target(dir: &Dir, rel: &str, vpath: &str) -> Result<RealTarget, MountError> {
     match dir.symlink_metadata(rel) {
         Ok(meta) if meta.is_symlink() => Ok(RealTarget::Symlink),
         Ok(meta) if meta.is_dir() => Ok(RealTarget::Dir),

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -703,8 +703,14 @@ fn mkdir(
                 RealTarget::Dir | RealTarget::File => {
                     return Err(MountError::io_err(ErrorKind::AlreadyExists, "File exists", vpath));
                 }
-                // `resolve_real` already refused any symlink in the path.
-                RealTarget::Symlink | RealTarget::Absent => {}
+                // Re-classification closes the final-component window after
+                // `resolve_real`: a link swapped in there is still refused.
+                RealTarget::Symlink => {
+                    return Err(MountError::PathEscape {
+                        virtual_path: vpath.to_owned(),
+                    });
+                }
+                RealTarget::Absent => {}
             }
         }
     }
@@ -936,7 +942,10 @@ fn stat(state: &OverlayState, relative: &str, ctx: &MountContext<'_>, vpath: &st
             let size = i64::try_from(file.content.len()).unwrap_or(i64::MAX);
             Ok(file_stat(0o644, size, file.mtime))
         }
-        Some(OverlayEntry::RealFileRef(file_ref)) => Ok(file_stat(0o644, file_ref.size, file_ref.mtime)),
+        Some(OverlayEntry::RealFileRef(file_ref)) => {
+            checked_ref_path(file_ref, ctx, vpath)?;
+            Ok(file_stat(0o644, file_ref.size, file_ref.mtime))
+        }
         Some(OverlayEntry::Directory { mtime }) => Ok(dir_stat(0o755, *mtime)),
         Some(OverlayEntry::Deleted) => Err(MountError::not_found(vpath)),
         None => {
@@ -1057,10 +1066,9 @@ fn rename(
         resolve_real(dst_vpath, ctx)?;
     }
 
-    // The source is a write path too — it ends up tombstoned — so the same
-    // "no symlink anywhere in the chain" rule applies to it as to `unlink` on
-    // that path. Only the source's own final component may be a link, and that
-    // one moves intact rather than being followed.
+    // The source is a write path too — it ends up tombstoned — so its parent
+    // chain is checked here and its final component by `resolve_real` below.
+    // A symlink anywhere in either is refused, as it is for `unlink`.
     ensure_parent_exists(state, &src_rel, ctx, src_vpath)?;
 
     if matches!(state.get(&src_rel), Some(OverlayEntry::Deleted)) {
@@ -1105,16 +1113,23 @@ fn rename(
     } else {
         let target = resolve_real(src_vpath, ctx)?;
         let rel = target.for_dir_op();
-        let entry = if host_is_file(ctx.mount_dir, rel) {
-            OverlayFileRef::from_relative(ctx.mount_dir, rel)
+        let entry = match classify_target(ctx.mount_dir, rel, src_vpath)? {
+            // `None` here means it stopped being a plain file between the two
+            // lookups — a special file, or gone.
+            RealTarget::File => OverlayFileRef::from_relative(ctx.mount_dir, rel)
                 .map(OverlayEntry::RealFileRef)
-                .ok_or_else(|| MountError::not_found(src_vpath))?
-        } else if host_is_dir(ctx.mount_dir, rel) {
-            OverlayEntry::Directory {
+                .ok_or_else(|| MountError::not_found(src_vpath))?,
+            RealTarget::Dir => OverlayEntry::Directory {
                 mtime: host_dir_mtime(ctx.mount_dir, rel),
+            },
+            // A link raced in behind `resolve_real` gets the refusal it would
+            // have got there, not the `FileNotFoundError` of a missing path.
+            RealTarget::Symlink => {
+                return Err(MountError::PathEscape {
+                    virtual_path: src_vpath.to_owned(),
+                });
             }
-        } else {
-            return Err(MountError::not_found(src_vpath));
+            RealTarget::Absent => return Err(MountError::not_found(src_vpath)),
         };
         Some(entry)
     };
@@ -1356,11 +1371,9 @@ fn collect_real_descendants(
             let file_type = entry
                 .file_type()
                 .map_err(|error| MountError::Io(error, vpath.to_owned()))?;
-            // A symlink can move neither way: capturing it as a file ref would
-            // resolve the target the overlay refuses to write through, and
-            // skipping it strands the link — unreachable at the new name, yet
-            // still live at the old one inside a directory the overlay now
-            // reports as deleted. Refuse the move, as for a non-UTF-8 name.
+            // The mode refuses symlinks, so one here can be neither captured
+            // (that resolves the target) nor moved as itself. Refusing the
+            // whole rename is the coherent answer, as for a non-UTF-8 name.
             if file_type.is_symlink() {
                 return Err(MountError::PathEscape {
                     virtual_path: vpath.to_owned(),
@@ -1368,6 +1381,9 @@ fn collect_real_descendants(
             }
             let child_rel = join_mount_relative(&current_rel, name);
             if file_type.is_file() {
+                // `None` means it stopped being a plain file since the entry
+                // was read. Skipping is safe even if it became a link: reads
+                // through one are refused, so it is reachable by neither name.
                 if let Some(file_ref) = OverlayFileRef::from_relative(dir, &child_rel) {
                     memory_usage = memory_usage
                         .saturating_add(as_u64(rel_key.len()))

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -49,10 +49,21 @@ fn relative_path(path: &str, ctx: &MountContext<'_>) -> Result<String, MountErro
 ///
 /// Every overlay operation that names a host path goes through here, so the
 /// mode's rule — it never follows a symlink — is enforced in one place rather
-/// than re-derived per operation. The `Symlink` arms that remain downstream
-/// are not redundant: this and a later `classify_target` are separate lookups,
-/// so a link swapped in between them must still land somewhere that refuses
-/// it rather than in a `File` arm.
+/// than re-derived per operation.
+///
+/// **This is a coherence policy, not the sandbox boundary, and it is not
+/// atomic with the operation that follows.** A host actor can swap a symlink
+/// into the path after the walk and before the read; the read then follows it.
+/// What bounds that is the descriptor: `Mount::dir` cannot resolve past the
+/// mount root and refuses an absolute target, so the worst case is in-mount
+/// content served under an aliased name — the same window the host already has
+/// by replacing a file outright (see `limitations/filesystem.md`). Closing it
+/// would need a per-component `openat` walk holding descriptors; `O_NOFOLLOW`
+/// would not, since it binds only the final component.
+///
+/// The `Symlink` arms downstream are therefore not redundant: where a caller
+/// does re-classify, a link swapped in mid-operation lands on a refusal rather
+/// than in a `File` arm.
 fn resolve_real(vpath: &str, ctx: &MountContext<'_>) -> Result<MountRelativePath, MountError> {
     let target = resolve_virtual_path(vpath, ctx.mount_virtual)?;
     reject_symlink_chain(ctx.mount_dir, target.for_dir_op(), vpath)?;
@@ -92,6 +103,22 @@ fn reject_symlink_chain(dir: &Dir, rel: &str, vpath: &str) -> Result<(), MountEr
         }
     }
     Ok(())
+}
+
+/// Re-checks a stored ref's path before dereferencing it.
+///
+/// The path was link-free when it was captured, but a lazy ref is precisely a
+/// path held across time, and the host can replace any component of it in the
+/// meantime. The descriptor still confines the read, so this is not what stops
+/// an escape — it is what keeps the mode's "never follow a symlink" rule true
+/// for refs, which would otherwise serve a different file under the old name.
+fn checked_ref_path<'r>(
+    file_ref: &'r OverlayFileRef,
+    ctx: &MountContext<'_>,
+    vpath: &str,
+) -> Result<&'r str, MountError> {
+    reject_symlink_chain(ctx.mount_dir, &file_ref.relative, vpath)?;
+    Ok(&file_ref.relative)
 }
 
 /// Returns budget available for a transient result alongside retained state.
@@ -336,7 +363,8 @@ fn read_text(
             Ok(MontyObject::String(bytes_to_utf8(file.content.clone())?))
         }
         Some(OverlayEntry::RealFileRef(file_ref)) => {
-            host_read_text(ctx.mount_dir, &file_ref.relative, vpath, available_memory(state, ctx)?)
+            let rel = checked_ref_path(file_ref, ctx, vpath)?;
+            host_read_text(ctx.mount_dir, rel, vpath, available_memory(state, ctx)?)
         }
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
@@ -362,7 +390,8 @@ fn read_bytes(
             Ok(MontyObject::Bytes(file.content.clone()))
         }
         Some(OverlayEntry::RealFileRef(file_ref)) => {
-            host_read_bytes(ctx.mount_dir, &file_ref.relative, vpath, available_memory(state, ctx)?)
+            let rel = checked_ref_path(file_ref, ctx, vpath)?;
+            host_read_bytes(ctx.mount_dir, rel, vpath, available_memory(state, ctx)?)
         }
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
@@ -507,7 +536,9 @@ fn existing_file_len(
     match state.get(relative) {
         Some(OverlayEntry::File(file)) => Ok(file.content.len()),
         Some(OverlayEntry::Deleted) => Ok(0),
-        Some(OverlayEntry::RealFileRef(file_ref)) => file_len(ctx.mount_dir, &file_ref.relative, vpath),
+        Some(OverlayEntry::RealFileRef(file_ref)) => {
+            file_len(ctx.mount_dir, checked_ref_path(file_ref, ctx, vpath)?, vpath)
+        }
         Some(OverlayEntry::Directory { .. }) => {
             Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath))
         }
@@ -542,7 +573,8 @@ fn existing_file_bytes(
         }
         Some(OverlayEntry::Deleted) => Ok(Vec::new()),
         Some(OverlayEntry::RealFileRef(file_ref)) => {
-            match host_read_bytes(ctx.mount_dir, &file_ref.relative, vpath, budget)? {
+            let rel = checked_ref_path(file_ref, ctx, vpath)?;
+            match host_read_bytes(ctx.mount_dir, rel, vpath, budget)? {
                 MontyObject::Bytes(bytes) => Ok(bytes),
                 _ => unreachable!("host_read_bytes should return bytes"),
             }

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -14,12 +14,16 @@ use super::{
     common::{
         LISTING_ENTRY_MEMORY_USAGE, MemoryBudget, MountContext, as_u64, bytes_to_utf8, check_write_limit,
         commit_write_bytes, current_timestamp, format_child_path, host_dir_mtime, host_is_dir, host_is_file,
-        host_list_visible_dir_entry_names, host_read_bytes, host_read_text, host_stat, join_mount_relative, map_io,
+        host_list_visible_dir_entry_names, host_lstat_is_dir, host_read_bytes, host_read_text, host_stat,
+        join_mount_relative, map_io,
     },
     dispatch::{FsRequest, file_handle_result},
     error::MountError,
     overlay_state::{ENTRY_MEMORY_USAGE, OverlayEntry, OverlayFile, OverlayFileRef, OverlayState},
-    path_security::{normalize_virtual_path, reject_drive_or_unc_segments, resolve_virtual_path, strip_mount_prefix},
+    path_security::{
+        normalize_virtual_path, reject_drive_or_unc_segments, reject_null_bytes, resolve_virtual_path,
+        strip_mount_prefix,
+    },
 };
 
 /// Conservative per-entry charge while capturing a real directory tree for a
@@ -30,8 +34,10 @@ const REAL_DESCENDANT_MEMORY_USAGE: u64 = 512;
 /// Resolves a virtual path to the mount-relative overlay key.
 ///
 /// Keys never reach a host path, but are rejected on the same grounds one
-/// would be — a name only this mode accepts is a divergence in itself.
+/// would be — a name only this mode accepts is a divergence in itself. That
+/// includes null bytes, which no syscall is ever reached to refuse here.
 fn relative_path(path: &str, ctx: &MountContext<'_>) -> Result<String, MountError> {
+    reject_null_bytes(path)?;
     let normalized = normalize_virtual_path(path);
     let relative = strip_mount_prefix(&normalized, ctx.mount_virtual)
         .map(str::to_owned)
@@ -521,16 +527,19 @@ fn reject_directory_target(
         }
         // An overlay file, ref, or tombstone already shadows whatever is real.
         Some(_) => Ok(()),
-        None => match resolve_virtual_path(vpath, ctx.mount_virtual) {
-            Ok(target) => match classify_write_target(ctx.mount_dir, target.for_dir_op(), vpath)? {
+        None => {
+            // Propagated, not swallowed: a path policy rejection here is the
+            // same refusal a direct mount raises, and discarding it let names
+            // only this mode accepts (embedded nulls) through to a write.
+            let target = resolve_virtual_path(vpath, ctx.mount_virtual)?;
+            match classify_write_target(ctx.mount_dir, target.for_dir_op(), vpath)? {
                 RealTarget::Dir => Err(MountError::io_err(ErrorKind::IsADirectory, "Is a directory", vpath)),
                 RealTarget::Symlink => Err(MountError::PathEscape {
                     virtual_path: vpath.to_owned(),
                 }),
                 RealTarget::File | RealTarget::Absent => Ok(()),
-            },
-            Err(_) => Ok(()),
-        },
+            }
+        }
     }
 }
 
@@ -979,6 +988,12 @@ fn rename(
         });
     }
 
+    // The source is a write path too — it ends up tombstoned — so the same
+    // "no symlink anywhere in the chain" rule applies to it as to `unlink` on
+    // that path. Only the source's own final component may be a link, and that
+    // one moves intact rather than being followed.
+    ensure_parent_exists(state, &src_rel, ctx, src_vpath)?;
+
     if matches!(state.get(&src_rel), Some(OverlayEntry::Deleted)) {
         return Err(MountError::not_found(src_vpath));
     }
@@ -989,8 +1004,11 @@ fn rename(
         Some(OverlayEntry::Directory { .. }) => true,
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_)) => false,
         Some(OverlayEntry::Deleted) => return Err(MountError::not_found(src_vpath)),
+        // `lstat`, not `stat`: a symlink to a directory is recorded as the link
+        // itself below, so it must not take the directory-move path as well —
+        // that would walk the target's children into a "file" entry.
         None => resolve_virtual_path(src_vpath, ctx.mount_virtual)
-            .is_ok_and(|target| host_is_dir(ctx.mount_dir, target.for_dir_op())),
+            .is_ok_and(|target| host_lstat_is_dir(ctx.mount_dir, target.for_dir_op())),
     };
 
     reject_rename_type_mismatch(state, &dst_rel, src_is_dir, ctx, dst_vpath)?;
@@ -1075,8 +1093,10 @@ fn rename(
             overlay_moves.push((key, new_key));
         }
 
+        // Same `lstat` as `src_is_dir`: only a real directory has children to
+        // capture, and following a link here would walk the target's.
         if let Ok(target) = resolve_virtual_path(src_vpath, ctx.mount_virtual)
-            && host_is_dir(ctx.mount_dir, target.for_dir_op())
+            && host_lstat_is_dir(ctx.mount_dir, target.for_dir_op())
         {
             let real_children = match collect_real_descendants(
                 ctx.mount_dir,
@@ -1172,7 +1192,11 @@ fn reject_rename_type_mismatch(
     let dst_is_dir = match state.get(dst_rel) {
         Some(OverlayEntry::Directory { .. }) => Some(true),
         Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_)) => Some(false),
-        Some(OverlayEntry::Deleted) | None => match resolve_virtual_path(dst_vpath, ctx.mount_virtual) {
+        // A tombstone means the destination is gone, whatever the host still
+        // has beneath it — reading through it would refuse a rename onto a
+        // path `exists()` already reports as `False`.
+        Some(OverlayEntry::Deleted) => None,
+        None => match resolve_virtual_path(dst_vpath, ctx.mount_virtual) {
             Ok(target) if host_is_dir(ctx.mount_dir, target.for_dir_op()) => Some(true),
             Ok(target) if ctx.mount_dir.exists(target.for_dir_op()) => Some(false),
             _ => None,

--- a/crates/monty-fs/src/overlay_state.rs
+++ b/crates/monty-fs/src/overlay_state.rs
@@ -6,7 +6,7 @@
 
 use std::{collections::BTreeMap, mem, ops::Bound};
 
-use cap_std::fs::{Dir, Metadata};
+use cap_std::fs::Dir;
 
 use super::{
     MountError,
@@ -246,26 +246,15 @@ pub(super) struct OverlayFileRef {
 }
 
 impl OverlayFileRef {
-    /// Builds a lazy reference, following symlinks so size and mtime describe
-    /// the target. Use [`from_lstat`](Self::from_lstat) to preserve a symlink.
+    /// Builds a lazy reference to a real file. The overlay refuses symlinks,
+    /// so there is never a link here whose identity could be lost.
     #[must_use]
     pub fn from_relative(dir: &Dir, relative: &str) -> Option<Self> {
-        Some(Self::build(&dir.metadata(relative).ok()?, relative))
-    }
-
-    /// Builds a lazy reference without following the final component, so a
-    /// symlink keeps its own identity across the rename.
-    #[must_use]
-    pub fn from_lstat(dir: &Dir, relative: &str) -> Option<Self> {
-        Some(Self::build(&dir.symlink_metadata(relative).ok()?, relative))
-    }
-
-    /// Shared construction from whichever metadata the caller obtained.
-    fn build(metadata: &Metadata, relative: &str) -> Self {
-        Self {
+        let metadata = dir.metadata(relative).ok()?;
+        Some(Self {
             relative: relative.to_owned(),
-            mtime: mtime_secs(metadata),
+            mtime: mtime_secs(&metadata),
             size: i64::try_from(metadata.len()).unwrap_or(i64::MAX),
-        }
+        })
     }
 }

--- a/crates/monty-fs/src/overlay_state.rs
+++ b/crates/monty-fs/src/overlay_state.rs
@@ -233,8 +233,8 @@ pub(super) struct OverlayFile {
 /// A lazy reference to a real file preserved during overlay rename.
 ///
 /// The path is *mount-relative*, so reads go back through the mount descriptor
-/// and the reference cannot come to name anything outside the mount however the
-/// host directory changes. That is what makes it safe to keep unvalidated.
+/// and cannot name anything outside the mount. Dereferences revalidate the path
+/// because a host actor can replace any component after capture.
 #[derive(Debug)]
 pub(super) struct OverlayFileRef {
     /// Path relative to the mount root.
@@ -246,12 +246,14 @@ pub(super) struct OverlayFileRef {
 }
 
 impl OverlayFileRef {
-    /// Builds a lazy reference to a real file. The overlay refuses symlinks,
-    /// so there is never a link here whose identity could be lost.
+    /// Builds a lazy reference only when the final component is a real file.
+    ///
+    /// The no-follow lookup closes the caller's final-component race without
+    /// resolving a link whose target identity the overlay cannot preserve.
     #[must_use]
     pub fn from_relative(dir: &Dir, relative: &str) -> Option<Self> {
-        let metadata = dir.metadata(relative).ok()?;
-        Some(Self {
+        let metadata = dir.symlink_metadata(relative).ok()?;
+        metadata.is_file().then(|| Self {
             relative: relative.to_owned(),
             mtime: mtime_secs(&metadata),
             size: i64::try_from(metadata.len()).unwrap_or(i64::MAX),

--- a/crates/monty-fs/src/path_security.rs
+++ b/crates/monty-fs/src/path_security.rs
@@ -132,7 +132,10 @@ fn is_windows_drive_prefix(segment: &str) -> bool {
 }
 
 /// Rejects embedded null bytes before any path manipulation occurs.
-fn reject_null_bytes(virtual_path: &str) -> Result<(), MountError> {
+///
+/// `OverlayMemory` needs it independently — its keys never reach a syscall, so
+/// nothing downstream would reject a name the kernel never sees.
+pub(super) fn reject_null_bytes(virtual_path: &str) -> Result<(), MountError> {
     if virtual_path.contains('\0') {
         Err(MountError::PathEscape {
             virtual_path: virtual_path.to_owned(),

--- a/crates/monty-fs/src/path_security.rs
+++ b/crates/monty-fs/src/path_security.rs
@@ -131,15 +131,25 @@ fn is_windows_drive_prefix(segment: &str) -> bool {
     bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
 }
 
+/// Whether `virtual_path` contains a null byte, which no filesystem name may.
+///
+/// The mount table checks this per call so it can raise CPython's wording for
+/// the operation; the helpers below re-check it as defence in depth, since a
+/// path that never reaches a syscall has nothing else to refuse it.
+pub(super) fn contains_null_byte(virtual_path: &str) -> bool {
+    virtual_path.contains('\0')
+}
+
 /// Rejects embedded null bytes before any path manipulation occurs.
 ///
-/// `OverlayMemory` needs it independently — its keys never reach a syscall, so
-/// nothing downstream would reject a name the kernel never sees.
+/// Unreachable through [`MountTable::handle_os_call`], which rejects them
+/// first with a per-operation message; this is the backstop for the generic
+/// wording, matching what CPython's `open()` layer says.
+///
+/// [`MountTable::handle_os_call`]: super::MountTable::handle_os_call
 pub(super) fn reject_null_bytes(virtual_path: &str) -> Result<(), MountError> {
-    if virtual_path.contains('\0') {
-        Err(MountError::PathEscape {
-            virtual_path: virtual_path.to_owned(),
-        })
+    if contains_null_byte(virtual_path) {
+        Err(MountError::EmbeddedNullByte("embedded null byte"))
     } else {
         Ok(())
     }

--- a/crates/monty-fs/tests/fs.rs
+++ b/crates/monty-fs/tests/fs.rs
@@ -2537,6 +2537,10 @@ fn ovl_mem_every_operation_on_a_symlink_is_refused() {
         sorted_names(&call_ok(&mut mt, &OsFunctionCall::Iterdir("/mnt/subdir".into()))),
         vec!["deep", "nested.txt"]
     );
+    assert_eq!(
+        call_ok(&mut mt, &OsFunctionCall::IsSymlink("/mnt/link_dir".into())),
+        MontyObject::Bool(true)
+    );
 }
 
 /// A directory symlink blocks everything under it, not just its own name — a

--- a/crates/monty-fs/tests/fs.rs
+++ b/crates/monty-fs/tests/fs.rs
@@ -2404,17 +2404,17 @@ fn ovl_mem_rename_overlay_file_onto_overlay_dir() {
 }
 
 // =============================================================================
-// Overlay rename: symlink preservation
+// Overlay refuses symlinks
 // =============================================================================
 
-/// Renaming a real symlink in overlay mode moves the link, not its target.
+/// Renaming a symlink is refused like every other overlay operation on one.
 ///
-/// The link is recorded as a reference to itself, so the target keeps its own
-/// name and content. What the *new* name reports diverges from CPython — see
-/// the assertions at the end and `limitations/filesystem.md`.
+/// Moving it would have to record the link as a reference to itself, leaving a
+/// name that is not a symlink, reports the link's own `stat`, and — for a link
+/// to a directory — has lost its children. Refusing keeps one rule.
 #[test]
 #[cfg(unix)]
-fn ovl_mem_rename_symlink_moves_the_link_not_its_target() {
+fn ovl_mem_rename_of_a_symlink_is_refused() {
     if !symlinks_supported() {
         return;
     }
@@ -2423,31 +2423,148 @@ fn ovl_mem_rename_symlink_moves_the_link_not_its_target() {
 
     let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
 
-    // Before rename: link should be a symlink
-    let result = call_ok(&mut mt, &OsFunctionCall::IsSymlink("/mnt/link.txt".into()));
-    assert_eq!(result, MontyObject::Bool(true));
+    // `is_symlink` is the one question a link still answers: it reports only
+    // that the name is a link, which is what CPython reports too.
+    assert_eq!(
+        call_ok(&mut mt, &OsFunctionCall::IsSymlink("/mnt/link.txt".into())),
+        MontyObject::Bool(true)
+    );
 
-    // Rename the symlink
-    call(&mut mt, &rename("/mnt/link.txt", "/mnt/moved_link.txt"))
-        .unwrap()
-        .unwrap();
+    let exc = call_err(&mut mt, &rename("/mnt/link.txt", "/mnt/moved_link.txt"));
+    assert_exc(
+        &exc,
+        ExcType::PermissionError,
+        "[Errno 13] Permission denied: '/mnt/link.txt'",
+    );
 
-    // After rename: the moved path should still be readable (via the stored host ref)
-    let result = call_ok(&mut mt, &OsFunctionCall::ReadText("/mnt/moved_link.txt".into()));
-    assert_eq!(result, MontyObject::String("hello world\n".to_owned()));
+    // Nothing moved, and the link's target is untouched.
+    assert_eq!(
+        call_ok(&mut mt, &OsFunctionCall::Exists("/mnt/moved_link.txt".into())),
+        MontyObject::Bool(false)
+    );
+    assert_eq!(
+        call_ok(&mut mt, &OsFunctionCall::ReadText("/mnt/hello.txt".into())),
+        MontyObject::String("hello world\n".to_owned())
+    );
+}
 
-    // Original symlink path should be gone
-    let result = call_ok(&mut mt, &OsFunctionCall::Exists("/mnt/link.txt".into()));
-    assert_eq!(result, MontyObject::Bool(false));
+/// Reading through a symlink is refused too, which is what makes the rule
+/// coherent: a link resolves on the host, so it would otherwise serve content
+/// the overlay has already replaced or deleted.
+#[test]
+#[cfg(unix)]
+fn ovl_mem_read_through_a_symlink_cannot_go_stale() {
+    if !symlinks_supported() {
+        return;
+    }
+    let dir = create_test_dir();
+    symlink_file("hello.txt", dir.path().join("link.txt"));
 
-    // Original target should still exist
-    let result = call_ok(&mut mt, &OsFunctionCall::Exists("/mnt/hello.txt".into()));
-    assert_eq!(result, MontyObject::Bool(true));
+    let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
+    call_ok(&mut mt, &write_text("/mnt/hello.txt", "OVERWRITTEN"));
 
-    // The divergence the docs record: no overlay entry is a symlink, so the
-    // moved name answers `False` where CPython answers `True`.
-    let result = call_ok(&mut mt, &OsFunctionCall::IsSymlink("/mnt/moved_link.txt".into()));
-    assert_eq!(result, MontyObject::Bool(false));
+    // Before the block, this returned the pre-overwrite host content.
+    let exc = call_err(&mut mt, &OsFunctionCall::ReadText("/mnt/link.txt".into()));
+    assert_exc(
+        &exc,
+        ExcType::PermissionError,
+        "[Errno 13] Permission denied: '/mnt/link.txt'",
+    );
+
+    // The same for a path that merely traverses a link, and for `stat`.
+    let exc = call_err(&mut mt, &OsFunctionCall::Stat("/mnt/link.txt".into()));
+    assert_exc(
+        &exc,
+        ExcType::PermissionError,
+        "[Errno 13] Permission denied: '/mnt/link.txt'",
+    );
+
+    // Predicates stay silent, as they do for any path leaving the mount.
+    assert_eq!(
+        call_ok(&mut mt, &OsFunctionCall::Exists("/mnt/link.txt".into())),
+        MontyObject::Bool(false)
+    );
+    assert_eq!(
+        call_ok(&mut mt, &OsFunctionCall::ReadText("/mnt/hello.txt".into())),
+        MontyObject::String("OVERWRITTEN".to_owned())
+    );
+}
+
+/// Every operation on a symlink is refused — the sweep that catches a single
+/// path slipping the rule.
+///
+/// `mkdir` did exactly that: it swallowed the refusal and created an overlay
+/// directory shadowing the link, which then made `iterdir` list it as empty.
+#[test]
+#[cfg(unix)]
+fn ovl_mem_every_operation_on_a_symlink_is_refused() {
+    if !symlinks_supported() {
+        return;
+    }
+    let dir = create_test_dir();
+    symlink_file("hello.txt", dir.path().join("link.txt"));
+    symlink_file("subdir", dir.path().join("link_dir"));
+
+    let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
+    for call in [
+        OsFunctionCall::ReadText("/mnt/link.txt".into()),
+        OsFunctionCall::ReadBytes("/mnt/link.txt".into()),
+        write_text("/mnt/link.txt", "x"),
+        write_bytes("/mnt/link.txt", b"x".to_vec()),
+        append_bytes("/mnt/link.txt", b"x".to_vec()),
+        OsFunctionCall::Stat("/mnt/link.txt".into()),
+        OsFunctionCall::Unlink("/mnt/link.txt".into()),
+        OsFunctionCall::Rmdir("/mnt/link_dir".into()),
+        mkdir("/mnt/link_dir", false, false),
+        mkdir("/mnt/link_dir", false, true),
+        mkdir("/mnt/link_dir", true, true),
+        OsFunctionCall::Iterdir("/mnt/link_dir".into()),
+        rename("/mnt/link.txt", "/mnt/moved.txt"),
+        rename("/mnt/hello.txt", "/mnt/link.txt"),
+        OsFunctionCall::ReadText("/mnt/link_dir/nested.txt".into()),
+    ] {
+        let label = format!("{call:?}");
+        let exc = call_err(&mut mt, &call);
+        assert_eq!(exc.exc_type(), ExcType::PermissionError, "{label} must be refused");
+    }
+
+    // Nothing was shadowed by a refused call: the real names still work.
+    assert_eq!(
+        call_ok(&mut mt, &OsFunctionCall::ReadText("/mnt/hello.txt".into())),
+        MontyObject::String("hello world\n".to_owned())
+    );
+    assert_eq!(
+        sorted_names(&call_ok(&mut mt, &OsFunctionCall::Iterdir("/mnt/subdir".into()))),
+        vec!["deep", "nested.txt"]
+    );
+}
+
+/// A directory symlink blocks everything under it, not just its own name — a
+/// single lookup of the final component would resolve through it unseen.
+#[test]
+#[cfg(unix)]
+fn ovl_mem_read_below_a_symlinked_directory_is_refused() {
+    if !symlinks_supported() {
+        return;
+    }
+    let dir = create_test_dir();
+    symlink_file("subdir", dir.path().join("link_dir"));
+
+    let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
+    for op in [
+        OsFunctionCall::ReadText("/mnt/link_dir/nested.txt".into()),
+        OsFunctionCall::Stat("/mnt/link_dir/nested.txt".into()),
+        OsFunctionCall::Iterdir("/mnt/link_dir".into()),
+    ] {
+        let exc = call_err(&mut mt, &op);
+        assert_eq!(exc.exc_type(), ExcType::PermissionError);
+    }
+
+    // Reached by its real name, the same file reads normally.
+    assert_eq!(
+        call_ok(&mut mt, &OsFunctionCall::ReadText("/mnt/subdir/nested.txt".into())),
+        MontyObject::String("nested content".to_owned())
+    );
 }
 
 // =============================================================================

--- a/crates/monty-fs/tests/fs.rs
+++ b/crates/monty-fs/tests/fs.rs
@@ -2407,10 +2407,14 @@ fn ovl_mem_rename_overlay_file_onto_overlay_dir() {
 // Overlay rename: symlink preservation
 // =============================================================================
 
-/// Renaming a real symlink in overlay mode should preserve its symlink identity.
+/// Renaming a real symlink in overlay mode moves the link, not its target.
+///
+/// The link is recorded as a reference to itself, so the target keeps its own
+/// name and content. What the *new* name reports diverges from CPython — see
+/// the assertions at the end and `limitations/filesystem.md`.
 #[test]
 #[cfg(unix)]
-fn ovl_mem_rename_symlink_preserves_symlink() {
+fn ovl_mem_rename_symlink_moves_the_link_not_its_target() {
     if !symlinks_supported() {
         return;
     }
@@ -2439,6 +2443,11 @@ fn ovl_mem_rename_symlink_preserves_symlink() {
     // Original target should still exist
     let result = call_ok(&mut mt, &OsFunctionCall::Exists("/mnt/hello.txt".into()));
     assert_eq!(result, MontyObject::Bool(true));
+
+    // The divergence the docs record: no overlay entry is a symlink, so the
+    // moved name answers `False` where CPython answers `True`.
+    let result = call_ok(&mut mt, &OsFunctionCall::IsSymlink("/mnt/moved_link.txt".into()));
+    assert_eq!(result, MontyObject::Bool(false));
 }
 
 // =============================================================================
@@ -2485,6 +2494,121 @@ fn ovl_mem_rmdir_real_dir_with_overlay_children() {
         &OsFunctionCall::ReadText("/mnt/subdir/overlay_only.txt".into()),
     );
     assert_eq!(result, MontyObject::String("overlay".to_owned()));
+}
+
+// =============================================================================
+// mkdir on a symlink to a directory
+// =============================================================================
+
+/// `exist_ok=True` must succeed on a symlink to a directory whether or not
+/// `parents` is set — CPython succeeds for both, and the two arms used to
+/// disagree because only the `parents=True` pre-check refused to follow.
+#[test]
+#[cfg(unix)]
+fn mkdir_on_symlink_to_dir_follows_for_exist_ok() {
+    if !symlinks_supported() {
+        return;
+    }
+    for parents in [false, true] {
+        let dir = create_test_dir();
+        symlink_file("subdir", dir.path().join("link_dir"));
+        let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
+
+        assert_eq!(
+            call_ok(&mut mt, &mkdir("/mnt/link_dir", parents, true)),
+            MontyObject::None,
+            "exist_ok on a symlink to a directory must succeed (parents={parents})"
+        );
+        // Without `exist_ok` it is still `FileExistsError`, as in CPython.
+        let exc = call_err(&mut mt, &mkdir("/mnt/link_dir", parents, false));
+        assert_exc(
+            &exc,
+            ExcType::FileExistsError,
+            "[Errno 17] File exists: '/mnt/link_dir'",
+        );
+    }
+}
+
+/// A dangling symlink and a symlink to a *file* both stay `FileExistsError`
+/// even with `exist_ok=True`: following finds no directory. CPython agrees.
+#[test]
+#[cfg(unix)]
+fn mkdir_exist_ok_still_refuses_non_directory_symlinks() {
+    if !symlinks_supported() {
+        return;
+    }
+    for parents in [false, true] {
+        let dir = create_test_dir();
+        symlink_file("nowhere", dir.path().join("dangling"));
+        symlink_file("hello.txt", dir.path().join("link.txt"));
+        let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
+
+        for name in ["dangling", "link.txt"] {
+            let exc = call_err(&mut mt, &mkdir(&format!("/mnt/{name}"), parents, true));
+            assert_exc(
+                &exc,
+                ExcType::FileExistsError,
+                &format!("[Errno 17] File exists: '/mnt/{name}'"),
+            );
+        }
+    }
+}
+
+// =============================================================================
+// Overlay rename onto a tombstoned destination
+// =============================================================================
+
+/// After `rmdir`, the destination is gone as far as the sandbox is concerned,
+/// so a rename onto it must not be refused for what the host still has there.
+///
+/// The tombstone used to be read through to the real directory underneath,
+/// giving `IsADirectoryError` for a path `exists()` already reported as
+/// `False` — and disagreeing with the non-empty-directory check next to it.
+#[test]
+fn ovl_mem_rename_onto_tombstoned_dir_succeeds() {
+    let dir = create_test_dir();
+    fs::create_dir(dir.path().join("target")).unwrap();
+    let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
+
+    call_ok(&mut mt, &OsFunctionCall::Rmdir("/mnt/target".into()));
+    assert_eq!(
+        call_ok(&mut mt, &OsFunctionCall::Exists("/mnt/target".into())),
+        MontyObject::Bool(false)
+    );
+
+    call_ok(&mut mt, &rename("/mnt/hello.txt", "/mnt/target"));
+    assert_eq!(
+        call_ok(&mut mt, &OsFunctionCall::ReadText("/mnt/target".into())),
+        MontyObject::String("hello world\n".to_owned())
+    );
+    assert_eq!(
+        call_ok(&mut mt, &OsFunctionCall::IsFile("/mnt/target".into())),
+        MontyObject::Bool(true)
+    );
+    assert_eq!(
+        call_ok(&mut mt, &OsFunctionCall::Exists("/mnt/hello.txt".into())),
+        MontyObject::Bool(false)
+    );
+}
+
+/// The mirror case: a directory renamed onto a tombstoned *file* must not be
+/// refused with `NotADirectoryError` either.
+#[test]
+fn ovl_mem_rename_dir_onto_tombstoned_file_succeeds() {
+    let dir = create_test_dir();
+    let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
+
+    call_ok(&mut mt, &OsFunctionCall::Unlink("/mnt/hello.txt".into()));
+    call_ok(&mut mt, &rename("/mnt/subdir", "/mnt/hello.txt"));
+
+    assert_eq!(
+        call_ok(&mut mt, &OsFunctionCall::IsDir("/mnt/hello.txt".into())),
+        MontyObject::Bool(true)
+    );
+    assert_eq!(
+        call_ok(&mut mt, &OsFunctionCall::ReadText("/mnt/hello.txt/nested.txt".into())),
+        MontyObject::String("nested content".to_owned())
+    );
 }
 
 // =============================================================================

--- a/crates/monty-fs/tests/fs_security.rs
+++ b/crates/monty-fs/tests/fs_security.rs
@@ -633,7 +633,8 @@ mod symlink_tests {
             "rmdir of a symlink must be refused, got {outcome:?}"
         );
 
-        // Nothing was shadowed, so both spellings still agree with the host.
+        // Nothing was shadowed: the real name still reads. The link's own
+        // spelling answers `False`, as any refused path does.
         assert_eq!(
             call(&mut mt, PathOp::ReadText, "/mnt/subdir/nested.txt")
                 .unwrap()
@@ -644,7 +645,7 @@ mod symlink_tests {
             call(&mut mt, PathOp::Exists, "/mnt/link_dir/nested.txt")
                 .unwrap()
                 .unwrap(),
-            MontyObject::Bool(true)
+            MontyObject::Bool(false)
         );
     }
 
@@ -674,9 +675,10 @@ mod symlink_tests {
             "renaming onto a symlink must be refused, got {outcome:?}"
         );
 
-        // The link still resolves to its own target, not the moved file.
+        // The link's target is untouched — read by its real name, since the
+        // link's own spelling is refused like every other.
         assert_eq!(
-            call(&mut mt, PathOp::ReadText, "/mnt/link.txt").unwrap().unwrap(),
+            call(&mut mt, PathOp::ReadText, "/mnt/hello.txt").unwrap().unwrap(),
             MontyObject::String("hello world\n".to_owned())
         );
         assert_eq!(
@@ -731,13 +733,10 @@ mod symlink_tests {
         );
     }
 
-    /// A symlink to a directory moves as the link, never as the directory.
-    ///
-    /// The source's type comes from `lstat`, so the move cannot both record the
-    /// link as a file *and* walk its target's children into the overlay — which
-    /// left the new name a "file" with readable children under it.
+    /// A symlink to a directory is refused like any other, so its target's
+    /// tree cannot be walked into the overlay under a new name.
     #[test]
-    fn overlay_rename_of_a_symlink_to_a_dir_does_not_move_its_children() {
+    fn overlay_rename_of_a_symlink_to_a_dir_is_refused() {
         if !symlinks_supported() {
             return;
         }
@@ -745,32 +744,24 @@ mod symlink_tests {
         symlink_dir("subdir", dir.path().join("link_dir"));
 
         let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
-        dispatch(
+        let outcome = dispatch(
             &mut mt,
             OsFunctionCall::Rename(RenameCallArgs {
                 src: MontyPath::new("/mnt/link_dir".to_owned()),
                 dst: MontyPath::new("/mnt/moved".to_owned()),
             }),
         )
-        .unwrap()
-        .expect("renaming a symlink source is allowed");
-
-        // The moved name is not a directory and has no children beneath it.
-        assert_eq!(
-            call(&mut mt, PathOp::IsDir, "/mnt/moved").unwrap().unwrap(),
-            MontyObject::Bool(false)
-        );
-        assert_eq!(
-            call(&mut mt, PathOp::Exists, "/mnt/moved/nested.txt").unwrap().unwrap(),
-            MontyObject::Bool(false)
-        );
-        let listed = call(&mut mt, PathOp::Iterdir, "/mnt/moved").unwrap();
+        .unwrap();
         assert!(
-            matches!(&listed, Err(MountError::Io(err, _)) if err.kind() == ErrorKind::NotADirectory),
-            "the moved link must not list as a directory, got {listed:?}"
+            matches!(&outcome, Err(MountError::PathEscape { .. })),
+            "renaming a symlink to a directory must be refused, got {outcome:?}"
         );
 
-        // The link's target is untouched: the rename moved a name, not a tree.
+        // Nothing moved, and the target keeps its own name and children.
+        assert_eq!(
+            call(&mut mt, PathOp::Exists, "/mnt/moved").unwrap().unwrap(),
+            MontyObject::Bool(false)
+        );
         assert_eq!(
             call(&mut mt, PathOp::IsDir, "/mnt/subdir").unwrap().unwrap(),
             MontyObject::Bool(true)

--- a/crates/monty-fs/tests/fs_security.rs
+++ b/crates/monty-fs/tests/fs_security.rs
@@ -434,6 +434,55 @@ fn null_byte_messages_match_cpython_per_operation() {
     );
 }
 
+/// `resolve()` names the `lstat` it was about to make, as CPython's does.
+/// `absolute()` gets the generic wording instead: Monty raises where CPython
+/// returns the path untouched, so there is no syscall to name.
+#[test]
+fn null_byte_messages_for_resolve_and_absolute() {
+    let dir = create_test_dir();
+    let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
+    let bad = "/mnt/evil\x00.txt";
+
+    assert_null_byte_error(
+        &mut mt,
+        OsFunctionCall::Resolve(MontyPath::new(bad.to_owned())),
+        "lstat: embedded null character in path",
+    );
+    assert_null_byte_error(
+        &mut mt,
+        OsFunctionCall::Absolute(MontyPath::new(bad.to_owned())),
+        "embedded null byte",
+    );
+}
+
+/// A path that is both over-long and null-containing reports its length, where
+/// CPython reports the null byte: the length check is the one that stays O(1)
+/// on a hostile path, so it must not run behind a full scan for `\0`.
+#[test]
+fn overlong_path_outranks_a_null_byte() {
+    let dir = create_test_dir();
+    let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
+    let bad = format!("/mnt/{}\x00.txt", "a".repeat(256));
+
+    for call in [
+        PathOp::Stat.build_path_only(&bad),
+        OsFunctionCall::Rename(RenameCallArgs {
+            src: MontyPath::new("/mnt/hello.txt".to_owned()),
+            dst: MontyPath::new(bad.clone()),
+        }),
+    ] {
+        let exc = dispatch(&mut mt, call)
+            .expect("handled without routing")
+            .expect_err("expected an OSError")
+            .into_exception();
+        assert_eq!(exc.exc_type(), ExcType::OSError);
+        assert_eq!(
+            exc.message().unwrap_or(""),
+            r"[Errno 36] File name too long: '/mnt/aaaaaaaaaaaaaaa…aaaaaaaaaaaaaaa\x00.txt'"
+        );
+    }
+}
+
 /// The predicates answer `False` instead of raising, as CPython's do —
 /// `pathlib` swallows `ValueError` there exactly as it swallows `OSError`.
 #[test]

--- a/crates/monty-fs/tests/fs_security.rs
+++ b/crates/monty-fs/tests/fs_security.rs
@@ -10,7 +10,7 @@ use std::{fmt, fs, io::ErrorKind};
 
 use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable, OverlayState};
 use monty_types::{
-    FileMode, MkdirCallArgs, MontyObject, MontyPath, OpenCallArgs, OsFunctionCall, PathBytesDataArgs,
+    ExcType, FileMode, MkdirCallArgs, MontyObject, MontyPath, OpenCallArgs, OsFunctionCall, PathBytesDataArgs,
     PathStringDataArgs, RenameCallArgs,
 };
 use tempfile::TempDir;
@@ -146,7 +146,13 @@ fn assert_blocked(mt: &mut MountTable, op: PathOp, path: &str) {
         _ => call(mt, op, path),
     };
     match result {
-        Some(Err(MountError::PathEscape { .. } | MountError::NoMountPoint(_) | MountError::Io(_, _))) | None => {}
+        Some(Err(
+            MountError::PathEscape { .. }
+            | MountError::NoMountPoint(_)
+            | MountError::Io(_, _)
+            | MountError::EmbeddedNullByte(_),
+        ))
+        | None => {}
         Some(Ok(val)) => panic!("expected blocked, got Ok({val:?}) for path: {path}"),
         Some(Err(other)) => panic!("unexpected error variant for {path}: {other}"),
     }
@@ -180,7 +186,13 @@ fn assert_write_blocked(mt: &mut MountTable, op: PathOp, path: &str) {
     };
     let result = dispatch(mt, call_variant);
     match result {
-        Some(Err(MountError::PathEscape { .. } | MountError::NoMountPoint(_) | MountError::Io(_, _))) | None => {}
+        Some(Err(
+            MountError::PathEscape { .. }
+            | MountError::NoMountPoint(_)
+            | MountError::Io(_, _)
+            | MountError::EmbeddedNullByte(_),
+        ))
+        | None => {}
         Some(Ok(val)) => panic!("expected write blocked, got Ok({val:?}) for path: {path}"),
         Some(Err(other)) => panic!("unexpected error variant for write to {path}: {other}"),
     }
@@ -197,7 +209,13 @@ fn assert_open_blocked(mt: &mut MountTable, path: &str, mode: &str) {
         }),
     );
     match result {
-        Some(Err(MountError::PathEscape { .. } | MountError::NoMountPoint(_) | MountError::Io(_, _))) | None => {}
+        Some(Err(
+            MountError::PathEscape { .. }
+            | MountError::NoMountPoint(_)
+            | MountError::Io(_, _)
+            | MountError::EmbeddedNullByte(_),
+        ))
+        | None => {}
         Some(Ok(val)) => panic!("expected open blocked, got Ok({val:?}) for path: {path} mode: {mode:?}"),
         Some(Err(other)) => panic!("unexpected error variant for open of {path}: {other}"),
     }
@@ -337,82 +355,135 @@ fn valid_dotdot_within_mount() {
 // Null byte injection
 // =============================================================================
 
+/// Asserts a call raises `ValueError` with exactly CPython's wording.
+#[track_caller]
+fn assert_null_byte_error(mt: &mut MountTable, call: OsFunctionCall, expected: &str) {
+    let exc = dispatch(mt, call)
+        .expect("a null byte is refused with or without a mount")
+        .expect_err("expected a ValueError")
+        .into_exception();
+    assert_eq!(exc.exc_type(), ExcType::ValueError);
+    assert_eq!(exc.message().unwrap_or(""), expected);
+}
+
+/// A null byte anywhere in the path raises, wherever it sits.
 #[test]
-fn null_byte_middle() {
+fn null_byte_position_does_not_matter() {
     let dir = create_test_dir();
     let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
-    assert_blocked(&mut mt, PathOp::ReadText, "/mnt/hello\x00.txt");
+    for path in [
+        "/mnt/hello\x00.txt",
+        "/mnt/\x00hello.txt",
+        "/mnt/hello.txt\x00",
+        "/mnt/sub\x00dir/nested.txt",
+    ] {
+        assert_null_byte_error(&mut mt, PathOp::ReadText.build_path_only(path), "embedded null byte");
+    }
 }
 
+/// CPython's wording is not uniform: the content operations report the byte
+/// from `open()`, while the metadata ones name the syscall they were about to
+/// make. Each of these strings was taken from CPython 3.14.
 #[test]
-fn null_byte_start() {
+fn null_byte_messages_match_cpython_per_operation() {
     let dir = create_test_dir();
     let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
-    assert_blocked(&mut mt, PathOp::Exists, "/mnt/\x00hello.txt");
-}
+    let bad = "/mnt/evil\x00.txt";
 
-#[test]
-fn null_byte_end() {
-    let dir = create_test_dir();
-    let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
-    assert_blocked(&mut mt, PathOp::Exists, "/mnt/hello.txt\x00");
-}
+    for (op, expected) in [
+        (PathOp::ReadText, "embedded null byte"),
+        (PathOp::ReadBytes, "embedded null byte"),
+        (PathOp::Stat, "stat: embedded null character in path"),
+        (PathOp::Iterdir, "scandir: embedded null character in path"),
+        (PathOp::Unlink, "unlink: embedded null character in path"),
+    ] {
+        assert_null_byte_error(&mut mt, op.build_path_only(bad), expected);
+    }
 
-#[test]
-fn null_byte_in_directory() {
-    let dir = create_test_dir();
-    let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
-    assert_blocked(&mut mt, PathOp::ReadText, "/mnt/sub\x00dir/nested.txt");
-}
+    assert_null_byte_error(
+        &mut mt,
+        OsFunctionCall::Rmdir(MontyPath::new(bad.to_owned())),
+        "rmdir: embedded null character in path",
+    );
+    assert_null_byte_error(
+        &mut mt,
+        OsFunctionCall::Mkdir(MkdirCallArgs {
+            path: MontyPath::new(bad.to_owned()),
+            parents: false,
+            exist_ok: false,
+        }),
+        "mkdir: embedded null character in path",
+    );
 
-#[test]
-fn null_byte_write_ops() {
-    let dir = create_test_dir();
-    let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
-    assert_write_blocked(&mut mt, PathOp::WriteText, "/mnt/evil\x00.txt");
-    assert_write_blocked(&mut mt, PathOp::WriteBytes, "/mnt/evil\x00.bin");
-}
-
-#[test]
-fn null_byte_overlay_memory() {
-    let dir = create_test_dir();
-    let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
-    assert_blocked(&mut mt, PathOp::ReadText, "/mnt/hello\x00.txt");
-    assert_blocked(&mut mt, PathOp::Exists, "/mnt/\x00evil");
-}
-
-/// Overlay *writes* need the null-byte check independently: the key never
-/// reaches a syscall, so nothing downstream would reject a name only this mode
-/// accepts. A direct mount and CPython both raise here.
-#[test]
-fn null_byte_overlay_write_ops() {
-    let dir = create_test_dir();
-    let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
-    assert_write_blocked(&mut mt, PathOp::WriteText, "/mnt/evil\x00.txt");
-    assert_write_blocked(&mut mt, PathOp::WriteBytes, "/mnt/evil\x00.bin");
-    assert_blocked(&mut mt, PathOp::Mkdir, "/mnt/evil\x00dir");
-    assert_open_blocked(&mut mt, "/mnt/evil\x00.txt", "w");
-    assert_open_blocked(&mut mt, "/mnt/evil\x00.txt", "a");
-
-    let renamed = dispatch(
+    // A rename names the argument that carried the byte.
+    assert_null_byte_error(
+        &mut mt,
+        OsFunctionCall::Rename(RenameCallArgs {
+            src: MontyPath::new(bad.to_owned()),
+            dst: MontyPath::new("/mnt/ok.txt".to_owned()),
+        }),
+        "rename: embedded null character in src",
+    );
+    assert_null_byte_error(
         &mut mt,
         OsFunctionCall::Rename(RenameCallArgs {
             src: MontyPath::new("/mnt/hello.txt".to_owned()),
-            dst: MontyPath::new("/mnt/evil\x00.txt".to_owned()),
+            dst: MontyPath::new(bad.to_owned()),
         }),
+        "rename: embedded null character in dst",
     );
-    assert!(
-        matches!(&renamed, Some(Err(MountError::PathEscape { .. })) | None),
-        "rename onto a null-byte name must be refused, got {renamed:?}"
-    );
+}
 
-    // Nothing was recorded under any of those names, so the overlay agrees
-    // with the direct backend about what exists.
-    assert_blocked(&mut mt, PathOp::Exists, "/mnt/evil\x00.txt");
-    assert_eq!(
-        call(&mut mt, PathOp::ReadText, "/mnt/hello.txt").unwrap().unwrap(),
-        MontyObject::String("hello world\n".to_owned())
+/// The predicates answer `False` instead of raising, as CPython's do —
+/// `pathlib` swallows `ValueError` there exactly as it swallows `OSError`.
+#[test]
+fn null_byte_predicates_answer_false() {
+    let dir = create_test_dir();
+    for (_, mode) in all_modes() {
+        let mut mt = mount_at_mnt(&dir, mode);
+        for op in [PathOp::Exists, PathOp::IsFile, PathOp::IsDir, PathOp::IsSymlink] {
+            assert_invisible(&mut mt, op, "/mnt/hello\x00.txt");
+        }
+    }
+}
+
+/// The refusal precedes routing, so it does not depend on a mount covering
+/// the path — CPython raises before any syscall too, and a null byte must
+/// never reach the host's `os` callback.
+#[test]
+fn null_byte_is_refused_without_a_mount() {
+    let mut mt = MountTable::new();
+    assert_null_byte_error(
+        &mut mt,
+        PathOp::ReadText.build_path_only("/nowhere/evil\x00.txt"),
+        "embedded null byte",
     );
+    assert_invisible(&mut mt, PathOp::Exists, "/nowhere/evil\x00.txt");
+}
+
+/// Writes are refused in every mode, and nothing is recorded under the name.
+///
+/// `OverlayMemory` is the mode that needs its own check: the key never reaches
+/// a syscall, so without one it would accept a name no other mode does.
+#[test]
+fn null_byte_write_ops_in_every_mode() {
+    let dir = create_test_dir();
+    for (name, mode) in all_modes() {
+        let mut mt = mount_at_mnt(&dir, mode);
+        assert_write_blocked(&mut mt, PathOp::WriteText, "/mnt/evil\x00.txt");
+        assert_write_blocked(&mut mt, PathOp::WriteBytes, "/mnt/evil\x00.bin");
+        assert_blocked(&mut mt, PathOp::Mkdir, "/mnt/evil\x00dir");
+        assert_open_blocked(&mut mt, "/mnt/evil\x00.txt", "w");
+        assert_open_blocked(&mut mt, "/mnt/evil\x00.txt", "a");
+
+        // Nothing was created or shadowed under any of those names.
+        assert_invisible(&mut mt, PathOp::Exists, "/mnt/evil\x00.txt");
+        assert_eq!(
+            call(&mut mt, PathOp::ReadText, "/mnt/hello.txt").unwrap().unwrap(),
+            MontyObject::String("hello world\n".to_owned()),
+            "{name}: an unrelated read must still work"
+        );
+    }
 }
 
 // =============================================================================
@@ -1505,11 +1576,11 @@ fn path_escape_error_only_contains_virtual_path() {
     let dir = create_test_dir();
     let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
 
-    // Null byte should trigger PathEscape.
-    let result = call(&mut mt, PathOp::Exists, "/mnt/file\x00evil");
+    // A drive-letter segment is refused as an escape on every host.
+    let result = call(&mut mt, PathOp::ReadText, "/mnt/C:/evil");
     match result {
         Some(Err(MountError::PathEscape { virtual_path })) => {
-            assert_eq!(virtual_path, "/mnt/file\x00evil");
+            assert_eq!(virtual_path, "/mnt/C:/evil");
             // Verify host path is not in the error.
             let host_str = dir.path().to_string_lossy();
             assert!(
@@ -1519,6 +1590,22 @@ fn path_escape_error_only_contains_virtual_path() {
         }
         other => panic!("expected PathEscape, got {other:?}"),
     }
+}
+
+/// The null-byte `ValueError` quotes no path at all, as CPython's does — it is
+/// raised from argument parsing, before anything echoes the path back.
+#[test]
+fn null_byte_error_quotes_no_path() {
+    let dir = create_test_dir();
+    let mut mt = mount_at_mnt(&dir, MountMode::ReadWrite);
+
+    let exc = dispatch(&mut mt, PathOp::ReadText.build_path_only("/mnt/evil\x00.txt"))
+        .expect("handled")
+        .expect_err("expected a ValueError")
+        .into_exception();
+    let msg = exc.message().expect("exception should have message");
+    assert_eq!(msg, "embedded null byte");
+    assert!(!msg.contains('\0'), "the message must not echo the path back");
 }
 
 #[test]

--- a/crates/monty-fs/tests/fs_security.rs
+++ b/crates/monty-fs/tests/fs_security.rs
@@ -381,6 +381,40 @@ fn null_byte_overlay_memory() {
     assert_blocked(&mut mt, PathOp::Exists, "/mnt/\x00evil");
 }
 
+/// Overlay *writes* need the null-byte check independently: the key never
+/// reaches a syscall, so nothing downstream would reject a name only this mode
+/// accepts. A direct mount and CPython both raise here.
+#[test]
+fn null_byte_overlay_write_ops() {
+    let dir = create_test_dir();
+    let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
+    assert_write_blocked(&mut mt, PathOp::WriteText, "/mnt/evil\x00.txt");
+    assert_write_blocked(&mut mt, PathOp::WriteBytes, "/mnt/evil\x00.bin");
+    assert_blocked(&mut mt, PathOp::Mkdir, "/mnt/evil\x00dir");
+    assert_open_blocked(&mut mt, "/mnt/evil\x00.txt", "w");
+    assert_open_blocked(&mut mt, "/mnt/evil\x00.txt", "a");
+
+    let renamed = dispatch(
+        &mut mt,
+        OsFunctionCall::Rename(RenameCallArgs {
+            src: MontyPath::new("/mnt/hello.txt".to_owned()),
+            dst: MontyPath::new("/mnt/evil\x00.txt".to_owned()),
+        }),
+    );
+    assert!(
+        matches!(&renamed, Some(Err(MountError::PathEscape { .. })) | None),
+        "rename onto a null-byte name must be refused, got {renamed:?}"
+    );
+
+    // Nothing was recorded under any of those names, so the overlay agrees
+    // with the direct backend about what exists.
+    assert_blocked(&mut mt, PathOp::Exists, "/mnt/evil\x00.txt");
+    assert_eq!(
+        call(&mut mt, PathOp::ReadText, "/mnt/hello.txt").unwrap().unwrap(),
+        MontyObject::String("hello world\n".to_owned())
+    );
+}
+
 // =============================================================================
 // Symlink escape
 // =============================================================================
@@ -577,6 +611,104 @@ mod symlink_tests {
         assert_eq!(
             call(&mut mt, PathOp::Exists, "/mnt/src.txt").unwrap().unwrap(),
             MontyObject::Bool(true)
+        );
+    }
+
+    /// A rename *source* is a write path too — it gets tombstoned — so a
+    /// symlink in its parent chain is refused exactly as `unlink` on the
+    /// identical path is. Only the source's final component is exempt.
+    #[test]
+    fn overlay_rename_out_of_a_symlinked_directory_is_refused() {
+        if !symlinks_supported() {
+            return;
+        }
+        let dir = create_test_dir();
+        symlink_dir("subdir", dir.path().join("link_dir"));
+
+        let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
+        let outcome = dispatch(
+            &mut mt,
+            OsFunctionCall::Rename(RenameCallArgs {
+                src: MontyPath::new("/mnt/link_dir/nested.txt".to_owned()),
+                dst: MontyPath::new("/mnt/moved.txt".to_owned()),
+            }),
+        )
+        .unwrap();
+        assert!(
+            matches!(&outcome, Err(MountError::PathEscape { .. })),
+            "renaming out of a symlinked directory must be refused, got {outcome:?}"
+        );
+
+        // `unlink` on that same path is refused identically — the consistency
+        // this test exists to pin.
+        let unlinked = call(&mut mt, PathOp::Unlink, "/mnt/link_dir/nested.txt").unwrap();
+        assert!(
+            matches!(&unlinked, Err(MountError::PathEscape { .. })),
+            "unlink must agree with rename, got {unlinked:?}"
+        );
+
+        // Neither spelling was shadowed, so both still agree with the host.
+        assert_eq!(
+            call(&mut mt, PathOp::ReadText, "/mnt/subdir/nested.txt")
+                .unwrap()
+                .unwrap(),
+            MontyObject::String("nested content".to_owned())
+        );
+        assert_eq!(
+            call(&mut mt, PathOp::Exists, "/mnt/moved.txt").unwrap().unwrap(),
+            MontyObject::Bool(false)
+        );
+    }
+
+    /// A symlink to a directory moves as the link, never as the directory.
+    ///
+    /// The source's type comes from `lstat`, so the move cannot both record the
+    /// link as a file *and* walk its target's children into the overlay — which
+    /// left the new name a "file" with readable children under it.
+    #[test]
+    fn overlay_rename_of_a_symlink_to_a_dir_does_not_move_its_children() {
+        if !symlinks_supported() {
+            return;
+        }
+        let dir = create_test_dir();
+        symlink_dir("subdir", dir.path().join("link_dir"));
+
+        let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
+        dispatch(
+            &mut mt,
+            OsFunctionCall::Rename(RenameCallArgs {
+                src: MontyPath::new("/mnt/link_dir".to_owned()),
+                dst: MontyPath::new("/mnt/moved".to_owned()),
+            }),
+        )
+        .unwrap()
+        .expect("renaming a symlink source is allowed");
+
+        // The moved name is not a directory and has no children beneath it.
+        assert_eq!(
+            call(&mut mt, PathOp::IsDir, "/mnt/moved").unwrap().unwrap(),
+            MontyObject::Bool(false)
+        );
+        assert_eq!(
+            call(&mut mt, PathOp::Exists, "/mnt/moved/nested.txt").unwrap().unwrap(),
+            MontyObject::Bool(false)
+        );
+        let listed = call(&mut mt, PathOp::Iterdir, "/mnt/moved").unwrap();
+        assert!(
+            matches!(&listed, Err(MountError::Io(err, _)) if err.kind() == ErrorKind::NotADirectory),
+            "the moved link must not list as a directory, got {listed:?}"
+        );
+
+        // The link's target is untouched: the rename moved a name, not a tree.
+        assert_eq!(
+            call(&mut mt, PathOp::IsDir, "/mnt/subdir").unwrap().unwrap(),
+            MontyObject::Bool(true)
+        );
+        assert_eq!(
+            call(&mut mt, PathOp::ReadText, "/mnt/subdir/nested.txt")
+                .unwrap()
+                .unwrap(),
+            MontyObject::String("nested content".to_owned())
         );
     }
 

--- a/crates/monty-fs/tests/mount_confinement.rs
+++ b/crates/monty-fs/tests/mount_confinement.rs
@@ -5,18 +5,19 @@
 //! `mount_survives_host_directory_rename` distinguish this design from
 //! path-based resolution — verified red against it, on Unix; Windows refuses to
 //! rename a mounted directory at all, so it gets its own pair. The other escape
-//! tests pass under both, so they are regression guards, not evidence, and
-//! `concurrent_rename_cannot_redirect_a_read` is a soak: the race was never won
-//! on macOS/APFS, so a green run proves little on any one platform.
+//! tests pass under both, so they are regression guards, not evidence, and the
+//! two timed races are soaks: neither was ever won on macOS/APFS, so a green
+//! run proves little on any one platform. Those two skip unless `MONTY_FS_SOAK`
+//! is set (see [`soak_enabled`]); everything else runs by default.
 
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::{
-    fs,
+    env, fs,
     io::ErrorKind,
     path::{Path, PathBuf},
     sync::{
-        Arc,
+        Arc, OnceLock,
         atomic::{AtomicBool, AtomicU32, Ordering},
         mpsc,
     },
@@ -38,6 +39,23 @@ mod common;
 /// Marker written to the out-of-mount file; its appearance in any result is the
 /// disclosure these tests guard against.
 const SECRET: &str = "SECRET-HOST-CONTENT";
+
+/// Whether the multi-second race soaks in this file should run.
+///
+/// They burn ~5s of wall clock on every `cargo test -p monty-fs` to prove very
+/// little: neither race was ever won on macOS/APFS, so a green run is a soak,
+/// not evidence. Set `MONTY_FS_SOAK=1` to run them — worth doing when changing
+/// the descriptor-relative open paths they cover.
+fn soak_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        let enabled = env::var_os("MONTY_FS_SOAK").is_some_and(|value| !value.is_empty() && value != "0");
+        if !enabled {
+            eprintln!("race soaks will skip: set MONTY_FS_SOAK=1 to run them");
+        }
+        enabled
+    })
+}
 
 /// Dispatches a call, panicking if the mount table declines to handle it.
 fn dispatch(mounts: &mut MountTable, call: OsFunctionCall) -> Result<MontyObject, MountError> {
@@ -172,10 +190,11 @@ fn read_through_swapped_intermediate_directory_is_rejected() {
 /// symlink to an out-of-mount file, so a read whose check and open disagree
 /// returns the secret. A descriptor-relative open has no window to lose — but
 /// this only ever *detects* the old failure when the race is won, which did not
-/// happen on macOS/APFS, so treat a green run as a soak rather than a proof.
+/// happen on macOS/APFS, so treat a green run as a soak rather than a proof —
+/// hence [`soak_enabled`].
 #[test]
 fn concurrent_rename_cannot_redirect_a_read() {
-    if !symlinks_supported() {
+    if !symlinks_supported() || !soak_enabled() {
         return;
     }
     let mount_dir = TempDir::new().unwrap();
@@ -714,9 +733,13 @@ fn fifo_in_the_mount_is_refused_promptly() {
 /// host-planted FIFO over a regular file between the check and the open. The
 /// open is non-blocking and the handle is re-checked, so neither the hang nor a
 /// successful FIFO read is reachable. Verified red with either half removed.
+/// A soak like the one above, so it is gated the same way.
 #[test]
 #[cfg(unix)]
 fn fifo_raced_into_place_between_check_and_open_is_refused() {
+    if !soak_enabled() {
+        return;
+    }
     let mount_dir = TempDir::new().unwrap();
     let target = mount_dir.path().join("file.txt");
     let regular = mount_dir.path().join("regular");

--- a/crates/monty-fs/tests/mount_confinement.rs
+++ b/crates/monty-fs/tests/mount_confinement.rs
@@ -42,10 +42,10 @@ const SECRET: &str = "SECRET-HOST-CONTENT";
 
 /// Whether the multi-second race soaks in this file should run.
 ///
-/// They burn ~5s of wall clock on every `cargo test -p monty-fs` to prove very
-/// little: neither race was ever won on macOS/APFS, so a green run is a soak,
-/// not evidence. Set `MONTY_FS_SOAK=1` to run them — worth doing when changing
-/// the descriptor-relative open paths they cover.
+/// They burn ~5s of wall clock to prove very little: neither race was ever won
+/// on macOS/APFS, so a green run is a soak, not evidence. Gating them keeps a
+/// local `cargo test -p monty-fs` fast; CI runs them on every OS with
+/// `MONTY_FS_SOAK=1`, as should anyone changing the paths they cover.
 fn soak_enabled() -> bool {
     static ENABLED: OnceLock<bool> = OnceLock::new();
     *ENABLED.get_or_init(|| {

--- a/crates/monty-fs/tests/overlay_stale_ref.rs
+++ b/crates/monty-fs/tests/overlay_stale_ref.rs
@@ -3,14 +3,14 @@
 //! dereferences one is exercised here: `read_text`, `read_bytes`, and the
 //! `existing_file_len` / `existing_file_bytes` pair an append goes through.
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 #[cfg(windows)]
 use std::process::Command;
 use std::{
     fs,
     path::{Path, PathBuf},
 };
-#[cfg(unix)]
-use std::{io::ErrorKind, os::unix::fs::PermissionsExt};
 
 use monty_fs::{MountCallOutcome, MountError, MountMode, MountTable, OverlayState};
 use monty_types::{MontyObject, OsFunctionCall, PathStringDataArgs, RenameCallArgs};
@@ -187,14 +187,15 @@ fn mount_root_swap_does_not_redirect_a_cached_ref() {
     assert_eq!(outcome.unwrap(), MontyObject::String("public".to_owned()));
 }
 
-/// Renaming an in-mount symlink whose target is unreadable must report the I/O
-/// error, not a path escape.
+/// Renaming a symlink is refused without ever consulting its target.
 ///
-/// `PathEscape` means the boundary caught something; a permission failure on a
-/// target that is plainly inside the mount is not that.
+/// The target here is unreadable, so a refusal that had resolved it would
+/// surface as a permission error instead. `PathEscape` is the proof the
+/// overlay stopped at the link itself — which is what lets the docs say the
+/// refusal reveals nothing about where a link points.
 #[test]
 #[cfg(unix)]
-fn renaming_symlink_to_denied_target_reports_the_io_error() {
+fn renaming_a_symlink_never_resolves_its_target() {
     if !symlinks_supported() {
         return;
     }
@@ -214,8 +215,8 @@ fn renaming_symlink_to_denied_target_reports_the_io_error() {
 
     fs::set_permissions(&sub, fs::Permissions::from_mode(0o755)).unwrap();
     assert!(
-        matches!(&outcome, Err(MountError::Io(err, _)) if err.kind() == ErrorKind::PermissionDenied),
-        "expected a permission error, got {outcome:?}"
+        matches!(&outcome, Err(MountError::PathEscape { .. })),
+        "expected the link itself to be refused, got {outcome:?}"
     );
 }
 

--- a/crates/monty-fs/tests/overlay_stale_ref.rs
+++ b/crates/monty-fs/tests/overlay_stale_ref.rs
@@ -1,6 +1,6 @@
 //! An `OverlayMemory` rename records a `RealFileRef` instead of copying the
 //! bytes, and reads followed that cached host path unchecked. Every path that
-//! dereferences one is exercised here: `read_text`, `read_bytes`, and the
+//! consumes one is exercised here: `read_text`, `read_bytes`, `stat`, and the
 //! `existing_file_len` / `existing_file_bytes` pair an append goes through.
 
 #[cfg(unix)]
@@ -127,6 +127,16 @@ fn stale_ref_is_revalidated_on_read_bytes() {
         return;
     }
     StaleRef::new().assert_rejected(OsFunctionCall::ReadBytes("/mnt/moved.txt".into()));
+}
+
+/// `stat` must not expose metadata through a backing path that is now a
+/// symlink, even though it does not need to reopen the file for fresh metadata.
+#[test]
+fn stale_ref_is_revalidated_on_stat() {
+    if !symlinks_supported() {
+        return;
+    }
+    StaleRef::new().assert_rejected(OsFunctionCall::Stat("/mnt/moved.txt".into()));
 }
 
 /// Appending materializes the backing file into the overlay via

--- a/crates/monty-fs/tests/overlay_stale_ref.rs
+++ b/crates/monty-fs/tests/overlay_stale_ref.rs
@@ -281,3 +281,31 @@ fn renaming_escaping_symlink_into_overlay_is_rejected() {
         "expected the rename to be refused with PathEscape, got {rename_outcome:?}"
     );
 }
+
+/// A cached ref whose backing path becomes an *in-mount* symlink must not be
+/// followed either. The escaping case is refused by the descriptor; this one
+/// resolves happily inside the mount, so only the overlay's own rule stops it.
+#[test]
+fn stale_ref_repointed_at_an_in_mount_symlink_is_refused() {
+    if !symlinks_supported() {
+        return;
+    }
+    let mount_dir = TempDir::new().unwrap();
+    fs::create_dir_all(mount_dir.path().join("inner")).unwrap();
+    let real_file = mount_dir.path().join("inner/file.txt");
+    fs::write(&real_file, "public").unwrap();
+    fs::write(mount_dir.path().join("other.txt"), "OTHER").unwrap();
+
+    let mut mt = mount_overlay(mount_dir.path());
+    dispatch(&mut mt, rename_call("/mnt/inner/file.txt", "/mnt/moved.txt")).expect("rename should succeed");
+
+    // A host-side actor re-points the backing path at another in-mount file.
+    fs::remove_file(&real_file).unwrap();
+    symlink_file("../other.txt", &real_file);
+
+    let outcome = dispatch(&mut mt, OsFunctionCall::ReadText("/mnt/moved.txt".into()));
+    assert!(
+        matches!(&outcome, Err(MountError::PathEscape { .. })),
+        "a ref must not follow a symlink swapped in behind it, got {outcome:?}"
+    );
+}

--- a/crates/monty-types/src/os.rs
+++ b/crates/monty-types/src/os.rs
@@ -184,6 +184,34 @@ impl OsFunctionCall {
         )
     }
 
+    /// CPython's `ValueError` message for a path containing a null byte.
+    ///
+    /// The wording is not uniform in CPython: it comes from whichever layer
+    /// first inspects the path, so the content operations go through `open()`
+    /// and say `embedded null byte`, while the metadata ones are named by the
+    /// syscall their `os` wrapper was about to make. `for_destination` picks
+    /// the rename argument that carried the byte.
+    #[must_use]
+    pub fn embedded_null_message(&self, for_destination: bool) -> &'static str {
+        match self {
+            Self::Mkdir(_) => "mkdir: embedded null character in path",
+            Self::Unlink(_) => "unlink: embedded null character in path",
+            Self::Rmdir(_) => "rmdir: embedded null character in path",
+            Self::Stat(_) => "stat: embedded null character in path",
+            // `pathlib.Path.iterdir` reaches `os.scandir`, not `os.listdir`.
+            Self::Iterdir(_) => "scandir: embedded null character in path",
+            Self::Rename(_) if for_destination => "rename: embedded null character in dst",
+            Self::Rename(_) => "rename: embedded null character in src",
+            // `resolve()` lstats each component; `absolute()` is pure string
+            // work in CPython and does not raise at all (see
+            // `limitations/filesystem.md`).
+            Self::Resolve(_) | Self::Absolute(_) => "lstat: embedded null character in path",
+            // Reads, writes, appends and `open` all land in `io.open`. The
+            // predicates never reach here — they answer `False`.
+            _ => "embedded null byte",
+        }
+    }
+
     /// The call's primary path if it's a FS operation, `None` otherwise.
     ///
     /// Used for routing and error reporting.

--- a/crates/monty-types/src/os.rs
+++ b/crates/monty-types/src/os.rs
@@ -202,12 +202,13 @@ impl OsFunctionCall {
             Self::Iterdir(_) => "scandir: embedded null character in path",
             Self::Rename(_) if for_destination => "rename: embedded null character in dst",
             Self::Rename(_) => "rename: embedded null character in src",
-            // `resolve()` lstats each component; `absolute()` is pure string
-            // work in CPython and does not raise at all (see
-            // `limitations/filesystem.md`).
-            Self::Resolve(_) | Self::Absolute(_) => "lstat: embedded null character in path",
-            // Reads, writes, appends and `open` all land in `io.open`. The
-            // predicates never reach here — they answer `False`.
+            // `resolve()` lstats each component before returning.
+            Self::Resolve(_) => "lstat: embedded null character in path",
+            // Reads, writes, appends and `open` all land in `io.open`.
+            // `absolute()` shares that generic wording: it is pure string work
+            // that CPython never raises from, so naming a syscall would be a
+            // fiction (see `limitations/filesystem.md`). The predicates never
+            // reach here — they answer `False`.
             _ => "embedded null byte",
         }
     }

--- a/crates/monty-types/src/os.rs
+++ b/crates/monty-types/src/os.rs
@@ -226,8 +226,7 @@ impl OsFunctionCall {
     /// for FS ops (with the path), `RuntimeError` for non-FS ops.
     #[must_use]
     pub fn on_no_handler(&self) -> MontyException {
-        if self.fs_primary_path().is_some() {
-            let path = self.fs_primary_path().unwrap_or("<unknown>");
+        if let Some(path) = self.fs_primary_path() {
             MontyException::new(
                 ExcType::PermissionError,
                 Some(format!("Permission denied: {}", StringRepr(path))),

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -216,6 +216,12 @@ unaffected and still follow relative in-mount links for reads and writes.
 `mkdir(parents=True)` through an escaping symlink raises `PermissionError` in
 every mode.
 
+The refusal is a coherence policy, not the sandbox boundary, and it is not
+atomic with the operation it guards: a host process that swaps a symlink into
+the path between the check and the read gets it followed. The descriptor still
+bounds the result to inside the mount, so this is the same window a host
+already has by replacing a file outright (above) — not a way out.
+
 ### `OverlayMemory` renames of real files
 
 A rename records a mount-relative reference to the existing file rather than

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -155,13 +155,14 @@ needs read permission, so a search-only directory (mode `0o111`) is refused —
 and read known paths inside. Linux opens directories with `O_PATH` and accepts
 it. Grant `r-x` on anything you intend to mount portably.
 
-### Symlink targets must be relative
+### Symlink targets must be relative (direct mounts)
 
-**A symlink inside a mount is followed only if its target is relative; an
-absolute target raises `PermissionError` even when it points back into the
-same mount.** CPython follows both. A descriptor has no path of its own, so a
-leading `/` cannot be interpreted and "absolute but inside" is
-indistinguishable from "absolute and outside".
+**A symlink inside a `ReadWrite` or `ReadOnly` mount is followed only if its
+target is relative; an absolute target raises `PermissionError` even when it
+points back into the same mount.** CPython follows both. A descriptor has no
+path of its own, so a leading `/` cannot be interpreted and "absolute but
+inside" is indistinguishable from "absolute and outside". `OverlayMemory`
+follows no link at all — see below.
 
 This is the one thing to check before mounting an existing directory.
 Sandboxed code cannot create symlinks, so only links **already present** are
@@ -191,31 +192,29 @@ whatever name it now has, and a *new* directory created at the original path
 is not picked up. CPython, resolving each path afresh, would see the
 replacement. Recreate the mount to follow a path.
 
-### `OverlayMemory` writes refuse symlinks
+### `OverlayMemory` refuses symlinks entirely
 
-CPython (and a direct mount) writes *through* a symlink to its target. An
-overlay write never touches the host, so it cannot do that — recording the
-entry under the link's spelling instead would silently alias the two paths.
-Any write (`write_text`, `open('w'/'a')`, `mkdir`, `unlink`, `rmdir`, rename
-destinations, …) whose path contains a symlink **anywhere** — as the final
-component or an intermediate directory, whether it resolves in-mount, dangles,
-is absolute, or escapes — raises `PermissionError`. A rename *source*'s final
-component is the one exception: the link itself moves (see below); anywhere
-earlier in the path it is refused like any other write. The
-refusal is uniform on purpose: the link's target is never even resolved, so
-the error reveals nothing about it. Deletes are included because tombstoning
-a link's spelling would report it gone while its target stayed readable under
-the real name — the same aliasing, reached by deleting rather than writing.
+**Any operation whose path contains a symlink — as the final component or an
+intermediate directory, whether it resolves in-mount, dangles, is absolute or
+escapes — raises `PermissionError`.** Reads, writes, deletes, `stat`,
+`iterdir` and both ends of a `rename` alike. CPython follows the link.
+
+An overlay entry is keyed by name, but a symlink resolves on the *host*, so it
+names a file the overlay only knows by its target's name. Following one would
+serve content the overlay has already replaced or deleted — write to
+`hello.txt`, then read `link.txt`, and CPython gives the new text while a
+following overlay would give the old. No in-memory representation fixes that,
+so the mode refuses links rather than answering wrongly. The target is never
+resolved, so the error reveals nothing about it.
 
 Renaming a **directory that contains a symlink** is refused for the same
-reason: the link cannot move with it (there is nothing to record) and cannot
-be left behind (it would stay readable inside a directory the overlay then
-reports as deleted). CPython moves the directory and the link together.
+reason: the link cannot move with it and cannot be left behind.
 
-Reads still follow relative in-mount links as before, and direct mounts
-still allow writes through them; only escaping/absolute links are refused
-there. `mkdir(parents=True)` through an escaping symlink raises
-`PermissionError` in every mode.
+`is_symlink()` still answers `True` — it reports only that the name is a link,
+as CPython does; the other predicates answer `False`. Direct mounts are
+unaffected and still follow relative in-mount links for reads and writes.
+`mkdir(parents=True)` through an escaping symlink raises `PermissionError` in
+every mode.
 
 ### `OverlayMemory` renames of real files
 
@@ -230,14 +229,6 @@ raises `OSError` (`directory contains an entry with a non-UTF-8 name`):
 Monty's sandbox namespace is strictly UTF-8, so the entry cannot follow the
 move. CPython renames the directory inode and never looks at the names
 inside.
-
-### `OverlayMemory` renames of symlinks
-
-A moved symlink becomes a reference to itself, so at the new name
-`is_symlink()` answers `False` and `stat()` reports the link's own size and
-mtime (reads still follow to the target). A link to a **directory** does not
-carry that directory with it: the new name is not a directory and nothing is
-reachable beneath it, where CPython keeps the link usable as one.
 
 ### Boolean predicates never raise
 

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -227,8 +227,9 @@ already has by replacing a file outright (above) — not a way out.
 A rename records a mount-relative reference to the existing file rather than
 copying its bytes, so it cannot come to name anything outside the mount. If
 the host replaces the underlying file before the read, the read sees whatever
-now occupies that path inside the mount; CPython, holding no such reference,
-would not find the renamed-away original.
+now occupies that path inside the mount — unless that is a symlink, refused
+like any other; CPython, holding no such reference, would not find the
+renamed-away original.
 
 Renaming a directory that really contains an entry with a non-UTF-8 name
 raises `OSError` (`directory contains an entry with a non-UTF-8 name`):

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -139,13 +139,13 @@ The error quotes the path with its middle elided — the first and last 20
 characters around a `…` — where CPython quotes it whole. An over-long path
 is by definition too big to repeat back.
 
-### A null byte raises `PermissionError`, not `ValueError`
+### `absolute()` raises on a null byte
 
-A path containing `\0` is refused before it reaches the filesystem, in every
-mount mode, for every operation. CPython raises `ValueError: embedded null
-byte` (the check is in `pathlib`/`os`, not the kernel); Monty raises
-`PermissionError`, because the refusal is part of the path boundary rather
-than argument validation.
+Null bytes otherwise behave as CPython's do, message for message. Only
+`absolute()` differs: CPython returns the path without inspecting it, while
+Monty refuses it at the boundary rather than carve out the one operation that
+never reaches a syscall. A path that is both over-long and null-containing
+reports the length error, where CPython reports the null byte.
 
 ### A search-only host directory may not be mountable
 
@@ -200,9 +200,8 @@ Any write (`write_text`, `open('w'/'a')`, `mkdir`, `unlink`, `rmdir`, rename
 destinations, …) whose path contains a symlink **anywhere** — as the final
 component or an intermediate directory, whether it resolves in-mount, dangles,
 is absolute, or escapes — raises `PermissionError`. A rename *source*'s final
-component is the one exception: a symlink named there is moved as itself rather
-than as its target (see below). A symlink anywhere earlier in a rename source's
-path is refused like any other write, the same as `unlink` on that path. The
+component is the one exception: the link itself moves (see below); anywhere
+earlier in the path it is refused like any other write. The
 refusal is uniform on purpose: the link's target is never even resolved, so
 the error reveals nothing about it. Deletes are included because tombstoning
 a link's spelling would report it gone while its target stayed readable under
@@ -234,16 +233,11 @@ inside.
 
 ### `OverlayMemory` renames of symlinks
 
-A symlink named as a rename source moves as a file reference to itself, which
-has two consequences at the new name, both divergent from CPython:
-
-- `is_symlink()` answers `False` there — no overlay entry is a symlink — while
-  `stat()` reports the link's own size and mtime rather than its target's.
-  Reads still follow through to the target's content.
-- A link to a **directory** does not carry that directory with it: the new name
-  is not a directory, `iterdir()` on it raises `NotADirectoryError`, and
-  nothing is reachable beneath it. CPython moves the link and keeps it usable
-  as a directory. The link's target is untouched under its real name.
+A moved symlink becomes a reference to itself, so at the new name
+`is_symlink()` answers `False` and `stat()` reports the link's own size and
+mtime (reads still follow to the target). A link to a **directory** does not
+carry that directory with it: the new name is not a directory and nothing is
+reachable beneath it, where CPython keeps the link usable as one.
 
 ### Boolean predicates never raise
 

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -139,6 +139,14 @@ The error quotes the path with its middle elided — the first and last 20
 characters around a `…` — where CPython quotes it whole. An over-long path
 is by definition too big to repeat back.
 
+### A null byte raises `PermissionError`, not `ValueError`
+
+A path containing `\0` is refused before it reaches the filesystem, in every
+mount mode, for every operation. CPython raises `ValueError: embedded null
+byte` (the check is in `pathlib`/`os`, not the kernel); Monty raises
+`PermissionError`, because the refusal is part of the path boundary rather
+than argument validation.
+
 ### A search-only host directory may not be mountable
 
 Mounting opens a descriptor on the host directory. On macOS and the BSDs that
@@ -191,9 +199,10 @@ entry under the link's spelling instead would silently alias the two paths.
 Any write (`write_text`, `open('w'/'a')`, `mkdir`, `unlink`, `rmdir`, rename
 destinations, …) whose path contains a symlink **anywhere** — as the final
 component or an intermediate directory, whether it resolves in-mount, dangles,
-is absolute, or escapes — raises `PermissionError`. A rename *source* is the
-exception: a symlink named as one is moved intact, recorded as itself rather
-than as its target. The
+is absolute, or escapes — raises `PermissionError`. A rename *source*'s final
+component is the one exception: a symlink named there is moved as itself rather
+than as its target (see below). A symlink anywhere earlier in a rename source's
+path is refused like any other write, the same as `unlink` on that path. The
 refusal is uniform on purpose: the link's target is never even resolved, so
 the error reveals nothing about it. Deletes are included because tombstoning
 a link's spelling would report it gone while its target stayed readable under
@@ -222,6 +231,19 @@ raises `OSError` (`directory contains an entry with a non-UTF-8 name`):
 Monty's sandbox namespace is strictly UTF-8, so the entry cannot follow the
 move. CPython renames the directory inode and never looks at the names
 inside.
+
+### `OverlayMemory` renames of symlinks
+
+A symlink named as a rename source moves as a file reference to itself, which
+has two consequences at the new name, both divergent from CPython:
+
+- `is_symlink()` answers `False` there — no overlay entry is a symlink — while
+  `stat()` reports the link's own size and mtime rather than its target's.
+  Reads still follow through to the target's content.
+- A link to a **directory** does not carry that directory with it: the new name
+  is not a directory, `iterdir()` on it raises `NotADirectoryError`, and
+  nothing is reachable beneath it. CPython moves the link and keeps it usable
+  as a directory. The link's target is untouched under its real name.
 
 ### Boolean predicates never raise
 

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -144,8 +144,10 @@ is by definition too big to repeat back.
 Null bytes otherwise behave as CPython's do, message for message. Only
 `absolute()` differs: CPython returns the path without inspecting it, while
 Monty refuses it at the boundary rather than carve out the one operation that
-never reaches a syscall. A path that is both over-long and null-containing
-reports the length error, where CPython reports the null byte.
+never reaches a syscall. It raises `ValueError: embedded null byte` — the
+generic wording, since no syscall is involved to name. A path that is both
+over-long and null-containing reports the length error, where CPython reports
+the null byte.
 
 ### A search-only host directory may not be mountable
 


### PR DESCRIPTION
Follow-up to #680, which was kept scoped to the confinement rewrite. Everything here predates it; none of it is a regression from that PR.

This started as the deferred-defect list and grew as review pulled on it.

### `OverlayMemory` refuses symlinks outright

The mode's contract — the overlay is the truth, the host only a fallback — is one a symlink cannot honour: an entry is keyed by name, but a link resolves on the *host*, naming a file the overlay knows only by its target's name. Following one served stale data: write `hello.txt`, then read `link.txt`, and you got the pre-write content; unlink `hello.txt` and `link.txt` stayed readable, reporting `exists() == True`. That is the same aliasing the write policy already refused, reached by reading instead — returning deleted content silently rather than refusing loudly.

Reads, writes, deletes, `stat`, `iterdir`, `mkdir` and both ends of a `rename` now refuse any path containing a symlink, at any component. `is_symlink()` still answers `True` — it reports only that the name is a link, as CPython does — and the other predicates answer `False`. Direct mounts are unaffected and still match CPython. It is enforced in one place, `resolve_real`, which walks the component chain.

This subsumes the rename fixes the branch started with: a symlink source is refused rather than moved as a reference to itself, so the incoherent "file with readable children" it used to produce cannot arise.

The lazy `RealFileRef` a rename caches was a standing hole in the same rule, found in review. Once cached, a host actor replacing the backing path with an *in-mount* symlink had it followed on every later read, serving a different file under the old name — no concurrency required. (An escaping link was already refused by the descriptor, which is why the existing stale-ref tests missed it.) Every dereference re-checks the path now.

One window stays open by choice: the refusal is a coherence policy, not the sandbox boundary, and it is not atomic with the read it guards. A host process can swap a link in between. What bounds that is the descriptor — `Mount::dir` cannot resolve past the mount root — so the worst case is in-mount content under an aliased name, the same window a host already has by replacing a file outright. Closing it would need a per-component `openat` walk on every read; `O_NOFOLLOW` would not do it, as it binds only the final component. Written down in the docstring and in `limitations/filesystem.md` rather than implied away.

### Null bytes raise `ValueError`, as CPython does

`OverlayMemory` accepted them entirely — `relative_path` never ran the check, and `reject_directory_target` swallowed it where it did reach one. Fixing that exposed the wrong exception type underneath. CPython raises `ValueError`, with wording that varies by the layer that first sees the path (`embedded null byte` for the read/write/`open` family, `mkdir:`/`stat:`/`scandir:` `embedded null character in path` elsewhere, `in src`/`in dst` for `rename`), and its predicates answer `False` rather than raising. Monty now matches all of it, verified end-to-end against CPython 3.14.

The check moved up beside the length check in `handle_os_call`, so it applies whether or not a mount covers the path — a null byte never reaches the host's `os` callback, as it never reaches a syscall in CPython.

### Smaller divergences

- `mkdir(parents=True, exist_ok=True)` on a symlink to a directory raised where `parents=False` succeeded; the pre-check now follows. Verified against CPython across the full parents/exist_ok × dir/dangling/file matrix. (Direct mounts — overlay refuses such a path outright.)
- `rename` onto a tombstoned directory read through to the host and raised `IsADirectoryError` for a path `exists()` already reported as `False`, disagreeing with `reject_rename_onto_nonempty_dir` next to it.
- Overlay lookups downgraded a genuine `EACCES` to "not found" once resolution began touching the filesystem, so `open()` inside a mode-`0o000` directory reported `FileNotFoundError`. The downgrade is now scoped to the predicates.
- `on_no_handler` called `fs_primary_path()` twice with a dead fallback.

### Deleted

`OverlayFileRef::from_lstat`, `host_lstat_is_dir`, the `Follow` enum and its parameter (on a link-free path `stat` and `lstat` agree, so the distinction had no meaning left), the rename source's symlink branch, and the now-redundant symlink checks in `rmdir` and the rename destination. Three overlapping `limitations/filesystem.md` sections collapse into one.

### Test hygiene

Two timed race soaks spent ~5s of every `cargo test -p monty-fs` to prove very little, by their own doc comments — neither race was ever won on macOS/APFS. They are gated behind `MONTY_FS_SOAK` so the local suite runs in ~0.35s, and CI runs them with the gate on across all three OSes, where the five seconds cost nothing.

Every fix is covered by a test checked red against the unfixed code, and the whole surface was driven end-to-end through the sandbox and compared with CPython.

Claude-Session: https://claude.ai/code/session_01Deav6TAzVd4Vaf7VyfYPBK

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes several long‑standing mount defects in `monty-fs`, tightens overlay symlink handling (including TOCTOU closes), aligns null‑byte errors with CPython, and ensures race soaks run in CI on all OSes. Also corrects `absolute()`’s null‑byte message to the generic “embedded null byte” and pins length‑before‑null precedence.

- **Bug Fixes**
  - `OverlayMemory` refuses any path that contains a symlink (reads, writes, `stat`, `iterdir`, `mkdir`, and both ends of `rename`); `is_symlink()` still answers `True`, other predicates answer `False`.
  - Closes overlay symlink races: `mkdir` re‑classifies a link swapped into the final component; `OverlayFileRef` capture is no‑follow and all dereferences (including `stat`) re‑validate like reads.
  - `rename` blocks symlink sources, handles tombstoned destinations correctly, and overlay lookups no longer mask real I/O errors (only predicates treat failures as absent).
  - Embedded null bytes are rejected before routing (both `src` and `dst` for `rename`) with CPython’s per‑operation messages; `absolute()` now uses the generic “embedded null byte” wording; predicates return `False`. Path length is checked first and outranks null‑byte scans.
  - `mkdir(parents=true, exist_ok=true)` follows a symlink to a directory; non‑directory links raise `FileExistsError`.

- **Refactors**
  - Centralize host‑path resolution via `resolve_real`; rename `classify_write_target` to `classify_target`; remove `Follow` and `OverlayFileRef::from_lstat`; make `is_symlink()` infallible.
  - Gate two multi‑second race soaks behind `MONTY_FS_SOAK`; CI runs them on all OSes (Linux via the coverage job and an explicit test step); expand tests and docs (overlay symlink refusal is a policy and not atomic, null‑byte `ValueError`, `absolute()` null‑byte wording and length‑precedence).  Fix `on_no_handler` to avoid double `fs_primary_path()`.

<sup>Written for commit 910a7cbd7aeb31279ffdd82886b6747b27e5c5aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

