### PR TITLE
Raise rejected-suspension NotImplementedError inside the callee's frames

### DIFF
--- a/crates/monty/src/builtins/sorted.rs
+++ b/crates/monty/src/builtins/sorted.rs
@@ -39,7 +39,7 @@ pub fn builtin_sorted(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     } else {
         ArgValues::Kwargs(kwargs)
     };
-    parse_and_sort(items, sort_args, vm)?;
+    parse_and_sort("sorted() key argument", items, sort_args, vm)?;
 
     let (items, vm) = items_guard.into_parts();
     let heap_id = vm.heap.allocate(HeapData::List(List::new(items)));

--- a/crates/monty/src/bytecode/vm/call.rs
+++ b/crates/monty/src/bytecode/vm/call.rs
@@ -371,6 +371,8 @@ impl VM<'_> {
     /// User-defined functions run until their frame returns. An unresolved name raises
     /// `NameError`; external, OS, method, and future suspensions raise a variant-specific
     /// `NotImplementedError` because this context cannot preserve and resume its state.
+    /// These are raised at the suspension point inside the callee's frames, so the
+    /// callee can catch them with an ordinary `try`/`except` like any other exception.
     ///
     /// The nested `self.run()` below recurses on the native Rust stack, so
     /// re-entry is bounded via [`enter_run_reentry`](Self::enter_run_reentry)
@@ -391,30 +393,39 @@ impl VM<'_> {
         let mut guard = RunReentryGuard::new(self);
         let this = &mut *guard;
 
-        let exit = match this.call_function(callable, args)? {
-            CallResult::Value(v) => return Ok(v),
+        match this.call_function(callable, args)? {
+            CallResult::Value(v) => Ok(v),
             CallResult::FramePushed => {
                 // A new frame was pushed for a defined function call - we need to run it
                 // to completion.
                 let stack_depth = this.frames.len();
                 // Mark the frame as an exit point from the `run()` loop
                 this.current_frame_mut().should_return = true;
-                match this.run()? {
-                    FrameExit::Return(v) => return Ok(v),
-                    exit => {
-                        // Pop frames off the stack from this failed evaluation
-                        // (including the one just pushed)
-                        while this.frames.len() >= stack_depth {
-                            this.pop_frame();
+                loop {
+                    match this.run()? {
+                        FrameExit::Return(v) => return Ok(v),
+                        exit => {
+                            // A suspension this context cannot service. Raise the
+                            // error *at the suspension point*, inside the still-live
+                            // callee frames, so a `try`/`except` in the callee
+                            // observes it like any other exception (#712).
+                            let error = this.unsupported_frame_exit(ctx, exit);
+                            if let Some(error) = this.handle_exception(error) {
+                                // Uncaught. Unwinding normally stops after popping
+                                // the `should_return` frame; the loop covers the
+                                // depth-1 direct-call case where it stops early.
+                                while this.frames.len() >= stack_depth {
+                                    this.pop_frame();
+                                }
+                                return Err(error);
+                            }
+                            // Caught inside the callee — keep running it.
                         }
-                        exit
                     }
                 }
             }
-            unsupported => return Err(this.unsupported_call_result(ctx, unsupported)),
-        };
-
-        Err(this.unsupported_frame_exit(ctx, exit))
+            unsupported => Err(this.unsupported_call_result(ctx, unsupported)),
+        }
     }
 
     /// Converts a direct call suspension into a specific synchronous-context error.

--- a/crates/monty/src/sorting.rs
+++ b/crates/monty/src/sorting.rs
@@ -39,7 +39,16 @@ struct ListSortArgs {
 /// builtin — sharing here is what makes unknown-kwarg errors uniformly
 /// read `sort() got an unexpected keyword argument 'X'` (matching
 /// CPython, whose `sorted` delegates to `list.sort` internally).
-pub fn parse_and_sort(items: &mut [Value], args: ArgValues, vm: &mut VM<'_>) -> RunResult<()> {
+///
+/// `key_context` names the calling builtin in rejected-suspension errors
+/// (`"sorted() key argument"` / `"sort() key argument"`), which are
+/// Monty-specific and so must name what the user actually called.
+pub fn parse_and_sort(
+    key_context: &'static str,
+    items: &mut [Value],
+    args: ArgValues,
+    vm: &mut VM<'_>,
+) -> RunResult<()> {
     let ListSortArgs { key, reverse } = ListSortArgs::from_args(args, vm)?;
     let key_fn = match key {
         Some(v) if matches!(v, Value::None) => {
@@ -49,11 +58,18 @@ pub fn parse_and_sort(items: &mut [Value], args: ArgValues, vm: &mut VM<'_>) -> 
         other => other,
     };
     defer_drop!(key_fn, vm);
-    sort_values(items, key_fn.as_ref(), reverse.bool(), vm)
+    sort_values(key_context, items, key_fn.as_ref(), reverse.bool(), vm)
 }
 
 /// Sorts a vector of values, with optional key function.
-pub fn sort_values(values: &mut [Value], key_fn: Option<&Value>, reverse: bool, vm: &mut VM<'_>) -> RunResult<()> {
+/// `key_context` names the calling builtin — see [`parse_and_sort`].
+pub fn sort_values(
+    key_context: &'static str,
+    values: &mut [Value],
+    key_fn: Option<&Value>,
+    reverse: bool,
+    vm: &mut VM<'_>,
+) -> RunResult<()> {
     if let Some(f) = key_fn {
         // Sort by key function: compute all the keys, sort an index buffer, then
         // rearrange the original values in-place according to the sorted indices.
@@ -66,7 +82,7 @@ pub fn sort_values(values: &mut [Value], key_fn: Option<&Value>, reverse: bool, 
         for (i, item) in values.iter().enumerate() {
             vm.heap.tracker.check_time_every(i)?;
             let item = item.clone_with_heap(vm);
-            keys.push(vm.evaluate_function("sorted() key argument", f, ArgValues::One(item))?);
+            keys.push(vm.evaluate_function(key_context, f, ArgValues::One(item))?);
         }
 
         // 2. Sort indices by comparing key values (or values themselves if no key)

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -860,7 +860,7 @@ fn do_list_sort<'h>(list: &mut HeapRead<'h, List>, args: ArgValues, vm: &mut VM<
     let items = mem::take(&mut list.get_mut(vm.heap).items);
     defer_drop_mut!(items, vm);
 
-    let sort_result = parse_and_sort(items, args, vm);
+    let sort_result = parse_and_sort("sort() key argument", items, args, vm);
 
     // Swap our (sorted) buffer back into the list. Whatever the user placed
     // on the live empty list during the sort ends up in `items`; if

--- a/crates/monty/tests/file_error_paths.rs
+++ b/crates/monty/tests/file_error_paths.rs
@@ -235,6 +235,42 @@ g.read()
 }
 
 #[test]
+fn rejected_read_suspension_catchable_inside_key_fn() {
+    // The NotImplementedError must surface at the `f.read(5)` call inside the
+    // key function, where a `try`/`except` observes it like any other
+    // exception (#712), and the sort completes with the fallback key.
+    let code = r"
+f = open('/x.txt')
+caught = []
+
+def key_fn(x):
+    try:
+        f.read(5)
+    except NotImplementedError as e:
+        caught.append(str(e))
+    return x
+
+sorted([1], key=key_fn)
+caught[0]
+";
+    let runner = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+    let progress = runner
+        .start(vec![], ResourceTracker::default(), PrintWriter::Stdout)
+        .unwrap();
+    let open_call = progress.into_os_call().expect("expected Open OsCall");
+    let progress = open_call
+        .resume(MontyObject::FileHandle(file_handle("/x.txt", "r")), PrintWriter::Stdout)
+        .unwrap();
+    let result = progress.into_complete().expect("expected Complete");
+    assert_eq!(
+        result,
+        MontyObject::String(
+            "sorted() key argument: OS function 'Path.read_text' is not yet supported in this context".to_owned()
+        )
+    );
+}
+
+#[test]
 fn rejected_write_suspension_in_sort_key_rolls_back_and_allows_retry() {
     let code = r"
 f = open('/x.txt', 'w')

--- a/crates/monty/tests/main.rs
+++ b/crates/monty/tests/main.rs
@@ -130,9 +130,10 @@ fn external_function_as_init_raises_not_implemented() {
 
 /// A user `__next__` calling an external function cannot suspend: like
 /// `__repr__`/`__str__` it runs synchronously via `evaluate_function`, so the
-/// call raises `NotImplementedError` (see `limitations/classes.md`). Rust-side
-/// for the same reason as `external_function_as_init_raises_not_implemented`:
-/// on CPython the external is a real function and the loop would succeed.
+/// call raises `NotImplementedError` at the `ext_fn()` call site inside
+/// `__next__` (see `limitations/classes.md`). Rust-side for the same reason as
+/// `external_function_as_init_raises_not_implemented`: on CPython the external
+/// is a real function and the loop would succeed.
 #[test]
 fn external_function_in_next_raises_not_implemented() {
     let code = "class Foo:\n    def __iter__(self):\n        return self\n\n    def __next__(self):\n        return ext_fn()\n\nfor _x in Foo():\n    pass";
@@ -151,7 +152,66 @@ fn external_function_in_next_raises_not_implemented() {
         .unwrap_err();
     assert_eq!(
         err.to_string(),
-        "Traceback (most recent call last):\n  File \"test.py\", line 8, in <module>\n    for _x in Foo():\n              ~~~~~\nNotImplementedError: __next__: external function 'ext_fn' is not yet supported in this context"
+        "Traceback (most recent call last):\n  File \"test.py\", line 6, in __next__\n    return ext_fn()\n           ~~~~~~~~\nNotImplementedError: __next__: external function 'ext_fn' is not yet supported in this context"
+    );
+}
+
+/// The rejected-suspension `NotImplementedError` is raised at the offending
+/// call *inside* the key function's frame, so an ordinary `try`/`except`
+/// there observes it and the surrounding sort completes (#712). Rust-side
+/// because on CPython the external is a real function and never raises.
+#[test]
+fn not_implemented_in_sort_key_catchable_inside_key_fn() {
+    let code = "
+def key_fn(x):
+    try:
+        ext_fn()
+    except NotImplementedError:
+        return -x
+    return 0
+
+sorted([1, 2, 3], key=key_fn)
+";
+    let ex = MontyRun::new(
+        code.to_owned(),
+        "test.py",
+        vec!["ext_fn".to_owned()],
+        CompileOptions::default(),
+    )
+    .unwrap();
+    let result = ex
+        .run_no_limits(vec![MontyObject::Function {
+            name: "ext_fn".to_owned(),
+            docstring: None,
+        }])
+        .unwrap();
+    assert_eq!(
+        result,
+        MontyObject::List(vec![MontyObject::Int(3), MontyObject::Int(2), MontyObject::Int(1)])
+    );
+}
+
+/// The rejected-suspension error names the builtin the user actually called:
+/// `list.sort()` must say `sort()`, not `sorted()` (#712).
+#[test]
+fn not_implemented_in_list_sort_key_names_sort() {
+    let code = "[1, 2].sort(key=lambda x: ext_fn())";
+    let ex = MontyRun::new(
+        code.to_owned(),
+        "test.py",
+        vec!["ext_fn".to_owned()],
+        CompileOptions::default(),
+    )
+    .unwrap();
+    let err = ex
+        .run_no_limits(vec![MontyObject::Function {
+            name: "ext_fn".to_owned(),
+            docstring: None,
+        }])
+        .unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Traceback (most recent call last):\n  File \"test.py\", line 1, in <lambda>\n    [1, 2].sort(key=lambda x: ext_fn())\n                              ~~~~~~~~\nNotImplementedError: sort() key argument: external function 'ext_fn' is not yet supported in this context"
     );
 }
 

--- a/crates/monty/tests/repl.rs
+++ b/crates/monty/tests/repl.rs
@@ -866,7 +866,13 @@ fn call_function_that_calls_undefined_name_fails() {
     let err = s
         .call_function("call_missing", vec![], PrintWriter::Stdout)
         .unwrap_err();
-    assert_snapshot!(err, @"NotImplementedError: MontyRepl::call_function: external function 'unknown_func' is not yet supported in this context");
+    assert_snapshot!(err, @r#"
+    Traceback (most recent call last):
+      File "<python-input-0>", line 1, in call_missing
+        def call_missing(): return unknown_func()
+                                   ~~~~~~~~~~~~~~
+    NotImplementedError: MontyRepl::call_function: external function 'unknown_func' is not yet supported in this context
+    "#);
 }
 
 #[test]

--- a/limitations/classes.md
+++ b/limitations/classes.md
@@ -203,7 +203,9 @@ e.g. return a `dict` of the fields.
   by default, so a custom `__ne__` is ignored.
 - `__iter__` / `__next__` / `__contains__` **are** dispatched, but like
   `__repr__`/`__str__` they run synchronously, so one that calls an external or
-  OS function cannot suspend and raises `NotImplementedError`. Two related
+  OS function cannot suspend and raises `NotImplementedError`. The error is
+  raised at the offending call inside the callee, so a `try`/`except` there
+  catches it like any other exception. Two related
   protocols are still not dispatched, so a class relying on either is not
   iterable:
   - the legacy `__getitem__`-only fallback — CPython iterates a class defining


### PR DESCRIPTION
## Summary

Fixes #712. **Stacked on #725** (the #711 fix) — a caught rejected suspension must not leave the stale `pending_os_effect` armed, so this lands on top of that branch; GitHub will retarget to `main` when #725 merges.

An external/OS call inside a `sort()`/`sorted()`/`min()`/`max()` key function (or any synchronously evaluated callback: `__next__`, `map`/`filter` functions, `iter(callable, sentinel)`, …) raised `NotImplementedError`, but the exception was constructed by `unsupported_frame_exit` *after* the callback's frames had been popped — so a `try`/`except` inside the callback could never see it, and the failure always aborted the whole operation.

## Fix

- `evaluate_function` now converts the rejected suspension to an exception and raises it via `handle_exception` **at the suspension point, inside the still-live callee frames**. A handler inside the callback catches it and execution continues; if uncaught, `handle_exception` unwinds to the nested-run boundary (the `should_return` frame) and the error propagates exactly as before. Tracebacks now point at the offending call inside the callee — consistent with how Monty already reports ordinary exceptions raised in these nested contexts.
- The minor naming issue from the issue: `parse_and_sort`/`sort_values` now take the calling builtin's context, so `list.sort()` reports `sort() key argument` instead of `sorted() key argument` (`min()`/`max()` already passed their own names).

## Tests

- `not_implemented_in_sort_key_catchable_inside_key_fn` — `try`/`except NotImplementedError` inside the key fn catches, and the sort completes using the fallback key.
- `not_implemented_in_list_sort_key_names_sort` — `list.sort()` message and traceback (now anchored at the `ext_fn()` call in the lambda).
- `rejected_read_suspension_catchable_inside_key_fn` (file_error_paths.rs) — the issue's repro shape: `f.read(5)` in a key fn, caught inside, message verified.
- Updated `external_function_in_next_raises_not_implemented` and the REPL snapshot for the traceback now showing the callee frame.
- Full `cargo test -p monty`, `make test-cases` (1134 cases), and the touched binaries under `--features memory-model-checks` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gjSGkZ6GJKLSWCKd5126p

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises rejected-suspension `NotImplementedError` at the call site inside callee frames so `try/except` in synchronous callbacks can catch it, and tracebacks point to the right line. Also fixes sort key errors to name the correct builtin.

- **Bug Fixes**
  - In `evaluate_function`, rejected suspensions are turned into exceptions and raised via `handle_exception` while callee frames are live; handlers in key functions, `__next__`, `map`/`filter`, etc. can catch them, otherwise they unwind as before.
  - Sorting now threads the calling builtin’s name (`"sorted() key argument"` / `"sort() key argument"`) through `parse_and_sort` and `sort_values`, so messages reference the function the user called.

<sup>Written for commit 0196be096eb0708748835063e2f2eeab80c5df4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

