### PR TITLE
Bound nested itertools adaptors by the recursion limit

### DIFF
--- a/crates/monty/src/types/itertools/mod.rs
+++ b/crates/monty/src/types/itertools/mod.rs
@@ -187,14 +187,26 @@ impl<'h> PyTrait<'h> for HeapRead<'h, ItertoolsIter> {
     }
 
     fn py_next(&mut self, _: Option<HeapId>, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
-        match self.get(vm.heap).kind() {
+        let kind = self.get(vm.heap).kind();
+        match kind {
+            // Self-contained adaptors: neither drives a wrapped iterator.
             Kind::Count => count::next(self, vm),
             Kind::Repeat => repeat::next(self, vm),
-            Kind::Pairwise => pairwise::next(self, vm),
-            Kind::Compress => compress::next(self, vm),
-            Kind::Islice => islice::next(self, vm),
-            Kind::Chain => chain::next(self, vm),
-            Kind::Cycle => cycle::next(self, vm),
+            // Source-driving adaptors re-enter `py_next` on their wrapped
+            // iterator, recursing on the native Rust stack; charge a recursion
+            // level so deep nesting raises `RecursionError`, not a stack overflow.
+            Kind::Pairwise | Kind::Compress | Kind::Islice | Kind::Chain | Kind::Cycle => {
+                let mut guard = vm.recursion_guard()?;
+                let vm = &mut *guard;
+                match kind {
+                    Kind::Pairwise => pairwise::next(self, vm),
+                    Kind::Compress => compress::next(self, vm),
+                    Kind::Islice => islice::next(self, vm),
+                    Kind::Chain => chain::next(self, vm),
+                    Kind::Cycle => cycle::next(self, vm),
+                    Kind::Count | Kind::Repeat => unreachable!("handled above"),
+                }
+            }
         }
     }
 

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -970,7 +970,24 @@ impl HeapItem for NamedTupleClass {
 /// Element-level results propagate exactly as in [`Tuple::py_cmp`]: a `NaN`
 /// yields [`CmpOrder::Unordered`] rather than an error, while a genuinely
 /// type-mismatched pair yields [`CmpOrder::Incomparable`].
+///
+/// Charges one recursion level: unlike equality/repr, ordering does not walk a
+/// token-bearing `NamedTupleIter` (it compares detached item vecs), so nested
+/// namedtuples (`a < b` where each wraps the last) would otherwise recurse
+/// through here per level and overflow the host stack instead of raising
+/// `RecursionError`. A [`RecursionToken`] rather than a `recursion_guard()` is
+/// used because both vecs are still owned on the failure path — the token does
+/// not borrow the VM, so they can be dropped before returning the error.
 pub(crate) fn cmp_item_seqs(a: Vec<Value>, b: Vec<Value>, vm: &mut VM<'_>) -> RunResult<CmpOrder> {
+    let token = match vm.recursion_token() {
+        Ok(token) => token,
+        Err(err) => {
+            a.drop_with(vm);
+            b.drop_with(vm);
+            return Err(err.into());
+        }
+    };
+
     let (a_len, b_len) = (a.len(), b.len());
     let mut result = None;
     for (av, bv) in a.iter().zip(b.iter()) {
@@ -1008,6 +1025,7 @@ pub(crate) fn cmp_item_seqs(a: Vec<Value>, b: Vec<Value>, vm: &mut VM<'_>) -> Ru
     }
     a.drop_with(vm);
     b.drop_with(vm);
+    token.drop_with(vm);
     // All compared pairs were equal, so the shorter sequence sorts first.
     result.unwrap_or_else(|| Ok(CmpOrder::Ordered(a_len.cmp(&b_len))))
 }

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -827,3 +827,60 @@ re.sub('(a+)+\\1b', 'X', 'a' * 30 + 'c')
         "expected backtracking error, got: {exc}"
     );
 }
+
+/// Source-driving `itertools` adaptors delegate `next()` to their wrapped
+/// iterator on the native Rust stack, so attacker-controlled nesting depth
+/// must be charged against the recursion limit — without the guard in
+/// `ItertoolsIter::py_next`, deep nesting overflowed the stack and aborted
+/// the process instead of raising a recoverable `RecursionError`.
+#[test]
+fn nested_itertools_adaptors_are_bounded_by_the_recursion_limit() {
+    for wrap in [
+        "itertools.islice(source, 0, None)",
+        "itertools.chain(source)",
+        "itertools.pairwise(source)",
+        "itertools.compress(source, itertools.repeat(1))",
+        "itertools.cycle(source)",
+    ] {
+        let code = format!(
+            r"
+import itertools
+source = iter([1, 2, 3])
+for _ in range(100):
+    source = {wrap}
+next(source)
+"
+        );
+        let ex = MontyRun::new(code, "test.py", vec![], CompileOptions::default()).unwrap();
+
+        let limits = ResourceLimits::default().max_recursion_depth(10);
+        let result = ex.run(vec![], ResourceTracker::new(limits), PrintWriter::Stdout);
+
+        let exc = result.expect_err("nested adaptors should exceed the recursion limit");
+        assert_eq!(exc.exc_type(), ExcType::RecursionError, "wrapper: {wrap}");
+    }
+}
+
+/// Companion to the test above: nesting *below* the limit still works — the
+/// per-delegation recursion charge is transient (released as each `next()`
+/// returns), so a legal nest must not accumulate depth across iterations.
+#[test]
+fn nested_itertools_adaptors_below_the_recursion_limit_iterate() {
+    let code = r"
+import itertools
+source = iter([1, 2, 3])
+for _ in range(150):
+    source = itertools.islice(source, 0, None)
+list(source)
+";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+
+    let limits = ResourceLimits::default().max_recursion_depth(200);
+    let result = ex.run(vec![], ResourceTracker::new(limits), PrintWriter::Stdout);
+
+    let list = result.expect("nesting below the recursion limit should succeed");
+    assert_eq!(
+        list,
+        MontyObject::List(vec![MontyObject::Int(1), MontyObject::Int(2), MontyObject::Int(3)])
+    );
+}

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -884,3 +884,32 @@ list(source)
         MontyObject::List(vec![MontyObject::Int(1), MontyObject::Int(2), MontyObject::Int(3)])
     );
 }
+
+/// Ordering deeply nested namedtuples must raise `RecursionError`, not overflow
+/// the native stack. Ordering compares detached item vecs via `cmp_item_seqs`
+/// rather than a token-bearing iterator, so it charges its own recursion level;
+/// without it, nested namedtuples aborted the process. Covers both the
+/// namedtuple-vs-namedtuple and mixed namedtuple-vs-tuple dispatch paths.
+#[test]
+fn nested_namedtuple_ordering_is_bounded_by_the_recursion_limit() {
+    for build in [
+        "a = NT(0)\nb = NT(0)\nfor _ in range(100):\n    a = NT(a)\n    b = NT(b)",
+        "a = NT(0)\nb = (0,)\nfor _ in range(100):\n    a = NT(a)\n    b = (b,)",
+    ] {
+        let code = format!(
+            r"
+from collections import namedtuple
+NT = namedtuple('NT', ['x'])
+{build}
+a < b
+"
+        );
+        let ex = MontyRun::new(code, "test.py", vec![], CompileOptions::default()).unwrap();
+
+        let limits = ResourceLimits::default().max_recursion_depth(10);
+        let result = ex.run(vec![], ResourceTracker::new(limits), PrintWriter::Stdout);
+
+        let exc = result.expect_err("nested namedtuple ordering should exceed the recursion limit");
+        assert_eq!(exc.exc_type(), ExcType::RecursionError, "build: {build}");
+    }
+}

--- a/limitations/itertools.md
+++ b/limitations/itertools.md
@@ -92,3 +92,9 @@ them, and that buffer is charged against `max_memory` as it grows — so cycling
 over a very long source raises `MemoryError` at the limit rather than at the
 point the source is exhausted. CPython buffers the same items with no such
 ceiling.
+
+Nesting the source-driving adaptors (`pairwise`, `compress`, `islice`, `chain`,
+`cycle`) is bounded by `max_recursion_depth`: each adaptor charges one recursion
+level while delegating `next()` to its wrapped iterator, so a nest deeper than
+the limit raises `RecursionError` when consumed. CPython imposes no comparable
+per-adaptor bound — deep nesting there is limited only by the C stack.


### PR DESCRIPTION
Source-driving adaptors (pairwise, compress, islice, chain, cycle) delegate next() to their wrapped iterator on the native Rust stack, so attacker-controlled nesting depth could overflow the stack and abort the process with a single next() call, bypassing max_recursion_depth. Charge one recursion level per delegation in ItertoolsIter::py_next so deep nesting raises a recoverable RecursionError instead.


Claude-Session: https://claude.ai/code/session_01Deav6TAzVd4Vaf7VyfYPBK

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent native stack overflows from deeply nested source-driving `itertools` adaptors and nested `namedtuple` ordering by enforcing `max_recursion_depth`. Deep nests now raise `RecursionError` instead of aborting.

- **Bug Fixes**
  - Charge one recursion level per delegation in `ItertoolsIter::py_next` for `pairwise`, `compress`, `islice`, `chain`, and `cycle` (self-contained adaptors unchanged).
  - Bound `namedtuple` ordering in `cmp_item_seqs` using a `RecursionToken` (covers `namedtuple` vs `namedtuple` and `namedtuple` vs tuple).
  - Added tests for deep and below-limit nesting; documented the `itertools` bound in `limitations/itertools.md`.

<sup>Written for commit a92a895630d464cc588cf5d27c6425a5d54c2611. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

