### PR TITLE
Tweaks to resource tracker intermittence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,13 +308,13 @@ Any code that builds a `String` whose final size is not already bounded by an ex
 
 ```rust
 // Bounded size known up front (padding to a given width):
-let mut builder = StringBuilder::with_capacity(width * fillchar.len_utf8(), vm.heap.tracker())?;
+let mut builder = StringBuilder::with_capacity(width * fillchar.len_utf8(), &vm.heap.tracker)?;
 builder.push_str(s)?;
 for _ in 0..pad { builder.push(fillchar)?; }
 builder.finish(vm.heap)
 
 // Size not bounded up front (e.g. attacker-controlled multiplier):
-let mut builder = StringBuilder::new(vm.heap.tracker());
+let mut builder = StringBuilder::new(&vm.heap.tracker);
 for c in input.chars() { builder.push(c)?; }
 builder.finish(vm.heap)
 ```
@@ -336,7 +336,7 @@ sprinkle them everywhere — every check is code noise and hot-path cost.
 Add a check only where ordinary code commonly allocates a multi-MiB burst
 inside a single builtin call (i.e. before the next instruction checkpoint):
 
-- Known-size bulk allocation: one up-front `tracker().check_allocation(n * VALUE_SIZE)`
+- Known-size bulk allocation: one up-front `tracker.check_allocation(n * VALUE_SIZE)`
   (container clone/copy, e.g. `clone_all_items`, `list_copy`) or
   `check_repeat_size`-style estimate (`resource_checks.rs`).
 - Iterator collection: `collect_python_iterator` / `checked_preallocation_hint`

--- a/crates/monty-bench/benches/main.rs
+++ b/crates/monty-bench/benches/main.rs
@@ -1,13 +1,14 @@
 // Use codspeed-criterion-compat when running on CodSpeed (CI), real criterion otherwise (for flamegraphs)
 #[cfg(not(codspeed))]
 use std::ffi::CString;
+use std::time::Duration;
 
 #[cfg(codspeed)]
 use codspeed_criterion_compat::{Bencher, Criterion, black_box, criterion_group, criterion_main};
 #[cfg(not(codspeed))]
 use criterion::{Bencher, Criterion, black_box, criterion_group, criterion_main};
 use monty::MontyRun;
-use monty_types::{CompileOptions, MontyObject};
+use monty_types::{CompileOptions, MontyObject, PrintWriter, ResourceLimits, ResourceTracker};
 #[cfg(all(not(codspeed), unix))]
 use pprof::criterion::{Output, PProfProfiler};
 // CPython benchmarks are only run locally, not on CodSpeed CI (requires Python + pyo3 setup)
@@ -57,6 +58,25 @@ fn run_monty_with_data(bench: &mut Bencher, code: &str, data: &str, expected: i6
         let int_value: i64 = r.as_ref().try_into().unwrap();
         black_box(int_value);
     });
+}
+
+/// Runs a benchmark with production-shaped resource limits armed (generous
+/// budgets that never trip), measuring the amortized limit-checking path
+/// sandboxes actually run rather than the no-limits fast path.
+fn run_monty_limits(bench: &mut Bencher, code: &str, expected: i64) {
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let limits = ResourceLimits::default()
+        .max_duration(Duration::from_mins(10))
+        .max_memory(1 << 40);
+    let run = |limits: &ResourceLimits| {
+        let r = ex
+            .run(vec![], ResourceTracker::new(limits.clone()), PrintWriter::Stdout)
+            .unwrap();
+        let int_value: i64 = r.as_ref().try_into().unwrap();
+        int_value
+    };
+    assert_eq!(run(&limits), expected);
+    bench.iter(|| black_box(run(&limits)));
 }
 
 /// Runs a benchmark using CPython.
@@ -473,6 +493,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("add_two__cpython", |b| run_cpython(b, ADD_TWO, 3));
 
     c.bench_function("loop_mod_13__monty", |b| run_monty(b, LOOP_MOD_13, 77));
+    c.bench_function("loop_mod_13_limits__monty", |b| run_monty_limits(b, LOOP_MOD_13, 77));
     #[cfg(not(codspeed))]
     c.bench_function("loop_mod_13__cpython", |b| run_cpython(b, LOOP_MOD_13, 77));
 
@@ -482,6 +503,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("end_to_end__cpython", end_to_end_cpython);
 
     c.bench_function("kitchen_sink__monty", |b| run_monty(b, KITCHEN_SINK, 373));
+    c.bench_function("kitchen_sink_limits__monty", |b| run_monty_limits(b, KITCHEN_SINK, 373));
     #[cfg(not(codspeed))]
     c.bench_function("kitchen_sink__cpython", |b| run_cpython(b, KITCHEN_SINK, 373));
 

--- a/crates/monty-types/src/resource.rs
+++ b/crates/monty-types/src/resource.rs
@@ -313,7 +313,10 @@ impl ResourceTracker {
     }
 
     /// Items processed between full checks in amortized per-item Rust loops
-    /// (see [`check_time_every`](Self::check_time_every)).
+    /// (see [`check_time_every`](Self::check_time_every)). A limit can be
+    /// overshot by up to this many items' work before the next check — an
+    /// accepted trade for cheap loops; the process-level hard limits backstop
+    /// pathological cases.
     pub const LOOP_CHECK_INTERVAL: usize = 64;
 
     /// Amortized per-item time check for Rust-side loops: a full clock read

--- a/crates/monty-types/src/resource.rs
+++ b/crates/monty-types/src/resource.rs
@@ -320,12 +320,14 @@ impl ResourceTracker {
     pub const LOOP_CHECK_INTERVAL: usize = 64;
 
     /// Amortized per-item time check for Rust-side loops: a full clock read
-    /// on every [`LOOP_CHECK_INTERVAL`](Self::LOOP_CHECK_INTERVAL)-th call,
+    /// once per [`LOOP_CHECK_INTERVAL`](Self::LOOP_CHECK_INTERVAL) calls,
     /// free otherwise. Key `i` on the loop's index or a monotonically
-    /// increasing counter.
+    /// increasing counter. Fires at the *end* of each block (`i % N == N-1`)
+    /// so loops shorter than the interval pay no clock read at all — the VM
+    /// dispatch checkpoint covers cadence between short calls.
     #[inline]
     pub fn check_time_every(&self, i: usize) -> Result<(), ResourceError> {
-        if i.is_multiple_of(Self::LOOP_CHECK_INTERVAL) {
+        if i % Self::LOOP_CHECK_INTERVAL == Self::LOOP_CHECK_INTERVAL - 1 {
             self.check_time()
         } else {
             Ok(())
@@ -338,7 +340,7 @@ impl ResourceTracker {
     /// runaway growth.
     #[inline]
     pub fn check_memory_time_every(&self, i: usize) -> Result<(), ResourceError> {
-        if i.is_multiple_of(Self::LOOP_CHECK_INTERVAL) {
+        if i % Self::LOOP_CHECK_INTERVAL == Self::LOOP_CHECK_INTERVAL - 1 {
             self.check_memory_time()
         } else {
             Ok(())

--- a/crates/monty-types/src/resource.rs
+++ b/crates/monty-types/src/resource.rs
@@ -144,14 +144,6 @@ impl ResourceLimits {
     }
 }
 
-/// How often to actually check `Instant::elapsed()` in `check_time`.
-///
-/// Calling `Instant::elapsed()` on every `check_time` invocation adds measurable
-/// overhead in tight loops (the VM calls `check_time` on every instruction).
-/// By only checking every N calls, we reduce this overhead while still catching
-/// timeouts promptly.
-const TIME_CHECK_INTERVAL: u16 = 10;
-
 /// A resource tracker that enforces configurable limits.
 ///
 /// Checks allocator-backed memory usage and tracks execution time, returning
@@ -180,8 +172,6 @@ pub struct ResourceTracker {
     /// executing.
     #[serde(skip)]
     running_since: Cell<Option<Instant>>,
-    /// Counter for rate-limiting `Instant::elapsed()` calls in `check_time`.
-    check_counter: Cell<u16>,
     /// Optional override applied on top of `limits.max_recursion_depth`.
     ///
     /// `None` (the default — also the value any pre-`test-hooks` snapshot
@@ -220,7 +210,6 @@ impl ResourceTracker {
             limits,
             total_execution_time: Cell::new(Duration::ZERO),
             running_since: Cell::new(None),
-            check_counter: Cell::new(0),
             recursion_limit_override: Cell::new(None),
         }
     }
@@ -257,6 +246,12 @@ impl ResourceTracker {
         self.limits.max_memory
     }
 
+    /// Returns whether the VM has a memory or time limit configured.
+    #[must_use]
+    pub fn has_memory_time_limit(&self) -> bool {
+        self.limits.max_memory.is_some() || self.limits.max_duration.is_some()
+    }
+
     /// Sets the maximum execution duration as a fresh budget from now,
     /// resetting the accumulated execution time to zero.
     ///
@@ -284,7 +279,7 @@ impl ResourceTracker {
         Ok(())
     }
 
-    /// Called periodically to check time and allocator-backed memory limits.
+    /// Called periodically to check allocator-backed memory and time limits.
     ///
     /// Returns `Ok(())` while configured limits are respected, or the relevant
     /// resource error once either limit is exceeded.
@@ -293,7 +288,7 @@ impl ResourceTracker {
     /// read-only operation. This allows time checks in contexts that only have
     /// an immutable heap reference, such as `py_repr_fmt`.
     #[inline]
-    pub fn check_time(&self) -> Result<(), ResourceError> {
+    pub fn check_memory_time(&self) -> Result<(), ResourceError> {
         if let Some(limit) = self.limits.max_memory {
             let used = probe_memory();
             if used > limit {
@@ -301,22 +296,50 @@ impl ResourceTracker {
             }
         }
 
+        self.check_time()
+    }
+
+    /// Called periodically to check the time limit. Latches on failure: once
+    /// the budget is exceeded every later call fails too (see `timed_out`).
+    #[inline]
+    pub fn check_time(&self) -> Result<(), ResourceError> {
         if let Some(max) = self.limits.max_duration {
-            self.check_counter.update(|c| c.wrapping_add(1));
-            if self.check_counter.get().is_multiple_of(TIME_CHECK_INTERVAL) {
-                // Only call Instant::elapsed() every TIME_CHECK_INTERVAL calls
-                let elapsed = self.elapsed();
-                if elapsed > max {
-                    // Reset counter so the very next check_time call also triggers
-                    // an elapsed check. This is important because some callers
-                    // (e.g. repr_sequence_fmt) catch the error and return normally,
-                    // and we need the VM loop's next check_time to re-detect timeout.
-                    self.check_counter.set(TIME_CHECK_INTERVAL.wrapping_sub(1));
-                    return Err(ResourceError::Time { limit: max, elapsed });
-                }
+            let elapsed = self.elapsed();
+            if elapsed > max {
+                return Err(ResourceError::Time { limit: max, elapsed });
             }
         }
         Ok(())
+    }
+
+    /// Items processed between full checks in amortized per-item Rust loops
+    /// (see [`check_time_every`](Self::check_time_every)).
+    pub const LOOP_CHECK_INTERVAL: usize = 64;
+
+    /// Amortized per-item time check for Rust-side loops: a full clock read
+    /// on every [`LOOP_CHECK_INTERVAL`](Self::LOOP_CHECK_INTERVAL)-th call,
+    /// a single-branch `timed_out` latch re-check otherwise. Key `i` on the
+    /// loop's index or a monotonically increasing counter.
+    #[inline]
+    pub fn check_time_every(&self, i: usize) -> Result<(), ResourceError> {
+        if i.is_multiple_of(Self::LOOP_CHECK_INTERVAL) {
+            self.check_time()
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Amortized per-item memory + time check; the memory-probing sibling of
+    /// [`check_time_every`](Self::check_time_every), for loops that allocate
+    /// per item. Between full checks the allocator's hard limit still bounds
+    /// runaway growth.
+    #[inline]
+    pub fn check_memory_time_every(&self, i: usize) -> Result<(), ResourceError> {
+        if i.is_multiple_of(Self::LOOP_CHECK_INTERVAL) {
+            self.check_memory_time()
+        } else {
+            Ok(())
+        }
     }
 
     /// Called before pushing a new call frame to check recursion depth.

--- a/crates/monty-types/src/resource.rs
+++ b/crates/monty-types/src/resource.rs
@@ -299,8 +299,8 @@ impl ResourceTracker {
         self.check_time()
     }
 
-    /// Called periodically to check the time limit. Latches on failure: once
-    /// the budget is exceeded every later call fails too (see `timed_out`).
+    /// Called periodically to check the time limit. Elapsed execution time is
+    /// monotonic, so once the budget is exceeded every later call fails too.
     #[inline]
     pub fn check_time(&self) -> Result<(), ResourceError> {
         if let Some(max) = self.limits.max_duration {
@@ -318,8 +318,8 @@ impl ResourceTracker {
 
     /// Amortized per-item time check for Rust-side loops: a full clock read
     /// on every [`LOOP_CHECK_INTERVAL`](Self::LOOP_CHECK_INTERVAL)-th call,
-    /// a single-branch `timed_out` latch re-check otherwise. Key `i` on the
-    /// loop's index or a monotonically increasing counter.
+    /// free otherwise. Key `i` on the loop's index or a monotonically
+    /// increasing counter.
     #[inline]
     pub fn check_time_every(&self, i: usize) -> Result<(), ResourceError> {
         if i.is_multiple_of(Self::LOOP_CHECK_INTERVAL) {

--- a/crates/monty/src/builtins/divmod.rs
+++ b/crates/monty/src/builtins/divmod.rs
@@ -34,7 +34,7 @@ pub fn builtin_divmod(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
                 Ok(allocate_tuple(smallvec![Value::Int(quot), Value::Int(rem)], vm.heap))
             } else {
                 // Overflow - promote to BigInt
-                check_div_size(64, vm.heap.tracker())?;
+                check_div_size(64, &vm.heap.tracker)?;
                 let (quot, rem) = bigint_floor_divmod(&BigInt::from(*x), &BigInt::from(*y));
                 let quot_val = LongInt::new(quot).into_value(vm.heap);
                 let rem_val = LongInt::new(rem).into_value(vm.heap);

--- a/crates/monty/src/builtins/map.rs
+++ b/crates/monty/src/builtins/map.rs
@@ -67,7 +67,7 @@ pub fn builtin_map(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
 
     // Validate and clamp the iterator's hint before reserving native memory.
     let hint = first_iter.iter_size_hint(vm);
-    let capacity = checked_preallocation_hint(hint, mem::size_of::<Value>(), vm.heap.tracker())?;
+    let capacity = checked_preallocation_hint(hint, mem::size_of::<Value>(), &vm.heap.tracker)?;
     let mut out = Vec::with_capacity(capacity);
 
     // map function over iterables until the shortest iter is exhausted

--- a/crates/monty/src/builtins/pow.rs
+++ b/crates/monty/src/builtins/pow.rs
@@ -163,7 +163,7 @@ fn int_pow_int(b: i64, e: i64, heap: &mut Heap) -> RunResult<Value> {
         } else {
             // Overflow - promote to LongInt
             // Check size before computing to prevent DoS
-            check_pow_size(i64_bits(b), u64::from(exp_u32), heap.tracker())?;
+            check_pow_size(i64_bits(b), u64::from(exp_u32), &heap.tracker)?;
             let bi = BigInt::from(b).pow(exp_u32);
             Ok(LongInt::new(bi).into_value(heap))
         }
@@ -173,7 +173,7 @@ fn int_pow_int(b: i64, e: i64, heap: &mut Heap) -> RunResult<Value> {
         #[expect(clippy::cast_sign_loss)]
         let exp_u64 = e as u64;
         // Check size before computing to prevent DoS
-        check_pow_size(i64_bits(b), exp_u64, heap.tracker())?;
+        check_pow_size(i64_bits(b), exp_u64, &heap.tracker)?;
         let base_bi = BigInt::from(b);
         let bi = bigint_pow_large(&base_bi, exp_u64)?;
         Ok(LongInt::new(bi).into_value(heap))
@@ -205,7 +205,7 @@ fn int_pow_longint(b: i64, e: &BigInt, heap: &Heap) -> RunResult<Value> {
         Ok(Value::Int(if is_even { 1 } else { -1 }))
     } else if let Some(exp_u32) = e.to_u32() {
         // Check size before computing to prevent DoS
-        check_pow_size(i64_bits(b), u64::from(exp_u32), heap.tracker())?;
+        check_pow_size(i64_bits(b), u64::from(exp_u32), &heap.tracker)?;
         let bi = BigInt::from(b).pow(exp_u32);
         Ok(LongInt::new(bi).into_value(heap))
     } else {
@@ -228,7 +228,7 @@ fn longint_pow_int(b: &BigInt, e: i64, heap: &Heap) -> RunResult<Value> {
         }
     } else if let Ok(exp_u32) = u32::try_from(e) {
         // Check size before computing to prevent DoS
-        check_pow_size(b.bits(), u64::from(exp_u32), heap.tracker())?;
+        check_pow_size(b.bits(), u64::from(exp_u32), &heap.tracker)?;
         let bi = b.pow(exp_u32);
         Ok(LongInt::new(bi).into_value(heap))
     } else {
@@ -237,7 +237,7 @@ fn longint_pow_int(b: &BigInt, e: i64, heap: &Heap) -> RunResult<Value> {
         #[expect(clippy::cast_sign_loss)]
         let exp_u64 = e as u64;
         // Check size before computing to prevent DoS
-        check_pow_size(b.bits(), exp_u64, heap.tracker())?;
+        check_pow_size(b.bits(), exp_u64, &heap.tracker)?;
         let bi = bigint_pow_large(b, exp_u64)?;
         Ok(LongInt::new(bi).into_value(heap))
     }
@@ -257,7 +257,7 @@ fn longint_pow_longint(b: &BigInt, e: &BigInt, heap: &Heap) -> RunResult<Value> 
         }
     } else if let Some(exp_u32) = e.to_u32() {
         // Check size before computing to prevent DoS
-        check_pow_size(b.bits(), u64::from(exp_u32), heap.tracker())?;
+        check_pow_size(b.bits(), u64::from(exp_u32), &heap.tracker)?;
         let bi = b.pow(exp_u32);
         Ok(LongInt::new(bi).into_value(heap))
     } else {

--- a/crates/monty/src/bytecode/vm/format.rs
+++ b/crates/monty/src/bytecode/vm/format.rs
@@ -81,7 +81,7 @@ impl VM<'_> {
 
                 // Pre-check: reject format specs with huge width before pad_string
                 // allocates an untracked Rust String.
-                check_repeat_size(spec.width, spec.fill.len_utf8(), this.heap.tracker())?;
+                check_repeat_size(spec.width, spec.fill.len_utf8(), &this.heap.tracker)?;
 
                 if conversion == 0 {
                     // No conversion: format the original value through its own

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -955,19 +955,25 @@ impl<'h> VM<'h> {
         // A turn shorter than the dispatch-checkpoint interval never probes
         // GC inside the run loop, so a stream of tiny feeds could otherwise
         // accumulate eligible cyclic garbage indefinitely — and the memory
-        // check below could trip on memory a collection would reclaim.
+        // check below could trip on memory a collection would reclaim. The
+        // collection is charged to the execution clock like dispatch-loop GC,
+        // so the limit check sees post-GC elapsed time as well as memory.
         if self.heap.should_gc() {
+            self.heap.tracker().on_execution_start();
             self.run_gc();
+            self.heap.tracker().on_execution_stop();
         }
-        match result {
-            Ok(value) => match self.heap.tracker.check_memory_time() {
-                Ok(()) => Ok(value),
-                Err(e) => {
+        // Checked for erroring turns too: session state survives Python
+        // exceptions, so allocate-then-raise feeds must not evade the limits.
+        // The uncatchable resource error out-ranks the turn's own error.
+        match self.heap.tracker.check_memory_time() {
+            Ok(()) => result,
+            Err(e) => {
+                if let Ok(value) = result {
                     value.drop_with(self);
-                    Err(e.into())
                 }
-            },
-            err => err,
+                Err(e.into())
+            }
         }
     }
 

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -936,9 +936,9 @@ impl<'h> VM<'h> {
     /// (task switches, `evaluate_function`) uses the raw private [`Self::run`]
     /// instead, whose time is already inside the enclosing window.
     pub(crate) fn run_external(&mut self) -> Result<FrameExit, RunError> {
-        self.heap.tracker().on_execution_start();
+        self.heap.tracker.on_execution_start();
         let result = self.run();
-        self.heap.tracker().on_execution_stop();
+        self.heap.tracker.on_execution_stop();
         self.finish_host_turn(result)
     }
 
@@ -959,9 +959,9 @@ impl<'h> VM<'h> {
         // collection is charged to the execution clock like dispatch-loop GC,
         // so the limit check sees post-GC elapsed time as well as memory.
         if self.heap.should_gc() {
-            self.heap.tracker().on_execution_start();
+            self.heap.tracker.on_execution_start();
             self.run_gc();
-            self.heap.tracker().on_execution_stop();
+            self.heap.tracker.on_execution_stop();
         }
         // Checked for erroring turns too: session state survives Python
         // exceptions, so allocate-then-raise feeds must not evade the limits.

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -939,14 +939,29 @@ impl<'h> VM<'h> {
         self.heap.tracker().on_execution_start();
         let result = self.run();
         self.heap.tracker().on_execution_stop();
-        // Re-surface a timeout that a truncating caller (e.g. repr's
-        // `...[timeout]`) swallowed after the run loop's last amortized check
-        // — without this, a turn finishing within the check interval would
-        // return to the host normally despite being over budget.
-        if result.is_ok() {
-            self.heap.tracker.check_time()?;
+        self.finish_host_turn(result)
+    }
+
+    /// Epilogue for every host-boundary execution window (here and
+    /// `MontyRepl::call_function`): re-checks both resource limits so an
+    /// overshoot that arose after the run loop's last amortized check — or
+    /// was swallowed by a truncating caller (repr's `...[timeout]`) — cannot
+    /// escape as a successful result. Consumes a discarded success so its
+    /// heap refcounts are released rather than leaked.
+    pub(crate) fn finish_host_turn<T: DropWithContext<Self>>(
+        &mut self,
+        result: Result<T, RunError>,
+    ) -> Result<T, RunError> {
+        match result {
+            Ok(value) => match self.heap.tracker.check_memory_time() {
+                Ok(()) => Ok(value),
+                Err(e) => {
+                    value.drop_with(self);
+                    Err(e.into())
+                }
+            },
+            err => err,
         }
-        result
     }
 
     /// Main execution loop.

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -972,13 +972,17 @@ impl<'h> VM<'h> {
         let mut countdown = CHECK_INTERVAL;
 
         loop {
-            if check_limits && countdown.checked_sub(1).is_none() {
-                countdown = CHECK_INTERVAL;
-                // Full memory + time check, amortized to every Nth
-                // instruction; a timeout swallowed by a truncating caller
-                // re-detects here (elapsed time is monotonic) or at the
-                // `run_external` exit latch check.
-                self.heap.tracker.check_memory_time()?;
+            if check_limits {
+                if let Some(c) = countdown.checked_sub(1) {
+                    countdown = c;
+                } else {
+                    countdown = CHECK_INTERVAL;
+                    // Full memory + time check, amortized to every Nth
+                    // instruction; a timeout swallowed by a truncating caller
+                    // re-detects here (elapsed time is monotonic) or at the
+                    // `run_external` exit latch check.
+                    self.heap.tracker.check_memory_time()?;
+                }
             }
 
             if self.heap.should_gc() {

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -964,6 +964,23 @@ impl<'h> VM<'h> {
         }
     }
 
+    /// Periodic dispatch-loop work, outlined (`#[inline(never)]`) so the hot
+    /// loop stays small: the amortized memory + time check — where a timeout
+    /// swallowed by a truncating caller re-detects (elapsed time is
+    /// monotonic), backstopped by the `run_external` exit check — and the
+    /// GC-scheduling probe, with the frame IP synced before a collection.
+    #[inline(never)]
+    fn dispatch_checkpoint(&mut self, check_limits: bool, ip: usize) -> Result<(), RunError> {
+        if check_limits {
+            self.heap.tracker.check_memory_time()?;
+        }
+        if self.heap.should_gc() {
+            self.current_frame_mut().ip = ip;
+            self.run_gc();
+        }
+        Ok(())
+    }
+
     /// Main execution loop.
     ///
     /// Fetches opcodes from the current frame's bytecode and executes them.
@@ -979,7 +996,8 @@ impl<'h> VM<'h> {
     /// `frames.last_mut().expect()` calls during operand fetching. The cache
     /// is reloaded after any operation that modifies the frame stack.
     fn run(&mut self) -> Result<FrameExit, RunError> {
-        /// How often the VM's dispatch loop runs a full `check_memory_time`
+        /// How often (in instructions) the dispatch loop runs its periodic
+        /// work: the full `check_memory_time` and the GC-scheduling probe.
         const CHECK_INTERVAL: u8 = 10;
 
         // Cache frame state locally to avoid repeated frames.last_mut() calls.
@@ -994,23 +1012,16 @@ impl<'h> VM<'h> {
         let mut countdown = CHECK_INTERVAL;
 
         loop {
-            if check_limits {
-                if let Some(c) = countdown.checked_sub(1) {
-                    countdown = c;
-                } else {
-                    countdown = CHECK_INTERVAL;
-                    // Full memory + time check, amortized to every Nth
-                    // instruction; a timeout swallowed by a truncating caller
-                    // re-detects here (elapsed time is monotonic) or at the
-                    // `run_external` exit check.
-                    self.heap.tracker.check_memory_time()?;
-                }
-            }
-
-            if self.heap.should_gc() {
-                // Sync IP before GC for safety
-                self.current_frame_mut().ip = cached_frame.ip;
-                self.run_gc();
+            // One decrement-and-branch per instruction; the periodic work
+            // runs every `CHECK_INTERVAL`-th, outlined to keep the hot loop
+            // small. GC triggering is allocation-count-based (intervals in
+            // the hundreds), so probing it a few instructions late is
+            // immaterial.
+            if let Some(c) = countdown.checked_sub(1) {
+                countdown = c;
+            } else {
+                countdown = CHECK_INTERVAL;
+                self.dispatch_checkpoint(check_limits, cached_frame.ip)?;
             }
 
             // Track instruction IP for exception table lookup

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -952,6 +952,13 @@ impl<'h> VM<'h> {
         &mut self,
         result: Result<T, RunError>,
     ) -> Result<T, RunError> {
+        // A turn shorter than the dispatch-checkpoint interval never probes
+        // GC inside the run loop, so a stream of tiny feeds could otherwise
+        // accumulate eligible cyclic garbage indefinitely — and the memory
+        // check below could trip on memory a collection would reclaim.
+        if self.heap.should_gc() {
+            self.run_gc();
+        }
         match result {
             Ok(value) => match self.heap.tracker.check_memory_time() {
                 Ok(()) => Ok(value),

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -958,7 +958,10 @@ impl<'h> VM<'h> {
         // check below could trip on memory a collection would reclaim. The
         // collection is charged to the execution clock like dispatch-loop GC,
         // so the limit check sees post-GC elapsed time as well as memory.
-        if self.heap.should_gc() {
+        // Skipped after a resource error, where refcounts are unreliable and
+        // trial deletion could free live entries; ordinary Python exceptions
+        // unwind through the drop machinery, so they still collect.
+        if !matches!(result, Err(RunError::UncatchableExc(_))) && self.heap.should_gc() {
             self.heap.tracker.on_execution_start();
             self.run_gc();
             self.heap.tracker.on_execution_stop();
@@ -1016,6 +1019,9 @@ impl<'h> VM<'h> {
         /// ~2% at u8::MAX (see the `_limits` benchmarks) — while detection
         /// latency stays sub-µs. Native ops poll internally and the host-turn
         /// epilogue re-checks, so only this dispatch cadence rides on it.
+        /// The countdown is per-`run()`, so `evaluate_function` re-entry
+        /// restarts it — a native loop calling a shorter callback reaches no
+        /// checkpoint at all and must poll the tracker itself.
         const CHECK_INTERVAL: u8 = u8::MAX;
 
         // Cache frame state locally to avoid repeated frames.last_mut() calls.

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -957,14 +957,29 @@ impl<'h> VM<'h> {
     /// `frames.last_mut().expect()` calls during operand fetching. The cache
     /// is reloaded after any operation that modifies the frame stack.
     fn run(&mut self) -> Result<FrameExit, RunError> {
+        /// How often the VM's dispatch loop runs a full `check_memory_time`
+        const CHECK_INTERVAL: u8 = 10;
+
         // Cache frame state locally to avoid repeated frames.last_mut() calls.
         // The Code reference has lifetime 'h (lives in Interns), independent of frame borrow.
         let mut cached_frame: CachedFrame<'h> = self.new_cached_frame();
 
+        // Limits cannot change mid-run (`set_max_duration` needs `&mut` at the
+        // host boundary), so with none configured the whole checkpoint reduces
+        // to this one hoisted, well-predicted branch per instruction.
+        let check_limits = self.heap.tracker.has_memory_time_limit();
+
+        let mut countdown = CHECK_INTERVAL;
+
         loop {
-            // Check time limit and trigger GC if needed at each instruction.
-            // With no limits configured these reduce to a single branch each.
-            self.heap.check_time()?;
+            if check_limits && countdown.checked_sub(1).is_none() {
+                countdown = CHECK_INTERVAL;
+                // Full memory + time check, amortized to every Nth
+                // instruction; a timeout swallowed by a truncating caller
+                // re-detects here (elapsed time is monotonic) or at the
+                // `run_external` exit latch check.
+                self.heap.tracker.check_memory_time()?;
+            }
 
             if self.heap.should_gc() {
                 // Sync IP before GC for safety

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -939,6 +939,13 @@ impl<'h> VM<'h> {
         self.heap.tracker().on_execution_start();
         let result = self.run();
         self.heap.tracker().on_execution_stop();
+        // Re-surface a timeout that a truncating caller (e.g. repr's
+        // `...[timeout]`) swallowed after the run loop's last amortized check
+        // — without this, a turn finishing within the check interval would
+        // return to the host normally despite being over budget.
+        if result.is_ok() {
+            self.heap.tracker.check_time()?;
+        }
         result
     }
 
@@ -980,7 +987,7 @@ impl<'h> VM<'h> {
                     // Full memory + time check, amortized to every Nth
                     // instruction; a timeout swallowed by a truncating caller
                     // re-detects here (elapsed time is monotonic) or at the
-                    // `run_external` exit latch check.
+                    // `run_external` exit check.
                     self.heap.tracker.check_memory_time()?;
                 }
             }

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -1005,7 +1005,12 @@ impl<'h> VM<'h> {
     fn run(&mut self) -> Result<FrameExit, RunError> {
         /// How often (in instructions) the dispatch loop runs its periodic
         /// work: the full `check_memory_time` and the GC-scheduling probe.
-        const CHECK_INTERVAL: u8 = 10;
+        /// The checkpoint reads the clock when limits are armed, so this sets
+        /// the entire cost of limit enforcement — ~40% on tight loops at 10,
+        /// ~2% at u8::MAX (see the `_limits` benchmarks) — while detection
+        /// latency stays sub-µs. Native ops poll internally and the host-turn
+        /// epilogue re-checks, so only this dispatch cadence rides on it.
+        const CHECK_INTERVAL: u8 = u8::MAX;
 
         // Cache frame state locally to avoid repeated frames.last_mut() calls.
         // The Code reference has lifetime 'h (lives in Interns), independent of frame borrow.

--- a/crates/monty/src/bytecode/vm/recursion.rs
+++ b/crates/monty/src/bytecode/vm/recursion.rs
@@ -56,7 +56,7 @@ impl<'h> VM<'h> {
     /// depth counter.
     #[inline]
     pub(crate) fn incr_recursion(&mut self) -> Result<(), ResourceError> {
-        self.heap.tracker().check_recursion_depth(self.recursion_depth)?;
+        self.heap.tracker.check_recursion_depth(self.recursion_depth)?;
         self.recursion_depth += 1;
         Ok(())
     }

--- a/crates/monty/src/fstring.rs
+++ b/crates/monty/src/fstring.rs
@@ -633,7 +633,7 @@ pub fn format_with_spec(value: &Value, spec: &ParsedFormatSpec, vm: &mut VM<'_>)
     // check, OOM-ing or aborting the host. Reject an over-budget width here,
     // up front, using the same guard sequence repeats and `str.ljust`/`zfill`
     // already use. The check is free below `LARGE_RESULT_THRESHOLD`.
-    check_repeat_size(spec.fill.len_utf8(), spec.width, vm.heap.tracker())?;
+    check_repeat_size(spec.fill.len_utf8(), spec.width, &vm.heap.tracker)?;
 
     // `spec.precision` on the float formats is rendered as that many decimal
     // digits. `fmt_float_fixed` / `fmt_float_exp` synthesise the digits beyond
@@ -672,7 +672,7 @@ pub fn format_with_spec(value: &Value, spec: &ParsedFormatSpec, vm: &mut VM<'_>)
             // three emitted digits, so the native string reaches ~4/3 × precision
             // before `allocate_string` accounts for it; budget the separators too.
             let separators = if spec.frac_grouping.is_some() { precision / 3 } else { 0 };
-            check_repeat_size(precision.saturating_add(separators), 1, vm.heap.tracker())?;
+            check_repeat_size(precision.saturating_add(separators), 1, &vm.heap.tracker)?;
         }
     }
 
@@ -774,7 +774,7 @@ pub fn format_with_spec(value: &Value, spec: &ParsedFormatSpec, vm: &mut VM<'_>)
     if let Value::Ref(id) = value
         && let HeapData::LongInt(li) = vm.heap.get(*id)
     {
-        return format_long_int(li, &value_type.name(vm.heap, vm.interns), spec, vm.heap.tracker());
+        return format_long_int(li, &value_type.name(vm.heap, vm.interns), spec, &vm.heap.tracker);
     }
 
     match (value, spec.type_char) {

--- a/crates/monty/src/heap/mod.rs
+++ b/crates/monty/src/heap/mod.rs
@@ -17,7 +17,7 @@ use std::{
     sync::Arc,
 };
 
-use monty_types::{ResourceError, ResourceTracker};
+use monty_types::ResourceTracker;
 use serde::ser::SerializeStruct;
 
 // Re-export items moved to `heap_traits` so that `crate::heap::DropGuard` etc. continue
@@ -803,7 +803,7 @@ pub(crate) struct Heap {
     /// Paged storage for heap entries with integrated free list.
     entries: StableHeap<HeapEntry>,
     /// Resource tracker for enforcing limits and scheduling GC.
-    tracker: ResourceTracker,
+    pub tracker: ResourceTracker,
     /// Number of entries currently flagged [`Purple`](CcColor::Purple) — i.e.,
     /// suspected cycle roots awaiting collection.
     ///
@@ -950,20 +950,6 @@ impl Heap {
     /// Returns a mutable reference to the resource tracker.
     pub fn tracker_mut(&mut self) -> &mut ResourceTracker {
         &mut self.tracker
-    }
-
-    /// Checks whether a configured time or memory limit has been exceeded.
-    ///
-    /// Delegates to the resource tracker's `check_time()`, which polls
-    /// allocator-backed usage against `max_memory` and elapsed execution time
-    /// against `max_duration` (each a no-op when unset).
-    ///
-    /// Call this inside Rust-side loops (builtins, sort, iterator collection)
-    /// that execute within a single bytecode instruction and would otherwise
-    /// bypass the VM's per-instruction checkpoint.
-    #[inline]
-    pub fn check_time(&self) -> Result<(), ResourceError> {
-        self.tracker.check_time()
     }
 
     /// Number of entries in the heap (including freed slots).

--- a/crates/monty/src/heap/mod.rs
+++ b/crates/monty/src/heap/mod.rs
@@ -942,16 +942,6 @@ impl Heap {
         this
     }
 
-    /// Returns a reference to the resource tracker.
-    pub fn tracker(&self) -> &ResourceTracker {
-        &self.tracker
-    }
-
-    /// Returns a mutable reference to the resource tracker.
-    pub fn tracker_mut(&mut self) -> &mut ResourceTracker {
-        &mut self.tracker
-    }
-
     /// Number of entries in the heap (including freed slots).
     pub fn size(&self) -> usize {
         self.entries.len()

--- a/crates/monty/src/modules/collections/counter.rs
+++ b/crates/monty/src/modules/collections/counter.rs
@@ -449,7 +449,7 @@ pub(crate) fn counter_elements(dict_id: HeapId, args: ArgValues, vm: &mut VM<'_>
     // large count (e.g. `c['a'] = 10**18`) would otherwise attempt to build a
     // multi-exabyte Rust-heap `Vec` before returning a graceful error.
     let total = lengths.iter().fold(0usize, |acc, len| acc.saturating_add(*len));
-    check_repeat_size(VALUE_SIZE, total, vm.heap.tracker())?;
+    check_repeat_size(VALUE_SIZE, total, &vm.heap.tracker)?;
 
     // `Vec::new()` (not `with_capacity(total)`): `total` is attacker-controlled,
     // and `check_repeat_size` above is the real guard (it fires before this loop

--- a/crates/monty/src/modules/sys.rs
+++ b/crates/monty/src/modules/sys.rs
@@ -123,7 +123,7 @@ fn setrecursionlimit(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     if new_limit == 0 {
         return Err(ExcType::value_error("recursion limit must be greater or equal than 1"));
     }
-    match vm.heap.tracker().lower_recursion_limit(new_limit) {
+    match vm.heap.tracker.lower_recursion_limit(new_limit) {
         Ok(()) => Ok(Value::None),
         Err(current) => Err(ExcType::value_error(format!(
             "sys.setrecursionlimit: cannot raise above current limit {current} (sandbox only allows lowering)"

--- a/crates/monty/src/modules/unicodedata.rs
+++ b/crates/monty/src/modules/unicodedata.rs
@@ -258,7 +258,7 @@ impl NormForm {
 /// single code point into several), so the result is built through
 /// [`StringBuilder`] which preflights allocator-backed usage as it grows.
 fn normalize_with(form: NormForm, text: &str, heap: &Heap) -> RunResult<Value> {
-    let mut builder = StringBuilder::new(heap.tracker());
+    let mut builder = StringBuilder::new(&heap.tracker);
     match form {
         NormForm::Nfc => {
             for c in text.nfc() {

--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -318,6 +318,10 @@ impl MontyRepl {
                 vm.heap.tracker().on_execution_start();
                 let eval_result = vm.evaluate_function("MontyRepl::call_function", callable, arg_values);
                 vm.heap.tracker().on_execution_stop();
+                // Same host-boundary epilogue as `run_external`: a limit
+                // overshoot the call swallowed must fail the call, not
+                // return a truncated value.
+                let eval_result = vm.finish_host_turn(eval_result);
 
                 let result = match eval_result {
                     Ok(value) => Ok(MontyObject::new(value, vm)),

--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -95,7 +95,7 @@ impl MontyRepl {
     /// This is primarily intended for host integrations that need to attach
     /// per-execution state, such as cancellation markers, to an existing REPL.
     pub fn tracker(&self) -> &ResourceTracker {
-        self.heap.tracker()
+        &self.heap.tracker
     }
 
     /// Returns mutable access to the resource tracker for the next snippet.
@@ -103,7 +103,7 @@ impl MontyRepl {
     /// REPL hosts use this to install ephemeral execution controls, such as
     /// async cancellation flags, before calling `feed_start()`.
     pub fn tracker_mut(&mut self) -> &mut ResourceTracker {
-        self.heap.tracker_mut()
+        &mut self.heap.tracker
     }
 
     /// Number of live heap entries (excluding the empty-tuple singleton) —
@@ -323,9 +323,9 @@ impl MontyRepl {
                 // advances (and accumulates) during the call. This cannot go
                 // through `VM::run_external` because `evaluate_function` must
                 // push and run a single function frame itself.
-                vm.heap.tracker().on_execution_start();
+                vm.heap.tracker.on_execution_start();
                 let eval_result = vm.evaluate_function("MontyRepl::call_function", callable, arg_values);
-                vm.heap.tracker().on_execution_stop();
+                vm.heap.tracker.on_execution_stop();
                 // Same host-boundary epilogue as `run_external`: a limit
                 // overshoot the call swallowed must fail the call, not
                 // return a truncated value.

--- a/crates/monty/src/repl.rs
+++ b/crates/monty/src/repl.rs
@@ -106,6 +106,14 @@ impl MontyRepl {
         self.heap.tracker_mut()
     }
 
+    /// Number of live heap entries (excluding the empty-tuple singleton) —
+    /// `ref-count-return`-only introspection for GC tests.
+    #[cfg(feature = "ref-count-return")]
+    #[must_use]
+    pub fn heap_entry_count(&self) -> usize {
+        self.heap.entry_count()
+    }
+
     /// Starts executing a new snippet and returns suspendable REPL progress.
     ///
     /// This is the REPL equivalent of `MontyRun::start`: execution may complete,

--- a/crates/monty/src/run_progress.rs
+++ b/crates/monty/src/run_progress.rs
@@ -145,13 +145,13 @@ impl FunctionCall {
     /// This allows modifying resource limits between execution phases,
     /// e.g. setting a time limit before resuming after an external function call.
     pub fn tracker_mut(&mut self) -> &mut ResourceTracker {
-        self.snapshot.heap.tracker_mut()
+        &mut self.snapshot.heap.tracker
     }
 
     /// Returns the resource tracker while execution is suspended.
     #[must_use]
     pub fn tracker(&self) -> &ResourceTracker {
-        self.snapshot.heap.tracker()
+        &self.snapshot.heap.tracker
     }
 
     /// Resumes execution with the return value or exception from the external function.
@@ -251,7 +251,7 @@ impl OsCall {
     /// Returns the resource tracker while execution is suspended.
     #[must_use]
     pub fn tracker(&self) -> &ResourceTracker {
-        self.snapshot.heap.tracker()
+        &self.snapshot.heap.tracker
     }
 }
 
@@ -294,7 +294,7 @@ impl NameLookup {
     /// Returns the resource tracker while execution is suspended.
     #[must_use]
     pub fn tracker(&self) -> &ResourceTracker {
-        self.snapshot.heap.tracker()
+        &self.snapshot.heap.tracker
     }
 
     /// Resumes execution after name resolution.
@@ -413,7 +413,7 @@ impl ResolveFutures {
     /// Returns the resource tracker while execution is suspended.
     #[must_use]
     pub fn tracker(&self) -> &ResourceTracker {
-        self.heap.tracker()
+        &self.heap.tracker
     }
 
     /// Forces a GC cycle against the exact root walk used by the live VM.

--- a/crates/monty/src/sorting.rs
+++ b/crates/monty/src/sorting.rs
@@ -76,7 +76,11 @@ pub fn sort_values(values: &mut [Value], key_fn: Option<&Value>, reverse: bool, 
     } else {
         // With no key function can sort directly on the original array
         let mut sort_result: RunResult<()> = Ok(());
-        values.sort_by(|a, b| compare_values(a, b, reverse, &mut sort_result, vm));
+        let mut n = 0usize;
+        values.sort_by(|a, b| {
+            n += 1;
+            compare_values(n, a, b, reverse, &mut sort_result, vm)
+        });
         sort_result
     }
 }
@@ -91,7 +95,11 @@ pub fn sort_values(values: &mut [Value], key_fn: Option<&Value>, reverse: bool, 
 /// or the pre-computed key values.
 pub fn sort_indices(indices: &mut [usize], values: &[Value], reverse: bool, vm: &mut VM<'_>) -> Result<(), RunError> {
     let mut sort_result: RunResult<()> = Ok(());
-    indices.sort_by(|&a, &b| compare_values(&values[a], &values[b], reverse, &mut sort_result, vm));
+    let mut n = 0usize;
+    indices.sort_by(|&a, &b| {
+        n += 1;
+        compare_values(n, &values[a], &values[b], reverse, &mut sort_result, vm)
+    });
     sort_result
 }
 
@@ -125,12 +133,20 @@ pub fn apply_permutation<T>(items: &mut [T], indices: &mut [usize]) {
 }
 
 /// Helper for the sort functions which compares two values, handling any exceptions and timeouts.
-fn compare_values(a: &Value, b: &Value, reverse: bool, sort_result: &mut RunResult<()>, vm: &mut VM<'_>) -> Ordering {
+/// `n` is the caller's running comparison count, keying the amortized time check.
+fn compare_values(
+    n: usize,
+    a: &Value,
+    b: &Value,
+    reverse: bool,
+    sort_result: &mut RunResult<()>,
+    vm: &mut VM<'_>,
+) -> Ordering {
     if sort_result.is_err() {
         // short-circuit if we've already encountered an error in a previous comparison
         return Ordering::Equal;
     }
-    if let Err(e) = vm.heap.check_time() {
+    if let Err(e) = vm.heap.tracker.check_time_every(n) {
         *sort_result = Err(e.into());
         return Ordering::Equal;
     }

--- a/crates/monty/src/sorting.rs
+++ b/crates/monty/src/sorting.rs
@@ -61,7 +61,10 @@ pub fn sort_values(values: &mut [Value], key_fn: Option<&Value>, reverse: bool, 
         let keys: Vec<Value> = Vec::with_capacity(values.len());
         defer_drop_mut!(keys, vm);
 
-        for item in values.iter() {
+        // Each key call re-enters `run()` with a fresh dispatch countdown, so a
+        // short key reaches no checkpoint: this is the pass's only clock poll.
+        for (i, item) in values.iter().enumerate() {
+            vm.heap.tracker.check_time_every(i)?;
             let item = item.clone_with_heap(vm);
             keys.push(vm.evaluate_function("sorted() key argument", f, ArgValues::One(item))?);
         }

--- a/crates/monty/src/string_builder.rs
+++ b/crates/monty/src/string_builder.rs
@@ -48,7 +48,7 @@ use crate::{exception_private::RunResult, heap::Heap, types::str::allocate_strin
 /// Typical use:
 ///
 /// ```ignore
-/// let mut builder = StringBuilder::with_capacity(cap, vm.heap.tracker())?;
+/// let mut builder = StringBuilder::with_capacity(cap, &vm.heap.tracker)?;
 /// builder.push_str(prefix)?;
 /// for _ in 0..pad { builder.push(fill)?; }
 /// builder.finish(vm.heap)

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -182,7 +182,7 @@ impl Bytes {
             let errors = errors.as_ref().map_or("strict", |e| e.as_str(vm));
             let encoding = encoding.as_str(vm);
             let codec = Codec::find(encoding).ok_or_else(|| ExcType::lookup_error_unknown_encoding(encoding))?;
-            let encoded = codec.encode(s, errors, vm.heap.tracker())?;
+            let encoded = codec.encode(s, errors, &vm.heap.tracker)?;
             let heap_id = vm.heap.allocate(HeapData::Bytes(Self::new(encoded)));
             return Ok(Value::Ref(heap_id));
         }
@@ -204,7 +204,7 @@ impl Bytes {
                 // very large `n` would attempt the native allocation directly
                 // and abort the host on failure rather than raising MemoryError.
                 // Mirrors the guard already used by `bytes.ljust`/`zfill`/`*`.
-                check_repeat_size(size, 1, vm.heap.tracker())?;
+                check_repeat_size(size, 1, &vm.heap.tracker)?;
                 vec![0u8; size]
             }
             Some(Value::InternBytes(bytes_id)) => {
@@ -240,7 +240,7 @@ struct BytesInitArgs {
 /// Concatenates two byte strings into a tracked heap value.
 pub(crate) fn concat_bytes(lhs: &[u8], rhs: &[u8], heap: &Heap) -> Result<Value, ResourceError> {
     let result_len = lhs.len().saturating_add(rhs.len());
-    check_repeat_size(result_len, 1, heap.tracker())?;
+    check_repeat_size(result_len, 1, &heap.tracker)?;
     let mut result = Vec::with_capacity(result_len);
     result.extend_from_slice(lhs);
     result.extend_from_slice(rhs);
@@ -249,7 +249,7 @@ pub(crate) fn concat_bytes(lhs: &[u8], rhs: &[u8], heap: &Heap) -> Result<Value,
 
 /// Repeats bytes after validating the allocation against resource limits.
 pub(crate) fn repeat_bytes(value: &[u8], count: usize, heap: &Heap) -> Result<Value, ResourceError> {
-    check_repeat_size(value.len(), count, heap.tracker())?;
+    check_repeat_size(value.len(), count, &heap.tracker)?;
     Ok(Value::Ref(heap.allocate(HeapData::Bytes(value.repeat(count).into()))))
 }
 
@@ -1716,7 +1716,7 @@ fn bytes_replace<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h
 
     let bytes = bytes.get(vm.heap);
 
-    check_replace_size(bytes.len(), old.len(), new.len(), count, vm.heap.tracker())?;
+    check_replace_size(bytes.len(), old.len(), new.len(), count, &vm.heap.tracker)?;
 
     let result = if count < 0 {
         bytes_replace_all(bytes, &old, &new, vm.heap)?
@@ -1854,7 +1854,7 @@ fn bytes_center<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h>
     let result = if width <= len {
         bytes.to_vec()
     } else {
-        check_repeat_size(width, 1, vm.heap.tracker())?;
+        check_repeat_size(width, 1, &vm.heap.tracker)?;
         let total_pad = width - len;
         let left_pad = total_pad / 2;
         let right_pad = total_pad - left_pad;
@@ -1884,7 +1884,7 @@ fn bytes_ljust<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h>)
     let result = if width <= len {
         bytes.to_vec()
     } else {
-        check_repeat_size(width, 1, vm.heap.tracker())?;
+        check_repeat_size(width, 1, &vm.heap.tracker)?;
         let pad = width - len;
         let mut result = Vec::with_capacity(width);
         result.extend_from_slice(bytes);
@@ -1909,7 +1909,7 @@ fn bytes_rjust<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h>)
     let result = if width <= len {
         bytes.to_vec()
     } else {
-        check_repeat_size(width, 1, vm.heap.tracker())?;
+        check_repeat_size(width, 1, &vm.heap.tracker)?;
         let pad = width - len;
         let mut result = Vec::with_capacity(width);
         for _ in 0..pad {
@@ -1975,7 +1975,7 @@ fn bytes_zfill<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h>)
     let result = if width <= len {
         bytes.to_vec()
     } else {
-        check_repeat_size(width, 1, vm.heap.tracker())?;
+        check_repeat_size(width, 1, &vm.heap.tracker)?;
         let pad = width - len;
         let mut result = Vec::with_capacity(width);
 

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -612,7 +612,7 @@ fn find_with(finder: &Finder<'_>, haystack: &[u8], heap: &Heap) -> Result<Option
     let stride = SCAN_CHUNK.max(needle_len);
     let mut start = 0;
     while start < haystack.len() {
-        heap.check_time()?;
+        heap.tracker.check_time()?;
         let end = start
             .saturating_add(stride + needle_len.saturating_sub(1))
             .min(haystack.len());
@@ -644,7 +644,7 @@ fn rfind_with(finder: &FinderRev<'_>, haystack: &[u8], heap: &Heap) -> Result<Op
     let stride = SCAN_CHUNK.max(needle_len);
     let mut end = haystack.len();
     while end > 0 {
-        heap.check_time()?;
+        heap.tracker.check_time()?;
         let start = end.saturating_sub(stride + needle_len.saturating_sub(1));
         if let Some(pos) = finder.rfind(&haystack[start..end]) {
             return Ok(Some(start + pos));
@@ -1316,8 +1316,8 @@ fn bytes_split<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h>)
     };
 
     let mut list_items = Vec::with_capacity(parts.len());
-    for part in parts {
-        vm.heap.check_time()?;
+    for (i, part) in parts.into_iter().enumerate() {
+        vm.heap.tracker.check_memory_time_every(i)?;
         list_items.push(allocate_bytes(part.to_vec(), vm.heap));
     }
 
@@ -1357,8 +1357,8 @@ fn bytes_rsplit<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM<'h>
     };
 
     let mut list_items = Vec::with_capacity(parts.len());
-    for part in parts {
-        vm.heap.check_time()?;
+    for (i, part) in parts.into_iter().enumerate() {
+        vm.heap.tracker.check_memory_time_every(i)?;
         list_items.push(allocate_bytes(part.to_vec(), vm.heap));
     }
 
@@ -1582,7 +1582,7 @@ fn bytes_splitlines<'h>(bytes: &HeapRead<'h, [u8]>, args: ArgValues, vm: &mut VM
     let len = bytes.len();
 
     while start < len {
-        vm.heap.check_time()?;
+        vm.heap.tracker.check_memory_time_every(lines.len())?;
 
         let mut end = start;
         let mut line_end = start;
@@ -1759,8 +1759,8 @@ fn bytes_replace_all(bytes: &[u8], old: &[u8], new: &[u8], heap: &Heap) -> Resul
     if old.is_empty() {
         // Empty pattern: insert new before each byte and at the end
         let mut result = Vec::with_capacity(bytes.len() + new.len() * (bytes.len() + 1));
-        for &b in bytes {
-            heap.check_time()?;
+        for (i, &b) in bytes.iter().enumerate() {
+            heap.tracker.check_memory_time_every(i)?;
             result.extend_from_slice(new);
             result.push(b);
         }
@@ -1769,8 +1769,10 @@ fn bytes_replace_all(bytes: &[u8], old: &[u8], new: &[u8], heap: &Heap) -> Resul
     } else if let Some(finder) = finder_for(old, bytes) {
         let mut result = Vec::new();
         let mut start = 0;
+        let mut matches = 0usize;
         while let Some(pos) = find_with(&finder, &bytes[start..], heap)? {
-            heap.check_time()?;
+            heap.tracker.check_memory_time_every(matches)?;
+            matches += 1;
             result.extend_from_slice(&bytes[start..start + pos]);
             result.extend_from_slice(new);
             start = start + pos + old.len();
@@ -1788,7 +1790,7 @@ fn bytes_replace_all(bytes: &[u8], old: &[u8], new: &[u8], heap: &Heap) -> Resul
 /// with it the `check_time()` it would have run first, so without this a
 /// no-match `replace` over a large input would never touch the clock.
 fn replace_nothing(bytes: &[u8], heap: &Heap) -> Result<Vec<u8>, ResourceError> {
-    heap.check_time()?;
+    heap.tracker.check_time()?;
     Ok(bytes.to_vec())
 }
 
@@ -1806,8 +1808,8 @@ fn bytes_replace_n(bytes: &[u8], old: &[u8], new: &[u8], n: usize, heap: &Heap) 
         // Empty pattern: insert new before each byte (up to n times)
         let mut result = Vec::new();
         let mut count = 0;
-        for &b in bytes {
-            heap.check_time()?;
+        for (i, &b) in bytes.iter().enumerate() {
+            heap.tracker.check_memory_time_every(i)?;
             if count < n {
                 result.extend_from_slice(new);
                 count += 1;
@@ -1823,7 +1825,7 @@ fn bytes_replace_n(bytes: &[u8], old: &[u8], new: &[u8], n: usize, heap: &Heap) 
         let mut start = 0;
         let mut count = 0;
         while count < n {
-            heap.check_time()?;
+            heap.tracker.check_memory_time_every(count)?;
             if let Some(pos) = find_with(&finder, &bytes[start..], heap)? {
                 result.extend_from_slice(&bytes[start..start + pos]);
                 result.extend_from_slice(new);

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -313,7 +313,7 @@ pub(crate) fn write_dataclass_repr<'h>(
         if i > 0 {
             // Same between-item checkpoint as sequence repr, so a wide dataclass
             // cannot outrun `max_duration`.
-            if vm.heap.tracker.check_memory_time().is_err() {
+            if vm.heap.tracker.check_memory_time_every(i).is_err() {
                 f.write_str(", ...[timeout]")?;
                 break;
             }

--- a/crates/monty/src/types/dataclass.rs
+++ b/crates/monty/src/types/dataclass.rs
@@ -313,7 +313,7 @@ pub(crate) fn write_dataclass_repr<'h>(
         if i > 0 {
             // Same between-item checkpoint as sequence repr, so a wide dataclass
             // cannot outrun `max_duration`.
-            if vm.heap.check_time().is_err() {
+            if vm.heap.tracker.check_memory_time().is_err() {
                 f.write_str(", ...[timeout]")?;
                 break;
             }

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -273,7 +273,7 @@ impl<'h> HeapRead<'h, Deque> {
     /// Clones every item, incrementing refcounts — used by `copy`, `+` and `*`.
     fn clone_all_items(&self, vm: &mut VM<'h>) -> RunResult<Vec<Value>> {
         let len = self.get(vm.heap).len();
-        vm.heap.tracker().check_allocation(len.saturating_mul(VALUE_SIZE))?;
+        vm.heap.tracker.check_allocation(len.saturating_mul(VALUE_SIZE))?;
         let mut out = Vec::with_capacity(len);
         for i in 0..len {
             let item = self.get(vm.heap).items[i].clone_with_heap(vm.heap);
@@ -999,7 +999,7 @@ pub(crate) fn deque_extend(deque_id: HeapId, iterable: Value, end: ExtendEnd, vm
         // the estimate at what it can actually keep.
         let hint = iter.iter_size_hint(vm);
         let retained = deque_maxlen(deque_id, vm).map_or(hint, |maxlen| hint.min(maxlen));
-        check_estimated_size(retained.saturating_mul(VALUE_SIZE), vm.heap.tracker())?;
+        check_estimated_size(retained.saturating_mul(VALUE_SIZE), &vm.heap.tracker)?;
         while let Some(item) = iter.py_next(vm)? {
             deque_push(deque_id, item, end, vm);
         }
@@ -1056,7 +1056,7 @@ fn repeat_deque(source: Vec<Value>, maxlen: Option<usize>, count: usize, vm: &mu
         // `Value` slots against the tracker and poll the time limit while building
         // — else the suffix could allocate/spin before the final `allocate` checks.
         let kept = len.saturating_mul(count).min(max);
-        check_repeat_size(mem::size_of::<Value>(), kept, vm.heap.tracker())?;
+        check_repeat_size(mem::size_of::<Value>(), kept, &vm.heap.tracker)?;
         // `Vec::new()` (not `with_capacity(kept)`): the check above is the real
         // guard, and reserving an attacker-sized capacity would itself abort.
         // The guard releases the clones built so far if the time poll trips.
@@ -1071,7 +1071,7 @@ fn repeat_deque(source: Vec<Value>, maxlen: Option<usize>, count: usize, vm: &mu
         }
         result.into_inner()
     } else {
-        check_repeat_size(len.saturating_mul(mem::size_of::<Value>()), count, vm.heap.tracker())?;
+        check_repeat_size(len.saturating_mul(mem::size_of::<Value>()), count, &vm.heap.tracker)?;
         let mut result = DropGuard::new(Vec::with_capacity(len * count), vm);
         for rep in 0..count {
             let (items, vm) = result.as_parts_mut();

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -1066,20 +1066,17 @@ fn repeat_deque(source: Vec<Value>, maxlen: Option<usize>, count: usize, vm: &mu
             for i in 0..kept {
                 let (items, vm) = result.as_parts_mut();
                 items.push(source[(start + i % len) % len].clone_with_heap(vm.heap));
-                // Poll once per notional copy.
-                if i % len == 0 {
-                    vm.heap.check_time()?;
-                }
+                vm.heap.tracker.check_time_every(i)?;
             }
         }
         result.into_inner()
     } else {
         check_repeat_size(len.saturating_mul(mem::size_of::<Value>()), count, vm.heap.tracker())?;
         let mut result = DropGuard::new(Vec::with_capacity(len * count), vm);
-        for _ in 0..count {
+        for rep in 0..count {
             let (items, vm) = result.as_parts_mut();
             items.extend(source.iter().map(|v| v.clone_with_heap(vm.heap)));
-            vm.heap.check_time()?;
+            vm.heap.tracker.check_time_every(rep)?;
         }
         result.into_inner()
     };

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -968,7 +968,7 @@ impl<'a, 'h> DictIter<'a, 'h> {
     /// Shared step for the iterator's borrowed and owned yield modes.
     ///
     /// Releases the previously-yielded slot (no-op when each slot is
-    /// `Undefined`), runs the per-step time check and the dict mutation
+    /// `Undefined`), runs the amortized time check and the dict mutation
     /// guard, then returns the entry index to read at — or `Ok(None)` when
     /// the iterator is exhausted. Bumps `self.index` on success.
     fn advance(&mut self, vm: &mut VM<'h>) -> RunResult<Option<usize>> {

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -974,7 +974,7 @@ impl<'a, 'h> DictIter<'a, 'h> {
     fn advance(&mut self, vm: &mut VM<'h>) -> RunResult<Option<usize>> {
         mem::replace(&mut self.current_key, Value::Undefined).drop_with(vm.heap);
         mem::replace(&mut self.current_value, Value::Undefined).drop_with(vm.heap);
-        vm.heap.check_time()?;
+        vm.heap.tracker.check_time_every(self.index)?;
         let current = self.dict.get(vm.heap);
         if current.entries.len() != self.expected_len {
             return Err(ExcType::runtime_error_dict_changed_size());

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -1058,7 +1058,7 @@ impl<'h> HeapRead<'h, Dict> {
         // snapshot — preflight them too so an over-budget Counter raises a
         // graceful `MemoryError` instead of hitting the allocator hard limit.
         vm.heap
-            .tracker()
+            .tracker
             .check_allocation(pairs.len().saturating_mul(VALUE_SIZE + mem::size_of::<usize>()))?;
         let counts = pairs.iter().map(|(_, value)| value.clone_with_heap(vm.heap)).collect();
         let order = counter_order(counts, vm)?;
@@ -1089,7 +1089,7 @@ impl<'h> HeapRead<'h, Dict> {
     /// `MemoryError` instead of bursting past the allocator's hard limit.
     fn clone_all_pairs(&self, vm: &mut VM<'h>) -> RunResult<Vec<(Value, Value)>> {
         let len = self.get(vm.heap).len();
-        vm.heap.tracker().check_allocation(len.saturating_mul(2 * VALUE_SIZE))?;
+        vm.heap.tracker.check_allocation(len.saturating_mul(2 * VALUE_SIZE))?;
         let mut pairs = Vec::with_capacity(len);
         // No user code runs during the snapshot, so `len` stays current and
         // the `expect`s cannot fire.

--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -95,7 +95,7 @@ impl<'h> HeapRead<'h, DictKeysView> {
     /// and for `isdisjoint(...)`.
     pub(crate) fn to_set(&self, vm: &mut VM<'h>) -> RunResult<Set> {
         let dict = self.dict(vm);
-        let capacity = Set::preallocation_capacity(dict.get(vm.heap).len(), vm.heap.tracker())?;
+        let capacity = Set::preallocation_capacity(dict.get(vm.heap).len(), &vm.heap.tracker)?;
         let iter = dict.iter(vm)?;
         defer_drop_mut!(iter, vm);
         let mut result_guard = DropGuard::new(Set::with_capacity(capacity), vm);
@@ -111,7 +111,7 @@ impl<'h> HeapRead<'h, DictKeysView> {
     fn intersection(&self, other: &Value, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         let other = collect_iterable_to_set(other.clone_with_heap(vm), vm)?;
         defer_drop!(other, vm);
-        let capacity = Set::preallocation_capacity(other.len(), vm.heap.tracker())?;
+        let capacity = Set::preallocation_capacity(other.len(), &vm.heap.tracker)?;
         let mut result_guard = DropGuard::new(Set::with_capacity(capacity), vm);
         let (result, vm) = result_guard.as_parts_mut();
         let dict = self.dict(vm);
@@ -328,7 +328,7 @@ impl<'h> HeapRead<'h, DictItemsView> {
     /// membership checks observe standard Python tuple semantics.
     pub(crate) fn to_set(&self, vm: &mut VM<'h>) -> RunResult<Set> {
         let dict = self.dict(vm);
-        let capacity = Set::preallocation_capacity(dict.get(vm.heap).len(), vm.heap.tracker())?;
+        let capacity = Set::preallocation_capacity(dict.get(vm.heap).len(), &vm.heap.tracker)?;
         let iter = dict.iter(vm)?;
         defer_drop_mut!(iter, vm);
         let mut result_guard = DropGuard::new(Set::with_capacity(capacity), vm);
@@ -371,7 +371,7 @@ impl<'h> HeapRead<'h, DictItemsView> {
 
     /// Intersects without hashing item tuples whose values are unhashable.
     fn intersect_unhashable_items(&self, other: &Set, vm: &mut VM<'h>) -> RunResult<Set> {
-        let capacity = Set::preallocation_capacity(other.len(), vm.heap.tracker())?;
+        let capacity = Set::preallocation_capacity(other.len(), &vm.heap.tracker)?;
         let mut result_guard = DropGuard::new(Set::with_capacity(capacity), vm);
         let (result, vm) = result_guard.as_parts_mut();
         for candidate in other.iter() {
@@ -781,7 +781,7 @@ fn dict_view_binary_op_value(
 
 /// Computes dictionary-view intersection.
 fn apply_dict_view_and(lhs: &Set, rhs: &Set, vm: &mut VM<'_>) -> RunResult<Set> {
-    let capacity = Set::preallocation_capacity(lhs.len().min(rhs.len()), vm.heap.tracker())?;
+    let capacity = Set::preallocation_capacity(lhs.len().min(rhs.len()), &vm.heap.tracker)?;
     let mut result_guard = DropGuard::new(Set::with_capacity(capacity), vm);
     let (result, vm) = result_guard.as_parts_mut();
     let (smaller, larger) = if lhs.len() <= rhs.len() { (lhs, rhs) } else { (rhs, lhs) };
@@ -795,7 +795,7 @@ fn apply_dict_view_and(lhs: &Set, rhs: &Set, vm: &mut VM<'_>) -> RunResult<Set> 
 
 /// Computes dictionary-view union.
 fn apply_dict_view_or(lhs: &Set, rhs: &Set, vm: &mut VM<'_>) -> RunResult<Set> {
-    let capacity = Set::preallocation_capacity(lhs.len().saturating_add(rhs.len()), vm.heap.tracker())?;
+    let capacity = Set::preallocation_capacity(lhs.len().saturating_add(rhs.len()), &vm.heap.tracker)?;
     let mut result_guard = DropGuard::new(Set::with_capacity(capacity), vm);
     let (result, vm) = result_guard.as_parts_mut();
     for value in lhs.iter().chain(rhs.iter()) {
@@ -806,7 +806,7 @@ fn apply_dict_view_or(lhs: &Set, rhs: &Set, vm: &mut VM<'_>) -> RunResult<Set> {
 
 /// Computes dictionary-view symmetric difference.
 fn apply_dict_view_xor(lhs: &Set, rhs: &Set, vm: &mut VM<'_>) -> RunResult<Set> {
-    let capacity = Set::preallocation_capacity(lhs.len().saturating_add(rhs.len()), vm.heap.tracker())?;
+    let capacity = Set::preallocation_capacity(lhs.len().saturating_add(rhs.len()), &vm.heap.tracker)?;
     let mut result_guard = DropGuard::new(Set::with_capacity(capacity), vm);
     let (result, vm) = result_guard.as_parts_mut();
     for value in lhs.iter() {
@@ -824,7 +824,7 @@ fn apply_dict_view_xor(lhs: &Set, rhs: &Set, vm: &mut VM<'_>) -> RunResult<Set> 
 
 /// Computes dictionary-view difference.
 fn apply_dict_view_sub(lhs: &Set, rhs: &Set, vm: &mut VM<'_>) -> RunResult<Set> {
-    let capacity = Set::preallocation_capacity(lhs.len(), vm.heap.tracker())?;
+    let capacity = Set::preallocation_capacity(lhs.len(), &vm.heap.tracker)?;
     let mut result_guard = DropGuard::new(Set::with_capacity(capacity), vm);
     let (result, vm) = result_guard.as_parts_mut();
     for value in lhs.iter() {
@@ -845,7 +845,7 @@ pub(crate) fn collect_iterable_to_set(value: Value, vm: &mut VM<'_>) -> Result<S
     let iter = value.py_iter(vm)?;
     defer_drop!(iter, vm);
     let mut iter = iter.read(vm);
-    let cap = checked_preallocation_hint(iter.iter_size_hint(vm), mem::size_of::<Value>() * 2, vm.heap.tracker())?;
+    let cap = checked_preallocation_hint(iter.iter_size_hint(vm), mem::size_of::<Value>() * 2, &vm.heap.tracker)?;
     let mut set_guard = DropGuard::new(Set::with_capacity(cap), vm);
     let (set, vm) = set_guard.as_parts_mut();
     while let Some(item) = iter.py_next(vm)? {

--- a/crates/monty/src/types/dict_view.rs
+++ b/crates/monty/src/types/dict_view.rs
@@ -663,7 +663,7 @@ fn dict_keys_eq_set_like<'h>(
     let vm = &mut *guard;
     let len = dict.get(vm.heap).len();
     for i in 0..len {
-        vm.heap.check_time()?;
+        vm.heap.tracker.check_time_every(i)?;
         let key = dict.get(vm.heap).key_at(i).unwrap().clone_with_heap(vm);
         defer_drop!(key, vm);
         if !contains(key, vm)? {
@@ -688,7 +688,7 @@ fn dict_items_eq_set_like<'h>(
     let vm = &mut *guard;
     let len = dict.get(vm.heap).len();
     for i in 0..len {
-        vm.heap.check_time()?;
+        vm.heap.tracker.check_time_every(i)?;
         let (key, value) = dict.get(vm.heap).item_at(i).unwrap();
         let item = allocate_tuple(smallvec![key.clone_with_heap(vm), value.clone_with_heap(vm)], vm.heap);
         defer_drop!(item, vm);

--- a/crates/monty/src/types/iter.rs
+++ b/crates/monty/src/types/iter.rs
@@ -85,7 +85,7 @@ impl<'h, I: CollectIter<'h>> Iterator for HeapedIterator<'_, 'h, I> {
             Ok(Some(value)) => {
                 self.yielded += 1;
                 let estimated = self.yielded.saturating_mul(VALUE_SIZE);
-                match check_estimated_size(estimated, self.vm.heap.tracker()) {
+                match check_estimated_size(estimated, &self.vm.heap.tracker) {
                     Ok(()) => Some(value),
                     Err(error) => {
                         *self.error = Some(error.into());
@@ -144,7 +144,7 @@ where
 {
     defer_drop!(iterator, vm);
     let mut iterator = iterator.read(vm);
-    let preallocation_hint = checked_preallocation_hint(iterator.iter_size_hint(vm), VALUE_SIZE, vm.heap.tracker())?;
+    let preallocation_hint = checked_preallocation_hint(iterator.iter_size_hint(vm), VALUE_SIZE, &vm.heap.tracker)?;
     let mut values_guard = DropGuard::new(T::default(), vm);
     let (values, vm) = values_guard.as_parts_mut();
     let mut error = None;

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -325,12 +325,12 @@ impl<'a, 'h> ListIter<'a, 'h> {
     /// until the iterator itself is dropped), at which point the held item
     /// is released.
     ///
-    /// Performs a [`check_time`](Heap::check_time) on every call so long
+    /// Performs a time-limit check on every call so long
     /// Rust-side loops cannot bypass the configured timeout.
     pub(crate) fn next<'i>(&'i mut self, vm: &mut VM<'h>) -> RunResult<Option<&'i Value>> {
         // Drop the previously-yielded item (no-op when `current` is `Undefined`).
         mem::replace(&mut self.current, Value::Undefined).drop_with(vm.heap);
-        vm.heap.check_time()?;
+        vm.heap.tracker.check_time_every(self.index)?;
         if self.index >= self.list.get(vm.heap).len() {
             return Ok(None);
         }
@@ -511,9 +511,9 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
         let value = self.get(vm.heap);
         check_repeat_size(value.len().saturating_mul(VALUE_SIZE), count, vm.heap.tracker())?;
         let mut result = Vec::with_capacity(value.len() * count);
-        for _ in 0..count {
+        for rep in 0..count {
             result.extend(value.as_slice().iter().map(|value| value.clone_with_heap(vm.heap)));
-            vm.heap.check_time()?;
+            vm.heap.tracker.check_time_every(rep)?;
         }
         Ok(Some(Value::Ref(vm.heap.allocate(HeapData::List(List::new(result))))))
     }
@@ -969,7 +969,7 @@ pub(crate) fn repr_items_fmt(
 /// keeping per-item overhead to one branch while still truncating huge reprs
 /// promptly with `", ...[timeout]"` (tested in `resource_limits.rs`).
 pub(crate) fn repr_check_time(i: usize, vm: &VM<'_>) -> bool {
-    i.is_multiple_of(64) && vm.heap.check_time().is_err()
+    vm.heap.tracker.check_memory_time_every(i).is_err()
 }
 
 /// Iterates over a list while observing changes to its current contents.

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -248,7 +248,7 @@ impl<'h> HeapRead<'h, List> {
     /// `MemoryError` instead of bursting past the allocator's hard limit.
     fn clone_all_items(&self, vm: &mut VM<'h>) -> RunResult<Vec<Value>> {
         let len = self.get(vm.heap).items.len();
-        vm.heap.tracker().check_allocation(len.saturating_mul(VALUE_SIZE))?;
+        vm.heap.tracker.check_allocation(len.saturating_mul(VALUE_SIZE))?;
         let mut result = Vec::with_capacity(len);
         for i in 0..len {
             result.push(self.clone_item(i, vm));
@@ -509,7 +509,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
             return Ok(None);
         };
         let value = self.get(vm.heap);
-        check_repeat_size(value.len().saturating_mul(VALUE_SIZE), count, vm.heap.tracker())?;
+        check_repeat_size(value.len().saturating_mul(VALUE_SIZE), count, &vm.heap.tracker)?;
         let mut result = Vec::with_capacity(value.len() * count);
         for rep in 0..count {
             result.extend(value.as_slice().iter().map(|value| value.clone_with_heap(vm.heap)));
@@ -532,7 +532,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
             // at 2× — the temporary clone plus the equal-sized target growth —
             // up front, while no owned values need releasing on failure.
             let len = self.get(vm.heap).items.len();
-            vm.heap.tracker().check_allocation(len.saturating_mul(2 * VALUE_SIZE))?;
+            vm.heap.tracker.check_allocation(len.saturating_mul(2 * VALUE_SIZE))?;
             let items = self.clone_all_items(vm)?;
             self.get_mut(vm.heap).items.extend(items);
         } else {
@@ -544,7 +544,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, List> {
             };
             let source_len = source_list.get(vm.heap).len();
             vm.heap
-                .tracker()
+                .tracker
                 .check_allocation(source_len.saturating_mul(2 * VALUE_SIZE))?;
             let source_items = source_list.clone_all_items(vm)?;
             // Check if new items contain refs
@@ -758,7 +758,7 @@ fn list_clear<'h>(list: &mut HeapRead<'h, List>, vm: &mut VM<'h>) {
 /// Returns a shallow copy of the list, preflighting the slot bytes like
 /// `clone_all_items` so a huge copy fails with a graceful `MemoryError`.
 fn list_copy(list: &List, heap: &Heap) -> RunResult<Value> {
-    heap.tracker()
+    heap.tracker
         .check_allocation(list.items.len().saturating_mul(VALUE_SIZE))?;
     let items: Vec<Value> = list.items.iter().map(|v| v.clone_with_heap(heap)).collect();
     let heap_id = heap.allocate(HeapData::List(List::new(items)));

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -325,8 +325,8 @@ impl<'a, 'h> ListIter<'a, 'h> {
     /// until the iterator itself is dropped), at which point the held item
     /// is released.
     ///
-    /// Performs a time-limit check on every call so long
-    /// Rust-side loops cannot bypass the configured timeout.
+    /// Performs an amortized time-limit check (a clock read every 64th
+    /// call) so long Rust-side loops cannot bypass the configured timeout.
     pub(crate) fn next<'i>(&'i mut self, vm: &mut VM<'h>) -> RunResult<Option<&'i Value>> {
         // Drop the previously-yielded item (no-op when `current` is `Undefined`).
         mem::replace(&mut self.current, Value::Undefined).drop_with(vm.heap);

--- a/crates/monty/src/types/long_int.rs
+++ b/crates/monty/src/types/long_int.rs
@@ -193,7 +193,7 @@ impl LongInt {
     /// Left-shifts an immediate integer, promoting only when the result requires it.
     pub(crate) fn left_shift_i64(value: i64, shift: u64, vm: &mut VM<'_>) -> RunResult<Value> {
         let bits = u64::from(i64::BITS - value.unsigned_abs().leading_zeros());
-        check_lshift_size(bits, shift, vm.heap.tracker())?;
+        check_lshift_size(bits, shift, &vm.heap.tracker)?;
         if value == 0 {
             Ok(Value::Int(0))
         } else if let Ok(shift) = u32::try_from(shift)
@@ -500,7 +500,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, LongInt> {
         let lhs = self.get(vm.heap);
         let result = match other {
             Value::Int(rhs) => {
-                check_mult_size(lhs.bits(), i64_bits(*rhs), vm.heap.tracker())?;
+                check_mult_size(lhs.bits(), i64_bits(*rhs), &vm.heap.tracker)?;
                 Some(LongInt::new(lhs.inner() * rhs).into_value(vm.heap))
             }
             Value::Bool(rhs) => Some(if *rhs {
@@ -510,7 +510,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, LongInt> {
             }),
             Value::Float(rhs) => Some(Value::Float(long_int_to_f64(lhs) * rhs)),
             Value::Ref(id) if let HeapData::LongInt(rhs) = vm.heap.get(*id) => {
-                check_mult_size(lhs.bits(), rhs.bits(), vm.heap.tracker())?;
+                check_mult_size(lhs.bits(), rhs.bits(), &vm.heap.tracker)?;
                 Some(LongInt::new(lhs.inner() * rhs.inner()).into_value(vm.heap))
             }
             _ => None,
@@ -560,7 +560,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, LongInt> {
         let result = match other {
             Value::Int(0) | Value::Bool(false) => return Err(ExcType::zero_division().into()),
             Value::Int(rhs) => {
-                check_div_size(lhs.bits(), vm.heap.tracker())?;
+                check_div_size(lhs.bits(), &vm.heap.tracker)?;
                 lhs.inner().div_floor(&BigInt::from(*rhs))
             }
             Value::Bool(true) => lhs.inner().clone(),
@@ -568,7 +568,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, LongInt> {
                 if rhs.is_zero() {
                     return Err(ExcType::zero_division().into());
                 }
-                check_div_size(lhs.bits(), vm.heap.tracker())?;
+                check_div_size(lhs.bits(), &vm.heap.tracker)?;
                 lhs.inner().div_floor(rhs.inner())
             }
             _ => return Ok(None),
@@ -586,7 +586,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, LongInt> {
             Value::Bool(lhs) => i64::from(*lhs),
             _ => return Ok(None),
         };
-        check_div_size(i64_bits(lhs), vm.heap.tracker())?;
+        check_div_size(i64_bits(lhs), &vm.heap.tracker)?;
         let result = BigInt::from(lhs).div_floor(rhs.inner());
         Ok(Some(LongInt::new(result).into_value(vm.heap)))
     }
@@ -640,7 +640,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, LongInt> {
             return Ok(None);
         };
         let value = self.get(vm.heap);
-        check_lshift_size(value.bits(), shift, vm.heap.tracker())?;
+        check_lshift_size(value.bits(), shift, &vm.heap.tracker)?;
         Ok(Some(LongInt::new(value.inner() << shift).into_value(vm.heap)))
     }
 
@@ -762,7 +762,7 @@ fn long_int_pow_value(base: &BigInt, exponent: &BigInt, heap: &Heap) -> RunResul
     } else if *base == BigInt::from(-1) {
         Ok(Some(Value::Int(if (exponent % 2i32).is_zero() { 1 } else { -1 })))
     } else if let Some(exponent) = exponent.to_u64() {
-        check_pow_size(base.bits(), exponent, heap.tracker())?;
+        check_pow_size(base.bits(), exponent, &heap.tracker)?;
         Ok(Some(LongInt::new(bigint_pow(base.clone(), exponent)).into_value(heap)))
     } else {
         Err(ExcType::overflow_exponent_too_large())

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -229,7 +229,7 @@ impl<'h> HeapRead<'h, NamedTuple> {
     /// `MemoryError` instead of bursting past the allocator's hard limit.
     pub(crate) fn cloned_items(&self, vm: &mut VM<'h>) -> RunResult<Vec<Value>> {
         let len = self.get(vm.heap).len();
-        vm.heap.tracker().check_allocation(len.saturating_mul(VALUE_SIZE))?;
+        vm.heap.tracker.check_allocation(len.saturating_mul(VALUE_SIZE))?;
         Ok((0..len).map(|i| self.clone_item(i, vm)).collect())
     }
 
@@ -428,7 +428,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
         if count == 0 || len == 0 {
             return Ok(Some(vm.heap.get_empty_tuple()));
         }
-        check_repeat_size(len.saturating_mul(mem::size_of::<Value>()), count, vm.heap.tracker())?;
+        check_repeat_size(len.saturating_mul(mem::size_of::<Value>()), count, &vm.heap.tracker)?;
         let mut result: TupleVec = SmallVec::with_capacity(len * count);
         for rep in 0..count {
             for i in 0..len {
@@ -1046,7 +1046,7 @@ fn cloned_tuple_like_items(value: &Value, vm: &VM<'_>) -> RunResult<Option<Vec<V
         HeapData::NamedTuple(nt) => nt.as_vec().len(),
         _ => return Ok(None),
     };
-    vm.heap.tracker().check_allocation(len.saturating_mul(VALUE_SIZE))?;
+    vm.heap.tracker.check_allocation(len.saturating_mul(VALUE_SIZE))?;
     let mut items = Vec::with_capacity(len);
     for i in 0..len {
         let item = match vm.heap.get(id) {

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -300,8 +300,8 @@ impl<'a, 'h> NamedTupleIter<'a, 'h> {
     /// The returned reference is valid until the next call to `next` (or
     /// until the iterator itself is dropped).
     ///
-    /// Performs a time-limit check on every call so long
-    /// Rust-side loops cannot bypass the configured timeout.
+    /// Performs an amortized time-limit check (a clock read every 64th
+    /// call) so long Rust-side loops cannot bypass the configured timeout.
     pub(crate) fn next<'i>(&'i mut self, vm: &mut VM<'h>) -> RunResult<Option<&'i Value>> {
         // Drop the previously-yielded item (no-op when `current` is `Undefined`).
         mem::replace(&mut self.current, Value::Undefined).drop_with(vm.heap);

--- a/crates/monty/src/types/namedtuple.rs
+++ b/crates/monty/src/types/namedtuple.rs
@@ -300,12 +300,12 @@ impl<'a, 'h> NamedTupleIter<'a, 'h> {
     /// The returned reference is valid until the next call to `next` (or
     /// until the iterator itself is dropped).
     ///
-    /// Performs a [`check_time`](Heap::check_time) on every call so long
+    /// Performs a time-limit check on every call so long
     /// Rust-side loops cannot bypass the configured timeout.
     pub(crate) fn next<'i>(&'i mut self, vm: &mut VM<'h>) -> RunResult<Option<&'i Value>> {
         // Drop the previously-yielded item (no-op when `current` is `Undefined`).
         mem::replace(&mut self.current, Value::Undefined).drop_with(vm.heap);
-        vm.heap.check_time()?;
+        vm.heap.tracker.check_time_every(self.index)?;
         let items = &self.tuple.get(vm.heap).items;
         if self.index >= items.len() {
             return Ok(None);
@@ -430,12 +430,12 @@ impl<'h> PyTrait<'h> for HeapRead<'h, NamedTuple> {
         }
         check_repeat_size(len.saturating_mul(mem::size_of::<Value>()), count, vm.heap.tracker())?;
         let mut result: TupleVec = SmallVec::with_capacity(len * count);
-        for _ in 0..count {
+        for rep in 0..count {
             for i in 0..len {
                 let item = self.get(vm.heap).as_vec()[i].clone_with_heap(vm.heap);
                 result.push(item);
             }
-            vm.heap.check_time()?;
+            vm.heap.tracker.check_time_every(rep)?;
         }
         Ok(Some(allocate_tuple(result, vm.heap)))
     }

--- a/crates/monty/src/types/re_pattern.rs
+++ b/crates/monty/src/types/re_pattern.rs
@@ -298,7 +298,7 @@ impl RePattern {
             caps.expand(rust_repl.as_ref(), &mut result);
             last_end = m.end();
             // Check running size: current result + remaining unprocessed text.
-            check_estimated_size(result.len() + (text.len() - last_end), heap.tracker())?;
+            check_estimated_size(result.len() + (text.len() - last_end), &heap.tracker)?;
         }
 
         result.push_str(&text[last_end..]);

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -525,7 +525,7 @@ impl<'h> HeapRead<'h, SetStorage> {
         // Format a refcount-bumped snapshot of the elements: CPython's set repr
         // copies to a list first, so a user `__repr__` mutating the set
         // mid-format changes nothing (and can't invalidate indices here).
-        vm.heap.tracker().check_allocation(len.saturating_mul(VALUE_SIZE))?;
+        vm.heap.tracker.check_allocation(len.saturating_mul(VALUE_SIZE))?;
         let mut items = Vec::with_capacity(len);
         for i in 0..len {
             // No user code runs during the snapshot, so `len` is still current.
@@ -678,7 +678,7 @@ impl Set {
         defer_drop!(iterator, vm);
         let mut iterator = iterator.read(vm);
         let hint = iterator.iter_size_hint(vm);
-        let capacity = checked_preallocation_hint(hint, mem::size_of::<SetEntry>(), vm.heap.tracker())?;
+        let capacity = checked_preallocation_hint(hint, mem::size_of::<SetEntry>(), &vm.heap.tracker)?;
         let mut set = Self::with_capacity(capacity);
         while let Some(item) = iterator.py_next(vm)? {
             set.add(item, vm)?;

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -354,7 +354,7 @@ impl<'a, 'h> SetIter<'a, 'h> {
     pub(crate) fn next<'i>(&'i mut self, vm: &mut VM<'h>) -> RunResult<Option<&'i Value>> {
         // Drop the previously-yielded element (no-op when `current` is `Undefined`).
         mem::replace(&mut self.current, Value::Undefined).drop_with(vm.heap);
-        vm.heap.check_time()?;
+        vm.heap.tracker.check_time_every(self.index)?;
         let current = self.storage.get(vm.heap);
         if current.entries.len() != self.expected_len {
             return Err(ExcType::runtime_error_set_changed_size());

--- a/crates/monty/src/types/slice.rs
+++ b/crates/monty/src/types/slice.rs
@@ -260,8 +260,10 @@ pub(crate) fn slice_collect_iterator<Iter: DoubleEndedIterator + Clone, U, T: Fr
     let length = iter.clone().count();
     let (start, stop, step) = slice.indices(length)?;
 
+    let mut i = 0usize;
     let final_collect_op = |item| -> RunResult<U> {
-        vm.heap.check_time()?;
+        vm.heap.tracker.check_time_every(i)?;
+        i += 1;
         Ok(collect_map(item))
     };
 

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -1361,8 +1361,8 @@ fn str_split<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h>) -> Run
 
     // Convert to list of strings (using interned empty string when applicable)
     let mut list_items = Vec::with_capacity(parts.len());
-    for part in parts {
-        vm.heap.check_time()?;
+    for (i, part) in parts.into_iter().enumerate() {
+        vm.heap.tracker.check_memory_time_every(i)?;
         list_items.push(allocate_string(part, vm.heap));
     }
 
@@ -1410,8 +1410,8 @@ fn str_rsplit<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h>) -> Ru
 
     // Convert to list of strings (using interned empty string when applicable)
     let mut list_items = Vec::with_capacity(parts.len());
-    for part in parts {
-        vm.heap.check_time()?;
+    for (i, part) in parts.into_iter().enumerate() {
+        vm.heap.tracker.check_memory_time_every(i)?;
         list_items.push(allocate_string(part, vm.heap));
     }
 
@@ -1520,7 +1520,7 @@ fn str_splitlines<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h>) -
     let len = bytes.len();
 
     while start < len {
-        vm.heap.check_time()?;
+        vm.heap.tracker.check_memory_time_every(lines.len())?;
 
         // Find the next line ending
         let mut end = start;

--- a/crates/monty/src/types/str.rs
+++ b/crates/monty/src/types/str.rs
@@ -200,7 +200,7 @@ pub fn allocate_string_no_interning(s: impl Into<Box<str>>, heap: &Heap) -> Valu
 
 /// Repeats a string after validating the allocation against resource limits.
 pub(crate) fn repeat_str(value: &str, count: usize, heap: &Heap) -> Result<Value, ResourceError> {
-    check_repeat_size(value.len(), count, heap.tracker())?;
+    check_repeat_size(value.len(), count, &heap.tracker)?;
     Ok(allocate_string(value.repeat(count), heap))
 }
 
@@ -227,7 +227,7 @@ pub fn allocate_char(c: char, heap: &Heap) -> Value {
 /// is fine per the `StringBuilder` rule.
 pub(crate) fn concat_allocate_str(a: &str, b: &str, heap: &Heap) -> Result<Value, ResourceError> {
     let result_len = a.len().saturating_add(b.len());
-    check_repeat_size(result_len, 1, heap.tracker())?;
+    check_repeat_size(result_len, 1, &heap.tracker)?;
     let mut concat = String::with_capacity(result_len);
     concat.push_str(a);
     concat.push_str(b);
@@ -1661,7 +1661,7 @@ fn str_replace<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h>) -> R
     let (old, new, count) = parse_replace_args("str.replace", args, vm)?;
     let s = s.get(vm.heap);
 
-    check_replace_size(s.len(), old.len(), new.len(), count, vm.heap.tracker())?;
+    check_replace_size(s.len(), old.len(), new.len(), count, &vm.heap.tracker)?;
 
     let result = if count < 0 {
         s.replace(&old, &new)
@@ -1724,7 +1724,7 @@ fn str_center<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h>) -> Ru
         // `width * fillchar.len_utf8()` would mis-charge the `s`-slot bytes.
         let total_pad = width - len;
         let capacity = s.len().saturating_add(total_pad.saturating_mul(fillchar.len_utf8()));
-        let mut builder = StringBuilder::with_capacity(capacity, vm.heap.tracker())?;
+        let mut builder = StringBuilder::with_capacity(capacity, &vm.heap.tracker)?;
         let left_pad = total_pad / 2;
         let right_pad = total_pad - left_pad;
         for _ in 0..left_pad {
@@ -1751,7 +1751,7 @@ fn str_ljust<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h>) -> Run
     } else {
         let pad = width - len;
         let capacity = s.len().saturating_add(pad.saturating_mul(fillchar.len_utf8()));
-        let mut builder = StringBuilder::with_capacity(capacity, vm.heap.tracker())?;
+        let mut builder = StringBuilder::with_capacity(capacity, &vm.heap.tracker)?;
         builder.push_str(s)?;
         for _ in 0..pad {
             builder.push(fillchar)?;
@@ -1773,7 +1773,7 @@ fn str_rjust<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h>) -> Run
     } else {
         let pad = width - len;
         let capacity = s.len().saturating_add(pad.saturating_mul(fillchar.len_utf8()));
-        let mut builder = StringBuilder::with_capacity(capacity, vm.heap.tracker())?;
+        let mut builder = StringBuilder::with_capacity(capacity, &vm.heap.tracker)?;
         for _ in 0..pad {
             builder.push(fillchar)?;
         }
@@ -1841,7 +1841,7 @@ fn str_zfill<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h>) -> Run
         // rather than `width` (character count).
         let pad = width - len;
         let capacity = s.len().saturating_add(pad);
-        let mut builder = StringBuilder::with_capacity(capacity, vm.heap.tracker())?;
+        let mut builder = StringBuilder::with_capacity(capacity, &vm.heap.tracker)?;
         let mut chars = s.chars();
         let first = chars.next();
 
@@ -1888,7 +1888,7 @@ fn str_expandtabs<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h>) -
     // know the result size up front, so use the unbounded builder — its 2×
     // growth policy rejects the build at the first push that would exceed the
     // memory limit, capping wasted intermediate allocation to `O(limit)`.
-    let mut builder = StringBuilder::new(vm.heap.tracker());
+    let mut builder = StringBuilder::new(&vm.heap.tracker);
     let mut column = 0;
 
     for c in s.chars() {
@@ -1939,7 +1939,7 @@ fn str_encode<'h>(s: &HeapRead<'h, str>, args: ArgValues, vm: &mut VM<'h>) -> Ru
     let errors = errors.as_ref().map_or("strict", |e| e.as_str(vm));
 
     let codec = Codec::find(encoding).ok_or_else(|| ExcType::lookup_error_unknown_encoding(encoding))?;
-    let bytes = codec.encode(s.get(vm.heap), errors, vm.heap.tracker())?;
+    let bytes = codec.encode(s.get(vm.heap), errors, &vm.heap.tracker)?;
     let heap_id = vm.heap.allocate(HeapData::Bytes(Bytes::new(bytes)));
     Ok(Value::Ref(heap_id))
 }

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -246,12 +246,12 @@ impl<'a, 'h> TupleIter<'a, 'h> {
     /// until the iterator itself is dropped), at which point the held item
     /// is released.
     ///
-    /// Performs a [`check_time`](Heap::check_time) on every call so long
+    /// Performs a time-limit check on every call so long
     /// Rust-side loops cannot bypass the configured timeout.
     pub(crate) fn next<'i>(&'i mut self, vm: &mut VM<'h>) -> RunResult<Option<&'i Value>> {
         // Drop the previously-yielded item (no-op when `current` is `Undefined`).
         mem::replace(&mut self.current, Value::Undefined).drop_with(vm.heap);
-        vm.heap.check_time()?;
+        vm.heap.tracker.check_time_every(self.index)?;
         let items = &self.tuple.get(vm.heap).items;
         if self.index >= items.len() {
             return Ok(None);
@@ -453,9 +453,9 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
             vm.heap.tracker(),
         )?;
         let mut result = SmallVec::with_capacity(value.as_slice().len() * count);
-        for _ in 0..count {
+        for rep in 0..count {
             result.extend(value.as_slice().iter().map(|value| value.clone_with_heap(vm.heap)));
-            vm.heap.check_time()?;
+            vm.heap.tracker.check_time_every(rep)?;
         }
         Ok(Some(allocate_tuple(result, vm.heap)))
     }

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -177,7 +177,7 @@ impl<'h> HeapRead<'h, Tuple> {
     /// `MemoryError` instead of bursting past the allocator's hard limit.
     fn clone_all_items(&self, vm: &mut VM<'h>) -> RunResult<TupleVec> {
         let len = self.get(vm.heap).items.len();
-        vm.heap.tracker().check_allocation(len.saturating_mul(VALUE_SIZE))?;
+        vm.heap.tracker.check_allocation(len.saturating_mul(VALUE_SIZE))?;
         let mut result = TupleVec::with_capacity(len);
         for i in 0..len {
             result.push(self.clone_item(i, vm));
@@ -450,7 +450,7 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Tuple> {
         check_repeat_size(
             value.as_slice().len().saturating_mul(mem::size_of::<Value>()),
             count,
-            vm.heap.tracker(),
+            &vm.heap.tracker,
         )?;
         let mut result = SmallVec::with_capacity(value.as_slice().len() * count);
         for rep in 0..count {

--- a/crates/monty/src/types/tuple.rs
+++ b/crates/monty/src/types/tuple.rs
@@ -246,8 +246,8 @@ impl<'a, 'h> TupleIter<'a, 'h> {
     /// until the iterator itself is dropped), at which point the held item
     /// is released.
     ///
-    /// Performs a time-limit check on every call so long
-    /// Rust-side loops cannot bypass the configured timeout.
+    /// Performs an amortized time-limit check (a clock read every 64th
+    /// call) so long Rust-side loops cannot bypass the configured timeout.
     pub(crate) fn next<'i>(&'i mut self, vm: &mut VM<'h>) -> RunResult<Option<&'i Value>> {
         // Drop the previously-yielded item (no-op when `current` is `Undefined`).
         mem::replace(&mut self.current, Value::Undefined).drop_with(vm.heap);

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -117,6 +117,10 @@ impl<'h> ValueRead<'h, '_> {
     /// This is the timeout boundary for Rust-side loops over retained iterators
     /// (amortized on the view's step count). Bytecode iteration dispatches
     /// directly after the VM's per-opcode check.
+    ///
+    /// The step count lives on the view, so a loop must hold one across its
+    /// iterations; rebuilding one per call (as `itertools.chain` does) never
+    /// polls, and is only safe under a caller whose own view counts.
     pub(crate) fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
         match self {
             Self::Immediate(value) => Err(ExcType::type_error_not_iterator(&value.py_type_name(vm))),

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -1002,7 +1002,7 @@ impl<'h> PyTrait<'h> for Value {
                             } else if let Some(result) = i128::from(*base).checked_pow(exp_u32) {
                                 Ok(Some(wide_i128_into_value(result, vm.heap)))
                             } else {
-                                check_pow_size(i64_bits(*base), u64::from(exp_u32), vm.heap.tracker())?;
+                                check_pow_size(i64_bits(*base), u64::from(exp_u32), &vm.heap.tracker)?;
                                 let bi = BigInt::from(*base).pow(exp_u32);
                                 Ok(Some(LongInt::new(bi).into_value(vm.heap)))
                             }
@@ -1013,7 +1013,7 @@ impl<'h> PyTrait<'h> for Value {
                             #[expect(clippy::cast_sign_loss)]
                             let exp_u64 = *exp as u64;
                             // Check size before computing to prevent DoS
-                            check_pow_size(i64_bits(*base), exp_u64, vm.heap.tracker())?;
+                            check_pow_size(i64_bits(*base), exp_u64, &vm.heap.tracker)?;
                             let bi = bigint_pow(BigInt::from(*base), exp_u64);
                             Ok(Some(LongInt::new(bi).into_value(vm.heap)))
                         }

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -121,7 +121,7 @@ impl<'h> ValueRead<'h, '_> {
         match self {
             Self::Immediate(value) => Err(ExcType::type_error_not_iterator(&value.py_type_name(vm))),
             Self::Heap { owner, value, steps } => {
-                vm.heap.tracker.check_time_every(*steps)?;
+                vm.heap.tracker.check_memory_time_every(*steps)?;
                 *steps += 1;
                 value.py_next(owner.ref_id(), vm)
             }

--- a/crates/monty/src/value.rs
+++ b/crates/monty/src/value.rs
@@ -105,19 +105,26 @@ pub(crate) enum ValueRead<'h, 'v> {
         /// to drive a user-defined `__next__`.
         owner: &'v Value,
         value: HeapReadOutput<'h>,
+        /// `py_next` calls made through this view, keying its amortized
+        /// time check.
+        steps: usize,
     },
 }
 
 impl<'h> ValueRead<'h, '_> {
     /// Advances this value without reacquiring its heap entry.
     ///
-    /// This is the timeout boundary for Rust-side loops over retained iterators.
-    /// Bytecode iteration dispatches directly after the VM's per-opcode check.
+    /// This is the timeout boundary for Rust-side loops over retained iterators
+    /// (amortized on the view's step count). Bytecode iteration dispatches
+    /// directly after the VM's per-opcode check.
     pub(crate) fn py_next(&mut self, vm: &mut VM<'h>) -> RunResult<Option<Value>> {
-        vm.heap.check_time()?;
         match self {
             Self::Immediate(value) => Err(ExcType::type_error_not_iterator(&value.py_type_name(vm))),
-            Self::Heap { owner, value } => value.py_next(owner.ref_id(), vm),
+            Self::Heap { owner, value, steps } => {
+                vm.heap.tracker.check_time_every(*steps)?;
+                *steps += 1;
+                value.py_next(owner.ref_id(), vm)
+            }
         }
     }
 
@@ -1589,6 +1596,7 @@ impl Value {
             Self::Ref(id) => ValueRead::Heap {
                 owner: self,
                 value: vm.heap.read(*id),
+                steps: 0,
             },
             _ => ValueRead::Immediate(self),
         }

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -582,7 +582,7 @@ fn timeout_in_str_join() {
 /// Test that the insertion sort inner loop in `sorted()` respects the time limit.
 ///
 /// Uses reverse-sorted data to trigger worst-case O(n^2) insertion sort behavior.
-/// The sort comparison loop has an explicit `heap.check_time()` call.
+/// The sort comparison loop polls the time limit (amortized, every 64th comparison).
 #[test]
 fn timeout_in_sorted_comparison_loop() {
     // Build a reverse-sorted list, then sort it. Insertion sort on reverse-sorted

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -723,6 +723,28 @@ fn call_function_enforces_max_duration() {
     assert_eq!(exc.exc_type(), ExcType::TimeoutError);
 }
 
+/// Feeds shorter than the dispatch-checkpoint interval never probe GC inside
+/// the run loop, so only the host-boundary probe in `finish_host_turn` keeps
+/// a stream of tiny cycle-making snippets from accumulating garbage (and from
+/// tripping the boundary memory check on memory a collection would reclaim).
+#[test]
+#[cfg(feature = "ref-count-return")]
+fn short_repl_feeds_still_collect_cycles() {
+    let limits = ResourceLimits::default().gc_interval(1);
+    let mut repl = MontyRepl::new("test.py", ResourceTracker::new(limits), CompileOptions::default());
+    for _ in 0..20 {
+        // Rebinding `c` orphans the previous iteration's cycle; each feed is
+        // fewer instructions than the dispatch checkpoint interval.
+        repl.feed_run("c = []", vec![], PrintWriter::Stdout).unwrap();
+        repl.feed_run("c.append(c)", vec![], PrintWriter::Stdout).unwrap();
+    }
+    assert!(
+        repl.heap_entry_count() <= 3,
+        "boundary GC probe should collect orphaned cycles: {} live heap entries",
+        repl.heap_entry_count()
+    );
+}
+
 /// `call_function` applies the same host-boundary epilogue as `feed_run`: a
 /// call whose over-budget repr truncates (swallowing the timeout) must still
 /// fail rather than return the truncated value, and the discarded result's

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -365,10 +365,11 @@ result
 
 // === Timeout enforcement in builtin iteration loops ===
 // These tests verify that `max_duration_secs` is enforced inside Rust-side loops
-// within builtin functions. Previously, builtins like sum(), sorted(), min(), max()
-// ran Rust loops entirely within a single bytecode instruction, bypassing the VM's
-// per-instruction timeout check. The fix adds `heap.check_time()` calls inside
-// Python iterator advancement and other non-iterator loops.
+// within builtin functions. Builtins like sum(), sorted(), min(), max() run Rust
+// loops entirely within a single bytecode instruction, so they would otherwise
+// bypass the VM's dispatch checkpoint entirely. Python iterator advancement and
+// the other non-iterator loops therefore poll the tracker themselves, amortized
+// via `check_time_every` / `check_memory_time_every`.
 
 /// Helper: runs code with a short time limit and asserts it produces a TimeoutError promptly.
 fn assert_timeout_in_builtin(code: &str, label: &str) {
@@ -394,7 +395,7 @@ fn assert_timeout_in_builtin(code: &str, label: &str) {
 
 /// Test that `sum(range(huge))` respects the time limit.
 ///
-/// `sum()` iterates via `for_next()` which now calls `heap.check_time()`.
+/// `sum()` iterates via `for_next()`, which polls the time limit every 64th step.
 #[test]
 fn timeout_in_sum_builtin() {
     assert_timeout_in_builtin("sum(range(10**18))", "sum(range(10**18))");
@@ -596,8 +597,8 @@ sorted(x)
 
 /// Test that `[1] * 10_000_000` (list repetition) respects the time limit.
 ///
-/// The sequence-repetition copy loop in `py_mult` now calls `heap.check_time()`
-/// on each repetition to prevent large sequence multiplications from bypassing timeout.
+/// The sequence-repetition copy loop in `py_mult` polls the time limit every
+/// 64th repetition, so a large multiplication cannot bypass the timeout.
 #[test]
 fn timeout_in_list_repetition() {
     assert_timeout_in_builtin("[1, 2, 3] * 10_000_000", "list repetition");
@@ -643,7 +644,7 @@ a == b
 /// Test that `str.splitlines()` on a large string respects the time limit.
 ///
 /// `str_splitlines()` scans the entire string for line endings in a while loop
-/// that now calls `heap.check_time()` on each iteration.
+/// that polls the limits every 64th line.
 #[test]
 fn timeout_in_str_splitlines() {
     let code = r"
@@ -668,8 +669,8 @@ s.splitlines()
 // === Timeout truncation in repr ===
 // These tests verify that `repr()` on large containers respects the time limit
 // and terminates promptly instead of hanging indefinitely. The repr methods
-// (`repr_sequence_fmt`, `Dict::py_repr_fmt`, `SetInner::repr_fmt`) call
-// `heap.check_time()` on each iteration and write `...[timeout]` when the
+// (`repr_sequence_fmt`, `Dict::py_repr_fmt`, `SetInner::repr_fmt`) poll the
+// limits every 64th item via `repr_check_time` and write `...[timeout]` when the
 // time limit is exceeded, returning normally instead of propagating an error.
 //
 // Each test uses the external function "interrupt" pattern: the large object is
@@ -721,6 +722,34 @@ fn call_function_enforces_max_duration() {
         .call_function("spin", vec![], PrintWriter::Stdout)
         .expect_err("infinite loop must hit the time limit");
     assert_eq!(exc.exc_type(), ExcType::TimeoutError);
+}
+
+/// The key pass computes every key before the first comparison, and a key
+/// shorter than the dispatch interval reaches no checkpoint — so the key
+/// loop's own poll is all that bounds it. `sort`, not `sorted`, so no
+/// collection phase polls first.
+#[test]
+fn timeout_in_sort_key_loop() {
+    let mut repl = MontyRepl::new("test.py", ResourceTracker::default(), CompileOptions::default());
+    repl.feed_run(
+        "x = [0] * 4_000_000\ndef f(v):\n    return v",
+        vec![],
+        PrintWriter::Stdout,
+    )
+    .unwrap();
+    repl.tracker_mut().set_max_duration(Duration::from_millis(50));
+    let start = Instant::now();
+    let exc = repl
+        .feed_run("x.sort(key=f)", vec![], PrintWriter::Stdout)
+        .expect_err("the key loop must hit the time limit");
+    let elapsed = start.elapsed();
+    assert_eq!(exc.exc_type(), ExcType::TimeoutError);
+    // Polled, this stops one budget in at any machine speed; unpolled it runs
+    // all 4M key calls before anything re-checks, which takes seconds.
+    assert!(
+        elapsed < Duration::from_millis(500),
+        "should stop promptly, took {elapsed:?}"
+    );
 }
 
 /// Feeds shorter than the dispatch-checkpoint interval never probe GC inside

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -767,6 +767,28 @@ fn call_function_rechecks_limits_at_exit() {
     assert_eq!(exc.exc_type(), ExcType::TimeoutError);
 }
 
+/// The boundary limit check also covers turns ending in a Python exception:
+/// session state survives exceptions, so an allocate-then-raise turn must
+/// surface the uncatchable resource error, not its own exception, or repeated
+/// short erroring feeds could evade the limits entirely.
+#[test]
+fn erroring_turns_still_hit_limits_at_exit() {
+    let mut repl = MontyRepl::new("test.py", ResourceTracker::default(), CompileOptions::default());
+    repl.feed_run(
+        "x = ['abcdefghij'] * 100_000\ndef f():\n    s = repr(x)\n    raise ValueError(s[:3])",
+        vec![],
+        PrintWriter::Stdout,
+    )
+    .unwrap();
+    // The over-budget repr truncates (swallowing the timeout), then the raise
+    // ends the turn before any dispatch checkpoint can fire.
+    repl.tracker_mut().set_max_duration(Duration::from_millis(10));
+    let exc = repl
+        .call_function("f", vec![], PrintWriter::Stdout)
+        .expect_err("the call must fail");
+    assert_eq!(exc.exc_type(), ExcType::TimeoutError);
+}
+
 /// Helper: builds a large object without time limit, then runs `repr()` on it
 /// with a short time limit and asserts it produces a TimeoutError promptly.
 ///

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -723,6 +723,28 @@ fn call_function_enforces_max_duration() {
     assert_eq!(exc.exc_type(), ExcType::TimeoutError);
 }
 
+/// `call_function` applies the same host-boundary epilogue as `feed_run`: a
+/// call whose over-budget repr truncates (swallowing the timeout) must still
+/// fail rather than return the truncated value, and the discarded result's
+/// refcounts are released (verified under `memory-model-checks`).
+#[test]
+fn call_function_rechecks_limits_at_exit() {
+    let mut repl = MontyRepl::new("test.py", ResourceTracker::default(), CompileOptions::default());
+    repl.feed_run(
+        "x = ['abcdefghij'] * 100_000\ndef f():\n    return repr(x)",
+        vec![],
+        PrintWriter::Stdout,
+    )
+    .unwrap();
+    // Arm a budget only for the call: repr of 100K strings blows it mid-format
+    // and truncates, so only the exit re-check can surface the timeout.
+    repl.tracker_mut().set_max_duration(Duration::from_millis(10));
+    let exc = repl
+        .call_function("f", vec![], PrintWriter::Stdout)
+        .expect_err("over-budget repr must fail the call even though it truncates");
+    assert_eq!(exc.exc_type(), ExcType::TimeoutError);
+}
+
 /// Helper: builds a large object without time limit, then runs `repr()` on it
 /// with a short time limit and asserts it produces a TimeoutError promptly.
 ///

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -133,12 +133,23 @@ overflow, which is why the sandbox exits deliberately instead.)
 
 ## Time
 
-- The host can set a `max_duration` budget; if exceeded the VM stops on
-  the next bytecode boundary with `ResourceError`.
+- The host can set a `max_duration` budget; if exceeded the VM stops with a
+  `ResourceError` at its next checkpoint.
 - Enforcement is polled, not preemptive: a single bytecode instruction may
   run a long native operation (a `bytes` substring scan, a sort, an iterator
   drain), and those poll the clock at a coarse granularity. A run can
   therefore overshoot `max_duration` before stopping.
+- Checkpoints are amortized rather than per-instruction: the dispatch loop
+  reads the clock every 256th instruction, and the native loops that poll for
+  themselves (iterator advancement, sequence repeats, comparisons, `repr`)
+  do so every 64th item. Both are unconditional overshoots of ordinary
+  `max_duration` enforcement, on top of the per-operation cases below.
+- Every host turn re-checks both limits as it returns, so a turn that
+  finished without reaching a checkpoint still fails rather than returning
+  its result. Two consequences: a turn whose Python code raised an exception
+  reports the resource error instead of that exception, and an operation
+  that swallows a timeout internally (`repr` truncating with `...[timeout]`)
+  still fails the turn that contained it.
 - `bytes` operations that search for a sub-sequence (`in` with a bytes-like
   probe, `find`, `count`, `split`, `partition`, `replace` and their
   variants) poll the clock every 64KiB, or every two lengths of the


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Raised the VM’s checkpoint interval and folded GC into it, then added a host-boundary epilogue that rechecks memory+time so short runs and truncating reprs can’t bypass limits. Made `heap.tracker` public and switched loops, iterators, and the sort key pass to cheap, amortized checks; boundary GC time is charged, and the epilogue skips GC when the turn ended with a resource error.

- **Refactors**
  - Added `ResourceTracker::{has_memory_time_limit, check_memory_time, check_time_every, check_memory_time_every}` and `LOOP_CHECK_INTERVAL` (64); amortized checks fire at block end.
  - Dispatch loop runs an outlined `dispatch_checkpoint` on a `u8::MAX` countdown; it checks limits only when armed and probes GC, keeping the hot path to one decrement-and-branch.
  - Introduced `VM::finish_host_turn` (used by `run_external` and `MontyRepl::call_function`) to re-check memory+time at the host boundary, probe GC once per turn while charging it to the execution clock, drop discarded results with `drop_with`, out-rank turn errors with uncatchable resource errors, and skip GC after a resource error.
  - Removed `Heap::{check_time, tracker, tracker_mut}`; `Heap::tracker` is public and call sites now pass `&heap.tracker`. Replaced per-call checks across comparisons, repr (incl. dataclass), bytes/str split/replace/splitlines, deque/list/tuple/namedtuple/set/dict views/iters, slice collection, `py_next`, and sorting (incl. key pass) with `tracker.check_time_every(...)`/`check_memory_time_every(...)`.
  - Added with-limits benches (`loop_mod_13_limits__monty`, `kitchen_sink_limits__monty`) to measure the amortized path.

- **Migration**
  - In Rust-side loops, replace `heap.check_time()` with:
    - `heap.tracker.check_time_every(i)` for pure time checks, or
    - `heap.tracker.check_memory_time_every(i)` when allocating per item; use `heap.tracker.check_time()`/`check_memory_time()` for single checks.
  - Where a tracker is passed, switch from `heap.tracker()`/`heap.tracker_mut()` to `&heap.tracker`/`&mut heap.tracker`.

<sup>Written for commit cc2a68b36c0427e14a7681fb2d25ba54fa8ea33f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

