### PR TITLE
Send a WebSocket Close frame on worker teardown

### DIFF
--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -664,11 +664,13 @@ impl Checkout {
     pub async fn finish(mut self) -> Result<(), PoolError> {
         // A websocket worker is single-use — the pool discards it after every
         // checkout — so there is no point round-tripping a `Reset` to ready it
-        // for reuse. Dropping it closes the socket, which the child reads as a
-        // clean EOF and exits. Only subprocess workers are reset and returned to
-        // the idle pool for the next checkout.
+        // for reuse. Closing the connection (Close frame, then socket) is what
+        // ends the session; the child reads it as a clean EOF and exits. Only
+        // subprocess workers are reset and returned to the idle pool for the
+        // next checkout.
         if self.pool.config.transport.is_websocket() {
-            if let Some(worker) = self.worker.take() {
+            if let Some(mut worker) = self.worker.take() {
+                worker.close_transport().await;
                 self.pool.release_worker(worker);
             }
             return Ok(());

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -670,7 +670,13 @@ impl Checkout {
         // next checkout.
         if self.pool.config.transport.is_websocket() {
             if let Some(mut worker) = self.worker.take() {
+                // guard, not a trailing release: the worker is already out of
+                // `self`, so a caller dropping this future mid-goodbye would
+                // leave `Checkout::drop` with nothing to release. Disarmed
+                // before `release_worker`, which releases the slot itself.
+                let capacity = CapacityGuard::new(&self.pool);
                 worker.close_transport().await;
+                capacity.disarm();
                 self.pool.release_worker(worker);
             }
             return Ok(());

--- a/crates/monty-pool/src/worker.rs
+++ b/crates/monty-pool/src/worker.rs
@@ -5,13 +5,21 @@
 //!
 //! `recv` must be cancel-safe: the checkout races each turn against a
 //! `tokio::time` deadline, and dropping a plain `read_exact` future mid-frame
-//! would lose bytes and desync the stream. Rather than paying for a pump task
-//! and channel per worker (a cross-task wakeup per event), cancel-safety comes
-//! from keeping the partial-frame state *in the worker*: [`FrameRecv`] holds
-//! the buffer and fill offset across polls, so a dropped `recv` future loses
-//! nothing and the next call resumes exactly where it stopped. The WebSocket
-//! transport gets the same property for free — partial-message state lives
-//! inside the `WebSocketStream`, and `Stream::poll_next` is cancel-safe.
+//! would lose bytes and desync the stream. For the subprocess transport,
+//! rather than paying for a pump task and channel per worker (a cross-task
+//! wakeup per event), cancel-safety comes from keeping the partial-frame
+//! state *in the worker*: [`FrameRecv`] holds the buffer and fill offset
+//! across polls, so a dropped `recv` future loses nothing and the next call
+//! resumes exactly where it stopped.
+//!
+//! The WebSocket transport *does* run a background reader task — not for
+//! cancel-safety but for liveness: tokio-tungstenite answers pings only while
+//! the stream is being polled, and an idle client (between feeds, or hosting
+//! a suspended external/`os` call) has no future of its own polling at all.
+//! Keepalive-pinging servers would drop such a session as vanished. The task
+//! owns the read half and polls it continuously; `recv` becomes a bounded
+//! channel read, which is cancel-safe, and partial-message state lives in the
+//! task, which is never cancelled mid-frame.
 
 use std::{
     env,
@@ -21,7 +29,10 @@ use std::{
     time::Duration,
 };
 
-use futures_util::{SinkExt, StreamExt};
+use futures_util::{
+    SinkExt, StreamExt,
+    stream::{SplitSink, SplitStream},
+};
 use monty_proto::{FrameError, MAX_FRAME_LEN, decode_frame, encode_framed_into, encode_to_capped_vec, pb};
 use rustls::crypto::aws_lc_rs::default_provider;
 use tokio::{
@@ -29,12 +40,13 @@ use tokio::{
     net::TcpStream,
     process::{Child, ChildStdin, ChildStdout, Command},
     runtime::{Handle, RuntimeFlavor},
-    task::block_in_place,
+    sync::mpsc,
+    task::{JoinHandle, block_in_place},
     time::timeout,
 };
 use tokio_tungstenite::{
     MaybeTlsStream, WebSocketStream, connect_async_tls_with_config,
-    tungstenite::{Error as WsError, Message, protocol::WebSocketConfig},
+    tungstenite::{Bytes, Error as WsError, Message, protocol::WebSocketConfig},
 };
 
 use crate::{MontyTransport, PoolConfig, PoolError};
@@ -76,19 +88,27 @@ struct SubprocessWorker {
 }
 
 /// A remote child reached over a WebSocket. One binary message per protocol
-/// frame (no length prefix — the message boundary is the frame). `Option` so
-/// teardown can drop the stream in place: dropping it closes the TCP
-/// connection — the async analogue of killing a child.
+/// frame (no length prefix — the message boundary is the frame). The read
+/// half lives in a spawned reader task (see the module docs) so pings are
+/// answered while the worker is idle.
 ///
-/// Teardown must also *say goodbye* with a Close frame (see
-/// [`WebSocketWorker::close`]); dropping alone is not enough through a proxy.
+/// Teardown must *say goodbye* with a Close frame (see
+/// [`WebSocketWorker::close`]) — dropping alone is not enough through a proxy
+/// — then abort the reader and drop the sink, which is what actually closes
+/// the TCP connection: the async analogue of killing a child.
 struct WebSocketWorker {
-    stream: Option<WsStream>,
+    /// `send()` writes here; `None` after teardown (the closed-connection sentinel).
+    sink: Option<SplitSink<WsStream, Message>>,
+    /// Binary frames (or the terminal error) forwarded by the reader task.
+    events: mpsc::Receiver<Result<Bytes, FrameError>>,
+    /// The task owning the read half; aborted on teardown/drop.
+    reader: JoinHandle<()>,
 }
 
 impl WebSocketWorker {
-    /// Ends the connection: a bounded, best-effort Close frame, then the drop
-    /// that actually closes the socket.
+    /// Ends the connection: a bounded, best-effort Close frame, then abort
+    /// the reader task and drop the sink — releasing both split halves is
+    /// what actually closes the socket.
     ///
     /// The frame is what a *proxied* peer sees — some load balancers forward a
     /// Close frame but never propagate a bare TCP disconnect upstream, so
@@ -97,16 +117,17 @@ impl WebSocketWorker {
     /// because a peer that has stopped draining must not be able to hang
     /// teardown, and the frame only has to reach the OS, not the peer.
     async fn close(&mut self) {
-        if let Some(stream) = &mut self.stream {
-            send_close(stream).await;
+        if let Some(sink) = &mut self.sink {
+            send_close(sink).await;
         }
-        self.stream = None;
+        self.reader.abort();
+        self.sink = None;
     }
 }
 
 /// Backstop for the teardown paths that are synchronous — an abandoned
 /// [`crate::Checkout`], a discarded worker — where [`WebSocketWorker::close`]
-/// cannot be awaited: hand the stream to a detached task that says goodbye and
+/// cannot be awaited: hand the sink to a detached task that says goodbye and
 /// drops it.
 ///
 /// Weaker than the awaited path, and deliberately so: the task only runs if the
@@ -114,20 +135,25 @@ impl WebSocketWorker {
 /// one no longer being polled) cancels it and the socket closes silently. With
 /// no runtime at all there is nothing to spawn onto. Both degrade to the plain
 /// drop this replaced, never to something worse.
+///
+/// The reader abort is unconditional: the reader task owns the read half, and
+/// on a quiet connection it never notices the worker is gone — left running it
+/// would hold the TCP connection (and the remote session slot) open forever.
 impl Drop for WebSocketWorker {
     fn drop(&mut self) {
-        if let Some(mut stream) = self.stream.take()
+        self.reader.abort();
+        if let Some(mut sink) = self.sink.take()
             && let Ok(handle) = Handle::try_current()
         {
-            handle.spawn(async move { send_close(&mut stream).await });
+            handle.spawn(async move { send_close(&mut sink).await });
         }
     }
 }
 
 /// Writes the goodbye frame, bounded so a peer that stopped draining cannot
 /// hang teardown. Shared by both paths above so they cannot drift apart.
-async fn send_close(stream: &mut WsStream) {
-    let _ = timeout(CLOSE_WRITE_TIMEOUT, stream.close(None)).await;
+async fn send_close(sink: &mut SplitSink<WsStream, Message>) {
+    let _ = timeout(CLOSE_WRITE_TIMEOUT, sink.close()).await;
 }
 
 impl Worker {
@@ -204,8 +230,17 @@ impl Worker {
             .await
             .map_err(|_| PoolError::Spawn(format!("{url}: connect timed out after {dial_timeout:?}")))?
             .map_err(|err| PoolError::Spawn(format!("{url}: {err}")))?;
+        // Split so a background task can poll (and thereby pong) the read
+        // half continuously, while `send` keeps synchronous errors on the sink.
+        let (sink, read_half) = stream.split();
+        let (tx, events) = mpsc::channel(WS_EVENT_CHANNEL_DEPTH);
+        let reader = tokio::spawn(read_ws_events(read_half, tx));
         Ok(Self {
-            kind: WorkerKind::WebSocket(Box::new(WebSocketWorker { stream: Some(stream) })),
+            kind: WorkerKind::WebSocket(Box::new(WebSocketWorker {
+                sink: Some(sink),
+                events,
+                reader,
+            })),
             checkouts_served: 0,
             #[cfg(feature = "telemetry-adapter")]
             recorder: None,
@@ -232,11 +267,8 @@ impl Worker {
             }
             WorkerKind::WebSocket(w) => {
                 let body = encode_to_capped_vec(request)?;
-                match &mut w.stream {
-                    Some(stream) => stream
-                        .send(Message::Binary(body.into()))
-                        .await
-                        .map_err(ws_to_frame_error),
+                match &mut w.sink {
+                    Some(sink) => sink.send(Message::Binary(body.into())).await.map_err(ws_to_frame_error),
                     None => Err(FrameError::Truncated),
                 }
             }
@@ -280,27 +312,19 @@ impl Worker {
                 None => Err(FrameError::Truncated), // clean EOF mid-checkout is still a vanished peer
             },
             WorkerKind::WebSocket(w) => {
-                // Read the next binary message. Ping/Pong are handled by
-                // tokio-tungstenite itself and skipped here; a close, EOF, or
-                // any frame the protocol never uses is surfaced as
-                // `Truncated`, which the checkout classifies as
-                // `PoolError::Disconnected`.
-                let Some(stream) = &mut w.stream else {
+                // Frames come from the reader task; a channel recv is
+                // cancel-safe, preserving the deadline race. A closed channel
+                // (reader exited without a terminal error — can't happen
+                // today, but harmless) or a torn-down worker is `Truncated`,
+                // which the checkout classifies as `PoolError::Disconnected`.
+                if w.sink.is_none() {
                     return Err(FrameError::Truncated);
-                };
-                let data = loop {
-                    match stream.next().await {
-                        Some(Ok(Message::Binary(data))) => break data,
-                        Some(Ok(Message::Ping(_) | Message::Pong(_))) => {}
-                        // A clean close, or text/raw frames the protocol never uses.
-                        Some(Ok(Message::Close(_) | Message::Text(_) | Message::Frame(_))) | None => {
-                            return Err(FrameError::Truncated);
-                        }
-                        Some(Err(WsError::Io(err))) => return Err(FrameError::Io(err)),
-                        Some(Err(_)) => return Err(FrameError::Truncated),
-                    }
-                };
-                decode_event(&data)
+                }
+                match w.events.recv().await {
+                    Some(Ok(data)) => decode_event(&data),
+                    Some(Err(err)) => Err(err),
+                    None => Err(FrameError::Truncated),
+                }
             }
         }?;
         // only after a complete decode, so a `recv` future dropped mid-frame
@@ -497,6 +521,38 @@ fn decode_event(body: &[u8]) -> Result<pb::ChildEvent, FrameError> {
         decode_frame(body)
     } else {
         block_in_place(|| decode_frame(body))
+    }
+}
+
+/// Depth of the reader-task → `recv` channel. Mid-turn a full channel blocks
+/// the reader (which then stops answering pings), but servers only ping
+/// *idle* sessions, whose channel is empty — so this just reproduces TCP
+/// backpressure with a few frames of slack. Keep it shallow: the server's
+/// print backpressure design assumes the client's unread data accumulates in
+/// the socket, not in client memory.
+const WS_EVENT_CHANNEL_DEPTH: usize = 8;
+
+/// The WebSocket reader task: polls the read half continuously so
+/// tokio-tungstenite answers pings even while the worker is idle (see the
+/// module docs), forwarding each binary frame — or the terminal error — to
+/// the worker's `recv`.
+async fn read_ws_events(mut read_half: SplitStream<WsStream>, events: mpsc::Sender<Result<Bytes, FrameError>>) {
+    loop {
+        let result = match read_half.next().await {
+            Some(Ok(Message::Binary(data))) => Ok(data),
+            // Polling is itself what answers a ping: tungstenite queues the
+            // pong on read and flushes it during read polling.
+            Some(Ok(Message::Ping(_) | Message::Pong(_))) => continue,
+            // A clean close, or text/raw frames the protocol never uses.
+            Some(Ok(Message::Close(_) | Message::Text(_) | Message::Frame(_))) | None => Err(FrameError::Truncated),
+            Some(Err(WsError::Io(err))) => Err(FrameError::Io(err)),
+            Some(Err(_)) => Err(FrameError::Truncated),
+        };
+        // Exit after any terminal error, or once the worker is gone.
+        let stop = result.is_err();
+        if events.send(result).await.is_err() || stop {
+            return;
+        }
     }
 }
 

--- a/crates/monty-pool/src/worker.rs
+++ b/crates/monty-pool/src/worker.rs
@@ -79,8 +79,46 @@ struct SubprocessWorker {
 /// frame (no length prefix — the message boundary is the frame). `Option` so
 /// teardown can drop the stream in place: dropping it closes the TCP
 /// connection — the async analogue of killing a child.
+///
+/// Teardown must also *say goodbye* with a Close frame (see
+/// [`WebSocketWorker::close`]); dropping alone is not enough through a proxy.
 struct WebSocketWorker {
     stream: Option<WsStream>,
+}
+
+impl WebSocketWorker {
+    /// Ends the connection: a bounded, best-effort Close frame, then the drop
+    /// that actually closes the socket.
+    ///
+    /// The frame is what a *proxied* peer sees — some load balancers forward a
+    /// Close frame but never propagate a bare TCP disconnect upstream, so
+    /// without it the far side keeps the session alive until its own idle
+    /// timeout, pinning a worker and a capacity slot. The write is bounded
+    /// because a peer that has stopped draining must not be able to hang
+    /// teardown, and the frame only has to reach the OS, not the peer.
+    async fn close(&mut self) {
+        if let Some(stream) = &mut self.stream {
+            let _ = timeout(CLOSE_WRITE_TIMEOUT, stream.close(None)).await;
+        }
+        self.stream = None;
+    }
+}
+
+/// Backstop for the teardown paths that are synchronous — an abandoned
+/// [`crate::Checkout`], a discarded worker — where [`WebSocketWorker::close`]
+/// cannot be awaited: hand the stream to a detached task that says goodbye and
+/// drops it. Outside a runtime there is nothing to spawn onto, so the stream is
+/// simply dropped, exactly as before.
+impl Drop for WebSocketWorker {
+    fn drop(&mut self) {
+        if let Some(mut stream) = self.stream.take()
+            && let Ok(handle) = Handle::try_current()
+        {
+            handle.spawn(async move {
+                let _ = timeout(CLOSE_WRITE_TIMEOUT, stream.close(None)).await;
+            });
+        }
+    }
 }
 
 impl Worker {
@@ -309,17 +347,26 @@ impl Worker {
                 w.child.wait().await.ok()
             }
             WorkerKind::WebSocket(w) => {
-                // Drop the stream rather than sending a WebSocket Close frame:
-                // a peer that has stopped draining could block the close write
-                // indefinitely. With the stream gone the TCP socket closes; the
-                // child reads that as a clean EOF and exits, so the graceful
-                // Close frame buys nothing here.
-                w.stream = None;
+                w.close().await;
                 None
             }
         }
     }
+
+    /// Ends the connection behind a worker the caller is *not* discarding as
+    /// dead — the single-use WebSocket worker of a cleanly finished checkout.
+    /// A no-op for subprocess workers, which the pool reuses or kills instead.
+    pub(crate) async fn close_transport(&mut self) {
+        if let WorkerKind::WebSocket(w) = &mut self.kind {
+            w.close().await;
+        }
+    }
 }
+
+/// How long teardown gives a WebSocket Close frame to reach the OS before
+/// giving up and dropping the socket. Short: the frame is a courtesy, and the
+/// only thing that can delay it is a peer that stopped reading.
+const CLOSE_WRITE_TIMEOUT: Duration = Duration::from_millis(250);
 
 /// Chunk size for speculative frame reads: large enough that a typical
 /// prefix + body arrives in a single `read` syscall, small enough to sit

--- a/crates/monty-pool/src/worker.rs
+++ b/crates/monty-pool/src/worker.rs
@@ -363,10 +363,10 @@ impl Worker {
     }
 }
 
-/// How long teardown gives a WebSocket Close frame to reach the OS before
-/// giving up and dropping the socket. Short: the frame is a courtesy, and the
-/// only thing that can delay it is a peer that stopped reading.
-const CLOSE_WRITE_TIMEOUT: Duration = Duration::from_millis(250);
+/// How long teardown gives a WebSocket Close frame to reach the OS. Not a
+/// latency budget — the write awaits no ACK or Close echo — it only rides out
+/// back-pressure from a peer that stopped reading.
+const CLOSE_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// Chunk size for speculative frame reads: large enough that a typical
 /// prefix + body arrives in a single `read` syscall, small enough to sit

--- a/crates/monty-pool/src/worker.rs
+++ b/crates/monty-pool/src/worker.rs
@@ -98,7 +98,7 @@ impl WebSocketWorker {
     /// teardown, and the frame only has to reach the OS, not the peer.
     async fn close(&mut self) {
         if let Some(stream) = &mut self.stream {
-            let _ = timeout(CLOSE_WRITE_TIMEOUT, stream.close(None)).await;
+            send_close(stream).await;
         }
         self.stream = None;
     }
@@ -107,18 +107,27 @@ impl WebSocketWorker {
 /// Backstop for the teardown paths that are synchronous — an abandoned
 /// [`crate::Checkout`], a discarded worker — where [`WebSocketWorker::close`]
 /// cannot be awaited: hand the stream to a detached task that says goodbye and
-/// drops it. Outside a runtime there is nothing to spawn onto, so the stream is
-/// simply dropped, exactly as before.
+/// drops it.
+///
+/// Weaker than the awaited path, and deliberately so: the task only runs if the
+/// runtime outlives this drop, so a runtime shutting down (or a current-thread
+/// one no longer being polled) cancels it and the socket closes silently. With
+/// no runtime at all there is nothing to spawn onto. Both degrade to the plain
+/// drop this replaced, never to something worse.
 impl Drop for WebSocketWorker {
     fn drop(&mut self) {
         if let Some(mut stream) = self.stream.take()
             && let Ok(handle) = Handle::try_current()
         {
-            handle.spawn(async move {
-                let _ = timeout(CLOSE_WRITE_TIMEOUT, stream.close(None)).await;
-            });
+            handle.spawn(async move { send_close(&mut stream).await });
         }
     }
+}
+
+/// Writes the goodbye frame, bounded so a peer that stopped draining cannot
+/// hang teardown. Shared by both paths above so they cannot drift apart.
+async fn send_close(stream: &mut WsStream) {
+    let _ = timeout(CLOSE_WRITE_TIMEOUT, stream.close(None)).await;
 }
 
 impl Worker {

--- a/crates/monty-pool/src/worker.rs
+++ b/crates/monty-pool/src/worker.rs
@@ -12,14 +12,11 @@
 //! across polls, so a dropped `recv` future loses nothing and the next call
 //! resumes exactly where it stopped.
 //!
-//! The WebSocket transport *does* run a background reader task — not for
-//! cancel-safety but for liveness: tokio-tungstenite answers pings only while
-//! the stream is being polled, and an idle client (between feeds, or hosting
-//! a suspended external/`os` call) has no future of its own polling at all.
-//! Keepalive-pinging servers would drop such a session as vanished. The task
-//! owns the read half and polls it continuously; `recv` becomes a bounded
-//! channel read, which is cancel-safe, and partial-message state lives in the
-//! task, which is never cancelled mid-frame.
+//! The WebSocket transport runs a background reader task instead — not for
+//! cancel-safety but for liveness: tokio-tungstenite pongs only while the
+//! stream is polled, and an idle client polls nothing, so a keepalive server
+//! would drop the session as vanished. `recv` reads the task's channel, which
+//! is cancel-safe.
 
 use std::{
     env,
@@ -88,14 +85,9 @@ struct SubprocessWorker {
 }
 
 /// A remote child reached over a WebSocket. One binary message per protocol
-/// frame (no length prefix — the message boundary is the frame). The read
-/// half lives in a spawned reader task (see the module docs) so pings are
-/// answered while the worker is idle.
-///
-/// Teardown must *say goodbye* with a Close frame (see
-/// [`WebSocketWorker::close`]) — dropping alone is not enough through a proxy
-/// — then abort the reader and drop the sink, which is what actually closes
-/// the TCP connection: the async analogue of killing a child.
+/// frame (no length prefix — the message boundary is the frame). The read half
+/// lives in a spawned reader task (see the module docs), so teardown must
+/// release both halves — see [`WebSocketWorker::close`].
 struct WebSocketWorker {
     /// `send()` writes here; `None` after teardown (the closed-connection sentinel).
     sink: Option<SplitSink<WsStream, Message>>,
@@ -106,16 +98,13 @@ struct WebSocketWorker {
 }
 
 impl WebSocketWorker {
-    /// Ends the connection: a bounded, best-effort Close frame, then abort
-    /// the reader task and drop the sink — releasing both split halves is
-    /// what actually closes the socket.
+    /// Ends the connection: a bounded Close frame, then abort the reader and
+    /// drop the sink — releasing both halves is what closes the socket.
     ///
-    /// The frame is what a *proxied* peer sees — some load balancers forward a
-    /// Close frame but never propagate a bare TCP disconnect upstream, so
-    /// without it the far side keeps the session alive until its own idle
-    /// timeout, pinning a worker and a capacity slot. The write is bounded
-    /// because a peer that has stopped draining must not be able to hang
-    /// teardown, and the frame only has to reach the OS, not the peer.
+    /// The frame is what a *proxied* peer sees: some load balancers forward a
+    /// Close but never a bare TCP disconnect, leaving the session (and its
+    /// capacity slot) alive until the far side's own idle timeout. Bounded so
+    /// a peer that stopped draining cannot hang teardown.
     async fn close(&mut self) {
         if let Some(sink) = &mut self.sink {
             send_close(sink).await;
@@ -125,20 +114,13 @@ impl WebSocketWorker {
     }
 }
 
-/// Backstop for the teardown paths that are synchronous — an abandoned
-/// [`crate::Checkout`], a discarded worker — where [`WebSocketWorker::close`]
-/// cannot be awaited: hand the sink to a detached task that says goodbye and
-/// drops it.
+/// Backstop for the synchronous teardown paths — an abandoned
+/// [`crate::Checkout`], a discarded worker — where `close` cannot be awaited:
+/// a detached task says goodbye instead. Best-effort, since a runtime shutting
+/// down cancels it; it then degrades to the plain drop this replaced.
 ///
-/// Weaker than the awaited path, and deliberately so: the task only runs if the
-/// runtime outlives this drop, so a runtime shutting down (or a current-thread
-/// one no longer being polled) cancels it and the socket closes silently. With
-/// no runtime at all there is nothing to spawn onto. Both degrade to the plain
-/// drop this replaced, never to something worse.
-///
-/// The reader abort is unconditional: the reader task owns the read half, and
-/// on a quiet connection it never notices the worker is gone — left running it
-/// would hold the TCP connection (and the remote session slot) open forever.
+/// The reader abort is unconditional: on a quiet connection the task never
+/// notices the worker is gone, and would hold the socket open forever.
 impl Drop for WebSocketWorker {
     fn drop(&mut self) {
         self.reader.abort();
@@ -150,8 +132,7 @@ impl Drop for WebSocketWorker {
     }
 }
 
-/// Writes the goodbye frame, bounded so a peer that stopped draining cannot
-/// hang teardown. Shared by both paths above so they cannot drift apart.
+/// Writes the goodbye frame, shared by both paths above so they cannot drift.
 async fn send_close(sink: &mut SplitSink<WsStream, Message>) {
     let _ = timeout(CLOSE_WRITE_TIMEOUT, sink.close()).await;
 }
@@ -230,8 +211,7 @@ impl Worker {
             .await
             .map_err(|_| PoolError::Spawn(format!("{url}: connect timed out after {dial_timeout:?}")))?
             .map_err(|err| PoolError::Spawn(format!("{url}: {err}")))?;
-        // Split so a background task can poll (and thereby pong) the read
-        // half continuously, while `send` keeps synchronous errors on the sink.
+        // split so a background task can poll (and thereby pong) the read half
         let (sink, read_half) = stream.split();
         let (tx, events) = mpsc::channel(WS_EVENT_CHANNEL_DEPTH);
         let reader = tokio::spawn(read_ws_events(read_half, tx));
@@ -312,11 +292,9 @@ impl Worker {
                 None => Err(FrameError::Truncated), // clean EOF mid-checkout is still a vanished peer
             },
             WorkerKind::WebSocket(w) => {
-                // Frames come from the reader task; a channel recv is
-                // cancel-safe, preserving the deadline race. A closed channel
-                // (reader exited without a terminal error — can't happen
-                // today, but harmless) or a torn-down worker is `Truncated`,
-                // which the checkout classifies as `PoolError::Disconnected`.
+                // frames come from the reader task; a channel recv is
+                // cancel-safe, preserving the deadline race. A torn-down worker
+                // or closed channel is `Truncated` — a `PoolError::Disconnected`.
                 if w.sink.is_none() {
                     return Err(FrameError::Truncated);
                 }
@@ -387,8 +365,8 @@ impl Worker {
     }
 
     /// Ends the connection behind a worker the caller is *not* discarding as
-    /// dead — the single-use WebSocket worker of a cleanly finished checkout.
-    /// A no-op for subprocess workers, which the pool reuses or kills instead.
+    /// dead — a cleanly finished checkout's single-use WebSocket worker. A
+    /// no-op for subprocess workers, which the pool reuses or kills instead.
     pub(crate) async fn close_transport(&mut self) {
         if let WorkerKind::WebSocket(w) = &mut self.kind {
             w.close().await;
@@ -397,7 +375,7 @@ impl Worker {
 }
 
 /// How long teardown gives a WebSocket Close frame to reach the OS. Not a
-/// latency budget — the write awaits no ACK or Close echo — it only rides out
+/// latency budget (no ACK or Close echo is awaited) — it only rides out
 /// back-pressure from a peer that stopped reading.
 const CLOSE_WRITE_TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -524,33 +502,40 @@ fn decode_event(body: &[u8]) -> Result<pb::ChildEvent, FrameError> {
     }
 }
 
-/// Depth of the reader-task → `recv` channel. Mid-turn a full channel blocks
-/// the reader (which then stops answering pings), but servers only ping
-/// *idle* sessions, whose channel is empty — so this just reproduces TCP
-/// backpressure with a few frames of slack. Keep it shallow: the server's
-/// print backpressure design assumes the client's unread data accumulates in
-/// the socket, not in client memory.
-const WS_EVENT_CHANNEL_DEPTH: usize = 8;
+/// Depth of the reader-task → `recv` channel. One slot, reserved before the
+/// poll, bounds an untrusted peer to a single queued frame (≤
+/// [`MAX_FRAME_LEN`]) per worker — what the unsplit stream held. Deeper buys
+/// nothing: pongs need polling, not buffering, and the server's print
+/// backpressure assumes unread data sits in the socket, not in client memory.
+const WS_EVENT_CHANNEL_DEPTH: usize = 1;
 
 /// The WebSocket reader task: polls the read half continuously so
-/// tokio-tungstenite answers pings even while the worker is idle (see the
-/// module docs), forwarding each binary frame — or the terminal error — to
-/// the worker's `recv`.
+/// tokio-tungstenite pongs even while the worker is idle (see the module
+/// docs), forwarding each binary frame — or the terminal error — to `recv`.
+///
+/// Reserving the slot before polling keeps the reader polling (and ponging)
+/// rather than blocked holding a frame.
 async fn read_ws_events(mut read_half: SplitStream<WsStream>, events: mpsc::Sender<Result<Bytes, FrameError>>) {
-    loop {
-        let result = match read_half.next().await {
-            Some(Ok(Message::Binary(data))) => Ok(data),
-            // Polling is itself what answers a ping: tungstenite queues the
-            // pong on read and flushes it during read polling.
-            Some(Ok(Message::Ping(_) | Message::Pong(_))) => continue,
-            // A clean close, or text/raw frames the protocol never uses.
-            Some(Ok(Message::Close(_) | Message::Text(_) | Message::Frame(_))) | None => Err(FrameError::Truncated),
-            Some(Err(WsError::Io(err))) => Err(FrameError::Io(err)),
-            Some(Err(_)) => Err(FrameError::Truncated),
+    // an Err from reserve means the receiver dropped: the worker is gone
+    while let Ok(permit) = events.reserve().await {
+        let result = loop {
+            match read_half.next().await {
+                Some(Ok(Message::Binary(data))) => break Ok(data),
+                // polling is itself what pongs: tungstenite queues the pong on
+                // read and flushes it during read polling
+                Some(Ok(Message::Ping(_) | Message::Pong(_))) => {}
+                // a clean close, or text/raw frames the protocol never uses
+                Some(Ok(Message::Close(_) | Message::Text(_) | Message::Frame(_))) | None => {
+                    break Err(FrameError::Truncated);
+                }
+                Some(Err(WsError::Io(err))) => break Err(FrameError::Io(err)),
+                Some(Err(_)) => break Err(FrameError::Truncated),
+            }
         };
-        // Exit after any terminal error, or once the worker is gone.
+        // any error is terminal: deliver it and exit
         let stop = result.is_err();
-        if events.send(result).await.is_err() || stop {
+        permit.send(result);
+        if stop {
             return;
         }
     }

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -3,11 +3,13 @@
 //! session. This exercises `Worker::websocket` (the async dial) and the WS
 //! send/recv path end-to-end without needing a real remote child.
 
+// only the windows-gated capacity test wedges a socket with a blocked channel
+#[cfg(not(windows))]
+use std::sync::mpsc;
 use std::{
     fs,
     future::ready,
     net::{TcpListener, TcpStream},
-    sync::mpsc,
     thread,
     time::Duration,
 };
@@ -17,7 +19,9 @@ use monty_pool::{
 };
 use monty_proto::{MAX_FRAME_LEN, WireFunctionCall, decode_frame, encode_to_capped_vec, pb};
 use monty_types::{MontyObject, PrintStream, ResourceLimits};
-use tokio::{task::spawn_blocking, time::timeout};
+use tokio::task::spawn_blocking;
+#[cfg(not(windows))]
+use tokio::time::timeout;
 use tungstenite::{Message, WebSocket};
 
 /// A mock child: accepts one WebSocket connection and answers each request with
@@ -1000,6 +1004,14 @@ async fn a_timed_out_turn_sends_a_close_frame() {
 /// buffers, and every later write queues behind it. The worker is already out
 /// of the `Checkout` by then, so without a `CapacityGuard` across the await
 /// nothing releases its slot and the pool shrinks by one for good.
+///
+/// Not run on Windows: dynamic send buffering grows the loopback socket's
+/// kernel buffer past the wedge, the goodbye never pends, and the cancel
+/// window this test needs cannot be forced open (the client socket is dialled
+/// inside `connect_async`, so its `SO_SNDBUF` — the only way to disable the
+/// growth — is out of reach). The guarded logic is platform-independent; do
+/// not "fix" this by enlarging the wedge, which only moves the flake.
+#[cfg(not(windows))]
 #[tokio::test]
 async fn cancelling_finish_does_not_leak_capacity() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind");

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -7,6 +7,7 @@ use std::{
     fs,
     future::ready,
     net::{TcpListener, TcpStream},
+    sync::mpsc,
     thread,
     time::Duration,
 };
@@ -16,7 +17,7 @@ use monty_pool::{
 };
 use monty_proto::{MAX_FRAME_LEN, WireFunctionCall, decode_frame, encode_to_capped_vec, pb};
 use monty_types::{MontyObject, PrintStream, ResourceLimits};
-use tokio::task::spawn_blocking;
+use tokio::{task::spawn_blocking, time::timeout};
 use tungstenite::{Message, WebSocket};
 
 /// A mock child: accepts one WebSocket connection and answers each request with
@@ -958,6 +959,54 @@ async fn a_timed_out_turn_sends_a_close_frame() {
         .expect_err("the turn must time out");
     assert!(matches!(err, PoolError::Timeout { .. }), "got {err:?}");
     join_server(server).await;
+}
+
+/// Cancelling `finish()` mid-goodbye must not leak the worker's capacity slot.
+///
+/// The goodbye only *pends* against a peer that stopped reading, so the socket
+/// is wedged first: one oversized feed the mock server never drains fills the
+/// buffers, and every later write queues behind it. The worker is already out
+/// of the `Checkout` by then, so without a `CapacityGuard` across the await
+/// nothing releases its slot and the pool shrinks by one for good.
+#[tokio::test]
+async fn cancelling_finish_does_not_leak_capacity() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    let (release, wait_for_release) = mpsc::channel::<()>();
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        expect_configure(&mut socket);
+        // never read again: the client's writes now back up in the socket
+        wait_for_release.recv().expect("release");
+    });
+
+    let mut config = PoolConfig::websocket(format!("ws://127.0.0.1:{port}"));
+    config.max_processes = 1;
+    config.checkout_timeout = Some(Duration::from_millis(200));
+    let pool = Pool::new(config).await.expect("pool");
+    let mut checkout = pool.checkout(&ReplConfig::default()).await.expect("checkout");
+
+    let wedge = "#".repeat(32 * 1024 * 1024);
+    let mut on_print = no_print;
+    let feed = checkout.feed(&wedge, vec![], vec![], false, &mut on_print);
+    assert!(
+        timeout(Duration::from_secs(1), feed).await.is_err(),
+        "the unread feed must block, wedging the socket"
+    );
+    assert!(
+        timeout(Duration::from_millis(200), checkout.finish()).await.is_err(),
+        "the goodbye must block behind the wedged socket, cancelling inside the window"
+    );
+
+    release.send(()).expect("release the server");
+    join_server(server).await;
+
+    // the slot came back: the next checkout gets as far as dialling (and fails
+    // to connect, the listener being gone) instead of reporting no capacity
+    let Err(err) = pool.checkout(&ReplConfig::default()).await else {
+        panic!("the listener is gone, so a checkout cannot succeed");
+    };
+    assert!(matches!(err, PoolError::Spawn(_)), "got {err:?}");
 }
 
 #[tokio::test]

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -874,6 +874,38 @@ async fn shutdown_without_a_session_carries_no_dump() {
     join_server(server).await;
 }
 
+/// The load-bearing keepalive check: a ping sent while the client sits idle
+/// (no turn in flight, so no `recv` polling the stream) is still answered,
+/// because the background reader task polls the read half continuously.
+/// Without that task the pong only goes out on the next turn — and a
+/// keepalive server would have dropped the session as vanished long before.
+#[tokio::test]
+async fn pings_are_answered_while_idle() {
+    let (listener, config) = ws_pool_config();
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        expect_configure(&mut socket);
+        // the client is now idle: nothing in flight, nothing awaited
+        socket.send(Message::Ping(b"live".as_slice().into())).expect("ping");
+        // bound the wait so a missing pong fails the test rather than hanging it
+        socket
+            .get_ref()
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .expect("read timeout");
+        match socket.read() {
+            Ok(Message::Pong(payload)) => assert_eq!(payload.as_ref(), b"live"),
+            other => panic!("expected a Pong while the client is idle, got {other:?}"),
+        }
+    });
+
+    let pool = Pool::new(config).await.expect("pool");
+    let checkout = pool.checkout(&ReplConfig::default()).await.expect("checkout");
+    // go idle: hold the checkout without driving a turn while the server
+    // pings; joining the server is what proves the pong arrived
+    join_server(server).await;
+    drop(checkout);
+}
+
 // === teardown says goodbye ===
 
 /// Reads until the client's Close frame, panicking on anything else.

--- a/crates/monty-pool/tests/websocket.rs
+++ b/crates/monty-pool/tests/websocket.rs
@@ -873,6 +873,93 @@ async fn shutdown_without_a_session_carries_no_dump() {
     join_server(server).await;
 }
 
+// === teardown says goodbye ===
+
+/// Reads until the client's Close frame, panicking on anything else.
+///
+/// Behind a proxy this is the *only* signal the far side gets: some load
+/// balancers forward a Close frame but never propagate a bare TCP disconnect
+/// upstream, so a teardown that only drops the socket leaves the remote session
+/// alive until its own idle timeout.
+fn expect_close(socket: &mut WebSocket<TcpStream>) {
+    loop {
+        match socket.read() {
+            Ok(Message::Close(_)) => return,
+            Ok(Message::Ping(_) | Message::Pong(_)) => {}
+            other => panic!("expected a Close frame, got {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn finishing_a_checkout_sends_a_close_frame() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        expect_configure(&mut socket);
+        expect_feed(&mut socket, "1 + 1");
+        send_kind(
+            &mut socket,
+            pb::child_event::Kind::Complete(pb::Complete {
+                value: Some(MontyObject::Int(42).into()),
+            }),
+        );
+        expect_close(&mut socket);
+    });
+
+    let (_pool, mut checkout) = websocket_checkout(port).await;
+    checkout
+        .feed("1 + 1", vec![], vec![], false, &mut no_print)
+        .await
+        .expect("feed");
+    checkout.finish().await.expect("finish");
+    join_server(server).await;
+}
+
+#[tokio::test]
+async fn an_abandoned_checkout_sends_a_close_frame() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        expect_configure(&mut socket);
+        expect_close(&mut socket);
+    });
+
+    let (_pool, checkout) = websocket_checkout(port).await;
+    // dropping a checkout is a synchronous teardown, so the goodbye is sent by
+    // a detached task rather than awaited here
+    drop(checkout);
+    join_server(server).await;
+}
+
+#[tokio::test]
+async fn a_timed_out_turn_sends_a_close_frame() {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+    let port = listener.local_addr().expect("addr").port();
+    let server = thread::spawn(move || {
+        let mut socket = accept_ws(&listener);
+        expect_configure(&mut socket);
+        expect_feed(&mut socket, "while True:\n    pass");
+        // never reply: the client's deadline must end the session, and the
+        // abandoned-session case is exactly when the server most wants the slot
+        expect_close(&mut socket);
+    });
+
+    let mut config = PoolConfig::websocket(format!("ws://127.0.0.1:{port}"));
+    config.max_processes = 1;
+    config.request_timeout = Some(Duration::from_millis(200));
+    let pool = Pool::new(config).await.expect("pool");
+    let mut checkout = pool.checkout(&ReplConfig::default()).await.expect("checkout");
+    let err = checkout
+        .feed("while True:\n    pass", vec![], vec![], false, &mut no_print)
+        .await
+        .expect_err("the turn must time out");
+    assert!(matches!(err, PoolError::Timeout { .. }), "got {err:?}");
+    join_server(server).await;
+}
+
 #[tokio::test]
 async fn a_dropped_connection_is_a_disconnect() {
     // Every server policy action other than shutdown (idle/session/turn


### PR DESCRIPTION
Tearing a remote worker down by dropping the stream costs nothing on a direct connection, where the peer sees EOF the moment the socket goes. Behind a proxy it costs everything: some load balancers forward a Close frame but never propagate a bare TCP disconnect upstream, so the server keeps the session alive — holding a worker, a capacity permit and a per-caller session slot — until its own idle timeout.

`WebSocketWorker::close` now sends the frame before dropping the stream, bounded by a 250ms timeout so a peer that stopped draining cannot hang teardown (the property the old comment was protecting), with the drop still the unconditional guarantee that the socket goes. `kill_and_reap` routes through it, covering `poison` and `poison_timeout`; `finish` awaits the new `Worker::close_transport`; and a `Drop` impl backstops the synchronous paths (an abandoned `Checkout`, a discarded worker) by handing the stream to a detached task.


Claude-Session: https://claude.ai/code/session_01XS2wa7mvgYXA6Yquy1BNDu

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send a WebSocket Close frame on teardown and run a background reader task to answer pings while idle. This makes proxy-facing disconnects immediate, prevents leaked sessions/capacity, and avoids idle keepalive drops.

- **Bug Fixes**
  - Added `WebSocketWorker::close` to send Close then drop (1s timeout). `kill_and_reap` and `Worker::close_transport` route through it; `Drop` aborts the reader and spawns a detached goodbye for sync paths.
  - Introduced a background WebSocket reader: split the stream, a task polls the read half to auto-pong via `tokio-tungstenite`, and `recv` reads from a depth‑1 channel (cancel-safe). Teardown/Drop aborts the task.
  - `Checkout::finish` awaits `close_transport` and holds a `CapacityGuard` across the await, disarming before `release_worker` to avoid slot leaks on cancellation.
  - Tests cover idle ping-pong, finish, abandoned checkout, timeout, and cancelling `finish()` without leaking capacity; the capacity-leak test is skipped on Windows.

<sup>Written for commit d093117f7895026602006d9b8e74644ac1982b01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

