### PR TITLE
Arm `pending_os_effect` only at the host boundary

### DIFF
--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -21,7 +21,7 @@ use crate::{
     heap_data::CellValue,
     intern::{FunctionId, StaticStrings, StringId},
     modules::dataclasses,
-    os_dispatch::PendingOsEffect,
+    os_dispatch::{PendingOsEffect, release_pending_effect},
     types::{
         Dict, Instance, PyTrait, Type, bytes::call_bytes_method, construct_namedtuple, instance::class_name,
         str::call_str_method,
@@ -68,11 +68,9 @@ pub(crate) enum CallResult {
     /// [`PendingOsEffect`] instead of being pushed onto the operand stack raw.
     ///
     /// Used by buffered file reads (`BufferStore`), buffered writes
-    /// (`WritePosition`), and `os.listdir` (`ListdirNames`). Carrying the
-    /// effect *in* the result — armed on the VM only at dispatch — guarantees
-    /// a call that is rejected and dropped without dispatch (e.g. inside a
-    /// synchronous nested-call context, see `unsupported_call_result`) cannot
-    /// leave a stale effect behind to corrupt the next OS call's resume.
+    /// (`WritePosition`), and `os.listdir` (`ListdirNames`). The effect stays
+    /// *in* the value, handed on to `FrameExit::OsCall`, so a call rejected on
+    /// the way out cannot corrupt the next OS call's resume.
     OsCallWithEffect {
         call: OsFunctionCall,
         effect: PendingOsEffect,
@@ -90,12 +88,8 @@ impl<C: ContainsHeap> DropWithContext<C> for CallResult {
             Self::FramePushed => {}
             Self::OsCallWithEffect { call, effect } => {
                 call.drop_with(heap);
-                // Single pin (see `inc_ref_for_pending_oscall`): release one
-                // ref if the call is discarded before dispatch arms the
-                // effect on `pending_os_effect`.
-                if let Some(file_id) = effect.pinned_file() {
-                    heap.heap_mut().dec_ref(file_id);
-                }
+                // Discarded before it ever became a `FrameExit`.
+                release_pending_effect(Some(effect), heap);
             }
         }
     }

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -37,7 +37,7 @@ use crate::{
     intern::{FunctionId, Interns, StaticStrings, StringId},
     modules::{StandardLib, json::JsonStringCache, re::RePatternCache},
     object_bridge::MontyObjectExt,
-    os_dispatch::{PendingOsEffect, listdir_names},
+    os_dispatch::{PendingOsEffect, listdir_names, release_pending_effect},
     parse::CodeRange,
     types::{
         Dict, LongInt, PyTrait,
@@ -171,19 +171,22 @@ macro_rules! handle_call_result {
                 let call_id = $self.allocate_call_id();
                 // Sync cached IP back to frame before snapshot for resume
                 $self.current_frame_mut().ip = $cached_frame.ip;
-                return Ok(FrameExit::OsCall { function_call, call_id });
+                return Ok(FrameExit::OsCall {
+                    function_call,
+                    call_id,
+                    effect: None,
+                });
             }
             Ok(CallResult::OsCallWithEffect { call, effect }) => {
                 let call_id = $self.allocate_call_id();
-                // Arm the resume effect only here, at dispatch — a rejected
-                // and dropped `CallResult` must never leave a stale effect
-                // (see `CallResult::OsCallWithEffect`).
-                $self.pending_os_effect = Some(effect);
                 // Sync cached IP back to frame before snapshot for resume
                 $self.current_frame_mut().ip = $cached_frame.ip;
+                // Not armed here — this exit may still be rejected on its
+                // way out, and only a dispatched call earns a `resume`.
                 return Ok(FrameExit::OsCall {
                     function_call: call,
                     call_id,
+                    effect: Some(effect),
                 });
             }
             Ok(CallResult::MethodCall(method_name, args)) => {
@@ -258,6 +261,10 @@ pub enum FrameExit {
         function_call: OsFunctionCall,
         /// Unique ID for this call, used for async correlation.
         call_id: CallId,
+        /// Post-processing for this call's result, armed on
+        /// [`VM::pending_os_effect`] only once the call reaches the host
+        /// (`convert_frame_exit`); dropping the exit releases it instead.
+        effect: Option<PendingOsEffect>,
     },
 
     /// Execution paused for a dataclass method call.
@@ -308,7 +315,13 @@ impl<C: ContainsHeap> DropWithContext<C> for FrameExit {
             Self::ExternalCall { args, .. } | Self::MethodCall { args, .. } => {
                 args.drop_with(heap);
             }
-            Self::OsCall { function_call, .. } => function_call.drop_with(heap),
+            Self::OsCall {
+                function_call, effect, ..
+            } => {
+                function_call.drop_with(heap);
+                // Never reached the host, so no `resume` will consume it.
+                release_pending_effect(effect, heap);
+            }
             Self::ResolveFutures(_) | Self::NameLookup { .. } => {}
         }
     }
@@ -2453,9 +2466,7 @@ impl ContainsHeap for VM<'_> {
 /// `take_globals`) are harmlessly drained as empty.
 impl Drop for VM<'_> {
     fn drop(&mut self) {
-        if let Some(file_id) = self.pending_os_effect.take().and_then(PendingOsEffect::pinned_file) {
-            self.heap.dec_ref(file_id);
-        }
+        release_pending_effect(self.pending_os_effect.take(), self.heap);
         self.exception_stack.drain(..).drop_with(self.heap);
         self.cleanup_current_task();
         self.scheduler.cleanup(self.heap);

--- a/crates/monty/src/os_dispatch.rs
+++ b/crates/monty/src/os_dispatch.rs
@@ -46,11 +46,11 @@ impl<C: ContainsHeap> DropWithContext<C> for OsFunctionCall {
 /// Work the VM must perform on the result of a paused OS call when it
 /// resumes, instead of pushing the raw host value onto the operand stack.
 ///
-/// Travels in [`CallResult::OsCallWithEffect`](crate::bytecode::CallResult)
-/// (which owns the arming/cleanup contract) and is held in the VM's single
-/// `pending_os_effect` slot while the call is in flight — at most one OS call
-/// is in flight per task. `resume_with_exception` clears/rolls back the
-/// pending state so user code that catches the host exception can retry.
+/// Rides inside the suspension value — [`CallResult::OsCallWithEffect`],
+/// then [`FrameExit::OsCall`](crate::bytecode::FrameExit) — and is armed on
+/// the VM's single slot (one call in flight per task) only once the call
+/// reaches the host, where a `resume` becomes guaranteed; anything discarding
+/// the suspension calls [`release_pending_effect`] instead.
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub(crate) enum PendingOsEffect {
     /// Store a full-file read result into the file buffer, then compute the
@@ -81,6 +81,17 @@ impl PendingOsEffect {
             Self::BufferStore { file_id } | Self::WritePosition { file_id, .. } => Some(file_id),
             Self::ListdirNames => None,
         }
+    }
+}
+
+/// Releases an effect that will never be resumed, dropping the file pin it
+/// carried (see `inc_ref_for_pending_oscall`).
+///
+/// Reached via the owner's `drop_with`, or `Drop for VM` once the effect is
+/// armed and no owning value remains.
+pub(crate) fn release_pending_effect(effect: Option<PendingOsEffect>, heap: &mut impl ContainsHeap) {
+    if let Some(file_id) = effect.and_then(PendingOsEffect::pinned_file) {
+        heap.heap_mut().dec_ref(file_id);
     }
 }
 

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -545,36 +545,34 @@ impl Executor {
 /// Used by non-iterative execution paths where suspendable outcomes (external calls,
 /// name lookups) are not supported and should produce errors.
 pub(crate) fn frame_exit_to_object(frame_exit_result: RunResult<FrameExit>, vm: &mut VM<'_>) -> RunResult<MontyObject> {
-    match frame_exit_result? {
-        FrameExit::Return(return_value) => Ok(MontyObject::new(return_value, vm)),
-        // Suspensions this path cannot service. Built from a borrow so one
-        // `drop_with` releases whatever the exit owns, fields added later too.
-        exit => {
-            let error = match &exit {
-                FrameExit::Return(_) => unreachable!("returns are handled above"),
-                FrameExit::ExternalCall { function_name, .. } => {
-                    let function_name = function_name.as_str(vm.interns);
-                    ExcType::not_implemented(format!(
-                        "External function '{function_name}' not implemented with standard execution"
-                    ))
-                }
-                FrameExit::OsCall { function_call, .. } => ExcType::not_implemented(format!(
-                    "OS function '{}' not implemented with standard execution",
-                    function_call.name()
-                )),
-                FrameExit::MethodCall { method_name, .. } => {
-                    let name = method_name.as_str(vm.interns);
-                    ExcType::not_implemented(format!("Method call '{name}' not implemented with standard execution"))
-                }
-                FrameExit::ResolveFutures(_) => {
-                    ExcType::not_implemented("async futures not supported by standard execution.")
-                }
-                FrameExit::NameLookup { name_id, .. } => ExcType::name_error(vm.interns.get_str(*name_id)),
-            };
-            exit.drop_with(vm);
-            Err(error.into())
+    // Suspensions this path cannot service. The error is built from a borrow
+    // so one `drop_with` releases whatever the exit owns, fields added later
+    // included.
+    let exit = match frame_exit_result? {
+        FrameExit::Return(return_value) => return Ok(MontyObject::new(return_value, vm)),
+        exit => exit,
+    };
+    let error = match &exit {
+        FrameExit::Return(_) => unreachable!("returns are handled above"),
+        FrameExit::ExternalCall { function_name, .. } => {
+            let function_name = function_name.as_str(vm.interns);
+            ExcType::not_implemented(format!(
+                "External function '{function_name}' not implemented with standard execution"
+            ))
         }
-    }
+        FrameExit::OsCall { function_call, .. } => ExcType::not_implemented(format!(
+            "OS function '{}' not implemented with standard execution",
+            function_call.name()
+        )),
+        FrameExit::MethodCall { method_name, .. } => {
+            let name = method_name.as_str(vm.interns);
+            ExcType::not_implemented(format!("Method call '{name}' not implemented with standard execution"))
+        }
+        FrameExit::ResolveFutures(_) => ExcType::not_implemented("async futures not supported by standard execution."),
+        FrameExit::NameLookup { name_id, .. } => ExcType::name_error(vm.interns.get_str(*name_id)),
+    };
+    exit.drop_with(vm);
+    Err(error.into())
 }
 
 /// Output from `run_ref_counts` containing reference count and heap information.

--- a/crates/monty/src/run.rs
+++ b/crates/monty/src/run.rs
@@ -547,38 +547,32 @@ impl Executor {
 pub(crate) fn frame_exit_to_object(frame_exit_result: RunResult<FrameExit>, vm: &mut VM<'_>) -> RunResult<MontyObject> {
     match frame_exit_result? {
         FrameExit::Return(return_value) => Ok(MontyObject::new(return_value, vm)),
-        FrameExit::ExternalCall {
-            function_name, args, ..
-        } => {
-            args.drop_with(vm);
-            let function_name = function_name.as_str(vm.interns);
-            Err(ExcType::not_implemented(format!(
-                "External function '{function_name}' not implemented with standard execution"
-            ))
-            .into())
-        }
-        FrameExit::OsCall { function_call, .. } => {
-            let name = function_call.name();
-            function_call.drop_with(vm);
-            Err(
-                ExcType::not_implemented(format!("OS function '{name}' not implemented with standard execution"))
-                    .into(),
-            )
-        }
-        FrameExit::MethodCall { method_name, args, .. } => {
-            args.drop_with(vm);
-            let name = method_name.as_str(vm.interns);
-            Err(
-                ExcType::not_implemented(format!("Method call '{name}' not implemented with standard execution"))
-                    .into(),
-            )
-        }
-        FrameExit::ResolveFutures(_) => {
-            Err(ExcType::not_implemented("async futures not supported by standard execution.").into())
-        }
-        FrameExit::NameLookup { name_id, .. } => {
-            let name = vm.interns.get_str(name_id);
-            Err(ExcType::name_error(name).into())
+        // Suspensions this path cannot service. Built from a borrow so one
+        // `drop_with` releases whatever the exit owns, fields added later too.
+        exit => {
+            let error = match &exit {
+                FrameExit::Return(_) => unreachable!("returns are handled above"),
+                FrameExit::ExternalCall { function_name, .. } => {
+                    let function_name = function_name.as_str(vm.interns);
+                    ExcType::not_implemented(format!(
+                        "External function '{function_name}' not implemented with standard execution"
+                    ))
+                }
+                FrameExit::OsCall { function_call, .. } => ExcType::not_implemented(format!(
+                    "OS function '{}' not implemented with standard execution",
+                    function_call.name()
+                )),
+                FrameExit::MethodCall { method_name, .. } => {
+                    let name = method_name.as_str(vm.interns);
+                    ExcType::not_implemented(format!("Method call '{name}' not implemented with standard execution"))
+                }
+                FrameExit::ResolveFutures(_) => {
+                    ExcType::not_implemented("async futures not supported by standard execution.")
+                }
+                FrameExit::NameLookup { name_id, .. } => ExcType::name_error(vm.interns.get_str(*name_id)),
+            };
+            exit.drop_with(vm);
+            Err(error.into())
         }
     }
 }

--- a/crates/monty/src/run_progress.rs
+++ b/crates/monty/src/run_progress.rs
@@ -644,6 +644,13 @@ impl ConvertedExit {
 /// All `Value` → `MontyObject` and `StringId` → `String` conversions happen here,
 /// while the VM (and its heap/interns) are still accessible.
 pub(crate) fn convert_frame_exit(result: RunResult<FrameExit>, vm: &mut VM<'_>) -> ConvertedExit {
+    // An effect still armed on arrival belongs to an OS call that was answered
+    // without consuming it — a host may reply `ExtFunctionResult::Future`,
+    // whose resume never takes it. It can never apply to whatever suspends
+    // next, so release it here rather than let it reshape an unrelated result
+    // (or leak its file pin when the next OS call overwrites the slot).
+    // Arming for *this* exit happens below, after the slot is clear.
+    release_pending_effect(vm.pending_os_effect.take(), vm.heap);
     match result {
         Ok(FrameExit::Return(value)) => ConvertedExit::Complete(MontyObject::new(value, vm)),
         Ok(FrameExit::ExternalCall {
@@ -669,12 +676,6 @@ pub(crate) fn convert_frame_exit(result: RunResult<FrameExit>, vm: &mut VM<'_>) 
         }) => {
             // The point of no return: the call is the host's, so a matching
             // `resume` is guaranteed. Every other destination drops it.
-            //
-            // A slot that is still armed means the previous OS call never
-            // consumed its effect — a host may answer one with
-            // `ExtFunctionResult::Future`, which resumes without taking it.
-            // Release it rather than overwrite it, or its file pin leaks.
-            release_pending_effect(vm.pending_os_effect.take(), vm.heap);
             vm.pending_os_effect = effect;
             ConvertedExit::OsCall {
                 function_call,

--- a/crates/monty/src/run_progress.rs
+++ b/crates/monty/src/run_progress.rs
@@ -661,10 +661,23 @@ pub(crate) fn convert_frame_exit(result: RunResult<FrameExit>, vm: &mut VM<'_>) 
                 method_call: false,
             }
         }
-        Ok(FrameExit::OsCall { function_call, call_id }) => ConvertedExit::OsCall {
+        Ok(FrameExit::OsCall {
             function_call,
-            call_id: call_id.raw(),
-        },
+            call_id,
+            effect,
+        }) => {
+            // The point of no return: the call is the host's, so a matching
+            // `resume` is guaranteed. Every other destination drops it.
+            debug_assert!(
+                vm.pending_os_effect.is_none(),
+                "an OS call is still in flight — its effect would be overwritten"
+            );
+            vm.pending_os_effect = effect;
+            ConvertedExit::OsCall {
+                function_call,
+                call_id: call_id.raw(),
+            }
+        }
         Ok(FrameExit::MethodCall {
             method_name,
             args,

--- a/crates/monty/src/run_progress.rs
+++ b/crates/monty/src/run_progress.rs
@@ -16,6 +16,7 @@ use crate::{
     exception_private::{ExcTypeExt, RunError, RunResult},
     heap::{Heap, HeapReader},
     object_bridge::MontyObjectExt,
+    os_dispatch::release_pending_effect,
     run::Executor,
 };
 
@@ -668,10 +669,12 @@ pub(crate) fn convert_frame_exit(result: RunResult<FrameExit>, vm: &mut VM<'_>) 
         }) => {
             // The point of no return: the call is the host's, so a matching
             // `resume` is guaranteed. Every other destination drops it.
-            debug_assert!(
-                vm.pending_os_effect.is_none(),
-                "an OS call is still in flight — its effect would be overwritten"
-            );
+            //
+            // A slot that is still armed means the previous OS call never
+            // consumed its effect — a host may answer one with
+            // `ExtFunctionResult::Future`, which resumes without taking it.
+            // Release it rather than overwrite it, or its file pin leaks.
+            release_pending_effect(vm.pending_os_effect.take(), vm.heap);
             vm.pending_os_effect = effect;
             ConvertedExit::OsCall {
                 function_call,

--- a/crates/monty/tests/os_tests.rs
+++ b/crates/monty/tests/os_tests.rs
@@ -906,3 +906,42 @@ os.getenv('PROBE')
         MontyObject::String("env-value".to_owned())
     );
 }
+
+#[test]
+fn future_answered_os_call_does_not_reshape_a_later_external_result() {
+    // The same stranded effect, reached through a *non-OS* suspension: the
+    // external call's return value must come back whole, not sliced by the
+    // abandoned file's `BufferStore`.
+    let code = r"
+f = open('/data/sample.txt')
+f.read(5)
+some_external('x')
+";
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let mut progress = runner
+        .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
+        .unwrap();
+    let RunProgress::OsCall(call) = progress else {
+        panic!("expected open, got {progress:?}")
+    };
+    progress = call
+        .resume(mock_file_handle("/data/sample.txt"), PrintWriter::Stdout)
+        .unwrap();
+    let RunProgress::OsCall(call) = progress else {
+        panic!("expected the buffered read, got {progress:?}")
+    };
+    assert_eq!(call.function_call.name(), "Path.read_text");
+    progress = call.resume(ExtFunctionResult::Future(7), PrintWriter::Stdout).unwrap();
+
+    let RunProgress::FunctionCall(call) = progress else {
+        panic!("expected the external call, got {progress:?}")
+    };
+    assert_eq!(call.function_name, "some_external");
+    let progress = call
+        .resume(MontyObject::String("external-result".to_owned()), PrintWriter::Stdout)
+        .unwrap();
+    assert_eq!(
+        progress.into_complete().expect("expected Complete"),
+        MontyObject::String("external-result".to_owned())
+    );
+}

--- a/crates/monty/tests/os_tests.rs
+++ b/crates/monty/tests/os_tests.rs
@@ -6,8 +6,8 @@
 
 use monty::{MontyRun, RunProgress};
 use monty_types::{
-    CompileOptions, FileMode, MontyDate, MontyDateTime, MontyFileHandle, MontyObject, OsFunctionCall, PrintWriter,
-    ResourceTracker, file_stat,
+    CompileOptions, ExtFunctionResult, FileMode, MontyDate, MontyDateTime, MontyFileHandle, MontyObject,
+    OsFunctionCall, PrintWriter, ResourceTracker, file_stat,
 };
 
 /// Helper to run code and extract the OsCall progress.
@@ -862,4 +862,47 @@ type(Path('/data/config.json').read_text()).__name__
         ],
     );
     assert_eq!(result, MontyObject::String("str".to_owned()));
+}
+
+#[test]
+fn os_call_answered_with_a_future_does_not_strand_its_effect() {
+    // A host may answer an OS call with `Future` instead of a value, and that
+    // resume never consumes the armed effect. The next OS call must release
+    // the stale one rather than overwrite it (leaking the file's pin) — and
+    // must not let it reshape its own result, as it did before #711.
+    let code = r"
+import os
+f = open('/data/sample.txt')
+f.read(5)
+os.getenv('PROBE')
+";
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let mut progress = runner
+        .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
+        .unwrap();
+
+    let RunProgress::OsCall(call) = progress else {
+        panic!("expected open, got {progress:?}")
+    };
+    progress = call
+        .resume(mock_file_handle("/data/sample.txt"), PrintWriter::Stdout)
+        .unwrap();
+
+    let RunProgress::OsCall(call) = progress else {
+        panic!("expected the buffered read, got {progress:?}")
+    };
+    assert_eq!(call.function_call.name(), "Path.read_text");
+    progress = call.resume(ExtFunctionResult::Future(7), PrintWriter::Stdout).unwrap();
+
+    let RunProgress::OsCall(call) = progress else {
+        panic!("expected getenv, got {progress:?}")
+    };
+    assert_eq!(call.function_call.name(), "os.getenv");
+    let progress = call
+        .resume(MontyObject::String("env-value".to_owned()), PrintWriter::Stdout)
+        .unwrap();
+    assert_eq!(
+        progress.into_complete().expect("expected Complete"),
+        MontyObject::String("env-value".to_owned())
+    );
 }

--- a/crates/monty/tests/os_tests.rs
+++ b/crates/monty/tests/os_tests.rs
@@ -765,3 +765,101 @@ os.getenv('PROBE')
     assert_eq!(func, "os.getenv");
     assert_eq!(result, MontyObject::String("value".to_owned()));
 }
+
+/// Drives `code` through a scripted sequence of OS calls, checking each call's
+/// stable name and answering it with the paired mock result. Returns the final
+/// completed value.
+fn run_oscall_sequence(code: &str, steps: Vec<(&str, MontyObject)>) -> MontyObject {
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let mut progress = runner
+        .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
+        .unwrap();
+    for (expected, result) in steps {
+        let RunProgress::OsCall(call) = progress else {
+            panic!("expected OsCall {expected}, got {progress:?}");
+        };
+        assert_eq!(call.function_call.name(), expected);
+        progress = call.resume(result, PrintWriter::Stdout).unwrap();
+    }
+    progress.into_complete().expect("expected Complete")
+}
+
+/// A read-mode handle for `path`, the host's answer to an `open` OS call.
+fn mock_file_handle(path: &str) -> MontyObject {
+    MontyObject::FileHandle(MontyFileHandle {
+        path: path.to_owned(),
+        mode: "r".parse::<FileMode>().unwrap(),
+        position: 0,
+    })
+}
+
+#[test]
+fn buffered_read_rejected_in_sync_context_leaves_no_stale_effect() {
+    // Regression: a `sorted()` key runs in a synchronous context, so the
+    // buffered read's OsCall is rejected after the nested `run()` already
+    // returned `FrameExit::OsCall`. A `BufferStore` outliving that rejection
+    // diverts the *next* OS result into the abandoned file's buffer.
+    let code = r"
+from pathlib import Path
+
+f = open('/data/sample.txt')
+try:
+    sorted([1], key=lambda x: f.read(5))
+except NotImplementedError:
+    pass
+Path('/data/config.json').read_text()
+";
+    let result = run_oscall_sequence(
+        code,
+        vec![
+            ("open", mock_file_handle("/data/sample.txt")),
+            ("Path.read_text", MontyObject::String("victim contents".to_owned())),
+        ],
+    );
+    assert_eq!(result, MontyObject::String("victim contents".to_owned()));
+}
+
+#[test]
+fn buffered_read_in_sync_context_reports_the_rejected_os_function() {
+    // The rejection users actually see (see `limitations/open.md`): the read
+    // never reaches the host, so it names the OS call it would have made.
+    let code = r"
+f = open('/data/sample.txt')
+try:
+    sorted([1], key=lambda x: f.read(5))
+except NotImplementedError as exc:
+    msg = str(exc)
+msg
+";
+    let result = run_oscall_sequence(code, vec![("open", mock_file_handle("/data/sample.txt"))]);
+    assert_eq!(
+        result,
+        MontyObject::String(
+            "sorted() key argument: OS function 'Path.read_text' is not yet supported in this context".to_owned()
+        )
+    );
+}
+
+#[test]
+fn buffered_readlines_rejected_in_sync_context_does_not_retype_next_result() {
+    // The same stale `BufferStore` armed by `readlines()` reshapes the next
+    // result, handing Python a `list` where `read_text()` promises a `str`.
+    let code = r"
+from pathlib import Path
+
+f = open('/data/sample.txt')
+try:
+    sorted([1], key=lambda x: f.readlines())
+except NotImplementedError:
+    pass
+type(Path('/data/config.json').read_text()).__name__
+";
+    let result = run_oscall_sequence(
+        code,
+        vec![
+            ("open", mock_file_handle("/data/sample.txt")),
+            ("Path.read_text", MontyObject::String("a\nb\n".to_owned())),
+        ],
+    );
+    assert_eq!(result, MontyObject::String("str".to_owned()));
+}

--- a/limitations/open.md
+++ b/limitations/open.md
@@ -123,6 +123,13 @@ protocol (`__iter__`/`__next__`, including `for line in f:`).
   reads.
 - `close()` releases the cached buffer (matching CPython), returning its memory
   when no other value, such as `data = f.read()`, retains it.
+- File I/O is rejected inside callbacks the interpreter evaluates in a
+  synchronous context that cannot suspend to the host — the `key` of
+  `sorted()`/`list.sort()`/`min()`/`max()`, `map()`/`filter()` functions,
+  `iter(callable, sentinel)`, `defaultdict`'s `default_factory`, and dunder
+  methods invoked implicitly. The first read that needs the host raises
+  `NotImplementedError: <context>: OS function 'Path.read_text' is not yet
+  supported in this context` where CPython would simply read.
 - A read that *fails* in the host leaves the file in a retry-safe state:
   `pending_read` is cleared, the buffer stays empty, and `eof` is not
   flipped. A user-caught exception followed by a retry will re-attempt


### PR DESCRIPTION
A file read inside a synchronously-evaluated callback (a `sorted()` key, `map`, an implicit dunder) armed `VM::pending_os_effect` as the `FrameExit::OsCall` was built, then had that exit rejected — leaving the effect to hijack the *next* OS result. Fixed by arming only once the call reaches the host.

Three notes, one root cause:

- **Not a sandbox escape** — silent corruption across the host boundary: `read_text()` truncated, or returning a `list`. One feed only.
- **Half-solved already** — `CallResult::OsCallWithEffect` carries its effect in the value; this applies that shape to `FrameExit`.
- **A third abandon site** — `frame_exit_to_object` leaked the same pin; all three now release through the owner's `drop_with`.

**Tests:** three in `os_tests.rs`, written failing first.

Fixes https://github.com/pydantic/monty/issues/711.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Arm `VM::pending_os_effect` only when an OS call reaches the host, and release any stranded effect on every exit to prevent result corruption and file-pin leaks. Previously we armed on `FrameExit::OsCall` construction; rejected exits or `ExtFunctionResult::Future` replies left stale effects that mutated the next suspension’s result and hit a debug-only assert.

- `FrameExit::OsCall` carries `effect: Option<PendingOsEffect>`; `convert_frame_exit` now arms it at the host boundary and first clears any already-armed, stranded effect (covers non-OS suspensions too).
- Add `release_pending_effect`; call it from `CallResult::drop_with`, `FrameExit::drop_with`, `convert_frame_exit` (pre-arm clear), and `Drop for VM`.
- Restructure `frame_exit_to_object`: early-return on `Return`, build errors from borrows, then one `drop_with` to release all fields safely.
- Tests cover sync-context rejections and future-answered OS calls (no stranded effect, no reshaped results); document the sync-context I/O rejection in `limitations/open.md`.

<sup>Written for commit 60c6f39c27cac0128ffd8169dd84e9ac8bb8a939. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

