### PR TITLE
Discard stale pending_os_effect when a suspension is rejected

### DIFF
--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -420,6 +420,11 @@ impl VM<'_> {
     /// Converts a direct call suspension into a specific synchronous-context error.
     #[cold]
     fn unsupported_call_result(&mut self, ctx: &'static str, result: CallResult) -> RunError {
+        // The rejected call will never be resumed. An un-dispatched
+        // `OsCallWithEffect` has not armed `pending_os_effect` (its pin is
+        // released by `result.drop_with` below), but discard defensively so a
+        // stale effect can never divert the next unrelated resume result.
+        self.discard_pending_os_effect();
         let error = match &result {
             CallResult::External(function_name, _) => ExcType::not_implemented(format!(
                 "{ctx}: external function '{}' is not yet supported in this context",
@@ -449,6 +454,11 @@ impl VM<'_> {
     /// Converts a nested VM suspension into a specific synchronous-context error.
     #[cold]
     fn unsupported_frame_exit(&mut self, ctx: &'static str, exit: FrameExit) -> RunError {
+        // The nested `run()` armed `pending_os_effect` at dispatch, but this
+        // suspension is rejected and will never be resumed — discard the
+        // effect (rolling back the pinned file's state) or the next unrelated
+        // resume result is silently diverted into the stale file buffer.
+        self.discard_pending_os_effect();
         let error = match &exit {
             FrameExit::Return(_) => unreachable!("return exits are handled above"),
             FrameExit::ExternalCall { function_name, .. } => ExcType::not_implemented(format!(

--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -1932,31 +1932,7 @@ impl<'h> VM<'h> {
     /// Also clears any pending file effect so user code that catches a
     /// host-side OS exception can retry without stale in-flight state.
     pub fn resume_with_exception(&mut self, error: RunError) -> Result<FrameExit, RunError> {
-        if let Some(effect) = self.pending_os_effect.take() {
-            match effect {
-                PendingOsEffect::BufferStore { file_id } => {
-                    if let HeapReadOutput::OpenFile(mut file) = self.heap.read(file_id) {
-                        file.get_mut(self.heap).clear_pending_read();
-                        drop(file);
-                    }
-                    self.heap.dec_ref(file_id);
-                }
-                PendingOsEffect::WritePosition {
-                    file_id,
-                    previous_position,
-                    previous_length,
-                } => {
-                    if let HeapReadOutput::OpenFile(mut file) = self.heap.read(file_id) {
-                        file.get_mut(self.heap)
-                            .rollback_write_position(previous_position, previous_length);
-                        drop(file);
-                    }
-                    self.heap.dec_ref(file_id);
-                }
-                // Holds no state or heap references — nothing to roll back.
-                PendingOsEffect::ListdirNames => {}
-            }
-        }
+        self.discard_pending_os_effect();
         // Use the normal exception handling mechanism
         // handle_exception returns None if caught, Some(error) if not caught
         if let Some(uncaught_error) = self.handle_exception(error) {
@@ -1964,6 +1940,43 @@ impl<'h> VM<'h> {
         }
         // Exception was caught, continue execution
         self.run_external()
+    }
+
+    /// Discards an in-flight [`PendingOsEffect`] whose OS call will never be
+    /// resumed with a result, rolling back the file state it guards and
+    /// releasing its pinned refcount.
+    ///
+    /// Must be called on every path that abandons a paused OS call — a
+    /// host-side exception, a suspension rejected in a synchronous context
+    /// (see `unsupported_frame_exit`), or VM teardown — otherwise the stale
+    /// effect diverts the next, unrelated resume result into the wrong file.
+    pub(crate) fn discard_pending_os_effect(&mut self) {
+        let Some(effect) = self.pending_os_effect.take() else {
+            return;
+        };
+        match effect {
+            PendingOsEffect::BufferStore { file_id } => {
+                if let HeapReadOutput::OpenFile(mut file) = self.heap.read(file_id) {
+                    file.get_mut(self.heap).clear_pending_read();
+                    drop(file);
+                }
+                self.heap.dec_ref(file_id);
+            }
+            PendingOsEffect::WritePosition {
+                file_id,
+                previous_position,
+                previous_length,
+            } => {
+                if let HeapReadOutput::OpenFile(mut file) = self.heap.read(file_id) {
+                    file.get_mut(self.heap)
+                        .rollback_write_position(previous_position, previous_length);
+                    drop(file);
+                }
+                self.heap.dec_ref(file_id);
+            }
+            // Holds no state or heap references — nothing to roll back.
+            PendingOsEffect::ListdirNames => {}
+        }
     }
 
     // ========================================================================
@@ -2453,9 +2466,7 @@ impl ContainsHeap for VM<'_> {
 /// `take_globals`) are harmlessly drained as empty.
 impl Drop for VM<'_> {
     fn drop(&mut self) {
-        if let Some(file_id) = self.pending_os_effect.take().and_then(PendingOsEffect::pinned_file) {
-            self.heap.dec_ref(file_id);
-        }
+        self.discard_pending_os_effect();
         self.exception_stack.drain(..).drop_with(self.heap);
         self.cleanup_current_task();
         self.scheduler.cleanup(self.heap);

--- a/crates/monty/tests/file_error_paths.rs
+++ b/crates/monty/tests/file_error_paths.rs
@@ -191,6 +191,79 @@ f.read(5)
 }
 
 // ---------------------------------------------------------------------------
+// A buffered-file suspension rejected in a synchronous context (a sort key
+// cannot yield to the host) must discard the armed `PendingOsEffect`;
+// otherwise the next, unrelated OS result is silently diverted into the stale
+// file's buffer (#711).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn rejected_read_suspension_in_sort_key_does_not_poison_next_os_result() {
+    let code = r"
+f = open('/x.txt')
+try:
+    [1].sort(key=lambda x: f.read(5))
+except NotImplementedError:
+    pass
+g = open('/y.txt')
+g.read()
+";
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let progress = runner
+        .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
+        .unwrap();
+    let open_call = progress.into_os_call().expect("expected Open OsCall for f");
+    assert_eq!(open_call.function_call.name(), "open");
+    // The rejected sort-key read happens in-VM between these two suspensions.
+    let progress = open_call
+        .resume(MontyObject::FileHandle(file_handle("/x.txt", "r")), PrintWriter::Stdout)
+        .unwrap();
+    let open_call = progress.into_os_call().expect("expected Open OsCall for g");
+    assert_eq!(open_call.function_call.name(), "open");
+    let progress = open_call
+        .resume(MontyObject::FileHandle(file_handle("/y.txt", "r")), PrintWriter::Stdout)
+        .unwrap();
+    // With a stale effect this resume would be routed into f's buffer and
+    // truncated to 5 chars; it must arrive as g's full content.
+    let read_call = progress.into_os_call().expect("expected ReadText OsCall for g");
+    assert_eq!(read_call.function_call.name(), "Path.read_text");
+    let progress = read_call
+        .resume(MontyObject::String("full content of y".to_owned()), PrintWriter::Stdout)
+        .unwrap();
+    let result = progress.into_complete().expect("expected Complete");
+    assert_eq!(result, MontyObject::String("full content of y".to_owned()));
+}
+
+#[test]
+fn rejected_write_suspension_in_sort_key_rolls_back_and_allows_retry() {
+    let code = r"
+f = open('/x.txt', 'w')
+try:
+    [1].sort(key=lambda x: f.write('abc'))
+except NotImplementedError:
+    pass
+f.write('retry')
+f.tell()
+";
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let progress = runner
+        .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
+        .unwrap();
+    let open_call = progress.into_os_call().expect("expected Open OsCall");
+    assert_eq!(open_call.function_call.name(), "open");
+    let progress = open_call
+        .resume(MontyObject::FileHandle(file_handle("/x.txt", "w")), PrintWriter::Stdout)
+        .unwrap();
+    // The rejected sort-key write must not leave a stale `WritePosition`
+    // effect: the retry write suspends afresh and its result lands cleanly.
+    let write_call = progress.into_os_call().expect("expected write OsCall for retry");
+    assert_eq!(write_call.function_call.name(), "Path.append_text");
+    let progress = write_call.resume(MontyObject::Int(5), PrintWriter::Stdout).unwrap();
+    let result = progress.into_complete().expect("expected Complete");
+    assert_eq!(result, MontyObject::Int(5));
+}
+
+// ---------------------------------------------------------------------------
 // apply_write_position: a host that returns a non-int (or negative) byte
 // count must surface as a clean Python error rather than panic. The
 // surfaced error from `as_int(...)?` is a TypeError; the negative-int


### PR DESCRIPTION
## Summary

Fixes #711.

When a `sort()`/`sorted()`/`min()`/`max()` key callback triggered a buffered file read, the nested `run()` armed `pending_os_effect` at dispatch before returning `FrameExit::OsCall`. The synchronous-context path then rejected the suspension in `unsupported_frame_exit`, dropping the `FrameExit` but leaving the effect armed and the file's `pending_read` set. The next `resume()` diverted **any** unrelated result — another file read, an external function return — into the stale file buffer: silently truncated strings, `read_text()` returning a `list`, or internal errors on type mismatch.

## Fix

- Extract the existing rollback from `resume_with_exception` into `VM::discard_pending_os_effect`: clear the file's `pending_read` / roll back write position, and release the pinned refcount.
- Call it from `unsupported_frame_exit` (the live bug — effect armed by the nested `run()`), `unsupported_call_result` (defensive; an un-dispatched `OsCallWithEffect` never arms the effect), and `Drop for VM` (which previously released the pin but not the file state).

## Tests

New regression tests in `crates/monty/tests/file_error_paths.rs`, driving the VM's OS-call suspensions directly:

- `rejected_read_suspension_in_sort_key_does_not_poison_next_os_result` — reproduces the issue's repro: after a rejected `f.read(5)` sort key, a second file's `read()` must return its full content, not a 5-char truncation. Fails on `main`, passes with the fix.
- `rejected_write_suspension_in_sort_key_rolls_back_and_allows_retry` — the `WritePosition` variant: a rejected write's effect is discarded (releasing the pinned refcount, previously leaked by dispatch-overwrite) and a retry write lands cleanly.

Both also run clean under `--features memory-model-checks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gjSGkZ6GJKLSWCKd5126p

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Discard any armed pending file effect when a suspension is rejected, so unrelated OS results are not diverted into the wrong file. Prevents truncated reads and bad write state after sort/min/max key callbacks that trigger I/O.

- **Bug Fixes**
  - Discard `pending_os_effect` on rejection paths: `unsupported_frame_exit`, `unsupported_call_result`, and `Drop` for the VM.
  - Roll back file state: clear `pending_read` or restore write position, and release the pinned refcount.
  - Regression tests cover rejected `f.read(5)` in a sort key (no poisoned next read) and rejected write (rolled back, retry succeeds).

- **Refactors**
  - Extract rollback into `VM::discard_pending_os_effect` and reuse it in `resume_with_exception`.

<sup>Written for commit 0e31cd0aaff943e4aa34fedeed07d8719d2ad4d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

