### PR TITLE
Warn about read-write mounts in the mount docstrings

### DIFF
--- a/crates/monty-fs/src/mount_mode.rs
+++ b/crates/monty-fs/src/mount_mode.rs
@@ -16,7 +16,12 @@ use super::overlay_state::OverlayState;
 #[derive(Debug)]
 pub enum MountMode {
     /// Full read and write access to the host directory.
-    /// Use with caution — sandbox code can modify real files.
+    ///
+    /// Files written by sandboxed code persist on the host and are untrusted;
+    /// the host must not execute them. That includes indirect execution — a
+    /// Python `import` when the directory is on `sys.path`, `conftest.py`,
+    /// `.git/hooks/*`. [`Self::OverlayMemory`] behaves the same inside the
+    /// sandbox but keeps writes in memory.
     ReadWrite,
 
     /// Read-only access. Write operations raise `PermissionError`.

--- a/crates/monty-fs/src/mount_mode.rs
+++ b/crates/monty-fs/src/mount_mode.rs
@@ -18,10 +18,10 @@ pub enum MountMode {
     /// Full read and write access to the host directory.
     ///
     /// Files written by sandboxed code persist on the host and are untrusted;
-    /// the host must not execute them. That includes indirect execution — a
-    /// Python `import` when the directory is on `sys.path`, `conftest.py`,
-    /// `.git/hooks/*`. [`Self::OverlayMemory`] behaves the same inside the
-    /// sandbox but keeps writes in memory.
+    /// the host must not execute them. That includes indirect execution: a
+    /// Python `import` when the directory is on `sys.path`, or a tool reading
+    /// `conftest.py` or `.git/hooks/*`. [`Self::OverlayMemory`] behaves the
+    /// same inside the sandbox but keeps writes in memory.
     ReadWrite,
 
     /// Read-only access. Write operations raise `PermissionError`.

--- a/crates/monty-fs/src/mount_table.rs
+++ b/crates/monty-fs/src/mount_table.rs
@@ -61,8 +61,8 @@ impl MountTable {
     /// Mount memory uses [`DEFAULT_MEMORY_USAGE_LIMIT`] unless a pre-built
     /// [`Mount`] overrides it.
     ///
-    /// With [`MountMode::ReadWrite`] sandboxed code leaves untrusted files on
-    /// the host — read that variant's warning before choosing it.
+    /// With [`MountMode::ReadWrite`], files written by sandboxed code persist
+    /// on the host. Read that variant's warning before choosing it.
     ///
     /// # Errors
     ///

--- a/crates/monty-fs/src/mount_table.rs
+++ b/crates/monty-fs/src/mount_table.rs
@@ -61,6 +61,9 @@ impl MountTable {
     /// Mount memory uses [`DEFAULT_MEMORY_USAGE_LIMIT`] unless a pre-built
     /// [`Mount`] overrides it.
     ///
+    /// With [`MountMode::ReadWrite`] sandboxed code leaves untrusted files on
+    /// the host — read that variant's warning before choosing it.
+    ///
     /// # Errors
     ///
     /// Returns [`MountError::InvalidMount`] if the virtual path is not absolute,

--- a/crates/monty-js/ts/mount.ts
+++ b/crates/monty-js/ts/mount.ts
@@ -37,6 +37,9 @@ export interface MountDirOptions {
    * Access mode (default `'overlay'`): `'read-only'` rejects writes,
    * `'read-write'` writes through to the host, `'overlay'` keeps writes in
    * memory and discards them when the feed ends.
+   *
+   * `'read-write'` leaves untrusted files on the host after the feed — see the
+   * warning on [`MountDir`] before choosing it.
    */
   mode?: MountDirMode
   /** Cap on total bytes written through this mount. */

--- a/crates/monty-js/ts/mount.ts
+++ b/crates/monty-js/ts/mount.ts
@@ -38,8 +38,8 @@ export interface MountDirOptions {
    * `'read-write'` writes through to the host, `'overlay'` keeps writes in
    * memory and discards them when the feed ends.
    *
-   * `'read-write'` leaves untrusted files on the host after the feed — see the
-   * warning on [`MountDir`] before choosing it.
+   * With `'read-write'`, files written by sandboxed code persist on the host.
+   * Read the warning on [`MountDir`] before choosing it.
    */
   mode?: MountDirMode
   /** Cap on total bytes written through this mount. */

--- a/crates/monty-js/ts/mountDir.ts
+++ b/crates/monty-js/ts/mountDir.ts
@@ -16,23 +16,23 @@ import {
  * Retained overlay data and filesystem results share a per-mount memory
  * budget, `memoryUsageLimit` (100 MB by default).
  *
- * ```ts
- * const mount = new MountDir({ hostPath: '/path/on/host', virtualPath: '/mnt/data', mode: 'read-only' })
- * await session.feedRun("open('/mnt/data/file.txt').read()", { mount })
- * ```
- *
  * Warning: with `mode: 'read-write'`, files written by sandboxed code persist
- * on the host and must be treated as untrusted. Never execute them. Loading a
- * module counts as executing: Node resolves imports from `node_modules`
- * directories up the tree, so a writable mount inside a project lets sandboxed
- * code shadow a package that has not been loaded yet. The same applies to
- * files tools read on their own: `.git/hooks/*`, `Makefile`, `.env`, CI
- * config. If Python also runs against the directory, it applies to `sys.path`
- * imports too — see the `MountDir` docs in the Python package.
+ * on the host and are untrusted; do not execute them. Importing counts as
+ * executing, and the import can be indirect: Node resolves imports from
+ * `node_modules` directories up the tree, so a writable mount inside a project
+ * lets sandboxed code shadow a package that has not been loaded yet. Tools
+ * also read files without an explicit import: `.git/hooks/*`, `Makefile`,
+ * `.env`, CI config. If Python runs against the directory, the same applies to
+ * `sys.path` imports; see the `MountDir` docs in the Python package.
  *
  * The `'overlay'` default keeps writes in memory, so nothing reaches the host
  * filesystem. Use `'read-write'` only with a directory that contains no code
  * or config.
+ *
+ * ```ts
+ * const mount = new MountDir({ hostPath: '/path/on/host', virtualPath: '/mnt/data', mode: 'read-only' })
+ * await session.feedRun("open('/mnt/data/file.txt').read()", { mount })
+ * ```
  */
 export class MountDir {
   readonly hostPath: string

--- a/crates/monty-js/ts/mountDir.ts
+++ b/crates/monty-js/ts/mountDir.ts
@@ -20,6 +20,19 @@ import {
  * const mount = new MountDir({ hostPath: '/path/on/host', virtualPath: '/mnt/data', mode: 'read-only' })
  * await session.feedRun("open('/mnt/data/file.txt').read()", { mount })
  * ```
+ *
+ * Warning: with `mode: 'read-write'`, files written by sandboxed code persist
+ * on the host and must be treated as untrusted. Never execute them. Loading a
+ * module counts as executing: Node resolves imports from `node_modules`
+ * directories up the tree, so a writable mount inside a project lets sandboxed
+ * code shadow a package that has not been loaded yet. The same applies to
+ * files tools read on their own: `.git/hooks/*`, `Makefile`, `.env`, CI
+ * config. If Python also runs against the directory, it applies to `sys.path`
+ * imports too — see the `MountDir` docs in the Python package.
+ *
+ * The `'overlay'` default keeps writes in memory, so nothing reaches the host
+ * filesystem. Use `'read-write'` only with a directory that contains no code
+ * or config.
  */
 export class MountDir {
   readonly hostPath: string

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -129,11 +129,12 @@ impl MountSpec {
 /// Access mode for a [`MountSpec`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MountSpecMode {
+    /// Reads only; writes raise `PermissionError` in the sandbox.
     ReadOnly,
-    /// Writes go through to the host directory and outlive the feed. Those
-    /// files are untrusted and must not be executed by the host, including
-    /// indirectly via a Python `import` when the directory is on `sys.path`.
-    /// [`Self::Overlay`] keeps writes in memory instead.
+    /// Files written by sandboxed code persist on the host and are untrusted;
+    /// the host must not execute them, including indirectly via a Python
+    /// `import` when the directory is on `sys.path`. [`Self::Overlay`] keeps
+    /// writes in memory instead.
     ReadWrite,
     /// Copy-on-write overlay in parent memory; writes are discarded when the
     /// feed ends.

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -130,6 +130,10 @@ impl MountSpec {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MountSpecMode {
     ReadOnly,
+    /// Writes go through to the host directory and outlive the feed. Those
+    /// files are untrusted and must not be executed by the host, including
+    /// indirectly via a Python `import` when the directory is on `sys.path`.
+    /// [`Self::Overlay`] keeps writes in memory instead.
     ReadWrite,
     /// Copy-on-write overlay in parent memory; writes are discarded when the
     /// feed ends.

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -87,6 +87,23 @@ class MountDir:
     that same directory — so build one and reuse it. `'overlay'` writes live in
     each feed's own table and are discarded when the feed ends.
 
+    **Warning: `mode='read-write'` writes files from untrusted code to your
+    real filesystem.**
+
+    Those files are untrusted input; do not execute them. Importing counts as
+    executing, and the import can be indirect: with a directory on `sys.path`
+    mounted, sandboxed code can write `json.py`, or any module not yet
+    imported, and the next `import` runs it. That includes imports made by
+    `pydantic_monty` itself. `sys.path[0]` is the script's directory, or the
+    cwd for `python -m`, `python -c` and the REPL.
+
+    Tools also read files without an explicit import: `conftest.py`,
+    `sitecustomize.py`, `.git/hooks/*`, `Makefile`, `.env`, `__pycache__`.
+
+    The `'overlay'` default keeps writes in memory, so nothing reaches the host
+    filesystem. Use `'read-write'` only with a directory that contains no code
+    or config and is not on `sys.path` or any other execution path.
+
     ```python
     from pathlib import Path
 
@@ -103,27 +120,6 @@ class MountDir:
     hands the directory back; feeds passed a closed mount raise `ValueError`.
     Without it the directory stays open until the object is collected: a file
     descriptor on Unix, but on Windows that blocks renaming or deleting it.
-
-    ### Warning
-
-    **`mode='read-write'` puts files from untrusted code onto your real filesystem.**
-
-    The sandbox cannot execute what it writes, but your machine might do so later.
-
-    Files left behind by a session are untrusted input; do not execute them.
-    Importing counts as executing, and the import can be an indirect one: any
-    mount of a directory on `sys.path` lets sandboxed code write `json.py`, or
-    any other module not yet imported, and have the next `import` run it —
-    including imports made by `pydantic_monty` itself. `sys.path[0]` is the
-    current working directory for `python -m`, `python -c`, the REPL,
-    and the script's directory for `python script.py`.
-
-    Other files are read by tools without an explicit import: `conftest.py`,
-    `sitecustomize.py`, `.git/hooks/*`, `Makefile`, `.env`, `__pycache__`.
-
-    The `'overlay'` default keeps writes in memory, so nothing reaches the host
-    filesystem. Use `'read-write'` only with a directory that contains no code
-    or config and is not on `sys.path` or any other execution path.
     """
 
     host_path: str
@@ -163,8 +159,8 @@ class MountDir:
                 (e.g. `'/data'`), regardless of host OS. Raises `ValueError`
                 if not absolute.
             mode: `'read-only'` — reads only, writes raise `PermissionError`;
-                `'read-write'` — writes through to the host directory, leaving
-                untrusted files there after the feed (see the warning above);
+                `'read-write'` — writes through to the host directory, where
+                the files persist after the feed (see the warning above);
                 `'overlay'` (default) — reads fall through to the host, writes
                 are captured in memory per feed and discarded when it ends.
             write_bytes_limit: Cap on cumulative bytes written through the

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -103,6 +103,27 @@ class MountDir:
     hands the directory back; feeds passed a closed mount raise `ValueError`.
     Without it the directory stays open until the object is collected: a file
     descriptor on Unix, but on Windows that blocks renaming or deleting it.
+
+    ### Warning
+
+    **`mode='read-write'` puts files from untrusted code onto your real filesystem.**
+
+    The sandbox cannot execute what it writes, but your machine might do so later.
+
+    Files left behind by a session are untrusted input; do not execute them.
+    Importing counts as executing, and the import can be an indirect one: any
+    mount of a directory on `sys.path` lets sandboxed code write `json.py`, or
+    any other module not yet imported, and have the next `import` run it —
+    including imports made by `pydantic_monty` itself. `sys.path[0]` is the
+    current working directory for `python -m`, `python -c`, the REPL,
+    and the script's directory for `python script.py`.
+
+    Other files are read by tools without an explicit import: `conftest.py`,
+    `sitecustomize.py`, `.git/hooks/*`, `Makefile`, `.env`, `__pycache__`.
+
+    The `'overlay'` default keeps writes in memory, so nothing reaches the host
+    filesystem. Use `'read-write'` only with a directory that contains no code
+    or config and is not on `sys.path` or any other execution path.
     """
 
     host_path: str
@@ -142,7 +163,8 @@ class MountDir:
                 (e.g. `'/data'`), regardless of host OS. Raises `ValueError`
                 if not absolute.
             mode: `'read-only'` — reads only, writes raise `PermissionError`;
-                `'read-write'` — writes through to the host directory;
+                `'read-write'` — writes through to the host directory, leaving
+                untrusted files there after the feed (see the warning above);
                 `'overlay'` (default) — reads fall through to the host, writes
                 are captured in memory per feed and discarded when it ends.
             write_bytes_limit: Cap on cumulative bytes written through the

--- a/crates/monty-python/src/mount.rs
+++ b/crates/monty-python/src/mount.rs
@@ -26,6 +26,13 @@ use pyo3::{exceptions::PyValueError, prelude::*, types::PyTuple};
 /// - `'read-only'` — sandbox can read but not write
 /// - `'read-write'` — sandbox can read and write real host files
 /// - `'overlay'` — reads fall through to host; writes are captured in memory
+///
+/// Warning: with `'read-write'`, files written by sandboxed code persist on
+/// the host and are untrusted; do not execute them. Importing counts as
+/// executing, so a mount of a directory on `sys.path` (including the cwd) lets
+/// sandboxed code write `json.py`, or any other module not yet imported, and
+/// have the next `import` run it — including imports made by `pydantic_monty`
+/// itself.
 #[pyclass(name = "MountDir")]
 pub struct PyMountDir {
     /// Validated configuration copied into each feed's mount table. `None`
@@ -53,7 +60,9 @@ impl PyMountDir {
     /// # Arguments
     /// * `host_path` — path to the real host directory
     /// * `virtual_path` — absolute virtual path prefix (e.g. `"/data"`)
-    /// * `mode` — access mode: `"read-only"`, `"read-write"`, or `"overlay"` (default)
+    /// * `mode` — access mode: `"read-only"`, `"read-write"`, or `"overlay"`
+    ///   (default). `"read-write"` leaves untrusted files on the host after
+    ///   the feed — see the warning on the type.
     ///
     /// # Raises
     /// `ValueError` if `mode` is not one of the allowed values, the virtual path

--- a/crates/monty-python/src/mount.rs
+++ b/crates/monty-python/src/mount.rs
@@ -30,8 +30,8 @@ use pyo3::{exceptions::PyValueError, prelude::*, types::PyTuple};
 /// Warning: with `'read-write'`, files written by sandboxed code persist on
 /// the host and are untrusted; do not execute them. Importing counts as
 /// executing, so a mount of a directory on `sys.path` (including the cwd) lets
-/// sandboxed code write `json.py`, or any other module not yet imported, and
-/// have the next `import` run it — including imports made by `pydantic_monty`
+/// sandboxed code write `json.py`, or any module not yet imported, and the
+/// next `import` runs it. That includes imports made by `pydantic_monty`
 /// itself.
 #[pyclass(name = "MountDir")]
 pub struct PyMountDir {
@@ -61,8 +61,8 @@ impl PyMountDir {
     /// * `host_path` — path to the real host directory
     /// * `virtual_path` — absolute virtual path prefix (e.g. `"/data"`)
     /// * `mode` — access mode: `"read-only"`, `"read-write"`, or `"overlay"`
-    ///   (default). `"read-write"` leaves untrusted files on the host after
-    ///   the feed — see the warning on the type.
+    ///   (default). With `"read-write"`, files written by sandboxed code
+    ///   persist on the host; see the warning on the type.
     ///
     /// # Raises
     /// `ValueError` if `mode` is not one of the allowed values, the virtual path

--- a/crates/monty-runtime/src/main.rs
+++ b/crates/monty-runtime/src/main.rs
@@ -50,6 +50,10 @@ pub(crate) struct Cli {
     /// Uses `::` as separator to avoid ambiguity with Windows drive letters.
     /// Modes: `ro` (read-only, default), `rw` (read-write), `overlay` (in-memory overlay).
     /// `write_limit_bytes` is optional and applies to all write modes.
+    ///
+    /// WARNING: `rw` leaves files written by untrusted code on your real
+    /// filesystem, where your own tools may later execute them.
+    /// Prefer `overlay` mode, when possible.
     #[arg(short = 'm', long = "mount")]
     mounts: Vec<String>,
 

--- a/crates/monty-runtime/src/main.rs
+++ b/crates/monty-runtime/src/main.rs
@@ -51,9 +51,8 @@ pub(crate) struct Cli {
     /// Modes: `ro` (read-only, default), `rw` (read-write), `overlay` (in-memory overlay).
     /// `write_limit_bytes` is optional and applies to all write modes.
     ///
-    /// WARNING: `rw` leaves files written by untrusted code on your real
-    /// filesystem, where your own tools may later execute them.
-    /// Prefer `overlay` mode, when possible.
+    /// WARNING: with `rw`, files written by sandboxed code persist on the
+    /// host, where your own tools may later execute them. Prefer `overlay`.
     #[arg(short = 'm', long = "mount")]
     mounts: Vec<String>,
 


### PR DESCRIPTION
Thanks @joshmeek for your report on hackmonty. While I don't think it's a vulnerability, it's worth adding warnings to the API docs, and future package documentation.

---

Files written by sandboxed code into a read-write mount persist on the host and may be executed there later, most subtly by an `import` when the mounted directory is on `sys.path` (the cwd usually is).

Document that on the Python `MountDir` (stub and pyclass), the JS `MountDir`, `MountMode::ReadWrite`, `MountSpecMode::ReadWrite`, `MountTable::mount` and the `--mount` CLI flag.


Claude-Session: https://claude.ai/code/session_01TTBcLKxm8c1N4hm11VkL3x

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit warnings for 'read-write' mounts across the Rust, Python, and JS APIs and the CLI. Files written by sandboxed code persist on the host and may be executed indirectly later (imports, tool discovery); prefer 'overlay'. No runtime behavior change.

- Touch points: Rust `MountMode::ReadWrite`, `MountSpecMode::{ReadOnly, ReadWrite}`, `MountTable::mount`; Python `MountDir` (stub and pyclass); JS `MountDir` and `MountDirOptions.mode`; `--mount` CLI flag.
- Docs call out indirect execution paths: Python `sys.path` (including `sys.path[0]` and imports made by `pydantic_monty`), Node module resolution and package shadowing, and common tool files (`conftest.py`, `sitecustomize.py`, `.git/hooks/*`, `Makefile`, `.env`, `__pycache__`). Use 'read-write' only with directories containing no code or config.

<sup>Written for commit a27d05ce0fb214c45eb037027b2253c58db6ceac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

