### PR TITLE
Drop map values on error paths

### DIFF
--- a/crates/monty/src/builtins/map.rs
+++ b/crates/monty/src/builtins/map.rs
@@ -7,7 +7,7 @@ use crate::{
     bytecode::VM,
     defer_drop, defer_drop_mut,
     exception_private::{ExcType, ExcTypeExt, RunResult},
-    heap::{DropWithContext, HeapData},
+    heap::{DropGuard, DropWithContext, HeapData},
     types::{List, iter::checked_preallocation_hint},
     value::Value,
 };
@@ -68,7 +68,8 @@ pub fn builtin_map(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
     // Validate and clamp the iterator's hint before reserving native memory.
     let hint = first_iter.iter_size_hint(vm);
     let capacity = checked_preallocation_hint(hint, mem::size_of::<Value>(), &vm.heap.tracker)?;
-    let mut out = Vec::with_capacity(capacity);
+    let out = Vec::with_capacity(capacity);
+    defer_drop_mut!(out, vm);
 
     // map function over iterables until the shortest iter is exhausted
     match extra_iterators.as_mut_slice() {
@@ -82,29 +83,30 @@ pub fn builtin_map(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
         // map(f, iter1, iter2)
         [single] => {
             while let Some(arg1) = first_iter.py_next(vm)? {
-                let Some(arg2) = single.py_next(vm)? else {
-                    arg1.drop_with(vm);
+                let mut arg1_guard = DropGuard::new(arg1, vm);
+                let Some(arg2) = single.py_next(arg1_guard.ctx())? else {
                     break;
                 };
+                let (arg1, vm) = arg1_guard.into_parts();
                 let args = ArgValues::Two(arg1, arg2);
                 out.push(vm.evaluate_function("map()", function, args)?);
             }
         }
         // map(f, iter1, iter2, *iterables)
         multiple => 'outer: loop {
-            let mut items = Vec::with_capacity(1 + multiple.len());
+            let items = Vec::with_capacity(1 + multiple.len());
+            defer_drop_mut!(items, vm);
 
             for result in iter::once(first_iter.py_next(vm)).chain(multiple.iter_mut().map(|iter| iter.py_next(vm))) {
                 if let Some(item) = result? {
                     items.push(item);
                 } else {
-                    items.drop_with(vm);
                     break 'outer;
                 }
             }
 
             let args = ArgValues::ArgsKargs {
-                args: items,
+                args: mem::take(items),
                 kwargs: KwargsValues::Empty,
             };
 
@@ -112,7 +114,7 @@ pub fn builtin_map(vm: &mut VM<'_>, args: ArgValues) -> RunResult<Value> {
         },
     }
 
-    let heap_id = vm.heap.allocate(HeapData::List(List::new(out)));
+    let heap_id = vm.heap.allocate(HeapData::List(List::new(mem::take(out))));
     Ok(Value::Ref(heap_id))
 }
 

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -267,15 +267,15 @@ result
 fn map_later_iterator_exhaustion_drops_current_arguments() {
     let code = r"
 def combine(a, b, c):
-    return (a, b, c)
+    return a[0] + b[0] + c[0]
 
-result = map(combine, [[1]], [[2]], [])
+result = map(combine, [[1], [4]], [[2], [5]], [[3]])
 result
 ";
     let run = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).expect("should parse");
     let output = run.run_ref_counts(vec![]).expect("should run");
 
-    assert_eq!(output.py_object, MontyObject::List(vec![]));
+    assert_eq!(output.py_object, MontyObject::List(vec![MontyObject::Int(6)]));
     assert_eq!(output.unreachable, Vec::<String>::new());
 }
 

--- a/crates/monty/tests/resource_limits.rs
+++ b/crates/monty/tests/resource_limits.rs
@@ -175,6 +175,110 @@ result
     );
 }
 
+/// `map()` must contextually drop earlier heap results when a later callback
+/// raises instead of leaking the native output vector.
+#[test]
+#[cfg(feature = "ref-count-return")]
+fn map_callback_error_drops_prior_heap_results() {
+    let code = r"
+def build(value):
+    if value == 2:
+        raise ValueError('stop')
+    return [value]
+
+try:
+    map(build, [1, 2])
+except ValueError:
+    pass
+
+result = 'done'
+result
+";
+    let run = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).expect("should parse");
+    let output = run.run_ref_counts(vec![]).expect("should run");
+
+    assert_eq!(output.unreachable, Vec::<String>::new());
+}
+
+/// The two-iterable fast path owns the first argument while advancing the
+/// second iterator. If that iterator raises, the first value must be dropped.
+#[test]
+#[cfg(feature = "ref-count-return")]
+fn map_second_iterator_error_drops_current_argument() {
+    let code = r"
+class RaisingIterator:
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        raise ValueError('stop')
+
+def combine(a, b):
+    return (a, b)
+
+try:
+    map(combine, [[1]], RaisingIterator())
+except ValueError:
+    pass
+
+result = 'done'
+result
+";
+    let run = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).expect("should parse");
+    let output = run.run_ref_counts(vec![]).expect("should run");
+
+    assert_eq!(output.unreachable, Vec::<String>::new());
+}
+
+/// The generic multi-iterable path accumulates arguments in a native vector.
+/// A later iterator error must drop every value already collected for the call.
+#[test]
+#[cfg(feature = "ref-count-return")]
+fn map_later_iterator_error_drops_current_arguments() {
+    let code = r"
+class RaisingIterator:
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        raise ValueError('stop')
+
+def combine(a, b, c):
+    return (a, b, c)
+
+try:
+    map(combine, [[1]], [[2]], RaisingIterator())
+except ValueError:
+    pass
+
+result = 'done'
+result
+";
+    let run = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).expect("should parse");
+    let output = run.run_ref_counts(vec![]).expect("should run");
+
+    assert_eq!(output.unreachable, Vec::<String>::new());
+}
+
+/// The generic multi-iterable path must also drop arguments already collected
+/// for a call when a later iterator is exhausted normally.
+#[test]
+#[cfg(feature = "ref-count-return")]
+fn map_later_iterator_exhaustion_drops_current_arguments() {
+    let code = r"
+def combine(a, b, c):
+    return (a, b, c)
+
+result = map(combine, [[1]], [[2]], [])
+result
+";
+    let run = MontyRun::new(code.to_owned(), "test.py", vec![], CompileOptions::default()).expect("should parse");
+    let output = run.run_ref_counts(vec![]).expect("should run");
+
+    assert_eq!(output.py_object, MontyObject::List(vec![]));
+    assert_eq!(output.unreachable, Vec::<String>::new());
+}
+
 /// Test that GC properly collects self-referencing list cycles.
 ///
 /// Each iteration's `a.append(a)` produces a self-referencing list; the next


### PR DESCRIPTION
## Summary

`map()` accumulated heap-owned values in native vectors without contextual cleanup. If a later iterator or callback returned an error, those values could remain unreachable instead of being decremented.

Guard the partial output and per-call argument vectors so error and shortest-iterator paths drop owned values exactly once. The two-iterator fast path also guards its first argument while advancing the second iterator. Successful `map()` results are unchanged.

## Tests

- `cargo test -p monty --test resource_limits --features ref-count-return,memory-model-checks map_`
- `cargo +nightly fmt --all -- --check`
- `make lint-rs`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `map()` from leaking heap-owned values when a callback or any iterator errors, or when the shortest iterator ends. Previously, partially accumulated outputs and per-call arguments could become unreachable without decref; now they are dropped exactly once. Successful results are unchanged.

- Guard the output vector and per-call argument vector with `defer_drop_mut!`; move them with `mem::take` only on success.
- In the two-iterator path, wrap the first argument in `DropGuard` while advancing the second iterator to ensure cleanup if it errors or exhausts.
- Add regressions for callback failure, iterator failure, and shortest-iterator exhaustion, and cover a successful three-iterator call before exhaustion to verify argument transfer and result correctness.

<sup>Written for commit 5dba24d8c38b6ff6325febf0023b7ca32f53bbc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

