### PR TITLE
writing style skill and update limitations

### DIFF
--- a/.agents/skills/writing-style/SKILL.md
+++ b/.agents/skills/writing-style/SKILL.md
@@ -137,6 +137,78 @@ Three checks:
 - Strip the rhythm and count the facts. One is the usual answer.
 - Is the sentence about the system, or about how the reader should feel?
 
+## Industry metaphor
+
+Software described as objects moving through space, or as people with
+intentions. It is the register of a startup design review, not of reference
+documentation; CPython's docs use plain verbs throughout ("raises", "returns",
+"is stored in", "propagates", "Changed in version 3.11").
+
+The metaphor also deletes the mechanism. "The error surfaces" does not say
+whether it raises, returns or logs. "Wire the tracker through" does not say
+parameter, field or global. "It lands in 3.14" does not say merged or released.
+
+Motion and logistics:
+
+| Instead of             | Write                         |
+| ---------------------- | ----------------------------- |
+| lands, landing         | merged, released in 3.14      |
+| ship, shipping         | release                       |
+| spin up, stand up      | start, launch                 |
+| wire up, plumb through | pass, connect                 |
+| thread X through       | pass X as a parameter         |
+| bubble up              | propagate, or name the caller |
+| surface (verb)         | raise, return, report, log    |
+| hand back, hand off    | return, transfer              |
+| bake in, baked into    | built in, compiled in         |
+| punt on                | defer, skip, leave to         |
+
+Structure as furniture:
+
+| Instead of            | Write                        |
+| --------------------- | ---------------------------- |
+| seam                  | interface, boundary          |
+| surface, surface area | API, the public functions    |
+| escape hatch          | override, opt-out            |
+| knobs, dials          | options, settings            |
+| load-bearing          | required, relied on by X     |
+| X-shaped              | with the same interface as X |
+| lives in              | is defined in, is stored in  |
+| sits on top of        | wraps                        |
+| under the hood        | internally                   |
+
+Code with intentions:
+
+| Instead of               | Write                          |
+| ------------------------ | ------------------------------ |
+| the checker is happy     | the check passes               |
+| knows about, is aware of | reads, checks, has a field for |
+| talks to                 | sends requests to              |
+| teach the parser to      | add X to the parser            |
+| wants, expects (of code) | requires                       |
+| reaches into             | accesses, reads                |
+
+Also: "for free", "just works", "out of the box", "first-class", "table
+stakes", "opinionated", "non-trivial", "unlock", "blast radius", "paper over".
+
+In prose:
+
+- ✗ "Errors from the worker surface to the caller."
+- ✓ "`Checkout::feed` returns `PoolError::Crashed` when the worker exits
+  without a `FatalError` event."
+
+- ✗ "The tracker is threaded through the whole VM."
+- ✓ "Every allocation path takes `&ResourceTracker` as a parameter."
+
+- ✗ "`WorkerTransport` is the `NativeSession`-shaped seam."
+- ✓ "`WorkerTransport` has the same methods as `NativeSession`, so
+  `session.ts` drives either one."
+
+Terms of art stay, even though they began as metaphors: heap, stack, pointer,
+hot path, propagate, boilerplate, tombstone, sandbox escape, attack surface.
+`CLAUDE.md` also sanctions foot-gun, happy path and single source of truth. The
+test is whether a plain verb would say more than the metaphor does.
+
 ## Structure
 
 - Lead with the fact, not the context. First line of a docstring says what the
@@ -163,6 +235,7 @@ Three checks:
 | is responsible for handling      | handles                    |
 
 Em dashes should be avoided, or used very sparingly.
+But do not update code just to remove em dashes.
 
 Contractions are fine. Second person for user-facing docs ("you can never see
 the host path"), imperative for instructions ("mount a dedicated directory").

--- a/.agents/skills/writing-style/SKILL.md
+++ b/.agents/skills/writing-style/SKILL.md
@@ -25,8 +25,8 @@ project's docs, it carries no information.
   symlinks cannot reach outside it."
 
 - ✗ "Resource limits provide robust protection against runaway code."
-- ✓ "The VM polls allocator usage before every instruction; crossing the hard
-  limit exits the process with `OOM_EXIT_CODE`."
+- ✓ "The VM polls allocator usage every 255 instructions; crossing the
+  allocator's hard limit exits the worker with `OOM_EXIT_CODE`."
 
 ### Throat-clearing
 
@@ -80,9 +80,9 @@ bug was found usually does not.
 - ✗ "This was demonstrated against a live deployment during Hack Monty, where
   sandboxed code wrote `dataclasses.py` and the client executed it during
   ordinary result conversion."
-- ✓ "Sandboxed code can write `json.py`, or any module not yet imported, and
-  have the next `import` run it, including imports made by `pydantic_monty`
-  itself."
+- ✓ "Sandboxed code can write `json.py` into a read-write mount, or any module
+  not yet imported, and have the host's next `import` run it, including imports
+  `pydantic_monty` makes itself."
 
 ## Smoothness
 

--- a/.agents/skills/writing-style/SKILL.md
+++ b/.agents/skills/writing-style/SKILL.md
@@ -219,8 +219,9 @@ test is whether a plain verb would say more than the metaphor does.
 - Comments and field docs: 1 line, 3 at most. Function and struct docstrings:
   5 lines or fewer. If the docstring is longer than the code, something is
   wrong with one of them.
-- Warnings state the consequence first, then the subtle path to it, then the
-  safe alternative. No preamble.
+- Warnings: the command or condition first, then the consequence and the
+  subtle path to it, then the safe alternative. No preamble. Put the warning
+  before the thing it warns about, not after.
 
 ## Words and punctuation
 
@@ -233,6 +234,26 @@ test is whether a plain verb would say more than the metaphor does.
 | a variety of, a number of        | several, or the number     |
 | allows you to, enables you to    | you can, or the imperative |
 | is responsible for handling      | handles                    |
+
+**One term per concept.** Choose the word and keep it. Alternating between
+`worker`, `child` and `subprocess` for one thing makes the reader stop to check
+whether they are the same thing. Consistency beats variety.
+
+- ✗ "The checkout feeds the child, and the worker replies with events."
+- ✓ "The checkout feeds the worker, and the worker replies with events."
+
+**Noun clusters: three words at most.** Longer stacks make the reader guess
+which noun modifies which.
+
+- ✗ "parent-side mount table memory usage limit"
+- ✓ "the memory limit for a parent-side mount table"
+
+**Active voice and simple tenses.** Use the passive only when the actor is
+unknown or irrelevant. Do not drop articles or verbs to save space, except in
+the Rust convention of a subjectless first line ("Returns the host path.").
+
+- ✗ "A `PermissionError` will have been raised by the mount."
+- ✓ "The mount raises `PermissionError`."
 
 Em dashes should be avoided, or used very sparingly.
 But do not update code just to remove em dashes.

--- a/.agents/skills/writing-style/SKILL.md
+++ b/.agents/skills/writing-style/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: writing-style
+description: How to write prose that reads like human technical documentation rather than LLM output. Use whenever writing or editing docstrings, comments, limitations/ docs, READMEs, commit messages or PR descriptions, and when prose reads as smooth, salesy or generic.
+---
+
+# Writing style
+
+Applies to prose written in this repo: docstrings, comments, `limitations/`,
+READMEs, commit messages, PR descriptions, and warnings like the one on
+`MountDir`.
+
+The reader is an engineer looking for a fact. Give them the fact. You are not
+persuading or building to a conclusion: say what happens, when, and what it
+costs.
+
+## Tells to avoid
+
+### Significance instead of mechanism
+
+The most common LLM tell. If a sentence would fit unchanged in any other
+project's docs, it carries no information.
+
+- ✗ "This ensures the sandbox remains secure."
+- ✓ "Every operation runs relative to a `Dir` opened at mount time, so `..` and
+  symlinks cannot reach outside it."
+
+- ✗ "Resource limits provide robust protection against runaway code."
+- ✓ "The VM polls allocator usage before every instruction; crossing the hard
+  limit exits the process with `OOM_EXIT_CODE`."
+
+### Throat-clearing
+
+Openers that delay the sentence: "It's worth noting that", "It's important to
+understand", "In essence", "Simply put", "At its core", "Let's take a look at".
+Delete them; the sentence underneath is the content.
+
+- ✗ "It's worth noting that overlay writes are discarded when the feed ends."
+- ✓ "Overlay writes are discarded when the feed ends."
+
+### The "not just X, but Y" reveal
+
+Building to a payoff is an essay move. Docs do not need one.
+
+- ✗ "`heap.rs` isn't just another module — it's the foundation of the entire
+  safety model."
+- ✓ "`heap.rs` contains the `unsafe` code that `HeapReader` soundness depends
+  on. Changes need explicit review."
+
+### Adjectives doing the work of facts
+
+"Powerful", "seamless", "robust", "elegant", "blazing fast", "significantly",
+"dramatically". Replace with a number, a mechanism, or nothing.
+
+- ✗ "Overlays are capped at a reasonable size."
+- ✓ "`memory_usage_limit` caps retained overlay data at 100 MB by default;
+  exceeding it raises `MemoryError` in the sandbox."
+
+### Restating what the reader can see
+
+A docstring that repeats the signature wastes the line it occupies. Say why it
+exists, what it costs, or where it bites.
+
+- ✗ "Adds a mount to the mount table."  (on `MountTable::mount`)
+- ✓ "Opens the host directory once; later operations run against that
+  descriptor, so renaming the path afterwards does not detach the mount."
+
+### Summarising yourself
+
+Do not close a section by restating it, and do not announce what the next
+section will do.
+
+- ✗ "In summary, mounts are confined structurally rather than by checking."
+- ✓ (nothing, you already said it)
+
+### War stories
+
+Provenance is worth a clause only when it changes what the reader does. How the
+bug was found usually does not.
+
+- ✗ "This was demonstrated against a live deployment during Hack Monty, where
+  sandboxed code wrote `dataclasses.py` and the client executed it during
+  ordinary result conversion."
+- ✓ "Sandboxed code can write `json.py`, or any module not yet imported, and
+  have the next `import` run it, including imports made by `pydantic_monty`
+  itself."
+
+## Smoothness
+
+A different failure from the tells above. Those pad out empty content; this
+dresses up real content, which makes it harder to spot and easier to approve.
+
+Sentences engineered for rhythm read as conclusions, so the prose sounds like
+it is arguing when it is only listing facts. Balanced clauses and a stressed
+last syllable make a sentence sound authoritative whatever it contains, so one
+fact wearing three clauses gets read as three facts. Reference prose usually
+ends flatly, on a qualifier or a noun phrase, because the writer stopped when
+the information ran out rather than when the cadence resolved.
+
+**Timing for suspense.** Commas and subordinate clauses arranged to delay the
+point.
+
+- ✗ "The sandbox cannot execute what it writes, but your machine will, later,
+  with your privileges, and the path from one to the other is easy to miss."
+- ✓ "Files written by sandboxed code stay on the host, where other programs may
+  execute them."
+
+**Telling the reader how to feel.** "you did not choose", "easy to miss",
+"without being asked", "often does". These supply a mood in place of a fact.
+
+- ✗ "`sys.path[0]` is a directory you did not choose."
+- ✓ "`sys.path[0]` is the script's directory, or the cwd for `python -m`,
+  `python -c` and the REPL."
+
+**Triples and reversals.** A three-item list where one item carries the fact,
+then a `but` clause positioned as the payoff.
+
+- ✗ "Sandboxed code reads, writes and deletes normally and sees its own
+  changes, but nothing reaches your disk."
+- ✓ "Writes are kept in memory and discarded when the feed ends. Sandboxed code
+  still sees its own writes."
+
+**The quotable closer.** A generalisation at the end of a section, memorable,
+carrying no new fact. Delete it. The section ends at its last fact.
+
+- ✗ "Principles alone produce prose that follows the rules and still reads like
+  an LLM."
+- ✗ "Most drafts get better by deleting the first sentence and the last."
+
+**Symmetry for its own sake.** Three-item lists where two items are real,
+paragraphs of matched length, every bullet opening with a bolded term. If the
+shape came first and the content was fitted to it, cut back to what is true.
+
+Three checks:
+
+- Does the sentence end on a beat? If the last three words could be duller
+  without losing meaning, they were there for rhythm.
+- Strip the rhythm and count the facts. One is the usual answer.
+- Is the sentence about the system, or about how the reader should feel?
+
+## Structure
+
+- Lead with the fact, not the context. First line of a docstring says what the
+  thing is.
+- Prose for reasoning, bullets for actual lists. A bulleted paragraph is
+  harder to read, not easier.
+- One idea per sentence. Split anything over about 30 words.
+- Comments and field docs: 1 line, 3 at most. Function and struct docstrings:
+  5 lines or fewer. If the docstring is longer than the code, something is
+  wrong with one of them.
+- Warnings state the consequence first, then the subtle path to it, then the
+  safe alternative. No preamble.
+
+## Words and punctuation
+
+| Instead of                       | Write                      |
+| -------------------------------- | -------------------------- |
+| utilize, leverage                | use                        |
+| in order to                      | to                         |
+| serves as, acts as, functions as | is                         |
+| prior to, subsequent to          | before, after              |
+| a variety of, a number of        | several, or the number     |
+| allows you to, enables you to    | you can, or the imperative |
+| is responsible for handling      | handles                    |
+
+Em dashes should be avoided, or used very sparingly.
+
+Contractions are fine. Second person for user-facing docs ("you can never see
+the host path"), imperative for instructions ("mount a dedicated directory").
+Hedges ("generally", "typically", "may") are for genuine uncertainty; if the
+behaviour is defined, state it.
+
+## Checking a draft
+
+- Could this sentence appear verbatim in another project's docs? Then it is
+  empty.
+- Can you point at the code each claim describes? If not, you are guessing.
+- Delete the first sentence. Was anything lost?
+- Read it aloud. Sentences that sound like a conference talk get cut.
+- Strip a sentence's rhythm. How many facts are left?
+- Would a reviewer learn anything they could not get from the signature?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,8 +325,8 @@ When the input *is* already bounded (e.g. `s.to_lowercase()`, slicing, `to_owned
 
 ### Soft memory-limit checks — when and why
 
-`max_memory` is a **soft** limit: the VM polls allocator-backed usage before every
-instruction (`check_time`), and everything pathological is caught by the hard
+`max_memory` is a **soft** limit: the VM polls allocator-backed usage every 255
+instructions (`check_memory_time`), and everything pathological is caught by the hard
 limits — the allocator's hard ceiling (soft + headroom, worker exits with
 `OOM_EXIT_CODE` and the pool replaces it) and the pool's turn timeout. Soft
 checks exist ONLY to turn *common* overshoots into a graceful `MemoryError`

--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ What Monty **can** do:
 - Be called from Rust, Python, or Javascript - because Monty has no dependencies on cpython, you can use it anywhere you can run Rust
 - Control resource usage - Monty can track memory usage, stack depth, and execution time and cancel execution if it exceeds preset limits
 - Collect stdout and stderr and return it to the caller
-- Run async or sync code on the host via async or sync code on the host
-- Use a small subset of the standard library: `sys`, `os`, `typing`, `asyncio`, `re`, `datetime`, `json`, `dataclasses` (soon)
+- Run async or sync sandboxed code, calling async or sync functions on the host
+- Use a small subset of the standard library: `asyncio`, `collections`, `dataclasses`, `datetime`, `itertools`, `json`, `math`, `os`, `pathlib`, `re`, `sys`, `typing`, `unicodedata`
 
 What Monty **cannot** do:
 
 - Use the rest of the standard library
 - Use third party libraries (like Pydantic), support for external python library is not a goal
-- define classes (support should come soon)
+- use class inheritance or metaclasses (plain classes work, support should come soon)
 - use match statements (again, support should come soon)
 
 ---
@@ -255,8 +255,8 @@ A session's `max_memory` is measured by the worker's allocator. The interpreter
 reports a graceful `MemoryError` after crossing the soft limit; a higher hard
 limit kills and replaces the worker if one allocation jumps too far between checkpoints.
 
-See [`limitations/resource_limits.md`](limitations/resource_limits.md) for how
-exceeding a limit surfaces to a host, and `monty-alloc` for the allocator both
+See [`limitations/resource_limits.md`](limitations/resource_limits.md) for what
+a host sees when a limit is exceeded, and `monty-alloc` for the allocator both
 the subprocess and WebAssembly workers run under.
 
 ## PydanticAI Integration
@@ -360,9 +360,9 @@ There are generally two responses when you show people Monty:
 
 Where X is some alternative technology. Oddly often these responses are combined, suggesting people have not yet found an alternative that works for them, but are incredulous that there's really no good alternative to creating an entire Python implementation from scratch.
 
-I'll try to run through the most obvious alternatives, and why there aren't right for what we wanted.
+I'll try to run through the most obvious alternatives, and why they aren't right for what we wanted.
 
-NOTE: all these technologies are impressive and have widespread uses, this commentary on their limitations for our use case should not be seen as a criticism. Most of these solutions were not conceived with the goal of providing an LLM sandbox, which is why they're not necessary great at it.
+NOTE: all these technologies are impressive and have widespread uses, this commentary on their limitations for our use case should not be seen as a criticism. Most of these solutions were not conceived with the goal of providing an LLM sandbox, which is why they're not necessarily great at it.
 
 | Tech               | Language completeness | Security     | Start latency | FOSS       | Setup complexity | File mounting  | Snapshotting |
 | ------------------ | --------------------- | ------------ | ------------- | ---------- | ---------------- | -------------- | ------------ |
@@ -424,7 +424,7 @@ Running Python in WebAssembly via [Wasmer](https://wasmer.io/).
 - **Security**: In principle WebAssembly should provide strong sandboxing guarantees.
 - **Start latency**: The [wasmer](https://pypi.org/project/wasmer/) python package hasn't been updated for 3 years and I couldn't find docs on calling Python in wasmer from Python, so I called it via subprocess. Start latency was 66ms.
 - **Setup complexity**: wasmer download is 100mb, the "python/python" package is 50mb.
-- **FOSS**: I marked this as "free \*" since the cost is zero but not everything seems to be open source. As of 2026-02-10 the [`python/python` wasmer package](https://wasmer.io/python/python) package has no readme, no license, no source link and no indication of how it's built, the recently uploaded versions show size as "0B" although the download is ~50MB - the build process for the Python binary is not clear and transparent. _(If I'm wrong here, please create an issue to correct correct me)_
+- **FOSS**: I marked this as "free \*" since the cost is zero but not everything seems to be open source. As of 2026-02-10 the [`python/python` wasmer package](https://wasmer.io/python/python) package has no readme, no license, no source link and no indication of how it's built, the recently uploaded versions show size as "0B" although the download is ~50MB - the build process for the Python binary is not clear and transparent. _(If I'm wrong here, please create an issue to correct me)_
 - **File mounting**: Supported
 - **Snapshotting**: Supported via journaling
 
@@ -440,7 +440,7 @@ There are similar challenges, more setup complexity but lower network latency fo
 - **FOSS**: Pay per execution or compute time, some implementations are open source
 - **Setup complexity**: API integration, auth tokens - fine for startups but generally a non-start for enterprises
 - **File mounting**: Upload/download via API calls
-- **Snapshotting**: Possible with durable execution solutions like Temporal, also the services offer some solutions for this, I think based con docker containers
+- **Snapshotting**: Possible with durable execution solutions like Temporal, also the services offer some solutions for this, I think based on docker containers
 
 ### YOLO Python
 

--- a/crates/monty-fs/README.md
+++ b/crates/monty-fs/README.md
@@ -14,10 +14,11 @@ Keeping that I/O in a separate crate means the interpreter (and worker
 artifacts built from it, such as the wasm worker) contain no host-filesystem
 code at all.
 
-All path resolution goes through a single security boundary
-(`path_security::resolve_path`) enforcing canonicalization, mount-boundary
-checks, and symlink escape detection: the sandbox can never read, write, or
-learn anything about files outside the mounted directories.
+Confinement is structural rather than a check: each mount holds a
+`cap_std::fs::Dir` opened at mount time, and every operation runs relative to
+that descriptor, so `..`, symlinks, and directories swapped mid-operation
+cannot reach outside it. `path_security.rs` is left with path policy alone —
+normalization, null-byte rejection, and length limits.
 
 Each mount has a configurable aggregate memory budget that defaults to 100 MB.
 Retained in-memory overlay data and transient filesystem results share that

--- a/crates/monty-pool/README.md
+++ b/crates/monty-pool/README.md
@@ -82,11 +82,11 @@ and restored later — including on a different worker or machine — with `Chec
   the impact of any slow leak.
 - **Memory limits** — a session's `max_memory` also caps the worker's live allocations,
   enforced in the worker's own global allocator
-  ([`monty-alloc`](https://crates.io/crates/monty-alloc)) with generous headroom, rather
-  than letting a worker grow the host until the OOM killer intervenes. Exceeding it, or a
-  refused allocation, exits the worker with a dedicated code so it surfaces as
-  `PoolError::Runtime`/`MemoryError` instead of an unclassifiable abort — the one
-  `Runtime` error whose worker does not survive.
+  ([`monty-alloc`](https://crates.io/crates/monty-alloc)) plus 4 MB of headroom (32 MB with
+  type checking), rather than letting a worker grow the host until the OOM killer
+  intervenes. Exceeding it, or a refused allocation, exits the worker with a dedicated code
+  so it is reported as `PoolError::Runtime`/`MemoryError` instead of an unclassifiable
+  abort — the one `Runtime` error whose worker does not survive.
 
 Runtime errors inside the sandbox (`PoolError::Runtime`) are not crashes: the worker and its
 session remain alive and usable — the one exception being the `MemoryError` above, raised for

--- a/crates/monty-proto/README.md
+++ b/crates/monty-proto/README.md
@@ -57,9 +57,10 @@ malformed wire data.
 
 ## Worker state machine
 
-This crate includes the `worker` feature and module
-
-A transport-agnostic Monty protocol-child state machine, shared by the native subprocess and the wasm worker.
+The `worker` cargo feature (off by default) adds the `worker` module: the
+transport-agnostic child state machine, shared by the native `monty subprocess`
+worker and the wasm worker. It links the `monty` interpreter, so only
+worker-side crates enable it.
 
 ## Monty crates
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,3 @@
 # Monty Examples
 
-Numerous examples of what monty can do, and how.
+Examples of what Monty can do, and how.

--- a/examples/sql_playground/README.md
+++ b/examples/sql_playground/README.md
@@ -10,7 +10,7 @@ Data is from <https://github.com/mafudge/datasets>.
 2. **Loop-based external calls**: Sentiment analysis for each tweet happens in a loop - with JSON tool calling this would flood the context window with 50+ results
 3. **In-sandbox computation**: Averages, correlation, and aggregation happen in Python - no need for the LLM to do mental math
 4. **Variable iteration**: Different customers have different numbers of tweets - code handles this naturally
-5. **File sandboxing**: Uses `OSAccess` to mount data files, demonstrating secure file access patterns
+5. **File sandboxing**: Uses `OSAccess` to mount the data files, so the code can read them and nothing else
 6. **Type checking**: Validates LLM-generated code against type stubs before execution
 
 ## To run

--- a/limitations/README.md
+++ b/limitations/README.md
@@ -1,25 +1,18 @@
 # Limitations
 
-This directory is the single source of truth for how Monty diverges from CPython.
-Module-level docstrings and inline comments are not
-sufficient on their own — divergences live here so users and contributors
-can find them in one place.
+How Monty diverges from CPython. Docstrings and inline comments do not count:
+the divergence has to be written down here.
 
-Every pull request that adds, changes, or removes user-visible behavior
-MUST land (or update) a markdown document here describing how the feature
-diverges from CPython and what subset of the CPython surface area Monty
-actually implements.
+Every pull request that adds, changes, or removes user-visible behavior MUST
+add (or update) a markdown document here describing how the feature diverges
+from CPython, and what subset of the CPython surface Monty implements.
 
-One file per feature, named after the builtin / module / construct it
-covers (e.g. `open.md`, `asyncio.md`, `re.md`). Add new sections to an
-existing file when the feature is already documented; only create a new
-file when there is no fit.
+One file per feature, named after the builtin, module, or construct it covers
+(`open.md`, `asyncio.md`, `re.md`). Add a section to an existing file when the
+feature is already documented; create a new file only when there is no fit.
 
-Keep entries concise but comprehensive — list every known divergence,
-including ones that "feel obvious". A divergence that is not written down
-is one that future readers (and future Claude) will assume does not exist.
-Reviewers should reject PRs that change behavior without updating this
-directory.
+List every known divergence, including the ones that feel obvious. Reviewers
+should reject PRs that change behavior without updating this directory.
 
 Structure each file around what a Python user would actually try:
 

--- a/limitations/assert.md
+++ b/limitations/assert.md
@@ -66,7 +66,7 @@ users or LLMs) can see the values involved instead of a blank
 Introspected annotations can be disabled per session, restoring CPython's empty
 message for bare asserts. This does not remove Monty's other exception
 constructor differences: with annotations disabled, an explicit assert message
-must still be a string; see `./exceptions.md`. The retained repr
+must still be a string; see ./exceptions.md. The retained repr
 length can also be customized (an int >= 1, in bytes; 0 means "off", not
 "retain no bytes"):
 

--- a/limitations/assert.md
+++ b/limitations/assert.md
@@ -1,9 +1,10 @@
 # `assert`
 
-Monty deliberately diverges from CPython on `assert` failure messages: failed
-asserts raise an `AssertionError` carrying a pytest-style introspected message,
-so sandboxed code (and hosts feeding errors back to users/LLMs) can see the
-values involved instead of a blank `AssertionError`.
+Monty deliberately diverges from CPython on `assert` failure messages: a
+failed `assert` raises an `AssertionError` carrying a pytest-style
+introspected message, so sandboxed code (and hosts feeding errors back to
+users or LLMs) can see the values involved instead of a blank
+`AssertionError`.
 
 ## Bare `assert` carries a message (CPython raises an empty `AssertionError`)
 
@@ -14,10 +15,10 @@ values involved instead of a blank `AssertionError`.
 - Applies when the test is a single binary comparison with one of
   `==`, `!=`, `<`, `<=`, `>`, `>=`, `is`, `is not`, `in`, `not in`:
   both operands' `repr()`s are substituted. Operands are evaluated exactly
-  once — side effects are not duplicated.
+  once, so side effects are not duplicated.
 - Any other failing test shows the falsy value's repr instead:
   `assert []` → `assert []`, `assert None` → `assert None`,
-  `assert 0` → `assert 0` — except `False` itself, which adds no information:
+  `assert 0` → `assert 0`. `False` itself adds no information, so
   `assert False` raises a plain message-less `AssertionError`, exactly like
   CPython.
 - Chained comparisons (`assert 1 < 2 > 3`) and `not` expressions produce
@@ -31,12 +32,12 @@ values involved instead of a blank `AssertionError`.
 - `assert 1 == 2, 'my message'` raises
   `AssertionError('my message\nassert 1 == 2')`; CPython raises
   `AssertionError('my message')`.
-- Consequently `e.args[0]` contains the combined string, not the original
+- `e.args[0]` therefore contains the combined string, not the original
   message object. Non-`str` messages are rendered with `str()`
   (`assert [], 123` → `123\nassert []`); CPython stores the object
   itself in `e.args`.
 - When the test value is literally `False` no detail is appended, so
-  `assert False, 'msg'` raises `AssertionError('msg')` — the same as CPython
+  `assert False, 'msg'` raises `AssertionError('msg')`, the same as CPython
   apart from the `str()` rendering of non-`str` messages.
 - A message that stringifies to the empty string is treated as absent, so only
   the detail is shown: `assert 1 == 2, ''` raises `AssertionError('assert 1 == 2')`
@@ -49,9 +50,9 @@ values involved instead of a blank `AssertionError`.
   boundary. A truncated repr gets a three-byte `…` suffix in addition to that
   limit. The retained-byte limit is configurable per session; see "Opt-out for
   embedders" below.
-- A failing assert calls `repr()` on its operands, which CPython never does:
+- A failing assert calls `repr()` on its operands, which CPython never does, so
   user `__repr__` side effects run. Rendering is streamed and stops at the
-  truncation cap, so parts of a container beyond the cap are never repr'd —
+  truncation cap, so parts of a container beyond the cap are never repr'd and
   their `__repr__`s (and any side effects) don't run at all. The temporary repr
   buffer and its formatting loop are not charged to the `ResourceTracker`.
 - If an operand's `__repr__` (or an explicit message's `__str__`) raises a
@@ -65,7 +66,7 @@ values involved instead of a blank `AssertionError`.
 Introspected annotations can be disabled per session, restoring CPython's empty
 message for bare asserts. This does not remove Monty's other exception
 constructor differences: with annotations disabled, an explicit assert message
-must still be a string; see [exceptions](exceptions.md). The retained repr
+must still be a string; see `./exceptions.md`. The retained repr
 length can also be customized (an int >= 1, in bytes; 0 means "off", not
 "retain no bytes"):
 

--- a/limitations/asyncio.md
+++ b/limitations/asyncio.md
@@ -29,7 +29,7 @@ surface.
 
 `asyncio.timeout()` / `asyncio.timeout_at()` would be unreachable in any
 case: they are async context managers, and `async with` is rejected at parse
-time (see `./language.md`).
+time (see ./language.md).
 
 ## `async def` / `await`
 
@@ -39,7 +39,7 @@ time (see `./language.md`).
   it again.
 - `await` on a non-awaitable raises `TypeError`.
 - `async for` and `async with` are **rejected at parse time** (see
-  `./language.md`). Async iteration and async context-manager
+  ./language.md). Async iteration and async context-manager
   protocols do not exist.
 - Async comprehensions (`[x async for x in ...]`) are rejected at parse
   time.

--- a/limitations/asyncio.md
+++ b/limitations/asyncio.md
@@ -1,8 +1,8 @@
 # `asyncio` module and `async` / `await`
 
-Monty's async support is a thin layer that lets `async def` functions
-suspend on `await` and lets the host drive long-running external calls.
-There is no event loop *inside* the sandbox — the host is the loop.
+`async def` functions can suspend on `await`, and the host drives long-running
+external calls. There is no event loop inside the sandbox; the host is the
+loop.
 
 ## Module surface
 
@@ -13,10 +13,10 @@ The `asyncio` module exposes exactly two functions:
 - `asyncio.gather(*awaitables)` — runs awaitables concurrently and returns
   a list of results. Always behaves as `return_exceptions=False`.
   Any keyword argument is rejected with
-  `NotImplementedError: gather() does not yet support keyword arguments`
-  (CPython would instead raise
+  `NotImplementedError: gather() does not yet support keyword arguments`,
+  where CPython raises
   `TypeError: gather() got an unexpected keyword argument 'X'` because
-  `return_exceptions` is a real kwarg there).
+  `return_exceptions` is a real kwarg there.
 
 Not implemented (raise `AttributeError`):
 
@@ -27,9 +27,9 @@ Not implemented (raise `AttributeError`):
 the whole `asyncio.subprocess` / `asyncio.streams` / `asyncio.protocols`
 surface.
 
-`asyncio.timeout()` / `asyncio.timeout_at()` would in any case be
-unreachable: they are async context managers, and `async with` is rejected
-at parse time (see [language.md](language.md)).
+`asyncio.timeout()` / `asyncio.timeout_at()` would be unreachable in any
+case: they are async context managers, and `async with` is rejected at parse
+time (see `./language.md`).
 
 ## `async def` / `await`
 
@@ -39,17 +39,17 @@ at parse time (see [language.md](language.md)).
   it again.
 - `await` on a non-awaitable raises `TypeError`.
 - `async for` and `async with` are **rejected at parse time** (see
-  [language.md](language.md)). Async iteration / context-manager protocols
-  do not exist.
+  `./language.md`). Async iteration and async context-manager
+  protocols do not exist.
 - Async comprehensions (`[x async for x in ...]`) are rejected at parse
   time.
-- There is no `__await__` protocol — awaitables are only the things Monty
-  knows internally (coroutines from `async def`, gather futures, external
-  function call futures returned by host bindings).
+- There is no `__await__` protocol. Awaitables are only the things Monty
+  knows internally: coroutines from `async def`, gather futures, and external
+  function call futures returned by host bindings.
 
 ## Concurrency model
 
-Concurrency is cooperative and host-driven. `gather` suspends Monty
-whenever every branch is blocked on an external call, hands the pending
-calls to the host, and resumes when the host returns results. There is no
-preemption, no threads, and no in-sandbox scheduler.
+Concurrency is cooperative and host-driven. `gather` suspends Monty whenever
+every branch is blocked on an external call, hands the pending calls to the
+host, and resumes when the host returns results. There is no preemption, no
+threads, and no in-sandbox scheduler.

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -1,8 +1,8 @@
 # Built-in functions
 
-Monty implements a deliberate subset of CPython's builtins. Referencing any
-name not listed here raises `NameError` at runtime — there is no fallback to
-a host Python.
+Monty implements a subset of CPython's builtins. Referencing any name not
+listed here raises `NameError` at runtime; there is no fallback to a host
+Python.
 
 ## Implemented builtin functions
 
@@ -21,7 +21,7 @@ a host Python.
 
 These raise `NameError`:
 
-- **Code execution**: `eval`, `exec`, `compile`, `__import__`. Deliberate —
+- **Code execution**: `eval`, `exec`, `compile`, `__import__`. Deliberate:
   sandboxed code must not be able to compile new code at runtime.
 - **Namespace introspection**: `globals`, `locals`, `vars`, `dir`.
 - **Interactive**: `input`, `breakpoint`, `help`.
@@ -31,9 +31,8 @@ These raise `NameError`:
   `object`, `format`, `ascii`.
 - **Other**: `callable`, `delattr`, `issubclass`, `aiter`, `anext`.
 
-`super()` is the biggest practical omission — combined with the lack of
-`class` statements (see [language.md](language.md)) there is no inheritance
-mechanism beyond dataclass field inheritance.
+`super()` is the biggest practical omission: with no class inheritance either
+(see `./classes.md`), there is no inheritance mechanism at all.
 
 ## Behavioural divergences
 
@@ -58,7 +57,7 @@ mechanism beyond dataclass field inheritance.
   `collections.deque`) will not raise when looped over via one of these. `zip`
   and multi-iterable `map` stop at the shortest input, so pairing an infinite
   iterable with a finite or empty one stays bounded. A plain `for x in
-  container` is lazy and does detect mutation. See [itertools.md](itertools.md).
+  container` is lazy and does detect mutation. See `./itertools.md`.
 - **Arity-error wording for some str/bytes methods** — a handful of
   keyword-accepting methods (e.g. `str.split`, `str.rsplit` and the `bytes`
   equivalents) report too-many-arguments as `split expected at most 2
@@ -81,13 +80,13 @@ mechanism beyond dataclass field inheritance.
   all work.
 - **`isinstance(obj, T)`** — `T` must be a built-in type (`int`, `str`,
   `list`, ...), a built-in exception class, a sandbox-defined class (see
-  [classes.md](classes.md)), or a tuple of those. Passing a host-supplied
+  `./classes.md`), or a tuple of those. Passing a host-supplied
   dataclass / namedtuple as the second argument raises `TypeError`.
-- **`iter()`** — see [iter.md](iter.md) for iterator and `iter(callable, sentinel)` divergences.
-- **`pow(base, exp, mod)`** — three-argument form requires all integers and
+- **`iter()`** — see `./iter.md` for iterator and `iter(callable, sentinel)` divergences.
+- **`pow(base, exp, mod)`** — the three-argument form requires all integers and
   rejects negative exponents with `ValueError` instead of computing a modular
   inverse. Non-modular exponents whose result cannot be materialized raise
-  `OverflowError` (see [resource_limits.md](resource_limits.md)).
+  `OverflowError` (see `./resource_limits.md`).
 - **`sorted(iterable, *, key=None, reverse=False)`** — `key` and `reverse`
   must be passed by keyword; positional forms raise `TypeError`.
 - **`round(n, ndigits)`** — `ndigits` values outside the i64 range are
@@ -111,8 +110,8 @@ mechanism beyond dataclass field inheritance.
     real builtin; Monty's modeled stdlib types map to their host stdlib class:
     `datetime`/`date`/`timedelta`/`timezone` → `datetime.*`,
     `re.Pattern`/`re.Match` → `re.*`, the binary/text file types → `io.*`. The
-    `pathlib.Path` class maps to `pathlib.PurePosixPath` (consistent with how Path
-    *instances* round-trip, and instantiable on every host OS). A type with no
+    `pathlib.Path` class maps to `pathlib.PurePosixPath`, consistent with how Path
+    *instances* round-trip, and instantiable on every host OS. A type with no
     faithful host class (e.g. an internal function or cell type) cannot be
     reconstructed and surfaces as an `AttributeError` from the host call.
   - *Host → sandbox* (input, or an external-call return value): the same recognized
@@ -122,5 +121,5 @@ mechanism beyond dataclass field inheritance.
     `__name__`/`__module__` to impersonate a builtin is *not* treated as one. Every
     `pathlib` path class collapses to `PurePosixPath` (it re-emerges as
     `PurePosixPath`). A host class Monty does **not** model (e.g. a user-defined
-    class) is not preserved as a type — it degrades to a callable, appearing inside
+    class) is not preserved as a type; it degrades to a callable, appearing inside
     the sandbox as a `function` rather than a `type`.

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -32,7 +32,7 @@ These raise `NameError`:
 - **Other**: `callable`, `delattr`, `issubclass`, `aiter`, `anext`.
 
 `super()` is the biggest practical omission: with no class inheritance either
-(see `./classes.md`), there is no inheritance mechanism at all.
+(see ./classes.md), there is no inheritance mechanism at all.
 
 ## Behavioural divergences
 
@@ -57,7 +57,7 @@ These raise `NameError`:
   `collections.deque`) will not raise when looped over via one of these. `zip`
   and multi-iterable `map` stop at the shortest input, so pairing an infinite
   iterable with a finite or empty one stays bounded. A plain `for x in
-  container` is lazy and does detect mutation. See `./itertools.md`.
+  container` is lazy and does detect mutation. See ./itertools.md.
 - **Arity-error wording for some str/bytes methods** — a handful of
   keyword-accepting methods (e.g. `str.split`, `str.rsplit` and the `bytes`
   equivalents) report too-many-arguments as `split expected at most 2
@@ -80,13 +80,13 @@ These raise `NameError`:
   all work.
 - **`isinstance(obj, T)`** — `T` must be a built-in type (`int`, `str`,
   `list`, ...), a built-in exception class, a sandbox-defined class (see
-  `./classes.md`), or a tuple of those. Passing a host-supplied
+  ./classes.md), or a tuple of those. Passing a host-supplied
   dataclass / namedtuple as the second argument raises `TypeError`.
-- **`iter()`** — see `./iter.md` for iterator and `iter(callable, sentinel)` divergences.
+- **`iter()`** — see ./iter.md for iterator and `iter(callable, sentinel)` divergences.
 - **`pow(base, exp, mod)`** — the three-argument form requires all integers and
   rejects negative exponents with `ValueError` instead of computing a modular
   inverse. Non-modular exponents whose result cannot be materialized raise
-  `OverflowError` (see `./resource_limits.md`).
+  `OverflowError` (see ./resource_limits.md).
 - **`sorted(iterable, *, key=None, reverse=False)`** — `key` and `reverse`
   must be passed by keyword; positional forms raise `TypeError`.
 - **`round(n, ndigits)`** — `ndigits` values outside the i64 range are

--- a/limitations/classes.md
+++ b/limitations/classes.md
@@ -37,9 +37,9 @@ and function-attributes-become-methods), bound methods, class variables
 `__repr__`/`__str__`/`__enter__`/`__exit__`/`__eq__`/`__hash__` dispatch,
 `obj.__class__`, `Foo.__name__`, `Foo.__doc__`/`obj.__doc__`,
 `Foo.__annotations__` (ordered; values stringized and provisional, see
-`./typing.md`), `type(obj)`/`isinstance(obj, Foo)`, and the 3-arg
+./typing.md), `type(obj)`/`isinstance(obj, Foo)`, and the 3-arg
 `type()` constructor. The `__enter__`/`__exit__` divergences are in
-`./with.md`.
+./with.md.
 
 ## Dynamic class creation — `type(name, bases, dict)`
 
@@ -133,7 +133,7 @@ order and error wording, but with these divergences:
   `RecursionError` in Monty. The same cap applies to synchronous callback
   evaluation such as `map()`, `filter()`, `sorted()`/`list.sort(key=...)`,
   `min()`/`max(key=...)`, and exotic `__init__` recursion (see the "Recursion"
-  section of `./resource_limits.md`).
+  section of ./resource_limits.md).
 - **Comprehensions in the class body** can see class variables, because Monty
   inlines comprehensions into the enclosing scope. In CPython a comprehension
   has its own scope that skips the class scope, so only the *leftmost iterable*
@@ -183,7 +183,7 @@ first, e.g. return a `dict` of the fields.
   on classes and on non-method functions are supported.
 - **Classes are barely introspectable**: `__dict__`, `__bases__` and `dir()`
   are all unavailable (`cls.__name__` and `cls.__annotations__` work, the
-  latter with stringized values, see `./typing.md`). A class decorator
+  latter with stringized values, see ./typing.md). A class decorator
   can therefore discover fields and nothing else.
 - **Tracebacks from decorator application point at the whole `class` statement**
   (a span from the first decorator through the body, with the body elided as
@@ -204,7 +204,7 @@ first, e.g. return a `dict` of the fields.
   - the legacy `__getitem__`-only fallback: CPython iterates a class defining
     `__getitem__` but not `__iter__` from index 0 until `IndexError`, while
     Monty reports it as not iterable. (`monty -t` accepts `iter(obj)` for
-    such a class, so this fails only at runtime, see `./iter.md`.)
+    such a class, so this fails only at runtime, see ./iter.md.)
   - `__reversed__`, so `reversed(obj)` on any user instance raises
     `TypeError: '{cls}' object is not reversible`. That matches CPython for a
     class defining neither `__reversed__` nor `__len__` + `__getitem__`, and
@@ -244,7 +244,7 @@ first, e.g. return a `dict` of the fields.
   expressions are captured as source text (stringized) and never evaluated, so
   the walrus never binds; CPython raises `SyntaxError`. This follows from
   annotations never being evaluated, so it would change if they ever are (see
-  `./typing.md`).
+  ./typing.md).
 - `del obj.attr` (the `del` statement is unsupported generally).
 
 ## `FrozenInstanceError`

--- a/limitations/classes.md
+++ b/limitations/classes.md
@@ -28,37 +28,34 @@ methods dispatch back to the host (see `test_cases/dataclass__basic.py`).
 
 ## Supported surface
 
-Per the `limitations/` convention this file documents only *divergences* from
-CPython; the supported surface is summarized here just to bound what the
-divergences below apply to. Working, CPython-matching features: instance
-methods, `__init__` (full parameter shapes), instance and class attribute
-get/set (including `setattr(Foo, ...)` and function-attributes-become-methods),
-bound methods, class variables (arbitrary expressions, evaluated in a real
-suspendable class-body scope), **class decorators** (`@deco class Foo`),
+Listed to bound what the divergences below apply to. Working,
+CPython-matching features: instance methods, `__init__` (full parameter
+shapes), instance and class attribute get/set (including `setattr(Foo, ...)`
+and function-attributes-become-methods), bound methods, class variables
+(arbitrary expressions, evaluated in a real suspendable class-body scope),
+**class decorators** (`@deco class Foo`),
 `__repr__`/`__str__`/`__enter__`/`__exit__`/`__eq__`/`__hash__` dispatch,
 `obj.__class__`, `Foo.__name__`, `Foo.__doc__`/`obj.__doc__`,
-`Foo.__annotations__` (ordered; values stringized and provisional — see
-[typing.md](typing.md)), `type(obj)`/`isinstance(obj, Foo)`, and the 3-arg
-`type()` constructor. The
-`__enter__`/`__exit__` divergences are in [with.md](with.md). Everything else
-below is where Monty differs from or does not implement CPython behaviour.
+`Foo.__annotations__` (ordered; values stringized and provisional, see
+`./typing.md`), `type(obj)`/`isinstance(obj, Foo)`, and the 3-arg
+`type()` constructor. The `__enter__`/`__exit__` divergences are in
+`./with.md`.
 
 ## Dynamic class creation — `type(name, bases, dict)`
 
 The 3-arg `type()` form creates classes at runtime with CPython's validation
 order and error wording, but with these divergences:
 
-- **`bases` must be the empty tuple `()`.** Any non-empty bases tuple — even
-  `(object,)` — raises `TypeError: type() bases are not supported` (the
-  runtime counterpart of the parse-time `class Foo(Bar)` rejection; no
-  inheritance).
+- **`bases` must be the empty tuple `()`.** Any non-empty bases tuple, even
+  `(object,)`, raises `TypeError: type() bases are not supported`, the
+  runtime counterpart of the parse-time `class Foo(Bar)` rejection.
 - **Keywords are always rejected.** CPython forwards extra keywords to
   `__init_subclass__`; Monty has no `__init_subclass__`, but the error
   message matches what `object.__init_subclass__` produces
   (`A.__init_subclass__() takes no keyword arguments`).
 - Only `__doc__` is synthesized into the namespace when absent (as `None`,
   matching CPython). CPython also sets `__module__`, `__qualname__`,
-  `__dict__`, `__weakref__`, etc. — those attributes raise `AttributeError`
+  `__dict__`, `__weakref__`, etc.; those attributes raise `AttributeError`
   in Monty, as for compiled classes.
 - **Non-string namespace keys raise `TypeError`**
   (`non-string key (int) in the namespace of class 'A'`). CPython accepts
@@ -71,22 +68,22 @@ order and error wording, but with these divergences:
   **bare** class name, where CPython uses the qualified name
   `<module.Foo object at 0x..>`.
 - **`__init__`/method argument-count errors** name the method without the
-  class qualifier — e.g. `__init__() missing 1 required positional argument:
+  class qualifier, e.g. `__init__() missing 1 required positional argument:
   'y'`, where CPython says `Foo.__init__() missing ...`.
 - **`type(obj)`** returns the class object (so identity works), but its own
-  `repr` is `<class 'Foo'>` with the bare name (CPython qualifies it).
+  `repr` is `<class 'Foo'>` with the bare name; CPython qualifies it.
 - **The class object is not itself a `type` instance.** The bare name `type`
   resolves to the builtin `type` *function*, not a type object, so
   `type(Foo) is type` is `False` (CPython: `True`) and `isinstance(Foo, type)`
   raises `TypeError: isinstance() arg 2 must be a type, a tuple of types, or a
   union` (CPython: `True`). There is no metaclass.
 - **Bound methods report `function`, not `method`.** `type(obj.method)` is
-  `<class 'function'>` where CPython says `<class 'method'>` — Monty has no
+  `<class 'function'>` where CPython says `<class 'method'>`; Monty has no
   dedicated `method` type.
 - **Ordering comparisons on instances raise, but a user `__lt__`/`__gt__`/… is
   not dispatched.** `a < b` on instances of a class with no comparison dunders
   raises `TypeError: '<' not supported between instances of 'Foo' and 'Foo'`
-  (matching CPython). A class that *defines* `__lt__` etc. still raises — those
+  (matching CPython). A class that *defines* `__lt__` etc. still raises: those
   dunders are not dispatched (see the not-dispatched dunder list below).
 - **`__repr__`/`__str__` cannot suspend**: they are run to completion
   synchronously, so a `__repr__`/`__str__` that calls an external/OS function
@@ -95,7 +92,7 @@ order and error wording, but with these divergences:
 - **Only a plain-function `__init__` can suspend.** When `__init__` is bound to
   something else (a builtin, another class, a bound method, ...), it is called
   with CPython's descriptor-binding semantics (no `self` prepended unless it is
-  a plain function) and CPython's `None`-return contract is enforced — but it
+  a plain function) and CPython's `None`-return contract is enforced, but it
   runs to completion synchronously, so it cannot yield to the host, and an
   external-function `__init__` raises `NotImplementedError` rather than
   suspending.
@@ -103,7 +100,7 @@ order and error wording, but with these divergences:
   completion synchronously, so one that calls an external/OS function raises
   rather than yielding to the host. An exception raised by `__eq__` terminates
   the run instead of being catchable by a `try` around the comparison.
-- **Ordering dunders are still not dispatched** — see the entry above.
+- **Ordering dunders are still not dispatched**; see the entry above.
   Instances are always truthy (no `__bool__`/`__len__` dispatch).
 - **Bound methods compare and hash by identity**: each `obj.method` access
   creates a fresh object, so `obj.method == obj.method` is `False` and two
@@ -111,34 +108,32 @@ order and error wording, but with these divergences:
   `(instance, func)`, making separate accesses equal.
 - **Bound-method `repr`** is the bare `<bound method>`; CPython renders
   `<bound method Foo.m of <__main__.Foo object at 0x..>>`.
-- **Assigning `Foo.__name__`** stores an ordinary class member: unlike CPython
-  (where `type.__name__` is a metaclass descriptor whose setter renames the
-  class), it does not rename the class, so `Foo.__name__` reads and `repr(Foo)`
+- **Assigning `Foo.__name__`** stores an ordinary class member. Unlike CPython,
+  where `type.__name__` is a metaclass descriptor whose setter renames the
+  class, it does not rename the class, so `Foo.__name__` reads and `repr(Foo)`
   keep the original name while instances see the member.
 - **Assigning `obj.__class__`** stores an ordinary instance attribute rather
   than reassigning the object's class. `obj.__class__ = X` then reads back `X`,
-  but `type(obj)` and `isinstance` still report the original class — an
+  but `type(obj)` and `isinstance` still report the original class, leaving an
   internally inconsistent object. CPython either reassigns the class (for a
   compatible class) or raises `TypeError: __class__ must be set to a class, not
   '...' object`.
 - **Recursive/deep `__repr__`/`__str__` raises `RecursionError` earlier than
   CPython.** A `__repr__` (or `__str__`) that reprs `self`, or a deep chain of
   instances whose reprs nest (e.g. a long linked list), re-enters the
-  interpreter on the native Rust call stack once per nesting level (unlike
+  interpreter on the native Rust call stack once per nesting level, unlike
   ordinary Python-level recursion, which lives on a heap-allocated frame stack
-  and is bounded at 1000 by the normal recursion limit). To avoid a native
-  stack overflow (which would abort the process — fatal for the
-  in-process/wasm API, which shares the host process), this native re-entry is
-  capped independently at a much lower, fixed depth, raising a catchable
-  `RecursionError` once exceeded. The practical effect: infinite `__repr__`
-  recursion now raises `RecursionError` (matching CPython's outcome, though
-  not its exact depth), but a deep-but-finite chain that CPython's default
-  1000-frame limit would still successfully render may raise `RecursionError`
-  in Monty where CPython succeeds — a deliberate divergence traded for avoiding
-  native stack overflow. The same cap also applies to synchronous callback
+  and is bounded at 1000 by the normal recursion limit. A native stack overflow
+  would abort the process, which is fatal for the in-process/wasm API sharing
+  the host process, so this native re-entry is capped independently at a much
+  lower, fixed depth, raising a catchable `RecursionError` once exceeded. So
+  infinite `__repr__` recursion raises `RecursionError` (matching CPython's
+  outcome, though not its exact depth), but a deep-but-finite chain that
+  CPython's default 1000-frame limit would still render may raise
+  `RecursionError` in Monty. The same cap applies to synchronous callback
   evaluation such as `map()`, `filter()`, `sorted()`/`list.sort(key=...)`,
-  `min()`/`max(key=...)`, and exotic `__init__` recursion (see
-  `limitations/resource_limits.md`'s "Recursion" section).
+  `min()`/`max(key=...)`, and exotic `__init__` recursion (see the "Recursion"
+  section of `./resource_limits.md`).
 - **Comprehensions in the class body** can see class variables, because Monty
   inlines comprehensions into the enclosing scope. In CPython a comprehension
   has its own scope that skips the class scope, so only the *leftmost iterable*
@@ -168,11 +163,11 @@ result = session.feed_run('class A:\n    x = 1\nA()')
 
 `A` (the class) and `A()` (an instance) both surface as their repr text (e.g.
 `"<class 'A'>"` and `"<A object at 0x..>"`), so the host cannot read
-attributes, call methods, or reconstruct the object. This is unlike the values
-Monty *does* round-trip structurally (numbers, str/bytes, list/tuple/dict/set,
-datetimes, and host-supplied dataclasses/namedtuples, which dispatch back to the
-host). To return class data to the host, convert it inside the sandbox first —
-e.g. return a `dict` of the fields.
+attributes, call methods, or reconstruct the object. Monty does round-trip
+other values structurally: numbers, str/bytes, list/tuple/dict/set,
+datetimes, and host-supplied dataclasses/namedtuples, which dispatch back to
+the host. To return class data to the host, convert it inside the sandbox
+first, e.g. return a `dict` of the fields.
 
 ## What does NOT exist for user code
 
@@ -187,8 +182,8 @@ e.g. return a `dict` of the fields.
   decorator on a `def` inside a class body (rejected at parse time). Decorators
   on classes and on non-method functions are supported.
 - **Classes are barely introspectable**: `__dict__`, `__bases__` and `dir()`
-  are all unavailable (`cls.__name__` and `cls.__annotations__` work — the
-  latter with stringized values, see [typing.md](typing.md)). A class decorator
+  are all unavailable (`cls.__name__` and `cls.__annotations__` work, the
+  latter with stringized values, see `./typing.md`). A class decorator
   can therefore discover fields and nothing else.
 - **Tracebacks from decorator application point at the whole `class` statement**
   (a span from the first decorator through the body, with the body elided as
@@ -206,16 +201,16 @@ e.g. return a `dict` of the fields.
   OS function cannot suspend and raises `NotImplementedError`. Two related
   protocols are still not dispatched, so a class relying on either is not
   iterable:
-  - the legacy `__getitem__`-only fallback — CPython iterates a class defining
+  - the legacy `__getitem__`-only fallback: CPython iterates a class defining
     `__getitem__` but not `__iter__` from index 0 until `IndexError`, while
-    Monty reports it as not iterable. (Note `monty -t` accepts `iter(obj)` for
-    such a class, so this fails only at runtime — see [iter.md](iter.md).)
-  - `__reversed__` — so `reversed(obj)` on any user instance raises
+    Monty reports it as not iterable. (`monty -t` accepts `iter(obj)` for
+    such a class, so this fails only at runtime, see `./iter.md`.)
+  - `__reversed__`, so `reversed(obj)` on any user instance raises
     `TypeError: '{cls}' object is not reversible`. That matches CPython for a
     class defining neither `__reversed__` nor `__len__` + `__getitem__`, and
     diverges for one that does.
 - `__next__` is looked up on the class only, never the instance `__dict__`, and
-  a `StopIteration` raised anywhere inside it ends the iteration — including one
+  a `StopIteration` raised anywhere inside it ends the iteration, including one
   that propagates out of a nested call, where CPython's PEP 479 protections
   apply only to generators, which Monty does not have.
 - **A `__contains__` returning a user instance is always `True`.** The result is
@@ -230,13 +225,13 @@ e.g. return a `dict` of the fields.
 - Introspection attributes other than `__name__`, `__doc__`, `__annotations__`
   and `obj.__class__`: `Foo.__dict__`, `obj.__dict__`, `Foo.__bases__`,
   `Foo.__mro__`, `Foo.__qualname__`, `Foo.__module__`, and explicit
-  `obj.__repr__()` / `obj.__str__()` calls when the class defines none — all
+  `obj.__repr__()` / `obj.__str__()` calls when the class defines none, all
   raise `AttributeError`.
 - Class-body statements other than a `def`, a simple `name [: T] = <expr>`
-  variable assignment, `pass`, `...`, or a docstring — e.g. `if`/`for`/`while`
+  variable assignment, `pass`, `...`, or a docstring, e.g. `if`/`for`/`while`
   in the class body, or tuple/multiple assignment targets (rejected at parse
   time).
-- Assignment expressions (`:=`) that bind in the class-body scope — in
+- Assignment expressions (`:=`) that bind in the class-body scope: in
   class-variable values, method parameter defaults, and lambda parameter
   defaults (rejected at parse time). In CPython the walrus target becomes a
   class member (`class C: x = (y := 5)` gives `C.y`); Monty's class-namespace
@@ -245,16 +240,16 @@ e.g. return a `dict` of the fields.
   (`f = lambda: (z := 1)`) binds in the lambda's own scope and works. A walrus
   in a comprehension in the class body is also rejected (CPython rejects that
   too, but as a `SyntaxError` with different wording). A walrus in an
-  *annotation* (`x: (y := int) = 5`) runs in Monty — annotation expressions are
-  captured as source text (stringized) and never evaluated, so the walrus never
-  binds — where CPython raises `SyntaxError`. This one follows from annotations
-  never being evaluated, so it would change if they ever are (see
-  [typing.md](typing.md)).
+  *annotation* (`x: (y := int) = 5`) runs in Monty, since annotation
+  expressions are captured as source text (stringized) and never evaluated, so
+  the walrus never binds; CPython raises `SyntaxError`. This follows from
+  annotations never being evaluated, so it would change if they ever are (see
+  `./typing.md`).
 - `del obj.attr` (the `del` statement is unsupported generally).
 
 ## `FrozenInstanceError`
 
 Raised when assigning to a field of a frozen host-supplied dataclass.
-Subclass of `AttributeError` — `except AttributeError:` catches it, as in
-CPython's `dataclasses` module. (User-defined classes in the sandbox are
-never frozen.)
+Subclass of `AttributeError`, so `except AttributeError:` catches it, as in
+CPython's `dataclasses` module. User-defined classes in the sandbox are
+never frozen.

--- a/limitations/collections.md
+++ b/limitations/collections.md
@@ -31,7 +31,7 @@ too, rather than something that type-checks and then fails at runtime.
   deque-ness are lost; sending it back yields a `list`. (Same as
   defaultdict/Counter, which arrive as plain dicts.)
 - **Mutation during iteration is not detected through `enumerate`/`zip`/`map`/
-  `filter`/`reversed`**: those are eager (see `./builtins.md`), so
+  `filter`/`reversed`**: those are eager (see ./builtins.md), so
   the deque is fully read before the loop body runs. `for x in d` and explicit
   `iter()`/`next()` detect it exactly as CPython does.
 - `d += <any iterable>` works (it is `extend`), even though `list`'s `+=` still
@@ -40,18 +40,18 @@ too, rather than something that type-checks and then fails at runtime.
   `extend`/`extendleft`/`+=` append each item as the source yields it, so an
   iterator raising part-way leaves the earlier items in place, as in CPython.
   But `map`/`filter`/`zip`/`enumerate` are eager (see
-  `./builtins.md`), so `d += map(f, xs)` with a raising `f` raises
+  ./builtins.md), so `d += map(f, xs)` with a raising `f` raises
   before the extend begins and appends nothing, where CPython appends whatever
   was yielded first.
 
 `del d[i]` and subclassing (`class Q(deque)`) both fail at *compile* time: the
 `del` statement and class inheritance are unimplemented Monty-wide (see
-`./language.md` / `./classes.md`), not deque limitations.
+./language.md / ./classes.md), not deque limitations.
 
 ## `namedtuple`
 
 Field-name validation matches CPython's messages exactly; see
-`./namedtuple.md` for the tuple-inherited surface and its
+./namedtuple.md for the tuple-inherited surface and its
 divergences. `repr(Point)` is `<class 'Point'>` where CPython gives
 `<class '__main__.Point'>`, the repo-wide unqualified-class-name pattern.
 

--- a/limitations/collections.md
+++ b/limitations/collections.md
@@ -1,7 +1,7 @@
 # `collections` module
 
 `deque`, `namedtuple`, `defaultdict`, and `Counter` are implemented and
-feature-complete against CPython 3.14 subject to the divergences below. The
+feature-complete against CPython 3.14 apart from the divergences below. The
 exact supported surface is pinned by the custom typeshed stub
 (`crates/monty-typeshed/custom/collections/__init__.pyi`) and
 `crates/monty/tests/collections.rs`. `defaultdict` and `Counter` are exposed as
@@ -21,48 +21,48 @@ too, rather than something that type-checks and then fails at runtime.
 
 - **`d * 1.5`** raises `TypeError: unsupported operand type(s) for *:
   'collections.deque' and 'float'`, where CPython says `can't multiply sequence
-  by non-int of type 'float'`. (Shared with `list`.)
-- **Repeat counts in `[2**63, 2**64)` are accepted** where CPython rejects them
-  — Monty's repeat count is a `usize`, CPython's a C `ssize_t`. Only observable
+  by non-int of type 'float'`. Shared with `list`.
+- **Repeat counts in `[2**63, 2**64)` are accepted** where CPython rejects them:
+  Monty's repeat count is a `usize`, CPython's a C `ssize_t`. Only observable
   for a bounded deque, whose result truncates to `maxlen`: `deque([1, 2],
   maxlen=2) * 2**63` yields `deque([1, 2], maxlen=2)` in Monty but `OverflowError`
   in CPython. `2**64` or more raises `OverflowError` in both.
-- **Returned to the host as a plain `list`** — the `maxlen` bound and the
+- **Returned to the host as a plain `list`**, so the `maxlen` bound and the
   deque-ness are lost; sending it back yields a `list`. (Same as
   defaultdict/Counter, which arrive as plain dicts.)
 - **Mutation during iteration is not detected through `enumerate`/`zip`/`map`/
-  `filter`/`reversed`** — those are eager (see [builtins.md](builtins.md)), so
+  `filter`/`reversed`**: those are eager (see `./builtins.md`), so
   the deque is fully read before the loop body runs. `for x in d` and explicit
   `iter()`/`next()` detect it exactly as CPython does.
 - `d += <any iterable>` works (it is `extend`), even though `list`'s `+=` still
   accepts only another list.
-- **Extending from an eager builtin loses the partial result when it raises** —
+- **Extending from an eager builtin loses the partial result when it raises.**
   `extend`/`extendleft`/`+=` append each item as the source yields it, so an
   iterator raising part-way leaves the earlier items in place, as in CPython.
   But `map`/`filter`/`zip`/`enumerate` are eager (see
-  [builtins.md](builtins.md)), so `d += map(f, xs)` with a raising `f` raises
+  `./builtins.md`), so `d += map(f, xs)` with a raising `f` raises
   before the extend begins and appends nothing, where CPython appends whatever
   was yielded first.
 
-`del d[i]` and subclassing (`class Q(deque)`) both fail at *compile* time — the
+`del d[i]` and subclassing (`class Q(deque)`) both fail at *compile* time: the
 `del` statement and class inheritance are unimplemented Monty-wide (see
-[language.md](language.md) / [classes.md](classes.md)), not deque limitations.
+`./language.md` / `./classes.md`), not deque limitations.
 
 ## `namedtuple`
 
 Field-name validation matches CPython's messages exactly; see
-[namedtuple.md](namedtuple.md) for the tuple-inherited surface and its
+`./namedtuple.md` for the tuple-inherited surface and its
 divergences. `repr(Point)` is `<class 'Point'>` where CPython gives
-`<class '__main__.Point'>` — the repo-wide unqualified-class-name pattern.
+`<class '__main__.Point'>`, the repo-wide unqualified-class-name pattern.
 
 ## `defaultdict`
 
-- **A `default_factory` cannot call an external or `os` function** — a
+- **A `default_factory` cannot call an external or `os` function**; a
   missing-key access then raises `NotImplementedError`. Plain factories (`int`,
   `list`, `lambda`, ordinary functions) work. This applies to every callback
   Monty invokes mid-expression (the `key=` of `sorted`/`min`/`max`, `map`,
   `filter`, `__repr__`), not just defaultdict.
-- **Crosses the host boundary as a plain `dict`** — the `default_factory` is a
+- **Crosses the host boundary as a plain `dict`**: the `default_factory` is a
   function and cannot cross, so sending the dict back yields a plain `dict`.
 
 ## `Counter`
@@ -73,8 +73,7 @@ divergences. `repr(Point)` is `<class 'Point'>` where CPython gives
 - **Crosses the host boundary as a plain `dict`.**
 - **Mixing `float` and big-int counts raises `TypeError`** (`Counter({'a': 3.5})
   + Counter({'a': 2**70})`, and `total()` over such a mix). This is Monty's
-  general arithmetic limitation — `3.5 + 2**70` raises identically — not a
-  Counter one.
+  general arithmetic limitation: `3.5 + 2**70` raises identically.
 - **In-place `c &= [list]`** (a non-mapping) subscripts `other[elem]` like
   CPython and raises `TypeError`, but with Monty's list-index wording (`list
   indices must be integers, not 'str'` vs CPython's `... or slices, not str`).
@@ -85,7 +84,7 @@ divergences. `repr(Point)` is `<class 'Point'>` where CPython gives
 
 Monty stores one name per type; CPython picks a qualified (`collections.deque`)
 or bare (`deque`) name *per surface*, depending on whether the type is written
-in C or in Python — so no single name matches everywhere. Each type takes the
+in C or in Python, so no single name matches everywhere. Each type takes the
 spelling CPython uses in the most places:
 
 | type | Monty's name | what diverges |
@@ -96,8 +95,8 @@ spelling CPython uses in the most places:
 
 `deque`/`defaultdict` are C types, so CPython qualifies them in `repr(T)` and in
 every type-naming error message (`unsupported operand type(s)`, `object is not
-callable`, `object has no attribute`) — Monty matches all of those and pays only
+callable`, `object has no attribute`); Monty matches all of those and pays only
 on `__name__`. `Counter` is a Python-level class, so those messages give the
-bare name, which Monty matches. Code that matches on a type name — parsing an
-error message or comparing `__name__` — may need to accept either spelling, as
+bare name, which Monty matches. Code that matches on a type name (parsing an
+error message or comparing `__name__`) may need to accept either spelling, as
 with `datetime.datetime`, `re.Pattern`, and `_io.TextIOWrapper`.

--- a/limitations/comprehensions.md
+++ b/limitations/comprehensions.md
@@ -2,9 +2,9 @@
 
 Monty inlines list, set, and dict comprehensions into the surrounding code
 object. The user-visible behaviour follows
-[PEP 709](https://peps.python.org/pep-0709/) (inlined comprehensions, no
+[PEP 709](https://peps.python.org/pep-0709/): inlined comprehensions, no
 synthetic frame in tracebacks, comprehension targets do not leak into the
-enclosing scope).
+enclosing scope.
 
 ## Divergences from CPython
 
@@ -15,9 +15,8 @@ enclosing scope).
   materialises to a `list` rather than a lazy iterator.
 - **Maximum number of `for` clauses.** Monty caps a single comprehension at
   255 `for` clauses; exceeding this raises `SyntaxError: comprehension has
-  too many nested clauses (N); maximum is 255`. In practice the
-  per-clause operand-stack growth means real comprehensions hit a tighter
-  `SyntaxError: comprehension target + iterator count exceeds u8 depth
-  operand` well before that point. CPython has no equivalent compile-time
-  limit. The cap exists to bound compiler recursion depth on
-  attacker-controlled source.
+  too many nested clauses (N); maximum is 255`. Per-clause operand-stack
+  growth means real comprehensions hit a tighter `SyntaxError: comprehension
+  target + iterator count exceeds u8 depth operand` well before that point.
+  CPython has no equivalent compile-time limit. The cap bounds compiler
+  recursion depth on attacker-controlled source.

--- a/limitations/dataclasses.md
+++ b/limitations/dataclasses.md
@@ -3,7 +3,7 @@
 Native, in-sandbox `@dataclass`: sandboxed code can define its own dataclasses,
 executed entirely inside the sandbox. Host-supplied dataclasses are a separate
 mechanism, passed in and dispatching back to the host (see
-`./classes.md`).
+./classes.md).
 
 ## Unsupported
 
@@ -44,7 +44,7 @@ default_factory`), and so is a non-default field after a defaulted one
 
 - **Annotations are stringized.** Fields come from the class's
   `__annotations__`, which Monty stores as never-evaluated source text (always
-  PEP 563); see `./typing.md`. Field
+  PEP 563); see ./typing.md. Field
   discovery and the generated methods are unaffected, the field *type* being
   inert metadata, but `C.__dataclass_fields__['x'].type` is the string `'int'`,
   not the `int` type object.
@@ -69,11 +69,11 @@ default_factory`), and so is a non-default field after a defaulted one
   Conversely any dotted spelling matches, so a same-named attribute on an
   unrelated module (`mymod.ClassVar`) is treated as `typing.ClassVar`.
 - **A field holding a function or bound method reprs differently**, since
-  Monty's own `repr` for those differs (see `./classes.md`). Only the
+  Monty's own `repr` for those differs (see ./classes.md). Only the
   text differs; the value and its equality match CPython.
 - **A class-body `__setattr__` never runs for the synthesized `__init__`**,
   which writes fields straight into the instance `__dict__`. This is the
-  never-dispatched attribute hook described in `./classes.md` rather than
+  never-dispatched attribute hook described in ./classes.md rather than
   something dataclass-specific, so `@dataclass` does not reject it.
 - **`@dataclass` on a non-class** (e.g. `dataclasses.dataclass(5)`) raises
   `TypeError: dataclass() should be called on a class, not '<type>'`. CPython

--- a/limitations/dataclasses.md
+++ b/limitations/dataclasses.md
@@ -1,19 +1,19 @@
 # `dataclasses` module
 
 Native, in-sandbox `@dataclass`: sandboxed code can define its own dataclasses,
-executed entirely inside the sandbox (unlike host-supplied dataclasses, which
-are passed in and dispatch back to the host — see [classes.md](classes.md)).
+executed entirely inside the sandbox. Host-supplied dataclasses are a separate
+mechanism, passed in and dispatching back to the host (see
+`./classes.md`).
 
 ## Unsupported
 
 Only the bare `@dataclass` decorator and `is_dataclass` exist. Everything below
-**raises at decoration time** rather than producing a subtly wrong class, so a
-class body Monty cannot honour never silently misbehaves.
+**raises at decoration time** rather than producing a subtly wrong class.
 
-Each raises `NotImplementedError` — a feature Monty has not built yet, not a
-mistake in the calling code. CPython accepts all of them, so the exception type
-is a divergence in its own right: code catching `TypeError` around a decoration
-will not catch these.
+Each raises `NotImplementedError`, marking a feature Monty has not built yet
+rather than a mistake in the calling code. CPython accepts all of them, so the
+exception type is a divergence in its own right: code catching `TypeError`
+around a decoration will not catch these.
 
 - **The `@dataclass(...)` keyword form** — `frozen`, `eq=False`, `order`,
   `unsafe_hash`, `kw_only` and the hashing/ordering they imply. Any keyword
@@ -44,14 +44,14 @@ default_factory`), and so is a non-default field after a defaulted one
 
 - **Annotations are stringized.** Fields come from the class's
   `__annotations__`, which Monty stores as never-evaluated source text (always
-  PEP 563) — see [typing.md](typing.md#class-annotations-are-stringized). Field
+  PEP 563); see `./typing.md`. Field
   discovery and the generated methods are unaffected, the field *type* being
   inert metadata, but `C.__dataclass_fields__['x'].type` is the string `'int'`,
   not the `int` type object.
 - **`__dataclass_fields__` holds only real fields.** CPython keeps `ClassVar`
   (and `InitVar`) entries in the mapping, marked `_FIELD_CLASSVAR`, and filters
-  them in `fields()`. Monty has no field kinds — the mapping *is* the field
-  list — so class variables never appear in it.
+  them in `fields()`. Monty has no field kinds, so the mapping *is* the field
+  list and class variables never appear in it.
 - **`Field` renders differently.** `repr(field)` follows CPython's layout but
   writes `MISSING` where CPython writes `<dataclasses._MISSING_TYPE object at
   0x..>`, and the stringized `type`. `repr(type(field))` is `<class 'Field'>`,
@@ -69,17 +69,17 @@ default_factory`), and so is a non-default field after a defaulted one
   Conversely any dotted spelling matches, so a same-named attribute on an
   unrelated module (`mymod.ClassVar`) is treated as `typing.ClassVar`.
 - **A field holding a function or bound method reprs differently**, since
-  Monty's own `repr` for those differs (see [classes.md](classes.md)). Only the
+  Monty's own `repr` for those differs (see `./classes.md`). Only the
   text differs; the value and its equality match CPython.
 - **A class-body `__setattr__` never runs for the synthesized `__init__`**,
-  which writes fields straight into the instance `__dict__`. Not a
-  dataclass-specific gap — the never-dispatched attribute hook of
-  [classes.md](classes.md) — so `@dataclass` does not reject it.
+  which writes fields straight into the instance `__dict__`. This is the
+  never-dispatched attribute hook described in `./classes.md` rather than
+  something dataclass-specific, so `@dataclass` does not reject it.
 - **`@dataclass` on a non-class** (e.g. `dataclasses.dataclass(5)`) raises
   `TypeError: dataclass() should be called on a class, not '<type>'`. CPython
   instead raises an incidental `AttributeError` about `__module__` from its
-  implementation; Monty reports the misuse directly. (The `@deco` syntax only
-  ever targets a class, so this affects only direct calls.)
+  implementation. The `@deco` syntax only ever targets a class, so this affects
+  only direct calls.
 
 ## Architectural gaps (cannot match)
 

--- a/limitations/datetime.md
+++ b/limitations/datetime.md
@@ -19,16 +19,16 @@ through C `long`, which is 32 bits on Windows, so `date(2**40, 1, 1)`
 raises `OverflowError: Python int too large to convert to C long` there,
 while 64-bit-`long` platforms raise the sign-aware `signed integer is
 greater than maximum` / `less than minimum`. Monty's ints are i64 on
-every host, so it always uses the 64-bit wording — matching CPython on
-Linux/macOS but not on Windows. (Same for `datetime`; values wider than
-i64 raise the `C long` message on all platforms, matching CPython.)
+every host, so it always uses the 64-bit wording, matching CPython on
+Linux/macOS but not on Windows. Same for `datetime`; values wider than
+i64 raise the `C long` message on all platforms, matching CPython.
 
 ## `datetime`
 
 Constructor: `datetime(year, month, day, hour=0, minute=0, second=0,
 microsecond=0, tzinfo=None, *, fold=0)`. `fold` is accepted and validated
 (must be 0 or 1) for CPython argument-parsing parity but does not affect
-the stored value — Monty does not track DST-fold disambiguation.
+the stored value: Monty does not track DST-fold disambiguation.
 Attributes: `year`, `month`, `day`, `hour`, `minute`, `second`,
 `microsecond`, `tzinfo`.
 Methods: `isoformat`, `strftime`, `replace`, `weekday`, `isoweekday`,
@@ -48,8 +48,8 @@ Class methods supported: `now(tz=None)`, `strptime(date_string, format)`,
 - `combine()`, `fromtimestamp()`, `fromordinal()`, `utcfromtimestamp()`
   are not implemented.
 
-Subclassing `datetime` is not possible (no `class` statement; see
-[language.md](language.md)).
+Subclassing `datetime` is not possible, since there is no class inheritance
+(see `./classes.md`).
 
 `datetime.replace()` and `date.replace()` accept **only keyword
 arguments** in Monty. CPython accepts positional args too
@@ -60,7 +60,7 @@ got N`.
 ## `timedelta`
 
 Constructor: `timedelta(days=0, seconds=0, microseconds=0, *,
-milliseconds=0, minutes=0, hours=0, weeks=0)` — note `milliseconds`,
+milliseconds=0, minutes=0, hours=0, weeks=0)`. `milliseconds`,
 `minutes`, `hours`, and `weeks` are keyword-only in Monty; CPython accepts
 all seven positionally.
 Attributes: `days`, `seconds`, `microseconds`.
@@ -86,7 +86,7 @@ defined. The abstract `tzinfo` base class is not exposed.
 One error-ordering corner: `timezone('x', offset=td)` (a non-`timedelta`
 positional *and* an `offset` kwarg) raises the name-and-position conflict in
 Monty, but the type error in CPython (`timezone() argument 1 must be
-datetime.timedelta, not str`) — CPython's parser type-checks `offset` while
+datetime.timedelta, not str`). CPython's parser type-checks `offset` while
 binding, whereas Monty validates the `timedelta` in the constructor body
 after binding completes.
 
@@ -99,11 +99,11 @@ Rust's defaults rather than the C locale and may differ from CPython.
 ### Unrecognised directives
 
 An **unrecognised directive is passed through verbatim**, matching glibc/Linux
-CPython (`strftime('%Q') == '%Q'`, `strftime('%') == '%'`). Note this is a
-deliberate choice of *one* CPython, not all of them: macOS CPython instead
-drops the `%` (`strftime('%Q') == 'Q'`), because unknown-directive handling is
-delegated to the platform C library and is genuinely platform-dependent. The
-same pass-through applies to f-string formatting (below).
+CPython (`strftime('%Q') == '%Q'`, `strftime('%') == '%'`). This is a choice
+of *one* CPython, not all of them: macOS CPython instead drops the `%`
+(`strftime('%Q') == 'Q'`), because unknown-directive handling is delegated to
+the platform C library and is genuinely platform-dependent. The same
+pass-through applies to f-string formatting (below).
 
 ### Directives that need data the value lacks
 
@@ -117,14 +117,14 @@ the way CPython does. The known cases:
 - `%z` / `%Z` on a naive `date`/`datetime`: Monty raises; CPython yields `''`.
 - `%z` / `%Z` on an **aware** `datetime`: Monty formats the wall-clock (naive)
   components and so raises rather than emitting the offset/name; CPython yields
-  `'+0200'` / `'CEST'`. (Threading the timezone through formatting is not yet
-  implemented.)
+  `'+0200'` / `'CEST'`. Threading the timezone through formatting is not yet
+  implemented.
 
 f-strings format `date`/`datetime` values through `strftime`, matching
 CPython's `__format__`: `f'{dt:%Y-%m-%d}'` is equivalent to
 `dt.strftime('%Y-%m-%d')`, and an empty spec (`f'{dt}'` or `f'{dt:}'`) uses
 `str(dt)`. One edge-case divergence: a spec that also happens to be a valid
 format mini-language spec (e.g. `f'{dt:>10}'` or a lone `f'{dt:%}'`) is
-applied as generic string formatting rather than handed to `strftime` —
+applied as generic string formatting rather than handed to `strftime`, where
 CPython treats the *entire* spec as a `strftime` string. Real strftime specs
 (those containing `%` directives like `%Y`) are unaffected.

--- a/limitations/datetime.md
+++ b/limitations/datetime.md
@@ -49,7 +49,7 @@ Class methods supported: `now(tz=None)`, `strptime(date_string, format)`,
   are not implemented.
 
 Subclassing `datetime` is not possible, since there is no class inheritance
-(see `./classes.md`).
+(see ./classes.md).
 
 `datetime.replace()` and `date.replace()` accept **only keyword
 arguments** in Monty. CPython accepts positional args too

--- a/limitations/encoding.md
+++ b/limitations/encoding.md
@@ -43,12 +43,12 @@ everywhere, since the BOM's order wins.
   raises `LookupError: unknown error handler name '{name}'`.
 - All other built-in handlers behave as in CPython, in both directions.
   `namereplace` output for recently-added code points is subject to the
-  Unicode version skew described in `./unicodedata.md`.
+  Unicode version skew described in ./unicodedata.md.
 
 ## `UnicodeEncodeError` / `UnicodeDecodeError`
 
 **Inside the sandbox** both are message-only, like every other Monty
-exception; see `./exceptions.md`.
+exception; see ./exceptions.md.
 CPython's `encoding`/`object`/`start`/`end`/`reason` attributes are not
 exposed to sandboxed code, and the in-sandbox constructor accepts only a
 single message argument.

--- a/limitations/encoding.md
+++ b/limitations/encoding.md
@@ -15,7 +15,7 @@ registry, so everything below applies to them too.
 Names are normalized like CPython (case-insensitive; runs of spaces/hyphens
 collapse to `_`) and each codec's CPython aliases are recognized (`utf8`,
 `u16`, `646`, `us-ascii`, ...). Any other encoding name raises
-`LookupError: unknown encoding: {name}` — including names CPython recognizes
+`LookupError: unknown encoding: {name}`, including names CPython recognizes
 (`latin-1`, `cp1252`, `iso-8859-1`, `big5`, ...).
 
 ## Byte order for bare `utf-16` / `utf-32`
@@ -25,7 +25,7 @@ order: encode writes a BOM in native order, and BOM-less input decodes as
 native order. Monty always uses **little-endian** for both, so behavior is
 identical on every little-endian host (all platforms Monty CI covers) but
 diverges on big-endian hosts. Input with a BOM decodes identically
-everywhere (the BOM's order wins).
+everywhere, since the BOM's order wins.
 
 ## Error handlers
 
@@ -43,12 +43,12 @@ everywhere (the BOM's order wins).
   raises `LookupError: unknown error handler name '{name}'`.
 - All other built-in handlers behave as in CPython, in both directions.
   `namereplace` output for recently-added code points is subject to the
-  Unicode version skew described in [unicodedata.md](unicodedata.md).
+  Unicode version skew described in `./unicodedata.md`.
 
 ## `UnicodeEncodeError` / `UnicodeDecodeError`
 
 **Inside the sandbox** both are message-only, like every other Monty
-exception — see [exceptions.md](exceptions.md#constructor-signature).
+exception; see `./exceptions.md`.
 CPython's `encoding`/`object`/`start`/`end`/`reason` attributes are not
 exposed to sandboxed code, and the in-sandbox constructor accepts only a
 single message argument.
@@ -59,15 +59,15 @@ single message argument.
 to a plain `ValueError` carrying the formatted message (both are caught by
 `except ValueError:`) in two cases:
 
-- the failing object is larger than 64 KiB — the payload is dropped so an
+- the failing object is larger than 64 KiB, where the payload is dropped so an
   exception cannot pin a huge input in memory outside the sandbox's
   resource limits (CPython's exception always references the full object);
 - the exception was raised manually inside the sandbox
   (`raise UnicodeDecodeError('msg')`), where no structured fields exist.
 
 The structured fields only travel with a *raised* exception that escapes the
-sandbox. A codec exception handled as a **value** — caught in the sandbox and
-then returned as the run result, or passed to an external function — crosses
+sandbox. A codec exception handled as a **value** (caught in the sandbox and
+then returned as the run result, or passed to an external function) crosses
 the boundary as a message-only exception object, so the host sees the
 `ValueError` fallback for it even though the same exception raised out of
 the sandbox would rebuild the real type.

--- a/limitations/exceptions.md
+++ b/limitations/exceptions.md
@@ -2,9 +2,9 @@
 
 Monty implements a fixed set of exception classes, listed below. Sandboxed
 code **cannot define new exception classes**: the `class` statement exists
-(see [classes.md](classes.md)) but classes cannot inherit, so there is no way
+(see `./classes.md`) but classes cannot inherit, so there is no way
 to subclass `BaseException`/`Exception`. `raise` must therefore use one of
-these built-ins — `raise MyClass()` on a plain user class raises
+these built-ins; `raise MyClass()` on a plain user class raises
 `TypeError: exceptions must derive from BaseException`, as in CPython.
 
 ## Implemented exception classes
@@ -34,14 +34,14 @@ both `OSError` and `ValueError`, matching CPython's dual parentage).
 `StopAsyncIteration`, `SystemError`, `TabError`, `IndentationError`,
 `UnicodeError` (parent), `UnicodeTranslateError`,
 `EncodingWarning`, `EnvironmentError` / `IOError` aliases,
-`ExceptionGroup` / `BaseExceptionGroup` (see [language.md](language.md)).
+`ExceptionGroup` / `BaseExceptionGroup` (see `./language.md`).
 
 ## Constructor signature
 
 All exception constructors accept **zero or one string argument** only.
 Multi-argument forms used in CPython (e.g. `OSError(errno, strerror,
 filename)`, `UnicodeDecodeError(encoding, obj, start, end, reason)`) are
-not supported — passing more than one argument raises an internal error.
+not supported; passing more than one argument raises an internal error.
 
 ## Attributes
 
@@ -51,12 +51,12 @@ not supported — passing more than one argument raises an internal error.
 - `repr(exc)` — `ClassName('message')` matching CPython, **except**
   `UnicodeDecodeError`/`UnicodeEncodeError`: CPython reprs these from their
   real 5-field constructor (`UnicodeDecodeError('ascii', b'\xff', 0, 1,
-  'ordinal not in range(128)')`), which Monty doesn't track — Monty's
+  'ordinal not in range(128)')`), which Monty doesn't track, so Monty's
   `repr()` uses the generic single-message form instead.
 
 **Not implemented:** `__cause__`, `__context__`, `__suppress_context__`,
 `__traceback__`, `__notes__`, `add_note()`. The `raise X from Y` syntax
-parses, but the `from Y` cause is **silently dropped** — chained
+parses, but the `from Y` cause is **silently dropped**: chained
 tracebacks are not preserved across `raise from`.
 
 ## Custom subclasses
@@ -74,8 +74,8 @@ that best fits.
 `break`/`continue`/`return` inside a `finally` block follows CPython
 semantics (the finally body runs exactly once and a `return`/`break`/
 `continue` that exits it discards any in-flight exception), but Monty does
-not emit CPython 3.14's PEP 765 `SyntaxWarning` for such statements — Monty
-has no warnings machinery.
+not emit CPython 3.14's PEP 765 `SyntaxWarning` for such statements, having
+no warnings machinery.
 
 ## Traceback behaviour
 
@@ -92,13 +92,13 @@ Known caret divergences:
   the frame's range.
 - For a frame whose location spans multiple lines (e.g. a caller frame covering
   a whole multi-line `class` statement), Monty renders the CPython-style source
-  block — all lines when the range covers at most three, otherwise
-  `...<N lines>...` elision — but never draws caret markers under it, where
-  CPython draws multi-line carets for partial-line ranges (e.g. a multi-line
-  binary expression).
+  block (all lines when the range covers at most three, otherwise
+  `...<N lines>...` elision) but never draws caret markers under it, where
+  CPython draws multi-line carets for partial-line ranges such as a multi-line
+  binary expression.
 
 Monty never emits CPython's `Did you mean: '...'?` suggestions on
-`NameError`/`AttributeError`. Note this divergence is invisible to the test
+`NameError`/`AttributeError`. This divergence is invisible to the test
 suite: `scripts/run_traceback.py` strips the suggestions from CPython's output
 before comparison, so traceback tests cannot catch it.
 
@@ -107,6 +107,6 @@ An exception raised inside a Python callable that native code invokes
 `sorted`/`min`/`max`, and a user-defined
 `__iter__`/`__next__`/`__contains__`/`__repr__`/`__str__` — omits the **calling**
 frame from its traceback; the callee frame is present.
-CPython shows both. This is a limitation of the re-entrant call path
-(`evaluate_function`), which does not splice the host call site into the
-traceback. The exception type and message are unaffected.
+CPython shows both. The re-entrant call path (`evaluate_function`) does not
+splice the host call site into the traceback. The exception type and message
+are unaffected.

--- a/limitations/exceptions.md
+++ b/limitations/exceptions.md
@@ -2,7 +2,7 @@
 
 Monty implements a fixed set of exception classes, listed below. Sandboxed
 code **cannot define new exception classes**: the `class` statement exists
-(see `./classes.md`) but classes cannot inherit, so there is no way
+(see ./classes.md) but classes cannot inherit, so there is no way
 to subclass `BaseException`/`Exception`. `raise` must therefore use one of
 these built-ins; `raise MyClass()` on a plain user class raises
 `TypeError: exceptions must derive from BaseException`, as in CPython.
@@ -34,7 +34,7 @@ both `OSError` and `ValueError`, matching CPython's dual parentage).
 `StopAsyncIteration`, `SystemError`, `TabError`, `IndentationError`,
 `UnicodeError` (parent), `UnicodeTranslateError`,
 `EncodingWarning`, `EnvironmentError` / `IOError` aliases,
-`ExceptionGroup` / `BaseExceptionGroup` (see `./language.md`).
+`ExceptionGroup` / `BaseExceptionGroup` (see ./language.md).
 
 ## Constructor signature
 

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -4,7 +4,7 @@ The sandbox has no default filesystem access. The host explicitly mounts
 real directories at virtual paths through Monty's `MountTable`; everything
 outside a mount is invisible. Without any mounts, `open()` and every
 `pathlib` I/O method raise `FileNotFoundError` for every path (see
-`./open.md` and `./pathlib.md`).
+./open.md and ./pathlib.md).
 
 ## Virtual paths are always POSIX
 
@@ -13,7 +13,7 @@ Inside the sandbox, paths use forward slashes regardless of host OS.
 path `C:/Users/foo`. Path repr is always `PosixPath(...)`.
 
 Bytes paths are accepted but decoded as strict UTF-8 (no `surrogateescape`
-/ PEP 383 round-tripping). See `./open.md` for the full rationale.
+/ PEP 383 round-tripping). See ./open.md for the full rationale.
 
 ## Mount modes
 
@@ -201,7 +201,7 @@ the attempt fails with `ERROR_SHARING_VIOLATION`. Unix is unaffected. The
 window is the mount's lifetime, which for `pydantic_monty` and
 `@pydantic/monty` is the lifetime of the mount object, not one feed. Close it
 (`MountDir.close()`, or the `with` / `using` block) to release the directory
-before the host touches it (see `./pool-architecture.md`).
+before the host touches it (see ./pool-architecture.md).
 
 ### A mount follows its directory, not its path
 
@@ -273,6 +273,6 @@ escapes. That matches CPython, and reveals nothing about the target.
 
 `open()` and pathlib I/O do not keep an OS handle alive between calls; each
 `read`/`write` is a separate one-shot host operation. This is what makes
-subprocess dump/load safe (see `./pool-architecture.md`), and it means
+subprocess dump/load safe (see ./pool-architecture.md), and it means
 external processes can observe partial state between writes. See the design
-note in `./open.md`.
+note in ./open.md.

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -2,18 +2,18 @@
 
 The sandbox has no default filesystem access. The host explicitly mounts
 real directories at virtual paths through Monty's `MountTable`; everything
-outside a mount is invisible. Without any mounts, [`open()`](open.md) and
-all of [pathlib](pathlib.md)'s I/O methods raise `FileNotFoundError` for
-every path.
+outside a mount is invisible. Without any mounts, `open()` and every
+`pathlib` I/O method raise `FileNotFoundError` for every path (see
+`./open.md` and `./pathlib.md`).
 
 ## Virtual paths are always POSIX
 
 Inside the sandbox, paths use forward slashes regardless of host OS.
-`Path("C:/Users/foo")` is not a Windows path — it is the literal POSIX
+`Path("C:/Users/foo")` is not a Windows path; it is the literal POSIX
 path `C:/Users/foo`. Path repr is always `PosixPath(...)`.
 
 Bytes paths are accepted but decoded as strict UTF-8 (no `surrogateescape`
-/ PEP 383 round-tripping). See [open.md](open.md) for the full rationale.
+/ PEP 383 round-tripping). See `./open.md` for the full rationale.
 
 ## Mount modes
 
@@ -24,7 +24,7 @@ Each mount is configured by the host as one of:
 - **`ReadWrite`** — full read/write into the underlying host directory.
 - **`OverlayMemory`** — copy-on-write: reads fall through to the host
   directory, writes are captured in memory and never touch the host. Via the
-  pool, the changes are discarded when the feed ends — each feed starts with
+  pool, the changes are discarded when the feed ends; each feed starts with
   a fresh overlay.
 
 ## Only regular files can be read, written, or opened
@@ -84,15 +84,15 @@ root.
 - Path segments a host parser reads as absolute are rejected
   (`PermissionError`) on every OS and in every mount mode: any segment
   containing a backslash or starting with `X:`. So names CPython allows on
-  Unix — `a\b.txt`, `a:b.txt` — are refused there too, since Windows would
+  Unix (`a\b.txt`, `a:b.txt`) are refused there too, since Windows would
   read them as drive-relative. Colons elsewhere are fine (`note:2026.txt`).
 - The mount root itself cannot be renamed or removed: `rename` and `rmdir` on
   the mount's own path raise `PermissionError` in every mode, where CPython on
-  an ordinary empty directory would succeed (the root has no name inside the
-  mount, so there is nothing to detach it from).
+  an ordinary empty directory would succeed. The root has no name inside the
+  mount, so there is nothing to detach it from.
 - A rename is only serviced when source and destination land in the *same*
-  mount. Any other combination — different mounts, or one side under no mount
-  at all — raises `OSError` `[Errno 18] Invalid cross-device link`, including
+  mount. Any other combination (different mounts, or one side under no mount
+  at all) raises `OSError` `[Errno 18] Invalid cross-device link`, including
   where CPython would report `FileNotFoundError` for a missing destination
   directory. Neither side moves.
 - Null bytes in any path component are rejected (`ValueError`).
@@ -108,7 +108,7 @@ directory are **not** available unless the host explicitly mounts them.
 always names the lexical parent. POSIX instead resolves it *after* following
 the preceding component, which differs whenever a symlink is involved: with
 `ld -> sub/deep`, CPython reads `ld/../sibling.txt` as `sub/sibling.txt`,
-while Monty reads it as `sibling.txt` — each finds a file the other does not.
+while Monty reads it as `sibling.txt`, so the two resolve to different files.
 The textual rule is what makes `..` unable to escape at all, so it is
 deliberate; only paths mixing `..` with symlinked directories are affected.
 
@@ -120,24 +120,23 @@ host, so a path macOS (`PATH_MAX` 1024) or Windows would reject is accepted,
 and a long one they would accept is not. The length counts the path as sent,
 before `.`/`..` are collapsed: `'/mnt/' + 'a/' * 5000 + '../' * 5000 + 'f.txt'`
 is refused even though it names `/mnt/f.txt`. CPython hands the uncollapsed
-bytes to the kernel and gets `ENAMETOOLONG` too, so this matches — but Monty
+bytes to the kernel and gets `ENAMETOOLONG` too, so this matches, but Monty
 applies it uniformly rather than deferring to the host filesystem.
 
 The check runs before anything else looks at the path, which has three visible
 consequences:
 
-- `resolve()` and `absolute()` raise, where CPython returns the path — they are
+- `resolve()` and `absolute()` raise, where CPython returns the path. They are
   the only operations that would otherwise succeed on an over-long path, since
   they never reach the filesystem. Collapsing a path costs memory proportional
   to its length, so an unbounded one is refused rather than normalized.
 - The rejection applies even where no mount covers the path, so an over-long
   path never reaches the `os` callback.
 - `exists()`, `is_file()`, `is_dir()` and `is_symlink()` answer `False`, as
-  CPython's do — `pathlib` swallows `ENAMETOOLONG` in the predicates.
+  CPython's do; `pathlib` swallows `ENAMETOOLONG` in the predicates.
 
-The error quotes the path with its middle elided — the first and last 20
-characters around a `…` — where CPython quotes it whole. An over-long path
-is by definition too big to repeat back.
+The error quotes the path with its middle elided, the first and last 20
+characters around a `…`, where CPython quotes it whole.
 
 ### At most 64 path components
 
@@ -146,9 +145,9 @@ File name too long`, with the same three consequences as the length limit
 above. CPython has no such limit: it hands the path to the kernel, which
 counts bytes, not levels.
 
-This one is Monty's own. Confinement resolves every path relative to the
+This limit is Monty's own. Confinement resolves every path relative to the
 mount's descriptor, and outside Linux-with-`openat2` that means walking it
-component by component in userspace — so the kernel never sees the whole path
+component by component in userspace, so the kernel never sees the whole path
 and its `ENAMETOOLONG` never fires. A 4096-byte path can name ~2000
 components, and each level costs at least one lookup, so a single call could
 fan out into millions of them. Components are counted as sent, like the
@@ -156,8 +155,8 @@ length, which can only over-count: `.` and empty segments are dropped by
 normalization and `..` removes a pair, so anything within the limit as sent is
 within it once collapsed.
 
-64 is far above real trees — the deepest path in this repository, nested
-`node_modules` included, is 20 — but code that builds paths by repeated
+64 is far above real trees (the deepest path in this repository, nested
+`node_modules` included, is 20), but code that builds paths by repeated
 `mkdir(parents=True)` on generated names can reach it where CPython would not.
 
 ### `absolute()` raises on a null byte
@@ -165,7 +164,7 @@ within it once collapsed.
 Null bytes otherwise behave as CPython's do, message for message. Only
 `absolute()` differs: CPython returns the path without inspecting it, while
 Monty refuses it at the boundary rather than carve out the one operation that
-never reaches a syscall. It raises `ValueError: embedded null byte` — the
+never reaches a syscall. It raises `ValueError: embedded null byte`, the
 generic wording, since no syscall is involved to name. A path that is both
 over-long and null-containing reports the length error, where CPython reports
 the null byte.
@@ -173,8 +172,8 @@ the null byte.
 ### A search-only host directory may not be mountable
 
 Mounting opens a descriptor on the host directory. On macOS and the BSDs that
-needs read permission, so a search-only directory (mode `0o111`) is refused —
-`MountDir` raises at construction — even though a host process can traverse it
+needs read permission, so a search-only directory (mode `0o111`) is refused:
+`MountDir` raises at construction, even though a host process can traverse it
 and read known paths inside. Linux opens directories with `O_PATH` and accepts
 it. Grant `r-x` on anything you intend to mount portably.
 
@@ -185,26 +184,24 @@ target is relative; an absolute target raises `PermissionError` even when it
 points back into the same mount.** CPython follows both. A descriptor has no
 path of its own, so a leading `/` cannot be interpreted and "absolute but
 inside" is indistinguishable from "absolute and outside". `OverlayMemory`
-follows no link at all — see below.
+follows no link at all, see below.
 
-This is the one thing to check before mounting an existing directory.
 Sandboxed code cannot create symlinks, so only links **already present** are
-affected — `node_modules` installs, Homebrew/Nix store trees, build output
-with linked artifacts. Only the links fail; the files themselves are readable,
-the error is loud, and nothing returns wrong data. `exists()`, `is_file()` and
-`is_dir()` answer `False` rather than raising. To keep such links working,
-rewrite them as relative before mounting.
+affected: `node_modules` installs, Homebrew/Nix store trees, build output
+with linked artifacts. Only the links fail; the files themselves are readable
+and no operation returns wrong data. `exists()`, `is_file()` and `is_dir()`
+answer `False` rather than raising. To keep such links working, rewrite them
+as relative before mounting.
 
 ### Windows locks a mounted directory against the host
 
 Windows refuses to rename or delete a directory while a handle to it is open,
-so the host cannot move or delete a directory for as long as it is mounted —
+so the host cannot move or delete a directory for as long as it is mounted;
 the attempt fails with `ERROR_SHARING_VIOLATION`. Unix is unaffected. The
 window is the mount's lifetime, which for `pydantic_monty` and
-`@pydantic/monty` is the lifetime of the mount object, not one feed — close it
+`@pydantic/monty` is the lifetime of the mount object, not one feed. Close it
 (`MountDir.close()`, or the `with` / `using` block) to release the directory
-before the host touches it (see
-[pool-architecture.md](pool-architecture.md)).
+before the host touches it (see `./pool-architecture.md`).
 
 ### A mount follows its directory, not its path
 
@@ -224,7 +221,7 @@ escapes — raises `PermissionError`.** Reads, writes, deletes, `stat`,
 
 An overlay entry is keyed by name, but a symlink resolves on the *host*, so it
 names a file the overlay only knows by its target's name. Following one would
-serve content the overlay has already replaced or deleted — write to
+serve content the overlay has already replaced or deleted: write to
 `hello.txt`, then read `link.txt`, and CPython gives the new text while a
 following overlay would give the old. No in-memory representation fixes that,
 so the mode refuses links rather than answering wrongly. The target is never
@@ -233,8 +230,8 @@ resolved, so the error reveals nothing about it.
 Renaming a **directory that contains a symlink** is refused for the same
 reason: the link cannot move with it and cannot be left behind.
 
-`is_symlink()` still answers `True` — it reports only that the name is a link,
-as CPython does; the other predicates answer `False`. Direct mounts are
+`is_symlink()` still answers `True`; it reports only that the name is a link,
+as CPython does. The other predicates answer `False`. Direct mounts are
 unaffected and still follow relative in-mount links for reads and writes.
 `mkdir(parents=True)` through an escaping symlink raises `PermissionError` in
 every mode.
@@ -244,14 +241,14 @@ atomic with the operation it guards: a host process that swaps a symlink into
 the path — while it is being checked, or between the check and the read — gets
 it followed. The descriptor still bounds the result to inside the mount, so
 this is the same window a host already has by replacing a file outright
-(above) — not a way out.
+(above).
 
 ### `OverlayMemory` renames of real files
 
 A rename records a mount-relative reference to the existing file rather than
 copying its bytes, so it cannot come to name anything outside the mount. If
 the host replaces the underlying file before the read, the read sees whatever
-now occupies that path inside the mount — unless that is a symlink, refused
+now occupies that path inside the mount, unless that is a symlink, refused
 like any other; CPython, holding no such reference, would not find the
 renamed-away original.
 
@@ -264,7 +261,7 @@ inside.
 ### Boolean predicates never raise
 
 `exists()`, `is_file()` and `is_dir()` answer `False` for any path leaving the
-mount, so a blocked path is indistinguishable from a missing one — raising
+mount, so a blocked path is indistinguishable from a missing one; raising
 would confirm something is there to be blocked. CPython follows the link and
 answers `True`.
 
@@ -274,8 +271,8 @@ escapes. That matches CPython, and reveals nothing about the target.
 
 ## No live host descriptors
 
-`open()` and pathlib I/O do not keep an OS handle alive between calls —
-each `read`/`write` is a separate one-shot host operation. This is what
-makes subprocess [dump/load](pool-architecture.md#execution-model) safe,
-and it means external processes can observe partial state between writes.
-See the design note in [open.md](open.md).
+`open()` and pathlib I/O do not keep an OS handle alive between calls; each
+`read`/`write` is a separate one-shot host operation. This is what makes
+subprocess dump/load safe (see `./pool-architecture.md`), and it means
+external processes can observe partial state between writes. See the design
+note in `./open.md`.

--- a/limitations/format.md
+++ b/limitations/format.md
@@ -6,7 +6,7 @@ interpolations. The mini-language is only reachable through f-strings.
 The other CPython formatting mechanisms are not implemented:
 
 - The `format()` builtin raises `NameError` and the `str.format()` method
-  raises `AttributeError` (see `./builtins.md`).
+  raises `AttributeError` (see ./builtins.md).
 - Printf-style `%` formatting (`'%5.3f' % math.pi`, `'%s %s' % (a, b)`) is not
   implemented. `str` has no `__mod__`, so `str % value` raises
   `TypeError: unsupported operand type(s) for %: 'str' and '...'`. Use an
@@ -16,8 +16,8 @@ The other CPython formatting mechanisms are not implemented:
 
 f-strings dispatch to a type's `__format__` only for `date`/`datetime`, which
 interpret the spec as a `strftime` string (`f'{dt:%Y-%m-%d}'`); see
-`./datetime.md`. There is no general `__format__` protocol: user
-classes can't customise formatting (see `./classes.md`), and all
+./datetime.md. There is no general `__format__` protocol: user
+classes can't customise formatting (see ./classes.md), and all
 other types use the builtin mini-language formatter. A format spec on a
 user-class instance is silently applied to `str(obj)` (`f'{obj:>10}'` pads),
 where CPython raises `TypeError: unsupported format string passed to
@@ -43,7 +43,7 @@ CPython prints it literally, or the reverse. Common text is unaffected.
   `SyntaxError: Invalid format specifier '...': width or precision overflows
   usize` rather than being accepted. CPython is bounded only by memory.
 - Very large widths/precisions are additionally bounded by the resource
-  tracker; see `./resource_limits.md`.
+  tracker; see ./resource_limits.md.
 
 ## When spec errors are raised
 

--- a/limitations/format.md
+++ b/limitations/format.md
@@ -1,24 +1,23 @@
 # Format mini-language (f-string specs)
 
 Monty implements CPython 3.14's format mini-language for f-string
-interpolations. The mini-language is only reachable through f-strings; the
-divergences and unsupported mechanisms are listed below.
+interpolations. The mini-language is only reachable through f-strings.
 
 The other CPython formatting mechanisms are not implemented:
 
 - The `format()` builtin raises `NameError` and the `str.format()` method
-  raises `AttributeError` (see [builtins.md](builtins.md)).
+  raises `AttributeError` (see `./builtins.md`).
 - Printf-style `%` formatting (`'%5.3f' % math.pi`, `'%s %s' % (a, b)`) is not
-  implemented — `str` has no `__mod__`, so `str % value` raises
+  implemented. `str` has no `__mod__`, so `str % value` raises
   `TypeError: unsupported operand type(s) for %: 'str' and '...'`. Use an
   f-string instead.
 
 ## Custom `__format__`
 
 f-strings dispatch to a type's `__format__` only for `date`/`datetime`, which
-interpret the spec as a `strftime` string (`f'{dt:%Y-%m-%d}'`) — see
-[datetime.md](datetime.md). There is no general `__format__` protocol: user
-classes can't customise formatting (see [classes.md](classes.md)), and all
+interpret the spec as a `strftime` string (`f'{dt:%Y-%m-%d}'`); see
+`./datetime.md`. There is no general `__format__` protocol: user
+classes can't customise formatting (see `./classes.md`), and all
 other types use the builtin mini-language formatter. A format spec on a
 user-class instance is silently applied to `str(obj)` (`f'{obj:>10}'` pads),
 where CPython raises `TypeError: unsupported format string passed to
@@ -26,35 +25,36 @@ Foo.__format__`.
 
 ## The `n` type uses the C locale only
 
-`n` always behaves as in the C/POSIX locale (Monty has no locale support): like
-`d` for integers and `g` for floats, with no digit grouping. CPython under a
-grouping locale would insert locale-specific separators; Monty never does.
+`n` always behaves as in the C/POSIX locale (Monty has no locale support):
+like `d` for integers and `g` for floats, with no digit grouping. CPython
+under a grouping locale would insert locale-specific separators; Monty never
+does.
 
 ## `repr` of non-printable Unicode
 
 `repr` escapes non-printable code points via the `unicode-general-category`
-crate, whose Unicode version may lag CPython's — so a code point assigned in a
+crate, whose Unicode version may lag CPython's, so a code point assigned in a
 newer Unicode release than the crate ships could be escaped by Monty while
-CPython prints it literally (or vice versa). Common text is unaffected.
+CPython prints it literally, or the reverse. Common text is unaffected.
 
 ## Width / precision bounds
 
 - A `width` or `precision` whose decimal value overflows `usize` raises
   `SyntaxError: Invalid format specifier '...': width or precision overflows
-  usize` rather than being accepted. (CPython is bounded only by memory.)
+  usize` rather than being accepted. CPython is bounded only by memory.
 - Very large widths/precisions are additionally bounded by the resource
-  tracker — see [resource_limits.md](resource_limits.md).
+  tracker; see `./resource_limits.md`.
 
 ## When spec errors are raised
 
 CPython validates a *static* (literal) spec only when the f-string executes, so
 a malformed spec in dead code never raises. Monty validates literal specs at
-**compile time** for the structurally-malformed cases — two or more trailing
+**compile time** for the structurally-malformed cases: two or more trailing
 characters after the type field (`f'{1:kk}'`, `f'{1:10xyz}'`) and `usize`
-overflow — raising `SyntaxError` instead of CPython's runtime `ValueError`. The
-message text otherwise matches (minus CPython's `for object of type '...'`
-suffix, which needs the runtime value type). Specs whose error *is*
-value-type-dependent or only resolvable at format time — `Unknown format code
+overflow, raising `SyntaxError` instead of CPython's runtime `ValueError`. The
+message text otherwise matches, minus CPython's `for object of type '...'`
+suffix, which needs the runtime value type. Specs whose error *is*
+value-type-dependent or only resolvable at format time (`Unknown format code
 'k'`, the `Cannot specify …` grouping conflicts, and `Format specifier missing
-precision` — are deferred to runtime and raise the exact CPython `ValueError`,
+precision`) are deferred to runtime and raise the exact CPython `ValueError`,
 as do all dynamically-built specs (`f'{1:{spec}}'`).

--- a/limitations/iter.md
+++ b/limitations/iter.md
@@ -3,7 +3,7 @@
 - `iter(callable, sentinel)` runs `callable` synchronously, so one that calls an external/OS function cannot suspend and raises `NotImplementedError`. Same limitation as `map`/`filter`/`sorted(key=...)`.
 - `iter(callable, sentinel)` compares `result == sentinel`, where CPython compares `sentinel == result`; only observable if the two sides have asymmetric `__eq__`.
 - A `StopIteration` raised by `callable` propagates; CPython treats it as clean exhaustion and stops iterating.
-- A user instance defining `__call__` is rejected as not callable, since `__call__` is not dispatched (see `./classes.md`).
+- A user instance defining `__call__` is rejected as not callable, since `__call__` is not dispatched (see ./classes.md).
 - The vendored type stub is upstream typeshed's verbatim, so `-t` accepts `iter(obj)` for an object with only `__getitem__`; Monty has no `__getitem__` iteration fallback and raises `TypeError` at runtime.
 - `-t` accepts `for x in obj` (though not `a, b = obj`) for a class that opts out of iteration with `__iter__ = None`, which raises `TypeError` at runtime as it does in CPython.
 - Iterator `repr()` values omit CPython's process-local memory address: `<list_iterator object>` rather than `<list_iterator object at 0x...>`.

--- a/limitations/iter.md
+++ b/limitations/iter.md
@@ -1,11 +1,11 @@
 # `iter()` and iterators
 
-- `iter(callable, sentinel)` runs `callable` synchronously, so one that calls an external/OS function cannot suspend and raises `NotImplementedError` — the same limitation as `map`/`filter`/`sorted(key=...)`.
+- `iter(callable, sentinel)` runs `callable` synchronously, so one that calls an external/OS function cannot suspend and raises `NotImplementedError`. Same limitation as `map`/`filter`/`sorted(key=...)`.
 - `iter(callable, sentinel)` compares `result == sentinel`, where CPython compares `sentinel == result`; only observable if the two sides have asymmetric `__eq__`.
 - A `StopIteration` raised by `callable` propagates; CPython treats it as clean exhaustion and stops iterating.
-- A user instance defining `__call__` is rejected as not callable, since `__call__` is not dispatched (see [classes.md](classes.md)).
+- A user instance defining `__call__` is rejected as not callable, since `__call__` is not dispatched (see `./classes.md`).
 - The vendored type stub is upstream typeshed's verbatim, so `-t` accepts `iter(obj)` for an object with only `__getitem__`; Monty has no `__getitem__` iteration fallback and raises `TypeError` at runtime.
 - `-t` accepts `for x in obj` (though not `a, b = obj`) for a class that opts out of iteration with `__iter__ = None`, which raises `TypeError` at runtime as it does in CPython.
-- Iterator `repr()` values omit CPython's process-local memory address, for example `<list_iterator object>` rather than `<list_iterator object at 0x...>`.
-- Built-in iterators do not expose their dunders as attributes: `hasattr(iter([1]), '__iter__')` is `False`, where CPython reports `True`. Iteration itself works — only attribute lookup of the dunder differs. This covers every built-in iterator, including the `itertools` adaptors.
+- Iterator `repr()` values omit CPython's process-local memory address: `<list_iterator object>` rather than `<list_iterator object at 0x...>`.
+- Built-in iterators do not expose their dunders as attributes: `hasattr(iter([1]), '__iter__')` is `False`, where CPython reports `True`. Iteration itself works; only attribute lookup of the dunder differs. This covers every built-in iterator, including the `itertools` adaptors.
 - Iterator-specific attributes such as `__length_hint__` are not exposed.

--- a/limitations/itertools.md
+++ b/limitations/itertools.md
@@ -51,7 +51,7 @@ raise `AttributeError` at runtime.
   detection in `repr()`, not specific to `itertools`.
 - **Adaptors without a custom `repr()` omit the address.** `repr(pairwise([]))`
   is `<itertools.pairwise object>`, where CPython appends ` at 0x...`. This is
-  Monty's general iterator treatment (see `./iter.md`), not specific
+  Monty's general iterator treatment (see ./iter.md), not specific
   to `itertools`.
 - **Crossing the host boundary loses the repr.** A `count` / `repeat` object
   returned to the host arrives as `<itertools.count object>` /

--- a/limitations/itertools.md
+++ b/limitations/itertools.md
@@ -1,7 +1,7 @@
 # `itertools` module
 
 Monty implements a small subset of `itertools`. The implemented callables match
-CPython 3.14 for arguments, values, `repr()` and error messages, subject to the
+CPython 3.14 for arguments, values, `repr()` and error messages, apart from the
 notes below.
 
 ## Implemented
@@ -51,7 +51,7 @@ raise `AttributeError` at runtime.
   detection in `repr()`, not specific to `itertools`.
 - **Adaptors without a custom `repr()` omit the address.** `repr(pairwise([]))`
   is `<itertools.pairwise object>`, where CPython appends ` at 0x...`. This is
-  Monty's general iterator treatment (see `limitations/iter.md`), not specific
+  Monty's general iterator treatment (see `./iter.md`), not specific
   to `itertools`.
 - **Crossing the host boundary loses the repr.** A `count` / `repeat` object
   returned to the host arrives as `<itertools.count object>` /
@@ -72,23 +72,23 @@ filter(p, itertools.repeat(1))   # likewise
 enumerate(itertools.count())     # likewise
 ```
 
-`zip()` is safe because it stops at the shortest input, so
-`zip(itertools.count(), 'ab')` behaves as in CPython — as does slicing an
-infinite iterator by hand via `next()`. This is a pre-existing property of those
-builtins rather than something `itertools` introduces, but `count()`/`repeat()`
-are the first easy way for sandboxed code to reach it.
+`zip()` stops at the shortest input, so `zip(itertools.count(), 'ab')` behaves
+as in CPython, as does slicing an infinite iterator by hand via `next()`. This
+is a pre-existing property of those builtins rather than something `itertools`
+introduces, but `count()`/`repeat()` are the first easy way for sandboxed code
+to reach it.
 
 ## Resource limits
 
 `count()` and `repeat(x)` are infinite, so consuming one without a bound
 (`list(itertools.count())`) only terminates if the host has configured a memory
-or duration limit — it then raises `MemoryError` rather than exhausting. Under
+or duration limit, and then raises `MemoryError` rather than exhausting. Under
 `ResourceLimits::default()`, which sets neither (only a recursion depth), it
 runs until the host itself runs out of memory. This is the same exposure as a
 `while True:` loop, not something specific to `itertools`.
 
 `cycle(iterable)` must buffer every item it has seen so far in order to replay
-them, and that buffer is charged against `max_memory` as it grows — so cycling
+them, and that buffer is charged against `max_memory` as it grows, so cycling
 over a very long source raises `MemoryError` at the limit rather than at the
 point the source is exhausted. CPython buffers the same items with no such
 ceiling.
@@ -97,4 +97,4 @@ Nesting the source-driving adaptors (`pairwise`, `compress`, `islice`, `chain`,
 `cycle`) is bounded by `max_recursion_depth`: each adaptor charges one recursion
 level while delegating `next()` to its wrapped iterator, so a nest deeper than
 the limit raises `RecursionError` when consumed. CPython imposes no comparable
-per-adaptor bound — deep nesting there is limited only by the C stack.
+per-adaptor bound; deep nesting there is limited only by the C stack.

--- a/limitations/json.md
+++ b/limitations/json.md
@@ -6,9 +6,9 @@ encoder matching CPython byte-for-byte for the supported keyword set.
 
 ## What's NOT in the module
 
-`json.JSONEncoder` and `json.JSONDecoder` classes are not implemented —
-the `cls=` keyword is rejected. `json.load(fp)` and `json.dump(obj, fp)`
-are not implemented (no file-object protocol).
+`json.JSONEncoder` and `json.JSONDecoder` are not implemented, and the `cls=`
+keyword is rejected. `json.load(fp)` and `json.dump(obj, fp)` are not
+implemented (no file-object protocol).
 
 ## `json.loads(s, **kwargs)`
 
@@ -16,8 +16,8 @@ are not implemented (no file-object protocol).
 - **No keyword arguments are accepted.** Passing any of `cls`,
   `object_hook`, `parse_float`, `parse_int`, `parse_constant`, or
   `object_pairs_hook` raises `TypeError: ... unexpected keyword argument`.
-- `NaN`, `Infinity`, `-Infinity` are *always* accepted (CPython requires
-  `parse_constant` or accepts them by default — same result, no toggle).
+- `NaN`, `Infinity`, `-Infinity` are *always* accepted, with no toggle to
+  reject them.
 - Nesting depth is capped at 200 levels; deeper inputs raise
   `json.JSONDecodeError`.
 - JSON integers that would exceed Monty's BigInt digit limit are rejected
@@ -26,22 +26,22 @@ are not implemented (no file-object protocol).
 
 ## `json.dumps(obj, **kwargs)`
 
-Supported kwargs: `indent`, `sort_keys`, `ensure_ascii`, `allow_nan`,
-`separators`, `skipkeys` — matching CPython semantics.
+Supported kwargs, with CPython semantics: `indent`, `sort_keys`,
+`ensure_ascii`, `allow_nan`, `separators`, `skipkeys`.
 
 Rejected with `TypeError` if passed:
 
 - `cls` — custom encoder classes are not supported.
-- `default` — fallback encoder callback is not supported. Non-serializable
-  values raise `TypeError` instead of routing through a callback.
+- `default` — there is no fallback encoder callback. Non-serializable
+  values raise `TypeError` instead of routing through one.
 - `check_circular` — circular reference detection is always on.
 
 ## `JSONDecodeError`
 
 Inherits from `ValueError` (catchable as `except ValueError:`). The class
 qualified name is `json.JSONDecodeError`; `__name__` matches CPython.
-Error messages use the same `line N column M (char K)` suffix as CPython
-(counting characters, not bytes).
+Error messages use the same `line N column M (char K)` suffix as CPython,
+counting characters, not bytes.
 
 When the input ends inside an unclosed array or object (`'['`, `'{'`,
 `'{"a"'`, …), Monty always reports `Expecting ',' delimiter`, where CPython
@@ -53,7 +53,7 @@ Inside the sandbox the exception is message-only: the `msg`, `doc`, `pos`,
 `lineno` and `colno` attributes CPython sets are not available. When a
 sandbox `JSONDecodeError` surfaces to the host (e.g. via `pydantic_monty`),
 it is rebuilt as a real `json.JSONDecodeError` with all five attributes from
-a structured payload attached at raise time — except that documents larger
+a structured payload attached at raise time, except that documents larger
 than 64 KiB are not carried, in which case `doc` is `''`. A `JSONDecodeError`
 raised manually inside the sandbox has no payload and surfaces as a plain
 `ValueError` carrying the message.

--- a/limitations/language.md
+++ b/limitations/language.md
@@ -12,12 +12,12 @@ any code runs.
   Rejected at parse time: base classes / metaclasses (`class Foo(Bar):`) and
   class-body statements other than `def`, a simple `name [: T] = <expr>`
   assignment, `pass`, or a docstring. There is no inheritance and no general
-  dunder protocol. See `./classes.md`.
+  dunder protocol. See ./classes.md.
 - **Decorators** (`@deco`) — supported on classes and on top-level or nested
   `def`/`async def`, taking any callable in scope, evaluated in the enclosing
   scope and applied bottom-up. Rejected at parse time on **methods**, so
   `@classmethod`, `@staticmethod`, `@property` and any decorator on a `def`
-  inside a class body are unavailable. See `./classes.md`.
+  inside a class body are unavailable. See ./classes.md.
 - **`async with` statements** — not yet supported.
 - **`yield` / `yield from` expressions** — no generator functions. Generator
   *expressions* (`(x for x in ...)`) parse but currently materialize to a
@@ -49,20 +49,20 @@ list literal. CPython instead names the callable by its module-qualified
 `__qualname__`: `__main__.f() argument after * must be an iterable, not int`,
 and correspondingly `__main__.C.m()`, `__main__.<lambda>()` or
 `__main__.outer.<locals>.inner()`. Monty has neither function `__qualname__`
-nor module-qualified names (see the class-name note in `./collections.md`), so
+nor module-qualified names (see the class-name note in ./collections.md), so
 it reports the generic form. Every other unpacking form matches CPython
 exactly.
 
 ## Source nesting depth
 
 - AST nesting is capped at 200 levels (30 in debug builds); exceeding it raises `SyntaxError: Source is too deeply nested`.
-- The budget is shared across every nesting-producing construct (parens, calls, subscripts, attribute chains, operators, comprehensions, control-flow blocks, `with`, etc.), including the synthetic nesting from a flat multi-item `with`; see `./with.md`.
+- The budget is shared across every nesting-producing construct (parens, calls, subscripts, attribute chains, operators, comprehensions, control-flow blocks, `with`, etc.), including the synthetic nesting from a flat multi-item `with`; see ./with.md.
 - The message differs from CPython, which uses construct-specific wording (`too many nested parentheses`, `too many statically nested blocks`, …).
-- Class-body annotations count against the budget even though they are stringized rather than evaluated (see `./typing.md`), as do class-variable values and method parameter defaults; all three are walked before being parsed. CPython imposes no comparable limit on a stringized annotation.
+- Class-body annotations count against the budget even though they are stringized rather than evaluated (see ./typing.md), as do class-variable values and method parameter defaults; all three are walked before being parsed. CPython imposes no comparable limit on a stringized annotation.
 
 ## Imports
 
-- Only the bundled stdlib modules listed in `./modules.md` can be
+- Only the bundled stdlib modules listed in ./modules.md can be
   imported. Importing anything else raises `ModuleNotFoundError`.
 - Relative imports (`from . import x`) raise `ImportError: "attempted
   relative import with no known parent package"`; there is no package
@@ -75,7 +75,7 @@ exactly.
 binds nothing and is accepted as a no-op. Of CPython's ten features, eight
 became mandatory in Python 3.7 or earlier and so are inert there too, and
 `annotations` is a no-op here because Monty already stringizes annotations
-(see `./typing.md`). Divergences:
+(see ./typing.md). Divergences:
 
 - **`barry_as_FLUFL`** (PEP 401) raises `NotImplementedError: "The monty
   syntax parser does not yet support the 'barry_as_FLUFL' future feature"`.
@@ -110,7 +110,7 @@ work. They are resolved on read; there is no real namespace entry behind them.
 
 In Monty `__doc__` is always `None`, since module docstrings are never
 extracted, and `__annotations__` is always an empty `dict` because
-module-level annotations are not stored (see `./typing.md`); CPython 3.14
+module-level annotations are not stored (see ./typing.md); CPython 3.14
 instead raises `NameError` when a module has no annotations (PEP 649).
 
 These names are **read-only**: assigning one at module or global scope (including

--- a/limitations/language.md
+++ b/limitations/language.md
@@ -12,17 +12,17 @@ any code runs.
   Rejected at parse time: base classes / metaclasses (`class Foo(Bar):`) and
   class-body statements other than `def`, a simple `name [: T] = <expr>`
   assignment, `pass`, or a docstring. There is no inheritance and no general
-  dunder protocol. See [classes.md](classes.md).
+  dunder protocol. See `./classes.md`.
 - **Decorators** (`@deco`) — supported on classes and on top-level or nested
   `def`/`async def`, taking any callable in scope, evaluated in the enclosing
   scope and applied bottom-up. Rejected at parse time on **methods**, so
   `@classmethod`, `@staticmethod`, `@property` and any decorator on a `def`
-  inside a class body are unavailable. See [classes.md](classes.md).
-- **`async with` statements** — not yet supported
+  inside a class body are unavailable. See `./classes.md`.
+- **`async with` statements** — not yet supported.
 - **`yield` / `yield from` expressions** — no generator functions. Generator
   *expressions* (`(x for x in ...)`) parse but currently materialize to a
-  `list` rather than a lazy iterator (this is a known temporary divergence;
-  see `iter__generator_expr_type.py`).
+  `list` rather than a lazy iterator, a known temporary divergence; see
+  `iter__generator_expr_type.py`.
 - **`match` statements** — structural pattern matching is not supported.
 - **`del` statements** — neither `del x` nor `del d[k]` parse.
 - **`try*` / `except*` exception groups** — PEP 654 syntax rejected.
@@ -39,33 +39,33 @@ any code runs.
 
 ## Starred unpacking
 
-Anything Monty can iterate may follow a `*`, matching CPython — `[*xs]`,
+Anything Monty can iterate may follow a `*`, matching CPython: `[*xs]`,
 `(*xs,)`, `{*xs}`, `f(*xs)`, `a, b = xs` and `a, *b = xs` all accept whatever
 `list(xs)` accepts.
 
 One message divergence: passing a non-iterable to a call, `f(*1)`, reports
-`TypeError: Value after * must be an iterable, not int` — the same wording as a
+`TypeError: Value after * must be an iterable, not int`, the same wording as a
 list literal. CPython instead names the callable by its module-qualified
 `__qualname__`: `__main__.f() argument after * must be an iterable, not int`,
 and correspondingly `__main__.C.m()`, `__main__.<lambda>()` or
 `__main__.outer.<locals>.inner()`. Monty has neither function `__qualname__`
-nor module-qualified names (see the class-name note in
-[collections.md](collections.md)), so it reports the generic form. Every other
-unpacking form matches CPython exactly.
+nor module-qualified names (see the class-name note in `./collections.md`), so
+it reports the generic form. Every other unpacking form matches CPython
+exactly.
 
 ## Source nesting depth
 
 - AST nesting is capped at 200 levels (30 in debug builds); exceeding it raises `SyntaxError: Source is too deeply nested`.
-- The budget is shared across every nesting-producing construct (parens, calls, subscripts, attribute chains, operators, comprehensions, control-flow blocks, `with`, etc.), including the synthetic nesting from a flat multi-item `with` — see with.md.
+- The budget is shared across every nesting-producing construct (parens, calls, subscripts, attribute chains, operators, comprehensions, control-flow blocks, `with`, etc.), including the synthetic nesting from a flat multi-item `with`; see `./with.md`.
 - The message differs from CPython, which uses construct-specific wording (`too many nested parentheses`, `too many statically nested blocks`, …).
-- Class-body annotations count against the budget even though they are stringized rather than evaluated (see typing.md), as do class-variable values and method parameter defaults — all three are walked before being parsed. CPython imposes no comparable limit on a stringized annotation.
+- Class-body annotations count against the budget even though they are stringized rather than evaluated (see `./typing.md`), as do class-variable values and method parameter defaults; all three are walked before being parsed. CPython imposes no comparable limit on a stringized annotation.
 
 ## Imports
 
-- Only the bundled stdlib modules listed in [modules.md](modules.md) can be
+- Only the bundled stdlib modules listed in `./modules.md` can be
   imported. Importing anything else raises `ModuleNotFoundError`.
 - Relative imports (`from . import x`) raise `ImportError: "attempted
-  relative import with no known parent package"` — there is no package
+  relative import with no known parent package"`; there is no package
   system.
 - `__import__` is not defined.
 
@@ -75,7 +75,7 @@ unpacking form matches CPython exactly.
 binds nothing and is accepted as a no-op. Of CPython's ten features, eight
 became mandatory in Python 3.7 or earlier and so are inert there too, and
 `annotations` is a no-op here because Monty already stringizes annotations
-(see [typing.md](typing.md)). Divergences:
+(see `./typing.md`). Divergences:
 
 - **`barry_as_FLUFL`** (PEP 401) raises `NotImplementedError: "The monty
   syntax parser does not yet support the 'barry_as_FLUFL' future feature"`.
@@ -91,7 +91,7 @@ became mandatory in Python 3.7 or earlier and so are inert there too, and
   precede all other statements (`SyntaxError: "from __future__ imports must
   occur at the beginning of the file"`); Monty accepts them anywhere.
 - `import __future__` (as opposed to `from __future__ import ...`) raises
-  `ModuleNotFoundError` — there is no `__future__` module object.
+  `ModuleNotFoundError`; there is no `__future__` module object.
 
 ## Module-level dunder variables
 
@@ -108,27 +108,28 @@ work. They are resolved on read; there is no real namespace entry behind them.
 | `__package__`     | `None`       | `None`                       |
 | `__annotations__` | empty `dict` | `NameError` (no annotations) |
 
-In Monty `__doc__` is always `None` — module docstrings are never extracted —
-and `__annotations__` is always an empty `dict` because module-level annotations
-are not stored (see [typing.md](typing.md)); CPython 3.14 instead raises
-`NameError` when a module has no annotations (PEP 649).
+In Monty `__doc__` is always `None`, since module docstrings are never
+extracted, and `__annotations__` is always an empty `dict` because
+module-level annotations are not stored (see `./typing.md`); CPython 3.14
+instead raises `NameError` when a module has no annotations (PEP 649).
 
 These names are **read-only**: assigning one at module or global scope (including
 via `global __name__` inside a function, and augmented assignment like
 `__name__ += ...`) is rejected at compile time with
 `NotImplementedError: cannot reassign read-only module attribute '<name>'`.
 CPython instead *allows* rebinding most of them (it is how you set a module
-docstring), and rejects only `__debug__` — with a `SyntaxError`.
+docstring), and rejects only `__debug__`, with a `SyntaxError`.
 
 Binding one of these names as a **function local** is allowed (it is an
-ordinary local in a separate namespace), matching CPython — except `__debug__`,
-which CPython rejects everywhere with `SyntaxError` but Monty permits as a local.
+ordinary local in a separate namespace), matching CPython, except `__debug__`,
+which CPython rejects everywhere with `SyntaxError` but Monty permits as a
+local.
 
 Other module dunders CPython defines (`__loader__`, `__file__`, `__builtins__`,
 `__cached__`, `__dict__`) are not exposed; reading them falls through to the host
 name lookup and ultimately raises `NameError` if unresolved. `__loader__` is
 omitted because CPython always binds it to a loader *object* (never `None`), so
-exposing `None` would diverge on type — and a real loader is neither available
+exposing `None` would diverge on type, and a real loader is neither available
 nor safe to surface in the sandbox. `__file__` is omitted so no host path can
 leak into the sandbox.
 
@@ -140,8 +141,8 @@ A function exposes **no** attributes: `__name__`, `__doc__`, `__qualname__` and
 'function' object has no attribute 'tag' and no __dict__ for setting new
 attributes`. CPython supports all of these.
 
-This is the ceiling on what a decorator can do: it can call, wrap, store or
-replace the function it receives, but cannot ask the function about itself, so
+This bounds what a decorator can do: it can call, wrap, store or replace the
+function it receives, but cannot ask the function about itself, so
 `functools.wraps`-style metadata copying, registries keyed by `fn.__name__`, and
 attribute tagging for later discovery all have no equivalent.
 
@@ -152,7 +153,7 @@ attribute tagging for later discovery all have no equivalent.
 CPython (int vs str, `None` vs `None`, user-class instances without comparison
 dunders, etc.). Lists and tuples order lexicographically as in CPython. A `NaN`
 operand is *unordered* rather than incomparable, so `float('nan') < 1` (and
-every operator/direction, including two NaNs) returns `False` without raising —
+every operator/direction, including two NaNs) returns `False` without raising,
 also matching CPython, and likewise inside `sorted`/`min`/`max`.
 
 One message divergence: when a **list or tuple** compares unequal only because
@@ -183,9 +184,9 @@ direct `x == x` (`False` on both). Named tuples inherit all of this from `tuple`
 ## What *does* work
 
 - Functions (`def`, `async def`), nested functions, closures, and decorators on
-  them (but not on methods — see above).
-- List / dict / set comprehensions (generator comprehensions degrade to
-  lists — see above).
+  them, but not on methods (see above).
+- List / dict / set comprehensions; generator comprehensions degrade to
+  lists (see above).
 - `try` / `except` / `else` / `finally`, `raise ... from ...`.
 - `for` / `while` / `if` / `elif` / `else`, `break`, `continue`, `pass`,
   `assert`, `global`, `nonlocal`, `return`.

--- a/limitations/math.md
+++ b/limitations/math.md
@@ -1,6 +1,7 @@
 # `math` module
 
-Wide coverage; behaviour matches CPython 3.14 for the implemented set.
+Behaviour matches CPython 3.14 for the implemented set, apart from the notes
+below.
 
 ## Implemented
 
@@ -26,10 +27,10 @@ payloads.
 ## Behavioural notes
 
 - `math.asin` / `math.acos` reject inputs outside `[-1, 1]` with
-  `ValueError: "expected a number in range from -1 up to 1, got <x>"`.
-  CPython uses `"math domain error"` — Monty's message is more specific.
-- Domain errors (e.g. `log(-1)`) raise `ValueError: "math domain error"`
+  `ValueError: "expected a number in range from -1 up to 1, got <x>"`, where
+  CPython says `"math domain error"`.
+- Domain errors (e.g. `log(-1)`) raise `ValueError: "math domain error"`,
   matching CPython.
-- Overflow (finite input → infinite result) raises `OverflowError: "math
-  range error"` matching CPython.
+- Overflow (finite input, infinite result) raises `OverflowError: "math
+  range error"`, matching CPython.
 - `math.gamma` rejects non-positive integers (poles) with `ValueError`.

--- a/limitations/modules.md
+++ b/limitations/modules.md
@@ -6,25 +6,25 @@ and no way for sandboxed code to load additional modules.
 
 ## Modules available
 
-| Module         | See                  |
-| -------------- | -------------------- |
-| `asyncio`      | `./asyncio.md`       |
-| `collections`  | `./collections.md`   |
-| `dataclasses`  | `./dataclasses.md`   |
-| `datetime`     | `./datetime.md`      |
-| `itertools`    | `./itertools.md`     |
-| `json`         | `./json.md`          |
-| `math`         | `./math.md`          |
-| `os`           | `./os.md`            |
-| `pathlib`      | `./pathlib.md`       |
-| `re`           | `./re.md`            |
-| `sys`          | `./sys.md`           |
-| `typing`       | `./typing.md`        |
-| `unicodedata`  | `./unicodedata.md`   |
+| Module         | See              |
+| -------------- | ---------------- |
+| `asyncio`      | ./asyncio.md     |
+| `collections`  | ./collections.md |
+| `dataclasses`  | ./dataclasses.md |
+| `datetime`     | ./datetime.md    |
+| `itertools`    | ./itertools.md   |
+| `json`         | ./json.md        |
+| `math`         | ./math.md        |
+| `os`           | ./os.md          |
+| `pathlib`      | ./pathlib.md     |
+| `re`           | ./re.md          |
+| `sys`          | ./sys.md         |
+| `typing`       | ./typing.md      |
+| `unicodedata`  | ./unicodedata.md |
 
 `collections` is importable and exposes `deque`, `Counter`, `defaultdict`,
 and `namedtuple`; `OrderedDict`, `ChainMap`, and the `UserDict` / `UserList`
-/ `UserString` wrappers are missing (see `./collections.md`).
+/ `UserString` wrappers are missing (see ./collections.md).
 
 A `gc` module exposing `collect()` / `enable()` / `disable()` is compiled
 in only under the `test-hooks` Cargo feature, for Monty's own test suite;

--- a/limitations/modules.md
+++ b/limitations/modules.md
@@ -1,34 +1,34 @@
 # Standard library modules
 
 Monty ships a fixed set of built-in stdlib modules. `import` of anything
-else raises `ModuleNotFoundError` — there is no `sys.path`, no site-packages,
+else raises `ModuleNotFoundError`: there is no `sys.path`, no site-packages,
 and no way for sandboxed code to load additional modules.
 
 ## Modules available
 
-| Module         | See                                  |
-| -------------- | ------------------------------------ |
-| `asyncio`      | [asyncio.md](asyncio.md)             |
-| `collections`  | [collections.md](collections.md)     |
-| `dataclasses`  | [dataclasses.md](dataclasses.md)     |
-| `datetime`     | [datetime.md](datetime.md)           |
-| `itertools`    | [itertools.md](itertools.md)         |
-| `json`         | [json.md](json.md)                   |
-| `math`         | [math.md](math.md)                   |
-| `os`           | [os.md](os.md)                       |
-| `pathlib`      | [pathlib.md](pathlib.md)             |
-| `re`           | [re.md](re.md)                       |
-| `sys`          | [sys.md](sys.md)                     |
-| `typing`       | [typing.md](typing.md)               |
-| `unicodedata`  | [unicodedata.md](unicodedata.md)     |
+| Module         | See                  |
+| -------------- | -------------------- |
+| `asyncio`      | `./asyncio.md`       |
+| `collections`  | `./collections.md`   |
+| `dataclasses`  | `./dataclasses.md`   |
+| `datetime`     | `./datetime.md`      |
+| `itertools`    | `./itertools.md`     |
+| `json`         | `./json.md`          |
+| `math`         | `./math.md`          |
+| `os`           | `./os.md`            |
+| `pathlib`      | `./pathlib.md`       |
+| `re`           | `./re.md`            |
+| `sys`          | `./sys.md`           |
+| `typing`       | `./typing.md`        |
+| `unicodedata`  | `./unicodedata.md`   |
 
 `collections` is importable and exposes `deque`, `Counter`, `defaultdict`,
 and `namedtuple`; `OrderedDict`, `ChainMap`, and the `UserDict` / `UserList`
-/ `UserString` wrappers are missing (see [collections.md](collections.md)).
+/ `UserString` wrappers are missing (see `./collections.md`).
 
 A `gc` module exposing `collect()` / `enable()` / `disable()` is compiled
-in only under the `test-hooks` Cargo feature for use by Monty's own test
-suite; production sandboxes never see it.
+in only under the `test-hooks` Cargo feature, for Monty's own test suite;
+production sandboxes never see it.
 
 ## Notable modules NOT available
 
@@ -41,12 +41,11 @@ Common modules that are *not* importable in Monty (non-exhaustive):
 `time`, `traceback`, `unittest`, `urllib`, `uuid`, `warnings`, `weakref`,
 `zipfile`, `zlib`.
 
-Many of these are deliberately excluded (`socket`, `subprocess`,
-`multiprocessing`, `threading`, `ctypes`) because they would breach the
-sandbox. Others (`functools`, `enum`) are simply unimplemented; they may
-appear over time.
+`socket`, `subprocess`, `multiprocessing`, `threading` and `ctypes` are
+excluded because they would breach the sandbox. Others (`functools`, `enum`)
+are unimplemented and may appear over time.
 
-Some available modules cover only part of their CPython surface — `itertools`
+Some available modules cover only part of their CPython surface: `itertools`
 implements just `count` and `repeat` so far, and `collections` only the four
 types above. The absent names are missing from the module namespace rather than
 stubbed, so they fail type checking as well as raising `AttributeError` at

--- a/limitations/namedtuple.md
+++ b/limitations/namedtuple.md
@@ -1,11 +1,11 @@
 # Named tuples
 
 Named tuples can be constructed with `collections.namedtuple` (see
-`./collections.md`), and also enter the sandbox as
+./collections.md), and also enter the sandbox as
 `sys.version_info` and as values passed in from the host via the `MontyObject`
 API. `typing.NamedTuple` is a marker only; subscripting it or inheriting from
 it does not produce a type, since there is no class inheritance (see
-`./classes.md`).
+./classes.md).
 
 Instances behave as CPython named tuples: integer indexing, attribute access,
 `len`/iteration/`bool`, equality and hashing against equivalent plain tuples,
@@ -29,4 +29,4 @@ tuples model CPython *structseqs*, which expose none of them
 - **Accessing a method without calling it** (`m = p._asdict`) raises
   `AttributeError`: methods are call-only, not bound-method values. Repo-wide,
   `[1].append`, `'a'.upper` and `{}.get` all do the same.
-- **Subclassing** is unsupported (see `./classes.md`).
+- **Subclassing** is unsupported (see ./classes.md).

--- a/limitations/namedtuple.md
+++ b/limitations/namedtuple.md
@@ -1,18 +1,18 @@
 # Named tuples
 
 Named tuples can be constructed with `collections.namedtuple` (see
-[collections.md](collections.md)), and also enter the sandbox as
+`./collections.md`), and also enter the sandbox as
 `sys.version_info` and as values passed in from the host via the `MontyObject`
-API. `typing.NamedTuple` remains a marker only; subscripting / `class`
-inheritance does not produce a type (no `class` statement; see
-[language.md](language.md)).
+API. `typing.NamedTuple` is a marker only; subscripting it or inheriting from
+it does not produce a type, since there is no class inheritance (see
+`./classes.md`).
 
 Instances behave as CPython named tuples: integer indexing, attribute access,
 `len`/iteration/`bool`, equality and hashing against equivalent plain tuples,
-and the inherited `tuple` surface — membership, `count`, `index`, ordering
-(against plain tuples and other namedtuple classes alike), slicing,
-concatenation, and repetition, each producing a plain `tuple`. `_fields` /
-`_field_defaults` and `_make` / `_replace` / `_asdict` require a
+and the inherited `tuple` surface (membership, `count`, `index`, ordering
+against plain tuples and other namedtuple classes alike, slicing,
+concatenation, and repetition, each producing a plain `tuple`). `_fields`,
+`_field_defaults`, `_make`, `_replace` and `_asdict` require a
 `collections.namedtuple` class: `sys.version_info` and host-supplied named
 tuples model CPython *structseqs*, which expose none of them
 (`sys.version_info._fields` raises `AttributeError`, as in CPython).
@@ -22,11 +22,11 @@ tuples model CPython *structseqs*, which expose none of them
 - **Concatenating with a `list`** reports `TypeError: unsupported operand
   type(s) for +: 'namedtuple' and 'list'` where CPython says `can only
   concatenate tuple (not "list") to tuple`. Monty's plain tuples word it the
-  same way — not namedtuple-specific.
+  same way, so this is not namedtuple-specific.
 - **A string subscript** (`nt['x']`) raises `TypeError` as in CPython, but reads
   `tuple indices must be integers, not 'str'` vs CPython's `... or slices, not
   str`. Plain tuples and lists word it the same way.
 - **Accessing a method without calling it** (`m = p._asdict`) raises
-  `AttributeError` — methods are call-only, not bound-method values. Repo-wide:
-  `[1].append`, `'a'.upper`, `{}.get` all do the same.
-- **Subclassing** is unsupported (see [classes.md](classes.md)).
+  `AttributeError`: methods are call-only, not bound-method values. Repo-wide,
+  `[1].append`, `'a'.upper` and `{}.get` all do the same.
+- **Subclassing** is unsupported (see `./classes.md`).

--- a/limitations/open.md
+++ b/limitations/open.md
@@ -1,14 +1,13 @@
 # `open()` and file objects
 
-Monty's `open()` builtin returns a file wrapper that supports a deliberate
-subset of CPython's file API. The list below tracks every known difference
-from CPython.
+Monty's `open()` builtin returns a file wrapper supporting a subset of
+CPython's file API. The list below tracks every known difference from CPython.
 
-`pathlib.Path.open()` is wired to the same machinery — it prepends `self`
+`pathlib.Path.open()` is wired to the same machinery: it prepends `self`
 as the `file` argument and forwards to the same internal entry point, so
 every divergence listed below applies equally whether the caller uses
 `open(path, ...)` or `path.open(...)`. The only `Path.open()`-specific
-quirks are listed in [Path.open()](#pathopen) at the bottom.
+quirks are in the "Path.open()" section at the bottom.
 
 ## Design note: no live host file descriptors
 
@@ -17,16 +16,15 @@ calls. `open()` itself yields an `OsFunction::Open` round-trip whose effect
 (create / truncate / existence-check) the host performs and immediately
 closes; every subsequent `read()`/`write()`/`append()` is a separate
 one-shot OS call that the host opens, acts on, and closes again. The Monty
-heap stores only path, mode, and small Python-visible state — no OS
+heap stores only path, mode, and small Python-visible state: no OS
 handle, no buffered data, no descriptor number.
 
-This is the property that makes subprocess `dump()` / `load()` safe: a
-session can be serialized at a pause point and resumed later without
-dangling references to host resources. The wasm in-process API exposes the
-same idea as `MontySnapshot`. It also means external processes can observe
-partial state between calls, and that there is no protection against the
-underlying file being changed or removed between calls — both documented
-further down.
+This is what makes subprocess `dump()` / `load()` safe: a session can be
+serialized at a pause point and resumed later without dangling references to
+host resources. The wasm in-process API exposes the same idea as
+`MontySnapshot`. It also means external processes can observe partial state
+between calls, and that there is no protection against the underlying file
+being changed or removed between calls, both documented further down.
 
 ## Mode strings
 
@@ -60,7 +58,7 @@ Two exceptions:
   raises a typed `TypeError: open() argument '<name>' must be str or None,
   not <type>` rather than the generic "not yet supported" message.
 
-Bytes paths are accepted but decoded as **strict** UTF-8 — not via CPython's
+Bytes paths are accepted but decoded as **strict** UTF-8, not via CPython's
 `os.fsdecode` / PEP 383 `surrogateescape` behavior. A non-UTF-8 bytes path
 raises `UnicodeDecodeError: can't decode bytes path as UTF-8`.
 
@@ -68,7 +66,7 @@ This is a deliberate divergence, not a "not yet implemented" gap. PEP 383
 relies on representing invalid bytes as lone surrogates (`U+DC80`–`U+DCFF`)
 inside the resulting `str`. Rust's `String` is strictly valid UTF-8 and
 cannot hold lone surrogates without `unsafe` code or a parallel `Vec<u8>`
-path storage type — neither of which is justified given that Monty paths
+path storage type, neither of which is justified given that Monty paths
 are virtual POSIX strings, not host-OS filenames. A lossy `U+FFFD`
 replacement was also rejected because it would silently re-route an
 `open()` call to a different (wrong) file rather than failing loudly.
@@ -103,7 +101,7 @@ methods and attributes are:
 - `write(data)` — full-file or appending write.
 - `close()`, `flush()`, `readable()`, `writable()`, `seekable()`.
 - `__enter__()` / `__exit__()` — `with open(...) as f:` works; see
-  [`with.md`](with.md) for the shared protocol divergences.
+  `./with.md` for the shared protocol divergences.
 - `name`, `mode`, `closed` attributes.
 - `encoding` attribute on text files (always `"utf-8"`).
 
@@ -118,8 +116,8 @@ protocol (`__iter__`/`__next__`, including `for line in f:`).
   call. The host serves only one full-file `ReadText`/`ReadBytes` per
   file; everything after is sliced in pure Monty. Memory cost: the whole
   file remains allocated and counts against the worker's allocator-backed
-  `max_memory`. The buffer is **never invalidated** — external modifications to
-  the underlying file after the first read are not visible to subsequent
+  `max_memory`. The buffer is **never invalidated**, so external modifications
+  to the underlying file after the first read are not visible to subsequent
   reads.
 - `close()` releases the cached buffer (matching CPython), returning its memory
   when no other value, such as `data = f.read()`, retains it.
@@ -138,9 +136,9 @@ protocol (`__iter__`/`__next__`, including `for line in f:`).
   restricts `TextIOWrapper.seek` to `seek(0)`, `seek(0, 2)`, and cookies
   from `tell()`. Monty is more permissive here.
 - `seek(-1)` raises `OSError("[Errno 22] Invalid argument")` matching
-  CPython's `BufferedReader.seek`. Note that CPython's `TextIOWrapper`
-  raises `ValueError("negative seek position -1")` instead — Monty uses the
-  binary-mode message in both modes for consistency.
+  CPython's `BufferedReader.seek`. CPython's `TextIOWrapper` raises
+  `ValueError("negative seek position -1")` instead; Monty uses the
+  binary-mode message in both modes.
 - `seek(0, 99)` raises `ValueError("whence value 99 unsupported")`
   matching CPython's `BufferedReader`. CPython's `TextIOWrapper` uses a
   different `"invalid whence ..."` message; Monty does not.
@@ -148,15 +146,15 @@ protocol (`__iter__`/`__next__`, including `for line in f:`).
   from CPython (CPython: `"argument should be integer or None, not 'str'"`;
   Monty: `"'str' object cannot be interpreted as an integer"`).
 - Write-only `seek()`/`tell()` maintain logical position state, so common
-  `write(); tell()` and `seek(0, 2)` cases match CPython. However, writes
-  are still full-file or append one-shot host operations: seeking backwards
-  and then writing does **not** overwrite at that offset the way CPython's
-  live file descriptor would.
-- `readline(size)` and `readlines(hint)` are zero-argument only — passing
+  `write(); tell()` and `seek(0, 2)` cases match CPython. Writes are still
+  full-file or append one-shot host operations, so seeking backwards and then
+  writing does **not** overwrite at that offset the way CPython's live file
+  descriptor would.
+- `readline(size)` and `readlines(hint)` are zero-argument only; passing
   a size/hint argument raises `TypeError`. CPython accepts both and uses
   them to cap the returned bytes/chars.
 - File iteration (`for line in f`) is NOT supported: it goes through the
-  `GetIter` opcode which cannot yield to the host. Use `readlines()` and
+  `GetIter` opcode, which cannot yield to the host. Use `readlines()` and
   iterate the resulting list instead.
 - `write()` to a text file requires `str`; to a binary file requires
   `bytes`. The error messages match CPython
@@ -166,7 +164,7 @@ protocol (`__iter__`/`__next__`, including `for line in f:`).
   translation; line endings written to a `'w'` file are preserved verbatim.
 - `io.UnsupportedOperation` (raised by `read()` on `'w'` files, `write()`
   on `'r'` files, etc.) inherits from both `OSError` and `ValueError` for
-  catch purposes — `except OSError:` and `except ValueError:` both work as
+  catch purposes, so `except OSError:` and `except ValueError:` both work as
   in CPython. Monty's class name is the qualified `io.UnsupportedOperation`
   whereas CPython's `__name__` is the bare `UnsupportedOperation`.
 - No host file descriptor is held between calls (see "Design note: no
@@ -191,8 +189,7 @@ These match CPython:
 `pathlib.Path.open(mode='r', ...)` forwards to the same `OsFunction::Open`
 round-trip as `open()` with `self` prepended as the `file` argument, so
 all the rules above (mode rejection, kwarg validation, returned wrapper
-types, open-time effects) apply identically. The only differences to be
-aware of:
+types, open-time effects) apply identically. The differences:
 
 - CPython's `Path.open()` signature lists only `mode, buffering, encoding,
   errors, newline` (no `closefd` / `opener`). Monty accepts `closefd=True`

--- a/limitations/open.md
+++ b/limitations/open.md
@@ -101,7 +101,7 @@ methods and attributes are:
 - `write(data)` — full-file or appending write.
 - `close()`, `flush()`, `readable()`, `writable()`, `seekable()`.
 - `__enter__()` / `__exit__()` — `with open(...) as f:` works; see
-  `./with.md` for the shared protocol divergences.
+  ./with.md for the shared protocol divergences.
 - `name`, `mode`, `closed` attributes.
 - `encoding` attribute on text files (always `"utf-8"`).
 

--- a/limitations/os.md
+++ b/limitations/os.md
@@ -1,8 +1,8 @@
 # `os` module
 
 The sandbox exposes a small, host-mediated subset of `os`. Filesystem
-functions route through the same OS-call mechanism as [pathlib](pathlib.md)
-and [open](open.md) — the host's mount table (or `os` callback) decides
+functions route through the same OS-call mechanism as `pathlib` and
+`open()` (see `./pathlib.md`, `./open.md`): the host's mount table (or `os` callback) decides
 whether each call is permitted.
 
 ## Implemented
@@ -27,42 +27,41 @@ whether each call is permitted.
 ## Divergences from CPython
 
 - **No file descriptors, no `bytes` paths.** Paths must be `str` or
-  `pathlib.Path`. `bytes` paths and integer fds (bools included — CPython
-  fd-converts them with only a `RuntimeWarning`) — which CPython accepts —
-  raise the path-converter `TypeError` with the accepted-types phrase
-  narrowed to what Monty takes, e.g.
-  `stat: path should be string or os.PathLike, not bytes`. For every other
+  `pathlib.Path`. `bytes` paths and integer fds (bools included, which CPython
+  fd-converts with only a `RuntimeWarning`) raise the path-converter
+  `TypeError` with the accepted-types phrase narrowed to what Monty takes,
+  e.g. `stat: path should be string or os.PathLike, not bytes`. For every other
   rejected type the phrase is CPython's verbatim, so `os.stat(1.5)` still
-  says `should be string, bytes, os.PathLike or integer`. (Note `open()`
+  says `should be string, bytes, os.PathLike or integer`. Note `open()`
   *does* accept `bytes` paths, decoding them as UTF-8; the `os` functions do
-  not.) The `os.listdir` wording always includes `integer` — POSIX CPython's
-  phrasing — even though Windows CPython omits it (no fd-based listdir there).
+  not. The `os.listdir` wording always includes `integer`, POSIX CPython's
+  phrasing, even though Windows CPython omits it (no fd-based listdir there).
 - **No `__fspath__` protocol.** `os.fspath` (and every path-taking function)
-  accepts only `str`, `bytes` (fspath only), and `pathlib.Path` — a
+  accepts only `str`, `bytes` (fspath only), and `pathlib.Path`: a
   user-defined class implementing `__fspath__` raises `TypeError` instead of
   having its method called.
 - **`dir_fd` keywords** (`dir_fd`, `src_dir_fd`, `dst_dir_fd`) are parsed
-  for signature parity but any non-`None` value raises the
+  for signature parity, but any non-`None` value raises the
   `NotImplementedError` CPython uses on platforms without them
   (`dir_fd unavailable on this platform`). Non-int values raise the
   converter `TypeError` (`argument should be integer or None, not str`).
 - **`os.stat(..., follow_symlinks=...)`** raises
   `NotImplementedError: stat: follow_symlinks unavailable on this platform`
-  for any *falsy* value — CPython truth-tests the argument, so `False`,
+  for any *falsy* value. CPython truth-tests the argument, so `False`,
   `None` and `0` all mean "lstat", which Monty has no behavior for.
   `os.lstat` itself is not implemented.
 - **All-keyword calls that overflow the signature** are not always reported
   the way CPython reports them. `os.fspath(path='a', foo=1)` and
   `os.listdir(path='.', foo=1)` match (`takes at most 1 keyword argument
-  (2 given)`), but functions with keyword-only slots — `os.stat`, `os.mkdir`,
-  `os.remove`, `os.rmdir`, `os.rename` — report the first unknown keyword
+  (2 given)`), but functions with keyword-only slots (`os.stat`, `os.mkdir`,
+  `os.remove`, `os.rmdir`, `os.rename`) report the first unknown keyword
   (`stat() got an unexpected keyword argument 'foo'`) where CPython reports
   the arity (`stat() takes at most 3 keyword arguments (4 given)`).
 - **No working directory.** `os.listdir()`'s default `'.'` (or any relative
   path) reaches the host unchanged; a mount table matches no mount and
   raises `PermissionError`.
 - **`mode` arguments** are type-checked (`'str' object cannot be
-  interpreted as an integer`) but otherwise ignored — Monty's filesystem
+  interpreted as an integer`) but otherwise ignored: Monty's filesystem
   backends do not model POSIX permission bits.
 - **`os.replace` is an alias of `os.rename`** at the host boundary: both
   suspend with the same rename OS call, so overwrite semantics are whatever
@@ -75,11 +74,11 @@ whether each call is permitted.
   `Path.rename`. A custom `os` callback cannot distinguish e.g. `os.listdir`
   from `Path.iterdir`.
 - **`os.stat` results** print as `StatResult(...)`, not
-  `os.stat_result(...)`, and carry only the 10 core fields (same as
-  `Path.stat()` — see [filesystem.md](filesystem.md)).
+  `os.stat_result(...)`, and carry only the 10 core fields, same as
+  `Path.stat()` (see `./filesystem.md`).
 - **Error side-effects differ slightly for `os.makedirs`**: Monty validates
   `mode` up front, while CPython only fails when it reaches the final
-  `mkdir` (after creating parent directories).
+  `mkdir`, after creating parent directories.
 
 ## Not implemented
 
@@ -93,4 +92,4 @@ Everything else, including but not limited to: `os.path.*` (use
 `os.getuid`, `os.getgid`, `os.uname`, `os.terminal_size`, `os.get_terminal_size`.
 
 `subprocess`, `signal`, `socket`, `threading`, `multiprocessing` are not
-importable either (see [modules.md](modules.md)).
+importable either (see `./modules.md`).

--- a/limitations/os.md
+++ b/limitations/os.md
@@ -2,7 +2,7 @@
 
 The sandbox exposes a small, host-mediated subset of `os`. Filesystem
 functions route through the same OS-call mechanism as `pathlib` and
-`open()` (see `./pathlib.md`, `./open.md`): the host's mount table (or `os` callback) decides
+`open()` (see ./pathlib.md, ./open.md): the host's mount table (or `os` callback) decides
 whether each call is permitted.
 
 ## Implemented
@@ -75,7 +75,7 @@ whether each call is permitted.
   from `Path.iterdir`.
 - **`os.stat` results** print as `StatResult(...)`, not
   `os.stat_result(...)`, and carry only the 10 core fields, same as
-  `Path.stat()` (see `./filesystem.md`).
+  `Path.stat()` (see ./filesystem.md).
 - **Error side-effects differ slightly for `os.makedirs`**: Monty validates
   `mode` up front, while CPython only fails when it reaches the final
   `mkdir`, after creating parent directories.
@@ -92,4 +92,4 @@ Everything else, including but not limited to: `os.path.*` (use
 `os.getuid`, `os.getgid`, `os.uname`, `os.terminal_size`, `os.get_terminal_size`.
 
 `subprocess`, `signal`, `socket`, `threading`, `multiprocessing` are not
-importable either (see `./modules.md`).
+importable either (see ./modules.md).

--- a/limitations/pathlib.md
+++ b/limitations/pathlib.md
@@ -36,7 +36,7 @@ These yield an `OsCall` for the host to resolve:
 - `mkdir(mode=0o777, parents=False, exist_ok=False)`, `unlink()`, `rmdir()`
 - `iterdir()`, `stat()`, `rename(target)`
 - `resolve()`, `absolute()`
-- `open(...)` — see `./open.md` for the supported file API and divergences
+- `open(...)` — see ./open.md for the supported file API and divergences
 
 `Path.mkdir()` parses `mode`, `parents`, and `exist_ok`, but `mode` is
 accepted only for signature compatibility: Monty does not model POSIX
@@ -56,4 +56,4 @@ Not implemented: `glob`, `rglob`, `touch`, `chmod`, `lchmod`, `owner`,
 ## Path normalization and the sandbox
 
 Every I/O call routes through the host's mount table; paths are resolved
-strictly within mounted roots. See `./filesystem.md`.
+strictly within mounted roots. See ./filesystem.md.

--- a/limitations/pathlib.md
+++ b/limitations/pathlib.md
@@ -1,18 +1,18 @@
 # `pathlib` module
 
 Only one class is exported: `pathlib.Path`. It always represents a virtual
-POSIX path inside the sandbox — `/mnt/data/foo.txt`, never a Windows path
+POSIX path inside the sandbox (`/mnt/data/foo.txt`), never a Windows path
 even when the host is Windows. `PurePath`, `PurePosixPath`, `PureWindowsPath`,
-`PosixPath`, `WindowsPath` are not separately exposed (the printed `repr`
-of a `Path` is `PosixPath(...)` for compatibility).
+`PosixPath`, `WindowsPath` are not separately exposed; the printed `repr`
+of a `Path` is `PosixPath(...)` for compatibility.
 
 ## Construction
 
 `Path(*segments)` works. Each segment may be a `str` or another `Path`.
 Bytes paths are rejected with `TypeError`.
 
-`Path.cwd()` and `Path.home()` are **not** implemented — there is no
-notion of "current directory" or "home" inside the sandbox.
+`Path.cwd()` and `Path.home()` are **not** implemented: the sandbox has no
+current directory and no home directory.
 
 ## Pure (no I/O) methods and attributes
 
@@ -36,10 +36,10 @@ These yield an `OsCall` for the host to resolve:
 - `mkdir(mode=0o777, parents=False, exist_ok=False)`, `unlink()`, `rmdir()`
 - `iterdir()`, `stat()`, `rename(target)`
 - `resolve()`, `absolute()`
-- `open(...)` — see [`open.md`](open.md) for the supported file API and divergences
+- `open(...)` — see `./open.md` for the supported file API and divergences
 
 `Path.mkdir()` parses `mode`, `parents`, and `exist_ok`, but `mode` is
-accepted only for signature compatibility — Monty does not model POSIX
+accepted only for signature compatibility: Monty does not model POSIX
 permission bits. The `missing_ok` and `target_is_directory` keyword arguments
 accepted by other CPython methods are not parsed; pass only the positional
 arguments documented above.
@@ -56,4 +56,4 @@ Not implemented: `glob`, `rglob`, `touch`, `chmod`, `lchmod`, `owner`,
 ## Path normalization and the sandbox
 
 Every I/O call routes through the host's mount table; paths are resolved
-strictly within mounted roots. See [filesystem.md](filesystem.md).
+strictly within mounted roots. See `./filesystem.md`.

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -1,23 +1,23 @@
 # Worker execution (`monty subprocess`, `monty-pool`, `Monty`/`AsyncMonty`)
 
 The monty type checker, compiler, and interpreter should run in a separate
-process, except in environments where that's not possible (like wasm), so
-that sandbox crashes that cannot be fully prevented — stack overflow aborts
-and allocator aborts — kill only the worker. The Python package
-(`pydantic_monty`) and the JS package (`@pydantic/monty`) both do this: they
-run everything in workers driven over a protobuf protocol
-(`crates/monty-proto`) and expose no in-process execution API. By default the
-worker is a local `monty subprocess` child; the Python package additionally
-offers `pydantic_monty.AsyncMontyWebsocket`, which reaches a remote child over
-a WebSocket instead (the JS package is subprocess-only). For a `monty subprocess`
-worker the language semantics are identical to embedding the interpreter directly
-(it is the same interpreter), and the notes below are about the *host API* surface.
+process, except where that's impossible (wasm), so that the sandbox crashes
+that cannot be fully prevented (stack overflow aborts, allocator aborts) kill
+only the worker. The Python package (`pydantic_monty`) and the JS package
+(`@pydantic/monty`) both do this: they run everything in workers driven over a
+protobuf protocol (`crates/monty-proto`) and expose no in-process execution
+API. By default the worker is a local `monty subprocess` child; the Python
+package additionally offers `pydantic_monty.AsyncMontyWebsocket`, which reaches
+a remote child over a WebSocket instead (the JS package is subprocess-only).
+For a `monty subprocess` worker the language semantics are identical to
+embedding the interpreter directly (it is the same interpreter), and the notes
+below are about the *host API* surface.
 
 A WebSocket worker is whatever the relay bridges to, and need not be a Monty
 sandbox at all: a remote child may run the snippet in **real CPython with no
 sandbox, no resource limits, and full host filesystem/network/subprocess
-access** (relying on the deployment — a container/VM per session — for
-isolation, not on the language). So none of Monty's in-process safety
+access**, relying on the deployment (a container/VM per session) for
+isolation rather than on the language. None of Monty's in-process safety
 guarantees hold for that transport; treat the remote as a trusted-deployment
 execution surface, not a sandbox.
 
@@ -25,7 +25,7 @@ execution surface, not a sandbox.
 
 The guarantees below describe a **Monty sandbox worker** (`monty subprocess`).
 A WebSocket remote honours the *protocol* shape (REPL turns, version-skew
-check, value encoding) but **none** of the sandbox guarantees — resource
+check, value encoding) but **none** of the sandbox guarantees: resource
 limits, the no-subprocess invariant (an embedded-CPython child shells out to
 `uv` for installs), and the empty-environment property are Monty-sandbox
 properties that real CPython does not provide, per the caveat above.
@@ -38,17 +38,16 @@ properties that real CPython does not provide, per the caveat above.
   or `MontyComplete`) for the caller to inspect, `dump()`, and `resume(...)`;
   see the snapshot divergences below.
 - A session whose worker crashed is lost: subsequent calls raise
-  `MontyCrashedError` — which also carries a worker's own account when it
+  `MontyCrashedError`, which also carries a worker's own account when it
   announced a `FatalError` before exiting (e.g. an unsupported protocol
-  version), plus the exit
-  status when the process could be reaped. The pool itself recovers by
-  replacing the worker.
+  version), plus the exit status when the process could be reaped. The pool
+  itself recovers by replacing the worker.
 - **WebSocket sessions are lost in two additional ways.** A connection that
   closes mid-session raises `MontyDisconnectError`: the client cannot tell a
   dead remote sandbox from a server-side policy drop (idle/session/turn
   timeout, over capacity), so the error claims no more than that the
   connection went away. A server that is shutting down instead answers the
-  session's next request with `MontyShutdown` — the request did **not** run,
+  session's next request with `MontyShutdown`. That request did **not** run,
   and its `dump` (when present) restores the session onto a fresh checkout
   via `session.load_session` / `session.load_snapshot`. If the interrupted
   request was answering a suspension (external function or `os` callback),
@@ -60,7 +59,7 @@ properties that real CPython does not provide, per the caveat above.
   and the worker rejects one it does not serve.** The protocol has no in-band
   negotiation, so a parent outside the child's supported range
   (`MIN_SUPPORTED_PROTOCOL_VERSION..=PROTOCOL_VERSION`) gets a `FatalError`
-  naming that range — enough to downgrade and retry — and the child exits
+  naming that range, enough to downgrade and retry, and the child exits
   non-zero rather than risk a frame desync. A version of `0` means the parent
   declared nothing and is always rejected. A local subprocess child ships with
   its parent, so this mostly matters for the WebSocket transport, where the
@@ -69,7 +68,7 @@ properties that real CPython does not provide, per the caveat above.
 - **The package version is not checked.** `Configure` also carries the
   parent's `monty_version`, but only for telemetry and to make a rejection
   legible. Parent and child may run different monty releases as long as their
-  protocol versions are compatible. Note this does *not* extend to dumps: the
+  protocol versions are compatible. This does *not* extend to dumps: the
   dump envelope is versioned separately again, and restoring one still
   requires a worker built from the same version (see the snapshot
   divergences below).
@@ -78,7 +77,7 @@ properties that real CPython does not provide, per the caveat above.
   worker process is reused for the next checkout.
 - Asyncio cancellation of an in-flight call (`feed_run`, `dump`, ...)
   **loses the session**: the protocol turn was abandoned mid-flight, so its
-  worker can no longer be trusted — it is killed immediately, or, when the
+  worker can no longer be trusted. It is killed immediately, or, when the
   checkout is contended by a concurrent call, discarded by the next call,
   which raises `RuntimeError`. A call cancelled while still queued behind
   another call never touched the worker, so the session stays usable. The
@@ -90,7 +89,7 @@ properties that real CPython does not provide, per the caveat above.
   deadline and killing the single worker PID. A worker that forked a
   grandchild would leave that grandchild running (and holding the stdout
   pipe) after the kill, so the no-subprocess property is a hard sandbox
-  invariant, not just a missing feature — and the pool deliberately does
+  invariant, not just a missing feature, and the pool deliberately does
   **not** add process-group / Job Object teardown to defend against it. A
   sandbox escape that bypassed the invariant is out of scope here: it is
   already arbitrary native code running in the worker.
@@ -101,51 +100,51 @@ properties that real CPython does not provide, per the caveat above.
   adapter uses non-blocking queued delivery and does not have this limitation.
 - **`max_duration` measures cumulative execution time, and the worker's
   clock is the single source of truth.** The in-sandbox clock runs only
-  while the interpreter executes — never while suspended waiting on the
-  host (external functions, OS callbacks) or between feeds — accumulates
+  while the interpreter executes, never while suspended waiting on the
+  host (external functions, OS callbacks) or between feeds, accumulates
   across feeds, and travels inside dumps. The worker reports its total on
   every protocol turn; the host never keeps a second clock.
 - **`max_duration` is backstopped by the host.** From the reported total the
   host bounds each execution turn by the remaining budget plus
   `duration_limit_grace` (default 1s) and kills the worker when it expires.
   The in-sandbox limit normally fires first with a clean `TimeoutError`; the
-  backstop covers cases where it cannot — a worker that stops answering
-  (e.g. compromised or wedged) — and surfaces as `MontyCrashedError`, losing
-  the session. Mount I/O runs on the host between protocol turns and does not
-  count against the worker's deadline. Because the budget and consumed time are also stamped onto the
-  worker's replies, sessions restored via the Rust `Checkout::restore`
-  regain the backstop too. A *compromised* worker could under-report its
-  total, stretching each turn to the full budget plus grace — turns stay
-  bounded, and `request_timeout` applies independently. Both deadlines fire
-  between the turn's polls, so decoding one maximal reply frame (~1s worst
-  case) can delay enforcement by that long.
+  backstop covers cases where it cannot, such as a worker that stops
+  answering (compromised or wedged), and surfaces as `MontyCrashedError`,
+  losing the session. Mount I/O runs on the host between protocol turns and
+  does not count against the worker's deadline. The budget and consumed time
+  are also stamped onto the worker's replies, so sessions restored via the
+  Rust `Checkout::restore` regain the backstop too. A *compromised* worker
+  could under-report its total, stretching each turn to the full budget plus
+  grace; turns stay bounded, and `request_timeout` applies independently.
+  Both deadlines fire between the turn's polls, so decoding one maximal reply
+  frame (~1s worst case) can delay enforcement by that long.
 - **`max_memory` is also enforced in the worker's allocator.** It caps the live
-  bytes the worker's allocator will hand out (plus headroom — see
-  `limitations/resource_limits.md`, which covers how exceeding it surfaces); a
+  bytes the worker's allocator will hand out, plus headroom (see
+  `./resource_limits.md`, which covers how exceeding it surfaces); a
   session without a limit is uncapped. The worker derives it from the session it
   holds, so nothing travels outside the protocol, and the wasm worker counts the
   same way (not the linear memory it has grown to, which never shrinks).
-  Ignored by the WebSocket transport (whose exit codes do
-  not travel, so a remote failure degrades to `Disconnected`). The exit code
+  Ignored by the WebSocket transport, whose exit codes do not travel, so a
+  remote failure degrades to `Disconnected`. The exit code
   borrows [`sysexits.h`](https://man.freebsd.org/sysexits) so a bare status is
   legible in a log.
 - **A refused allocation is the one `MemoryError` that kills the session.** The
-  worker's allocator exits 65 (`EX_DATAERR` — the fed snippet asked for more than
+  worker's allocator exits 65 (`EX_DATAERR`: the fed snippet asked for more than
   it may have) rather than letting Rust abort (`SIGABRT`, which a stack overflow
   also produces and which would be unclassifiable), so the host gets
   `MontyRuntimeError`/`MemoryError` with a
-  distinct message instead of `MontyCrashedError` — but the worker is already
+  distinct message instead of `MontyCrashedError`. The worker is already
   dead and later calls on that checkout report `Finished`. An ordinary in-sandbox
   exception leaves the session usable; a failed `load_session` / `load_snapshot`
   is the other `MontyRuntimeError` that does not (see below). Applies on all
-  platforms, with or without a session budget — except in the wasm worker, which
+  platforms, with or without a session budget, except in the wasm worker, which
   has no exit status to carry the distinction and so reports `MontyCrashedError`
   for both.
 - **Workers are spawned with an empty environment** (on Windows only
   `SystemRoot` is kept, which CRT/WinAPI lookups need): host secrets are
   never in a worker's memory, where a sandbox escape or memory disclosure
-  could reach them. This is invisible to sandbox code — `os.getenv` etc. are
-  OS calls answered by the host, never reads of the worker's own
+  could reach them. This is invisible to sandbox code, since `os.getenv` etc.
+  are OS calls answered by the host, never reads of the worker's own
   environment. The public Python and JS bindings expose no worker
   configuration channel outside the protocol.
 - **Worker binary resolution is part of the host trust boundary.** Python and
@@ -174,19 +173,19 @@ properties that real CPython does not provide, per the caveat above.
   Monty code cannot catch that error inside the aborted feed.
 - The same frame limit applies to `dump()`: a session whose serialized state
   (heap plus any retained suspension payload) exceeds 256 MiB cannot be
-  dumped. The call raises a `RuntimeError` and the session is unaffected — a
+  dumped. The call raises a `RuntimeError` and the session is unaffected: a
   suspended session stays suspended and resumable.
 - Independently of the wire-byte limit, a frame is rejected if the values it
-  decodes into would exceed a **per-frame host-memory budget** — a hard,
+  decodes into would exceed a **per-frame host-memory budget**, a hard,
   non-configurable limit of 1 GiB of *resident* decoded bytes. The wire cap
   bounds bytes, but the cheapest elements (e.g. `None` in a list, ~4 wire bytes)
-  materialize into 88-byte `MontyObject`s — a ~22× blow-up that a ≤256 MiB frame
+  materialize into 88-byte `MontyObject`s, a ~22× blow-up that a ≤256 MiB frame
   could turn into multiple GiB on the host. The budget is charged incrementally
   during decode and trips before the full value is built, so a parent reading
   such a frame discards the worker with a protocol error rather than risking an
   out-of-memory abort. A value large enough to hit it (tens of millions of
   elements) cannot cross the boundary even though it is under the wire-byte
-  limit. Every payload — containers and function/OS-call args & kwargs alike —
+  limit. Every payload, containers and function/OS-call args & kwargs alike,
   decodes straight into its final type with no intermediate copy, so the
   worst-case host *peak* is ~1× the budget plus the ≤256 MiB frame buffer, and
   the bound applies per concurrent worker.
@@ -203,52 +202,52 @@ properties that real CPython does not provide, per the caveat above.
 - **Typing errors** (`checkout(type_check=True)`) raise `MontyTypingError`
   whose diagnostics were rendered *in the worker*, so the format is a
   checkout argument (`type_check_format=`, `type_check_color=`; JS
-  `typeCheckFormat` / `typeCheckColor`) and `display()` takes no arguments —
+  `typeCheckFormat` / `typeCheckColor`) and `display()` takes no arguments:
   it cannot re-render, because ty's structured diagnostics resolve their spans
   against the checker's database and so never cross the wire. Formats are
   ty's: `full` (default), `concise`, `azure`, `json`, `jsonlines`, `rdjson`,
   `pylint`, `gitlab`, `github`; only `full` and `concise` carry colour.
 - **Print callbacks** receive buffered chunks flushed at newline boundaries
-  or once ~8 KiB accumulates — not per-fragment writes. A chunk may contain
+  or once ~8 KiB accumulates, not per-fragment writes. A chunk may contain
   more than one line, and output larger than the threshold is split into
-  ~8 KiB pieces (so a chunk is bounded, but is not guaranteed to be exactly
-  one line). A callback that raises aborts the feed after the current
+  ~8 KiB pieces, so a chunk is bounded but not guaranteed to be exactly
+  one line. A callback that raises aborts the feed after the current
   protocol turn, not mid-`print`; if that turn had suspended (an external
   function, OS call, or name lookup), the binding resets/discards the
   suspension before surfacing the print error so later feeds can continue.
 - **The sync API adapts to the caller's Tokio context.** `Monty` methods block
   the calling thread on the binding's Tokio runtime. Called from a worker
-  thread of a multi-thread runtime — e.g. a sync external function or
-  `print_callback` invoked by an `AsyncMonty` drive — the wait is wrapped in
+  thread of a multi-thread runtime, e.g. a sync external function or
+  `print_callback` invoked by an `AsyncMonty` drive, the wait is wrapped in
   `tokio::task::block_in_place`, so opening an independent nested sync
   pool/session works (each concurrent nested call occupies an extra OS thread
   while it waits). Called from any *current-thread* Tokio runtime context,
   blocking would starve the tasks that drive the pool, so every sync method
   raises `RuntimeError: the synchronous Monty API cannot run inside a
   current-thread Tokio runtime`. Only independent nested pools/sessions are
-  supported — re-entering the *same* session from its own callback deadlocks
+  supported: re-entering the *same* session from its own callback deadlocks
   on the session's internal lock.
 - **Mounts are host-side.** `MountDir` objects contribute configuration only;
   the pool builds a fresh mount table per feed on the *host* and services the
-  worker's filesystem OS calls itself — the worker never sees host paths, so
+  worker's filesystem OS calls itself. The worker never sees host paths, so
   mounts work identically for local subprocess and remote WebSocket workers.
   `mode='overlay'` writes live in that per-feed table and are discarded when
-  the feed ends — the `MountDir` object's overlay state is never updated.
+  the feed ends; the `MountDir` object's overlay state is never updated.
   `read-write` mounts write through to the real host directory as before. An
   invalid mount (host path missing / not a directory) raises when the mount
   object is *created*, not at `feed` time: constructing it opens the directory.
 - **A mount object is bound to a directory, not to a path.** `MountDir` opens
   the host directory once and every feed mounts that descriptor, so renaming or
-  replacing the directory afterwards does not change what the mount serves —
+  replacing the directory afterwards does not change what the mount serves:
   the mount keeps following the original directory under its new name, and a
   new directory at the old path is not picked up. Recreate the `MountDir` to
-  follow a path instead. (This is deliberate: the sandbox can rename inside a
+  follow a path instead. This is deliberate: the sandbox can rename inside a
   `read-write` mount, so a path re-resolved each feed is a path the sandbox can
-  redirect.)
+  redirect.
 - **On Windows a mounted directory is locked for as long as the mount object
   lives.** It holds an open descriptor, and Windows refuses to rename or delete
   a directory while a handle to it is open, so the host gets
-  `ERROR_SHARING_VIOLATION` until the mount is closed — not just until the feed
+  `ERROR_SHARING_VIOLATION` until the mount is closed, not just until the feed
   ends. `MountDir.close()` releases it (also `with` in Python, `using` in
   JavaScript); a feed already running keeps its own reference, and feeding a
   closed mount raises. Unix is unaffected, and closing is optional there.
@@ -259,20 +258,20 @@ properties that real CPython does not provide, per the caveat above.
   read comes back as a `FunctionSnapshot` with `is_os_function` set, and it is
   `resume_auto()` that offers the call to the mounts and then to `os=`.
   Answering such a snapshot with an explicit `resume(...)` bypasses the mount
-  entirely — the value you supply is what the sandbox sees.
+  entirely; the value you supply is what the sandbox sees.
 - **Special files are rejected.** Reading, writing, or `open()`ing a
   non-regular file in a mounted directory (FIFO, socket, device) raises
-  `PermissionError` instead of blocking — CPython would block until a peer
+  `PermissionError` instead of blocking. CPython would block until a peer
   appears, but mount I/O blocks the feed (and holds a host thread) for its
   full duration and must never wait on sandbox-reachable input.
 - **Mount I/O is not bounded by any timeout.** Covered filesystem calls run
-  on the host *between* protocol turns, with no turn deadline armed — and the
+  on the host *between* protocol turns, with no turn deadline armed, and the
   deadline's only lever, killing the worker, could not interrupt host I/O
   anyway. Special files are rejected (above) so sandbox code cannot hang the
   host, but a stalled NFS/FUSE volume blocks the feed indefinitely; hang-free
   host I/O is the embedder's responsibility, as for `print_callback` and
   external functions. The I/O runs on Tokio's blocking thread pool, so a
-  stalled mount ties up its own feed and one blocking thread — not the
+  stalled mount ties up its own feed and one blocking thread, not the
   runtime workers that drive other sessions' turns and timers. Cancelling the
   feed does not cancel the filesystem call: the detached operation keeps its
   blocking thread until it returns, and a `read-write` mount's write, rename,
@@ -285,7 +284,7 @@ properties that real CPython does not provide, per the caveat above.
 - **`os=` fallback** receives `(function_name, args, kwargs)`. On the
   automatic path (`feed_run`, `resume_auto`) mounts get first refusal, so
   mount-covered filesystem calls never reach the callback. Under `feed_start`
-  the callback is consulted only by `resume_auto()` — it is never invoked
+  the callback is consulted only by `resume_auto()`; it is never invoked
   between snapshots.
 - **Mounts have a 100 MB memory budget by default.** Retained overlay data and
   transient filesystem results share the configurable per-mount budget.
@@ -296,12 +295,12 @@ properties that real CPython does not provide, per the caveat above.
   returning the data.
 - **`external_lookup` resolves undefined names lazily.** `feed_run` /
   `feedRun` take `external_lookup` (`externalLookup` in JS): a name the snippet
-  leaves undefined is resolved on first reference against this dict — a
+  leaves undefined is resolved on first reference against this dict. A
   *callable* entry becomes a host function proxy (invoked on the eventual call),
   any *other value* is converted and returned directly, and an absent name
   raises `NameError`. It is the lazy counterpart to the eager `inputs` (a name
   present in both is served by the `inputs` binding, so no lookup fires). A
-  non-callable value that cannot be converted rejects the turn host-side —
+  non-callable value that cannot be converted rejects the turn host-side:
   because `external_lookup` (and `inputs`) may hold untrusted values, an
   unrepresentable *type* surfaces as a dedicated `MontyError` subclass (in
   `pydantic_monty`, `MontyConversionError`; its `exception()` reconstructs a
@@ -313,14 +312,14 @@ properties that real CPython does not provide, per the caveat above.
   does not re-fire `NameLookup` (a later host mutation of the dict entry is not
   observed), whereas an embedded-CPython worker caches only function proxies and
   re-fires `NameLookup` on every value reference (re-reading live). Function
-  proxies are cached by both — but unlike a CPython function object, a proxy
+  proxies are cached by both, but unlike a CPython function object, a proxy
   dispatches by *name* against the dict passed to the current feed at call
   time: replacing an entry rebinds every reference already holding the proxy,
   and replacing it with a non-callable makes calls raise the `TypeError`
   CPython would for calling that value (`'int' object is not callable`).
   Because only *undefined* names fire lookups, an entry shadowing a builtin
   (e.g. `{'len': ...}`) is silently ignored. `feed_start` / `feedStart` take no
-  `external_lookup` — they surface name lookups as snapshots, which resolve only
+  `external_lookup`; they surface name lookups as snapshots, which resolve only
   to a function (see below).
 - **Dependency installation is only available on an embedded-CPython worker.**
   `session.install_dependencies([...])` (sync and async in `pydantic_monty`;
@@ -334,13 +333,13 @@ properties that real CPython does not provide, per the caveat above.
 - **PEP 723 inline dependencies are auto-installed by a CPython worker.**
   Before running a feed, an embedded-CPython worker scans the snippet for a
   PEP 723 `# /// script` block and installs its `dependencies` (same `uv` path
-  as above) so the imports resolve — no protocol involvement, mirroring
+  as above) so the imports resolve, with no protocol involvement, mirroring
   `uv run`. The Monty sandbox worker has no such behavior: a `# /// script`
   block is just a comment and its dependencies are never installed.
 - **`dump()`** bytes carry monty's own versioned session format and can only be
   restored into a worker built with the same `DUMP_VERSION`, via
   `session.load_session` / `session.load_snapshot` (Rust `Checkout::restore`).
-  A version mismatch is reported as such — naming both versions — so a stale
+  A version mismatch is reported as such, naming both versions, so a stale
   snapshot is distinguishable from a corrupt one.
 - **`feed_start` snapshots are live cursors, not owned state.** The execution
   state lives in the worker, so only one suspension is live per session, each
@@ -356,23 +355,23 @@ properties that real CPython does not provide, per the caveat above.
   dumped (`session.dump()` between feeds vs `snapshot.dump()`); using the wrong
   method raises. Both restore *into* a freshly checked-out worker, so they are
   rejected (`RuntimeError`) after any `feed_run` / `feed_start` / `load_session`
-  / `load_snapshot` — restoring would otherwise discard work. The dump restores
-  its own `script_name` / limits / type-check state (the `checkout()` config
-  for those is not applied); the dataclass registry from `checkout()` is reused.
-  A *failed* load (wrong dump kind, or a protocol desync) poisons the session
-  — its worker is discarded, so every later feed fails too; the load is not
-  retryable and the caller must check out a fresh session.
+  / `load_snapshot`, since restoring would otherwise discard work. The dump
+  restores its own `script_name` / limits / type-check state (the `checkout()`
+  config for those is not applied); the dataclass registry from `checkout()` is
+  reused. A *failed* load (wrong dump kind, or a protocol desync) poisons the
+  session: its worker is discarded, so every later feed fails too; the load is
+  not retryable and the caller must check out a fresh session.
 - **`resume` takes no `mount=` or `os=`.** Mounts and the OS fallback are
   fixed for the whole feed (passed to `feed_start` / `load_snapshot`), and a
-  plain `resume(...)` answers only the call in hand — it consults neither.
+  plain `resume(...)` answers only the call in hand, consulting neither.
   `resume_auto()` is the method that uses them.
 - **Mounts are re-supplied to `load_snapshot`, not stored in the dump.** Mounts
   are host configuration serviced by the host, not sandbox state, so nothing
   about them (host paths included) enters the (opaque, possibly-transmitted)
-  dump bytes — dump contents can never cause any directory to be mounted. To
+  dump bytes; dump contents can never cause any directory to be mounted. To
   resume a suspended feed with its mounts, pass the same `mount=` the original
   `feed_start` used to `load_snapshot`; the pool rebuilds its mount table.
-  (`load_session` takes no `mount` — an idle session has no in-flight feed; the
+  (`load_session` takes no `mount`: an idle session has no in-flight feed; the
   next feed supplies its own.)
 - **Re-supplied mounts are not validated.** The dump records nothing about the
   feed's mounts, so `load_snapshot` cannot check what you pass: a mount

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -120,7 +120,7 @@ properties that real CPython does not provide, per the caveat above.
   frame (~1s worst case) can delay enforcement by that long.
 - **`max_memory` is also enforced in the worker's allocator.** It caps the live
   bytes the worker's allocator will hand out, plus headroom (see
-  `./resource_limits.md`, which covers how exceeding it surfaces); a
+  ./resource_limits.md, which covers how exceeding it surfaces); a
   session without a limit is uncapped. The worker derives it from the session it
   holds, so nothing travels outside the protocol, and the wasm worker counts the
   same way (not the linear memory it has grown to, which never shrinks).

--- a/limitations/print.md
+++ b/limitations/print.md
@@ -1,8 +1,8 @@
 # `print()`
 
-Output always goes to the host via a print callback (`vm.print_writer`).
-The host decides where it ends up — there is no real `sys.stdout`
-underneath (see [sys.md](sys.md)).
+Output always goes to the host via a print callback (`vm.print_writer`). The
+host decides where it ends up; there is no real `sys.stdout` underneath (see
+`./sys.md`).
 
 ## Supported keyword arguments
 
@@ -13,30 +13,30 @@ underneath (see [sys.md](sys.md)).
 
 ## Rejected / ignored
 
-- `file=...` — explicitly rejected with `TypeError: "print() 'file'
-  argument is not supported"`. Code that does `print(..., file=sys.stderr)`
-  will not work; `sys.stderr` is an opaque marker (see [sys.md](sys.md)).
-- `flush=...` — silently accepted but ignored. Output is delivered to the
-  host through the subprocess protocol, which line-buffers and also flushes
-  large partial lines.
+- `file=...` — rejected with `TypeError: "print() 'file' argument is not
+  supported"`. Code that does `print(..., file=sys.stderr)` will not work;
+  `sys.stderr` is an opaque marker (see `./sys.md`).
+- `flush=...` — accepted and ignored. Output is delivered to the host through
+  the subprocess protocol, which line-buffers and also flushes large partial
+  lines.
 - Any other keyword raises `TypeError: ... unexpected keyword argument`.
 
 ## Behaviour
 
-- Each positional argument is converted via `py_str` (equivalent to
-  `str(x)`) before being written.
-- The host callback receives formatted chunks. In subprocess execution,
-  chunks are flushed on newline or after an internal buffer reaches roughly
-  8 KiB; a single `print()` call can therefore arrive in more than one
-  callback. There is no atomicity guarantee across multiple `print()` calls
-  if the host interleaves with other output.
+- Each positional argument is converted via `py_str` (equivalent to `str(x)`)
+  before being written.
+- The host callback receives formatted chunks. In subprocess execution, chunks
+  are flushed on newline or after an internal buffer reaches roughly 8 KiB, so
+  a single `print()` call can arrive in more than one callback. There is no
+  atomicity guarantee across multiple `print()` calls if the host interleaves
+  with other output.
 
 ## CollectString / CollectStreams caps
 
 `CollectString` and `CollectStreams` (Rust `PrintWriter` variants and the
 matching `pydantic_monty` collectors) accumulate print output in **host-side**
-buffers. That growth is **not** covered by
-`ResourceLimits.max_memory` (heap-only, and in the pool only on the worker).
+buffers. That growth is **not** covered by `ResourceLimits.max_memory`
+(heap-only, and in the pool only on the worker).
 
 - Default cap: **10 MiB** (`DEFAULT_MAX_PRINT_COLLECT_BYTES`).
 - Exceeding the cap raises host-visible `MemoryError` with
@@ -44,8 +44,8 @@ buffers. That growth is **not** covered by
   heap `ResourceError::Memory`).
 - Pass `max_bytes=None` to disable the cap (trusted hosts only).
 - Python `CollectStreams` also charges a fixed per-entry overhead toward the
-  cap (many tiny fragments would otherwise OOM the host before payload bytes
-  hit the limit). Rust `PrintWriter::CollectStreams` merges consecutive
+  cap, since many tiny fragments would otherwise OOM the host before payload
+  bytes hit the limit. Rust `PrintWriter::CollectStreams` merges consecutive
   same-stream fragments, so entry count stays small for normal `print()`.
 - JS (`@pydantic/monty`): `CollectString` / `CollectStreams` accept `maxBytes`
   (camelCase), same 10 MiB default and message; `CollectStreams` charges the
@@ -53,7 +53,7 @@ buffers. That growth is **not** covered by
   merge consecutive same-stream fragments (unlike Rust in-process
   `PrintWriter::CollectStreams`). Output entries are `{ stream, text }` objects
   rather than Python tuples. The cap is a **logical UTF-8 charge**, not a hard
-  V8/host-RSS bound (JS stores strings as UTF-16, so host RSS can exceed the
-  stated cap).
-- `Stdout` / `Disabled` / `Callback` are unchanged — `Callback` hosts can
+  V8/host-RSS bound: JS stores strings as UTF-16, so host RSS can exceed the
+  stated cap.
+- `Stdout` / `Disabled` / `Callback` are unchanged; `Callback` hosts can
   already self-limit by returning an error.

--- a/limitations/print.md
+++ b/limitations/print.md
@@ -2,7 +2,7 @@
 
 Output always goes to the host via a print callback (`vm.print_writer`). The
 host decides where it ends up; there is no real `sys.stdout` underneath (see
-`./sys.md`).
+./sys.md).
 
 ## Supported keyword arguments
 
@@ -15,7 +15,7 @@ host decides where it ends up; there is no real `sys.stdout` underneath (see
 
 - `file=...` — rejected with `TypeError: "print() 'file' argument is not
   supported"`. Code that does `print(..., file=sys.stderr)` will not work;
-  `sys.stderr` is an opaque marker (see `./sys.md`).
+  `sys.stderr` is an opaque marker (see ./sys.md).
 - `flush=...` — accepted and ignored. Output is delivered to the host through
   the subprocess protocol, which line-buffers and also flushes large partial
   lines.

--- a/limitations/re.md
+++ b/limitations/re.md
@@ -1,8 +1,8 @@
 # `re` module
 
 Monty's `re` module is backed by the Rust `fancy-regex` crate, not
-CPython's regex engine. Most patterns behave identically, but the
-underlying engine differs in syntax extensions and error reporting.
+CPython's regex engine. Most patterns behave identically; the engines differ
+in syntax extensions and error reporting.
 
 ## Module functions
 
@@ -64,7 +64,7 @@ mapping), `scanner`. The `pos` / `endpos` arguments accepted by
 
 A non-str subject passed to a Pattern *method* raises `expected string, not
 {type}` rather than CPython's `expected string or bytes-like object, got
-'{type}'` (the module-level functions match CPython's wording).
+'{type}'`. The module-level functions match CPython's wording.
 
 ## `re.Match` objects
 
@@ -72,12 +72,12 @@ Attributes: `re`, `string`.
 Methods: `group`, `groups`, `groupdict`, `start`, `end`, `span`.
 
 Not implemented: `lastindex`, `lastgroup`, `expand`, `pos`, `endpos`,
-`regs`. Indexing (`m[0]`, `m["name"]`) is not supported — use `.group()`.
+`regs`. Indexing (`m[0]`, `m["name"]`) is not supported; use `.group()`.
 
 ## `re.PatternError` / `re.error`
 
 Raised for invalid regex patterns. Unlike CPython, `pattern`, `pos`,
-`lineno`, and `colno` attributes are not populated — `fancy-regex`'s error
+`lineno`, and `colno` attributes are not populated: `fancy-regex`'s error
 representation does not carry them.
 
 ## Engine-level differences
@@ -87,6 +87,6 @@ representation does not carry them.
 - Backreference syntax `\10` and higher is not recognized; only `\1`–`\9`.
 - Error messages for invalid patterns come from `fancy-regex` and do not
   match CPython's wording.
-- Patterns whose *compiled* form is very large — e.g. huge counted repeats
-  like `a{5000000}` — raise `re.PatternError` (`fancy-regex`/`regex` enforce a
+- Patterns whose *compiled* form is very large, e.g. huge counted repeats
+  like `a{5000000}`, raise `re.PatternError` (`fancy-regex`/`regex` enforce a
   compiled-size limit), whereas CPython compiles them.

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -77,7 +77,7 @@ without one is unlimited.
   and replaced rather than allowed to grow indefinitely.
 - **Restoring a dump is bounded by the checkout it lands in.** `load_session` /
   `load_snapshot` restore the dump's own limits (see
-  `./pool-architecture.md`), and the cap is re-derived from
+  ./pool-architecture.md), and the cap is re-derived from
   them once the session exists, but the load *itself* runs under the limit the
   `checkout()` config applied. Restoring a large dump into a checkout with a
   much smaller `max_memory` can therefore exceed it while loading; pass a
@@ -128,7 +128,7 @@ indistinguishable from a stack overflow.
   during construction. Native re-entry is capped independently at a lower
   fixed depth than the 1000-frame Python limit, so Monty raises
   `RecursionError` before a native stack overflow would abort the process. See
-  the `__repr__`/`__str__` entry in `./classes.md` for the main
+  the `__repr__`/`__str__` entry in ./classes.md for the main
   user-visible divergence this causes.
 
 ## Time

--- a/limitations/resource_limits.md
+++ b/limitations/resource_limits.md
@@ -12,11 +12,11 @@ bytecode compilation do not consume it. In workers, allocations retained by
 compiled code do count toward `max_memory`; transient compilation allocations
 are released before execution reaches its first memory checkpoint.
 Compilation has separate structural caps for parser nesting, bytecode operand
-sizes, comprehension nesting, and repeated `finally` expansion. In particular,
-a code object requiring more than 1,024 emitted copies of `finally` bodies is
-rejected with `SyntaxError`; CPython has no equivalent limit. Production hosts
-should still isolate compilation when accepting untrusted source, as the
-subprocess and WebAssembly runtimes do.
+sizes, comprehension nesting, and repeated `finally` expansion. A code object
+requiring more than 1,024 emitted copies of `finally` bodies is rejected with
+`SyntaxError`; CPython has no equivalent limit. Production hosts should still
+isolate compilation when accepting untrusted source, as the subprocess and
+WebAssembly runtimes do.
 
 ## Memory / size limits
 
@@ -32,7 +32,7 @@ subprocess and WebAssembly runtimes do.
   (`str.replace`, `bytes.replace`), padding (`str.ljust`, `str.center`,
   `str.zfill`, `bytes.ljust`, …), and f-string formatting
   (both dynamic width `f"{v:>{w}}"` and dynamic precision on float
-  formats `f"{v:.{p}f}"` / `e` / `%`). The pre-check threshold is 100 KB —
+  formats `f"{v:.{p}f}"` / `e` / `%`). The pre-check threshold is 100 KB:
   estimates above that are checked against the remaining budget and rejected
   with `MemoryError` before allocation when they would exceed it.
 - `bigint.pow(base, exp)` estimates result size as `bits(base) * exp` with
@@ -55,20 +55,20 @@ without one is unlimited.
   result operations are pre-checked to avoid this path when their size is known.
 - **Work outside Python execution is hard-limit-only.** Request framing, input
   decoding, loading snapshots, and type checking do not reach an interpreter
-  checkpoint. A sufficiently large allocation there can therefore cross the
-  hard ceiling and kill the worker.
+  checkpoint. A sufficiently large allocation there can cross the hard ceiling
+  and kill the worker.
 - **It binds the worker's allocator, not the process.** Only bytes requested
   from Rust's global allocator are counted, which is everything sandboxed code
   can cause to be allocated, but not memory obtained another way: thread stacks,
   the binary's own mapped image, or a direct `mmap`. It is not a kernel-enforced
-  bound on process memory — an inherited `ulimit -v` or cgroup limit is the tool
-  for that, and still applies independently (a worker whose allocation the
-  kernel then refuses reports the same `MemoryError`).
+  bound on process memory. An inherited `ulimit -v` or cgroup limit is the tool
+  for that, and still applies independently: a worker whose allocation the
+  kernel then refuses reports the same `MemoryError`.
 - **It counts requested bytes, not resident ones.** Per-allocation overhead and
   fragmentation sit between the count and the process's real footprint, so RSS
   runs somewhat above the limit.
 - **`max_memory` alone does not bound worker memory.** The hard ceiling includes
-  the worker's baseline plus a fixed gap above the soft limit — a few MiB, more
+  the worker's baseline plus a fixed gap above the soft limit: a few MiB, more
   with type checking. Use `max_processes` and an OS-level limit to bound a host.
 - **Per session, but against a fixed baseline.** A worker serves many checkouts
   and re-derives the cap for each session, always from the leanest the process
@@ -77,8 +77,8 @@ without one is unlimited.
   and replaced rather than allowed to grow indefinitely.
 - **Restoring a dump is bounded by the checkout it lands in.** `load_session` /
   `load_snapshot` restore the dump's own limits (see
-  `limitations/pool-architecture.md`), and the cap is re-derived from them
-  once the session exists — but the load *itself* runs under the limit the
+  `./pool-architecture.md`), and the cap is re-derived from
+  them once the session exists, but the load *itself* runs under the limit the
   `checkout()` config applied. Restoring a large dump into a checkout with a
   much smaller `max_memory` can therefore exceed it while loading; pass a
   comparable limit to `checkout()`.
@@ -94,11 +94,11 @@ plain host OOM, or a request beyond the usable address space such as
 `' ' * (1 << 60)` — takes this same path: on a worker with an exit status the
 host sees that `MemoryError` with its session gone, and on wasm the same
 refusal traps, reported as `MontyCrashedError` per the bullet above. CPython
-raises a catchable `MemoryError` in-process and carries on. Monty cannot: the failure
-happens below the interpreter, where no Python-level exception can be raised, so
-the worker classifies the failure into a dedicated exit code and dies. (Without
-that, the process would abort with `SIGABRT` — indistinguishable from a stack
-overflow, which is why the sandbox exits deliberately instead.)
+raises a catchable `MemoryError` in-process and carries on. Monty cannot: the
+failure happens below the interpreter, where no Python-level exception can be
+raised, so the worker classifies the failure into a dedicated exit code and
+dies. Without that, the process would abort with `SIGABRT`, which is
+indistinguishable from a stack overflow.
 
 ## Integer-specific caps
 
@@ -128,7 +128,7 @@ overflow, which is why the sandbox exits deliberately instead.)
   during construction. Native re-entry is capped independently at a lower
   fixed depth than the 1000-frame Python limit, so Monty raises
   `RecursionError` before a native stack overflow would abort the process. See
-  `limitations/classes.md`'s `__repr__`/`__str__` entry for the main
+  the `__repr__`/`__str__` entry in `./classes.md` for the main
   user-visible divergence this causes.
 
 ## Time

--- a/limitations/sys.md
+++ b/limitations/sys.md
@@ -1,19 +1,19 @@
 # `sys` module
 
-Minimal. The module exposes only the attributes listed below; every other
-`sys.*` access raises `AttributeError`.
+The module exposes only the attributes listed below; every other `sys.*`
+access raises `AttributeError`.
 
 ## Attributes
 
 - `sys.version` — the string `"3.14.0 (Monty)"`.
 - `sys.version_info` — named tuple `(major=3, minor=14, micro=0,
   releaselevel='final', serial=0)`.
-- `sys.platform` — the string `"monty"` (not `"linux"` / `"darwin"` /
-  `"win32"`). Code that branches on the host OS will not work; the
-  sandbox deliberately hides it.
-- `sys.stdout` / `sys.stderr` — opaque marker objects with no methods.
-  They cannot be written to via `.write()`; printing always goes through
-  the host print callback regardless.
+- `sys.platform` — the string `"monty"`, not `"linux"` / `"darwin"` /
+  `"win32"`. Code that branches on the host OS will not work; the sandbox
+  does not expose which OS it runs on.
+- `sys.stdout` / `sys.stderr` — opaque marker objects with no methods. They
+  cannot be written to via `.write()`; printing always goes through the host
+  print callback regardless.
 
 ## Not implemented
 
@@ -26,4 +26,4 @@ Minimal. The module exposes only the attributes listed below; every other
 Production builds do not expose `sys.setrecursionlimit`. Test builds expose a
 lowering-only hook so shared fixtures can force deterministic recursion errors;
 it cannot raise the host-configured ceiling. See
-[resource_limits.md](resource_limits.md).
+`./resource_limits.md`.

--- a/limitations/sys.md
+++ b/limitations/sys.md
@@ -26,4 +26,4 @@ access raises `AttributeError`.
 Production builds do not expose `sys.setrecursionlimit`. Test builds expose a
 lowering-only hook so shared fixtures can force deterministic recursion errors;
 it cannot raise the host-configured ceiling. See
-`./resource_limits.md`.
+./resource_limits.md.

--- a/limitations/typing.md
+++ b/limitations/typing.md
@@ -67,7 +67,7 @@ This is a known temporary divergence; see `class__annotations.py`.
   binds the name but annotates nothing is accepted, and its binding stands.
 - **`from __future__ import annotations`** is accepted as a **no-op**, since it
   describes what Monty already does. See
-  `./language.md` for the other features.
+  ./language.md for the other features.
 - Consequences: `get_type_hints()` (which would evaluate the strings) is still
   not implemented, and code that reads `__annotations__` expecting type
   *objects* sees strings. CPython 3.14's `@dataclass` reads evaluated objects

--- a/limitations/typing.md
+++ b/limitations/typing.md
@@ -1,10 +1,9 @@
 # `typing` module
 
-`typing` exists purely so type-annotated code can `import` it without
+`typing` exists so type-annotated code can `import` it without
 `ModuleNotFoundError`. **No runtime type checking happens.** The forms are
 inert marker objects; subscripting them (`list[int]`, `Optional[str]`,
-`Union[int, str]`) returns a placeholder value but does not validate
-anything.
+`Union[int, str]`) returns a placeholder value and validates nothing.
 
 ## Names defined
 
@@ -13,7 +12,7 @@ anything.
 `Generator`, `ClassVar`, `Final`, `Literal`, `TypeVar`, `Generic`,
 `Protocol`, `Annotated`, `Self`, `Never`, `NoReturn`, `TYPE_CHECKING`.
 
-`TYPE_CHECKING` is `False` (as in CPython at runtime).
+`TYPE_CHECKING` is `False`, as in CPython at runtime.
 
 ## Not implemented
 
@@ -22,12 +21,12 @@ anything.
   `NamedTuple`, `TypedDict`, `dataclass_transform`, `ParamSpec`,
   `Concatenate`, `Unpack`, `TypeAlias`, `TypeAliasType`, `LiteralString`.
 - Annotation introspection on **functions and modules**: `__annotations__` is
-  not populated there. (Class `__annotations__` **is** populated — see below.)
+  not populated there. Class `__annotations__` **is** populated; see below.
 
 ## Class annotations are stringized
 
 A class body's annotations **are** recorded, in order, on the class's
-`__annotations__` dict — but in **stringized** form, unconditionally. The values
+`__annotations__` dict, but in **stringized** form, unconditionally. The values
 are the annotation expression rendered back to source, never evaluated. As in
 CPython's PEP 563 stringizer the expression is *unparsed* rather than sliced out
 of the file, so original spacing, line breaks and quote style are normalized
@@ -45,7 +44,7 @@ This is a known temporary divergence; see `class__annotations.py`.
 - **Divergence from CPython 3.14's default** (PEP 649), where these are the
   evaluated objects (`C.__annotations__['x'] is int`). CPython only agrees with
   Monty when the calling code uses `from __future__ import annotations`
-  (PEP 563), which Monty's behaviour is otherwise equivalent to — except that
+  (PEP 563), which Monty's behaviour is otherwise equivalent to, except that
   Monty stringizes whether or not that import is present.
 - The blocker is that Monty has no generic types: `list[int]` and
   `dict[str, int]` raise `TypeError: 'type' object is not subscriptable`, and
@@ -58,22 +57,22 @@ This is a known temporary divergence; see `class__annotations.py`.
   *keys* and their order are stable either way.
 - Only **simple `name: T` targets** are recorded, as in CPython. A bare
   `obj.attr: T` contributes nothing to `__annotations__` on either, but CPython
-  still *evaluates the target expression* — `undefined.attr: int` raises
+  still *evaluates the target expression*: `undefined.attr: int` raises
   `NameError` there and is silently dropped by Monty. With a value
   (`obj.attr: T = v`) Monty raises `NotImplementedError`.
 - Binding **`__annotations__` explicitly** in a class body that *also* has
   annotated names raises `NotImplementedError`. CPython instead stores the
-  collected annotations into whatever the name holds — merging into an explicit
+  collected annotations into whatever the name holds, merging into an explicit
   `dict`, or raising `TypeError` if it holds something else. A class body that
   binds the name but annotates nothing is accepted, and its binding stands.
 - **`from __future__ import annotations`** is accepted as a **no-op**, since it
   describes what Monty already does. See
-  [language.md](language.md#__future__-imports) for the other features.
+  `./language.md` for the other features.
 - Consequences: `get_type_hints()` (which would evaluate the strings) is still
   not implemented, and code that reads `__annotations__` expecting type
   *objects* sees strings. CPython 3.14's `@dataclass` reads evaluated objects
   (`annotationlib.Format.FORWARDREF`), but keeps a string path for `ClassVar` /
-  `InitVar` so PEP 563 code still works — which is what makes stringized
+  `InitVar` so PEP 563 code still works, which is what makes stringized
   annotations enough to build on.
 
 If you need real type validation, do it on the *host* side around the

--- a/limitations/unicodedata.md
+++ b/limitations/unicodedata.md
@@ -1,7 +1,7 @@
 # `unicodedata` module
 
-Covers the widely-used Unicode Character Database queries. Implemented
-functions mostly match CPython 3.14, subject to the behavioural notes below.
+Covers the most-used Unicode Character Database queries. Implemented functions
+match CPython 3.14 apart from the notes below.
 
 ## Implemented
 
@@ -13,8 +13,8 @@ functions mostly match CPython 3.14, subject to the behavioural notes below.
 
 `decimal`, `digit`, `numeric` (numeric-value tables), `bidirectional`,
 `east_asian_width`, `mirrored`, `decomposition`, and the `ucd_3_2_0` object.
-These require Unicode property data not available in the lightweight backing
-crates; accessing them raises `AttributeError`.
+These need Unicode property data the backing crates do not carry; accessing
+them raises `AttributeError`.
 
 ## Behavioural notes
 
@@ -26,12 +26,11 @@ crates; accessing them raises `AttributeError`.
   therefore diverge from CPython. Long-established code points (ASCII, common
   Latin/Greek, CJK) are unaffected.
 - `lookup` resolves character names and some aliases, but named sequences that
-  CPython accepts (e.g. `"KEYCAP NUMBER SIGN"`) are not supported and raise
-  `KeyError`.
+  CPython accepts (e.g. `"KEYCAP NUMBER SIGN"`) raise `KeyError`.
 - `lookup` requires a `str` argument; CPython also accepts `bytes`. A non-`str`
   argument raises `TypeError: "expected string, not <type>"` rather than
   CPython's bytes-oriented message.
 - All implemented functions are positional-only, but keyword-argument error
   wording does not match CPython. CPython raises
-  `unicodedata.<fn>() takes no keyword arguments`; Monty instead reports the
-  generated positional arity or unexpected-keyword error.
+  `unicodedata.<fn>() takes no keyword arguments`; Monty reports the generated
+  positional arity or unexpected-keyword error.

--- a/limitations/with.md
+++ b/limitations/with.md
@@ -2,14 +2,14 @@
 
 Monty supports the `with` statement for built-in types that implement
 `__enter__` / `__exit__` (currently just file objects produced by `open()`,
-see `./open.md`) **and for user-defined classes** that define the two
+see ./open.md) **and for user-defined classes** that define the two
 dunders. Semantics follow CPython for the supported subset: `__enter__` runs
 before the body, `__exit__` runs on every exit path (normal completion,
 exception, `return`, `break`, `continue`), and a truthy return from
 `__exit__` suppresses an in-flight exception.
 
 User-class `__enter__` / `__exit__` run as real frames, so unlike
-`__repr__` / `__str__` (see `./classes.md`) they may suspend on
+`__repr__` / `__str__` (see ./classes.md) they may suspend on
 external/OS calls and resume mid-`with`. The protocol check matches CPython:
 a value whose class lacks `__exit__` raises `TypeError: '...' object does
 not support the context manager protocol (missed __exit__ method)`; one with
@@ -28,7 +28,7 @@ explicit `obj.__enter__()` call, which is an ordinary method call.
 
   Each extra item counts against the parser's nesting budget as if it were
   written as explicitly nested `with` blocks; see
-  `./language.md`.
+  ./language.md.
 
 ## Not supported
 
@@ -74,10 +74,10 @@ explicit `obj.__enter__()` call, which is an ordinary method call.
 
 ## Current implementers of the protocol
 
-| Type           | Notes                                                          |
-| -------------- | -------------------------------------------------------------- |
-| `open()`       | Closes the file on exit; see `./open.md` for details. |
-| user classes   | Class must define `__exit__` (and `__enter__`); see above.     |
+| Type           | Notes                                                     |
+| -------------- | --------------------------------------------------------- |
+| `open()`       | Closes the file on exit; see ./open.md for details.       |
+| user classes   | Class must define `__exit__` (and `__enter__`); see above. |
 
 Adding a new context-manager-capable built-in takes three pieces on the
 type's `HeapRead` impl:

--- a/limitations/with.md
+++ b/limitations/with.md
@@ -1,22 +1,22 @@
 # `with` statement (context managers)
 
 Monty supports the `with` statement for built-in types that implement
-`__enter__` / `__exit__` (currently just file objects produced by
-[`open()`](open.md)) **and for user-defined classes** that define the two
+`__enter__` / `__exit__` (currently just file objects produced by `open()`,
+see `./open.md`) **and for user-defined classes** that define the two
 dunders. Semantics follow CPython for the supported subset: `__enter__` runs
 before the body, `__exit__` runs on every exit path (normal completion,
 exception, `return`, `break`, `continue`), and a truthy return from
 `__exit__` suppresses an in-flight exception.
 
-User-class `__enter__` / `__exit__` run as real frames, so — unlike
-`__repr__` / `__str__` (see [classes.md](classes.md)) — they may suspend on
+User-class `__enter__` / `__exit__` run as real frames, so unlike
+`__repr__` / `__str__` (see `./classes.md`) they may suspend on
 external/OS calls and resume mid-`with`. The protocol check matches CPython:
 a value whose class lacks `__exit__` raises `TypeError: '...' object does
 not support the context manager protocol (missed __exit__ method)`; one with
 `__exit__` but no `__enter__` gets the `(missed __enter__ method)` variant.
 Lookup is type-level, as in CPython: an instance attribute named
-`__enter__`/`__exit__` is ignored by the `with` statement (but used by an
-explicit `obj.__enter__()` call, which is an ordinary method call).
+`__enter__`/`__exit__` is ignored by the `with` statement, but used by an
+explicit `obj.__enter__()` call, which is an ordinary method call.
 
 ## Supported but desugared
 
@@ -27,7 +27,8 @@ explicit `obj.__enter__()` call, which is an ordinary method call).
   inner-most `with` line, not the original multi-item line.
 
   Each extra item counts against the parser's nesting budget as if it were
-  written as explicitly nested `with` blocks — see language.md
+  written as explicitly nested `with` blocks; see
+  `./language.md`.
 
 ## Not supported
 
@@ -41,50 +42,49 @@ explicit `obj.__enter__()` call, which is an ordinary method call).
 - The third argument to `__exit__` (the traceback object) is always `None`.
   Monty has no traceback objects; the type and value arguments are passed
   through unchanged (`typ is ValueError` etc. works). Code that inspects the
-  traceback object inside `__exit__` will see `None` where CPython would
+  traceback object inside `__exit__` sees `None` where CPython would
   provide a `traceback` instance.
 - If `__exit__` itself raises during the exception path, the new exception
-  replaces the original (the original is dropped). This matches CPython's
-  behavior, but is called out here because some readers expect the original
-  to be preserved as `__context__` — Monty does not currently track exception
-  chaining.
+  replaces the original and the original is dropped. This matches CPython's
+  behavior, and is listed here because some readers expect the original
+  to be preserved as `__context__`; Monty does not track exception chaining.
 - CPython's `BEFORE_WITH` looks up **and binds** `__enter__`/`__exit__` once,
   when the `with` statement is entered; Monty's `WithExit`/`WithExceptStart`
   opcodes look `__exit__` up again when the block exits. A class whose
   `__exit__` attribute is reassigned *during* the body calls the new
-  function in Monty but the originally-bound one in CPython (and a
+  function in Monty but the originally-bound one in CPython, and a
   reassignment that removes it raises `AttributeError` in Monty where
-  CPython would still call the original).
+  CPython would still call the original.
 - Direct `obj.__exit__(typ, val, tb)` invocation on a **built-in** context
   manager forwards `val` to the type's `py_exit` only when it is `None` or a
-  heap-allocated value (matching CPython for the `None` / exception-instance
-  cases real callers use). A non-`None` *scalar* `val` (e.g.
+  heap-allocated value, matching CPython for the `None` / exception-instance
+  cases real callers use. A non-`None` *scalar* `val` (e.g.
   `f.__exit__(int, 5, None)`) cannot be expressed through the internal
-  `Option<HeapId>` abstraction and is treated as if `val` were `None` —
-  every built-in context manager ignores `val`'s content beyond `is None`,
+  `Option<HeapId>` abstraction and is treated as if `val` were `None`. Every
+  built-in context manager ignores `val`'s content beyond `is None`,
   so this is not observable in practice. User-class instances are exempt:
   their explicit dunder calls are ordinary method calls and receive all
   three arguments verbatim.
 - Direct `obj.__exit__(...)` on a **built-in** context manager requires
-  **exactly three** positional arguments — any other arity raises
+  **exactly three** positional arguments; any other arity raises
   `TypeError`. CPython's file/`IOBase.__exit__` is declared `*args` and
   accepts any number, so `f.__exit__()` returns `None` there but raises in
-  Monty. (User-class `__exit__` is an ordinary method, so its arity matches
-  whatever the user defined, exactly as in CPython.)
+  Monty. User-class `__exit__` is an ordinary method, so its arity matches
+  whatever the user defined, exactly as in CPython.
 
 ## Current implementers of the protocol
 
 | Type           | Notes                                                          |
 | -------------- | -------------------------------------------------------------- |
-| `open()`       | Closes the file on exit; see [`open.md`](open.md) for details. |
+| `open()`       | Closes the file on exit; see `./open.md` for details. |
 | user classes   | Class must define `__exit__` (and `__enter__`); see above.     |
 
-Adding a new context-manager-capable built-in requires three pieces on the
+Adding a new context-manager-capable built-in takes three pieces on the
 type's `HeapRead` impl:
 
-1. Override `PyTrait::py_is_context_manager` to return `true` — this is
-   what the `BeforeWith` opcode checks to raise CPython's specific
-   `TypeError` for non-CM values, *before* `py_enter` runs.
+1. Override `PyTrait::py_is_context_manager` to return `true`. The
+   `BeforeWith` opcode checks it to raise CPython's specific `TypeError` for
+   non-CM values, *before* `py_enter` runs.
 2. Override `PyTrait::py_enter` / `PyTrait::py_exit`.
 3. Add the type's arms in `HeapReadOutput::py_is_context_manager`,
    `py_enter`, and `py_exit` (in `heap_data.rs`) so the dispatch

--- a/packages/pydantic-monty/README.md
+++ b/packages/pydantic-monty/README.md
@@ -277,7 +277,7 @@ with Monty() as pool:
 
 ### Crash/failure isolation
 
-All failures in monty code execution should surface as a subclass of `MontyError`.
+Every failure in monty code execution raises a subclass of `MontyError`.
 
 ```python test="skip"
 from pydantic_monty import Monty, MontyError


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a `writing-style` skill and revises `limitations/` and docs for mechanism-first accuracy. Corrects filesystem confinement, stdlib coverage, memory headroom, and the soft-memory polling interval, with no runtime or API changes.

- New `/.agents/skills/writing-style/SKILL.md`: prescriptive guidance for docstrings, comments, `limitations/`, READMEs, commit messages, and PR descriptions; fixes examples to clarify read-write mounts and host-run imports.
- Edited `limitations/*`: active voice, uniform CPython-divergence framing, standardized cross-links and error messages; drops backticks in cross-references and realigns tables; no semantic changes.
- Docs corrections in READMEs and `CLAUDE.md`: confinement uses `cap_std::fs::Dir`; updated stdlib list; clearer async wording; explicit memory headroom (4 MB; 32 MB with type checking) and soft-memory polling every 255 instructions via `check_memory_time`; tightened wording across `crates/monty-proto`, `crates/monty-pool`, `packages/pydantic-monty`, and `examples/*`.
- Required action: future user-visible behavior changes must add or update a `limitations/*.md` entry and follow the `writing-style` guidance.

<sup>Written for commit 33ee885d994f64a9993b37bd0e6db0b67d50c446. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

