### PR TITLE
Add raw wire-level turns to monty-pool, bump logfire to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,9 +2169,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logfire"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60ab073230edf8760a3565c315d6b058c74093070ca4168b78c230a0facb734"
+checksum = "32c1632fcb0c1257b14cdec68c1cdd262928a14eee111b0638f1727a0fe7efab"
 dependencies = [
  "chrono",
  "env_filter",
@@ -2192,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "logfire-core"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345c70b7197595007b1b9a4d71b25ee8f646759732995b4984adbf666f43e4b4"
+checksum = "067d61220d3bd337bc7a6e50dc5bc2c4f9e4b24f04b5c8e6e6b7746711c05656"
 
 [[package]]
 name = "logos"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,8 @@ rustls = { version = "0.23", features = ["aws_lc_rs"] }
 # Async runtime. Only the version is pinned here — tokio has no default
 # features and each consumer needs a very different slice of it.
 tokio = { version = "1" }
+# Feature-free: monty-pool builds spans only, while monty-runtime adds its exporter.
+logfire = { version = "0.12", default-features = false }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/crates/monty-pool/Cargo.toml
+++ b/crates/monty-pool/Cargo.toml
@@ -45,7 +45,7 @@ futures-util = { workspace = true }
 # before the first `wss://` dial (see `install_crypto_provider` in worker.rs).
 rustls = { workspace = true }
 # Span construction only; applications choose and configure exporter features.
-logfire = { version = "0.12", default-features = false, optional = true }
+logfire = { workspace = true, optional = true }
 # telemetry_json's logfire-style value encoding
 num-traits = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }

--- a/crates/monty-pool/Cargo.toml
+++ b/crates/monty-pool/Cargo.toml
@@ -45,7 +45,7 @@ futures-util = { workspace = true }
 # before the first `wss://` dial (see `install_crypto_provider` in worker.rs).
 rustls = { workspace = true }
 # Span construction only; applications choose and configure exporter features.
-logfire = { version = "0.11", default-features = false, optional = true }
+logfire = { version = "0.12", default-features = false, optional = true }
 # telemetry_json's logfire-style value encoding
 num-traits = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -784,9 +784,13 @@ impl Checkout {
     /// typed checkout, and so are the duration bookkeeping and the deadline
     /// derived from it — a raw-driven session keeps its `max_duration` backstop,
     /// and a raw `Load` re-adopts the dump's budget just as [`Checkout::restore`]
-    /// does. A `FatalError` (or, over WebSocket, `ShutdownDump`) turn-ender is
-    /// returned like any other so the driver can forward it, but the worker
-    /// behind it is discarded first — later calls report [`PoolError::Finished`].
+    /// does. Lifecycle requests (`Configure`/`Reset`/`Shutdown`) are refused
+    /// without reaching the worker: they belong to the checkout, and forwarding
+    /// a client's would let it re-`Configure` its way out of the session's
+    /// resource limits. A `FatalError` (or, over WebSocket, `ShutdownDump`)
+    /// turn-ender is returned like any other so the driver can forward it, but
+    /// the worker behind it is discarded first — later calls report
+    /// [`PoolError::Finished`].
     ///
     /// # Errors
     /// As [`Checkout::feed`]: a dead worker, a protocol violation, or a turn
@@ -798,11 +802,33 @@ impl Checkout {
         on_event: OnRawEvent<'_>,
     ) -> Result<pb::ChildEvent, PoolError> {
         self.ensure_ready()?;
-        // as `restore`: the dump carries its own limits and consumed time, so
+        // Lifecycle requests are the checkout's own business — `create` sends
+        // `Configure`, `finish` sends `Reset`, the pool owns `Shutdown` — and
+        // forwarding a client's would let it disarm the operator-chosen limits:
+        // `Reset` returns the child to its default (unlimited) session budget,
+        // and a follow-up `Configure` re-establishes with limits of the
+        // client's choosing. Caller misuse, so the worker stays usable.
+        if matches!(
+            request.kind,
+            None | Some(
+                pb::parent_request::Kind::Configure(_)
+                    | pb::parent_request::Kind::Reset(_)
+                    | pb::parent_request::Kind::Shutdown(_)
+            )
+        ) {
+            return Err(PoolError::Protocol(
+                "lifecycle requests (Configure/Reset/Shutdown) cannot be driven through turn_raw".into(),
+            ));
+        }
+        // As `restore`: the dump carries its own limits and consumed time, so
         // forget what `Configure` established and re-adopt both from the
         // reply's timing fields — otherwise the backstop below would keep
-        // measuring the restored session against the wrong budget
-        if matches!(request.kind, Some(pb::parent_request::Kind::Load(_))) {
+        // measuring the restored session against the wrong budget. Snapshot
+        // first: the pre-send frame-size rejection leaves the worker synced
+        // and the session live, so the budget must survive it too.
+        let saved_timing = matches!(request.kind, Some(pb::parent_request::Kind::Load(_)))
+            .then(|| (self.duration_budget, self.reported_execution));
+        if saved_timing.is_some() {
             self.duration_budget = None;
             self.reported_execution = Duration::ZERO;
         }
@@ -821,6 +847,16 @@ impl Checkout {
             None => self.turn_io_raw(request, on_event).await,
         };
         self.turn_in_flight = false;
+        // a failure that left the worker alive means the `Load` never reached
+        // the child (an oversize frame, rejected before any bytes were
+        // written) — the session continues on its original budget
+        if let Some((budget, reported)) = saved_timing
+            && outcome.is_err()
+            && self.worker.is_some()
+        {
+            self.duration_budget = budget;
+            self.reported_execution = reported;
+        }
         outcome
     }
 

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -5,6 +5,7 @@ use std::{
     future::{Future, ready},
     path::Path,
     pin::Pin,
+    process::ExitStatus,
     sync::Arc,
     time::Duration,
 };
@@ -781,7 +782,11 @@ impl Checkout {
     /// interleaved with `feed`/`resume`/`restore`. The lifecycle is shared:
     /// `create`, `finish` and worker poisoning behave exactly as they do for a
     /// typed checkout, and so are the duration bookkeeping and the deadline
-    /// derived from it — a raw-driven session keeps its `max_duration` backstop.
+    /// derived from it — a raw-driven session keeps its `max_duration` backstop,
+    /// and a raw `Load` re-adopts the dump's budget just as [`Checkout::restore`]
+    /// does. A `FatalError` (or, over WebSocket, `ShutdownDump`) turn-ender is
+    /// returned like any other so the driver can forward it, but the worker
+    /// behind it is discarded first — later calls report [`PoolError::Finished`].
     ///
     /// # Errors
     /// As [`Checkout::feed`]: a dead worker, a protocol violation, or a turn
@@ -793,6 +798,14 @@ impl Checkout {
         on_event: OnRawEvent<'_>,
     ) -> Result<pb::ChildEvent, PoolError> {
         self.ensure_ready()?;
+        // as `restore`: the dump carries its own limits and consumed time, so
+        // forget what `Configure` established and re-adopt both from the
+        // reply's timing fields — otherwise the backstop below would keep
+        // measuring the restored session against the wrong budget
+        if matches!(request.kind, Some(pb::parent_request::Kind::Load(_))) {
+            self.duration_budget = None;
+            self.reported_execution = Duration::ZERO;
+        }
         self.turn_in_flight = true;
         // as `expect_turn`: `request_timeout` alone would drop the `max_duration`
         // backstop, leaving a wedged child bounded only by a timeout that may be
@@ -849,15 +862,29 @@ impl Checkout {
             // turn-ender — so anything that is not a print ends the turn
             if matches!(event.kind, Some(pb::child_event::Kind::Print(_))) {
                 on_event(&event).await;
-            } else if matches!(event.kind, Some(pb::child_event::Kind::Shutdown(_)))
-                && !self.pool.config.transport.is_websocket()
-            {
-                // Only a serving relay sends this, never a child — `turn_io`
-                // refuses it for the same reason. It matters more here: a raw
-                // driver hands the turn-ender straight back to its own client,
-                // and a relay signs the dump on the way past, so accepting one
-                // would have the relay vouch for bytes its child minted.
-                return Err(self.protocol_violation("subprocess worker sent a ShutdownDump"));
+            } else if matches!(event.kind, Some(pb::child_event::Kind::FatalError(_))) {
+                // The far end is gone (see `fatal_error`): reap and discard
+                // the worker exactly as the typed path does — but still hand
+                // the frame back, since a raw driver forwards the child's own
+                // account of its death to its client.
+                self.reap_announced_exit().await;
+                return Ok(event);
+            } else if matches!(event.kind, Some(pb::child_event::Kind::Shutdown(_))) {
+                return if self.pool.config.transport.is_websocket() {
+                    // The serving relay is gone, and this checkout's
+                    // connection with it: discard the worker as `turn_io`
+                    // does, handing the frame (and the dump it carries) back
+                    // for the driver to forward.
+                    self.discard_worker();
+                    Ok(event)
+                } else {
+                    // Only a serving relay sends this, never a child — `turn_io`
+                    // refuses it for the same reason. It matters more here: a raw
+                    // driver hands the turn-ender straight back to its own client,
+                    // and a relay signs the dump on the way past, so accepting one
+                    // would have the relay vouch for bytes its child minted.
+                    Err(self.protocol_violation("subprocess worker sent a ShutdownDump"))
+                };
             } else if event.kind.is_none() {
                 // Every proto field is optional, so a broken or hostile worker
                 // can send an event whose oneof is unset. It ends no turn — the
@@ -1120,7 +1147,22 @@ impl Checkout {
     /// handles crashes by starting a new session needs no extra arm, and the
     /// worker's own account lands in [`CrashCause::Announced`].
     async fn fatal_error(&mut self, message: &str) -> PoolError {
-        let status = match self.worker.take() {
+        let status = self.reap_announced_exit().await;
+        self.pending = None;
+        self.feed_mounts = None;
+        PoolError::Crashed {
+            status,
+            cause: CrashCause::Announced {
+                reason: message.to_owned(),
+            },
+        }
+    }
+
+    /// Takes and reaps the worker behind a `FatalError` frame, returning its
+    /// exit status when one was observed. Shared by [`Self::fatal_error`] and
+    /// the raw path, which discards the worker but returns the frame itself.
+    async fn reap_announced_exit(&mut self) -> Option<ExitStatus> {
+        match self.worker.take() {
             // the child exits right after the frame, so give it a moment to do
             // so before killing: that is what surfaces e.g. the non-zero status
             // of a version-skew exit, which a SIGKILL would replace with the
@@ -1134,14 +1176,6 @@ impl Checkout {
                 status
             }
             None => None,
-        };
-        self.pending = None;
-        self.feed_mounts = None;
-        PoolError::Crashed {
-            status,
-            cause: CrashCause::Announced {
-                reason: message.to_owned(),
-            },
         }
     }
 

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -205,6 +205,11 @@ pub type PrintFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 /// copies of whatever it needs (including the text, if consumed async).
 pub type OnPrint<'a> = &'a mut (dyn FnMut(PrintStream, &str) -> PrintFuture + Send);
 
+/// Callback for the events a [`Checkout::turn_raw`] streams before the
+/// turn-ender — `Print`s today. Returns a future for the same reason
+/// [`OnPrint`] does: a slow sink backpressures the worker.
+pub type OnRawEvent<'a> = &'a mut (dyn FnMut(&pb::ChildEvent) -> PrintFuture + Send);
+
 /// Adapts a synchronous print sink to the [`OnPrint`] callback shape.
 ///
 /// ```rust,no_run
@@ -757,6 +762,113 @@ impl Checkout {
         };
         self.turn_in_flight = false;
         outcome
+    }
+
+    /// Sends `request` and returns the child's turn-ending event, as protobuf —
+    /// no conversion to [`TurnEvent`].
+    ///
+    /// For callers that already speak the wire: a relay or server bridging a
+    /// remote client has to hand the client a `ChildEvent` frame, and rebuilding
+    /// one from a [`TurnEvent`] means hand-inverting the whole protocol —
+    /// every arm of `OsFunctionCall` included. This hands back what the child
+    /// actually sent.
+    ///
+    /// `on_event` sees each streamed event (`Print`) before the turn-ender.
+    ///
+    /// **Bypasses this checkout's suspension bookkeeping.** `pending`,
+    /// `feed_mounts` and `restored_script_name` are not maintained, so a
+    /// checkout driven this way must be driven *only* this way — never
+    /// interleaved with `feed`/`resume`/`restore`. The lifecycle is shared:
+    /// `create`, `finish` and worker poisoning behave exactly as they do for a
+    /// typed checkout, and so are the duration bookkeeping and the deadline
+    /// derived from it — a raw-driven session keeps its `max_duration` backstop.
+    ///
+    /// # Errors
+    /// As [`Checkout::feed`]: a dead worker, a protocol violation, or a turn
+    /// that outlived `request_timeout` or the session's remaining
+    /// `max_duration` budget.
+    pub async fn turn_raw(
+        &mut self,
+        request: &pb::ParentRequest,
+        on_event: OnRawEvent<'_>,
+    ) -> Result<pb::ChildEvent, PoolError> {
+        self.ensure_ready()?;
+        self.turn_in_flight = true;
+        // as `expect_turn`: `request_timeout` alone would drop the `max_duration`
+        // backstop, leaving a wedged child bounded only by a timeout that may be
+        // longer or unset. `turn_io_raw` maintains the reported-time bookkeeping
+        // the backstop reads, so it is as accurate here as on the typed path.
+        let deadline = min_deadline(self.pool.config.request_timeout, self.backstop_deadline());
+        self.armed_deadline = deadline;
+        let outcome = match deadline {
+            Some(limit) => match timeout(limit, self.turn_io_raw(request, on_event)).await {
+                Ok(outcome) => outcome,
+                Err(_elapsed) => Err(self.poison_timeout().await),
+            },
+            None => self.turn_io_raw(request, on_event).await,
+        };
+        self.turn_in_flight = false;
+        outcome
+    }
+
+    /// The body of [`Self::turn_raw`]: send, stream, return the turn-ender.
+    ///
+    /// Mirrors `turn_io`'s failure handling exactly — the difference is only
+    /// that events are returned rather than classified.
+    async fn turn_io_raw(
+        &mut self,
+        request: &pb::ParentRequest,
+        on_event: OnRawEvent<'_>,
+    ) -> Result<pb::ChildEvent, PoolError> {
+        let Some(worker) = self.worker.as_mut() else {
+            return Err(PoolError::Finished);
+        };
+        if let Err(err) = worker.send(request).await {
+            // an oversize frame is rejected before any bytes are written, so
+            // the worker is still synced — see `turn_io`
+            return Err(match err {
+                FrameError::FrameTooLarge { len, max } => PoolError::Runtime(MontyException::new(
+                    ExcType::RuntimeError,
+                    Some(format!(
+                        "request frame of {len} bytes exceeds the maximum of {max} bytes"
+                    )),
+                )),
+                _ => self.poison("sending a request").await,
+            });
+        }
+        loop {
+            let event = match self.worker.as_mut().expect("checked above").recv().await {
+                Ok(event) => event,
+                Err(FrameError::Decode(err)) => {
+                    return Err(self.protocol_violation(format!("invalid payload from worker: {err}")));
+                }
+                Err(_) => return Err(self.poison("waiting for a reply").await),
+            };
+            self.note_reported_time(&event);
+            // strict alternation: zero or more `Print`s, then exactly one
+            // turn-ender — so anything that is not a print ends the turn
+            if matches!(event.kind, Some(pb::child_event::Kind::Print(_))) {
+                on_event(&event).await;
+            } else if matches!(event.kind, Some(pb::child_event::Kind::Shutdown(_)))
+                && !self.pool.config.transport.is_websocket()
+            {
+                // Only a serving relay sends this, never a child — `turn_io`
+                // refuses it for the same reason. It matters more here: a raw
+                // driver hands the turn-ender straight back to its own client,
+                // and a relay signs the dump on the way past, so accepting one
+                // would have the relay vouch for bytes its child minted.
+                return Err(self.protocol_violation("subprocess worker sent a ShutdownDump"));
+            } else if event.kind.is_none() {
+                // Every proto field is optional, so a broken or hostile worker
+                // can send an event whose oneof is unset. It ends no turn — the
+                // typed path calls the same frame an "unexpected event" — and a
+                // raw driver would otherwise forward it to its own client as a
+                // valid turn-ender and go back to idle.
+                return Err(self.protocol_violation("worker sent an event with no kind"));
+            } else {
+                return Ok(event);
+            }
+        }
     }
 
     /// Fails fast when the checkout cannot start protocol work: the worker is

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -768,46 +768,41 @@ impl Checkout {
     /// Sends `request` and returns the child's turn-ending event, as protobuf —
     /// no conversion to [`TurnEvent`].
     ///
-    /// For callers that already speak the wire: a relay or server bridging a
-    /// remote client has to hand the client a `ChildEvent` frame, and rebuilding
-    /// one from a [`TurnEvent`] means hand-inverting the whole protocol —
-    /// every arm of `OsFunctionCall` included. This hands back what the child
-    /// actually sent.
+    /// For callers that already speak the wire (a relay bridging a remote
+    /// client): rebuilding a `ChildEvent` frame from a [`TurnEvent`] means
+    /// hand-inverting the whole protocol, so this hands back what the child
+    /// actually sent. `on_event` sees each streamed `Print` before the
+    /// turn-ender.
     ///
-    /// `on_event` sees each streamed event (`Print`) before the turn-ender.
-    ///
-    /// **Bypasses this checkout's suspension bookkeeping.** `pending`,
-    /// `feed_mounts` and `restored_script_name` are not maintained, so a
-    /// checkout driven this way must be driven *only* this way — never
-    /// interleaved with `feed`/`resume`/`restore`. The lifecycle is shared:
-    /// `create`, `finish` and worker poisoning behave exactly as they do for a
-    /// typed checkout, and so are the duration bookkeeping and the deadline
-    /// derived from it — a raw-driven session keeps its `max_duration` backstop,
-    /// and a raw `Load` re-adopts the dump's budget just as [`Checkout::restore`]
-    /// does. Lifecycle requests (`Configure`/`Reset`/`Shutdown`) are refused
-    /// without reaching the worker: they belong to the checkout, and forwarding
-    /// a client's would let it re-`Configure` its way out of the session's
-    /// resource limits. A `FatalError` (or, over WebSocket, `ShutdownDump`)
-    /// turn-ender is returned like any other so the driver can forward it, but
-    /// the worker behind it is discarded first — later calls report
+    /// **Bypasses this checkout's suspension bookkeeping** (`pending`,
+    /// `feed_mounts`, `restored_script_name`) — never interleave with
+    /// `feed`/`resume`/`restore`. Worker lifecycle, poisoning and the
+    /// `max_duration` backstop work as on the typed path; a raw `Load`
+    /// re-adopts the dump's budget like [`Checkout::restore`]. A `FatalError`
+    /// (or WebSocket `ShutdownDump`) turn-ender is returned so the driver can
+    /// forward it, but discards the worker first — later calls report
     /// [`PoolError::Finished`].
+    ///
+    /// # Security
+    /// `request` is typically a remote client's, so it is treated as hostile:
+    /// `Configure`/`Reset`/`Shutdown` are refused here (a client could
+    /// otherwise `Reset` away the operator-chosen resource limits and
+    /// re-`Configure` its own). A `Load`'s bytes DO reach the worker's
+    /// deserialiser — the driver must verify a dump is one it issued
+    /// (monty-server signs and checks them) before passing it in.
     ///
     /// # Errors
     /// As [`Checkout::feed`]: a dead worker, a protocol violation, or a turn
-    /// that outlived `request_timeout` or the session's remaining
-    /// `max_duration` budget.
+    /// that outlived `request_timeout` or the remaining `max_duration` budget.
     pub async fn turn_raw(
         &mut self,
         request: &pb::ParentRequest,
         on_event: OnRawEvent<'_>,
     ) -> Result<pb::ChildEvent, PoolError> {
         self.ensure_ready()?;
-        // Lifecycle requests are the checkout's own business — `create` sends
-        // `Configure`, `finish` sends `Reset`, the pool owns `Shutdown` — and
-        // forwarding a client's would let it disarm the operator-chosen limits:
-        // `Reset` returns the child to its default (unlimited) session budget,
-        // and a follow-up `Configure` re-establishes with limits of the
-        // client's choosing. Caller misuse, so the worker stays usable.
+        // A raw client could otherwise `Reset` the child back to its default
+        // (unlimited) session budget and re-`Configure` with its own limits.
+        // Caller misuse, so the worker stays usable.
         if matches!(
             request.kind,
             None | Some(
@@ -820,12 +815,9 @@ impl Checkout {
                 "lifecycle requests (Configure/Reset/Shutdown) cannot be driven through turn_raw".into(),
             ));
         }
-        // As `restore`: the dump carries its own limits and consumed time, so
-        // forget what `Configure` established and re-adopt both from the
-        // reply's timing fields — otherwise the backstop below would keep
-        // measuring the restored session against the wrong budget. Snapshot
-        // first: the pre-send frame-size rejection leaves the worker synced
-        // and the session live, so the budget must survive it too.
+        // As `restore`: forget the Configure-time budget and re-adopt the
+        // dump's from the reply's timing fields. Snapshotted because the
+        // pre-send frame-size rejection leaves the session live.
         let saved_timing = matches!(request.kind, Some(pb::parent_request::Kind::Load(_)))
             .then(|| (self.duration_budget, self.reported_execution));
         if saved_timing.is_some() {
@@ -834,9 +826,7 @@ impl Checkout {
         }
         self.turn_in_flight = true;
         // as `expect_turn`: `request_timeout` alone would drop the `max_duration`
-        // backstop, leaving a wedged child bounded only by a timeout that may be
-        // longer or unset. `turn_io_raw` maintains the reported-time bookkeeping
-        // the backstop reads, so it is as accurate here as on the typed path.
+        // backstop, leaving a wedged child bounded by a timeout that may be unset
         let deadline = min_deadline(self.pool.config.request_timeout, self.backstop_deadline());
         self.armed_deadline = deadline;
         let outcome = match deadline {
@@ -847,9 +837,8 @@ impl Checkout {
             None => self.turn_io_raw(request, on_event).await,
         };
         self.turn_in_flight = false;
-        // a failure that left the worker alive means the `Load` never reached
-        // the child (an oversize frame, rejected before any bytes were
-        // written) — the session continues on its original budget
+        // an error with the worker still alive is the pre-send frame-size
+        // rejection: the `Load` never reached the child, put the budget back
         if let Some((budget, reported)) = saved_timing
             && outcome.is_err()
             && self.worker.is_some()
@@ -862,8 +851,9 @@ impl Checkout {
 
     /// The body of [`Self::turn_raw`]: send, stream, return the turn-ender.
     ///
-    /// Mirrors `turn_io`'s failure handling exactly — the difference is only
-    /// that events are returned rather than classified.
+    /// Mirrors `turn_io`'s failure handling, but events are returned rather
+    /// than classified — including `FatalError`/`Shutdown`, which discard the
+    /// worker yet still hand the frame back.
     async fn turn_io_raw(
         &mut self,
         request: &pb::ParentRequest,
@@ -899,34 +889,28 @@ impl Checkout {
             if matches!(event.kind, Some(pb::child_event::Kind::Print(_))) {
                 on_event(&event).await;
             } else if matches!(event.kind, Some(pb::child_event::Kind::FatalError(_))) {
-                // The far end is gone (see `fatal_error`): reap and discard
-                // the worker exactly as the typed path does — but still hand
-                // the frame back, since a raw driver forwards the child's own
-                // account of its death to its client.
+                // the far end is gone (see `fatal_error`): discard the worker
+                // as the typed path does, but still hand back the child's own
+                // account of its death for the driver to forward
                 self.reap_announced_exit().await;
                 return Ok(event);
             } else if matches!(event.kind, Some(pb::child_event::Kind::Shutdown(_))) {
                 return if self.pool.config.transport.is_websocket() {
-                    // The serving relay is gone, and this checkout's
-                    // connection with it: discard the worker as `turn_io`
-                    // does, handing the frame (and the dump it carries) back
-                    // for the driver to forward.
+                    // the serving relay is gone: discard as `turn_io` does,
+                    // handing the frame (and its dump) back to forward
                     self.discard_worker();
                     Ok(event)
                 } else {
-                    // Only a serving relay sends this, never a child — `turn_io`
-                    // refuses it for the same reason. It matters more here: a raw
-                    // driver hands the turn-ender straight back to its own client,
-                    // and a relay signs the dump on the way past, so accepting one
-                    // would have the relay vouch for bytes its child minted.
+                    // Only a serving relay sends this, never a child — and a
+                    // raw driver's relay signs dumps on the way past, so
+                    // accepting one would have it vouch for bytes its child
+                    // minted.
                     Err(self.protocol_violation("subprocess worker sent a ShutdownDump"))
                 };
             } else if event.kind.is_none() {
-                // Every proto field is optional, so a broken or hostile worker
-                // can send an event whose oneof is unset. It ends no turn — the
-                // typed path calls the same frame an "unexpected event" — and a
-                // raw driver would otherwise forward it to its own client as a
-                // valid turn-ender and go back to idle.
+                // every proto field is optional, so a hostile worker can send
+                // an event with no kind set; it ends no turn and must not
+                // reach the driver's client as one
                 return Err(self.protocol_violation("worker sent an event with no kind"));
             } else {
                 return Ok(event);

--- a/crates/monty-pool/src/lib.rs
+++ b/crates/monty-pool/src/lib.rs
@@ -17,7 +17,8 @@ use monty_types::MontyException;
 
 pub use crate::{
     checkout::{
-        Checkout, MountSpec, MountSpecMode, OnPrint, PrintFuture, ReplConfig, ResumeValue, TurnEvent, on_print_sync,
+        Checkout, MountSpec, MountSpecMode, OnPrint, OnRawEvent, PrintFuture, ReplConfig, ResumeValue, TurnEvent,
+        on_print_sync,
     },
     pool::Pool,
 };

--- a/crates/monty-pool/src/telemetry_adapter.rs
+++ b/crates/monty-pool/src/telemetry_adapter.rs
@@ -72,6 +72,25 @@ impl TelemetryAdapterHandle {
 }
 
 impl TelemetryContext {
+    /// Records the pool's spans straight into `logfire`, with no adapter.
+    ///
+    /// The rest of this module exists to hand spans to a *foreign* SDK, so its
+    /// pipeline is exporter-free and the host owns delivery. A Rust host has no
+    /// boundary to cross: it already has a configured `Logfire`, and the
+    /// recorder only needs one to write into. Without this it would have to
+    /// implement [`TelemetryAdapter`] and stand up a second OTLP exporter to
+    /// receive its own spans — or define a second span vocabulary of its own.
+    ///
+    /// Unparented, like [`TelemetryAdapterHandle::unparented_context`]: a Rust
+    /// host's ambient span is in the same process, so the pool's roots attach
+    /// to it through `tracing` rather than through W3C fields.
+    #[must_use]
+    pub fn for_logfire(logfire: Logfire) -> Self {
+        Self { parent: None, logfire }
+    }
+}
+
+impl TelemetryContext {
     /// Returns the isolated recorder installed while processing this checkout.
     pub(crate) fn logfire(&self) -> Logfire {
         self.logfire.clone()

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -26,6 +26,9 @@ use monty_pool::{
     MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, PrintFuture, ReplConfig, ResumeValue, TurnEvent,
     on_print_sync,
 };
+// only the unix-gated raw-path test forges worker frames
+#[cfg(unix)]
+use monty_proto::{encode_framed_into, pb};
 use monty_types::{MontyObject, PrintStream, ResourceLimits, TypeCheckingConfig, TypeCheckingFormat};
 use tokio::time::sleep;
 
@@ -1170,6 +1173,123 @@ async fn unrecognised_exit_code_stays_an_opaque_death() {
     // the message says only what the pool was doing and what it reaped — no
     // memory wording, which is what `OOM_EXIT_CODE` alone earns
     assert_snapshot!(err.to_string(), @"monty worker crashed while waiting for a reply (exit status: 64)");
+}
+
+/// A local child cannot pass a `ShutdownDump` off as a turn-ender on the raw
+/// path.
+///
+/// Only a serving relay sends one; a subprocess claiming to shut down is
+/// lying about what it is. `turn_io` has always refused it, but `turn_raw` —
+/// the API a relay drives — took any non-`Print` event as the turn-ender, so a
+/// compromised child could hand back a dump it minted itself. That dump would
+/// travel out through the relay, which signs whatever it forwards, and reach
+/// the relay's own client as trusted, server-vouched session state.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_subprocess_shutdown_dump_is_refused_on_the_raw_path() {
+    let dir = tempfile::tempdir().unwrap();
+    // the two frames the stand-in replays, in order: `Ok` answers the
+    // `Configure` that establishes the session, then the forged dump
+    let mut replies = framed(&child_event(pb::child_event::Kind::Ok(pb::Ok {})));
+    replies.extend(framed(&child_event(pb::child_event::Kind::Shutdown(
+        pb::ShutdownDump {
+            dump: Some(b"a dump the child minted itself".to_vec()),
+        },
+    ))));
+    let replies_path = dir.path().join("replies.bin");
+    fs::write(&replies_path, &replies).unwrap();
+
+    let fake = dir.path().join("monty");
+    // both frames are written up front and the process stays alive; the parent
+    // reads them in turn as it sends `Configure` and then the raw request
+    fs::write(&fake, format!("#!/bin/sh\ncat '{}'\nsleep 5\n", replies_path.display())).unwrap();
+    fs::set_permissions(&fake, PermissionsExt::from_mode(0o755)).unwrap();
+
+    let pool = Pool::new(PoolConfig::subprocess(&fake)).await.unwrap();
+    let mut checkout = pool
+        .checkout(&ReplConfig::default())
+        .await
+        .expect("the stand-in answers Configure with Ok");
+    let request = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::Feed(pb::Feed {
+            code: "1 + 1".to_owned(),
+            inputs: vec![],
+            skip_type_check: false,
+        })),
+        ..pb::ParentRequest::default()
+    };
+    let mut on_event = |_: &pb::ChildEvent| Box::pin(ready(())) as PrintFuture;
+    let err = checkout
+        .turn_raw(&request, &mut on_event)
+        .await
+        .expect_err("a subprocess ShutdownDump must not be accepted");
+    assert_snapshot!(
+        err.to_string(),
+        @"monty worker protocol error: subprocess worker sent a ShutdownDump"
+    );
+}
+
+/// An event with no `kind` ends no turn on the raw path.
+///
+/// Every field of `ChildEvent` is optional on the wire, so a broken or hostile
+/// worker can send one whose oneof is simply unset. `turn_io` calls that an
+/// "unexpected event" and discards the worker, but `turn_raw` returned any
+/// non-`Print` event as the turn-ender — so the frame reached the raw driver's
+/// own client as a successful turn, and the session went back to idle on the
+/// strength of a frame that means nothing.
+#[cfg(unix)]
+#[tokio::test]
+async fn an_event_with_no_kind_is_refused_on_the_raw_path() {
+    let dir = tempfile::tempdir().unwrap();
+    // `Ok` answers the establishing `Configure`, then the kindless frame
+    let mut replies = framed(&child_event(pb::child_event::Kind::Ok(pb::Ok {})));
+    replies.extend(framed(&pb::ChildEvent::default()));
+    let replies_path = dir.path().join("replies.bin");
+    fs::write(&replies_path, &replies).unwrap();
+
+    let fake = dir.path().join("monty");
+    fs::write(&fake, format!("#!/bin/sh\ncat '{}'\nsleep 5\n", replies_path.display())).unwrap();
+    fs::set_permissions(&fake, PermissionsExt::from_mode(0o755)).unwrap();
+
+    let pool = Pool::new(PoolConfig::subprocess(&fake)).await.unwrap();
+    let mut checkout = pool
+        .checkout(&ReplConfig::default())
+        .await
+        .expect("the stand-in answers Configure with Ok");
+    let request = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::Feed(pb::Feed {
+            code: "1 + 1".to_owned(),
+            inputs: vec![],
+            skip_type_check: false,
+        })),
+        ..pb::ParentRequest::default()
+    };
+    let mut on_event = |_: &pb::ChildEvent| Box::pin(ready(())) as PrintFuture;
+    let err = checkout
+        .turn_raw(&request, &mut on_event)
+        .await
+        .expect_err("a kindless event must not be accepted as a turn-ender");
+    assert_snapshot!(
+        err.to_string(),
+        @"monty worker protocol error: worker sent an event with no kind"
+    );
+}
+
+/// Length-prefixes one event exactly as a worker writes it.
+#[cfg(unix)]
+fn framed(event: &pb::ChildEvent) -> Vec<u8> {
+    let mut buf = Vec::new();
+    encode_framed_into(event, &mut buf).expect("encode");
+    buf
+}
+
+/// A `ChildEvent` carrying `kind` and nothing else.
+#[cfg(unix)]
+fn child_event(kind: pb::child_event::Kind) -> pb::ChildEvent {
+    pb::ChildEvent {
+        kind: Some(kind),
+        ..pb::ChildEvent::default()
+    }
 }
 
 /// A refused allocation is the one `Runtime` error whose worker is already

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -1176,14 +1176,9 @@ async fn unrecognised_exit_code_stays_an_opaque_death() {
 }
 
 /// A local child cannot pass a `ShutdownDump` off as a turn-ender on the raw
-/// path.
-///
-/// Only a serving relay sends one; a subprocess claiming to shut down is
-/// lying about what it is. `turn_io` has always refused it, but `turn_raw` —
-/// the API a relay drives — took any non-`Print` event as the turn-ender, so a
-/// compromised child could hand back a dump it minted itself. That dump would
-/// travel out through the relay, which signs whatever it forwards, and reach
-/// the relay's own client as trusted, server-vouched session state.
+/// path: only a serving relay sends one, and accepting it would let a
+/// compromised child hand a dump it minted itself out through a relay that
+/// signs whatever it forwards.
 #[cfg(unix)]
 #[tokio::test]
 async fn a_subprocess_shutdown_dump_is_refused_on_the_raw_path() {
@@ -1229,14 +1224,9 @@ async fn a_subprocess_shutdown_dump_is_refused_on_the_raw_path() {
     );
 }
 
-/// An event with no `kind` ends no turn on the raw path.
-///
-/// Every field of `ChildEvent` is optional on the wire, so a broken or hostile
-/// worker can send one whose oneof is simply unset. `turn_io` calls that an
-/// "unexpected event" and discards the worker, but `turn_raw` returned any
-/// non-`Print` event as the turn-ender — so the frame reached the raw driver's
-/// own client as a successful turn, and the session went back to idle on the
-/// strength of a frame that means nothing.
+/// An event with no `kind` ends no turn on the raw path. Every wire field is
+/// optional, so a hostile worker can send one whose oneof is unset — it must
+/// not reach the raw driver's client as a successful turn-ender.
 #[cfg(unix)]
 #[tokio::test]
 async fn an_event_with_no_kind_is_refused_on_the_raw_path() {
@@ -1275,13 +1265,9 @@ async fn an_event_with_no_kind_is_refused_on_the_raw_path() {
     );
 }
 
-/// A `FatalError` ends a raw turn *and* the worker behind it.
-///
-/// The frame is handed back — a raw driver forwards the child's own account of
-/// its death to its client — but the child exits right after writing it, so the
-/// worker must be reaped and discarded exactly as on the typed path. It used to
-/// be kept, leaving a dead process holding its pool slot until the failure
-/// resurfaced as an unexplained crash on the next turn.
+/// A `FatalError` ends a raw turn *and* the worker behind it: the frame is
+/// handed back for the driver to forward, but the dead child is reaped and
+/// discarded rather than holding its pool slot until the next failure.
 #[cfg(unix)]
 #[tokio::test]
 async fn a_fatal_error_on_the_raw_path_discards_the_worker() {

--- a/crates/monty-pool/tests/pool_test.rs
+++ b/crates/monty-pool/tests/pool_test.rs
@@ -1275,6 +1275,58 @@ async fn an_event_with_no_kind_is_refused_on_the_raw_path() {
     );
 }
 
+/// A `FatalError` ends a raw turn *and* the worker behind it.
+///
+/// The frame is handed back — a raw driver forwards the child's own account of
+/// its death to its client — but the child exits right after writing it, so the
+/// worker must be reaped and discarded exactly as on the typed path. It used to
+/// be kept, leaving a dead process holding its pool slot until the failure
+/// resurfaced as an unexplained crash on the next turn.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_fatal_error_on_the_raw_path_discards_the_worker() {
+    let dir = tempfile::tempdir().unwrap();
+    // `Ok` answers the establishing `Configure`, then the fatal frame
+    let mut replies = framed(&child_event(pb::child_event::Kind::Ok(pb::Ok {})));
+    replies.extend(framed(&child_event(pb::child_event::Kind::FatalError(
+        pb::FatalError {
+            message: "the child is done".to_owned(),
+        },
+    ))));
+    let replies_path = dir.path().join("replies.bin");
+    fs::write(&replies_path, &replies).unwrap();
+
+    let fake = dir.path().join("monty");
+    fs::write(&fake, format!("#!/bin/sh\ncat '{}'\nsleep 5\n", replies_path.display())).unwrap();
+    fs::set_permissions(&fake, PermissionsExt::from_mode(0o755)).unwrap();
+
+    let pool = Pool::new(PoolConfig::subprocess(&fake)).await.unwrap();
+    let mut checkout = pool
+        .checkout(&ReplConfig::default())
+        .await
+        .expect("the stand-in answers Configure with Ok");
+    let request = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::Feed(pb::Feed {
+            code: "1 + 1".to_owned(),
+            inputs: vec![],
+            skip_type_check: false,
+        })),
+        ..pb::ParentRequest::default()
+    };
+    let mut on_event = |_: &pb::ChildEvent| Box::pin(ready(())) as PrintFuture;
+    let event = checkout
+        .turn_raw(&request, &mut on_event)
+        .await
+        .expect("the fatal frame is the turn-ender");
+    let Some(pb::child_event::Kind::FatalError(fatal)) = event.kind else {
+        panic!("expected the FatalError frame back, got {:?}", event.kind);
+    };
+    assert_eq!(fatal.message, "the child is done");
+    // the worker was discarded with the frame, not kept until the next failure
+    let err = checkout.turn_raw(&request, &mut on_event).await.unwrap_err();
+    assert!(matches!(err, PoolError::Finished), "got {err:?}");
+}
+
 /// Length-prefixes one event exactly as a worker writes it.
 #[cfg(unix)]
 fn framed(event: &pb::ChildEvent) -> Vec<u8> {

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -14,7 +14,7 @@ use std::{
 use monty_pool::{
     Checkout, MountSpec, MountSpecMode, Pool, PoolConfig, PoolError, PrintFuture, ReplConfig, ResumeValue, TurnEvent,
 };
-use monty_proto::{WireFunctionCall, decode_frame, encode_to_capped_vec, pb};
+use monty_proto::{MAX_FRAME_LEN, WireFunctionCall, decode_frame, encode_to_capped_vec, pb};
 use monty_types::{MontyObject, PrintStream, ResourceLimits};
 use tokio::task::spawn_blocking;
 use tungstenite::{Message, WebSocket};
@@ -402,6 +402,127 @@ async fn a_raw_load_adopts_the_dumps_duration_budget() {
         panic!("expected Timeout, got {err:?}");
     };
     // the dump's 100ms budget plus the grace — not the Configure-time 5s
+    assert_eq!(timeout, Duration::from_millis(400));
+    join_server(server).await;
+}
+
+/// Lifecycle requests are refused on the raw path without reaching the worker.
+///
+/// `Configure`, `Reset` and `Shutdown` belong to the checkout (`create`,
+/// `finish`, the pool); forwarding a raw client's would let it `Reset` the
+/// child back to its default (unlimited) session budget and re-`Configure`
+/// with limits of its own choosing. The refusal is caller misuse, not worker
+/// misbehaviour — the session stays live, which the mock server proves by
+/// seeing the `Feed` as its very next frame.
+#[tokio::test]
+async fn lifecycle_requests_are_refused_on_the_raw_path() {
+    let (listener, config) = ws_pool_config();
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        assert!(matches!(
+            read_request(&mut socket),
+            pb::parent_request::Kind::Configure(_)
+        ));
+        send_event(&mut socket, &event_kind(pb::child_event::Kind::Ok(pb::Ok {})));
+        // the refused requests never arrive: the next frame is the Feed
+        assert!(matches!(read_request(&mut socket), pb::parent_request::Kind::Feed(_)));
+        send_event(
+            &mut socket,
+            &event_kind(pb::child_event::Kind::Complete(pb::Complete {
+                value: Some(MontyObject::Int(2).into()),
+            })),
+        );
+    });
+
+    let pool = Pool::new(config).await.expect("pool");
+    let mut checkout = pool.checkout(&ReplConfig::default()).await.expect("checkout");
+    let mut on_event = |_: &pb::ChildEvent| Box::pin(ready(())) as PrintFuture;
+    let lifecycle_kinds = [
+        None,
+        Some(pb::parent_request::Kind::Configure(pb::Configure::default())),
+        Some(pb::parent_request::Kind::Reset(pb::Reset {})),
+        Some(pb::parent_request::Kind::Shutdown(pb::Shutdown {})),
+    ];
+    for kind in lifecycle_kinds {
+        let request = pb::ParentRequest {
+            kind,
+            ..pb::ParentRequest::default()
+        };
+        let err = checkout.turn_raw(&request, &mut on_event).await.unwrap_err();
+        assert!(matches!(err, PoolError::Protocol(_)), "got {err:?}");
+    }
+    // the session survived every refusal
+    let feed = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::Feed(pb::Feed {
+            code: "1 + 1".to_owned(),
+            inputs: vec![],
+            skip_type_check: false,
+        })),
+        ..pb::ParentRequest::default()
+    };
+    let event = checkout.turn_raw(&feed, &mut on_event).await.expect("feed");
+    assert!(
+        matches!(event.kind, Some(pb::child_event::Kind::Complete(_))),
+        "got {:?}",
+        event.kind
+    );
+    join_server(server).await;
+}
+
+/// An oversize raw `Load` keeps the session's duration budget.
+///
+/// The frame is rejected before any bytes are written, leaving the worker
+/// synced and the session live — so the budget cleared in anticipation of the
+/// dump's own limits must be put back, or the session would run on with no
+/// `max_duration` backstop at all.
+#[tokio::test]
+async fn an_oversize_raw_load_keeps_the_duration_budget() {
+    let (listener, mut config) = ws_pool_config();
+    config.duration_limit_grace = Some(Duration::from_millis(300));
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        assert!(matches!(
+            read_request(&mut socket),
+            pb::parent_request::Kind::Configure(_)
+        ));
+        send_event(&mut socket, &event_kind(pb::child_event::Kind::Ok(pb::Ok {})));
+        // the oversize Load never arrives: the next frame is the Feed, which
+        // is never answered so only the backstop can end it
+        assert!(matches!(read_request(&mut socket), pb::parent_request::Kind::Feed(_)));
+        let _ = socket.read();
+    });
+
+    let pool = Pool::new(config).await.expect("pool");
+    let mut checkout = pool
+        .checkout(&ReplConfig {
+            limits: Some(ResourceLimits::default().max_duration(Duration::from_millis(100))),
+            ..ReplConfig::default()
+        })
+        .await
+        .expect("checkout");
+    let mut on_event = |_: &pb::ChildEvent| Box::pin(ready(())) as PrintFuture;
+    let load = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::Load(pb::Load {
+            state: vec![0; MAX_FRAME_LEN as usize + 1],
+        })),
+        ..pb::ParentRequest::default()
+    };
+    let err = checkout.turn_raw(&load, &mut on_event).await.unwrap_err();
+    assert!(matches!(err, PoolError::Runtime(_)), "got {err:?}");
+    let feed = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::Feed(pb::Feed {
+            code: "while True:\n    pass".to_owned(),
+            inputs: vec![],
+            skip_type_check: false,
+        })),
+        ..pb::ParentRequest::default()
+    };
+    let err = checkout.turn_raw(&feed, &mut on_event).await.unwrap_err();
+    let PoolError::Timeout { timeout } = err else {
+        panic!("expected Timeout, got {err:?}");
+    };
+    // the Configure-time budget plus the grace still arms — it was not lost
+    // to the rejected Load
     assert_eq!(timeout, Duration::from_millis(400));
     join_server(server).await;
 }

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -295,12 +295,8 @@ async fn duration_backstop_kills_an_unresponsive_worker() {
 }
 
 /// The same backstop arms on the raw path, which a relay drives instead of
-/// `feed`.
-///
-/// `turn_raw` used to arm `request_timeout` alone, so a session whose only
-/// bound was `max_duration` — the shape a serving relay configures, since it
-/// applies limits rather than client timeouts — had no parent-side deadline at
-/// all, and a wedged child held the turn indefinitely.
+/// `feed`. `turn_raw` used to arm `request_timeout` alone, so a session whose
+/// only bound was `max_duration` had no parent-side deadline at all.
 #[tokio::test]
 async fn duration_backstop_arms_on_the_raw_path() {
     let (listener, mut config) = ws_pool_config();
@@ -342,12 +338,9 @@ async fn duration_backstop_arms_on_the_raw_path() {
     join_server(server).await;
 }
 
-/// A raw `Load` re-adopts the dump's duration budget, exactly as `restore`.
-///
-/// `turn_raw` used to keep the `Configure`-time budget across a `Load`, so a
-/// restored session's backstop measured it against the wrong limit — here the
-/// checkout's own 5s budget would have left a wedged post-restore turn running
-/// for 5.3s instead of being killed at the dump's 100ms + grace.
+/// A raw `Load` re-adopts the dump's duration budget, exactly as `restore` —
+/// it used to keep the `Configure`-time budget, so a restored session's
+/// backstop measured turns against the wrong limit.
 #[tokio::test]
 async fn a_raw_load_adopts_the_dumps_duration_budget() {
     let (listener, mut config) = ws_pool_config();
@@ -406,14 +399,10 @@ async fn a_raw_load_adopts_the_dumps_duration_budget() {
     join_server(server).await;
 }
 
-/// Lifecycle requests are refused on the raw path without reaching the worker.
-///
-/// `Configure`, `Reset` and `Shutdown` belong to the checkout (`create`,
-/// `finish`, the pool); forwarding a raw client's would let it `Reset` the
-/// child back to its default (unlimited) session budget and re-`Configure`
-/// with limits of its own choosing. The refusal is caller misuse, not worker
-/// misbehaviour — the session stays live, which the mock server proves by
-/// seeing the `Feed` as its very next frame.
+/// Lifecycle requests are refused on the raw path without reaching the
+/// worker: forwarding a client's `Reset`/`Configure` would let it disarm the
+/// operator-chosen resource limits. The session stays live, which the mock
+/// server proves by seeing the `Feed` as its very next frame.
 #[tokio::test]
 async fn lifecycle_requests_are_refused_on_the_raw_path() {
     let (listener, config) = ws_pool_config();
@@ -469,12 +458,9 @@ async fn lifecycle_requests_are_refused_on_the_raw_path() {
     join_server(server).await;
 }
 
-/// An oversize raw `Load` keeps the session's duration budget.
-///
-/// The frame is rejected before any bytes are written, leaving the worker
-/// synced and the session live — so the budget cleared in anticipation of the
-/// dump's own limits must be put back, or the session would run on with no
-/// `max_duration` backstop at all.
+/// An oversize raw `Load` keeps the session's duration budget: the frame is
+/// rejected pre-send with the session live, so the budget cleared in
+/// anticipation of the dump's limits must be put back.
 #[tokio::test]
 async fn an_oversize_raw_load_keeps_the_duration_budget() {
     let (listener, mut config) = ws_pool_config();
@@ -527,12 +513,9 @@ async fn an_oversize_raw_load_keeps_the_duration_budget() {
     join_server(server).await;
 }
 
-/// A `ShutdownDump` ends a raw turn *and* the connection behind it.
-///
-/// The frame is handed back — the dump it carries is the driver's to forward —
-/// but the serving relay that sent it is gone, so the worker is discarded as on
-/// the typed path. It used to be kept, resurfacing later as an unexplained
-/// crash on the next turn.
+/// A `ShutdownDump` ends a raw turn *and* the connection behind it: the frame
+/// (and its dump) is handed back for the driver to forward, but the gone
+/// relay's worker is discarded rather than kept until the next failure.
 #[tokio::test]
 async fn a_shutdown_dump_on_the_raw_path_discards_the_worker() {
     let (listener, config) = ws_pool_config();

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -294,6 +294,54 @@ async fn duration_backstop_kills_an_unresponsive_worker() {
     join_server(server).await;
 }
 
+/// The same backstop arms on the raw path, which a relay drives instead of
+/// `feed`.
+///
+/// `turn_raw` used to arm `request_timeout` alone, so a session whose only
+/// bound was `max_duration` — the shape a serving relay configures, since it
+/// applies limits rather than client timeouts — had no parent-side deadline at
+/// all, and a wedged child held the turn indefinitely.
+#[tokio::test]
+async fn duration_backstop_arms_on_the_raw_path() {
+    let (listener, mut config) = ws_pool_config();
+    config.duration_limit_grace = Some(Duration::from_millis(300));
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        assert!(matches!(
+            read_request(&mut socket),
+            pb::parent_request::Kind::Configure(_)
+        ));
+        send_event(&mut socket, &event_kind(pb::child_event::Kind::Ok(pb::Ok {})));
+        assert!(matches!(read_request(&mut socket), pb::parent_request::Kind::Feed(_)));
+        // never reply; only the backstop can end this turn
+        let _ = socket.read();
+    });
+
+    let pool = Pool::new(config).await.expect("pool");
+    let mut checkout = pool
+        .checkout(&ReplConfig {
+            limits: Some(ResourceLimits::default().max_duration(Duration::from_millis(100))),
+            ..ReplConfig::default()
+        })
+        .await
+        .expect("checkout");
+    let request = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::Feed(pb::Feed {
+            code: "while True:\n    pass".to_owned(),
+            inputs: vec![],
+            skip_type_check: false,
+        })),
+        ..pb::ParentRequest::default()
+    };
+    let mut on_event = |_: &pb::ChildEvent| Box::pin(ready(())) as PrintFuture;
+    let err = checkout.turn_raw(&request, &mut on_event).await.unwrap_err();
+    let PoolError::Timeout { timeout } = err else {
+        panic!("expected Timeout, got {err:?}");
+    };
+    assert!(timeout <= Duration::from_millis(400), "deadline was {timeout:?}");
+    join_server(server).await;
+}
+
 /// A single turn is still bounded by `request_timeout` even when the worker is
 /// making mount-coverable calls: the OS call surfaces rather than being
 /// serviced inside the turn, so a worker that simply runs too long before

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -342,6 +342,120 @@ async fn duration_backstop_arms_on_the_raw_path() {
     join_server(server).await;
 }
 
+/// A raw `Load` re-adopts the dump's duration budget, exactly as `restore`.
+///
+/// `turn_raw` used to keep the `Configure`-time budget across a `Load`, so a
+/// restored session's backstop measured it against the wrong limit — here the
+/// checkout's own 5s budget would have left a wedged post-restore turn running
+/// for 5.3s instead of being killed at the dump's 100ms + grace.
+#[tokio::test]
+async fn a_raw_load_adopts_the_dumps_duration_budget() {
+    let (listener, mut config) = ws_pool_config();
+    config.duration_limit_grace = Some(Duration::from_millis(300));
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        assert!(matches!(
+            read_request(&mut socket),
+            pb::parent_request::Kind::Configure(_)
+        ));
+        send_event(&mut socket, &event_kind(pb::child_event::Kind::Ok(pb::Ok {})));
+        assert!(matches!(read_request(&mut socket), pb::parent_request::Kind::Load(_)));
+        // an idle-dump `Load` reply, stamped with the dump's own limits
+        send_event(
+            &mut socket,
+            &pb::ChildEvent {
+                total_execution_micros: 0,
+                max_duration_micros: Some(100_000),
+                restored_script_name: None,
+                kind: Some(pb::child_event::Kind::Ok(pb::Ok {})),
+            },
+        );
+        assert!(matches!(read_request(&mut socket), pb::parent_request::Kind::Feed(_)));
+        // never reply; only the backstop can end this turn
+        let _ = socket.read();
+    });
+
+    let pool = Pool::new(config).await.expect("pool");
+    let mut checkout = pool
+        .checkout(&ReplConfig {
+            limits: Some(ResourceLimits::default().max_duration(Duration::from_secs(5))),
+            ..ReplConfig::default()
+        })
+        .await
+        .expect("checkout");
+    let mut on_event = |_: &pb::ChildEvent| Box::pin(ready(())) as PrintFuture;
+    let load = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::Load(pb::Load { state: vec![1, 2, 3] })),
+        ..pb::ParentRequest::default()
+    };
+    checkout.turn_raw(&load, &mut on_event).await.expect("load");
+    let feed = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::Feed(pb::Feed {
+            code: "while True:\n    pass".to_owned(),
+            inputs: vec![],
+            skip_type_check: false,
+        })),
+        ..pb::ParentRequest::default()
+    };
+    let err = checkout.turn_raw(&feed, &mut on_event).await.unwrap_err();
+    let PoolError::Timeout { timeout } = err else {
+        panic!("expected Timeout, got {err:?}");
+    };
+    // the dump's 100ms budget plus the grace — not the Configure-time 5s
+    assert_eq!(timeout, Duration::from_millis(400));
+    join_server(server).await;
+}
+
+/// A `ShutdownDump` ends a raw turn *and* the connection behind it.
+///
+/// The frame is handed back — the dump it carries is the driver's to forward —
+/// but the serving relay that sent it is gone, so the worker is discarded as on
+/// the typed path. It used to be kept, resurfacing later as an unexplained
+/// crash on the next turn.
+#[tokio::test]
+async fn a_shutdown_dump_on_the_raw_path_discards_the_worker() {
+    let (listener, config) = ws_pool_config();
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        assert!(matches!(
+            read_request(&mut socket),
+            pb::parent_request::Kind::Configure(_)
+        ));
+        send_event(&mut socket, &event_kind(pb::child_event::Kind::Ok(pb::Ok {})));
+        assert!(matches!(read_request(&mut socket), pb::parent_request::Kind::Feed(_)));
+        send_event(
+            &mut socket,
+            &event_kind(pb::child_event::Kind::Shutdown(pb::ShutdownDump {
+                dump: Some(b"relay-signed state".to_vec()),
+            })),
+        );
+    });
+
+    let pool = Pool::new(config).await.expect("pool");
+    let mut checkout = pool.checkout(&ReplConfig::default()).await.expect("checkout");
+    let request = pb::ParentRequest {
+        kind: Some(pb::parent_request::Kind::Feed(pb::Feed {
+            code: "1 + 1".to_owned(),
+            inputs: vec![],
+            skip_type_check: false,
+        })),
+        ..pb::ParentRequest::default()
+    };
+    let mut on_event = |_: &pb::ChildEvent| Box::pin(ready(())) as PrintFuture;
+    let event = checkout
+        .turn_raw(&request, &mut on_event)
+        .await
+        .expect("the shutdown frame is the turn-ender");
+    let Some(pb::child_event::Kind::Shutdown(shutdown)) = event.kind else {
+        panic!("expected the ShutdownDump frame back, got {:?}", event.kind);
+    };
+    assert_eq!(shutdown.dump.as_deref(), Some(b"relay-signed state".as_slice()));
+    // the connection was discarded with the frame
+    let err = checkout.turn_raw(&request, &mut on_event).await.unwrap_err();
+    assert!(matches!(err, PoolError::Finished), "got {err:?}");
+    join_server(server).await;
+}
+
 /// A single turn is still bounded by `request_timeout` even when the worker is
 /// making mount-coverable calls: the OS call surfaces rather than being
 /// serviced inside the turn, so a worker that simply runs too long before

--- a/crates/monty-runtime/Cargo.toml
+++ b/crates/monty-runtime/Cargo.toml
@@ -33,7 +33,7 @@ anstream = { version = "0.6", optional = true }
 anstyle = { version = "1", optional = true }
 clap = { workspace = true }
 # The standalone CLI owns process-level telemetry configuration.
-logfire = { version = "0.12", default-features = false, features = ["export-http-protobuf"], optional = true }
+logfire = { workspace = true, features = ["export-http-protobuf"], optional = true }
 monty = { workspace = true }
 monty-fs = { workspace = true }
 monty-alloc = { workspace = true, features = ["exit-code"] }

--- a/crates/monty-runtime/Cargo.toml
+++ b/crates/monty-runtime/Cargo.toml
@@ -33,7 +33,7 @@ anstream = { version = "0.6", optional = true }
 anstyle = { version = "1", optional = true }
 clap = { workspace = true }
 # The standalone CLI owns process-level telemetry configuration.
-logfire = { version = "0.11", default-features = false, features = ["export-http-protobuf"], optional = true }
+logfire = { version = "0.12", default-features = false, features = ["export-http-protobuf"], optional = true }
 monty = { workspace = true }
 monty-fs = { workspace = true }
 monty-alloc = { workspace = true, features = ["exit-code"] }

--- a/limitations/pathlib.md
+++ b/limitations/pathlib.md
@@ -32,10 +32,11 @@ These yield an `OsCall` for the host to resolve:
 
 - `exists()`, `is_file()`, `is_dir()`, `is_symlink()`
 - `read_text()`, `read_bytes()`
-- `write_text(data)`, `write_bytes(data)`
+- `write_text(data)`, `write_bytes(data)`, `append_text(data)`, `append_bytes(data)`
 - `mkdir(mode=0o777, parents=False, exist_ok=False)`, `unlink()`, `rmdir()`
 - `iterdir()`, `stat()`, `rename(target)`
 - `resolve()`, `absolute()`
+- `open(...)` — see [`open.md`](open.md) for the supported file API and divergences
 
 `Path.mkdir()` parses `mode`, `parents`, and `exist_ok`, but `mode` is
 accepted only for signature compatibility — Monty does not model POSIX
@@ -50,8 +51,7 @@ were given`).
 
 Not implemented: `glob`, `rglob`, `touch`, `chmod`, `lchmod`, `owner`,
 `group`, `symlink_to`, `hardlink_to`, `link_to`, `readlink`, `lstat`,
-`samefile`, `walk`, `open` (use the builtin `open()` instead),
-`replace`, `expanduser`.
+`samefile`, `walk`, `replace`, `expanduser`.
 
 ## Path normalization and the sandbox
 


### PR DESCRIPTION
- `Checkout::turn_raw` / `OnRawEvent`: drive a turn at the protobuf frame level for callers that already speak the wire (e.g. a serving relay), returning the child's turn-ending event unconverted. Hardened against a subprocess child forging a `ShutdownDump` or a kind-less event as a turn-ender, and the `max_duration` backstop arms on this path too.
- `TelemetryContext::for_logfire`: record pool spans straight into a Rust host's own `Logfire`, with no adapter or second exporter.
- logfire 0.11 -> 0.12 in monty-pool and monty-runtime.
- limitations/pathlib.md: document `append_text`/`append_bytes` and `Path.open()`, which are implemented but were listed as missing.


Claude-Session: https://claude.ai/code/session_01WjubuMt4kE7pSBiKRuHUQt

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a raw wire-level turn API to `monty-pool` and lets Rust hosts record spans directly into `logfire`. Moves `logfire` to the workspace root and bumps it to 0.12.

- **New Features**
  - `Checkout::turn_raw` with `OnRawEvent` to drive turns at the protobuf frame level and return the child’s turn-ending event unconverted (ideal for relays).
  - `TelemetryContext::for_logfire` to record pool spans directly into a Rust host’s `logfire`, no adapter/exporter needed.
  - Docs: document `Path.append_text/append_bytes`, `Path.open()`, and `turn_raw`’s security contract.

- **Bug Fixes**
  - Raw path hardening: refuse subprocess `ShutdownDump` and kind-less events; return terminal frames (`FatalError`, WebSocket `ShutdownDump`) but discard the worker.
  - Duration safety: raw `Load` re-adopts the dump’s `max_duration`; if an oversize `Load` is rejected pre-send, restore the prior budget so the session keeps its backstop.
  - The `max_duration` backstop now arms on raw turns too.
  - Lifecycle requests (`Configure`/`Reset`/`Shutdown`) are refused on the raw path with a protocol error (session stays live).

<sup>Written for commit 8007e41409a698e429887fe38fcdb197e00f507a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

