### PR TITLE
Clarify server operations documentation

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -125,58 +125,127 @@ kubectl create secret docker-registry monty-image-key \
 ## Configuration
 
 Every flag has an environment variable: the flag name in upper snake case with a `MONTY_SERVER_` prefix
-(`--max-sessions` → `MONTY_SERVER_MAX_SESSIONS`), except `MONTY_BIN` and `LOGFIRE_TOKEN`, which keep their established
-names.
+(`--max-sessions` → `MONTY_SERVER_MAX_SESSIONS`), except `--monty-bin` and `--logfire-token`, which use `MONTY_BIN` and
+`LOGFIRE_TOKEN` respectively.
 A flag on the command line wins over its variable.
-Flags passed to `docker run <image> ...` replace the default `CMD` (`--host 0.0.0.0`) wholesale, so include `--host
-0.0.0.0` when passing your own.
-Bind to an IP literal, not a hostname — the `scratch` image has no name resolution.
 
-The flags an operator usually sets first:
+The server binary defaults to `--host 127.0.0.1`, but the image's default `CMD` supplies `--host 0.0.0.0` so a published
+Docker port is reachable. Arguments after the image name in `docker run <image> ...` replace that `CMD` wholesale, so
+include `--host 0.0.0.0` when passing any flags. Hostnames are accepted, but `--host localhost` resolves to the
+container's loopback interface and is not reachable through `-p 8000:8000`.
 
-| Flag                            | Meaning                                        | Default     |
-| ------------------------------- | ---------------------------------------------- | ----------- |
-| `--host` / `--port`             | bind address; port 0 binds ephemeral           | 8000        |
-| `--max-sessions`                | concurrent sessions across the server          | 64          |
-| `--max-sessions-per-client`     | concurrent sessions per caller; 0 disables     | 10          |
-| `--turn-timeout <secs>`         | wall-clock cap on a single turn                | 300         |
-| `--idle-timeout <secs>`         | cap on the gap between requests                | 60          |
-| `--session-timeout <secs>`      | cap on total session lifetime                  | 3600        |
-| `--max-duration <secs>`         | sandbox execution time within a session        | 60          |
-| `--max-memory-mib <MiB>`        | per-session memory ceiling                     | 64          |
-| `--max-recursion-depth <n>`     | per-session call-stack ceiling                 | 1000        |
-| `--dump-key <key>`              | required; signs session dumps                  | —           |
-| `--logfire-token <token>`       | export traces to Logfire                       | off         |
+| Flag                                | Meaning                                                                  | Default                                    |
+| ----------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------ |
+| `--host <address>`                  | interface to bind                                                        | image: `0.0.0.0`; binary: `127.0.0.1`      |
+| `--port <port>`                     | port to bind; 0 selects an ephemeral port                                | 8000                                       |
+| `--monty-bin <path>`                | worker binary                                                            | image: `/usr/local/bin/monty`               |
+| `--max-sessions <n>`                | concurrent sessions across the server                                    | 64                                         |
+| `--max-sessions-per-client <n>`     | concurrent sessions per caller; 0 disables                              | 10                                         |
+| `--idle-timeout <seconds>`          | maximum gap between requests; 0 disables                                 | 60                                         |
+| `--keepalive <seconds>`             | WebSocket ping interval for detecting vanished clients; 0 disables       | 5                                          |
+| `--session-timeout <seconds>`       | maximum total session lifetime; 0 disables                               | 3600                                       |
+| `--turn-timeout <seconds>`          | wall-clock cap on one request; 0 disables                                | 300                                        |
+| `--drain-grace <seconds>`           | time after SIGTERM for existing sessions to collect a dump               | 30                                         |
+| `--max-memory-mib <MiB>`            | per-session memory ceiling; 0 disables                                   | 64                                         |
+| `--max-duration <seconds>`          | cumulative sandbox execution time per session; 0 disables                | 60                                         |
+| `--max-recursion-depth <n>`         | per-session call-stack ceiling                                           | 1000                                       |
+| `--trust-forwarded-for`             | use the last `X-Forwarded-For` entry as the caller identity               | off                                        |
+| `--dump-key <key>`                  | required key of at least 16 bytes for signing session dumps              | —                                          |
+| `--logfire-token <token>`           | export traces to Logfire                                                 | off                                        |
 
-Run `--help` for the full list.
-Prefer environment variables for `--dump-key` and `--logfire-token`: a command line is world-readable via `ps`.
+When the global session limit is full, a new WebSocket upgrade gets `503 Service Unavailable`; exceeding the
+per-client limit gets `429 Too Many Requests`.
 
-Each of the three resource limits is a ceiling.
-A client that configures no value gets the server's; a client that asks for more is clamped to it; asking for less
-always works.
-The worker enforces the clamped value, so a `MemoryError` or duration error quotes the effective limit.
+Run the image's `--help` for the authoritative list for the version you pulled:
+
+```bash
+docker run --rm \
+  --platform=linux/amd64 \
+  us-docker.pkg.dev/pydantic-public-registries/monty/monty-server:latest \
+  --help
+```
+
+Prefer environment variables for container configuration so the image's `CMD` remains intact. Always use environment
+variables for `--dump-key` and `--logfire-token`: a command line is world-readable via `ps` and commonly lands in shell
+history.
+
+### Resource limits
+
+The server's three sandbox resource limits are ceilings. A client that configures no value gets the server's limit; a
+client that asks for more is clamped to it; asking for less always works.
+
+The server flags and Python client keys use different names and, for memory, different units:
+
+| Server flag                       | `pool.checkout(limits=...)` key | Unit    |
+| --------------------------------- | ------------------------------- | ------- |
+| `--max-duration <seconds>`        | `max_duration_secs`             | seconds |
+| `--max-memory-mib <MiB>`          | `max_memory`                    | bytes   |
+| `--max-recursion-depth <n>`       | `max_recursion_depth`           | count   |
+
+For example, this asks for 30 seconds, 32 MiB and a recursion depth of 500; the server may lower any value to its own
+ceiling:
+
+```python
+import asyncio
+
+from pydantic_monty import AsyncMontyWebsocket
+
+
+async def main() -> None:
+    async with AsyncMontyWebsocket('ws://localhost:8000/') as pool:
+        async with pool.checkout(
+            limits={
+                'max_duration_secs': 30,
+                'max_memory': 32 * 1024 * 1024,
+                'max_recursion_depth': 500,
+            },
+        ) as session:
+            result = await session.feed_run('1 + 1')
+            print(result)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())
+```
+
+Save this as `limits_client.py` and run `uv run limits_client.py`; with the default server configuration, it prints
+`2`.
+
+`--max-duration` counts cumulative interpreter execution across the session and excludes time suspended waiting for
+the client. `--turn-timeout` is instead wall-clock time for one complete request, including time waiting for a client
+callback. Keep the server's turn timeout above the clients' `request_timeout` so the client watchdog can report a more
+specific failure first. A keepalive ping that goes unanswered for one further `--keepalive` interval ends the session;
+keep that interval below half of `--idle-timeout` if keepalive should detect a vanished client first.
+
+The worker enforces the effective limits. Memory and duration errors include the effective byte or time ceiling in
+their messages.
 
 ## Sizing the container
 
-Each worker's process memory is capped at roughly `--max-memory-mib` + a small baseline + headroom (4 MiB, or 32 MiB
-with type checking), so:
+Workers are created on demand for active connections and exit when their sessions close; `--max-sessions` is a capacity
+limit, not a number of preallocated workers. Each worker's process memory is capped at roughly `--max-memory-mib` plus a
+small baseline and headroom (4 MiB, or 32 MiB with type checking), so a peak-capacity planning estimate is:
 
 ```
-container memory ≈ --max-sessions × (--max-memory-mib + baseline + headroom)
+peak container memory ≈ --max-sessions × (--max-memory-mib + baseline + headroom) + server overhead
 ```
 
-The defaults (64 sessions × 64 MiB) reach several GiB.
-Lower one of the two to fit your instance.
+At full utilization, the defaults (64 sessions × 64 MiB) reach several GiB. Lower `--max-sessions` or
+`--max-memory-mib` to fit your instance.
 
 ## Health probes and drain
 
-`GET /health` answers 200 normally and 503 from the moment drain begins, so point your readiness probe there.
-Point liveness at `GET /`, which answers regardless of drain — a readiness probe on `/` would keep a draining pod in
-rotation, and a liveness probe on `/health` would restart one that is shutting down cleanly.
+While the server is accepting traffic, `GET /health` returns an empty 200 response and `GET /` returns a 200 info page.
+Use `/health` for readiness and `/` for liveness.
 
-On SIGTERM the server drains: each session's next request is answered with a signed dump the client can restore into a
-fresh session on another replica (`MontyShutdown` in `pydantic_monty`).
-Sessions still silent after `--drain-grace` (default 30s) are dropped.
+On SIGTERM, the server stops listening immediately, so new HTTP and WebSocket connections are refused rather than
+receiving a 503 response. Existing WebSocket sessions remain connected while the server drains. Each existing session's
+next request raises `pydantic_monty.MontyShutdown`; that request did not run, so it is safe to retry. Its `dump` contains
+the signed session state when state exists and dumping succeeds. Restore an idle dump on a fresh session with
+`await session.load_session(exc.dump)` before retrying the request; a dump captured while a feed is suspended instead
+uses `await session.load_snapshot(exc.dump, ...)`.
+
+Sessions that remain silent through `--drain-grace` (default 30s) are dropped without a dump.
 Set the pod's `terminationGracePeriodSeconds` above `--drain-grace`, and use the same `MONTY_SERVER_DUMP_KEY` on every
 replica — a dump signed by one replica must verify on the one the client reconnects to.
 Dumps only load into a worker of the same Monty version, so roll clients and servers together.
@@ -184,7 +253,7 @@ Dumps only load into a worker of the same Monty version, so roll clients and ser
 ## Tracing
 
 Pass `--logfire-token` (or set `LOGFIRE_TOKEN`) to export traces to [Pydantic Logfire](https://pydantic.dev/logfire).
-Without a token the server behaves identically and logs to stderr only.
+Without a token the server behaves identically and emits its console traces and logs to stderr only.
 
 The server records one span per connection, and beneath it the same session, run and host-call spans every monty client
 emits — a dashboard built against any monty client works here.
@@ -199,5 +268,7 @@ Point the token only at a backend those callers may be exposed to.
 
 There is no authentication and the listener speaks plain `ws://`.
 Terminate TLS at an ingress or load balancer and keep the listener on a private network.
-Behind a proxy you control, set `--trust-forwarded-for` so per-caller limits key on `X-Forwarded-For` rather than the
-proxy's address; never set it on a directly exposed listener, where callers write the header themselves.
+By default, `--max-sessions-per-client` identifies a caller by the direct peer IP. A proxy or NAT can therefore make
+many callers share one quota. Behind a proxy you control, set `--trust-forwarded-for` to identify callers by the last
+`X-Forwarded-For` entry instead. Configure that proxy to sanitize the header, and never enable this flag on a directly
+exposed listener, where callers can forge a fresh identity per connection and bypass the quota.

--- a/docs/server.md
+++ b/docs/server.md
@@ -264,8 +264,8 @@ emits — a dashboard built against any monty client works here.
 Policy outcomes (capacity rejections, timeouts, drain) are logged as events on the connection span, one line each naming
 the limit that fired.
 
-Traces carry caller data — the code fed to each session, call arguments, results and print output — with no flag to turn
-that off.
+Traces carry caller data — WebSocket handshake request headers, the code fed to each session, call arguments, results
+and print output — with no flag to turn that off.
 Point the token only at a backend those callers may be exposed to.
 
 ## Security

--- a/docs/server.md
+++ b/docs/server.md
@@ -147,7 +147,7 @@ container's loopback interface and is not reachable through `-p 8000:8000`.
 | `--drain-grace <seconds>`           | time after SIGTERM for existing sessions to collect a dump               | 30                                         |
 | `--max-memory-mib <MiB>`            | per-session memory ceiling; 0 disables                                   | 64                                         |
 | `--max-duration <seconds>`          | cumulative sandbox execution time per session; 0 disables                | 60                                         |
-| `--max-recursion-depth <n>`         | per-session call-stack ceiling                                           | 1000                                       |
+| `--max-recursion-depth <n>`         | per-session call-stack ceiling; cannot be disabled                       | 1000                                       |
 | `--trust-forwarded-for`             | use the last `X-Forwarded-For` entry as the caller identity               | off                                        |
 | `--dump-key <key>`                  | required key of at least 16 bytes for signing session dumps              | none (required)                            |
 | `--logfire-token <token>`           | export traces to Logfire                                                 | off                                        |
@@ -170,7 +170,8 @@ Prefer environment variables for container configuration so the image's `CMD` re
 ### Resource limits
 
 The server's three sandbox resource limits are ceilings. If a client omits a limit, the server limit applies. A higher
-value is clamped to the server limit. A lower value is accepted and becomes the effective ceiling.
+value is clamped to the server limit. A lower value is accepted and becomes the effective ceiling. Duration and memory
+limits can be disabled, but recursion depth is always bounded.
 
 The server flags and Python client keys use different names and, for memory, different units:
 
@@ -223,15 +224,20 @@ their messages.
 ## Sizing the container
 
 Workers are created on demand for active connections and exit when their sessions close. `--max-sessions` is a capacity
-limit, not a number of preallocated workers. Each worker's process memory is capped at roughly `--max-memory-mib` plus a
-small baseline and headroom (4 MiB, or 32 MiB with type checking). Estimate peak memory as:
+limit, not a number of preallocated workers.
+
+`--max-memory-mib` limits per-session live bytes requested through the worker's global allocator. It does not cap total
+process memory or RSS. Thread stacks, the mapped binary image, direct `mmap`, allocator overhead and fragmentation are
+not included. The allocator's hard ceiling also includes the worker baseline and 4 MiB of headroom, or 32 MiB with type
+checking. Estimate the peak allocator budget as:
 
 ```
-peak container memory ≈ --max-sessions × (--max-memory-mib + baseline + headroom) + server overhead
+peak worker allocator budget ≈ --max-sessions × (--max-memory-mib + baseline + headroom)
 ```
 
-At full utilization, the defaults (64 sessions × 64 MiB) reach several GiB. Lower `--max-sessions` or
-`--max-memory-mib` to fit your instance.
+At full utilization, the default session limits alone allow 4 GiB of allocator-backed live bytes. Container RSS will be
+higher. Account for untracked worker memory and server overhead, and use an OS or cgroup memory limit to enforce a hard
+container bound. Lower `--max-sessions` or `--max-memory-mib` to fit your instance.
 
 ## Health probes and drain
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -124,7 +124,7 @@ kubectl create secret docker-registry monty-image-key \
 
 ## Configuration
 
-Every flag has an environment variable: the flag name in upper snake case with a `MONTY_SERVER_` prefix
+Every configuration flag has an environment variable: the flag name in upper snake case with a `MONTY_SERVER_` prefix
 (`--max-sessions` → `MONTY_SERVER_MAX_SESSIONS`), except `--monty-bin` and `--logfire-token`, which use `MONTY_BIN` and
 `LOGFIRE_TOKEN` respectively.
 A flag on the command line wins over its variable.
@@ -165,14 +165,13 @@ docker run --rm \
   --help
 ```
 
-Prefer environment variables for container configuration so the image's `CMD` remains intact. Always use environment
-variables for `--dump-key` and `--logfire-token`: a command line is world-readable via `ps` and commonly lands in shell
-history.
+Prefer environment variables for container configuration so the image's `CMD` remains intact, especially for
+`--dump-key` and `--logfire-token`: a command line is world-readable via `ps` and commonly lands in shell history.
 
 ### Resource limits
 
 The server's three sandbox resource limits are ceilings. A client that configures no value gets the server's limit; a
-client that asks for more is clamped to it; asking for less always works.
+client that asks for more is clamped to it; a lower requested value is accepted and becomes the effective ceiling.
 
 The server flags and Python client keys use different names and, for memory, different units:
 
@@ -240,10 +239,15 @@ Use `/health` for readiness and `/` for liveness.
 
 On SIGTERM, the server stops listening immediately, so new HTTP and WebSocket connections are refused rather than
 receiving a 503 response. Existing WebSocket sessions remain connected while the server drains. Each existing session's
-next request raises `pydantic_monty.MontyShutdown`; that request did not run, so it is safe to retry. Its `dump` contains
-the signed session state when state exists and dumping succeeds. Restore an idle dump on a fresh session with
-`await session.load_session(exc.dump)` before retrying the request; a dump captured while a feed is suspended instead
-uses `await session.load_snapshot(exc.dump, ...)`.
+next request raises `pydantic_monty.MontyShutdown`; that protocol request did not run and can be resent after restoration.
+Its `dump` contains the signed session state when state exists and dumping succeeds, or `None` otherwise. Check that the
+dump is not `None`, then restore an idle dump on a fresh session with `await session.load_session(exc.dump)` before
+resending the request; a dump captured while a feed is suspended instead uses
+`await session.load_snapshot(exc.dump, ...)`.
+
+If the interrupted request was answering an external function or `os` callback, the host already ran that callback and
+the restored snapshot re-announces it. Make such callbacks idempotent or deduplicate them before restoring across a
+shutdown.
 
 Sessions that remain silent through `--drain-grace` (default 30s) are dropped without a dump.
 Set the pod's `terminationGracePeriodSeconds` above `--drain-grace`, and use the same `MONTY_SERVER_DUMP_KEY` on every

--- a/docs/server.md
+++ b/docs/server.md
@@ -7,26 +7,25 @@ client to another.
 `pydantic_monty.AsyncMontyWebsocket` connects directly from Python; the TypeScript package (`@pydantic/monty`) is
 subprocess-only today and cannot dial a remote server.
 The server adds capacity limits, timeouts, per-caller quotas, health probes, graceful drain and tracing to [Pydantic
-Logfire](https://pydantic.dev/logfire); the sandboxing itself is entirely the `monty` worker's.
+Logfire](https://pydantic.dev/logfire). The `monty` worker provides the sandboxing.
 
 The server is closed-source and distributed as a container image.
 For access and licensing, [contact us](https://pydantic.dev/contact).
 
 ## Why Monty over WebSocket
 
-This is not a sales document, but it's worth briefly enumerating why someone would want to use Monty running on a remote
-server:
+Running Monty on a remote server provides:
 
-- **Security**: escaping the sandbox gets you the machine running Monty, not the machine running the agent / application
-  code — and that machine is an empty container.
+- **Security**: escaping the sandbox gets you the machine running Monty, not the machine running the agent or
+  application code. That machine is an empty container.
 - **Centralized monitoring, observability, and scaling**: one horizontally scalable service for all Monty code
   execution, instead of every service running its own worker pool.
 - **Density**: Monty workers have a small baseline footprint (as little as 2MB), plus additional memory for limits and
   optional type checking, so a single machine can run hundreds.
 - **Same behavior as local Monty**: the wire protocol carries host callbacks, name lookups, async futures and mounted
   client directories, so code that runs against a local pool runs unchanged against the server.
-- **(In future) switch to a full monty sandbox with a parameter**: the same interface, but a full VM running CPython —
-  for code that needs dependencies, bash and a real filesystem.
+- **Future full sandbox option**: a VM running CPython for code that needs dependencies, bash or a real filesystem,
+  exposed through the same interface.
 
 ## Quickstart
 
@@ -106,10 +105,10 @@ It should print:
 2
 ```
 
-An ordinary `GET /` on the server URL answers with a short info page.
+`GET /` on the server URL returns a short info page.
 
-The image bundles the matching `monty` worker binary and runs as non-root uid 65532 on a `scratch` base — no shell, no
-package manager. The bound URL is the only line written to stdout; all logging goes to stderr.
+The image bundles the matching `monty` worker binary and runs as non-root uid 65532 on a `scratch` base with no shell or
+package manager. The bound URL is the only line written to stdout. All logging goes to stderr.
 
 ### Kubernetes
 
@@ -150,7 +149,7 @@ container's loopback interface and is not reachable through `-p 8000:8000`.
 | `--max-duration <seconds>`          | cumulative sandbox execution time per session; 0 disables                | 60                                         |
 | `--max-recursion-depth <n>`         | per-session call-stack ceiling                                           | 1000                                       |
 | `--trust-forwarded-for`             | use the last `X-Forwarded-For` entry as the caller identity               | off                                        |
-| `--dump-key <key>`                  | required key of at least 16 bytes for signing session dumps              | —                                          |
+| `--dump-key <key>`                  | required key of at least 16 bytes for signing session dumps              | none (required)                            |
 | `--logfire-token <token>`           | export traces to Logfire                                                 | off                                        |
 
 When the global session limit is full, a new WebSocket upgrade gets `503 Service Unavailable`; exceeding the
@@ -170,8 +169,8 @@ Prefer environment variables for container configuration so the image's `CMD` re
 
 ### Resource limits
 
-The server's three sandbox resource limits are ceilings. A client that configures no value gets the server's limit; a
-client that asks for more is clamped to it; a lower requested value is accepted and becomes the effective ceiling.
+The server's three sandbox resource limits are ceilings. If a client omits a limit, the server limit applies. A higher
+value is clamped to the server limit. A lower value is accepted and becomes the effective ceiling.
 
 The server flags and Python client keys use different names and, for memory, different units:
 
@@ -211,19 +210,21 @@ Save this as `limits_client.py` and run `uv run limits_client.py`; with the defa
 `2`.
 
 `--max-duration` counts cumulative interpreter execution across the session and excludes time suspended waiting for
-the client. `--turn-timeout` is instead wall-clock time for one complete request, including time waiting for a client
+the client. `--turn-timeout` measures wall-clock time for one complete request, including time waiting for a client
 callback. Keep the server's turn timeout above the clients' `request_timeout` so the client watchdog can report a more
-specific failure first. A keepalive ping that goes unanswered for one further `--keepalive` interval ends the session;
-keep that interval below half of `--idle-timeout` if keepalive should detect a vanished client first.
+specific failure first.
+
+A keepalive ping that goes unanswered for one further `--keepalive` interval ends the session. Keep that interval below
+half of `--idle-timeout` if keepalive should detect a vanished client first.
 
 The worker enforces the effective limits. Memory and duration errors include the effective byte or time ceiling in
 their messages.
 
 ## Sizing the container
 
-Workers are created on demand for active connections and exit when their sessions close; `--max-sessions` is a capacity
+Workers are created on demand for active connections and exit when their sessions close. `--max-sessions` is a capacity
 limit, not a number of preallocated workers. Each worker's process memory is capped at roughly `--max-memory-mib` plus a
-small baseline and headroom (4 MiB, or 32 MiB with type checking), so a peak-capacity planning estimate is:
+small baseline and headroom (4 MiB, or 32 MiB with type checking). Estimate peak memory as:
 
 ```
 peak container memory ≈ --max-sessions × (--max-memory-mib + baseline + headroom) + server overhead
@@ -250,23 +251,23 @@ the restored snapshot re-announces it. Make such callbacks idempotent or dedupli
 shutdown.
 
 Sessions that remain silent through `--drain-grace` (default 30s) are dropped without a dump.
-Set the pod's `terminationGracePeriodSeconds` above `--drain-grace`, and use the same `MONTY_SERVER_DUMP_KEY` on every
-replica — a dump signed by one replica must verify on the one the client reconnects to.
+Set the pod's `terminationGracePeriodSeconds` above `--drain-grace`. Use the same `MONTY_SERVER_DUMP_KEY` on every
+replica so the client can restore a dump after reconnecting to a different one.
 Dumps only load into a worker of the same Monty version, so roll clients and servers together.
 
 ## Tracing
 
 Pass `--logfire-token` (or set `LOGFIRE_TOKEN`) to export traces to [Pydantic Logfire](https://pydantic.dev/logfire).
-Without a token the server behaves identically and emits its console traces and logs to stderr only.
+Without a token, execution is unchanged. Traces and logs are written to stderr but not exported.
 
-The server records one span per connection, and beneath it the same session, run and host-call spans every monty client
-emits — a dashboard built against any monty client works here.
+The server records one span per connection. Beneath it are the same session, run and host-call spans emitted by other
+Monty clients, so existing Monty dashboards work with the server.
 Policy outcomes (capacity rejections, timeouts, drain) are logged as events on the connection span, one line each naming
 the limit that fired.
 
-Traces carry caller data — WebSocket handshake request headers, the code fed to each session, call arguments, results
-and print output — with no flag to turn that off.
-Point the token only at a backend those callers may be exposed to.
+Traces carry WebSocket handshake request headers, the code fed to each session, call arguments, results and print
+output. There is no option to disable collection of these fields.
+Only export to a Logfire project that is authorized to receive this caller data.
 
 ## Security
 


### PR DESCRIPTION
## Summary

- replace the partial configuration table with the shipped image's complete operator-facing flags and defaults
- correct the container bind explanation: hostnames resolve, but container loopback is not reachable through a published port
- document global-capacity `503` and per-client-quota `429` responses
- map server resource flags to Python client keys and units, with an executable client that prints `2`
- clarify cumulative execution time versus wall-clock turn timeout and keepalive behavior
- explain that workers are created for active connections rather than preallocated
- correct health/drain behavior and document optional dump restoration methods
- strengthen proxy/NAT, `X-Forwarded-For`, and caller-data guidance

## Why

This follows #757's quickstart fix with an audit of every section from Configuration through Security against the published image.

Two existing statements did not match the shipped server:

1. `--host localhost` is accepted and resolves to `127.0.0.1`; the actual Docker pitfall is that container loopback is not reachable through `-p`.
2. On SIGTERM, the listener closes immediately. New requests to both `/health` and `/` are connection-refused rather than receiving `503` and `200`. Existing WebSocket sessions continue draining and can obtain a signed dump.

The rest of the behavior matched, but several important controls and client-side units were missing or easy to misread.

## Validation

Tested the current amd64 image under Docker emulation on Apple Silicon:

- compared the full `--help`, image metadata, entrypoint, CMD, architecture, user, and required dump key with the docs
- verified environment configuration and command-line precedence by enforcing a CLI session cap over a different environment value
- observed `503 Service Unavailable` at global capacity and `429 Too Many Requests` at the per-client limit
- verified `X-Forwarded-For` is ignored by default and separates quota identities only with `--trust-forwarded-for`
- tested omitted, looser, and stricter client values for duration, memory, and recursion limits
- tested turn, session, and idle timeouts plus an unanswered keepalive ping
- verified normal `/health` and `/` responses, listener closure during SIGTERM, cross-replica restoration to `42` with a shared key, and silent-session removal after drain grace
- confirmed workers appear only for active connections and exit when the session closes
- confirmed no-token console telemetry contains caller code and checked the public telemetry implementation for inputs, outputs, call arguments, return values, and print data
- ran the exact new limits client against a fresh default container and observed `2`
- ran `uv run prek --files docs/server.md`, `git diff --check`, and Ruff formatting on the Python example

Exported two uniquely tagged traces from the shipped server to `dmontagu/my-demo-project` and queried them back through Logfire. The records confirmed the connection → session → run hierarchy, submitted code, result and print output, plus a host-call span containing positional arguments, keyword arguments and the return value. The live connection span also confirmed that WebSocket handshake request headers are exported, so the disclosure now names them explicitly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies and corrects server operations docs to match the shipped image, including drain behavior, proxy/quotas, tracing fields, and resource limit semantics. Previously the docs suggested 503s during drain; the server instead closes the listener on SIGTERM, refuses new connections, and existing sessions raise `pydantic_monty.MontyShutdown`.

- Use `/health` for readiness and `/` for liveness. On SIGTERM the listener closes; new connections are refused. Restore with `load_session` for idle dumps or `load_snapshot` for suspended feeds; make host callbacks idempotent. Set `terminationGracePeriodSeconds` above `--drain-grace`, share `MONTY_SERVER_DUMP_KEY` across replicas, and note dumps only load into the same Monty version.
- When overriding container args, include `--host 0.0.0.0`. `--host localhost` binds container loopback and is not reachable via `-p`.
- Expect `503` at global capacity and `429` at the per-client quota. Behind a trusted proxy, enable `--trust-forwarded-for` and sanitize `X-Forwarded-For`; leave it off on directly exposed listeners. Per-client quotas key on the last forwarded-for entry when trusted, otherwise on the peer IP.
- Resource limits: map server flags to Python client keys and units. `--max-duration` is cumulative interpreter time; `--turn-timeout` is wall-clock per request. Keep server `--turn-timeout` above client `request_timeout`. Set `--keepalive` below half of `--idle-timeout`. Memory is an allocator ceiling, not RSS; workers are created on demand; size peak usage with `--max-sessions` and `--max-memory-mib`.
- Prefer environment variables; `--monty-bin` and `--logfire-token` use `MONTY_BIN` and `LOGFIRE_TOKEN`. Traces include WebSocket handshake headers, code, arguments, results and print output and cannot be scrubbed; without a token, traces and logs go to stderr only and are not exported.

<sup>Written for commit cb0922b5f744539f86b09208eda0d6d963d3ca8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pydantic/monty/pull/758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

