### PR TITLE
Bump version to v0.0.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "monty"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "ahash",
  "chrono",
@@ -2419,14 +2419,14 @@ dependencies = [
 
 [[package]]
 name = "monty-alloc"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "monty-types",
 ]
 
 [[package]]
 name = "monty-bench"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "monty-datatest"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "ahash",
  "chrono",
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "monty-fs"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "ahash",
  "cap-std",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "monty-fuzz"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "monty-js"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "monty-pool",
  "monty-types",
@@ -2499,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "monty-macros"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "insta",
  "proc-macro2",
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "monty-pool"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "futures-util",
  "insta",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "monty-proto"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "monty",
  "monty-type-checking",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "monty-runtime"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "monty-type-checking"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "monty-types"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "chrono",
  "monty-macros",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "monty-typeshed"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "path-slash",
  "ruff_db",
@@ -2610,7 +2610,7 @@ dependencies = [
 
 [[package]]
 name = "monty-wasm-runtime"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "monty-alloc",
  "monty-proto",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-monty-client"
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
  "ahash",
  "monty-fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default-members = ["crates/monty-runtime"]
 
 [workspace.package]
 edition = "2024"
-version = "0.0.19"
+version = "0.0.20"
 rust-version = "1.95"
 license = "MIT"
 authors = ["Samuel Colvin <samuel@pydantic.dev>"]
@@ -58,15 +58,15 @@ strip = false
 # rejects path-only dependencies). These versions MUST be kept in lockstep with
 # `workspace.package.version` above and bumped together on each release — see
 # RELEASING.md.
-monty = { path = "crates/monty", version = "0.0.19" }
-monty-types = { path = "crates/monty-types", version = "0.0.19" }
-monty-alloc = { path = "crates/monty-alloc", version = "0.0.19" }
-monty-fs = { path = "crates/monty-fs", version = "0.0.19" }
-monty-macros = { path = "crates/monty-macros", version = "0.0.19" }
-monty-proto = { path = "crates/monty-proto", version = "0.0.19" }
-monty-pool = { path = "crates/monty-pool", version = "0.0.19" }
-monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.19" }
-monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.19" }
+monty = { path = "crates/monty", version = "0.0.20" }
+monty-types = { path = "crates/monty-types", version = "0.0.20" }
+monty-alloc = { path = "crates/monty-alloc", version = "0.0.20" }
+monty-fs = { path = "crates/monty-fs", version = "0.0.20" }
+monty-macros = { path = "crates/monty-macros", version = "0.0.20" }
+monty-proto = { path = "crates/monty-proto", version = "0.0.20" }
+monty-pool = { path = "crates/monty-pool", version = "0.0.20" }
+monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.20" }
+monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.20" }
 # ruff, ty and related crates
 ruff_python_parser = "0.0.3"
 ruff_python_stdlib = "0.0.3"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,8 +18,7 @@ and sync the `pydantic-monty` metapackage's version and its exact pins on
 
 ```bash
 git checkout -b prepare-release-vX.Y.Z
-git add .
-git commit -m "Bump version to vX.Y.Z"
+git commit -am "Bump version to vX.Y.Z"
 git push
 ```
 

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pydantic/monty",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "MIT",
       "devDependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.1",
@@ -29,11 +29,11 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@pydantic/monty-darwin-arm64": "0.0.19",
-        "@pydantic/monty-darwin-x64": "0.0.19",
-        "@pydantic/monty-linux-arm64-gnu": "0.0.19",
-        "@pydantic/monty-linux-x64-gnu": "0.0.19",
-        "@pydantic/monty-win32-x64-msvc": "0.0.19"
+        "@pydantic/monty-darwin-arm64": "0.0.20",
+        "@pydantic/monty-darwin-x64": "0.0.20",
+        "@pydantic/monty-linux-arm64-gnu": "0.0.20",
+        "@pydantic/monty-linux-x64-gnu": "0.0.20",
+        "@pydantic/monty-win32-x64-msvc": "0.0.20"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2433,84 +2433,19 @@
       "license": "MIT"
     },
     "node_modules/@pydantic/monty-darwin-arm64": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-arm64/-/monty-darwin-arm64-0.0.19.tgz",
-      "integrity": "sha512-lVBvwAnStWUtSUw/AFcnqFNgUTvbGgyXxLW8ECUWKn3o1iWJLLsuYbhyn+qYmB1F+vZVZqP/tY7CYeoiIO0c/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-darwin-x64": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-x64/-/monty-darwin-x64-0.0.19.tgz",
-      "integrity": "sha512-0zvFDj8CHoE7m2AOJ9MQCgb+7nldjvNdAjUqvM1EjZYKJnenVt/egYZdrjOOjEyEAxsSMoae6mgPvk3DorFfgg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-linux-arm64-gnu": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-arm64-gnu/-/monty-linux-arm64-gnu-0.0.19.tgz",
-      "integrity": "sha512-dXsOAaKWdPsNyJOYwOo2bWjBnnLmM05G8wQJXOM1pMomqD8g0DhK4z5LypJHLg/I280AHL6Nd08+Oi39axbu7Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-linux-x64-gnu": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-x64-gnu/-/monty-linux-x64-gnu-0.0.19.tgz",
-      "integrity": "sha512-h1hx2YAOBFUqXXI7sMBTHwi4JdWHUT4r+MuiXW7xbarPwkaRlsnq7iHbT+goHoG9qj8hIQxJnb7GD/eyDVauiQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@pydantic/monty-win32-x64-msvc": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@pydantic/monty-win32-x64-msvc/-/monty-win32-x64-msvc-0.0.19.tgz",
-      "integrity": "sha512-Z4ZFK7cwoY5+FLmfNeREnx0v6IChnLdOcVqHxxCV3QrVfzq1gfZ7bJFs57AQy+XpbHI39f5ZKooC8uY+mHyfuw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "optional": true
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",

--- a/crates/monty-js/package.json
+++ b/crates/monty-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "description": "Sandboxed Python interpreter running in crash-isolated subprocess workers",
   "main": "dist/index.js",
@@ -92,10 +92,10 @@
     "arrowParens": "always"
   },
   "optionalDependencies": {
-    "@pydantic/monty-darwin-x64": "0.0.19",
-    "@pydantic/monty-darwin-arm64": "0.0.19",
-    "@pydantic/monty-linux-x64-gnu": "0.0.19",
-    "@pydantic/monty-linux-arm64-gnu": "0.0.19",
-    "@pydantic/monty-win32-x64-msvc": "0.0.19"
+    "@pydantic/monty-darwin-x64": "0.0.20",
+    "@pydantic/monty-darwin-arm64": "0.0.20",
+    "@pydantic/monty-linux-x64-gnu": "0.0.20",
+    "@pydantic/monty-linux-arm64-gnu": "0.0.20",
+    "@pydantic/monty-win32-x64-msvc": "0.0.20"
   }
 }

--- a/packages/pydantic-monty/pyproject.toml
+++ b/packages/pydantic-monty/pyproject.toml
@@ -33,10 +33,10 @@ classifiers = [
 ]
 # version and both pins are rewritten from the Cargo workspace version by
 # `crates/monty-python/build.rs` — don't edit them by hand
-version = "0.0.19"
+version = "0.0.20"
 dependencies = [
-    "pydantic-monty-client==0.0.19",
-    "pydantic-monty-runtime==0.0.19",
+    "pydantic-monty-client==0.0.20",
+    "pydantic-monty-runtime==0.0.20",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -404,7 +404,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-monty"
-version = "0.0.19"
+version = "0.0.20"
 source = { editable = "packages/pydantic-monty" }
 dependencies = [
     { name = "pydantic-monty-client" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepare v0.0.20 release by bumping versions across Rust crates, NPM, and Python packages, and aligning all pins. No functional changes.

- **Dependencies**
  - Set Cargo workspace and all `monty*` crates to `0.0.20`; update `Cargo.lock`.
  - Bump `@pydantic/monty` and optional platform packages to `0.0.20`; update `package-lock.json`.
  - Set `pydantic-monty` to `0.0.20` and pin `pydantic-monty-client` and `pydantic-monty-runtime` to `0.0.20`; update `uv.lock`.
  - RELEASING.md: simplify release step to `git commit -am "Bump version to vX.Y.Z"`.

<sup>Written for commit 492e28bdc17c336336f6a945e638fe380c12b662. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

