### PR TITLE
Ci split `test-rust`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
       - name: Check vendored typeshed stubs are in sync
         run: make check-typeshed
 
+  # The interpreter itself, under every feature config. Each `--features` flag
+  # forces a full rebuild of `monty`, so the three configs are kept together
+  # here; the crates layered on top run in parallel in `test-rust-crates`.
   test-rust:
     runs-on: ubuntu-latest
 
@@ -93,18 +96,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
-      # The instrumented (llvm-cov) builds of every feature config don't fit on
-      # the runner's free disk when the rust-cache is cold: the job fills the
-      # disk mid-link, which also fails the cache save, so the next run is cold
-      # again. Drop the large preinstalled toolchains we never use (~25-30 GB)
-      # so cold runs fit and the cache can re-establish itself.
-      - name: free disk space
-        run: |
-          df -h /
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force
-          df -h /
 
       # no release versioning, see https://github.com/dtolnay/rust-toolchain/issues/180
       - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
@@ -144,6 +135,54 @@ jobs:
       # coverage for `make test-ref-count-return`
       - run: cargo llvm-cov --no-report -p monty --features ref-count-return
       - run: cargo llvm-cov run --no-report -p monty-datatest --features ref-count-return
+      # Generating text report:
+      - run: cargo llvm-cov report --ignore-filename-regex "$LLVM_COV_IGNORE_FILENAME_REGEX"
+      # Generate codecov report (use `report` subcommand to avoid recompilation)
+      - run: cargo llvm-cov report --codecov --output-path=rust-coverage.json --ignore-filename-regex "$LLVM_COV_IGNORE_FILENAME_REGEX"
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: rust-coverage-report
+          path: rust-coverage.json
+          if-no-files-found: error
+
+  # The crates layered on top of the interpreter: the type checker (which does
+  # not depend on `monty` at all) and the subprocess stack. Both build `monty`
+  # only with default features, so this job pays no feature-flag rebuilds and
+  # runs in parallel with `test-rust`.
+  test-rust-crates:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # no release versioning, see https://github.com/dtolnay/rust-toolchain/issues/180
+      - uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        with:
+          toolchain: stable
+          components: llvm-tools
+
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          lookup-only: false # zizmor: ignore[cache-poisoning] -- Job does not produce release artifacts and does not have sensitive permissions
+          cache-on-failure: true
+
+      - uses: taiki-e/install-action@1ed3272338f573e042a2e6bca3893aa19f43b47a # v2.71.3
+        with:
+          tool: cargo-llvm-cov
+
+      # this means pyo3 will use Python 3.14 in tests
+      - name: set up python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.14'
+
+      - run: rustc --version --verbose
+      - run: python3 -V
+      - run: cargo llvm-cov clean --workspace
+
       # coverage for `make test-type-checking`
       - run: cargo llvm-cov --no-report -p monty-type-checking -p monty-typeshed
       # subprocess protocol + child mode + worker pool. The pool tests spawn a
@@ -156,12 +195,12 @@ jobs:
       # Generating text report:
       - run: cargo llvm-cov report --ignore-filename-regex "$LLVM_COV_IGNORE_FILENAME_REGEX"
       # Generate codecov report (use `report` subcommand to avoid recompilation)
-      - run: cargo llvm-cov report --codecov --output-path=rust-coverage.json --ignore-filename-regex "$LLVM_COV_IGNORE_FILENAME_REGEX"
+      - run: cargo llvm-cov report --codecov --output-path=rust-crates-coverage.json --ignore-filename-regex "$LLVM_COV_IGNORE_FILENAME_REGEX"
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: rust-coverage-report
-          path: rust-coverage.json
+          name: rust-crates-coverage-report
+          path: rust-crates-coverage.json
           if-no-files-found: error
 
   test-python-coverage:
@@ -225,6 +264,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test-rust
+      - test-rust-crates
       - test-python-coverage
 
     permissions:
@@ -250,7 +290,7 @@ jobs:
 
       - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
-          files: coverage-reports/rust-coverage.json,coverage-reports/python-rust-coverage.json
+          files: coverage-reports/rust-coverage.json,coverage-reports/rust-crates-coverage.json,coverage-reports/python-rust-coverage.json
           disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
           name: rust-coverage
@@ -258,7 +298,7 @@ jobs:
       - uses: getsentry/codecov-action@03112cc3b486a3397dc8d17a58680008721fc86f # 0.3.7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          files: coverage-reports/rust-coverage.json,coverage-reports/python-rust-coverage.json
+          files: coverage-reports/rust-coverage.json,coverage-reports/rust-crates-coverage.json,coverage-reports/python-rust-coverage.json
           disable-search: true
           coverage-format: codecov
           post-pr-comment: true
@@ -453,6 +493,7 @@ jobs:
     needs:
       - lint
       - test-rust
+      - test-rust-crates
       - test-python-coverage
       - coverage-upload
       - test-rust-os

--- a/crates/monty/tests/heap_reader_compile_fail.rs
+++ b/crates/monty/tests/heap_reader_compile_fail.rs
@@ -24,6 +24,21 @@
 //! UPDATE_EXPECT=1 cargo test -p monty --test heap_reader_compile_fail
 //! ```
 
+// Gated to the default feature config, and off Windows.
+//
+// Every case shells out to `cargo rustc -p monty` without forwarding the
+// features of the crate under test, so `memory-model-checks` and
+// `ref-count-return` produce byte-identical diagnostics — they only repeat the
+// cost. That cost is not small: each case compiles `monty` under a different
+// `--cfg`, so the seven of them evict each other from the shared target dir and
+// re-run the whole set (~50s, ~65s cold). CI runs all three configs, so without
+// this gate it pays for the same seven compilations three times.
+//
+// Windows is excluded because rustc writes backslashes in diagnostic paths
+// (`crates\monty\src\..`) while the `.stderr` files use forward slashes. The
+// borrow-checker guarantees under test are platform-independent.
+#![cfg(not(any(target_os = "windows", feature = "memory-model-checks", feature = "ref-count-return")))]
+
 use std::{
     env, fs,
     path::{Path, PathBuf},
@@ -133,48 +148,37 @@ fn check_compile_fail(test_name: &str) {
     );
 }
 
-// These tests are disabled on Windows because rustc uses backslashes in diagnostic
-// paths (`crates\monty\src\..`) while the `.stderr` expectation files use forward
-// slashes. The borrow-checker guarantees being tested are platform-independent.
-
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn heap_mutation_while_reading() {
     check_compile_fail("heap_mutation_while_reading");
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn double_get_mut() {
     check_compile_fail("double_get_mut");
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn dec_ref_while_reading() {
     check_compile_fail("dec_ref_while_reading");
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn smuggle_heap_read() {
     check_compile_fail("smuggle_heap_read");
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn mutation_in_map_closure() {
     check_compile_fail("mutation_in_map_closure");
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn smuggle_vm() {
     check_compile_fail("smuggle_vm");
 }
 
 #[test]
-#[cfg(not(target_os = "windows"))]
 fn smuggle_and_swap_reader() {
     check_compile_fail("smuggle_and_swap_reader");
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Split CI `test-rust` into two parallel jobs and gated a heavy compile-fail suite to the default feature set to reduce redundant builds and speed up runs. Coverage upload paths and dependencies were updated accordingly, and an unnecessary disk cleanup step was removed.

- **Refactors**
  - Split CI: kept the interpreter feature matrix in `test-rust`, and moved layered crates to `test-rust-crates` to run in parallel without feature rebuilds (`monty-type-checking`, `monty-typeshed`, and subprocess crates build `monty` only with default features).
  - Removed the “free disk space” step; each job now holds at most one `monty` feature-config’s instrumented artifacts.
  - Adjusted coverage: added `rust-crates-coverage.json`, uploaded as `rust-crates-coverage-report`, and updated `coverage-upload`/`check` needs and both Codecov inputs to include it.
  - Gated `crates/monty/tests/heap_reader_compile_fail.rs` to default features and non-Windows to avoid repeating seven costly compilations under `memory-model-checks` and `ref-count-return`.

<sup>Written for commit 9ebfee80dd26b4a2afe277eb982f0d92ecf6d16a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

