### PR TITLE
Better python executables and readmes

### DIFF
--- a/crates/monty-python/README.md
+++ b/crates/monty-python/README.md
@@ -8,7 +8,7 @@ instead, which pulls in this package plus
 is documented in full on its PyPI page.
 
 Install this package directly to use the websocket client alone,
-or if you're installing the  `monty` binary another way.
+or if you're installing the `monty` binary another way.
 
 ```bash
 uv add pydantic-monty-client
@@ -16,7 +16,7 @@ uv add pydantic-monty-client
 pip install pydantic-monty-client
 ```
 
-# Usage with a remote monty server and websockets
+## Usage with a remote monty server and websockets
 
 You can use this library alone to connect to a remote monty server via websockets.
 

--- a/crates/monty-python/README.md
+++ b/crates/monty-python/README.md
@@ -20,7 +20,7 @@ pip install pydantic-monty-client
 
 You can use this library alone to connect to a remote monty server via websockets.
 
-```python
+```python test="skip"
 from pydantic_monty import AsyncMontyWebsocket
 
 
@@ -34,6 +34,7 @@ async def main() -> None:
 
 if __name__ == '__main__':
     import asyncio
+
     asyncio.run(main())
 ```
 
@@ -62,10 +63,12 @@ async def main() -> None:
         async with pool.checkout() as session:
             output = await session.feed_run('1 + 1')
             print('output from local worker ->', output)
+            #> output from local worker -> 2
 
 
 if __name__ == '__main__':
     import asyncio
+
     asyncio.run(main())
 ```
 

--- a/crates/monty-python/README.md
+++ b/crates/monty-python/README.md
@@ -5,9 +5,10 @@ Python client for the Monty sandboxed Python interpreter.
 Most users want [`pydantic-monty`](https://pypi.org/project/pydantic-monty/)
 instead, which pulls in this package plus
 [`pydantic-monty-runtime`](https://pypi.org/project/pydantic-monty-runtime/) and
-is documented in full on its PyPI page. Install this one directly only when the
-`monty` binary is supplied some other way — a base image, a system package, or a
-build of this repository:
+is documented in full on its PyPI page.
+
+Install this package directly to use the websocket client alone,
+or if you're installing the  `monty` binary another way.
 
 ```bash
 uv add pydantic-monty-client

--- a/crates/monty-python/README.md
+++ b/crates/monty-python/README.md
@@ -10,29 +10,36 @@ is documented in full on its PyPI page. Install this one directly only when the
 build of this repository:
 
 ```bash
+uv add pydantic-monty-client
+# or
 pip install pydantic-monty-client
 ```
 
-## Locating the worker binary
+# Usage with a remote monty server and websockets
 
-Execution always happens in a pool of `monty` worker subprocesses: a monty
-process can never be made fully crash-proof against memory errors (stack
-overflows, allocator aborts) triggered by adversarial input, so crash isolation
-is built in. Without `pydantic-monty-runtime` installed, `pydantic_monty` has to
-find that binary itself, in this order:
+You can use this library alone to connect to a remote monty server via websockets.
 
-1. the `binary_path=` argument to `Monty(...)` / `AsyncMonty(...)`
-2. the `MONTY_BIN` environment variable
-3. the environment's scripts directory (where `pydantic-monty-runtime` installs it)
-4. a `monty` executable on `PATH`
-5. a cargo-built binary in the monty workspace, for editable installs of this repo
+```python
+from pydantic_monty import AsyncMontyWebsocket
 
-If none match, constructing a pool raises `FileNotFoundError`. The binary need not
-be the same release as this package, but it must speak a compatible wire protocol
-version — the worker rejects an incompatible one when a session is checked out,
-reporting the range it serves.
 
-## Usage
+async def main() -> None:
+    url = '...'
+    async with AsyncMontyWebsocket(url) as pool:
+        async with pool.checkout() as session:
+            output = await session.feed_run('1 + 1')
+            print('output ->', output)
+
+
+if __name__ == '__main__':
+    import asyncio
+    asyncio.run(main())
+```
+
+## Usage with a local monty worker
+
+This requires the `pydantic-monty-runtime` package, which is generally
+installed as part of the `pydantic-monty` meta-package.
 
 ```python
 from pydantic_monty import Monty
@@ -43,7 +50,23 @@ with Monty() as pool:
         #> 3
 ```
 
+or in async code:
+
+```python
+from pydantic_monty import AsyncMonty
+
+
+async def main() -> None:
+    async with AsyncMonty() as pool:
+        async with pool.checkout() as session:
+            output = await session.feed_run('1 + 1')
+            print('output from local worker ->', output)
+
+
+if __name__ == '__main__':
+    import asyncio
+    asyncio.run(main())
+```
+
 See the [`pydantic-monty`](https://pypi.org/project/pydantic-monty/) README for
-async usage, external functions, snapshots, resource limits, type checking and
-observability, and `limitations/pool-architecture.md` in the repository for the
-behavioural details of subprocess execution.
+more details.

--- a/crates/monty-python/python/pydantic_monty/__main__.py
+++ b/crates/monty-python/python/pydantic_monty/__main__.py
@@ -1,0 +1,7 @@
+"""Makes `python -m pydantic_monty` run the `monty` binary; see [`_cli`]."""
+
+from __future__ import annotations
+
+from ._cli import main
+
+raise SystemExit(main())

--- a/crates/monty-python/python/pydantic_monty/_cli.py
+++ b/crates/monty-python/python/pydantic_monty/_cli.py
@@ -1,0 +1,41 @@
+"""Runs the `monty` binary, forwarding this process's arguments to it.
+
+Reached two ways: `python -m pydantic_monty` (via `__main__.py`) and the
+`pydantic-monty` console script the metapackage declares. Both exist because the
+binary ships in `pydantic-monty-runtime`, so neither of the other two
+distributions provides an executable of its own; the console script deliberately
+is NOT named `monty`, since that would collide with — and silently overwrite —
+the real binary in the scripts directory, leaving [`find_monty_binary`]
+resolving to the shim itself.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+from ._binary import find_monty_binary
+
+
+def main() -> int:
+    """Hands this process's arguments, streams and exit status to the `monty` binary."""
+    try:
+        binary = find_monty_binary()
+    except FileNotFoundError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+
+    argv = [binary, *sys.argv[1:]]
+    if os.name == 'posix':
+        os.execv(binary, argv)  # never returns, so signals and the exit status are the binary's own
+    else:
+        # Windows has no `exec`, so wait on a child instead. Ctrl-C reaches the
+        # whole console group, so ignore it here and let the binary decide whether
+        # a SIGINT ends the session — exiting early would orphan it on the terminal.
+        proc = subprocess.Popen(argv)
+        while True:
+            try:
+                return proc.wait()
+            except KeyboardInterrupt:
+                pass

--- a/crates/monty-python/python/pydantic_monty/_cli.py
+++ b/crates/monty-python/python/pydantic_monty/_cli.py
@@ -25,17 +25,17 @@ def main() -> int:
     except FileNotFoundError as exc:
         print(exc, file=sys.stderr)
         return 1
-
-    argv = [binary, *sys.argv[1:]]
-    if os.name == 'posix':
-        os.execv(binary, argv)  # never returns, so signals and the exit status are the binary's own
     else:
-        # Windows has no `exec`, so wait on a child instead. Ctrl-C reaches the
-        # whole console group, so ignore it here and let the binary decide whether
-        # a SIGINT ends the session — exiting early would orphan it on the terminal.
-        proc = subprocess.Popen(argv)
-        while True:
-            try:
-                return proc.wait()
-            except KeyboardInterrupt:
-                pass
+        argv = [binary, *sys.argv[1:]]
+        if os.name == 'posix':
+            os.execv(binary, argv)  # never returns, so signals and the exit status are the binary's own
+        else:
+            # Windows has no `exec`, so wait on a child instead. Ctrl-C reaches the
+            # whole console group, so ignore it here and let the binary decide whether
+            # a SIGINT ends the session — exiting early would orphan it on the terminal.
+            proc = subprocess.Popen(argv)
+            while True:
+                try:
+                    return proc.wait()
+                except KeyboardInterrupt:
+                    pass

--- a/crates/monty-python/python/pydantic_monty/_cli.py
+++ b/crates/monty-python/python/pydantic_monty/_cli.py
@@ -20,22 +20,20 @@ from ._binary import find_monty_binary
 
 def main() -> int:
     """Hands this process's arguments, streams and exit status to the `monty` binary."""
-    try:
-        binary = find_monty_binary()
-    except FileNotFoundError as exc:
-        print(exc, file=sys.stderr)
-        return 1
+    # find_monty_binary may raise FileNotFoundError, which we let propagate to the caller
+    binary = find_monty_binary()
+    argv = [binary, *sys.argv[1:]]
+    if os.name == 'posix':
+        # can raise OSError, which we let propagate to the caller
+        # os.execv never returns, so signals and the exit status are the binary's own
+        os.execv(binary, argv)
     else:
-        argv = [binary, *sys.argv[1:]]
-        if os.name == 'posix':
-            os.execv(binary, argv)  # never returns, so signals and the exit status are the binary's own
-        else:
-            # Windows has no `exec`, so wait on a child instead. Ctrl-C reaches the
-            # whole console group, so ignore it here and let the binary decide whether
-            # a SIGINT ends the session — exiting early would orphan it on the terminal.
-            proc = subprocess.Popen(argv)
-            while True:
-                try:
-                    return proc.wait()
-                except KeyboardInterrupt:
-                    pass
+        # Windows has no `exec`, so wait on a child instead. Ctrl-C reaches the
+        # whole console group, so ignore it here and let the binary decide whether
+        # a SIGINT ends the session — exiting early would orphan it on the terminal.
+        proc = subprocess.Popen(argv)
+        while True:
+            try:
+                return proc.wait()
+            except KeyboardInterrupt:
+                pass

--- a/crates/monty-runtime/Cargo.toml
+++ b/crates/monty-runtime/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "monty-runtime"
-readme = "README.md"
+# `README.md` is the PyPI readme for the `pydantic-monty-runtime` wheels built
+# from this crate; crates.io gets the one about cargo features and siblings
+readme = "README-crate.md"
 version = { workspace = true }
 license = { workspace = true }
 rust-version = { workspace = true }

--- a/crates/monty-runtime/README-crate.md
+++ b/crates/monty-runtime/README-crate.md
@@ -1,0 +1,93 @@
+# monty-runtime
+
+The `monty` command-line binary for the
+[Monty](https://github.com/pydantic/monty) sandboxed Python interpreter.
+
+```bash
+cargo install monty-runtime
+```
+
+```console
+$ monty -c "print('hello world')"
+hello world
+```
+
+## Usage
+
+- `monty` — start an interactive REPL
+- `monty file.py` — run a Python file
+- `monty -c "<code>"` — run a program passed as a string (like `python -c`)
+- `-i` / `--interactive` — run the file or `-c` program in a REPL session
+  (like `python -i`)
+- `-t` / `--type-check` — type check (powered by [ty](https://docs.astral.sh/ty/))
+  before executing
+- `-m` / `--mount /host/path::/virtual/path[::mode[::write_limit_bytes]]` —
+  mount a host directory into the sandbox (`ro`, `rw`, or `overlay`)
+- `--max-memory 10MB`, `--max-duration 0.5`, `--max-recursion-depth`,
+  `--gc-interval` — sandbox resource limits
+
+## Features
+
+- `standalone` (default) — the `monty <file>` / `-c` / REPL path and its
+  terminal stack (`rustyline`, `anstream`, `anstyle`). Without it the binary
+  serves `monty subprocess` alone, which is all a pool ever spawns; the flags
+  still parse, but anything other than `subprocess` is refused.
+- `telemetry` — see below. Implies `standalone`, since it only instruments that
+  path.
+
+## Observability
+
+Behind the `telemetry` feature, off by default because its exporter links MBs
+of TLS that `monty subprocess` — which never exports — would otherwise carry.
+Without it, `LOGFIRE_TOKEN` is ignored.
+
+Built with `--features telemetry`, standalone CLI runs configure the Rust
+Logfire SDK when `LOGFIRE_TOKEN` is set. The SDK also honors standard
+OpenTelemetry exporter and resource environment variables. The CLI owns the SDK
+lifecycle and flushes it before exiting.
+
+`monty subprocess` deliberately ignores telemetry environment configuration:
+worker processes are instrumented by their parent pool, avoiding duplicate
+exporters and keeping credentials out of sandbox workers.
+
+## Worker mode
+
+`monty subprocess` runs the binary as a wire-protocol child: framed protobuf
+requests on stdin, framed events on stdout (see the
+[`monty-proto`](https://crates.io/crates/monty-proto) crate). This is how the
+[`monty-pool`](https://crates.io/crates/monty-pool) crate — and through it the
+[`pydantic-monty`](https://pypi.org/project/pydantic-monty/) and
+[`@pydantic/monty`](https://www.npmjs.com/package/@pydantic/monty) packages —
+runs Monty with crash isolation. It is meant to be driven by a parent
+process, not by hand.
+
+The binary runs under the
+[`monty-alloc`](https://crates.io/crates/monty-alloc) global allocator, which
+provides the session's soft-limit usage and enforces a higher hard ceiling.
+Crossing the soft limit raises `MemoryError` at an interpreter checkpoint;
+crossing the hard limit exits with a dedicated status the parent can classify.
+
+## PyPI packaging (`pydantic-monty-runtime`)
+
+The binary is also packaged for PyPI as
+[`pydantic-monty-runtime`](https://pypi.org/project/pydantic-monty-runtime/), the same
+way `uv` and `ruff` package theirs: installing the wheel places the compiled
+binary in the environment's scripts directory. It exists so that
+`pydantic-monty-client` can find a `monty` binary without any manual setup, and
+is pulled in automatically by the `pydantic-monty` metapackage — you normally
+don't install it directly.
+
+Those wheels carry `README.md` instead of this file, since the cargo features
+and crate links below mean nothing to someone installing from PyPI.
+
+## Monty crates
+
+- [`monty`](https://crates.io/crates/monty) — the core interpreter: Python parser, bytecode VM, and sandbox.
+- [`monty-types`](https://crates.io/crates/monty-types) — the shared boundary data types (values, exceptions, OS calls, resource limits) hosts use without linking the interpreter.
+- [`monty-fs`](https://crates.io/crates/monty-fs) — host-side filesystem mounts: maps virtual sandbox paths to real host directories.
+- [`monty-runtime`](https://crates.io/crates/monty-runtime) — the `monty` binary: REPL, file runner, and subprocess worker mode. **this crate**
+- [`monty-pool`](https://crates.io/crates/monty-pool) — an elastic pool of crash-isolated `monty` worker subprocesses.
+- [`monty-proto`](https://crates.io/crates/monty-proto) — the protobuf wire protocol spoken between pool parents and workers.
+- [`monty-type-checking`](https://crates.io/crates/monty-type-checking) — type checking of sandboxed code, powered by [ty](https://docs.astral.sh/ty/).
+- [`monty-typeshed`](https://crates.io/crates/monty-typeshed) — the trimmed typeshed stubs describing the stdlib subset Monty implements.
+- [`monty-macros`](https://crates.io/crates/monty-macros) — the proc macros behind `monty`'s argument parsing.

--- a/crates/monty-runtime/README.md
+++ b/crates/monty-runtime/README.md
@@ -3,9 +3,26 @@
 The `monty` command-line binary for the
 [Monty](https://github.com/pydantic/monty) sandboxed Python interpreter.
 
-```console
-$ monty -c "print('hello world')"
-hello world
+Installing the wheel puts the compiled binary in the environment's scripts directory.
+
+You normally don't install this directly — the
+[`pydantic-monty`](https://pypi.org/project/pydantic-monty/) metapackage pulls
+it in alongside the Python bindings, which need it to spawn worker
+subprocesses. Install it on its own to get just the CLI, or to supply the binary
+to an existing [`pydantic-monty-client`](https://pypi.org/project/pydantic-monty-client/)
+install:
+
+```bash
+uv tool install pydantic-monty-runtime
+# or
+pip install pydantic-monty-runtime
+```
+
+Or to install the `monty` binary as a tool
+
+```bash
+uv tool install pydantic-monty-runtime
+monty --help
 ```
 
 ## Usage
@@ -22,65 +39,13 @@ hello world
 - `--max-memory 10MB`, `--max-duration 0.5`, `--max-recursion-depth`,
   `--gc-interval` — sandbox resource limits
 
-## Features
-
-- `standalone` (default) — the `monty <file>` / `-c` / REPL path and its
-  terminal stack (`rustyline`, `anstream`, `anstyle`). Without it the binary
-  serves `monty subprocess` alone, which is all a pool ever spawns; the flags
-  still parse, but anything other than `subprocess` is refused.
-- `telemetry` — see below. Implies `standalone`, since it only instruments that
-  path.
-
-## Observability
-
-Behind the `telemetry` feature, off by default because its exporter links MBs
-of TLS that `monty subprocess` — which never exports — would otherwise carry.
-Without it, `LOGFIRE_TOKEN` is ignored.
-
-Built with `--features telemetry`, standalone CLI runs configure the Rust
-Logfire SDK when `LOGFIRE_TOKEN` is set. The SDK also honors standard
-OpenTelemetry exporter and resource environment variables. The CLI owns the SDK
-lifecycle and flushes it before exiting.
-
-`monty subprocess` deliberately ignores telemetry environment configuration:
-worker processes are instrumented by their parent pool, avoiding duplicate
-exporters and keeping credentials out of sandbox workers.
-
 ## Worker mode
 
 `monty subprocess` runs the binary as a wire-protocol child: framed protobuf
-requests on stdin, framed events on stdout (see the
-[`monty-proto`](https://crates.io/crates/monty-proto) crate). This is how the
-[`monty-pool`](https://crates.io/crates/monty-pool) crate — and through it the
-[`pydantic-monty`](https://pypi.org/project/pydantic-monty/) and
-[`@pydantic/monty`](https://www.npmjs.com/package/@pydantic/monty) packages —
-runs Monty with crash isolation. It is meant to be driven by a parent
+requests on stdin, framed events on stdout. This is how `pydantic-monty` runs
+sandboxed code with crash isolation, and is meant to be driven by a parent
 process, not by hand.
 
-The binary runs under the
-[`monty-alloc`](https://crates.io/crates/monty-alloc) global allocator, which
-provides the session's soft-limit usage and enforces a higher hard ceiling.
-Crossing the soft limit raises `MemoryError` at an interpreter checkpoint;
-crossing the hard limit exits with a dedicated status the parent can classify.
-
-## PyPI packaging (`pydantic-monty-runtime`)
-
-The binary is also packaged for PyPI as
-[`pydantic-monty-runtime`](https://pypi.org/project/pydantic-monty-runtime/), the same
-way `uv` and `ruff` package theirs: installing the wheel places the compiled
-binary in the environment's scripts directory. It exists so that
-`pydantic-monty-client` can find a `monty` binary without any manual setup, and
-is pulled in automatically by the `pydantic-monty` metapackage — you normally
-don't install it directly.
-
-## Monty crates
-
-- [`monty`](https://crates.io/crates/monty) — the core interpreter: Python parser, bytecode VM, and sandbox.
-- [`monty-types`](https://crates.io/crates/monty-types) — the shared boundary data types (values, exceptions, OS calls, resource limits) hosts use without linking the interpreter.
-- [`monty-fs`](https://crates.io/crates/monty-fs) — host-side filesystem mounts: maps virtual sandbox paths to real host directories.
-- [`monty-runtime`](https://crates.io/crates/monty-runtime) — the `monty` binary: REPL, file runner, and subprocess worker mode. **this crate**
-- [`monty-pool`](https://crates.io/crates/monty-pool) — an elastic pool of crash-isolated `monty` worker subprocesses.
-- [`monty-proto`](https://crates.io/crates/monty-proto) — the protobuf wire protocol spoken between pool parents and workers.
-- [`monty-type-checking`](https://crates.io/crates/monty-type-checking) — type checking of sandboxed code, powered by [ty](https://docs.astral.sh/ty/).
-- [`monty-typeshed`](https://crates.io/crates/monty-typeshed) — the trimmed typeshed stubs describing the stdlib subset Monty implements.
-- [`monty-macros`](https://crates.io/crates/monty-macros) — the proc macros behind `monty`'s argument parsing.
+The wheels are built from the
+[`monty-runtime`](https://crates.io/crates/monty-runtime) crate; see its
+readme for cargo features, telemetry, and the rest of the Rust-side detail.

--- a/crates/monty-runtime/README.md
+++ b/crates/monty-runtime/README.md
@@ -13,7 +13,7 @@ to an existing [`pydantic-monty-client`](https://pypi.org/project/pydantic-monty
 install:
 
 ```bash
-uv tool install pydantic-monty-runtime
+uv add pydantic-monty-runtime
 # or
 pip install pydantic-monty-runtime
 ```

--- a/crates/monty-runtime/src/main.rs
+++ b/crates/monty-runtime/src/main.rs
@@ -23,7 +23,7 @@ static ALLOC: monty_alloc::LimitedAllocator = monty_alloc::LimitedAllocator;
 #[derive(Parser)]
 #[command(version)]
 pub(crate) struct Cli {
-    /// Start interactive REPL mode.
+    /// Start interactive REPL mode, this is the default if no file or command is provided.
     #[arg(short = 'i', long = "interactive")]
     interactive: bool,
 

--- a/packages/pydantic-monty/README.md
+++ b/packages/pydantic-monty/README.md
@@ -11,6 +11,8 @@ replaced transparently — your process is never at risk.
 ## Installation
 
 ```bash
+uv add pydantic-monty
+# or
 pip install pydantic-monty
 ```
 
@@ -26,6 +28,31 @@ distributions that make up a working sandbox:
 Install `pydantic-monty-client` on its own when the worker binary comes from
 somewhere else — a base image, a system package, a build of this repo — and
 point `pydantic_monty` at it via `MONTY_BIN`, `binary_path=`, or `PATH`.
+
+## CLI
+
+Usage without installing via [uvx](https://docs.astral.sh/uv/guides/tools/):
+
+```bash
+uvx pydantic-monty --help
+```
+
+`uvx pydantic-monty` runs a REPL, or `uvx pydantic-monty <file>` runs a file.
+
+Or to install `monty` locally, run
+
+```bash
+uv tool install pydantic-monty-runtime
+# then to run the repl:
+monty
+# or run a file:
+monty <file>
+# or for help:
+monty --help
+```
+
+Within an environment that already has `pydantic-monty` installed,
+`python -m pydantic_monty` runs the same binary.
 
 ## Usage
 
@@ -248,10 +275,12 @@ with Monty() as pool:
             """
 ```
 
-### Crash isolation
+### Crash/failure isolation
+
+All failures in monty code execution should surface as a subclass of `MontyError`.
 
 ```python test="skip"
-from pydantic_monty import Monty, MontyCrashedError
+from pydantic_monty import Monty, MontyError
 
 hostile_code = '...'
 
@@ -259,24 +288,6 @@ with Monty() as pool:
     with pool.checkout() as session:
         try:
             session.feed_run(hostile_code)  # even a segfault is contained
-        except MontyCrashedError:
+        except MontyError:
             ...  # the worker died; the pool already replaced it
 ```
-
-### Observability
-
-The Python Logfire integration instruments the pool through a private adapter
-hook. It propagates the active Python OTel context into each checkout, which
-becomes one session span with nested feed and suspension
-spans recording code, inputs, external calls, exceptions, and `print` output.
-Session dumps and restores are recorded by size only.
-
-Logfire's Python SDK owns sampling, export credentials, resources, flushing,
-and shutdown. The Rust binding runs only an exporter-free processor pipeline;
-workers receive no credentials. Instrumentation is disabled unless an adapter
-is explicitly installed. Enabled instrumentation captures content, truncating
-large values at the telemetry attribute size limit.
-
-See `limitations/pool-architecture.md` in the repository for the behavioural
-details of subprocess execution (host-side mounts, buffered print
-callbacks, session dumps).

--- a/packages/pydantic-monty/pyproject.toml
+++ b/packages/pydantic-monty/pyproject.toml
@@ -39,6 +39,13 @@ dependencies = [
     "pydantic-monty-runtime==0.0.20",
 ]
 
+[project.scripts]
+# the `monty` binary comes from `pydantic-monty-runtime`, so without this the
+# metapackage provides no executable of its own and `uvx pydantic-monty` fails.
+# The implementation lives in the exactly-pinned client; it must NOT be named
+# `monty` — see that module's docstring.
+pydantic-monty = "pydantic_monty._cli:main"
+
 [project.urls]
 Homepage = "https://github.com/pydantic/monty"
 Source = "https://github.com/pydantic/monty"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Python CLI entry points so `uvx pydantic-monty` and `python -m pydantic_monty` run the real `monty` binary. Refreshes READMEs with clearer CLI vs websocket usage, `uv`/`uvx` snippets, and fixes examples; avoids binary name collisions by not shipping a `monty` shim.

- **New Features**
  - Console script `pydantic-monty` delegates to the real `monty` via `find_monty_binary` (POSIX exec; Windows child with Ctrl-C passthrough).
  - `python -m pydantic_monty` now runs the same binary (`__main__.py`).

- **Refactors**
  - Docs: clear split between remote websocket use (`pydantic-monty-client`) and local worker usage requiring `pydantic-monty-runtime`; adds async examples, `uv`/`uvx` usage, and fixes examples to use `MontyError`.
  - `monty-runtime` READMEs split: crates.io gets `README-crate.md` (features/telemetry/crate links); PyPI `README.md` focuses on CLI install/usage (incl. `uv tool install`); `-i/--interactive` help text clarified.

<sup>Written for commit ff4ff243e4c8537b83544906fe07a369a2743ff7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

