### PR TITLE
Bump version to v0.0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "monty"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "ahash",
  "chrono",
@@ -2419,14 +2419,14 @@ dependencies = [
 
 [[package]]
 name = "monty-alloc"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "monty-types",
 ]
 
 [[package]]
 name = "monty-bench"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "monty-datatest"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "ahash",
  "chrono",
@@ -2459,7 +2459,7 @@ dependencies = [
 
 [[package]]
 name = "monty-fs"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "ahash",
  "cap-std",
@@ -2471,7 +2471,7 @@ dependencies = [
 
 [[package]]
 name = "monty-fuzz"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "arbitrary",
  "libfuzzer-sys",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "monty-js"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "monty-pool",
  "monty-types",
@@ -2499,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "monty-macros"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "insta",
  "proc-macro2",
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "monty-pool"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "futures-util",
  "insta",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "monty-proto"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "monty",
  "monty-type-checking",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "monty-runtime"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "anstream 0.6.21",
  "anstyle",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "monty-type-checking"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "codspeed-criterion-compat",
  "criterion",
@@ -2586,7 +2586,7 @@ dependencies = [
 
 [[package]]
 name = "monty-types"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "chrono",
  "monty-macros",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "monty-typeshed"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "path-slash",
  "ruff_db",
@@ -2610,7 +2610,7 @@ dependencies = [
 
 [[package]]
 name = "monty-wasm-runtime"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "monty-alloc",
  "monty-proto",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "pydantic-monty-client"
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
  "ahash",
  "monty-fs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default-members = ["crates/monty-runtime"]
 
 [workspace.package]
 edition = "2024"
-version = "0.0.20"
+version = "0.0.21"
 rust-version = "1.95"
 license = "MIT"
 authors = ["Samuel Colvin <samuel@pydantic.dev>"]
@@ -58,15 +58,15 @@ strip = false
 # rejects path-only dependencies). These versions MUST be kept in lockstep with
 # `workspace.package.version` above and bumped together on each release — see
 # RELEASING.md.
-monty = { path = "crates/monty", version = "0.0.20" }
-monty-types = { path = "crates/monty-types", version = "0.0.20" }
-monty-alloc = { path = "crates/monty-alloc", version = "0.0.20" }
-monty-fs = { path = "crates/monty-fs", version = "0.0.20" }
-monty-macros = { path = "crates/monty-macros", version = "0.0.20" }
-monty-proto = { path = "crates/monty-proto", version = "0.0.20" }
-monty-pool = { path = "crates/monty-pool", version = "0.0.20" }
-monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.20" }
-monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.20" }
+monty = { path = "crates/monty", version = "0.0.21" }
+monty-types = { path = "crates/monty-types", version = "0.0.21" }
+monty-alloc = { path = "crates/monty-alloc", version = "0.0.21" }
+monty-fs = { path = "crates/monty-fs", version = "0.0.21" }
+monty-macros = { path = "crates/monty-macros", version = "0.0.21" }
+monty-proto = { path = "crates/monty-proto", version = "0.0.21" }
+monty-pool = { path = "crates/monty-pool", version = "0.0.21" }
+monty-type-checking = { path = "crates/monty-type-checking", version = "0.0.21" }
+monty-typeshed = { path = "crates/monty-typeshed", version = "0.0.21" }
 # ruff, ty and related crates
 ruff_python_parser = "0.0.3"
 ruff_python_stdlib = "0.0.3"

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pydantic/monty",
-      "version": "0.0.20",
+      "version": "0.0.21",
       "license": "MIT",
       "devDependencies": {
         "@bjorn3/browser_wasi_shim": "^0.4.1",
@@ -29,11 +29,11 @@
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@pydantic/monty-darwin-arm64": "0.0.20",
-        "@pydantic/monty-darwin-x64": "0.0.20",
-        "@pydantic/monty-linux-arm64-gnu": "0.0.20",
-        "@pydantic/monty-linux-x64-gnu": "0.0.20",
-        "@pydantic/monty-win32-x64-msvc": "0.0.20"
+        "@pydantic/monty-darwin-arm64": "0.0.21",
+        "@pydantic/monty-darwin-x64": "0.0.21",
+        "@pydantic/monty-linux-arm64-gnu": "0.0.21",
+        "@pydantic/monty-linux-x64-gnu": "0.0.21",
+        "@pydantic/monty-win32-x64-msvc": "0.0.21"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/crates/monty-js/package.json
+++ b/crates/monty-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pydantic/monty",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "type": "module",
   "description": "Sandboxed Python interpreter running in crash-isolated subprocess workers",
   "main": "dist/index.js",
@@ -92,10 +92,10 @@
     "arrowParens": "always"
   },
   "optionalDependencies": {
-    "@pydantic/monty-darwin-x64": "0.0.20",
-    "@pydantic/monty-darwin-arm64": "0.0.20",
-    "@pydantic/monty-linux-x64-gnu": "0.0.20",
-    "@pydantic/monty-linux-arm64-gnu": "0.0.20",
-    "@pydantic/monty-win32-x64-msvc": "0.0.20"
+    "@pydantic/monty-darwin-x64": "0.0.21",
+    "@pydantic/monty-darwin-arm64": "0.0.21",
+    "@pydantic/monty-linux-x64-gnu": "0.0.21",
+    "@pydantic/monty-linux-arm64-gnu": "0.0.21",
+    "@pydantic/monty-win32-x64-msvc": "0.0.21"
   }
 }

--- a/packages/pydantic-monty/pyproject.toml
+++ b/packages/pydantic-monty/pyproject.toml
@@ -33,10 +33,10 @@ classifiers = [
 ]
 # version and both pins are rewritten from the Cargo workspace version by
 # `crates/monty-python/build.rs` — don't edit them by hand
-version = "0.0.20"
+version = "0.0.21"
 dependencies = [
-    "pydantic-monty-client==0.0.20",
-    "pydantic-monty-runtime==0.0.20",
+    "pydantic-monty-client==0.0.21",
+    "pydantic-monty-runtime==0.0.21",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "pydantic-monty"
-version = "0.0.20"
+version = "0.0.21"
 source = { editable = "packages/pydantic-monty" }
 dependencies = [
     { name = "pydantic-monty-client" },


### PR DESCRIPTION
Version bump to v0.0.21, per RELEASING.md.

v0.0.20 published to PyPI and npm, but the crates.io publish aborted partway: `monty-alloc` had no trusted-publishing config (403), which left `monty-type-checking`, `monty-fs`, `monty-proto`, `monty-pool` and `monty-runtime` unpublished behind it. `cargo publish --workspace` cannot be re-run once some members are published, so v0.0.21 is the fix.

**Before tagging:** configure trusted publishing for `monty-alloc` on crates.io (repo `pydantic/monty`, workflow `ci.yml`, environment `release-crates`) — otherwise this release fails identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XS2wa7mvgYXA6Yquy1BNDu

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump everything to v0.0.21 to recover from the partial v0.0.20 release and unblock crates.io publishing. Aligns versions across Rust crates, the `@pydantic/monty` npm package, and the `pydantic-monty` Python package.

- **Dependencies**
  - Rust: update workspace version and all `monty-*` crates to 0.0.21.
  - npm: update `@pydantic/monty` and platform packages to 0.0.21.
  - Python: update `pydantic-monty` and pins for `pydantic-monty-client` and `pydantic-monty-runtime` to 0.0.21.

- **Migration**
  - Before tagging: enable crates.io trusted publishing for `monty-alloc` (repo `pydantic/monty`, workflow `ci.yml`, environment `release-crates`) to avoid another partial publish.

<sup>Written for commit dd5c712e3171fe65be423e137b436c54ad32d656. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

