### PR TITLE
update `package-lock.json` and improve pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,15 +45,27 @@ repos:
         types: [rust]
         language: system
         pass_filenames: false
-      - id: format-lint-py
-        name: Format & Lint Python
-        entry: make format-lint-py
+      - id: format--py
+        name: Format Python
+        entry: make format-py
         types: [python]
         language: system
         pass_filenames: false
-      - id: format-lint-js
-        name: Format & Lint TypeScript
-        entry: make format-js lint-js
+      - id: lint-py
+        name: Lint Python
+        entry: make lint-py
+        types: [python]
+        language: system
+        pass_filenames: false
+      - id: format-js
+        name: Format TypeScript
+        entry: make format-js
+        types: [ts]
+        language: system
+        pass_filenames: false
+      - id: lint-js
+        name: Lint TypeScript
+        entry: make lint-js
         types: [ts]
         language: system
         pass_filenames: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,8 +381,6 @@ make generate-proto       Regenerate monty-proto's checked-in code from the .pro
 make check-proto          Verify monty-proto's checked-in code matches the .proto schema
 make lint-py              Lint Python code with ruff
 make lint                 Lint the code with ruff and clippy
-make format-lint-rs       Format and lint Rust code with fmt and clippy
-make format-lint-py       Format and lint Python code with ruff
 make test-no-features     Run rust tests without any features enabled
 make test-memory-model-checks Run rust tests with memory-model-checks enabled - THIS IS EXTREMELY SLOW, SHOULD MOSTLY BE RUN IN CI OR IF ABSOLUTELY NECESSARY
 make test-ref-count-return Run rust tests with ref-count-return enabled

--- a/Makefile
+++ b/Makefile
@@ -124,12 +124,6 @@ lint-py: dev-py ## Lint Python code with ruff
 .PHONY: lint
 lint: lint-rs lint-py ## Lint the code with ruff and clippy
 
-.PHONY: format-lint-rs
-format-lint-rs: format-rs lint-rs ## Format and lint Rust code with fmt and clippy
-
-.PHONY: format-lint-py
-format-lint-py: format-py lint-py ## Format and lint Python code with ruff
-
 .PHONY: test-no-features
 test-no-features: ## Run rust tests without any features enabled
 	cargo test -p monty -p monty-fs

--- a/crates/monty-js/package-lock.json
+++ b/crates/monty-js/package-lock.json
@@ -2433,19 +2433,90 @@
       "license": "MIT"
     },
     "node_modules/@pydantic/monty-darwin-arm64": {
-      "optional": true
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-arm64/-/monty-darwin-arm64-0.0.21.tgz",
+      "integrity": "sha512-Awo+F3nRN6yswwUlaiD+rQHOYcPEQsO6mnMp2kPYPpjGc94qwE5+1RA+P+KMQtgt8bR8vTn3hktFk8HSvXuyEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@pydantic/monty-darwin-x64": {
-      "optional": true
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-darwin-x64/-/monty-darwin-x64-0.0.21.tgz",
+      "integrity": "sha512-DCuK8VsSJ+ojHiNGKX4UhlX3ieMW4SMl/KhIiZ/jd8bsksILZioV1T77OkqL02epJkM2DiXMmPRb/g4Q+CRUNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@pydantic/monty-linux-arm64-gnu": {
-      "optional": true
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-arm64-gnu/-/monty-linux-arm64-gnu-0.0.21.tgz",
+      "integrity": "sha512-RvFQPBqXA093OreVcTEV0vtQYItdyFvRjJZrv76urbhVhybaOlhTo+2X75Z3LmEkOyJI5Qij/rKGeNeuGiM2YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@pydantic/monty-linux-x64-gnu": {
-      "optional": true
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-linux-x64-gnu/-/monty-linux-x64-gnu-0.0.21.tgz",
+      "integrity": "sha512-HZ6cg641Ag/uxLaSi8jfWvoB2RSJTWinTv94Hj7+DJy/Ax1YyvXOUpREIwfztbvRR9KVIibFVrKjXhpw8ZRotg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@pydantic/monty-win32-x64-msvc": {
-      "optional": true
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@pydantic/monty-win32-x64-msvc/-/monty-win32-x64-msvc-0.0.21.tgz",
+      "integrity": "sha512-BnKIbwllixx1NgsDFWbRPtc7ldlMpwZ1/Q+9JxrrHcbyos0f4O33FHGjn8o+EAG/YthGRSLoXkXWOpTtXL61ZA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Splits combined format+lint hooks into separate Python and TypeScript hooks and removes the old combo Makefile targets. Updates `crates/monty-js/package-lock.json` to pin platform-specific `@pydantic/monty-*` binaries at v0.0.21 for reproducible installs and to enforce Node >= 20 for those artifacts.

**Reviewer notes / rollout**
- Pre-commit hooks now run separately: `format--py`, `lint-py`, `format-js`, `lint-js`. The `format-lint-rs` and `format-lint-py` Makefile targets are removed. Replace any usages with `format-*` and `lint-*`.
- After pulling, run `pre-commit install`. Ensure dev and CI use Node 20+ to install the `@pydantic/monty-*` binaries.

<sup>Written for commit fd0843a967a71a6e91f07d0408abeefc7e5d09d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

