### PR TITLE
Reject overlapping host directories at mount registration

### DIFF
--- a/crates/monty-fs/src/error.rs
+++ b/crates/monty-fs/src/error.rs
@@ -4,6 +4,7 @@ use std::{
     error::Error,
     fmt,
     io::{self, ErrorKind},
+    path::PathBuf,
 };
 
 use monty_types::{ExcData, ExcType, MontyException, StringRepr, unicode_decode_error_msg};
@@ -65,6 +66,22 @@ pub enum MountError {
 
     /// Invalid mount configuration (e.g., host path doesn't exist or isn't a directory).
     InvalidMount(String),
+
+    /// Two mounts' host directories overlap (equal, or one inside the other).
+    /// Refused at registration: access is checked against whichever mount the
+    /// *virtual* path selects, so a file reachable through two mounts would get
+    /// the weaker mount's mode — a read-write mount over a read-only one
+    /// silently defeats the protection the caller thought they had configured.
+    OverlappingMounts {
+        /// Virtual path of the mount being added.
+        virtual_path: String,
+        /// Canonical host path of the mount being added.
+        host_path: PathBuf,
+        /// Virtual path of the already-registered mount it overlaps.
+        existing_virtual_path: String,
+        /// Canonical host path of that existing mount.
+        existing_host_path: PathBuf,
+    },
 
     /// Cumulative write bytes exceeded the configured per-mount limit.
     /// The configured byte limit that was exceeded.
@@ -151,6 +168,25 @@ impl MountError {
             )
             .with_data(data),
             Self::InvalidMount(msg) => MontyException::new(ExcType::TypeError, Some(msg)),
+            // The caller's intent (e.g. "keep this subdirectory read-only") is
+            // reasonable, so the message must say why the configuration cannot
+            // deliver it. This error reaches the host configuring the mounts,
+            // never sandboxed code, so naming host paths is fine.
+            Self::OverlappingMounts {
+                virtual_path,
+                host_path,
+                existing_virtual_path,
+                existing_host_path,
+            } => MontyException::new(
+                ExcType::ValueError,
+                Some(format!(
+                    "cannot mount '{}' at '{virtual_path}': its host directory overlaps the mount of '{}' at \
+                     '{existing_virtual_path}', which would let the less restrictive mount's mode apply to the \
+                     other's files",
+                    host_path.display(),
+                    existing_host_path.display(),
+                )),
+            ),
             Self::WriteLimitExceeded(limit) => MontyException::new(
                 ExcType::OSError,
                 Some(format!("disk write limit of {} exceeded", format_bytes_pretty(limit))),
@@ -189,6 +225,17 @@ impl fmt::Display for MountError {
                 write!(f, "invalid UTF-8 byte 0x{first_byte:02x} at position {start}")
             }
             Self::InvalidMount(msg) => write!(f, "invalid mount: {msg}"),
+            Self::OverlappingMounts {
+                virtual_path,
+                host_path,
+                existing_virtual_path,
+                existing_host_path,
+            } => write!(
+                f,
+                "overlapping mounts: '{virtual_path}' ('{}') and '{existing_virtual_path}' ('{}')",
+                host_path.display(),
+                existing_host_path.display()
+            ),
             Self::WriteLimitExceeded(limit) => {
                 write!(f, "disk write limit of {} exceeded", format_bytes_pretty(*limit))
             }

--- a/crates/monty-fs/src/mount_table.rs
+++ b/crates/monty-fs/src/mount_table.rs
@@ -70,6 +70,8 @@ impl MountTable {
     /// the host path doesn't exist or isn't a directory, or it cannot be opened
     /// — on macOS/BSD that includes a search-only (`0o111`) directory, which
     /// Linux accepts because it opens directories with `O_PATH`.
+    /// Returns [`MountError::OverlappingMounts`] if the host directory overlaps
+    /// an already-registered mount's (see [`Self::push_mount`]).
     pub fn mount(
         &mut self,
         virtual_path: &str,
@@ -77,21 +79,47 @@ impl MountTable {
         mode: MountMode,
         write_bytes_limit: Option<u64>,
     ) -> Result<(), MountError> {
-        let mount = Mount::new(virtual_path, host_path, mode, write_bytes_limit)?;
-        self.push_mount(mount);
-        Ok(())
+        self.push_mount(Mount::new(virtual_path, host_path, mode, write_bytes_limit)?)
     }
 
     /// Adds a pre-built [`Mount`] to the table.
     ///
     /// Use this when a mount was validated before the table was assembled.
-    pub fn push_mount(&mut self, mount: Mount) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MountError::OverlappingMounts`] if the mount's canonical host
+    /// directory equals, contains, or is contained by an existing mount's.
+    /// Access mode is checked only against the mount the *virtual* path
+    /// selects, so a host file reachable through two mounts would take the
+    /// weaker mode — e.g. a read-write mount of a directory silently defeats a
+    /// read-only mount of its subdirectory. Mounting disjoint host directories
+    /// at nested virtual paths (`/data`, `/data/sub`) remains fine: the
+    /// longest-prefix rule routes each path to exactly one mount.
+    pub fn push_mount(&mut self, mount: Mount) -> Result<(), MountError> {
+        // Canonical host paths cannot see two routes to the same file through a
+        // hard link or bind mount, but the sandbox can create neither — that
+        // would need pre-existing host state, i.e. a hostile *host*, which
+        // mount configuration already trusts.
+        if let Some(existing) = self
+            .mounts
+            .iter()
+            .find(|existing| host_paths_overlap(existing.host_path(), mount.host_path()))
+        {
+            return Err(MountError::OverlappingMounts {
+                virtual_path: mount.virtual_path().to_owned(),
+                host_path: mount.host_path().to_owned(),
+                existing_virtual_path: existing.virtual_path().to_owned(),
+                existing_host_path: existing.host_path().to_owned(),
+            });
+        }
         // Keep mounts sorted longest-prefix-first so dispatch can stop at the
         // first match without re-sorting the whole table on every insertion.
         let insert_at = self
             .mounts
             .partition_point(|existing| existing.virtual_path().len() > mount.virtual_path().len());
         self.mounts.insert(insert_at, mount);
+        Ok(())
     }
 
     /// Handles an OS call using the mount table.
@@ -258,7 +286,9 @@ impl Mount {
         self.root.virtual_path()
     }
 
-    /// Returns the canonical host directory path. Diagnostics only.
+    /// Returns the canonical host directory path. Used for diagnostics and the
+    /// overlap check in [`MountTable::push_mount`]; operations never resolve
+    /// through it.
     #[must_use]
     pub fn host_path(&self) -> &Path {
         self.root.host_path()
@@ -318,8 +348,9 @@ impl Mount {
     }
 }
 
-/// A host directory opened once, mountable as often as the host likes; cloning
-/// shares the descriptor.
+/// A host directory opened once, mountable as often as the host likes — though
+/// at most once per table, see [`MountTable::push_mount`]; cloning shares the
+/// descriptor.
 ///
 /// Reuse one instead of re-deriving a mount from its path: sandbox code that
 /// can rename inside a parent mount redirects that name between rebuilds, and
@@ -328,7 +359,8 @@ impl Mount {
 pub struct MountRoot {
     /// Virtual path prefix (absolute, normalized).
     virtual_path: String,
-    /// Canonical host directory path. Diagnostics only — see `dir`.
+    /// Canonical host directory path. Diagnostics and the overlap check only —
+    /// operations resolve through `dir`, never this path.
     host_path: PathBuf,
     /// Descriptor for the mounted directory — the sandbox boundary, which
     /// resolution cannot leave. Shared, so every mount built from this root is
@@ -362,11 +394,12 @@ impl MountRoot {
         let dir = Dir::open_ambient_dir(host_path, ambient_authority())
             .map_err(|e| MountError::InvalidMount(format!("cannot open host path '{}': {e}", host_path.display())))?;
 
-        // Diagnostics only — nothing resolves through this path. Resolved after
-        // the open, so a host racing it leaves a stale label on the right
-        // descriptor, never the reverse. Still fatal on failure: callers copy
-        // this out as a mount's durable identity, and a relative path would
-        // later re-resolve against the process CWD.
+        // Nothing resolves through this path — it labels the descriptor for
+        // diagnostics and keys the overlap check in `MountTable::push_mount`.
+        // Resolved after the open, so a host racing it leaves a stale label on
+        // the right descriptor, never the reverse. Still fatal on failure:
+        // callers copy this out as a mount's durable identity, and a relative
+        // path would later re-resolve against the process CWD.
         let canonical_host = fs::canonicalize(host_path).map_err(|e| {
             MountError::InvalidMount(format!("cannot resolve host path '{}': {e}", host_path.display()))
         })?;
@@ -384,11 +417,18 @@ impl MountRoot {
         &self.virtual_path
     }
 
-    /// Returns the canonical host directory path. Diagnostics only.
+    /// Returns the canonical host directory path. Diagnostics and the overlap
+    /// check only — operations never resolve through it.
     #[must_use]
     pub fn host_path(&self) -> &Path {
         &self.host_path
     }
+}
+
+/// Whether two canonical host paths name the same directory or nest one inside
+/// the other. Component-wise, so `/a/bc` does not overlap `/a/b`.
+fn host_paths_overlap(a: &Path, b: &Path) -> bool {
+    a.starts_with(b) || b.starts_with(a)
 }
 
 /// Checks whether `normalized_path` falls under `mount_virtual_path`.

--- a/crates/monty-fs/tests/fs.rs
+++ b/crates/monty-fs/tests/fs.rs
@@ -1628,9 +1628,10 @@ fn empty_mount_table() {
 #[test]
 fn mount_table_len() {
     let dir = create_test_dir();
+    let dir2 = TempDir::new().unwrap();
     let mut mt = MountTable::new();
     mt.mount("/a", dir.path(), MountMode::ReadWrite, None).unwrap();
-    mt.mount("/b", dir.path(), MountMode::ReadOnly, None).unwrap();
+    mt.mount("/b", dir2.path(), MountMode::ReadOnly, None).unwrap();
     assert_eq!(mt.len(), 2);
     assert!(!mt.is_empty());
 }
@@ -1752,7 +1753,7 @@ fn mount_at_mnt_with_memory_limit(tmpdir: &TempDir, mode: MountMode, limit: u64)
         .unwrap()
         .with_memory_usage_limit(limit);
     let mut table = MountTable::new();
-    table.push_mount(mount);
+    table.push_mount(mount).unwrap();
     table
 }
 

--- a/crates/monty-fs/tests/mount_escape_repro.rs
+++ b/crates/monty-fs/tests/mount_escape_repro.rs
@@ -1,4 +1,4 @@
-//! Regression tests for three mount-confinement defects.
+//! Regression tests for mount-confinement defects.
 
 use std::{fs, io::ErrorKind};
 
@@ -81,7 +81,9 @@ fn mount_root_stays_pinned_across_rebuilds() {
 
     // Feed 2: the same configuration, rebuilt into a fresh table.
     let mut rebuilt = MountTable::new();
-    rebuilt.push_mount(Mount::with_root(child_root, MountMode::ReadOnly, None));
+    rebuilt
+        .push_mount(Mount::with_root(child_root, MountMode::ReadOnly, None))
+        .unwrap();
 
     // The rebuild still serves the directory that was validated, and the file
     // the redirect aimed at is simply not in it.
@@ -100,6 +102,85 @@ fn mount_root_stays_pinned_across_rebuilds() {
         .unwrap();
     let leaked = read_text(&mut from_path, "/child/secret.txt").unwrap();
     assert_eq!(leaked, MontyObject::String("HOST SECRET".to_owned()));
+}
+
+/// One host file reachable through two mounts lets the *spelling* of a path
+/// pick which mount's mode applies, so the weaker mode wins (Hack Monty
+/// round 3): a read-write mount of a directory silently defeated a read-only
+/// mount of its subdirectory, directly or through a host-planted symlink.
+/// Overlap is therefore refused at registration — in host-path space, since
+/// the colliding mounts' virtual paths need not be related at all.
+#[test]
+fn overlapping_host_mounts_are_rejected() {
+    let base = TempDir::new().unwrap();
+    let protected = base.path().join("protected");
+    fs::create_dir(&protected).unwrap();
+
+    // The same directory twice, at unrelated virtual paths — the modes need
+    // not even differ, and rejection does not depend on them.
+    let mut mt = MountTable::new();
+    mt.mount("/m", base.path(), MountMode::ReadWrite, None).unwrap();
+    let err = mt.mount("/ro", base.path(), MountMode::ReadOnly, None).unwrap_err();
+    assert_overlap(&err, "/ro", "/m");
+    let canonical_base = fs::canonicalize(base.path()).unwrap();
+    assert_eq!(
+        err.into_exception().message().unwrap(),
+        format!(
+            "cannot mount '{0}' at '/ro': its host directory overlaps the mount of '{0}' at '/m', which would \
+             let the less restrictive mount's mode apply to the other's files",
+            canonical_base.display()
+        )
+    );
+
+    // A subdirectory of an already-mounted directory — the "keep this
+    // subdirectory read-only" configuration, which cannot deliver what it
+    // promises and so must refuse rather than half-work.
+    let mut mt = MountTable::new();
+    mt.mount("/m", base.path(), MountMode::ReadWrite, None).unwrap();
+    let err = mt
+        .mount("/m/protected", &protected, MountMode::ReadOnly, None)
+        .unwrap_err();
+    assert_overlap(&err, "/m/protected", "/m");
+
+    // The ancestor arriving second is caught the same way.
+    let mut mt = MountTable::new();
+    mt.mount("/m/protected", &protected, MountMode::ReadOnly, None).unwrap();
+    let err = mt.mount("/m", base.path(), MountMode::ReadWrite, None).unwrap_err();
+    assert_overlap(&err, "/m", "/m/protected");
+}
+
+/// Asserts registration failed as [`MountError::OverlappingMounts`] naming the
+/// expected added/existing virtual-path pair.
+fn assert_overlap(err: &MountError, added: &str, existing: &str) {
+    match err {
+        MountError::OverlappingMounts {
+            virtual_path,
+            existing_virtual_path,
+            ..
+        } => {
+            assert_eq!(virtual_path, added);
+            assert_eq!(existing_virtual_path, existing);
+        }
+        other => panic!("expected OverlappingMounts, got {other:?}"),
+    }
+}
+
+/// Overlap means the same host directory or an ancestor of one, measured in
+/// path components: siblings sharing a name prefix are disjoint, and disjoint
+/// host directories may sit at nested *virtual* paths — the longest-prefix
+/// rule routes every path to exactly one mount, so no file has two spellings.
+#[test]
+fn disjoint_host_mounts_still_register() {
+    let base = TempDir::new().unwrap();
+    let sub = base.path().join("sub");
+    let sub2 = base.path().join("sub2");
+    fs::create_dir(&sub).unwrap();
+    fs::create_dir(&sub2).unwrap();
+
+    let mut mt = MountTable::new();
+    mt.mount("/data", &sub, MountMode::ReadWrite, None).unwrap();
+    mt.mount("/data/nested", &sub2, MountMode::ReadOnly, None).unwrap();
+    assert_eq!(mt.len(), 2);
 }
 
 /// Once either side of a rename is covered, the table owns the call: the

--- a/crates/monty-js/ts/mountDir.ts
+++ b/crates/monty-js/ts/mountDir.ts
@@ -16,6 +16,11 @@ import {
  * Retained overlay data and filesystem results share a per-mount memory
  * budget, `memoryUsageLimit` (100 MB by default).
  *
+ * Mounts passed to one feed must cover disjoint host directories: overlap
+ * (the same directory, or one inside the other) is rejected when the feed
+ * starts, since the stricter mount's mode could otherwise be bypassed
+ * through the other mount's paths.
+ *
  * Warning: with `mode: 'read-write'`, files written by sandboxed code persist
  * on the host and are untrusted; do not execute them. Importing counts as
  * executing, and the import can be indirect: Node resolves imports from

--- a/crates/monty-pool/src/checkout.rs
+++ b/crates/monty-pool/src/checkout.rs
@@ -368,7 +368,7 @@ impl Checkout {
         on_print: OnPrint<'_>,
     ) -> Result<(Option<TurnEvent>, Option<String>), PoolError> {
         self.ensure_ready()?;
-        let feed_mounts = Self::build_feed_mounts(mounts);
+        let feed_mounts = Self::build_feed_mounts(mounts)?;
         // the dump carries its own limits/consumed time/script name — forget
         // what the worker's Configure established and re-adopt from the reply
         self.pending = None;
@@ -392,8 +392,8 @@ impl Checkout {
 
     /// Executes one snippet against the session. Inputs become sandbox
     /// globals; mounts apply to this feed only and are serviced by the parent
-    /// (an invalid host path fails here, before any frame is sent, as a
-    /// session-preserving [`PoolError::Runtime`]). Returns the first
+    /// (specs with overlapping host directories fail here, before any frame is
+    /// sent, as a session-preserving [`PoolError::Runtime`]). Returns the first
     /// suspension (or completion); `print()` output streams to `on_print`
     /// throughout.
     ///
@@ -415,7 +415,7 @@ impl Checkout {
             ));
         }
         ensure_sendable(inputs.iter().map(|(_, value)| value))?;
-        self.feed_mounts = Self::build_feed_mounts(mounts);
+        self.feed_mounts = Self::build_feed_mounts(mounts)?;
         let request = request(pb::parent_request::Kind::Feed(pb::Feed {
             code: code.to_owned(),
             inputs: inputs
@@ -1142,9 +1142,10 @@ impl Checkout {
 
     /// Builds this feed's mount table, or `None` for the common mount-less
     /// feed. Runs inline: the specs' directories were opened when the caller
-    /// built them, so nothing here touches the host filesystem.
-    fn build_feed_mounts(mounts: Vec<MountSpec>) -> Option<MountTable> {
-        (!mounts.is_empty()).then(|| build_mount_table(mounts))
+    /// built them, so nothing here touches the host filesystem. Fails
+    /// (session-preserving) when two specs' host directories overlap.
+    fn build_feed_mounts(mounts: Vec<MountSpec>) -> Result<Option<MountTable>, PoolError> {
+        (!mounts.is_empty()).then(|| build_mount_table(mounts)).transpose()
     }
 
     /// Runs blocking host mount work on tokio's blocking pool, so a stalled
@@ -1359,9 +1360,12 @@ fn min_deadline(a: Option<Duration>, b: Option<Duration>) -> Option<Duration> {
 }
 
 /// Builds the parent-side [`MountTable`] for one feed from its (non-empty)
-/// specs. Infallible and free of filesystem I/O: each spec already carries its
-/// opened directory, so this only pairs those descriptors with a per-feed mode.
-fn build_mount_table(mounts: Vec<MountSpec>) -> MountTable {
+/// specs. Free of filesystem I/O: each spec already carries its opened
+/// directory, so this only pairs those descriptors with a per-feed mode. Specs
+/// whose host directories overlap are rejected here — as a session-preserving
+/// [`PoolError::Runtime`], since specs are built independently and only meet
+/// at feed time.
+fn build_mount_table(mounts: Vec<MountSpec>) -> Result<MountTable, PoolError> {
     let mut table = MountTable::new();
     for mount in mounts {
         let mode = match mount.mode {
@@ -1374,7 +1378,9 @@ fn build_mount_table(mounts: Vec<MountSpec>) -> MountTable {
         // No filesystem access: the root was opened when the spec was built.
         let mount = monty_fs::Mount::with_root(mount.root, mode, mount.write_bytes_limit)
             .with_memory_usage_limit(mount.memory_usage_limit);
-        table.push_mount(mount);
+        table
+            .push_mount(mount)
+            .map_err(|err| PoolError::Runtime(err.into_exception()))?;
     }
-    table
+    Ok(table)
 }

--- a/crates/monty-python/python/pydantic_monty/_monty.pyi
+++ b/crates/monty-python/python/pydantic_monty/_monty.pyi
@@ -87,6 +87,12 @@ class MountDir:
     that same directory — so build one and reuse it. `'overlay'` writes live in
     each feed's own table and are discarded when the feed ends.
 
+    Mounts passed to one feed must cover disjoint host directories: a mount
+    whose host directory overlaps another's (the same directory, or one inside
+    the other) is rejected with `ValueError` when the feed starts, since the
+    stricter mount's mode could otherwise be bypassed through the other
+    mount's paths.
+
     **Warning: `mode='read-write'` writes files from untrusted code to your
     real filesystem.**
 

--- a/crates/monty-python/src/mount.rs
+++ b/crates/monty-python/src/mount.rs
@@ -22,6 +22,11 @@ use pyo3::{exceptions::PyValueError, prelude::*, types::PyTuple};
 /// Retained overlay data and filesystem results share a configurable memory
 /// budget, which defaults to 100 MB.
 ///
+/// Mounts passed to one feed must cover disjoint host directories: overlap
+/// (the same directory, or one inside the other) is rejected with
+/// `ValueError` when the feed starts, since the stricter mount's mode could
+/// otherwise be bypassed through the other mount's paths.
+///
 /// The `mode` controls sandbox access:
 /// - `'read-only'` — sandbox can read but not write
 /// - `'read-write'` — sandbox can read and write real host files

--- a/crates/monty-python/tests/test_mount_table.py
+++ b/crates/monty-python/tests/test_mount_table.py
@@ -412,6 +412,23 @@ b = Path('/rw/file2.txt').read_text()
         assert result == snapshot(('hello world', 'from mount2'))
 
 
+def test_overlapping_mounts_rejected(monty_run: RunMonty, test_dir: Path):
+    """Mounts over overlapping host directories are refused: the path spelling
+    would pick which mount's mode applies, so the weaker mode would win."""
+    mounts = [
+        MountDir(host_path=test_dir, virtual_path='/m', mode='read-write'),
+        MountDir(host_path=test_dir / 'subdir', virtual_path='/m/subdir', mode='read-only'),
+    ]
+    with pytest.raises(MontyRuntimeError) as exc_info:
+        monty_run('1', mount=mounts)
+    resolved = test_dir.resolve()
+    assert str(exc_info.value) == (
+        f"ValueError: cannot mount '{resolved / 'subdir'}' at '/m/subdir': its host directory overlaps the "
+        f"mount of '{resolved}' at '/m', which would let the less restrictive mount's mode apply to the "
+        "other's files"
+    )
+
+
 # =============================================================================
 # Session (multi-feed) mount support
 # =============================================================================

--- a/crates/monty-runtime/src/main.rs
+++ b/crates/monty-runtime/src/main.rs
@@ -50,6 +50,8 @@ pub(crate) struct Cli {
     /// Uses `::` as separator to avoid ambiguity with Windows drive letters.
     /// Modes: `ro` (read-only, default), `rw` (read-write), `overlay` (in-memory overlay).
     /// `write_limit_bytes` is optional and applies to all write modes.
+    /// Host directories must be disjoint: mounting a directory and a
+    /// subdirectory of it (or the same directory twice) is rejected.
     ///
     /// WARNING: with `rw`, files written by sandboxed code persist on the
     /// host, where your own tools may later execute them. Prefer `overlay`.

--- a/limitations/filesystem.md
+++ b/limitations/filesystem.md
@@ -27,6 +27,24 @@ Each mount is configured by the host as one of:
   pool, the changes are discarded when the feed ends; each feed starts with
   a fresh overlay.
 
+### Overlapping host directories cannot both be mounted
+
+A mount whose host directory is the same as, contains, or is contained by
+another mount's is refused with a `ValueError` naming both mounts — at
+registration, which via the pool means when the feed starts, since that is
+where the per-feed mount table is assembled.
+
+The access mode is checked against whichever mount the *virtual* path selects
+(longest prefix), so a host file reachable through two mounts would take the
+weaker mount's mode. In particular, mounting a directory read-write and a
+subdirectory of it read-only would **not** protect the subdirectory — every
+file in it would still be writable under the parent mount's spelling — so
+that configuration is rejected rather than half-honoured. To expose parts of
+a tree with different modes, mount disjoint directories.
+
+Disjoint host directories at nested virtual paths (`/data`, `/data/sub`)
+remain fine: each virtual path routes to exactly one mount.
+
 ## Only regular files can be read, written, or opened
 
 Reading, writing, appending to, or `open()`ing a path that resolves to an


### PR DESCRIPTION
A mount's mode is selected by longest-prefix match on the virtual path, so one host file reachable through two mounts takes whichever mount the spelling selects — the weaker mode wins. Mounting a directory read-write and a subdirectory of it read-only did not protect the subdirectory (Hack Monty round 3).

MountTable::push_mount now returns Result and refuses a mount whose canonical host path equals, contains, or is contained by an existing mount's, unconditionally on mode. Via the pool this surfaces at feed time as a session-preserving ValueError, since specs only meet there. Disjoint host directories at nested virtual paths still work.

Claude-Session: https://claude.ai/code/session_015xsqqc7SY9Gaw8W5ojgMKS

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects mounts whose host directories overlap (same directory, ancestor, or descendant) at registration to prevent bypassing stricter modes. Previously, a file reachable through two mounts used the weaker mode via longest-prefix virtual-path routing (e.g., rw parent over ro child); now registration fails with a session-preserving ValueError.

- `monty-fs`: `MountTable::push_mount` returns `Result` and rejects overlaps using canonical host paths; disjoint host directories at nested virtual paths remain valid.
- New `MountError::OverlappingMounts` with a clear message naming both mounts; surfaced via the pool as `PoolError::Runtime` when a feed starts. JS/Python bindings and CLI help document the restriction; tests cover rejection and allowed cases.

**Migration**
- Ensure feed mounts cover disjoint host directories. Overlapping mounts will now fail at feed start with `ValueError`.
- Update callers that use `MountTable::push_mount` to handle a `Result` and propagate or report the error.

<sup>Written for commit 0a5efb306e80b4ede97c1b45ef7c0760170cf673. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

