### PR TITLE
Stop mount path walks costing a lookup per level squared

### DIFF
--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -57,11 +57,15 @@ fn relative_path(path: &str, ctx: &MountContext<'_>) -> Result<String, MountErro
 /// What bounds that is the descriptor: `Mount::dir` cannot resolve past the
 /// mount root and refuses an absolute target, so the worst case is in-mount
 /// content served under an aliased name — the same window the host already has
-/// by replacing a file outright (see `limitations/filesystem.md`). The walk
-/// holds a descriptor per component, so it cannot itself be fooled mid-walk,
-/// but it hands back a path the operation re-resolves from the mount root.
-/// Closing the window would mean the operation running against the walk's final
-/// descriptor; `O_NOFOLLOW` would not, since it binds only the last component.
+/// by replacing a file outright (see `limitations/filesystem.md`). Nor is the
+/// walk itself atomic: each descent follows, so a component that is a directory
+/// when classified and a symlink when opened is descended through.
+///
+/// Both windows are the same size and end the same way, so narrowing one alone
+/// buys nothing: the walk hands back a *path*, which the operation re-resolves
+/// from the mount root whatever the walk held. Closing this would mean opening
+/// every component no-follow **and** running the operation against the
+/// descriptor the walk ends on.
 ///
 /// The `Symlink` arms downstream are therefore not redundant: where a caller
 /// does re-classify, a link swapped in mid-operation lands on a refusal rather
@@ -1481,11 +1485,6 @@ enum RealTarget {
     Absent,
 }
 
-/// Classifies what sits at `rel`, without ever resolving a symlink.
-///
-/// The overlay refuses symlinks outright (see [`reject_symlink_chain`]), so
-/// every caller treats `Symlink` as `PermissionError`. The single `lstat`
-/// never resolves the target, so the refusal reveals nothing about it.
 /// Classifies a mount-relative path one component at a time, descending a
 /// descriptor as it goes.
 ///
@@ -1520,6 +1519,10 @@ impl<'d> ComponentWalk<'d> {
     ///
     /// Only a directory continues the walk: nothing is reachable below a file,
     /// every caller refuses a symlink, and absence ends it.
+    ///
+    /// The descent follows, so a directory swapped to a symlink between the two
+    /// lookups is descended through rather than refused — a bounded in-mount
+    /// window, and the same one [`resolve_real`] documents and tolerates.
     fn step(&mut self, component: &str, vpath: &str) -> Result<RealTarget, MountError> {
         if self.exhausted {
             return Ok(RealTarget::Absent);
@@ -1546,6 +1549,8 @@ impl<'d> ComponentWalk<'d> {
     }
 }
 
+/// Classifies what sits at `rel` with one `lstat`, never resolving a symlink —
+/// so the `Symlink` every caller refuses leaks nothing about its target.
 fn classify_target(dir: &Dir, rel: &str, vpath: &str) -> Result<RealTarget, MountError> {
     match dir.symlink_metadata(rel) {
         Ok(meta) if meta.is_symlink() => Ok(RealTarget::Symlink),

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -1533,8 +1533,14 @@ impl<'d> ComponentWalk<'d> {
             let opened = self.here().open_dir(component);
             match opened {
                 Ok(next) => self.current = Some(next),
-                // Raced away between the two lookups; nothing below it exists.
-                Err(err) if err.kind() == ErrorKind::NotFound => self.exhausted = true,
+                // Raced away between the two lookups. Reported as `Absent`,
+                // not the stale `Dir`: a caller told `Dir` records nothing
+                // for the component, and would then hang descendants under a
+                // parent that no longer exists anywhere.
+                Err(err) if err.kind() == ErrorKind::NotFound => {
+                    self.exhausted = true;
+                    return Ok(RealTarget::Absent);
+                }
                 Err(err) => return Err(map_io(err, vpath)),
             }
         } else {

--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -57,9 +57,11 @@ fn relative_path(path: &str, ctx: &MountContext<'_>) -> Result<String, MountErro
 /// What bounds that is the descriptor: `Mount::dir` cannot resolve past the
 /// mount root and refuses an absolute target, so the worst case is in-mount
 /// content served under an aliased name — the same window the host already has
-/// by replacing a file outright (see `limitations/filesystem.md`). Closing it
-/// would need a per-component `openat` walk holding descriptors; `O_NOFOLLOW`
-/// would not, since it binds only the final component.
+/// by replacing a file outright (see `limitations/filesystem.md`). The walk
+/// holds a descriptor per component, so it cannot itself be fooled mid-walk,
+/// but it hands back a path the operation re-resolves from the mount root.
+/// Closing the window would mean the operation running against the walk's final
+/// descriptor; `O_NOFOLLOW` would not, since it binds only the last component.
 ///
 /// The `Symlink` arms downstream are therefore not redundant: where a caller
 /// does re-classify, a link swapped in mid-operation lands on a refusal rather
@@ -84,22 +86,19 @@ fn reject_symlink_chain(dir: &Dir, rel: &str, vpath: &str) -> Result<(), MountEr
     if rel.is_empty() || rel == "." {
         return Ok(());
     }
-    let mut current = String::new();
+    let mut walk = ComponentWalk::new(dir);
     for component in rel.split('/') {
-        if !current.is_empty() {
-            current.push('/');
-        }
-        current.push_str(component);
-        match classify_target(dir, &current, vpath)? {
+        match walk.step(component, vpath)? {
             RealTarget::Symlink => {
                 return Err(MountError::PathEscape {
                     virtual_path: vpath.to_owned(),
                 });
             }
-            // Nothing below a missing component can exist, so there is no
-            // further link to find — and absence is not a refusal.
-            RealTarget::Absent => return Ok(()),
-            RealTarget::Dir | RealTarget::File => {}
+            // Nothing is reachable below a missing component or a plain file,
+            // so no deeper link can be followed either. The operation this
+            // guards still raises what a whole-path lookup would have.
+            RealTarget::Absent | RealTarget::File => return Ok(()),
+            RealTarget::Dir => {}
         }
     }
     Ok(())
@@ -642,31 +641,31 @@ fn ensure_parent_exists(
     let Some((parents, _)) = relative.rsplit_once('/') else {
         return Ok(());
     };
+    let mut walk = ComponentWalk::new(ctx.mount_dir);
     let mut current = String::new();
     for component in parents.split('/') {
         if !current.is_empty() {
             current.push('/');
         }
         current.push_str(component);
+        // Stepped even where the overlay answers, so the descriptor keeps pace
+        // with the key: a real directory below an overlay one is still reached
+        // by a single-component lookup. An overlay-only parent exhausts the
+        // walk at its first component, after which stepping is free.
+        let real = walk.step(component, vpath)?;
         match state.get(&current) {
             // Overlay directories are symlink-free by construction.
             Some(OverlayEntry::Directory { .. }) => {}
             Some(_) => return Err(MountError::not_found(vpath)),
-            None => {
-                let dir_vpath = format!("{}/{current}", ctx.mount_virtual);
-                let Ok(target) = resolve_virtual_path(&dir_vpath, ctx.mount_virtual) else {
-                    return Err(MountError::not_found(vpath));
-                };
-                match classify_target(ctx.mount_dir, target.for_dir_op(), vpath)? {
-                    RealTarget::Dir => {}
-                    RealTarget::Symlink => {
-                        return Err(MountError::PathEscape {
-                            virtual_path: vpath.to_owned(),
-                        });
-                    }
-                    RealTarget::File | RealTarget::Absent => return Err(MountError::not_found(vpath)),
+            None => match real {
+                RealTarget::Dir => {}
+                RealTarget::Symlink => {
+                    return Err(MountError::PathEscape {
+                        virtual_path: vpath.to_owned(),
+                    });
                 }
-            }
+                RealTarget::File | RealTarget::Absent => return Err(MountError::not_found(vpath)),
+            },
         }
     }
     Ok(())
@@ -737,6 +736,7 @@ fn mkdir(
 /// `PermissionError` instead of being shadowed by (or aliased under) an
 /// in-memory tree.
 fn create_overlay_parents(state: &mut OverlayState, relative: &str, ctx: &MountContext<'_>) -> Result<(), MountError> {
+    let mut walk = ComponentWalk::new(ctx.mount_dir);
     let mut current = String::new();
 
     for component in relative.split('/') {
@@ -745,10 +745,14 @@ fn create_overlay_parents(state: &mut OverlayState, relative: &str, ctx: &MountC
         }
         current.push_str(component);
 
+        let current_vpath = format_child_path(ctx.mount_virtual, &current);
+        // Stepped for every component, overlay-answered ones included, so the
+        // descriptor stays level with the key (see [`ComponentWalk`]).
+        let real = walk.step(component, &current_vpath)?;
+
         match state.get(&current) {
             Some(OverlayEntry::Directory { .. }) => {}
             Some(OverlayEntry::File(_) | OverlayEntry::RealFileRef(_)) => {
-                let current_vpath = format!("{}/{current}", ctx.mount_virtual);
                 return Err(MountError::io_err(
                     ErrorKind::NotADirectory,
                     "Not a directory",
@@ -765,24 +769,22 @@ fn create_overlay_parents(state: &mut OverlayState, relative: &str, ctx: &MountC
                 )?;
             }
             None => {
-                let current_vpath = format!("{}/{current}", ctx.mount_virtual);
-                if let Ok(resolved) = resolve_virtual_path(&current_vpath, ctx.mount_virtual) {
-                    match classify_target(ctx.mount_dir, resolved.for_dir_op(), &current_vpath)? {
-                        RealTarget::Dir => continue,
-                        RealTarget::Symlink => {
-                            return Err(MountError::PathEscape {
-                                virtual_path: current_vpath,
-                            });
-                        }
-                        RealTarget::File => {
-                            return Err(MountError::io_err(
-                                ErrorKind::NotADirectory,
-                                "Not a directory",
-                                &current_vpath,
-                            ));
-                        }
-                        RealTarget::Absent => {}
+                match real {
+                    // Already a real directory, so nothing to record.
+                    RealTarget::Dir => continue,
+                    RealTarget::Symlink => {
+                        return Err(MountError::PathEscape {
+                            virtual_path: current_vpath,
+                        });
                     }
+                    RealTarget::File => {
+                        return Err(MountError::io_err(
+                            ErrorKind::NotADirectory,
+                            "Not a directory",
+                            &current_vpath,
+                        ));
+                    }
+                    RealTarget::Absent => {}
                 }
 
                 state.insert(
@@ -1484,6 +1486,66 @@ enum RealTarget {
 /// The overlay refuses symlinks outright (see [`reject_symlink_chain`]), so
 /// every caller treats `Symlink` as `PermissionError`. The single `lstat`
 /// never resolves the target, so the refusal reveals nothing about it.
+/// Classifies a mount-relative path one component at a time, descending a
+/// descriptor as it goes.
+///
+/// Every lookup then names a single component, so a walk costs one resolution
+/// step per level. Re-spelling a longer prefix each time makes it quadratic
+/// wherever `cap-std` has no `openat2` and resolves component-by-component in
+/// userspace itself (macOS, Windows, pre-5.6 Linux) — at 300 levels, ~45k
+/// steps rather than ~600. Callers walking overlay keys alongside host state
+/// should [`step`](Self::step) every component, including ones the overlay
+/// already answers, so the descriptor stays level with the key.
+struct ComponentWalk<'d> {
+    /// The mount root, used until the first descent.
+    root: &'d Dir,
+    /// Deepest directory opened so far; `None` while still at the root.
+    current: Option<Dir>,
+    /// Set once a component is missing: nothing below one can exist, so every
+    /// remaining component answers `Absent` without a syscall.
+    exhausted: bool,
+}
+
+impl<'d> ComponentWalk<'d> {
+    fn new(root: &'d Dir) -> Self {
+        Self {
+            root,
+            current: None,
+            exhausted: false,
+        }
+    }
+
+    /// Classifies `component` where the walk stands, descending into it when it
+    /// is a directory so the next call is single-component too.
+    ///
+    /// Only a directory continues the walk: nothing is reachable below a file,
+    /// every caller refuses a symlink, and absence ends it.
+    fn step(&mut self, component: &str, vpath: &str) -> Result<RealTarget, MountError> {
+        if self.exhausted {
+            return Ok(RealTarget::Absent);
+        }
+        let target = classify_target(self.here(), component, vpath)?;
+        if matches!(target, RealTarget::Dir) {
+            // Bound before the match so the borrow of `self` ends here.
+            let opened = self.here().open_dir(component);
+            match opened {
+                Ok(next) => self.current = Some(next),
+                // Raced away between the two lookups; nothing below it exists.
+                Err(err) if err.kind() == ErrorKind::NotFound => self.exhausted = true,
+                Err(err) => return Err(map_io(err, vpath)),
+            }
+        } else {
+            self.exhausted = true;
+        }
+        Ok(target)
+    }
+
+    /// The directory the next lookup is relative to.
+    fn here(&self) -> &Dir {
+        self.current.as_ref().unwrap_or(self.root)
+    }
+}
+
 fn classify_target(dir: &Dir, rel: &str, vpath: &str) -> Result<RealTarget, MountError> {
     match dir.symlink_metadata(rel) {
         Ok(meta) if meta.is_symlink() => Ok(RealTarget::Symlink),

--- a/crates/monty-fs/src/path_security.rs
+++ b/crates/monty-fs/src/path_security.rs
@@ -18,6 +18,18 @@ const PATH_MAX: usize = 4096;
 /// Maximum single path component length in bytes (universal `NAME_MAX`).
 const NAME_MAX: usize = 255;
 
+/// Maximum number of components in a path.
+///
+/// Monty's own limit, with no POSIX counterpart. Confinement resolves a path
+/// relative to a descriptor, which on every platform but Linux with `openat2`
+/// means walking it component by component in userspace — so the kernel never
+/// sees the whole path and its own `ENAMETOOLONG` never fires, leaving
+/// [`PATH_MAX`] as the only bound at ~2000 components. Since the walkers cost
+/// at least one step per level, that let a single call fan out into millions
+/// of lookups. 64 is far above real trees (the deepest path in this repo,
+/// nested `node_modules` included, is 20) and caps the fan-out at ~4k.
+const DEPTH_MAX: usize = 64;
+
 /// A virtual path checked against Monty's path policy and made relative to its
 /// mount, ready to hand to a [`Dir`](cap_std::fs::Dir) method.
 ///
@@ -155,7 +167,8 @@ pub(super) fn reject_null_bytes(virtual_path: &str) -> Result<(), MountError> {
     }
 }
 
-/// Rejects paths that exceed Linux filesystem length limits.
+/// Rejects paths that exceed Linux filesystem length limits, or [`DEPTH_MAX`]
+/// components.
 ///
 /// Applied regardless of host OS so the sandbox behaves identically everywhere,
 /// rather than inheriting whatever the host filesystem happens to allow. Measures
@@ -163,8 +176,19 @@ pub(super) fn reject_null_bytes(virtual_path: &str) -> Result<(), MountError> {
 /// short, and the kernel would reject the bytes handed to it, not the collapsed
 /// form. Checking first also keeps the per-segment normalization off oversized
 /// input.
+///
+/// The component count is measured the same way, which only ever over-counts:
+/// normalization drops `.` and empty segments and `..` removes a pair, so a
+/// path within the limit as sent is within it once collapsed too.
 pub(super) fn reject_overlong_path(path: &str) -> Result<(), MountError> {
-    let too_long = path.len() > PATH_MAX || path.split('/').any(|component| component.len() > NAME_MAX);
+    let mut components = path.split('/');
+    // `ENAMETOOLONG` for depth as well: it is the error a kernel that saw the
+    // whole path would raise, and the one every predicate already swallows.
+    // The per-component scan stops at the limit, since anything past it is
+    // refused on depth anyway — so no check here walks a hostile path whole.
+    let too_long = path.len() > PATH_MAX
+        || components.by_ref().take(DEPTH_MAX).any(|c| c.len() > NAME_MAX)
+        || components.next().is_some();
     if too_long {
         // Elided, because the error echoes the path back: quoting it whole would
         // make the largest input produce the largest allocation, on the cheapest

--- a/crates/monty-fs/tests/fs_security.rs
+++ b/crates/monty-fs/tests/fs_security.rs
@@ -483,6 +483,61 @@ fn overlong_path_outranks_a_null_byte() {
     }
 }
 
+/// A path may name at most 64 components, counted as sent.
+///
+/// The kernel's own `ENAMETOOLONG` never fires under descriptor-relative
+/// resolution, which walks a path component by component and so never hands
+/// the whole thing to a syscall. Without this limit `PATH_MAX` alone allowed
+/// ~2000 components, and every walker costs at least a lookup per level.
+#[test]
+fn too_many_components_is_refused() {
+    let dir = create_test_dir();
+    // "/mnt/<n>" splits to n + 2 components, the leading empty included.
+    let at_limit = format!("/mnt/{}", vec!["d"; 62].join("/"));
+    let over_limit = format!("/mnt/{}", vec!["d"; 63].join("/"));
+
+    for (_, mode) in all_modes() {
+        let mut mt = mount_at_mnt(&dir, mode);
+
+        // At the limit the path is merely missing, not refused.
+        assert_eq!(
+            call(&mut mt, PathOp::Exists, &at_limit).unwrap().unwrap(),
+            MontyObject::Bool(false)
+        );
+        let err = call(&mut mt, PathOp::Stat, &at_limit).unwrap().unwrap_err();
+        assert_eq!(err.into_exception().exc_type(), ExcType::FileNotFoundError);
+
+        // One deeper is refused, with the same wording an over-long path gets.
+        let exc = call(&mut mt, PathOp::Stat, &over_limit)
+            .unwrap()
+            .unwrap_err()
+            .into_exception();
+        assert_eq!(exc.exc_type(), ExcType::OSError);
+        assert!(
+            exc.message().unwrap_or("").starts_with("[Errno 36] File name too long"),
+            "got {:?}",
+            exc.message()
+        );
+        // Predicates swallow it, as they swallow every `OSError`.
+        assert_eq!(
+            call(&mut mt, PathOp::Exists, &over_limit).unwrap().unwrap(),
+            MontyObject::Bool(false)
+        );
+    }
+
+    // The rename destination is checked too, and neither side needs a mount.
+    let mut empty = MountTable::new();
+    let outcome = dispatch(
+        &mut empty,
+        OsFunctionCall::Rename(RenameCallArgs {
+            src: MontyPath::new("/nowhere/a.txt".to_owned()),
+            dst: MontyPath::new(over_limit),
+        }),
+    )
+    .expect("a too-deep destination is refused without a mount");
+    assert!(matches!(outcome, Err(MountError::Io(_, _))), "got {outcome:?}");
+}
+
 /// The predicates answer `False` instead of raising, as CPython's do —
 /// `pathlib` swallows `ValueError` there exactly as it swallows `OSError`.
 #[test]
@@ -1217,6 +1272,75 @@ mod symlink_tests {
         let result = call_mkdir(&mut mt, "/mnt/internal_link/new_child", true, true);
         assert!(result.unwrap().is_ok(), "mkdir through internal symlink should succeed");
         assert!(dir.path().join("subdir/new_child").exists());
+    }
+
+    /// Depth of the chain the walk is exercised against. Deep enough that a
+    /// walk re-spelling the whole prefix per component would be quadratic.
+    const DEEP_CHAIN: usize = 40;
+
+    /// The overlay's symlink refusal holds at every depth of a long chain.
+    ///
+    /// Guards the descriptor-descending walk in `reject_symlink_chain`: it looks
+    /// up one component at a time rather than a growing prefix, so a link that
+    /// used to be seen by a whole-path lookup must still be seen by a
+    /// single-component one — wherever in the chain it sits.
+    #[test]
+    fn overlay_symlink_is_refused_at_every_depth_of_a_deep_chain() {
+        if !symlinks_supported() {
+            return;
+        }
+        let names: Vec<String> = (0..DEEP_CHAIN).map(|i| format!("d{i}")).collect();
+        let chain = names.join("/");
+
+        // A link-free chain of the same depth still resolves, so the walk is
+        // being passed rather than short-circuited.
+        let dir = create_test_dir();
+        fs::create_dir_all(dir.path().join(&chain)).unwrap();
+        fs::write(dir.path().join(&chain).join("leaf.txt"), "deep").unwrap();
+        let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
+        assert_eq!(
+            call(&mut mt, PathOp::ReadText, &format!("/mnt/{chain}/leaf.txt"))
+                .unwrap()
+                .unwrap(),
+            MontyObject::String("deep".to_owned())
+        );
+
+        // Now rebuild the chain with one component replaced by a symlink to a
+        // sibling directory of the same shape, at each depth in turn.
+        for swapped in 0..DEEP_CHAIN {
+            let dir = create_test_dir();
+            let prefix = names[..swapped].join("/");
+            let parent = if prefix.is_empty() {
+                dir.path().to_owned()
+            } else {
+                dir.path().join(&prefix)
+            };
+            // `real/<rest of chain>` holds the leaf; the swapped component is a
+            // link to `real`, so the path only resolves by following it.
+            fs::create_dir_all(parent.join("real").join(names[swapped + 1..].join("/"))).unwrap();
+            fs::write(
+                parent
+                    .join("real")
+                    .join(names[swapped + 1..].join("/"))
+                    .join("leaf.txt"),
+                "deep",
+            )
+            .unwrap();
+            symlink_dir("real", parent.join(&names[swapped]));
+
+            let mut mt = mount_at_mnt(&dir, MountMode::OverlayMemory(OverlayState::new()));
+            let vpath = format!("/mnt/{chain}/leaf.txt");
+            let outcome = call(&mut mt, PathOp::ReadText, &vpath).unwrap();
+            assert!(
+                matches!(&outcome, Err(MountError::PathEscape { .. })),
+                "a link at depth {swapped} must be refused, got {outcome:?}"
+            );
+            assert_eq!(
+                call(&mut mt, PathOp::Exists, &vpath).unwrap().unwrap(),
+                MontyObject::Bool(false),
+                "a link at depth {swapped} must make the path invisible"
+            );
+        }
     }
 }
 

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -241,9 +241,10 @@ every mode.
 
 The refusal is a coherence policy, not the sandbox boundary, and it is not
 atomic with the operation it guards: a host process that swaps a symlink into
-the path between the check and the read gets it followed. The descriptor still
-bounds the result to inside the mount, so this is the same window a host
-already has by replacing a file outright (above) — not a way out.
+the path — while it is being checked, or between the check and the read — gets
+it followed. The descriptor still bounds the result to inside the mount, so
+this is the same window a host already has by replacing a file outright
+(above) — not a way out.
 
 ### `OverlayMemory` renames of real files
 

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -139,6 +139,27 @@ The error quotes the path with its middle elided — the first and last 20
 characters around a `…` — where CPython quotes it whole. An over-long path
 is by definition too big to repeat back.
 
+### At most 64 path components
+
+A path naming more than 64 components raises the same `OSError` `[Errno 36]
+File name too long`, with the same three consequences as the length limit
+above. CPython has no such limit: it hands the path to the kernel, which
+counts bytes, not levels.
+
+This one is Monty's own. Confinement resolves every path relative to the
+mount's descriptor, and outside Linux-with-`openat2` that means walking it
+component by component in userspace — so the kernel never sees the whole path
+and its `ENAMETOOLONG` never fires. A 4096-byte path can name ~2000
+components, and each level costs at least one lookup, so a single call could
+fan out into millions of them. Components are counted as sent, like the
+length, which can only over-count: `.` and empty segments are dropped by
+normalization and `..` removes a pair, so anything within the limit as sent is
+within it once collapsed.
+
+64 is far above real trees — the deepest path in this repository, nested
+`node_modules` included, is 20 — but code that builds paths by repeated
+`mkdir(parents=True)` on generated names can reach it where CPython would not.
+
 ### `absolute()` raises on a null byte
 
 Null bytes otherwise behave as CPython's do, message for message. Only


### PR DESCRIPTION
Confinement resolves paths relative to the mount descriptor, which outside Linux-with-openat2 means cap-std walks them component by component in userspace. The three overlay walkers each re-spelled a longer prefix per level, so every one of those lookups paid for the whole prefix again.

`ComponentWalk` descends a descriptor instead, so each lookup names a single component: 20 overlay writes under a 60-deep tree go from 894ms to 75ms.

The same userspace walk means the kernel never sees a whole path, so its ENAMETOOLONG never fires and PATH_MAX alone allowed ~2000 components. A 64-component limit restores that bound, and covers cap-std's own quadratic create_dir_all, which we cannot restructure from here.


Claude-Session: https://claude.ai/code/session_01Deav6TAzVd4Vaf7VyfYPBK

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make mount path walks linear by resolving one component at a time, removing the quadratic cost on deep trees. Adds a 64‑component path limit, and clarifies walks aren’t atomic (a link swapped mid‑walk may be followed) but the window stays bounded inside the mount.

- **Refactors**
  - Introduced `ComponentWalk` to descend descriptors per-component where `cap-std` walks in userspace; 20 overlay writes under a 60‑deep tree drop from 894ms to 75ms.
  - Switched overlay walkers to it, keeping the descriptor level with overlay keys and rejecting symlink chains at any depth; added a 64‑component limit (counted as sent) that raises `[Errno 36] File name too long`; docs and tests updated.

- **Bug Fixes**
  - If a directory is classified as a dir but disappears before open, report it as Absent; prevents creating overlay children under a deleted parent and makes parent checks fail as they should.

<sup>Written for commit 85b107a6d81800012433904a3ca9826792974772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

