### PR TITLE
Avoid stack overflow in nested asyncio task chains

### DIFF
--- a/crates/monty/src/bytecode/vm/exceptions.rs
+++ b/crates/monty/src/bytecode/vm/exceptions.rs
@@ -14,6 +14,14 @@ use crate::{
     value::Value,
 };
 
+/// Result of handling an exception until execution can resume, it escapes, or
+/// it needs to be propagated in a waiting task.
+enum ExceptionHandlingResult {
+    Caught,
+    Unhandled(RunError),
+    PropagateToWaiter(RunError),
+}
+
 impl VM<'_> {
     /// Returns the current function name, or `<module>` outside a function.
     /// The empty-stack fallback keeps traceback generation total after async
@@ -246,8 +254,19 @@ impl VM<'_> {
     pub(super) fn handle_exception_with_value(
         &mut self,
         mut error: RunError,
-        raised: Option<Value>,
+        mut raised: Option<Value>,
     ) -> Option<RunError> {
+        loop {
+            match self.handle_exception_step(error, raised.take()) {
+                ExceptionHandlingResult::Caught => return None,
+                ExceptionHandlingResult::Unhandled(error) => return Some(error),
+                ExceptionHandlingResult::PropagateToWaiter(waiter_error) => error = waiter_error,
+            }
+        }
+    }
+
+    /// Handles one propagation step, yielding when the error moves to a waiter.
+    fn handle_exception_step(&mut self, mut error: RunError, raised: Option<Value>) -> ExceptionHandlingResult {
         // Ensure exception has initial frame info
         error = self.attach_frame_to_error(error);
 
@@ -257,7 +276,7 @@ impl VM<'_> {
             if let Some(raised) = raised {
                 raised.drop_with(self);
             }
-            return Some(self.unwind_for_traceback(error));
+            return ExceptionHandlingResult::Unhandled(self.unwind_for_traceback(error));
         }
 
         let exc_value = if let Some(raised) = raised {
@@ -320,7 +339,7 @@ impl VM<'_> {
                 // Jump to handler
                 this.current_frame_mut().ip = handler_offset;
 
-                return None; // Continue execution at handler
+                return ExceptionHandlingResult::Caught;
             }
 
             // No handler in this frame - pop frame and try outer
@@ -333,19 +352,16 @@ impl VM<'_> {
 
                 // For spawned tasks, fail the task instead of propagating
                 if is_spawned {
-                    match self.handle_task_failure(error) {
+                    return match self.handle_task_failure(error) {
                         Ok(()) => {
                             // Switched to next task - continue execution
-                            return None;
+                            ExceptionHandlingResult::Caught
                         }
-                        Err(waiter_error) => {
-                            // Switched to waiter - handle error in waiter's context
-                            return self.handle_exception(waiter_error);
-                        }
-                    }
+                        Err(waiter_error) => ExceptionHandlingResult::PropagateToWaiter(waiter_error),
+                    };
                 }
 
-                return Some(error);
+                return ExceptionHandlingResult::Unhandled(error);
             }
 
             // Get the caller's call-site offset before popping frame.
@@ -356,7 +372,7 @@ impl VM<'_> {
             if this.pop_frame() {
                 // The frame indicated evaluation should stop - e.g. inside `evaluate_function` - return the error
                 // now to stop unwinding.
-                return Some(error);
+                return ExceptionHandlingResult::Unhandled(error);
             }
 
             // Add caller frame info to traceback (if we have a call site).

--- a/crates/monty/src/bytecode/vm/exceptions.rs
+++ b/crates/monty/src/bytecode/vm/exceptions.rs
@@ -17,8 +17,11 @@ use crate::{
 /// Result of handling an exception until execution can resume, it escapes, or
 /// it needs to be propagated in a waiting task.
 enum ExceptionHandlingResult {
+    /// Execution can resume without propagating an error to the caller.
     Caught,
+    /// The error should be returned to the VM caller.
     Unhandled(RunError),
+    /// The error should be handled in the waiting task.
     PropagateToWaiter(RunError),
 }
 

--- a/crates/monty/tests/asyncio.rs
+++ b/crates/monty/tests/asyncio.rs
@@ -994,8 +994,6 @@ caught
 
     let runner = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
 
-    let result = runner
-        .run_no_limits(vec![])
-        .expect("the original exception should be caught");
+    let result = runner.run_no_limits(vec![]).expect("should complete");
     assert_eq!(result, MontyObject::Bool(true));
 }

--- a/crates/monty/tests/asyncio.rs
+++ b/crates/monty/tests/asyncio.rs
@@ -968,3 +968,34 @@ await main()
     let result = progress.into_complete().expect("should complete");
     assert_eq!(result, MontyObject::Int(333));
 }
+
+/// Propagating a failure through deeply nested gather waiters must not recurse
+/// on the native Rust stack.
+#[test]
+fn deeply_nested_gather_failure_does_not_overflow_stack() {
+    let code = r"
+import asyncio
+
+async def leaf():
+    raise ValueError('boom')
+
+async def chain(n):
+    if n == 0:
+        return await asyncio.gather(leaf())
+    return await asyncio.gather(chain(n - 1))
+
+caught = False
+try:
+    await asyncio.gather(chain(4000))
+except ValueError:
+    caught = True
+caught
+";
+
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+
+    let result = runner
+        .run_no_limits(vec![])
+        .expect("the original exception should be caught");
+    assert_eq!(result, MontyObject::Bool(true));
+}


### PR DESCRIPTION
The waiter-error path re-entered `VM::handle_exception` recursively, adding one native Rust stack frame for each nested `asyncio.gather` waiter.

This changes waiter error propagation to an iterative loop while preserving the existing exception handling and ownership behavior.

A regression test covers a 4,000-level nested `asyncio.gather` chain and verifies that the original `ValueError` remains catchable.

## Tests

- `cargo test -p monty --test asyncio`
- `cargo test -p monty`

Fixes #649

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stack overflow when exceptions propagate through deep `asyncio.gather` waiter chains by switching from recursive to iterative handling. Preserves exception behavior; adds a regression test.

- **Bug Fixes**
  - Made `handle_exception_with_value` iterative via a loop over `handle_exception_step`.
  - Added `ExceptionHandlingResult` with `Caught`, `Unhandled`, and `PropagateToWaiter` to control propagation and handle waiter handoff without growing the stack.
  - Added a regression test for a 4,000-level nested `asyncio.gather`; verifies the original `ValueError` is catchable.

<sup>Written for commit 4f9202499a566a04a58fdb6519e0a942bf26bab3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

