### PR TITLE
Bound `asyncio.gather` nesting to avoid a stack overflow

### DIFF
--- a/crates/monty/src/bytecode/vm/async_exec.rs
+++ b/crates/monty/src/bytecode/vm/async_exec.rs
@@ -18,7 +18,10 @@ use crate::{
         AwaitedGather, Awaiter, CallId, Coroutine, CoroutineState, ExternalFuture, ExternalFutureState, GatherFuture,
         GatherState, TaskId,
     },
-    bytecode::vm::scheduler::{Scheduler, SerializedTaskFrame, TaskState},
+    bytecode::vm::{
+        recursion::charge_gather_nesting,
+        scheduler::{Scheduler, SerializedTaskFrame, TaskState},
+    },
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunError, RunResult, SimpleException},
     heap::{DropGuard, DropWithContext, HeapData, HeapId, HeapRead, HeapReadOutput, HeapReader},
@@ -54,7 +57,8 @@ impl<'h> VM<'h> {
                 let heap_id = *heap_id;
                 let poll = match this.heap.read(heap_id) {
                     HeapReadOutput::Coroutine(coro) => return this.await_coroutine(coro),
-                    HeapReadOutput::GatherFuture(gather) => this.await_gather_future(heap_id, gather, awaiter)?,
+                    // Depth 0: this is the outermost gather on the native stack.
+                    HeapReadOutput::GatherFuture(gather) => this.await_gather_future(heap_id, gather, awaiter, 0)?,
                     HeapReadOutput::ExternalFuture(mut fut) => this.await_external_future(&mut fut, awaiter)?,
                     _ => return Err(ExcType::object_not_awaitable(&awaitable.py_type_name(this))),
                 };
@@ -99,11 +103,15 @@ impl<'h> VM<'h> {
     }
 
     /// Awaits a gather future from the user's `await gather` site.
+    ///
+    /// `depth` is how many gathers are already open on the native stack above
+    /// this one — 0 at an `await` site (see [`charge_gather_nesting`]).
     fn await_gather_future(
         &mut self,
         gather_id: HeapId,
         mut gather: HeapRead<'h, GatherFuture>,
         awaiter: Awaiter,
+        depth: u8,
     ) -> Result<Poll<Value>, RunError> {
         let mut awaiter_guard = DropGuard::new(awaiter, self);
         let this = awaiter_guard.ctx();
@@ -144,7 +152,7 @@ impl<'h> VM<'h> {
         // Roll back already-committed siblings if a later child fails during
         // this commit pass; otherwise spawned tasks or awaiters can outlive a
         // gather that never reached `Awaited`.
-        if let Err(err) = this.commit_gather_items(gather_id, &gather, &mut pending_children, results) {
+        if let Err(err) = this.commit_gather_items(gather_id, &gather, &mut pending_children, results, depth) {
             gather.get_mut(this.heap).state = GatherState::Failed(err.clone());
             drop_committed_children(pending_children, &mut this.scheduler, this.heap, &err);
             return Err(err);
@@ -176,7 +184,9 @@ impl<'h> VM<'h> {
     /// Commits `gather`'s items left-to-right into result slots or pending children.
     ///
     /// Spawns coroutine children, installs awaiters on external futures, and
-    /// recursively awaits nested gathers. Any error leaves already-committed
+    /// recursively awaits nested gathers, each level charged via
+    /// [`charge_gather_nesting`] so the bound is a hard cap rather than the
+    /// native stack. Any error leaves already-committed
     /// entries in `pending_children`; the caller must pass them to
     /// [`drop_committed_children`] before propagating the error.
     fn commit_gather_items(
@@ -185,6 +195,7 @@ impl<'h> VM<'h> {
         gather: &HeapRead<'h, GatherFuture>,
         pending_children: &mut AHashMap<HeapId, SmallVec<[usize; 1]>>,
         results: &mut [Option<Value>],
+        depth: u8,
     ) -> Result<(), RunError> {
         for (idx, result) in results.iter_mut().enumerate() {
             let item_id = gather.get(self.heap).items[idx];
@@ -220,12 +231,15 @@ impl<'h> VM<'h> {
                     self.await_external_future(&mut fut, sub_awaiter)?
                 }
                 HeapReadOutput::GatherFuture(child_gather) => {
+                    // Charged before the `inc_ref`: nothing is committed yet,
+                    // so the error path needs no cleanup.
+                    let depth = charge_gather_nesting(depth)?;
                     self.heap.inc_ref(gather_id);
                     let sub_awaiter = Awaiter::GatherSlot {
                         gather: gather_id,
                         source: item_id,
                     };
-                    self.await_gather_future(item_id, child_gather, sub_awaiter)?
+                    self.await_gather_future(item_id, child_gather, sub_awaiter, depth)?
                 }
                 _ => panic!("gather item is not a Coroutine, ExternalFuture, or GatherFuture"),
             };

--- a/crates/monty/src/bytecode/vm/recursion.rs
+++ b/crates/monty/src/bytecode/vm/recursion.rs
@@ -187,6 +187,33 @@ impl Drop for RunReentryGuard<'_, '_> {
     }
 }
 
+/// Hard cap on `asyncio.gather` nesting, enforced by [`charge_gather_nesting`].
+///
+/// Committing a nested gather recurses, and the nesting costs no Python frames
+/// (`g = asyncio.gather(g)` in a loop), so the recursion limit neither sees it
+/// nor is small enough for it: at ~4 KiB a frame, 1,000 levels overflows 2 MiB.
+/// Like [`MAX_RUN_REENTRY_DEPTH`] a hard constant, not a Python-visible setting.
+///
+/// Measured on macOS/arm64 only — ~14x below the ~450 a 2 MiB thread holds, so
+/// the margin should cover unmeasured targets; revalidate before raising it.
+pub(crate) const MAX_GATHER_NEST_DEPTH: u8 = 32;
+
+/// Charges one level of gather nesting, returning the depth for the nested walk;
+/// errors once [`MAX_GATHER_NEST_DEPTH`] is exhausted.
+///
+/// A function rather than a guard: nothing is reserved, so there is no level to
+/// release — the depth lives in the recursive call's argument.
+pub(crate) fn charge_gather_nesting(depth: u8) -> Result<u8, ResourceError> {
+    if depth >= MAX_GATHER_NEST_DEPTH {
+        Err(ResourceError::Recursion {
+            limit: MAX_GATHER_NEST_DEPTH as usize,
+            depth: depth as usize + 1,
+        })
+    } else {
+        Ok(depth + 1)
+    }
+}
+
 /// Zero-size reservation of one recursion level, returned by [`VM::incr_recursion`].
 ///
 /// Released via [`DropWithContext`] (it cannot reach the VM counter through the heap).

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -1008,3 +1008,165 @@ a < b
         assert_eq!(exc.exc_type(), ExcType::RecursionError, "build: {build}");
     }
 }
+
+/// Nested gathers are committed by a native recursive walk, and the nesting
+/// costs no Python frames (`g = asyncio.gather(g)` in a loop), so without the
+/// `MAX_GATHER_NEST_DEPTH` cap deep nesting aborted the process instead of
+/// raising. 5,000 is far past the ~1,900 the pre-fix build managed.
+#[test]
+fn deeply_nested_gather_futures_do_not_overflow_the_stack() {
+    let ex = MontyRun::new(nested_gather_code(5000), "test.py", vec![], CompileOptions::default()).unwrap();
+
+    let exc = ex
+        .run_no_limits(vec![])
+        .expect_err("deeply nested gathers should raise rather than overflow the stack");
+    assert_eq!(exc.exc_type(), ExcType::RecursionError);
+}
+
+/// The cap is a fixed native-stack bound, not the Python recursion limit, so a
+/// generous `max_recursion_depth` must not buy any extra gather nesting.
+#[test]
+fn nested_gather_futures_are_capped_independently_of_the_recursion_limit() {
+    let ex = MontyRun::new(nested_gather_code(100), "test.py", vec![], CompileOptions::default()).unwrap();
+
+    let limits = ResourceLimits::default().max_recursion_depth(100_000);
+    let result = ex.run(vec![], ResourceTracker::new(limits), PrintWriter::Stdout);
+
+    let exc = result.expect_err("nesting past the cap should raise regardless of the recursion limit");
+    assert_eq!(exc.exc_type(), ExcType::RecursionError);
+}
+
+/// Boundary: the outermost gather is awaited at depth 0, so 33 gathers sit
+/// exactly on the cap and must resolve while 34 must raise.
+#[test]
+fn nested_gather_futures_resolve_up_to_the_cap() {
+    let ex = MontyRun::new(nested_gather_code(33), "test.py", vec![], CompileOptions::default()).unwrap();
+    let result = ex.run_no_limits(vec![]).expect("nesting on the cap should succeed");
+    assert_eq!(result, MontyObject::Int(1));
+
+    let ex = MontyRun::new(nested_gather_code(34), "test.py", vec![], CompileOptions::default()).unwrap();
+    let exc = ex.run_no_limits(vec![]).expect_err("nesting past the cap should raise");
+    assert_eq!(exc.exc_type(), ExcType::RecursionError);
+}
+
+/// Builds `depth` `asyncio.gather` futures nested inside one another, awaits
+/// the outermost, and unwraps the resulting nested single-item lists back down
+/// to the leaf's `1`.
+fn nested_gather_code(depth: usize) -> String {
+    format!(
+        r"
+import asyncio
+
+async def leaf():
+    return 1
+
+g = leaf()
+for _ in range({depth}):
+    g = asyncio.gather(g)
+result = await g
+for _ in range({depth}):
+    result = result[0]
+result
+"
+    )
+}
+
+/// A coroutine child breaks the native chain: it is spawned as a task, so the
+/// walk unwinds before that task later runs at depth 0. Nesting far past the
+/// cap through coroutines must still resolve — the reset is only sound because
+/// it coincides with the unwind, and this is what fails if they come apart.
+#[test]
+fn gather_nesting_through_coroutines_does_not_accumulate() {
+    // Each iteration adds two gathers, so 200 levels leave 400 lists to unwrap.
+    let code = r"
+import asyncio
+
+async def leaf():
+    return 1
+
+async def wrap(g):
+    return await g
+
+g = leaf()
+for _ in range(200):
+    g = asyncio.gather(wrap(asyncio.gather(g)))
+result = await g
+for _ in range(400):
+    result = result[0]
+result
+";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+
+    let result = ex
+        .run_no_limits(vec![])
+        .expect("coroutine boundaries must not accumulate native depth");
+    assert_eq!(result, MontyObject::Int(1));
+}
+
+/// Companion with segments just under the cap: 100 runs of 31, each separated
+/// by a coroutine. Every segment is charged from zero, so all 3,100 levels
+/// resolve even though any two segments together would exceed the cap.
+#[test]
+fn near_cap_gather_segments_separated_by_coroutines_resolve() {
+    let code = r"
+import asyncio
+
+async def leaf():
+    return 1
+
+async def wrap(g):
+    return await g
+
+def segment(inner):
+    g = inner
+    for _ in range(31):
+        g = asyncio.gather(g)
+    return g
+
+g = leaf()
+for _ in range(100):
+    g = segment(wrap(g))
+result = await g
+for _ in range(3100):
+    result = result[0]
+result
+";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+
+    let result = ex
+        .run_no_limits(vec![])
+        .expect("each segment must be charged from zero");
+    assert_eq!(result, MontyObject::Int(1));
+}
+
+/// Sibling gathers commit one after another, not inside one another, so each
+/// item's level comes from the enclosing walk rather than accumulating.
+#[test]
+fn gather_width_is_not_charged_as_nesting_depth() {
+    let code = r"
+import asyncio
+
+async def leaf():
+    return 1
+
+def deep(n):
+    g = leaf()
+    for _ in range(n):
+        g = asyncio.gather(g)
+    return g
+
+shallow = await asyncio.gather(*[asyncio.gather(leaf()) for _ in range(500)])
+assert len(shallow) == 500
+
+wide = await asyncio.gather(*[deep(31) for _ in range(100)])
+assert len(wide) == 100
+
+shallow[499][0]
+";
+    let ex = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).unwrap();
+
+    let result = ex
+        .run_no_limits(vec![])
+        .expect("gather width must not be charged as depth");
+    assert_eq!(result, MontyObject::Int(1));
+}

--- a/limitations/asyncio.md
+++ b/limitations/asyncio.md
@@ -17,6 +17,16 @@ The `asyncio` module exposes exactly two functions:
   where CPython raises
   `TypeError: gather() got an unexpected keyword argument 'X'` because
   `return_exceptions` is a real kwarg there.
+- Gathers may nest at most **32 levels** deep inside one another
+  (`asyncio.gather(asyncio.gather(...))`). Awaiting a deeper nest raises
+  `RecursionError: maximum recursion depth exceeded`. CPython has no such
+  limit: its event loop drives nested futures iteratively, whereas Monty
+  commits a nested gather by recursing on the native stack. The cap is
+  fixed and independent of `sys.setrecursionlimit`, which cannot raise it.
+  Only a gather passed *directly as an item of another gather* counts, so
+  recursion through coroutines (`await asyncio.gather(recurse(n - 1))`) and
+  `gather()` width are unaffected. In practice the cap is only reachable by
+  building an awaitable tree without awaiting it (`g = asyncio.gather(g)`).
 
 Not implemented (raise `AttributeError`):
 


### PR DESCRIPTION
Nesting `asyncio.gather` futures aborted the worker (SIGABRT, uncatchable): `g = asyncio.gather(g)` in a loop costs no Python frames, so the recursion limit never saw the native `await_gather_future` → `commit_gather_items` recursion that commits it.

A `recursion_guard()` charge was not enough — these frames run ~4 KiB, so 1,000 levels still overflowed a 2 MiB thread. Instead a hard `MAX_GATHER_NEST_DEPTH = 32` is threaded through the commit walk (alongside `MAX_RUN_REENTRY_DEPTH`), which also bounds teardown in `drop_committed_children` and `Scheduler::cancel_task`.

Tests written first (`resource_limits.rs`) cover the 5,000-level crash, independence from `max_recursion_depth`, the 33-resolves/34-raises boundary, and the invariant the design rests on — depth resets only where the native stack unwinds, so nesting through coroutines (200 alternating levels, and 100 near-cap segments) and gather *width* are unaffected; `limitations/asyncio.md` records the divergence.

> **Functionality Change** - gathers now nest at most 32 deep; deeper raises a catchable `RecursionError` instead of crashing. The cap is fixed, not raisable via `sys.setrecursionlimit`, and has no CPython equivalent. Only a gather passed directly as an item of another gather counts — recursion through coroutines (`await asyncio.gather(recurse(n - 1))`) and `gather()` width are unaffected.

Sibling of #704, same class as #649, and a concrete instance of #440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds `asyncio.gather` nesting to prevent native stack overflow. Previously deep gather-in-gather chains aborted; now exceeding 32 charged levels raises `RecursionError`, while chains at or under the cap resolve.

- Enforces `MAX_GATHER_NEST_DEPTH = 32` via `charge_gather_nesting`, threading a `depth` through `await_gather_future` and `commit_gather_items`; depth starts at 0 at each `await`.
- Charges child gathers before `inc_ref`; only a gather passed directly as an item of another gather is charged. Boundary: 33 nested gathers resolve; 34 raise.
- Teardown/cancel paths are implicitly bounded because deeper nests cannot be committed.
- Adds resource-limit tests for crash repro, boundary, coroutine resets, and width; documents the limit in `limitations/asyncio.md`.

**Migration**
- If your code builds more than 32 direct gather-as-item links (e.g., `g = asyncio.gather(g)` in a loop), insert a coroutine boundary, await earlier, or flatten. `sys.setrecursionlimit` does not raise this cap.

<sup>Written for commit 1d2ebff17a1af74c7fb7df18b55581e379a5462f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

