### PR TITLE
Propagate overlay directory listing errors

### DIFF
--- a/crates/monty-fs/src/overlay.rs
+++ b/crates/monty-fs/src/overlay.rs
@@ -1016,11 +1016,7 @@ fn iterdir(
 
     if let Some(host_dir) = host_dir_to_merge {
         let remaining = budget.shrink(transient_usage)?;
-        let names = match host_list_visible_dir_entry_names(ctx.mount_dir, &host_dir, vpath, remaining.halved()) {
-            Ok(names) => names,
-            Err(error @ MountError::MemoryUsageLimitExceeded(_)) => return Err(error),
-            Err(_) => Vec::new(),
-        };
+        let names = host_list_visible_dir_entry_names(ctx.mount_dir, &host_dir, vpath, remaining.halved())?;
         if !names.is_empty() {
             transient_usage = names.iter().fold(transient_usage, |usage, name| {
                 usage

--- a/crates/monty-fs/tests/mount_confinement.rs
+++ b/crates/monty-fs/tests/mount_confinement.rs
@@ -429,6 +429,7 @@ fn overlay_permission_errors_match_direct_mode() {
         mounts.mount("/mnt", dir.path(), mode, None).expect("failed to mount");
 
         for call in [
+            OsFunctionCall::Iterdir("/mnt/sub".into()),
             OsFunctionCall::ReadText("/mnt/sub/f.txt".into()),
             OsFunctionCall::Open(OpenCallArgs {
                 path: "/mnt/sub/f.txt".into(),


### PR DESCRIPTION
Overlay `iterdir` returned an empty list when the host directory listing failed.
Direct mounts return the mapped error, so permission, not-found, not-a-directory, and entry iteration failures could appear as an empty directory only in overlay mode.

Propagate the error returned by `host_list_visible_dir_entry_names`.
The helper's existing symlink filtering and memory accounting remain unchanged.

The existing direct and overlay permission parity test now covers `Iterdir`.

## Tests

- `cargo test -p monty-fs overlay_permission_errors_match_direct_mode`
- `cargo test -p monty-fs`
- `make format-rs`
- `make lint-rs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates host directory listing errors from overlay iterdir to match direct mounts. Previously overlay returned an empty list on host listing failure; now it returns the mapped error (permission, not-found, not-a-directory, iteration).

- Return the host error from host_list_visible_dir_entry_names; keep symlink filtering and memory accounting unchanged.
- Extend the `overlay_permission_errors_match_direct_mode` test to cover iterdir.
- Migration: callers that treated an empty list as success must handle iterdir errors in overlay mode.

<sup>Written for commit ee5078555177e4af906f6f321a1d7b9554aa448a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

