### PR TITLE
Move monty version to types

### DIFF
--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -11,10 +11,10 @@ use std::{
 };
 
 use monty_fs::{MountCallOutcome, MountMode, MountRoot, MountTable, OverlayState};
-use monty_proto::{FrameError, MONTY_VERSION, exceeds_max_value_depth, pb, validate_requirement};
+use monty_proto::{FrameError, exceeds_max_value_depth, pb, validate_requirement};
 use monty_types::{
-    AssertMessageAnnotations, ExcType, MontyException, MontyObject, OsFunctionCall, PrintStream, ResourceLimits,
-    TypeCheckingConfig,
+    AssertMessageAnnotations, ExcType, MONTY_VERSION, MontyException, MontyObject, OsFunctionCall, PrintStream,
+    ResourceLimits, TypeCheckingConfig,
 };
 use tokio::{task::spawn_blocking, time::timeout};
 

--- a/crates/monty-proto/src/lib.rs
+++ b/crates/monty-proto/src/lib.rs
@@ -18,8 +18,5 @@ pub use frame::{
     encode_to_capped_vec, exceeds_max_frame_len, write_frame,
 };
 pub use generated::pb;
-// Re-exported so wire-protocol users keep a single import for the
-// `Configure.monty_version` skew check; the constant lives in `monty-types`.
-pub use monty_types::MONTY_VERSION;
 pub use requirement::validate_requirement;
 pub use wire::{WireFunctionCall, WireObject, reset_decode_budget};

--- a/crates/monty-proto/src/lib.rs
+++ b/crates/monty-proto/src/lib.rs
@@ -12,18 +12,14 @@ mod wire;
 #[cfg(feature = "worker")]
 pub mod worker;
 
-/// The monty version this build speaks the wire protocol as, used for the
-/// `Configure.monty_version` skew check. Parent and child must be deployed in
-/// lockstep (the protocol has no in-band negotiation), so both sides compare
-/// against this single constant instead of each reading `CARGO_PKG_VERSION`
-/// independently. Equals the workspace version, since every crate shares it.
-pub const MONTY_VERSION: &str = env!("CARGO_PKG_VERSION");
-
 pub use convert::{MAX_VALUE_DEPTH, ProtoConvertError, exceeds_max_value_depth, future_results_from_proto};
 pub use frame::{
     DEFAULT_MAX_DECODE_BYTES, FrameError, FrameReader, MAX_FRAME_LEN, decode_frame, encode_framed_into,
     encode_to_capped_vec, exceeds_max_frame_len, write_frame,
 };
 pub use generated::pb;
+// Re-exported so wire-protocol users keep a single import for the
+// `Configure.monty_version` skew check; the constant lives in `monty-types`.
+pub use monty_types::MONTY_VERSION;
 pub use requirement::validate_requirement;
 pub use wire::{WireFunctionCall, WireObject, reset_decode_budget};

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -21,13 +21,13 @@ use std::{borrow::Cow, mem};
 use monty::{MontyRepl, ReplProgress, ReplStartError};
 use monty_type_checking::{SourceFile, TypeChecker};
 use monty_types::{
-    AssertMessageAnnotations, CompileOptions, ExcType, ExtFunctionResult, MontyException, MontyObject, OsFunctionCall,
-    PrintWriter, PrintWriterCallback, ResourceTracker, TypeCheckingConfig, TypeCheckingFormat,
+    AssertMessageAnnotations, CompileOptions, ExcType, ExtFunctionResult, MONTY_VERSION, MontyException, MontyObject,
+    OsFunctionCall, PrintWriter, PrintWriterCallback, ResourceTracker, TypeCheckingConfig, TypeCheckingFormat,
 };
 
 use super::{
-    FrameError, FrameReader, MAX_FRAME_LEN, MONTY_VERSION, WireFunctionCall, exceeds_max_frame_len,
-    exceeds_max_value_depth, future_results_from_proto, pb, write_frame,
+    FrameError, FrameReader, MAX_FRAME_LEN, WireFunctionCall, exceeds_max_frame_len, exceeds_max_value_depth,
+    future_results_from_proto, pb, write_frame,
 };
 use crate::convert::usize_field;
 

--- a/crates/monty-proto/tests/dispatch.rs
+++ b/crates/monty-proto/tests/dispatch.rs
@@ -7,11 +7,11 @@
 
 use monty::{MontyRepl, ReplProgress};
 use monty_proto::{
-    FrameReader, MONTY_VERSION, WireObject, pb,
+    FrameReader, WireObject, pb,
     worker::{Child, DUMP_VERSION, HandleOutcome, dispatch_frame},
     write_frame,
 };
-use monty_types::{CompileOptions, MontyObject, PrintWriter, ResourceTracker};
+use monty_types::{CompileOptions, MONTY_VERSION, MontyObject, PrintWriter, ResourceTracker};
 
 /// Frames one request the way a host transport would before posting it.
 fn frame_request(kind: pb::parent_request::Kind) -> Vec<u8> {

--- a/crates/monty-python/src/lib.rs
+++ b/crates/monty-python/src/lib.rs
@@ -43,7 +43,7 @@ use version::cargo_version_to_pep440;
 fn get_version() -> &'static str {
     static VERSION: OnceLock<String> = OnceLock::new();
 
-    VERSION.get_or_init(|| cargo_version_to_pep440(env!("CARGO_PKG_VERSION")))
+    VERSION.get_or_init(|| cargo_version_to_pep440(monty_types::MONTY_VERSION))
 }
 
 /// Private Python object type used for the public `NOT_HANDLED` singleton.

--- a/crates/monty-types/src/lib.rs
+++ b/crates/monty-types/src/lib.rs
@@ -1,5 +1,11 @@
 #![doc = include_str!("../README.md")]
 
+/// The monty version this build was compiled as. Every crate shares the
+/// workspace version, so hosts and workers alike can compare against this
+/// single constant — notably the wire protocol's `Configure.monty_version`
+/// skew check, where parent and child must be deployed in lockstep.
+pub const MONTY_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub mod args;
 mod builtins;
 mod exceptions;

--- a/crates/monty-types/src/lib.rs
+++ b/crates/monty-types/src/lib.rs
@@ -1,9 +1,6 @@
 #![doc = include_str!("../README.md")]
 
-/// The monty version this build was compiled as. Every crate shares the
-/// workspace version, so hosts and workers alike can compare against this
-/// single constant — notably the wire protocol's `Configure.monty_version`
-/// skew check, where parent and child must be deployed in lockstep.
+/// The monty version this build was compiled as.
 pub const MONTY_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub mod args;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved `MONTY_VERSION` to `monty-types` so hosts and workers share one build/version source without `monty-proto`. Wire-protocol skew check and Python PEP 440 version now use it.

- **Refactors**
  - Added `MONTY_VERSION` to `monty-types`; removed from `monty-proto`.
  - Updated `monty-pool`, `monty-proto` worker/tests, and `monty-python` to import `monty_types::MONTY_VERSION`.
  - Simplified the constant’s doc comment.

- **Migration**
  - Replace `monty_proto::MONTY_VERSION` with `monty_types::MONTY_VERSION`.

<sup>Written for commit b56f50ce1affae0e3b34b59f5dfc568d389392ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

