### PR TITLE
Fix container repr panics when a user `__repr__` mutates the container

### DIFF
--- a/crates/monty-bench/benches/main.rs
+++ b/crates/monty-bench/benches/main.rs
@@ -215,6 +215,28 @@ const EMPTY_TUPLES: &str = "len([() for _ in range(100_000)])";
 /// 2-tuple creation benchmark - creates 100,000 2-tuples in a list.
 const PAIR_TUPLES: &str = "len([(i, i + 1) for i in range(100_000)])";
 
+/// Container repr throughput over 1,000-element containers (half tracked
+/// strings, so per-item refcount bumps are priced). Guards the
+/// mutation-safe repr paths: live checked iteration for list/tuple/dict,
+/// snapshotting for deque/set/Counter, and the amortized time polls.
+const CONTAINER_REPR: &str = "
+from collections import Counter, deque
+
+words = [str(i) for i in range(500)]
+xs = words + list(range(500))
+tup = tuple(xs)
+d = {w: i for i, w in enumerate(words)}
+st = set(words)
+dq = deque(xs)
+c = Counter({w: i % 7 for i, w in enumerate(words)})
+
+n = 0
+for _ in range(20):
+    n += len(repr(xs)) + len(repr(tup)) + len(repr(d))
+    n += len(repr(st)) + len(repr(dq)) + len(repr(c))
+n
+";
+
 // --- Agent-workload benchmarks -------------------------------------------
 //
 // Monty's primary real-world use is "code mode" agents (pydantic-ai
@@ -502,6 +524,10 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("pair_tuples__monty", |b| run_monty(b, PAIR_TUPLES, 100_000));
     #[cfg(not(codspeed))]
     c.bench_function("pair_tuples__cpython", |b| run_cpython(b, PAIR_TUPLES, 100_000));
+
+    c.bench_function("container_repr__monty", |b| run_monty(b, CONTAINER_REPR, 628_320));
+    #[cfg(not(codspeed))]
+    c.bench_function("container_repr__cpython", |b| run_cpython(b, CONTAINER_REPR, 628_320));
 
     c.bench_function("json_loads__monty", |b| {
         run_monty_with_data(b, JSON_LOADS, JSON_MEDIUM, 2);

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -9,7 +9,7 @@ use crate::{
     heap::{DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
     intern::StaticStrings,
     resource_checks::{check_estimated_size, check_repeat_size},
-    types::{LazyHeapSet, Type, list::repr_sequence_fmt, long_int::repeat_count},
+    types::{LazyHeapSet, Type, list::repr_items_fmt, long_int::repeat_count},
     value::{EitherStr, VALUE_SIZE, Value},
 };
 
@@ -467,14 +467,15 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Deque> {
         let items = self.clone_all_items(vm)?;
         defer_drop!(items, vm);
         f.write_str("deque(")?;
-        repr_sequence_fmt(
-            '[',
-            ']',
-            |heap, i| items.get(i).map(|v| v.clone_with_heap(heap)),
-            f,
-            vm,
-            heap_ids,
-        )?;
+        if let Ok(mut guard) = vm.recursion_guard() {
+            let vm = &mut *guard;
+            f.write_char('[')?;
+            repr_items_fmt(items, f, vm, heap_ids)?;
+            f.write_char(']')?;
+        } else {
+            // Depth limit reached — same elision `repr_sequence_fmt` emits.
+            f.write_str("...")?;
+        }
         // CPython only shows maxlen when the deque is bounded.
         if let Some(max) = self.get(vm.heap).maxlen() {
             write!(f, ", maxlen={max}")?;

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -461,9 +461,20 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Deque> {
     }
 
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, heap_ids: &mut LazyHeapSet) -> RunResult<()> {
-        let len = self.get(vm.heap).len();
+        // Format a snapshot of the items: CPython's deque repr copies to a list
+        // first, so a user `__repr__` mutating the deque mid-format changes
+        // nothing (and can't invalidate indices here).
+        let items = self.clone_all_items(vm)?;
+        defer_drop!(items, vm);
         f.write_str("deque(")?;
-        repr_sequence_fmt('[', ']', len, |heap, i| &self.get(heap).items[i], f, vm, heap_ids)?;
+        repr_sequence_fmt(
+            '[',
+            ']',
+            |heap, i| items.get(i).map(|v| v.clone_with_heap(heap)),
+            f,
+            vm,
+            heap_ids,
+        )?;
         // CPython only shows maxlen when the deque is bounded.
         if let Some(max) = self.get(vm.heap).maxlen() {
             write!(f, ", maxlen={max}")?;

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -461,14 +461,15 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Deque> {
     }
 
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, heap_ids: &mut LazyHeapSet) -> RunResult<()> {
-        // Format a snapshot of the items: CPython's deque repr copies to a list
-        // first, so a user `__repr__` mutating the deque mid-format changes
-        // nothing (and can't invalidate indices here).
-        let items = self.clone_all_items(vm)?;
-        defer_drop!(items, vm);
         f.write_str("deque(")?;
         if let Ok(mut guard) = vm.recursion_guard() {
             let vm = &mut *guard;
+            // Format a snapshot of the items (taken only once the depth limit
+            // allows a body at all): CPython's deque repr copies to a list
+            // first, so a user `__repr__` mutating the deque mid-format
+            // changes nothing (and can't invalidate indices here).
+            let items = self.clone_all_items(vm)?;
+            defer_drop!(items, vm);
             f.write_char('[')?;
             repr_items_fmt(items, f, vm, heap_ids)?;
             f.write_char(']')?;

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -26,7 +26,7 @@ use crate::{
         defaultdict::defaultdict_missing,
     },
     types::Type,
-    value::{EitherStr, Value},
+    value::{EitherStr, VALUE_SIZE, Value},
 };
 
 /// Python dict type preserving insertion order.
@@ -225,13 +225,6 @@ impl Dict {
             Some(DictSpecial::Default(_)) => Type::DefaultDict,
             Some(DictSpecial::Counter) => Type::Counter,
         }
-    }
-
-    /// Clones every entry's value, for the `Counter` orderings that must compare
-    /// counts through the VM (see [`counter_order`]).
-    #[must_use]
-    pub fn cloned_values(&self, heap: &impl ContainsHeap) -> Vec<Value> {
-        self.entries.iter().map(|e| e.value.clone_with_heap(heap)).collect()
     }
 
     /// Returns the `default_factory` callable, or `None` for a plain dict or a
@@ -1017,9 +1010,16 @@ impl<'h> HeapRead<'h, Dict> {
         };
         let vm = &mut *guard;
 
+        // Format a refcount-bumped snapshot of the entries: live indices would
+        // panic (or skew) if a user `__repr__` deleted entries mid-format. For
+        // deletions this prints what CPython's tombstone-stable iteration does;
+        // insertions during repr are the one divergence (see
+        // `limitations/builtins.md`).
+        let pairs = self.clone_all_pairs(vm)?;
+        defer_drop!(pairs, vm);
+
         f.write_char('{')?;
-        let len = self.get(vm.heap).len();
-        for i in 0..len {
+        for (i, (key, value)) in pairs.iter().enumerate() {
             if i > 0 {
                 if vm.heap.check_time().is_err() {
                     f.write_str(", ...[timeout]")?;
@@ -1027,20 +1027,8 @@ impl<'h> HeapRead<'h, Dict> {
                 }
                 f.write_str(", ")?;
             }
-            let key = self
-                .get(vm.heap)
-                .key_at(i)
-                .expect("index in range")
-                .clone_with_heap(vm.heap);
-            defer_drop!(key, vm);
             key.py_repr_fmt(f, vm, heap_ids)?;
             f.write_str(": ")?;
-            let value = self
-                .get(vm.heap)
-                .value_at(i)
-                .expect("index in range")
-                .clone_with_heap(vm.heap);
-            defer_drop!(value, vm);
             value.py_repr_fmt(f, vm, heap_ids)?;
         }
         f.write_char('}')?;
@@ -1056,31 +1044,45 @@ impl<'h> HeapRead<'h, Dict> {
         };
         let vm = &mut *guard;
 
-        let counts = self.get(vm.heap).cloned_values(vm.heap);
+        // Snapshot the entries BEFORE ordering: `counter_order` compares counts
+        // through the VM, so user `__lt__`/`__repr__` code can mutate the
+        // Counter — live indices would then panic or skew.
+        let pairs = self.clone_all_pairs(vm)?;
+        defer_drop!(pairs, vm);
+        let counts = pairs.iter().map(|(_, value)| value.clone_with_heap(vm.heap)).collect();
         let order = counter_order(counts, vm)?;
         f.write_char('{')?;
         for (n, &i) in order.iter().enumerate() {
             if n > 0 {
                 f.write_str(", ")?;
             }
-            let key = self
-                .get(vm.heap)
-                .key_at(i)
-                .expect("index in range")
-                .clone_with_heap(vm.heap);
-            defer_drop!(key, vm);
+            let (key, value) = &pairs[i];
             key.py_repr_fmt(f, vm, heap_ids)?;
             f.write_str(": ")?;
-            let value = self
-                .get(vm.heap)
-                .value_at(i)
-                .expect("index in range")
-                .clone_with_heap(vm.heap);
-            defer_drop!(value, vm);
             value.py_repr_fmt(f, vm, heap_ids)?;
         }
         f.write_char('}')?;
         Ok(())
+    }
+
+    /// Clones every entry as a refcount-bumped `(key, value)` pair, for reprs
+    /// that must not hold live indices while user `__repr__` code runs.
+    ///
+    /// Preflights the slot bytes so an over-budget clone raises a graceful
+    /// `MemoryError` instead of bursting past the allocator's hard limit.
+    fn clone_all_pairs(&self, vm: &mut VM<'h>) -> RunResult<Vec<(Value, Value)>> {
+        let len = self.get(vm.heap).len();
+        vm.heap.tracker().check_allocation(len.saturating_mul(2 * VALUE_SIZE))?;
+        let mut pairs = Vec::with_capacity(len);
+        // No user code runs during the snapshot, so `len` stays current and
+        // the `expect`s cannot fire.
+        for i in 0..len {
+            let dict = self.get(vm.heap);
+            let key = dict.key_at(i).expect("index in range").clone_with_heap(vm.heap);
+            let value = dict.value_at(i).expect("index in range").clone_with_heap(vm.heap);
+            pairs.push((key, value));
+        }
+        Ok(pairs)
     }
 
     /// Handles dict attribute assignment. Only `defaultdict.default_factory` is

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -1049,16 +1049,26 @@ impl<'h> HeapRead<'h, Dict> {
         };
         let vm = &mut *guard;
 
-        // Snapshot the entries BEFORE ordering: `counter_order` compares counts
-        // through the VM, so user `__lt__`/`__repr__` code can mutate the
-        // Counter — live indices would then panic or skew.
+        // Snapshot the entries BEFORE ordering: the reprs printed below run
+        // user `__repr__` code that can mutate the Counter, so the ordered
+        // indices must refer to the snapshot, not live entries.
         let pairs = self.clone_all_pairs(vm)?;
         defer_drop!(pairs, vm);
+        // The counts clone and the order indices live alongside the pair
+        // snapshot — preflight them too so an over-budget Counter raises a
+        // graceful `MemoryError` instead of hitting the allocator hard limit.
+        vm.heap
+            .tracker()
+            .check_allocation(pairs.len().saturating_mul(VALUE_SIZE + mem::size_of::<usize>()))?;
         let counts = pairs.iter().map(|(_, value)| value.clone_with_heap(vm.heap)).collect();
         let order = counter_order(counts, vm)?;
         f.write_char('{')?;
         for (n, &i) in order.iter().enumerate() {
             if n > 0 {
+                if repr_check_time(n, vm) {
+                    f.write_str(", ...[timeout]")?;
+                    break;
+                }
                 f.write_str(", ")?;
             }
             let (key, value) = &pairs[i];
@@ -1071,9 +1081,9 @@ impl<'h> HeapRead<'h, Dict> {
     }
 
     /// Clones every entry as a refcount-bumped `(key, value)` pair, for the
-    /// Counter repr: its ordering pass (`counter_order`) runs user comparison
-    /// code before anything is printed, so live indices would panic or skew —
-    /// and CPython's `most_common()` snapshots the same way.
+    /// Counter repr: printing runs user `__repr__` code against indices from
+    /// the ordering pass, so live indices would panic or skew once that code
+    /// mutates the Counter — and CPython's `most_common()` snapshots the same way.
     ///
     /// Preflights the slot bytes so an over-budget clone raises a graceful
     /// `MemoryError` instead of bursting past the allocator's hard limit.

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -9,7 +9,7 @@ use hashbrown::HashTable;
 use serde::ser::SerializeStruct;
 use smallvec::{SmallVec, smallvec};
 
-use super::{DictItemsView, DictKeysView, DictValuesView, LazyHeapSet, PyTrait, allocate_tuple};
+use super::{DictItemsView, DictKeysView, DictValuesView, LazyHeapSet, PyTrait, allocate_tuple, list::repr_check_time};
 use crate::{
     args::{ArgValues, FromArgs, KwargsValues},
     bytecode::{CallResult, ContainsVM, RecursionToken, VM},
@@ -1021,7 +1021,7 @@ impl<'h> HeapRead<'h, Dict> {
         f.write_char('{')?;
         for (i, (key, value)) in pairs.iter().enumerate() {
             if i > 0 {
-                if vm.heap.check_time().is_err() {
+                if repr_check_time(i, vm) {
                     f.write_str(", ...[timeout]")?;
                     break;
                 }

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -1010,16 +1010,21 @@ impl<'h> HeapRead<'h, Dict> {
         };
         let vm = &mut *guard;
 
-        // Format a refcount-bumped snapshot of the entries: live indices would
-        // panic (or skew) if a user `__repr__` deleted entries mid-format. For
-        // deletions this prints what CPython's tombstone-stable iteration does;
-        // insertions during repr are the one divergence (see
-        // `limitations/builtins.md`).
-        let pairs = self.clone_all_pairs(vm)?;
-        defer_drop!(pairs, vm);
-
         f.write_char('{')?;
-        for (i, (key, value)) in pairs.iter().enumerate() {
+        // Iterate the live entries like CPython, cloning only the current pair
+        // (refcount bumps — required because the reprs below run user
+        // `__repr__` code that may drop the dict's references). Bounds are
+        // re-checked every index, so mid-repr mutation cannot panic: inserted
+        // entries append and are printed (matching CPython); a deletion shifts
+        // `entries` where CPython leaves a tombstone, so later entries can be
+        // skipped (see `limitations/builtins.md`).
+        for i in 0.. {
+            let Some((key, value)) = self.get(vm.heap).item_at(i) else {
+                break;
+            };
+            let pair = (key.clone_with_heap(vm.heap), value.clone_with_heap(vm.heap));
+            defer_drop!(pair, vm);
+            let (key, value) = pair;
             if i > 0 {
                 if repr_check_time(i, vm) {
                     f.write_str(", ...[timeout]")?;
@@ -1065,8 +1070,10 @@ impl<'h> HeapRead<'h, Dict> {
         Ok(())
     }
 
-    /// Clones every entry as a refcount-bumped `(key, value)` pair, for reprs
-    /// that must not hold live indices while user `__repr__` code runs.
+    /// Clones every entry as a refcount-bumped `(key, value)` pair, for the
+    /// Counter repr: its ordering pass (`counter_order`) runs user comparison
+    /// code before anything is printed, so live indices would panic or skew —
+    /// and CPython's `most_common()` snapshots the same way.
     ///
     /// Preflights the slot bytes so an over-budget clone raises a graceful
     /// `MemoryError` instead of bursting past the allocator's hard limit.

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -491,14 +491,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
     }
 
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, heap_ids: &mut LazyHeapSet) -> RunResult<()> {
-        repr_sequence_fmt(
-            '[',
-            ']',
-            |heap, i| self.get(heap).as_slice().get(i).map(|v| v.clone_with_heap(heap)),
-            f,
-            vm,
-            heap_ids,
-        )
+        repr_sequence_fmt('[', ']', |heap, i| self.get(heap).as_slice().get(i), f, vm, heap_ids)
     }
 
     fn py_add_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
@@ -891,23 +884,25 @@ fn do_list_sort<'h>(list: &mut HeapRead<'h, List>, args: ArgValues, vm: &mut VM<
 /// lists and tuples. It writes items as comma-separated repr interns.
 ///
 /// There is no length parameter: `get_item` is asked for indices from 0 until
-/// it returns `None`, so a user `__repr__` growing or shrinking the sequence
-/// mid-format is observed rather than panicking on a stale bound — CPython's
-/// list repr re-checks the live length the same way.
+/// it returns `None`. For an immutable sequence (tuple) that is simply its
+/// fixed end; for a mutable one (list) it means a user `__repr__` growing or
+/// shrinking the sequence mid-format is observed rather than panicking on a
+/// stale bound — CPython's list repr re-checks the live length the same way.
 ///
 /// # Arguments
 /// * `start` - The opening character (e.g., '[' for lists, '(' for tuples)
 /// * `end` - The closing character (e.g., ']' for lists, ')' for tuples)
-/// * `get_item` - Returns an owned clone of the i-th value (refcount bumped so
-///   a mutating `__repr__` can't free it mid-format), or `None` once `i` is
-///   out of range
+/// * `get_item` - Returns the i-th value via brief immutable heap access, or
+///   `None` once `i` is out of range. The `for<'r>` bound means only
+///   heap-derived borrows fit — containers whose repr snapshots up front
+///   (deque, set, dict) own their clones already and use [`repr_items_fmt`].
 /// * `f` - The formatter to write to
 /// * `vm` - The VM for resolving value references and looking up interned strings
 /// * `heap_ids` - Set of heap IDs being repr'd (for cycle detection)
 pub(crate) fn repr_sequence_fmt<'h>(
     start: char,
     end: char,
-    get_item: impl Fn(&HeapReader<'h>, usize) -> Option<Value>,
+    get_item: impl for<'r> Fn(&'r HeapReader<'h>, usize) -> Option<&'r Value>,
     f: &mut impl Write,
     vm: &mut VM<'h>,
     heap_ids: &mut LazyHeapSet,
@@ -920,13 +915,18 @@ pub(crate) fn repr_sequence_fmt<'h>(
 
     f.write_char(start)?;
     // The item is fetched before the separator is written so nothing is emitted
-    // for an index that turned out to be out of range. `check_time` bounds
+    // for an index that turned out to be out of range. `repr_check_time` bounds
     // reprs that keep growing the sequence from inside a user `__repr__`.
     for i in 0.. {
         let Some(item) = get_item(vm.heap, i) else { break };
+        // The clone (a refcount bump, not a deep copy) is load-bearing: the
+        // recursion below runs user `__repr__` code that may drop the
+        // container's reference to this very item — CPython incref's the same
+        // way. It also releases the heap borrow the getter's reference holds.
+        let item = item.clone_with_heap(vm.heap);
         defer_drop!(item, vm);
         if i > 0 {
-            if vm.heap.check_time().is_err() {
+            if repr_check_time(i, vm) {
                 f.write_str(", ...[timeout]")?;
                 break;
             }
@@ -937,6 +937,39 @@ pub(crate) fn repr_sequence_fmt<'h>(
     f.write_char(end)?;
 
     Ok(())
+}
+
+/// Writes the comma-separated reprs of an already-snapshotted item slice.
+///
+/// The slice is a refcount-bumped snapshot owned by the caller (deque, set),
+/// so items are formatted by reference with no per-item clone; the caller owns
+/// the recursion guard and any surrounding brackets. Live containers must go
+/// through [`repr_sequence_fmt`] instead, which re-fetches (and clones) each
+/// item so a mutating user `__repr__` is observed safely.
+pub(crate) fn repr_items_fmt(
+    items: &[Value],
+    f: &mut impl Write,
+    vm: &mut VM<'_>,
+    heap_ids: &mut LazyHeapSet,
+) -> RunResult<()> {
+    for (i, item) in items.iter().enumerate() {
+        if i > 0 {
+            if repr_check_time(i, vm) {
+                f.write_str(", ...[timeout]")?;
+                break;
+            }
+            f.write_str(", ")?;
+        }
+        item.py_repr_fmt(f, vm, heap_ids)?;
+    }
+    Ok(())
+}
+
+/// Polls the time/memory soft limits every 64th item rather than every item,
+/// keeping per-item overhead to one branch while still truncating huge reprs
+/// promptly with `", ...[timeout]"` (tested in `resource_limits.rs`).
+pub(crate) fn repr_check_time(i: usize, vm: &VM<'_>) -> bool {
+    i.is_multiple_of(64) && vm.heap.check_time().is_err()
 }
 
 /// Iterates over a list while observing changes to its current contents.

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -491,8 +491,14 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
     }
 
     fn py_repr_fmt(&self, f: &mut impl Write, vm: &mut VM<'h>, heap_ids: &mut LazyHeapSet) -> RunResult<()> {
-        let len = self.get(vm.heap).len();
-        repr_sequence_fmt('[', ']', len, |heap, i| &self.get(heap).as_slice()[i], f, vm, heap_ids)
+        repr_sequence_fmt(
+            '[',
+            ']',
+            |heap, i| self.get(heap).as_slice().get(i).map(|v| v.clone_with_heap(heap)),
+            f,
+            vm,
+            heap_ids,
+        )
     }
 
     fn py_add_impl(&self, other: &Value, vm: &mut VM<'h>, _self_id: Option<HeapId>) -> RunResult<Option<Value>> {
@@ -884,19 +890,24 @@ fn do_list_sort<'h>(list: &mut HeapRead<'h, List>, args: ArgValues, vm: &mut VM<
 /// This helper function is used to implement `__repr__` for sequence types like
 /// lists and tuples. It writes items as comma-separated repr interns.
 ///
+/// There is no length parameter: `get_item` is asked for indices from 0 until
+/// it returns `None`, so a user `__repr__` growing or shrinking the sequence
+/// mid-format is observed rather than panicking on a stale bound — CPython's
+/// list repr re-checks the live length the same way.
+///
 /// # Arguments
 /// * `start` - The opening character (e.g., '[' for lists, '(' for tuples)
 /// * `end` - The closing character (e.g., ']' for lists, ')' for tuples)
-/// * `len` - The number of items to format
-/// * `get_item` - Returns the i-th value via brief immutable heap access
+/// * `get_item` - Returns an owned clone of the i-th value (refcount bumped so
+///   a mutating `__repr__` can't free it mid-format), or `None` once `i` is
+///   out of range
 /// * `f` - The formatter to write to
 /// * `vm` - The VM for resolving value references and looking up interned strings
 /// * `heap_ids` - Set of heap IDs being repr'd (for cycle detection)
 pub(crate) fn repr_sequence_fmt<'h>(
     start: char,
     end: char,
-    len: usize,
-    get_item: impl for<'r> Fn(&'r HeapReader<'h>, usize) -> &'r Value,
+    get_item: impl Fn(&HeapReader<'h>, usize) -> Option<Value>,
     f: &mut impl Write,
     vm: &mut VM<'h>,
     heap_ids: &mut LazyHeapSet,
@@ -908,7 +919,12 @@ pub(crate) fn repr_sequence_fmt<'h>(
     let vm = &mut *guard;
 
     f.write_char(start)?;
-    for i in 0..len {
+    // The item is fetched before the separator is written so nothing is emitted
+    // for an index that turned out to be out of range. `check_time` bounds
+    // reprs that keep growing the sequence from inside a user `__repr__`.
+    for i in 0.. {
+        let Some(item) = get_item(vm.heap, i) else { break };
+        defer_drop!(item, vm);
         if i > 0 {
             if vm.heap.check_time().is_err() {
                 f.write_str(", ...[timeout]")?;
@@ -916,8 +932,6 @@ pub(crate) fn repr_sequence_fmt<'h>(
             }
             f.write_str(", ")?;
         }
-        let item = get_item(vm.heap, i).clone_with_heap(vm.heap);
-        defer_drop!(item, vm);
         item.py_repr_fmt(f, vm, heap_ids)?;
     }
     f.write_char(end)?;

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     intern::StaticStrings,
     types::{LazyHeapSet, Type},
-    value::{EitherStr, Value},
+    value::{EitherStr, VALUE_SIZE, Value},
 };
 
 /// Entry in the set storage, containing a value and its cached hash.
@@ -522,8 +522,20 @@ impl<'h> HeapRead<'h, SetStorage> {
             write!(f, "{type_name}(")?;
         }
 
-        f.write_char('{')?;
+        // Format a refcount-bumped snapshot of the elements: CPython's set repr
+        // copies to a list first, so a user `__repr__` mutating the set
+        // mid-format changes nothing (and can't invalidate indices here).
+        vm.heap.tracker().check_allocation(len.saturating_mul(VALUE_SIZE))?;
+        let mut items = Vec::with_capacity(len);
         for i in 0..len {
+            // No user code runs during the snapshot, so `len` is still current.
+            let value = self.get(vm.heap).value_at(i).expect("index in range");
+            items.push(value.clone_with_heap(vm.heap));
+        }
+        defer_drop!(items, vm);
+
+        f.write_char('{')?;
+        for (i, value) in items.iter().enumerate() {
             if i > 0 {
                 if vm.heap.check_time().is_err() {
                     f.write_str(", ...[timeout]")?;
@@ -531,14 +543,6 @@ impl<'h> HeapRead<'h, SetStorage> {
                 }
                 f.write_str(", ")?;
             }
-            // Refcount-bump each element before recursing so a user-defined
-            // `__repr__` mutating the set can't free the entry mid-format.
-            let value = self
-                .get(vm.heap)
-                .value_at(i)
-                .expect("index in range")
-                .clone_with_heap(vm.heap);
-            defer_drop!(value, vm);
             value.py_repr_fmt(f, vm, heap_ids)?;
         }
         f.write_char('}')?;

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -16,7 +16,7 @@ use crate::{
         HeapRead, HeapReadOutput, heap_read_ref_as_field, heap_read_ref_as_field_mut,
     },
     intern::StaticStrings,
-    types::{LazyHeapSet, Type},
+    types::{LazyHeapSet, Type, list::repr_items_fmt},
     value::{EitherStr, VALUE_SIZE, Value},
 };
 
@@ -535,16 +535,7 @@ impl<'h> HeapRead<'h, SetStorage> {
         defer_drop!(items, vm);
 
         f.write_char('{')?;
-        for (i, value) in items.iter().enumerate() {
-            if i > 0 {
-                if vm.heap.check_time().is_err() {
-                    f.write_str(", ...[timeout]")?;
-                    break;
-                }
-                f.write_str(", ")?;
-            }
-            value.py_repr_fmt(f, vm, heap_ids)?;
-        }
+        repr_items_fmt(items, f, vm, heap_ids)?;
         f.write_char('}')?;
 
         if needs_prefix {

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -505,14 +505,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
             return Ok(());
         }
 
-        repr_sequence_fmt(
-            '(',
-            ')',
-            |heap, i| self.get(heap).as_slice().get(i).map(|v| v.clone_with_heap(heap)),
-            f,
-            vm,
-            heap_ids,
-        )
+        repr_sequence_fmt('(', ')', |heap, i| self.get(heap).as_slice().get(i), f, vm, heap_ids)
     }
 }
 

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -505,7 +505,14 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
             return Ok(());
         }
 
-        repr_sequence_fmt('(', ')', len, |heap, i| &self.get(heap).as_slice()[i], f, vm, heap_ids)
+        repr_sequence_fmt(
+            '(',
+            ')',
+            |heap, i| self.get(heap).as_slice().get(i).map(|v| v.clone_with_heap(heap)),
+            f,
+            vm,
+            heap_ids,
+        )
     }
 }
 

--- a/crates/monty/test_cases/repr__mutation.py
+++ b/crates/monty/test_cases/repr__mutation.py
@@ -73,8 +73,8 @@ st2 = {SetAdder(1), SetAdder(2)}
 assert repr(st2) == '{A1, A2}'
 
 
-# === dict: keys deleted mid-repr still print all original entries ===
-class KeyPopper:
+# === dict: keys inserted mid-repr are appended and printed ===
+class KeyAdder:
     def __init__(self, n):
         self.n = n
 
@@ -85,12 +85,37 @@ class KeyPopper:
         return self is other
 
     def __repr__(self):
-        d.pop(next(iter(d)), None)
+        if self.n == 1:
+            d['new'] = 99
         return f'K{self.n}'
 
 
-d = {KeyPopper(1): 1, KeyPopper(2): 2, KeyPopper(3): 3}
-assert repr(d) == '{K1: 1, K2: 2, K3: 3}'
+d = {KeyAdder(1): 1, KeyAdder(2): 2}
+assert repr(d) == "{K1: 1, K2: 2, 'new': 99}"
+
+
+# === dict: a deletion after the affected entries have printed is harmless ===
+# (deleting an entry that has NOT yet printed diverges: Monty's dense storage
+# shifts where CPython leaves a tombstone — see limitations/builtins.md)
+class KeyPopper:
+    def __init__(self, n, mutate=False):
+        self.n = n
+        self.mutate = mutate
+
+    def __hash__(self):
+        return self.n
+
+    def __eq__(self, other):
+        return self is other
+
+    def __repr__(self):
+        if self.mutate:
+            d2.pop(next(iter(d2)), None)
+        return f'K{self.n}'
+
+
+d2 = {KeyPopper(1): 1, KeyPopper(2): 2, KeyPopper(3, mutate=True): 3}
+assert repr(d2) == '{K1: 1, K2: 2, K3: 3}'
 
 
 # === Counter: repr orders and prints a snapshot despite mid-repr pops ===

--- a/crates/monty/test_cases/repr__mutation.py
+++ b/crates/monty/test_cases/repr__mutation.py
@@ -1,3 +1,4 @@
+import sys
 from collections import Counter, deque
 
 
@@ -95,8 +96,7 @@ assert repr(d) == "{K1: 1, K2: 2, 'new': 99}"
 
 
 # === dict: a deletion after the affected entries have printed is harmless ===
-# (deleting an entry that has NOT yet printed diverges: Monty's dense storage
-# shifts where CPython leaves a tombstone — see limitations/builtins.md)
+# (early deletions diverge — see the sys.platform sections below)
 class KeyPopper:
     def __init__(self, n, mutate=False):
         self.n = n
@@ -116,6 +116,72 @@ class KeyPopper:
 
 d2 = {KeyPopper(1): 1, KeyPopper(2): 2, KeyPopper(3, mutate=True): 3}
 assert repr(d2) == '{K1: 1, K2: 2, K3: 3}'
+
+
+# === dict: deleting a NOT-yet-printed entry mid-repr diverges ===
+# Monty's dense storage shifts later entries down where CPython leaves a
+# tombstone, so the entry that moves into an already-printed slot is skipped
+# (see limitations/builtins.md). These also prove the live bounds re-check
+# cannot panic when the dict shrinks under the repr cursor.
+class ShiftPopper:
+    def __init__(self, n, mutate=False):
+        self.n = n
+        self.mutate = mutate
+
+    def __hash__(self):
+        return self.n
+
+    def __eq__(self, other):
+        return self is other
+
+    def __repr__(self):
+        if self.mutate:
+            target.pop(next(iter(target)), None)
+        return f'K{self.n}'
+
+
+# the FIRST key deletes itself while printing: K2 shifts into the printed slot
+target = {ShiftPopper(1, mutate=True): 1, ShiftPopper(2): 2, ShiftPopper(3): 3}
+if sys.platform == 'monty':
+    assert repr(target) == '{K1: 1, K3: 3}'
+else:
+    assert repr(target) == '{K1: 1, K2: 2, K3: 3}'
+
+# a LATER key deletes the already-printed first entry: the tail shifts past
+# the repr cursor and is skipped
+target = {ShiftPopper(1): 1, ShiftPopper(2, mutate=True): 2, ShiftPopper(3): 3}
+if sys.platform == 'monty':
+    assert repr(target) == '{K1: 1, K2: 2}'
+else:
+    assert repr(target) == '{K1: 1, K2: 2, K3: 3}'
+
+
+# === dict: a VALUE repr mutating the dict ===
+# The mutation runs between the key printing and the value printing: the
+# entry's pair was already copied, so the value still prints even though its
+# entry is gone; the shrink is only seen at the next entry (divergent, as
+# above — CPython's tombstone keeps the middle entry).
+class ValuePopper:
+    def __init__(self, n, mutate=False):
+        self.n = n
+        self.mutate = mutate
+
+    def __repr__(self):
+        if self.mutate:
+            target.pop(next(iter(target)), None)
+        return f'V{self.n}'
+
+
+target = {'a': ValuePopper(1, mutate=True), 'b': ValuePopper(2), 'c': ValuePopper(3)}
+if sys.platform == 'monty':
+    assert repr(target) == "{'a': V1, 'c': V3}"
+else:
+    assert repr(target) == "{'a': V1, 'b': V2, 'c': V3}"
+
+# the LAST value deleting an already-printed entry changes nothing on either
+# engine — everything affected has already printed
+target = {'a': ValuePopper(1), 'b': ValuePopper(2), 'c': ValuePopper(3, mutate=True)}
+assert repr(target) == "{'a': V1, 'b': V2, 'c': V3}"
 
 
 # === Counter: repr orders and prints a snapshot despite mid-repr pops ===

--- a/crates/monty/test_cases/repr__mutation.py
+++ b/crates/monty/test_cases/repr__mutation.py
@@ -1,0 +1,113 @@
+from collections import Counter, deque
+
+
+# === list: repr sees live length, so mid-repr pops truncate the output ===
+class ListPopper:
+    def __repr__(self):
+        xs.pop()
+        return 'X'
+
+
+xs = [ListPopper(), ListPopper(), ListPopper()]
+assert repr(xs) == '[X, X]'
+
+
+# === list: mid-repr appends are picked up (each element appends once) ===
+class ListGrower:
+    def __init__(self):
+        self.done = False
+
+    def __repr__(self):
+        if not self.done:
+            self.done = True
+            ys.append('tail')
+        return 'X'
+
+
+ys = [ListGrower(), ListGrower()]
+assert repr(ys) == "[X, X, 'tail', 'tail']"
+
+
+# === deque: repr formats a snapshot, so mid-repr pops change nothing ===
+class DequePopper:
+    def __repr__(self):
+        dq.pop()
+        return 'X'
+
+
+dq = deque([DequePopper(), DequePopper(), DequePopper()])
+assert repr(dq) == 'deque([X, X, X])'
+
+
+# === set: repr formats a snapshot, so mid-repr discards change nothing ===
+class SetPopper:
+    def __init__(self, n):
+        self.n = n
+
+    def __hash__(self):
+        return self.n
+
+    def __repr__(self):
+        st.discard(next(iter(st)))
+        return f'S{self.n}'
+
+
+st = {SetPopper(1), SetPopper(2), SetPopper(3)}
+assert repr(st) == '{S1, S2, S3}'
+
+
+# === set: elements added mid-repr are not shown (snapshot on both) ===
+class SetAdder:
+    def __init__(self, n):
+        self.n = n
+
+    def __hash__(self):
+        return self.n
+
+    def __repr__(self):
+        st2.add(self.n * 100)
+        return f'A{self.n}'
+
+
+st2 = {SetAdder(1), SetAdder(2)}
+assert repr(st2) == '{A1, A2}'
+
+
+# === dict: keys deleted mid-repr still print all original entries ===
+class KeyPopper:
+    def __init__(self, n):
+        self.n = n
+
+    def __hash__(self):
+        return self.n
+
+    def __eq__(self, other):
+        return self is other
+
+    def __repr__(self):
+        d.pop(next(iter(d)), None)
+        return f'K{self.n}'
+
+
+d = {KeyPopper(1): 1, KeyPopper(2): 2, KeyPopper(3): 3}
+assert repr(d) == '{K1: 1, K2: 2, K3: 3}'
+
+
+# === Counter: repr orders and prints a snapshot despite mid-repr pops ===
+class CountPopper:
+    def __init__(self, n):
+        self.n = n
+
+    def __hash__(self):
+        return self.n
+
+    def __eq__(self, other):
+        return self is other
+
+    def __repr__(self):
+        c.pop(next(iter(c)), None)
+        return f'C{self.n}'
+
+
+c = Counter({CountPopper(1): 5, CountPopper(2): 3})
+assert repr(c) == 'Counter({C1: 5, C2: 3})'

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -37,6 +37,13 @@ mechanism beyond dataclass field inheritance.
 
 ## Behavioural divergences
 
+- **`repr` of a dict being mutated by its own elements** — Monty formats a
+  snapshot of the entries taken when the repr starts, so a key inserted into
+  the dict from inside a user `__repr__` running *during that dict's repr* is
+  not shown; CPython's live slot iteration includes it. Deletions match
+  CPython (all original entries still print), as do list (live length,
+  mid-repr pops truncate / appends extend), `set`, `collections.deque` and
+  `collections.Counter` (all snapshot, like CPython).
 - **`enumerate`, `zip`, `map`, `filter` and `reversed` are eager, not lazy** —
   each drains its source and returns a `list`, so `type(enumerate(x)).__name__`
   is `'list'` rather than `'enumerate'`. Observable several ways: a

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -37,13 +37,15 @@ mechanism beyond dataclass field inheritance.
 
 ## Behavioural divergences
 
-- **`repr` of a dict being mutated by its own elements** — Monty formats a
-  snapshot of the entries taken when the repr starts, so a key inserted into
-  the dict from inside a user `__repr__` running *during that dict's repr* is
-  not shown; CPython's live slot iteration includes it. Deletions match
-  CPython (all original entries still print), as do list (live length,
-  mid-repr pops truncate / appends extend), `set`, `collections.deque` and
-  `collections.Counter` (all snapshot, like CPython).
+- **`repr` of a dict being mutated by its own elements** — Monty iterates the
+  live entries like CPython, but deletion compacts Monty's dense entry storage
+  where CPython leaves a tombstone in place: a key deleted from inside a user
+  `__repr__` running *during that dict's repr* shifts later entries down, so
+  the entry after the deleted one can be skipped from the output where CPython
+  would still print it. Insertions during repr match CPython (appended and
+  printed), as do list (live length, mid-repr pops truncate / appends extend),
+  `set`, `collections.deque` and `collections.Counter` (all snapshot, like
+  CPython).
 - **`enumerate`, `zip`, `map`, `filter` and `reversed` are eager, not lazy** —
   each drains its source and returns a `list`, so `type(enumerate(x)).__name__`
   is `'list'` rather than `'enumerate'`. Observable several ways: a


### PR DESCRIPTION
Container reprs snapshotted `len` once and then indexed with stale indices, so a user `__repr__` shrinking the container mid-format panicked (`index out of bounds` for list/deque, `expect("index in range")` for dict/set/Counter).

Match CPython per container: list reprs re-check the live length every iteration (pops truncate, appends extend); deque, set, dict and Counter format a refcount-bumped snapshot taken up front — for deque and set that is exactly CPython's copy-to-list repr, for dict it matches CPython's tombstone-stable iteration on deletion, diverging only for keys inserted during the repr (documented in limitations/builtins.md). The Counter snapshot is taken before `counter_order`, whose count comparisons can also run user code.


Claude-Session: https://claude.ai/code/session_01TA5eDdFnwN1ugoBy4BU1Ys

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes container repr panics when an element’s `__repr__` mutates the container, tightens repr helpers to cut overhead, and adds a throughput benchmark. Aligns with CPython and keeps repr output stable under mutation and resource limits.

- **Bug Fixes**
  - List: repr re-checks live length each iteration; pops truncate, appends extend.
  - Deque/Set: repr formats a refcount-bumped snapshot; deque now snapshots only after the recursion guard (depth elision prints "..." without snapshot).
  - Dict: repr iterates live and clones only the current `(key, value)`; keys inserted during repr are appended and printed; deletions can skip the next entry due to dense storage (documented).
  - Counter: snapshot taken before ordering; counts/order allocations are preflighted; print loop is time-guarded.

- **Refactors**
  - `repr_sequence_fmt`: fetch-until-`None` getter with a single load-bearing clone per item; removes stale-length indexing.
  - `repr_items_fmt`: formats a snapshotted `&[Value]` without per-item clones; used by deque and set.
  - Limits/allocations: `repr_check_time` polls every 64th item and truncates with `", ...[timeout]"`; preflight for set snapshots and Counter temporaries; added dict helper to clone `(key, value)` pairs for safe Counter snapshotting; docs updated for dict deletion divergence.
  - Benchmark: added a container repr benchmark covering list/tuple/dict/set/deque/Counter, with Monty vs CPython runs.

<sup>Written for commit b737c276a7e07f9165c2bfffc0aa28fee85f7d67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

