### PR TITLE
Fix stale-index panics when a user `__eq__` mutates the container mid-lookup

### DIFF
--- a/crates/monty/src/bytecode/vm/mod.rs
+++ b/crates/monty/src/bytecode/vm/mod.rs
@@ -78,6 +78,17 @@ macro_rules! try_catch_sync {
     };
 }
 
+/// Persists the cached frame IP before an operation that can execute Python.
+///
+/// A nested `run()` restores `instruction_ip` from the caller frame, so the
+/// caller must hold its resume IP for exceptions to find the right handler.
+macro_rules! try_catch_reentrant {
+    ($self:expr, $cached_frame:ident, $expr:expr) => {{
+        $self.current_frame_mut().ip = $cached_frame.ip;
+        try_catch_sync!($self, $cached_frame, $expr);
+    }};
+}
+
 /// Handles an exception and reloads cached frame state if caught.
 ///
 /// Use this in the main run loop where `cached_frame`
@@ -1205,16 +1216,16 @@ impl<'h> VM<'h> {
                 }
                 Opcode::BinaryMatMul => try_catch_sync!(self, cached_frame, self.binary_matmul()),
                 // Comparison Operations
-                Opcode::CompareEq => try_catch_sync!(self, cached_frame, self.compare_eq()),
-                Opcode::CompareNe => try_catch_sync!(self, cached_frame, self.compare_ne()),
-                Opcode::CompareLt => try_catch_sync!(self, cached_frame, self.compare_lt()),
-                Opcode::CompareLe => try_catch_sync!(self, cached_frame, self.compare_le()),
-                Opcode::CompareGt => try_catch_sync!(self, cached_frame, self.compare_gt()),
-                Opcode::CompareGe => try_catch_sync!(self, cached_frame, self.compare_ge()),
+                Opcode::CompareEq => try_catch_reentrant!(self, cached_frame, self.compare_eq()),
+                Opcode::CompareNe => try_catch_reentrant!(self, cached_frame, self.compare_ne()),
+                Opcode::CompareLt => try_catch_reentrant!(self, cached_frame, self.compare_lt()),
+                Opcode::CompareLe => try_catch_reentrant!(self, cached_frame, self.compare_le()),
+                Opcode::CompareGt => try_catch_reentrant!(self, cached_frame, self.compare_gt()),
+                Opcode::CompareGe => try_catch_reentrant!(self, cached_frame, self.compare_ge()),
                 Opcode::CompareIs => try_catch_sync!(self, cached_frame, self.compare_is()),
                 Opcode::CompareIsNot => try_catch_sync!(self, cached_frame, self.compare_is_not()),
-                Opcode::CompareIn => try_catch_sync!(self, cached_frame, self.compare_in()),
-                Opcode::CompareNotIn => try_catch_sync!(self, cached_frame, self.compare_not_in()),
+                Opcode::CompareIn => try_catch_reentrant!(self, cached_frame, self.compare_in()),
+                Opcode::CompareNotIn => try_catch_reentrant!(self, cached_frame, self.compare_not_in()),
                 // Unary Operations
                 Opcode::UnaryNot => {
                     let value = self.pop();
@@ -1657,9 +1668,12 @@ impl<'h> VM<'h> {
                     reload_cache!(self, cached_frame);
                 }
                 Opcode::Assert => {
-                    match decode_assert_flags(cached_frame.fetch_u8()).expect("invalid assert flags in bytecode") {
-                        Some(op) => try_catch_sync!(self, cached_frame, self.assert_cmp(op)),
-                        None => try_catch_sync!(self, cached_frame, self.assert_test()),
+                    if let Some(op) =
+                        decode_assert_flags(cached_frame.fetch_u8()).expect("invalid assert flags in bytecode")
+                    {
+                        try_catch_reentrant!(self, cached_frame, self.assert_cmp(op));
+                    } else {
+                        try_catch_reentrant!(self, cached_frame, self.assert_test());
                     }
                 }
                 Opcode::AssertFailed => {

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1910,6 +1910,14 @@ pub(crate) trait ExcTypeExt: Sized {
         SimpleException::new_msg(ExcType::RuntimeError, "deque mutated during iteration").into()
     }
 
+    /// Creates an IndexError for a user `__eq__` mutating a deque during
+    /// `deque.remove` — CPython quirkily raises IndexError there, with the
+    /// same message its RuntimeError sibling uses.
+    #[must_use]
+    fn index_error_deque_mutated() -> RunError {
+        SimpleException::new_msg(ExcType::IndexError, "deque mutated during iteration").into()
+    }
+
     /// `IndexError: deque index out of range` — indexing or assigning out of bounds.
     #[must_use]
     fn index_error_deque_out_of_range() -> RunError {

--- a/crates/monty/src/identity.rs
+++ b/crates/monty/src/identity.rs
@@ -22,8 +22,9 @@ const MAX_FIXED_BYTES: usize = 14;
 /// Complete identity key for a runtime value.
 ///
 /// Equality is the implementation of Python's `is`; the integer encoding is
-/// injective and used to expose the same key through `id()`.
-#[derive(PartialEq, Eq)]
+/// injective and used to expose the same key through `id()`. `Hash` lets
+/// identity sets answer "seen this object?" in O(1) (see the dict/set probes).
+#[derive(PartialEq, Eq, Hash)]
 pub(crate) enum Identity {
     /// Internal uninitialized-value sentinel.
     Undefined,

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -332,7 +332,8 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Deque> {
 
     /// `in` walks the deque comparing each item by `==`, like `list`.
     fn py_contains_impl(&self, _self_id: HeapId, item: &Value, vm: &mut VM<'h>) -> RunResult<Option<bool>> {
-        let len = self.get(vm.heap).len();
+        let this = self.get(vm.heap);
+        let (len, start_state) = (this.len(), this.state());
         for i in 0..len {
             let el = self
                 .get(vm.heap)
@@ -343,6 +344,11 @@ impl<'h> PyTrait<'h> for HeapRead<'h, Deque> {
             el.drop_with(vm);
             if eq? {
                 return Ok(Some(true));
+            }
+            // A user `__eq__` mutating the deque invalidates the walk (and the
+            // indices above); CPython raises, checking only after a false compare.
+            if self.get(vm.heap).state() != start_state {
+                return Err(ExcType::runtime_error_deque_mutated());
             }
         }
         Ok(Some(false))
@@ -857,11 +863,20 @@ fn remove<'h>(deque: &mut HeapRead<'h, Deque>, args: ArgValues, vm: &mut VM<'h>)
     let target = args.get_one_arg("deque.remove", vm.heap)?;
     defer_drop!(target, vm);
 
-    let len = deque.get(vm.heap).len();
+    let (len, start_state) = {
+        let this = deque.get(vm.heap);
+        (this.len(), this.state())
+    };
     for i in 0..len {
         let item = deque.get(vm.heap).items[i].clone_with_heap(vm.heap);
         defer_drop!(item, vm);
-        if item.py_eq(target, vm)? {
+        let eq = item.py_eq(target, vm)?;
+        // CPython checks for mutation by the user `__eq__` before acting on the
+        // comparison — even a matching one — and quirkily raises IndexError here.
+        if deque.get(vm.heap).state() != start_state {
+            return Err(ExcType::index_error_deque_mutated());
+        }
+        if eq {
             let this = deque.get_mut(vm.heap);
             let removed = this.items.remove(i).expect("index in range");
             // Only a successful removal bumps: a `remove()` that raises ValueError
@@ -897,11 +912,17 @@ fn index<'h>(deque: &mut HeapRead<'h, Deque>, args: ArgValues, vm: &mut VM<'h>) 
     };
     let stop = bound_arg(stop, len, len, vm)?;
 
+    let start_state = deque.get(vm.heap).state();
     for i in start..stop.min(len) {
         let item = deque.get(vm.heap).items[i].clone_with_heap(vm.heap);
         defer_drop!(item, vm);
         if item.py_eq(target, vm)? {
             return Ok(Value::Int(i64::try_from(i).expect("index fits in i64")));
+        }
+        // A user `__eq__` mutating the deque invalidates the walk; CPython
+        // raises, checking only after a false compare.
+        if deque.get(vm.heap).state() != start_state {
+            return Err(ExcType::runtime_error_deque_mutated());
         }
     }
     Err(ExcType::value_error_deque_index())
@@ -912,13 +933,21 @@ fn count<'h>(deque: &mut HeapRead<'h, Deque>, args: ArgValues, vm: &mut VM<'h>) 
     let target = args.get_one_arg("deque.count", vm.heap)?;
     defer_drop!(target, vm);
 
-    let len = deque.get(vm.heap).len();
+    let (len, start_state) = {
+        let this = deque.get(vm.heap);
+        (this.len(), this.state())
+    };
     let mut total: i64 = 0;
     for i in 0..len {
         let item = deque.get(vm.heap).items[i].clone_with_heap(vm.heap);
         defer_drop!(item, vm);
         if item.py_eq(target, vm)? {
             total += 1;
+        }
+        // A user `__eq__` mutating the deque invalidates the walk; CPython
+        // checks after counting each compare.
+        if deque.get(vm.heap).state() != start_state {
+            return Err(ExcType::runtime_error_deque_mutated());
         }
     }
     Ok(Value::Int(total))

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -28,7 +28,7 @@ use crate::{
         defaultdict::defaultdict_missing,
     },
     types::Type,
-    value::{EitherStr, VALUE_SIZE, Value},
+    value::{EitherStr, VALUE_SIZE, Value, eq_bigint, eq_bytes, eq_f64, eq_i64, eq_str},
 };
 
 /// Python dict type preserving insertion order.
@@ -668,6 +668,37 @@ struct DictInitArgs {
     extras: KwargsValues,
 }
 
+/// Heap-only equality for probe candidates, mirroring `py_eq` for pairs whose
+/// comparison can never re-enter the VM.
+///
+/// Returns `None` when the pair may need the VM (user `__eq__`, container
+/// recursion, or a cross-type pair the native helpers do not decide); the
+/// caller then falls back to the guarded snapshot path. Runs no user code, so
+/// it is safe to call while the index-table borrow is held.
+pub(crate) fn probe_native_eq(candidate: &Value, key: &Value, vm: &VM<'_>) -> Option<bool> {
+    // `py_eq` starts with identity, so this must too (it is what makes a NaN
+    // key findable).
+    if candidate.is(key) {
+        Some(true)
+    } else {
+        match candidate {
+            Value::Bool(b) => eq_i64(i64::from(*b), key, vm),
+            Value::Int(i) => eq_i64(*i, key, vm),
+            Value::Float(f) => eq_f64(*f, key, vm),
+            Value::InternLongInt(id) => eq_bigint(vm.interns.get_long_int(*id), key, vm),
+            Value::InternString(id) => eq_str(vm.interns.get_str(*id), key, vm),
+            Value::InternBytes(id) => eq_bytes(vm.interns.get_bytes(*id), key, vm),
+            Value::Ref(id) => match vm.heap.get(*id) {
+                HeapData::Str(s) => eq_str(s.as_str(), key, vm),
+                HeapData::Bytes(b) => eq_bytes(b.as_slice(), key, vm),
+                HeapData::LongInt(li) => eq_bigint(li.inner(), key, vm),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+
 /// Whether an equality comparison involving `value` can never re-enter the VM.
 ///
 /// True for immediates and for heap types whose `py_eq` is fully native.
@@ -724,14 +755,36 @@ impl<'h> HeapRead<'h, Dict> {
             let mut candidate_keys: SmallVec<[Value; 2]> = SmallVec::new();
             let mut all_native = key_native;
             let this = self.get(vm.heap);
-            this.indices.find(hash, |v| {
-                if this.entries[*v].hash == hash {
-                    candidate_indices.push(*v);
-                    candidate_keys.push(this.entries[*v].key.clone_with_heap(vm.heap));
-                    all_native = all_native && eq_is_native(&this.entries[*v].key, vm.heap);
-                }
-                false
-            });
+            // The `find` predicate doubles as the probe walk: native pairs are
+            // compared inline (a `true` stops at the match), and only pairs
+            // that may need user code are cloned for the guarded loop below.
+            // Once one is deferred, later candidates queue behind it so
+            // comparisons keep CPython's probe order.
+            let found = this
+                .indices
+                .find(hash, |v| {
+                    let entry = &this.entries[*v];
+                    if entry.hash != hash {
+                        return false;
+                    }
+                    if candidate_indices.is_empty()
+                        && let Some(eq) = probe_native_eq(&entry.key, key, vm)
+                    {
+                        eq
+                    } else {
+                        candidate_indices.push(*v);
+                        candidate_keys.push(entry.key.clone_with_heap(vm.heap));
+                        all_native = all_native && eq_is_native(&entry.key, vm.heap);
+                        false
+                    }
+                })
+                .copied();
+            if let Some(index) = found {
+                return Ok((Some(index), hash));
+            }
+            if candidate_indices.is_empty() {
+                return Ok((None, hash));
+            }
             defer_drop!(candidate_keys, vm);
 
             for (&candidate_index, candidate_key) in candidate_indices.iter().zip(candidate_keys.iter()) {
@@ -752,9 +805,8 @@ impl<'h> HeapRead<'h, Dict> {
 
             // Nothing matched. Comparisons can themselves add colliding keys the
             // snapshot never saw, so a pass that ran any hands over to the
-            // mutation-aware continuation — unless none could run user code;
-            // with no candidates it is simply a miss.
-            if all_native || candidate_keys.is_empty() {
+            // mutation-aware continuation — unless none could run user code.
+            if all_native {
                 return Ok((None, hash));
             }
             match self.probe_after_compare(hash, key, candidate_keys, vm)? {

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -825,6 +825,13 @@ impl<'h> HeapRead<'h, Dict> {
     /// already compared so no `__eq__` runs twice — CPython, walking the live
     /// probe chain, never repeats one either. Only reached once user code has
     /// run, so it is off the ordinary lookup path.
+    ///
+    /// Native pairs compared inline before the first deferral are not in the
+    /// seen set and may be re-compared here. That is deliberate: such
+    /// comparisons are side-effect-free and deterministic (the no-repeat
+    /// invariant protects user `__eq__` observability, which native pairs
+    /// lack), and recording them would put clone and identity bookkeeping on
+    /// the pure-native fast path.
     fn probe_after_compare(
         &self,
         hash: u64,

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -668,6 +668,23 @@ struct DictInitArgs {
     extras: KwargsValues,
 }
 
+/// Whether an equality comparison involving `value` can never re-enter the VM.
+///
+/// True for immediates and for heap types whose `py_eq` is fully native.
+/// Instances and dataclasses dispatch to user `__eq__`, and containers
+/// (tuples, frozensets) recurse into element comparisons that might; those and
+/// any unlisted heap type return false. A conservative fast-path filter for
+/// the dict/set probes, not a complete classification.
+pub(crate) fn eq_is_native(value: &Value, heap: &Heap) -> bool {
+    match value {
+        Value::Ref(id) => matches!(
+            heap.get(*id),
+            HeapData::Str(_) | HeapData::Bytes(_) | HeapData::LongInt(_) | HeapData::Range(_)
+        ),
+        _ => true,
+    }
+}
+
 /// How a probe continued after user `__eq__` code may have mutated the
 /// container; shared by the dict and set lookups, which mirror each other.
 pub(crate) enum ProbeOutcome {
@@ -693,30 +710,38 @@ impl<'h> HeapRead<'h, Dict> {
         // `lookdict`. Restarts poll the limits — this native loop calls back into
         // the VM, which restarts the dispatch countdown, so it reaches no
         // checkpoint of its own.
+        //
+        // When neither the key nor any candidate can dispatch to user code,
+        // no comparison can mutate the dict, so revalidation and the miss
+        // continuation are skipped — this is the common (str/int keys) path.
+        let key_native = eq_is_native(key, vm.heap);
+
         'restart: loop {
             // Collected inline rather than through `probe_candidates`: every
             // lookup runs this, and moving the buffers out of a call shows up
             // in the dict benchmarks.
             let mut candidate_indices: SmallVec<[usize; 2]> = SmallVec::new();
             let mut candidate_keys: SmallVec<[Value; 2]> = SmallVec::new();
+            let mut all_native = key_native;
             let this = self.get(vm.heap);
             this.indices.find(hash, |v| {
                 if this.entries[*v].hash == hash {
                     candidate_indices.push(*v);
                     candidate_keys.push(this.entries[*v].key.clone_with_heap(vm.heap));
+                    all_native = all_native && eq_is_native(&this.entries[*v].key, vm.heap);
                 }
                 false
             });
             defer_drop!(candidate_keys, vm);
 
             for (&candidate_index, candidate_key) in candidate_indices.iter().zip(candidate_keys.iter()) {
-                if !self.probe_valid(candidate_index, hash, candidate_key, vm) {
+                if !all_native && !self.probe_valid(candidate_index, hash, candidate_key, vm) {
                     vm.heap.tracker.check_memory_time()?;
                     continue 'restart;
                 }
                 // CPython compares the stored key on the left.
                 let eq = candidate_key.py_eq(key, vm)?;
-                if !self.probe_valid(candidate_index, hash, candidate_key, vm) {
+                if !all_native && !self.probe_valid(candidate_index, hash, candidate_key, vm) {
                     vm.heap.tracker.check_memory_time()?;
                     continue 'restart;
                 }
@@ -727,8 +752,9 @@ impl<'h> HeapRead<'h, Dict> {
 
             // Nothing matched. Comparisons can themselves add colliding keys the
             // snapshot never saw, so a pass that ran any hands over to the
-            // mutation-aware continuation; with no candidates it is simply a miss.
-            if candidate_keys.is_empty() {
+            // mutation-aware continuation — unless none could run user code;
+            // with no candidates it is simply a miss.
+            if all_native || candidate_keys.is_empty() {
                 return Ok((None, hash));
             }
             match self.probe_after_compare(hash, key, candidate_keys, vm)? {

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -673,26 +673,29 @@ impl<'h> HeapRead<'h, Dict> {
             .ok_or_else(|| ExcType::type_error_unhashable_dict_key(&key.py_type_name(vm)))?
             .raw();
 
-        // Candidate indices are collected up front (avoiding a borrow conflict
-        // between the index table and `py_eq`), but a user `__eq__` re-entering
-        // the VM can mutate the dict and leave them stale. Mirroring CPython's
-        // `lookdict`, every `py_eq` is followed by [`Self::probe_valid`]; on any
-        // mutation the whole probe restarts against the live entries.
+        // Candidate snapshots avoid holding the index-table borrow while
+        // `py_eq` runs user code. Each is checked on both sides of that call so
+        // a mutation cannot turn a queued index into an unrelated comparison.
         'restart: loop {
-            let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
+            let mut candidate_indices: SmallVec<[usize; 2]> = SmallVec::new();
+            let mut candidate_keys: SmallVec<[Value; 2]> = SmallVec::new();
             let this = self.get(vm.heap);
             let len = this.entries.len();
             this.indices.find(hash, |v| {
                 if this.entries[*v].hash == hash {
-                    candidates.push(*v);
+                    candidate_indices.push(*v);
+                    candidate_keys.push(this.entries[*v].key.clone_with_heap(vm.heap));
                 }
                 false
             });
+            defer_drop!(candidate_keys, vm);
 
-            for candidate_index in candidates {
-                let candidate_key = self.get(vm.heap).entries[candidate_index].key.clone_with_heap(vm);
-                defer_drop!(candidate_key, vm);
-                let eq = key.py_eq(candidate_key, vm)?;
+            for (&candidate_index, candidate_key) in candidate_indices.iter().zip(candidate_keys.iter()) {
+                if !self.probe_valid(len, candidate_index, hash, candidate_key, vm) {
+                    continue 'restart;
+                }
+                // CPython compares the stored key on the left.
+                let eq = candidate_key.py_eq(key, vm)?;
                 if !self.probe_valid(len, candidate_index, hash, candidate_key, vm) {
                     continue 'restart;
                 }
@@ -705,10 +708,9 @@ impl<'h> HeapRead<'h, Dict> {
         }
     }
 
-    /// True if a probe candidate is still valid after `py_eq` possibly ran user
-    /// code: the dict's length is unchanged and the entry at `index` still holds
-    /// the identical key with the same hash. A `false` return means the dict was
-    /// mutated mid-lookup and [`Self::find_index_hash`] must restart its probe.
+    /// Checks that a snapshotted candidate still names the same live entry.
+    ///
+    /// The caller checks before and after `py_eq`; a mismatch restarts the probe.
     fn probe_valid(&self, len: usize, index: usize, hash: u64, key: &Value, vm: &VM<'h>) -> bool {
         let this = self.get(vm.heap);
         this.entries.len() == len

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -5,6 +5,7 @@ use std::{
     mem, slice, vec,
 };
 
+use ahash::AHashSet;
 use hashbrown::HashTable;
 use serde::ser::SerializeStruct;
 use smallvec::{SmallVec, smallvec};
@@ -17,6 +18,7 @@ use crate::{
     exception_private::{ExcType, ExcTypeExt, RunResult},
     expressions::CmpOperator,
     heap::{ContainsHeap, DropGuard, DropWithContext, Heap, HeapData, HeapId, HeapItem, HeapRead, HeapReadOutput},
+    identity::Identity,
     intern::{Interns, StaticStrings},
     modules::collections::{
         counter::{
@@ -752,16 +754,26 @@ impl<'h> HeapRead<'h, Dict> {
         already_compared: &[Value],
         vm: &mut VM<'h>,
     ) -> RunResult<ProbeOutcome> {
+        // The clones keep every compared key alive so its heap slot cannot be
+        // recycled into a new key that would then be skipped by identity.
         let compared: SmallVec<[Value; 2]> = already_compared.iter().map(|k| k.clone_with_heap(vm.heap)).collect();
         defer_drop_mut!(compared, vm);
+        // Identity set for O(1) seen-checks — a linear scan is quadratic over
+        // a fully colliding dict, all skips, before the poll below is reached.
+        let mut compared_ids: AHashSet<Identity> = compared.iter().map(Value::id).collect();
 
         loop {
+            // Polled up front so every entry checks the limits at least once:
+            // the comparisons that brought us here ran user code, restarting
+            // the VM dispatch countdown, so no checkpoint fires otherwise —
+            // including on the no-mutation pass that returns `Missing`.
+            vm.heap.tracker.check_memory_time()?;
             let (candidate_indices, candidate_keys) = self.probe_candidates(hash, vm);
             defer_drop!(candidate_keys, vm);
             let mut compared_any = false;
 
             for (&candidate_index, candidate_key) in candidate_indices.iter().zip(candidate_keys.iter()) {
-                if compared.iter().any(|seen| seen.is(candidate_key)) {
+                if !compared_ids.insert(candidate_key.id()) {
                     continue;
                 }
                 if !self.probe_valid(candidate_index, hash, candidate_key, vm) {
@@ -784,7 +796,6 @@ impl<'h> HeapRead<'h, Dict> {
             if !compared_any {
                 return Ok(ProbeOutcome::Missing);
             }
-            vm.heap.tracker.check_memory_time()?;
         }
     }
 

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -673,29 +673,49 @@ impl<'h> HeapRead<'h, Dict> {
             .ok_or_else(|| ExcType::type_error_unhashable_dict_key(&key.py_type_name(vm)))?
             .raw();
 
-        // Dict keys are typically shallow (strings, ints, tuples of primitives),
-        // so recursion errors are unlikely. If one occurs, treat it as "not equal" -
-        // the key lookup fails but doesn't crash.
-        //
-        // Collect candidate indices during the lookup to avoid borrow tracker issues
-        let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
-        let this = self.get(vm.heap);
-        this.indices.find(hash, |v| {
-            if this.entries[*v].hash == hash {
-                candidates.push(*v);
-            }
-            false
-        });
+        // Candidate indices are collected up front (avoiding a borrow conflict
+        // between the index table and `py_eq`), but a user `__eq__` re-entering
+        // the VM can mutate the dict and leave them stale. Mirroring CPython's
+        // `lookdict`, every `py_eq` is followed by [`Self::probe_valid`]; on any
+        // mutation the whole probe restarts against the live entries.
+        'restart: loop {
+            let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
+            let this = self.get(vm.heap);
+            let len = this.entries.len();
+            this.indices.find(hash, |v| {
+                if this.entries[*v].hash == hash {
+                    candidates.push(*v);
+                }
+                false
+            });
 
-        for candidate_index in candidates {
-            let candidate_key = self.get(vm.heap).entries[candidate_index].key.clone_with_heap(vm);
-            defer_drop!(candidate_key, vm);
-            if key.py_eq(candidate_key, vm)? {
-                return Ok((Some(candidate_index), hash));
+            for candidate_index in candidates {
+                let candidate_key = self.get(vm.heap).entries[candidate_index].key.clone_with_heap(vm);
+                defer_drop!(candidate_key, vm);
+                let eq = key.py_eq(candidate_key, vm)?;
+                if !self.probe_valid(len, candidate_index, hash, candidate_key, vm) {
+                    continue 'restart;
+                }
+                if eq {
+                    return Ok((Some(candidate_index), hash));
+                }
             }
+
+            return Ok((None, hash));
         }
+    }
 
-        Ok((None, hash))
+    /// True if a probe candidate is still valid after `py_eq` possibly ran user
+    /// code: the dict's length is unchanged and the entry at `index` still holds
+    /// the identical key with the same hash. A `false` return means the dict was
+    /// mutated mid-lookup and [`Self::find_index_hash`] must restart its probe.
+    fn probe_valid(&self, len: usize, index: usize, hash: u64, key: &Value, vm: &VM<'h>) -> bool {
+        let this = self.get(vm.heap);
+        this.entries.len() == len
+            && this
+                .entries
+                .get(index)
+                .is_some_and(|entry| entry.hash == hash && entry.key.is(key))
     }
 
     /// Checks whether the dict contains a given key.

--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -666,6 +666,17 @@ struct DictInitArgs {
     extras: KwargsValues,
 }
 
+/// How a probe continued after user `__eq__` code may have mutated the
+/// container; shared by the dict and set lookups, which mirror each other.
+pub(crate) enum ProbeOutcome {
+    /// The key was found in this entry.
+    Found(usize),
+    /// Every live candidate has been compared, none matched.
+    Missing,
+    /// A candidate moved mid-probe, so the whole probe must start over.
+    Restart,
+}
+
 impl<'h> HeapRead<'h, Dict> {
     fn find_index_hash(&self, key: &Value, vm: &mut VM<'h>) -> RunResult<(Option<usize>, u64)> {
         let hash = key
@@ -675,12 +686,18 @@ impl<'h> HeapRead<'h, Dict> {
 
         // Candidate snapshots avoid holding the index-table borrow while
         // `py_eq` runs user code. Each is checked on both sides of that call so
-        // a mutation cannot turn a queued index into an unrelated comparison.
+        // a mutation cannot turn a queued index into an unrelated comparison;
+        // only a candidate that moved restarts the whole probe, as in CPython's
+        // `lookdict`. Restarts poll the limits — this native loop calls back into
+        // the VM, which restarts the dispatch countdown, so it reaches no
+        // checkpoint of its own.
         'restart: loop {
+            // Collected inline rather than through `probe_candidates`: every
+            // lookup runs this, and moving the buffers out of a call shows up
+            // in the dict benchmarks.
             let mut candidate_indices: SmallVec<[usize; 2]> = SmallVec::new();
             let mut candidate_keys: SmallVec<[Value; 2]> = SmallVec::new();
             let this = self.get(vm.heap);
-            let len = this.entries.len();
             this.indices.find(hash, |v| {
                 if this.entries[*v].hash == hash {
                     candidate_indices.push(*v);
@@ -691,12 +708,14 @@ impl<'h> HeapRead<'h, Dict> {
             defer_drop!(candidate_keys, vm);
 
             for (&candidate_index, candidate_key) in candidate_indices.iter().zip(candidate_keys.iter()) {
-                if !self.probe_valid(len, candidate_index, hash, candidate_key, vm) {
+                if !self.probe_valid(candidate_index, hash, candidate_key, vm) {
+                    vm.heap.tracker.check_memory_time()?;
                     continue 'restart;
                 }
                 // CPython compares the stored key on the left.
                 let eq = candidate_key.py_eq(key, vm)?;
-                if !self.probe_valid(len, candidate_index, hash, candidate_key, vm) {
+                if !self.probe_valid(candidate_index, hash, candidate_key, vm) {
+                    vm.heap.tracker.check_memory_time()?;
                     continue 'restart;
                 }
                 if eq {
@@ -704,20 +723,101 @@ impl<'h> HeapRead<'h, Dict> {
                 }
             }
 
-            return Ok((None, hash));
+            // Nothing matched. Comparisons can themselves add colliding keys the
+            // snapshot never saw, so a pass that ran any hands over to the
+            // mutation-aware continuation; with no candidates it is simply a miss.
+            if candidate_keys.is_empty() {
+                return Ok((None, hash));
+            }
+            match self.probe_after_compare(hash, key, candidate_keys, vm)? {
+                ProbeOutcome::Found(index) => return Ok((Some(index), hash)),
+                ProbeOutcome::Missing => return Ok((None, hash)),
+                // a candidate moved: fall through to the next probe from scratch
+                ProbeOutcome::Restart => (),
+            }
         }
+    }
+
+    /// Continues a probe whose comparisons all missed, in case one of them
+    /// mutated the dict and added a colliding key.
+    ///
+    /// Re-reads the candidates until a pass finds nothing new, skipping keys
+    /// already compared so no `__eq__` runs twice — CPython, walking the live
+    /// probe chain, never repeats one either. Only reached once user code has
+    /// run, so it is off the ordinary lookup path.
+    fn probe_after_compare(
+        &self,
+        hash: u64,
+        key: &Value,
+        already_compared: &[Value],
+        vm: &mut VM<'h>,
+    ) -> RunResult<ProbeOutcome> {
+        let compared: SmallVec<[Value; 2]> = already_compared.iter().map(|k| k.clone_with_heap(vm.heap)).collect();
+        defer_drop_mut!(compared, vm);
+
+        loop {
+            let (candidate_indices, candidate_keys) = self.probe_candidates(hash, vm);
+            defer_drop!(candidate_keys, vm);
+            let mut compared_any = false;
+
+            for (&candidate_index, candidate_key) in candidate_indices.iter().zip(candidate_keys.iter()) {
+                if compared.iter().any(|seen| seen.is(candidate_key)) {
+                    continue;
+                }
+                if !self.probe_valid(candidate_index, hash, candidate_key, vm) {
+                    vm.heap.tracker.check_memory_time()?;
+                    return Ok(ProbeOutcome::Restart);
+                }
+                compared.push(candidate_key.clone_with_heap(vm.heap));
+                compared_any = true;
+                // CPython compares the stored key on the left.
+                let eq = candidate_key.py_eq(key, vm)?;
+                if !self.probe_valid(candidate_index, hash, candidate_key, vm) {
+                    vm.heap.tracker.check_memory_time()?;
+                    return Ok(ProbeOutcome::Restart);
+                }
+                if eq {
+                    return Ok(ProbeOutcome::Found(candidate_index));
+                }
+            }
+
+            if !compared_any {
+                return Ok(ProbeOutcome::Missing);
+            }
+            vm.heap.tracker.check_memory_time()?;
+        }
+    }
+
+    /// Snapshots the live entries colliding on `hash`: their indices, plus an
+    /// owned reference to each of their keys.
+    ///
+    /// Cloning the keys lets `py_eq` run without the index-table borrow held;
+    /// the caller owns the returned keys and must drop them. Only the
+    /// mutation-aware continuation calls this — the fast path above inlines the
+    /// same collection.
+    fn probe_candidates(&self, hash: u64, vm: &VM<'h>) -> (SmallVec<[usize; 2]>, SmallVec<[Value; 2]>) {
+        let mut indices: SmallVec<[usize; 2]> = SmallVec::new();
+        let mut keys: SmallVec<[Value; 2]> = SmallVec::new();
+        let this = self.get(vm.heap);
+        this.indices.find(hash, |v| {
+            if this.entries[*v].hash == hash {
+                indices.push(*v);
+                keys.push(this.entries[*v].key.clone_with_heap(vm.heap));
+            }
+            false
+        });
+        (indices, keys)
     }
 
     /// Checks that a snapshotted candidate still names the same live entry.
     ///
     /// The caller checks before and after `py_eq`; a mismatch restarts the probe.
-    fn probe_valid(&self, len: usize, index: usize, hash: u64, key: &Value, vm: &VM<'h>) -> bool {
+    #[inline]
+    fn probe_valid(&self, index: usize, hash: u64, key: &Value, vm: &VM<'h>) -> bool {
         let this = self.get(vm.heap);
-        this.entries.len() == len
-            && this
-                .entries
-                .get(index)
-                .is_some_and(|entry| entry.hash == hash && entry.key.is(key))
+        this.entries
+            .get(index)
+            .is_some_and(|entry| entry.hash == hash && entry.key.is(key))
     }
 
     /// Checks whether the dict contains a given key.

--- a/crates/monty/src/types/list.rs
+++ b/crates/monty/src/types/list.rs
@@ -736,9 +736,14 @@ fn list_remove<'h>(list: &mut HeapRead<'h, List>, args: ArgValues, vm: &mut VM<'
 
     match found_idx {
         Some(idx) => {
-            // Remove the element and drop its refcount
-            let removed = list.get_mut(vm.heap).items.remove(idx);
-            removed.drop_with(vm.heap);
+            // A matching user `__eq__` may itself have shrunk the list, leaving
+            // `idx` stale; CPython clamps the deletion (`list_ass_slice`), so a
+            // gone index removes nothing rather than panicking.
+            let this = list.get_mut(vm.heap);
+            if idx < this.items.len() {
+                let removed = this.items.remove(idx);
+                removed.drop_with(vm.heap);
+            }
             Ok(Value::None)
         }
         None => Err(ExcType::value_error_remove_not_in_list()),

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -20,7 +20,7 @@ use crate::{
     intern::StaticStrings,
     types::{
         LazyHeapSet, Type,
-        dict::{ProbeOutcome, eq_is_native},
+        dict::{ProbeOutcome, eq_is_native, probe_native_eq},
         list::repr_items_fmt,
     },
     value::{EitherStr, VALUE_SIZE, Value},
@@ -231,14 +231,34 @@ impl<'h> HeapRead<'h, SetStorage> {
             let mut candidate_values: SmallVec<[Value; 2]> = SmallVec::new();
             let mut all_native = value_native;
             let storage = self.get(vm.heap);
-            storage.indices.find(hash, |&idx| {
-                if storage.entries[idx].hash == hash {
-                    candidate_indices.push(idx);
-                    candidate_values.push(storage.entries[idx].value.clone_with_heap(vm.heap));
-                    all_native = all_native && eq_is_native(&storage.entries[idx].value, vm.heap);
-                }
-                false
-            });
+            // Native pairs are compared inline during the probe walk; only
+            // pairs that may need user code are cloned for the guarded loop —
+            // see the dict twin.
+            let found = storage
+                .indices
+                .find(hash, |&idx| {
+                    let entry = &storage.entries[idx];
+                    if entry.hash != hash {
+                        return false;
+                    }
+                    if candidate_indices.is_empty()
+                        && let Some(eq) = probe_native_eq(&entry.value, value, vm)
+                    {
+                        eq
+                    } else {
+                        candidate_indices.push(idx);
+                        candidate_values.push(entry.value.clone_with_heap(vm.heap));
+                        all_native = all_native && eq_is_native(&entry.value, vm.heap);
+                        false
+                    }
+                })
+                .copied();
+            if let Some(index) = found {
+                return Ok(Some(index));
+            }
+            if candidate_indices.is_empty() {
+                return Ok(None);
+            }
             defer_drop!(candidate_values, vm);
 
             for (&candidate_index, candidate_value) in candidate_indices.iter().zip(candidate_values.iter()) {
@@ -259,9 +279,8 @@ impl<'h> HeapRead<'h, SetStorage> {
 
             // A comparison can itself have added a colliding value the snapshot
             // never saw, so a pass that ran any hands over to the mutation-aware
-            // continuation — unless none could run user code; with no
-            // candidates it is a miss.
-            if all_native || candidate_values.is_empty() {
+            // continuation — unless none could run user code.
+            if all_native {
                 return Ok(None);
             }
             match self.probe_after_compare(hash, value, candidate_values, vm)? {

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -125,28 +125,7 @@ impl<'h> HeapRead<'h, SetStorage> {
     fn remove(&mut self, value: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
         let hash = set_element_hash(value, vm)?;
 
-        // Collect candidates by hash
-        let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
-        let storage = &self.get(vm.heap);
-        storage.indices.find(hash, |&idx| {
-            if storage.entries[idx].hash == hash {
-                candidates.push(idx);
-            }
-            false
-        });
-
-        // Compare each candidate
-        let mut found_index = None;
-        for candidate_index in candidates {
-            let candidate_value = self.get(vm.heap).entries[candidate_index].value.clone_with_heap(vm);
-            defer_drop!(candidate_value, vm);
-            if value.py_eq(candidate_value, vm)? {
-                found_index = Some(candidate_index);
-                break;
-            }
-        }
-
-        let Some(index) = found_index else {
+        let Some(index) = self.find_index(value, hash, vm)? else {
             return Ok(false);
         };
 
@@ -221,27 +200,56 @@ impl<'h> HeapRead<'h, SetStorage> {
     /// Checks if the set contains a value.
     pub fn contains(&self, value: &Value, vm: &mut VM<'h>) -> RunResult<bool> {
         let hash = set_element_hash(value, vm)?;
+        Ok(self.find_index(value, hash, vm)?.is_some())
+    }
 
-        // Collect candidates by hash
-        let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
-        let storage = &self.get(vm.heap);
-        storage.indices.find(hash, |&idx| {
-            if storage.entries[idx].hash == hash {
-                candidates.push(idx);
-            }
-            false
-        });
+    /// Finds the index of the entry equal to `value`, or `None` if absent.
+    ///
+    /// Candidate indices are collected up front (avoiding a borrow conflict
+    /// between the index table and `py_eq`), but a user `__eq__` re-entering the
+    /// VM can mutate the set and leave them stale. Mirroring CPython's set
+    /// `lookkey`, every `py_eq` is followed by a validity check — length
+    /// unchanged and the identical value still at the candidate slot — and on
+    /// any mutation the whole probe restarts against the live entries.
+    fn find_index(&self, value: &Value, hash: u64, vm: &mut VM<'h>) -> RunResult<Option<usize>> {
+        'restart: loop {
+            let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
+            let storage = &self.get(vm.heap);
+            let len = storage.entries.len();
+            storage.indices.find(hash, |&idx| {
+                if storage.entries[idx].hash == hash {
+                    candidates.push(idx);
+                }
+                false
+            });
 
-        // Compare each candidate
-        for candidate_index in candidates {
-            let candidate_value = self.get(vm.heap).entries[candidate_index].value.clone_with_heap(vm);
-            defer_drop!(candidate_value, vm);
-            if value.py_eq(candidate_value, vm)? {
-                return Ok(true);
+            for candidate_index in candidates {
+                let candidate_value = self.get(vm.heap).entries[candidate_index].value.clone_with_heap(vm);
+                defer_drop!(candidate_value, vm);
+                let eq = value.py_eq(candidate_value, vm)?;
+                if !self.probe_valid(len, candidate_index, hash, candidate_value, vm) {
+                    continue 'restart;
+                }
+                if eq {
+                    return Ok(Some(candidate_index));
+                }
             }
+
+            return Ok(None);
         }
+    }
 
-        Ok(false)
+    /// True if a probe candidate is still valid after `py_eq` possibly ran user
+    /// code: the set's length is unchanged and the entry at `index` still holds
+    /// the identical value with the same hash. A `false` return means the set
+    /// was mutated mid-lookup and [`Self::find_index`] must restart its probe.
+    fn probe_valid(&self, len: usize, index: usize, hash: u64, value: &Value, vm: &VM<'h>) -> bool {
+        let storage = self.get(vm.heap);
+        storage.entries.len() == len
+            && storage
+                .entries
+                .get(index)
+                .is_some_and(|entry| entry.hash == hash && entry.value.is(value))
     }
 }
 
@@ -694,29 +702,16 @@ impl<'h> HeapRead<'h, Set> {
     /// `Ok(false)` if the element was already in the set (and the value is dropped).
     /// Returns `Err` if the element is unhashable (and the value is dropped).
     ///
-    /// Uses a two-phase lookup (collect candidates, then compare) to avoid
-    /// holding a borrow on the set storage during `py_eq` calls.
+    /// Uses the mutation-safe storage lookup ([`HeapRead::find_index`]) to
+    /// detect duplicates, so a user `__eq__` mutating the set mid-add cannot
+    /// leave the probe holding stale indices.
     pub fn add(&mut self, value: Value, vm: &mut VM<'h>) -> RunResult<bool> {
         let mut value_guard = DropGuard::new(value, vm);
         let (value, vm) = value_guard.as_parts();
         let hash = set_element_hash(value, vm)?;
 
-        // Collect candidate indices to avoid borrow conflict between set storage and py_eq
-        let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
-        let storage = &self.get(vm.heap).0;
-        storage.indices.find(hash, |&idx| {
-            if storage.entries[idx].hash == hash {
-                candidates.push(idx);
-            }
-            false
-        });
-
-        for candidate_index in candidates {
-            let candidate_value = self.get(vm.heap).0.entries[candidate_index].value.clone_with_heap(vm);
-            defer_drop!(candidate_value, vm);
-            if value.py_eq(candidate_value, vm)? {
-                return Ok(false);
-            }
+        if self.storage().find_index(value, hash, vm)?.is_some() {
+            return Ok(false);
         }
 
         // Add new entry

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -296,8 +296,10 @@ impl<'h> HeapRead<'h, SetStorage> {
     /// mutated the set and added a colliding value.
     ///
     /// The twin of [`HeapRead::<Dict>::probe_after_compare`]: re-reads the
-    /// candidates until a pass finds nothing new, never comparing a value
-    /// twice, and off the ordinary lookup path.
+    /// candidates until a pass finds nothing new, never re-running user
+    /// `__eq__` on a value, and off the ordinary lookup path. As in the dict
+    /// twin, inline-compared native pairs may be re-compared — deliberate,
+    /// see there.
     fn probe_after_compare(
         &self,
         hash: u64,

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -1,5 +1,6 @@
 use std::{cell::Cell, fmt::Write, mem};
 
+use ahash::AHashSet;
 use hashbrown::HashTable;
 use monty_types::{ResourceError, ResourceTracker};
 use smallvec::SmallVec;
@@ -15,6 +16,7 @@ use crate::{
         BorrowedHeapRead, BorrowedHeapReadMut, ContainsHeap, DropGuard, DropWithContext, HeapData, HeapId, HeapItem,
         HeapRead, HeapReadOutput, heap_read_ref_as_field, heap_read_ref_as_field_mut,
     },
+    identity::Identity,
     intern::StaticStrings,
     types::{LazyHeapSet, Type, dict::ProbeOutcome, list::repr_items_fmt},
     value::{EitherStr, VALUE_SIZE, Value},
@@ -272,16 +274,24 @@ impl<'h> HeapRead<'h, SetStorage> {
         already_compared: &[Value],
         vm: &mut VM<'h>,
     ) -> RunResult<ProbeOutcome> {
+        // The clones keep every compared value alive so its heap slot cannot
+        // be recycled into a new value that would then be skipped by identity.
         let compared: SmallVec<[Value; 2]> = already_compared.iter().map(|v| v.clone_with_heap(vm.heap)).collect();
         defer_drop_mut!(compared, vm);
+        // Identity set for O(1) seen-checks; see the dict twin for why the
+        // linear alternative is quadratic.
+        let mut compared_ids: AHashSet<Identity> = compared.iter().map(Value::id).collect();
 
         loop {
+            // Polled up front so every entry checks the limits at least once —
+            // see the dict twin.
+            vm.heap.tracker.check_memory_time()?;
             let (candidate_indices, candidate_values) = self.probe_candidates(hash, vm);
             defer_drop!(candidate_values, vm);
             let mut compared_any = false;
 
             for (&candidate_index, candidate_value) in candidate_indices.iter().zip(candidate_values.iter()) {
-                if compared.iter().any(|seen| seen.is(candidate_value)) {
+                if !compared_ids.insert(candidate_value.id()) {
                     continue;
                 }
                 if !self.probe_valid(candidate_index, hash, candidate_value, vm) {
@@ -304,7 +314,6 @@ impl<'h> HeapRead<'h, SetStorage> {
             if !compared_any {
                 return Ok(ProbeOutcome::Missing);
             }
-            vm.heap.tracker.check_memory_time()?;
         }
     }
 

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -18,7 +18,11 @@ use crate::{
     },
     identity::Identity,
     intern::StaticStrings,
-    types::{LazyHeapSet, Type, dict::ProbeOutcome, list::repr_items_fmt},
+    types::{
+        LazyHeapSet, Type,
+        dict::{ProbeOutcome, eq_is_native},
+        list::repr_items_fmt,
+    },
     value::{EitherStr, VALUE_SIZE, Value},
 };
 
@@ -215,29 +219,36 @@ impl<'h> HeapRead<'h, SetStorage> {
     /// native loop reaches no checkpoint of its own. See
     /// [`HeapRead::<Dict>::find_index_hash`] — the two must stay in sync.
     fn find_index(&self, value: &Value, hash: u64, vm: &mut VM<'h>) -> RunResult<Option<usize>> {
+        // When no comparison can dispatch to user code, nothing can mutate the
+        // set mid-probe: skip revalidation and the miss continuation, as in
+        // the dict twin.
+        let value_native = eq_is_native(value, vm.heap);
+
         'restart: loop {
             // Collected inline rather than through `probe_candidates`, for the
             // reason given in the dict twin.
             let mut candidate_indices: SmallVec<[usize; 2]> = SmallVec::new();
             let mut candidate_values: SmallVec<[Value; 2]> = SmallVec::new();
+            let mut all_native = value_native;
             let storage = self.get(vm.heap);
             storage.indices.find(hash, |&idx| {
                 if storage.entries[idx].hash == hash {
                     candidate_indices.push(idx);
                     candidate_values.push(storage.entries[idx].value.clone_with_heap(vm.heap));
+                    all_native = all_native && eq_is_native(&storage.entries[idx].value, vm.heap);
                 }
                 false
             });
             defer_drop!(candidate_values, vm);
 
             for (&candidate_index, candidate_value) in candidate_indices.iter().zip(candidate_values.iter()) {
-                if !self.probe_valid(candidate_index, hash, candidate_value, vm) {
+                if !all_native && !self.probe_valid(candidate_index, hash, candidate_value, vm) {
                     vm.heap.tracker.check_memory_time()?;
                     continue 'restart;
                 }
                 // CPython compares the stored value on the left.
                 let eq = candidate_value.py_eq(value, vm)?;
-                if !self.probe_valid(candidate_index, hash, candidate_value, vm) {
+                if !all_native && !self.probe_valid(candidate_index, hash, candidate_value, vm) {
                     vm.heap.tracker.check_memory_time()?;
                     continue 'restart;
                 }
@@ -247,9 +258,10 @@ impl<'h> HeapRead<'h, SetStorage> {
             }
 
             // A comparison can itself have added a colliding value the snapshot
-            // never saw, so a pass that ran any hands over to the
-            // mutation-aware continuation; with no candidates it is a miss.
-            if candidate_values.is_empty() {
+            // never saw, so a pass that ran any hands over to the mutation-aware
+            // continuation — unless none could run user code; with no
+            // candidates it is a miss.
+            if all_native || candidate_values.is_empty() {
                 return Ok(None);
             }
             match self.probe_after_compare(hash, value, candidate_values, vm)? {

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -205,28 +205,29 @@ impl<'h> HeapRead<'h, SetStorage> {
 
     /// Finds the index of the entry equal to `value`, or `None` if absent.
     ///
-    /// Candidate indices are collected up front (avoiding a borrow conflict
-    /// between the index table and `py_eq`), but a user `__eq__` re-entering the
-    /// VM can mutate the set and leave them stale. Mirroring CPython's set
-    /// `lookkey`, every `py_eq` is followed by a validity check — length
-    /// unchanged and the identical value still at the candidate slot — and on
-    /// any mutation the whole probe restarts against the live entries.
+    /// Snapshots candidates so each index and value can be validated around
+    /// user `__eq__` without retaining a borrow of the hash table.
     fn find_index(&self, value: &Value, hash: u64, vm: &mut VM<'h>) -> RunResult<Option<usize>> {
         'restart: loop {
-            let mut candidates: SmallVec<[usize; 2]> = SmallVec::new();
+            let mut candidate_indices: SmallVec<[usize; 2]> = SmallVec::new();
+            let mut candidate_values: SmallVec<[Value; 2]> = SmallVec::new();
             let storage = &self.get(vm.heap);
             let len = storage.entries.len();
             storage.indices.find(hash, |&idx| {
                 if storage.entries[idx].hash == hash {
-                    candidates.push(idx);
+                    candidate_indices.push(idx);
+                    candidate_values.push(storage.entries[idx].value.clone_with_heap(vm.heap));
                 }
                 false
             });
+            defer_drop!(candidate_values, vm);
 
-            for candidate_index in candidates {
-                let candidate_value = self.get(vm.heap).entries[candidate_index].value.clone_with_heap(vm);
-                defer_drop!(candidate_value, vm);
-                let eq = value.py_eq(candidate_value, vm)?;
+            for (&candidate_index, candidate_value) in candidate_indices.iter().zip(candidate_values.iter()) {
+                if !self.probe_valid(len, candidate_index, hash, candidate_value, vm) {
+                    continue 'restart;
+                }
+                // CPython compares the stored value on the left.
+                let eq = candidate_value.py_eq(value, vm)?;
                 if !self.probe_valid(len, candidate_index, hash, candidate_value, vm) {
                     continue 'restart;
                 }
@@ -239,10 +240,9 @@ impl<'h> HeapRead<'h, SetStorage> {
         }
     }
 
-    /// True if a probe candidate is still valid after `py_eq` possibly ran user
-    /// code: the set's length is unchanged and the entry at `index` still holds
-    /// the identical value with the same hash. A `false` return means the set
-    /// was mutated mid-lookup and [`Self::find_index`] must restart its probe.
+    /// Checks that a snapshotted candidate still names the same live entry.
+    ///
+    /// The caller checks before and after `py_eq`; a mismatch restarts the probe.
     fn probe_valid(&self, len: usize, index: usize, hash: u64, value: &Value, vm: &VM<'h>) -> bool {
         let storage = self.get(vm.heap);
         storage.entries.len() == len

--- a/crates/monty/src/types/set.rs
+++ b/crates/monty/src/types/set.rs
@@ -16,7 +16,7 @@ use crate::{
         HeapRead, HeapReadOutput, heap_read_ref_as_field, heap_read_ref_as_field_mut,
     },
     intern::StaticStrings,
-    types::{LazyHeapSet, Type, list::repr_items_fmt},
+    types::{LazyHeapSet, Type, dict::ProbeOutcome, list::repr_items_fmt},
     value::{EitherStr, VALUE_SIZE, Value},
 };
 
@@ -206,13 +206,19 @@ impl<'h> HeapRead<'h, SetStorage> {
     /// Finds the index of the entry equal to `value`, or `None` if absent.
     ///
     /// Snapshots candidates so each index and value can be validated around
-    /// user `__eq__` without retaining a borrow of the hash table.
+    /// user `__eq__` without retaining a borrow of the hash table. Only a
+    /// candidate that moved restarts the whole probe; a mutation that merely
+    /// adds colliding values continues with those. Restarts poll the limits,
+    /// since calling back into the VM restarts its dispatch countdown and this
+    /// native loop reaches no checkpoint of its own. See
+    /// [`HeapRead::<Dict>::find_index_hash`] — the two must stay in sync.
     fn find_index(&self, value: &Value, hash: u64, vm: &mut VM<'h>) -> RunResult<Option<usize>> {
         'restart: loop {
+            // Collected inline rather than through `probe_candidates`, for the
+            // reason given in the dict twin.
             let mut candidate_indices: SmallVec<[usize; 2]> = SmallVec::new();
             let mut candidate_values: SmallVec<[Value; 2]> = SmallVec::new();
-            let storage = &self.get(vm.heap);
-            let len = storage.entries.len();
+            let storage = self.get(vm.heap);
             storage.indices.find(hash, |&idx| {
                 if storage.entries[idx].hash == hash {
                     candidate_indices.push(idx);
@@ -223,12 +229,14 @@ impl<'h> HeapRead<'h, SetStorage> {
             defer_drop!(candidate_values, vm);
 
             for (&candidate_index, candidate_value) in candidate_indices.iter().zip(candidate_values.iter()) {
-                if !self.probe_valid(len, candidate_index, hash, candidate_value, vm) {
+                if !self.probe_valid(candidate_index, hash, candidate_value, vm) {
+                    vm.heap.tracker.check_memory_time()?;
                     continue 'restart;
                 }
                 // CPython compares the stored value on the left.
                 let eq = candidate_value.py_eq(value, vm)?;
-                if !self.probe_valid(len, candidate_index, hash, candidate_value, vm) {
+                if !self.probe_valid(candidate_index, hash, candidate_value, vm) {
+                    vm.heap.tracker.check_memory_time()?;
                     continue 'restart;
                 }
                 if eq {
@@ -236,20 +244,101 @@ impl<'h> HeapRead<'h, SetStorage> {
                 }
             }
 
-            return Ok(None);
+            // A comparison can itself have added a colliding value the snapshot
+            // never saw, so a pass that ran any hands over to the
+            // mutation-aware continuation; with no candidates it is a miss.
+            if candidate_values.is_empty() {
+                return Ok(None);
+            }
+            match self.probe_after_compare(hash, value, candidate_values, vm)? {
+                ProbeOutcome::Found(index) => return Ok(Some(index)),
+                ProbeOutcome::Missing => return Ok(None),
+                // a candidate moved: fall through to the next probe from scratch
+                ProbeOutcome::Restart => (),
+            }
         }
+    }
+
+    /// Continues a probe whose comparisons all missed, in case one of them
+    /// mutated the set and added a colliding value.
+    ///
+    /// The twin of [`HeapRead::<Dict>::probe_after_compare`]: re-reads the
+    /// candidates until a pass finds nothing new, never comparing a value
+    /// twice, and off the ordinary lookup path.
+    fn probe_after_compare(
+        &self,
+        hash: u64,
+        value: &Value,
+        already_compared: &[Value],
+        vm: &mut VM<'h>,
+    ) -> RunResult<ProbeOutcome> {
+        let compared: SmallVec<[Value; 2]> = already_compared.iter().map(|v| v.clone_with_heap(vm.heap)).collect();
+        defer_drop_mut!(compared, vm);
+
+        loop {
+            let (candidate_indices, candidate_values) = self.probe_candidates(hash, vm);
+            defer_drop!(candidate_values, vm);
+            let mut compared_any = false;
+
+            for (&candidate_index, candidate_value) in candidate_indices.iter().zip(candidate_values.iter()) {
+                if compared.iter().any(|seen| seen.is(candidate_value)) {
+                    continue;
+                }
+                if !self.probe_valid(candidate_index, hash, candidate_value, vm) {
+                    vm.heap.tracker.check_memory_time()?;
+                    return Ok(ProbeOutcome::Restart);
+                }
+                compared.push(candidate_value.clone_with_heap(vm.heap));
+                compared_any = true;
+                // CPython compares the stored value on the left.
+                let eq = candidate_value.py_eq(value, vm)?;
+                if !self.probe_valid(candidate_index, hash, candidate_value, vm) {
+                    vm.heap.tracker.check_memory_time()?;
+                    return Ok(ProbeOutcome::Restart);
+                }
+                if eq {
+                    return Ok(ProbeOutcome::Found(candidate_index));
+                }
+            }
+
+            if !compared_any {
+                return Ok(ProbeOutcome::Missing);
+            }
+            vm.heap.tracker.check_memory_time()?;
+        }
+    }
+
+    /// Snapshots the live entries colliding on `hash`: their indices, plus an
+    /// owned reference to each of their values.
+    ///
+    /// Cloning the values lets `py_eq` run without the hash-table borrow held;
+    /// the caller owns the returned values and must drop them. Only the
+    /// mutation-aware continuation calls this — the fast path above inlines the
+    /// same collection.
+    fn probe_candidates(&self, hash: u64, vm: &VM<'h>) -> (SmallVec<[usize; 2]>, SmallVec<[Value; 2]>) {
+        let mut indices: SmallVec<[usize; 2]> = SmallVec::new();
+        let mut values: SmallVec<[Value; 2]> = SmallVec::new();
+        let storage = self.get(vm.heap);
+        storage.indices.find(hash, |&idx| {
+            if storage.entries[idx].hash == hash {
+                indices.push(idx);
+                values.push(storage.entries[idx].value.clone_with_heap(vm.heap));
+            }
+            false
+        });
+        (indices, values)
     }
 
     /// Checks that a snapshotted candidate still names the same live entry.
     ///
     /// The caller checks before and after `py_eq`; a mismatch restarts the probe.
-    fn probe_valid(&self, len: usize, index: usize, hash: u64, value: &Value, vm: &VM<'h>) -> bool {
+    #[inline]
+    fn probe_valid(&self, index: usize, hash: u64, value: &Value, vm: &VM<'h>) -> bool {
         let storage = self.get(vm.heap);
-        storage.entries.len() == len
-            && storage
-                .entries
-                .get(index)
-                .is_some_and(|entry| entry.hash == hash && entry.value.is(value))
+        storage
+            .entries
+            .get(index)
+            .is_some_and(|entry| entry.hash == hash && entry.value.is(value))
     }
 }
 

--- a/crates/monty/test_cases/lookup__mutation.py
+++ b/crates/monty/test_cases/lookup__mutation.py
@@ -99,6 +99,75 @@ D4[DictClearer4()] = 'x'
 assert len(D4) == 101
 
 
+# === dict/set: same-length mutation never compares a stale queued index ===
+def stale_candidate_lookup(kind):
+    target = {} if kind == 'dict' else set()
+    active = False
+    mutated = False
+
+    class Key:
+        def __hash__(self):
+            return 1
+
+        def __eq__(self, other):
+            nonlocal active, mutated
+            if isinstance(other, int):
+                raise RuntimeError('compared against mismatched hash')
+            if active and not mutated:
+                mutated = True
+                if kind == 'dict':
+                    target.pop(keys[-1])
+                    target[100] = None
+                else:
+                    target.remove(keys[-1])
+                    target.add(100)
+            return False
+
+    keys = [Key() for _ in range(4)]
+    for key in keys:
+        if kind == 'dict':
+            target[key] = None
+        else:
+            target.add(key)
+    active = True
+    return Key() in target
+
+
+assert stale_candidate_lookup('dict') is False
+assert stale_candidate_lookup('set') is False
+
+
+# === dict/set lookup calls the stored candidate's equality first ===
+equality_calls = []
+
+
+class StoredLookupKey:
+    def __hash__(self):
+        return 1
+
+    def __eq__(self, other):
+        equality_calls.append('stored')
+        return False
+
+
+class QueryLookupKey:
+    def __hash__(self):
+        return 1
+
+    def __eq__(self, other):
+        equality_calls.append('query')
+        return False
+
+
+stored_lookup_key = StoredLookupKey()
+query_lookup_key = QueryLookupKey()
+assert query_lookup_key not in {stored_lookup_key: None}
+assert equality_calls == ['stored']
+equality_calls.clear()
+assert query_lookup_key not in {stored_lookup_key}
+assert equality_calls == ['stored']
+
+
 # === set: `in`, `discard` and `add` with a clearing __eq__ ===
 S = set()
 

--- a/crates/monty/test_cases/lookup__mutation.py
+++ b/crates/monty/test_cases/lookup__mutation.py
@@ -1,0 +1,290 @@
+from collections import deque
+
+# Container lookups (`in`, `[]`, `.get`, `.pop`, `.remove`, ...) call user
+# `__eq__` methods that may mutate the container being searched. CPython
+# restarts dict/set probes, clamps `list.remove`, and raises for deque;
+# Monty matches (see issue #729 — these previously panicked the worker).
+
+
+# === dict: `in` with a clearing __eq__ restarts the probe (issue #729 repro) ===
+D = {}
+
+
+class DictClearer:
+    def __hash__(self):
+        return 1
+
+    def __eq__(self, other):
+        D.clear()
+        for i in range(3000):
+            D[i] = i
+        return False
+
+
+for j in range(10):
+    D[DictClearer()] = j
+
+assert (DictClearer() in D) is False
+assert len(D) == 3000
+
+
+# === dict: `.get` and `.pop` with defaults survive the mutation ===
+D2 = {}
+
+
+class DictClearer2:
+    def __hash__(self):
+        return 1
+
+    def __eq__(self, other):
+        D2.clear()
+        for i in range(100):
+            D2[i] = i
+        return False
+
+
+for j in range(10):
+    D2[DictClearer2()] = j
+
+assert D2.get(DictClearer2(), 'missing') == 'missing'
+assert D2.pop(DictClearer2(), 'missing') == 'missing'
+
+
+# === dict: `[]` raises KeyError after the restarted probe finds nothing ===
+D3 = {}
+
+
+class DictClearer3:
+    def __hash__(self):
+        return 1
+
+    def __eq__(self, other):
+        D3.clear()
+        for i in range(100):
+            D3[i] = i
+        return False
+
+
+for j in range(10):
+    D3[DictClearer3()] = j
+
+# the KeyError message is the missing key's repr, which contains an object
+# address, so only the exception type can be asserted
+try:
+    D3[DictClearer3()]
+    assert False, 'expected KeyError'
+except KeyError:
+    pass
+
+
+# === dict: assignment restarts the probe, then inserts ===
+D4 = {}
+
+
+class DictClearer4:
+    def __hash__(self):
+        return 1
+
+    def __eq__(self, other):
+        D4.clear()
+        for i in range(100):
+            D4[i] = i
+        return False
+
+
+for j in range(10):
+    D4[DictClearer4()] = j
+
+D4[DictClearer4()] = 'x'
+assert len(D4) == 101
+
+
+# === set: `in`, `discard` and `add` with a clearing __eq__ ===
+S = set()
+
+
+class SetClearer:
+    def __hash__(self):
+        return 1
+
+    def __eq__(self, other):
+        S.clear()
+        for i in range(100):
+            S.add(i)
+        return False
+
+
+for j in range(10):
+    S.add(SetClearer())
+
+assert (SetClearer() in S) is False
+assert len(S) == 100
+S.discard(SetClearer())
+assert len(S) == 100
+S.add(SetClearer())
+assert len(S) == 101
+
+
+# === set: `remove` raises KeyError after the restarted probe finds nothing ===
+S2 = set()
+
+
+class SetClearer2:
+    def __hash__(self):
+        return 1
+
+    def __eq__(self, other):
+        S2.clear()
+        for i in range(100):
+            S2.add(i)
+        return False
+
+
+for j in range(10):
+    S2.add(SetClearer2())
+
+# as above, the KeyError message contains an object address
+try:
+    S2.remove(SetClearer2())
+    assert False, 'expected KeyError'
+except KeyError:
+    pass
+
+
+# === list: a matching __eq__ that shrinks the list clamps the removal ===
+L = [1, 2, 3]
+
+
+class ListClearTrue:
+    def __eq__(self, other):
+        L.clear()
+        return True
+
+
+L.remove(ListClearTrue())
+assert L == []
+
+
+# === list: a matching __eq__ that shifts the list removes the shifted slot ===
+# CPython deletes position 2 even though the match happened there before the
+# shift, so the element that moved into it (4) is what goes
+L2 = [1, 2, 3, 4]
+
+
+class ListShiftTrue:
+    def __eq__(self, other):
+        if other == 3:
+            L2.pop(0)
+            return True
+        return False
+
+
+L2.remove(ListShiftTrue())
+assert L2 == [2, 3]
+
+
+# === list: `in` walks the live length, so a clearing __eq__ just ends the walk ===
+L3 = [1, 2, 3]
+
+
+class ListClearFalse:
+    def __eq__(self, other):
+        L3.clear()
+        return False
+
+
+assert (ListClearFalse() in L3) is False
+assert L3 == []
+
+
+# === deque: mutation from __eq__ raises during `in` / `index` / `count` ===
+dq = deque()
+
+
+class DequeAppender:
+    def __eq__(self, other):
+        dq.append(99)
+        return False
+
+
+dq.append(DequeAppender())
+
+
+# `in` goes via a helper so the raise crosses a call boundary — a bare
+# `0 in dq` inside `try` is uncatchable due to a separate monty bug where
+# comparison opcodes don't sync the frame ip before running user `__eq__`
+def dq_contains(x):
+    return x in dq
+
+
+try:
+    dq_contains(0)
+    assert False, 'expected RuntimeError'
+except RuntimeError as exc:
+    assert str(exc) == 'deque mutated during iteration'
+
+try:
+    dq.index(0)
+    assert False, 'expected RuntimeError'
+except RuntimeError as exc:
+    assert str(exc) == 'deque mutated during iteration'
+
+try:
+    dq.count(0)
+    assert False, 'expected RuntimeError'
+except RuntimeError as exc:
+    assert str(exc) == 'deque mutated during iteration'
+
+
+# === deque: `remove` raises IndexError (CPython quirk), even on a match ===
+dq2 = deque()
+
+
+class DequeAppender2:
+    def __init__(self, ret):
+        self.ret = ret
+
+    def __eq__(self, other):
+        dq2.append(99)
+        return self.ret
+
+
+dq2.append(DequeAppender2(False))
+
+try:
+    dq2.remove(0)
+    assert False, 'expected IndexError'
+except IndexError as exc:
+    assert str(exc) == 'deque mutated during iteration'
+
+dq3 = deque()
+
+
+class DequeAppender3:
+    def __eq__(self, other):
+        dq3.append(99)
+        return True
+
+
+dq3.append(DequeAppender3())
+
+try:
+    dq3.remove(0)
+    assert False, 'expected IndexError'
+except IndexError as exc:
+    assert str(exc) == 'deque mutated during iteration'
+
+
+# === deque: a matching compare returns before the mutation check ===
+dq4 = deque()
+
+
+class DequeAppender4:
+    def __eq__(self, other):
+        dq4.append(99)
+        return True
+
+
+dq4.append(DequeAppender4())
+assert (0 in dq4) is True
+assert dq4.index(0) == 0

--- a/crates/monty/test_cases/lookup__mutation.py
+++ b/crates/monty/test_cases/lookup__mutation.py
@@ -197,6 +197,24 @@ assert (ListClearFalse() in L3) is False
 assert L3 == []
 
 
+# === comparison exceptions are caught in the frame running the opcode ===
+class ComparisonRaiser:
+    def __eq__(self, other):
+        raise ValueError('comparison failed')
+
+
+try:
+    ComparisonRaiser() == 0
+    assert False, 'expected ValueError'
+except ValueError as exc:
+    assert str(exc) == 'comparison failed'
+
+try:
+    assert ComparisonRaiser() == 0
+except ValueError as exc:
+    assert str(exc) == 'comparison failed'
+
+
 # === deque: mutation from __eq__ raises during `in` / `index` / `count` ===
 dq = deque()
 
@@ -209,16 +227,8 @@ class DequeAppender:
 
 dq.append(DequeAppender())
 
-
-# `in` goes via a helper so the raise crosses a call boundary — a bare
-# `0 in dq` inside `try` is uncatchable due to a separate monty bug where
-# comparison opcodes don't sync the frame ip before running user `__eq__`
-def dq_contains(x):
-    return x in dq
-
-
 try:
-    dq_contains(0)
+    0 in dq
     assert False, 'expected RuntimeError'
 except RuntimeError as exc:
     assert str(exc) == 'deque mutated during iteration'

--- a/crates/monty/test_cases/lookup__mutation.py
+++ b/crates/monty/test_cases/lookup__mutation.py
@@ -137,6 +137,99 @@ assert stale_candidate_lookup('dict') is False
 assert stale_candidate_lookup('set') is False
 
 
+# === dict/set: a mutation that leaves the candidate in place compares once ===
+# CPython's `lookdict` only restarts when the compared entry itself changed, so
+# an insertion elsewhere must not repeat the comparison
+insert_calls = []
+D5 = {}
+
+
+class DictInserter:
+    def __hash__(self):
+        return 1
+
+    def __eq__(self, other):
+        insert_calls.append('eq')
+        D5[len(D5) + 100] = 0
+        return True
+
+
+D5[DictInserter()] = 'v'
+assert D5[DictInserter()] == 'v'
+assert insert_calls == ['eq']
+assert len(D5) == 2
+
+insert_calls.clear()
+S3 = set()
+
+
+class SetInserter:
+    def __hash__(self):
+        return 1
+
+    def __eq__(self, other):
+        insert_calls.append('eq')
+        S3.add(len(S3) + 100)
+        return False
+
+
+S3.add(SetInserter())
+assert (SetInserter() in S3) is False
+assert insert_calls == ['eq']
+assert len(S3) == 2
+
+
+# === dict/set: a colliding key inserted by __eq__ is still found ===
+# the probe re-reads the candidates and meets the new key, as CPython does by
+# carrying on through the live table — and like CPython it never re-compares a
+# candidate it already compared
+def inserted_candidate_lookup(kind, calls):
+    target = {} if kind == 'dict' else set()
+    inserted = False
+
+    class Wanted:
+        def __hash__(self):
+            return 1
+
+        def __eq__(self, other):
+            calls.append('wanted')
+            return isinstance(other, Wanted)
+
+    wanted = Wanted()
+
+    class Inserter:
+        def __hash__(self):
+            return 1
+
+        def __eq__(self, other):
+            nonlocal inserted
+            calls.append('inserter')
+            if not inserted:
+                inserted = True
+                if kind == 'dict':
+                    target[wanted] = 'inserted'
+                else:
+                    target.add(wanted)
+            return False
+
+    if kind == 'dict':
+        target[Inserter()] = 'original'
+        return target.get(Wanted(), 'MISS')
+    target.add(Inserter())
+    return Wanted() in target
+
+
+# the second 'inserter' is the nested insertion comparing against the entry
+# already stored, before the outer lookup goes on to the key it added
+dict_calls = []
+assert inserted_candidate_lookup('dict', dict_calls) == 'inserted'
+assert dict_calls == ['inserter', 'inserter', 'wanted']
+
+set_calls = []
+assert inserted_candidate_lookup('set', set_calls) is True
+assert set_calls == ['inserter', 'inserter', 'wanted']
+
+
 # === dict/set lookup calls the stored candidate's equality first ===
 equality_calls = []
 
@@ -280,6 +373,7 @@ except ValueError as exc:
 
 try:
     assert ComparisonRaiser() == 0
+    assert False, 'expected ValueError'
 except ValueError as exc:
     assert str(exc) == 'comparison failed'
 

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -680,6 +680,55 @@ Mutator() in container
     assert_timeout_in_builtin(&set, "set probe restarted by __eq__");
 }
 
+/// Missing lookups in a fully colliding container must not rescan their
+/// already-compared candidates quadratically.
+///
+/// `H` hashes constant but keeps identity equality, so every probe hands all
+/// N entries to the mutation-aware continuation and misses. Its seen-check
+/// must be O(1): a linear scan makes each lookup Θ(N²) — ~4s on these inputs
+/// versus ~1s, dominated by the unavoidable quadratic build — and that pass
+/// reaches no limit poll. The generous budget keeps the timing assertion
+/// robust on loaded CI.
+#[test]
+fn colliding_lookup_is_not_quadratic() {
+    let template = r"
+class H:
+    def __hash__(self):
+        return 1
+
+
+container = MAKE_CONTAINER
+for _ in range(800):
+    ADD_ENTRY
+
+probe = H()
+for _ in range(400):
+    assert probe not in container
+";
+    let dict = template
+        .replace("ADD_ENTRY", "container[H()] = 0")
+        .replace("MAKE_CONTAINER", "{}");
+    let set = template
+        .replace("ADD_ENTRY", "container.add(H())")
+        .replace("MAKE_CONTAINER", "set()");
+    for (label, code) in [("dict", dict), ("set", set)] {
+        let run = MontyRun::new(code, "test.py", vec![], CompileOptions::default()).unwrap();
+        let start = Instant::now();
+        let result = run.run(
+            vec![],
+            ResourceTracker::new(ResourceLimits::default()),
+            PrintWriter::Stdout,
+        );
+        let elapsed = start.elapsed();
+
+        assert!(result.is_ok(), "{label}: expected success, got {result:?}");
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "{label}: took {elapsed:?}, expected linear seen-checks"
+        );
+    }
+}
+
 /// Test that `str.splitlines()` on a large string respects the time limit.
 ///
 /// `str_splitlines()` scans the entire string for line endings in a while loop

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -641,6 +641,45 @@ a == b
     assert_timeout_in_builtin(code, "dict equality");
 }
 
+/// Test that a dict/set probe restarted by a mutating `__eq__` respects the
+/// time limit.
+///
+/// Every comparison adds another colliding key whose own `__eq__` does the
+/// same, so the probe never runs out of new candidates (CPython, walking the
+/// live chain, hangs on this too). Re-entering the VM for the callback restarts
+/// the dispatch countdown, so only the probe's own `check_time()` can end it.
+#[test]
+fn timeout_in_mutating_lookup_probe() {
+    let template = r"
+busy = False
+
+
+class Mutator:
+    def __hash__(self):
+        return 1
+
+    def __eq__(self, other):
+        global busy
+        if not busy:
+            busy = True
+            ADD_MUTATOR
+            busy = False
+        return False
+
+
+container = MAKE_CONTAINER
+Mutator() in container
+";
+    let dict = template
+        .replace("ADD_MUTATOR", "container[Mutator()] = 0")
+        .replace("MAKE_CONTAINER", "{Mutator(): 0}");
+    let set = template
+        .replace("ADD_MUTATOR", "container.add(Mutator())")
+        .replace("MAKE_CONTAINER", "{Mutator()}");
+    assert_timeout_in_builtin(&dict, "dict probe restarted by __eq__");
+    assert_timeout_in_builtin(&set, "set probe restarted by __eq__");
+}
+
 /// Test that `str.splitlines()` on a large string respects the time limit.
 ///
 /// `str_splitlines()` scans the entire string for line endings in a while loop

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -683,15 +683,18 @@ Mutator() in container
 /// Missing lookups in a fully colliding container must not rescan their
 /// already-compared candidates quadratically.
 ///
-/// `H` hashes constant but keeps identity equality, so every probe hands all
-/// N entries to the mutation-aware continuation and misses. Its seen-check
-/// must be O(1): a linear scan makes each lookup Θ(N²) — ~4s on these inputs
-/// versus ~1s, dominated by the unavoidable quadratic build — and that pass
-/// reaches no limit poll. The generous budget keeps the timing assertion
-/// robust on loaded CI.
+/// `H` instances hash constant and are never `eq_is_native`, so a missing
+/// probe hands all N entries to the mutation-aware continuation, whose
+/// seen-check must be O(1) — a linear scan makes each miss Θ(N²), and that
+/// pass reaches no limit poll. Found lookups walk the same candidate chain
+/// but never reach the continuation, so timing misses against finds on the
+/// same container isolates exactly the continuation's cost — the ratio is
+/// independent of machine speed, coverage instrumentation, and feature
+/// flags. Healthy misses cost about the same as finds (~1.4x); the old
+/// linear seen-scan cost ~10x.
 #[test]
 fn colliding_lookup_is_not_quadratic() {
-    let template = r"
+    let build_template = r"
 class H:
     def __hash__(self):
         return 1
@@ -700,31 +703,45 @@ class H:
 container = MAKE_CONTAINER
 for _ in range(800):
     ADD_ENTRY
-
+";
+    // 800 found lookups: same per-candidate machinery as the misses below
+    // (every comparison still dispatches through the guarded snapshot loop),
+    // but the probe ends at its match, before the continuation.
+    let found_lookups = r"
+for k in list(container):
+    assert k in container
+";
+    // 400 misses, each comparing all 800 candidates and then entering the
+    // continuation — in total the same number of comparisons as the finds.
+    let missing_lookups = r"
 probe = H()
 for _ in range(400):
     assert probe not in container
 ";
-    let dict = template
-        .replace("ADD_ENTRY", "container[H()] = 0")
-        .replace("MAKE_CONTAINER", "{}");
-    let set = template
-        .replace("ADD_ENTRY", "container.add(H())")
-        .replace("MAKE_CONTAINER", "set()");
-    for (label, code) in [("dict", dict), ("set", set)] {
-        let run = MontyRun::new(code, "test.py", vec![], CompileOptions::default()).unwrap();
-        let start = Instant::now();
-        let result = run.run(
-            vec![],
-            ResourceTracker::new(ResourceLimits::default()),
-            PrintWriter::Stdout,
-        );
-        let elapsed = start.elapsed();
+    for (label, make_container, add_entry) in [
+        ("dict", "{}", "container[H()] = 0"),
+        ("set", "set()", "container.add(H())"),
+    ] {
+        let build = build_template
+            .replace("MAKE_CONTAINER", make_container)
+            .replace("ADD_ENTRY", add_entry);
+        let mut repl = MontyRepl::new("test.py", ResourceTracker::default(), CompileOptions::default());
+        repl.feed_run(&build, vec![], PrintWriter::Stdout)
+            .unwrap_or_else(|e| panic!("{label}: build failed: {e}"));
 
-        assert!(result.is_ok(), "{label}: expected success, got {result:?}");
+        let start = Instant::now();
+        repl.feed_run(found_lookups, vec![], PrintWriter::Stdout)
+            .unwrap_or_else(|e| panic!("{label}: found lookups failed: {e}"));
+        let found_elapsed = start.elapsed();
+
+        let start = Instant::now();
+        repl.feed_run(missing_lookups, vec![], PrintWriter::Stdout)
+            .unwrap_or_else(|e| panic!("{label}: missing lookups failed: {e}"));
+        let missing_elapsed = start.elapsed();
+
         assert!(
-            elapsed < Duration::from_secs(3),
-            "{label}: took {elapsed:?}, expected linear seen-checks"
+            missing_elapsed < found_elapsed * 3,
+            "{label}: misses took {missing_elapsed:?} vs finds {found_elapsed:?}, expected linear seen-checks"
         );
     }
 }

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -48,15 +48,16 @@ mechanism beyond dataclass field inheritance.
   CPython).
 - **dict/set lookups under a mutating `__eq__`** — like CPython, a lookup
   (`in`, `d[k]`, `set.remove`, …) whose user `__eq__` mutates the container
-  keeps probing rather than raising, and never repeats a comparison it has
-  already made. Monty re-reads the colliding candidates after each comparison
-  where CPython walks the live probe chain, so an `__eq__` that moves the entry
-  being compared makes Monty re-compare the other candidates from scratch —
-  extra `__eq__` calls CPython would not make (CPython restarts on that too, but
-  only after a resize or when that entry's own slot changed). An `__eq__` that
-  adds a colliding key on *every* comparison never finishes in either engine;
-  under `max_duration` Monty raises `TimeoutError`. No mutation pattern can
-  panic or corrupt either engine.
+  keeps probing rather than raising, and a mutation that only *adds* colliding
+  keys never makes it repeat a comparison. Monty re-reads the colliding
+  candidates after each comparison where CPython walks the live probe chain, so
+  an `__eq__` that moves the entry being compared restarts the probe and
+  re-compares the other candidates from scratch — extra `__eq__` calls CPython
+  would not make (CPython restarts and re-compares too, but only after a resize
+  or when that entry's own slot changed). An `__eq__` that adds a colliding key
+  on *every* comparison never finishes in either engine; under `max_duration`
+  Monty raises `TimeoutError`. No mutation pattern can panic or corrupt either
+  engine.
 - **`enumerate`, `zip`, `map`, `filter` and `reversed` are eager, not lazy** —
   each drains its source and returns a `list`, so `type(enumerate(x)).__name__`
   is `'list'` rather than `'enumerate'`. Observable several ways: a

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -48,12 +48,12 @@ mechanism beyond dataclass field inheritance.
   CPython).
 - **dict/set lookups under a mutating `__eq__`** — like CPython, a lookup
   (`in`, `d[k]`, `set.remove`, …) whose user `__eq__` mutates the container
-  restarts its probe rather than raising. Monty detects the mutation via the
-  container's length plus the identity of the compared entry, where CPython
-  probes the live table; a `__eq__` that removes one entry *and* inserts a
-  colliding key equal to the one being looked up (leaving the length
-  unchanged) can therefore be missed by that same lookup, where CPython may
-  find it. No mutation pattern can panic or corrupt either engine.
+  restarts its probe rather than raising. Monty snapshots candidate identities
+  and validates each before and after comparison, where CPython probes the live
+  table; a `__eq__` that removes a non-candidate entry and inserts a colliding
+  key equal to the one being looked up (leaving the length and every existing
+  candidate unchanged) can therefore be missed by that same lookup, where
+  CPython may find it. No mutation pattern can panic or corrupt either engine.
 - **`enumerate`, `zip`, `map`, `filter` and `reversed` are eager, not lazy** —
   each drains its source and returns a `list`, so `type(enumerate(x)).__name__`
   is `'list'` rather than `'enumerate'`. Observable several ways: a

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -48,12 +48,15 @@ mechanism beyond dataclass field inheritance.
   CPython).
 - **dict/set lookups under a mutating `__eq__`** — like CPython, a lookup
   (`in`, `d[k]`, `set.remove`, …) whose user `__eq__` mutates the container
-  restarts its probe rather than raising. Monty snapshots candidate identities
-  and validates each before and after comparison, where CPython probes the live
-  table; a `__eq__` that removes a non-candidate entry and inserts a colliding
-  key equal to the one being looked up (leaving the length and every existing
-  candidate unchanged) can therefore be missed by that same lookup, where
-  CPython may find it. No mutation pattern can panic or corrupt either engine.
+  keeps probing rather than raising, and never repeats a comparison it has
+  already made. Monty re-reads the colliding candidates after each comparison
+  where CPython walks the live probe chain, so an `__eq__` that moves the entry
+  being compared makes Monty re-compare the other candidates from scratch —
+  extra `__eq__` calls CPython would not make (CPython restarts on that too, but
+  only after a resize or when that entry's own slot changed). An `__eq__` that
+  adds a colliding key on *every* comparison never finishes in either engine;
+  under `max_duration` Monty raises `TimeoutError`. No mutation pattern can
+  panic or corrupt either engine.
 - **`enumerate`, `zip`, `map`, `filter` and `reversed` are eager, not lazy** —
   each drains its source and returns a `list`, so `type(enumerate(x)).__name__`
   is `'list'` rather than `'enumerate'`. Observable several ways: a

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -46,6 +46,14 @@ mechanism beyond dataclass field inheritance.
   printed), as do list (live length, mid-repr pops truncate / appends extend),
   `set`, `collections.deque` and `collections.Counter` (all snapshot, like
   CPython).
+- **dict/set lookups under a mutating `__eq__`** — like CPython, a lookup
+  (`in`, `d[k]`, `set.remove`, …) whose user `__eq__` mutates the container
+  restarts its probe rather than raising. Monty detects the mutation via the
+  container's length plus the identity of the compared entry, where CPython
+  probes the live table; a `__eq__` that removes one entry *and* inserts a
+  colliding key equal to the one being looked up (leaving the length
+  unchanged) can therefore be missed by that same lookup, where CPython may
+  find it. No mutation pattern can panic or corrupt either engine.
 - **`enumerate`, `zip`, `map`, `filter` and `reversed` are eager, not lazy** —
   each drains its source and returns a `list`, so `type(enumerate(x)).__name__`
   is `'list'` rather than `'enumerate'`. Observable several ways: a


### PR DESCRIPTION
Closes #729

Container lookups collected candidate slot indices and then ran the element's __eq__, so a guest __eq__ that mutated the same container left the indices stale and panicked the worker (#729). Match CPython per container, verified against CPython 3.14 rather than the issue's claims:

- dict find_index_hash and a shared set find_index revalidate after every py_eq (length unchanged, identical key/value still at the slot) and restart the whole probe on mutation, like CPython's lookdict/lookkey — no exception is raised.
- list.remove clamps the deletion like CPython's list_ass_slice when a matching __eq__ shrank the list.
- deque in/index/count/remove check the existing state counter after each compare and raise "deque mutated during iteration" (RuntimeError, or IndexError for remove, matching CPython's quirk).

The one divergence — a length-preserving remove+insert during a colliding lookup can hide the inserted key from that same lookup — is documented in limitations/builtins.md.

Claude-Session: https://claude.ai/code/session_01GxkXLsdhnH2FQJkTQPtHY6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stale-index crashes and hangs when a user `__eq__` mutates a container during lookup (fixes #729). Old behavior: dict/set queued slot indices then ran `__eq__`, so mutations left stale indices and could panic or spin; deque/list diverged from CPython; some comparison opcodes delivered exceptions to the wrong frame. New behavior: dict/set inline native candidate comparisons and guard only when `__eq__` can run user code; lookups keep probing safely, restart only if the compared entry moved, and mutation-heavy probes respect time limits; deque/list match CPython; comparison/assert exceptions reach the caller’s handler.

- Dict/set
  - Compare native candidates inline; snapshot only when a pair may run user code; always compare the stored key/value on the left.
  - Validate a candidate before and after `py_eq`; restarts only when that entry moved. After an all-miss pass that ran user code, re-read colliding candidates and compare only unseen ones using an identity hash set (O(1) seen-checks). Native pairs compared inline before the first deferral may be re-compared in this continuation; this is deliberate and documented.
  - Skip revalidation and the continuation entirely when all comparisons are native (`eq_is_native`). Poll resource limits on every restart and continuation pass.
  - Lookups never raise on mutation; pathological always-mutate patterns raise `TimeoutError`. `Identity` now implements `Hash`.

- Deque/list/VM
  - Deque `in`/`index`/`count` raise `RuntimeError("deque mutated during iteration")` on mutation; `remove` raises `IndexError` with the same message (CPython quirk).
  - `list.remove` clamps the removal index when a matching `__eq__` shrinks or shifts the list.
  - Comparison ops (`==`, `!=`, `<`, `<=`, `>`, `>=`, `in`, `not in`) and `assert` use a reentrant try/catch so exceptions land in the caller’s frame.
  - Tests cover mutation-aware probing, O(1) seen-checks, and timeouts; docs describe restart behavior, timeouts, and the deliberate native re-comparison in the continuation.

<sup>Written for commit 4df7d4ca3aacee94eab93e5712b418af3b01a599. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

