### PR TITLE
Clarify server quickstart

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -37,15 +37,6 @@ mechanism as self-hosted Logfire images, which live on the same registry host):
 docker login us-docker.pkg.dev -u _json_key --password-stdin < key.json
 ```
 
-On Kubernetes, the same file becomes an image pull secret referenced from the pod spec:
-
-```bash
-kubectl create secret docker-registry monty-image-key \
-  --docker-server=us-docker.pkg.dev \
-  --docker-username=_json_key \
-  --docker-password="$(cat key.json)"
-```
-
 The image refuses to start without a dump-signing key of at least 16 bytes:
 
 ```bash
@@ -55,21 +46,81 @@ docker run --rm \
   us-docker.pkg.dev/pydantic-public-registries/monty/monty-server:latest
 ```
 
-The bound URL (`ws://0.0.0.0:8000/`) is the only line written to stdout; all logging goes to stderr.
-The image bundles the matching `monty` worker binary and runs as non-root uid 65532 on a `scratch` base — no shell, no
-package manager.
+The image currently only has a `linux/amd64` manifest. On an Apple Silicon Mac or another ARM64 host, run it through
+Docker's amd64 emulation by adding `--platform=linux/amd64`:
 
-## Connecting a client
-
-```python
-from pydantic_monty import AsyncMontyWebsocket
-
-async with AsyncMontyWebsocket('ws://localhost:8000/') as pool:
-    async with pool.checkout() as session:
-        result = await session.feed_run('1 + 1')
+```bash
+docker run --rm \
+  --platform=linux/amd64 \
+  -e MONTY_SERVER_DUMP_KEY="$(openssl rand -hex 16)" \
+  -p 8000:8000 \
+  us-docker.pkg.dev/pydantic-public-registries/monty/monty-server:latest
 ```
 
-An ordinary `GET /` on the same URL answers with a short info page.
+Native ARM64 images are planned. Until they are available, omitting `--platform=linux/amd64` on an ARM64 host fails
+with `no matching manifest for linux/arm64/v8`.
+
+When the server is ready, it prints its bound URL to stdout:
+
+```text
+ws://0.0.0.0:8000/
+```
+
+In another terminal, create a Python client project and add `pydantic-monty`:
+
+```bash
+mkdir monty-server-quickstart
+cd monty-server-quickstart
+uv init --bare
+uv add pydantic-monty
+```
+
+Create `client.py`:
+
+```python
+import asyncio
+
+from pydantic_monty import AsyncMontyWebsocket
+
+
+async def main() -> None:
+    async with AsyncMontyWebsocket('ws://localhost:8000/') as pool:
+        async with pool.checkout() as session:
+            result = await session.feed_run('1 + 1')
+            print(result)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())
+```
+
+Run the client:
+
+```bash
+uv run client.py
+```
+
+It should print:
+
+```text
+2
+```
+
+An ordinary `GET /` on the server URL answers with a short info page.
+
+The image bundles the matching `monty` worker binary and runs as non-root uid 65532 on a `scratch` base — no shell, no
+package manager. The bound URL is the only line written to stdout; all logging goes to stderr.
+
+### Kubernetes
+
+On Kubernetes, `key.json` becomes an image pull secret referenced from the pod spec:
+
+```bash
+kubectl create secret docker-registry monty-image-key \
+  --docker-server=us-docker.pkg.dev \
+  --docker-username=_json_key \
+  --docker-password="$(cat key.json)"
+```
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

- document the `linux/amd64` emulation flag required on Apple Silicon and other ARM64 hosts until native images are available
- turn the Python client fragment into a complete executable example
- show how to create a `uv` project and install `pydantic-monty`
- document the server-ready message and expected client output
- keep the Kubernetes image-pull instructions after the local verification path

## Why

The published image currently has no ARM64 manifest, so the existing `docker run` command fails on ARM64 hosts with `no matching manifest for linux/arm64/v8`. The existing Python fragment also uses `async with` at module scope, does not install its dependency, and does not display its result, so it cannot be copied and run as written.

## Validation

- `uv run prek --files docs/server.md`
- started the amd64 image with Docker emulation on Apple Silicon and observed `ws://0.0.0.0:8000/`
- created a clean `uv` project, installed `pydantic-monty`, and ran the documented client against the container
- confirmed the client prints `2`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the server quickstart so users can run the container on ARM64 hosts and copy-paste a working Python client. Adds an end-to-end local verification path before Kubernetes to reduce setup failures.

- ARM64 users must pass `--platform=linux/amd64` when running the image; omitting it currently fails with “no matching manifest for linux/arm64/v8.”
- Shows a complete `docker run` command with a valid `MONTY_SERVER_DUMP_KEY` and explains startup output (bound URL on stdout; logs on stderr).
- Provides a runnable `uv` client flow: initialize a project, `uv add pydantic-monty`, and a full `client.py` using `AsyncMontyWebsocket` that prints `2`.
- Keeps Kubernetes image-pull secret steps in a separate section following the local verification path.

<sup>Written for commit a9df3db170fd3c121d5002dc152bfb9d84d7ca8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

