### PR TITLE
Server docs

### DIFF
--- a/.agents/skills/writing-style/SKILL.md
+++ b/.agents/skills/writing-style/SKILL.md
@@ -223,6 +223,20 @@ test is whether a plain verb would say more than the metaphor does.
   subtle path to it, then the safe alternative. No preamble. Put the warning
   before the thing it warns about, not after.
 
+### Markdown line wrapping
+
+Hard-wrap markdown at 120 characters, one sentence per line where possible: each
+sentence starts a new line, and only a sentence longer than 120 characters wraps
+onto continuation lines. This keeps diffs one-sentence-sized — editing a
+sentence does not rewrap the paragraph around it.
+
+Continuation lines of a list item are indented to the content column of the
+marker. Code blocks, tables and headings are never rewrapped; a table whose rows
+cannot fit 120 characters should become a list instead.
+
+To reformat an existing file: `python3 .claude/skills/writing-style/rewrap_md.py <file>...`
+(rewrites in place, skips fences/tables/headings/frontmatter).
+
 ## Words and punctuation
 
 | Instead of                       | Write                      |

--- a/.agents/skills/writing-style/rewrap_md.py
+++ b/.agents/skills/writing-style/rewrap_md.py
@@ -1,9 +1,17 @@
 """Rewrap markdown prose: one sentence per line, hard-wrapped at 120 chars.
 
-Skips fenced code blocks, tables, headings, and frontmatter. Paragraph and
-list-item lines are first joined, then split into sentences (one per line),
-then any line over 120 chars is wrapped at word boundaries. List continuation
-lines are indented to the content column of their marker.
+Skips fenced code blocks (``` or ~~~, closed only by a matching fence),
+tables, headings, thematic breaks / setext underlines, and frontmatter.
+Paragraph and list-item lines are joined, split into sentences (one per
+line), then any line over 120 chars is wrapped at word boundaries. List
+continuation lines are indented to the content column of their marker;
+indented paragraphs keep their indent. Hard breaks (two trailing spaces)
+are preserved.
+
+Known limitations: tables must use leading pipes (house style does), and a
+sentence starting with a lowercase letter stays on the previous line — the
+splitter requires a capital/code start so abbreviations like "e.g." never
+split.
 """
 
 import re
@@ -16,11 +24,13 @@ WIDTH = 120
 ABBREV = re.compile(r'\b(e\.g|i\.e|etc|vs|approx|cf|no|v[0-9.]*)\.$', re.IGNORECASE)
 SENT_END = re.compile(r'([.!?][)"\']?)\s+(?=[A-Z`\[($~0-9])')
 BULLET = re.compile(r'^(\s*)([-*+]|\d+\.)\s+')
+FENCE = re.compile(r'^(`{3,}|~{3,})')
+# Thematic breaks and setext underlines: a run of -/=/*/_ (spaces allowed).
+BREAK_LINE = re.compile(r'^(?:[-=*_]\s*){3,}$|^={1,2}$|^-{1,2}$')
 
 
 def split_sentences(text: str) -> list[str]:
-    parts: list[str] = []
-    last = 0
+    parts, last = [], 0
     for m in SENT_END.finditer(text):
         candidate = text[last : m.end(1)]
         if ABBREV.search(candidate):
@@ -47,23 +57,44 @@ def flush(buf: list[str], out: list[str]) -> None:
         return
     m = BULLET.match(buf[0])
     if m:
-        marker, indent = m.group(0), ' ' * len(m.group(0))
-        text = ' '.join([buf[0][len(marker) :]] + [ln.strip() for ln in buf[1:]])
-        for i, sent in enumerate(split_sentences(text)):
-            out.extend(wrap(sent, marker if i == 0 else indent, indent))
+        marker = m.group(0)
+        first_prefix, cont_prefix = marker, ' ' * len(marker)
+        texts = [buf[0][len(marker) :]] + [ln.strip() for ln in buf[1:]]
     else:
-        text = ' '.join(ln.strip() for ln in buf)
-        for sent in split_sentences(text):
-            out.extend(wrap(sent, '', ''))
+        # A plain block keeps its indent, so the continuation paragraph of a
+        # list item stays indented under its marker.
+        indent = buf[0][: len(buf[0]) - len(buf[0].lstrip())]
+        first_prefix = cont_prefix = indent
+        texts = [ln.strip() for ln in buf]
+    first = True
+
+    def emit(segment: list[str], hard_break: bool) -> None:
+        nonlocal first
+        for sent in split_sentences(' '.join(segment)):
+            out.extend(wrap(sent, first_prefix if first else cont_prefix, cont_prefix))
+            first = False
+        if hard_break and out:
+            out[-1] += '  '
+
+    # A line ending in two spaces is a markdown hard break: wrap each side
+    # separately and keep the marker on the break's last line.
+    segment: list[str] = []
+    for raw, text in zip(buf, texts):
+        segment.append(text)
+        if raw.endswith('  '):
+            emit(segment, True)
+            segment = []
+    if segment:
+        emit(segment, False)
     buf.clear()
 
 
 def rewrap(src: str) -> str:
     out: list[str] = []
     buf: list[str] = []
-    in_fence = in_front = False
-    lines = src.splitlines()
-    for i, line in enumerate(lines):
+    fence: str | None = None  # the opening run, e.g. '```' or '~~~~'
+    in_front = False
+    for i, line in enumerate(src.splitlines()):
         stripped = line.strip()
         if i == 0 and stripped == '---':
             in_front = True
@@ -74,12 +105,22 @@ def rewrap(src: str) -> str:
             if stripped == '---':
                 in_front = False
             continue
-        if stripped.startswith('```'):
+        if fence:
+            out.append(line)
+            # A closing fence is a run of the opening character at least as
+            # long as the opener, and nothing else on the line.
+            if len(stripped) >= len(fence) and set(stripped) == {fence[0]}:
+                fence = None
+            continue
+        if opening := FENCE.match(stripped):
             flush(buf, out)
-            in_fence = not in_fence
+            fence = opening.group(1)
             out.append(line)
             continue
-        if in_fence or stripped.startswith(('#', '|', '>')) or not stripped:
+        # Setext underlines are indistinguishable from thematic breaks here;
+        # both survive because the buffered heading text flushes unchanged
+        # (short, single line) and the marker line passes through verbatim.
+        if not stripped or stripped.startswith(('#', '|', '>')) or BREAK_LINE.match(stripped):
             flush(buf, out)
             out.append(line)
             continue

--- a/.agents/skills/writing-style/rewrap_md.py
+++ b/.agents/skills/writing-style/rewrap_md.py
@@ -1,0 +1,100 @@
+"""Rewrap markdown prose: one sentence per line, hard-wrapped at 120 chars.
+
+Skips fenced code blocks, tables, headings, and frontmatter. Paragraph and
+list-item lines are first joined, then split into sentences (one per line),
+then any line over 120 chars is wrapped at word boundaries. List continuation
+lines are indented to the content column of their marker.
+"""
+
+import re
+import sys
+import textwrap
+
+WIDTH = 120
+
+# Don't split after these (abbreviations, initialisms).
+ABBREV = re.compile(r'\b(e\.g|i\.e|etc|vs|approx|cf|no|v[0-9.]*)\.$', re.IGNORECASE)
+SENT_END = re.compile(r'([.!?][)"\']?)\s+(?=[A-Z`\[($~0-9])')
+BULLET = re.compile(r'^(\s*)([-*+]|\d+\.)\s+')
+
+
+def split_sentences(text: str) -> list[str]:
+    parts: list[str] = []
+    last = 0
+    for m in SENT_END.finditer(text):
+        candidate = text[last : m.end(1)]
+        if ABBREV.search(candidate):
+            continue
+        parts.append(candidate.strip())
+        last = m.end()
+    parts.append(text[last:].strip())
+    return [p for p in parts if p]
+
+
+def wrap(sentence: str, first_prefix: str, cont_prefix: str) -> list[str]:
+    return textwrap.wrap(
+        sentence,
+        width=WIDTH,
+        initial_indent=first_prefix,
+        subsequent_indent=cont_prefix,
+        break_long_words=False,
+        break_on_hyphens=False,
+    ) or [first_prefix.rstrip()]
+
+
+def flush(buf: list[str], out: list[str]) -> None:
+    if not buf:
+        return
+    m = BULLET.match(buf[0])
+    if m:
+        marker, indent = m.group(0), ' ' * len(m.group(0))
+        text = ' '.join([buf[0][len(marker) :]] + [ln.strip() for ln in buf[1:]])
+        for i, sent in enumerate(split_sentences(text)):
+            out.extend(wrap(sent, marker if i == 0 else indent, indent))
+    else:
+        text = ' '.join(ln.strip() for ln in buf)
+        for sent in split_sentences(text):
+            out.extend(wrap(sent, '', ''))
+    buf.clear()
+
+
+def rewrap(src: str) -> str:
+    out: list[str] = []
+    buf: list[str] = []
+    in_fence = in_front = False
+    lines = src.splitlines()
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if i == 0 and stripped == '---':
+            in_front = True
+            out.append(line)
+            continue
+        if in_front:
+            out.append(line)
+            if stripped == '---':
+                in_front = False
+            continue
+        if stripped.startswith('```'):
+            flush(buf, out)
+            in_fence = not in_fence
+            out.append(line)
+            continue
+        if in_fence or stripped.startswith(('#', '|', '>')) or not stripped:
+            flush(buf, out)
+            out.append(line)
+            continue
+        # A new bullet starts its own block; continuation lines join the current one.
+        if BULLET.match(line):
+            flush(buf, out)
+        buf.append(line)
+    flush(buf, out)
+    return '\n'.join(out) + '\n'
+
+
+for path in sys.argv[1:]:
+    with open(path) as f:
+        original = f.read()
+    result = rewrap(original)
+    with open(path, 'w') as f:
+        f.write(result)
+    print(f'{path}: {len(original.splitlines())} -> {len(result.splitlines())} lines')

--- a/docs/server.md
+++ b/docs/server.md
@@ -12,6 +12,22 @@ The server adds capacity limits, timeouts, per-caller quotas, health probes, gra
 The server is closed-source and distributed as a container image.
 For access and licensing, [contact us](https://pydantic.dev/contact).
 
+## Why Monty over WebSocket
+
+This is not a sales document, but it's worth briefly enumerating why someone would want to use Monty running on a
+remote server:
+
+- **Security**: escaping the sandbox gets you the machine running Monty, not the machine running the agent /
+  application code — and that machine is an empty container.
+- **Centralized monitoring, observability, and scaling**: one horizontally scalable service for all Monty code
+  execution, instead of every service running its own worker pool.
+- **Density**: Monty workers have a small baseline footprint (as little as 2MB), plus additional memory for limits and
+  optional type checking, so a single machine can run hundreds.
+- **Same behavior as local Monty**: the wire protocol carries host callbacks, name lookups, async futures and mounted
+  client directories, so code that runs against a local pool runs unchanged against the server.
+- **(In future) switch to a full monty sandbox with a parameter**: the same interface, but a full VM running CPython — for
+  code that needs dependencies, bash and a real filesystem.
+
 ## Quickstart
 
 The image refuses to start without a dump-signing key of at least 16 bytes:

--- a/docs/server.md
+++ b/docs/server.md
@@ -4,21 +4,21 @@
 subprocess from an elastic pool.
 A worker serves one session at a time and is reset or replaced between sessions, so no sandbox state crosses from one
 client to another.
-Any `monty-pool` WebSocket client connects directly — `pydantic_monty.AsyncMontyWebsocket` in Python, `@pydantic/monty`
-in TypeScript.
-The server adds capacity limits, timeouts, per-caller quotas, health probes, graceful drain and tracing to
-[Pydantic Logfire](https://pydantic.dev/logfire); the sandboxing itself is entirely the `monty` worker's.
+`pydantic_monty.AsyncMontyWebsocket` connects directly from Python; the TypeScript package (`@pydantic/monty`) is
+subprocess-only today and cannot dial a remote server.
+The server adds capacity limits, timeouts, per-caller quotas, health probes, graceful drain and tracing to [Pydantic
+Logfire](https://pydantic.dev/logfire); the sandboxing itself is entirely the `monty` worker's.
 
 The server is closed-source and distributed as a container image.
 For access and licensing, [contact us](https://pydantic.dev/contact).
 
 ## Why Monty over WebSocket
 
-This is not a sales document, but it's worth briefly enumerating why someone would want to use Monty running on a
-remote server:
+This is not a sales document, but it's worth briefly enumerating why someone would want to use Monty running on a remote
+server:
 
-- **Security**: escaping the sandbox gets you the machine running Monty, not the machine running the agent /
-  application code — and that machine is an empty container.
+- **Security**: escaping the sandbox gets you the machine running Monty, not the machine running the agent / application
+  code — and that machine is an empty container.
 - **Centralized monitoring, observability, and scaling**: one horizontally scalable service for all Monty code
   execution, instead of every service running its own worker pool.
 - **Density**: Monty workers have a small baseline footprint (as little as 2MB), plus additional memory for limits and
@@ -30,8 +30,8 @@ remote server:
 
 ## Quickstart
 
-The image is private: commercial access comes with a `key.json` service-account file that authenticates pulls
-(the same mechanism as self-hosted Logfire images, which live on the same registry host):
+The image is private: commercial access comes with a `key.json` service-account file that authenticates pulls (the same
+mechanism as self-hosted Logfire images, which live on the same registry host):
 
 ```bash
 docker login us-docker.pkg.dev -u _json_key --password-stdin < key.json
@@ -132,17 +132,16 @@ Dumps only load into a worker of the same Monty version, so roll clients and ser
 
 ## Tracing
 
-Pass `--logfire-token` (or set `LOGFIRE_TOKEN`) to export traces to
-[Pydantic Logfire](https://pydantic.dev/logfire).
+Pass `--logfire-token` (or set `LOGFIRE_TOKEN`) to export traces to [Pydantic Logfire](https://pydantic.dev/logfire).
 Without a token the server behaves identically and logs to stderr only.
 
 The server records one span per connection, and beneath it the same session, run and host-call spans every monty client
 emits — a dashboard built against any monty client works here.
-Policy outcomes (capacity rejections, timeouts, drain) are logged as events on the connection span, one line each
-naming the limit that fired.
+Policy outcomes (capacity rejections, timeouts, drain) are logged as events on the connection span, one line each naming
+the limit that fired.
 
-Traces carry caller data — the code fed to each session, call arguments, results and print output — with no flag to
-turn that off.
+Traces carry caller data — the code fed to each session, call arguments, results and print output — with no flag to turn
+that off.
 Point the token only at a backend those callers may be exposed to.
 
 ## Security

--- a/docs/server.md
+++ b/docs/server.md
@@ -1,0 +1,121 @@
+# Running monty-server
+
+`monty-server` is a WebSocket server that hosts Monty sandbox workers: each connection gets its own `monty` worker
+subprocess from an elastic pool.
+A worker serves one session at a time and is reset or replaced between sessions, so no sandbox state crosses from one
+client to another.
+Any `monty-pool` WebSocket client connects directly — `pydantic_monty.AsyncMontyWebsocket` in Python, `@pydantic/monty`
+in TypeScript.
+The server adds capacity limits, timeouts, per-caller quotas, health probes, graceful drain and tracing to
+[Pydantic Logfire](https://pydantic.dev/logfire); the sandboxing itself is entirely the `monty` worker's.
+
+The server is closed-source and distributed as a container image.
+For access and licensing, [contact us](https://pydantic.dev/contact).
+
+## Quickstart
+
+The image refuses to start without a dump-signing key of at least 16 bytes:
+
+```bash
+docker run --rm \
+  -e MONTY_SERVER_DUMP_KEY="$(openssl rand -hex 16)" \
+  -p 8000:8000 \
+  us-docker.pkg.dev/pydantic-public-registries/monty/monty-server:latest
+```
+
+The bound URL (`ws://0.0.0.0:8000/`) is the only line written to stdout; all logging goes to stderr.
+The image bundles the matching `monty` worker binary and runs as non-root uid 65532 on a `scratch` base — no shell, no
+package manager.
+
+## Connecting a client
+
+```python
+from pydantic_monty import AsyncMontyWebsocket
+
+async with AsyncMontyWebsocket('ws://localhost:8000/') as pool:
+    async with pool.checkout() as session:
+        result = await session.feed_run('1 + 1')
+```
+
+An ordinary `GET /` on the same URL answers with a short info page.
+
+## Configuration
+
+Every flag has an environment variable: the flag name in upper snake case with a `MONTY_SERVER_` prefix
+(`--max-sessions` → `MONTY_SERVER_MAX_SESSIONS`), except `MONTY_BIN` and `LOGFIRE_TOKEN`, which keep their established
+names.
+A flag on the command line wins over its variable.
+Flags passed to `docker run <image> ...` replace the default `CMD` (`--host 0.0.0.0`) wholesale, so include `--host
+0.0.0.0` when passing your own.
+Bind to an IP literal, not a hostname — the `scratch` image has no name resolution.
+
+The flags an operator usually sets first:
+
+| Flag                            | Meaning                                        | Default     |
+| ------------------------------- | ---------------------------------------------- | ----------- |
+| `--host` / `--port`             | bind address; port 0 binds ephemeral           | 8000        |
+| `--max-sessions`                | concurrent sessions across the server          | 64          |
+| `--max-sessions-per-client`     | concurrent sessions per caller; 0 disables     | 10          |
+| `--turn-timeout <secs>`         | wall-clock cap on a single turn                | 300         |
+| `--idle-timeout <secs>`         | cap on the gap between requests                | 60          |
+| `--session-timeout <secs>`      | cap on total session lifetime                  | 3600        |
+| `--max-duration <secs>`         | sandbox execution time within a session        | 60          |
+| `--max-memory-mib <MiB>`        | per-session memory ceiling                     | 64          |
+| `--max-recursion-depth <n>`     | per-session call-stack ceiling                 | 1000        |
+| `--dump-key <key>`              | required; signs session dumps                  | —           |
+| `--logfire-token <token>`       | export traces to Logfire                       | off         |
+
+Run `--help` for the full list.
+Prefer environment variables for `--dump-key` and `--logfire-token`: a command line is world-readable via `ps`.
+
+Each of the three resource limits is a ceiling.
+A client that configures no value gets the server's; a client that asks for more is clamped to it; asking for less
+always works.
+The worker enforces the clamped value, so a `MemoryError` or duration error quotes the effective limit.
+
+## Sizing the container
+
+Each worker's process memory is capped at roughly `--max-memory-mib` + a small baseline + headroom (4 MiB, or 32 MiB
+with type checking), so:
+
+```
+container memory ≈ --max-sessions × (--max-memory-mib + baseline + headroom)
+```
+
+The defaults (64 sessions × 64 MiB) reach several GiB.
+Lower one of the two to fit your instance.
+
+## Health probes and drain
+
+`GET /health` answers 200 normally and 503 from the moment drain begins, so point your readiness probe there.
+Point liveness at `GET /`, which answers regardless of drain — a readiness probe on `/` would keep a draining pod in
+rotation, and a liveness probe on `/health` would restart one that is shutting down cleanly.
+
+On SIGTERM the server drains: each session's next request is answered with a signed dump the client can restore into a
+fresh session on another replica (`MontyShutdown` in `pydantic_monty`).
+Sessions still silent after `--drain-grace` (default 30s) are dropped.
+Set the pod's `terminationGracePeriodSeconds` above `--drain-grace`, and use the same `MONTY_SERVER_DUMP_KEY` on every
+replica — a dump signed by one replica must verify on the one the client reconnects to.
+Dumps only load into a worker of the same Monty version, so roll clients and servers together.
+
+## Tracing
+
+Pass `--logfire-token` (or set `LOGFIRE_TOKEN`) to export traces to
+[Pydantic Logfire](https://pydantic.dev/logfire).
+Without a token the server behaves identically and logs to stderr only.
+
+The server records one span per connection, and beneath it the same session, run and host-call spans every monty client
+emits — a dashboard built against any monty client works here.
+Policy outcomes (capacity rejections, timeouts, drain) are logged as events on the connection span, one line each
+naming the limit that fired.
+
+Traces carry caller data — the code fed to each session, call arguments, results and print output — with no flag to
+turn that off.
+Point the token only at a backend those callers may be exposed to.
+
+## Security
+
+There is no authentication and the listener speaks plain `ws://`.
+Terminate TLS at an ingress or load balancer and keep the listener on a private network.
+Behind a proxy you control, set `--trust-forwarded-for` so per-caller limits key on `X-Forwarded-For` rather than the
+proxy's address; never set it on a directly exposed listener, where callers write the header themselves.

--- a/docs/server.md
+++ b/docs/server.md
@@ -25,10 +25,26 @@ remote server:
   optional type checking, so a single machine can run hundreds.
 - **Same behavior as local Monty**: the wire protocol carries host callbacks, name lookups, async futures and mounted
   client directories, so code that runs against a local pool runs unchanged against the server.
-- **(In future) switch to a full monty sandbox with a parameter**: the same interface, but a full VM running CPython — for
-  code that needs dependencies, bash and a real filesystem.
+- **(In future) switch to a full monty sandbox with a parameter**: the same interface, but a full VM running CPython —
+  for code that needs dependencies, bash and a real filesystem.
 
 ## Quickstart
+
+The image is private: commercial access comes with a `key.json` service-account file that authenticates pulls
+(the same mechanism as self-hosted Logfire images, which live on the same registry host):
+
+```bash
+docker login us-docker.pkg.dev -u _json_key --password-stdin < key.json
+```
+
+On Kubernetes, the same file becomes an image pull secret referenced from the pod spec:
+
+```bash
+kubectl create secret docker-registry monty-image-key \
+  --docker-server=us-docker.pkg.dev \
+  --docker-username=_json_key \
+  --docker-password="$(cat key.json)"
+```
 
 The image refuses to start without a dump-signing key of at least 16 bytes:
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds server docs and a Markdown rewrap tool to standardize style. The docs cover operating the private `monty-server` image (pull auth, config, health/drain, sizing, tracing, security) and correct that `@pydantic/monty` is subprocess-only; the tool enforces 120‑char, one‑sentence‑per‑line formatting to keep diffs small.

- New `docs/server.md`: quickstart with Google Artifact Registry auth (`docker login` via `_json_key` and a Kubernetes image pull secret), `MONTY_SERVER_DUMP_KEY` requirement, Python `AsyncMontyWebsocket` example, config via flags/env (including `--trust-forwarded-for`), sizing formula, health/readiness and drain behavior, Logfire tracing, and security guidance.
- New `.agents/skills/writing-style/rewrap_md.py`: rewrites Markdown in place; now matches closing fences by character and length (```/~~~), preserves hard breaks and continuation indents, and passes thematic breaks/setext underlines through; documents two limitations (leading‑pipe tables, lowercase sentence starts). `.agents/skills/writing-style/SKILL.md` adds the wrapping guideline.
- Contributors must run `python3 .agents/skills/writing-style/rewrap_md.py <file>...` when editing Markdown.

**Review notes**
- Fix the path in `SKILL.md`: replace `.claude/skills/writing-style/rewrap_md.py` with `.agents/skills/writing-style/rewrap_md.py`.
- Docs-only; no runtime behavior changes.

<sup>Written for commit 892292f32d0da9bf0662b64dd2ba084a72912643. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

