### PR TITLE
Fix OverflowError for a large 32-bit usize

### DIFF
--- a/crates/monty-js/__test__/wasm_word_size.spec.ts
+++ b/crates/monty-js/__test__/wasm_word_size.spec.ts
@@ -25,14 +25,12 @@ const OVER_32_BIT = [
 for (const [name, code, message] of OVER_32_BIT) {
   test(`an over-32-bit ${name} raises rather than trapping`, async (ctx) => {
     skipIfBrowser(ctx)
-    const pool = await Monty.create()
-    const session = await pool.checkout({})
+    await using pool = await Monty.create()
+    await using session = await pool.checkout({})
     const error = await t.throwsAsync(() => session.feedRun(code), { instanceOf: MontyRuntimeError })
     t.is(error.exception.typeName, 'OverflowError')
     t.is(error.exception.message, message)
     // the instance survived: a trap would have taken the session with it
     t.is(await session.feedRun('1 + 1'), 2)
-    await session.close()
-    await pool.close()
   })
 }

--- a/crates/monty-js/__test__/wasm_word_size.spec.ts
+++ b/crates/monty-js/__test__/wasm_word_size.spec.ts
@@ -1,0 +1,38 @@
+// Values that exceed a 32-bit `usize` reach the interpreter only here.
+//
+// Interpreter semantics normally belong in `crates/monty/test_cases`, but the
+// wasm worker is Monty's one 32-bit target: an `int` above `usize::MAX` yet
+// inside `i64` — `2**40` — is a conversion no 64-bit build ever performs, so
+// this is the only harness that can reach the case at all. The `i64` overflow
+// these mirror is covered on every target by `collections__deque.py`.
+//
+// Each must raise the `OverflowError` a 32-bit CPython gives, not trap the
+// instance. The two messages differ because CPython's do: `deque` converts
+// `maxlen` with `PyLong_AsSsize_t`, `bytes` its count with `PyNumber_AsSsize_t`.
+
+import { test } from 'vitest'
+
+import { t } from './assertions.js'
+import { skipIfBrowser } from './env.js'
+import { Monty, MontyRuntimeError } from '@pydantic/monty/wasm'
+
+// each case is `(2**40)`: over a 32-bit `usize`, under `i64::MAX`
+const OVER_32_BIT = [
+  ['deque maxlen', 'from collections import deque\ndeque([], 2**40)', 'Python int too large to convert to C ssize_t'],
+  ['bytes count', 'bytes(2**40)', "cannot fit 'int' into an index-sized integer"],
+] as const
+
+for (const [name, code, message] of OVER_32_BIT) {
+  test(`an over-32-bit ${name} raises rather than trapping`, async (ctx) => {
+    skipIfBrowser(ctx)
+    const pool = await Monty.create()
+    const session = await pool.checkout({})
+    const error = await t.throwsAsync(() => session.feedRun(code), { instanceOf: MontyRuntimeError })
+    t.is(error.exception.typeName, 'OverflowError')
+    t.is(error.exception.message, message)
+    // the instance survived: a trap would have taken the session with it
+    t.is(await session.feedRun('1 + 1'), 2)
+    await session.close()
+    await pool.close()
+  })
+}

--- a/crates/monty/src/exception_private.rs
+++ b/crates/monty/src/exception_private.rs
@@ -1268,11 +1268,13 @@ pub(crate) trait ExcTypeExt: Sized {
         SimpleException::new_msg(ExcType::ZeroDivisionError, "division by zero")
     }
 
-    /// Creates an OverflowError for string/sequence repetition with count too large.
+    /// Creates an OverflowError for an int too large for an index-sized integer.
     ///
-    /// Matches CPython's format: `OverflowError('cannot fit 'int' into an index-sized integer')`
+    /// This is CPython's `PyNumber_AsSsize_t` wording, used wherever a count or
+    /// size goes through `__index__` (repetition counts, `bytes(n)`) — unlike
+    /// [`Self::overflow_c_ssize_t`], which is `PyLong_AsSsize_t`'s.
     #[must_use]
-    fn overflow_repeat_count() -> SimpleException {
+    fn overflow_index_sized_int() -> SimpleException {
         SimpleException::new_msg(ExcType::OverflowError, "cannot fit 'int' into an index-sized integer")
     }
 

--- a/crates/monty/src/types/bytes.rs
+++ b/crates/monty/src/types/bytes.rs
@@ -198,7 +198,10 @@ impl Bytes {
                 if *n < 0 {
                     return Err(ExcType::value_error_negative_bytes_count());
                 }
-                let size = usize::try_from(*n).expect("bytes count validated non-negative");
+                // Fallible on a 32-bit target (`wasm32-wasip1`), where `bytes(2**40)`
+                // is a count no `usize` can hold. On 64-bit the conversion always
+                // succeeds and the size check below rejects it with `MemoryError`.
+                let size = usize::try_from(*n).map_err(|_| ExcType::overflow_index_sized_int())?;
                 // Pre-check the requested size against resource limits before
                 // touching the global allocator. Without this, `bytes(n)` for a
                 // very large `n` would attempt the native allocation directly

--- a/crates/monty/src/types/deque.rs
+++ b/crates/monty/src/types/deque.rs
@@ -214,11 +214,16 @@ impl Deque {
 }
 
 /// Rejects a negative `maxlen`, converting a validated one to `usize`.
+///
+/// The conversion is fallible on a 32-bit target (`wasm32-wasip1`), where an
+/// `i64` `maxlen` above `usize::MAX` is a real input — `deque([], 2**40)`. It
+/// reports the same `OverflowError` [`read_ssize`] gives a `maxlen` too large
+/// for `i64`, so the two ways of overflowing an index-sized integer agree.
 fn check_maxlen(n: i64) -> RunResult<usize> {
     if n < 0 {
         Err(ExcType::value_error_maxlen_negative())
     } else {
-        Ok(usize::try_from(n).expect("maxlen validated non-negative"))
+        usize::try_from(n).map_err(|_| ExcType::overflow_c_ssize_t())
     }
 }
 

--- a/crates/monty/src/types/long_int.rs
+++ b/crates/monty/src/types/long_int.rs
@@ -163,7 +163,8 @@ impl LongInt {
         if self.is_negative() {
             Ok(0)
         } else {
-            self.to_usize().ok_or_else(|| ExcType::overflow_repeat_count().into())
+            self.to_usize()
+                .ok_or_else(|| ExcType::overflow_index_sized_int().into())
         }
     }
 
@@ -223,7 +224,7 @@ pub(crate) fn repeat_count(value: &Value, vm: &VM<'_>) -> RunResult<Option<usize
         Value::Int(value) => Ok(Some(if *value <= 0 {
             0
         } else {
-            usize::try_from(*value).map_err(|_| ExcType::overflow_repeat_count())?
+            usize::try_from(*value).map_err(|_| ExcType::overflow_index_sized_int())?
         })),
         Value::Bool(value) => Ok(Some(usize::from(*value))),
         Value::Ref(id) if let HeapData::LongInt(value) = vm.heap.get(*id) => Ok(Some(value.repeat_count()?)),

--- a/limitations/builtins.md
+++ b/limitations/builtins.md
@@ -78,7 +78,8 @@ mechanism beyond dataclass field inheritance.
 - **`bytes(source)`** — an iterable of ints is not supported: CPython's
   `bytes([65, 66])` == `b'AB'`, Monty raises `TypeError: cannot convert
   'list' object to bytes`. The int / str-with-encoding / bytes source forms
-  all work.
+  all work. A count above `i64` (`bytes(2**70)`) gives that same `TypeError`,
+  not CPython's `OverflowError: cannot fit 'int' into an index-sized integer`.
 - **`isinstance(obj, T)`** — `T` must be a built-in type (`int`, `str`,
   `list`, ...), a built-in exception class, a sandbox-defined class (see
   [classes.md](classes.md)), or a tuple of those. Passing a host-supplied

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -141,6 +141,10 @@ properties that real CPython does not provide, per the caveat above.
   platforms, with or without a session budget — except in the wasm worker, which
   has no exit status to carry the distinction and so reports `MontyCrashedError`
   for both.
+- **The wasm worker is 32-bit, so size-like arguments overflow sooner.** An
+  `int` above `usize::MAX` but inside `i64` — `deque([], 2**40)`, `bytes(2**40)`
+  — raises `OverflowError` there, where the 64-bit subprocess worker accepts it. Each worker matches the CPython
+  build of its own word size; what differs is which worker ran the snippet.
 - **Workers are spawned with an empty environment** (on Windows only
   `SystemRoot` is kept, which CRT/WinAPI lookups need): host secrets are
   never in a worker's memory, where a sandbox escape or memory disclosure

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -141,13 +141,6 @@ properties that real CPython does not provide, per the caveat above.
   platforms, with or without a session budget — except in the wasm worker, which
   has no exit status to carry the distinction and so reports `MontyCrashedError`
   for both.
-- **The wasm worker is 32-bit, so size-like arguments overflow sooner.** An
-  `int` above `usize::MAX` but inside `i64` — `deque([], 2**40)`, `bytes(2**40)`
-  — raises `OverflowError` there, where the 64-bit subprocess worker converts it
-  and the call then succeeds (`deque([], 2**40)`) or fails later on size
-  (`bytes(2**40)` hits the size check, raising `MemoryError` under a memory
-  limit). Each worker matches the CPython build of
-  its own word size; what differs is which worker ran the snippet.
 - **Workers are spawned with an empty environment** (on Windows only
   `SystemRoot` is kept, which CRT/WinAPI lookups need): host secrets are
   never in a worker's memory, where a sandbox escape or memory disclosure

--- a/limitations/pool-architecture.md
+++ b/limitations/pool-architecture.md
@@ -143,8 +143,11 @@ properties that real CPython does not provide, per the caveat above.
   for both.
 - **The wasm worker is 32-bit, so size-like arguments overflow sooner.** An
   `int` above `usize::MAX` but inside `i64` — `deque([], 2**40)`, `bytes(2**40)`
-  — raises `OverflowError` there, where the 64-bit subprocess worker accepts it. Each worker matches the CPython
-  build of its own word size; what differs is which worker ran the snippet.
+  — raises `OverflowError` there, where the 64-bit subprocess worker converts it
+  and the call then succeeds (`deque([], 2**40)`) or fails later on size
+  (`bytes(2**40)` hits the size check, raising `MemoryError` under a memory
+  limit). Each worker matches the CPython build of
+  its own word size; what differs is which worker ran the snippet.
 - **Workers are spawned with an empty environment** (on Windows only
   `SystemRoot` is kept, which CRT/WinAPI lookups need): host secrets are
   never in a worker's memory, where a sandbox escape or memory disclosure


### PR DESCRIPTION
Two issues would cause crashes (traps) in wasm (needs a 32-bit build):
- `collections.deque([], 2**40)`
- `bytes(2**40)` 

Raise an OverflowError error pre-emptively instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 32-bit wasm traps by raising OverflowError when size-like ints exceed `usize`. Previously `deque([], 2**40)` and `bytes(2**40)` crashed; now they raise CPython-matching messages. 64-bit behavior is unchanged.

- Add `crates/monty-js/__test__/wasm_word_size.spec.ts` to assert exceptions and session survival in `@pydantic/monty/wasm` (skipped in browser).
- `bytes`: make `usize::try_from` fallible and map errors to `OverflowError` via `overflow_index_sized_int`.
- `deque`: make `maxlen` conversion fallible and map errors to `OverflowError` via `overflow_c_ssize_t` to match CPython wording.
- Rename internal helper `overflow_repeat_count` to `overflow_index_sized_int`; update callers in `long_int.rs`.
- Docs: clarify 32-bit vs 64-bit behavior and note `bytes` edge cases; pool architecture limitations wording updated.

<sup>Written for commit a1d3eda9a12dcd095cfd497f30f9d7b0a0c29ad8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

