### PR TITLE
Protocol version utils

### DIFF
--- a/crates/monty-proto/src/lib.rs
+++ b/crates/monty-proto/src/lib.rs
@@ -24,46 +24,17 @@ pub mod worker;
 pub const PROTOCOL_VERSION: u32 = 1;
 
 /// Oldest [`PROTOCOL_VERSION`] this build still serves.
-///
-/// The gap between this and `PROTOCOL_VERSION` is the migration window: how far
-/// a separately-deployed parent (a WebSocket client, say) may lag behind its
-/// worker before being rejected. Raise it only when supporting an old version
-/// becomes a real cost — every raise is a breaking change for lagging clients.
 pub const MIN_SUPPORTED_PROTOCOL_VERSION: u32 = 1;
 
-// The supported range must be non-empty, and must exclude zero — which is what
-// a parent that declared no version sends, and must never be servable.
+// The supported range must be non-empty, and must exclude zero
 const _: () = assert!(MIN_SUPPORTED_PROTOCOL_VERSION >= 1);
 const _: () = assert!(MIN_SUPPORTED_PROTOCOL_VERSION <= PROTOCOL_VERSION);
 
 /// Protocol versions this build serves; a `Configure` outside it is fatal.
-///
-/// Zero is excluded by construction, so a peer that declared nothing — one
-/// predating `Configure.protocol_version`, or not a monty peer at all — is
-/// rejected rather than assumed compatible.
 const SUPPORTED_PROTOCOL_VERSIONS: RangeInclusive<u32> = MIN_SUPPORTED_PROTOCOL_VERSION..=PROTOCOL_VERSION;
 
 /// Checks a peer's declared [`pb::Configure::protocol_version`] against the
 /// range this build serves.
-///
-/// Lives here rather than in [`worker`] because every peer that terminates a
-/// `Configure` runs the same check and owes the peer the same sentence: the
-/// child, and equally a relay that serves clients over its own transport. The
-/// `Err` string is that sentence, ready to put in a `FatalError` — callers
-/// append their own diagnostics (package versions, say) rather than reword it,
-/// so a client reads one wording wherever it is refused.
-///
-/// ```
-/// use monty_proto::{PROTOCOL_VERSION, check_protocol_version};
-///
-/// assert!(check_protocol_version(PROTOCOL_VERSION).is_ok());
-/// // A peer that declared no version sends zero, which is never servable.
-/// assert!(check_protocol_version(0).is_err());
-/// ```
-///
-/// # Errors
-/// The refusal message naming what this build does support — the only way a
-/// peer learns what to downgrade to, since the protocol has no handshake.
 pub fn check_protocol_version(version: u32) -> Result<(), String> {
     if SUPPORTED_PROTOCOL_VERSIONS.contains(&version) {
         Ok(())
@@ -75,8 +46,8 @@ pub fn check_protocol_version(version: u32) -> Result<(), String> {
     }
 }
 
-/// Names [`SUPPORTED_PROTOCOL_VERSIONS`] for the refusal above. Singular while
-/// the window is one version wide, which "1 to 1" reads as a range it is not.
+/// Names [`SUPPORTED_PROTOCOL_VERSIONS`] for the refusal above, singular while
+/// the window is one version wide — "1 to 1" reads as a range it is not.
 fn supported_versions() -> String {
     if MIN_SUPPORTED_PROTOCOL_VERSION == PROTOCOL_VERSION {
         format!("this build supports protocol version {PROTOCOL_VERSION}")

--- a/crates/monty-proto/src/lib.rs
+++ b/crates/monty-proto/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!("../README.md")]
 
+use std::ops::RangeInclusive;
+
 mod convert;
 mod frame;
 mod generated;
@@ -33,6 +35,55 @@ pub const MIN_SUPPORTED_PROTOCOL_VERSION: u32 = 1;
 // a parent that declared no version sends, and must never be servable.
 const _: () = assert!(MIN_SUPPORTED_PROTOCOL_VERSION >= 1);
 const _: () = assert!(MIN_SUPPORTED_PROTOCOL_VERSION <= PROTOCOL_VERSION);
+
+/// Protocol versions this build serves; a `Configure` outside it is fatal.
+///
+/// Zero is excluded by construction, so a peer that declared nothing — one
+/// predating `Configure.protocol_version`, or not a monty peer at all — is
+/// rejected rather than assumed compatible.
+const SUPPORTED_PROTOCOL_VERSIONS: RangeInclusive<u32> = MIN_SUPPORTED_PROTOCOL_VERSION..=PROTOCOL_VERSION;
+
+/// Checks a peer's declared [`pb::Configure::protocol_version`] against the
+/// range this build serves.
+///
+/// Lives here rather than in [`worker`] because every peer that terminates a
+/// `Configure` runs the same check and owes the peer the same sentence: the
+/// child, and equally a relay that serves clients over its own transport. The
+/// `Err` string is that sentence, ready to put in a `FatalError` — callers
+/// append their own diagnostics (package versions, say) rather than reword it,
+/// so a client reads one wording wherever it is refused.
+///
+/// ```
+/// use monty_proto::{PROTOCOL_VERSION, check_protocol_version};
+///
+/// assert!(check_protocol_version(PROTOCOL_VERSION).is_ok());
+/// // A peer that declared no version sends zero, which is never servable.
+/// assert!(check_protocol_version(0).is_err());
+/// ```
+///
+/// # Errors
+/// The refusal message naming what this build does support — the only way a
+/// peer learns what to downgrade to, since the protocol has no handshake.
+pub fn check_protocol_version(version: u32) -> Result<(), String> {
+    if SUPPORTED_PROTOCOL_VERSIONS.contains(&version) {
+        Ok(())
+    } else {
+        Err(format!(
+            "unsupported protocol version {version} ({})",
+            supported_versions()
+        ))
+    }
+}
+
+/// Names [`SUPPORTED_PROTOCOL_VERSIONS`] for the refusal above. Singular while
+/// the window is one version wide, which "1 to 1" reads as a range it is not.
+fn supported_versions() -> String {
+    if MIN_SUPPORTED_PROTOCOL_VERSION == PROTOCOL_VERSION {
+        format!("this build supports protocol version {PROTOCOL_VERSION}")
+    } else {
+        format!("this build supports protocol versions {MIN_SUPPORTED_PROTOCOL_VERSION} to {PROTOCOL_VERSION}")
+    }
+}
 
 pub use convert::{MAX_VALUE_DEPTH, ProtoConvertError, exceeds_max_value_depth, future_results_from_proto};
 pub use frame::{

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -21,8 +21,8 @@ use std::{borrow::Cow, mem};
 use monty::{Dump, MontyRepl, ReplProgress, ReplStartError, Session, SessionRef, dump};
 use monty_type_checking::{SourceFile, TypeChecker};
 use monty_types::{
-    AssertMessageAnnotations, CompileOptions, ExcType, ExtFunctionResult, MONTY_VERSION, MontyException, MontyObject,
-    OsFunctionCall, PrintWriter, PrintWriterCallback, ResourceTracker, TypeCheckState, TypeCheckingConfig,
+    AssertMessageAnnotations, CompileOptions, ExcType, ExtFunctionResult, MontyException, MontyObject, OsFunctionCall,
+    PrintWriter, PrintWriterCallback, ResourceTracker, TypeCheckState, TypeCheckingConfig,
 };
 
 use super::{
@@ -227,16 +227,8 @@ impl Child {
                 // An unsupported protocol version is fatal: the parent may frame
                 // or interpret later messages differently, so serving it risks a
                 // silent desync. Emit the fatal last gasp and stop the child.
-                //
-                // The shared check names what this build serves, so a parent
-                // deployed separately from its worker can downgrade and retry —
-                // there is no handshake to discover it from. The package
-                // versions ride along purely as a diagnostic.
                 if let Err(refusal) = check_protocol_version(configure.protocol_version) {
-                    sink.send(&self.fatal_event(&format!(
-                        "{refusal}; parent monty {:?}, child monty {MONTY_VERSION:?}",
-                        configure.monty_version,
-                    )))?;
+                    sink.send(&self.fatal_event(&refusal))?;
                     return Ok(HandleOutcome::Fatal);
                 }
                 self.handle_configure(configure)
@@ -416,7 +408,7 @@ impl Child {
             type_check_color: _,
             // range-checked when `Configure` arrived
             protocol_version: _,
-            // informational only — reported, never checked
+            // informational only — never checked
             monty_version: _,
         } = *config;
         let limits = limits.unwrap_or_default().into();

--- a/crates/monty-proto/src/worker.rs
+++ b/crates/monty-proto/src/worker.rs
@@ -16,7 +16,7 @@
 //! the host transport surfaces that; it only ensures every *graceful* turn ends
 //! with exactly one turn-ending event.
 
-use std::{borrow::Cow, mem, ops::RangeInclusive};
+use std::{borrow::Cow, mem};
 
 use monty::{Dump, MontyRepl, ReplProgress, ReplStartError, Session, SessionRef, dump};
 use monty_type_checking::{SourceFile, TypeChecker};
@@ -26,16 +26,9 @@ use monty_types::{
 };
 
 use super::{
-    FrameError, FrameReader, MAX_FRAME_LEN, MIN_SUPPORTED_PROTOCOL_VERSION, PROTOCOL_VERSION, WireFunctionCall,
-    exceeds_max_frame_len, exceeds_max_value_depth, future_results_from_proto, pb, write_frame,
+    FrameError, FrameReader, MAX_FRAME_LEN, WireFunctionCall, check_protocol_version, exceeds_max_frame_len,
+    exceeds_max_value_depth, future_results_from_proto, pb, write_frame,
 };
-
-/// Protocol versions this build serves; a `Configure` outside it is fatal.
-///
-/// Zero is excluded by construction, so a parent that declared nothing — one
-/// predating `Configure.protocol_version`, or not a monty parent at all — is
-/// rejected rather than assumed compatible.
-const SUPPORTED_PROTOCOL_VERSIONS: RangeInclusive<u32> = MIN_SUPPORTED_PROTOCOL_VERSION..=PROTOCOL_VERSION;
 
 /// A sink for framed [`pb::ChildEvent`]s, decoupling the child from its
 /// transport.
@@ -235,17 +228,13 @@ impl Child {
                 // or interpret later messages differently, so serving it risks a
                 // silent desync. Emit the fatal last gasp and stop the child.
                 //
-                // The message names the range this build serves so a parent
+                // The shared check names what this build serves, so a parent
                 // deployed separately from its worker can downgrade and retry —
                 // there is no handshake to discover it from. The package
                 // versions ride along purely as a diagnostic.
-                if !SUPPORTED_PROTOCOL_VERSIONS.contains(&configure.protocol_version) {
+                if let Err(refusal) = check_protocol_version(configure.protocol_version) {
                     sink.send(&self.fatal_event(&format!(
-                        "unsupported protocol version {} (this build serves {}..={}); \
-                         parent monty {:?}, child monty {MONTY_VERSION:?}",
-                        configure.protocol_version,
-                        MIN_SUPPORTED_PROTOCOL_VERSION,
-                        PROTOCOL_VERSION,
+                        "{refusal}; parent monty {:?}, child monty {MONTY_VERSION:?}",
                         configure.monty_version,
                     )))?;
                     return Ok(HandleOutcome::Fatal);

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -1066,8 +1066,8 @@ fn unsupported_protocol_version_on_create_is_a_fatal_error() {
         message.contains(&format!("unsupported protocol version {}", PROTOCOL_VERSION + 1)),
         "message should name the rejected version: {message}"
     );
-    // Spelled out rather than taken from `check_protocol_version`, so a reword
-    // fails the journey a parent actually reads the sentence through.
+    // Spelled out rather than taken from `check_protocol_version`, so rewording
+    // the refusal a parent actually reads fails here.
     let supported = if MIN_SUPPORTED_PROTOCOL_VERSION == PROTOCOL_VERSION {
         format!("this build supports protocol version {PROTOCOL_VERSION}")
     } else {

--- a/crates/monty-runtime/tests/subprocess.rs
+++ b/crates/monty-runtime/tests/subprocess.rs
@@ -1066,10 +1066,15 @@ fn unsupported_protocol_version_on_create_is_a_fatal_error() {
         message.contains(&format!("unsupported protocol version {}", PROTOCOL_VERSION + 1)),
         "message should name the rejected version: {message}"
     );
+    // Spelled out rather than taken from `check_protocol_version`, so a reword
+    // fails the journey a parent actually reads the sentence through.
+    let supported = if MIN_SUPPORTED_PROTOCOL_VERSION == PROTOCOL_VERSION {
+        format!("this build supports protocol version {PROTOCOL_VERSION}")
+    } else {
+        format!("this build supports protocol versions {MIN_SUPPORTED_PROTOCOL_VERSION} to {PROTOCOL_VERSION}")
+    };
     assert!(
-        message.contains(&format!(
-            "this build serves {MIN_SUPPORTED_PROTOCOL_VERSION}..={PROTOCOL_VERSION}"
-        )),
+        message.contains(&supported),
         "message should name the supported range: {message}"
     );
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Centralized protocol version validation in `monty-proto` and unified the refusal message. `worker` now uses the shared helper, reducing duplication and keeping error wording consistent.

- **Refactors**
  - Added `check_protocol_version(u32)` and internal `SUPPORTED_PROTOCOL_VERSIONS`; refusal now says "this build supports protocol version(s) ..." with correct singular/plural.
  - Switched `worker` to the helper and removed package-version diagnostics from the fatal; updated `monty-runtime` subprocess test to assert the new wording.

<sup>Written for commit c243313da89b8721790b76111c54d19ff752ff77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

