### PR TITLE
Reject unknown keys in the limits dict instead of silently ignoring them

### DIFF
--- a/crates/monty-python/src/limits.rs
+++ b/crates/monty-python/src/limits.rs
@@ -58,9 +58,13 @@ fn check_unknown_keys(dict: &Bound<'_, PyDict>) -> PyResult<()> {
         let known = key.extract::<&str>().is_ok_and(|k| KNOWN_KEYS.contains(&k));
         if !known {
             let accepted = KNOWN_KEYS.map(|k| format!("'{k}'")).join(", ");
+            // `repr()` runs user `__repr__`, which may itself raise — fall back
+            // so the promised `TypeError` is raised for every unknown key.
+            let key_repr = key
+                .repr()
+                .map_or_else(|_| "<unprintable key>".to_owned(), |r| r.to_string());
             return Err(PyTypeError::new_err(format!(
-                "unknown limits key {}; accepted keys are {accepted}",
-                key.repr()?
+                "unknown limits key {key_repr}; accepted keys are {accepted}"
             )));
         }
     }

--- a/crates/monty-python/src/limits.rs
+++ b/crates/monty-python/src/limits.rs
@@ -2,14 +2,7 @@
 
 use std::time::Duration;
 
-use pyo3::{
-    exceptions::{PyTypeError, PyValueError},
-    prelude::*,
-    types::PyDict,
-};
-
-/// The keys `extract_limits` understands; anything else is a hard error so typos can't fail open.
-const KNOWN_KEYS: [&str; 4] = ["max_duration_secs", "max_memory", "gc_interval", "max_recursion_depth"];
+use pyo3::{exceptions::PyValueError, prelude::*, types::PyDict};
 
 /// Extracts resource limits from a Python dict.
 ///
@@ -22,69 +15,66 @@ const KNOWN_KEYS: [&str; 4] = ["max_duration_secs", "max_memory", "gc_interval",
 /// If a key is missing or set to `None`, that limit is not applied
 /// (except `max_recursion_depth` which defaults to 1000).
 ///
-/// Raises `TypeError` if a value is present but has the wrong type, or if the dict
-/// contains an unknown key — limits are a security surface, so a misspelled key
-/// (e.g. `max_memroy`) must not silently run without the intended cap.
-/// Raises `ValueError` if `max_duration_secs` is not a valid duration value.
+/// Raises `TypeError` if a value is present but has the wrong type.
+/// Raises `ValueError` if the dict contains an unknown key — limits are a
+/// security surface, so a misspelled key (e.g. `max_memroy`) must not silently
+/// run without the intended cap — or if `max_duration_secs` is not a valid
+/// duration value.
 pub fn extract_limits(dict: &Bound<'_, PyDict>) -> PyResult<monty_types::ResourceLimits> {
-    check_unknown_keys(dict)?;
-    let max_duration_secs = extract_optional_f64(dict, "max_duration_secs")?;
-    let max_memory = extract_optional_usize(dict, "max_memory")?;
-    let gc_interval = extract_optional_usize(dict, "gc_interval")?;
-    let max_recursion_depth = extract_optional_usize(dict, "max_recursion_depth")?;
-
     let mut limits = monty_types::ResourceLimits::default();
-
-    if let Some(max_recursion_depth) = max_recursion_depth {
-        limits = limits.max_recursion_depth(max_recursion_depth);
+    // Keys parse into `LimitKey` and values are read from the same entry, so
+    // validation and extraction share one path — no re-lookup that a `str`
+    // subclass with a custom `__hash__` could dodge.
+    for (key, value) in dict.iter() {
+        let key: LimitKey = key.extract()?;
+        if value.is_none() {
+            // An explicit `None` disables the limit, like an absent key.
+            continue;
+        }
+        limits = match key {
+            LimitKey::MaxDurationSecs => {
+                let d = Duration::try_from_secs_f64(value.extract()?)
+                    .map_err(|err| PyValueError::new_err(err.to_string()))?;
+                limits.max_duration(d)
+            }
+            LimitKey::MaxMemory => limits.max_memory(value.extract()?),
+            LimitKey::GcInterval => limits.gc_interval(value.extract()?),
+            LimitKey::MaxRecursionDepth => limits.max_recursion_depth(value.extract()?),
+        };
     }
-    if let Some(secs) = max_duration_secs {
-        let d = Duration::try_from_secs_f64(secs).map_err(|err| PyValueError::new_err(err.to_string()))?;
-        limits = limits.max_duration(d);
-    }
-    if let Some(max) = max_memory {
-        limits = limits.max_memory(max);
-    }
-    if let Some(interval) = gc_interval {
-        limits = limits.gc_interval(interval);
-    }
-
     Ok(limits)
 }
 
-/// Rejects unrecognized (or non-string) keys with a `TypeError` naming the key and the accepted set.
-fn check_unknown_keys(dict: &Bound<'_, PyDict>) -> PyResult<()> {
-    for key in dict.keys() {
-        let known = key.extract::<&str>().is_ok_and(|k| KNOWN_KEYS.contains(&k));
-        if !known {
-            let accepted = KNOWN_KEYS.map(|k| format!("'{k}'")).join(", ");
-            // `repr()` runs user `__repr__`, which may itself raise — fall back
-            // so the promised `TypeError` is raised for every unknown key.
-            let key_repr = key
-                .repr()
-                .map_or_else(|_| "<unprintable key>".to_owned(), |r| r.to_string());
-            return Err(PyTypeError::new_err(format!(
-                "unknown limits key {key_repr}; accepted keys are {accepted}"
-            )));
+/// One recognized `limits` key. Anything else fails extraction with a
+/// `ValueError`, so a typo can't silently run without the intended cap.
+#[derive(Clone, Copy)]
+enum LimitKey {
+    MaxDurationSecs,
+    MaxMemory,
+    GcInterval,
+    MaxRecursionDepth,
+}
+
+impl<'a, 'py> FromPyObject<'a, 'py> for LimitKey {
+    type Error = PyErr;
+
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
+        match ob.extract::<&str>().unwrap_or_default() {
+            "max_duration_secs" => Ok(Self::MaxDurationSecs),
+            "max_memory" => Ok(Self::MaxMemory),
+            "gc_interval" => Ok(Self::GcInterval),
+            "max_recursion_depth" => Ok(Self::MaxRecursionDepth),
+            _ => {
+                // `repr()` runs user `__repr__`, which may itself raise — fall
+                // back so the promised `ValueError` is raised for every unknown key.
+                let key_repr = ob
+                    .repr()
+                    .map_or_else(|_| "<unprintable key>".to_owned(), |r| r.to_string());
+                Err(PyValueError::new_err(format!(
+                    "unknown limits key {key_repr}; accepted keys are 'max_duration_secs', \
+                     'max_memory', 'gc_interval', 'max_recursion_depth'"
+                )))
+            }
         }
-    }
-    Ok(())
-}
-
-/// Extracts an optional usize from a dict, raising `TypeError` if the value has the wrong type.
-fn extract_optional_usize(dict: &Bound<'_, PyDict>, key: &str) -> PyResult<Option<usize>> {
-    match dict.get_item(key)? {
-        None => Ok(None),
-        Some(value) if value.is_none() => Ok(None),
-        Some(value) => Ok(Some(value.extract()?)),
-    }
-}
-
-/// Extracts an optional f64 from a dict, raising `TypeError` if the value has the wrong type.
-fn extract_optional_f64(dict: &Bound<'_, PyDict>, key: &str) -> PyResult<Option<f64>> {
-    match dict.get_item(key)? {
-        None => Ok(None),
-        Some(value) if value.is_none() => Ok(None),
-        Some(value) => Ok(Some(value.extract()?)),
     }
 }

--- a/crates/monty-python/src/limits.rs
+++ b/crates/monty-python/src/limits.rs
@@ -2,7 +2,14 @@
 
 use std::time::Duration;
 
-use pyo3::{exceptions::PyValueError, prelude::*, types::PyDict};
+use pyo3::{
+    exceptions::{PyTypeError, PyValueError},
+    prelude::*,
+    types::PyDict,
+};
+
+/// The keys `extract_limits` understands; anything else is a hard error so typos can't fail open.
+const KNOWN_KEYS: [&str; 4] = ["max_duration_secs", "max_memory", "gc_interval", "max_recursion_depth"];
 
 /// Extracts resource limits from a Python dict.
 ///
@@ -15,9 +22,12 @@ use pyo3::{exceptions::PyValueError, prelude::*, types::PyDict};
 /// If a key is missing or set to `None`, that limit is not applied
 /// (except `max_recursion_depth` which defaults to 1000).
 ///
-/// Raises `TypeError` if a value is present but has the wrong type.
+/// Raises `TypeError` if a value is present but has the wrong type, or if the dict
+/// contains an unknown key — limits are a security surface, so a misspelled key
+/// (e.g. `max_memroy`) must not silently run without the intended cap.
 /// Raises `ValueError` if `max_duration_secs` is not a valid duration value.
 pub fn extract_limits(dict: &Bound<'_, PyDict>) -> PyResult<monty_types::ResourceLimits> {
+    check_unknown_keys(dict)?;
     let max_duration_secs = extract_optional_f64(dict, "max_duration_secs")?;
     let max_memory = extract_optional_usize(dict, "max_memory")?;
     let gc_interval = extract_optional_usize(dict, "gc_interval")?;
@@ -40,6 +50,21 @@ pub fn extract_limits(dict: &Bound<'_, PyDict>) -> PyResult<monty_types::Resourc
     }
 
     Ok(limits)
+}
+
+/// Rejects unrecognized (or non-string) keys with a `TypeError` naming the key and the accepted set.
+fn check_unknown_keys(dict: &Bound<'_, PyDict>) -> PyResult<()> {
+    for key in dict.keys() {
+        let known = key.extract::<&str>().is_ok_and(|k| KNOWN_KEYS.contains(&k));
+        if !known {
+            let accepted = KNOWN_KEYS.map(|k| format!("'{k}'")).join(", ");
+            return Err(PyTypeError::new_err(format!(
+                "unknown limits key {}; accepted keys are {accepted}",
+                key.repr()?
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Extracts an optional usize from a dict, raising `TypeError` if the value has the wrong type.

--- a/crates/monty-python/tests/test_limits.py
+++ b/crates/monty-python/tests/test_limits.py
@@ -104,6 +104,26 @@ def test_limits_wrong_type_raises_error(pool: Monty):
             pass
 
 
+def test_limits_unknown_key_raises_error(pool: Monty):
+    with pytest.raises(TypeError) as exc_info:
+        with pool.checkout(limits={'max_memroy': 10_000_000}):  # pyright: ignore[reportArgumentType]
+            pass
+    assert exc_info.value.args[0] == snapshot(
+        "unknown limits key 'max_memroy'; accepted keys are 'max_duration_secs', 'max_memory', "
+        "'gc_interval', 'max_recursion_depth'"
+    )
+
+
+def test_limits_non_string_key_raises_error(pool: Monty):
+    with pytest.raises(TypeError) as exc_info:
+        with pool.checkout(limits={1: 100}):  # pyright: ignore[reportArgumentType]
+            pass
+    assert exc_info.value.args[0] == snapshot(
+        "unknown limits key 1; accepted keys are 'max_duration_secs', 'max_memory', "
+        "'gc_interval', 'max_recursion_depth'"
+    )
+
+
 def test_limits_none_value_allowed(monty_run: RunMonty):
     # None is valid to explicitly disable a limit
     assert monty_run('1 + 1', limits={'max_memory': None}) == snapshot(2)

--- a/crates/monty-python/tests/test_limits.py
+++ b/crates/monty-python/tests/test_limits.py
@@ -124,6 +124,20 @@ def test_limits_non_string_key_raises_error(pool: Monty):
     )
 
 
+def test_limits_unprintable_key_still_raises_type_error(pool: Monty):
+    class BadRepr:
+        def __repr__(self) -> str:
+            raise RuntimeError('boom')
+
+    with pytest.raises(TypeError) as exc_info:
+        with pool.checkout(limits={BadRepr(): 1}):  # pyright: ignore[reportArgumentType]
+            pass
+    assert exc_info.value.args[0] == snapshot(
+        "unknown limits key <unprintable key>; accepted keys are 'max_duration_secs', 'max_memory', "
+        "'gc_interval', 'max_recursion_depth'"
+    )
+
+
 def test_limits_none_value_allowed(monty_run: RunMonty):
     # None is valid to explicitly disable a limit
     assert monty_run('1 + 1', limits={'max_memory': None}) == snapshot(2)

--- a/crates/monty-python/tests/test_limits.py
+++ b/crates/monty-python/tests/test_limits.py
@@ -105,7 +105,7 @@ def test_limits_wrong_type_raises_error(pool: Monty):
 
 
 def test_limits_unknown_key_raises_error(pool: Monty):
-    with pytest.raises(TypeError) as exc_info:
+    with pytest.raises(ValueError) as exc_info:
         with pool.checkout(limits={'max_memroy': 10_000_000}):  # pyright: ignore[reportArgumentType]
             pass
     assert exc_info.value.args[0] == snapshot(
@@ -115,7 +115,7 @@ def test_limits_unknown_key_raises_error(pool: Monty):
 
 
 def test_limits_non_string_key_raises_error(pool: Monty):
-    with pytest.raises(TypeError) as exc_info:
+    with pytest.raises(ValueError) as exc_info:
         with pool.checkout(limits={1: 100}):  # pyright: ignore[reportArgumentType]
             pass
     assert exc_info.value.args[0] == snapshot(
@@ -124,18 +124,31 @@ def test_limits_non_string_key_raises_error(pool: Monty):
     )
 
 
-def test_limits_unprintable_key_still_raises_type_error(pool: Monty):
+def test_limits_unprintable_key_still_raises_value_error(pool: Monty):
     class BadRepr:
         def __repr__(self) -> str:
             raise RuntimeError('boom')
 
-    with pytest.raises(TypeError) as exc_info:
+    with pytest.raises(ValueError) as exc_info:
         with pool.checkout(limits={BadRepr(): 1}):  # pyright: ignore[reportArgumentType]
             pass
     assert exc_info.value.args[0] == snapshot(
         "unknown limits key <unprintable key>; accepted keys are 'max_duration_secs', 'max_memory', "
         "'gc_interval', 'max_recursion_depth'"
     )
+
+
+def test_limits_str_subclass_key_is_honored(monty_run: RunMonty):
+    # A str subclass with a custom __hash__ passes a name check but dodges a
+    # dict re-lookup under the plain string's hash; extraction reads the value
+    # from the same entry as the key, so the limit must still be enforced.
+    class WeirdHashKey(str):
+        def __hash__(self) -> int:
+            return 0
+
+    with pytest.raises(MontyRuntimeError) as exc_info:
+        monty_run('2 ** 10000000', limits={WeirdHashKey('max_memory'): 1_000_000})  # pyright: ignore[reportArgumentType]
+    assert isinstance(exc_info.value.exception(), MemoryError)
 
 
 def test_limits_none_value_allowed(monty_run: RunMonty):


### PR DESCRIPTION
## Summary

Fixes #534.

`extract_limits` read each known key with `get_item` and never checked for unrecognized keys, so a misspelled key (`max_memroy`) was silently dropped and the session ran **with no limit** while the caller believed one was set. Limits are a security surface — failing open on a typo is the worst outcome, and it was inconsistent with the function's existing strictness (wrong-typed values already raise `TypeError`).

`extract_limits` now rejects any unknown or non-string key with a `TypeError` naming the offending key and the accepted set:

```python
pool.checkout(limits={'max_memroy': 10_000_000})
# TypeError: unknown limits key 'max_memroy'; accepted keys are 'max_duration_secs',
# 'max_memory', 'gc_interval', 'max_recursion_depth'
```

The JS bindings are unaffected: `ResourceLimits` there is a typed napi object, not an open dict.

## Tests

- `test_limits_unknown_key_raises_error` — misspelled key raises `TypeError` with the full message
- `test_limits_non_string_key_raises_error` — non-string keys are rejected the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gjSGkZ6GJKLSWCKd5126p

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects unknown or non-string keys in the Python limits dict so typos no longer fail open. Previously unrecognized keys were ignored; now we raise ValueError naming the bad key and the accepted keys.

- Keys are parsed through a LimitKey enum while iterating the dict, and values are read from the same entry to prevent str-subclass `__hash__` bypasses. Wrong-typed values still raise TypeError; invalid `max_duration_secs` still raises ValueError; explicit None continues to disable a limit. If a key’s repr raises, we still raise ValueError and show "<unprintable key>".

**Migration**
- Use only these keys: max_duration_secs, max_memory, gc_interval, max_recursion_depth. Fix any typos; non-string keys are invalid.

<sup>Written for commit da82bfd6bdf22d1f0ccdbbc221b059e323bb4f4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

