### PR TITLE
End `itertools.chain` when an argument fails

### DIFF
--- a/crates/monty/src/types/itertools/chain.rs
+++ b/crates/monty/src/types/itertools/chain.rs
@@ -73,19 +73,13 @@ pub(super) fn next<'h>(iter: &mut HeapRead<'h, ItertoolsIter>, vm: &mut VM<'h>) 
         let Some(current) = chain.current.as_ref().map(|c| c.clone_with_heap(vm.heap)) else {
             // No live source: resolve the next argument, or finish.
             let Some(raw) = chain.sources.get(chain.started).map(|s| s.clone_with_heap(vm.heap)) else {
-                let ItertoolsIter::Chain(chain) = iter.get_mut(vm.heap) else {
-                    unreachable!("dispatched on Kind::Chain")
-                };
-                chain.done = true;
+                chain_mut(iter, vm).done = true;
                 return Ok(None);
             };
             // `into_py_iter` consumes `raw` on both paths, and raises here for a
             // non-iterable argument — matching CPython's lazy rejection.
             let resolved = into_py_iter_tracking(iter, raw, vm)?;
-            let ItertoolsIter::Chain(chain) = iter.get_mut(vm.heap) else {
-                unreachable!("dispatched on Kind::Chain")
-            };
-            chain.current = Some(resolved);
+            chain_mut(iter, vm).current = Some(resolved);
             continue;
         };
 
@@ -99,19 +93,37 @@ pub(super) fn next<'h>(iter: &mut HeapRead<'h, ItertoolsIter>, vm: &mut VM<'h>) 
             return Ok(Some(item));
         }
         // This source is spent; release it and move to the next argument.
-        let ItertoolsIter::Chain(chain) = iter.get_mut(vm.heap) else {
-            unreachable!("dispatched on Kind::Chain")
-        };
-        chain.current.take().drop_with(vm);
+        chain_mut(iter, vm).current.take().drop_with(vm);
     }
 }
 
 /// Resolves one argument to an iterator, marking it started first so a
 /// `TypeError` from a non-iterable does not leave it to be retried.
+///
+/// A failure here also *ends* the chain: CPython clears its source on an
+/// `iter()` failure, so the arguments after the bad one are never reached and
+/// every later `next()` is a plain `StopIteration`. Note the asymmetry — an
+/// error raised by a resolved source's `__next__` leaves the chain live, since
+/// CPython keeps that iterator in place.
 fn into_py_iter_tracking<'h>(iter: &mut HeapRead<'h, ItertoolsIter>, raw: Value, vm: &mut VM<'h>) -> RunResult<Value> {
+    chain_mut(iter, vm).started += 1;
+    match raw.into_py_iter(vm) {
+        Ok(resolved) => Ok(resolved),
+        Err(err) => {
+            chain_mut(iter, vm).done = true;
+            Err(err)
+        }
+    }
+}
+
+/// The `Chain` behind an iterator already dispatched as one.
+///
+/// `next` re-borrows the heap around every step that can run user code, so the
+/// same match-or-`unreachable!` appeared at each one; naming it once keeps those
+/// steps readable.
+fn chain_mut<'r, 'h>(iter: &mut HeapRead<'h, ItertoolsIter>, vm: &'r mut VM<'h>) -> &'r mut Chain {
     let ItertoolsIter::Chain(chain) = iter.get_mut(vm.heap) else {
         unreachable!("dispatched on Kind::Chain")
     };
-    chain.started += 1;
-    raw.into_py_iter(vm)
+    chain
 }

--- a/crates/monty/src/types/itertools/chain.rs
+++ b/crates/monty/src/types/itertools/chain.rs
@@ -1,5 +1,7 @@
 //! `itertools.chain(*iterables)` — the arguments' items, back to back.
 
+use std::mem;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -18,7 +20,8 @@ use crate::{
 /// `TypeError` part-way through consumption.
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct Chain {
-    /// The arguments, still as passed; resolved one at a time by `next`.
+    /// The arguments, still as passed; resolved one at a time by `next`, and
+    /// dropped wholesale by `finish` once the chain can reach no more of them.
     sources: Vec<Value>,
     started: usize,
     /// The resolved iterator currently being drained.
@@ -73,7 +76,7 @@ pub(super) fn next<'h>(iter: &mut HeapRead<'h, ItertoolsIter>, vm: &mut VM<'h>) 
         let Some(current) = chain.current.as_ref().map(|c| c.clone_with_heap(vm.heap)) else {
             // No live source: resolve the next argument, or finish.
             let Some(raw) = chain.sources.get(chain.started).map(|s| s.clone_with_heap(vm.heap)) else {
-                chain_mut(iter, vm).done = true;
+                finish(iter, vm);
                 return Ok(None);
             };
             // `into_py_iter` consumes `raw` on both paths, and raises here for a
@@ -110,10 +113,30 @@ fn into_py_iter_tracking<'h>(iter: &mut HeapRead<'h, ItertoolsIter>, raw: Value,
     match raw.into_py_iter(vm) {
         Ok(resolved) => Ok(resolved),
         Err(err) => {
-            chain_mut(iter, vm).done = true;
+            finish(iter, vm);
             Err(err)
         }
     }
+}
+
+/// Ends the chain, releasing the arguments it will now never reach.
+///
+/// Both ways a chain ends come through here, because CPython `Py_CLEAR`s its
+/// source either way: a spent chain that stays bound must not pin its arguments
+/// until it is itself destroyed.
+///
+/// `current` is already `None` at both callsites — the chain only ends while
+/// resolving the next argument — but clearing it keeps this correct for any
+/// future path that ends a chain mid-source.
+fn finish<'h>(iter: &mut HeapRead<'h, ItertoolsIter>, vm: &mut VM<'h>) {
+    let chain = chain_mut(iter, vm);
+    chain.done = true;
+    let sources = mem::take(&mut chain.sources);
+    let current = chain.current.take();
+    // Dropping these can free the chain's own referrers, so it happens once
+    // `chain` (and its borrow of the heap) is out of the way.
+    sources.drop_with(vm);
+    current.drop_with(vm);
 }
 
 /// The `Chain` behind an iterator already dispatched as one.

--- a/crates/monty/test_cases/itertools__adaptors.py
+++ b/crates/monty/test_cases/itertools__adaptors.py
@@ -179,6 +179,33 @@ try:
 except TypeError as exc:
     assert str(exc) == "'int' object is not iterable"
 
+# An argument that fails `iter()` ends the chain: CPython drops the source, so
+# the arguments after the bad one are never reached and the chain stays spent.
+spent = itertools.chain([1], 5, [2, 3])
+assert next(spent) == 1
+try:
+    next(spent)
+    assert False, 'expected TypeError'
+except TypeError as exc:
+    assert str(exc) == "'int' object is not iterable"
+for _ in range(2):
+    try:
+        next(spent)
+        assert False, 'expected the chain to be spent'
+    except StopIteration:
+        pass
+assert list(spent) == []
+
+# the same when the very first argument is the one that fails
+first_bad = itertools.chain(5, [2, 3])
+try:
+    next(first_bad)
+    assert False, 'expected TypeError'
+except TypeError as exc:
+    assert str(exc) == "'int' object is not iterable"
+assert list(first_bad) == []
+
+
 try:
     itertools.chain(x=[1])
     assert False, 'expected TypeError'
@@ -307,6 +334,17 @@ for failing in (
 ):
     try:
         next(failing)
+        assert False, 'expected ValueError'
+    except ValueError as exc:
+        assert str(exc) == 'boom'
+
+# For chain the error is not the end of it: only a source that fails `iter()`
+# ends the chain, so a source that fails `__next__` stays in place and CPython
+# hands back the same error on the next call rather than moving to `[9]`.
+still_live = itertools.chain(Boom(), [9])
+for _ in range(2):
+    try:
+        next(still_live)
         assert False, 'expected ValueError'
     except ValueError as exc:
         assert str(exc) == 'boom'

--- a/crates/monty/test_cases/itertools__gc.py
+++ b/crates/monty/test_cases/itertools__gc.py
@@ -25,8 +25,19 @@ def count_cycle():
     return len(items)
 
 
+def chain_cycle():
+    # A chain ends by RELEASING its arguments, and here an argument is the list
+    # that holds the chain: the release runs while the chain is mid-`next`, so
+    # it must cope with dropping objects that refer back to it.
+    items = []
+    items.append(itertools.chain(items))
+    drained = list(items[0])
+    return len(drained)
+
+
 assert repeat_cycle() == 1
 assert count_cycle() == 2
+assert chain_cycle() == 1
 gc.collect()
 
 # Iterators still work after a collection.

--- a/crates/monty/test_cases/refcount__itertools_adaptors.py
+++ b/crates/monty/test_cases/refcount__itertools_adaptors.py
@@ -101,5 +101,24 @@ drained_source = iter([1, 2])
 drained_islice = itertools.islice(drained_source, 5)
 list(drained_islice)
 
+# chain holds its arguments UNRESOLVED, so what an ended chain must release is
+# the ARGUMENT itself, not just the iterator it resolved from it. Both ways a
+# chain ends have to release: draining the last argument...
+chain_drained_source = [1, 2]
+chain_drained = itertools.chain(chain_drained_source)
+list(chain_drained)
+
+# ...and an argument that fails `iter()`, which ends the chain for good. The
+# arguments after the bad one are unreachable, so pinning them keeps objects
+# alive that nothing can ever yield.
+chain_unreached_source = [3, 4]
+chain_failed = itertools.chain([1], 5, chain_unreached_source)
+next(chain_failed)
+try:
+    next(chain_failed)
+    assert False, 'expected TypeError'
+except TypeError as exc:
+    assert str(exc) == "'int' object is not iterable"
+
 len('done')
-# ref-counts={'itertools': 1, 'live': 1, 'primed': 1, 'cyclic': 2, 'paired': 1, 'sliced': 1, 'chained': 1, 'cycled': 1, 'replaying': 1, 'Boom': 2, 'erroring': 1, 'spent_source': 1, 'spent_pairwise': 1, 'stopped_source': 1, 'stopped_islice': 1, 'drained_source': 1, 'drained_islice': 1}
+# ref-counts={'itertools': 1, 'live': 1, 'primed': 1, 'cyclic': 2, 'paired': 1, 'sliced': 1, 'chained': 1, 'cycled': 1, 'replaying': 1, 'Boom': 2, 'erroring': 1, 'spent_source': 1, 'spent_pairwise': 1, 'stopped_source': 1, 'stopped_islice': 1, 'drained_source': 1, 'drained_islice': 1, 'chain_drained_source': 1, 'chain_drained': 1, 'chain_unreached_source': 1, 'chain_failed': 1}


### PR DESCRIPTION
Fixes `itertools.chain` so that when an argument fails iter(), the chain is permanently exhausted (raising StopIteration afterwards, as CPython does) instead of silently skipping the bad argument and continuing into the next one

Expected behaviour (CPython):

```python
c = chain([1], 5, [2, 3])
next(c) 
next(c) # TypeError
next(c) # StopIteration
```

Fix - set `chain_mut(iter, vm).done = true` as we propagate the error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
End `itertools.chain` when an argument fails `iter()` and clear its sources when the chain ends, matching CPython. Previously the chain skipped the bad argument and continued; now it raises `TypeError` once and is then exhausted (`StopIteration`), and it releases its arguments so a spent chain does not pin them.

- Set the chain’s `done` latch in `into_py_iter_tracking` on `iter()` failure and call `finish` to take and drop `sources` and `current`; later arguments are never reached and subsequent `next()` calls return `StopIteration`.
- Preserve the asymmetry: if a resolved source’s `__next__` raises, the chain stays live and surfaces the same error on the next call.
- Add tests for both behaviors and for GC/refcount: a spent chain releases its arguments on both endings (draining the last source and `iter()` failure), including cycles.
- Refactor: introduce `chain_mut` to avoid repeated matches and `finish` to centralize chain teardown; no functional change beyond the new latch and releases.

<sup>Written for commit 085e73695cb988a4068a4941d13b950c73761e35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

