### PR TITLE
Fix `StackFrame` wire validation rejecting multi-line spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2535,6 +2535,7 @@ dependencies = [
 name = "monty-proto"
 version = "0.0.21"
 dependencies = [
+ "insta",
  "monty",
  "monty-type-checking",
  "monty-types",

--- a/crates/monty-proto/Cargo.toml
+++ b/crates/monty-proto/Cargo.toml
@@ -55,6 +55,7 @@ name = "dispatch"
 required-features = ["worker"]
 
 [dev-dependencies]
+insta = { workspace = true }
 monty = { workspace = true }
 
 [lints]

--- a/crates/monty-proto/src/convert/exception.rs
+++ b/crates/monty-proto/src/convert/exception.rs
@@ -197,12 +197,16 @@ impl TryFrom<pb::StackFrame> for StackFrame {
         let start = CodeLoc::from(frame.start.ok_or(ProtoConvertError::MissingField("StackFrame.start"))?);
         let end = CodeLoc::from(frame.end.ok_or(ProtoConvertError::MissingField("StackFrame.end"))?);
         // Frames are untrusted wire data, and `StackFrame`'s `Display` derives
-        // caret padding/width from the columns when a preview is present.
-        // Unvalidated coordinates would let a compromised peer trigger an
-        // integer-underflow panic or a huge allocation when the traceback is
-        // rendered. Monty only attaches a preview for same-line spans with
-        // in-bounds columns, so rejecting anything else loses no real frames.
-        if let Some(preview) = &frame.preview_line {
+        // caret padding/width from the columns when a preview is present *and*
+        // the span is single-line. Unvalidated coordinates would let a
+        // compromised peer trigger an integer-underflow panic or a huge
+        // allocation when the traceback is rendered. Multi-line spans carry a
+        // pre-rendered preview block and are printed without any caret math
+        // (their end column is routinely below the start column, e.g. a call
+        // closed by a hanging `)`), so the column checks must not apply there.
+        if let Some(preview) = &frame.preview_line
+            && start.line == end.line
+        {
             if end.column < start.column {
                 return Err(ProtoConvertError::InvalidValue {
                     field: "StackFrame.end.column",

--- a/crates/monty-proto/tests/roundtrip.rs
+++ b/crates/monty-proto/tests/roundtrip.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use insta::assert_snapshot;
 use monty::MontyRun;
 use monty_proto::{MAX_VALUE_DEPTH, ProtoConvertError, WireObject, exceeds_max_value_depth, pb};
 use monty_types::{
@@ -266,6 +267,32 @@ fn invalid_stack_frame_coordinates_are_rejected() {
         })
     ));
     StackFrame::try_from(frame(1, 6)).expect("in-range columns must convert");
+}
+
+/// Multi-line spans render their preview as a pre-computed block with no
+/// caret math, and legitimately end on a lower column than they start (a
+/// call closed by a hanging `)`), so the same-line column validation must
+/// not reject them — regression test for issue #631, where such frames were
+/// discarded as "invalid exception payload", replacing the real exception.
+#[test]
+fn multiline_stack_frame_with_lower_end_column_converts() {
+    let frame = pb::StackFrame {
+        filename: "main.py".to_owned(),
+        start: Some(pb::CodeLoc { line: 4, column: 5 }),
+        end: Some(pb::CodeLoc { line: 6, column: 2 }),
+        frame_name: None,
+        preview_line: Some("r = f(\n    a=1,\n)".to_owned()),
+        hide_caret: false,
+        hide_frame_name: false,
+    };
+    let frame = StackFrame::try_from(frame).expect("multi-line span must convert");
+    // rendering takes the caret-free block path, so hostile columns are inert
+    assert_snapshot!(frame, @r#"
+      File "main.py", line 4, in <module>
+        r = f(
+            a=1,
+        )
+    "#);
 }
 
 #[test]

--- a/crates/monty-python/tests/test_exceptions.py
+++ b/crates/monty-python/tests/test_exceptions.py
@@ -364,6 +364,24 @@ ValueError: test message\
 """)
 
 
+def test_multiline_span_traceback(monty_run: RunMonty):
+    # Regression test for #631: a frame spanning multiple lines can end on a
+    # lower column than it starts (hanging-indent `)`); the parent-side wire
+    # validation used to reject the whole exception payload as malformed.
+    with pytest.raises(MontyRuntimeError) as exc_info:
+        monty_run('def f(a):\n    raise ValueError("boom")\n\nr = f(\n    a=1,\n)\n')
+    assert exc_info.value.display() == snapshot("""\
+Traceback (most recent call last):
+  File "<python-input-0>", line 4, in <module>
+    r = f(
+        a=1,
+    )
+  File "<python-input-0>", line 2, in f
+    raise ValueError("boom")
+ValueError: boom\
+""")
+
+
 def test_str_returns_msg(monty_run: RunMonty):
     with pytest.raises(MontyRuntimeError) as exc_info:
         monty_run("raise ValueError('test message')")


### PR DESCRIPTION
The parent-side StackFrame deserializer compared end.column against start.column (and the preview-line length) on every frame with a preview, but those checks only protect the caret math in Display, which runs solely for same-line spans. Multi-line spans carry a pre-rendered preview block, are printed without caret math, and routinely end on a lower column than they start (a call closed by a hanging paren) — so legitimate exception payloads were discarded and replaced by a protocol error that also killed the session.

Scope both column checks to same-line spans, matching Display's branch exactly, and correct the comment that claimed previews are only attached to same-line spans.

Fixes #631 (and folded-in duplicates #572, #707, #710).


Claude-Session: https://claude.ai/code/session_019gjSGkZ6GJKLSWCKd5126p

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stack frame wire validation to accept multi-line spans by enforcing column checks only for same-line previews. Prevents valid exceptions from being rejected and avoids protocol errors that killed sessions (fixes #631).

- **Bug Fixes**
  - Apply column validation only when `start.line == end.line` and `preview_line` exists; allow multi-line frames with lower end columns (e.g., hanging parens).
  - Add regression tests (Rust snapshot and Python) to verify multi-line traceback rendering and exception round-trips.

- **Dependencies**
  - Add `insta` as a dev dependency in `monty-proto` for snapshot testing.

<sup>Written for commit b06362d67c6777093962055ea1223156d51560b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

