### PR TITLE
fix(dict): raise 'dictionary changed size during iteration' on last-element mutation

### DIFF
--- a/crates/monty/src/types/dict.rs
+++ b/crates/monty/src/types/dict.rs
@@ -1846,15 +1846,32 @@ struct DictIteratorState {
     dict: HeapId,
     index: usize,
     expected_len: usize,
+    /// Set once a `next` call has reached the end. Mirrors CPython clearing
+    /// `di_dict`: an already-exhausted iterator returns `StopIteration` on every
+    /// further call and never re-checks the size, even if the dict was mutated
+    /// after exhaustion. Defaulted for backward-compatible snapshot decode.
+    #[serde(default)]
+    exhausted: bool,
 }
 
 impl DictIteratorState {
     /// Validates mutation and returns the next storage index.
+    ///
+    /// Matches CPython's `dictiterobject`: the size-change guard fires only while
+    /// the iterator is still live, and it is checked *before* exhaustion so a
+    /// mutation on the final element still raises on the terminating `next()`
+    /// (the case a plain `index >= expected_len` check first would mask). Once a
+    /// call has reached the end, `exhausted` makes every later call a plain
+    /// `StopIteration` with no size check — mutating the dict after the iterator
+    /// is spent is not an error.
     fn next_index(&mut self, current_len: usize) -> RunResult<Option<usize>> {
-        if self.index >= self.expected_len {
+        if self.exhausted {
             Ok(None)
         } else if current_len != self.expected_len {
             Err(ExcType::runtime_error_dict_changed_size())
+        } else if self.index >= self.expected_len {
+            self.exhausted = true;
+            Ok(None)
         } else {
             let index = self.index;
             self.index += 1;
@@ -1889,6 +1906,7 @@ macro_rules! impl_dict_iterator {
                     dict,
                     index: 0,
                     expected_len,
+                    exhausted: false,
                 })));
                 vm.heap.inc_ref(dict);
                 Value::Ref(id)

--- a/crates/monty/test_cases/iter__dict_mutation_last_element.py
+++ b/crates/monty/test_cases/iter__dict_mutation_last_element.py
@@ -1,0 +1,53 @@
+# Mutating a dict during iteration must raise even when the size change lands on
+# the LAST element yielded: the terminating step still checks the size guard.
+# Regression for DictIteratorState::next_index, which checked exhaustion before
+# the size change and so missed the terminal step for keys/items/values/pop alike.
+
+# === for k in d: insert on the last key ===
+try:
+    d = {'a': 1, 'b': 2}
+    for k in d:
+        if k == 'b':
+            d['z'] = 9
+    assert False, 'expected RuntimeError'
+except RuntimeError as exc:
+    assert str(exc) == 'dictionary changed size during iteration'
+
+# === d.items(): insert on the last pair ===
+try:
+    d = {'a': 1, 'b': 2}
+    for k, v in d.items():
+        if k == 'b':
+            d['z'] = 9
+    assert False, 'expected RuntimeError'
+except RuntimeError as exc:
+    assert str(exc) == 'dictionary changed size during iteration'
+
+# === d.values(): insert on the last value ===
+try:
+    d = {'a': 1, 'b': 2}
+    for v in d.values():
+        if v == 2:
+            d['z'] = 9
+    assert False, 'expected RuntimeError'
+except RuntimeError as exc:
+    assert str(exc) == 'dictionary changed size during iteration'
+
+# === delete (pop) on the last key ===
+try:
+    d = {'a': 1, 'b': 2}
+    for k in d:
+        if k == 'b':
+            d.pop('a')
+    assert False, 'expected RuntimeError'
+except RuntimeError as exc:
+    assert str(exc) == 'dictionary changed size during iteration'
+
+# === single-element dict: the only element is also the last ===
+try:
+    d = {'a': 1}
+    for k in d:
+        d['z'] = 9
+    assert False, 'expected RuntimeError'
+except RuntimeError as exc:
+    assert str(exc) == 'dictionary changed size during iteration'


### PR DESCRIPTION
## Summary

Mutating a dict during iteration raises `RuntimeError: dictionary changed size during iteration`, matching CPython — **except when the size change lands on the final element yielded**, where Monty silently finishes the loop. CPython raises. Sets and lists are correct; only dict iteration is affected, and it affects `keys()`, `items()`, `values()` and deletion (`pop`) alike, since they share `DictIteratorState`.

```python
d = {'a': 1, 'b': 2}
for k in d:
    if k == 'b':        # mutate while on the LAST key
        d['z'] = 9
# CPython: RuntimeError: dictionary changed size during iteration
# Monty before this PR: falls through, prints nothing / len(d) == 3
```

This contradicts `limitations/collections.md` and `limitations/builtins.md`, which both state a plain `for x in d` loop "detect[s] mutation exactly as CPython does". With this fix that becomes true.

## Root cause

`DictIteratorState::next_index` (`crates/monty/src/types/dict.rs`) checked exhaustion **before** the size-change guard, so on the terminating step (`index == expected_len`) it returned `Ok(None)` before the guard ran. `SetIter::next` and the internal `DictIter::advance` both check the size first, which is why sets and internal iteration are unaffected.

Swapping the two checks alone would over-correct: an *already-exhausted* iterator, mutated and stepped again, would then wrongly raise where CPython returns `StopIteration` (CPython clears `di_dict` on exhaustion and skips the guard thereafter — see the case in `dict__views.py`). The fix adds a sticky `exhausted` flag mirroring that, so the guard applies only while the iterator is live.

## Tests

- New `crates/monty/test_cases/iter__dict_mutation_last_element.py`: last-element mutation for `keys`/`items`/`values`/`pop` and a single-element dict.
- Existing `iter__dict_mutation.py` (first-element) and `dict__views.py` (exhausted-then-mutate) continue to pass.

No Monty-side regressions in the full `test_cases` suite.

## Cross-environment verification

Reproduced on both macOS (host, arm64) and Linux (Docker `rust:1-bookworm`, aarch64) by running the same repro through the built `monty` binary before and after the fix:

| Environment | Pre-fix | Post-fix |
| --- | --- | --- |
| host (macOS, arm64) | BUG — no error, mutation on last element missed | FIXED — RuntimeError raised |
| docker (Linux, aarch64) | BUG — no error, mutation on last element missed | FIXED — RuntimeError raised |

The behaviour is identical across both, so the bug is deterministic interpreter logic, not a host-specific artifact.
