### PR TITLE
Stop wasm type-check feeds serving stale Salsa results

### DIFF
--- a/crates/monty-js/__test__/wasm_type_check.spec.ts
+++ b/crates/monty-js/__test__/wasm_type_check.spec.ts
@@ -1,0 +1,73 @@
+// Type checking across feeds in the wasm worker, driven in Node so it needs no
+// browser.
+//
+// A feed whose check fails writes its source file twice, and wasm's clock is
+// only millisecond-granular, so the second write used to be invisible to Salsa
+// and the next feed reused the stale result.
+
+import { test } from 'vitest'
+
+// everything comes from `/wasm`, which re-exports the error classes: importing
+// them from `@pydantic/monty` would pull in the napi loader, and this suite
+// runs where only the wasm module has been built
+import { Monty, MontyTypingError } from '@pydantic/monty/wasm'
+
+import { t } from './assertions.js'
+import { skipIfBrowser } from './env.js'
+
+// a single pass only sometimes lands both writes in one millisecond
+const ATTEMPTS = 15
+
+test('a feed after a failed type check leaves the worker alive', async (ctx) => {
+  skipIfBrowser(ctx)
+  const pool = await Monty.create()
+  for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
+    const session = await pool.checkout({ typeCheck: true })
+    await session.feedRun('x = 1')
+
+    // the message is the first diagnostic, here the narrowed reassignment
+    const error = await t.throwsAsync(() => session.feedRun('x = 2\n"hello" + 1'), {
+      instanceOf: MontyTypingError,
+    })
+    t.is(
+      error.message,
+      'TypeError: error[invalid-assignment]: Object of type `Literal[2]` is not assignable to `Literal[1]`',
+    )
+
+    // the rejected snippet left neither a binding nor a stale type-check file
+    t.is(await session.feedRun('x'), 1)
+    await session.close()
+  }
+  await pool.close()
+})
+
+test('a repeated failing feed reports the same diagnostic every time', async (ctx) => {
+  skipIfBrowser(ctx)
+  const pool = await Monty.create()
+  const session = await pool.checkout({ typeCheck: true })
+  await session.feedRun('x = 1')
+  for (let attempt = 0; attempt < ATTEMPTS; attempt++) {
+    // rendering reads the db text back, so a stale file misquotes the source
+    const error = await t.throwsAsync(() => session.feedRun('"hello" + 1'), {
+      instanceOf: MontyTypingError,
+    })
+    t.is(
+      error.display(),
+      [
+        'error[unsupported-operator]: Unsupported `+` operation',
+        ' --> main.py:1:1',
+        '  |',
+        '1 | "hello" + 1',
+        '  | -------^^^-',
+        '  | |         |',
+        '  | |         Has type `Literal[1]`',
+        '  | Has type `Literal["hello"]`',
+        '  |',
+        '',
+        '',
+      ].join('\n'),
+    )
+  }
+  await session.close()
+  await pool.close()
+})

--- a/crates/monty-type-checking/src/type_check.rs
+++ b/crates/monty-type-checking/src/type_check.rs
@@ -2,14 +2,17 @@ use std::{fmt, io::ErrorKind, mem};
 
 use monty_types::{TypeCheckingConfig, TypeCheckingFormat};
 use ruff_db::{
+    Db as _,
     diagnostic::{
         Annotation, Diagnostic, DiagnosticFormat, DiagnosticId, DisplayDiagnosticConfig, DisplayDiagnostics,
         UnifiedFile,
     },
+    file_revision::FileRevision,
     files::{File, system_path_to_file},
-    system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPathBuf},
+    system::{DbWithTestSystem, DbWithWritableSystem as _, SystemPath, SystemPathBuf},
 };
 use ruff_text_size::{TextRange, TextSize};
+use salsa::Setter as _;
 use ty_python_semantic::check_file_unwrap;
 
 use crate::db::{MemoryDb, SRC_ROOT};
@@ -96,15 +99,16 @@ impl TypeChecker {
             // and then adjust each span in the error message to account for the injected stubs import
             if code_offset > 0 {
                 let offset = TextSize::new(code_offset);
+                let source_len = TextSize::try_from(main_source.len()).map_err(to_string)?;
                 for diagnostic in &mut diagnostics {
                     // Adjust spans in main diagnostic annotations (only for spans in the main file)
                     for ann in diagnostic.annotations_mut() {
-                        adjust_annotation_span(ann, main_file, offset);
+                        adjust_annotation_span(ann, main_file, offset, source_len);
                     }
                     // Adjust spans in sub-diagnostic annotations (e.g., "info: Function defined here")
                     for sub in diagnostic.sub_diagnostics_mut() {
                         for ann in sub.annotations_mut() {
-                            adjust_annotation_span(ann, main_file, offset);
+                            adjust_annotation_span(ann, main_file, offset, source_len);
                         }
                     }
                 }
@@ -127,6 +131,7 @@ impl TypeChecker {
     /// so the tracking list must not grow with the number of feeds.
     fn write_root_file(&mut self, path: &SystemPathBuf, source: &str) -> Result<File, String> {
         self.db.write_file(path, source).map_err(to_string)?;
+        self.bump_revisions(path);
 
         // The write above succeeded, so interning the path must succeed — otherwise the
         // file would live in the db but be untracked, poisoning cleanup, hence the panic.
@@ -150,7 +155,31 @@ impl TypeChecker {
             self.touched_files.iter().any(|t| &t.path == path),
             "rewrite_root_file called for untracked path '{path}' — must call write_root_file first",
         );
-        self.db.write_file(path, source).map_err(to_string)
+        self.db.write_file(path, source).map_err(to_string)?;
+        self.bump_revisions(path);
+        Ok(())
+    }
+
+    /// Force a fresh Salsa revision for `path` and its ancestor directories.
+    ///
+    /// `write_file` derives the revision from an mtime, and wasm's clock only
+    /// ticks once a millisecond, so two writes to one path can share a revision
+    /// and the second becomes invisible. Directories need it too — module
+    /// resolution keys off them, so stubs recreated after [`Self::reset`] would
+    /// stay unresolvable.
+    fn bump_revisions(&mut self, path: &SystemPath) {
+        let mut files = Vec::new();
+        let mut current = Some(path);
+        while let Some(path) = current {
+            if let Some(file) = self.db.files().try_system(&self.db, path) {
+                files.push(file);
+            }
+            current = path.parent();
+        }
+        for file in files {
+            let next = FileRevision::new(file.revision(&self.db).as_u128() + 1);
+            file.set_revision(&mut self.db).to(next);
+        }
     }
 
     /// Remove every file written since the last reset and sync the filesystem
@@ -180,14 +209,19 @@ impl TypeChecker {
 /// This is used when we inject a stub import at the beginning of the source code,
 /// and need to adjust all spans to account for the injected code.
 /// Only adjusts spans that belong to the main file being type-checked.
-fn adjust_annotation_span(ann: &mut Annotation, main_file: File, offset: TextSize) {
+///
+/// The result is clamped into the source: `TextSize` is a `u32`, so a span
+/// inside the injected import would wrap and panic the renderer, killing the
+/// session.
+fn adjust_annotation_span(ann: &mut Annotation, main_file: File, offset: TextSize, source_len: TextSize) {
     let span = ann.get_span();
     // Only adjust spans for the main file (not stubs or other files)
     if let UnifiedFile::Ty(span_file) = span.file()
         && *span_file == main_file
         && let Some(range) = span.range()
     {
-        let new_range = TextRange::new(range.start() - offset, range.end() - offset);
+        let shift = |position: TextSize| position.checked_sub(offset).unwrap_or_default().min(source_len);
+        let new_range = TextRange::new(shift(range.start()), shift(range.end()));
         let new_span = span.clone().with_range(new_range);
         ann.set_span(new_span);
     }


### PR DESCRIPTION
`type_check.spec.ts > "failing snippet does not execute and session survives"` fails intermittently because Salsa treats a file as unchanged when its modified time is unchanged, and wasm's clock only ticks once a millisecond. So with two writes to the same file in a millisecond Salsa does not detect the change.

Observed in CI:

| Date | Branch | Run |
| --- | --- | --- |
| 2026-08-13 | `host-memory-probe` | [31736318169](https://github.com/pydantic/monty/actions/runs/31736318169) |
| 2026-08-14 | `fix-chain-source-latch` ([#748](https://github.com/pydantic/monty/pull/748)) | [31837343813](https://github.com/pydantic/monty/actions/runs/31837343813) |

https://github.com/pydantic/monty/blob/edeb82a6d2594410010cdb319419289decbf3399/crates/monty-js/__test__/type_check.spec.ts#L161

Changes:

- `bump_revisions` is to bump Salsa revisions explicitly on write instead of relying on modified times
- `adjust_annotation_span` is a defensive clamp if invalid to prevent crash


🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents wasm type-check feeds from reusing stale Salsa results and crashing by explicitly bumping file and directory revisions and clamping diagnostic spans to the source. Previously, consecutive writes could share an mtime-based revision in wasm, causing stale checks and `TextSize` wrap that killed the worker; now each write produces a fresh revision and span math is safe.

- `TypeChecker::{write_root_file,rewrite_root_file}` call `bump_revisions` after `write_file`.
- `bump_revisions` walks ancestor directories and sets the next `FileRevision` via `salsa::Setter`, avoiding mtime reliance and fixing stub re-resolution after `reset`.
- `adjust_annotation_span` takes `source_len` and clamps with `checked_sub`/`min` to prevent wrap on injected import offsets.
- Adds `crates/monty-js/__test__/wasm_type_check.spec.ts` to verify session survivability and consistent diagnostics across repeated failures using `@pydantic/monty/wasm`.

<sup>Written for commit 38ec51eec72fa797176b68c3b2231731f5ed6974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

