### PR TITLE
Outline cold opcode handlers from the VM dispatch loop

### DIFF
--- a/crates/monty/src/bytecode/vm/attr.rs
+++ b/crates/monty/src/bytecode/vm/attr.rs
@@ -27,6 +27,10 @@ impl VM<'_> {
     ///
     /// Returns an ImportError (not AttributeError) if the attribute doesn't exist,
     /// matching CPython's behavior for `from module import name`.
+    ///
+    /// Out-of-line: cold opcode; keeps `VM::run`'s dispatch loop small
+    /// (I-cache/register pressure).
+    #[inline(never)]
     pub(super) fn load_attr_import(&mut self, name_id: StringId) -> Result<CallResult, RunError> {
         let this = self;
 

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -208,6 +208,10 @@ impl VM<'_> {
     /// Pops the object, positional args, and keyword args from the stack,
     /// builds the appropriate `ArgValues`, and calls the attribute.
     /// Returns a `CallResult` which may indicate an OS or external call.
+    ///
+    /// Out-of-line: uncommon call shape; keeps `VM::run`'s dispatch loop
+    /// small (I-cache/register pressure).
+    #[inline(never)]
     pub(super) fn exec_call_attr_kw(
         &mut self,
         name_id: StringId,

--- a/crates/monty/src/bytecode/vm/collections.rs
+++ b/crates/monty/src/bytecode/vm/collections.rs
@@ -169,6 +169,10 @@ impl VM<'_> {
     ///
     /// Uses `defer_drop!` for `mapping` (always dropped) and `DropGuard` for
     /// `dict_ref` (pushed back on success, dropped on error).
+    ///
+    /// Out-of-line: cold opcode; keeps `VM::run`'s dispatch loop
+    /// small (I-cache/register pressure).
+    #[inline(never)]
     pub(super) fn dict_merge(&mut self, func_name_id: u16) -> Result<(), RunError> {
         let func_name = func_name_for_dict_merge(func_name_id, self);
         self.dict_merge_inner(&func_name)
@@ -180,6 +184,10 @@ impl VM<'_> {
     /// kwargs_dict, mapping]`), since the call body hasn't issued any pops
     /// yet. Produces e.g. `list.sort() got multiple values for keyword
     /// argument 'key'` to match CPython.
+    ///
+    /// Out-of-line: cold opcode; keeps `VM::run`'s dispatch loop small
+    /// (I-cache/register pressure).
+    #[inline(never)]
     pub(super) fn method_dict_merge(&mut self, func_name_id: u16) -> Result<(), RunError> {
         let func_name = if func_name_id == 0xFFFF {
             "<unknown>".to_string()
@@ -527,6 +535,10 @@ impl VM<'_> {
     ///
     /// For example, `first, *rest, last = [1, 2, 3, 4, 5]` has before=1, after=1.
     /// After execution, the stack has: first (top), rest_list, last.
+    ///
+    /// Out-of-line: cold opcode; keeps `VM::run`'s dispatch loop small
+    /// (I-cache/register pressure).
+    #[inline(never)]
     pub(super) fn unpack_ex(&mut self, before: usize, after: usize) -> Result<(), RunError> {
         let this = self;
 

--- a/crates/monty/src/bytecode/vm/context_manager.rs
+++ b/crates/monty/src/bytecode/vm/context_manager.rs
@@ -24,6 +24,10 @@ impl VM<'_> {
     /// `TypeError` is gated on [`PyTrait::py_is_context_manager`] so we never
     /// have to sniff exception messages — a real context manager whose
     /// `__enter__` itself raises `AttributeError` propagates unchanged.
+    ///
+    /// Out-of-line: cold opcode; keeps `VM::run`'s dispatch loop small
+    /// (I-cache/register pressure).
+    #[inline(never)]
     pub(super) fn exec_before_with(&mut self) -> RunResult<CallResult> {
         // Pattern-matching `*self.peek()` is a place expression so it doesn't
         // move the whole Value — Rust only copies the HeapId out. Non-Ref
@@ -43,6 +47,10 @@ impl VM<'_> {
     /// and push the result. The compiler emits a trailing `Pop` to discard the
     /// result; splitting "call + discard" lets the call yield to the host while
     /// the discard happens once the host has resumed with the return value.
+    ///
+    /// Out-of-line: cold opcode; keeps `VM::run`'s dispatch loop small
+    /// (I-cache/register pressure).
+    #[inline(never)]
     pub(super) fn exec_with_exit(&mut self) -> RunResult<CallResult> {
         let this = self;
         let ctx = this.pop();
@@ -65,6 +73,10 @@ impl VM<'_> {
     /// compiler-emitted `JumpIfTrue` then branches on its truthiness to either
     /// suppress (Pop ctx, Pop exc, ClearException) or re-raise (Pop ctx, Pop exc,
     /// Reraise).
+    ///
+    /// Out-of-line: cold opcode; keeps `VM::run`'s dispatch loop small
+    /// (I-cache/register pressure).
+    #[inline(never)]
     pub(super) fn exec_with_except_start(&mut self) -> RunResult<CallResult> {
         let len = self.stack.len();
         // Pattern-match via place expressions so neither stack slot is moved.

--- a/crates/monty/src/bytecode/vm/exceptions.rs
+++ b/crates/monty/src/bytecode/vm/exceptions.rs
@@ -243,6 +243,10 @@ impl VM<'_> {
     /// [`handle_exception`](Self::handle_exception) reusing an already-built
     /// exception instead of reallocating an identical one per level; this also
     /// preserves its identity, as CPython does. Owned: dropped if unused.
+    ///
+    /// Out-of-line: raise/unwind path expanded at many `catch_sync!` sites;
+    /// keeps `VM::run` small.
+    #[inline(never)]
     pub(super) fn handle_exception_with_value(
         &mut self,
         mut error: RunError,
@@ -433,6 +437,9 @@ impl VM<'_> {
     /// on the first match: an invalid element raises the `TypeError` even when an
     /// earlier element already matched (e.g. `except (TypeError, (ValueError,))`
     /// raising `TypeError` still raises the `TypeError` about catching classes).
+    ///
+    /// Out-of-line: only runs in `except` clauses; keeps `VM::run`'s dispatch loop small.
+    #[inline(never)]
     pub(super) fn check_exc_match(&self, exception: &Value, exc_type: &Value) -> Result<bool, RunError> {
         let exc_type_enum = exception.py_type(self);
         match exc_type {


### PR DESCRIPTION
Mark ten cold handler methods (`unpack_ex`, `dict_merge`, with-statement ops, exception match/unwind, kw method calls, import attr loads) `#[inline(never)]` so their bodies stay out of `VM::run`. 

This frees enough registers for the hot loop to keep the cached code pointer live instead of reloading it from a spill slot on every opcode.


Claude-Session: https://claude.ai/code/session_01HbZqFxoKRfCeBgU239PMij

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Outlined ten cold opcode handlers with #[inline(never)] to move them out of `VM::run`’s dispatch loop. This lowers register/I-cache pressure, keeps the cached code pointer in a register, shrinks `VM::run` ~4%, and delivers ~1% geomean speedups with 0.7–3.6% wins on interpreter-heavy benches and ~1% regressions on a few (json_dumps, end_to_end, func_call_kwargs).

- **Refactors**
  - Handlers outlined: `load_attr_import`, `exec_call_attr_kw`; `dict_merge`, `method_dict_merge`, `unpack_ex`; `exec_before_with`, `exec_with_exit`, `exec_with_except_start`, `handle_exception_with_value`, `check_exc_match`.

<sup>Written for commit db30bd393df923dba0f3c297cff82aa9ade6b17f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

