### PR TITLE
Let hosts install a custom memory probe

### DIFF
--- a/crates/monty-types/src/lib.rs
+++ b/crates/monty-types/src/lib.rs
@@ -35,7 +35,7 @@ pub use crate::{
     },
     resource::{
         BASELINE_MEMORY, DEFAULT_MAX_RECURSION_DEPTH, LARGE_RESULT_THRESHOLD, LIVE_MEMORY, OOM_EXIT_CODE,
-        ResourceError, ResourceLimits, ResourceTracker,
+        ResourceError, ResourceLimits, ResourceTracker, set_memory_probe,
     },
     results::{ExtFunctionResult, NameLookupResult},
     run_options::{AssertMessageAnnotations, CompileOptions},

--- a/crates/monty-types/src/resource.rs
+++ b/crates/monty-types/src/resource.rs
@@ -7,7 +7,10 @@ use std::{
     cell::Cell,
     error::Error,
     fmt,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::{
+        OnceLock,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::Duration,
 };
 
@@ -30,6 +33,24 @@ pub static LIVE_MEMORY: AtomicUsize = AtomicUsize::new(0);
 /// The leanest the process has ever been at an arming point: what the worker
 /// costs to exist, before any session ran.
 pub static BASELINE_MEMORY: AtomicUsize = AtomicUsize::new(usize::MAX);
+static MEMORY_PROBE: OnceLock<fn() -> usize> = OnceLock::new();
+
+/// Replaces the default `LIVE_MEMORY` minus `BASELINE_MEMORY` read behind
+/// the tracker's memory checks.
+///
+/// The default counters are process-wide, which fits one interpreter per
+/// worker process fed by `monty-alloc`. A host embedding interpreters
+/// in-process can run several at once, and one shared baseline cannot tell
+/// their allocations apart. A probe over the host's own accounting (say a
+/// thread-local live count fed by its global allocator) gives each run its
+/// own numbers, and the tracker keeps raising `MemoryError` against
+/// `max_memory` at the same checkpoints.
+///
+/// Install once at startup, like a global allocator; a later install is
+/// refused and the first probe stays.
+pub fn set_memory_probe(probe: fn() -> usize) -> Result<(), &'static str> {
+    MEMORY_PROBE.set(probe).map_err(|_| "memory probe already installed")
+}
 
 /// Threshold in bytes above which `check_large_result` is called.
 ///
@@ -88,7 +109,8 @@ pub struct ResourceLimits {
     pub max_duration: Option<Duration>,
     /// Maximum allocator-backed memory in bytes.
     ///
-    /// Requires the executable to install and arm `monty-alloc`.
+    /// Requires the executable to install and arm `monty-alloc`, or to
+    /// install a [`set_memory_probe`].
     pub max_memory: Option<usize>,
     /// Run garbage collection every N GC-tracked allocations.
     pub gc_interval: Option<usize>,
@@ -121,8 +143,8 @@ impl ResourceLimits {
 
     /// Sets allocator-backed maximum memory usage in bytes.
     ///
-    /// Requires the executable to install and arm `monty-alloc`; otherwise
-    /// the limit is silently not enforced.
+    /// Requires the executable to install and arm `monty-alloc` or install a
+    /// [`set_memory_probe`]; otherwise the limit is silently not enforced.
     #[must_use]
     pub fn max_memory(mut self, limit: usize) -> Self {
         self.max_memory = Some(limit);
@@ -203,7 +225,8 @@ impl ResourceTracker {
     /// executes, so the tracker can be created any amount of time before
     /// the first run without consuming the duration budget. A configured
     /// `max_memory` requires `monty-alloc` installed as the global allocator
-    /// and armed via its `set_limit`; otherwise it is silently not enforced.
+    /// and armed via its `set_limit`, or a [`set_memory_probe`] installed;
+    /// otherwise it is silently not enforced.
     #[must_use]
     pub fn new(limits: ResourceLimits) -> Self {
         Self {
@@ -438,7 +461,10 @@ impl ResourceTracker {
 
 /// Returns memory used in bytes
 fn probe_memory() -> usize {
-    LIVE_MEMORY
-        .load(Ordering::Relaxed)
-        .saturating_sub(BASELINE_MEMORY.load(Ordering::Relaxed))
+    match MEMORY_PROBE.get() {
+        Some(probe) => probe(),
+        None => LIVE_MEMORY
+            .load(Ordering::Relaxed)
+            .saturating_sub(BASELINE_MEMORY.load(Ordering::Relaxed)),
+    }
 }

--- a/crates/monty-types/tests/memory_probe.rs
+++ b/crates/monty-types/tests/memory_probe.rs
@@ -1,0 +1,22 @@
+//! Verifies the tracker's memory checks read a host-installed probe.
+
+use monty_types::{ResourceError, ResourceLimits, ResourceTracker, set_memory_probe};
+
+fn probed_usage(tracker: &ResourceTracker) -> usize {
+    match tracker.check_memory_time() {
+        Err(ResourceError::Memory { used, .. }) => used,
+        other => panic!("expected a memory error from the probe, got {other:?}"),
+    }
+}
+
+/// One test, since the probe is process-wide and installs exactly once.
+#[test]
+fn tracker_reads_the_installed_probe() {
+    set_memory_probe(|| 2048).unwrap();
+
+    let tracker = ResourceTracker::new(ResourceLimits::default().max_memory(1024));
+    assert_eq!(probed_usage(&tracker), 2048);
+
+    set_memory_probe(|| 0).expect_err("a second install is refused");
+    assert_eq!(probed_usage(&tracker), 2048, "the first probe stays");
+}


### PR DESCRIPTION
The tracker reads memory from the process-wide `LIVE_MEMORY`/`BASELINE_MEMORY` pair, which fits one interpreter per `monty-alloc` worker.

A host that embeds the interpreter in-process and runs several at once cannot keep that accounting straight: arming the shared baseline for one run forgives another run's usage, and the limit silently stops enforcing.

`set_memory_probe` points the read at the host's own accounting instead, say a thread-local live count fed by its global allocator, installed once like a global allocator.

Enforcement is unchanged: the tracker still checks `max_memory` at checkpoints, and workers never call the new API so they keep the default read.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows hosts to install a custom memory probe to replace the default `LIVE_MEMORY - BASELINE_MEMORY` read, so concurrent in-process interpreters enforce `max_memory` independently. Previously, shared counters rebased each other and could silently disable enforcement under concurrent load; default behavior remains unchanged unless a host installs a probe.

**Review and rollout**
- Exposes `set_memory_probe` in `monty-types`; installs once via `OnceLock`, a second install returns "memory probe already installed".
- `probe_memory()` delegates to the installed probe or falls back to `LIVE_MEMORY - BASELINE_MEMORY`.
- Docs for `ResourceLimits::max_memory` and `ResourceTracker::new` now state enforcement requires `monty-alloc` or a probe.
- If you embed multiple interpreters in one process, install the probe once at startup; no action needed for worker-per-interpreter setups using `monty-alloc`.

<sup>Written for commit 38f9d7a91b3c3cbda39801fb0c9e1ae1e6074a17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

